### PR TITLE
Fix remote requirements in Python 3

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -32,7 +32,7 @@ xmlrpclib_transport = xmlrpclib.Transport()
 
 def get_file_content(url, comes_from=None):
     """Gets the content of a file; it may be a filename, file: URL, or
-    http: URL.  Returns (location, content)"""
+    http: URL.  Returns (location, content).  Content is unicode."""
     match = _scheme_re.search(url)
     if match:
         scheme = match.group(1).lower()
@@ -54,7 +54,13 @@ def get_file_content(url, comes_from=None):
         else:
             ## FIXME: catch some errors
             resp = urlopen(url)
-            return geturl(resp), resp.read()
+            try:
+                encoding = resp.headers.get_param('charset', 'utf8')
+            except AttributeError:
+                encoding = resp.headers.getparam('charset')
+                if encoding is None:
+                    encoding = 'utf8'
+            return geturl(resp), resp.read().decode(encoding)
     try:
         f = open(url)
         content = f.read()

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -29,6 +29,17 @@ def test_requirements_file():
     assert result.files_created[env.site_packages/fn].dir
 
 
+def test_remote_reqs():
+    """
+    Test installing from a remote requirements file.
+    """
+    env = reset_env()
+    result = run_pip(
+        'install', '--download', env.scratch_path, '-r',
+        'https://raw.github.com/pypa/pip-test-package/master/requirements.txt')
+    assert result.files_created, result.files_created
+
+
 def test_schema_check_in_requirements_file():
     """
     Test installing from a requirements file with an invalid vcs schema..


### PR DESCRIPTION
This was issue #760.
Also add a test (the exact url depends on pulling pypa/pip-test-package#2).
