### PR TITLE
unsuppress the help for --log-file

### DIFF
--- a/docs/logic.rst
+++ b/docs/logic.rst
@@ -93,6 +93,9 @@ A few examples on how the parameters work to affect the level:
 The most practical use case for users is either ``-v`` or ``-vv`` to see
 additional logging to help troubleshoot an issue.
 
+
+.. _`FileLogging`:
+
 File logging
 ~~~~~~~~~~~~
 
@@ -101,13 +104,13 @@ verbosity log will be kept.  This option is empty by default. This log appends
 to previous logging.
 
 Additionally, when commands fail (i.e. return a non-zero exit code), pip writes
-a full DEBUG "failure log" for the failed command. This log overwrites previous
+a "failure log" for the failed command. This log overwrites previous
 logging. The default location is as follows:
 
 * On Unix and Mac OS X: :file:`$HOME/.pip/pip.log`
 * On Windows, the configuration file is: :file:`%HOME%\\pip\\pip.log`
 
-The option for this  "failure log", although hidden in the help, is ``--log-file``.
+The option for the failure log, is :ref:`--log-file <--log-file>`.
 
 Both logs add a line per execution to specify the date and what pip executable wrote the log.
 

--- a/docs/pipext.py
+++ b/docs/pipext.py
@@ -8,6 +8,7 @@ from docutils.statemachine import ViewList
 from textwrap import dedent
 from pip import commands
 from pip import cmdoptions
+from pip.locations import default_log_file
 from pip.util import get_prog
 
 
@@ -58,6 +59,7 @@ class PipOptions(rst.Directive):
         opt_help = option.help.replace('%default', str(option.default))
         #fix paths with sys.prefix
         opt_help = opt_help.replace(sys.prefix, "<sys.prefix>")
+        opt_help = opt_help.replace(default_log_file, "<see :ref:`FileLogging`>")
         return [bookmark_line, "", line, "", "    %s" % opt_help, ""]
 
     def _format_options(self, options, cmd_name=None):

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -75,8 +75,8 @@ quiet = OptionMaker(
 log = OptionMaker(
     '--log',
     dest='log',
-    metavar='file',
-    help='Log file where a complete (maximum verbosity) record will be kept.')
+    metavar='path',
+    help='Path to a verbose appending log. This log is inactive by default.')
 
 log_explicit_levels = OptionMaker(
     # Writes the log levels explicitely to the log'
@@ -88,11 +88,11 @@ log_explicit_levels = OptionMaker(
 
 log_file = OptionMaker(
     # The default log file
-    '--local-log', '--log-file',
+    '--log-file', '--local-log',
     dest='log_file',
-    metavar='file',
+    metavar='path',
     default=default_log_file,
-    help=SUPPRESS_HELP)
+    help='Path to a verbose non-appending log, that only logs failures. This log is active by default at %default.')
 
 no_input = OptionMaker(
     # Don't ask for input
@@ -339,9 +339,9 @@ general_group = {
         verbose,
         version,
         quiet,
+        log_file,
         log,
         log_explicit_levels,
-        log_file,
         no_input,
         proxy,
         timeout,


### PR DESCRIPTION
the changes:
- unsuppress the help for `--log-file`
- added better help text for both `--log` and `--log-file` (they do serve different functions)
- updated the docs we have on logging (that I added a few weeks back;http://www.pip-installer.org/en/develop/logic.html#logging )

One might argue that it's confusing to have 2 options showing with a similar name, but IMO it's more confusing to hide one of them, especially given that the one that's hidden, controls the log that is active by default.

fwiw, I considered a PR awhile back that would have aliased these two, but was concerned about backward compatibility, so didn't move forward with it.
