### PR TITLE
version-less wheels should raise InvalidWheelFilename

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -394,7 +394,7 @@ class Wheel(object):
     # TODO: maybe move the install code into this class
 
     wheel_file_re = re.compile(
-                r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.*?))?)
+                r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.*?)))
                 ((-(?P<build>\d.*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
                 \.whl|\.dist-info)$""",
                 re.VERBOSE)

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -53,6 +53,41 @@ def test_uninstallation_paths():
 
 class TestWheelFile(object):
 
+    def test_std_wheel_pattern(self):
+        w = wheel.Wheel('simple-1.1.1.1-py2-none-any.whl')
+        assert w.name == 'simple'
+        assert w.version == '1.1.1.1'
+        assert w.pyversions == ['py2']
+        assert w.abis == ['none']
+        assert w.plats == ['any']
+
+    def test_wheel_pattern_multi_values(self):
+        w = wheel.Wheel('simple-1.1-py2.py3-abi1.abi2-any.whl')
+        assert w.name == 'simple'
+        assert w.version == '1.1'
+        assert w.pyversions == ['py2', 'py3']
+        assert w.abis == ['abi1', 'abi2']
+        assert w.plats == ['any']
+
+    def test_wheel_with_build_tag(self):
+        # pip doesn't do anything with build tags, but theoretically, we might
+        # see one, in this case the build tag = '4'
+        w = wheel.Wheel('simple-1.1-4-py2-none-any.whl')
+        assert w.name == 'simple'
+        assert w.version == '1.1'
+        assert w.pyversions == ['py2']
+        assert w.abis == ['none']
+        assert w.plats == ['any']
+
+    def test_single_digit_version(self):
+        w = wheel.Wheel('simple-1-py2-none-any.whl')
+        assert w.version == '1'
+
+    def test_wheel_missing_segment_is_invalid(self):
+        # the version is missing in this case
+        with pytest.raises(InvalidWheelFilename):
+            w = wheel.Wheel('simple-py2-none-any.whl')
+
     def test_inavlid_filename_raises(self):
         with pytest.raises(InvalidWheelFilename):
             w = wheel.Wheel('invalid.whl')
@@ -135,12 +170,6 @@ class TestWheelFile(object):
         w = wheel.Wheel('simple-0.1_1-py2-none-any.whl')
         assert w.version == '0.1-1'
 
-    def test_single_digit_version(self):
-        """
-        Test that a single digit version works
-        """
-        w = wheel.Wheel('simple-1-py2-none-any.whl')
-        assert w.version == '1'
 
 
 class TestPEP425Tags(object):


### PR DESCRIPTION
version-less wheels should raise InvalidWheelFilename
more wheel tests:
  1) when wheels have multiple values for tags
  2) when wheels have no version
  3) when wheels have a build tag

cc @schmir  @dholth
