### PR TITLE
Added a --target parameter to uninstall to allow uninstalling from custom folders

### DIFF
--- a/pip/commands/uninstall.py
+++ b/pip/commands/uninstall.py
@@ -35,6 +35,12 @@ class UninstallCommand(Command):
             dest='yes',
             action='store_true',
             help="Don't ask for confirmation of uninstall deletions.")
+        self.cmd_opts.add_option(
+            '-t', '--target',
+            dest='target',
+            default=None,
+            help="Uninstall from a target directory.  This is similar to the "
+                 "flag of same name on the install command.")
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -61,4 +67,5 @@ class UninstallCommand(Command):
                 'You must give at least one requirement to %(name)s (see "pip '
                 'help %(name)s")' % dict(name=self.name)
             )
-        requirement_set.uninstall(auto_confirm=options.yes)
+        requirement_set.uninstall(auto_confirm=options.yes,
+                                  target=options.target)

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -146,9 +146,9 @@ class RequirementSet(object):
                 return self.requirements[self.requirement_aliases[name]]
         raise KeyError("No project with the name %r" % project_name)
 
-    def uninstall(self, auto_confirm=False):
+    def uninstall(self, auto_confirm=False, target=None):
         for req in self.requirements.values():
-            req.uninstall(auto_confirm=auto_confirm)
+            req.uninstall(auto_confirm=auto_confirm, target=target)
             req.commit_uninstall()
 
     def locate_files(self):

--- a/pip/req/req_uninstall.py
+++ b/pip/req/req_uninstall.py
@@ -13,9 +13,10 @@ from pip.util import (rmtree, ask, is_local, dist_is_local, renames,
 class UninstallPathSet(object):
     """A set of file paths to be removed in the uninstallation of a
     requirement."""
-    def __init__(self, dist):
+    def __init__(self, dist, target=None):
         self.paths = set()
         self._refuse = set()
+        self.target = target
         self.pth = {}
         self.dist = dist
         self.save_dir = None
@@ -27,10 +28,10 @@ class UninstallPathSet(object):
         remove/modify, False otherwise.
 
         """
-        return is_local(path)
+        return is_local(path, target=self.target)
 
     def _can_uninstall(self):
-        if not dist_is_local(self.dist):
+        if not dist_is_local(self.dist, self.target):
             logger.notify(
                 "Not uninstalling %s at %s, outside environment %s" %
                 (
@@ -115,7 +116,7 @@ class UninstallPathSet(object):
                     new_path = self._stash(path)
                     logger.info('Removing file or directory %s' % path)
                     self._moved_paths.append(path)
-                    renames(path, new_path)
+                    renames(path, new_path, preserve=self.target)
                 for pth in self.pth.values():
                     pth.remove()
                 logger.notify(

--- a/pip/util.py
+++ b/pip/util.py
@@ -306,7 +306,7 @@ def renames(old, new, preserve=None):
 
     head, tail = os.path.split(old)
     if head and tail and (preserve is None or
-                          normalize_path(head) == normalize_path(preserve)):
+                          normalize_path(head) != normalize_path(preserve)):
         try:
             os.removedirs(head)
         except OSError:

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -8,6 +8,7 @@ from tempfile import mkdtemp
 from mock import patch
 from tests.lib import assert_all_changes, pyversion
 from tests.lib.local_repos import local_repo, local_checkout
+from tests.lib.path import Path
 
 from pip.util import rmtree
 
@@ -354,4 +355,31 @@ def test_uninstall_wheel(script, data):
     dist_info_folder = script.site_packages / 'simple.dist-0.1.dist-info'
     assert dist_info_folder in result.files_created
     result2 = script.pip('uninstall', 'simple.dist', '-y')
+    assert_all_changes(result, result2, [])
+
+
+def test_uninstall_package_with_target(script, data):
+    """
+    Test uninstalling a package from a target.
+    """
+    target_dir = script.scratch_path / 'target'
+    result = script.pip('install', '-t', target_dir, 'initools==0.1')
+    pkg_path = Path('scratch') / 'target' / 'initools'
+    assert pkg_path in result.files_created, (str(result))
+    result2 = script.pip('uninstall', 'initools', '-y', '-t', target_dir)
+    assert_all_changes(result, result2, [])
+
+
+def test_uninstall_wheel_with_target(script, data):
+    """
+    Test uninstalling a package from a target.
+    """
+    target_dir = script.scratch_path / 'target'
+    package = data.packages.join("simple.dist-0.1-py2.py3-none-any.whl")
+    result = script.pip('install', package, '--no-index', '-t', target_dir)
+    pkg_path = Path('scratch') / 'target' / 'simpledist'
+    assert pkg_path in result.files_created, (str(result))
+    dist_info_folder = Path('scratch') / 'target' / 'simple.dist-0.1.dist-info'
+    assert dist_info_folder in result.files_created
+    result2 = script.pip('uninstall', 'simple.dist', '-y', '-t', target_dir)
     assert_all_changes(result, result2, [])


### PR DESCRIPTION
Essentially what it says on the tin.  It adds a --target parameter that allows pip uninstall to uninstall from a specific folder instead of the site packages.

This is necessary for pips installed into a virtualenv as otherwise the virtualenv containment check prevents a deinstallation.  It also is a bit safer because it will not uninstall from outside.