### PR TITLE
pip-1.4.1 did not work with Python-3.1

### DIFF
--- a/pip/backwardcompat/__init__.py
+++ b/pip/backwardcompat/__init__.py
@@ -122,4 +122,4 @@ def product(*args, **kwds):
 try:
     from ssl import match_hostname, CertificateError
 except ImportError:
-    from ssl_match_hostname import match_hostname, CertificateError
+    from pip.backwardcompat.ssl_match_hostname import match_hostname, CertificateError


### PR DESCRIPTION
Python3(.1) can't import relative module without dot('.').
