### PR TITLE
Add the --pypi option to the show command

### DIFF
--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -3,12 +3,11 @@ import textwrap
 import pkg_resources
 import pip.download
 from pip.basecommand import Command, SUCCESS
-from pip.util import get_terminal_size
+from pip.util import get_terminal_size, highest_version
 from pip.log import logger
-from pip.backwardcompat import xmlrpclib, reduce, cmp
+from pip.backwardcompat import xmlrpclib
 from pip.exceptions import CommandError
 from pip.status_codes import NO_MATCHES_FOUND
-from distutils.version import StrictVersion, LooseVersion
 
 
 class SearchCommand(Command):
@@ -109,22 +108,3 @@ def print_results(hits, name_column_width=25, terminal_width=None):
                     logger.indent -= 2
         except UnicodeEncodeError:
             pass
-
-
-def compare_versions(version1, version2):
-    try:
-        return cmp(StrictVersion(version1), StrictVersion(version2))
-    # in case of abnormal version number, fall back to LooseVersion
-    except ValueError:
-        pass
-    try:
-        return cmp(LooseVersion(version1), LooseVersion(version2))
-    except TypeError:
-    # certain LooseVersion comparions raise due to unorderable types,
-    # fallback to string comparison
-        return cmp([str(v) for v in LooseVersion(version1).version],
-                   [str(v) for v in LooseVersion(version2).version])
-
-
-def highest_version(versions):
-    return reduce((lambda v1, v2: compare_versions(v1, v2) == 1 and v1 or v2), versions)

--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -1,15 +1,23 @@
 import os
+import textwrap
 import pkg_resources
-from pip.basecommand import Command
+import pip.download
+
 from pip.log import logger
+from pip.cmdoptions import index_group, make_option_group, index_url
+from pip.basecommand import Command
+from pip.backwardcompat import xmlrpclib
+from pip.util import uniqify
+from pip.status_codes import NO_MATCHES_FOUND, SUCCESS
 
 
 class ShowCommand(Command):
-    """Show information about one or more installed packages."""
     name = 'show'
     usage = """
       %prog [options] <package> ..."""
-    summary = 'Show information about installed packages.'
+    summary = 'Show information about available packages.'
+    description = """
+      Show information about one or more installed or remote packages."""
 
     def __init__(self, *args, **kw):
         super(ShowCommand, self).__init__(*args, **kw)
@@ -20,19 +28,82 @@ class ShowCommand(Command):
             default=False,
             help='Show the full list of installed files for each package.')
 
+        self.cmd_opts.add_option(
+            '--pypi',
+            dest='use_pypi',
+            action='store_true',
+            help='Query package information from PyPi.')
+
+        index_url.default = 'http://pypi.python.org/pypi'
+        index_group['options'] = [index_url]
+        index_opts = make_option_group(index_group, self.parser)
+
         self.parser.insert_option_group(0, self.cmd_opts)
+        self.parser.insert_option_group(1, index_opts)
 
     def run(self, options, args):
         if not args:
-            logger.warn('ERROR: Please provide a package name or names.')
+            logger.warn('ERROR: Please provide one or more package names.')
             return
-        query = args
 
-        results = search_packages_info(query)
-        print_results(results, options.files)
+        names = uniqify(args, key=str.lower)  # do not process duplicates
+
+        if options.use_pypi:
+            results = search_package_info_pypi(names, options.index_url)
+            results = list(results)
+            if not results:
+                return NO_MATCHES_FOUND
+            print_results_pypi(results)
+        else:
+            results = list(search_packages_info(names))
+            if not results:
+                return NO_MATCHES_FOUND
+            print_results(results, options.files)
+
+        return SUCCESS
 
 
-def search_packages_info(query):
+def search_package_info_pypi(names, index_url):
+    idx = xmlrpclib.ServerProxy(index_url, pip.download.xmlrpclib_transport)
+
+    packages = []
+    for name in names:
+        res = idx.search({'name' : name})
+
+        for i in res:
+            if i['name'].lower() == name.lower():
+                packages.append((i['name'], i['version']))
+
+    for name, version in packages:
+        data = idx.release_data(name, version)
+        info = {
+            'name': name,
+            'version': version,
+            'homepage': data['home_page'],
+            'url': data['package_url'],
+            'author': data['author'],
+            'summary': data['summary'],
+            'description': data['description'], }
+
+        yield info
+
+
+def print_results_pypi(info):
+    fmt = '''\
+    ---
+    Name: %(name)s
+    Version: %(version)s
+    Summary: %(summary)s
+    Author: %(author)s
+    Url: %(url)s
+    Homepage: %(homepage)s\
+    '''
+
+    for item in info:
+        logger.notify(textwrap.dedent(fmt) % item)
+
+
+def search_packages_info(names):
     """
     Gather details from installed distributions. Print distribution name,
     version, location, and installed files. Installed files requires a
@@ -41,7 +112,7 @@ def search_packages_info(query):
     """
     installed_packages = dict(
         [(p.project_name.lower(), p) for p in pkg_resources.working_set])
