### PR TITLE
Show the subdirectory where a VCS operation failed 

### DIFF
--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -252,12 +252,12 @@ def call_subprocess(cmd, show_stdout=True,
                 logger.notify('Complete output from command %s:' % command_desc)
                 logger.notify('\n'.join(all_output) + '\n----------------------------------------')
             raise InstallationError(
-                "Command %s failed with error code %s"
-                % (command_desc, proc.returncode))
+                "Command %s failed with error code %s in %s"
+                % (command_desc, proc.returncode, cwd))
         else:
             logger.warn(
-                "Command %s had error code %s"
-                % (command_desc, proc.returncode))
+                "Command %s had error code %s in %s"
+                % (command_desc, proc.returncode, cwd))
     if stdout is not None:
         return ''.join(all_output)
 


### PR DESCRIPTION
This was brought up in [a comment](https://github.com/pypa/pip/issues/58#issuecomment-3739105) to issue #58. This should help users if they encounter the problem described in issue #58 (pip freeze failing if a Git repository has no remote.origin.url setting).
