### PR TITLE
Fixed issue #1334.

### DIFF
--- a/pip/req.py
+++ b/pip/req.py
@@ -1191,6 +1191,9 @@ class RequirementSet(object):
                                     req_to_install.conflicts_with = req_to_install.satisfied_by
                                 req_to_install.satisfied_by = None
                             else:
+                                # Failure must be logged after unpack for wheels and sdists
+                                logger.notify('Requirement already up-to-date: %s'
+                                      % req_to_install.name)
                                 install = False
                 if not (is_bundle or is_wheel):
                     ## FIXME: shouldn't be globally added:


### PR DESCRIPTION
When installing from archives, the proper error message should be logged before exit. On an aside, this is my first pull request, so apologies if it's not formatted properly.
