### PR TITLE
Fixes #772

### DIFF
--- a/pip/baseparser.py
+++ b/pip/baseparser.py
@@ -153,7 +153,7 @@ class ConfigOptionParser(CustomOptionParser):
                     continue
                 # handle multiline configs
                 if option.action == 'append':
-                    val = val.split()
+                    val = val.split() if len(val) > 1 else val
                 else:
                     option.nargs = 1
                 if option.action in ('store_true', 'store_false', 'count'):


### PR DESCRIPTION
This fixes  #772 which makes using PIP_EXISTS_ACTION throw an error.

However I noticed that in the current state pip exists actions are never called 

In download.py this code:

``` python
   if download_dir and not already_downloaded:
        _copy_file(temp_location, download_dir, content_type, link)
```

Prevents `_copy_file` from being called when files are already downloaded and thus
exists actions are not taken into account and shows instead this message:

> File was already downloaded <package>

I was not sure if this is the right behavior for exists_action can someone explain how 
it is supposed to work. I could add a better explanation for this option in the docs. 
