### PR TITLE
Update news to reflect the forward passage of time.

### DIFF
--- a/docs/news.txt
+++ b/docs/news.txt
@@ -8,7 +8,7 @@ Changelog
 Next release (1.1) schedule
 ---------------------------
 
-Beta release November 2011, final release December.
+Beta and final releases planned for the first half of 2012.
 
 develop (unreleased)
 --------------------


### PR DESCRIPTION
They currently indicate something will happen in the future at a date in the past.  This is confusing.
