### PR TITLE
Update list.py

### DIFF
--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -175,7 +175,8 @@ class ListCommand(Command):
                     line = '%s (%s)' % (dist.project_name, dist.version)
             except:
                 logger.notify(str(dist))
-            logger.notify(line)
+            else:
+                logger.notify(line)
 
     def run_uptodate(self, options):
         uptodate = []
@@ -184,3 +185,4 @@ class ListCommand(Command):
             if dist.parsed_version == remote_version_parsed:
                 uptodate.append(dist)
         self.output_package_listing(uptodate)
+


### PR DESCRIPTION
Some times 'pip list' fails due to wrong package version format. In this case 'pip list' prints only
part of listing and stops. This patch force pip to show package info as is and continue
