### PR TITLE
pip uninstall with req's file fails with --commands at top of file

### DIFF
--- a/pip/commands/uninstall.py
+++ b/pip/commands/uninstall.py
@@ -1,6 +1,7 @@
 from pip.req import InstallRequirement, RequirementSet, parse_requirements
 from pip.basecommand import Command
 from pip.exceptions import InstallationError
+from pip.index import PackageFinder
 
 
 class UninstallCommand(Command):
@@ -47,12 +48,15 @@ class UninstallCommand(Command):
             download_dir=None,
             session=session,
         )
+        # Need a finder so we can ignore
+        finder = PackageFinder(find_links=[], index_urls=[], session=session)
         for name in args:
             requirement_set.add_requirement(
                 InstallRequirement.from_line(name))
         for filename in options.requirements:
             for req in parse_requirements(
                     filename,
+                    finder=finder,
                     options=options,
                     session=session):
                 requirement_set.add_requirement(req)

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -253,7 +253,12 @@ def test_uninstall_from_reqs_file(script, tmpdir):
             -f http://www.example.com
             -i http://www.example.com
             --extra-index-url http://www.example.com
-
+            --use-wheel
+            --no-index
+            --allow-external dummypackage
+            --allow-all-external
+            --allow-insecure dummypackage
+            --allow-unverified dummypackage
             -e %s#egg=initools-dev
             # and something else to test out:
             PyLogo<0.4


### PR DESCRIPTION
If you add --find-links, --allow-all-external, --allow-unverified lines at the top of a requirements file, you can no longer use it with

```
pip uninstall -r <filename> 
```

as it thinks there is a syntax error.

The following fixes this... but it may not be the best fix?

Closes #1719
