### PR TITLE
Drop the license for pip/cacert.pem

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -18,22 +18,3 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-License for Bundle of CA Root Certificates (pip/cacert.pem)
-===========================================================
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-02110-1301


### PR DESCRIPTION
While packaging pip 1.3.1 for Debian, I was surprised to find the CA certificate bundle listed as being licensed under LGPL2.1.

IANAL, but I fail to see how CA certificates (which are essentially factual information combined with large numbers) have any creative content which would be protected by Copyright. I suggest we drop this.

I dug around and saw that other people seem to [agree with this position](http://bugs.debian.org/687693#49).

On the other hand, If we _really do_ believe that there is some reason that this license has any effect, then there should be a copyright owner listed as well as a license.
