### PR TITLE
fix a bug for git 1.8.3

### DIFF
--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -142,7 +142,7 @@ class Git(VersionControl):
         branches = self._get_all_branch_names(location)
         branch_revs = {}
         for line in branches.splitlines():
-            if '(no branch)' in line:
+            if '(no branch)' in line or '(detached from ' in line:
                 continue
             line = line.split('->')[0].strip()
             # actual branch case


### PR DESCRIPTION
in git 1.8.3 the default branch name is "detached from REVISION" when you `git checkout -q <REVISION>`

if doesn't skip it then `git rev-parse ...` will raise a error while invoking Git._get_revision_from_rev_parse method.