-    for name in query:
+    for name in names:
         normalized_name = name.lower()
         if normalized_name in installed_packages:
             dist = installed_packages[normalized_name]
@@ -51,10 +122,9 @@ def search_packages_info(query):
                 'location': dist.location,
                 'requires': [dep.project_name for dep in dist.requires()],
             }
-            filelist = os.path.join(
-                       dist.location,
-                       dist.egg_name() + '.egg-info',
-                       'installed-files.txt')
+            filelist = os.path.join(dist.location,
+                                    dist.egg_name() + '.egg-info',
+                                    'installed-files.txt')
             if os.path.isfile(filelist):
                 package['files'] = filelist
             yield package

--- a/pip/util.py
+++ b/pip/util.py
@@ -686,3 +686,17 @@ def compare_versions(version1, version2):
 
 def highest_version(versions):
     return reduce((lambda v1, v2: compare_versions(v1, v2) == 1 and v1 or v2), versions)
+
+
+def uniqify(seq, key=None):
+    "Yield only unique items from sequence."
+    if not key:
+        key = lambda x: x
+
+    seen = set()
+    for item in seq:
+        mark = key(item)
+        if mark in seen:
+            continue
+        seen.add(mark)
+        yield item

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,8 +1,6 @@
 import pip.download
-from pip.commands.search import (compare_versions,
-                                 highest_version,
-                                 transform_hits,
-                                 SearchCommand)
+from pip.util import compare_versions, highest_version
+from pip.commands.search import transform_hits, SearchCommand
 from pip.status_codes import NO_MATCHES_FOUND, SUCCESS
 from pip.backwardcompat import xmlrpclib, b
 from pip.baseparser import create_main_parser

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -57,7 +57,7 @@ def test_missing_argument():
     """
     reset_env()
     result = run_pip('show')
-    assert 'ERROR: Please provide a package name or names.' in result.stdout
+    assert 'ERROR: Please provide one or more package names.' in result.stdout
 
 
 def test_find_package_not_found():

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,7 +1,14 @@
+from __future__ import with_statement
+
 import re
+import contextlib
+import pip.download
+from mock import patch, Mock
 from pip import __version__
-from pip.commands.show import search_packages_info
+from pip.commands.show import search_packages_info, ShowCommand
+from pip.baseparser import create_main_parser
 from tests.test_pip import reset_env, run_pip
+from pip.status_codes import NO_MATCHES_FOUND, SUCCESS
 
 
 def test_show():
@@ -86,3 +93,88 @@ def test_more_than_one_package():
     """
     result = list(search_packages_info(['Pip', 'Nose', 'Virtualenv']))
     assert len(result) == 3
