### PR TITLE
update submodules after checkout

### DIFF
--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -117,8 +117,7 @@ class Git(VersionControl):
                 'Cloning %s%s to %s', url, rev_display, display_path(dest),
             )
             call_subprocess([self.cmd, 'clone', '-q', url, dest])
-            #: repo may contain submodules
-            self.update_submodules(dest)
+
             if rev:
                 rev_options = self.check_rev_options(rev, dest, rev_options)
                 # Only do a checkout if rev_options differs from HEAD
@@ -127,6 +126,8 @@ class Git(VersionControl):
                         [self.cmd, 'checkout', '-q'] + rev_options,
                         cwd=dest,
                     )
+            #: repo may contain submodules
+            self.update_submodules(dest)
 
     def get_url(self, location):
         url = call_subprocess(


### PR DESCRIPTION
Prior to this fix the git submodule feature and the git version feature did not play nicely together.  Specifically, if you run `pip install git+https://some.repo@some-branch` where `some-branch` includes submodules but `master` does not, the submodules will not be updated.

To fix, just update_submodules after the rev check.
