### PR TITLE
Alter the use of the Link objects in PackageFinder to store the version and package name

### DIFF
--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -149,9 +149,9 @@ class ListCommand(Command):
                     # method that returned version
                     remote_version = finder._link_package_versions(
                         link, req.name
-                    )[0]
-                    remote_version_raw = remote_version[2]
-                    remote_version_parsed = remote_version[0]
+                    )
+                    remote_version_raw = remote_version.version
+                    remote_version_parsed = remote_version.parsed_version
                 yield dist, remote_version_raw, remote_version_parsed
 
     def run_listing(self, options):

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -208,16 +208,12 @@ class TestWheel:
         Test link sorting
         """
         links = [
-            (parse_version('2.0'), Link(Inf), '2.0'),
-            (parse_version('2.0'), Link('simple-2.0.tar.gz'), '2.0'),
-            (
-                parse_version('1.0'),
-                Link('simple-1.0-pyT-none-TEST.whl'),
-                '1.0',
-            ),
-            (parse_version('1.0'), Link('simple-1.0-pyT-TEST-any.whl'), '1.0'),
-            (parse_version('1.0'), Link('simple-1.0-pyT-none-any.whl'), '1.0'),
-            (parse_version('1.0'), Link('simple-1.0.tar.gz'), '1.0'),
+            Link(Inf, version='2.0'),
+            Link('simple-2.0.tar.gz', version='2.0'),
+            Link('simple-1.0-pyT-none-TEST.whl', version='1.0'),
+            Link('simple-1.0-pyT-TEST-any.whl', version='1.0'),
+            Link('simple-1.0-pyT-none-any.whl', version='1.0'),
+            Link('simple-1.0.tar.gz', version='1.0'),
         ]
 
         finder = PackageFinder([], [], session=PipSession())
@@ -231,11 +227,7 @@ class TestWheel:
     @patch('pip.pep425tags.supported_tags', [])
     def test_link_sorting_raises_when_wheel_unsupported(self):
         links = [
-            (
-                parse_version('1.0'),
-                Link('simple-1.0-py2.py3-none-TEST.whl'),
-                '1.0',
-            ),
+            Link('simple-1.0-py2.py3-none-TEST.whl', version='1.0'),
         ]
         finder = PackageFinder([], [], use_wheel=True, session=PipSession())
         with pytest.raises(InstallationError):


### PR DESCRIPTION
Also fixes bug I noticed in pip/commands/list.py where an uninitialised variable could have been used.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/1965)
<!-- Reviewable:end -->
