### PR TITLE
Enable listing all the installed files in pip status command

### DIFF
--- a/pip/commands/status.py
+++ b/pip/commands/status.py
@@ -11,6 +11,12 @@ class StatusCommand(Command):
 
     def __init__(self):
         super(StatusCommand, self).__init__()
+        self.parser.add_option(
+            '-f', '--files',
+            dest='files',
+            action='store_true',
+            default=False,
+            help='If should show a full list of files for every installed package')
 
     def run(self, options, args):
         if not args:
@@ -19,7 +25,7 @@ class StatusCommand(Command):
         query = args
 
         results = search_packages_info(query)
-        print_results(results)
+        print_results(results, options.files)
 
 
 def search_packages_info(query):
@@ -50,7 +56,7 @@ def search_packages_info(query):
             yield package
 
 
-def print_results(distributions):
+def print_results(distributions, list_all_files):
     """
     Print the informations from installed distributions found.
     """
@@ -59,12 +65,13 @@ def print_results(distributions):
         logger.notify("Name: %s" % dist['name'])
         logger.notify("Version: %s" % dist['version'])
         logger.notify("Location: %s" % dist['location'])
-        logger.notify("Files:")
-        if 'files' in dist:
-            for line in open(dist['files']):
-                logger.notify("  %s" % line.strip())
-        else:
-            logger.notify("Cannot locate installed-files.txt")
+        if list_all_files:
+            logger.notify("Files:")
+            if 'files' in dist:
+                for line in open(dist['files']):
+                    logger.notify("  %s" % line.strip())
+            else:
+                logger.notify("Cannot locate installed-files.txt")
 
 
 StatusCommand()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,3 +1,4 @@
+import re
 from pip import __version__
 from pip.commands.status import search_packages_info
 from tests.test_pip import reset_env, run_pip
@@ -11,6 +12,22 @@ def test_status():
     reset_env()
     result = run_pip('status', 'pip')
     lines = result.stdout.split('\n')
+    assert len(lines) == 5
+    assert lines[0] == '---', lines[0]
+    assert lines[1] == 'Name: pip', lines[1]
+    assert lines[2] == 'Version: %s' % __version__, lines[2]
+    assert lines[3].startswith('Location: '), lines[3]
+
+
+def test_status_with_files_not_found():
+    """
+    Test for status command with installed files listing enabled and 
+    installed-files.txt not found.
+
+    """
+    reset_env()
+    result = run_pip('status', '-f', 'pip')
+    lines = result.stdout.split('\n')
     assert len(lines) == 7
     assert lines[0] == '---', lines[0]
     assert lines[1] == 'Name: pip', lines[1]
@@ -18,6 +35,17 @@ def test_status():
     assert lines[3].startswith('Location: '), lines[3]
     assert lines[4] ==  'Files:', lines[4]
     assert lines[5] == 'Cannot locate installed-files.txt', lines[5]
+
+
+def test_status_with_all_files():
+    """
+    Test listing all files in the status command.
+
+    """
+    reset_env()
+    result = run_pip('install', 'initools==0.2')
+    result = run_pip('status', '--files', 'initools')
+    assert re.search(r"Files:\n(  .+\n)+", result.stdout)
 
 
 def test_missing_argument():


### PR DESCRIPTION
This pull request is for enabling a full list of the installed files from a specified package in the status command included in issue #664.
