### PR TITLE
.travis.yml: Remove py32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - TOXENV=packaging
   - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py32
+  # - TOXENV=py32   # Commented out because py32 is old and takes MUCH longer on Travis vs. other py3 versions
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=pypy


### PR DESCRIPTION
because Python 3.2 is kind of old and Python 3.2 takes way longer on Travis CI vs. other Python 3.x versions.

Fixes: GH-2164
