### PR TITLE
Fix whitespace, etc for pep8 compliance

### DIFF
--- a/contrib/get-pip.py
+++ b/contrib/get-pip.py
@@ -1106,6 +1106,7 @@ import zlib
 import tempfile
 import shutil
 
+
 def unpack(sources):
     temp_dir = tempfile.mkdtemp('-scratchdir', 'unpacker-')
     for package, content in sources.items():
@@ -1122,7 +1123,7 @@ def unpack(sources):
     return temp_dir
 
 if __name__ == "__main__":
-    if sys.version_info >= (3,0):
+    if sys.version_info >= (3, 0):
         exec("def do_exec(co, loc): exec(co, loc)\n")
         import pickle
         sources = sources.encode("ascii") # ensure bytes

--- a/contrib/packager/__init__.py
+++ b/contrib/packager/__init__.py
@@ -8,6 +8,7 @@ import base64
 import os
 import fnmatch
 
+
 def find_toplevel(name):
     for syspath in sys.path:
         lib = os.path.join(syspath, name)
@@ -18,9 +19,11 @@ def find_toplevel(name):
             return mod
     raise LookupError(name)
 
+
 def pkgname(toplevel, rootpath, path):
     parts = path.split(os.sep)[len(rootpath.split(os.sep)):]
     return '.'.join([toplevel] + [os.path.splitext(x)[0] for x in parts])
+
 
 def pkg_to_mapping(name):
     toplevel = find_toplevel(name)

--- a/contrib/packager/template.py
+++ b/contrib/packager/template.py
@@ -10,6 +10,7 @@ import zlib
 import tempfile
 import shutil
 
+
 def unpack(sources):
     temp_dir = tempfile.mkdtemp('-scratchdir', 'unpacker-')
     for package, content in sources.items():
@@ -25,8 +26,9 @@ def unpack(sources):
             mod.close()
     return temp_dir
 
+
 if __name__ == "__main__":
-    if sys.version_info >= (3,0):
+    if sys.version_info >= (3, 0):
         exec("def do_exec(co, loc): exec(co, loc)\n")
         import pickle
         sources = sources.encode("ascii") # ensure bytes

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -115,6 +115,7 @@ def main(initial_args=None):
     command = command_dict[command]
     return command.main(initial_args, args[1:], options)
 
+
 def bootstrap():
     """
     Bootstrapping function to be called from install-pip.py script.

--- a/pip/backwardcompat.py
+++ b/pip/backwardcompat.py
@@ -50,12 +50,16 @@ if sys.version_info >= (3,):
     import xmlrpc.client as xmlrpclib
     import urllib.parse as urlparse
     import http.client as httplib
+
     def cmp(a, b):
         return (a > b) - (a < b)
+
     def b(s):
         return s.encode('utf-8')
+
     def u(s):
         return s.decode('utf-8')
+
     def console_to_str(s):
         return s.decode(console_encoding)
     bytes = bytes
@@ -73,10 +77,13 @@ else:
     import ConfigParser
     import xmlrpclib
     import httplib
+
     def b(s):
         return s
+
     def u(s):
         return s
+
     def console_to_str(s):
         return s
     bytes = str
@@ -92,6 +99,7 @@ except ImportError:
     from email.FeedParser import FeedParser
 
 from distutils.sysconfig import get_python_lib, get_python_version
+
 
 def copytree(src, dst):
     if sys.version_info < (2, 5):

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -154,8 +154,6 @@ class Command(object):
         return exit
 
 
-
-
 def format_exc(exc_info=None):
     if exc_info is None:
         exc_info = sys.exc_info()

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 from pip.req import InstallRequirement, RequirementSet
 from pip.req import parse_requirements
 from pip.log import logger

--- a/pip/commands/uninstall.py
+++ b/pip/commands/uninstall.py
@@ -2,6 +2,7 @@ from pip.req import InstallRequirement, RequirementSet, parse_requirements
 from pip.basecommand import Command
 from pip.exceptions import InstallationError
 
+
 class UninstallCommand(Command):
     name = 'uninstall'
     usage = '%prog [OPTIONS] PACKAGE_NAMES ...'

--- a/pip/download.py
+++ b/pip/download.py
@@ -64,6 +64,7 @@ def get_file_content(url, comes_from=None):
 _scheme_re = re.compile(r'^(http|https|file):', re.I)
 _url_slash_drive_re = re.compile(r'/*([a-z])\|', re.I)
 
+
 class URLOpener(object):
     """
     pip's own URL helper that adds HTTP auth and proxy support

--- a/pip/req.py
+++ b/pip/req.py
@@ -91,15 +91,15 @@ class InstallRequirement(object):
         # If the line has an egg= definition, but isn't editable, pull the requirement out.
         # Otherwise, assume the name is the req for the non URL/path/archive case.
         if link and req is None:
-          url = link.url_fragment
-          req = link.egg_fragment
+            url = link.url_fragment
+            req = link.egg_fragment
 
-          # Handle relative file URLs
-          if link.scheme == 'file' and re.search(r'\.\./', url):
-            url = path_to_url(os.path.normpath(os.path.abspath(link.path)))
+            # Handle relative file URLs
+            if link.scheme == 'file' and re.search(r'\.\./', url):
+                url = path_to_url(os.path.normpath(os.path.abspath(link.path)))
 
         else:
-          req = name
+            req = name
 
         return cls(req, comes_from, url=url)
 
@@ -768,7 +768,7 @@ class Requirements(object):
         return self._dict[key]
 
     def __repr__(self):
-        values = [ '%s: %s' % (repr(k), repr(self[k])) for k in self.keys() ]
+        values = ['%s: %s' % (repr(k), repr(self[k])) for k in self.keys()]
         return 'Requirements({%s})' % ', '.join(values)
 
 

--- a/pip/util.py
+++ b/pip/util.py
@@ -98,9 +98,10 @@ def find_command(cmd, paths=None, pathext=None):
 def get_pathext(default_pathext=None):
     """Returns the path extensions from environment or a default"""
     if default_pathext is None:
-        default_pathext = os.pathsep.join([ '.COM', '.EXE', '.BAT', '.CMD' ])
+        default_pathext = os.pathsep.join(['.COM', '.EXE', '.BAT', '.CMD'])
     pathext = os.environ.get('PATHEXT', default_pathext)
     return pathext
+
 
 def ask(message, options):
     """Ask the message interactively, with the given possible responses"""

--- a/pip/vcs/bazaar.py
+++ b/pip/vcs/bazaar.py
@@ -18,7 +18,6 @@ class Bazaar(VersionControl):
     guide = ('# This was a Bazaar branch; to make it a branch again run:\n'
              'bzr branch -r %(rev)s %(url)s .\n')
 
-
     def __init__(self, url=None, *args, **kwargs):
         super(Bazaar, self).__init__(url, *args, **kwargs)
         urlparse.non_hierarchical.extend(['lp'])

--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -8,6 +8,7 @@ from pip.backwardcompat import url2pathname, urlparse
 urlsplit = urlparse.urlsplit
 urlunsplit = urlparse.urlunsplit
 
+
 class Git(VersionControl):
     name = 'git'
     dirname = '.git'

--- a/tests/path.py
+++ b/tests/path.py
@@ -15,6 +15,7 @@ _base = os.path.supports_unicode_filenames and unicode or str
 
 from pip.util import rmtree
 
+
 class Path(_base):
     """ Models a path in an object oriented way. """
 
@@ -32,7 +33,7 @@ class Path(_base):
         """ path_obj / 'bc.d' """
         """ path_obj / path_obj2 """
         return Path(self, path)
