### PR TITLE
Change the name of the command introduced in issue #664 from status to show

### DIFF
--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -4,13 +4,13 @@ from pip.basecommand import Command
 from pip.log import logger
 
 
-class StatusCommand(Command):
-    name = 'status'
+class ShowCommand(Command):
+    name = 'show'
     usage = '%prog QUERY'
     summary = 'Output installed distributions (exact versions, files) to stdout'
 
     def __init__(self):
-        super(StatusCommand, self).__init__()
+        super(ShowCommand, self).__init__()
 
     def run(self, options, args):
         if not args:
@@ -70,4 +70,4 @@ def print_results(distributions):
             logger.notify("Cannot locate installed-files.txt")
 
 
-StatusCommand()
+ShowCommand()

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,15 +1,15 @@
 from pip import __version__
-from pip.commands.status import search_packages_info
+from pip.commands.show import search_packages_info
 from tests.test_pip import reset_env, run_pip
 
 
-def test_status():
+def test_show_command():
     """
-    Test end to end test for status command.
+    Test end to end test for show command.
 
     """
     reset_env()
-    result = run_pip('status', 'pip')
+    result = run_pip('show', 'pip')
     lines = result.stdout.split('\n')
     assert len(lines) == 7
     assert lines[0] == '---', lines[0]
@@ -22,11 +22,11 @@ def test_status():
 
 def test_missing_argument():
     """
-    Test status command with no arguments.
+    Test show command with no arguments.
 
     """
     reset_env()
-    result = run_pip('status')
+    result = run_pip('show')
     assert 'ERROR: Please provide a project name or names.' in result.stdout
 
 


### PR DESCRIPTION
As discussed in issue #664. I changed the name of the command `status` to `show`.
