### PR TITLE
Clean up doc to (hopefully) make it easier to understand

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -1,7 +1,21 @@
 pip
 ===
 
-pip installs Python packages.
+pip is a tool for installing and managing Python packages, such as those
+found in the `Python Package Index <http://pypi.python.org/pypi>`_.
+
+pip is a replacement for `easy_install
+<http://peak.telecommunity.com/DevCenter/EasyInstall>`_.  It mostly
+uses the same techniques for finding packages, so packages that are
+easy_installable should be pip-installable as well.  This means that
+you can use ``pip install SomePackage`` instead of ``easy_install
+SomePackage``.
+
+In order to use pip, you must first install `setuptools
+<http://pypi.python.org/pypi/setuptools>`_ or `distribute
+<http://pypi.python.org/pypi/distribute>`_.
+If you use virtualenv, a copy of pip will be automatically be installed
+in each virtual environment you create.
 
 .. toctree::
    :maxdepth: 1
@@ -15,14 +29,8 @@ pip installs Python packages.
 
 .. comment: split here
 
-Introduction
-------------
-
-pip installs packages.  Python packages.
-
-If you use `virtualenv <http://virtualenv.openplans.org>`__ -- a tool
-for installing libraries in a local and isolated manner -- you'll
-automatically get a copy of pip.  Free bonus!
+Usage
+-----
 
 Once you have pip, you can use it like this::
 
@@ -53,11 +61,6 @@ specific version.
 
 Pip Compared To easy_install
 ----------------------------
-
-pip is a replacement for `easy_install
-<http://peak.telecommunity.com/DevCenter/EasyInstall>`_.  It uses mostly the
-same techniques for finding packages, so packages that were made
-easy_installable should be pip-installable as well.
 
 pip is meant to improve on easy_install.  Some of the improvements:
 
@@ -103,10 +106,9 @@ virtualenv to isolate your installation.
 Community
 ---------
 
-The homepage for pip is temporarily located `on PyPI
-<http://pypi.python.org/pypi/pip>`_ -- a more proper homepage will
-follow.  Bugs can go on the `pip issue tracker
-<https://github.com/pypa/pip/issues/>`_.  Discussion should happen on the
+The homepage for pip is at `pip-installer.org <http://www.pip-installer.org/>`_.
+Bugs can be filed in the `pip issue tracker
+<https://github.com/pypa/pip/issues/>`_.  Discussion happens on the
 `virtualenv email group
 <http://groups.google.com/group/python-virtualenv?hl=en>`_.
 

--- a/docs/installing.txt
+++ b/docs/installing.txt
@@ -11,6 +11,7 @@ installation. For instance::
     $ . my_new_env/bin/activate
     (my_new_env)$ pip install ...
 
+When used in this manner, pip will only affect the active virtual environment.
 If you do want to install pip globally into your Python installation, see the
 instructions below.
 


### PR DESCRIPTION
I think the pip documentation is a little bit hard to understand. This is my attempt at making it a little more clear.

Some of the things that I tried to improve:
- be more specific about what pip is and what it does
- explain that pip depends on setuptools (or distribute)
- more clearly explain the relationship between virtualenv and pip
