### PR TITLE
Parallelize running tests with pytest-xdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - pip install --upgrade setuptools
   - pip install tox
 
-script: tox
+script: .travis/run.sh
 
 branches:
   only:

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+case $TOXENV in
+    py32)
+        tox
+        ;;
+    *)
+        tox -- -n 8
+        ;;
+esac

--- a/tox.ini
+++ b/tox.ini
@@ -10,10 +10,6 @@ deps =
     scripttest>=1.3
     https://github.com/pypa/virtualenv/archive/develop.zip#egg=virtualenv
 commands =
-    py.test -n 8 []
-
-[testenv:py32]
-commands =
     py.test []
 
 [testenv:docs]


### PR DESCRIPTION
We've had a number of problems with pytest-xdist, primarily on Python 3.x where we had intermittent failure. However we're also getting intermittent failures on Travis due to how long the tests actually take to run. Given two different intermittent failures it seems that the one that runs faster should be preferred.
