### PR TITLE
Add support for relative file: URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ pip-log.txt
 pip.log
 *.~
 .tox
+.noseids
 

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -13,6 +13,7 @@ Christian Oudard
 Clay McClure
 Cody Soyland
 Daniel Holth
+Daniel Miller
 Dave Abrahams
 Donald Stufft
 Francesco

--- a/pip/download.py
+++ b/pip/download.py
@@ -214,11 +214,12 @@ def url_to_path(url):
     """
     assert url.startswith('file:'), (
         "You can only turn file: urls into filenames (not %r)" % url)
+    is_absolute = url.startswith('file:/')
     path = url[len('file:'):].lstrip('/')
     path = urllib.unquote(path)
     if _url_drive_re.match(path):
         path = path[0] + ':' + path[2:]
-    else:
+    elif is_absolute:
         path = '/' + path
     return path
 

--- a/pip/download.py
+++ b/pip/download.py
@@ -215,7 +215,7 @@ def url_to_path(url):
     assert url.startswith('file:'), (
         "You can only turn file: urls into filenames (not %r)" % url)
     is_absolute = url.startswith('file:/')
-    path = url[len('file:'):].lstrip('/')
+    path = url[len('file:'):].lstrip('/').split('#egg=', 1)[0]
     path = urllib.unquote(path)
     if _url_drive_re.match(path):
         path = path[0] + ':' + path[2:]

--- a/pip/index.py
+++ b/pip/index.py
@@ -14,7 +14,6 @@ import pkg_resources
 import random
 import socket
 import string
-import urllib
 import zlib
 from pip.log import logger
 from pip.util import Inf
@@ -22,7 +21,7 @@ from pip.util import normalize_name, splitext
 from pip.exceptions import DistributionNotFound, BestVersionAlreadyInstalled
 from pip.backwardcompat import (WindowsError, BytesIO,
                                 Queue, urlparse,
-                                URLError, HTTPError, u,
+                                URLError, HTTPError, u, urllib,
                                 product, url2pathname)
 from pip.backwardcompat import Empty as QueueEmpty
 from pip.download import urlopen, path_to_url2, url_to_path, geturl, Urllib2HeadRequest

--- a/pip/index.py
+++ b/pip/index.py
@@ -677,7 +677,13 @@ class Link(object):
     @property
     def url_without_fragment(self):
         scheme, netloc, path, query, fragment = urlparse.urlsplit(self.url)
-        return urlparse.urlunsplit((scheme, netloc, path, query, None))
+        if scheme == 'file' and not path.startswith('/'):
+            # Preserve relative file URL (work around bug in urlunsplit)
+            url = urlparse.urlunsplit(('', netloc, path, query, None))
+            url = scheme + ':' + url
+        else:
+            url = urlparse.urlunsplit((scheme, netloc, path, query, None))
+        return url
 
     _egg_fragment_re = re.compile(r'#egg=([^&]*)')
 

--- a/pip/req.py
+++ b/pip/req.py
@@ -340,7 +340,19 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
 
     @property
     def dependency_links(self):
-        return self.egg_info_lines('dependency_links.txt')
+        links = self.egg_info_lines('dependency_links.txt')
+        if self.source_dir is not None:
+            for i, url in enumerate(list(links)):
+                if not url.startswith('file:') or url.startswith('file:/'):
+                    continue
+                if '#egg=' in url:
+                    egg_index = url.find('#egg=')
+                    url, extra = url[:egg_index], url[egg_index:]
+                else:
+                    extra = ''
+                path = os.path.join(self.source_dir, url_to_path(url))
+                links[i] = path_to_url(path) + extra
+        return links
 
     _requirements_section_re = re.compile(r'\[(.*?)\]')
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -504,6 +504,34 @@ def test_install_package_with_root():
     assert Path('scratch')/'root'/'lib'/'python'/'initools' in result.files_created, str(result)
 
 
+def test_relative_file_url_install():
+    """
+    Test relative file URL installation.
+    """
+    packages = Path(here).abspath/'packages'
+    vendor = Path('vendor')
+    env = reset_env()
+    mkdir(vendor)
+    shutil.copy(str(packages/'simple-1.0.tar.gz'), str(env.cwd/vendor))
+    result = run_pip('install', 'file:vendor/simple-1.0.tar.gz')
+    simple_egg_info = env.site_packages/'simple-1.0-py%s.egg-info' % pyversion
+    assert simple_egg_info in result.files_created, str(result)
+
+
+def test_install_with_relative_find_links_file_url():
+    """
+    Test install with relative file: URL in --find-links.
+    """
+    packages = Path(here).abspath/'packages'
+    vendor = Path('vendor')
+    env = reset_env()
+    mkdir(vendor)
+    shutil.copy(str(packages/'simple-1.0.tar.gz'), str(env.cwd/vendor))
+    result = run_pip('install', '--no-index', '--find-links=file:vendor', 'simple==1.0')
+    simple_egg_info = env.site_packages/'simple-1.0-py%s.egg-info' % pyversion
+    assert simple_egg_info in result.files_created, str(result)
+
+
 def test_install_with_relative_dependency_links():
     """
     Test installing a package with relative file: URLs in dependency_links

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -552,6 +552,34 @@ def test_install_with_relative_dependency_links_dir():
     assert simple_egg_info in result.files_created, str(result)
 
 
