### PR TITLE
Only warn for mis-versioned packages.

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -352,18 +352,9 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
 
     def assert_source_matches_version(self):
         assert self.source_dir
-        if self.comes_from is None:
-            # We don't check the versions of things explicitly installed.
-            # This makes, e.g., "pip Package==dev" possible
-            return
         version = self.installed_version
         if version not in self.req:
-            logger.fatal(
-                'Source in %s has the version %s, which does not match the requirement %s'
-                % (display_path(self.source_dir), version, self))
-            raise InstallationError(
-                'Source in %s has version %s that conflicts with %s'
-                % (display_path(self.source_dir), version, self))
+            logger.warn('Requested %s, but installing version %s' % (self, self.installed_version))
         else:
             logger.debug('Source in %s has version %s, which satisfies requirement %s'
                          % (display_path(self.source_dir), version, self))
@@ -445,7 +436,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                     paths_to_remove.add(path)
                     paths_to_remove.add(path + '.py')
                     paths_to_remove.add(path + '.pyc')
-                    
+
         elif dist.location.endswith(easy_install_egg):
             # package installed by easy_install
             paths_to_remove.add(dist.location)


### PR DESCRIPTION
Allows `Package==dev` in requirements.

Prevents this:

![](http://f.cl.ly/items/1d2I3b1F1O0O050F0f0c/Screen%20Shot%202012-01-19%20at%201.13.22%20PM.png)

Now this happens:

![](http://f.cl.ly/items/1o0d3O2E0k312s1s1x11/Screen%20Shot%202012-01-19%20at%201.11.55%20PM.png)

:sparkles: :cake: :sparkles:
