### PR TITLE
remove tag_svn_revision to fix test, same as PR #2045

### DIFF
--- a/tests/data/packages/symlinks/setup.cfg
+++ b/tests/data/packages/symlinks/setup.cfg
@@ -1,3 +1,2 @@
 [egg_info]
 tag_build = dev
-tag_svn_revision = true


### PR DESCRIPTION
Fixes the test shown failing here: https://travis-ci.org/pypa/pip/jobs/39972689

Output copied for convenience:

```
=================================== FAILURES ===================================
________ test_install_from_local_directory_with_symlinks_to_directories ________
[gw7] linux2 -- Python 2.6.9 /home/travis/build/pypa/pip/.tox/py26/bin/python2.6
script = <tests.lib.PipTestEnvironment object at 0x23729d0>
data = <tests.lib.TestData object at 0x2372f10>
    def test_install_from_local_directory_with_symlinks_to_directories(
            script, data):
        """
        Test installing from a local directory containing symlinks to directories.
        """
        to_install = data.packages.join("symlinks")
        result = script.pip('install', to_install, expect_error=False)
        pkg_folder = script.site_packages / 'symlinks'
        egg_info_folder = (
            script.site_packages / 'symlinks-0.1dev-py%s.egg-info' % pyversion
        )
        assert pkg_folder in result.files_created, str(result.stdout)

        print
        print 'looking for:', egg_info_folder
        print
        for f in result.files_created:
            print f
>       assert egg_info_folder in result.files_created, str(result)
E       AssertionError: Script result: pip install /tmp/pytest-1/popen-gw7/test_install_from_local_directory_with_symlinks_to_directories0/data/packages/symlinks
E         -- stdout: --------------------
E         Unpacking /tmp/pytest-1/popen-gw7/test_install_from_local_directory_with_symlinks_to_directories0/data/packages/symlinks
E           Running setup.py (path:/tmp/pytest-1/popen-gw7/test_install_from_local_directory_with_symlinks_to_directories0/workspace/tmp/pip-e9EVjD-build/setup.py) egg_info for package from file:///tmp/pytest-1/popen-gw7/test_install_from_local_directory_with_symlinks_to_directories0/data/packages/symlinks
E         Installing collected packages: symlinks
E           Running setup.py install for symlinks
E             warning: build_py: byte-compiling is disabled, skipping.
E             warning: install_lib: byte-compiling is disabled, skipping.
E         Successfully installed symlinks
E         Cleaning up...
E         
E         -- created: -------------------
E           venv/lib/python2.6/site-packages/symlinks
E                           symlinks-0.1dev_r0-py2.6.egg-info
E                               PKG-INFO  (186 bytes)
E                               SOURCES.txt  (158 bytes)
E                               dependency_links.txt  (1 bytes)
E                               installed-files.txt  (108 bytes)
E                               top_level.txt  (9 bytes)
E                           symlinks/__init__.py  (2 bytes)
E         -- updated: -------------------
E           venv/lib/python2.6/site-packages
E       assert 'venv/lib/python2.6/site-packages/symlinks-0.1dev-py2.6.egg-info' in {'venv/lib/python2.6/site-packages/symlinks': <FoundDir /tmp/pytest-1/popen-gw7/test_install_from_local_directory_with..._from_local_directory_with_syml...venv/lib/python2.6/site-packages/symlinks-0.1dev_r0-py2.6.egg-info/SOURCES.txt>, ...}
E        +  where {'venv/lib/python2.6/site-packages/symlinks': <FoundDir /tmp/pytest-1/popen-gw7/test_install_from_local_directory_with..._from_local_directory_with_syml...venv/lib/python2.6/site-packages/symlinks-0.1dev_r0-py2.6.egg-info/SOURCES.txt>, ...} = <tests.lib.TestPipResult object at 0x2372dd0>.files_created
tests/functional/test_install.py:325: AssertionError
----------------------------- Captured stdout call -----------------------------
looking for: venv/lib/python2.6/site-packages/symlinks-0.1dev-py2.6.egg-info
venv/lib/python2.6/site-packages/symlinks/__init__.py
venv/lib/python2.6/site-packages/symlinks-0.1dev_r0-py2.6.egg-info/installed-files.txt
venv/lib/python2.6/site-packages/symlinks-0.1dev_r0-py2.6.egg-info
venv/lib/python2.6/site-packages/symlinks-0.1dev_r0-py2.6.egg-info/PKG-INFO
venv/lib/python2.6/site-packages/symlinks-0.1dev_r0-py2.6.egg-info/SOURCES.txt
venv/lib/python2.6/site-packages/symlinks-0.1dev_r0-py2.6.egg-info/top_level.txt
venv/lib/python2.6/site-packages/symlinks
venv/lib/python2.6/site-packages/symlinks-0.1dev_r0-py2.6.egg-info/dependency_links.txt
============== 1 failed, 225 passed, 2 skipped in 233.98 seconds ===============
```
