### PR TITLE
Add Appveyor control files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ exclude .travis.yml
 exclude pip/_vendor/Makefile
 exclude tox.ini
 exclude dev-requirements.txt
+exclude appveyor.yml
 
 recursive-include pip/_vendor *.pem
 recursive-include docs Makefile *.rst *.py *.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+      TOXENV: "py27"
+
+    - PYTHON: "C:\\Python33"
+      TOXENV: "py33"
+
+    - PYTHON: "C:\\Python34"
+      TOXENV: "py34"
+
+    - PYTHON: "C:\\Python35"
+      TOXENV: "py35"
+
+    - PYTHON: "C:\\Python27-x64"
+      TOXENV: "py27"
+
+    - PYTHON: "C:\\Python33-x64"
+      TOXENV: "py33"
+
+    - PYTHON: "C:\\Python34-x64"
+      TOXENV: "py34"
+
+    - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py35"
+
+install:
+    cmd: "%PYTHON%\\python.exe -m pip install tox"
+build: off
+test_script:
+    - "%PYTHON%\\Scripts\\tox.exe -e %TOXENV% -- -m unit -n 8"


### PR DESCRIPTION
Note that these will not activate appveyor testing, as the pypa/pip project has not been registered with appveyor. However, it will allow forks (such as mine) to add appveyor testing without needing to maintain a separate branch to do so.

Ultimately it would be good to activate appveyor on the main repository, but I would rather wait until the tests pass, and we are sure that we can do so without interfering with the Travis builds.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/2078)
<!-- Reviewable:end -->
