### PR TITLE
Use pip-test-package instead of virtualenv

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -425,16 +425,17 @@ def test_install_using_install_option_and_editable(script, tmpdir):
     """
     folder = 'script_folder'
     script.scratch_path.join(folder).mkdir()
-    url = 'git+git://github.com/pypa/virtualenv'
+    url = 'git+git://github.com/pypa/pip-test-package'
     result = script.pip(
-        'install', '-e', '%s#egg=virtualenv' %
+        'install', '-e', '%s#egg=pip-test-package' %
         local_checkout(url, tmpdir.join("cache")),
         '--install-option=--script-dir=%s' % folder
     )
-    virtualenv_bin = (
-        script.venv / 'src' / 'virtualenv' / folder / 'virtualenv' + script.exe
+    script_file = (
+        script.venv / 'src' / 'pip-test-package' /
+        folder / 'pip-test-package' + script.exe
     )
-    assert virtualenv_bin in result.files_created
+    assert script_file in result.files_created
 
 
 def test_install_global_option_using_editable(script, tmpdir):


### PR DESCRIPTION
Thanks to #1721

Change checked out package to be pip-test-package, instead of virtualenv.

Observe old:

```
 pip ivo·ivosung ~/code/pypa/pip develop ± time py.test tests/functional/test_install.py -k test_install_using_install_option_and_editable
=============================================================================================== test session starts ================================================================================================
platform linux2 -- Python 2.7.6 -- py-1.4.20 -- pytest-2.5.2
collected 40 items 

tests/functional/test_install.py .

==================================================================== 39 tests deselected by '-ktest_install_using_install_option_and_editable' =====================================================================
===================================================================================== 1 passed, 39 deselected in 68.95 seconds =====================================================================================

real  1m9.146s
user  0m4.440s
sys   0m1.570s
```

Observe new:

```
 pip ivo·ivosung ~/code/pypa/pip speedup_test_editable ± time py.test tests/functional/test_install.py -k test_install_using_install_option_and_editable
=============================================================================================== test session starts ================================================================================================
platform linux2 -- Python 2.7.6 -- py-1.4.20 -- pytest-2.5.2
collected 40 items 

tests/functional/test_install.py .

==================================================================== 39 tests deselected by '-ktest_install_using_install_option_and_editable' =====================================================================
===================================================================================== 1 passed, 39 deselected in 3.93 seconds ======================================================================================

real  0m4.132s
user  0m2.397s
sys   0m0.413s
```
