### PR TITLE
Code cleanup: URL generation

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -59,7 +59,6 @@ def warn_if_location_is_insecure(location):
                         ctx)
 
 
-
 def mkurl_pypi_url(url, url_name):
     loc = posixpath.join(url, url_name)
     # For maximum compatibility with easy_install, ensure the path
@@ -70,7 +69,6 @@ def mkurl_pypi_url(url, url_name):
     if not loc.endswith('/'):
         loc = loc + '/'
     return loc
-
 
 
 class PackageFinder(object):
@@ -204,9 +202,6 @@ class PackageFinder(object):
             reverse=True
         )
 
-
-
-
     # TODO: Why is this needed?  Wouldn't it be better to just
     #       fail and force the user to specify the correct
     #       package name?  I recommend that we just remove
@@ -219,7 +214,6 @@ class PackageFinder(object):
         req_name = req.url_name
 
         if self.index_urls:
-            
             # This line suggests that the req_name can *never*
             # be None.  Otherwise, it seems like the previous
             # versions of the code would have exploded.
@@ -250,7 +244,6 @@ class PackageFinder(object):
 
         return req_name
 
-
     # The previous version of this code only generated URL's
     # for the primary index url.  This version searches the
     # primary index and all extra indexes.
@@ -258,7 +251,6 @@ class PackageFinder(object):
         """
         Generates URLs that append the version number to the path
         """
-
         # Yeah, I'm sure there's a better way to do this.
         locations = []
         for url in self.index_urls:
@@ -266,10 +258,7 @@ class PackageFinder(object):
                 locations = [
                     posixpath.join(url, req_name, version)] + locations
 
-
         return locations
-
-
 
     def find_requirement(self, req, upgrade):
         # FIXME: This does not belong here!  We should instead require
@@ -284,11 +273,10 @@ class PackageFinder(object):
             logger.debug("req_name is None for req: %s", req)
         else:
             locations += self._get_locations_for_versions(req, req_name)
-            locations += [mkurl_pypi_url(url, req_name) for url in self.index_urls]
+            locations += [mkurl_pypi_url(url, req_name)
+                            for url in self.index_urls]
 
         locations += list(self.find_links)
-
-
 
         file_locations, url_locations = self._sort_locations(locations)
 
@@ -300,7 +288,6 @@ class PackageFinder(object):
         for location in locations:
             logger.debug('* %s' % location)
             warn_if_location_is_insecure(location)
-
 
         found_versions = []
         found_versions.extend(

--- a/pip/index.py
+++ b/pip/index.py
@@ -28,6 +28,36 @@ INSECURE_SCHEMES = {
 }
 
 
+def warn_if_location_is_insecure(location):
+    """
+    Logs a warning if the location uses an insecure transport mechanism
+    """
+    # Determine if this url used a secure transport mechanism
+    parsed = urlparse.urlparse(str(location))
+    if parsed.scheme in INSECURE_SCHEMES:
+        secure_schemes = INSECURE_SCHEMES[parsed.scheme]
+
+        if len(secure_schemes) == 1:
+            ctx = (location, parsed.scheme, secure_schemes[0],
+                   parsed.netloc)
+            logger.warn("%s uses an insecure transport scheme (%s). "
+                        "Consider using %s if %s has it available" %
+                        ctx)
+        elif len(secure_schemes) > 1:
+            ctx = (
+                location,
+                parsed.scheme,
+                ", ".join(secure_schemes),
+                parsed.netloc,
+            )
+            logger.warn("%s uses an insecure transport scheme (%s). "
+                        "Consider using one of %s if %s has any of "
+                        "them available" % ctx)
+        else:
+            ctx = (location, parsed.scheme)
+            logger.warn("%s uses an insecure transport scheme (%s)." %
+                        ctx)
+
 class PackageFinder(object):
     """This finds packages.
 
@@ -210,32 +240,8 @@ class PackageFinder(object):
         logger.debug('URLs to search for versions for %s:' % req)
         for location in locations:
             logger.debug('* %s' % location)
+            warn_if_location_is_insecure(location)
 
-            # Determine if this url used a secure transport mechanism
-            parsed = urlparse.urlparse(str(location))
-            if parsed.scheme in INSECURE_SCHEMES:
-                secure_schemes = INSECURE_SCHEMES[parsed.scheme]
-
-                if len(secure_schemes) == 1:
-                    ctx = (location, parsed.scheme, secure_schemes[0],
-                           parsed.netloc)
-                    logger.warn("%s uses an insecure transport scheme (%s). "
-                                "Consider using %s if %s has it available" %
-                                ctx)
-                elif len(secure_schemes) > 1:
-                    ctx = (
-                        location,
-                        parsed.scheme,
-                        ", ".join(secure_schemes),
-                        parsed.netloc,
-                    )
-                    logger.warn("%s uses an insecure transport scheme (%s). "
-                                "Consider using one of %s if %s has any of "
-                                "them available" % ctx)
-                else:
-                    ctx = (location, parsed.scheme)
-                    logger.warn("%s uses an insecure transport scheme (%s)." %
-                                ctx)
 
         found_versions = []
         found_versions.extend(

--- a/pip/index.py
+++ b/pip/index.py
@@ -274,7 +274,7 @@ class PackageFinder(object):
         else:
             locations += self._get_locations_for_versions(req, req_name)
             locations += [mkurl_pypi_url(url, req_name)
-                            for url in self.index_urls]
+                          for url in self.index_urls]
 
         locations += list(self.find_links)
 

--- a/pip/index.py
+++ b/pip/index.py
@@ -58,6 +58,21 @@ def warn_if_location_is_insecure(location):
             logger.warn("%s uses an insecure transport scheme (%s)." %
                         ctx)
 
+
+
+def mkurl_pypi_url(url, url_name):
+    loc = posixpath.join(url, url_name)
+    # For maximum compatibility with easy_install, ensure the path
+    # ends in a trailing slash.  Although this isn't in the spec
+    # (and PyPI can handle it without the slash) some other index
+    # implementations might break if they relied on easy_install's
+    # behavior.
+    if not loc.endswith('/'):
+        loc = loc + '/'
+    return loc
+
+
+
 class PackageFinder(object):
     """This finds packages.
 
@@ -189,18 +204,10 @@ class PackageFinder(object):
             reverse=True
         )
 
