### PR TITLE
Skip setuptools test if we have distribute

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -378,6 +378,10 @@ def test_install_subversion_usersite_editable_with_setuptools_fails():
     # We don't try to use setuptools for 3.X.
     elif sys.version_info >= (3,):
         raise SkipTest()
+    # our test environment contains distribute
+    import setuptools
+    if getattr(setuptools, '_distribute', False):
+        raise SkipTest()
     env = reset_env()
     no_site_packages = env.lib_path/'no-global-site-packages.txt'
     if os.path.isfile(no_site_packages):


### PR DESCRIPTION
This particular test fails if the Python environment already contains "distribute".
