### PR TITLE
Accepts '-e' flag and ignores it, treating the following as normal vcs

### DIFF
--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -43,6 +43,13 @@ class WheelCommand(Command):
         cmd_opts = self.cmd_opts
 
         cmd_opts.add_option(
+            '-e', '--editable',
+            dest='not_used',
+            action='store_true',
+            help='Ignore editable flag and treat as normal path. Useful when'
+            'building wheels from requirements.txt.')
+
+        cmd_opts.add_option(
             '-w', '--wheel-dir',
             dest='wheel_dir',
             metavar='dir',


### PR DESCRIPTION
This is extremely useful when generating wheels from requirements.txt
that have a -e flag.
