### PR TITLE
git clone only the last/required commit (--depth 1)

### DIFF
--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -104,7 +104,7 @@ class Git(VersionControl):
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.notify('Cloning %s%s to %s' % (url, rev_display, display_path(dest)))
-            call_subprocess([self.cmd, 'clone', '-q', url, dest])
+            call_subprocess([self.cmd, 'clone', '--depth', '1', '-q', url, dest])
             if rev:
                 rev_options = self.check_rev_options(rev, dest, rev_options)
                 # Only do a checkout if rev_options differs from HEAD


### PR DESCRIPTION
There is probably no reason to clone all commit history if you need just to install a package and delete its source. I have added '--depth 1' to the clone command to download just the required commit.

https://git.wiki.kernel.org/index.php/GitFaq#How_do_I_do_a_quick_clone_without_history_revisions.3F
http://www.kernel.org/pub/software/scm/git/docs/git-clone.html