-    def find_requirement(self, req, upgrade):
 
-        def mkurl_pypi_url(url):
-            loc = posixpath.join(url, url_name)
-            # For maximum compatibility with easy_install, ensure the path
-            # ends in a trailing slash.  Although this isn't in the spec
-            # (and PyPI can handle it without the slash) some other index
-            # implementations might break if they relied on easy_install's
-            # behavior.
-            if not loc.endswith('/'):
-                loc = loc + '/'
-            return loc
+
+
+    def find_requirement(self, req, upgrade):
 
         url_name = req.url_name
         # Only check main index if index URL is given:
@@ -208,7 +215,7 @@ class PackageFinder(object):
         if self.index_urls:
             # Check that we have the url_name correctly spelled:
             main_index_url = Link(
-                mkurl_pypi_url(self.index_urls[0]),
+                mkurl_pypi_url(self.index_urls[0], url_name),
                 trusted=True,
             )
             # This will also cache the page, so it's okay that we get it again
@@ -222,7 +229,7 @@ class PackageFinder(object):
 
         if url_name is not None:
             locations = [
-                mkurl_pypi_url(url)
+                mkurl_pypi_url(url, url_name)
                 for url in self.index_urls] + self.find_links
         else:
             locations = list(self.find_links)

--- a/pip/index.py
+++ b/pip/index.py
@@ -241,6 +241,10 @@ class PackageFinder(object):
                 if fixed_name:
                     url_name = fixed_name
 
+                # And, if that failed... I guess we just assume
+                # that another package index will have it?
+                # That seems dangerous...
+
         return url_name
 
 
@@ -265,7 +269,8 @@ class PackageFinder(object):
 
 
     def find_requirement(self, req, upgrade):
-        # FIXME: This does not belong here!
+        # FIXME: This does not belong here!  We should instead require
+        #        end-users to specify the correct names for requirements!
         url_name = self._fix_the_req_name(req)
 
         locations = self._get_locations_for_versions(req, url_name)
@@ -276,7 +281,6 @@ class PackageFinder(object):
         locations += list(self.find_links)
 
 
-        logger.info("locations: %s", locations)
 
         file_locations, url_locations = self._sort_locations(locations)
 


### PR DESCRIPTION
Attempted to cleanup the code that is used when generating potential URL's for reqs.  Additionally, it appeared that version-specific URL's were only being generated for the primary index.  I modified the code to ensure that these URL's would be generated for the extra indexes as well.