### PR TITLE
Try to reduce log size for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
   - 2.7
   - 3.1
   - 3.2
-before_install: sudo apt-get install subversion bzr mercurial
+before_install:
+    - sudo apt-get install subversion bzr mercurial
+    - echo -e "[web]\ncacerts = /etc/ssl/certs/ca-certificates.crt" >> ~/.hgrc
 install: pip install nose virtualenv scripttest mock
 script: nosetests
 notifications:


### PR DESCRIPTION
I think the mercurial ca spam was causing issues with overflowing the size of the logs, I get a green build for everything with this.

http://travis-ci.org/#!/pnasrat/pip/builds/1229722
