### PR TITLE
Add the possibility to follow symlinks on copytree also for py3

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -26,6 +26,7 @@ from pip.utils import (splitext, rmtree, format_size, display_path,
 from pip.utils.filesystem import check_path_owner
 from pip.utils.ui import DownloadProgressBar, DownloadProgressSpinner
 from pip.locations import write_delete_marker_file
+from pip.compat import copytree
 from pip.vcs import vcs
 from pip._vendor import requests, six
 from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
@@ -694,7 +695,7 @@ def unpack_file_url(link, location, download_dir=None):
     if os.path.isdir(link_path):
         if os.path.isdir(location):
             rmtree(location)
-        shutil.copytree(link_path, location, symlinks=True)
+        copytree(link_path, location, symlinks=True)
         if download_dir:
             logger.info('Link is a directory, ignoring download_dir')
         return

--- a/pip/download.py
+++ b/pip/download.py
@@ -695,7 +695,7 @@ def unpack_file_url(link, location, download_dir=None):
     if os.path.isdir(link_path):
         if os.path.isdir(location):
             rmtree(location)
-        copytree(link_path, location, symlinks=True)
+        copytree(link_path, location)
         if download_dir:
             logger.info('Link is a directory, ignoring download_dir')
         return

--- a/pip/download.py
+++ b/pip/download.py
@@ -26,7 +26,7 @@ from pip.utils import (splitext, rmtree, format_size, display_path,
 from pip.utils.filesystem import check_path_owner
 from pip.utils.ui import DownloadProgressBar, DownloadProgressSpinner
 from pip.locations import write_delete_marker_file
-from pip.compat import copytree
+from pip.utils import copytree
 from pip.vcs import vcs
 from pip._vendor import requests, six
 from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter

--- a/pip/exceptions.py
+++ b/pip/exceptions.py
@@ -45,3 +45,13 @@ class InvalidWheelFilename(InstallationError):
 
 class UnsupportedWheel(InstallationError):
     """Unsupported wheel."""
+
+
+class CircularSymlinkException(PipError):
+    """When a circular symbolic link is detected."""
+    def __init__(self, resources):
+        message = (
+            'Circular reference detected in "%s" ("%s" > "%s").'
+            '' % (resources[0], '" > "'.join(resources), resources[0]),
+        )
+        PipError.__init__(self, message)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -13,9 +13,13 @@ import pytest
 
 from mock import Mock, patch
 from pip.exceptions import BadCommand
+from pip.exceptions import CircularSymlinkException
 from pip.utils import (egg_link_path, Inf, get_installed_distributions,
                        find_command, untar_file, unzip_file, rmtree)
+from pip.utils import validate_path
 from pip.operations.freeze import freeze_excludes
+from tests.lib import DATA_DIR
+from tests.lib import Path
 
 
 class Tests_EgglinkPath:
@@ -456,3 +460,74 @@ def test_rmtree_retries_for_3sec(tmpdir, monkeypatch):
     monkeypatch.setattr(shutil, 'rmtree', Failer(duration=5).call)
     with pytest.raises(OSError):
         rmtree('foo')
+
+
+class TestValidatePath(object):
+    def setup(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.old_mask = os.umask(0o022)
+        self.dir = DATA_DIR.join('util').join('bar')
+        self.file = self.dir.join('foo')
+        self.symlinksDir = Path(self.tempdir)
+
+    def teardown(self):
+        os.umask(self.old_mask)
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def testRegularFile(self):
+        foo_file = self.file.join('foo')
+        validate_path(foo_file)
+
+    @pytest.mark.skipif(
+        not hasattr(os, 'symlink'),
+        reason="requires os.symlink",
+    )
+    def testRegularSymlinkToFile(self):
+        foo_file = self.file
+        symfoo_link = self.symlinksDir.join('symfoo')
+        try:
+            os.symlink(foo_file, symfoo_link)
+            validate_path(symfoo_link)
+        except OSError:
+            return
+        finally:
+            os.unlink(symfoo_link)
+
+    @pytest.mark.skipif(
+        not hasattr(os, 'symlink'),
+        reason="requires os.symlink",
+    )
+    def testRegularSymlinkToDirectory(self):
+        bar_dir = self.dir
+        symbar_link = self.symlinksDir.join('symbar')
+        try:
+            os.symlink(bar_dir, symbar_link)
+            validate_path(symbar_link)
+        except OSError:
+            return
+        finally:
+            os.unlink(symbar_link)
+
+    @pytest.mark.skipif(
+        not hasattr(os, 'symlink'),
+        reason="requires os.symlink",
+    )
+    def testCircularSymlink(self):
+        foo_file = self.file.join('foo')
+        symfoo_link = self.symlinksDir.join('symfoo')
+        to_symfoo_link = self.symlinksDir.join('to_symfoo')
+        to_to_symfoo_link = self.symlinksDir.join('to_to_symfoo')
+        try:
+            os.symlink(foo_file, symfoo_link)
+            os.symlink(symfoo_link, to_symfoo_link)
+            os.symlink(to_symfoo_link, to_to_symfoo_link)
+            os.unlink(symfoo_link)
+            os.symlink(to_to_symfoo_link, symfoo_link)
+            with pytest.raises(CircularSymlinkException):
+                validate_path(symfoo_link)
+        except OSError:
+            return
+        finally:
+            os.unlink(symfoo_link)
+            os.unlink(to_symfoo_link)
+            os.unlink(to_to_symfoo_link)


### PR DESCRIPTION
Hello,

Reply to #1311

It's an answer of https://github.com/pypa/pip/pull/1311/files#r7640350

If a project contains true NTFS symlinks it require elevated privileges indeed (source: [@docs.python: os.symlink](http://docs.python.org/3.3/library/os.html?highlight=os.symlink#os.symlink) and [@wikipedia: NTFS_symbolic_link](https://en.wikipedia.org/wiki/NTFS_symbolic_link))

- [x] Fix shutil.copytree for py3 when a symlink points to a directory
- [x] Prevent circular symbolic links
- [x] Add test with circular symbolic links
- [x] revert pypa/pip@f579c178bc206004ac332c38ed9155f6e58ccfd3

It should be also update `tests.lib.path.Path.copytree` method (e.g. git revert pypa/pip@99a4f6f4e17a3a3643c1289b1306363943b766d5) but it will add a dependency to `pip.util` module.

All comments are welcome