### PR TITLE
Modify wheel check for setuptools to work with setuptools zip file

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -34,13 +34,10 @@ except ImportError:
 
 def wheel_setuptools_support():
     """
-    Return True if we have a setuptools that supports wheel.
+    Return a Distribution object for the installed setuptools
     """
-    fulfilled = False
     try:
-        installed_setuptools = pkg_resources.get_distribution('setuptools')
-        if installed_setuptools in setuptools_requirement:
-            fulfilled = True
+        return pkg_resources.get_distribution('setuptools')
     except pkg_resources.DistributionNotFound:
         try:
             ver = setuptools_version()

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -47,11 +47,23 @@ class TestWheelSupported(object):
         finder.use_wheel = True
 
     @patch("pip.wheel.pkg_resources.get_distribution")
-    def test_wheel_supported_true(self, mock_get_distribution):
+    def test_wheel_get_setuptools(self, mock_get_distribution):
+        mock_get_distribution.return_value = pkg_resources.Distribution(project_name='setuptools', version='0.9')
+        assert wheel.get_setuptools_distribution() is not None
+
+    # TODO: If it is possible to mock "import setuptools" to fail, do so here and add this test.
+    # As it stands, the test will succeed if setuptools>=0.8 is importable.
+    #@patch("pip.wheel.pkg_resources.get_distribution")
+    #def test_wheel_get_setuptools_no_install(self, mock_get_distribution):
+    #    mock_get_distribution.side_effect = self.raise_not_found
+    #    assert wheel.get_setuptools_distribution() is None
+
+    @patch("pip.wheel.get_setuptools_distribution")
+    def test_wheel_supported_true(self, mock_get_setuptools_distribution):
         """
         Test wheel_supported returns true, when setuptools is installed and requirement is met
         """
-        mock_get_distribution.return_value = pkg_resources.Distribution(project_name='setuptools', version='0.9')
+        mock_get_setuptools_distribution.return_value = pkg_resources.Distribution(project_name='setuptools', version='0.9')
         assert wheel.wheel_setuptools_support()
 
     @patch("pip.wheel.setuptools_version")
@@ -65,12 +77,12 @@ class TestWheelSupported(object):
         mock_setuptools_version.return_value = None
         assert not wheel.wheel_setuptools_support()
 
-    @patch("pip.wheel.pkg_resources.get_distribution")
-    def test_wheel_supported_false_req_fail(self, mock_get_distribution):
+    @patch("pip.wheel.get_setuptools_distribution")
+    def test_wheel_supported_false_req_fail(self, mock_get_setuptools_distribution):
         """
         Test wheel_supported returns false, when setuptools is installed, but req is not met
         """
-        mock_get_distribution.return_value = pkg_resources.Distribution(project_name='setuptools', version='0.7')
+        mock_get_setuptools_distribution.return_value = pkg_resources.Distribution(project_name='setuptools', version='0.7')
         assert not wheel.wheel_setuptools_support()
 
     @patch("pip.wheel.setuptools_version")
@@ -88,12 +100,12 @@ class TestWheelSupported(object):
         p = PackageFinder([], [])
         assert_raises_regexp(InstallationError, 'wheel support', self.set_use_wheel_true, p)
 
-    @patch("pip.wheel.pkg_resources.get_distribution")
-    def test_finder_no_raises_error(self, mock_get_distribution):
+    @patch("pip.wheel.wheel_setuptools_support")
+    def test_finder_no_raises_error(self, mock_setuptools_support):
         """
         Test the PackageFinder doesn't raises an error when use_wheel is False, and wheel is supported
         """
-        mock_get_distribution.return_value = pkg_resources.Distribution(project_name='setuptools', version='0.9')
+        mock_setuptools_support.return_value = True
         p = PackageFinder( [], [], use_wheel=False)
         p = PackageFinder([], [])
         p.use_wheel = False


### PR DESCRIPTION
The current check for setuptools in pip/wheel.py fails if setuptools is being imported from a zip file (or wheel), because pkg_resources.find_distributions does not support zip files.

This patch falls back on importing setuptools and using its **version** attribute if find_distrinutions fails.
