### PR TITLE
--target-dir implies --ignore-installed.

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -186,6 +186,7 @@ class InstallCommand(Command):
         if options.use_user_site:
             install_options.append('--user')
         if options.target_dir:
+            options.ignore_installed = True
             temp_target_dir = tempfile.mkdtemp()
             options.target_dir = os.path.abspath(options.target_dir)
             if os.path.exists(options.target_dir) and not os.path.isdir(options.target_dir):


### PR DESCRIPTION
Implements #448, which helped.