+
+
+initools_release_data = {
+    '_pypi_hidden': False,
+    '_pypi_ordering': 13,
+    'author': 'Ian Bicking',
+    'author_email': 'ianb@colorstudy.com',
+    'bugtrack_url': None,
+    'cheesecake_code_kwalitee_id': None,
+    'cheesecake_documentation_id': None,
+    'cheesecake_installability_id': None,
+    'classifiers': ['Intended Audience :: Developers',
+                    'License :: OSI Approved :: MIT License',
+                    'Topic :: Software Development :: Libraries'],
+    'description': '''\
+A set of tools for parsing and using ``.ini``-style files, including
+an abstract parser and several tools built on that parser.
+
+Repository available at `http://bitbucket.org/ianb/initools
+<http://bitbucket.org/ianb/initools>`_, or `download a tarball
+of the development version
+<http://bitbucket.org/ianb/initools/get/tip.gz#egg=INITools-dev>`_
+using ``easy_install INITools==dev``''',
+    'docs_url': '',
+    'download_url': 'UNKNOWN',
+    'home_page': 'http://pythonpaste.org/initools/',
+    'keywords': 'config parser ini',
+    'license': 'MIT',
+    'maintainer': None,
+    'maintainer_email': None,
+    'name': 'INITools',
+    'package_url': 'http://pypi.python.org/pypi/INITools',
+    'platform': 'UNKNOWN',
+    'release_url': 'http://pypi.python.org/pypi/INITools/0.3.1',
+    'requires_python': None,
+    'stable_version': None,
+    'summary': 'Tools for parsing and using INI-style files',
+    'version': '0.3.1'}
+
+
+initools_search = [
+    {'_pypi_ordering': 9999,
+     'name': 'INITools',
+     'summary': 'Tools for parsing and using INI-style files',
+     'version': '0.3.1'}]
+
+
+def transport_side_effects(*args, **kwargs):
+    name = initools_search[0]['name'].encode('utf-8')
+    if 'search'.encode('utf-8') in args[2]:
+        if re.search(name, args[2], re.I):
+            return (initools_search,)
+        else:
+            return []
+    if 'release_data'.encode('utf-8') in args[2]:
+        if re.search(name, args[2], re.I):
+            return (initools_release_data,)
+
+
+def test_pypi_show():
+    "Test getting package information from PyPi."
+    options = Mock()
+    options.use_pypi = True
+    options.index_url = 'http://pypi.python.org/pypi'
+
+    @contextlib.contextmanager
+    def command():
+        with patch('pip.download.xmlrpclib_transport') as transport:
+            cmd = ShowCommand(create_main_parser())
+            transport.request.side_effect = transport_side_effects
+            yield cmd, transport.request
+
+    with command() as (cmd, request):
+        res = cmd.run(options, ['INITools'])
+        assert res == SUCCESS
+        assert request.call_count == 2
+
+    with command() as (cmd, request):
+        res = cmd.run(options, ['#$@#ASDOASD'])
+        assert res == NO_MATCHES_FOUND
+
+    with command() as (cmd, request):
+        res = cmd.run(options, ['initools', '#$@#ASDOASD', 'INITools'])
+        assert request.call_count == 3  # 2 search() + 1 request_data()
+        assert res == SUCCESS

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,7 @@ import pkg_resources
 from mock import Mock, patch
 from nose.tools import eq_
 from tests.path import Path
-from pip.util import egg_link_path, Inf, get_installed_distributions, dist_is_editable
+from pip.util import egg_link_path, Inf, get_installed_distributions, dist_is_editable, uniqify
 
 
 class Tests_EgglinkPath:
@@ -196,6 +196,8 @@ class Tests_get_installed_distributions:
         assert len(dists) == 3
 
 
-
-
-
+def test_uniqify():
+    assert list(uniqify('123')) == ['1', '2', '3']
+    assert list(uniqify('112223333')) == ['1', '2', '3']
+    assert list(uniqify(['abc', 'zxc', 'AbC', 'ZXC'], str.upper)) == \
+           ['abc', 'zxc']


### PR DESCRIPTION
This pull request extends the show command with functionality for getting package information from PyPi. This was was originally proposed in #485. Usage is follows:

```
$ pip show --pypi ipdb evdev
---
Name: ipdb
Version: 0.7
Summary: IPython-enabled pdb
Author: Godefroid Chapelle
Url: http://pypi.python.org/pypi/ipdb
Homepage: https://github.com/gotcha/ipdb    
---
Name: evdev
Version: 0.3.1
Summary: bindings for the linux input handling subsystem
Author: Georgi Valkov
Url: http://pypi.python.org/pypi/evdev
Homepage: https://github.com/gvalkov/python-evdev
```

I've also made some small changes to the `pip show`'s exit status:

```
$ pip show --pypi ipdb evdev &>/dev/null ; echo $?
0
pip show --pypi non-existant &>/dev/null ; echo $?
23  # status.NO_MATCHES_FOUND
pip show --pypi ipdb non-existant &>/dev/null ; echo $?
0
# same logic applies to pip show ...
```

I couldn't figure out the how to use the mock xmlrcp transport, so I haven't written any unit tests yet. 
 