### PR TITLE
raise awareness of 'user scheme' and 'PYTHONUSERBASE'

### DIFF
--- a/docs/other-tools.txt
+++ b/docs/other-tools.txt
@@ -94,21 +94,17 @@ Using pip with the "user scheme"
 With Python 2.6 came the "user scheme" for installation, which means that all
 Python distributions support an alternative install location that is specific to a user.
 The default location for each OS is explained in the python documentation
-for the ``site.USER_BASE`` variable.  This mode of installation can be turned on by
-specifying the ``--user`` option to ``setup.py install``, which pip supports with it's
-``--install-option`` parameter.
+for the `site.USER_BASE <http://docs.python.org/library/site.html#site.USER_BASE>`_ variable.
+This mode of installation can be turned on by
+specifying the ``--user`` option to ``pip install``.
 
-More importantly though, the "user scheme" install location can be customized by setting the 
+Moreover, the "user scheme" can be customized by setting the
 ``PYTHONUSERBASE`` environment variable, which updates the value of ``site.USER_BASE``.
-This offers developers another alternative to 3rd party tools like
-`virtualenv <http://pypi.python.org/pypi/virtualenv>`_ and
-`zc.buildout <http://pypi.python.org/pypi/zc.buildout>`_ for
-isolating packages to a specific application.  Isolation occurs via a distinct value for ``PYTHONUSERBASE``.
 
-To install "somepackage" into an environment with site.USER_BASE equal to '/myenv', simply do the following::
+To install "somepackage" into an environment with site.USER_BASE customized to '/myappenv', do the following::
 
-    export PYTHONUSERBASE=/myenv
-    pip install --install-option="--user" somepackage
+    export PYTHONUSERBASE=/myappenv
+    pip install --user somepackage
 
 
 Command line completion


### PR DESCRIPTION
With Pip being so prominent, it would be nice for it to raise awareness of the 'user scheme' and 'PYTHONUSERBASE', and how it offers a simple alternative to virtualenv or buildout for creating package isolation.  I'm guessing more people would use this feature if they were aware of it.  

I recently got a pull request accepted into the distribute/easy_install docs related to this.

I've added a new section called  'Using pip with the “user scheme”' to the "other tools" section.

Although the "user scheme" is not a tool, it seemed the most reasonable place to add the section.
