### PR TITLE
Add option --no-ssl-verify to skip ssl cert verification

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -59,6 +59,8 @@ class Command(object):
         # Handle custom ca-bundles from the user
         if options.cert:
             session.verify = options.cert
+        elif options.no_check_certificate:
+            session.verify = False
 
         # Handle SSL client certificate
         if options.client_cert:

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -175,6 +175,14 @@ client_cert = OptionMaker(
     help="Path to SSL client certificate, a single file containing the "
          "private key and the certificate in PEM format.")
 
+no_check_certificate = OptionMaker(
+    "--no-check-certificate",
+    dest="no_check_certificate",
+    action="store_true",
+    default=False,
+    help="Don't validate SSL certificates.",
+)
+
 index_url = OptionMaker(
     '-i', '--index-url', '--pypi-url',
     dest='index_url',
@@ -367,6 +375,7 @@ general_group = {
         exists_action,
         cert,
         client_cert,
+        no_check_certificate,
     ]
 }
 

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -259,6 +259,11 @@ class TestGeneralOptions(object):
         options2, args2 = main(['fake', '--client-cert', 'path'])
         assert options1.client_cert == options2.client_cert == 'path'
 
+    def test_no_check_certificate(self):
+        options1, args1 = main(['--no-check-certificate', 'fake'])
+        options2, args2 = main(['fake', '--no-check-certificate'])
+        assert options1.no_check_certificate == options2.no_check_certificate
+
 
 class TestOptionsConfigFiles(object):
 


### PR DESCRIPTION
This change tries to address issue #990 among likely others but providing a simple, practical solution.

There are times, particularly in "enterprise" environments where the nobility of forcing SSL verification results in decreased security. As an example, my actual reason for wanting this feature resulted from the following:
1. Corporate firewall intercepted *.fastly.net wildcard CDN ssl certificate when pypi switched over to forcing https. pip 1.4.x refused to download because of a chain verification error, as expected.
2. I deployed pip 1.2.1 to all my machines because this was easier than dealing with deploying the cert chain everywhere. I planned to deploy it eventually.
3. Today I wanted to run the latest pip and decided to use my working (but undeployed) cert chain solution. When it didn't work, I manually debugged it and discovered that the corporate firewall was no longer intercepting the ssl connection.
4. I discovered that openssl 0.9.8 does not like the *.fastly.net wildcard cert that is behind pypi. This version of openssl is all that is available in all existing versions of SUSE Enterprise Linux 11.

So, now my options seem to be limited to sticking with pip 1.2.1 forever or getting an option to ignore certificate errors. I think adding this option is a better solution.
