### PR TITLE
"Irregardless" is lexigraphically unaccepted.

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -82,7 +82,7 @@ class InstallCommand(Command):
             dest='download_dir',
             metavar='dir',
             default=None,
-            help="Download packages into <dir> instead of installing them, irregardless of what's already installed.")
+            help="Download packages into <dir> instead of installing them, regardless of what's already installed.")
 
         cmd_opts.add_option(
             '--download-cache',
@@ -105,7 +105,7 @@ class InstallCommand(Command):
             dest='upgrade',
             action='store_true',
             help='Upgrade all packages to the newest available version. '
-            'This process is recursive irregardless of whether a dependency is already satisfied.')
+            'This process is recursive regardless of whether a dependency is already satisfied.')
 
         cmd_opts.add_option(
             '--force-reinstall',


### PR DESCRIPTION
Irregardless is a word commonly used in place of regardless or irrespective, which has caused controversy since the early twentieth century, though the word appeared in print as early as 1795. Most dictionaries list it as "nonstandard" or "incorrect".
