### PR TITLE
Adds support for dashes in wheel version names

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -494,6 +494,8 @@ class PackageFinder(object):
                             "Wheel on an unsupported platform" % link
                         )
                         return []
+                # To match the "safe" version that pkg_resources creates:
+                version = link.wheel.version.replace('_','-')
 
         if not version:
             version = self._egg_info_matches(egg_info, search_name, link)


### PR DESCRIPTION
Couldn't find any contribution guidelines, so I apologize in advance if this is off the wrong branch, etc.  It's supposed to be for tag 1.4.1

This fix is for when a package has a dash in their version name (ie python-inotify==0.6-test).  When generating a wheel, the file name becomes python_inotify-0.6_test_blah_blah.whl.  However, when that is uploaded to pypi/local pypi proxy, pip sees the version as 0.6_test and ignores it:

```
Ignoring link http://mypypiproxy/+f/2ca1d470df63cef4c00bafed6cd5e110/python_inotify-0.6_test-cp27-none-linux_x86_64.whl#md5=2ca1d470df63cef4c00bafed6cd5e110 (from http:
//mypypiproxy/+simple/python-inotify/), version 0.6_test doesn't match ==0.6-test
```

The fix simply applies the same rule as is used for egg versioning (replace '_' with '-')
