### PR TITLE
Fix issue #219: I/O operation on closed file exception with --log

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -94,6 +94,7 @@ class Command(object):
         level -= options.quiet
         level = logger.level_for_integer(4 - level)
         complete_log = []
+        initial_logger_consumers = logger.consumers[::] # copy
         logger.consumers.extend(
             [(level, sys.stdout),
              (logger.DEBUG, complete_log.append)])
@@ -167,20 +168,21 @@ class Command(object):
             logger.fatal('Exception:\n%s' % format_exc())
             store_log = True
             exit = UNKNOWN_ERROR
-        if log_fp is not None:
-            log_fp.close()
         if store_log:
             log_fn = options.log_file
             text = '\n'.join(complete_log)
             try:
-                log_fp = open_logfile(log_fn, 'w')
+                log_file_fp = open_logfile(log_fn, 'w')
             except IOError:
                 temp = tempfile.NamedTemporaryFile(delete=False)
                 log_fn = temp.name
-                log_fp = open_logfile(log_fn, 'w')
+                log_file_fp = open_logfile(log_fn, 'w')
             logger.fatal('Storing complete log in %s' % log_fn)
-            log_fp.write(text)
+            log_file_fp.write(text)
+            log_file_fp.close()
+        if options.log:
             log_fp.close()
+        logger.consumers = initial_logger_consumers
         return exit
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+from pip.baseparser import create_main_parser
+from pip.basecommand import Command
+
+
+class FakeCommand(Command):
+    name = "fake"
+
+    def run(self, options, args):
+        # raise an error to trigger --log-file writing
+        raise Exception("testing")
+
+
+def test_should_accept_custom_log_location():
+    """Test custom log location through --log
+    """
+    log_path = tempfile.mktemp()
+    parser = create_main_parser()
+    options, args = parser.parse_args(["fake", "--log", log_path])
+
+    cmd = FakeCommand(parser)
+    cmd.main(args, options)
+
+    assert os.path.exists(log_path)
+    os.remove(log_path)


### PR DESCRIPTION
fix for #219 

`log_fp` was closed and then used, and `log_fp` name was reused and that makes some confusion.

I mentioned side effects on issue #917, and that explain why `logger.consumers = initial_logger_consumers` exists.
