### PR TITLE
For issue #57 pip wrongly selects a macosx binary .zip file

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -294,7 +294,7 @@ class PackageFinder(object):
                     logger.debug('Skipping link %s; unknown archive format: %s' % (link, ext))
                     self.logged_links.add(link)
                 return []
-            if "macosx10" in link.path and ext in ('.zip'):
+            if "macosx10" in link.path and ext == '.zip':
                 if link not in self.logged_links:
                     logger.debug('Skipping link %s; macosx10 one' % (link))
                     self.logged_links.add(link)


### PR DESCRIPTION
Instead of a source file pip downloads a binary macosx .zip file which contains a binary installer.

This patch checks to see if 'macosx10' is in the file name, and if so rejects that file name.  This text is put into the file name by bdist_mpkg when zipped, and there doesn't appear to be any source files that use this in their file names.

More details in issue #57.

k, ta, thanks
