### PR TITLE
gh-406 - improper relative urls resolution

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -1246,7 +1246,7 @@ def parse_requirements(filename, finder=None, comes_from=None, options=None):
                 req_url = line[len('--requirement'):].strip().strip('=')
             if _scheme_re.search(filename):
                 # Relative to a URL
-                req_url = urlparse.urljoin(req_url, filename)
+                req_url = urlparse.urljoin(filename, req_url)
             elif not _scheme_re.search(req_url):
                 req_url = os.path.join(os.path.dirname(filename), req_url)
             for item in parse_requirements(req_url, finder, comes_from=filename, options=options):


### PR DESCRIPTION
The problem is described in https://github.com/pypa/pip/issues/406

This one-line fix makes pip to properly resolve relative urls when one http-hosted requirements file refers to another http-hosted requirements file.
