### PR TITLE
Add --install-options and --global-options to requirement parser + refactor

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -2,7 +2,8 @@ import os
 import sys
 import tempfile
 import shutil
-from pip.req import InstallRequirement, RequirementSet, parse_requirements
+from pip.req import InstallRequirement, RequirementSet
+from pip.req_parser import parse_requirements
 from pip.log import logger
 from pip.locations import src_prefix, virtualenv_no_global
 from pip.basecommand import Command

--- a/pip/commands/uninstall.py
+++ b/pip/commands/uninstall.py
@@ -1,4 +1,5 @@
-from pip.req import InstallRequirement, RequirementSet, parse_requirements
+from pip.req import InstallRequirement, RequirementSet
+from pip.req_parser import parse_requirements
 from pip.basecommand import Command
 from pip.exceptions import InstallationError
 

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -7,7 +7,8 @@ from pip.basecommand import Command
 from pip.index import PackageFinder
 from pip.log import logger
 from pip.exceptions import CommandError
-from pip.req import InstallRequirement, RequirementSet, parse_requirements
+from pip.req import InstallRequirement, RequirementSet
+from pip.req_parser import parse_requirements
 from pip.util import normalize_path
 from pip.wheel import WheelBuilder
 from pip import cmdoptions

--- a/pip/req.py
+++ b/pip/req.py
@@ -20,7 +20,7 @@ from pip.util import (display_path, rmtree, ask, ask_path_exists, backup_dir,
                       dist_in_usersite, dist_in_site_packages, renames,
                       normalize_path, egg_link_path, make_path_relative,
                       call_subprocess, is_prerelease)
-from pip.backwardcompat import (urlparse, urllib, uses_pycache,
+from pip.backwardcompat import (urllib, uses_pycache,
                                 ConfigParser, string_types, HTTPError,
                                 get_python_version, b)
 from pip.index import Link
@@ -1339,78 +1339,6 @@ def _write_delete_marker_message(filepath):
 
 
 _scheme_re = re.compile(r'^(http|https|file):', re.I)
-
-
-def parse_requirements(filename, finder=None, comes_from=None, options=None):
-    skip_match = None
-    skip_regex = options.skip_requirements_regex if options else None
-    if skip_regex:
-        skip_match = re.compile(skip_regex)
-    reqs_file_dir = os.path.dirname(os.path.abspath(filename))
-    filename, content = get_file_content(filename, comes_from=comes_from)
-    for line_number, line in enumerate(content.splitlines()):
-        line_number += 1
-        line = line.strip()
-        if not line or line.startswith('#'):
-            continue
-        if skip_match and skip_match.search(line):
-            continue
-        if line.startswith('-r') or line.startswith('--requirement'):
-            if line.startswith('-r'):
-                req_url = line[2:].strip()
-            else:
-                req_url = line[len('--requirement'):].strip().strip('=')
-            if _scheme_re.search(filename):
-                # Relative to a URL
-                req_url = urlparse.urljoin(filename, req_url)
-            elif not _scheme_re.search(req_url):
-                req_url = os.path.join(os.path.dirname(filename), req_url)
-            for item in parse_requirements(req_url, finder, comes_from=filename, options=options):
-                yield item
-        elif line.startswith('-Z') or line.startswith('--always-unzip'):
-            # No longer used, but previously these were used in
-            # requirement files, so we'll ignore.
-            pass
-        elif line.startswith('-f') or line.startswith('--find-links'):
-            if line.startswith('-f'):
-                line = line[2:].strip()
-            else:
-                line = line[len('--find-links'):].strip().lstrip('=')
-            ## FIXME: it would be nice to keep track of the source of
-            ## the find_links:
-            # support a find-links local path relative to a requirements file
-            relative_to_reqs_file = os.path.join(reqs_file_dir, line)
-            if os.path.exists(relative_to_reqs_file):
-                line = relative_to_reqs_file
-            if finder:
-                finder.find_links.append(line)
-        elif line.startswith('-i') or line.startswith('--index-url'):
-            if line.startswith('-i'):
-                line = line[2:].strip()
-            else:
-                line = line[len('--index-url'):].strip().lstrip('=')
-            if finder:
-                finder.index_urls = [line]
-        elif line.startswith('--extra-index-url'):
-            line = line[len('--extra-index-url'):].strip().lstrip('=')
-            if finder:
-                finder.index_urls.append(line)
-        elif line.startswith('--use-wheel'):
-            finder.use_wheel = True
-        elif line.startswith('--no-index'):
-            finder.index_urls = []
-        else:
-            comes_from = '-r %s (line %s)' % (filename, line_number)
-            if line.startswith('-e') or line.startswith('--editable'):
-                if line.startswith('-e'):
-                    line = line[2:].strip()
-                else:
-                    line = line[len('--editable'):].strip().lstrip('=')
-                req = InstallRequirement.from_editable(
-                    line, comes_from=comes_from, default_vcs=options.default_vcs)
-            else:
-                req = InstallRequirement.from_line(line, comes_from, prereleases=getattr(options, "pre", None))
-            yield req
 
 
 def parse_editable(editable_req, default_vcs=None):

--- a/pip/req.py
+++ b/pip/req.py
@@ -39,7 +39,7 @@ PIP_DELETE_MARKER_FILENAME = 'pip-delete-this-directory.txt'
 class InstallRequirement(object):
 
     def __init__(self, req, comes_from, source_dir=None, editable=False,
-                 url=None, as_egg=False, update=True, prereleases=None):
+                 url=None, as_egg=False, update=True, prereleases=None, options=None):
         self.extras = ()
         if isinstance(req, string_types):
             req = pkg_resources.Requirement.parse(req)
