### PR TITLE
Allow editable packages to explicitly include a blank password for svn

### DIFF
--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -264,7 +264,7 @@ def get_rev_options(url, rev):
 
     if username:
         rev_options += ['--username', username]
-    if password:
+    if password is not None:
         rev_options += ['--password', password]
     return rev_options
 

--- a/tests/functional/test_install_vcs_svn.py
+++ b/tests/functional/test_install_vcs_svn.py
@@ -21,3 +21,21 @@ def test_export_should_recognize_auth_info_in_url(call_subprocess_mock):
     assert call_subprocess_mock.call_args[0] == ([
         svn.cmd, 'export', '--username', 'username', '--password', 'password',
         'http://username:password@svn.example.com/', env.scratch_path/'test'],)
+
+@patch('pip.vcs.subversion.call_subprocess')
+def test_update_should_allow_explicit_empty_password(call_subprocess_mock):
+    env = reset_env()
+    svn = Subversion(url='svn+http://username:@svn.example.com/')
+    svn.export(env.scratch_path/'test')
+    assert call_subprocess_mock.call_args[0] == ([
+        svn.cmd, 'export', '--username', 'username', '--password', '',
+        'http://username:@svn.example.com/', env.scratch_path/'test'],)
+
+@patch('pip.vcs.subversion.call_subprocess')
+def test_update_should_skip_implicit_empty_password(call_subprocess_mock):
+    env = reset_env()
+    svn = Subversion(url='svn+http://username@svn.example.com/')
+    svn.export(env.scratch_path/'test')
+    assert call_subprocess_mock.call_args[0] == ([
+        svn.cmd, 'export', '--username', 'username',
+        'http://username@svn.example.com/', env.scratch_path/'test'],)


### PR DESCRIPTION
For example, with these:

    -e svn+http://user@repo/path
    -e svn+http://user:@repo/path
    -e svn+http://user:pass@repo/path

The first and third forms were working as expected (ask for a password, and use "pass"), however the middle one wasn't.  This is perfectly valid with svn, but wasn't possible with pip before:

    svn update --username user --password ''

Useful for automated deployments, with an svn user that isn't allowed to commit.