### PR TITLE
Bugfix: when not find a version that satisfies the requirement. show all versions but duplicate

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -349,10 +349,10 @@ class PackageFinder(object):
                 (
                     req,
                     ', '.join(
-                        sorted(list(set([
+                        sorted(set([
                             version
                             for parsed_version, link, version in all_versions
-                        ]))))
+                        ])))
                 )
             )
 


### PR DESCRIPTION
When i install ipython:

```
sudo pip install ipython==1.0.dev
Downloading/unpacking ipython==1.0.dev
  Could not find a version that satisfies the requirement ipython==1.0.dev (from versions: 0.10.1, 0.10.1, 0.10.2, 0.10.2, 0.10, 0.11, 0.11, 0.12.1, 0.12.1, 0.12, 0.12, 0.13.1, 0.13.1, 0.13.2, 0.13.2, 0.13, 0.13, 1.0.0, 1.0.0, 1.1.0, 1.1.0)
  Some externally hosted files were ignored (use --allow-external to allow).
Cleaning up...
No distributions matching the version for ipython==1.0.dev
Storing debug log for failure in /home/dongwm/.pip/pip.log
```

You can see `0.10.2` display twice, and more  duplicate.

IPython put a zip and tar.gz but use same version, so need to remove duplicate
