### PR TITLE
fix for test_install_user_in_global_virtualenv_with_conflict_fails

### DIFF
--- a/tests/test_user_site.py
+++ b/tests/test_user_site.py
@@ -189,6 +189,8 @@ class Tests_UserSite:
         env = reset_env(system_site_packages=True)
         result1 = run_pip('install', 'INITools==0.2')
         result2 = run_pip('install', '--user', 'INITools==0.1', expect_error=True)
+        resultp = env.run('python', '-c', "import pkg_resources; print(pkg_resources.get_distribution('initools').location)")
+        dist_location = resultp.stdout.strip()
         assert result2.stdout.startswith("Will not install to the user site because it will lack sys.path precedence to %s in %s"
-                                        %('INITools',env.root_path / env.site_packages)), result2.stdout
+                                        %('INITools', dist_location)), result2.stdout
 


### PR DESCRIPTION
test fix in response to @pnasrat comment in issue #573

I changed the test to generate the distribution location the same way as it's generated in pip.req.

This should prevent the kind of failure you saw.

I didn't want to remove the path from the test, because I felt like the confirming the path in the error is an important part of the test.
