### PR TITLE
Fix GH-1867: non-deterministic name for git editables on Python 3

### DIFF
--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -159,8 +159,12 @@ class Git(VersionControl):
         current_rev = self.get_revision(location)
         refs = self.get_refs(location)
         # refs maps names to commit hashes; we need the inverse
-        # if multiple names map to a single commit, this arbitrarily picks one
-        names_by_commit = dict((commit, ref) for ref, commit in sorted(refs.items()))
+        # if multiple names map to a single commit, we pick the first one
+        # alphabetically
+        names_by_commit = {}
+        for ref, commit in sorted(refs.items()):
+            if commit not in names_by_commit:
+                names_by_commit[commit] = ref
 
         if current_rev in names_by_commit:
             # It's a tag

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -34,7 +34,7 @@ def test_git_get_src_requirements():
     assert ret == ''.join([
         'git+http://github.com/pypa/pip-test-package',
         '@5547fa909e83df8bd743d3978d6667497983a4b7',
-        '#egg=pip_test_package-origin/master'
+        '#egg=pip_test_package-bar'
     ])
 
 


### PR DESCRIPTION
Determine `names_by_commit` deterministically.

This fixes GH-1867.
