### PR TITLE
Add a --use-2to3 option to `pip install`

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -144,6 +144,12 @@ class InstallCommand(Command):
             default=False,
             help="Include pre-release and development versions. By default, pip only finds stable versions.")
 
+        cmd_opts.add_option(
+            '--use-2to3',
+            action='store_true',
+            default=False,
+            help="Process packages with 2to3 before installing.")
+
         cmd_opts.add_option(cmdoptions.no_clean.make())
 
         index_opts = cmdoptions.make_option_group(cmdoptions.index_group, self.parser)
@@ -226,6 +232,7 @@ class InstallCommand(Command):
             use_user_site=options.use_user_site,
             target_dir=temp_target_dir,
             session=session,
+            use_2to3=options.use_2to3,
         )
         for name in args:
             requirement_set.add_requirement(

--- a/pip/req.py
+++ b/pip/req.py
@@ -873,7 +873,7 @@ class RequirementSet(object):
     def __init__(self, build_dir, src_dir, download_dir, download_cache=None,
                  upgrade=False, ignore_installed=False, as_egg=False, target_dir=None,
                  ignore_dependencies=False, force_reinstall=False, use_user_site=False,
-                 session=None):
+                 session=None, use_2to3=False):
         self.build_dir = build_dir
         self.src_dir = src_dir
         self.download_dir = download_dir
@@ -893,6 +893,7 @@ class RequirementSet(object):
         self.use_user_site = use_user_site
         self.target_dir = target_dir #set from --target option
         self.session = session or PipSession()
+        self.use_2to3 = use_2to3
 
     def __str__(self):
         reqs = [req for req in self.requirements.values()
@@ -1149,6 +1150,9 @@ class RequirementSet(object):
                                     reqs.append(subreq)
                                     self.add_requirement(subreq)
                         else:
+                            if self.use_2to3:
+                                import lib2to3.main
+                                lib2to3.main.main('lib2to3.fixes', args=['-w', '--no-diffs', location])
                             req_to_install.source_dir = location
                             req_to_install.run_egg_info()
                             if force_root_egg_info:


### PR DESCRIPTION
This might be a good feature for pip or it might be completely stupid... :smile: 

It is an option to automatically run `2to3` when installing a package.

I was waiting for someone to accept a PR to add `use_2to3=True` to their `setup.py` and then I thought — what if I as the package installer could just decide to run `2to3` myself and not have to wait for the maintainer to support it?

Obviously it may not work on all packages and it's caveat emptor for the user who decides to use it.

But I was able to do: `pip install —use-2to3 PasteScript` and get PasteScript working well enough to run tests that were relying on it.

``` bash
(_py33.venv)marca@marca-mac2:~/dev/git-repos/pip$ pip install PasteScript
...
  File "/Users/marca/dev/git-repos/pip/_py33.venv/build/PasteScript/setup.py", line 16

    print 'Warning: no news for this version found'

                                                  ^

SyntaxError: invalid syntax
...

(_py33.venv)marca@marca-mac2:~/dev/git-repos/pip$ pip install --help | grep 2to3
  --use-2to3                  Process packages with 2to3 before installing.

(_py33.venv)marca@marca-mac2:~/dev/git-repos/pip$ pip install --use-2to3 PasteScript
...
Successfully installed PasteScript Paste PasteDeploy
Cleaning up...

(_py33.venv)marca@marca-mac2:~/dev/git-repos/pip$ ipython3
Python 3.3.3rc1 (default, Nov 11 2013, 14:08:38)
Type "copyright", "credits" or "license" for more information.

IPython 1.1.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import paste.script.command

In [2]: paste.script.command.get_commands()
Out[2]:
{'create': EntryPoint.parse('create = paste.script.create_distro:CreateDistroCommand [templating]'),
 'exe': EntryPoint.parse('exe = paste.script.exe:ExeCommand'),
 'help': EntryPoint.parse('help = paste.script.help:HelpCommand'),
 'make-config': EntryPoint.parse('make-config = paste.script.appinstall:MakeConfigCommand'),
 'points': EntryPoint.parse('points = paste.script.entrypoints:EntryPointCommand'),
 'post': EntryPoint.parse('post = paste.script.request:RequestCommand [config]'),
 'request': EntryPoint.parse('request = paste.script.request:RequestCommand [config]'),
 'serve': EntryPoint.parse('serve = paste.script.serve:ServeCommand [config]'),
 'setup-app': EntryPoint.parse('setup-app = paste.script.appinstall:SetupCommand')}
```
