### PR TITLE
Use base85 instead of base64 for the bundled pip

### DIFF
--- a/tasks/generate.py
+++ b/tasks/generate.py
@@ -40,7 +40,7 @@ def installer(installer_path=os.path.join(paths.CONTRIB, "get-pip.py")):
     print("[generate.installer] Generating installer")
 
     # Define our wrapper script
-    WRAPPER_SCRIPT = b"""
+    WRAPPER_SCRIPT = """
 #!/usr/bin/env python
 #
 # Hi There!
@@ -67,12 +67,60 @@ ZIPFILE = b\"\"\"
 {zipfile}
 \"\"\"
 
-import base64
 import os.path
 import pkgutil
 import shutil
 import sys
+import struct
 import tempfile
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    iterbytes = iter
+else:
+    def iterbytes(buf):
+        return (ord(byte) for byte in buf)
+
+try:
+    from base64 import b85decode
+except ImportError:
+    _b85alphabet = (b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                    b"abcdefghijklmnopqrstuvwxyz!#$%&()*+-;<=>?@^_`{{|}}~")
+
+    def b85decode(b):
+        _b85dec = [None] * 256
+        for i, c in enumerate(iterbytes(_b85alphabet)):
+            _b85dec[c] = i
+
+        padding = (-len(b)) % 5
+        b = b + b'~' * padding
+        out = []
+        packI = struct.Struct('!I').pack
+        for i in range(0, len(b), 5):
+            chunk = b[i:i + 5]
+            acc = 0
+            try:
+                for c in iterbytes(chunk):
+                    acc = acc * 85 + _b85dec[c]
+            except TypeError:
+                for j, c in enumerate(iterbytes(chunk)):
+                    if _b85dec[c] is None:
+                        raise ValueError('bad base85 character at position %d'
+                                        % (i + j))
+                raise
+            try:
+                out.append(packI(acc))
+            except struct.error:
+                raise ValueError('base85 overflow in hunk starting at byte %d'
+                                 % i)
+
+        result = b''.join(out)
+        if padding:
+            result = result[:-padding]
+        return result
 
 
 def bootstrap(tmpdir=None):
@@ -131,7 +179,7 @@ def main():
         # Unpack the zipfile into the temporary directory
         pip_zip = os.path.join(tmpdir, "pip.zip")
         with open(pip_zip, "wb") as fp:
-            fp.write(base64.decodestring(ZIPFILE))
+            fp.write(b85decode(ZIPFILE.replace(b"\\n", b"")))
 
         # Add the zipfile to sys.path so that we can import it
         sys.path.insert(0, pip_zip)
@@ -188,8 +236,15 @@ if __name__ == "__main__":
         "[generate.installer] Write the wrapper script with the bundled zip "
         "file"
     )
-    with open(installer_path, "wb") as fp:
-        fp.write(WRAPPER_SCRIPT.format(zipfile=base64.encodestring(data)))
+
+    zipdata = base64.b85encode(data).decode("utf8")
+    chunked = []
+
+    for i in range(0, len(zipdata), 79):
+        chunked.append(zipdata[i:i + 79])
+
+    with open(installer_path, "w") as fp:
+        fp.write(WRAPPER_SCRIPT.format(zipfile="\n".join(chunked)))
 
     # Ensure the permissions on the newly created file
     oldmode = os.stat(installer_path).st_mode & 0o7777


### PR DESCRIPTION
This changes it so that instead of using base64 encoding we're using base85. This represents a savings of ~88kb for the `get-pip.py` script. Because older versions of Python do not have base85, this also backports base85 decoding from Python 3.4.

This does however, make it so `inv generate.installer` must be run on Python 3.4+
