### PR TITLE
add --save-download option to pip install

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -95,6 +95,12 @@ class InstallCommand(Command):
             default=None,
             help='Cache downloaded packages in DIR')
         self.parser.add_option(
+            '--save-download',
+            dest='save_download',
+            metavar='DIR',
+            default=None,
+            help="Save downloaded packages into DIR")
+        self.parser.add_option(
             '--src', '--source', '--source-dir', '--source-directory',
             dest='src_dir',
             metavar='DIR',
@@ -190,6 +196,7 @@ class InstallCommand(Command):
             src_dir=options.src_dir,
             download_dir=options.download_dir,
             download_cache=options.download_cache,
+            save_download=options.save_download,
             upgrade=options.upgrade,
             ignore_installed=options.ignore_installed,
             ignore_dependencies=options.ignore_dependencies,

--- a/pip/download.py
+++ b/pip/download.py
@@ -406,7 +406,8 @@ def _copy_file(filename, location, content_type, link):
         logger.notify('Saved %s' % display_path(download_location))
 
 
-def unpack_http_url(link, location, download_cache, only_download):
+def unpack_http_url(link, location, download_cache, only_download,
+                    save_download=None):
     temp_dir = tempfile.mkdtemp('-unpack', 'pip-')
     target_url = link.url.split('#', 1)[0]
     target_file = None
@@ -453,6 +454,10 @@ def unpack_http_url(link, location, download_cache, only_download):
     if only_download:
         _copy_file(temp_location, location, content_type, link)
     else:
+        if save_download:
+            if not os.path.exists(save_download):
+                os.makedirs(save_download)
+            _copy_file(temp_location, save_download, content_type, link)
         unpack_file(temp_location, location, content_type, link)
     if target_file and target_file != temp_location:
         cache_download(target_file, temp_location, content_type)

--- a/pip/req.py
+++ b/pip/req.py
@@ -1100,7 +1100,9 @@ class RequirementSet(object):
         else:
             if self.download_cache:
                 self.download_cache = os.path.expanduser(self.download_cache)
-            return unpack_http_url(link, location, self.download_cache, only_download)
+            return unpack_http_url(link, location, self.download_cache,
+                                   only_download,
+                                   save_download=self.save_download)
 
     def install(self, install_options, global_options=()):
         """Install everything in this set (after having downloaded and unpacked the packages)"""


### PR DESCRIPTION
This commit adds an `--save-download` option to `pip install` command.  It received a directory path as the argument.  When pip installs the package and dependencies, all the downloaded packages will be saved in that directory.

It is different from the `--download` option, which forbids the installation, and only downloads the specific package, no dependencies would be downloaded.  (as described in #315)

It is also different from the `--download-cache` option, which saves downloaded files using url as their filenames.  This cause the cache directory is not suitable to reuse via the `--find-links` option later.

The purpose of this option is to create a local package directory.  So that one can use `pip install --find-links file://<path> --no-index` command to install the same packages offline later on.

For example, the programmer runs (maybe in a no-global-site-package virtualenv):

```
pip install --save-download pkgs pyramid
```

and give the system administrator the pkgs directory.  The SA can run:

```
pip install pyramid --find-links file:///path/to/pkgs --no-index
```

to setup an identical virtualenv on servers, without the needs of slow internet access.
