### PR TITLE
fix version sort in PackageFinder

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,4 +1,6 @@
-from pip.index import package_to_requirement, HTMLPage
+from pip.index import package_to_requirement, HTMLPage, Link, InfLink
+from pip.index import PackageFinder
+from pkg_resources import parse_version
 
 
 def test_package_name_should_be_converted_to_requirement():
@@ -25,4 +27,42 @@ def test_html_page_should_be_able_to_scrap_rel_links():
     links = list(page.scraped_rel_links())
     assert len(links) == 1
     assert links[0].url == 'http://supervisord.org/'
+
+
+def test_inflink_greater():
+    """Test InfLink compares greater."""
+    assert InfLink > Link(object())
+
+
+def test_version_sort():
+    """Test version sorting."""
+    finder = PackageFinder(None, None)
+    versions = []
+    versions.append((parse_version('3.0'), Link('link3'), '3.0'))
+    versions.append((parse_version('2.0'), Link('link2'), '2.0'))
+    assert finder._sort_versions(versions)[0][2] == '3.0'
+    versions.reverse()
+    assert finder._sort_versions(versions)[0][2] == '3.0'
+
+
+def test_version_sort_inflink_latest():
+    """Test version sorting with InfLink tied as latest version."""
+    finder = PackageFinder(None, None)
+    versions = []
+    versions.append((parse_version('2.0'), Link('link'), '2.0'))
+    versions.append((parse_version('2.0'), InfLink, '2.0'))
+    assert finder._sort_versions(versions)[0][1] is InfLink
+    versions.reverse()
+    assert finder._sort_versions(versions)[0][1] is InfLink
+
+
+def test_version_sort_inflink_not_latest():
+    """Test version sorting with InfLink not latest version."""
+    finder = PackageFinder(None, None)
+    versions = []
+    versions.append((parse_version('3.0'), Link('link'), '3.0'))
+    versions.append((parse_version('2.0'), InfLink, '2.0'))
+    assert finder._sort_versions(versions)[0][2] == '3.0'
+    versions.reverse()
+    assert finder._sort_versions(versions)[0][2] == '3.0'
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@ from mock import Mock
 from nose.tools import eq_
 from tests.path import Path
 from pip.util import egg_link_path
+from pip.util import Inf
 
 
 class Tests_EgglinkPath:
@@ -138,3 +139,7 @@ class Tests_EgglinkPath:
         self.mock_isfile.return_value = False
         eq_(egg_link_path(self.mock_dist), None)
 
+
+def test_inf_greater():
+    """Test Inf compares greater."""
+    assert Inf > object()


### PR DESCRIPTION
When working on for tests for #598 (and possibly #571), I noticed when using -U and --find-links together, it would always re-install pkgs and never return "Requirement already up-to-date"

What I found to be the issue was the version sorting in PackageFinder.find_requirement. The sorting was only coincidentally accurate most of the time due to the order the various lists were put together.

There seemed to be an intention in the code to somehow be using the "Inf" object for sorting, but it wasn't actually using it, as best I could tell. In this change, I tried to change as little possible to fulfill the intention of using the Inf object.  I did pull the sorting out into a specific method to make it easy to unit test.

Also, I discovered a condition, that would _never_ evaluate to true. I added a FIXME comment.

_I am aware that tests are failing with this._  

This change seems to be exposing other cases where things were ok only by coincidence.  I'll look at that tomorrow.

Posting this in incomplete form to possibly get feedback to make sure I'm not off the track with this change.
