### PR TITLE
Include a "simple" User-Agent string as well as the JSON

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -100,7 +100,10 @@ def user_agent():
     if platform.machine():
         data["cpu"] = platform.machine()
 
-    return json.dumps(data, separators=(",", ":"), sort_keys=True)
+    return "{data[installer][name]}/{data[installer][version]} {json}".format(
+        data=data,
+        json=json.dumps(data, separators=(",", ":"), sort_keys=True),
+    )
 
 
 class MultiDomainBasicAuth(AuthBase):


### PR DESCRIPTION
To facilitate detection of pip in scenarios where parsing JSON isn't easy but simple string matching is, change the User-Agent to be of the form `"pip/{version} {json}"` instead of just `"{json}"`.

The contents of the JSON data has not changed.
