### PR TITLE
Add Python 3 support to standalone scripts

### DIFF
--- a/contrib/build-installer
+++ b/contrib/build-installer
@@ -29,8 +29,8 @@ def main():
         f.close()
     sys.stdout.write('done.\n')
     if hasattr(os, 'chmod'):
-        oldmode = os.stat(file_name).st_mode & 07777
-        newmode = (oldmode | 0555) & 07777
+        oldmode = os.stat(file_name).st_mode & 0o7777
+        newmode = (oldmode | 0o555) & 0o7777
         os.chmod(file_name, newmode)
         sys.stdout.write('Made resulting file %s executable.\n\n' % file_name)
 

--- a/contrib/build-standalone
+++ b/contrib/build-standalone
@@ -29,8 +29,8 @@ def main():
         f.close()
     sys.stdout.write('done.\n')
     if hasattr(os, 'chmod'):
-        oldmode = os.stat(file_name).st_mode & 07777
-        newmode = (oldmode | 0555) & 07777
+        oldmode = os.stat(file_name).st_mode & 0o7777
+        newmode = (oldmode | 0o555) & 0o7777
         os.chmod(file_name, newmode)
         sys.stdout.write('Made resulting file %s executable.\n\n' % file_name)
 

--- a/contrib/packager/__init__.py
+++ b/contrib/packager/__init__.py
@@ -6,6 +6,7 @@ import pickle
 import bz2
 import base64
 import os
+import quopri
 
 
 def find_toplevel(name):
@@ -36,7 +37,8 @@ def pkg_to_mapping(name):
                 pkg = pkgname(name, toplevel, os.path.join(root, pyfile))
                 f = open(os.path.join(root, pyfile))
                 try:
-                    name2src[pkg] = f.read().encode('quoted-printable')
+                    name2src[pkg] = quopri.encodestring(
+                        f.read().encode('utf-8'))
                 finally:
                     f.close()
     return name2src


### PR DESCRIPTION
Earlier (in #969), I noticed that these did not support Python 3.
