### PR TITLE
pip.utils log level: INFO => WARNING

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -173,7 +173,8 @@ class Command(object):
                         ),
                     },
                 )
-                for name in ["pip._vendor", "distlib", "requests", "urllib3"]
+                for name in ["pip._vendor", "pip.utils",
+                             "distlib", "requests", "urllib3"]
             ),
         })
 


### PR DESCRIPTION
Eliminates a bunch of `pip install` output that is not useful most of the time.

See: GH-1070

Before:

```
❯ pip install --no-cache-dir --ignore-installed Jinja2
Downloading/unpacking Jinja2
  Downloading Jinja2-2.7.3.tar.gz (378kB)
    100% |################################| 380kB 6.6MB/s
  Running setup.py (path:/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-iT7uhu/Jinja2/setup.py) egg_info for package Jinja2

    warning: no files found matching '*' under directory 'custom_fixers'
    warning: no previously-included files matching '*' found under directory 'docs/_build'
    warning: no previously-included files matching '*.pyc' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
Downloading/unpacking markupsafe (from Jinja2)
  Downloading MarkupSafe-0.23.tar.gz
  Running setup.py (path:/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-iT7uhu/markupsafe/setup.py) egg_info for package markupsafe

Installing collected packages: markupsafe, Jinja2
  Running setup.py install for markupsafe

    building 'markupsafe._speedups' extension
    gcc -fno-strict-aliasing -fno-common -dynamic -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c markupsafe/_speedups.c -o build/temp.macosx-10.4-x86_64-2.7/markupsafe/_speedups.o
    gcc -bundle -undefined dynamic_lookup build/temp.macosx-10.4-x86_64-2.7/markupsafe/_speedups.o -o build/lib.macosx-10.4-x86_64-2.7/markupsafe/_speedups.so
  Running setup.py install for Jinja2

    warning: no files found matching '*' under directory 'custom_fixers'
    warning: no previously-included files matching '*' found under directory 'docs/_build'
    warning: no previously-included files matching '*.pyc' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
Successfully installed markupsafe Jinja2
Cleaning up...

❯ pip install --no-cache-dir --ignore-installed Jinja2 | wc -l
      30
```

After:

```
❯ pip install --no-cache-dir --ignore-installed Jinja2
Downloading/unpacking Jinja2
  Downloading Jinja2-2.7.3.tar.gz (378kB)
    100% |################################| 380kB 5.7MB/s
  Running setup.py (path:/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-28LxTj/Jinja2/setup.py) egg_info for package Jinja2
Downloading/unpacking markupsafe (from Jinja2)
  Downloading MarkupSafe-0.23.tar.gz
  Running setup.py (path:/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-28LxTj/markupsafe/setup.py) egg_info for package markupsafe
Installing collected packages: markupsafe, Jinja2
  Running setup.py install for markupsafe
  Running setup.py install for Jinja2
Successfully installed markupsafe Jinja2
Cleaning up...

❯ pip install --no-cache-dir --ignore-installed Jinja2 | wc -l
      11
```

Note that https://github.com/pypa/pip/pull/2175 eliminates the `Cleaning up...` message at the end, so that would get it down to 10 lines for that install.

Hopefully, turning `pip.utils` down to `WARNING` doesn't hide useful things (though they could always add `-v` to get much more info).
