### PR TITLE
Use the real URL, raw.github is just a redirect these days

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -21,7 +21,7 @@ Install pip
 -----------
 
 To install pip, securely download `get-pip.py
-<https://raw.github.com/pypa/pip/master/contrib/get-pip.py>`_. [1]_
+<https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py>`_. [1]_
 
 Then run the following (which may require administrator access):
 


### PR DESCRIPTION
And some tools don't follow redirects by default.
