### PR TITLE
Only update git submodules after checking out specified revision

### DIFF
--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -109,13 +109,13 @@ class Git(VersionControl):
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.notify('Cloning %s%s to %s' % (url, rev_display, display_path(dest)))
             call_subprocess([self.cmd, 'clone', '-q', url, dest])
-            #: repo may contain submodules
-            self.update_submodules(dest)
             if rev:
                 rev_options = self.check_rev_options(rev, dest, rev_options)
                 # Only do a checkout if rev_options differs from HEAD
                 if not self.get_revision(dest).startswith(rev_options[0]):
                     call_subprocess([self.cmd, 'checkout', '-q'] + rev_options, cwd=dest)
+            #: repo may contain submodules
+            self.update_submodules(dest)
 
     def get_url(self, location):
         url = call_subprocess(


### PR DESCRIPTION
This caused a problem with a repo that referenced a submodule in the `master` branch, but not in the branch specified in the requirements file; the box in question had firewall rules that disabled outgoing SSH connections.