### PR TITLE
Move pip.call_subprocess to pip.util.call_subprocess

### DIFF
--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -7,7 +7,7 @@ import sys
 import re
 import difflib
 
-from pip.backwardcompat import walk_packages, console_to_str
+from pip.backwardcompat import walk_packages
 from pip.basecommand import command_dict, load_command, load_all_commands, command_names
 from pip.baseparser import parser
 from pip.exceptions import InstallationError
@@ -190,76 +190,6 @@ class FrozenRequirement(object):
         if self.editable:
             req = '-e %s' % req
         return '\n'.join(list(self.comments)+[str(req)])+'\n'
-
-############################################################
-## Requirement files
-
-
-def call_subprocess(cmd, show_stdout=True,
-                    filter_stdout=None, cwd=None,
-                    raise_on_returncode=True,
-                    command_level=logger.DEBUG, command_desc=None,
-                    extra_environ=None):
-    if command_desc is None:
-        cmd_parts = []
-        for part in cmd:
-            if ' ' in part or '\n' in part or '"' in part or "'" in part:
-                part = '"%s"' % part.replace('"', '\\"')
-            cmd_parts.append(part)
-        command_desc = ' '.join(cmd_parts)
-    if show_stdout:
-        stdout = None
-    else:
-        stdout = subprocess.PIPE
-    logger.log(command_level, "Running command %s" % command_desc)
-    env = os.environ.copy()
-    if extra_environ:
-        env.update(extra_environ)
-    try:
-        proc = subprocess.Popen(
-            cmd, stderr=subprocess.STDOUT, stdin=None, stdout=stdout,
-            cwd=cwd, env=env)
-    except Exception:
-        e = sys.exc_info()[1]
-        logger.fatal(
-            "Error %s while executing command %s" % (e, command_desc))
-        raise
-    all_output = []
-    if stdout is not None:
-        stdout = proc.stdout
-        while 1:
-            line = console_to_str(stdout.readline())
-            if not line:
-                break
-            line = line.rstrip()
-            all_output.append(line + '\n')
-            if filter_stdout:
-                level = filter_stdout(line)
-                if isinstance(level, tuple):
-                    level, line = level
-                logger.log(level, line)
-                if not logger.stdout_level_matches(level):
-                    logger.show_progress()
-            else:
-                logger.info(line)
-    else:
-        returned_stdout, returned_stderr = proc.communicate()
-        all_output = [returned_stdout or '']
-    proc.wait()
-    if proc.returncode:
-        if raise_on_returncode:
-            if all_output:
-                logger.notify('Complete output from command %s:' % command_desc)
-                logger.notify('\n'.join(all_output) + '\n----------------------------------------')
-            raise InstallationError(
-                "Command %s failed with error code %s in %s"
-                % (command_desc, proc.returncode, cwd))
-        else:
-            logger.warn(
-                "Command %s had error code %s in %s"
-                % (command_desc, proc.returncode, cwd))
-    if stdout is not None:
-        return ''.join(all_output)
 
 
 if __name__ == '__main__':

--- a/pip/req.py
+++ b/pip/req.py
@@ -15,7 +15,7 @@ from pip.util import ask, ask_path_exists, backup_dir
 from pip.util import is_installable_dir, is_local, dist_is_local
 from pip.util import renames, normalize_path, egg_link_path
 from pip.util import make_path_relative
-from pip import call_subprocess
+from pip.util import call_subprocess
 from pip.backwardcompat import (any, copytree, urlparse, urllib,
                                 ConfigParser, string_types, HTTPError,
                                 FeedParser, get_python_version,

--- a/pip/vcs/bazaar.py
+++ b/pip/vcs/bazaar.py
@@ -1,10 +1,9 @@
 import os
 import tempfile
 import re
-from pip import call_subprocess
 from pip.backwardcompat import urlparse
 from pip.log import logger
-from pip.util import rmtree, display_path
+from pip.util import rmtree, display_path, call_subprocess
 from pip.vcs import vcs, VersionControl
 from pip.download import path_to_url2
 

--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -1,6 +1,6 @@
 import tempfile
 import re
-from pip import call_subprocess
+from pip.util import call_subprocess
 from pip.util import display_path, rmtree
 from pip.vcs import vcs, VersionControl
 from pip.log import logger

--- a/pip/vcs/mercurial.py
+++ b/pip/vcs/mercurial.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import re
 import sys
-from pip import call_subprocess
+from pip.util import call_subprocess
 from pip.util import display_path, rmtree
 from pip.log import logger
 from pip.vcs import vcs, VersionControl

--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -1,9 +1,9 @@
 import os
 import re
 from pip.backwardcompat import urlparse
-from pip import call_subprocess, InstallationError
+from pip import InstallationError
 from pip.index import Link
-from pip.util import rmtree, display_path
+from pip.util import rmtree, display_path, call_subprocess
 from pip.log import logger
 from pip.vcs import vcs, VersionControl
 


### PR DESCRIPTION
Function `call_subprocess` would fit better in the `pip.util` module.

Factored out of [pull request 463](https://github.com/pypa/pip/pull/463)
