### PR TITLE
Skip tests that depend on system deps (hg|bzr|svn|..) that are missing.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -146,7 +146,7 @@ def _has_reqs(reqs):
             except OSError:
                 memoize[req] = False
 
-        # If memoize dict says requirement is missing, return negative
+        # If memoize dict says requirement is missing, return false
         if not memoize[req]:
             return False
 

--- a/tests/functional/test_bundle.py
+++ b/tests/functional/test_bundle.py
@@ -1,10 +1,12 @@
 import zipfile
 import textwrap
+import pytest
 from os.path import exists, join
 from pip.download import path_to_url
 from tests.lib.local_repos import local_checkout
 
 
+@pytest.mark.skip_if_missing('svn')
 def test_create_bundle(script, tmpdir, data):
     """
     Test making a bundle.  We'll grab one package from the filesystem
@@ -44,6 +46,7 @@ def test_create_bundle(script, tmpdir, data):
     assert 'build/pip/' in files
 
 
+@pytest.mark.skip_if_missing('git', 'svn')
 def test_cleanup_after_create_bundle(script, tmpdir, data):
     """
     Test clean up after making a bundle. Make sure (build|src)-bundle/ dirs are

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -1,6 +1,7 @@
 import sys
 import re
 import textwrap
+import pytest
 from doctest import OutputChecker, ELLIPSIS
 
 from tests.lib.local_repos import local_checkout, local_repo
@@ -63,6 +64,7 @@ def test_freeze_basic(script):
     _check_output(result, expected)
 
 
+@pytest.mark.skip_if_missing('svn')
 def test_freeze_svn(script, tmpdir):
     """Test freezing a svn checkout"""
 
@@ -95,6 +97,7 @@ def test_freeze_svn(script, tmpdir):
     _check_output(result, expected)
 
 
+@pytest.mark.skip_if_missing('git')
 def test_freeze_git_clone(script, tmpdir):
     """
     Test freezing a Git clone.
@@ -162,6 +165,7 @@ def test_freeze_git_clone(script, tmpdir):
     _check_output(result, expected)
 
 
+@pytest.mark.skip_if_missing('hg')
 def test_freeze_mercurial_clone(script, tmpdir):
     """
     Test freezing a Mercurial clone.
@@ -223,6 +227,7 @@ def test_freeze_mercurial_clone(script, tmpdir):
     _check_output(result, expected)
 
 
+@pytest.mark.skip_if_missing('bzr')
 def test_freeze_bazaar_clone(script, tmpdir):
     """
     Test freezing a Bazaar clone.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -66,6 +66,7 @@ def test_editable_install(script):
     assert not result.files_updated, result.files_updated
 
 
+@pytest.mark.skip_if_missing('svn')
 def test_install_editable_from_svn(script, tmpdir):
     """
     Test checking out from svn.
@@ -82,6 +83,7 @@ def test_install_editable_from_svn(script, tmpdir):
     result.assert_installed('INITools', with_files=['.svn'])
 
 
+@pytest.mark.skip_if_missing('svn')
 def test_download_editable_to_custom_path(script, tmpdir):
     """
     Test downloading an editable using a relative custom src folder.
@@ -116,6 +118,7 @@ def test_download_editable_to_custom_path(script, tmpdir):
     assert customdl_files_created
 
 
+@pytest.mark.skip_if_missing('svn')
 def test_editable_no_install_followed_by_no_download(script, tmpdir):
     """
     Test installing an editable in two steps (first with --no-install, then
@@ -211,6 +214,7 @@ def test_install_dev_version_from_pypi(script):
     )
 
 
+@pytest.mark.skip_if_missing('git')
 def test_install_editable_from_git(script, tmpdir):
     """
     Test cloning from Git.
@@ -228,6 +232,7 @@ def test_install_editable_from_git(script, tmpdir):
     result.assert_installed('pip-test-package', with_files=['.git'])
 
 
+@pytest.mark.skip_if_missing('hg')
 def test_install_editable_from_hg(script, tmpdir):
     """
     Test cloning from Mercurial.
@@ -244,6 +249,7 @@ def test_install_editable_from_hg(script, tmpdir):
     result.assert_installed('ScriptTest', with_files=['.hg'])
 
 
+@pytest.mark.skip_if_missing('hg')
 def test_vcs_url_final_slash_normalization(script, tmpdir):
     """
     Test that presence or absence of final slash in VCS URL is normalized.
@@ -262,6 +268,7 @@ def test_vcs_url_final_slash_normalization(script, tmpdir):
     )
 
 
+@pytest.mark.skip_if_missing('bzr')
 def test_install_editable_from_bazaar(script, tmpdir):
     """
     Test checking out from Bazaar.
