### PR TITLE
Minor tweak to handle not passing options to parse_requirements.

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -1274,7 +1274,7 @@ _scheme_re = re.compile(r'^(http|https|file):', re.I)
 
 def parse_requirements(filename, finder=None, comes_from=None, options=None):
     skip_match = None
-    skip_regex = options.skip_requirements_regex
+    skip_regex = options.skip_requirements_regex if options else None
     if skip_regex:
         skip_match = re.compile(skip_regex)
     filename, content = get_file_content(filename, comes_from=comes_from)


### PR DESCRIPTION
Options is supposed to be an optional argument, this makes it optional.
