### PR TITLE
install -d works on vcs links fix #798 fix #1060

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -65,6 +65,7 @@ Jonas Nockert <jonasnockert@gmail.com>
 Jorge Niedbalski <niedbalski@gmail.com>
 Josh Bronson <jabronson@gmail.com>
 Josh Hansen <josh@skwash.net>
+Josh Schneier <josh.schneier@gmail.com>
 Kamal Bin Mustafa <kamal@smach.net>
 Kelsey Hightower <kelsey.hightower@gmail.com>
 Kenneth Belitzky <kenny@belitzky.com>

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 **1.6.0.dev1 (unreleased)**
 
+* Fixed :issue:`798` and :issue:`1060`. `pip install --download` works with vcs links.
+  (:pull:`1926`)
 
 * **BACKWARD INCOMPATIBLE** Dropped support for Python 3.1.
 

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -507,11 +507,7 @@ class RequirementSet(object):
 
         # non-editable vcs urls
         if is_vcs_url(link):
-            if only_download:
-                loc = download_dir
-            else:
-                loc = location
-            unpack_vcs_link(link, loc, only_download)
+            unpack_vcs_link(link, location, only_download)
 
         # file urls
         elif is_file_url(link):

--- a/tests/functional/test_install_download.py
+++ b/tests/functional/test_install_download.py
@@ -125,3 +125,17 @@ def test_download_should_skip_existing_files(script):
     assert Path('scratch') / 'INITools-0.1.tar.gz' not in result.files_created
     assert script.site_packages / 'initools' not in result.files_created
     assert script.site_packages / 'openid' not in result.files_created
+
+
+def test_download_vcs_link(script):
+    """
+    It should allow -d flag for vcs links, regression test for issue #798.
+    """
+    result = script.pip(
+        'install', '-d', '.', 'git+git://github.com/pypa/pip-test-package.git'
+    )
+    assert (
+        Path('scratch') / 'pip-test-package-0.1.1.zip'
+        in result.files_created
+    )
+    assert script.site_packages / 'piptestpackage' not in result.files_created


### PR DESCRIPTION
I believe `only_download` was being overloaded here.
