### PR TITLE
Switch to using py.test as the test runner instead of nose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
     - echo -e "[web]\ncacerts = /etc/ssl/certs/ca-certificates.crt" >> ~/.hgrc
     - git config --global user.email "python-virtualenv@googlegroups.com"
     - git config --global user.name "Pip"
-install: pip install nose git+https://github.com/pypa/virtualenv@develop#egg=virtualenv scripttest mock
-script: nosetests
+install: pip install pytest git+https://github.com/pypa/virtualenv@develop#egg=virtualenv scripttest mock
+script: py.test
 notifications:
   irc: "irc.freenode.org#pip"
 branches:

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -29,14 +29,14 @@ Running tests
 
 OS Requirements: subversion, bazaar, git, and mercurial.
 
-Python Requirements: nose, virtualenv, scripttest, and mock
+Python Requirements: pytest, virtualenv, scripttest, and mock
 
 Ways to run the tests locally:
 
 ::
 
  $ python setup.py test  # Using the setuptools test plugin
- $ nosetests             # Using nosetests directly
+ $ py.test               # Using py.test directly
  $ tox                   # Using tox against pip's tox.ini
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
-[nosetests]
-where=tests
+[pytest]
+addopts = --ignore pip/vendor --ignore tests/tests_cache
 
 [wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,26 @@ import codecs
 import os
 import re
 import sys
+
 from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
 
 here = os.path.abspath(os.path.dirname(__file__))
+
+
+class PyTest(TestCommand):
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        #import here, cause outside the eggs aren't loaded
+        import pytest
+
+        sys.exit(pytest.main(self.test_args))
 
 
 def read(*parts):
@@ -24,7 +41,7 @@ def find_version(*file_paths):
 long_description = "\n" + "\n".join([read('PROJECT.txt'),
                                      read('docs', 'quickstart.rst')])
 
-tests_require = ['nose>=1.3.0', 'virtualenv>=1.10', 'scripttest>=1.1.1', 'mock']
+tests_require = ['pytest', 'virtualenv>=1.10', 'scripttest>=1.1.1', 'mock']
 
 setup(name="pip",
       version=find_version('pip', '__init__.py'),
@@ -52,9 +69,10 @@ setup(name="pip",
       package_data={'pip': ['*.pem']},
       entry_points=dict(console_scripts=['pip=pip:main', 'pip%s=pip:main' % sys.version[:1],
           'pip%s=pip:main' % sys.version[:3]]),
-      test_suite='nose.collector',
       tests_require=tests_require,
       zip_safe=False,
       extras_require={
           'testing': tests_require,
-      })
+      },
+      cmdclass = {'test': PyTest},
+)

--- a/tests/functional/test_help.py
+++ b/tests/functional/test_help.py
@@ -1,10 +1,11 @@
+import pytest
+
 from pip.exceptions import CommandError
 from pip.baseparser import create_main_parser
 from pip.basecommand import ERROR, SUCCESS
 from pip.commands.help import HelpCommand
 from pip.commands import commands
 from mock import Mock
-from nose.tools import assert_raises
 from tests.lib import run_pip, reset_env
 
 
@@ -37,7 +38,9 @@ def test_run_method_should_raise_command_error_when_command_does_not_exist():
     options_mock = Mock()
     args = ('mycommand',)
     help_cmd = HelpCommand(create_main_parser())
-    assert_raises(CommandError, help_cmd.run, options_mock, args)
+
+    with pytest.raises(CommandError):
+        help_cmd.run(options_mock, args)
 
 
 def test_help_command_should_exit_status_ok_when_command_exists():

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1,9 +1,11 @@
 import os
 import sys
 import textwrap
+
 from os.path import abspath, join, curdir, pardir
 
-from nose import SkipTest
+import pytest
+
 from pip.util import rmtree
 from tests.lib import tests_data, reset_env, run_pip, pyversion, mkdir, pip_install_local, write_file, find_links
 from tests.lib.local_repos import local_checkout
@@ -439,6 +441,8 @@ def test_install_package_with_root():
     assert root_path in result.files_created, str(result)
 
 
+# skip on win/py3 for now, see issue #782
+@pytest.mark.skipif("sys.platform == 'win32' and sys.version_info >= (3,)")
 def test_install_package_that_emits_unicode():
     """
     Install a package with a setup.py that emits UTF-8 output and then fails.
@@ -454,11 +458,6 @@ def test_install_package_that_emits_unicode():
 
     Refs https://github.com/pypa/pip/issues/326
     """
