### PR TITLE
Temporarily disable flaky test.

### DIFF
--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,5 +1,6 @@
 import textwrap
 from os.path import join
+from nose.tools import nottest
 from tests.test_pip import (here, reset_env, run_pip, assert_all_changes,
                             write_file, pyversion, _create_test_package,
                             _change_test_package_version)
@@ -150,7 +151,8 @@ def test_uninstall_rollback():
     assert env.run('python', '-c', "import broken; print(broken.VERSION)").stdout == '0.1\n'
     assert_all_changes(result.files_after, result2, [env.venv/'build', 'pip-log.txt'])
 
-
+# Issue #530 - temporarily disable flaky test
+@nottest
 def test_editable_git_upgrade():
     """
     Test installing an editable git package from a repository, upgrading the repository,


### PR DESCRIPTION
The build breakages are causing noise in push requests, and the fix for
this will be larger than I can get to today. To unblock other merges I'm
disabling this test for now and will re-enable when I've cleaned up the
testing.
