### PR TITLE
Rework command handling

### DIFF
--- a/pip/baseparser.py
+++ b/pip/baseparser.py
@@ -179,6 +179,7 @@ class ConfigOptionParser(optparse.OptionParser):
                 defaults[option.dest] = option.check_value(opt_str, default)
         return optparse.Values(defaults)
 
+
 try:
     pip_dist = pkg_resources.get_distribution('pip')
     version = '%s from %s (python %s)' % (
@@ -187,108 +188,133 @@ except pkg_resources.DistributionNotFound:
     # when running pip.py without installing
     version=None
 
-parser = ConfigOptionParser(
-    usage='%prog COMMAND [OPTIONS]',
-    version=version,
-    add_help_option=False,
-    formatter=UpdatingDefaultsHelpFormatter(),
-    name='global')
 
-parser.add_option(
-    '-h', '--help',
-    dest='help',
-    action='store_true',
-    help='Show help')
-parser.add_option(
+def create_main_parser():
+    from textwrap import dedent
+
+    epilog = '''
+    Further help:
+     - http://www.pip-installer.org/en/latest/index.html
+    '''
+
+    parser_kw = {
+        'usage' : '%prog <command> [options]',
+        'add_help_option' : False,
+        'formatter' : UpdatingDefaultsHelpFormatter(),
+        'name' : 'global',
+        'epilog' : dedent(epilog),
+    }
+
+    parser = ConfigOptionParser(**parser_kw)
+    parser.disable_interspersed_args()
+
+    # having a default version action just causes trouble
+    parser.version = version
+
+    general_opts = optparse.OptionGroup(parser, 'General options')
+    padd = parser.add_option
+    gadd = general_opts.add_option
+
+    # populate the main parser and the 'general options' group
+    gadd( '-h', '--help',
+          dest='help',
+          action='store_true',
+          help='Show help' )
+
     # Run only if inside a virtualenv, bail if not.
-    '--require-virtualenv', '--require-venv',
-    dest='require_venv',
-    action='store_true',
-    default=False,
-    help=optparse.SUPPRESS_HELP)
+    padd( '--require-virtualenv', '--require-venv',
+          dest='require_venv',
+          action='store_true',
+          default=False,
+          help=optparse.SUPPRESS_HELP)
 
-parser.add_option(
-    '-v', '--verbose',
-    dest='verbose',
-    action='count',
-    default=0,
-    help='Give more output')
-parser.add_option(
-    '-q', '--quiet',
-    dest='quiet',
-    action='count',
-    default=0,
-    help='Give less output')
-parser.add_option(
-    '--log',
-    dest='log',
-    metavar='FILENAME',
-    help='Log file where a complete (maximum verbosity) record will be kept')
-parser.add_option(
+    gadd( '-v', '--verbose',
+          dest='verbose',
+          action='count',
+          default=0,
+          help='Give more output')
+
+    gadd( '-V', '--version',
+          dest='version',
+          action='store_true',
+          help='show version and exit')
+
+    gadd( '-q', '--quiet',
+          dest='quiet',
+          action='count',
+          default=0,
+          help='Give less output')
+
+    gadd( '--log',
+          dest='log',
+          metavar='FILENAME',
+          help='Log file where a complete (maximum verbosity) record will be kept')
+
     # Writes the log levels explicitely to the log'
-    '--log-explicit-levels',
-    dest='log_explicit_levels',
-    action='store_true',
-    default=False,
-    help=optparse.SUPPRESS_HELP)
-parser.add_option(
+    padd( '--log-explicit-levels',
+          dest='log_explicit_levels',
+          action='store_true',
+          default=False,
+          help=optparse.SUPPRESS_HELP)
+
     # The default log file
-    '--local-log', '--log-file',
-    dest='log_file',
-    metavar='FILENAME',
-    default=default_log_file,
-    help=optparse.SUPPRESS_HELP)
-parser.add_option(
+    padd( '--local-log', '--log-file',
+          dest='log_file',
+          metavar='FILENAME',
+          default=default_log_file,
+          help=optparse.SUPPRESS_HELP)
+
     # Don't ask for input
-    '--no-input',
-    dest='no_input',
-    action='store_true',
-    default=False,
-    help=optparse.SUPPRESS_HELP)
+    padd( '--no-input',
+          dest='no_input',
+          action='store_true',
+          default=False,
+          help=optparse.SUPPRESS_HELP)
 
-parser.add_option(
-    '--proxy',
-    dest='proxy',
-    type='str',
-    default='',
-    help="Specify a proxy in the form user:passwd@proxy.server:port. "
-    "Note that the user:password@ is optional and required only if you "
-    "are behind an authenticated proxy.  If you provide "
-    "user@proxy.server:port then you will be prompted for a password.")
-parser.add_option(
-    '--timeout', '--default-timeout',
-    metavar='SECONDS',
-    dest='timeout',
-    type='float',
-    default=15,
-    help='Set the socket timeout (default %default seconds)')
-parser.add_option(
+    gadd( '--proxy',
+          dest='proxy',
+          type='str',
+          default='',
+          help="Specify a proxy in the form user:passwd@proxy.server:port. "
+          "Note that the user:password@ is optional and required only if you "
+          "are behind an authenticated proxy.  If you provide "
+          "user@proxy.server:port then you will be prompted for a password.")
+
+    gadd( '--timeout', '--default-timeout',
+          metavar='SECONDS',
+          dest='timeout',
+          type='float',
+          default=15,
+          help='Set the socket timeout (default %default seconds)')
+
     # The default version control system for editables, e.g. 'svn'
-    '--default-vcs',
-    dest='default_vcs',
-    type='str',
-    default='',
-    help=optparse.SUPPRESS_HELP)
-parser.add_option(
+    padd( '--default-vcs',
+          dest='default_vcs',
+          type='str',
+          default='',
+          help=optparse.SUPPRESS_HELP)
+
     # A regex to be used to skip requirements
-    '--skip-requirements-regex',
-    dest='skip_requirements_regex',
-    type='str',
-    default='',
-    help=optparse.SUPPRESS_HELP)
+    padd( '--skip-requirements-regex',
+          dest='skip_requirements_regex',
+          type='str',
+          default='',
+          help=optparse.SUPPRESS_HELP)
 
-parser.add_option(
     # Option when path already exist
-    '--exists-action',
-    dest='exists_action',
-    type='choice',
-    choices=['s', 'i', 'w', 'b'],
-    default=[],
-    action='append',
-    help="Default action when a path already exists."
-         "Use this option more then one time to specify "
-         "another action if a certain option is not "
-         "available, choices: "
-         "(s)witch, (i)gnore, (w)ipe, (b)ackup")
+    gadd( '--exists-action',
+          dest='exists_action',
+          type='choice',
+          choices=['s', 'i', 'w', 'b'],
+          default=[],
+          action='append',
+          help="Default action when a path already exists."
+               "Use this option more then one time to specify "
+               "another action if a certain option is not "
+               "available, choices: "
+               "(s)witch, (i)gnore, (w)ipe, (b)ackup")
 
-parser.disable_interspersed_args()
+
+    parser.add_option_group(general_opts)
+    return parser
+

--- a/pip/commands/__init__.py
+++ b/pip/commands/__init__.py
@@ -1,1 +1,56 @@
-#
+
+"""
+Package containing all pip commands
+"""
+
+
+from pip.commands.bundle     import BundleCommand
+from pip.commands.completion import CompletionCommand
+from pip.commands.freeze     import FreezeCommand
+from pip.commands.help       import HelpCommand
+from pip.commands.search     import SearchCommand
+from pip.commands.install    import InstallCommand
+from pip.commands.uninstall  import UninstallCommand
+from pip.commands.unzip      import UnzipCommand
+from pip.commands.zip        import ZipCommand
+
+
+commands = {
+    BundleCommand.name      : BundleCommand,
+    CompletionCommand.name  : CompletionCommand,
+    FreezeCommand.name      : FreezeCommand,
+    HelpCommand.name        : HelpCommand,
+    SearchCommand.name      : SearchCommand,
+    InstallCommand.name     : InstallCommand,
+    UninstallCommand.name   : UninstallCommand,
+    UnzipCommand.name       : UnzipCommand,
+    ZipCommand.name         : ZipCommand,
+}
+
+
+def get_summaries(ignore_hidden=True):
+    """Return a sorted list of (command name, command summary)."""
+    items = []
+
+    for name, command_class in commands.items():
+        if ignore_hidden and command_class.hidden:
+            continue
+
+        items.append( (name, command_class.summary) )
+
+    return sorted(items)
+
+
+def get_similar_commands(name):
+    """Command name auto-correct."""
+    from difflib import get_close_matches
+
+    close_commands = get_close_matches(name, commands.keys())
+
+    if close_commands:
+        guess = close_commands[0]
+    else:
+        guess = False
+
+    return guess
+

--- a/pip/commands/bundle.py
+++ b/pip/commands/bundle.py
@@ -11,13 +11,15 @@ class BundleCommand(InstallCommand):
     summary = 'Create pybundles (archives containing multiple packages)'
     bundle = True
 
-    def __init__(self):
-        super(BundleCommand, self).__init__()
+    def __init__(self, *args, **kw):
+        super(BundleCommand, self).__init__(*args, **kw)
+
         # bundle uses different default source and build dirs
         build_opt = self.parser.get_option("--build")
         build_opt.default = backup_dir(build_prefix, '-bundle')
         src_opt = self.parser.get_option("--src")
         src_opt.default = backup_dir(src_prefix, '-bundle')
+
         self.parser.set_defaults(**{
                 src_opt.dest: src_opt.default,
                 build_opt.dest: build_opt.default,
@@ -33,6 +35,3 @@ class BundleCommand(InstallCommand):
         self.bundle_filename = args.pop(0)
         requirement_set = super(BundleCommand, self).run(options, args)
         return requirement_set
-
-
-BundleCommand()

--- a/pip/commands/completion.py
+++ b/pip/commands/completion.py
@@ -32,20 +32,23 @@ class CompletionCommand(Command):
     summary = 'A helper command to be used for command completion'
     hidden = True
 
-    def __init__(self):
-        super(CompletionCommand, self).__init__()
-        self.parser.add_option(
-            '--bash', '-b',
-            action='store_const',
-            const='bash',
-            dest='shell',
-            help='Emit completion code for bash')
-        self.parser.add_option(
-            '--zsh', '-z',
-            action='store_const',
-            const='zsh',
-            dest='shell',
-            help='Emit completion code for zsh')
+    def __init__(self, *args, **kw):
+        super(CompletionCommand, self).__init__(*args, **kw)
+        gadd = self.command_group.add_option
+
+        gadd( '--bash', '-b',
+              action='store_const',
+              const='bash',
+              dest='shell',
+              help='Emit completion code for bash')
+
+        gadd( '--zsh', '-z',
+              action='store_const',
+              const='zsh',
+              dest='shell',
+              help='Emit completion code for zsh')
+
+        self.parser.add_option_group(self.command_group)
 
     def run(self, options, args):
         """Prints the completion code of the given shell"""
@@ -56,5 +59,3 @@ class CompletionCommand(Command):
             print(BASE_COMPLETION % {'script': script, 'shell': options.shell})
         else:
             sys.stderr.write('ERROR: You must pass %s\n' % ' or '.join(shell_options))
-
-CompletionCommand()

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -13,28 +13,31 @@ class FreezeCommand(Command):
     usage = '%prog [OPTIONS]'
     summary = 'Output all currently installed packages (exact versions) to stdout'
 
-    def __init__(self):
-        super(FreezeCommand, self).__init__()
-        self.parser.add_option(
-            '-r', '--requirement',
-            dest='requirement',
-            action='store',
-            default=None,
-            metavar='FILENAME',
-            help='Use the given requirements file as a hint about how to generate the new frozen requirements')
-        self.parser.add_option(
-            '-f', '--find-links',
-            dest='find_links',
-            action='append',
-            default=[],
-            metavar='URL',
-            help='URL for finding packages, which will be added to the frozen requirements file')
-        self.parser.add_option(
-            '-l', '--local',
-            dest='local',
-            action='store_true',
-            default=False,
-            help='If in a virtualenv, do not report globally-installed packages')
+    def __init__(self, *args, **kw):
+        super(FreezeCommand, self).__init__(*args, **kw)
+        gadd = self.command_group.add_option
+
+        gadd( '-r', '--requirement',
+              dest='requirement',
+              action='store',
+              default=None,
+              metavar='FILENAME',
+              help='Use the given requirements file as a hint about how to generate the new frozen requirements')
+
+        gadd( '-f', '--find-links',
+              dest='find_links',
+              action='append',
+              default=[],
+              metavar='URL',
+              help='URL for finding packages, which will be added to the frozen requirements file')
+
+        gadd( '-l', '--local',
+              dest='local',
+              action='store_true',
+              default=False,
+              help='If in a virtualenv, do not report globally-installed packages')
+
+        self.parser.add_option_group(self.command_group)
 
     def setup_logging(self):
         logger.move_stdout_to_stderr()
@@ -106,6 +109,3 @@ class FreezeCommand(Command):
             f.write('## The following requirements were added by pip --freeze:\n')
         for installation in sorted(installations.values(), key=lambda x: x.name):
             f.write(str(installation))
-
-
-FreezeCommand()

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -17,153 +17,151 @@ class InstallCommand(Command):
     summary = 'Install packages'
     bundle = False
 
-    def __init__(self):
-        super(InstallCommand, self).__init__()
-        self.parser.add_option(
-            '-e', '--editable',
-            dest='editables',
-            action='append',
-            default=[],
-            metavar='VCS+REPOS_URL[@REV]#egg=PACKAGE',
-            help='Install a package directly from a checkout. Source will be checked '
-            'out into src/PACKAGE (lower-case) and installed in-place (using '
-            'setup.py develop). You can run this on an existing directory/checkout (like '
-            'pip install -e src/mycheckout). This option may be provided multiple times. '
-            'Possible values for VCS are: svn, git, hg and bzr.')
-        self.parser.add_option(
-            '-r', '--requirement',
-            dest='requirements',
-            action='append',
-            default=[],
-            metavar='FILENAME',
-            help='Install all the packages listed in the given requirements file.  '
-            'This option can be used multiple times.')
-        self.parser.add_option(
-            '-f', '--find-links',
-            dest='find_links',
-            action='append',
-            default=[],
-            metavar='URL',
-            help='URL to look for packages at')
-        self.parser.add_option(
-            '-i', '--index-url', '--pypi-url',
-            dest='index_url',
-            metavar='URL',
-            default='http://pypi.python.org/simple/',
-            help='Base URL of Python Package Index (default %default)')
-        self.parser.add_option(
-            '--extra-index-url',
-            dest='extra_index_urls',
-            metavar='URL',
-            action='append',
-            default=[],
-            help='Extra URLs of package indexes to use in addition to --index-url')
-        self.parser.add_option(
-            '--no-index',
-            dest='no_index',
-            action='store_true',
-            default=False,
-            help='Ignore package index (only looking at --find-links URLs instead)')
-        self.parser.add_option(
-            '-M', '--use-mirrors',
-            dest='use_mirrors',
-            action='store_true',
-            default=False,
-            help='Use the PyPI mirrors as a fallback in case the main index is down.')
-        self.parser.add_option(
-            '--mirrors',
-            dest='mirrors',
-            metavar='URL',
-            action='append',
-            default=[],
-            help='Specific mirror URLs to query when --use-mirrors is used')
+    def __init__(self, *args, **kw):
+        super(InstallCommand, self).__init__(*args, **kw)
+        gadd = self.command_group.add_option
 
-        self.parser.add_option(
-            '-b', '--build', '--build-dir', '--build-directory',
-            dest='build_dir',
-            metavar='DIR',
-            default=build_prefix,
-            help='Unpack packages into DIR (default %default) and build from there')
-        self.parser.add_option(
-            '-t', '--target',
-            dest='target_dir',
-            metavar='DIR',
-            default=None,
-            help='Install packages into DIR.')
-        self.parser.add_option(
-            '-d', '--download', '--download-dir', '--download-directory',
-            dest='download_dir',
-            metavar='DIR',
-            default=None,
-            help='Download packages into DIR instead of installing them')
-        self.parser.add_option(
-            '--download-cache',
-            dest='download_cache',
-            metavar='DIR',
-            default=None,
-            help='Cache downloaded packages in DIR')
-        self.parser.add_option(
-            '--src', '--source', '--source-dir', '--source-directory',
-            dest='src_dir',
-            metavar='DIR',
-            default=src_prefix,
-            help='Check out --editable packages into DIR (default %default)')
+        gadd( '-e', '--editable',
+              dest='editables',
+              action='append',
+              default=[],
+              metavar='VCS+REPOS_URL[@REV]#egg=PACKAGE',
+              help='Install a package directly from a checkout. Source will be checked '
+              'out into src/PACKAGE (lower-case) and installed in-place (using '
+              'setup.py develop). You can run this on an existing directory/checkout (like '
+              'pip install -e src/mycheckout). This option may be provided multiple times. '
+              'Possible values for VCS are: svn, git, hg and bzr.')
 
-        self.parser.add_option(
-            '-U', '--upgrade',
-            dest='upgrade',
-            action='store_true',
-            help='Upgrade all packages to the newest available version')
-        self.parser.add_option(
-            '--force-reinstall',
-            dest='force_reinstall',
-            action='store_true',
-            help='When upgrading, reinstall all packages even if they are '
-                 'already up-to-date.')
-        self.parser.add_option(
-            '-I', '--ignore-installed',
-            dest='ignore_installed',
-            action='store_true',
-            help='Ignore the installed packages (reinstalling instead)')
-        self.parser.add_option(
-            '--no-deps', '--no-dependencies',
-            dest='ignore_dependencies',
-            action='store_true',
-            default=False,
-            help='Ignore package dependencies')
-        self.parser.add_option(
-            '--no-install',
-            dest='no_install',
-            action='store_true',
-            help="Download and unpack all packages, but don't actually install them")
-        self.parser.add_option(
-            '--no-download',
-            dest='no_download',
-            action="store_true",
-            help="Don't download any packages, just install the ones already downloaded "
-            "(completes an install run with --no-install)")
+        gadd( '-r', '--requirement',
+              dest='requirements',
+              action='append',
+              default=[],
+              metavar='FILENAME',
+              help='Install all the packages listed in the given requirements file.  '
+              'This option can be used multiple times.')
 
-        self.parser.add_option(
-            '--install-option',
-            dest='install_options',
-            action='append',
-            help="Extra arguments to be supplied to the setup.py install "
-            "command (use like --install-option=\"--install-scripts=/usr/local/bin\").  "
-            "Use multiple --install-option options to pass multiple options to setup.py install.  "
-            "If you are using an option with a directory path, be sure to use absolute path.")
+        gadd( '-f', '--find-links',
+              dest='find_links',
+              action='append',
+              default=[],
+              metavar='URL',
+              help='URL to look for packages at')
 
-        self.parser.add_option(
-            '--global-option',
-            dest='global_options',
-            action='append',
-            help="Extra global options to be supplied to the setup.py"
-            "call before the install command")
+        gadd( '-i', '--index-url', '--pypi-url',
+              dest='index_url',
+              metavar='URL',
+              default='http://pypi.python.org/simple/',
+              help='Base URL of Python Package Index (default %default)')
 
-        self.parser.add_option(
-            '--user',
-            dest='use_user_site',
-            action='store_true',
-            help='Install to user-site')
+        gadd( '--extra-index-url',
+              dest='extra_index_urls',
+              metavar='URL',
+              action='append',
+              default=[],
+              help='Extra URLs of package indexes to use in addition to --index-url')
+
+        gadd( '--no-index',
+              dest='no_index',
+              action='store_true',
+              default=False,
+              help='Ignore package index (only looking at --find-links URLs instead)')
+
+        gadd( '-M', '--use-mirrors',
+              dest='use_mirrors',
+              action='store_true',
+              default=False,
+              help='Use the PyPI mirrors as a fallback in case the main index is down.')
+
+        gadd( '--mirrors',
+              dest='mirrors',
+              metavar='URL',
+              action='append',
+              default=[],
+              help='Specific mirror URLs to query when --use-mirrors is used')
+
+        gadd( '-b', '--build', '--build-dir', '--build-directory',
+              dest='build_dir',
+              metavar='DIR',
+              default=build_prefix,
+              help='Unpack packages into DIR (default %default) and build from there')
+
+        gadd( '-t', '--target',
+              dest='target_dir',
+              metavar='DIR',
+              default=None,
+              help='Install packages into DIR.')
+
+        gadd( '-d', '--download', '--download-dir', '--download-directory',
+              dest='download_dir',
+              metavar='DIR',
+              default=None,
+              help='Download packages into DIR instead of installing them')
+
+        gadd( '--download-cache',
+              dest='download_cache',
+              metavar='DIR',
+              default=None,
+              help='Cache downloaded packages in DIR')
+
+        gadd( '--src', '--source', '--source-dir', '--source-directory',
+              dest='src_dir',
+              metavar='DIR',
+              default=src_prefix,
+              help='Check out --editable packages into DIR (default %default)')
+
+        gadd( '-U', '--upgrade',
+              dest='upgrade',
+              action='store_true',
+              help='Upgrade all packages to the newest available version')
+
+        gadd( '--force-reinstall',
+              dest='force_reinstall',
+              action='store_true',
+              help='When upgrading, reinstall all packages even if they are '
+                   'already up-to-date.')
+
+        gadd( '-I', '--ignore-installed',
+              dest='ignore_installed',
+              action='store_true',
+              help='Ignore the installed packages (reinstalling instead)')
+
+        gadd( '--no-deps', '--no-dependencies',
+              dest='ignore_dependencies',
+              action='store_true',
+              default=False,
+              help='Ignore package dependencies')
+
+        gadd( '--no-install',
+              dest='no_install',
+              action='store_true',
+              help="Download and unpack all packages, but don't actually install them")
+
+        gadd( '--no-download',
+              dest='no_download',
+              action="store_true",
+              help="Don't download any packages, just install the ones already downloaded "
+              "(completes an install run with --no-install)")
+
+        gadd( '--install-option',
+              dest='install_options',
+              action='append',
+              help="Extra arguments to be supplied to the setup.py install "
+              "command (use like --install-option=\"--install-scripts=/usr/local/bin\").  "
+              "Use multiple --install-option options to pass multiple options to setup.py install.  "
+              "If you are using an option with a directory path, be sure to use absolute path.")
+
+        gadd( '--global-option',
+              dest='global_options',
+              action='append',
+              help="Extra global options to be supplied to the setup.py"
+                   "call before the install command")
+
+        gadd( '--user',
+              dest='use_user_site',
+              action='store_true',
+              help='Install to user-site')
+
+        self.parser.add_option_group(self.command_group)
 
     def _build_package_finder(self, options, index_urls):
         """
@@ -274,6 +272,3 @@ class InstallCommand(Command):
                     )
             shutil.rmtree(temp_target_dir)
         return requirement_set
-
-
-InstallCommand()

--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -16,14 +16,17 @@ class SearchCommand(Command):
     usage = '%prog QUERY'
     summary = 'Search PyPI'
 
-    def __init__(self):
-        super(SearchCommand, self).__init__()
-        self.parser.add_option(
-            '--index',
-            dest='index',
-            metavar='URL',
-            default='http://pypi.python.org/pypi',
-            help='Base URL of Python Package Index (default %default)')
+    def __init__(self, *args, **kw):
+        super(SearchCommand, self).__init__(*args, **kw)
+        gadd = self.command_group.add_option
+
+        gadd( '--index',
+              dest='index',
+              metavar='URL',
+              default='http://pypi.python.org/pypi',
+              help='Base URL of Python Package Index (default %default)')
+
+        self.parser.add_option_group(self.command_group)
 
     def run(self, options, args):
         if not args:
@@ -124,6 +127,3 @@ def compare_versions(version1, version2):
 
 def highest_version(versions):
     return reduce((lambda v1, v2: compare_versions(v1, v2) == 1 and v1 or v2), versions)
-
-
-SearchCommand()

--- a/pip/commands/uninstall.py
+++ b/pip/commands/uninstall.py
@@ -8,21 +8,24 @@ class UninstallCommand(Command):
     usage = '%prog [OPTIONS] PACKAGE_NAMES ...'
     summary = 'Uninstall packages'
 
-    def __init__(self):
-        super(UninstallCommand, self).__init__()
-        self.parser.add_option(
-            '-r', '--requirement',
-            dest='requirements',
-            action='append',
-            default=[],
-            metavar='FILENAME',
-            help='Uninstall all the packages listed in the given requirements file.  '
-            'This option can be used multiple times.')
-        self.parser.add_option(
-            '-y', '--yes',
-            dest='yes',
-            action='store_true',
-            help="Don't ask for confirmation of uninstall deletions.")
+    def __init__(self, *args, **kw):
+        super(UninstallCommand, self).__init__(*args, **kw)
+        gadd = self.command_group.add_option
+
+        gadd( '-r', '--requirement',
+              dest='requirements',
+              action='append',
+              default=[],
+              metavar='FILENAME',
+              help='Uninstall all the packages listed in the given requirements file.  '
+              'This option can be used multiple times.')
+
+        gadd( '-y', '--yes',
+              dest='yes',
+              action='store_true',
+              help="Don't ask for confirmation of uninstall deletions.")
+
+        self.parser.add_option_group(self.command_group)
 
     def run(self, options, args):
         requirement_set = RequirementSet(
@@ -39,5 +42,3 @@ class UninstallCommand(Command):
             raise InstallationError('You must give at least one requirement '
                 'to %(name)s (see "pip help %(name)s")' % dict(name=self.name))
         requirement_set.uninstall(auto_confirm=options.yes)
-
-UninstallCommand()

--- a/pip/commands/unzip.py
+++ b/pip/commands/unzip.py
@@ -4,6 +4,3 @@ from pip.commands.zip import ZipCommand
 class UnzipCommand(ZipCommand):
     name = 'unzip'
     summary = 'Unzip individual packages'
-
-
-UnzipCommand()

--- a/pip/commands/zip.py
+++ b/pip/commands/zip.py
@@ -15,45 +15,47 @@ class ZipCommand(Command):
     usage = '%prog [OPTIONS] PACKAGE_NAMES...'
     summary = 'Zip individual packages'
 
-    def __init__(self):
-        super(ZipCommand, self).__init__()
+    def __init__(self, *args, **kw):
+        super(ZipCommand, self).__init__(*args, **kw)
+        gadd = self.command_group.add_option
+
         if self.name == 'zip':
-            self.parser.add_option(
-                '--unzip',
-                action='store_true',
-                dest='unzip',
-                help='Unzip (rather than zip) a package')
+            gadd( '--unzip',
+                  action='store_true',
+                  dest='unzip',
+                  help='Unzip (rather than zip) a package')
         else:
-            self.parser.add_option(
-                '--zip',
-                action='store_false',
-                dest='unzip',
-                default=True,
-                help='Zip (rather than unzip) a package')
-        self.parser.add_option(
-            '--no-pyc',
-            action='store_true',
-            dest='no_pyc',
-            help='Do not include .pyc files in zip files (useful on Google App Engine)')
-        self.parser.add_option(
-            '-l', '--list',
-            action='store_true',
-            dest='list',
-            help='List the packages available, and their zip status')
-        self.parser.add_option(
-            '--sort-files',
-            action='store_true',
-            dest='sort_files',
-            help='With --list, sort packages according to how many files they contain')
-        self.parser.add_option(
-            '--path',
-            action='append',
-            dest='paths',
-            help='Restrict operations to the given paths (may include wildcards)')
-        self.parser.add_option(
-            '-n', '--simulate',
-            action='store_true',
-            help='Do not actually perform the zip/unzip operation')
+            gadd( '--zip',
+                  action='store_false',
+                  dest='unzip',
+                  default=True,
+                  help='Zip (rather than unzip) a package')
+
+        gadd( '--no-pyc',
+              action='store_true',
+              dest='no_pyc',
+              help='Do not include .pyc files in zip files (useful on Google App Engine)')
+
+        gadd( '-l', '--list',
+              action='store_true',
+              dest='list',
+              help='List the packages available, and their zip status')
+
+        gadd( '--sort-files',
+              action='store_true',
+              dest='sort_files',
+              help='With --list, sort packages according to how many files they contain')
+
+        gadd( '--path',
+              action='append',
+              dest='paths',
+              help='Restrict operations to the given paths (may include wildcards)')
+
+        gadd( '-n', '--simulate',
+              action='store_true',
+              help='Do not actually perform the zip/unzip operation')
+
+        self.parser.add_option_group(self.command_group)
 
     def paths(self):
         """All the entries of sys.path, possibly restricted by --path"""
@@ -342,5 +344,3 @@ class ZipCommand(Command):
             total += len(filenames)
         return total
 
-
-ZipCommand()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,6 +4,7 @@ from pip.commands.search import (compare_versions,
                                  transform_hits,
                                  SearchCommand)
 from pip.status_codes import NO_MATCHES_FOUND, SUCCESS
+from pip.baseparser import create_main_parser
 from pip.backwardcompat import xmlrpclib, b
 from mock import Mock
 from tests.test_pip import run_pip, reset_env, pyversion
@@ -85,7 +86,7 @@ def test_searching_through_Search_class():
     dumped_xmlrpc_request = b(xmlrpclib.dumps(({'name': query, 'summary': query}, 'or'), 'search'))
     expected = [{'_pypi_ordering': 100, 'name': 'foo', 'summary': 'foo summary', 'version': '1.0'}]
     fake_transport.request.return_value = (expected,)
-    pypi_searcher = SearchCommand()
+    pypi_searcher = SearchCommand(create_main_parser())
     result = pypi_searcher.search(query, 'http://pypi.python.org/pypi')
     try:
         assert expected == result, result
@@ -109,7 +110,7 @@ def test_run_method_should_return_sucess_when_find_packages():
     """
     options_mock = Mock()
     options_mock.index = 'http://pypi.python.org/pypi'
-    search_cmd = SearchCommand()
+    search_cmd = SearchCommand(create_main_parser())
     status = search_cmd.run(options_mock, ('pip',))
     assert status == SUCCESS
 
@@ -120,7 +121,7 @@ def test_run_method_should_return_no_matches_found_when_does_not_find_packages()
     """
     options_mock = Mock()
     options_mock.index = 'http://pypi.python.org/pypi'
-    search_cmd = SearchCommand()
+    search_cmd = SearchCommand(create_main_parser())
     status = search_cmd.run(options_mock, ('non-existant-package',))
     assert status == NO_MATCHES_FOUND, status
 


### PR DESCRIPTION
Rework pip command handling
- Remove module-singleton baseparser.parser object. A parser instance is
  created in pip.main() and passed as the first argument to each command. Each
  command can access the main parser from self.main_parser.
- Remove all global command instances. Commands are instantiated on demand in
  pip.main(). Deferred command module imports were removed.
- Factor option handling out of pip.main() and into pip.parseopts()
- The list of available commands is now part of the parser's description and
  comes before all other options. 'Pip help' is more targeted at showing the
  options of a command instead of all available commands.
- Move command specific options under a 'Command Options' OptionGroup
- Move general options under a 'General Options' OptionGroup 

This pull request depends on pull requests [464](https://github.com/pypa/pip/pull/464) [465](https://github.com/pypa/pip/pull/465) [466](https://github.com/pypa/pip/pull/466)
