### PR TITLE
Raise SuspiciousVersion exception if git branch/tag looks like commit id

### DIFF
--- a/pip/exceptions.py
+++ b/pip/exceptions.py
@@ -45,3 +45,7 @@ class InvalidWheelFilename(InstallationError):
 
 class UnsupportedWheel(InstallationError):
     """Unsupported wheel."""
+
+
+class SuspiciousVersion(PipError):
+    """git branch or tag name that looks like commit id."""

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -3,6 +3,7 @@ import pytest
 from mock import patch
 
 from pip.vcs.git import Git
+from pip.exceptions import SuspiciousVersion
 from tests.lib import _create_test_package
 from tests.lib.git_submodule_helpers import (
     _change_test_package_submodule,
@@ -82,6 +83,16 @@ def test_check_rev_options_should_handle_ambiguous_commit(get_refs_mock):
 
     result = git.check_rev_options('0.1', '.', [])
     assert result == ['123456'], result
+
+
+@patch('pip.vcs.git.Git.get_refs')
+def test_check_rev_options_should_abort_suspicious_version(get_refs_mock):
+    get_refs_mock.return_value = {'1b0e77e5048e936fb3fdd1d46a4d03855526f1df':
+                                  '123456'}
+    git = Git()
+
+    pytest.raises(SuspiciousVersion, git.check_rev_options,
+                  '1b0e77e5048e936fb3fdd1d46a4d03855526f1df', '.', [])
 
 
 # TODO(pnasrat) fix all helpers to do right things with paths on windows.


### PR DESCRIPTION
I think the current behavior when installing a specific revision from a git repository is potentially problematic. When specifying a revision using `@`, pip will first check if there is a remote branch that matches, then will check for local branch or tag and after that will assume a commit id (`"Could not find a tag or branch '%s', assuming commit." % rev,`).
This means that it is possible to name a branch or tag like a previous commit, thus replacing the commit with different code.
If there are projects that install packages from github and pin them to specific revisions in requirements.txt (I frequently do), than it would be possible for a person gaining access to the git repo to replace this commit with different code. Admittedly this is pretty far fetched, but I think pip should nonetheless make sure that this cannot be done. I've created a "proof of concept" here: [https://bitbucket.org/jeverling/pip_git_issue/](https://bitbucket.org/jeverling/pip_git_issue/)

There is a commit b6b948c237013603e2eb77d29d4463c8d0e51229 that contains a module that does nothing more than printing "hello world!" when imported. Then I've created a branch that is named like this commit id. If you do now install this package using pip (`pip install -e "git+git@bitbucket.org:jeverling/pip_git_issue.git@b6b948c237013603e2eb77d29d4463c8d0e51229#egg=pip_git_issue"` or using requirements.txt from the repo) a different module will be installed that will start a HTTP server that serves your root directory (on localhost, to demonstrate the potential for abuse). I thought for a while about how to deal with this (albeit very artificial) case, and I think the best course of action is to just raise an exception if a branch or tag is named like a git commit id hash. It would be possible to e.g. ask for user interaction, but I think it is extremely unlikely that a 40 character hex-string is being used as branch or tag name without something being not quite right.

I have defined a new exception `pip.exceptions.SuspiciousVersion`, which is raised by `pip.vcs.git.check_rev_options` if rev matches `r"\b[a-f0-9]{40}\b"`. In my opinion this should take care of this potential problem.

Best Regards,

Jesaja Everling
