### PR TITLE
refactor: convert "link tuple" to FoundVersion class

### DIFF
--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -93,12 +93,12 @@ class ListCommand(Command):
             self.run_listing(options)
 
     def run_outdated(self, options):
-        for dist, remote_version_raw, remote_version_parsed in \
+        for dist, found in \
                 self.find_packages_latests_versions(options):
-            if remote_version_parsed > dist.parsed_version:
+            if found.parsed_version > dist.parsed_version:
                 logger.info(
                     '%s (Current: %s Latest: %s)',
-                    dist.project_name, dist.version, remote_version_raw,
+                    dist.project_name, dist.version, found.version,
                 )
 
     def find_packages_latests_versions(self, options):
@@ -153,12 +153,10 @@ class ListCommand(Command):
                 else:
                     # It might be a good idea that link or finder had a public
                     # method that returned version
-                    remote_version = finder._link_package_versions(
+                    found = finder._link_package_versions(
                         link, req.name
                     )[0]
-                    remote_version_raw = remote_version[2]
-                    remote_version_parsed = remote_version[0]
-                yield dist, remote_version_raw, remote_version_parsed
+                yield dist, found
 
     def run_listing(self, options):
         installed_packages = get_installed_distributions(
@@ -191,8 +189,8 @@ class ListCommand(Command):
 
     def run_uptodate(self, options):
         uptodate = []
-        for dist, remote_version_raw, remote_version_parsed in \
+        for dist, found in \
                 self.find_packages_latests_versions(options):
-            if dist.parsed_version == remote_version_parsed:
+            if dist.parsed_version == found.parsed_version:
                 uptodate.append(dist)
         self.output_package_listing(uptodate)

--- a/pip/index.py
+++ b/pip/index.py
@@ -168,7 +168,9 @@ class PackageFinder(object):
             if version.currently_installed:
                 pri = 1
             elif version.link.ext == wheel_ext:
-                wheel = Wheel(version.link.filename)  # can raise InvalidWheelFilename
+                wheel = Wheel(
+                    version.link.filename
+                )  # can raise InvalidWheelFilename
                 if not wheel.supported():
                     raise UnsupportedWheel(
                         "%s is not a supported wheel for this platform. It "

--- a/pip/index.py
+++ b/pip/index.py
@@ -313,7 +313,7 @@ class PackageFinder(object):
                 FoundVersion(req.satisfied_by.version, INSTALLED_VERSION)
             ]
         if file_versions:
-            file_versions.sort(reverse=True)
+            file_versions = self._sort_versions(file_versions)
             logger.debug(
                 'Local files found: %s',
                 ', '.join([

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -226,7 +226,7 @@ class TestWheel:
         finder.use_wheel = True
 
         results = finder._sort_versions(links)
-        results2 = finder._sort_versions(sorted(links, reverse=True))
+        results2 = finder._sort_versions(reversed(links))
 
         assert links == results == results2, results2
 

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -5,7 +5,7 @@ import pip.pep425tags
 
 from pkg_resources import parse_version, Distribution
 from pip.req import InstallRequirement
-from pip.index import PackageFinder, Link
+from pip.index import PackageFinder, Link, FoundVersion
 from pip.exceptions import (
     BestVersionAlreadyInstalled, DistributionNotFound, InstallationError,
 )
@@ -214,16 +214,12 @@ class TestWheel:
         Test link sorting
         """
         links = [
-            (parse_version('2.0'), Link(Inf), '2.0'),
-            (parse_version('2.0'), Link('simple-2.0.tar.gz'), '2.0'),
-            (
-                parse_version('1.0'),
-                Link('simple-1.0-pyT-none-TEST.whl'),
-                '1.0',
-            ),
-            (parse_version('1.0'), Link('simple-1.0-pyT-TEST-any.whl'), '1.0'),
-            (parse_version('1.0'), Link('simple-1.0-pyT-none-any.whl'), '1.0'),
-            (parse_version('1.0'), Link('simple-1.0.tar.gz'), '1.0'),
+            FoundVersion('2.0', Link(Inf)),
+            FoundVersion('2.0', Link('simple-2.0.tar.gz')),
+            FoundVersion('1.0', Link('simple-1.0-pyT-none-TEST.whl')),
+            FoundVersion('1.0', Link('simple-1.0-pyT-TEST-any.whl')),
+            FoundVersion('1.0', Link('simple-1.0-pyT-none-any.whl')),
+            FoundVersion('1.0', Link('simple-1.0.tar.gz')),
         ]
 
         finder = PackageFinder([], [], session=PipSession())
@@ -237,11 +233,7 @@ class TestWheel:
     @patch('pip.pep425tags.supported_tags', [])
     def test_link_sorting_raises_when_wheel_unsupported(self):
         links = [
-            (
-                parse_version('1.0'),
-                Link('simple-1.0-py2.py3-none-TEST.whl'),
-                '1.0',
-            ),
+            FoundVersion('1.0', Link('simple-1.0-py2.py3-none-TEST.whl')),
         ]
         finder = PackageFinder([], [], use_wheel=True, session=PipSession())
         with pytest.raises(InstallationError):


### PR DESCRIPTION
This changeset builds on top of buck-cachedproperty.
See the diff here: https://github.com/bukzor/pip/compare/buck-cachedproperty...buck-found-versions

This makes things significantly simpler and more readable, and paves the way for more significant simplifications.