### PR TITLE
skip the test that installs a wheel with headers on pypy

### DIFF
--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -41,6 +41,21 @@ def test_install_from_wheel_file(script, data):
     """
     Test installing directly from a wheel file.
     """
+    package = data.packages.join("simple.dist-0.1-py2.py3-none-any.whl")
+    result = script.pip('install', package, '--no-index', expect_error=False)
+    dist_info_folder = script.site_packages/'simple.dist-0.1.dist-info'
+    assert dist_info_folder in result.files_created, (dist_info_folder,
+                                                      result.files_created,
+                                                      result.stdout)
+
+
+# header installs are broke in pypy virtualenvs
+# https://github.com/pypa/virtualenv/issues/510
+@pytest.mark.skipif("hasattr(sys, 'pypy_version_info')")
+def test_install_from_wheel_with_headers(script, data):
+    """
+    Test installing from a wheel file with headers
+    """
     package = data.packages.join("headers.dist-0.1-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=False)
     dist_info_folder = script.site_packages/'headers.dist-0.1.dist-info'


### PR DESCRIPTION
- have the basic wheel install test, use a basic wheel
- have a separate test for a wheel with headers
- skip the header test on pypy for now due to virtualenv bug
