### PR TITLE
delete read-only file in Windows

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -11,8 +11,7 @@ import zipfile
 
 from pip.exceptions import InstallationError, BadCommand
 from pip.backwardcompat import(
-    WindowsError, string_types, raw_input, console_to_str,
-    PermissionError, stdlib_pkgs
+    string_types, raw_input, console_to_str, stdlib_pkgs
 )
 from pip.locations import (
     site_packages, user_site, running_under_virtualenv, virtualenv_no_global,


### PR DESCRIPTION
Modify `rmtree_errorhandler` can delete read-only file in stage clean up.

That means resolve #1744
