### PR TITLE
Fixes path issue in Windows exe launchers

### DIFF
--- a/pip/_vendor/distlib/scripts.py
+++ b/pip/_vendor/distlib/scripts.py
@@ -92,7 +92,6 @@ class ScriptMaker(object):
         return executable
 
     def _get_shebang(self, encoding, post_interp=b'', options=None):
-        enquote = True
         if self.executable:
             executable = self.executable
             enquote = False     # assume this will be taken care of
@@ -109,10 +108,6 @@ class ScriptMaker(object):
         if options:
             executable = self._get_alternate_executable(executable, options)
 
-        # If the user didn't specify an executable, it may be necessary to
-        # cater for executable paths with spaces (not uncommon on Windows)
-        if enquote and ' ' in executable:
-            executable = '"%s"' % executable
         executable = fsencode(executable)
         shebang = b'#!' + executable + post_interp + b'\n'
         # Python parser starts to read a script using UTF-8 until


### PR DESCRIPTION
Using spaces in Windows is common. This patch fixes an issue in the exe launch
wrappers generated in the "Scripts" directory where unnecessary quoting causes
the following error.

Fatal error in launcher: Unable to create process using '""C:\Program Files (x86)\Cloudbase    Solutions\OpenStack\Nova\Python27\python.exe"" "C:\Program Files (x86)\Cloudbase Solutions\OpenStack\Nova\Python27\Scripts\nova.exe" '

Closes issue: #1997
