### PR TITLE
Close record file before cleanup

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -648,6 +648,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                     break
             else:
                 logger.warn('Could not find .egg-info directory in install record for %s' % self)
+                f.close()
                 ## FIXME: put the record somewhere
                 ## FIXME: should this be an error?
                 return


### PR DESCRIPTION
This patch fixes a bug with pip on Windows where pip tries to `os.remove()` the record file before closing it. A demonstration of the bug:

```
$ pip install bento
Downloading/unpacking bento
  Downloading bento-0.1.1.tar.gz (582kB): 582kB downloaded
  Running setup.py egg_info for package bento
Installing collected packages: bento
  Running setup.py install for bento
  Could not find .egg-info directory in install record for bento
Cleaning up...
Exception:
Traceback (most recent call last):
  File "O:\venv\lib\site-packages\pip\basecommand.py", line 134, in main
    status = self.run(options, args)
  File "O:\venv\lib\site-packages\pip\commands\install.py", line 241, in run
    requirement_set.install(install_options, global_options, root=options.root_p
ath)
  File "O:\venv\lib\site-packages\pip\req.py", line 1298, in install
    requirement.install(install_options, global_options, *args, **kwargs)
  File "O:\venv\lib\site-packages\pip\req.py", line 668, in install
    os.remove(record_filename)
WindowsError: [Error 32] The process cannot access the file because it is being
used by another process: 'c:\\docume~1\\enojb\\locals~1\\temp\\pip-oyyyxt-record
\\install-record.txt'

Storing complete log in C:\Documents and Settings\enojb\pip\pip.log
```

With this patch the output is

```
$ pip install bento
Downloading/unpacking bento
  Running setup.py egg_info for package bento
Installing collected packages: bento
  Running setup.py install for bento
  Could not find .egg-info directory in install record for bento
Successfully installed bento
Cleaning up...
```

And bento is installed:

```
$ bentomaker
Type 'bentomaker help' for usage.
```
