### PR TITLE
Catches BadCommand in get_src_requirement()

### DIFF
--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -244,9 +244,13 @@ def get_src_requirement(dist, location, find_tags):
     version_control = vcs.get_backend_from_location(location)
     if version_control:
         try:
-            return version_control().get_src_requirement(dist, location, find_tags)
+            return version_control().get_src_requirement(dist,
+                                                         location,
+                                                         find_tags)
         except BadCommand:
-            logger.warn('cannot determine version of editable source in %s (%s command not found in path)' % (location, version_control.name))
+            logger.warn('cannot determine version of editable source in %s '
+                        '(%s command not found in path)' % (
+                            location, version_control.name))
             return dist.as_requirement()
     logger.warn(
         'cannot determine version of editable source in %s (is not SVN '


### PR DESCRIPTION
This catches the BadCommand that get raised by vcs modules when the VCS
software is not installed or not in the PATH. In this case, we behave as
if the .git, .svn or .hg folder hadn't been found at all (but with the
correct warning).

Fixes #930.