@@ -67,6 +67,7 @@ class InstallRequirement(object):
         self.uninstalled = None
         self.use_user_site = False
         self.target_dir = None
+        self.options = options if options else {}
 
         # True if pre-releases are acceptable
         if prereleases:
@@ -92,7 +93,7 @@ class InstallRequirement(object):
         return res
 
     @classmethod
-    def from_line(cls, name, comes_from=None, prereleases=None):
+    def from_line(cls, name, comes_from=None, prereleases=None, options=None):
         """Creates an InstallRequirement from a name, which might be a
         requirement, directory containing 'setup.py', filename, or URL.
         """
@@ -126,7 +127,7 @@ class InstallRequirement(object):
         else:
             req = name
 
-        return cls(req, comes_from, url=url, prereleases=prereleases)
+        return cls(req, comes_from, url=url, prereleases=prereleases, options=options)
 
     def __str__(self):
         if self.req:

--- a/pip/req.py
+++ b/pip/req.py
@@ -585,13 +585,21 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
 
         return cmd % setup_py_path
 
-    def install(self, install_options, global_options=(), root=None):
+    def install(self, install_options, global_options=[], root=None):
         if self.editable:
             self.install_editable(install_options, global_options)
             return
         if self.is_wheel:
             self.move_wheel_files(self.source_dir)
             return
+
+        # Extend the list of global/install options passed on the
+        # command line with the global/install options specified in
+        # requirement files. Options specified in requirement files
+        # override those specified on the command line, since the last
+        # option given to setuptools is the one that will be used.
+        global_options += self.options.get('global_options', [])
+        install_options += self.options.get('install_options', [])
 
         temp_location = tempfile.mkdtemp('-record', 'pip-')
         record_filename = os.path.join(temp_location, 'install-record.txt')

--- a/pip/req_parser.py
+++ b/pip/req_parser.py
@@ -53,7 +53,7 @@ def parse_content(filename, content, finder=None, comes_from=None, options=None)
         if linetype == REQUIREMENT:
             comes_from = '-r %s (line %s)' % (filename, nr)
             req, opts = value
-            yield InstallRequirement.from_line(req, comes_from)
+            yield InstallRequirement.from_line(req, comes_from, options=opts)
 
         if linetype == REQUIREMENT_EDITABLE:
             comes_from = '-r %s (line %s)' % (filename, nr)
@@ -85,6 +85,12 @@ def parse_content(filename, content, finder=None, comes_from=None, options=None)
 def parse_line(line, number, filename, opts=True):
     if not line.startswith('-'):
         opts = get_options(line) if opts else {}
