### PR TITLE
Fixed 2 problems on Jython and older POSIX environments

### DIFF
--- a/pip/locations.py
+++ b/pip/locations.py
@@ -61,9 +61,10 @@ def _get_build_prefix():
     except OSError:
         file_uid = None
         try:
-            fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
-            file_uid = os.fstat(fd).st_uid
-            os.close(fd)
+            if not os.path.islink(path):
+                # Use `os.stat()` instead of `os.fstat()` since Jython 2.5 lacks `os.fstat()`
+                # http://bugs.jython.org/issue1736
+                file_uid = os.stat(path).st_uid
         except OSError:
             file_uid = None
         if file_uid != os.getuid():


### PR DESCRIPTION
Fixed 2 problems on Jython and older POSIX environments. This is a patch for #849.
1. Stop using `os.O_NOFOLLOW` since it might not exist if the platform is not GNU or POSIX prior to 2008.
2. Jython 2.5.x/2.7.x cannot handle directories by `os.open()`
