### PR TITLE
Fix file corruption on download

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -447,7 +447,7 @@ def _download_url(resp, link, temp_location):
                 # Special case for urllib3.
                 try:
                     for chunk in resp.iter_content(chunk_size):
-                        if chunk: # filter out keep-alive new chunks
+                        if chunk:  # Filter out keep-alive new chunks
                             yield chunk
                 except IncompleteRead as e:
                     raise ChunkedEncodingError(e)


### PR DESCRIPTION
I am getting a lot of invalid hash errors with pip 1.5.4.

For instance, when I try to install Twisted from a local proxy, it claims that md5 hash is invalid:

```
$ pip install Twisted==13.2.0 --index-url=http://pypi.example.com/proxy
Downloading/unpacking Twisted==13.2.0
  http://pypi.example.com/proxy/Twisted/13.2.0 uses an insecure transport scheme (http). Consider using https if pypi.example.com has it available
  http://pypi.example.com/proxy/Twisted/ uses an insecure transport scheme (http). Consider using https if pypi.example.com has it available
  Downloading Twisted-13.2.0.tar.bz2 (unknown size): 2.7MB downloaded
  Hash of the package http://pypi.example.com/proxy/packages/source/T/Twisted/Twisted-13.2.0.tar.bz2#md5=83fe6c0c911cc1602dbffb036be0ba79 (from http://pypi.example.com/proxy/simple/Twisted/) (876f102623d87f451c86d260f49c3ec7) doesn't match the expected hash 83fe6c0c911cc1602dbffb036be0ba79!
Cleaning up...
Bad md5 hash for package http://pypi.example.com/proxy/packages/source/T/Twisted/Twisted-13.2.0.tar.bz2#md5=83fe6c0c911cc1602dbffb036be0ba79 (from http://pypi.example.com/proxy/simple/Twisted/)
Storing debug log for failure in /opt/puppet/.pip/pip.log
```

But if I download the file directly from my proxy, it is just fine:

```
$ wget http://pypi.example.com/proxy/packages/source/T/Twisted/Twisted-13.2.0.tar.bz2#md5=83fe6c0c911cc1602dbffb036be0ba79 -O remote.tar.bz2
--2014-03-26 10:35:09--  http://pypi.example.com/proxy/packages/source/T/Twisted/Twisted-13.2.0.tar.bz2
Resolving pypi.example.com... 192.168..129.187
Connecting to pypi.example.com|192.168.129.187|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2704819 (2.6M) [text/html]
Saving to: `remote.tar.bz2'

100%[====================================================================================================================================================================================================>] 2,704,819   --.-K/s   in 0.09s

2014-03-26 10:35:10 (27.9 MB/s) - `remote.tar.bz2' saved [2704819/2704819]

$ md5sum remote.tar.bz2
83fe6c0c911cc1602dbffb036be0ba79  remote.tar.bz2
```

And the file download by pip is really corrupted:

```
$ sudo md5sum /tmp/pip-gvpeUI-unpack/Twisted-13.2.0.tar.bz2
876f102623d87f451c86d260f49c3ec7  /tmp/pip-gvpeUI-unpack/Twisted-13.2.0.tar.bz2
```

My change has fixed the problem, but I don't know what was the exact reason that was causing the error.
