### PR TITLE
Display hashdigest instead of hash object upon failure.

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -447,7 +447,7 @@ def _check_hash(download_hash, link):
         raise InstallationError('Hash name mismatch for package %s' % link)
     if download_hash.hexdigest() != link.hash:
         logger.fatal("Hash of the package %s (%s) doesn't match the expected hash %s!"
-                     % (link, download_hash, link.hash))
+                     % (link, download_hash.hexdigest(), link.hash))
         raise InstallationError('Bad %s hash for package %s' % (link.hash_name, link))
 
 


### PR DESCRIPTION
I noticed that when an md5 has failure occurs, it shows the hash object reference instead of the hex digest. This is a simple fix to display the actual hex digest for visual comparison.

```
[localhost] out: Downloading/unpacking sqlalchemy==0.8.0 (from zql==0.1.6)
[localhost] out:   Downloading SQLAlchemy-0.8.0.tar.gz (3.8MB): 1.3MB downloaded
[localhost] out:   Hash of the package https://pypi.python.org/packages/source/S/SQLAlchemy/SQLAlchemy-0.8.0.tar.gz#md5=11cd07ca81fab78d53f2922b5fb187a3 (from https://pypi.python.org/simple/SQLAlchemy/) (<md5 HASH object @ 0x287d260>) doesn't match the expected hash 11cd07ca81fab78d53f2922b5fb187a3!
[localhost] out: Bad md5 hash for package https://pypi.python.org/packages/source/S/SQLAlchemy/SQLAlchemy-0.8.0.tar.gz#md5=11cd07ca81fab78d53f2922b5fb187a3 (from https://pypi.python.org/simple/SQLAlchemy/)
[localhost] out: Storing complete log in /home/josh/.pip/pip.log
```
