### PR TITLE
Fix pep8 CI build.

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -24,6 +24,7 @@ command_dict = {}
 # for backwards compatibiliy
 get_proxy = urlopen.get_proxy
 
+
 class Command(object):
     name = None
     usage = None
@@ -74,10 +75,10 @@ class Command(object):
             logger.explicit_levels = True
 
         self.setup_logging()
-        
+
         if options.no_input:
             os.environ['PIP_NO_INPUT'] = '1'
-            
+
         if options.exists_action:
             os.environ['PIP_EXISTS_ACTION'] = ''.join(options.exists_action)
 

--- a/pip/exceptions.py
+++ b/pip/exceptions.py
@@ -18,6 +18,7 @@ class BestVersionAlreadyInstalled(Exception):
     installed.
     """
 
+
 class BadCommand(Exception):
     """Raised when virtualenv or a command is not found"""
 

--- a/pip/req.py
+++ b/pip/req.py
@@ -445,7 +445,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                     paths_to_remove.add(path)
                     paths_to_remove.add(path + '.py')
                     paths_to_remove.add(path + '.pyc')
-                    
+
         elif dist.location.endswith(easy_install_egg):
             # package installed by easy_install
             paths_to_remove.add(dist.location)

--- a/pip/util.py
+++ b/pip/util.py
@@ -109,6 +109,7 @@ def ask_path_exists(message, options):
             return action
     return ask(message, options)
 
+
 def ask(message, options):
     """Ask the message interactively, with the given possible responses"""
     while 1:

--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -13,6 +13,7 @@ _svn_revision_re = re.compile(r'Revision: (.+)')
 _svn_info_xml_rev_re = re.compile(r'\s*revision="(\d+)"')
 _svn_info_xml_url_re = re.compile(r'<url>(.*)</url>')
 
+
 class Subversion(VersionControl):
     name = 'svn'
     dirname = '.svn'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,6 +47,7 @@ def test_env_vars_override_config_file():
         os.close(fd)
         os.remove(config_file)
 
+
 def _test_env_vars_override_config_file(config_file):
     environ = clear_environ(os.environ.copy())
     environ['PIP_CONFIG_FILE'] = config_file # set this to make pip load it
@@ -65,6 +66,7 @@ def _test_env_vars_override_config_file(config_file):
     reset_env(environ)
     result = run_pip('install', '-vvv', 'INITools', expect_error=True)
     assert "Successfully installed INITools" in result.stdout
+
 
 def test_command_line_append_flags():
     """

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -2,6 +2,7 @@ from os.path import join
 
 from tests.test_pip import reset_env, run_pip
 
+
 def test_simple_extras_install_from_pypi():
     """
     Test installing a package from PyPI using extras dependency Paste[openid].

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -9,7 +9,6 @@ from tests.test_pip import here
 find_links = 'file://' + urllib.quote(str(Path(here).abspath/'packages').replace('\\', '/'))
 
 
-
 def test_no_mpkg():
     """Finder skips zipfiles with "macosx10" in the name."""
     finder = PackageFinder([find_links], [])

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -204,6 +204,7 @@ def test_freeze_with_local_option():
         <BLANKLINE>""")
     _check_output(result, expected)
 
+
 def test_freeze_with_requirement_option():
     """
     Test that new requirements are created correctly with --requirement hints

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -17,6 +17,7 @@ def test_run_method_should_return_sucess_when_finds_command_name():
     status = help_cmd.run(options_mock, args)
     assert status == SUCCESS
 
+
 def test_run_method_should_return_sucess_when_command_name_not_specified():
     """
     Test HelpCommand.run when there are no args
@@ -27,6 +28,7 @@ def test_run_method_should_return_sucess_when_command_name_not_specified():
     status = help_cmd.run(options_mock, args)
     assert status == SUCCESS
 
+
 def test_run_method_should_raise_command_error_when_command_does_not_exist():
     """
     Test HelpCommand.run for non-existing command
@@ -36,6 +38,7 @@ def test_run_method_should_raise_command_error_when_command_does_not_exist():
     help_cmd = HelpCommand()
     assert_raises(CommandError, help_cmd.run, options_mock, args)
 
+
 def test_help_command_should_exit_status_ok_when_command_exists():
     """
     Test `help` command for existing command
@@ -43,6 +46,7 @@ def test_help_command_should_exit_status_ok_when_command_exists():
     reset_env()
     result = run_pip('help', 'freeze')
     assert result.returncode == SUCCESS
+
 
 def test_help_command_should_exit_status_ok_when_no_command_is_specified():
     """
@@ -52,6 +56,7 @@ def test_help_command_should_exit_status_ok_when_no_command_is_specified():
     result = run_pip('help')
     assert result.returncode == SUCCESS
 
+
 def test_help_command_should_exit_status_error_when_command_does_not_exist():
     """
     Test `help` command for non-existing command
@@ -59,4 +64,3 @@ def test_help_command_should_exit_status_error_when_command_does_not_exist():
     reset_env()
     result = run_pip('help', 'mycommand', expect_error=True)
     assert result.returncode == ERROR
-

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -428,7 +428,6 @@ class FastTestPipEnvironment(TestPipEnvironment):
             demand_dirs(self.venv_path)
             demand_dirs(self.scratch_path)
 
-
             # Create a virtualenv and remember where it's putting things.
             create_virtualenv(self.venv_path, distribute=self.use_distribute)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -90,6 +90,7 @@ def test_search_missing_argument():
     result = run_pip('search', expect_error=True)
     assert 'ERROR: Missing required argument (search query).' in result.stdout
 
+
 def test_run_method_should_return_sucess_when_find_packages():
     """
     Test SearchCommand.run for found package
@@ -99,6 +100,7 @@ def test_run_method_should_return_sucess_when_find_packages():
     search_cmd = SearchCommand()
     status = search_cmd.run(options_mock, ('pip',))
     assert status == SUCCESS
+
 
 def test_run_method_should_return_no_matches_found_when_does_not_find_packages():
     """
@@ -110,6 +112,7 @@ def test_run_method_should_return_no_matches_found_when_does_not_find_packages()
     status = search_cmd.run(options_mock, ('non-existant-package',))
     assert status == NO_MATCHES_FOUND, status
 
+
 def test_search_should_exit_status_code_zero_when_find_packages():
     """
     Test search exit status code for package found
@@ -117,6 +120,7 @@ def test_search_should_exit_status_code_zero_when_find_packages():
     env = reset_env(use_distribute=True)
     result = run_pip('search', 'pip')
     assert result.returncode == SUCCESS
+
 
 def test_search_exit_status_code_when_finds_no_package():
     """


### PR DESCRIPTION
# Tested locally:

================== Running pep8 =====================

Searching for pep8
Reading http://pypi.python.org/simple/pep8/
Reading http://github.com/cburroughs/pep8.py/tree/master
Reading http://github.com/jcrocholl/pep8
Best match: pep8 0.6.1
Processing pep8-0.6.1-py2.7.egg
pep8 0.6.1 is already the active version in easy-install.pth
Installing pep8 script to
/Users/pnasrat/Development/pip/pip_virtualenv/bin

Using
/Users/pnasrat/Development/pip/pip_virtualenv/lib/python2.7/site-packages/pep8-0.6.1-py2.7.egg
Processing dependencies for pep8
Finished processing dependencies for pep8
# ==================== Ended pep8 =====================