-    
+
     __truediv__ = __div__
 
     def __rdiv__(self, path):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -17,6 +17,7 @@ from tests.test_pip import (here, reset_env, run_pip, pyversion, mkdir,
 from tests.local_repos import local_checkout
 from tests.path import Path
 
+
 def test_correct_pip_version():
     """
     Check we are running proper version of pip in run_pip.
@@ -388,6 +389,7 @@ def test_install_subversion_usersite_editable_with_setuptools_fails():
                      expect_error=True)
     assert '--user --editable not supported with setuptools, use distribute' in result.stdout
 
+
 def test_install_pardir():
     """
     Test installing parent directory ('..').
@@ -418,6 +420,7 @@ def test_install_with_pax_header():
     reset_env()
     run_from = abspath(join(here, 'packages'))
     run_pip('install', 'paxpkg.tar.bz2', cwd=run_from)
+
 
 def test_install_using_install_option_and_editable():
     """
@@ -502,6 +505,7 @@ def test_install_folder_using_relative_path():
     egg_folder = env.site_packages / 'mock-100.1-py%s.egg-info' % pyversion
     assert egg_folder in result.files_created, str(result)
 
+
 def test_install_package_which_contains_dev_in_name():
     """
     Test installing package from pypi which contains 'dev' in name
@@ -513,6 +517,7 @@ def test_install_package_which_contains_dev_in_name():
     assert devserver_folder in result.files_created, str(result.stdout)
     assert egg_info_folder in result.files_created, str(result)
 
+
 def test_find_command_folder_in_path():
     """
     If a folder named e.g. 'git' is in PATH, and find_command is looking for
@@ -520,12 +525,15 @@ def test_find_command_folder_in_path():
     looking.
     """
     env = reset_env()
-    mkdir('path_one'); path_one = env.scratch_path/'path_one'
+    mkdir('path_one')
+    path_one = env.scratch_path/'path_one'
     mkdir(path_one/'foo')
-    mkdir('path_two'); path_two = env.scratch_path/'path_two'
+    mkdir('path_two')
+    path_two = env.scratch_path/'path_two'
     write_file(path_two/'foo', '# nothing')
     found_path = find_command('foo', map(str, [path_one, path_two]))
     assert found_path == path_two/'foo'
+
 
 def test_does_not_find_command_because_there_is_no_path():
     """
@@ -534,15 +542,16 @@ def test_does_not_find_command_because_there_is_no_path():
     environ_before = os.environ
     os.environ = {}
     try:
-      try:
-          find_command('anycommand')
-      except BadCommand:
-          e = sys.exc_info()[1]
-          assert e.args == ("Cannot find command 'anycommand'",)
-      else:
-          raise AssertionError("`find_command` should raise `BadCommand`")
+        try:
+            find_command('anycommand')
+        except BadCommand:
+            e = sys.exc_info()[1]
+            assert e.args == ("Cannot find command 'anycommand'",)
+        else:
+            raise AssertionError("`find_command` should raise `BadCommand`")
     finally:
         os.environ = environ_before
+
 
 @patch('pip.util.get_pathext')
 @patch('os.path.isfile')
@@ -558,8 +567,8 @@ def test_find_command_trys_all_pathext(mock_isfile, getpath_mock):
 
     getpath_mock.return_value = os.pathsep.join([".COM", ".EXE"])
 
-    paths = [ os.path.join('path_one', f)  for f in ['foo.com', 'foo.exe', 'foo'] ]
-    expected = [ ((p,),) for p in paths ]
+    paths = [os.path.join('path_one', f)  for f in ['foo.com', 'foo.exe', 'foo']]
+    expected = [((p,),) for p in paths]
 
     try:
         assert_raises(BadCommand, find_command, 'foo', 'path_one')
@@ -567,6 +576,7 @@ def test_find_command_trys_all_pathext(mock_isfile, getpath_mock):
         assert getpath_mock.called, "Should call get_pathext"
     finally:
         os.pathsep = old_sep
+
 
 @patch('pip.util.get_pathext')
 @patch('os.path.isfile')
@@ -582,8 +592,8 @@ def test_find_command_trys_supplied_pathext(mock_isfile, getpath_mock):
 
     pathext = os.pathsep.join([".RUN", ".CMD"])
 
-    paths = [ os.path.join('path_one', f)  for f in ['foo.run', 'foo.cmd', 'foo'] ]
-    expected = [ ((p,),) for p in paths ]
+    paths = [os.path.join('path_one', f)  for f in ['foo.run', 'foo.cmd', 'foo']]
+    expected = [((p,),) for p in paths]
 
     try:
         assert_raises(BadCommand, find_command, 'foo', 'path_one', pathext)

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -6,6 +6,7 @@ from tests.test_pip import (here, reset_env, run_pip, write_file, mkdir,
 from tests.local_repos import local_checkout
 from tests.path import Path
 
+
 def test_cleanup_after_install_from_pypi():
     """
     Test clean up after installing a package from PyPI.
@@ -48,6 +49,7 @@ def test_cleanup_after_install_from_local_directory():
     src = env.venv_path/'src'
     assert not exists(build), "unexpected build/ dir exists: %s" % build
     assert not exists(src), "unexpected src/ dir exist: %s" % src
+
 
 def test_cleanup_after_create_bundle():
     """

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -32,6 +32,7 @@ def _check_output(result, expected):
         return '\n========== %s ==========\n' % msg
     assert checker.check_output(expected, actual, ELLIPSIS), banner('EXPECTED')+expected+banner('ACTUAL')+actual+banner(6*'=')
 
+
 def test_freeze_basic():
     """
     Some tests of freeze, first we have to install some stuff.  Note that
@@ -56,6 +57,7 @@ def test_freeze_basic():
         MarkupSafe==0.12...
         <BLANKLINE>""")
     _check_output(result, expected)
+
 
 def test_freeze_svn():
     """Now lets try it with an svn checkout"""

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,5 +1,6 @@
 from pip.index import package_to_requirement
 
+
 def test_package_name_should_be_converted_to_requirement():
     """
     Test that it translates a name like Foo-1.2 to Foo==1.3

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -468,6 +468,7 @@ class FastTestPipEnvironment(TestPipEnvironment):
     def __del__(self):
         pass # shutil.rmtree(str(self.root_path), ignore_errors=True)
 
+
 def run_pip(*args, **kw):
     result = env.run('pip', *args, **kw)
     ignore = []

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -6,6 +6,7 @@ from tests.test_pip import reset_env, run_pip, write_file, pyversion, here, path
 from tests.local_repos import local_checkout
 from tests.path import Path
 
+
 def test_requirements_file():
     """
     Test installing from a requirements file.
@@ -25,6 +26,7 @@ def test_requirements_file():
     fn = '%s-%s-py%s.egg-info' % (other_lib_name, other_lib_version, pyversion)
     assert result.files_created[env.site_packages/fn].dir
 
+
 def test_relative_requirements_file():
     """
     Test installing from a requirements file with a relative path with an egg= definition..
@@ -38,6 +40,7 @@ def test_relative_requirements_file():
     result = run_pip('install', '-vvv', '-r', env.scratch_path / 'file-egg-req.txt')
     assert (env.site_packages/'FSPkg-0.1dev-py%s.egg-info' % pyversion) in result.files_created, str(result)
     assert (env.site_packages/'fspkg') in result.files_created, str(result.stdout)
+
 
 def test_multiple_requirements_files():
     """
@@ -88,12 +91,14 @@ def test_requirements_data_structure_keeps_order():
     assert ['pip', 'nose', 'coverage'] == list(requirements.values())
     assert ['pip', 'nose', 'coverage'] == list(requirements.keys())
 
+
 def test_requirements_data_structure_implements__repr__():
     requirements = Requirements()
     requirements['pip'] = 'pip'
     requirements['nose'] = 'nose'
 
     assert "Requirements({'pip': 'pip', 'nose': 'nose'})" == repr(requirements)
+
 
 def test_requirements_data_structure_implements__contains__():
     requirements = Requirements()

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -7,6 +7,7 @@ from tests.local_repos import local_repo, local_checkout
 
 from pip.util import rmtree
 
+
 def test_simple_uninstall():
     """
     Test simple install and uninstall.

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -54,6 +54,7 @@ def test_uninstall_before_upgrade():
     result3 = run_pip('uninstall', 'initools', '-y', expect_error=True)
     assert_all_changes(result, result3, [env.venv/'build', 'cache'])
 
+
 def test_uninstall_before_upgrade_from_url():
     """
     Automatic uninstall-before-upgrade from URL.
@@ -66,6 +67,7 @@ def test_uninstall_before_upgrade_from_url():
     assert result2.files_created, 'upgrade to INITools 0.3 failed'
     result3 = run_pip('uninstall', 'initools', '-y', expect_error=True)
     assert_all_changes(result, result3, [env.venv/'build', 'cache'])
+
 
 def test_upgrade_to_same_version_from_url():
     """
@@ -80,6 +82,7 @@ def test_upgrade_to_same_version_from_url():
     assert not result2.files_updated, 'INITools 0.3 reinstalled same version'
     result3 = run_pip('uninstall', 'initools', '-y', expect_error=True)
     assert_all_changes(result, result3, [env.venv/'build', 'cache'])
+
 
 def test_upgrade_from_reqs_file():
     """
@@ -133,6 +136,7 @@ def test_editable_git_upgrade():
     run_pip('install', '-e', '%s#egg=version_pkg' % ('git+file://' + version_pkg_path))
     version2 = env.run('version_pkg')
     assert 'some different version' in version2.stdout
+
 
 def test_should_not_install_always_from_cache():
     """

--- a/tests/test_vcs_backends.py
+++ b/tests/test_vcs_backends.py
@@ -2,6 +2,7 @@ from tests.test_pip import (reset_env, run_pip,
                       _create_test_package, _change_test_package_version)
 from tests.local_repos import local_checkout
 
+
 def test_install_editable_from_git_with_https():
     """
     Test cloning from Git with https.
@@ -82,6 +83,7 @@ def test_git_branch_should_not_be_changed():
     result = env.run('git', 'branch', cwd=source_dir)
     assert '* master' in result.stdout
 
+
 def test_git_with_non_editable_unpacking():
     """
     Test cloning a git repository from a non-editable URL with a given tag.
@@ -92,6 +94,7 @@ def test_git_with_non_editable_unpacking():
                      ), expect_error=True)
     assert '0.3.1\n' in result.stdout
 
