### PR TITLE
install: "Cleaning up..." msg: info => debug

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -494,7 +494,7 @@ class RequirementSet(object):
 
     def cleanup_files(self):
         """Clean up files, remove builds."""
-        logger.info('Cleaning up...')
+        logger.debug('Cleaning up...')
         with indent_log():
             for req in self.reqs_to_cleanup:
                 req.remove_temporary_source()


### PR DESCRIPTION
This message isn't particularly useful to an end user and clutters the output IMHO.

Helps a (tiny) bit with some past issues that raised an issue about pip being too verbose:
- https://github.com/pypa/pip/issues/1070
- https://github.com/pypa/pip/issues/1132