@@ -279,6 +286,7 @@ def test_install_editable_from_bazaar(script, tmpdir):
     result.assert_installed('django-wikiapp', with_files=['.bzr'])
 
 
+@pytest.mark.skip_if_missing('bzr')
 def test_vcs_url_urlquote_normalization(script, tmpdir):
     """
     Test that urlquoted characters are normalized for repo URL comparison.
@@ -419,6 +427,7 @@ def test_install_with_hacked_egg_info(script, data):
     assert 'Successfully installed hackedegginfo\n' in result.stdout
 
 
+@pytest.mark.skip_if_missing('git')
 def test_install_using_install_option_and_editable(script, tmpdir):
     """
     Test installing a tool using -e and --install-option
@@ -437,6 +446,7 @@ def test_install_using_install_option_and_editable(script, tmpdir):
     assert virtualenv_bin in result.files_created
 
 
+@pytest.mark.skip_if_missing('hg')
 def test_install_global_option_using_editable(script, tmpdir):
     """
     Test using global distutils options, but in an editable installation

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -2,6 +2,7 @@ import os
 
 from os.path import exists
 
+import pytest
 from tests.lib.local_repos import local_checkout
 from tests.lib.path import Path
 from pip.locations import write_delete_marker_file
@@ -27,6 +28,7 @@ def test_no_clean_option_blocks_cleaning_after_install(script, data):
     Test --no-clean option blocks cleaning after install
     """
     result = script.pip(
+
         'install', '--no-clean', '--no-index',
         '--find-links=%s' % data.find_links, 'simple'
     )
@@ -34,6 +36,7 @@ def test_no_clean_option_blocks_cleaning_after_install(script, data):
     assert exists(build), "build/simple should still exist %s" % str(result)
 
 
+@pytest.mark.skip_if_missing('hg')
 def test_cleanup_after_install_editable_from_hg(script, tmpdir):
     """
     Test clean up after cloning from Mercurial.

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -73,6 +73,7 @@ def test_relative_requirements_file(script, data):
     )
 
 
+@pytest.mark.skip_if_missing('svn')
 def test_multiple_requirements_files(script, tmpdir):
     """
     Test installing from multiple nested requirements files.
@@ -130,6 +131,7 @@ def test_respect_order_in_requirements_file(script, data):
     )
 
 
+@pytest.mark.skip_if_missing('git')
 def test_install_local_editable_with_subdirectory(script):
     version_pkg_path = _create_test_package_with_subdirectory(script,
                                                               'version_subpkg')

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -260,6 +260,7 @@ def test_install_with_ignoreinstalled_requested(script):
     )
 
 
+@pytest.mark.skip_if_missing('git')
 def test_upgrade_vcs_req_with_no_dists_found(script, tmpdir):
     """It can upgrade a VCS requirement that has no distributions otherwise."""
     req = "%s#egg=pip-test-package" % local_checkout(
@@ -271,6 +272,7 @@ def test_upgrade_vcs_req_with_no_dists_found(script, tmpdir):
     assert not result.returncode
 
 
+@pytest.mark.skip_if_missing('git')
 def test_upgrade_vcs_req_with_dist_found(script):
     """It can upgrade a VCS requirement that has distributions on the index."""
     # TODO(pnasrat) Using local_checkout fails on windows - oddness with the

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -4,10 +4,9 @@ tests specific to "pip install --user"
 import imp
 import os
 import textwrap
+import pytest
 
 from os.path import curdir, isdir, isfile
-
-import pytest
 
 from pip.backwardcompat import uses_pycache
 
@@ -57,6 +56,7 @@ class Tests_UserSite:
             project_name
         )
 
+    @pytest.mark.skip_if_missing('svn')
     def test_install_subversion_usersite_editable_with_distribute(
             self, script, virtualenv, tmpdir):
         """

--- a/tests/functional/test_install_vcs.py
+++ b/tests/functional/test_install_vcs.py
@@ -1,7 +1,9 @@
+import pytest
 from tests.lib import _create_test_package, _change_test_package_version
 from tests.lib.local_repos import local_checkout
 
 
+@pytest.mark.skip_if_missing('git')
 def test_install_editable_from_git_with_https(script, tmpdir):
     """
     Test cloning from Git with https.
