### PR TITLE
Normalize names in a URL

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -256,7 +256,7 @@ class InstallRequirement(object):
     def url_name(self):
         if self.req is None:
             return None
-        return urllib_parse.quote(self.req.unsafe_name)
+        return urllib_parse.quote(self.req.project_name.lower())
 
     @property
     def setup_py(self):

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -25,7 +25,7 @@ def test_command_line_options_override_env_vars(script, virtualenv):
     script.environ['PIP_INDEX_URL'] = 'http://b.pypi.python.org/simple/'
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
     assert (
-        "Getting page http://b.pypi.python.org/simple/INITools"
+        "Getting page http://b.pypi.python.org/simple/initools"
         in result.stdout
     )
     virtualenv.clear()
@@ -141,7 +141,7 @@ def _test_config_file_override_stack(script, virtualenv, config_file):
         """))
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
     assert (
-        "Getting page http://download.zope.org/ppix/INITools" in result.stdout
+        "Getting page http://download.zope.org/ppix/initools" in result.stdout
     )
     virtualenv.clear()
     (script.scratch_path / config_file).write(textwrap.dedent("""\
@@ -151,7 +151,7 @@ def _test_config_file_override_stack(script, virtualenv, config_file):
         index-url = https://pypi.gocept.com/
         """))
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
-    assert "Getting page https://pypi.gocept.com/INITools" in result.stdout
+    assert "Getting page https://pypi.gocept.com/initools" in result.stdout
     result = script.pip(
         'install', '-vvv', '--index-url', 'http://pypi.python.org/simple',
         'INITools',
@@ -163,7 +163,7 @@ def _test_config_file_override_stack(script, virtualenv, config_file):
     )
     assert "Getting page https://pypi.gocept.com/INITools" not in result.stdout
     assert (
-        "Getting page http://pypi.python.org/simple/INITools" in result.stdout
+        "Getting page http://pypi.python.org/simple/initools" in result.stdout
     )
 
 


### PR DESCRIPTION
PyPI and Bandersnatch now normalize the project name in their URLs. This change matches that and will reduce the number of redirects we hit on PyPI and will reduce the need to hit /simple/ on a Bandersnatch mirror.

Note: This should not be merged until https://bitbucket.org/pypa/bandersnatch/pull-request/7/prefer-normalized-directory-names-but-keep/ is merged and released.
