### PR TITLE
Fixing import error for tempfile

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -4,6 +4,7 @@ import os
 from pkgutil import walk_packages
 import socket
 import sys
+import tempfile
 import traceback
 import time
 


### PR DESCRIPTION
A change was made to add extra logging whenever pip log files cannot be added. 

Here is the changeset that caused the issue:  https://github.com/pypa/pip/commit/8ebc7a316016c4eb01cb77c8df1fe538c7bddf2a#pip/basecommand.py
