### PR TITLE
Fix broken progress bar on Windows

### DIFF
--- a/pip/log.py
+++ b/pip/log.py
@@ -246,10 +246,15 @@ class Logger(object):
         for level, consumer in self.consumers:
             if consumer is sys.stdout:
                 return level
+            elif isinstance(consumer, colorama.AnsiToWin32):
+                return level
         return self.FATAL
 
     def level_matches(self, level, consumer_level):
         """
+        Returns True if given message level > consumer_level,
+        for example message with self.NOTIFY (25) > self.DEBUG (10)
+
         >>> l = Logger()
         >>> l.level_matches(3, 4)
         False


### PR DESCRIPTION
Checks for log level for progress bar fail when terminal's stdout
is wrapped with colorama on Windows. The proper fix is to check for
if consumer is terminal/console (isatty) rather than it is stdout.

But it looks like proper fix would break code in util.py, so this
should do the trick in short term.
