### PR TITLE
Raise NotImplementedError (not NotImplemented)

### DIFF
--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -165,7 +165,7 @@ class VersionControl(object):
         """
         Switch the repo at ``dest`` to point to ``URL``.
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def update(self, dest, rev_options):
         """


### PR DESCRIPTION
NotImplemented is a singleton intended for use in **eq** methods where comparison is not possible for some reason.
