### PR TITLE
Updated pip.locations.running_under_virtualenv for pyvenv.

### DIFF
--- a/pip/locations.py
+++ b/pip/locations.py
@@ -16,8 +16,8 @@ def running_under_virtualenv():
     Return True if we're running inside a virtualenv, False otherwise.
 
     """
-    return hasattr(sys, 'real_prefix')
-
+    return (hasattr(sys, 'real_prefix') or
+            (hasattr(sys, 'base_prefix') and sys.prefix != sys.base_prefix))
 
 def virtualenv_no_global():
     """


### PR DESCRIPTION
Because a virtual environment created by pyvenv doesn't have sys.real_prefix, 
running_under_virtualenv function should return True when sys.base_prefix exists and differs from sys.prefix.