+
+        # make sure that install|global_options are lists
+        for i in ('install_options', 'global_options'):
+            if i in opts:
+                opts[i] = shlex.split(opts[i]) if opts[i] else []
+
         line = line.split('--')[0].strip()
         return REQUIREMENT, (line, opts)
 
@@ -130,7 +136,7 @@ def parse_line(line, number, filename, opts=True):
 
 _option_parser_cache = {}
 def get_options_parser(flags, args):
-    if (flags,args) in _option_parser_cache:
+    if (flags, args) in _option_parser_cache:
         return _option_parser_cache[(flags, args)]
 
     parser = optparse.OptionParser()

--- a/pip/req_parser.py
+++ b/pip/req_parser.py
@@ -1,0 +1,144 @@
+
+"""
+Requirement file constants and parsing functions.
+"""
+
+import os
+import re
+
+from pip.log import logger
+from pip.download import get_file_content
+from pip.req import InstallRequirement
+from pip.backwardcompat import urlparse
+
+
+# The different types of lines understood by the parser
+REQUIREMENT = 0x1
+REQUIREMENT_FILE = 0x2
+REQUIREMENT_EDITABLE = 0x3
+FINDLINKS = 0x4
+INDEXURL = 0x5
+EXTRAINDEXURL = 0x6
+NOINDEX = 0x7
+UNKNOWN = 0xFF
+
+
+def parse_requirements(filename, finder=None, comes_from=None, options=None):
+    '''Parse a requirements file and yield InstallRequirement instances.
+    @param fn: path or url to requirements file.
+    @param finder: pip.index.PackageFinder or None
+    @param comes_from: used as a source for generated InstallRequirements
+    @param options: dictionary of options
+    '''
+    fn, content = get_file_content(filename, comes_from=comes_from)
+    for item in parse_content(filename, content, finder, comes_from, options):
+        yield item
+
+
+def parse_content(filename, content, finder=None, comes_from=None, options=None):
+    content = ignore_comments(content.splitlines())
+    content = join_lines(content)
+    content = (line.strip() for line in content)
+
+    for nr, line in enumerate(content):
+        nr += 1
+
+        linetype, value = parse_line(line, nr, filename)
+
+        if linetype == REQUIREMENT:
+            comes_from = '-r %s (line %s)' % (filename, nr)
+            yield InstallRequirement.from_line(value, comes_from)
+
+        if linetype == REQUIREMENT_EDITABLE:
+            comes_from = '-r %s (line %s)' % (filename, nr)
+            default_vcs = options.default_vcs if options else None
+            yield InstallRequirement.from_editable(value, comes_from, default_vcs)
+
+        if linetype == REQUIREMENT_FILE:
+            parser = parse_requirements(value, finder, filename, options)
+            for item in parser:
+                yield item
+
+        if linetype == FINDLINKS and finder:
+            finder.find_links.append(value)
+
+        if linetype == INDEXURL and finder:
+            finder.index_urls = [value]
+
+        if linetype == EXTRAINDEXURL and finder:
+            finder.index_urls.append(value)
+
+        if linetype == NOINDEX:
+            finder.index_urls = []
+
+        if linetype == UNKNOWN:
+            msg = 'Ignoring unrecognized line at %s:%d: %s'
+            logger.info(msg, filename, nr, value)
+
+
+def parse_line(line, number, filename):
+    if not line.startswith('-'):
+        return REQUIREMENT, line.strip()
+
+    if line.startswith('-e') or line.startswith('--editable'):
+        _, line = re.split(r'[\s=]', line, 1)
+        return REQUIREMENT_EDITABLE, line.strip()
+
+    if line.startswith('-r') or line.startswith('--requirement'):
+        _, req_url = re.split(r'[\s=]', line, 1)
+        if re.search(r'^(http|https|file):', filename, re.I):
+            req_url = urlparse.urljoin(filename, req_url)  # relative to an url
+        else:
+            req_url = os.path.join(os.path.dirname(filename), req_url)
+        return REQUIREMENT_FILE, req_url
+
+    if line.startswith('-f') or line.startswith('--find-links'):
+        _, line = re.split(r'[\s=]', line, 1)
+        # FIXME: it would be nice to keep track of the source of
+        # the find_links: support a find-links local path relative
+        # to a requirements file
+        reqs_file_dir = os.path.dirname(os.path.abspath(filename))
+        relative_to_reqs_file = os.path.join(reqs_file_dir, line)
+        if os.path.exists(relative_to_reqs_file):
+            line = relative_to_reqs_file
+        return FINDLINKS, line
+
+    if line.startswith('-i') or line.startswith('--index-url'):
+        _, line = re.split(r'[\s=]', line, 1)
+        return INDEXURL, line
+
+    if line.startswith('--extra-index-url'):
+        _, line = re.split(r'[\s=]', line, 1)
+        return EXTRAINDEXURL, line
+
+    if line.startswith('--no-index'):
+        return NOINDEX, None
+
+    if line.startswith('-Z') or line.startswith('--always-unzip'):
+        return UNKNOWN, line  # backwards compatibility
+
+    return UNKNOWN, line
+
+
+def join_lines(it):
+    '''Joins a line that end in a '\' with the previous line.'''
+    # TODO: handle '\ '
+    # TODO: handle '\' on last line
+    lines = []
+    for line in it:
+        if not line.endswith('\\'):
+            if lines:
+                lines.append(line)
+                yield ''.join(lines)
+                lines = []
+            else:
+                yield line
+        else:
+            lines.append(line.strip('\\'))
+
+
+def ignore_comments(it):
+    'Filters empty or commented lines.'
+    for line in it:
+        if line and not line.startswith('#'):
+            yield line

