### PR TITLE
Fix windows CI build tests.

### DIFF
--- a/pip/backwardcompat.py
+++ b/pip/backwardcompat.py
@@ -41,6 +41,7 @@ if sys.version_info >= (3,):
     from functools import reduce
     from urllib.error import URLError, HTTPError
     from queue import Queue, Empty
+    from urllib.request import pathname2url
     from urllib.request import url2pathname
     from urllib.request import urlretrieve
     from email import message as emailmessage
@@ -76,7 +77,7 @@ else:
     from cStringIO import StringIO
     from urllib2 import URLError, HTTPError
     from Queue import Queue, Empty
-    from urllib import url2pathname, urlretrieve
+    from urllib import pathname2url, url2pathname, urlretrieve
     from email import Message as emailmessage
     import urllib
     import urllib2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -2,7 +2,7 @@ import os.path
 import textwrap
 from nose.tools import assert_equal, assert_raises
 from mock import patch
-from pip.backwardcompat import urllib
+from pip.backwardcompat import urllib, pathname2url
 from pip.req import Requirements, parse_editable
 from tests.test_pip import reset_env, run_pip, write_file, pyversion, here, path_to_url
 from tests.local_repos import local_checkout
@@ -127,11 +127,13 @@ def test_parse_editable_local(isdir_mock, exists_mock):
     exists_mock.return_value = isdir_mock.return_value = True
     assert_equal(
         parse_editable('.', 'git'),
-        (None, 'file://' + os.getcwd(), None)
+        (None, 'file://' + pathname2url(os.getcwd()), None)
     )
     assert_equal(
         parse_editable('foo', 'git'),
-        (None, 'file://' + os.path.join(os.getcwd(), 'foo'), None)
+        (None,
+         'file://' + pathname2url(os.path.join(os.getcwd(), 'foo')),
+         None)
     )
 
 def test_parse_editable_default_vcs():
@@ -158,11 +160,14 @@ def test_parse_editable_local_extras(isdir_mock, exists_mock):
     exists_mock.return_value = isdir_mock.return_value = True
     assert_equal(
         parse_editable('.[extras]', 'git'),
-        (None, 'file://' + os.getcwd(), ('extras',))
+        (None, 'file://' + pathname2url(os.getcwd()), ('extras',))
     )
     assert_equal(
         parse_editable('foo[bar,baz]', 'git'),
-        (None, 'file://' + os.path.join(os.getcwd(), 'foo'), ('bar', 'baz'))
+        (None,
+         'file://' + pathname2url(os.path.join(os.getcwd(), 'foo')),
+         ('bar', 'baz')
+        )
     )
 
 def test_install_local_editable_with_extras():


### PR DESCRIPTION
On windows we can't assume os.getcwd returns url friendly format. Use
urllib pathname2url.
