### PR TITLE
Remove uses of sys.exc_info()[1]

### DIFF
--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -175,9 +175,8 @@ def main(initial_args=None):
 
     try:
         cmd_name, cmd_args = parseopts(initial_args)
-    except PipError:
-        e = sys.exc_info()[1]
-        sys.stderr.write("ERROR: %s" % e)
+    except PipError as exc:
+        sys.stderr.write("ERROR: %s" % exc)
         sys.stderr.write(os.linesep)
         sys.exit(1)
 
@@ -220,9 +219,8 @@ class FrozenRequirement(object):
             editable = True
             try:
                 req = get_src_requirement(dist, location, find_tags)
-            except InstallationError:
-                ex = sys.exc_info()[1]
-                logger.warn("Error when trying to get requirement for VCS system %s, falling back to uneditable format" % ex)
+            except InstallationError as exc:
+                logger.warn("Error when trying to get requirement for VCS system %s, falling back to uneditable format" % exc)
                 req = None
             if req is None:
                 logger.warn('Could not determine repository location of %s' % location)

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -124,27 +124,23 @@ class Command(object):
             # and when it is done, isinstance is not needed anymore
             if isinstance(status, int):
                 exit = status
-        except PreviousBuildDirError:
-            e = sys.exc_info()[1]
-            logger.fatal(str(e))
+        except PreviousBuildDirError as exc:
+            logger.fatal(str(exc))
             logger.info('Exception information:\n%s' % format_exc())
             store_log = True
             exit = PREVIOUS_BUILD_DIR_ERROR
-        except (InstallationError, UninstallationError):
-            e = sys.exc_info()[1]
-            logger.fatal(str(e))
+        except (InstallationError, UninstallationError) as exc:
+            logger.fatal(str(exc))
             logger.info('Exception information:\n%s' % format_exc())
             store_log = True
             exit = ERROR
-        except BadCommand:
-            e = sys.exc_info()[1]
-            logger.fatal(str(e))
+        except BadCommand as exc:
+            logger.fatal(str(exc))
             logger.info('Exception information:\n%s' % format_exc())
             store_log = True
             exit = ERROR
-        except CommandError:
-            e = sys.exc_info()[1]
-            logger.fatal('ERROR: %s' % e)
+        except CommandError as exc:
+            logger.fatal('ERROR: %s' % exc)
             logger.info('Exception information:\n%s' % format_exc())
             exit = ERROR
         except KeyboardInterrupt:

--- a/pip/baseparser.py
+++ b/pip/baseparser.py
@@ -149,9 +149,8 @@ class ConfigOptionParser(CustomOptionParser):
     def check_default(self, option, key, val):
         try:
             return option.check_value(key, val)
-        except optparse.OptionValueError:
-            e = sys.exc_info()[1]
-            print("An error occurred during configuration: %s" % e)
+        except optparse.OptionValueError as exc:
+            print("An error occurred during configuration: %s" % exc)
             sys.exit(3)
 
     def update_defaults(self, defaults):

--- a/pip/download.py
+++ b/pip/download.py
@@ -273,9 +273,8 @@ def get_file_content(url, comes_from=None, session=None):
     try:
         f = open(url)
         content = f.read()
-    except IOError:
-        e = sys.exc_info()[1]
-        raise InstallationError('Could not open requirements file: %s' % str(e))
+    except IOError as exc:
+        raise InstallationError('Could not open requirements file: %s' % str(exc))
     else:
         f.close()
     return url, content

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -955,10 +955,9 @@ def parse_editable(editable_req, default_vcs=None):
 
     try:
         options = _build_editable_options(editable_req)
-    except Exception:
-        message = sys.exc_info()[1]
+    except Exception as exc:
         raise InstallationError(
-            '--editable=%s error in editable options:%s' % (editable_req, message))
+            '--editable=%s error in editable options:%s' % (editable_req, exc))
 
     if not options or 'egg' not in options:
         req = _build_req_from_url(editable_req)

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -206,8 +206,8 @@ class RequirementSet(object):
                             except BestVersionAlreadyInstalled:
                                 best_installed = True
                                 install = False
