### PR TITLE
Display URL downloading from

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -19,6 +19,7 @@ from pip._vendor.six.moves.urllib import parse as urllib_parse
 import pip
 
 from pip.exceptions import InstallationError, HashMismatch
+from pip.models import PyPI
 from pip.utils import (splitext, rmtree, format_size, display_path,
                        backup_dir, ask_path_exists, unpack_file)
 from pip.utils.ui import DownloadProgressBar, DownloadProgressSpinner
@@ -535,21 +536,26 @@ def _download_url(resp, link, content_file):
 
         progress_indicator = lambda x, *a, **k: x
 
+        if link.netloc == PyPI.netloc:
+            url = show_url
+        else:
+            url = link.url_without_fragment
+
         if show_progress:  # We don't show progress on cached responses
             if total_length:
                 logger.info(
-                    "Downloading %s (%s)", show_url, format_size(total_length),
+                    "Downloading %s (%s)", url, format_size(total_length),
                 )
                 progress_indicator = DownloadProgressBar(
                     max=total_length,
                 ).iter
             else:
-                logger.info("Downloading %s", show_url)
+                logger.info("Downloading %s", url)
                 progress_indicator = DownloadProgressSpinner().iter
         elif cached_resp:
-            logger.info("Using cached %s", show_url)
+            logger.info("Using cached %s", url)
         else:
-            logger.info("Downloading %s", show_url)
+            logger.info("Downloading %s", url)
 
         logger.debug('Downloading from URL %s', link)
 

--- a/pip/index.py
+++ b/pip/index.py
@@ -22,6 +22,7 @@ from pip.exceptions import (
     UnsupportedWheel,
 )
 from pip.download import url_to_path, path_to_url
+from pip.models import PyPI
 from pip.wheel import Wheel, wheel_ext
 from pip.pep425tags import supported_tags, supported_tags_noarch, get_platform
 from pip.req.req_requirement import InstallationCandidate
@@ -45,21 +46,6 @@ SECURE_ORIGINS = [
 
 
 logger = logging.getLogger(__name__)
-
-
-class Index(object):
-    def __init__(self, url):
-        self.url = url
-        self.netloc = urllib_parse.urlsplit(url).netloc
-        self.simple_url = self.url_to_path('simple')
-        self.pypi_url = self.url_to_path('pypi')
-        self.pip_json_url = self.url_to_path('pypi/pip/json')
-
-    def url_to_path(self, path):
-        return urllib_parse.urljoin(self.url, path)
-
-
-PyPI = Index('https://pypi.python.org/')
 
 
 class PackageFinder(object):
@@ -1113,6 +1099,10 @@ class Link(object):
     @property
     def scheme(self):
         return urllib_parse.urlsplit(self.url)[0]
+
+    @property
+    def netloc(self):
+        return urllib_parse.urlsplit(self.url)[1]
 
     @property
     def path(self):

--- a/pip/models/__init__.py
+++ b/pip/models/__init__.py
@@ -1,0 +1,1 @@
+from pip.models.index import Index, PyPI  # noqa

--- a/pip/models/index.py
+++ b/pip/models/index.py
@@ -1,0 +1,16 @@
+from pip._vendor.six.moves.urllib import parse as urllib_parse
+
+
+class Index(object):
+    def __init__(self, url):
+        self.url = url
+        self.netloc = urllib_parse.urlsplit(url).netloc
+        self.simple_url = self.url_to_path('simple')
+        self.pypi_url = self.url_to_path('pypi')
+        self.pip_json_url = self.url_to_path('pypi/pip/json')
+
+    def url_to_path(self, path):
+        return urllib_parse.urljoin(self.url, path)
+
+
+PyPI = Index('https://pypi.python.org/')


### PR DESCRIPTION
Display URL downloading from instead of just filename when using index other than PyPI.

It's useful to distinguish between downloading from PyPI or from an internal devpi server, for example. In the latter case, it is useful to see the full URL, to know which index pip is downloading from.

E.g.:

Downloading from PyPI is unchanged:

```
$ pip install --no-cache-dir --ignore-installed Jinja2
...
  Downloading Jinja2-2.7.3.tar.gz (378kB)
```

But downloading from a different server results in displaying the full URL:

```
$ pip install --no-cache-dir --ignore-installed -i http://mirror.picosecond.org/pypi/simple jinja2
...
  Downloading http://mirror.picosecond.org/pypi/packages/source/J/Jinja2/Jinja2-2.7.3.tar.gz (378kB)
```
