### PR TITLE
Add a link to the configuration file section from the cookbook.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,6 +3,8 @@
 Configuration
 =================
 
+.. _config-file:
+
 Config file
 ------------
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -78,7 +78,8 @@ pip's support for wheels currently requires `Setuptools`_ >=0.8.
 
 To have pip find and prefer wheels, use the :ref:`--use-wheel <install_--use-wheel>` flag for :ref:`pip install`.
 If no satisfactory wheels are found, pip will default to finding source archives.
-If you want to make pip use wheels by default, set the environment variable ``PIP_USE_WHEEL`` or set ``use-wheel`` in your ``pip.ini`` file.
+If you want to make pip use wheels by default, set the environment variable ``PIP_USE_WHEEL``
+or set ``use-wheel`` in your :ref:`configuration file<config-file>`.
 
 To install from wheels on PyPI, if they were to exist (which is not likely for the short term):
 


### PR DESCRIPTION
I was trying to figure out how to configure pip to install wheel file.

The documentation prompted me to add an option to my `pip.ini` file but I had to search again where to put this file (and, as it turns out, the file is called `pip.conf` on my system).

This pull request changes the wording to be platform-neutral and adds a link to the right section so that the info is just one click away.
