### PR TITLE
Change "Downloading/unpacking" to "Collecting"

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -285,7 +285,7 @@ class RequirementSet(object):
                         display_path(url_to_path(req_to_install.url)),
                     )
                 else:
-                    logger.info('Downloading/unpacking %s', req_to_install)
+                    logger.info('Collecting %s', req_to_install)
 
             with indent_log():
                 # ################################ #

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -117,7 +117,7 @@ def test_respect_order_in_requirements_file(script, data):
     )
 
     downloaded = [line for line in result.stdout.split('\n')
-                  if 'Downloading/unpacking' in line]
+                  if 'Collecting' in line]
 
     assert 'parent' in downloaded[0], (
         'First download should be "parent" but was "%s"' % downloaded[0]


### PR DESCRIPTION
"Downloading/unpacking" was misleading and confusing, especially when the package is never found, as nothing was ever downloaded or unpacked in this case.

The word "collecting" seems general enough to be accurate and it goes well with the fact that later on pip will say, "Installing collected packages".

So a successful install looks like this:

```
[marca@marca-mac2 pip]$ pip install --no-cache-dir --ignore-installed Jinja2
Collecting Jinja2
  Downloading Jinja2-2.7.3.tar.gz (378kB)
    100% |################################| 380kB 705kB/s
Collecting markupsafe (from Jinja2)
  Downloading MarkupSafe-0.23.tar.gz
Installing collected packages: markupsafe, Jinja2
  Running setup.py install for markupsafe
    building 'markupsafe._speedups' extension
    gcc -fno-strict-aliasing -fno-common -dynamic -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c markupsafe/_speedups.c -o build/temp.macosx-10.4-x86_64-2.7/markupsafe/_speedups.o
    gcc -bundle -undefined dynamic_lookup build/temp.macosx-10.4-x86_64-2.7/markupsafe/_speedups.o -o build/lib.macosx-10.4-x86_64-2.7/markupsafe/_speedups.so
  Running setup.py install for Jinja2
Successfully installed markupsafe Jinja2
```

and a failed install looks like this:

```
[marca@marca-mac2 pip]$ pip install --no-cache-dir --ignore-installed thispackagedoesntexist
Collecting thispackagedoesntexist
  DEPRECATION: One or more of your dependencies required using a deprecated fallback to looking at /simple/ to discover it's real name. It is suggested to upgrade your index to  support normalized names as the name in /simple/{name}.
  Could not find any downloads that satisfy the requirement thispackagedoesntexist
  No distributions at all found for thispackagedoesntexist
```

(The "deprecated fallback" message is confusing; I wonder if it's indicating the pip had trouble finding the package, but maybe it should be suppressed in the case where ultimately the package is not found?)

Fixes: GH-376
