### PR TITLE
Handle KeyboardInterrupt in basecommand

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -134,6 +134,10 @@ class Command(object):
             logger.fatal(str(e))
             logger.info('Exception information:\n%s' % format_exc())
             exit = 1
+        except KeyboardInterrupt:
+            logger.fatal('Operation cancelled by user')
+            logger.info('Exception information:\n%s' % format_exc())
+            exit = 1
         except:
             logger.fatal('Exception:\n%s' % format_exc())
             exit = 2


### PR DESCRIPTION
Fixes issue #250

Manually tested:

python pip/runner.py install --no-install django
Downloading/unpacking django
  Downloading Django-1.3.tar.gz (6.5Mb): 2.6Mb downloaded
Operation cancelled by user
Storing complete log in /Users/pnasrat/.pip/pip.log
