### PR TITLE
Set the executable bit on files generated by distlib's ScriptMaker

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -219,6 +219,11 @@ def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None):
     maker = ScriptMaker(None, scheme['scripts'])
     maker.variants = set(('', ))
 
+    # This is required because otherwise distlib creates scripts that are not
+    # executable.
+    # See https://bitbucket.org/pypa/distlib/issue/32/
+    maker.set_mode = True
+
     # Special case pip and setuptools to generate versioned wrappers
     #
     # The issue is that some projects (specifically, pip and setuptools) use

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -117,6 +117,9 @@ def test_install_from_wheel_gen_entrypoint(script, data):
         wrapper_file = script.bin / 't1'
     assert wrapper_file in result.files_created
 
+    if os.name != "nt":
+        assert bool(os.access(script.base_path / wrapper_file, os.X_OK))
+
 def test_install_from_wheel_with_legacy(script, data):
     """
     Test installing scripts (legacy scripts are preserved)


### PR DESCRIPTION
Fixes #1280
