### PR TITLE
Mock out getcwd.

### DIFF
--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -121,17 +121,19 @@ def test_requirements_data_structure_implements__contains__():
     assert 'pip' in requirements
     assert 'nose' not in requirements
 
+@patch('pip.req.os.getcwd')
 @patch('pip.req.os.path.exists')
 @patch('pip.req.os.path.isdir')
-def test_parse_editable_local(isdir_mock, exists_mock):
+def test_parse_editable_local(isdir_mock, exists_mock, getcwd_mock):
     exists_mock.return_value = isdir_mock.return_value = True
+    getcwd_mock.return_value = "/some/path"
     assert_equal(
         parse_editable('.', 'git'),
-        (None, 'file://' + os.getcwd(), None)
+        (None, 'file:///some/path', None)
     )
     assert_equal(
         parse_editable('foo', 'git'),
-        (None, 'file://' + os.path.join(os.getcwd(), 'foo'), None)
+        (None, 'file://' + os.path.join("/some/path", 'foo'), None)
     )
 
 def test_parse_editable_default_vcs():
@@ -152,17 +154,19 @@ def test_parse_editable_vcs_extras():
         ('foo[extras]', 'svn+https://foo#egg=foo[extras]', None)
     )
 
+@patch('pip.req.os.getcwd')
 @patch('pip.req.os.path.exists')
 @patch('pip.req.os.path.isdir')
-def test_parse_editable_local_extras(isdir_mock, exists_mock):
+def test_parse_editable_local_extras(isdir_mock, exists_mock, getcwd_mock):
     exists_mock.return_value = isdir_mock.return_value = True
+    getcwd_mock.return_value = "/some/path"
     assert_equal(
         parse_editable('.[extras]', 'git'),
-        (None, 'file://' + os.getcwd(), ('extras',))
+        (None, 'file://' + "/some/path", ('extras',))
     )
     assert_equal(
         parse_editable('foo[bar,baz]', 'git'),
-        (None, 'file://' + os.path.join(os.getcwd(), 'foo'), ('bar', 'baz'))
+        (None, 'file://' + os.path.join("/some/path", 'foo'), ('bar', 'baz'))
     )
 
 def test_install_local_editable_with_extras():


### PR DESCRIPTION
File urls on Windows32 are fragile, the test doesn't actually care about
the filesystem as it's already mocking exists and isdir.

Hopefully fixes two win32 build failures as in Issue #557
