### PR TITLE
install: Make some warnings DEBUG rather than INFO

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -912,9 +912,11 @@ exec(compile(
                 r'^byte-compiling ',
                 r'^SyntaxError:',
                 r'^SyntaxWarning:',
+                r'^warning: no previously-included files matching \'.*\'',
+                r'^warning: no files found matching \'.*\' under directory',
                 # Not sure what this warning is, but it seems harmless:
                 r"^warning: manifest_maker: standard file '-c' not found$"]:
-            if re.search(regex, line.strip()):
+            if not line or re.search(regex, line.strip()):
                 level = logging.DEBUG
                 break
         return (level, line)


### PR DESCRIPTION
- `warning: no previously-included files matching`
- `warning: no files found matching`

See: GH-1070

Cc: @dstufft 
