### PR TITLE
Condense --allow-external and --allow-unverified into one option.

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -40,8 +40,6 @@ Additionally, the following Package Index Options are supported:
   *  :ref:`--no-index <--no-index>`
   *  :ref:`-f, --find-links <--find-links>`
   *  :ref:`--allow-external <--allow-external>`
-  *  :ref:`--allow-all-external <--allow-external>`
-  *  :ref:`--allow-unverified <--allow-unverified>`
 
 For example, to specify :ref:`--no-index <--no-index>` and 2 :ref:`--find-links <--find-links>` locations:
 
@@ -105,31 +103,28 @@ that will enable installing pre-releases and development releases.
 Externally Hosted Files
 +++++++++++++++++++++++
 
-Starting with v1.4, pip will warn about installing any file that does not come
-from the primary index. As of version 1.5, pip defaults to ignoring these files
-unless asked to consider them.
+When searching an index for a file pip will, by default, ignore any externally
+hosted files. This has been done because generally externally hosted files
+are unsafely hosted in a way that pip cannot verify the contents before
+installing them.
 
 The ``pip install`` command supports a
-:ref:`--allow-external PROJECT <--allow-external>` option that will enable
-installing links that are linked directly from the simple index but to an
-external host that also have a supported hash fragment. Externally hosted
-files for all projects may be enabled using the
-:ref:`--allow-all-external <--allow-all-external>` flag to the ``pip install``
-command.
+:ref:`--allow-external PROJECT <--allow-external>` options which will enable
+installing files which are externally hosted. These files may be hosted on a
+host which is unreliable, they may be able to be safely downloaded however they
+may not be able to be safely downloaded and will then propose a security risk
+installing them.
 
-The ``pip install`` command also supports a
-:ref:`--allow-unverified PROJECT <--allow-unverified>` option that will enable
-installing insecurely linked files. These are either directly linked (as above)
-files without a hash, or files that are linked from either the home page or the
-download url of a package.
-
-These options can be used in a requirements file.  Assuming some fictional
-`ExternalPackage` that is hosted external and unverified, then your requirements
-file would be like so::
+This option can be used in a requirements file.  Assuming some fictional
+`ExternalPackage` that is hosted externally, then your requirements file would
+be like so::
 
     --allow-external ExternalPackage
-    --allow-unverified ExternalPackage
     ExternalPackage
+
+This would be equivalent to executing::
+
+    pip install --allow-external ExternalPackage ExternalPackage
 
 
 .. _`VCS Support`:

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -240,18 +240,10 @@ allow_external = OptionMaker(
     action="append",
     default=[],
     metavar="PACKAGE",
-    help="Allow the installation of externally hosted files",
+    help="Allow the installation of externally and potentially unsafely "
+         "hosted files",
 )
 
