### PR TITLE
Add --location param to list command

### DIFF
--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -39,6 +39,10 @@ class ListCommand(Command):
             action='store_true',
             default=False,
             help='If in a virtualenv that has global access, do not list globally-installed packages.')
+        cmd_opts.add_option(
+            '--location',
+            default=None,
+            help='Show only packages that are located in specific directory.')
 
         index_opts = make_option_group(index_group, self.parser)
 
@@ -77,7 +81,7 @@ class ListCommand(Command):
             index_urls = []
 
         dependency_links = []
-        for dist in get_installed_distributions(local_only=options.local):
+        for dist in get_installed_distributions(local_only=options.local, location=options.location):
             if dist.has_metadata('dependency_links.txt'):
                 dependency_links.extend(
                     dist.get_metadata_lines('dependency_links.txt'),
@@ -86,7 +90,8 @@ class ListCommand(Command):
         finder = self._build_package_finder(options, index_urls)
         finder.add_dependency_links(dependency_links)
 
-        installed_packages = get_installed_distributions(local_only=options.local, include_editables=False)
+        installed_packages = get_installed_distributions(local_only=options.local,
+            location=options.location, include_editables=False)
         for dist in installed_packages:
             req = InstallRequirement.from_line(dist.key, None)
             try:
@@ -108,11 +113,12 @@ class ListCommand(Command):
             yield dist, remote_version_raw, remote_version_parsed
 
     def run_listing(self, options):
-        installed_packages = get_installed_distributions(local_only=options.local)
+        installed_packages = get_installed_distributions(local_only=options.local, location=options.location)
         self.output_package_listing(installed_packages)
 
     def run_editables(self, options):
-        installed_packages = get_installed_distributions(local_only=options.local, editables_only=True)
+        installed_packages = get_installed_distributions(local_only=options.local,
+            location=options.location, editables_only=True)
         self.output_package_listing(installed_packages)
 
     def output_package_listing(self, installed_packages):

--- a/pip/util.py
+++ b/pip/util.py
@@ -347,10 +347,19 @@ def dist_is_editable(dist):
     req = FrozenRequirement.from_dist(dist, [])
     return req.editable
 
+
+def dist_check_location(dist, location):
+    """
+    Checks if dist location matches provided path
+    """
+    return normalize_path(dist_location(dist)) == normalize_path(location)
+
+
 def get_installed_distributions(local_only=True,
                                 skip=('setuptools', 'pip', 'python'),
                                 include_editables=True,
-                                editables_only=False):
+                                editables_only=False,
+                                location=None):
     """
     Return a list of installed Distribution objects.
 
@@ -381,8 +390,14 @@ def get_installed_distributions(local_only=True,
     else:
         editables_only_test = lambda d: True
 
+    if location:
+        location_test = lambda d, l: dist_check_location(d, l)
+    else:
+        location_test = lambda d, l: True
+
     return [d for d in pkg_resources.working_set
             if local_test(d)
+            and location_test(d, location)
             and d.key not in skip
             and editable_test(d)
             and editables_only_test(d)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import re
 import textwrap
 from tests.test_pip import pyversion, reset_env, run_pip, write_file, path_to_url, here
@@ -68,3 +69,16 @@ def test_editables_flag():
     assert 'simple (1.0)' not in result.stdout, str(result)
     assert os.path.join('src', 'pip-test-package') in result.stdout, str(result)
 
+
+def test_location_flag():
+    """
+    Test the behavior of --location param in the list command
+
+    """
+    reset_env()
+    run_pip('install', '-f', find_links, '--no-index', 'simple==1.0')
+    location = os.path.join(here, 'tests_cache', 'test_ws', '.virtualenv', 'lib',
+        'python%d.%d' % (sys.version_info.major, sys.version_info.minor),
+        'site-packages')
+    result = run_pip('list', '--location', os.path.normcase(os.path.realpath(location)))
+    assert 'simple (1.0)' in result.stdout


### PR DESCRIPTION
This will be helpful for Debian/Ubuntu systems which have two packages location: /usr/lib/pythonx.x/dist-packages for Debian/Ubuntu internal packages and /usr/local/lib/pythonx.x/dist-packages for pip installed packages
