### PR TITLE
Handle multiple requirements for one package

### DIFF
--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -169,6 +169,12 @@ no_clean = make_option(
     default=False,
     help="Don't clean up build directories.")
 
+ignore_incompatibles = make_option(
+    '--ignore-incompatibles',
+    action='store_true',
+    default=False,
+    help="Ignore the incompatible requirements to the same package.")
+
 
 ##########
 # groups #

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -145,6 +145,7 @@ class InstallCommand(Command):
             help="Include pre-release and development versions. By default, pip only finds stable versions.")
 
         cmd_opts.add_option(cmdoptions.no_clean)
+        cmd_opts.add_option(cmdoptions.ignore_incompatibles)
 
         index_opts = cmdoptions.make_option_group(cmdoptions.index_group, self.parser)
 
@@ -219,7 +220,8 @@ class InstallCommand(Command):
             ignore_dependencies=options.ignore_dependencies,
             force_reinstall=options.force_reinstall,
             use_user_site=options.use_user_site,
-            target_dir=temp_target_dir)
+            target_dir=temp_target_dir,
+            ignore_incompatibles=options.ignore_incompatibles)
         for name in args:
             requirement_set.add_requirement(
                 InstallRequirement.from_line(name, None))
@@ -240,6 +242,7 @@ class InstallCommand(Command):
                        'to %(name)s (see "pip help %(name)s")' % opts)
             logger.warn(msg)
             return
+        requirement_set.process_multiple_requirements()
 
         try:
             if not options.no_download:

--- a/pip/commands/uninstall.py
+++ b/pip/commands/uninstall.py
@@ -1,6 +1,7 @@
 from pip.req import InstallRequirement, RequirementSet, parse_requirements
 from pip.basecommand import Command
 from pip.exceptions import InstallationError
+from pip import cmdoptions
 
 
 class UninstallCommand(Command):
@@ -34,6 +35,7 @@ class UninstallCommand(Command):
             dest='yes',
             action='store_true',
             help="Don't ask for confirmation of uninstall deletions.")
+        self.cmd_opts.add_option(cmdoptions.ignore_incompatibles)
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -41,7 +43,8 @@ class UninstallCommand(Command):
         requirement_set = RequirementSet(
             build_dir=None,
             src_dir=None,
-            download_dir=None)
+            download_dir=None,
+            ignore_incompatibles=options.ignore_incompatibles)
         for name in args:
             requirement_set.add_requirement(
                 InstallRequirement.from_line(name))
@@ -51,4 +54,5 @@ class UninstallCommand(Command):
         if not requirement_set.has_requirements:
             raise InstallationError('You must give at least one requirement '
                 'to %(name)s (see "pip help %(name)s")' % dict(name=self.name))
+        requirement_set.process_multiple_requirements()
         requirement_set.uninstall(auto_confirm=options.yes)

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -75,6 +75,7 @@ class WheelCommand(Command):
             help="Include pre-release and development versions. By default, pip only finds stable versions.")
 
         cmd_opts.add_option(cmdoptions.no_clean)
+        cmd_opts.add_option(cmdoptions.ignore_incompatibles)
 
         index_opts = cmdoptions.make_option_group(cmdoptions.index_group, self.parser)
 
@@ -125,7 +126,8 @@ class WheelCommand(Command):
             download_dir=None,
             download_cache=options.download_cache,
             ignore_dependencies=options.ignore_dependencies,
-            ignore_installed=True)
+            ignore_installed=True,
+            ignore_incompatibles=options.ignore_incompatibles)
 
         #parse args and/or requirements files
         for name in args:
@@ -149,6 +151,7 @@ class WheelCommand(Command):
                    'to %(name)s (see "pip help %(name)s")' % opts)
             logger.error(msg)
             return
+        requirement_set.process_multiple_requirements()
 
         try:
             #build wheels


### PR DESCRIPTION
Sometimes a developer needs to install dependencies for several packages, and each of them has its own requirements.txt file. A good example can be OpenStack - a Python project that has the largest open source community.

Often, the same package is referenced in several files, possibly with different version requirements:

$ cat a/requirements.txt
prettytable>=0.6
$ cat b/requirements.txt
prettytable<0.8

pip should install prettytable>=0.6,<0.8, but it will just complain:

$ pip install -r a/requirements.txt -r b/requirements.txt 
Double requirement given: prettytable<0.8 (from -r b/requirements.txt (line 1)) (already in prettytable>=0.6 (from -r a/requirements.txt (line 1)), name='prettytable')

My patch fixes the problem:

pip install -r a/requirements.txt -r b/requirements.txt 
Downloading/unpacking prettytable>=0.6,<0.8 (from aggregated requirements)
  Downloading prettytable-0.7.2.zip
...