### PR TITLE
logs from --log have extra line breaks.

### DIFF
--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,4 +1,5 @@
-from pip.log import should_color, should_warn
+import StringIO
+from pip.log import should_color, should_warn, Logger
 
 
 def test_should_color_std():
@@ -42,3 +43,21 @@ def test_should_warn_greater():
 
 def test_should_warn_significance():
     assert should_warn("1.4.dev1", "1.6")
+
+
+def test_log_no_extra_line_break():
+    """
+    Confirm that multiple `.write()` consumers doesn't result in additional '\n's per write
+    """
+    consumer1 = StringIO.StringIO()
+    consumer2 = StringIO.StringIO()
+    logger = Logger()
+    logger.add_consumers(
+            (logger.NOTIFY, consumer1),
+            (logger.NOTIFY, consumer2)
+            )
+    logger.notify("one line")
+    # splitlines(True) will detect empty line-breaks
+    assert 1 == len(consumer1.getvalue().splitlines(True))
+    assert 1 == len(consumer2.getvalue().splitlines(True))
+


### PR DESCRIPTION
Fixes a general problem in our logger class where multiple .write() log consumers resulted in extra line breaks for the later ones.   The specific bug at the moment was that logs from --log had extra line breaks.

Added a test for this.
