### PR TITLE
revert xdg compliance (#582)

### DIFF
--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -52,7 +52,7 @@ global setting with the same name will be overridden; e.g. decreasing the
 
     [global]
     timeout = 60
-    
+
     [freeze]
     timeout = 10
 
@@ -84,8 +84,8 @@ Location
 The names and locations of the configuration files vary slightly across
 platforms.
 
-On Unix and Mac OS X the configuration file is: 
-:file:`$HOME/.config/pip/pip.conf`
+On Unix and Mac OS X the configuration file is:
+:file:`$HOME/.pip/pip.conf`
 
 And on Windows, the configuration file is: :file:`%HOME%\\pip\\pip.ini`
 

--- a/docs/news.txt
+++ b/docs/news.txt
@@ -53,9 +53,6 @@ develop (unreleased)
 * Added "pip show" command to get information about an installed package.
   Fixes #131. Thanks Kelsey Hightower and Rafael Caricio.
 
-* Moved pip configuration data to ~/.config/pip, the XDG standard for config
-  files on Unix/Linux systems. Thanks Ben Rosser. (Pull #582)
-
 * Added `--root` option for "pip install" to specify root directory. Behaves
   like the same option in distutils but also plays nice with pip's egg-info.
   Thanks Przemek Wrzos.  (Issue #253 / Pull #693)

--- a/pip/locations.py
+++ b/pip/locations.py
@@ -3,7 +3,6 @@
 import sys
 import site
 import os
-import shutil
 import tempfile
 from pip.backwardcompat import get_python_lib
 
@@ -61,29 +60,10 @@ if sys.platform == 'win32':
     default_log_file = os.path.join(default_storage_dir, 'pip.log')
 else:
     bin_py = os.path.join(sys.prefix, 'bin')
-
-    # Use XDG_CONFIG_HOME instead of the ~/.pip
-    # On some systems, we may have to create this, on others it probably exists
-    xdg_dir = os.path.join(user_dir, '.config')
-    xdg_dir = os.environ.get('XDG_CONFIG_HOME', xdg_dir)
-    if not os.path.exists(xdg_dir):
-        os.mkdir(xdg_dir)
-    default_storage_dir = os.path.join(xdg_dir, 'pip')
+    default_storage_dir = os.path.join(user_dir, '.pip')
     default_config_file = os.path.join(default_storage_dir, 'pip.conf')
     default_log_file = os.path.join(default_storage_dir, 'pip.log')
-    
-    # Migration path for users- move things from the old dir if it exists
-    # If the new dir exists and has no pip.conf and the old dir does, move it
-    # When these checks are finished, delete the old directory
-    old_storage_dir = os.path.join(user_dir, '.pip')
-    old_config_file = os.path.join(old_storage_dir, 'pip.conf')
-    if os.path.exists(old_storage_dir):
-        if not os.path.exists(default_storage_dir):
-            shutil.copytree(old_storage_dir, default_storage_dir)
-        elif os.path.exists(old_config_file) and not os.path.exists(default_config_file):
-            shutil.copy2(old_config_file, default_config_file)
-        shutil.rmtree(old_storage_dir)
-    
+
     # Forcing to use /usr/local/bin for standard Mac OS X framework installs
     # Also log to ~/Library/Logs/ for use with the Console.app log viewer
     if sys.platform[:6] == 'darwin' and sys.prefix[:16] == '/System/Library/':


### PR DESCRIPTION
reverting #582 for now, because:
- we were concerned about the automatic migration code being too risky
- ~/.config/pip doesn't make sense on OSX
- general confusion this might cause.
