### PR TITLE
When using svn with revisions in the URL, corretly handly when they are deleted

### DIFF
--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -124,11 +124,19 @@ class VersionControl(object):
         assert '+' in self.url, error_message % self.url
         url = self.url.split('+', 1)[1]
         scheme, netloc, path, query, frag = urlparse.urlsplit(url)
+        path, rev = self.extract_rev_from_path(path)
+        url = urlparse.urlunsplit((scheme, netloc, path, query, ''))
+        return url, rev
+
+    def extract_rev_from_path(self, path):
+        """
+        Returns (path, rev) from a string represeting the path
+        """
         rev = None
         if '@' in path:
             path, rev = path.rsplit('@', 1)
-        url = urlparse.urlunsplit((scheme, netloc, path, query, ''))
-        return url, rev
+        return path, rev
+
 
     def get_info(self, location):
         """

--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -53,6 +53,17 @@ class Subversion(VersionControl):
             return rest, rev
         return None, None
 
+    def extract_rev_from_path(self, path):
+        """
+        Returns (path, rev) from a string represeting the path.
+        Unlike most VCS, we need to keep the the @REV to the URL.
+        cf. http://svnbook.red-bean.com/en/1.7/svn-book.html#svn.advanced.pegrevs
+        """
+        rev = None
+        if '@' in path:
+            dont_care, rev = path.rsplit('@', 1)
+        return path, rev
+
     def export(self, location):
         """Export the svn repository at the url to the destination location"""
         url, rev = self.get_url_rev()

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -30,7 +30,7 @@ def test_bazaar_simple_urls():
 
 def test_svn_extra_rev_from_url():
     svn_repo_w_rev = Subversion(url="svn+svn://example.com/path/to/project@100")
-    assert svn_repo_w_rev.get_url_rev() == ("svn://example.com/path/to/project@100", 100)
+    assert svn_repo_w_rev.get_url_rev() == ("svn://example.com/path/to/project@100", '100')
 
     svn_repo_wo_rev = Subversion(url="svn+svn://example.com/path/to/project")
-    assert svn_repo_w_rev.get_url_rev() == ("svn://example.com/path/to/project", None)
+    assert svn_repo_wo_rev.get_url_rev() == ("svn://example.com/path/to/project", None)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -30,7 +30,7 @@ def test_bazaar_simple_urls():
 
 def test_svn_extra_rev_from_url():
     svn_repo_w_rev = Subversion(url="svn+svn://example.com/path/to/project@100")
-    assert svn_repo_w_rev.get_url_rev() == ("svn+svn://example.com/path/to/project@100", 100)
+    assert svn_repo_w_rev.get_url_rev() == ("svn://example.com/path/to/project@100", 100)
 
     svn_repo_wo_rev = Subversion(url="svn+svn://example.com/path/to/project")
-    assert svn_repo_w_rev.get_url_rev() == ("svn+svn://example.com/path/to/project", None)
+    assert svn_repo_w_rev.get_url_rev() == ("svn://example.com/path/to/project", None)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -1,5 +1,6 @@
 from tests.lib import pyversion
 from pip.vcs.bazaar import Bazaar
+from pip.vcs.subversion import Subversion
 
 if pyversion >= '3':
     VERBOSE_FALSE = False
@@ -27,3 +28,9 @@ def test_bazaar_simple_urls():
     assert sftp_bzr_repo.get_url_rev() == ('sftp://bzr.myproject.org/MyProject/trunk/', None)
     assert launchpad_bzr_repo.get_url_rev() == ('lp:MyLaunchpadProject', None)
 
+def test_svn_extra_rev_from_url():
+    svn_repo_w_rev = Subversion(url="svn+svn://example.com/path/to/project@100")
+    assert svn_repo_w_rev.get_url_rev() == ("svn+svn://example.com/path/to/project@100", 100)
+
+    svn_repo_wo_rev = Subversion(url="svn+svn://example.com/path/to/project")
+    assert svn_repo_w_rev.get_url_rev() == ("svn+svn://example.com/path/to/project", None)


### PR DESCRIPTION
If you have a SVN path that's deleted in a later revision, you need to
include the revision number in the URL to fetch so that SVN will send
you the code at that revision.

We had a problem with pip installing from a svn URL (i.e. ``svn+svn://example.com/path/to/code@100``), since the SVN server was now at version 150, and in version 140 we had deleted the directory ``/path/to/code``. In theory everything should still work, because at revision 100, the directory was still there. However pip wasn't able to make the URLs in the correct format.

The SVN book talks about this: http://svnbook.red-bean.com/en/1.7/svn-book.html#svn.advanced.pegrevs