### PR TITLE
Fix exception in unknown commands that contain capital letters.

### DIFF
--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -153,7 +153,7 @@ def parseopts(args):
 
     #all the args without the subcommand
     cmd_args = args[:]
-    cmd_args.remove(args_else[0].lower())
+    cmd_args.remove(args_else[0])
 
     if cmd_name not in commands:
         guess = get_similar_commands(cmd_name)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -638,3 +638,14 @@ def test_no_compiles_pyc(script, data):
     )
 
     assert not any(exists)
+
+
+def test_capital_install_is_legal(script):
+    result = script.run(
+        "python", "-c",
+        "import pip; pip.main(['Install', 'INITools==0.2'])",
+    )
+    assert (
+        "ERROR: unknown command"
+        not in result.stdout
+    )

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -3,8 +3,10 @@ import pytest
 import pip.baseparser
 from pip import main
 from pip import cmdoptions
+from pip import parseopts
 from pip.basecommand import Command
 from pip.commands import commands
+from pip.exceptions import CommandError
 
 
 class FakeCommand(Command):
@@ -270,3 +272,49 @@ class TestOptionsConfigFiles(object):
         monkeypatch.setattr(os.path, 'exists', lambda filename: True)
         cp = pip.baseparser.ConfigOptionParser()
         assert len(cp.get_config_files()) == 2
+
+
+class TestParseOpts(object):
+
+    def test_install(self):
+        cmd_name, cmd_args = parseopts(['install', 'foobar'])
+        assert cmd_name == 'install'
+        assert cmd_args == ['foobar']
+
+    def test_INSTALL_is_valid_replacement_for_install(self):
+        cmd_name, cmd_args = parseopts(['INSTALL', 'foobar'])
+        assert cmd_name == 'install'
+        assert cmd_args == ['foobar']
+
+    def test_invalid_command(self):
+        try:
+            parseopts(['yoyo', 'foobar'])
+            assert False
+        except CommandError:
+            # desired
+            pass
+
+    def test_capital_invalid_command(self):
+        # Issue #1561.
+        try:
+            parseopts(['Yoyo', 'foobar'])
+            assert False
+        except CommandError:
+            # desired
+            pass
+
+    def test_exit_on_empty_args(self):
+        try:
+            parseopts([])
+            assert False
+        except SystemExit:
+            # desired
+            pass
+
+    def test_exit_on_help(self):
+        try:
+            parseopts(['help'])
+            assert False
+        except SystemExit:
+            # desired
+            pass


### PR DESCRIPTION
Fixes #1561. Removes an erroneous call to .lower() and adds regression tests.

This is my second contribution to PIP, any and all feedback is welcome.
