### PR TITLE
Followup build and src dir fixes

### DIFF
--- a/pip/locations.py
+++ b/pip/locations.py
@@ -24,7 +24,11 @@ else:
     build_prefix = os.path.join(tempfile.gettempdir(), 'pip-build')
     
     ## FIXME: keep src in cwd for now (it is not a temporary folder)
-    src_prefix = os.path.join(os.getcwd(), 'src')
+    try:
+        src_prefix = os.path.join(os.getcwd(), 'src')
+    except OSError:
+        # In case the current working directory has been renamed or deleted
+        sys.exit("The folder you are executing pip from can no longer be found.")
 
 # under Mac OS X + virtualenv sys.prefix is not properly resolved
 # it is something like /path/to/python/bin/..


### PR DESCRIPTION
So this pull request is a followup to #516. To recap: there were two issues with the solution I provided in that request:
1. It broke the workflow of `--no-install` followed by `--no-download`, because the temporary directory pip created was different each time. 
2. The handling of the `src` dir was bad- it could not be a temporary directory, it needed to be somewhere permanent.

So what I've done is changed the temporary `build` directory to always be called pip-build (ex: /tmp/pip-build) , fixing issue 1, and moving `src` back into cwd to fix issue 2. I have the latter still flagged as a FIXME because I do think that things shouldn't arbitrarily be created in cwd- but it currently seems to be the best possible option.
