### PR TITLE
RequirementSet: normalize paths (esp. wheel_download_dir)

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -58,7 +58,7 @@ class RequirementSet(object):
         self.src_dir = src_dir
         self.download_dir = download_dir
         if download_cache:
-            download_cache = os.path.expanduser(download_cache)
+            download_cache = normalize_path(download_cache)
         self.download_cache = download_cache
         self.upgrade = upgrade
         self.ignore_installed = ignore_installed


### PR DESCRIPTION
Normalize `wheel_download_dir` passed to RequirementSet

This handles `wheel_dir = ~/.cache/pip/wheelhouse` correctly when invoked via `pip wheel -r requirements.txt`.

This also uses `normalize_path` for `download_cache`, because this appears to be in line with other places where paths are normalized.
