### PR TITLE
Better ignore syntaxerror stack traces in wheels

### DIFF
--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -662,14 +662,14 @@ def unpack_file(filename, location, content_type, link):
 
 
 def remove_tracebacks(output):
-    pattern = (r'\W+File "(.*)", line (.*)\W+(.*)\W+\^\W+'
-               r'Syntax(Error|Warning): (.*)')
+    pattern = (r'(?:\W+File "(?:.*)", line (?:.*)\W+(?:.*)\W+\^\W+)?'
+               r'Syntax(?:Error|Warning): (?:.*)')
     output = re.sub(pattern, '', output)
     if PY2:
         return output
     # compileall.compile_dir() prints different messages to stdout
     # in Python 3
-    return re.sub(r"\*\*\* Error compiling (.*)", '', output)
+    return re.sub(r"\*\*\* Error compiling (?:.*)", '', output)
 
 
 def call_subprocess(cmd, show_stdout=True,

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -27,7 +27,6 @@ from pip.utils.logging import indent_log
 from pip._vendor.distlib.scripts import ScriptMaker
 from pip._vendor import pkg_resources
 from pip._vendor.six.moves import configparser
-from pip._vendor.six import PY2
 
 
 wheel_ext = '.whl'
@@ -162,16 +161,7 @@ def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
     if pycompile:
         with captured_stdout() as stdout:
             compileall.compile_dir(source, force=True, quiet=True)
-        # compileall.compile_dir() prints different exception to stdout
-        # in Python 2, so we need a new helper to remove tracebacks
-        # for Python 3
-        if PY2:
-            lines = [line for line in stdout.getvalue().splitlines()
-                     if not line.startswith(('SyntaxError:',
-                                             'SyntaxWarning:'))]
-            print('\n'.join(lines))
-        else:
-            print(remove_tracebacks(stdout.getvalue()))
+        logger.info(remove_tracebacks(stdout.getvalue()))
 
     def normpath(src, p):
         return make_path_relative(src, p).replace(os.path.sep, '/')

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -319,4 +319,5 @@ def test_install_from_wheel_uninstalls_old_version(script, data):
 def test_wheel_compile_syntax_error(script, data):
     package = data.packages.join("compilewheel-1.0-py2.py3-none-any.whl")
     result = script.pip('install', '--compile', package, '--no-index')
+    assert 'yield from' not in result.stdout
     assert 'SyntaxError: ' not in result.stdout


### PR DESCRIPTION
This already got stripped just fine for non-wheel installs, but for
wheels, it only stripped the lined where `SyntaxError` was present
leaving the rest of the stacktrace.

This has fixed a bug left behind with #1984, but inside that PR, this logic was explicitly done. So I have no idea if I'm breaking something by doing this.

With my patch:

```
$ pip install https://pypi.python.org/packages/2.7/g/gunicorn/gunicorn-19.1.1-py2.py3-none-any.whl\#md5\=905b2a090447c82bd66e62ee29b2287c
DEPRECATION: --download-cache has been deprecated and will be removed in the future. Pip now automatically uses and configures its cache.
Downloading/unpacking gunicorn==19.1.1 from https://pypi.python.org/packages/2.7/g/gunicorn/gunicorn-19.1.1-py2.py3-none-any.whl#md5=905b2a090447c82bd66e62ee29b2287c
  Using cached gunicorn-19.1.1-py2.py3-none-any.whl
Installing collected packages: gunicorn
Compiling /Users/matt/.virtualenvs/pip/build/gunicorn/gunicorn/workers/_gaiohttp.py


Successfully installed gunicorn
Cleaning up...
```

Without:

```
$ pip install https://pypi.python.org/packages/2.7/g/gunicorn/gunicorn-19.1.1-py2.py3-none-any.whl\#md5\=905b2a090447c82bd66e62ee29b2287c
DEPRECATION: --download-cache has been deprecated and will be removed in the future. Pip now automatically uses and configures its cache.
Downloading/unpacking gunicorn==19.1.1 from https://pypi.python.org/packages/2.7/g/gunicorn/gunicorn-19.1.1-py2.py3-none-any.whl#md5=905b2a090447c82bd66e62ee29b2287c
  Using cached gunicorn-19.1.1-py2.py3-none-any.whl
Installing collected packages: gunicorn
Compiling /Users/matt/.virtualenvs/pip/build/gunicorn/gunicorn/workers/_gaiohttp.py ...
  File "/Users/matt/.virtualenvs/pip/build/gunicorn/gunicorn/workers/_gaiohttp.py", line 64
    yield from self.wsgi.close()
             ^

Successfully installed gunicorn
Cleaning up...
```
