### PR TITLE
Fix build_prefix on osx (swing 2)

### DIFF
--- a/pip/locations.py
+++ b/pip/locations.py
@@ -54,14 +54,15 @@ def _get_build_prefix():
             raise pip.exceptions.InstallationError(msg)
     return path
 
-# Use tempfile to create a temporary folder for build
-# Note: we are NOT using mkdtemp so we can have a consistent build dir
-# Note: using realpath due to tmp dirs on OSX being symlinks
-build_prefix = os.path.abspath(os.path.realpath(_get_build_prefix()))
-
 if running_under_virtualenv():
+    build_prefix = os.path.realpath(os.path.join(sys.prefix, 'build'))
     src_prefix = os.path.join(sys.prefix, 'src')
 else:
+    # Use tempfile to create a temporary folder for build
+    # Note: we are NOT using mkdtemp so we can have a consistent build dir
+    # Note: using realpath due to tmp dirs on OSX being symlinks
+    build_prefix = os.path.realpath(_get_build_prefix())
+
     ## FIXME: keep src in cwd for now (it is not a temporary folder)
     try:
         src_prefix = os.path.join(os.getcwd(), 'src')
@@ -71,6 +72,7 @@ else:
 
 # under Mac OS X + virtualenv sys.prefix is not properly resolved
 # it is something like /path/to/python/bin/..
+build_prefix = os.path.abspath(build_prefix)
 src_prefix = os.path.abspath(src_prefix)
 
 # FIXME doesn't account for venv linked to global site-packages


### PR DESCRIPTION
There was a recent fix (#768) for issue #707 that fixed the brew
install use case, but not the virtualenv use case.  This commit
consolidates the logic.  This was discovered when testing wheel
generation using qwcode's wheel_install branch.

Testing performed (simplejson, numpy 1.7):
- osx lion (using virtualenv)
- osx lion (installed via root)
- ubuntu lucid (using virtualenv)
- ubuntu lucid (installed via root)

Reference:
- https://github.com/pypa/pip/issues/707
- https://github.com/pypa/pip/pull/768
