### PR TITLE
CI for feature branches, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,6 @@ install: .travis/install.sh
 
 script: .travis/run.sh
 
-branches:
-  only:
-    - master
-    - develop
-    - /^[0-9]+\.[0-9]+\.[Xx]$/
-
 notifications:
   irc:
     channels:


### PR DESCRIPTION
I've been frustrated that I haven't been able to get CI for my feature branches till _after_ I issue a pull request.
These deleted lines were the cause.

Presumably it was to prevent IRC notification from forks' feature branches.
Was it a real, observed problem?
If not, I'd like to test the hypothesis that it was a premature optimization.
