### PR TITLE
Add ability to authenticate using GSSAPI

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -54,7 +54,7 @@ class Command(object):
         self.parser.add_option_group(gen_opts)
 
     def _build_session(self, options):
-        session = PipSession()
+        session = PipSession(gssapi=options.gssapi)
 
         # Handle custom ca-bundles from the user
         if options.cert:

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -107,6 +107,14 @@ no_input = OptionMaker(
     default=False,
     help=SUPPRESS_HELP)
 
+gssapi = OptionMaker(
+    # Don't ask for input
+    '--gssapi',
+    dest='gssapi',
+    action='store_true',
+    default=False,
+    help="Use Kerberos for authentication")
+
 proxy = OptionMaker(
     '--proxy',
     dest='proxy',
@@ -352,6 +360,7 @@ general_group = {
         log_explicit_levels,
         no_input,
         proxy,
+        gssapi,
         timeout,
         default_vcs,
         skip_requirements_regex,


### PR DESCRIPTION
GSSAPI auth may be available on server-side Apache, make it available on
client side as well using requests_kerberos module.

Unfortunately this supports only install operation, not search that uses XMLRPC