-                            except DistributionNotFound:
-                                not_found = sys.exc_info()[1]
+                            except DistributionNotFound as exc:
+                                not_found = exc
                             else:
                                 # Avoid the need to call find_requirement again
                                 req_to_install.url = url.url
@@ -291,10 +291,9 @@ class RequirementSet(object):
                         if url:
                             try:
                                 self.unpack_url(url, location, self.is_download)
-                            except HTTPError:
-                                e = sys.exc_info()[1]
+                            except HTTPError as exc:
                                 logger.fatal('Could not install requirement %s because of error %s'
-                                             % (req_to_install, e))
+                                             % (req_to_install, exc))
                                 raise InstallationError(
                                     'Could not install requirement %s because of HTTP error %s for URL %s'
                                     % (req_to_install, e, url))
@@ -364,10 +363,9 @@ class RequirementSet(object):
                         for req in req_to_install.requirements(req_to_install.extras):
                             try:
                                 name = pkg_resources.Requirement.parse(req).project_name
-                            except ValueError:
-                                e = sys.exc_info()[1]
+                            except ValueError as exc:
                                 ## FIXME: proper warning
-                                logger.error('Invalid requirement: %r (%s) in requirement %s' % (req, e, req_to_install))
+                                logger.error('Invalid requirement: %r (%s) in requirement %s' % (req, exc, req_to_install))
                                 continue
                             if self.has_requirement(name):
                                 ## FIXME: check for conflict

--- a/pip/util.py
+++ b/pip/util.py
@@ -562,24 +562,22 @@ def untar_file(filename, location):
             elif member.issym():
                 try:
                     tar._extract_member(member, path)
-                except:
-                    e = sys.exc_info()[1]
+                except Exception as exc:
                     # Some corrupt tar files seem to produce this
                     # (specifically bad symlinks)
                     logger.warn(
                         'In the tar file %s the member %s is invalid: %s'
-                        % (filename, member.name, e))
+                        % (filename, member.name, exc))
                     continue
             else:
                 try:
                     fp = tar.extractfile(member)
-                except (KeyError, AttributeError):
-                    e = sys.exc_info()[1]
+                except (KeyError, AttributeError) as exc:
                     # Some corrupt tar files seem to produce this
                     # (specifically bad symlinks)
                     logger.warn(
                         'In the tar file %s the member %s is invalid: %s'
-                        % (filename, member.name, e))
+                        % (filename, member.name, exc))
                     continue
                 if not os.path.exists(os.path.dirname(path)):
                     os.makedirs(os.path.dirname(path))
@@ -662,10 +660,9 @@ def call_subprocess(cmd, show_stdout=True,
         proc = subprocess.Popen(
             cmd, stderr=subprocess.STDOUT, stdin=None, stdout=stdout,
             cwd=cwd, env=env)
-    except Exception:
-        e = sys.exc_info()[1]
+    except Exception as exc:
         logger.fatal(
-            "Error %s while executing command %s" % (e, command_desc))
+            "Error %s while executing command %s" % (exc, command_desc))
         raise
     all_output = []
     if stdout is not None:

--- a/pip/vcs/mercurial.py
+++ b/pip/vcs/mercurial.py
@@ -54,11 +54,10 @@ class Mercurial(VersionControl):
             config_file = open(repo_config, 'w')
             config.write(config_file)
             config_file.close()
-        except (OSError, ConfigParser.NoSectionError):
-            e = sys.exc_info()[1]
+        except (OSError, ConfigParser.NoSectionError) as exc:
             logger.warn(
                 'Could not switch Mercurial repository to %s: %s'
-                % (url, e))
+                % (url, exc))
         else:
             call_subprocess([self.cmd, 'update', '-q'] + rev_options, cwd=dest)
 


### PR DESCRIPTION
Using sys.exc_info()[1] is a hack that was used to use a shared source approach to Python 3.x support that also included versions of Python that didn't include the `except ... as exc:` construction. Pip no longer supports any of these versions of Python so we can remove it.
