### PR TITLE
Fix pip install -e bzr+...#egg=Package

### DIFF
--- a/pip/vcs/bazaar.py
+++ b/pip/vcs/bazaar.py
@@ -24,7 +24,7 @@ class Bazaar(VersionControl):
         urlparse.uses_fragment.extend(['lp'])
 
     def __init__(self, url=None, *args, **kwargs):
-        if "#egg=" in url:
+        if url is not None and "#egg=" in url:
             url = url[:url.index("#egg")]
         super(Bazaar, self).__init__(url, *args, **kwargs)
 


### PR DESCRIPTION
Using pip with bzr like that was broken because #egg=Package would end
up being passed all the way down to bzr. With this simple patch #egg
fragment is stripped.
