### PR TITLE
Fix for Python 3.1 compatibility.

### DIFF
--- a/pip/backwardcompat/__init__.py
+++ b/pip/backwardcompat/__init__.py
@@ -122,4 +122,4 @@ def product(*args, **kwds):
 try:
     from ssl import match_hostname, CertificateError
 except ImportError:
-    from ssl_match_hostname import match_hostname, CertificateError
+    from .ssl_match_hostname import match_hostname, CertificateError

--- a/pip/vendor/distlib/compat.py
+++ b/pip/vendor/distlib/compat.py
@@ -137,7 +137,11 @@ else:
     from itertools import filterfalse
     filter = filter
 
-    from ssl import match_hostname, CertificateError
+    try:
+        from ssl import match_hostname, CertificateError
+    except ImportError:
+        # For Python 3.1 default to local compat versions.
+        pass
 
 # ZipFile is a context manager in 2.7, but not in 2.6
 


### PR DESCRIPTION
Fix for issue #1105 where the backwardcompat features are required
for Python 3.1. Causes failures in automated tox builds with a
py31 target.
