### PR TITLE
change to make file:// urls to work for custom dependencies

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -213,6 +213,7 @@ def url_to_path(url):
     """
     assert url.startswith('file:'), (
         "You can only turn file: urls into filenames (not %r)" % url)
+    path = path.split('#')[0]
     path = url[len('file:'):].lstrip('/')
     path = urllib.unquote(path)
     if _url_drive_re.match(path):


### PR DESCRIPTION
Added a strip that will allow urls in the form 'file:///path/to/dir#egg=project-dev' to be successfully used in the "dependency_links" option of setuptools setup.

I was using pip and that was failing on a package available in the local filesystem. with this change it works.