-allow_all_external = OptionMaker(
-    "--allow-all-external",
-    dest="allow_all_external",
-    action="store_true",
-    default=False,
-    help="Allow the installation of all externally hosted files",
-)
-
-# Remove after 1.7
 no_allow_external = OptionMaker(
     "--no-allow-external",
     dest="allow_all_external",
@@ -260,14 +252,13 @@ no_allow_external = OptionMaker(
     help=SUPPRESS_HELP,
 )
 
-# Remove --allow-insecure after 1.7
 allow_unsafe = OptionMaker(
     "--allow-unverified", "--allow-insecure",
     dest="allow_unverified",
     action="append",
     default=[],
     metavar="PACKAGE",
-    help="Allow the installation of insecure and unverifiable files",
+    help=SUPPRESS_HELP,
 )
 
 # Remove after 1.7
@@ -427,7 +418,6 @@ index_group = {
         use_mirrors,
         mirrors,
         allow_external,
-        allow_all_external,
         no_allow_external,
         allow_unsafe,
         no_allow_unsafe,

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -172,13 +172,21 @@ class InstallCommand(Command):
         This method is meant to be overridden by subclasses, not
         called directly.
         """
+
+        allow_external = options.allow_external
+        if options.allow_unverified:
+            logger.deprecated(
+                "1.8",
+                "--allow-unverified/--allow-insecure have been deprecated and "
+                "folded into --allow-external."
+            )
+            allow_external.extend(options.allow_unverified)
+
         return PackageFinder(
             find_links=options.find_links,
             index_urls=index_urls,
             use_wheel=options.use_wheel,
-            allow_external=options.allow_external,
-            allow_unverified=options.allow_unverified,
-            allow_all_external=options.allow_all_external,
+            allow_external=allow_external,
             allow_all_prereleases=options.pre,
             session=session,
         )

--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -63,12 +63,20 @@ class ListCommand(Command):
         """
         Create a package finder appropriate to this list command.
         """
+
+        allow_external = options.allow_external
+        if options.allow_unverified:
+            logger.deprecated(
+                "1.8",
+                "--allow-unverified/--allow-insecure have been deprecated and "
+                "folded into --allow-external."
+            )
+            allow_external.extend(options.allow_unverified)
+
         return PackageFinder(
             find_links=options.find_links,
             index_urls=index_urls,
-            allow_external=options.allow_external,
-            allow_unverified=options.allow_unverified,
-            allow_all_external=options.allow_all_external,
+            allow_external=allow_external,
             allow_all_prereleases=options.pre,
             session=session,
         )

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -154,13 +154,20 @@ class WheelCommand(Command):
 
         session = self._build_session(options)
 
+        allow_external = options.allow_external
+        if options.allow_unverified:
+            logger.deprecated(
+                "1.8",
+                "--allow-unverified/--allow-insecure have been deprecated and "
+                "folded into --allow-external."
+            )
+            allow_external.extend(options.allow_unverified)
+
         finder = PackageFinder(
             find_links=options.find_links,
             index_urls=index_urls,
             use_wheel=options.use_wheel,
-            allow_external=options.allow_external,
-            allow_unverified=options.allow_unverified,
-            allow_all_external=options.allow_all_external,
+            allow_external=allow_external,
             allow_all_prereleases=options.pre,
             session=session,
         )

--- a/pip/index.py
+++ b/pip/index.py
@@ -36,9 +36,8 @@ class PackageFinder(object):
     """
 
     def __init__(self, find_links, index_urls,
-                 use_wheel=True, allow_external=[], allow_unverified=[],
-                 allow_all_external=False, allow_all_prereleases=False,
-                 session=None):
+                 use_wheel=True, allow_external=[],
+                 allow_all_prereleases=False, session=None):
         if session is None:
             raise TypeError(
                 "PackageFinder() missing 1 required keyword argument: "
@@ -56,24 +55,9 @@ class PackageFinder(object):
         # Do we allow (safe and verifiable) externally hosted files?
         self.allow_external = set(normalize_name(n) for n in allow_external)
 
-        # Which names are allowed to install insecure and unverifiable files?
-        self.allow_unverified = set(
-            normalize_name(n) for n in allow_unverified
-        )
-
-        # Anything that is allowed unverified is also allowed external
-        self.allow_external |= self.allow_unverified
-
-        # Do we allow all (safe and verifiable) externally hosted files?
-        self.allow_all_external = allow_all_external
-
         # Stores if we ignored any external links so that we can instruct
         #   end users how to install them if no distributions are available
         self.need_warn_external = False
-
-        # Stores if we ignored any unsafe links so that we can instruct
-        #   end users how to install them if no distributions are available
-        self.need_warn_unverified = False
 
         # Do we want to allow _all_ pre-releases?
         self.allow_all_prereleases = allow_all_prereleases
@@ -185,13 +169,13 @@ class PackageFinder(object):
             # Check that we have the url_name correctly spelled:
             main_index_url = Link(
                 mkurl_pypi_url(self.index_urls[0]),
-                trusted=True,
+                external=False,
             )
 
             page = self._get_page(main_index_url, req)
             if page is None:
                 url_name = self._find_url_name(
-                    Link(self.index_urls[0], trusted=True),
+                    Link(self.index_urls[0], external=False),
                     url_name, req
                 ) or req.url_name
 
@@ -210,7 +194,7 @@ class PackageFinder(object):
 
         # We trust every url that the user has given us whether it was given
         #   via --index-url or --find-links
-        locations = [Link(url, trusted=True) for url in url_locations]
+        locations = [Link(url, external=False) for url in url_locations]
 
         logger.debug('URLs to search for versions for %s:' % req)
         for location in locations:
@@ -246,7 +230,7 @@ class PackageFinder(object):
         found_versions.extend(
             self._package_versions(
                 # We trust every directly linked archive in find_links
-                [Link(url, '-f', trusted=True) for url in self.find_links],
+                [Link(url, '-f', external=False) for url in self.find_links],
                 req.name.lower()
             )
         )
@@ -262,7 +246,7 @@ class PackageFinder(object):
                 logger.indent -= 2
         file_versions = list(
             self._package_versions(
-                [Link(url) for url in file_locations],
+                [Link(url, external=False) for url in file_locations],
                 req.name.lower()
             )
         )
@@ -277,14 +261,10 @@ class PackageFinder(object):
             if self.need_warn_external:
                 logger.warn(
                     "Some externally hosted files were ignored as access to "
-                    "them may be unreliable (use --allow-external %s to "
-                    "allow)." % req.name
+                    "them may be unreliable and/or they may be insecure and "
+                    "unverifiable (use --allow-external %s to allow)." %
+                    req.name
                 )
-
-            if self.need_warn_unverified:
-                logger.warn("Some insecure and unverifiable files were ignored"
-                            " (use --allow-unverified %s to allow)." %
-                            req.name)
 
             raise DistributionNotFound(
                 'No distributions at all found for %s' % req
@@ -367,13 +347,9 @@ class PackageFinder(object):
             if self.need_warn_external:
                 logger.warn(
                     "Some externally hosted files were ignored as access to "
-                    "them may be unreliable (use --allow-external to allow)."
+                    "them may be unreliable or they may not be able to be "
+                    "safely downloaded (use --allow-external to allow)."
                 )
-
-            if self.need_warn_unverified:
-                logger.warn("Some insecure and unverifiable files were ignored"
-                            " (use --allow-unverified %s to allow)." %
-                            req.name)
 
             raise DistributionNotFound(
                 'No distributions matching the version for %s' % req
@@ -403,10 +379,12 @@ class PackageFinder(object):
 
         selected_version = applicable_versions[0][1]
 
-        if (selected_version.verifiable is not None
-                and not selected_version.verifiable):
-            logger.warn("%s is potentially insecure and "
-                        "unverifiable." % req.name)
+        if selected_version.external:
+            logger.warn(
+                "%s is an externally hosted file and access to it may be "
+                "unreliable or it may not be able to be safely downloaded." %
+                req.name
+            )
 
         if selected_version._deprecated_regex:
             logger.deprecated(
@@ -464,22 +442,13 @@ class PackageFinder(object):
             for link in page.rel_links():
                 normalized = normalize_name(req.name).lower()
 
-                if (normalized not in self.allow_external
-                        and not self.allow_all_external):
+                if link.external and normalized not in self.allow_external:
                     self.need_warn_external = True
-                    logger.debug("Not searching %s for files because external "
-                                 "urls are disallowed." % link)
-                    continue
-
-                if (link.trusted is not None
-                        and not link.trusted
-                        and normalized not in self.allow_unverified):
                     logger.debug(
                         "Not searching %s for urls, it is an "
-                        "untrusted link and cannot produce safe or "
+                        "untrusted external link and cannot produce safe or "
                         "verifiable files." % link
                     )
-                    self.need_warn_unverified = True
                     continue
 
                 all_locations.append(link)
@@ -606,27 +575,15 @@ class PackageFinder(object):
             )
             return []
 
-        if (link.internal is not None
-                and not link.internal
-                and not normalize_name(search_name).lower()
-                in self.allow_external
-                and not self.allow_all_external):
+        if (link.external
+                and not normalize_name(search_name) in self.allow_external):
             # We have a link that we are sure is external, so we should skip
             #   it unless we are allowing externals
-            logger.debug("Skipping %s because it is externally hosted." % link)
+            logger.debug(
+                "Skipping %s because it is externally hosted and access is "
+                "potentially unreliable and/or insecure." % link
+            )
             self.need_warn_external = True
-            return []
-
-        if (link.verifiable is not None
-                and not link.verifiable
-                and not (normalize_name(search_name).lower()
-                         in self.allow_unverified)):
-            # We have a link that we are sure we cannot verify its integrity,
-            #   so we should skip it unless we are allowing unsafe installs
-            #   for this requirement.
-            logger.debug("Skipping %s because it is an insecure and "
-                         "unverifiable file." % link)
-            self.need_warn_unverified = True
             return []
 
         match = self._py_version_re.search(version)
@@ -675,12 +632,12 @@ class HTMLPage(object):
         re.I | re.S
     )
 
-    def __init__(self, content, url, headers=None, trusted=None):
+    def __init__(self, content, url, headers=None, external=None):
         self.content = content
         self.parsed = html5lib.parse(self.content, namespaceHTMLElements=False)
         self.url = url
         self.headers = headers
-        self.trusted = trusted
+        self.external = external
 
     def __str__(self):
         return self.url
@@ -756,7 +713,12 @@ class HTMLPage(object):
                 )
                 return
 
-            inst = cls(resp.text, resp.url, resp.headers, trusted=link.trusted)
+            return cls(
+                resp.text,
+                resp.url,
+                resp.headers,
+                external=link.external,
+            )
         except requests.HTTPError as exc:
             level = 2 if exc.response.status_code == 404 else 1
             cls._handle_fail(req, link, exc, url, level=level)
@@ -774,8 +736,6 @@ class HTMLPage(object):
                 level=2,
                 meth=logger.notify,
             )
-        else:
-            return inst
 
     @staticmethod
     def _handle_fail(req, link, reason, url, level=1, meth=None):
@@ -801,23 +761,6 @@ class HTMLPage(object):
         return resp.headers.get("Content-Type", "")
 
     @property
-    def api_version(self):
-        if not hasattr(self, "_api_version"):
-            _api_version = None
-
-            metas = [
-                x for x in self.parsed.findall(".//meta")
-                if x.get("name", "").lower() == "api-version"
-            ]
-            if metas:
-                try:
-                    _api_version = int(metas[0].get("value", None))
-                except (TypeError, ValueError):
-                    _api_version = None
-            self._api_version = _api_version
-        return self._api_version
-
-    @property
     def base_url(self):
         if not hasattr(self, "_base_url"):
             base = self.parsed.find(".//base")
@@ -835,19 +778,26 @@ class HTMLPage(object):
                 href = anchor.get("href")
                 url = self.clean_link(urlparse.urljoin(self.base_url, href))
 
-                # Determine if this link is internal. If that distinction
-                #   doesn't make sense in this context, then we don't make
-                #   any distinction.
-                internal = None
-                if self.api_version and self.api_version >= 2:
-                    # Only api_versions >= 2 have a distinction between
-                    #   external and internal links
-                    internal = bool(
-                        anchor.get("rel")
-                        and "internal" in anchor.get("rel").split()
-                    )
+                # Assume all pages are external by default unless we find
+                # evidence to the contrary
+                external = True
 
-                yield Link(url, self, internal=internal)
+                # Only a page that is itself not external can produce links
+                # which are not external.
+                if not self.external:
+                    page_netloc = urlparse.urlparse(self.url).netloc
+                    other_netloc = urlparse.urlparse(url).netloc
+
+                    if page_netloc == other_netloc:
+                        external = False
+
+                    # Override the external detection with a rel=internal on
+                    # the link.
+                    if (anchor.get("rel")
+                            and "internal" in anchor.get("rel").split()):
+                        external = False
+
+                yield Link(url, self, external=external)
 
     def rel_links(self):
         for url in self.explicit_rel_links():
@@ -869,7 +819,7 @@ class HTMLPage(object):
                     url = self.clean_link(
                         urlparse.urljoin(self.base_url, href)
                     )
-                    yield Link(url, self, trusted=False)
+                    yield Link(url, self, external=True)
 
     def scraped_rel_links(self):
         # Can we get rid of this horrible horrible method?
@@ -888,7 +838,12 @@ class HTMLPage(object):
             if not url:
                 continue
             url = self.clean_link(urlparse.urljoin(self.base_url, url))
-            yield Link(url, self, trusted=False, _deprecated_regex=True)
+            yield Link(
+                url,
+                self,
+                external=True,
+                _deprecated_regex=True,
+            )
 
     _clean_re = re.compile(r'[^a-z0-9$&+,/:;=?@.#%_\\|-]', re.I)
 
@@ -902,12 +857,11 @@ class HTMLPage(object):
 
 class Link(object):
 
-    def __init__(self, url, comes_from=None, internal=None, trusted=None,
+    def __init__(self, url, comes_from=None, external=None,
                  _deprecated_regex=False):
         self.url = url
         self.comes_from = comes_from
-        self.internal = internal
-        self.trusted = trusted
+        self.external = external
         self._deprecated_regex = _deprecated_regex
 
     def __str__(self):
@@ -997,41 +951,6 @@ class Link(object):
     @property
     def show_url(self):
         return posixpath.basename(self.url.split('#', 1)[0].split('?', 1)[0])
-
-    @property
-    def verifiable(self):
-        """
-        Returns True if this link can be verified after download, False if it
-        cannot, and None if we cannot determine.
-        """
-        trusted = self.trusted or getattr(self.comes_from, "trusted", None)
-        if trusted is not None and trusted:
-            # This link came from a trusted source. It *may* be verifiable but
-            #   first we need to see if this page is operating under the new
-            #   API version.
-            try:
-                api_version = getattr(self.comes_from, "api_version", None)
-                api_version = int(api_version)
-            except (ValueError, TypeError):
-                api_version = None
-
-            if api_version is None or api_version <= 1:
-                # This link is either trusted, or it came from a trusted,
-                #   however it is not operating under the API version 2 so
-                #   we can't make any claims about if it's safe or not
-                return
-
-            if self.hash:
-                # This link came from a trusted source and it has a hash, so we
-                #   can consider it safe.
-                return True
-            else:
-                # This link came from a trusted source, using the new API
-                #   version, and it does not have a hash. It is NOT verifiable
-                return False
-        elif trusted is not None:
-            # This link came from an untrusted source and we cannot trust it
-            return False
 
 
 # An object to represent the "link" for the installed version of a requirement.

--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -88,8 +88,6 @@ def parse_requirements(filename, finder=None, comes_from=None, options=None,
         elif line.startswith("--allow-external"):
             line = line[len("--allow-external"):].strip().lstrip("=")
             finder.allow_external |= set([normalize_name(line).lower()])
-        elif line.startswith("--allow-all-external"):
-            finder.allow_all_external = True
         # Remove in 1.7
         elif line.startswith("--no-allow-external"):
             pass
@@ -99,10 +97,10 @@ def parse_requirements(filename, finder=None, comes_from=None, options=None,
         # Remove after 1.7
         elif line.startswith("--allow-insecure"):
             line = line[len("--allow-insecure"):].strip().lstrip("=")
-            finder.allow_unverified |= set([normalize_name(line).lower()])
+            finder.allow_external |= set([normalize_name(line).lower()])
         elif line.startswith("--allow-unverified"):
             line = line[len("--allow-unverified"):].strip().lstrip("=")
-            finder.allow_unverified |= set([normalize_name(line).lower()])
+            finder.allow_external |= set([normalize_name(line).lower()])
         else:
             comes_from = '-r %s (line %s)' % (filename, line_number)
             if line.startswith('-e') or line.startswith('--editable'):

--- a/tests/data/indexes/externals/bar/index.html
+++ b/tests/data/indexes/externals/bar/index.html
@@ -3,9 +3,9 @@
     <meta name="api-version" value="2" />
   </head>
   <body>
-    <a rel="internal" href="bar-1.0.tar.gz#md5=7b8a4e19dfd3be354046b97f62cefc09">bar-1.0.tar.gz</a>
-    <a href="../foo/bar-2.0.tar.gz#md5=d41d8cd98f00b204e9800998ecf8427e">bar-2.0.tar.gz</a>
-    <a href="../foo/bar-3.0.tar.gz">bar-3.0.tar.gz</a>
+    <a href="bar-1.0.tar.gz">bar-1.0.tar.gz</a>
+    <a href="https://example.com/foo/bar-2.0.tar.gz" rel="internal">bar-2.0.tar.gz</a>
+    <a href="https://example.com/foo/bar-3.0.tar.gz">bar-3.0.tar.gz</a>
     <a rel="download" href="../bar2/">
   </body>
 </html>

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -365,11 +365,12 @@ def test_finder_installs_pre_releases_with_version_spec():
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
 
-def test_finder_ignores_external_links(data):
+def test_finder_ignores_external_links_same_domain(data):
     """
-    Tests that PackageFinder ignores external links, with or without hashes.
+    Tests that PackageFinder ignores external links and that the same domain
+    check works.
     """
-    req = InstallRequirement.from_line("bar", None)
+    req = InstallRequirement.from_line("bar!=2", None)
 
     # using a local index
     finder = PackageFinder(
@@ -381,12 +382,28 @@ def test_finder_ignores_external_links(data):
     assert link.filename == "bar-1.0.tar.gz"
 
 
-def test_finder_finds_external_links_with_hashes_per_project(data):
+def test_finder_ignores_external_links_rel_interal(data):
     """
-    Tests that PackageFinder finds external links but only if they have a hash
-    using the per project configuration.
+    Tests that PackageFinder ignores external links and that the rel=internal
+    check works.
     """
     req = InstallRequirement.from_line("bar", None)
+
+    # using a local index
+    finder = PackageFinder(
+        [],
+        [data.index_url("externals")],
+        session=PipSession(),
+    )
+    link = finder.find_requirement(req, False)
+    assert link.filename == "bar-2.0.tar.gz"
+
+
+def test_finder_finds_external_links(data):
+    """
+    Tests that PackageFinder finds external links if they do not have a hash
+    """
+    req = InstallRequirement.from_line("bar<4", None)
 
     # using a local index
     finder = PackageFinder(
@@ -396,65 +413,10 @@ def test_finder_finds_external_links_with_hashes_per_project(data):
         session=PipSession(),
     )
     link = finder.find_requirement(req, False)
-    assert link.filename == "bar-2.0.tar.gz"
-
-
-def test_finder_finds_external_links_with_hashes_all(data):
-    """
-    Tests that PackageFinder finds external links but only if they have a hash
-    using the all externals flag.
-    """
-    req = InstallRequirement.from_line("bar", None)
-
-    # using a local index
-    finder = PackageFinder(
-        [],
-        [data.index_url("externals")],
-        allow_all_external=True,
-        session=PipSession(),
-    )
-    link = finder.find_requirement(req, False)
-    assert link.filename == "bar-2.0.tar.gz"
-
-
-def test_finder_finds_external_links_without_hashes_per_project(data):
-    """
-    Tests that PackageFinder finds external links if they do not have a hash
-    """
-    req = InstallRequirement.from_line("bar==3.0", None)
-
-    # using a local index
-    finder = PackageFinder(
-        [],
-        [data.index_url("externals")],
-        allow_external=["bar"],
-        allow_unverified=["bar"],
-        session=PipSession(),
-    )
-    link = finder.find_requirement(req, False)
     assert link.filename == "bar-3.0.tar.gz"
 
 
-def test_finder_finds_external_links_without_hashes_all(data):
-    """
-    Tests that PackageFinder finds external links if they do not have a hash
-    using the all external flag
-    """
-    req = InstallRequirement.from_line("bar==3.0", None)
-
-    # using a local index
-    finder = PackageFinder(
-        [],
-        [data.index_url("externals")],
-        allow_all_external=True,
-        allow_unverified=["bar"],
-        session=PipSession(),
-    )
-    link = finder.find_requirement(req, False)
-    assert link.filename == "bar-3.0.tar.gz"
-
-
-def test_finder_finds_external_links_without_hashes_scraped_per_project(data):
+def test_finder_finds_external_links_via_scraped(data):
     """
     Tests that PackageFinder finds externally scraped links
     """
@@ -465,120 +427,6 @@ def test_finder_finds_external_links_without_hashes_scraped_per_project(data):
         [],
         [data.index_url("externals")],
         allow_external=["bar"],
-        allow_unverified=["bar"],
-        session=PipSession(),
-    )
-    link = finder.find_requirement(req, False)
-    assert link.filename == "bar-4.0.tar.gz"
-
-
-def test_finder_finds_external_links_without_hashes_scraped_all(data):
-    """
-    Tests that PackageFinder finds externally scraped links using the all
-    external flag.
-    """
-    req = InstallRequirement.from_line("bar", None)
-
-    # using a local index
-    finder = PackageFinder(
-        [],
-        [data.index_url("externals")],
-        allow_all_external=True,
-        allow_unverified=["bar"],
-        session=PipSession(),
-    )
-    link = finder.find_requirement(req, False)
-    assert link.filename == "bar-4.0.tar.gz"
-
-
-def test_finder_finds_external_links_without_hashes_per_project_all_insecure(
-        data):
-    """
-    Tests that PackageFinder finds external links if they do not have a hash
-    """
-    req = InstallRequirement.from_line("bar==3.0", None)
-
-    # using a local index
-    finder = PackageFinder(
-        [],
-        [data.index_url("externals")],
-        allow_external=["bar"],
-        allow_unverified=["bar"],
-        session=PipSession(),
-    )
-    link = finder.find_requirement(req, False)
-    assert link.filename == "bar-3.0.tar.gz"
-
-
-def test_finder_finds_external_links_without_hashes_all_all_insecure(data):
-    """
-    Tests that PackageFinder finds external links if they do not have a hash
-    using the all external flag
-    """
-    req = InstallRequirement.from_line("bar==3.0", None)
-
-    # using a local index
-    finder = PackageFinder(
-        [],
-        [data.index_url("externals")],
-        allow_all_external=True,
-        allow_unverified=["bar"],
-        session=PipSession(),
-    )
-    link = finder.find_requirement(req, False)
-    assert link.filename == "bar-3.0.tar.gz"
-
-
-def test_finder_finds_external_links_without_hashes_scraped_per_project_all_insecure(data):  # noqa
-    """
-    Tests that PackageFinder finds externally scraped links
-    """
-    req = InstallRequirement.from_line("bar", None)
-
-    # using a local index
-    finder = PackageFinder(
-        [],
-        [data.index_url("externals")],
-        allow_external=["bar"],
-        allow_unverified=["bar"],
-        session=PipSession(),
-    )
-    link = finder.find_requirement(req, False)
-    assert link.filename == "bar-4.0.tar.gz"
-
-
-def test_finder_finds_external_links_without_hashes_scraped_all_all_insecure(
-        data):
-    """
-    Tests that PackageFinder finds externally scraped links using the all
-    external flag.
-    """
-    req = InstallRequirement.from_line("bar", None)
-
-    # using a local index
-    finder = PackageFinder(
-        [],
-        [data.index_url("externals")],
-        allow_all_external=True,
-        allow_unverified=["bar"],
-        session=PipSession(),
-    )
-    link = finder.find_requirement(req, False)
-    assert link.filename == "bar-4.0.tar.gz"
-
-
-def test_finder_finds_external_links_without_hashes_scraped_insecure(data):
-    """
-    Tests that PackageFinder finds externally scraped links without the
-    external flag
-    """
-    req = InstallRequirement.from_line("bar", None)
-
-    # using a local index
-    finder = PackageFinder(
-        [],
-        [data.index_url("externals")],
-        allow_unverified=["bar"],
         session=PipSession(),
     )
     link = finder.find_requirement(req, False)


### PR DESCRIPTION
The decision to support --allow-external and --allow-unverified was made in order to allow people to safely host their files externally to the index (generally PyPI). However since the implementation of this it has become abundantly clear that people are simply not choosing to host their files externally but safely. Additionally the difference between a external but safe and an external but unsafe file is dificult to explain and leaves users confused.

This will condense the two into a single option, --allow-external which has the semantics of both options specified together. This means that it is no longer possible to select safely externally hosted files but exclude unsafely externally hosted files.

This is spawned from [this distutils-sig thread](https://mail.python.org/pipermail/distutils-sig/2014-May/024200.html) (which itself was spawned from [this python-dev thread](https://mail.python.org/pipermail/python-dev/2014-May/134448.html)).

The below text is an adapted reproduction from one of my posts in the distutils-sig thread.
#### Rationale

I unequivocally believe that unsafe downloads _must_ be opt in by default. 

I also believe that external downloads  _should_ be opt in by default.

In the current situation we have two knobs that control these independently. The paranoid security person in me loves this because it means that for some set of projects I can still opt in to the reliability hit but not the security hit. However the UX person in me hates this because more knobs is more confusion, especially in this situation because the line between what is external+safe and what is external+unsafe isn’t very easy to explain.

So In my mind I've had to reconcile between these two viewpoints and when I look at the set of projects which are utilizing the external+safe hosting option I cannot find anything that tells me that many people are ever going utilize the external+safe option because the fact is projects simply are not using it in any meaningful numbers.

There are currently 0.06% (23 total) of projects on PyPI that have _all_ of their files hosted off of PyPI but done so safely. Looking closer at them I can see that the number that have files that will actually be installed by pip specifically that number drops down to 0.04% (15).

Originally I had pointed out that 0.2% of projects host _any_ files externally but safely. Looking again closer at them and removing projects which have also uploaded all files to PyPI, or which the file(s) that are safely hosted externally are not otherwise suitable I've determined that only 0.08% (32) of projects which I was able to discover any files for would be helped _in any way_ by the external+safe option. And looking even closer at those, only 0.07% (26) of them will have the outcome of `pip install whatever` change (in other words, the latest version requires external+safe).

So when I look at the data, I cannot make a very good claim to the UX side of me that external+safe deserves it's own option when the number of projects which would ever use it instead of external+unsafe is minuscule, and of those projects I can only point to argparse and mysql-connector-python which are likely to affect many people at all.

So my beliefs are (in order of priority/conviction):
1. Unsafe downloads _MUST_ but opt in.
2. External downloads _SHOULD_ be opt in.
3. There is not enough potential users for separate knobs that allow external+safe or external+unsafe individually and they should be collapsed into a single option.

So following those beliefs lead me to conclude that the best result for these options are (in order of preference):
1. Collapse the two options into a single option and have it off by default.
   - Satisfies 1 and 2 because they are opt in.
   - Satisfies 3 because users don't have to futz with two different options.
   - Slightly makes me sad that people can't install externally things safely, but the UX win makes up for it.
2. Leave the situation as, two options and one off by default.
   - Satisfies 1 and 2 because they are opt in.
   - Throws away 3.
3. Keep the options separate, but enable --allow-all-external by default and re-add the --no-allow-external option.
   - Satisfies 1 because it is opt in.
   - Makes 2 sad because it is opt out.
   - Throws away 3
4. Remove the --allow-external family of options and enable them by default and always.
   - Satisfies 1 because it is opt in.
   - Throws away 2.
   - Throws away 3.

There are bother benefits to option 1 of course. I'm someone of a public figure with packaging so people often come to me with questions, concerns, comments, etc. In that capacity I've had a number of people confused about the difference between an external file and an unverifiable file. In these cases I've had some difficulty in explaining what the difference is, especially since a lot of people have zero idea how the installer API even works. In the words of the Zen -> "If the implementation is hard to explain, it's a bad idea." and I can tell you that it is quite difficult to explain it to people. The rules are:

```
    If there is a <meta api-version="2"> tag:
        Trust all URLs with rel="internal" on the simple page
        Require --allow-external for any URL on the simple page that links
           directly to something that looks installable to pip and that also
           includes a hash fragment like #<hash_name>=<hash_value> which can
           be either md5, sha1, or in the sha-2 family.
        Require --allow-unverifiable for any URL on that simple page that
           directly links to something that looks installable to pip and that
           does not include a hash fragment with a hash in it. Also any URL
           that can be found by looking for URLs on the simple page that are
           linked with a rel=download or rel=homepage, fetching that page,
           and processing it's HTML looking for direct links to files that
           look installable to pip.
    else:
        Trust all URLs that directly link to a file on the simple page
        Trust all URLs that can be found by looking for links with rel=download
        or rel=homepage, fetching that page, and processing it's HTML looking
        for direct links that look installable to pip.
```

That's complex, and quite often when I explain that the first response is "what's a simple index?". Although I mostly only need to explain the first part and the "else" part I don't because most people don't install from not-PyPI.

On the flip side option (A) allows us to make this much simpler overall. We can simply do:

```
    If it's hosted on PyPI:
        Trust it.
    else if it's not hosted on PyPI:
        Require a --allow-external
```

This is _much_, _much_, _much_ easier to explain, and I think it may be a good idea ala the Zen.
