### PR TITLE
Remove index for which the base_url failed

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -206,12 +206,22 @@ class PackageFinder(object):
     def _find_url_name(self, index_url, url_name, req):
         """Finds the true URL name of a package, when the given name isn't quite correct.
         This is usually used to implement case-insensitivity."""
+        def remove_index(link):
+            try:
+                self.index_urls.remove(link.url)
+            except ValueError:
+                try:
+                    self.index_urls.remove(link.url.rstrip('/'))
+                except ValueError:
+                    logger.fatal('Failed to remove index %s' % index_url)
+
         if not index_url.url.endswith('/'):
             # Vaguely part of the PyPI API... weird but true.
             ## FIXME: bad to modify this?
             index_url.url += '/'
         page = self._get_page(index_url, req)
         if page is None:
+            remove_index(index_url)
             logger.fatal('Cannot fetch index base URL %s' % index_url)
             return
         norm_name = normalize_name(req.url_name)


### PR DESCRIPTION
# Problem description

If an index is not available, pip will continue to try the index when installing each file.

When installing a long requirements file, the whole timeouts take a long time.

It would be nice if pip could remove the index and stop trying it.

This can be useful for development and when running continuous integration together with --find-links=file:/// . In case the index is down, pip will just use the cached files.

This can simplifies the build system, since there is no need to look for index failures and then to retry without the index.

I know that index lookup can be explicitly turned off, so I am not sure if this behavior is wanted.
# Changes

When get_page will fail for index's base URL, the index url will be removed from the list of indexes.
# How to test

There are no tests for now, since I don't know if such behavior is wanted in pip.

I will add the required tests.

Thanks!
