### PR TITLE
another case for our shutil.rmtree onerror function

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -44,10 +44,10 @@ def rmtree_errorhandler(func, path, exc_info):
     remove them, an exception is thrown.  We catch that here, remove the
     read-only attribute, and hopefully continue without problems."""
     exctype, value = exc_info[:2]
-    # On Python 2.4, it will be OSError number 13
-    # On all more recent Pythons, it'll be WindowsError number 5
-    if not ((exctype is WindowsError and value.args[0] == 5) or
-            (exctype is OSError and value.args[0] == 13)):
+    if not ((exctype is WindowsError and value.args[0] == 5) or #others
+            (exctype is OSError and value.args[0] == 13) or #python2.4
+            (exctype is PermissionError and value.args[3] == 5) #python3.3
+            ):
         raise
     # file type should currently be read only
     if ((os.stat(path).st_mode & stat.S_IREAD) != stat.S_IREAD):


### PR DESCRIPTION
fixes access denied issues in python3.3 on windows during our test setup
see here for errors:  http://jenkins.qwcode.com/job/pip_win_33/4/console
