### PR TITLE
Clarify pip dependencies; fix typo

### DIFF
--- a/docs/installing.txt
+++ b/docs/installing.txt
@@ -6,7 +6,7 @@ The recommended way to use pip is within `virtualenv
 automatically. This does not require root access or modify your system Python
 installation. For instance::
 
-    $ curl -O https://github.com/pypa/virtualenv/blob/master/virtualenv.py
+    $ curl -O https://github.com/pypa/virtualenv/raw/master/virtualenv.py
     $ python virtualenv.py my_new_env
     $ . my_new_env/bin/activate
     (my_new_env)$ pip install ...


### PR DESCRIPTION
The sample code in `installing.txt` for fetching virtualenv.py is incorrect as written: it fetches an HTML page from Github instead of the raw virtualenv.py file.

Also, I added a section to `installing.txt` about pip's non-stdlib dependencies.  I think it's useful to note the non-stdlib modules that pip needs to import; it's not immediately obvious that pip imports setuptools, pkg_resources and (sometimes) virtualenv at run-time.

In most circumstances these requirements will never be missing, but in some setups they can be, with odd and unintuitive results.  For example: https://gist.github.com/906093 ... though I'm not sure if the extended documentation makes it any more clear why that fails.
