### PR TITLE
Fix special characters in HTTP Basic Auth

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -113,11 +113,10 @@ class URLOpener(object):
         # see if we have a password stored
         if stored_username is None:
             if username is None and self.prompting:
-                username = urllib.quote(raw_input('User for %s: ' % netloc))
-                password = urllib.quote(getpass.getpass('Password: '))
+                username = raw_input('User for %s: ' % netloc)
+                password = getpass.getpass('Password: ')
             if username and password:
                 self.passman.add_password(None, netloc, username, password)
-            stored_username, stored_password = self.passman.find_user_password(None, netloc)
         authhandler = urllib2.HTTPBasicAuthHandler(self.passman)
         opener = urllib2.build_opener(authhandler)
         # FIXME: should catch a 401 and offer to let the user reenter credentials


### PR DESCRIPTION
When doing basic http auth in download.py, you are using url.quote to encode the username and password which breaks authentication when usersname or password contain special characters like "@". The url quoting is not needed there since the username and password are not sent as part of url, but send as part of http request and base64 encoded.