@@ -18,6 +20,7 @@ def test_install_editable_from_git_with_https(script, tmpdir):
     result.assert_installed('pip-test-package', with_files=['.git'])
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_with_sha1_revisions(script):
     """
     Git backend should be able to install from SHA1 revisions
@@ -37,6 +40,7 @@ def test_git_with_sha1_revisions(script):
     assert '0.1' in version.stdout, version.stdout
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_with_branch_name_as_revision(script):
     """
     Git backend should be able to install from branch names
@@ -56,6 +60,7 @@ def test_git_with_branch_name_as_revision(script):
     assert 'some different version' in version.stdout
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_with_tag_name_as_revision(script):
     """
     Git backend should be able to install from tag names
@@ -75,6 +80,7 @@ def test_git_with_tag_name_as_revision(script):
     assert '0.1' in version.stdout
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_with_tag_name_and_update(script, tmpdir):
     """
     Test cloning a git repository and updating to a different version.
@@ -100,6 +106,7 @@ def test_git_with_tag_name_and_update(script, tmpdir):
     assert '0.1.2' in result.stdout
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_branch_should_not_be_changed(script, tmpdir):
     """
     Editable installations should not change branch
@@ -118,6 +125,7 @@ def test_git_branch_should_not_be_changed(script, tmpdir):
     assert '* master' in result.stdout, result.stdout
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_with_non_editable_unpacking(script, tmpdir):
     """
     Test cloning a git repository from a non-editable URL with a given tag.
@@ -134,6 +142,7 @@ def test_git_with_non_editable_unpacking(script, tmpdir):
     assert '0.1.2' in result.stdout
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_with_editable_where_egg_contains_dev_string(script, tmpdir):
     """
     Test cloning a git repository from an editable url which contains "dev"
@@ -150,6 +159,7 @@ def test_git_with_editable_where_egg_contains_dev_string(script, tmpdir):
     result.assert_installed('django-devserver', with_files=['.git'])
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_with_non_editable_where_egg_contains_dev_string(script, tmpdir):
     """
     Test cloning a git repository from a non-editable url which contains "dev"
@@ -167,6 +177,7 @@ def test_git_with_non_editable_where_egg_contains_dev_string(script, tmpdir):
     assert devserver_folder in result.files_created, str(result)
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_with_ambiguous_revs(script):
     """
     Test git with two "names" (tag/branch) pointing to the same commit
@@ -184,6 +195,7 @@ def test_git_with_ambiguous_revs(script):
     result.assert_installed('version-pkg', with_files=['.git'])
 
 
+@pytest.mark.skip_if_missing('git')
 def test_git_works_with_editable_non_origin_repo(script):
     # set up, create a git repo and install it as editable from a local
     # directory path

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -11,6 +11,7 @@ from tests.lib.git_submodule_helpers import (
 )
 
 
+@pytest.mark.skip_if_missing('git')
 def test_get_refs_should_return_tag_name_and_commit_pair(script):
     version_pkg_path = _create_test_package(script)
     script.run('git', 'tag', '0.1', cwd=version_pkg_path)
@@ -25,6 +26,7 @@ def test_get_refs_should_return_tag_name_and_commit_pair(script):
     assert result['0.2'] == commit, result
 
 
+@pytest.mark.skip_if_missing('git')
 def test_get_refs_should_return_branch_name_and_commit_pair(script):
     version_pkg_path = _create_test_package(script)
     script.run('git', 'branch', 'branch0.1', cwd=version_pkg_path)
@@ -38,6 +40,7 @@ def test_get_refs_should_return_branch_name_and_commit_pair(script):
     assert result['branch0.1'] == commit, result
 
 
+@pytest.mark.skip_if_missing('git')
 def test_get_refs_should_ignore_no_branch(script):
     version_pkg_path = _create_test_package(script)
     script.run('git', 'branch', 'branch0.1', cwd=version_pkg_path)
@@ -66,6 +69,7 @@ def test_check_rev_options_should_handle_branch_name(get_refs_mock):
     assert result == ['123456']
 
 
+@pytest.mark.skip_if_missing('git')
 @patch('pip.vcs.git.Git.get_refs')
 def test_check_rev_options_should_handle_tag_name(get_refs_mock):
     get_refs_mock.return_value = {'master': '123456', '0.1': '123456'}
@@ -86,6 +90,7 @@ def test_check_rev_options_should_handle_ambiguous_commit(get_refs_mock):
 
 # TODO(pnasrat) fix all helpers to do right things with paths on windows.
 @pytest.mark.skipif("sys.platform == 'win32'")
+@pytest.mark.skip_if_missing('git')
 def test_check_submodule_addition(script):
     """
     Submodules are pulled in on install and updated on upgrade.