--- a/pip/req_parser.py
+++ b/pip/req_parser.py
@@ -152,7 +152,7 @@ def get_options_parser(flags, args):
 def get_options(line, flags=None, args=None):
     '''Parse options and flags from a requirement line. Example:
     >>> get_options('INITools --one --options="--two", ['--one'], ['--options'])
-    {'--two' : True, '--options' : "--two"}'''
+    {'--one' : True, '--options' : "--two"}'''
     args = args if args else requirement_args
     flags = flags if flags else requirement_flags
 
@@ -162,7 +162,7 @@ def get_options(line, flags=None, args=None):
 
 
 def join_lines(it):
-    '''Joins a line that end in a '\' with the previous line.'''
+    '''Joins a line that ends in a '\' with the previous line.'''
     # TODO: handle '\ '
     # TODO: handle '\' on last line
     lines = []

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -204,6 +204,3 @@ def test_url_req_case_mismatch():
     assert egg_folder in result.files_created, str(result)
     egg_folder = env.site_packages / 'Upper-2.0-py%s.egg-info' % pyversion
     assert egg_folder not in result.files_created, str(result)
-
-
-

--- a/tests/test_requirements_parse.py
+++ b/tests/test_requirements_parse.py
@@ -1,0 +1,88 @@
+from textwrap import dedent
+from tempfile import NamedTemporaryFile
+from nose.tools import assert_equal, assert_raises
+
+from pip.req_parser import *
+from pip.index import PackageFinder
+
+
+def test_line_continuations():
+    test = '''\
+    line 1
+    line 2:1 \\
+    line 2:2
+    line 3:1 \\
+     line 3:2 \\
+      line 3:3'''
+
+    expect = ['line 1', 'line 2:1 line 2:2', 'line 3:1  line 3:2   line 3:3']
+    assert expect == list(join_lines(dedent(test).splitlines()))
+
+
+def test_parse_simple_requirement():
+    line = 'INITools==0.2'
+    assert parse_line(line, 0, 't') == (REQUIREMENT, 'INITools==0.2')
+
+    # TODO: replace with next() if support for Py2.5 is dropped
+    ireq = list(parse_content('t', line))[0]
+    assert ireq.name == 'INITools'
+    assert ireq.req.specs == [('==', '0.2')]
+
+
+def test_parse_editable_requirement():
+    lines = ('--editable svn+https://foo#egg=foo',
+             '--editable=svn+https://foo#egg=foo',
+             '-e svn+https://foo#egg=foo')
+
+    res = map_parse(lines)
+    assert res == [(REQUIREMENT_EDITABLE, 'svn+https://foo#egg=foo')] * 3
+
+    ireq = list(parse_content('t', lines[0]))[0]
+    assert ireq.name == 'foo'
+    assert ireq.url == 'svn+https://foo#egg=foo'
+
+
+def test_parse_requirements_include():
+    with NamedTemporaryFile() as fh:
+        lines = ('-r %s' % fh.name,
+                 '--requirement %s' % fh.name,
+                 '--requirement=%s' % fh.name)
+
+        res = map_parse(lines)
+        assert res == [(REQUIREMENT_FILE, fh.name)] * 3
+
+        fh.write('INITools==0.2\ndistribute\n')
+        fh.flush()
+
+        ireq = list(parse_content('t', lines[0]))
+        assert len(ireq) == 2
+        assert (ireq[0].name, ireq[1].name) == ('INITools', 'distribute')
+
+
+def test_parse_find_links():
+    lines = ('-f abc', '--find-links abc', '--find-links=abc')
+    res = map_parse(lines)
+    assert res == [(FINDLINKS, 'abc')] * 3
+
+    finder = PackageFinder([], [])
+    res = list(parse_content('t', lines[0], finder=finder))
+    assert finder.find_links == ['abc']
+
+
+def test_parse_index_url():
+    lines = ('-i abc', '--index-url abc', '--index-url=abc')
+    res = map_parse(lines)
+    assert res == [(INDEXURL, 'abc')] * 3
+
+    line = '--extra-index-url=123'
+    res = parse_line(line, 0, 't')
+    assert res == (EXTRAINDEXURL, '123')
+
+    finder = PackageFinder([], [])
+    res = list(parse_content('t', lines[0], finder=finder))
+    res = list(parse_content('t', line, finder=finder))
+    assert finder.index_urls == ['abc', '123']
+
+
+def map_parse(lines):
+    return list(map(lambda x: parse_line(x, 0, 't'), lines))

