### PR TITLE
Optional finder variable must be validated before use in parse_requirements()

### DIFF
--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -85,14 +85,18 @@ def parse_requirements(filename, finder=None, comes_from=None, options=None,
             # Default in 1.6
             pass
         elif line.startswith('--no-use-wheel'):
-            finder.use_wheel = False
+            if finder:
+                finder.use_wheel = False
         elif line.startswith('--no-index'):
-            finder.index_urls = []
+            if finder:
+                finder.index_urls = []
         elif line.startswith("--allow-external"):
             line = line[len("--allow-external"):].strip().lstrip("=")
-            finder.allow_external |= set([normalize_name(line).lower()])
+            if finder:
+                finder.allow_external |= set([normalize_name(line).lower()])
         elif line.startswith("--allow-all-external"):
-            finder.allow_all_external = True
+            if finder:
+                finder.allow_all_external = True
         # Remove in 1.7
         elif line.startswith("--no-allow-external"):
             pass
@@ -102,10 +106,12 @@ def parse_requirements(filename, finder=None, comes_from=None, options=None,
         # Remove after 1.7
         elif line.startswith("--allow-insecure"):
             line = line[len("--allow-insecure"):].strip().lstrip("=")
-            finder.allow_unverified |= set([normalize_name(line).lower()])
+            if finder:
+                finder.allow_unverified |= set([normalize_name(line).lower()])
         elif line.startswith("--allow-unverified"):
             line = line[len("--allow-unverified"):].strip().lstrip("=")
-            finder.allow_unverified |= set([normalize_name(line).lower()])
+            if finder:
+                finder.allow_unverified |= set([normalize_name(line).lower()])
         else:
             comes_from = '-r %s (line %s)' % (filename, line_number)
             if line.startswith('-e') or line.startswith('--editable'):


### PR DESCRIPTION
In req/req_file.py:

```
def parse_requirements(filename, finder=None, comes_from=None, options=None,
                       session=None):
```

`finder` is optional, but code assumes it exists. Maybe it should be required? IDK. I doubled up on the if statements for layout consistency.

Discovered while using caniusepython3 when requirements.txt contains --allow-external or --allow-unverified:

```
user@server:~/project$ caniusepython3 -r requirements.txt
Traceback (most recent call last):
  File "/usr/local/project/bin/caniusepython3", line 11, in <module>
    sys.exit(main())
  File "/usr/local/project/local/lib/python2.7/site-packages/caniusepython3/__main__.py", line 157, in main
    check(projects_from_cli(args))
  File "/usr/local/project/local/lib/python2.7/site-packages/caniusepython3/__main__.py", line 84, in projects_from_cli
    projects.extend(projects_from_requirements(parsed.requirements))
  File "/usr/local/project/local/lib/python2.7/site-packages/caniusepython3/__main__.py", line 37, in projects_from_requirements
    for req in reqs:
  File "/usr/local/project/local/lib/python2.7/site-packages/pip/req.py", line 1569, in parse_requirements
    for item in parse_requirements(req_url, finder, comes_from=filename, options=options, session=session):
  File "/usr/local/project/local/lib/python2.7/site-packages/pip/req.py", line 1620, in parse_requirements
    finder.allow_unverified |= set([normalize_name(line).lower()])
AttributeError: 'NoneType' object has no attribute 'allow_unverified'
```
