### PR TITLE
--user fixes part 1

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -615,3 +615,17 @@ def test_find_command_trys_supplied_pathext(mock_isfile, getpath_mock):
     assert_raises(BadCommand, find_command, 'foo', 'path_one', pathext)
     assert mock_isfile.call_args_list == expected, "Actual: %s\nExpected %s" % (mock_isfile.call_args_list, expected)
     assert not getpath_mock.called, "Should not call get_pathext"
+
+
+def test_reset_env_system_site_packages_user_site():
+    """
+    reset_env(system_site_packages=True) produces env where a --user install can be found using pkg_resources
+    """
+    if sys.version_info < (2, 6):
+        raise SkipTest() #no PYTHONUSERBASE
+    env = reset_env(system_site_packages=True)
+    run_pip('install', '--user', 'INITools==0.2')
+    result = env.run('python', '-c', "import pkg_resources; print(pkg_resources.get_distribution('initools').project_name)")
+    project_name = result.stdout.strip()
+    assert 'INITools'== project_name, "'%s' should be 'INITools'" %project_name
+


### PR DESCRIPTION
per exchange with Paul/Carl, this is part 1 of a breakup of pull request #511
full plan is here: https://gist.github.com/2822510

part 1:

1)
A new system_site_packages option for reset_env, that creates a --system-site-packages virtualenv.
This is needed to test --user install scenarios (coming in subsequest pull requests).
Without this option, the virtualenv created by reset_env doesn't have the user site on the sys.path.

2)
pypi_server.PyPIProxy.setup() now occurs in a sitecustomize.py file (not a pth file).
This was necessary to prevent pkg_resources.working_set corruption (see comment in the code).
An accurate pkg_resources.working_set is required so that pkg_resources.get_distribution (used in pip.req)
can find --user installed distributions