--- a/tests/test_requirements_parse.py
+++ b/tests/test_requirements_parse.py
@@ -21,12 +21,20 @@ def test_line_continuations():
 
 def test_parse_simple_requirement():
     line = 'INITools==0.2'
-    assert parse_line(line, 0, 't') == (REQUIREMENT, 'INITools==0.2')
+    res = parse_line(line, 0, 't', opts=False)
+    assert res == (REQUIREMENT, ('INITools==0.2', {}))
 
     # TODO: replace with next() if support for Py2.5 is dropped
     ireq = list(parse_content('t', line))[0]
     assert ireq.name == 'INITools'
     assert ireq.req.specs == [('==', '0.2')]
+
+
+def test_parse_requirement_with_options():
+    line = 'INITools==0.2 --install-options="--prefix=/opt" --global-options="--bindir=/usr/bin"'
+    res = parse_line(line, 0, 't')
+    assert res == (REQUIREMENT, ('INITools==0.2', {'install_options': '--prefix=/opt',
+                                                   'global_options': '--bindir=/usr/bin'}))
 
 
 def test_parse_editable_requirement():
@@ -82,6 +90,19 @@ def test_parse_index_url():
     res = list(parse_content('t', lines[0], finder=finder))
     res = list(parse_content('t', line, finder=finder))
     assert finder.index_urls == ['abc', '123']
+
+
+def test_get_requirement_options():
+    go = get_options
+    opts = go('ign --aflag --bflag', ['--aflag', '--bflag'])
+    assert opts == {'install_options': None, 'aflag': True, 'global_options': None, 'bflag': True}
+
+    opts = go('ign --install-options="--abc --zxc"', [], ['--install-options'])
+    assert opts == {'install_options': '--abc --zxc'}
+
+    opts = go('ign --aflag --global-options="--abc" --install-options="--aflag"',
+              ['--aflag'], ['--install-options', '--global-options'])
+    assert opts == {'install_options': '--aflag', 'aflag': True, 'global_options': '--abc'}
 
 
 def map_parse(lines):


### PR DESCRIPTION
Hi all,

This pull requests adds the functionality requested in #271 and #515. In brief, it allows you to pass `--install-options` and `--global-options` in the requirements file. Example:

```INITools==2.0 --global-options="--help" --install-options="--prefix=/opt"```

I've also completely refactored  `parse_requirements()` and added more tests.

Reviewing by commit might be easier than going to 'Files Changed', imho.