### PR TITLE
Feature addition for issue #341

### DIFF
--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -1,3 +1,4 @@
+from datetime import date
 import re
 import sys
 import pkg_resources
@@ -111,7 +112,8 @@ class FreezeCommand(Command):
                 if not changed_only:
                     f.write(str(installations[line_req.name]))
                 del installations[line_req.name]
-            f.write('## The following requirements were added by pip --freeze:\n')
+            if installations:
+                f.write('## The following requirements were added by pip --freeze on %s:\n' % (date.today().strftime("%Y-%m-%d"),))
         for installation in sorted(installations.values(), key=lambda x: x.name):
             f.write(str(installation))
 

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -79,7 +79,8 @@ class FreezeCommand(Command):
             req_f = open(requirement)
             for line in req_f:
                 if not line.strip() or line.strip().startswith('#'):
-                    f.write(line)
+                    if not changed_only:
+                        f.write(line)
                     continue
                 if skip_match and skip_match.search(line):
                     f.write(line)

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -35,6 +35,12 @@ class FreezeCommand(Command):
             action='store_true',
             default=False,
             help='If in a virtualenv, do not report globally-installed packages')
+        self.parser.add_option(
+            '-c', '--changed',
+            dest='changed',
+            action='store_true',
+            default=False,
+            help='Only report packages that are new or have changed relative to a provided requirements file (-r). If you havn\'t specified a requirements file this option has no effect.')
 
     def setup_logging(self):
         logger.move_stdout_to_stderr()
@@ -43,6 +49,7 @@ class FreezeCommand(Command):
         requirement = options.requirement
         find_links = options.find_links or []
         local_only = options.local
+        changed_only = options.changed
         ## FIXME: Obviously this should be settable:
         find_tags = False
         skip_match = None
@@ -101,7 +108,8 @@ class FreezeCommand(Command):
                     logger.warn("Requirement file contains %s, but that package is not installed"
                                 % line.strip())
                     continue
-                f.write(str(installations[line_req.name]))
+                if not changed_only:
+                    f.write(str(installations[line_req.name]))
                 del installations[line_req.name]
             f.write('## The following requirements were added by pip --freeze:\n')
         for installation in sorted(installations.values(), key=lambda x: x.name):

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -253,6 +253,22 @@ def test_freeze_with_changed_option():
     result = run_pip('install', '-r', env.scratch_path/'initools-req.txt')
 
     # Now install something else and check that only that is reported
+    result = run_pip('install', 'MarkupSafe<=0.11')
+    result = run_pip('freeze', '--local', '--changed', '-r', env.scratch_path/'initools-req.txt', expect_stderr=True)
+    expected = textwrap.dedent("""\
+        Script result: pip freeze --local --changed...
+        -- stdout: --------------------
+        ## The following requirements were added by pip --freeze on...
+        MarkupSafe==0.11...
+        <BLANKLINE>""")
+    _check_output(result, expected)
+
+
+    # Check that upgraded packages are shown as changed
+    write_file('initools-req.txt', textwrap.dedent("""\
+        INITools==0.2
+        MarkupSafe<=0.11
+        """))
     result = run_pip('install', 'MarkupSafe<=0.12')
     result = run_pip('freeze', '--local', '--changed', '-r', env.scratch_path/'initools-req.txt', expect_stderr=True)
     expected = textwrap.dedent("""\
@@ -262,3 +278,4 @@ def test_freeze_with_changed_option():
         MarkupSafe==0.12...
         <BLANKLINE>""")
     _check_output(result, expected)
+    

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -253,13 +253,13 @@ def test_freeze_with_changed_option():
     result = run_pip('install', '-r', env.scratch_path/'initools-req.txt')
 
     # Now install something else and check that only that is reported
-    result = run_pip('install', 'MarkupSafe<=0.11')
+    result = run_pip('install', 'wsgiref==0.1.1')
     result = run_pip('freeze', '--local', '--changed', '-r', env.scratch_path/'initools-req.txt', expect_stderr=True)
     expected = textwrap.dedent("""\
         Script result: pip freeze --local --changed...
         -- stdout: --------------------
         ## The following requirements were added by pip --freeze on...
-        MarkupSafe==0.11...
+        wsgiref==0.1.1...
         <BLANKLINE>""")
     _check_output(result, expected)
 
@@ -267,15 +267,15 @@ def test_freeze_with_changed_option():
     # Check that upgraded packages are shown as changed
     write_file('initools-req.txt', textwrap.dedent("""\
         INITools==0.2
-        MarkupSafe<=0.11
+        wsgiref==0.1.1
         """))
-    result = run_pip('install', 'MarkupSafe<=0.12')
+    result = run_pip('install', 'wsgiref==0.1.2')
     result = run_pip('freeze', '--local', '--changed', '-r', env.scratch_path/'initools-req.txt', expect_stderr=True)
     expected = textwrap.dedent("""\
         Script result: pip freeze --local --changed...
         -- stdout: --------------------
         ## The following requirements were added by pip --freeze on...
-        MarkupSafe==0.12...
+        wsgiref==0.1.2...
         <BLANKLINE>""")
     _check_output(result, expected)
     

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -238,4 +238,27 @@ def test_freeze_with_requirement_option():
         -- stdout: --------------------
         INITools==0.2
         """) + ignores + "## The following requirements were added by pip --freeze:..."
+
+
+def test_freeze_with_changed_option():
+    """
+    Test that pip only reports new/changed packages with the --changed option.
+
+    """
+    env = reset_env()
+    # First install something
+    write_file('initools-req.txt', textwrap.dedent("""\
+        INITools==0.2
+        """))
+    result = run_pip('install', '-r', env.scratch_path/'initools-req.txt')
+
+    # Now install something else and check that only that is reported
+    result = run_pip('install', 'MarkupSafe<=0.12')
+    result = run_pip('freeze', '--local', '--changed', '-r', env.scratch_path/'initools-req.txt', expect_stderr=True)
+    expected = textwrap.dedent("""\
+        Script result: pip freeze --local --changed...
+        -- stdout: --------------------
+        ## The following requirements were added by pip --freeze on...
+        MarkupSafe==0.12...
+        <BLANKLINE>""")
     _check_output(result, expected)


### PR DESCRIPTION
This patch adds the functionality proposed in #341. 

In contrast to the proposal I chose to use "-c / --changed" as the option name as it seemed more natural. 

I also slightly updated the "## The following requirements were added by pip --freeze" message by adding the current date to the end.