### PR TITLE
simpler, local --root test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,7 +12,7 @@ from pip.util import rmtree, find_command
 from pip.exceptions import BadCommand
 
 from tests.test_pip import (here, reset_env, run_pip, pyversion, mkdir,
-                            src_folder, write_file)
+                            src_folder, write_file, path_to_url)
 from tests.local_repos import local_checkout
 from tests.path import Path
 
@@ -497,10 +497,13 @@ def test_install_package_with_root():
     """
     env = reset_env()
     root_dir = env.scratch_path/'root'
-    result = run_pip('install', '--root', root_dir, "--install-option=--home=''",
-                     '--install-option=--install-lib=lib/python', "initools==0.1")
-
-    assert Path('scratch')/'root'/'lib'/'python'/'initools' in result.files_created, str(result)
+    find_links = path_to_url(os.path.join(here, 'packages'))
+    result = run_pip('install', '--root', root_dir, '-f', find_links, '--no-index', 'simple==1.0')
+    normal_install_path = env.root_path / env.site_packages / 'simple-1.0-py%s.egg-info' % pyversion
+    #use distutils to change the root exactly how the --root option does it
+    from distutils.util import change_root
+    root_path = change_root(os.path.join(env.scratch, 'root'), normal_install_path)
+    assert root_path in result.files_created, str(result)
 
 
 def test_find_command_folder_in_path():


### PR DESCRIPTION
the previous one was using --home/--root/--install-lib together at the same.
hard to follow.

also, made the test use a local test package

passes on windows
http://jenkins.qwcode.com/job/pip_win_27/32/console
