### PR TITLE
docs/make.bat: Fix Sphinx invokation on Windows

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -3,7 +3,7 @@
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=sphinx-build
+	set SPHINXBUILD=python -m sphinx.__init__
 )
 set BUILDDIR=_build
 set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .


### PR DESCRIPTION
Sphinx doesn't have installer and therefore is never
available from PATH on user system unless user adds
it manually. Sphinx can only be installed with
`python`, which is added to system PATH, so it is
more reliable way to execute Sphinx in Windows.
