### PR TITLE
Introduce 'retry' option

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -54,7 +54,7 @@ class Command(object):
         self.parser.add_option_group(gen_opts)
 
     def _build_session(self, options):
-        session = PipSession()
+        session = PipSession(retries=options.retries)
 
         # Handle custom ca-bundles from the user
         if options.cert:

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -114,6 +114,14 @@ proxy = OptionMaker(
     default='',
     help="Specify a proxy in the form [user:passwd@]proxy.server:port.")
 
+retries = OptionMaker(
+    '--retries',
+    dest='retries',
+    type='int',
+    default=3,
+    help="Maximum number of retries each connection should attempt "
+         "(default %default times).")
+
 timeout = OptionMaker(
     '--timeout', '--default-timeout',
     metavar='sec',
@@ -352,6 +360,7 @@ general_group = {
         log_explicit_levels,
         no_input,
         proxy,
+        retries,
         timeout,
         default_vcs,
         skip_requirements_regex,

--- a/pip/download.py
+++ b/pip/download.py
@@ -215,6 +215,8 @@ class PipSession(requests.Session):
     timeout = None
 
     def __init__(self, *args, **kwargs):
+        retries = kwargs.pop('retries', None)
+
         super(PipSession, self).__init__(*args, **kwargs)
 
         # Attach our User Agent to the request
@@ -222,6 +224,12 @@ class PipSession(requests.Session):
 
         # Attach our Authentication handler to the session
         self.auth = MultiDomainBasicAuth()
+
+        # Configure retries
+        if retries:
+            http_adapter = requests.adapters.HTTPAdapter(max_retries=retries)
+            self.mount("http://", http_adapter)
+            self.mount("https://", http_adapter)
 
         # Enable file:// urls
         self.mount("file://", LocalFSAdapter())

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -223,6 +223,11 @@ class TestGeneralOptions(object):
         options2, args2 = main(['fake', '--proxy', 'path'])
         assert options1.proxy == options2.proxy == 'path'
 
+    def test_retries(self):
+        options1, args1 = main(['--retries', '-1', 'fake'])
+        options2, args2 = main(['fake', '--retries', '-1'])
+        assert options1.retries == options2.retries == -1
+
     def test_timeout(self):
         options1, args1 = main(['--timeout', '-1', 'fake'])
         options2, args2 = main(['fake', '--timeout', '-1'])


### PR DESCRIPTION
Add a 'retry' option which allows to configure how many
retries pip should make before giving up on HTTP request.

When the retries count is specified by user, its value is
passed to HTTPAdapter from requests which handles all
the underlying operations.
