### PR TITLE
troublesome pypy failure

### DIFF
--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -80,20 +80,23 @@ def test_multiple_requirements_files():
 def test_respect_order_in_requirements_file():
     env = reset_env()
     write_file('frameworks-req.txt', textwrap.dedent("""\
-        bidict
-        ordereddict
-        initools
+        parent
+        child
+        simple
         """))
-    result = run_pip('install', '-r', env.scratch_path / 'frameworks-req.txt')
+
+    find_links = 'file://' + os.path.join(here, 'packages')
+    result = run_pip('install', '--no-index', '-f', find_links, '-r', env.scratch_path / 'frameworks-req.txt')
+
     downloaded = [line for line in result.stdout.split('\n')
                   if 'Downloading/unpacking' in line]
 
-    assert 'bidict' in downloaded[0], 'First download should ' \
-            'be "bidict" but was "%s"' % downloaded[0]
-    assert 'ordereddict' in downloaded[1], 'Second download should ' \
-            'be "ordereddict" but was "%s"' % downloaded[1]
-    assert 'initools' in downloaded[2], 'Third download should ' \
-            'be "initools" but was "%s"' % downloaded[2]
+    assert 'parent' in downloaded[0], 'First download should ' \
+            'be "parent" but was "%s"' % downloaded[0]
+    assert 'child' in downloaded[1], 'Second download should ' \
+            'be "child" but was "%s"' % downloaded[1]
+    assert 'simple' in downloaded[2], 'Third download should ' \
+            'be "simple" but was "%s"' % downloaded[2]
 
 
 def test_requirements_data_structure_keeps_order():


### PR DESCRIPTION
`tests.test_requirements.test_respect_order_in_requirements_file` has been "randomly" failing with increasing frequency it seems in pypy only.

e.g. https://travis-ci.org/#!/pypa/pip/builds/2657688

the failure is `OSError: [Errno 11] Resource temporarily unavailable: '/usr/local/pypy/lib-python/2.7'`
during a `pkg_resources.get_distribution` call for ordereddict right after running egg-info.

I'm not sure what's going on, but here's the factors:  travis, pypy1.9 (emulation of py2.7),  ordereddict

orderedict is not something you'd normally install into 2.7 since it's a "A drop-in substitute for Py2.7's new collections.OrderedDict that works in Python 2.4-2.6."

my fix is too use local packages for this test and pass on this odd ball.  

ordereddict has _nothing_ to do with this test.
