### PR TITLE
Upgrade CacheControl to 0.10.2

### DIFF
--- a/pip/_vendor/cachecontrol/filewrapper.py
+++ b/pip/_vendor/cachecontrol/filewrapper.py
@@ -32,4 +32,11 @@ class CallbackFileWrapper(object):
         if is_fp_closed(self.__fp):
             self.__callback(self.__buf.getvalue())
 
+            # We assign this to None here, because otherwise we can get into
+            # really tricky problems where the CPython interpreter dead locks
+            # because the callback is holding a reference to something which
+            # has a __del__ method. Setting this to None breaks the cycle
+            # and allows the garbage collector to do it's thing normally.
+            self.__callback = None
+
         return data

--- a/pip/_vendor/vendor.txt
+++ b/pip/_vendor/vendor.txt
@@ -3,5 +3,5 @@ html5lib==1.0b3
 six==1.6.1
 colorama==0.3.1
 requests==2.3.0
-CacheControl==0.10.1
+CacheControl==0.10.2
 lockfile==0.9.1


### PR DESCRIPTION
This fixes a reference cycle issue where pip would randomly hang forever in some of the tests.
