### PR TITLE
--find-links detection for files generated by --download-cache

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -259,7 +259,8 @@ class PackageFinder(object):
                 pending_queue.put(link)
 
     _egg_fragment_re = re.compile(r'#egg=([^&]*)')
-    _egg_info_re = re.compile(r'([a-z0-9_.]+)-([a-z0-9_.-]+)', re.I)
+    _egg_info_re = re.compile(
+        r'(?P<url_end>252f)?(?P<name>([a-z0-9_.]+)-([a-z0-9_.-]+))', re.I)
     _py_version_re = re.compile(r'-py([123]\.?[0-9]?)$')
 
     def _sort_links(self, links):
@@ -332,13 +333,13 @@ class PackageFinder(object):
         if not match:
             logger.debug('Could not parse version from link: %s' % link)
             return None
-        name = match.group(0).lower()
+        name = match.group('name').lower()
         # To match the "safe" name that pkg_resources creates:
         name = name.replace('_', '-')
         # project name and version must be separated by a dash
         look_for = search_name.lower() + "-"
         if name.startswith(look_for):
-            return match.group(0)[len(look_for):]
+            return match.group('name')[len(look_for):]
         else:
             return None
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -105,3 +105,58 @@ def test_file_index_url_quoting():
 def test_inflink_greater():
     """Test InfLink compares greater."""
     assert InfLink > Link(object())
+
+
+def test_egg_info_matches_cached_file():
+    """
+    Test that a cached file is recognized by PackageFinder._egg_info_matches
+    """
+    find_links_url = 'file://' + os.path.join(here, 'packages')
+    find_links = [find_links_url]
+    finder = PackageFinder(find_links, [])
+    egg_info = (
+        'http%253A%252F%252Fpypi%253A8080%252F'
+        'packages%252Fzope.interface-1.1.2'
+        )
+    search_name = 'zope.interface'
+    link = "Link to zope.interface-1.1.2"
+
+    found_version = finder._egg_info_matches(egg_info, search_name, link)
+
+    assert found_version and found_version == '1.1.2', (
+        "failed to extract version from: %s" % egg_info)
+
+
+def test_egg_info_matches_normal_file():
+    """
+    Test that a normal file is recognized by PackageFinder._egg_info_matches
+    """
+    find_links_url = 'file://' + os.path.join(here, 'packages')
+    find_links = [find_links_url]
+    finder = PackageFinder(find_links, [])
+    egg_info = 'zope.interface-1.1.2'
+    search_name = 'zope.interface'
+    link = "Link to zope.interface-1.1.2"
+
+    found_version = finder._egg_info_matches(egg_info, search_name, link)
+
+    assert found_version and found_version == '1.1.2', (
+        "failed to extract version from: %s" % egg_info)
+
+
+def test_egg_info_matches_normal_file_bad_name():
+    """
+    Test that a file with bad name is not recognized by
+    PackageFinder._egg_info_matches
+    """
+    find_links_url = 'file://' + os.path.join(here, 'packages')
+    find_links = [find_links_url]
+    finder = PackageFinder(find_links, [])
+    egg_info = 'zope.interface-1.1.2'
+    search_name = 'zope.testrunner'
+    link = "Link to zope.test-1.1.2"
+
+    found_version = finder._egg_info_matches(egg_info, search_name, link)
+
+    assert found_version is None, (
+        "extracted wrong version from: %s" % egg_info)


### PR DESCRIPTION
Hi,
# Problem description

--download-cache is nice to avoid re-downloading files.

--find-links does not recognizes files created using --download-cache since the repository name is contained in the file name.

It would be nice if --find-links could also use cached files.

This problem was also raised in #246 but it look like the original reported did not continue to support it.
# Changes

The regular expression for _egg_info_re was updated to extract the package name from file names created using --download-cache options.

RE named groups are used instead of group numbers.

The tests were done on 'private' method. Not sure if this is the right thing to do, but I saw some other tests for private methods.

I wanted to add the test on a public method, but PackageFinder.find_requirement is doing a lot of things and it would be hard to focus the test.

This is my first contribution to pip, so there is high probability of doing something wrong.
Please do not hesitate to raise any issues, even minor ones.
# How to test

Test were added for PackageFinder._egg_info_matches

```
nosetests tests.test_index
```

Thanks!
