### PR TITLE
Add note to help new users install

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -31,6 +31,11 @@ The easiest way to install and use pip is with `virtualenv
 <http://www.virtualenv.org>`_, since every virtualenv has pip (and it's dependencies) installed into it
 automatically.
 
+.. note:: 
+    
+    If you do not have virtualenv installed, you can :ref:`install pip globally <Installing Globally>`
+    using :ref:`get-pip <Using get-pip>`.
+
 This does not require root access or modify your system Python
 installation. For instance::
 


### PR DESCRIPTION
pip's installation guide can be a bit confusing for new Python users. As [demonstrated in this reddit post](http://www.reddit.com/r/Python/comments/1ca8g0/the_suggested_way_to_install_pip_is_with/), the installation guide seems to suggest that you should use virtualenv to install pip. The virtualenv installation guide says you should use pip to install virtualenv. While the relationship between the two might be obvious to experienced users, new users would easily get caught in this self-referential loop.

Adding this note might help new users get started with pip.
