### PR TITLE
Implement site-wide configuration settings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,8 @@
   
 * Added a virtualenv-specific configuration file. (:pull:`1364`)
 
+* Added site-wide configuation files. (:pull:`1978`)
+
 * `wsgiref` and `argparse` (for >py26) are now excluded from `pip list` and `pip
   freeze` (:pull:`1606`, :pull:`1369`)
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -237,12 +237,45 @@ pip allows you to set all command line option defaults in a standard ini
 style config file.
 
 The names and locations of the configuration files vary slightly across
-platforms.
+platforms. You may have per-user, per-virtualenv or site-wide (shared amongst
+all users) configuration:
+
+**Per-user**:
 
 * On Unix and Mac OS X the configuration file is: :file:`$HOME/.pip/pip.conf`
-* On Windows, the configuration file is: :file:`%HOME%\\pip\\pip.ini`
+* On Windows the configuration file is: :file:`%HOME%\\pip\\pip.ini`
 
-You can set a custom path location for the config file using the environment variable ``PIP_CONFIG_FILE``.
+You can set a custom path location for this config file using the environment
+variable ``PIP_CONFIG_FILE``.
+
+**Inside a virtualenv**:
+
+* On Unix and Mac OS X the file is :file:`$VIRTUAL_ENV/pip.conf`
+* On Windows the file is: :file:`%VIRTUAL_ENV%\\pip.ini`
+
+**Site-wide**:
+
+* On Unix the file may be located in in :file:`/etc/pip.conf`. Alternatively
+  it may be in a "pip" subdirectory of any of the paths set in the
+  environment variable ``XDG_CONFIG_DIRS`` (if it exists), for example
+  :file:`/etc/xdg/pip/pip.conf`.
+* On Mac OS X the file is: :file:`/Library/Application Support/pip/pip.conf`
+* On Windows XP the file is:
+  :file:`C:\\Documents and Settings\\All Users\\Application Data\\PyPA\\pip\\pip.conf`
+* On Windows 7 and later the file is hidden, but writeable at
+  :file:`C:\\ProgramData\\PyPA\\pip\\pip.conf`
+* Site-wide configuration is not supported on Windows Vista
+
+If multiple configuration files are found by pip then they are combined in
+the following order:
+
+1. Firstly the site-wide file is read, then
+2. The per-user file is read, and finally
+3. The virtualenv-specific file is read.
+
+Each file read overrides any values read from previous files, so if the
+global timeout is specified in both the site-wide file and the per-user file
+then the latter value is the one that will be used.
 
 The names of the settings are derived from the long command line option, e.g.
 if you want to use a different package index (``--index-url``) and set the

--- a/pip/locations.py
+++ b/pip/locations.py
@@ -202,6 +202,11 @@ else:
         bin_py = '/usr/local/bin'
         default_log_file = os.path.join(user_dir, 'Library/Logs/pip.log')
 
+site_config_files = [
+    os.path.join(path, default_config_basename)
+    for path in appdirs.site_config_dirs('pip')
+]
+
 
 def distutils_scheme(dist_name, user=False, home=None, root=None):
     """

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -275,6 +275,9 @@ class TestOptionsConfigFiles(object):
             lambda self: None,
         )
 
+        # strict limit on the site_config_files list
+        monkeypatch.setattr(pip.baseparser, 'site_config_files', ['/a/place'])
+
         # If we are running in a virtualenv and all files appear to exist,
         # we should see two config files.
         monkeypatch.setattr(
@@ -284,4 +287,4 @@ class TestOptionsConfigFiles(object):
         )
         monkeypatch.setattr(os.path, 'exists', lambda filename: True)
         cp = pip.baseparser.ConfigOptionParser()
-        assert len(cp.get_config_files()) == 2
+        assert len(cp.get_config_files()) == 3


### PR DESCRIPTION
- add site_config_dirs() to appdirs to determine locations across OSes
- add system_config_files to locations.py
- add system_config_files to get_config_files() and re-order files entries to correct precedence
- document changes to configuration files in user guide

Closes #309
