### PR TITLE
Incorrect operation sequence in bzr-handling code

### DIFF
--- a/pip/vcs/bazaar.py
+++ b/pip/vcs/bazaar.py
@@ -112,11 +112,11 @@ class Bazaar(VersionControl):
 
     def get_src_requirement(self, dist, location, find_tags):
         repo = self.get_url(location)
+        if not repo:
+            return None
         if not repo.lower().startswith('bzr:'):
             repo = 'bzr+' + repo
         egg_project_name = dist.egg_name().split('-', 1)[0]
-        if not repo:
-            return None
         current_rev = self.get_revision(location)
         tag_revs = self.get_tag_revs(location)
 


### PR DESCRIPTION
In get_src_requirement, the test to see if repo was valid was happening after a method was being called on it, which gave me some problems when pip went digging around one of my projects which was in bzr but lacked a remote repo.
