### PR TITLE
Use latin encoding to store filestrings

### DIFF
--- a/contrib/packager/__init__.py
+++ b/contrib/packager/__init__.py
@@ -37,7 +37,7 @@ def pkg_to_mapping(name):
                 f = open(os.path.join(root, pyfile), 'rb')
                 try:
                     b = f.read()
-                    name2src[pkg] = base64.b64encode(b)
+                    name2src[pkg] = b
                 finally:
                     f.close()
     return name2src

--- a/contrib/packager/template.py
+++ b/contrib/packager/template.py
@@ -3,7 +3,6 @@
 sources = """
 @SOURCES@"""
 
-import codecs
 import os
 import sys
 import base64
@@ -11,35 +10,40 @@ import bz2
 import tempfile
 import shutil
 
-def unpack(sources):
-    temp_dir = tempfile.mkdtemp('-scratchdir', 'unpacker-')
+
+def unpack(sources, into_dir):
     for package, content in sources.items():
         filepath = package.split("/")
         dirpath = os.sep.join(filepath[:-1])
-        packagedir = os.path.join(temp_dir, dirpath)
+        packagedir = os.path.join(into_dir, dirpath)
         if not os.path.isdir(packagedir):
             os.makedirs(packagedir)
         mod = open(os.path.join(packagedir, filepath[-1]), 'wb')
         try:
-            mod.write(base64.b64decode(content))
+            if sys.version_info >= (3, 0):
+                content = content.encode('latin1')
+            mod.write(content)
         finally:
             mod.close()
-    return temp_dir
 
 
 if __name__ == "__main__":
     if sys.version_info >= (3, 0):
         exec("def do_exec(co, loc): exec(co, loc)\n")
         import pickle
-        sources = sources.encode("ascii") # ensure bytes
-        sources = pickle.loads(bz2.decompress(base64.decodebytes(sources)))
+        sources = sources.encode("ascii")  # ensure bytes
+        up = lambda s: pickle.loads(s, encoding='latin1')
+        b64decode = base64.decodebytes
     else:
         import cPickle as pickle
         exec("def do_exec(co, loc): exec co in loc\n")
-        sources = pickle.loads(bz2.decompress(base64.decodestring(sources)))
+        up = lambda s: pickle.loads(s)
+        b64decode = base64.decodestring
+    sources = up(bz2.decompress(b64decode(sources)))
 
     try:
-        temp_dir = unpack(sources)
+        temp_dir = tempfile.mkdtemp('-scratchdir', 'unpacker-')
+        unpack(sources, temp_dir)
         sys.path.insert(0, temp_dir)
 
         entry = """@ENTRY@"""


### PR DESCRIPTION
I think this makes get-pip.py a little smaller as well, because instead of 

txt->b64->bz2->b64 it's just txt->bz2->b64

latin1 essentially allows py3 to decode whole bytes instead of just 127 values, lol.

works for me on archlinux py33 and py27, toothrot said it worked for him on py33 windows venv, and user reports it solves py32 for #1503

I thought `temp_dir` worked better inside the try instead of in `unpack()`, makes `unpack()` a little more invariant.
