### PR TITLE
delete two unused functions

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -1103,28 +1103,3 @@ class Link(object):
 # An object to represent the "link" for the installed version of a requirement.
 # Using Inf as the url makes it sort higher.
 INSTALLED_VERSION = Link(Inf)
-
-
-def get_requirement_from_url(url):
-    """Get a requirement from the URL, if possible.  This looks for #egg
-    in the URL"""
-    link = Link(url)
-    egg_info = link.egg_fragment
-    if not egg_info:
-        egg_info = splitext(link.filename)[0]
-    return package_to_requirement(egg_info)
-
-
-def package_to_requirement(package_name):
-    """Translate a name like Foo-1.2 to Foo==1.3"""
-    match = re.search(r'^(.*?)-(dev|\d.*)', package_name)
-    if match:
-        name = match.group(1)
-        version = match.group(2)
-    else:
-        name = package_name
-        version = ''
-    if version:
-        return '%s==%s' % (name, version)
-    else:
-        return name

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,17 +1,8 @@
 import pytest
 
 from pip.download import PipSession
-from pip.index import package_to_requirement, HTMLPage
+from pip.index import HTMLPage
 from pip.index import PackageFinder, Link, INSTALLED_VERSION
-
-
-def test_package_name_should_be_converted_to_requirement():
-    """
-    Test that it translates a name like Foo-1.2 to Foo==1.3
-    """
-    assert package_to_requirement('Foo-1.2') == 'Foo==1.2'
-    assert package_to_requirement('Foo-dev') == 'Foo==dev'
-    assert package_to_requirement('Foo') == 'Foo'
 
 
 def test_html_page_should_be_able_to_scrap_rel_links():


### PR DESCRIPTION
These two functions are completely unused, as far as I can see.
The only possibility is an outside project importing them.

I don't believe they're part of documented interface though, so this should be fine.
