### PR TITLE
Fix #1424 -- add support for SSL client certificates

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@
 * `wsgiref` and `argparse` (for >py26) are now excluded from `pip list` and `pip
   freeze` (PR #1606, #1369)
 
+* Fixed #1424. Add ``--client-cert`` option for SSL client certificates.
+
 **1.5.4 (2014-02-21)**
 
 

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -60,6 +60,10 @@ class Command(object):
         if options.cert:
             session.verify = options.cert
 
+        # Handle SSL client certificate
+        if options.client_cert:
+            session.cert = options.client_cert
+
         # Handle timeouts
         if options.timeout:
             session.timeout = options.timeout

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -166,6 +166,15 @@ cert = OptionMaker(
     metavar='path',
     help="Path to alternate CA bundle.")
 
+client_cert = OptionMaker(
+    '--client-cert',
+    dest='client_cert',
+    type='str',
+    default=None,
+    metavar='path',
+    help="Path to SSL client certificate, a single file containing the "
+         "private key and the certificate in PEM format.")
+
 index_url = OptionMaker(
     '-i', '--index-url', '--pypi-url',
     dest='index_url',
@@ -357,6 +366,7 @@ general_group = {
         skip_requirements_regex,
         exists_action,
         cert,
+        client_cert,
     ]
 }
 

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -254,6 +254,11 @@ class TestGeneralOptions(object):
         options2, args2 = main(['fake', '--cert', 'path'])
         assert options1.cert == options2.cert == 'path'
 
+    def test_client_cert(self):
+        options1, args1 = main(['--client-cert', 'path', 'fake'])
+        options2, args2 = main(['fake', '--client-cert', 'path'])
+        assert options1.client_cert == options2.client_cert == 'path'
+
 
 class TestOptionsConfigFiles(object):
 


### PR DESCRIPTION
The test is a bit basic but follows what's being done for the `--cert`. I had test failures when running tox locally but the test I added passes.

I tried locally with a self-signed CA and it worked fine. It'd be perfect for [securing devpi instances](https://bitbucket.org/hpk42/devpi/issue/74/add-option-to-devpi-client-to-send-ssl) :)
