### PR TITLE
Clarify requirement specifier format

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -76,8 +76,9 @@ Some Examples:
 
 .. note::
 
-  Use single or double quotes around specifiers to avoid ``>`` and ``<`` being
+  Use single or double quotes around specifiers when using them in a shell to avoid ``>`` and ``<`` being
   interpreted as shell redirects. e.g. ``pip install 'FooProject>=1.2'``.
+  Don't use single or double quotes in a ``requirements.txt`` file.
 
 
 


### PR DESCRIPTION
If you use single or double quotes in a `requirements.txt` file, pip exits with an error. This change clarifies that single or double quotes should only be used in the shell.
