### PR TITLE
allow pip to install mac wheels from pypi

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -107,7 +107,8 @@ To install from wheels on PyPI, if they were to exist (which is not likely for t
 
 .. note::
 
-  pip currently disallows non-windows platform-specific wheels from being downloaded from PyPI.  See :ref:`Should you upload wheels to PyPI`.
+  pip currently disallows platform-specific wheels (except for Windows and Mac)
+  from being downloaded from PyPI.  See :ref:`Should you upload wheels to PyPI`.
 
 
 To install directly from a wheel archive:
@@ -168,13 +169,12 @@ to be constantly kept up-to-date for security. Regardless of whether a
 compatible pre-build package is available, many Linux users will prefer
 to always compile their own anyway.
 
-On Windows the case for binary wheels on pypi is stronger both because
-Windows machines are much more uniform than Linux and because it's harder
-for the end user to compile their own. Windows-compatible wheels uploaded
-to pypi should be compatible with the Python distributions downloaded
-from http://python.org/.  If you already upload other binary formats to
-pypi, upload wheels as well.  Unlike the older formats, wheels are
-compatible with virtual environments.
+On Windows and Mac, the case for binary wheels on pypi is stronger due to the
+systems being much more uniform than Linux and because it's harder for the end
+user to compile their own. Windows and Mac wheels uploaded to pypi should be
+compatible with the Python distributions downloaded from http://python.org/.  If
+you already upload other binary formats to pypi, upload wheels as well.  Unlike
+the older formats, wheels are compatible with virtual environments.
 
 
 .. _`Downloading Archives`:

--- a/pip/index.py
+++ b/pip/index.py
@@ -477,19 +477,20 @@ class PackageFinder(object):
                 if link.wheel.name.lower() != search_name.lower():
                     logger.debug('Skipping link %s; wrong project name (not %s)' % (link, search_name))
                     return []
-                version = link.wheel.version
                 if not link.wheel.supported():
                     logger.debug('Skipping %s because it is not compatible with this Python' % link)
                     return []
-
                 # This is a dirty hack to prevent installing Binary Wheels from
-                #   PyPI unless it is a Windows Binary Wheel. This is paired
-                #   with a change to PyPI disabling uploads for the same. Once
-                #   we have a mechanism for enabling support for binary wheels
-                #   on linux that deals with the inherent problems of binary
-                #   distribution this can be removed.
+                # PyPI unless it is a Windows or Mac Binary Wheel. This is
+                # paired with a change to PyPI disabling uploads for the
+                # same. Once we have a mechanism for enabling support for binary
+                # wheels on linux that deals with the inherent problems of
+                # binary distribution this can be removed.
                 comes_from = getattr(link, "comes_from", None)
-                if (not platform.startswith('win')
+                if ((
+                        not platform.startswith('win')
+                        and not platform.startswith('macosx')
+                        )
                     and comes_from is not None
                     and urlparse.urlparse(comes_from.url).netloc.endswith(
                                                         "pypi.python.org")):
@@ -499,6 +500,7 @@ class PackageFinder(object):
                             "Wheel on an unsupported platform" % link
                         )
                         return []
+                version = link.wheel.version
 
         if not version:
             version = self._egg_info_matches(egg_info, search_name, link)


### PR DESCRIPTION
sames as #1277 but with updates to docs and comments, and little bit of restructure in the surrounding code block.
