### PR TITLE
Fix docs security

### DIFF
--- a/docs/installing.txt
+++ b/docs/installing.txt
@@ -64,13 +64,13 @@ On a Fedora system, you can install it with::
 Installing on other operating systems
 +++++++++++++++++++++++++++++++++++++
 
-A global install of pip requires either `setuptools <http://pypi.python.org/pypi/setuptools>`_
-or `distribute <http://pypi.python.org/pypi/distribute>`_ to be installed globally as well.
+A global install of pip requires either `setuptools <https://pypi.python.org/pypi/setuptools>`_
+or `distribute <https://pypi.python.org/pypi/distribute>`_ to be installed globally as well.
 
 In many cases, these can be installed using your OS package manager.
 
-See the `Distribute Install Instructions <http://pypi.python.org/pypi/distribute/>`_ or the
-`Setuptools Install Instructions <http://pypi.python.org/pypi/setuptools#installation-instructions>`_
+See the `Distribute Install Instructions <https://pypi.python.org/pypi/distribute/>`_ or the
+`Setuptools Install Instructions <https://pypi.python.org/pypi/setuptools#installation-instructions>`_
 
 .. warning::
 
@@ -86,7 +86,7 @@ and execute it using Python::
 
 or alternatively, you can install the package from sources::
 
- $ curl -O http://pypi.python.org/packages/source/p/pip/pip-X.X.tar.gz
+ $ curl -O https://pypi.python.org/packages/source/p/pip/pip-X.X.tar.gz
  $ tar xvfz pip-X.X.tar.gz
  $ cd pip-X.X
  $ [sudo] python setup.py install


### PR DESCRIPTION
Initial attempt at improving documentation (for issue #800).

The patch already uses SSL for PyPI urls (the official certificate will be deployed in the next few days).

For global install, since on Linux there is a very secure path (using the system package manager), I highlighted this path, and refactored the rest of the doc to be a general "on other operating systems".

For Mac, homebrew docs say that to get pip one should install their Python version, or alternatively use easy_install. I will submit a patch there as well, suggesting to use get-pip.
