### PR TITLE
Fixing issues with install's --target option.

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -357,15 +357,19 @@ class InstallCommand(Command):
                                 % target_item_dir
                             )
                             continue
-                        if not os.path.isdir(target_item_dir):
+                        if os.path.islink(target_item_dir):
                             logger.warn(
                                 'Target directory %s already exists and is '
-                                'not a directory. Please remove in order '
-                                'for replacement.'
+                                'a link. Pip will not automatically replace '
+                                'links, please remove if replacement is '
+                                'desired.'
                                 % target_item_dir
                             )
                             continue
-                        shutil.rmtree(target_item_dir)
+                        if os.path.isdir(target_item_dir):
+                            shutil.rmtree(target_item_dir)
+                        else:
+                            os.remove(target_item_dir)
 
                     shutil.move(
                         os.path.join(lib_dir, item),

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -543,6 +543,17 @@ def test_install_package_with_target(script):
         str(result)
     )
 
+    # Test install and upgrade of single-module package
+    result = script.pip('install', '-t', target_dir, 'six')
+    assert Path('scratch') / 'target' / 'six.py' in result.files_created, (
+        str(result)
+    )
+
+    result = script.pip('install', '-t', target_dir, '--upgrade', 'six')
+    assert Path('scratch') / 'target' / 'six.py' in result.files_updated, (
+        str(result)
+    )
+
 
 def test_install_package_with_root(script, data):
     """


### PR DESCRIPTION
1. Check for the existence of a directory before copying from temporary directory to final target. If it exists, warn the user.
2. If the user specifies the --upgrade option and the directory exists, delete it and continue with installation.
3. Adding tests for above cases.

This resolves #1489, #1710 completely and parts of #1833.
