### PR TITLE
Added test case for issue #1791

### DIFF
--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -22,7 +22,7 @@ def test_proxy_detection_and_url_with_embedded_login_password():
     make the url too long.
     This may happen with localshop mirror.
     """
-    url = "https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy@localhost/simple/"
+    url = "https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:" \
+        "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy@localhost/simple/"
     from pip._vendor.requests.utils import get_environ_proxies
-    proxies = get_environ_proxies(url)
-
+    get_environ_proxies(url)

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -14,3 +14,15 @@ def test_correct_pip_version():
 
     """
     assert Path(pip.__file__).folder.folder.abspath == SRC_DIR
+
+
+def test_proxy_detection_and_url_with_embedded_login_password():
+    """
+    Ensure that we can call the proxy detection even if embedded login/password
+    make the url too long.
+    This may happen with localshop mirror.
+    """
+    url = "https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy@localhost/simple/"
+    from pip._vendor.requests.utils import get_environ_proxies
+    proxies = get_environ_proxies(url)
+


### PR DESCRIPTION
This test will fail against python 3.x because the url string is too long.
If someone can give me a direction on how to fix this, I'll be fine finishing it. Should the login/password be striped in the request module or within the PipSession class ?