### PR TITLE
Mention wheel as an egg replacement

### DIFF
--- a/docs/other-tools.rst
+++ b/docs/other-tools.rst
@@ -47,9 +47,9 @@ pip was originally written to improve on `easy_install <http://pythonhosted.org/
 
 pip doesn't do everything that easy_install does. Specifically:
 
-* It cannot install from eggs.  It only installs from source.  (In the
-  future it would be good if it could install binaries from Windows ``.exe``
-  or ``.msi`` -- binary install on other platforms is not a priority.)
+* It cannot install from eggs.  That’s not a problem anymore though because pip
+  supports the superior binary `wheel format
+  <https://wheel.readthedocs.org/en/latest/>`_ since the 1.4 release.
 
 * It is incompatible with some packages that extensively customize distutils
   or setuptools in their ``setup.py`` files.


### PR DESCRIPTION
While it’s true that pip can’t install eggs, it’s not true anymore that it installs only source distributions.

I got an angry email because of my blog post where I say that easy_install is supplanted by pip and the writer is insistive that pip can’t handle binary packages citing this document.
