### PR TITLE
Fix unit decimal prefix (KB->kB)

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -149,9 +149,9 @@ def format_size(bytes):
     if bytes > 1000*1000:
         return '%.1fMB' % (bytes/1000.0/1000)
     elif bytes > 10*1000:
-        return '%iKB' % (bytes/1000)
+        return '%ikB' % (bytes/1000)
     elif bytes > 1000:
-        return '%.1fKB' % (bytes/1000.0)
+        return '%.1fkB' % (bytes/1000.0)
     else:
         return '%ibytes' % bytes
 


### PR DESCRIPTION
Kilobytes should be written as kB (http://en.wikipedia.org/wiki/Byte)
