### PR TITLE
Fixes #1038 --pre flag should affect the finder and not the requirements

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -166,6 +166,7 @@ class InstallCommand(Command):
                              allow_insecure=options.allow_insecure,
                              allow_all_external=options.allow_all_external,
                              allow_all_insecure=options.allow_all_insecure,
+                             allow_all_prereleases=options.pre,
                             )
 
     def run(self, options, args):
@@ -211,7 +212,7 @@ class InstallCommand(Command):
             target_dir=temp_target_dir)
         for name in args:
             requirement_set.add_requirement(
-                InstallRequirement.from_line(name, None, prereleases=options.pre))
+                InstallRequirement.from_line(name, None))
         for name in options.editables:
             requirement_set.add_requirement(
                 InstallRequirement.from_editable(name, default_vcs=options.default_vcs))

--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -66,6 +66,7 @@ class ListCommand(Command):
                              allow_insecure=options.allow_insecure,
                              allow_all_external=options.allow_all_external,
                              allow_all_insecure=options.allow_all_insecure,
+                             allow_all_prereleases=options.pre,
                         )
 
     def run(self, options, args):
@@ -102,7 +103,7 @@ class ListCommand(Command):
 
         installed_packages = get_installed_distributions(local_only=options.local, include_editables=False, skip=self.skip)
         for dist in installed_packages:
-            req = InstallRequirement.from_line(dist.key, None, prereleases=options.pre)
+            req = InstallRequirement.from_line(dist.key, None)
             try:
                 link = finder.find_requirement(req, True)
 

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -105,6 +105,7 @@ class WheelCommand(Command):
                                allow_insecure=options.allow_insecure,
                                allow_all_external=options.allow_all_external,
                                allow_all_insecure=options.allow_all_insecure,
+                               allow_all_prereleases=options.pre,
                             )
 
         options.build_dir = os.path.abspath(options.build_dir)
@@ -122,7 +123,7 @@ class WheelCommand(Command):
                 logger.notify("ignoring %s" % name)
                 continue
             requirement_set.add_requirement(
-                InstallRequirement.from_line(name, None, prereleases=options.pre))
+                InstallRequirement.from_line(name, None))
 
         for filename in options.requirements:
             for req in parse_requirements(filename, finder=finder, options=options):


### PR DESCRIPTION
Storing the --pre flag on the finder enables easily being able
to have it affect all package discoveries made with that finder.
The previous method of passing it into the InstallRequirement
meant that only top level dependencies were controlled by
--pre

This fixes #1038.
