### PR TITLE
'pip.commands' entry point for pip command plugins

### DIFF
--- a/pip/commands/__init__.py
+++ b/pip/commands/__init__.py
@@ -2,6 +2,7 @@
 Package containing all pip commands
 """
 
+from pkg_resources import iter_entry_points
 
 from pip.commands.bundle import BundleCommand
 from pip.commands.completion import CompletionCommand
@@ -47,6 +48,12 @@ commands_order = [
     HelpCommand,
 ]
 
+# add plugin commands
+for entry_point in iter_entry_points('pip.commands', name='command'):
+    project = entry_point.dist.project_name
+    commandClass = entry_point.load()
+    commandClass.summary = "(From %s) %s" % (project, commandClass.summary)
+    commands[commandClass.name] = commandClass
 
 def get_summaries(ignore_hidden=True, ordered=True):
     """Yields sorted (command name, command summary) tuples."""

--- a/tests/data/packages/plugin/plugin/__init__.py
+++ b/tests/data/packages/plugin/plugin/__init__.py
@@ -1,0 +1,14 @@
+
+from pip.basecommand import Command
+
+class PluginCommand(Command):
+    """
+    Do Plugin stuff
+    """
+    name = 'plugin'
+    usage = """
+      %prog [options] """
+    summary = 'Do Plugin stuff'
+
+    def run(self, options, args):
+        pass

--- a/tests/data/packages/plugin/setup.py
+++ b/tests/data/packages/plugin/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+setup(
+    name = "plugin",
+    version = '1.0',
+    packages=find_packages(),
+    entry_points = {'pip.commands': ['command = plugin:PluginCommand']}
+)
+
+

--- a/tests/functional/test_plugin.py
+++ b/tests/functional/test_plugin.py
@@ -1,0 +1,14 @@
+import pytest
+from pip.basecommand import SUCCESS
+
+def test_plugin_found(script, data):
+    """
+    Test extending the 'pip.commands' entry point
+    """
+    # the 'plugin' project provides the 'plugin' command
+    plugin_path = data.packages.join("plugin")
+    script.pip('install', plugin_path)
+    result = script.pip('plugin')
+    assert result.returncode == SUCCESS
+    result = script.pip('help')
+    assert '(From plugin) Do Plugin stuff' in result.stdout


### PR DESCRIPTION
this adds support for external projects adding pip commands using a new 'pip.commands' entry point.
pretty simple.  more could be done with the help formatting.
see the test for an example project using the entry point.
#1061 mentions doing this with "git style redirection" (with an example gist link).  the example was about execution. it was unclear to me how it provided a solution similar to entry points, but maybe I was missing something.
