### PR TITLE
If we don't have ssl.match_hostname, monkeypatch it in, so that it's available to vendored libraries like distlib

### DIFF
--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -5,6 +5,16 @@ import optparse
 import sys
 import re
 
+try:
+    from ssl import match_hostname, CertificateError
+except ImportError:
+    # If we don't have ssl.match_hostname, monkeypatch it in, so that it's
+    # available to vendored libraries like distlib
+    from pip.backwardcompat.ssl_match_hostname import match_hostname, CertificateError
+    import ssl
+    ssl.match_hostname = match_hostname
+    ssl.CertificateError = CertificateError
+
 from pip import cmdoptions
 from pip.exceptions import InstallationError, CommandError, PipError
 from pip.log import logger

--- a/pip/backwardcompat/ssl_match_hostname.py
+++ b/pip/backwardcompat/ssl_match_hostname.py
@@ -1,0 +1,68 @@
+"""The match_hostname() function from Python 3.2, essential when using SSL."""
+
+import re
+
+__version__ = '3.2a3'
+
+class CertificateError(ValueError):
+    pass
+
+def _dnsname_to_pat(dn, max_wildcards=1):
+    pats = []
+    for frag in dn.split(r'.'):
+        if frag.count('*') > max_wildcards:
+            # Issue #17980: avoid denials of service by refusing more
+            # than one wildcard per fragment.  A survery of established
+            # policy among SSL implementations showed it to be a
+            # reasonable choice.
+            raise CertificateError(
+                "too many wildcards in certificate DNS name: " + repr(dn))
+
+        if frag == '*':
+            # When '*' is a fragment by itself, it matches a non-empty dotless
+            # fragment.
+            pats.append('[^.]+')
+        else:
+            # Otherwise, '*' matches any dotless fragment.
+            frag = re.escape(frag)
+            pats.append(frag.replace(r'\*', '[^.]*'))
+    return re.compile(r'\A' + r'\.'.join(pats) + r'\Z', re.IGNORECASE)
+
+def match_hostname(cert, hostname):
+    """Verify that *cert* (in decoded format as returned by
+    SSLSocket.getpeercert()) matches the *hostname*.  RFC 2818 rules
+    are mostly followed, but IP addresses are not accepted for *hostname*.
+
+    CertificateError is raised on failure. On success, the function
+    returns nothing.
+    """
+    if not cert:
+        raise ValueError("empty or no certificate")
+    dnsnames = []
+    san = cert.get('subjectAltName', ())
+    for key, value in san:
+        if key == 'DNS':
+            if _dnsname_to_pat(value).match(hostname):
+                return
+            dnsnames.append(value)
+    if not san:
+        # The subject is only checked when subjectAltName is empty
+        for sub in cert.get('subject', ()):
+            for key, value in sub:
+                # XXX according to RFC 2818, the most specific Common Name
+                # must be used.
+                if key == 'commonName':
+                    if _dnsname_to_pat(value).match(hostname):
+                        return
+                    dnsnames.append(value)
+    if len(dnsnames) > 1:
+        raise CertificateError("hostname %r "
+            "doesn't match either of %s"
+            % (hostname, ', '.join(map(repr, dnsnames))))
+    elif len(dnsnames) == 1:
+        raise CertificateError("hostname %r "
+            "doesn't match %r"
+            % (hostname, dnsnames[0]))
+    else:
+        raise CertificateError("no appropriate commonName or "
+            "subjectAltName fields were found")


### PR DESCRIPTION
This solves an error on Python 3.1:

``` python
(py31.venv)marca@marca-mac:~/dev/git-repos/pip$ pip --version
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/pip/py31.venv/bin/pip", line 9, in <module>
    load_entry_point('pip==1.5.dev1', 'console_scripts', 'pip')()
  File "/Users/marca/dev/git-repos/pip/py31.venv/lib/python3.1/site-packages/pkg_resources.py", line 378, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/marca/dev/git-repos/pip/py31.venv/lib/python3.1/site-packages/pkg_resources.py", line 2566, in load_entry_point
    return ep.load()
  File "/Users/marca/dev/git-repos/pip/py31.venv/lib/python3.1/site-packages/pkg_resources.py", line 2260, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/Users/marca/dev/git-repos/pip/pip/__init__.py", line 11, in <module>
    from pip.util import get_installed_distributions, get_prog
  File "/Users/marca/dev/git-repos/pip/pip/util.py", line 17, in <module>
    from pip.vendor.distlib import version
  File "/Users/marca/dev/git-repos/pip/pip/vendor/distlib/version.py", line 13, in <module>
    from .compat import string_types
  File "/Users/marca/dev/git-repos/pip/pip/vendor/distlib/compat.py", line 140, in <module>
    from ssl import match_hostname, CertificateError
ImportError: cannot import name match_hostname
```
