### PR TITLE
Fix unpack directory contains symlinks on py3k

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -380,7 +380,9 @@ def unpack_file_url(link, location):
         # delete the location since shutil will create it again :(
         if os.path.isdir(location):
             rmtree(location)
-        shutil.copytree(source, location)
+        # The py3k version of `shutil.copytree` fails when symlinks point on
+        # directories. So `symlinks` argument must be True
+        shutil.copytree(source, location, symlinks=True)
     else:
         unpack_file(source, location, content_type, link)
 


### PR DESCRIPTION
| Q | A |
| --: | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | yes |
| Fixed tickets | #611 |
| License | MIT |

Hello,

On python3 installation fail when the source directory contains symlinks.
See: https://api.travis-ci.org/jobs/4900020/log.txt?deansi=true

Before apply this fix tests fails on py32 and py33. https://travis-ci.org/alquerci/pip/builds/4980091

Symbolic links are not followed.