+
 def test_git_with_editable_where_egg_contains_dev_string():
     """
     Test cloning a git repository from an editable url which contains "dev" string
@@ -100,6 +103,7 @@ def test_git_with_editable_where_egg_contains_dev_string():
     result = run_pip('install', '-e', '%s#egg=django-devserver' %
                      local_checkout('git+git://github.com/dcramer/django-devserver.git'))
     result.assert_installed('django-devserver', with_files=['.git'])
+
 
 def test_git_with_non_editable_where_egg_contains_dev_string():
     """

--- a/tests/test_vcs_bazaar.py
+++ b/tests/test_vcs_bazaar.py
@@ -18,7 +18,7 @@ def test_bazaar_simple_urls():
     ssh_bzr_repo = Bazaar(url='bzr+ssh://bzr.myproject.org/MyProject/trunk/#egg=MyProject')
     ftp_bzr_repo = Bazaar(url='bzr+ftp://bzr.myproject.org/MyProject/trunk/#egg=MyProject')
     sftp_bzr_repo = Bazaar(url='bzr+sftp://bzr.myproject.org/MyProject/trunk/#egg=MyProject')
-    launchpad_bzr_repo  = Bazaar(url='bzr+lp:MyLaunchpadProject#egg=MyLaunchpadProject')
+    launchpad_bzr_repo = Bazaar(url='bzr+lp:MyLaunchpadProject#egg=MyLaunchpadProject')
 
     assert http_bzr_repo.get_url_rev() == ('http://bzr.myproject.org/MyProject/trunk/', None)
     assert https_bzr_repo.get_url_rev() == ('https://bzr.myproject.org/MyProject/trunk/', None)


### PR DESCRIPTION
Reran tests after changes on 2.4, 2.6, 3.2 all pass.
# 

================== Running pep8 =====================

Searching for pep8
Reading http://pypi.python.org/simple/pep8/
Reading http://github.com/cburroughs/pep8.py/tree/master
Reading http://github.com/jcrocholl/pep8
Best match: pep8 0.6.1
Processing pep8-0.6.1-py2.6.egg
pep8 0.6.1 is already the active version in easy-install.pth
Installing pep8 script to /Users/pnasrat/Development/pip/pip_virtualenv/bin

Using /Users/pnasrat/Development/pip/pip_virtualenv/lib/python2.6/site-packages/pep8-0.6.1-py2.6.egg
Processing dependencies for pep8
Finished processing dependencies for pep8
# ==================== Ended pep8 =====================
