### PR TITLE
Update __init__.py

### DIFF
--- a/pip/backwardcompat/__init__.py
+++ b/pip/backwardcompat/__init__.py
@@ -27,7 +27,7 @@ try:
 except NameError:
     PermissionError = NeverUsedException
 
-console_encoding = sys.__stdout__.encoding
+console_encoding = sys.stdout.encoding
 
 
 try:


### PR DESCRIPTION
in python3.3 'sys.__stdout__' has no attribute 'encoding'.