-
-    #skip on win/py3 for now, see issue #782
-    if sys.platform == 'win32' and sys.version_info >= (3,):
-        raise SkipTest()
-
     env = reset_env()
     to_install = os.path.abspath(os.path.join(tests_data, 'packages', 'BrokenEmitsUTF8'))
     result = run_pip('install', to_install, expect_error=True, expect_temp=True, quiet=True)

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -1,7 +1,10 @@
 import os.path
 import textwrap
-from nose.tools import assert_equal, assert_raises
+
+import pytest
+
 from mock import patch
+
 from pip.backwardcompat import urllib
 from pip.req import Requirements, parse_editable, parse_requirements
 from tests.lib import (reset_env, run_pip, write_file, pyversion, tests_data,
@@ -39,7 +42,9 @@ def test_schema_check_in_requirements_file():
     write_file('file-egg-req.txt', textwrap.dedent("""\
         git://github.com/alex/django-fixture-generator.git#egg=fixture_generator
         """))
-    assert_raises(AssertionError, run_pip, 'install', '-vvv', '-r', env.scratch_path / 'file-egg-req.txt')
+
+    with pytest.raises(AssertionError):
+        run_pip("install", "-vvv", "-r", env.scratch_path / "file-egg-req.txt")
 
 
 def test_relative_requirements_file():

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -1,9 +1,11 @@
 import os
 import sys
 import textwrap
+
 from os.path import join
-from nose.tools import nottest
-from nose import SkipTest
+
+import pytest
+
 from tests.lib import (reset_env, run_pip, assert_all_changes, src_folder,
                        write_file, pyversion, _create_test_package, pip_install_local,
                        _change_test_package_version, path_to_url, find_links)
@@ -154,7 +156,7 @@ def test_uninstall_rollback():
     assert_all_changes(result.files_after, result2, [env.venv/'build', 'pip-log.txt'])
 
 # Issue #530 - temporarily disable flaky test
-@nottest
+@pytest.mark.skipif
 def test_editable_git_upgrade():
     """
     Test installing an editable git package from a repository, upgrading the repository,
@@ -235,9 +237,8 @@ class TestUpgradeSetuptools(object):
         self.env.run(self.ve_bin/'pip', 'uninstall', '-y', 'pip')
         self.env.run(self.ve_bin/'python', 'setup.py', 'install', cwd=src_folder, expect_stderr=True)
 
+    @pytest.mark.skipif("sys.version_info >= (3,0)")
     def test_py2_from_setuptools_6_to_setuptools_7(self):
-        if sys.version_info >= (3,):
-            raise SkipTest()
         self.prep_ve('1.9.1')
         result = self.env.run(self.ve_bin/'pip', 'install', '--no-index', '--find-links=%s' % find_links, '-U', 'setuptools')
         assert "Found existing installation: setuptools 0.6c11" in result.stdout

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -1,11 +1,13 @@
 """
 tests specific to "--user" option
 """
-
 import sys
 import os
+
 from os.path import abspath, join, curdir, isdir, isfile
-from nose import SkipTest
+
+import pytest
+
 from tests.lib.local_repos import local_checkout
 from tests.lib import (tests_data, reset_env, run_pip, pyversion, assert_all_changes,
                             path_to_url, find_links, pip_install_local)
@@ -19,13 +21,9 @@ patch_dist_in_site_packages = """
 """
 
 
+# --user option is broken in pypy
+@pytest.mark.skipif("hasattr(sys, 'pypy_version_info')")
 class Tests_UserSite:
-
-    def setup(self):
-        # --user option is broken in pypy
-        if hasattr(sys, "pypy_version_info"):
-            raise SkipTest()
-
 
     def test_reset_env_system_site_packages_usersite(self):
         """

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -1,6 +1,9 @@
 import sys
+
+import pytest
+
 from mock import patch
-from nose import SkipTest
+
 from pip.vcs.git import Git
 from tests.lib import (reset_env, run_pip,
                             _create_test_package,)
@@ -78,14 +81,13 @@ def test_check_rev_options_should_handle_ambiguous_commit(get_refs_mock):
     assert result == ['123456'], result
 
 
+# TODO(pnasrat) fix all helpers to do right things with paths on windows.
+@pytest.mark.skipif("sys.platform == 'win32'")
 def test_check_submodule_addition():
     """
     Submodules are pulled in on install and updated on upgrade.
 
     """
-    # TODO(pnasrat) fix all helpers to do right things with paths on windows.
-    if sys.platform == 'win32':
-      raise SkipTest()
     env = reset_env()
     module_path, submodule_path = _create_test_package_with_submodule(env)
 

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -1,6 +1,5 @@
 from os.path import abspath, join
 
-from nose import SkipTest
 from tests.lib import tests_data, reset_env, run_pip, pip_install_local, find_links
 from tests.lib.path import Path
 
@@ -23,10 +22,6 @@ def test_install_from_wheel_with_extras():
     """
     Test installing from a wheel with extras.
     """
-    try:
-        import ast
-    except ImportError:
-        raise SkipTest("Need ast module to interpret wheel extras")
     env = reset_env()
     result = run_pip('install', 'complex-dist[simple]', '--use-wheel',
                      '--no-index', '--find-links='+find_links,

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -84,5 +84,5 @@ def test_more_than_one_package():
     Search for more than one package.
 
     """
-    result = list(search_packages_info(['Pip', 'Nose', 'Virtualenv']))
+    result = list(search_packages_info(['Pip', 'pytest', 'Virtualenv']))
     assert len(result) == 3

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -2,9 +2,9 @@
 import os
 import sys
 import textwrap
+
 from os.path import exists
 
-from nose import SkipTest
 from pip import wheel
 from pip.download import path_to_url as path_to_url_d
 from tests.lib import tests_data, reset_env, run_pip, pyversion_nodot, write_file, path_to_url, find_links, pip_install_local

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -6,7 +6,6 @@ import re
 import sys
 from os.path import join, isdir
 
-from nose import SkipTest
 from pip.backwardcompat import uses_pycache
 from tests.lib import tests_lib, reset_env, run_pip, src_folder
 

--- a/tests/unit/test_download_hashes.py
+++ b/tests/unit/test_download_hashes.py
@@ -1,6 +1,6 @@
 import os
 
-from nose.tools import assert_raises
+import pytest
 
 from pip.download import _get_hash_from_file, _check_hash
 from pip.exceptions import InstallationError
@@ -92,7 +92,8 @@ def test_check_hash_md5_invalid():
 
     download_hash = _get_hash_from_file(file_path, file_link)
 
-    assert_raises(InstallationError, _check_hash, download_hash, file_link)
+    with pytest.raises(InstallationError):
+        _check_hash(download_hash, file_link)
 
 
 def test_check_hash_sha1_valid():
@@ -110,7 +111,8 @@ def test_check_hash_sha1_invalid():
 
     download_hash = _get_hash_from_file(file_path, file_link)
 
-    assert_raises(InstallationError, _check_hash, download_hash, file_link)
+    with pytest.raises(InstallationError):
+        _check_hash(download_hash, file_link)
 
 
 def test_check_hash_sha224_valid():
@@ -128,7 +130,8 @@ def test_check_hash_sha224_invalid():
 
     download_hash = _get_hash_from_file(file_path, file_link)
 
-    assert_raises(InstallationError, _check_hash, download_hash, file_link)
+    with pytest.raises(InstallationError):
+        _check_hash(download_hash, file_link)
 
 
 def test_check_hash_sha384_valid():
@@ -146,7 +149,8 @@ def test_check_hash_sha384_invalid():
 
     download_hash = _get_hash_from_file(file_path, file_link)
 
-    assert_raises(InstallationError, _check_hash, download_hash, file_link)
+    with pytest.raises(InstallationError):
+        _check_hash(download_hash, file_link)
 
 
 def test_check_hash_sha256_valid():
@@ -164,7 +168,8 @@ def test_check_hash_sha256_invalid():
 
     download_hash = _get_hash_from_file(file_path, file_link)
 
-    assert_raises(InstallationError, _check_hash, download_hash, file_link)
+    with pytest.raises(InstallationError):
+        _check_hash(download_hash, file_link)
 
 
 def test_check_hash_sha512_valid():
@@ -182,7 +187,8 @@ def test_check_hash_sha512_invalid():
 
     download_hash = _get_hash_from_file(file_path, file_link)
 
-    assert_raises(InstallationError, _check_hash, download_hash, file_link)
+    with pytest.raises(InstallationError):
+        _check_hash(download_hash, file_link)
 
 
 def test_check_hasher_mismsatch():
@@ -192,4 +198,5 @@ def test_check_hasher_mismsatch():
 
     download_hash = _get_hash_from_file(file_path, file_link)
 
-    assert_raises(InstallationError, _check_hash, download_hash, other_link)
+    with pytest.raises(InstallationError):
+        _check_hash(download_hash, other_link)

--- a/tests/unit/test_download_ssl.py
+++ b/tests/unit/test_download_ssl.py
@@ -1,18 +1,17 @@
-
-import sys
 import os
-import ssl
-from mock import Mock, patch
+
+import pytest
+
+from mock import patch
+
 from pip.download import urlopen, VerifiedHTTPSHandler
-from tests.lib import assert_raises_regexp, tests_data, reset_env, run_pip
-from nose import SkipTest
-from nose.tools import assert_raises
+from tests.lib import assert_raises_regexp, tests_data
 from pip.backwardcompat import urllib2, URLError
 from pip.backwardcompat import CertificateError
-from pip.exceptions import PipError
 
 pypi_https = 'https://pypi.python.org/simple/'
 pypi_http = 'http://pypi.python.org/simple/'
+
 
 class TestsSSL:
     """ssl tests"""
@@ -77,7 +76,9 @@ class TestsSSL:
 
         mock_match_hostname.side_effect = mock_matchhostname
         opener = urlopen.get_opener(scheme='https')
-        assert_raises(CertificateError, opener.open, pypi_https)
+
+        with pytest.raises(CertificateError):
+            opener.open(pypi_https)
 
 
     def test_bad_pem_fails(self):

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -1,4 +1,7 @@
 import os
+
+import pytest
+
 from pkg_resources import parse_version, Distribution
 from pip.backwardcompat import urllib
 from pip.req import InstallRequirement
@@ -7,7 +10,6 @@ from pip.exceptions import BestVersionAlreadyInstalled, DistributionNotFound
 from pip.util import Inf
 from tests.lib.path import Path
 from tests.lib import tests_data, path_to_url, find_links, find_links2
-from nose.tools import assert_raises
 from mock import Mock, patch
 
 
@@ -58,7 +60,9 @@ def test_finder_detects_latest_already_satisfied_find_links():
         )
     req.satisfied_by = satisfied_by
     finder = PackageFinder([find_links], [])
-    assert_raises(BestVersionAlreadyInstalled, finder.find_requirement, req, True)
+
+    with pytest.raises(BestVersionAlreadyInstalled):
+        finder.find_requirement(req, True)
 
 
 def test_finder_detects_latest_already_satisfied_pypi_links():
@@ -73,7 +77,9 @@ def test_finder_detects_latest_already_satisfied_pypi_links():
         )
     req.satisfied_by = satisfied_by
     finder = PackageFinder([], ["http://pypi.python.org/simple"])
-    assert_raises(BestVersionAlreadyInstalled, finder.find_requirement, req, True)
+
+    with pytest.raises(BestVersionAlreadyInstalled):
+        finder.find_requirement(req, True)
 
 
 # patch this for travis which has distribute in it's base env for now
@@ -87,7 +93,9 @@ class TestWheel(object):
         """
         req = InstallRequirement.from_line("simple.dist")
         finder = PackageFinder([find_links], [], use_wheel=True)
-        assert_raises(DistributionNotFound, finder.find_requirement, req, True)
+
+        with pytest.raises(DistributionNotFound):
+            finder.find_requirement(req, True)
 
 
     @patch('pip.pep425tags.supported_tags', [('py2', 'none', 'any')])
@@ -126,8 +134,9 @@ class TestWheel(object):
             )
         req.satisfied_by = satisfied_by
         finder = PackageFinder([find_links], [], use_wheel=True)
-        assert_raises(BestVersionAlreadyInstalled, finder.find_requirement, req, True)
 
+        with pytest.raises(BestVersionAlreadyInstalled):
+            finder.find_requirement(req, True)
 
     @patch('pip.pep425tags.supported_tags', [
             ('pyT', 'none', 'TEST'),

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -7,9 +7,10 @@ import sys
 import shutil
 import tempfile
 import getpass
+
+import pytest
+
 from mock import Mock
-from nose import SkipTest
-from nose.tools import assert_raises, assert_equal
 import pip
 
 if sys.platform == 'win32':
@@ -84,16 +85,14 @@ class TestLocations:
         """ test the path name for the build_prefix
         """
         from pip import locations
-        assert_equal(locations._get_build_prefix(),
-            self.get_build_dir_location())
+        assert locations._get_build_prefix() == self.get_build_dir_location()
 
+    #skip on windows, build dir is not created
+    @pytest.mark.skipif("sys.platform == 'win32'")
     def test_dir_created(self):
         """ test that the build_prefix directory is generated when
             _get_build_prefix is called.
         """
-        #skip on windows, build dir is not created
-        if sys.platform == 'win32':
-            raise SkipTest()
         assert not os.path.exists(self.get_build_dir_location() ), \
             "the build_prefix directory should not exist yet!"
         from pip import locations
@@ -101,17 +100,18 @@ class TestLocations:
         assert os.path.exists(self.get_build_dir_location() ), \
             "the build_prefix directory should now exist!"
 
+    #skip on windows; this exception logic only runs on linux
+    @pytest.mark.skipif("sys.platform == 'win32'")
     def test_error_raised_when_owned_by_another(self):
         """ test calling _get_build_prefix when there is a temporary
             directory owned by another user raises an InstallationError.
         """
-        #skip on windows; this exception logic only runs on linux
-        if sys.platform == 'win32':
-            raise SkipTest()
         from pip import locations
         os.geteuid = lambda : 1111
         os.mkdir(self.get_build_dir_location() )
-        assert_raises(pip.exceptions.InstallationError, locations._get_build_prefix)
+
+        with pytest.raises(pip.exceptions.InstallationError):
+            locations._get_build_prefix()
 
     def test_no_error_raised_when_owned_by_you(self):
         """ test calling _get_build_prefix when there is a temporary

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -2,9 +2,10 @@ import os
 import shutil
 import tempfile
 
+import pytest
+
 from pkg_resources import Distribution
 from mock import Mock, patch
-from nose.tools import assert_equal, assert_raises
 from pip.exceptions import PreviousBuildDirError
 from pip.index import PackageFinder
 from pip.log import logger
@@ -92,33 +93,18 @@ def test_parse_editable_local(isdir_mock, exists_mock, getcwd_mock, normcase_moc
     exists_mock.return_value = isdir_mock.return_value = True
     # mocks needed to support path operations on windows tests
     normcase_mock.return_value = getcwd_mock.return_value = "/some/path"
-    assert_equal(
-        parse_editable('.', 'git'),
-        (None, 'file:///some/path', None)
-    )
+    assert parse_editable('.', 'git') == (None, 'file:///some/path', None)
     normcase_mock.return_value = "/some/path/foo"
-    assert_equal(
-        parse_editable('foo', 'git'),
-        (None, 'file:///some/path/foo', None)
-    )
+    assert parse_editable('foo', 'git') == (None, 'file:///some/path/foo', None)
 
 def test_parse_editable_default_vcs():
-    assert_equal(
-        parse_editable('https://foo#egg=foo', 'git'),
-        ('foo', 'git+https://foo#egg=foo', None)
-    )
+    assert parse_editable('https://foo#egg=foo', 'git') == ('foo', 'git+https://foo#egg=foo', None)
 
 def test_parse_editable_explicit_vcs():
-    assert_equal(
-        parse_editable('svn+https://foo#egg=foo', 'git'),
-        ('foo', 'svn+https://foo#egg=foo', None)
-    )
+    assert parse_editable('svn+https://foo#egg=foo', 'git') == ('foo', 'svn+https://foo#egg=foo', None)
 
 def test_parse_editable_vcs_extras():
-    assert_equal(
-        parse_editable('svn+https://foo#egg=foo[extras]', 'git'),
-        ('foo[extras]', 'svn+https://foo#egg=foo[extras]', None)
-    )
+    assert parse_editable('svn+https://foo#egg=foo[extras]', 'git') == ('foo[extras]', 'svn+https://foo#egg=foo[extras]', None)
 
 @patch('os.path.normcase')
 @patch('pip.req.os.getcwd')
@@ -127,15 +113,9 @@ def test_parse_editable_vcs_extras():
 def test_parse_editable_local_extras(isdir_mock, exists_mock, getcwd_mock, normcase_mock):
     exists_mock.return_value = isdir_mock.return_value = True
     normcase_mock.return_value = getcwd_mock.return_value = "/some/path"
-    assert_equal(
-        parse_editable('.[extras]', 'git'),
-        (None, 'file://' + "/some/path", ('extras',))
-    )
+    assert parse_editable('.[extras]', 'git') == (None, 'file://' + "/some/path", ('extras',))
     normcase_mock.return_value = "/some/path/foo"
-    assert_equal(
-        parse_editable('foo[bar,baz]', 'git'),
-        (None, 'file:///some/path/foo', ('bar', 'baz'))
-    )
+    assert parse_editable('foo[bar,baz]', 'git') == (None, 'file:///some/path/foo', ('bar', 'baz'))
 
 def test_remote_reqs_parse():
     """

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -8,8 +8,9 @@ import sys
 import shutil
 import tempfile
 
+import pytest
+
 from mock import Mock, patch
-from nose.tools import eq_, assert_raises
 from pip.exceptions import BadCommand
 from pip.util import (egg_link_path, Inf, get_installed_distributions, find_command,
                       untar_file, unzip_file)
@@ -67,19 +68,19 @@ class Tests_EgglinkPath:
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = False
         self.mock_isfile.side_effect = self.eggLinkInUserSite
-        eq_(egg_link_path(self.mock_dist), self.user_site_egglink)
+        assert egg_link_path(self.mock_dist) == self.user_site_egglink
 
     def test_egglink_in_usersite_venv_noglobal(self):
         self.mock_virtualenv_no_global.return_value = True
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.side_effect = self.eggLinkInUserSite
-        eq_(egg_link_path(self.mock_dist), None)
+        assert egg_link_path(self.mock_dist) is None
 
     def test_egglink_in_usersite_venv_global(self):
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.side_effect = self.eggLinkInUserSite
-        eq_(egg_link_path(self.mock_dist), self.user_site_egglink)
+        assert egg_link_path(self.mock_dist) == self.user_site_egglink
 
     #########################
     ## egglink in sitepkgs ##
@@ -88,19 +89,19 @@ class Tests_EgglinkPath:
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = False
         self.mock_isfile.side_effect = self.eggLinkInSitePackages
-        eq_(egg_link_path(self.mock_dist), self.site_packages_egglink)
+        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
 
     def test_egglink_in_sitepkgs_venv_noglobal(self):
         self.mock_virtualenv_no_global.return_value = True
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.side_effect = self.eggLinkInSitePackages
-        eq_(egg_link_path(self.mock_dist), self.site_packages_egglink)
+        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
 
     def test_egglink_in_sitepkgs_venv_global(self):
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.side_effect = self.eggLinkInSitePackages
-        eq_(egg_link_path(self.mock_dist), self.site_packages_egglink)
+        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
 
     ####################################
     ## egglink in usersite & sitepkgs ##
@@ -109,19 +110,19 @@ class Tests_EgglinkPath:
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = False
         self.mock_isfile.return_value = True
-        eq_(egg_link_path(self.mock_dist), self.user_site_egglink)
+        assert egg_link_path(self.mock_dist) == self.user_site_egglink
 
     def test_egglink_in_both_venv_noglobal(self):
         self.mock_virtualenv_no_global.return_value = True
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.return_value = True
-        eq_(egg_link_path(self.mock_dist), self.site_packages_egglink)
+        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
 
     def test_egglink_in_both_venv_global(self):
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.return_value = True
-        eq_(egg_link_path(self.mock_dist), self.site_packages_egglink)
+        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
 
     ################
     ## no egglink ##
@@ -130,19 +131,19 @@ class Tests_EgglinkPath:
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = False
         self.mock_isfile.return_value = False
-        eq_(egg_link_path(self.mock_dist), None)
+        assert egg_link_path(self.mock_dist) is None
 
     def test_noegglink_in_sitepkgs_venv_noglobal(self):
         self.mock_virtualenv_no_global.return_value = True
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.return_value = False
-        eq_(egg_link_path(self.mock_dist), None)
+        assert egg_link_path(self.mock_dist) is None
 
     def test_noegglink_in_sitepkgs_venv_global(self):
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.return_value = False
-        eq_(egg_link_path(self.mock_dist), None)
+        assert egg_link_path(self.mock_dist) is None
 
 def test_Inf_greater():
     """Test Inf compares greater."""
@@ -252,7 +253,9 @@ def test_find_command_trys_all_pathext(mock_isfile, getpath_mock):
     paths = [os.path.join('path_one', f)  for f in ['foo.com', 'foo.exe', 'foo']]
     expected = [((p,),) for p in paths]
 
-    assert_raises(BadCommand, find_command, 'foo', 'path_one')
+    with pytest.raises(BadCommand):
+        find_command("foo", "path_one")
+
     assert mock_isfile.call_args_list == expected, "Actual: %s\nExpected %s" % (mock_isfile.call_args_list, expected)
     assert getpath_mock.called, "Should call get_pathext"
 
@@ -272,7 +275,9 @@ def test_find_command_trys_supplied_pathext(mock_isfile, getpath_mock):
     paths = [os.path.join('path_one', f)  for f in ['foo.run', 'foo.cmd', 'foo']]
     expected = [((p,),) for p in paths]
 
-    assert_raises(BadCommand, find_command, 'foo', 'path_one', pathext)
+    with pytest.raises(BadCommand):
+        find_command("foo", "path_one", pathext)
+
     assert mock_isfile.call_args_list == expected, "Actual: %s\nExpected %s" % (mock_isfile.call_args_list, expected)
     assert not getpath_mock.called, "Should not call get_pathext"
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -1,11 +1,15 @@
 """Tests for wheel binary packages and .dist-info."""
+import os
+
+import pytest
+
 import pkg_resources
 from mock import patch, Mock
 from pip import wheel
 from pip.exceptions import InstallationError
 from pip.index import PackageFinder
 from tests.lib import assert_raises_regexp
-from nose.tools import assert_raises
+
 
 def test_uninstallation_paths():
     class dist(object):
@@ -138,11 +142,10 @@ class TestWheelFile(object):
         from tempfile import mkdtemp
         from shutil import rmtree
         import os
-        from nose import SkipTest
 
         filepath = '../data/packages/meta-1.0-py2.py3-none-any.whl'
         if not os.path.exists(filepath):
-            raise SkipTest
+            pytest.skip("%s does not exist" % filepath)
         try:
             tmpdir = mkdtemp()
             util.unpack_file(filepath, tmpdir, 'application/zip', None )
@@ -155,8 +158,8 @@ class TestWheelFile(object):
         """
         Test the "wheel is purelib/platlib" code.
         """
-        packages =  [("pure_wheel", "data/packages/pure_wheel-1.7", True),
-                     ("plat_wheel", "data/packages/plat_wheel-1.7", False)]
+        packages =  [("pure_wheel", os.path.join(os.path.dirname(__file__), os.pardir, "data/packages/pure_wheel-1.7"), True),
+                     ("plat_wheel", os.path.join(os.path.dirname(__file__), os.pardir, "data/packages/plat_wheel-1.7"), False)]
         for name, path, expected in packages:
             assert wheel.root_is_purelib(name, path) == expected
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ envlist =
 
 [testenv]
 deps=
-    nose>=1.3.0
+    pytest
     mock
     scripttest>=1.1.1
     git+https://github.com/pypa/virtualenv@develop#egg=virtualenv
 commands =
-    nosetests -s -v tests
+    py.test
 


### PR DESCRIPTION
### Why py.test
- Better output with the bare asserts we use throughout the tests
- Function fixtures are pretty nice, especially as a way to start a background server or create an isolated virtualenv
  - Automatic clean up of test resources between tests, can be scoped to per test, per module, or per test run
  - Very little boilerplate, just add a parameter to your test function
- Parametrized tests are great, write one test with parameters and a list of parameters and it will be expanded out as if you wrote multiple test functions for each entry in the parameter list.
- Overall I'm more familar with py.test
- We've talked on and off about switching to it before
- We're not really using anything nose specific besides a smattering of small helper functions
- I have a series of changes I'd love to do to make our test suite more "ergonomic" and these changes will be easier for me to implement (and thus more likely I'll actually do them) in py.test
  - Concurrent testing to speed up test suite
  - Spinning up a local test PyPI in a background thread and running our tests against it
  - Reduction of boilerplate required in tests
  - More as I think of more things to make our test suite awesome...
