### PR TITLE
Fix error message for pip install -e path

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -1336,7 +1336,9 @@ def parse_editable(editable_req, default_vcs=None):
     else:
         url_no_extras = url
 
-    if os.path.isdir(url_no_extras) and os.path.exists(os.path.join(url_no_extras, 'setup.py')):
+    if os.path.isdir(url_no_extras):
+        if not os.path.exists(os.path.join(url_no_extras, 'setup.py')):
+            raise InstallationError("Directory %r is not installable. File 'setup.py' not found.", url_no_extras)
         # Treating it as code that has already been checked out
         url_no_extras = path_to_url(url_no_extras)
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -302,6 +302,17 @@ def test_install_from_local_directory_with_no_setup_py():
     assert "is not installable. File 'setup.py' not found." in result.stdout
 
 
+def test_editable_install_from_local_directory_with_no_setup_py():
+    """
+    Test installing from a local directory with no 'setup.py'.
+    """
+    reset_env()
+    result = run_pip('install', '-e', here, expect_error=True)
+    assert len(result.files_created) == 1, result.files_created
+    assert 'pip-log.txt' in result.files_created, result.files_created
+    assert "is not installable. File 'setup.py' not found." in result.stdout
+
+
 def test_install_as_egg():
     """
     Test installing as egg, instead of flat install.


### PR DESCRIPTION
When setup.py missing give appropriate error message.

Fixes issue #546
