### PR TITLE
Add os.path.expanduser call to normalize_path.

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -272,7 +272,7 @@ def normalize_path(path):
     Convert a path to its canonical, case-normalized, absolute version.
 
     """
-    return os.path.normcase(os.path.realpath(path))
+    return os.path.normcase(os.path.realpath(os.path.expanduser(path)))
 
 
 def splitext(path):


### PR DESCRIPTION
realpath by itself won't expand tildes, which could lead to things like:

pip wheel --wheel-path=~/wheels -r requirements.txt

Producing:

Destination directory: /home/foo/src/dir/~/wheels

Which is pretty much never what you wanted.
