### PR TITLE
remove duplicate 'if cr == (0, 0):' in get_terminal_size

### DIFF
--- a/pip/util.py
+++ b/pip/util.py
@@ -467,8 +467,6 @@ def get_terminal_size():
             return None
         if cr == (0, 0):
             return None
-        if cr == (0, 0):
-            return None
         return cr
     cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
     if not cr:


### PR DESCRIPTION
@pfmoore -- submitting a separate patch for duplicate code in util.get_terminal_size
