### PR TITLE
write pip delete marker into global build dir upon creation

### DIFF
--- a/pip/locations.py
+++ b/pip/locations.py
@@ -11,6 +11,25 @@ import pip.exceptions
 
 default_cert_path = os.path.join(os.path.dirname(__file__), 'cacert.pem')
 
+DELETE_MARKER_MESSAGE = '''\
+This file is placed here by pip to indicate the source was put
+here by pip.
+
+Once this package is successfully installed this source code will be
+deleted (unless you remove this file).
+'''
+PIP_DELETE_MARKER_FILENAME = 'pip-delete-this-directory.txt'
+
+def write_delete_marker_file(directory):
+    """
+    Write the pip delete marker file into this directory.
+    """
+    filepath = os.path.join(directory, PIP_DELETE_MARKER_FILENAME)
+    marker_fp = open(filepath, 'w')
+    marker_fp.write(DELETE_MARKER_MESSAGE)
+    marker_fp.close()
+
+
 def running_under_virtualenv():
     """
     Return True if we're running inside a virtualenv, False otherwise.
@@ -38,6 +57,7 @@ def _get_build_prefix():
         return path
     try:
         os.mkdir(path)
+        write_delete_marker_file(path)
     except OSError:
         file_uid = None
         try:

--- a/pip/req.py
+++ b/pip/req.py
@@ -10,7 +10,8 @@ import textwrap
 import zipfile
 
 from distutils.util import change_root
-from pip.locations import bin_py, running_under_virtualenv
+from pip.locations import (bin_py, running_under_virtualenv,PIP_DELETE_MARKER_FILENAME,
+                           write_delete_marker_file)
 from pip.exceptions import (InstallationError, UninstallationError,
                             BestVersionAlreadyInstalled,
                             DistributionNotFound, PreviousBuildDirError)
@@ -32,10 +33,6 @@ from pip.download import (get_file_content, is_url, url_to_path,
                           unpack_file_url, unpack_http_url)
 import pip.wheel
 from pip.wheel import move_wheel_files
-
-
-PIP_DELETE_MARKER_FILENAME = 'pip-delete-this-directory.txt'
-
 
 class InstallRequirement(object):
 
@@ -801,15 +798,6 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
         return os.path.join(self.source_dir, PIP_DELETE_MARKER_FILENAME)
 
 
-DELETE_MARKER_MESSAGE = '''\
-This file is placed here by pip to indicate the source was put
-here by pip.
-
-Once this package is successfully installed this source code will be
-deleted (unless you remove this file).
-'''
-
-
 class Requirements(object):
 
     def __init__(self):
@@ -1220,7 +1208,7 @@ class RequirementSet(object):
                 self.download_cache = os.path.expanduser(self.download_cache)
             retval = unpack_http_url(link, location, self.download_cache, self.download_dir)
             if only_download:
-                _write_delete_marker_message(os.path.join(location, PIP_DELETE_MARKER_FILENAME))
+                write_delete_marker_file(location)
             return retval
 
     def install(self, install_options, global_options=(), *args, **kwargs):
@@ -1335,13 +1323,7 @@ class RequirementSet(object):
 
 def _make_build_dir(build_dir):
     os.makedirs(build_dir)
-    _write_delete_marker_message(os.path.join(build_dir, PIP_DELETE_MARKER_FILENAME))
-
-
-def _write_delete_marker_message(filepath):
-    marker_fp = open(filepath, 'w')
-    marker_fp.write(DELETE_MARKER_MESSAGE)
-    marker_fp.close()
+    write_delete_marker_file(build_dir)
 
 
 _scheme_re = re.compile(r'^(http|https|file):', re.I)


### PR DESCRIPTION
a "partial" fix for #939.

this change writes the pip delete marker into the global build dir upon creation, so it can be removed during the cleanup step.

this change is _not_ helpful if the user already has the global build dir, which will be most pre-existing users.  so, this fix is not so exciting.
#906 (in milestone 1.5), intends to handle this better by moving to mkdtemp build dirs in all cases.
