### PR TITLE
Close a file to prevent a WindowsError

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -670,6 +670,7 @@ exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
                 logger.warn('Could not find .egg-info directory in install record for %s' % self)
                 ## FIXME: put the record somewhere
                 ## FIXME: should this be an error?
+                f.close()
                 return
             f.close()
             new_lines = []


### PR DESCRIPTION
WindowsError: [Error 32] The process cannot access the file because it
is being used by another process: 'C:\docume~1\...'

https://mail.python.org/pipermail/distutils-sig/2013-August/022528.html

Btw, a context manager to handle this opened file is probably a good idea. In the interim, this fixes the problem that I am stumbling into.
