### PR TITLE
resolve symlinks in local files

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -457,6 +457,7 @@ def cache_download(target_file, temp_location, content_type):
 
 
 def unpack_file(filename, location, content_type, link):
+    filename = os.path.realpath(filename)
     if (content_type == 'application/zip'
         or filename.endswith('.zip')
         or filename.endswith('.pybundle')


### PR DESCRIPTION
this allows --find-links to point to a local folder of symlinks to valid archives

the tar libraries choke when checking valid
filenames because they don't resolve symlinks
