### PR TITLE
Add the --dependents option to the show command.

### DIFF
--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -45,11 +45,18 @@ def search_packages_info(query):
         normalized_name = name.lower()
         if normalized_name in installed_packages:
             dist = installed_packages[normalized_name]
+
+            required_by = []
+            for _, p in installed_packages.iteritems():
+                if dist.project_name in [dep.project_name for dep in p.requires()]:
+                    required_by += [p.project_name]
+                    
             package = {
                 'name': dist.project_name,
                 'version': dist.version,
                 'location': dist.location,
                 'requires': [dep.project_name for dep in dist.requires()],
+                'required_by': required_by
             }
             filelist = os.path.join(
                        dist.location,
@@ -70,6 +77,7 @@ def print_results(distributions, list_all_files):
         logger.notify("Version: %s" % dist['version'])
         logger.notify("Location: %s" % dist['location'])
         logger.notify("Requires: %s" % ', '.join(dist['requires']))
+        logger.notify("Required by(%d): %s" % (len(dist['required_by']), ', '.join(dist['required_by'])))
         if list_all_files:
             logger.notify("Files:")
             if 'files' in dist:

--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -20,6 +20,13 @@ class ShowCommand(Command):
             default=False,
             help='Show the full list of installed files for each package.')
 
+        self.cmd_opts.add_option(
+            '-d', '--dependents',
+            dest='dependents',
+            action='store_true',
+            default=False,
+            help='Add a list of packages that depend on the passed packages.')
+
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
@@ -29,7 +36,7 @@ class ShowCommand(Command):
         query = args
 
         results = search_packages_info(query)
-        print_results(results, options.files)
+        print_results(results, options.files, options.dependents)
 
 
 def search_packages_info(query):
@@ -67,7 +74,7 @@ def search_packages_info(query):
             yield package
 
 
-def print_results(distributions, list_all_files):
+def print_results(distributions, list_all_files, add_dependents):
     """
     Print the informations from installed distributions found.
     """
@@ -77,7 +84,8 @@ def print_results(distributions, list_all_files):
         logger.notify("Version: %s" % dist['version'])
         logger.notify("Location: %s" % dist['location'])
         logger.notify("Requires: %s" % ', '.join(dist['requires']))
-        logger.notify("Required by(%d): %s" % (len(dist['required_by']), ', '.join(dist['required_by'])))
+        if add_dependents:
+            logger.notify("Required by(%d): %s" % (len(dist['required_by']), ', '.join(dist['required_by'])))
         if list_all_files:
             logger.notify("Files:")
             if 'files' in dist:


### PR DESCRIPTION
The show command should be able to list every installed package that depends on the packages passed as argument. 

```
$ pip show --dependents requests
---
Name: requests
Version: 0.14.2
Location: /path/to/requests/
Requires: 
Required by(1): httpie
```

This may be useful if you're going to uninstall some packages and don't want to break nothing.
