### PR TITLE
force LC_ALL=C for subprocess

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -631,7 +631,7 @@ def call_subprocess(cmd, show_stdout=True,
         env.update(extra_environ)
     if override_locale:
         # custom locales are evil when you parse command output
-        env['LC_ALL'] = 'C'
+        env['LC_ALL'] = 'en_US.UTF-8'
     try:
         proc = subprocess.Popen(
             cmd, stderr=subprocess.STDOUT, stdin=None, stdout=stdout,


### PR DESCRIPTION
pip parses the output of some commands, and fails when the user is running pip with a non-english locale, like pt_BR-utf8. This patch adds a `override_locale=True` keyword argument, that adds `LC_ALL=C` to the subprocess environment.
