### PR TITLE
Make the unknown VCS error message generate its text from the actual list of known VCSs rather than hard-coding the ones supported now.

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -1359,8 +1359,10 @@ def parse_editable(editable_req, default_vcs=None):
                 '--editable=%s should be formatted with svn+URL, git+URL, hg+URL or bzr+URL' % editable_req)
     vc_type = url.split('+', 1)[0].lower()
     if not vcs.get_backend(vc_type):
-        raise InstallationError(
-            'For --editable=%s only svn (svn+URL), Git (git+URL), Mercurial (hg+URL) and Bazaar (bzr+URL) is currently supported' % editable_req)
+        error_message = 'For --editable=%s only ' % editable_req + \
+            ', '.join([backend.name + '+URL' for backend in vcs.backends]) + \
+            ' is currently supported'
+        raise InstallationError(error_message)
     match = re.search(r'(?:#|#.*?&)egg=([^&]*)', editable_req)
     if (not match or not match.group(1)) and vcs.get_backend(vc_type):
         parts = [p for p in editable_req.split('#', 1)[0].split('/') if p]


### PR DESCRIPTION
The idea came for this while debugging this error wrongfully occurring on Python 3.3 and realizing that `vcs.backends` was empty -- if the error message showed this it would've pointed me to the error much sooner.

Sample error messages:

```
$ .tox/py32/bin/pip install -e gitx+https://github.com/msabramo/spec.git@python-3#egg=spec
For --editable=gitx+https://github.com/msabramo/spec.git@python-3#egg=spec only svn+URL, git+URL, bzr+URL, hg+URL is currently supported
```

```
$ .tox/py33/bin/pip install -e git+https://github.com/msabramo/spec.git@python-3#egg=spec
For --editable=git+https://github.com/msabramo/spec.git@python-3#egg=spec only  is currently supported
Storing complete log in /Users/marca/.pip/pip.log
```
