### PR TITLE
[issue 1548] Make pip install -e uninstall existing versions

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -876,6 +876,10 @@ exec(compile(
                 return True
             else:
                 self.satisfied_by = pkg_resources.get_distribution(self.req)
+
+            if self.editable and self.satisfied_by:
+                self.conflicts_with = self.satisfied_by
+                return True
         except pkg_resources.DistributionNotFound:
             return False
         except pkg_resources.VersionConflict:

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -879,6 +879,9 @@ exec(compile(
 
             if self.editable and self.satisfied_by:
                 self.conflicts_with = self.satisfied_by
+                # when installing editables, nothing pre-existing should ever
+                # satisfy
+                self.satisfied_by = None
                 return True
         except pkg_resources.DistributionNotFound:
             return False

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -625,6 +625,8 @@ class RequirementSet(object):
                         # distribute wasn't installed, so nothing to do
                         pass
 
+                requirement.check_if_exists()
+
                 if requirement.conflicts_with:
                     logger.notify('Found existing installation: %s'
                                   % requirement.conflicts_with)

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -625,7 +625,8 @@ class RequirementSet(object):
                         # distribute wasn't installed, so nothing to do
                         pass
 
-                requirement.check_if_exists()
+                if not self.ignore_installed:
+                    requirement.check_if_exists()
 
                 if requirement.conflicts_with:
                     logger.notify('Found existing installation: %s'

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -217,7 +217,7 @@ class RequirementSet(object):
             ## Search for archive to fulfill requirement ##
             ###############################################
 
-            if not self.ignore_installed and not req_to_install.editable:
+            if not self.ignore_installed:
                 req_to_install.check_if_exists()
                 if req_to_install.satisfied_by:
                     if self.upgrade:
@@ -624,9 +624,6 @@ class RequirementSet(object):
                     except pkg_resources.DistributionNotFound:
                         # distribute wasn't installed, so nothing to do
                         pass
-
-                if not self.ignore_installed:
-                    requirement.check_if_exists()
 
                 if requirement.conflicts_with:
                     logger.notify('Found existing installation: %s'

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -228,6 +228,33 @@ def test_install_editable_from_git(script, tmpdir):
     result.assert_installed('pip-test-package', with_files=['.git'])
 
 
+def test_install_editable_uninstalls_existing(data, script, tmpdir):
+    """
+    Test that installing an editable uninstalls a previously installed
+    non-editable version.
+    https://github.com/pypa/pip/issues/1548
+    https://github.com/pypa/pip/pull/1552
+    """
+    to_install = data.packages.join("pip-test-package-0.1.tar.gz")
+    result = script.pip_install_local(to_install)
+    assert 'Successfully installed pip-test-package' in result.stdout
+    result.assert_installed('piptestpackage', editable=False)
+
+    result = script.pip(
+        'install', '-e',
+        '%s#egg=pip-test-package' %
+        local_checkout(
+            'git+http://github.com/pypa/pip-test-package.git',
+            tmpdir.join("cache"),
+        ),
+        # @todo: Why do other tests specify `expect_error=True`?
+    )
+    result.assert_installed('pip-test-package', with_files=['.git'])
+    assert 'Found existing installation: pip-test-package 0.1' in result.stdout
+    assert 'Uninstalling pip-test-package:' in result.stdout
+    assert 'Successfully uninstalled pip-test-package' in result.stdout
+
+
 def test_install_editable_from_hg(script, tmpdir):
     """
     Test cloning from Mercurial.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -247,7 +247,6 @@ def test_install_editable_uninstalls_existing(data, script, tmpdir):
             'git+http://github.com/pypa/pip-test-package.git',
             tmpdir.join("cache"),
         ),
-        # @todo: Why do other tests specify `expect_error=True`?
     )
     result.assert_installed('pip-test-package', with_files=['.git'])
     assert 'Found existing installation: pip-test-package 0.1' in result.stdout


### PR DESCRIPTION
by adding an additional call to `requirement.check_if_exists()` to
`RequirementSet.install`.

Fixes GH-1548

## Example output with this PR:

```bash
$ virtualenv pip_test
...

$ cd pip_test && source bin/activate

$ pip install requests==0.5.0
Downloading/unpacking requests==0.5.0
  Using download cache from /Users/marca/.pip/download-cache/http%3A%2F%2Flocalhost%3A3141%2Froot%2Fpypi%2F%2Bf%2F6dfdc1688217d774d524e056ec6605a6%2Frequests-0.5.0.tar.gz
  Running setup.py egg_info for package requests

Installing collected packages: requests
  Running setup.py install for requests

Successfully installed requests
Cleaning up...

$ python -c 'import requests; print(requests); print(requests.__version__)'
<module 'requests' from '/private/tmp/pip_test/lib/python2.7/site-packages/requests/__init__.pyc'>
0.5.0

$ pip install -e 'git+git@github.com:msabramo/pip.git@issue_1548_make_pip_install_editable_uninstall_existing_versions#egg=pip'
Obtaining pip from git+git@github.com:msabramo/pip.git@issue_1548_make_pip_install_editable_uninstall_existing_versions#egg=pip
...
Successfully installed pip
Cleaning up...

$ pip install -e ~/dev/git-repos/requests/
Obtaining file:///Users/marca/dev/git-repos/requests
  Running setup.py (path:/Users/marca/dev/git-repos/requests/setup.py) egg_info for package from file:///Users/marca/dev/git-repos/requests

Installing collected packages: requests
  Found existing installation: requests 0.5.0
    Uninstalling requests:
      Successfully uninstalled requests
  Running setup.py develop for requests

    Creating /private/tmp/pip_test/lib/python2.7/site-packages/requests.egg-link (link to .)
    Adding requests 2.0.1 to easy-install.pth file

    Installed /Users/marca/dev/git-repos/requests
Successfully installed requests
Cleaning up...

$ python -c 'import requests; print(requests); print(requests.__version__)'
<module 'requests' from '/Users/marca/dev/git-repos/requests/requests/__init__.pyc'>
2.0.1

$ pip uninstall --verbose --yes requests
Uninstalling requests:
  Removing file or directory /private/tmp/pip_test/lib/python2.7/site-packages/requests.egg-link
  Removing pth entries from /private/tmp/pip_test/lib/python2.7/site-packages/easy-install.pth:
  Removing entry: /Users/marca/dev/git-repos/requests
  Successfully uninstalled requests

$ pip uninstall --verbose --yes requests
Cannot uninstall requirement requests, not installed
Exception information:
Traceback (most recent call last):
  File "/private/tmp/pip_test/src/pip/pip/basecommand.py", line 129, in main
    status = self.run(options, args)
  File "/private/tmp/pip_test/src/pip/pip/commands/uninstall.py", line 64, in run
    requirement_set.uninstall(auto_confirm=options.yes)
  File "/private/tmp/pip_test/src/pip/pip/req/req_set.py", line 147, in uninstall
    req.uninstall(auto_confirm=auto_confirm)
  File "/private/tmp/pip_test/src/pip/pip/req/req_install.py", line 531, in uninstall
    "Cannot uninstall requirement %s, not installed" % (self.name,)
UninstallationError: Cannot uninstall requirement requests, not installed
```

Note that when I do `pip install -e` on requests above, the previous version gets found and uninstalled.

```bash
$ pip install -e ~/dev/git-repos/requests/
Obtaining file:///Users/marca/dev/git-repos/requests
  Running setup.py (path:/Users/marca/dev/git-repos/requests/setup.py) egg_info for package from file:///Users/marca/dev/git-repos/requests

Installing collected packages: requests
↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
  Found existing installation: requests 0.5.0
    Uninstalling requests:
      Successfully uninstalled requests
↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
  Running setup.py develop for requests
```

Cc: @sontek, @aconrad, @whitmo