### PR TITLE
Write MD5 footer to `pip freeze` output

### DIFF
--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -302,6 +302,8 @@ def test_freeze_with_local_option(script):
         Script result: ...pip freeze --local
         -- stdout: --------------------
         INITools==0.2
+        <BLANKLINE>
+        # MD5 for package list: 6a93c9c4b618caf5643d9a82b86fe4b4
         <BLANKLINE>""")
     _check_output(result, expected)
 


### PR DESCRIPTION
This is an experiment with writing the MD5 for the requirements to the bottom of the `pip freeze` output.

The idea is that the MD5 could be used to quickly compare whether two virtualenvs have the exact same set of packages.

Sure, on a UNIX system one could pipe `pip freeze` to `md5sum`, but this is not necessarily easy on a Windows system and even with the pipe, you'd have to run `pip freeze` twice if you wanted to see the package list and the MD5.

I'm not convinced that this is worth it; I'm actually learning towards thinking it's not worth it, but since it took some time and it might be useful to someone, I thought I'd share it, in case it was useful to someone or sparked some discussion about comparing pip requirements.

Cc: @aconrad
