### PR TITLE
On a 32-bit Linux Python installation install 32-bit binary packages

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -32,8 +32,18 @@ def get_impl_ver():
 def get_platform():
     """Return our platform name 'win32', 'linux_x86_64'"""
     # XXX remove distutils dependency
-    return distutils.util.get_platform().replace('.', '_').replace('-', '_')
+    platform = distutils.util.get_platform().replace('.', '_').replace('-', '_')
 
+    if platform == 'linux_x86_64':
+        # HACK: work around get_platform() claiming we're running in 64-bit
+        #       mode just because we have a 64-bit kernel, even though this
+        #       Python version has been compiled for 32-bit mode.
+        import struct
+        ptr_size = struct.calcsize('P') * 8
+        if ptr_size == 32:
+            return 'linux_x86_32'
+
+    return platform
 
 def get_supported(versions=None, noarch=False):
     """Return a list of supported tags for each version specified in


### PR DESCRIPTION
I.e. instead of deciding to install 64-bit packages just because the
host systems' kernel is running in 64-bit mode.

The current/previous behaviour causes problems when I'm trying to install packages on a 32-bit Python installation running on a system with a 32bit kernel

    $ uname -a
    Linux m1001 2.6.34.9-rt-WR4.2.0.0_preempt_rt #1 SMP PREEMPT RT Fri Nov 29 22:11:53 MET 2013 x86_64 x86_64 x86_64 GNU/Linux
    $ file `which python2.7`
    /opt/python-2.7-x86_32/bin/python2.7: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically linked (uses shared libs), for GNU/Linux 2.6.34, stripped
    $ python2.7 -V
    2.7.5
    $ python2.7 -c 'import distutils.util, platform ; print distutils.util.get_platform(), platform.architecture()'
    linux-x86_64 ('32bit', 'ELF')

This patch catches this error and fixes it. Albeit in a hackish way.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/1377)
<!-- Reviewable:end -->
