### PR TITLE
Don't double "remove" an item from "dirs"

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -401,7 +401,7 @@ exec(compile(
                                 )):
                             dirs.remove(dir)
                         # Also don't search through tests
-                        if dir == 'test' or dir == 'tests':
+                        elif dir == 'test' or dir == 'tests':
                             dirs.remove(dir)
                     filenames.extend([os.path.join(root, dir)
                                      for dir in dirs])


### PR DESCRIPTION
Use "elif" to only call `dirs.remove(dir)` once if both conditions are true. This is possible if a virtualenv called "test" is present, so both "test/bin/python" exists, and `dir == 'test'`. It would execute `dirs.remove('test')` twice, the second time raising an exception.