--- a/tests/functional/test_install_vcs_svn.py
+++ b/tests/functional/test_install_vcs_svn.py
@@ -1,7 +1,9 @@
+import pytest
 from mock import patch
 from pip.vcs.subversion import Subversion
 
 
+@pytest.mark.skip_if_missing('svn')
 @patch('pip.vcs.subversion.call_subprocess')
 def test_obtain_should_recognize_auth_info_url(call_subprocess_mock, script):
     svn = Subversion(url='svn+http://username:password@svn.example.com/')
@@ -13,6 +15,7 @@ def test_obtain_should_recognize_auth_info_url(call_subprocess_mock, script):
     ])
 
 
+@pytest.mark.skip_if_missing('svn')
 @patch('pip.vcs.subversion.call_subprocess')
 def test_export_should_recognize_auth_info_url(call_subprocess_mock, script):
     svn = Subversion(url='svn+http://username:password@svn.example.com/')

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -1,6 +1,8 @@
 import os
+import pytest
 
 
+@pytest.mark.skip_if_missing('git')
 def test_list_command(script, data):
     """
     Test default behavior of list command.
@@ -15,6 +17,7 @@ def test_list_command(script, data):
     assert 'simple2 (3.0)' in result.stdout, str(result)
 
 
+@pytest.mark.skip_if_missing('git')
 def test_local_flag(script, data):
     """
     Test the behavior of --local flag in the list command
@@ -25,6 +28,7 @@ def test_local_flag(script, data):
     assert 'simple (1.0)' in result.stdout
 
 
+@pytest.mark.skip_if_missing('git')
 def test_uptodate_flag(script, data):
     """
     Test the behavior of --uptodate flag in the list command
@@ -46,6 +50,7 @@ def test_uptodate_flag(script, data):
     assert 'simple2 (3.0)' in result.stdout, str(result)
 
 
+@pytest.mark.skip_if_missing('git')
 def test_outdated_flag(script, data):
     """
     Test the behavior of --outdated flag in the list command
@@ -67,6 +72,7 @@ def test_outdated_flag(script, data):
     assert 'simple2' not in result.stdout, str(result)  # 3.0 is latest
 
 
+@pytest.mark.skip_if_missing('git')
 def test_editables_flag(script, data):
     """
     Test the behavior of --editables flag in the list command

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -6,6 +6,7 @@ import sys
 from os.path import join, normpath
 from tempfile import mkdtemp
 from mock import patch
+import pytest
 from tests.lib import assert_all_changes, pyversion
 from tests.lib.local_repos import local_repo, local_checkout
 
@@ -162,6 +163,7 @@ def test_uninstall_easy_installed_console_scripts(script):
     )
 
 
+@pytest.mark.skip_if_missing('svn')
 def test_uninstall_editable_from_svn(script, tmpdir):
     """
     Test uninstalling an editable installation from svn.
@@ -206,6 +208,7 @@ def test_uninstall_editable_with_source_outside_venv(script, tmpdir):
         rmtree(temp)
 
 
+@pytest.mark.skip_if_missing('git')
 def _test_uninstall_editable_with_source_outside_venv(
         script, tmpdir, cache_dir):
     result = script.run(
@@ -229,6 +232,7 @@ def _test_uninstall_editable_with_source_outside_venv(
     )
 
 
+@pytest.mark.skip_if_missing('svn')
 def test_uninstall_from_reqs_file(script, tmpdir):
     """
     Test uninstall from a requirements file.

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -2,7 +2,6 @@
 tests specific to uninstalling --user installs
 """
 from os.path import isdir, isfile
-
 import pytest
 
 from tests.lib import pyversion, assert_all_changes

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     scripttest>=1.3
     git+https://github.com/pypa/virtualenv@develop#egg=virtualenv
 commands =
-    py.test []
+    py.test [] --ignore-dep-checks
 
 [testenv:docs]
 deps = sphinx


### PR DESCRIPTION
Currently many tests will fail if you don't have certain tools on your system such as hg, git, bzr, and subversion. The failure messages when this happens do not outrightly state this, making it very hard to understand.

This change adds a decorator for tests the specify their system dependencies so they may be skipped if one or more of their dependencies are not found. The decorator is memoized and runs test commands (eg: "git -v") to determine if a dependency is there.

This is my first contribution to PIP, so any and all feedback is welcome.