### PR TITLE
Display download URL (with -v) instead of just the name of the file.

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -374,7 +374,7 @@ def _download_url(resp, link, temp_location):
                 logger.start_progress('Downloading %s (unknown size): ' % show_url)
         else:
             logger.notify('Downloading %s' % show_url)
-        logger.debug('Downloading from URL %s' % link)
+        logger.info('Downloading from URL %s' % link)
 
         while True:
             chunk = resp.read(4096)


### PR DESCRIPTION
It is quite useful to be able to see the full download URL, particularly when you're deal with multiple PyPI servers.
## Motivation

I'm working with multiple PyPI servers (e.g.: Regular public PyPI and an internal
PyPI server for internal-only packages) and it's really nice to know which one pip is pulling packages from.

For example if I do:

```
pip install -v --extra-index-url http://python.tools.mycompany.com/djangopypi/simple mypackage
```

Without this change, all I see is:

```
Downloading mypackage-0.2.2.tar.gz
```

(And note that I am passing "-v" for verbose)

With this change, I see:

```
Downloading http://python.tools.mycompany.com/media/dists/mypackage-0.2.2.tar.gz#md5=29e3279eec239c52ed130ed820826dc9
```

which is much more useful.
