### PR TITLE
make sure that wheel files with a single digit version do work

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -401,7 +401,7 @@ class Wheel(object):
     # TODO: maybe move the install code into this class
 
     wheel_file_re = re.compile(
-                r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)
+                r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.*?))?)
                 ((-(?P<build>\d.*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
                 \.whl|\.dist-info)$""",
                 re.VERBOSE)

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -175,6 +175,13 @@ class TestWheelFile(object):
         w = wheel.Wheel('simple-0.1_1-py2-none-any.whl')
         assert w.version == '0.1-1'
 
+    def test_single_digit_version(self):
+        """
+        Test that a single digit version works
+        """
+        w = wheel.Wheel('simple-1-py2-none-any.whl')
+        assert w.version == '1'
+
 
 class TestPEP425Tags(object):
 


### PR DESCRIPTION
this is a rather serious bug, since it makes 'pip wheel ...' fail with
the following error if the wheelhouse contains such a wheel:

,----
| ...
|   File "/home/ralf/.ve/dev/local/lib/python2.7/site-packages/pip/wheel.py", line 420, in **init**
|     self.version = wheel_info.group('ver').replace('_', '-')
| AttributeError: 'NoneType' object has no attribute 'replace'
`----
