### PR TITLE
Fix `pip install --user` when upgrading an existing system package.

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -417,7 +417,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
             raise UninstallationError("Cannot uninstall requirement %s, not installed" % (self.name,))
         dist = self.satisfied_by or self.conflicts_with
 
-        paths_to_remove = UninstallPathSet(dist)
+        paths_to_remove = UninstallPathSet(dist, use_user_site=self.use_user_site)
 
         pip_egg_info_path = os.path.join(dist.location,
                                          dist.egg_name()) + '.egg-info'
@@ -1405,13 +1405,14 @@ def parse_editable(editable_req, default_vcs=None):
 class UninstallPathSet(object):
     """A set of file paths to be removed in the uninstallation of a
     requirement."""
-    def __init__(self, dist):
+    def __init__(self, dist, use_user_site=False):
         self.paths = set()
         self._refuse = set()
         self.pth = {}
         self.dist = dist
         self.save_dir = None
         self._moved_paths = []
+        self.use_user_site = use_user_site
 
     def _permitted(self, path):
         """
@@ -1426,6 +1427,11 @@ class UninstallPathSet(object):
             logger.notify("Not uninstalling %s at %s, outside environment %s"
                           % (self.dist.project_name, normalize_path(self.dist.location), sys.prefix))
             return False
+        if self.use_user_site and not dist_in_usersite(self.dist):
+            logger.notify("Not uninstalling %s at %s, not in user site-packages"
+                          % (self.dist.project_name, normalize_path(self.dist.location)))
+            return False
+
         return True
 
     def add(self, path):


### PR DESCRIPTION
I'm on a machine with old system packages and I want to install newer versions in my user-site.  Despite all the recent work on `--user`, no combination of `--upgrade` and `--ignore-installed` completed successfully; pip would always try to remove the system package and, naturally, fail.

This is a somewhat dumb patch that fixes the behavior for me.  I can't imagine how to write a test for it, and the existing user-site tests confirm this is unsupported, but it's simple enough.

(fwiw, the existing code didn't cover this case because while `check_if_exists` has some `use_user_site` guards, they only come into play when there's a version conflict; a simple upgrade instead causes an assignment to `.satisfied_by`, which is _later_ assigned to `.conflicts_with` and then triggers the uninstallation.)
