### PR TITLE
"Running setup.py...egg_info" log: INFO => DEBUG

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -308,12 +308,12 @@ class InstallRequirement(object):
     def run_egg_info(self):
         assert self.source_dir
         if self.name:
-            logger.info(
+            logger.debug(
                 'Running setup.py (path:%s) egg_info for package %s',
                 self.setup_py, self.name,
             )
         else:
-            logger.info(
+            logger.debug(
                 'Running setup.py (path:%s) egg_info for package from %s',
                 self.setup_py, self.url,
             )


### PR DESCRIPTION
Change log level of `"Running setup.py (path:%s) egg_info"` log messages from `INFO` to `DEBUG`. The average user does not know or care that pip is running `python setup.py egg_info`, unless things are broken, IMHO.

See: GH-1070