+def test_install_with_relative_dependency_links_package_dir():
+    """
+    Test installing a package with a relative package path in dependency_links
+    """
+    packages = Path(here).abspath/'packages'
+    env = reset_env()
+    mkdir('pkg')
+    mkdir('pkg/sub-pkg')
+    pkg_path = env.scratch_path/'pkg'
+    write_file('setup.py', textwrap.dedent('''\
+        from setuptools import setup
+        setup(
+            name='pkg',
+            version='1.0',
+            install_requires=['sub-pkg'],
+            dependency_links=['file:sub-pkg#egg=sub-pkg-dev'],
+        )'''), pkg_path)
+    write_file('sub-pkg/setup.py', textwrap.dedent('''\
+        from setuptools import setup
+        setup(
+            name='sub-pkg',
+            version='1.0',
+        )'''), pkg_path)
+    result = run_pip('install', '-vv', '--no-index', pkg_path)
+    sub_pkg_egg_info = env.site_packages/'sub_pkg-1.0-py%s.egg-info' % pyversion
+    assert sub_pkg_egg_info in result.files_created, str(result)
+
+
 def test_find_command_folder_in_path():
     """
     If a folder named e.g. 'git' is in PATH, and find_command is looking for

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -528,6 +528,30 @@ def test_install_with_relative_dependency_links():
     assert simple_egg_info in result.files_created, str(result)
 
 
+def test_install_with_relative_dependency_links_dir():
+    """
+    Test installing a package with a relative directory path in in dependency_links
+    """
+    packages = Path(here).abspath/'packages'
+    env = reset_env()
+    vendor = Path('pkg')/'vendor'
+    mkdir('pkg')
+    mkdir(vendor)
+    shutil.copy(str(packages/'simple-1.0.tar.gz'), str(env.cwd/vendor))
+    pkg_path = env.scratch_path/'pkg'
+    write_file('setup.py', textwrap.dedent('''\
+        from setuptools import setup
+        setup(
+            name='pkg',
+            version='1.0',
+            install_requires=['simple'],
+            dependency_links=['file:vendor'],
+        )'''), pkg_path)
+    result = run_pip('install', '-vv', '--no-index', pkg_path)
+    simple_egg_info = env.site_packages/'simple-1.0-py%s.egg-info' % pyversion
+    assert simple_egg_info in result.files_created, str(result)
+
+
 def test_find_command_folder_in_path():
     """
     If a folder named e.g. 'git' is in PATH, and find_command is looking for

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,4 +1,5 @@
 import textwrap
