### PR TITLE
arguments to freeze are used to filter  installed packages

### DIFF
--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -69,9 +69,16 @@ class FreezeCommand(Command):
         for link in find_links:
             f.write('-f %s\n' % link)
         installations = {}
+        args_low = [arg.lower() for arg in args]
         for dist in get_installed_distributions(local_only=local_only):
             req = pip.FrozenRequirement.from_dist(dist, dependency_links, find_tags=find_tags)
-            installations[req.name] = req
+            if args:
+                for arg in args_low:
+                    if arg in req.name.lower():
+                        installations[req.name] = req
+                        break
+            else:
+                installations[req.name] = req
         if requirement:
             req_f = open(requirement)
             for line in req_f:


### PR DESCRIPTION
Any arguments to the freeze command used to be discarded. That makes freeze less useful in finding which versions of a few specific packages you have installed, especially if the list is long.

This change makes pip freeze only output that have an argument as part of the package name so you can do:
     pip freeze xl pymongo
and get 
    openpyxl==1.6.1
    pymongo==2.5
    xlrd==0.9.0
    xlutils==1.5.2
    xlwt==0.7.4
and not a list of 158 packages. The comparison is done lowercase.

You can of course pipe the output of pip freeze through fgrep , but especially when trying to select multiple patterns in one go, that is not trivial.
