### PR TITLE
Assume versions are a pre-release if we cannot parse them

### DIFF
--- a/docs/logic.rst
+++ b/docs/logic.rst
@@ -64,7 +64,7 @@ Pre-release Versions
 
 Starting with v1.4, pip will only install stable versions as specified by `PEP426`_ by default. If
 a version cannot be parsed as a compliant `PEP426`_ version then it is assumed
-to be stable.
+to be a pre-release.
 
 If a Requirement specifier includes a pre-release or development version (e.g. ``>=0.0.dev0``) then
 pip will allow pre-release and development versions for that requirement. This does not include

--- a/pip/util.py
+++ b/pip/util.py
@@ -680,14 +680,14 @@ def is_prerelease(vers):
     """
     Attempt to determine if this is a pre-release using PEP386/PEP426 rules.
 
-    Will return True if it is a pre-release, False is not, and None if we cannot
-    determine.
+    Will return True if it is a pre-release and False if not. Versions are
+    assumed to be a pre-release if they cannot be parsed.
     """
     normalized = version.suggest_normalized_version(vers)
 
     if normalized is None:
-        # Cannot normalize
-        return
+        # Cannot normalize, assume it is a pre-release
+        return True
 
     parsed = version.normalized_key(normalized)
     return any([any([y in set(["a", "b", "c", "rc", "dev"]) for y in x]) for x in parsed])


### PR DESCRIPTION
The most likely unparseable version is something like "dev" or "py6-dev" etc. The number of sane version numbers that are not normalizable and should be conisdered stable are fairly low.
