### PR TITLE
also try the legacy matcher when determining prereleases

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -707,19 +707,22 @@ def call_subprocess(cmd, show_stdout=True,
 
 def is_prerelease(vers):
     """
-    Attempt to determine if this is a pre-release using PEP386/PEP426 rules.
+    Attempt to determine if this is a pre-release using Normalized rules
+    (PEP426), and then Legacy Rules (pkg_resources)
 
     Will return True if it is a pre-release and False if not. Versions are
     assumed to be a pre-release if they cannot be parsed.
     """
-    normalized = version._suggest_normalized_version(vers)
+    vers_normalized = version._suggest_normalized_version(vers)
+    if vers_normalized is None:
+        try:
+            v = version.LegacyVersion(vers)
+        except version.UnsupportedVersionError:
+            return True
+    else:
+        v = version.NormalizedVersion(vers_normalized)
+    return v.is_prerelease
 
-    if normalized is None:
-        # Cannot normalize, assume it is a pre-release
-        return True
-
-    parsed = version._normalized_key(normalized)
-    return any([any([y in set(["a", "b", "c", "rc", "dev"]) for y in x]) for x in parsed])
 
 def read_text_file(filename):
     """Return the contents of *filename*.

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -13,7 +13,7 @@ import pytest
 from mock import Mock, patch
 from pip.exceptions import BadCommand
 from pip.util import (egg_link_path, Inf, get_installed_distributions,
-                      find_command, untar_file, unzip_file)
+                      find_command, untar_file, unzip_file, is_prerelease)
 
 
 class Tests_EgglinkPath:
@@ -348,3 +348,19 @@ class TestUnpackArchives(object):
         test_file = data.packages.join("test_zip.zip")
         unzip_file(test_file, self.tempdir)
         self.confirm_files()
+
+
+class Tests_is_prerelease(object):
+
+    def test_is_prerelease_already_normal(self):
+        assert is_prerelease('1.2a4')
+        assert is_prerelease('1.2rc4')
+        assert is_prerelease('1.2.dev4')
+
+    def test_is_prerelease_gets_normalized(self):
+        assert is_prerelease('1.2.a4')
+        assert is_prerelease('1.2.rc4')
+        assert is_prerelease('1.2dev4')
+
+    def test_is_not_prerelease_legacy(self):
+        assert not is_prerelease('1.2-fork1')


### PR DESCRIPTION
2 changes here:
1.  our prerelease function now additionally tries the legacy matcher, when normalization fails (i.e. when it fails to be close to PEP426).  this specifically makes it so something like  "1.3-fork1" will _not_ be called a prerelease
2.  we now use the distlib  `is_prelease` properties, which were added after our function was added.
