### PR TITLE
fix distlib import error  (DO NOT MERGE)

### DIFF
--- a/pip/vendor/distlib/wheel.py
+++ b/pip/vendor/distlib/wheel.py
@@ -21,8 +21,7 @@ import sys
 import tempfile
 import zipfile
 
-import distlib
-from . import DistlibException
+from . import __version__, DistlibException
 from .compat import sysconfig, ZipFile, fsdecode, text_type
 from .database import DistributionPath, InstalledDistribution
 from .scripts import ScriptMaker
@@ -305,7 +304,7 @@ class Wheel(object):
 
         wheel_metadata = [
             'Wheel-Version: %d.%d' % self.wheel_version,
-            'Generator: distlib %s' % distlib.__version__,
+            'Generator: distlib %s' % __version__,
             'Root-Is-Purelib: %s' % is_pure,
         ]
         for pyver, abi, arch in self.tags:


### PR DESCRIPTION
Reproduce import bug:

```
>>> from pip.vendor.distlib.locators import get_all_distribution_names
  import pkg_resources
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named vendor.distlib.locators
```
