### PR TITLE
Add pypy3 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=pypy
+  - TOXENV=pypy3
   - TOXENV=py27 VENDOR=no
   - TOXENV=py34 VENDOR=no
   - TOXENV=py27 VENDOR=no WHEELS=yes

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = docs, packaging, pep8, py3pep8, py26, py27, py32, py33, py34, pypy
+envlist =
+    docs, packaging, pep8, py3pep8, py26, py27, py32, py33, py34, pypy, pypy3
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt


### PR DESCRIPTION
If we don't drop Python 3.2 support in #2164 then we should add PyPy3 to the build matrix.