### PR TITLE
followup fix to pull #619

### DIFF
--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -322,7 +322,10 @@ class TestPipEnvironment(TestFileEnvironment):
 
         assert self.venv == TestPipEnvironment.venv # sanity check
 
-        self.site_packages = self.lib/'site-packages'
+        if hasattr(sys, "pypy_version_info"):
+            self.site_packages = self.venv/'site-packages'
+        else:
+            self.site_packages = self.lib/'site-packages'
         self.user_base_path = self.venv_path/'user'
         self.user_site_path = self.venv_path/'user'/site_packages_suffix
 


### PR DESCRIPTION
this corrects the site-packages path for pypy in response to my lib_path fix.

this got the pypy failures down to 2 for me.
