### PR TITLE
Fixes test requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ long_description = "\n" + "\n".join([
         read('docs', 'quickstart.rst'),
         read('CHANGES.txt')])
 
-tests_require = ['nose', 'virtualenv>=1.7', 'scripttest>=1.1.1', 'mock']
+tests_require = ['nose>=1.3.0', 'virtualenv>=1.7', 'scripttest>=1.1.1', 'mock',
+                 'distribute>=0.6.34']
 
 setup(name="pip",
       version=find_version('pip', '__init__.py'),


### PR DESCRIPTION
I had an old nose that broke a lot of tests. I didn't bisect the precise version needed. 1.3.0 is the current one that works.
distribute>=0.6.34 was needed to make wheel tests pass