+from nose.tools import assert_equal
 from tests.test_pip import reset_env, run_pip, write_file
 from tests.path import Path
 from pip.download import url_to_path
@@ -72,14 +73,14 @@ def test_download_should_skip_existing_files():
 
 
 def test_url_to_path():
-    def test(url, path):
+    def assert_equal(url, path):
         result = url_to_path(url)
         assert result == path, '%s != %s' % (result, path)
-    yield test, 'file://', '/'
-    yield test, 'file:///foo/bar', '/foo/bar'
-    yield test, 'file://C:/foo/bar', 'C:/foo/bar'
-    yield test, 'file:///foo/bar%20baz', '/foo/bar baz'
-    yield test, 'file:.', '.'
-    yield test, 'file:relative/path', 'relative/path'
-    yield test, 'file:./relative/path', './relative/path'
-    yield test, 'file:../relative/path', '../relative/path'
+    assert_equal('file://', '/')
+    assert_equal('file:///foo/bar', '/foo/bar')
+    assert_equal('file://C:/foo/bar', 'C:/foo/bar')
+    assert_equal('file:///foo/bar%20baz', '/foo/bar baz')
+    assert_equal('file:.', '.')
+    assert_equal('file:relative/path', 'relative/path')
+    assert_equal('file:./relative/path', './relative/path')
+    assert_equal('file:../relative/path', '../relative/path')

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,6 +1,7 @@
 import textwrap
 from tests.test_pip import reset_env, run_pip, write_file
 from tests.path import Path
+from pip.download import url_to_path
 
 
 def test_download_if_requested():
@@ -68,3 +69,17 @@ def test_download_should_skip_existing_files():
     assert Path('scratch')/ 'INITools-0.1.tar.gz' not in result.files_created
     assert env.site_packages/ 'initools' not in result.files_created
     assert env.site_packages/ 'openid' not in result.files_created
+
+
+def test_url_to_path():
+    def test(url, path):
+        result = url_to_path(url)
+        assert result == path, '%s != %s' % (result, path)
+    yield test, 'file://', '/'
+    yield test, 'file:///foo/bar', '/foo/bar'
+    yield test, 'file://C:/foo/bar', 'C:/foo/bar'
+    yield test, 'file:///foo/bar%20baz', '/foo/bar baz'
+    yield test, 'file:.', '.'
+    yield test, 'file:relative/path', 'relative/path'
+    yield test, 'file:./relative/path', './relative/path'
+    yield test, 'file:../relative/path', '../relative/path'


### PR DESCRIPTION
This patch set adds support for installing local dependencies, which is necessary in environments where it is not possible to download dependencies from online sources such as PyPI.

In addition to supporting relative ``file:`` urls on the command line and in requirements files, this also extends pip's ``setup.py:dependency_links`` processing code to handle relative paths as well, which is very powerful for projects that include dependencies, for example in a ``vendor`` subdirectory. Shipping dependencies in a ``vendor`` subdirectory is a pattern that Ian Bicking has mentioned several times:

http://blog.ianbicking.org/2012/02/29/python-application-package/
http://blog.ianbicking.org/2011/03/31/python-webapp-package/

Quote from the first link:

> I think it’s much more reliable if applications primarily rely on bundling their dependencies directly (i.e., using a vendor directory). The tool support for this is a bit spotty, but I believe this package format could clarify the problems and solutions. Here is an example of how you might set up a virtualenv environment for managing vendor libraries (you then do not need virtualenv to use those same libraries), and do so in a way where you can check the results into source control. It’s kind of complicated, but works (well, almost works – bin/ files need fixing up). It’s a start at least.

As he noted, the tool support for what he's proposing is spotty, and it's kind of complicated. This patch feels to me like a simpler and more pragmatic solution to the problem of bundling dependencies with an app.

See http://stackoverflow.com/q/12982406/10840
See also issue #328 which appears to have stalled. I believe this patch fixes that issue.
Finally, I believe this addresses the issue mentioned at #397 as well.