### PR TITLE
--user installs work properly with --upgrade

### DIFF
--- a/docs/news.txt
+++ b/docs/news.txt
@@ -14,6 +14,8 @@ Beta and final releases planned for the end of 2012.
 develop (unreleased)
 --------------------
 
+* --user/--upgrade install options now work together; thanks eevee.
+
 * Added check in ``install --download`` to prevent re-downloading if the target
   file already exists. Thanks Andrey Bulgakov.
 

--- a/pip/req.py
+++ b/pip/req.py
@@ -903,7 +903,9 @@ class RequirementSet(object):
                 req_to_install.check_if_exists()
                 if req_to_install.satisfied_by:
                     if self.upgrade:
-                        req_to_install.conflicts_with = req_to_install.satisfied_by
+                        #don't uninstall conflict if user install and and conflict is not user install
+                        if not (self.use_user_site and not dist_in_usersite(req_to_install.satisfied_by)):
+                            req_to_install.conflicts_with = req_to_install.satisfied_by
                         req_to_install.satisfied_by = None
                     else:
                         install_needed = False
@@ -955,7 +957,9 @@ class RequirementSet(object):
                                 req_to_install.url = url.url
 
                         if not best_installed:
-                            req_to_install.conflicts_with = req_to_install.satisfied_by
+                            #don't uninstall conflict if user install and conflict is not user install
+                            if not (self.use_user_site and not dist_in_usersite(req_to_install.satisfied_by)):
+                                req_to_install.conflicts_with = req_to_install.satisfied_by
                             req_to_install.satisfied_by = None
                     else:
                         install = False
@@ -1054,7 +1058,9 @@ class RequirementSet(object):
                         req_to_install.check_if_exists()
                         if req_to_install.satisfied_by:
                             if self.upgrade or self.ignore_installed:
-                                req_to_install.conflicts_with = req_to_install.satisfied_by
+                                #don't uninstall conflict if user install and and conflict is not user install
+                                if not (self.use_user_site and not dist_in_usersite(req_to_install.satisfied_by)):
+                                    req_to_install.conflicts_with = req_to_install.satisfied_by
                                 req_to_install.satisfied_by = None
                             else:
                                 install = False

--- a/tests/test_user_site.py
+++ b/tests/test_user_site.py
@@ -148,6 +148,37 @@ class Tests_UserSite:
         assert isdir(initools_folder)
 
 
+    def test_upgrade_user_conflict_in_globalsite(self):
+        """
+        Test user install/upgrade with conflict in global site ignores site and installs to usersite
+        """
+
+        # the test framework only supports testing using virtualenvs
+        # the sys.path ordering for virtualenvs with --system-site-packages is this: virtualenv-site, user-site, global-site
+        # this test will use 2 modifications to simulate the user-site/global-site relationship
+        # 1) a monkey patch which will make it appear INITools==0.2 is not in in the virtualenv site
+        #    if we don't patch this, pip will return an installation error:  "Will not install to the usersite because it will lack sys.path precedence..."
+        # 2) adding usersite to PYTHONPATH, so usersite as sys.path precedence over the virtualenv site
+
+        env = reset_env(system_site_packages=True, sitecustomize=patch_dist_in_site_packages)
+        env.environ["PYTHONPATH"] = env.root_path / env.user_site
+
+        result1 = run_pip('install', 'INITools==0.2')
+        result2 = run_pip('install', '--user', '--upgrade', 'INITools')
+
+        #usersite has 0.3.1
+        egg_info_folder = env.user_site / 'INITools-0.3.1-py%s.egg-info' % pyversion
+        initools_folder = env.user_site / 'initools'
+        assert egg_info_folder in result2.files_created, str(result2)
+        assert initools_folder in result2.files_created, str(result2)
+
+        #site still has 0.2 (can't look in result1; have to check)
+        egg_info_folder = env.root_path / env.site_packages / 'INITools-0.2-py%s.egg-info' % pyversion
+        initools_folder = env.root_path / env.site_packages / 'initools'
+        assert isdir(egg_info_folder), result2.stdout
+        assert isdir(initools_folder)
+
+
     def test_install_user_conflict_in_globalsite_and_usersite(self):
         """
         Test user install with conflict in globalsite and usersite ignores global site and updates usersite.


### PR DESCRIPTION
this in in response to pull #704.
this fixes the same problem, but also provides a test.
#704 fixes the issue via the "_permitted" check during uninstallation.

This pull is more direct, in that it doesn't allow the global install to be a conflict in the first place, which it shouldn't be during any --user install.
