### PR TITLE
index.txt, news.txt and __init__.py are UTF-8 (see #761)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ from setuptools import setup
 
 
 def read(*parts):
-    return codecs.open(os.path.join(os.path.abspath(os.path.dirname(__file__)), *parts), 'r').read()
+    base = os.path.abspath(os.path.dirname(__file__))
+    return codecs.open(os.path.join(base, *parts), 'r', 'utf8').read()
 
 
 def find_version(*file_paths):


### PR DESCRIPTION
this is needed to use "LC_ALL=C" in py32 tox testing. see #761 for details.
