### PR TITLE
Fix #297 adding deflate and gzip handling

### DIFF
--- a/pip/backwardcompat.py
+++ b/pip/backwardcompat.py
@@ -37,7 +37,7 @@ except NameError:
 console_encoding = sys.__stdout__.encoding
 
 if sys.version_info >= (3,):
-    from io import StringIO
+    from io import StringIO, BytesIO
     from functools import reduce
     from urllib.error import URLError, HTTPError
     from queue import Queue, Empty
@@ -91,6 +91,7 @@ else:
     reduce = reduce
     cmp = cmp
     raw_input = raw_input
+    BytesIO = StringIO
 
 try:
     from email.parser import FeedParser


### PR DESCRIPTION
Tested on py24, py27 and py32 and the failing tests on 3.2 go away, the content
we're getting back is still gzipped so this is a valid manual test.  Add
BytesIO to backwardcompat, fallingback to StringIO on py2x.

I'd like to get the CI build green then comeback and improve the testing around
this.  I've not added tests at the moment, but want to come back to that. There is
quite a lot of complexity around downloads split between pip.index and
pip.download.
