### PR TITLE
Handle UTF-8 characters in filenames coming from tar.

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -549,7 +549,10 @@ def untar_file(filename, location):
             if member.name != 'pax_global_header'
         ])
         for member in tar.getmembers():
-            fn = member.name.decode('utf-8') if sys.version_info.major <= 2 else member.name
+            if sys.version_info.major <= 2:
+                fn = member.name.decode('utf-8')
+            else:
+                fn = member.name
             if fn == 'pax_global_header':
                 continue
             if leading:

--- a/pip/util.py
+++ b/pip/util.py
@@ -549,7 +549,7 @@ def untar_file(filename, location):
             if member.name != 'pax_global_header'
         ])
         for member in tar.getmembers():
-            fn = member.name.decode('utf-8')
+            fn = member.name.decode('utf-8') if sys.version_info.major <= 2 else member.name
             if fn == 'pax_global_header':
                 continue
             if leading:

--- a/pip/util.py
+++ b/pip/util.py
@@ -215,7 +215,6 @@ def file_contents(filename):
 
 
 def split_leading_dir(path):
-    path = str(path)
     path = path.lstrip('/').lstrip('\\')
     if '/' in path and (('\\' in path and path.find('/') < path.find('\\'))
                         or '\\' not in path):
@@ -542,7 +541,7 @@ def untar_file(filename, location):
     else:
         logger.warn('Cannot determine compression type for file %s' % filename)
         mode = 'r:*'
-    tar = tarfile.open(filename, mode)
+    tar = tarfile.open(filename, mode, encoding='utf-8')
     try:
         # note: python<=2.5 doesnt seem to know about pax headers, filter them
         leading = has_leading_dir([
@@ -550,7 +549,7 @@ def untar_file(filename, location):
             if member.name != 'pax_global_header'
         ])
         for member in tar.getmembers():
-            fn = member.name
+            fn = member.name.decode('utf-8')
             if fn == 'pax_global_header':
                 continue
             if leading:

--- a/pip/util.py
+++ b/pip/util.py
@@ -549,7 +549,7 @@ def untar_file(filename, location):
             if member.name != 'pax_global_header'
         ])
         for member in tar.getmembers():
-            if sys.version_info.major <= 2:
+            if sys.version_info[0] < 3:
                 fn = member.name.decode('utf-8')
             else:
                 fn = member.name


### PR DESCRIPTION
When location comes into untar_file() as a unicode string and member.name is not in the
ASCII subset of UTF-8 then os.path.join() raises a UnicodeDecodeError in python 2.7.3

The problem is that the python 2.x default string encoding is 'ascii' but the string
coming from tarfile is actually utf-8
(per http://at4j.sourceforge.net/releases/current/pg/ch08.xhtml POSIX 2001 it is
possible for it to be encoded with some other encoding, but this would be unwise
in a distributed tar file.)

The most proper place to do the decoding appears to be as soon as we first assign the
string to fn, this means we need to remove the path = str(path) in split_leading_dir().
This line appears to serve no purpose, but it looks like something one might write for
None safety, in which case it could be replaced with another construct such as
  if type(path) == type(None):
    path = ''"

Note: The problem can be reproduced by installing a package that requires another
package containing a file with non-ascii characters. In our case the problem package
was pyramid 1.3.3 which contains a unicode test file. Installing pyramid 1.3.3 directly
worked, but installing a package that required pyramid did not.