### PR TITLE
Issue #482 search raises exception.

### DIFF
--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -61,6 +61,8 @@ def transform_hits(hits):
         summary = hit['summary']
         version = hit['version']
         score = hit['_pypi_ordering']
+        if score is None:
+            score = 0
 
         if name not in packages.keys():
             packages[name] = {'name': name, 'summary': summary, 'versions': [version], 'score': score}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -39,8 +39,18 @@ def test_pypi_xml_transformation():
             {'_pypi_ordering': 50, 'name': 'bar', 'summary': 'bar summary', 'version': '1.0'}]
     expected = [{'score': 200, 'versions': ['1.0', '2.0'], 'name': 'foo', 'summary': 'foo summary v2'},
             {'score': 50, 'versions': ['1.0'], 'name': 'bar', 'summary': 'bar summary'}]
-    assert_equal(expected, transform_hits(pypi_hits))
+    assert_equal(transform_hits(pypi_hits), expected)
 
+def test_invalid_pypi_transformation():
+    """
+    Test transformation of pypi when ordering None
+    """
+    pypi_hits = [{'_pypi_ordering': None, 'name': 'bar', 'summary': 'bar summary', 'version': '1.0'},
+        {'_pypi_ordering': 100, 'name': 'foo', 'summary': 'foo summary', 'version': '1.0'}]
+
+    expected = [{'score': 100, 'versions': ['1.0'], 'name': 'foo', 'summary': 'foo summary'},
+            {'score': 0, 'versions': ['1.0'], 'name': 'bar', 'summary': 'bar summary'}]
+    assert_equal(transform_hits(pypi_hits), expected)
 
 def test_search():
     """


### PR DESCRIPTION
Handle pypi results for packages with no ordering.

TESTED=2.4.6 2.7.1 3.2.2
