### PR TITLE
Fix unpack_http_url for already downloaded files

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -566,7 +566,7 @@ def unpack_http_url(link, location, download_cache, download_dir=None):
         logger.notify('Using download cache from %s' % target_file)
     elif already_downloaded:
         temp_location = already_downloaded
-        content_type = mimetypes.guess_type(already_downloaded)
+        content_type = mimetypes.guess_type(already_downloaded)[0]
         if link.hash:
             download_hash = _get_hash_from_file(temp_location, link)
         logger.notify('File was already downloaded %s' % already_downloaded)


### PR DESCRIPTION
mimetypes.guess_type returns a tuple (type, encoding),
so, use element number 0 as content_type.

Otherwise, TypeError is raised in cache_download
(cannot write a tuple to file).
