### PR TITLE
Fix for #295 install -I when package installed

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -997,7 +997,7 @@ class RequirementSet(object):
                         # repeat check_if_exists to uninstall-on-upgrade (#14)
                         req_to_install.check_if_exists()
                         if req_to_install.satisfied_by:
-                            if self.upgrade:
+                            if self.upgrade or self.ignore_installed:
                                 req_to_install.conflicts_with = req_to_install.satisfied_by
                                 req_to_install.satisfied_by = None
                             else:

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -149,3 +149,14 @@ def test_should_not_install_always_from_cache():
     result = run_pip('install', 'INITools==0.1', expect_error=True)
     assert env.site_packages/'INITools-0.2-py%s.egg-info' % pyversion not in result.files_created
     assert env.site_packages/'INITools-0.1-py%s.egg-info' % pyversion in result.files_created
+
+def test_install_with_ignoreinstalled_requested():
+    """
+    It installs package if ignore installed is set.
+
+    """
+    env = reset_env()
+    run_pip('install', 'INITools==0.1', expect_error=True)
+    result = run_pip('install', '-I' , 'INITools', expect_error=True)
+    assert result.files_created, 'pip install -I did not install'
+    assert env.site_packages/'INITools-0.1-py%s.egg-info' % pyversion not in result.files_created


### PR DESCRIPTION
Add simple test and fix to ensure install() runs with -I.

Tests run clean on 2.4, 2.7, 3.2
