### PR TITLE
Avoid extra HTTP redirect when querying for package on PyPi

### DIFF
--- a/docs/news.txt
+++ b/docs/news.txt
@@ -13,6 +13,9 @@ Beta and final releases planned for the second half of 2012.
 develop (unreleased)
 -------------------
 
+* Avoid extra HTTP request when querying for package on PyPi. Thanks Domen
+  Kožar.
+
 * Write failure log to temp file if default location is not writable. Thanks
   andreigc.
 


### PR DESCRIPTION
Due to failing tests because of my git setup (returns stderr which makes a lot of tests fail), I wasn't able to find any related failing tests.
