### PR TITLE
Work around failing test due to distutils.version issue

### DIFF
--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -106,7 +106,14 @@ def compare_versions(version1, version2):
         return cmp(StrictVersion(version1), StrictVersion(version2))
     # in case of abnormal version number, fall back to LooseVersion
     except ValueError:
+        pass
+    try:
         return cmp(LooseVersion(version1), LooseVersion(version2))
+    except TypeError:
+    # certain LooseVersion comparions raise due to unorderable types,
+    # fallback to string comparison
+        return cmp([str(v) for v in LooseVersion(version1).version],
+                   [str(v) for v in LooseVersion(version2).version])
 
 
 def highest_version(versions):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -23,6 +23,7 @@ def test_version_compare():
     assert compare_versions('1.0', '1.1') == -1
     assert compare_versions('1.1', '1.0') == 1
     assert compare_versions('1.1a1', '1.1') == -1
+    assert compare_versions('1.1.1', '1.1a') == -1
     assert highest_version(['1.0', '2.0', '0.1']) == '2.0'
     assert highest_version(['1.0a1', '1.0']) == '1.0'
 


### PR DESCRIPTION
In py3k the following fails, handle this and use string comparison in worst
case.

Tested on 2.6 and 3.2

<pre>
>> from distutils.version import LooseVersion as LV
>>> v1, v2, v3 = (LV('1.1'), LV('1.1.2'), LV('1.1a1'))
>>> v1 > v2
False
>>> v1 > v3
False
>>> v2 > v3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "distutils/version.py", line 70, in __gt__
    c = self._cmp(other)
  File "distutils/version.py", line 343, in _cmp
    if self.version < other.version:
TypeError: unorderable types: int() < str()
</pre>
