### PR TITLE
Enable Python 3.3 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - 2.5
   - 2.6
   - 2.7
-  - 3.1
   - 3.2
+  - 3.3
   - pypy
 before_install:
     - sudo apt-get install subversion bzr mercurial
@@ -16,8 +16,5 @@ notifications:
 branches:
   only:
     - develop
-matrix:
-  allow_failures:
-    - python: 3.1
 env:
   - PIP_USE_MIRRORS=true


### PR DESCRIPTION
Travis CI now supports Python 3.3. But it no longer supports Python 3.1.
