### PR TITLE
pip/download.py: use proxy for https

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -132,7 +132,7 @@ class URLOpener(object):
         self.prompting = prompting
         proxy = self.get_proxy(proxystr)
         if proxy:
-            proxy_support = urllib2.ProxyHandler({"http": proxy, "ftp": proxy})
+            proxy_support = urllib2.ProxyHandler({"http": proxy, "ftp": proxy, "https": proxy})
             opener = urllib2.build_opener(proxy_support, urllib2.CacheFTPHandler)
             urllib2.install_opener(opener)
 


### PR DESCRIPTION
Signed-off-by: Ross Brattain ross.b.brattain@intel.com
