### PR TITLE
Removed reduce from pip's compat module

### DIFF
--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -1,15 +1,17 @@
 import sys
 import textwrap
 
+from distutils.version import StrictVersion, LooseVersion
+from functools import reduce
+
 from pip.basecommand import Command, SUCCESS
 from pip.util import get_terminal_size
 from pip.log import logger
-from pip.compat import reduce, cmp
+from pip.compat import cmp
 from pip.exceptions import CommandError
 from pip.status_codes import NO_MATCHES_FOUND
 from pip._vendor import pkg_resources
 from pip._vendor.six.moves import xmlrpc_client
-from distutils.version import StrictVersion, LooseVersion
 
 
 class SearchCommand(Command):

--- a/pip/compat.py
+++ b/pip/compat.py
@@ -45,7 +45,6 @@ except NameError:
 
 if sys.version_info >= (3,):
     from io import StringIO
-    from functools import reduce
     from urllib.error import URLError, HTTPError
     from urllib.request import url2pathname, urlretrieve, pathname2url
     import urllib.parse as urllib
@@ -91,7 +90,6 @@ else:
         result = http_message.getparam(param)
         return result or default_value
 
-    reduce = reduce
     cmp = cmp
 
 


### PR DESCRIPTION
It already has a consistent location across Py2/3.
