### PR TITLE
Fixed error message

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -1588,7 +1588,7 @@ def parse_editable(editable_req, default_vcs=None):
             url = default_vcs + '+' + url
         else:
             raise InstallationError(
-                '%s should either by a path to a local project or a VCS url beginning with svn+, git+, hg+, or bzr+' % editable_req)
+                '%s should either be a path to a local project or a VCS url beginning with svn+, git+, hg+, or bzr+' % editable_req)
 
     vc_type = url.split('+', 1)[0].lower()
 


### PR DESCRIPTION
Seems like this should be "be", not "by"
