### PR TITLE
wheel: Normalize wheel_dir

### DIFF
--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -156,6 +156,7 @@ class WheelCommand(Command):
         )
 
         options.build_dir = os.path.abspath(options.build_dir)
+        options.wheel_dir = normalize_path(options.wheel_dir)
         requirement_set = RequirementSet(
             build_dir=options.build_dir,
             src_dir=None,

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -20,7 +20,7 @@ from pip.exceptions import InvalidWheelFilename, UnsupportedWheel
 from pip.locations import distutils_scheme
 from pip.log import logger
 from pip import pep425tags
-from pip.util import call_subprocess, normalize_path, make_path_relative
+from pip.util import call_subprocess, make_path_relative
 from pip._vendor.distlib.scripts import ScriptMaker
 from pip._vendor import pkg_resources
 
@@ -505,7 +505,7 @@ class WheelBuilder(object):
                  global_options=[]):
         self.requirement_set = requirement_set
         self.finder = finder
-        self.wheel_dir = normalize_path(wheel_dir)
+        self.wheel_dir = wheel_dir
         self.build_options = build_options
         self.global_options = global_options
 


### PR DESCRIPTION
wheel_dir wasn't normalized properly when set in config file or command
line.

pip wheel --wheel-dir=~/foo creates a ./~/foo directory instead of ~/foo
