### PR TITLE
Fix installation stacktrace when winterm not defined.

### DIFF
--- a/pip/_vendor/colorama/ansitowin32.py
+++ b/pip/_vendor/colorama/ansitowin32.py
@@ -7,6 +7,7 @@ from .winterm import WinTerm, WinColor, WinStyle
 from .win32 import windll
 
 
+winterm = None
 if windll is not None:
     winterm = WinTerm()
 


### PR DESCRIPTION
Outside of the python.org CPython distribution, winterm can not defined
in colorama, causing a stack trace during installation.

This patch fixes that issue.  It has been reported to upstream colorama
at:

  http://code.google.com/p/colorama/issues/detail?id=54&q=winterm
