### PR TITLE
Correct handling of default pathext case

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -76,7 +76,8 @@ def find_command(cmd, paths=None, pathext=None):
         paths = [paths]
     # check if there are funny path extensions for executables, e.g. Windows
     if pathext is None:
-        pathext = os.environ.get('PATHEXT', '.COM;.EXE;.BAT;.CMD')
+        default_pathext = os.pathsep.join([ '.COM', '.EXE', '.BAT', '.CMD' ])
+        pathext = os.environ.get('PATHEXT', default_pathext)
     pathext = [ext for ext in pathext.lower().split(os.pathsep)]
     # don't use extensions if the command ends with one of them
     if os.path.splitext(cmd)[1].lower() in pathext:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -6,8 +6,9 @@ import sys
 from os.path import abspath, join, curdir, pardir
 
 from nose import SkipTest
+from mock import Mock, patch
 
-from pip.util import rmtree
+from pip.util import rmtree, find_command
 
 from tests.test_pip import (here, reset_env, run_pip, pyversion, mkdir,
                             src_folder, write_file)
@@ -521,6 +522,26 @@ def test_find_command_folder_in_path():
     mkdir(path_one/'foo')
     mkdir('path_two'); path_two = env.scratch_path/'path_two'
     write_file(path_two/'foo', '# nothing')
-    from pip.util import find_command
     found_path = find_command('foo', map(str, [path_one, path_two]))
     assert found_path == path_two/'foo'
+
+@patch('os.path.isfile')
+def test_find_command_trys_all_pathext(mock_isfile):
+    """
+    If no pathext should check default list of extensions, if file does not
+    exist.
+    """
+    mock_isfile.return_value = False
+    # Patching os.pathsep failed on type checking
+    old_sep = os.pathsep
+    os.pathsep = ':'
+
+    found_path = find_command('foo', 'path_one')
+
+    paths = [ 'path_one/foo.com', 'path_one/foo.exe', 'path_one/foo.bat', 
+              'path_one/foo.cmd', 'path_one/foo' ]
+    expected = [ ((p,),) for p in paths ]
+    assert found_path is None, "Should not find path"
+    assert mock_isfile.call_args_list == expected, "%s" % (mock_isfile.call_args_list,)
+
+    os.pathsep = old_sep


### PR DESCRIPTION
Fixes #233

This adds tests which failed with existing code and then fixed with change.

Ran tests for test_basic in nose on 2.4.4, 2.7.1, 3.2

Ran full suite under 2.7

---

Ran 107 tests in 172.398s
