### PR TITLE
Don't warn about /simple/ fallback for PyPI

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -302,12 +302,11 @@ class PackageFinder(object):
             )
 
             page = self._get_page(main_index_url, req)
-            if page is None:
+            if page is None and 'pypi.python.org' not in str(main_index_url):
                 warnings.warn(
-                    "One or more of your dependencies required using a "
-                    "deprecated fallback to looking at /simple/ to discover "
-                    "it's real name. It is suggested to upgrade your index to "
-                    " support normalized names as the name in /simple/{name}.",
+                    "Failed to find %r at %s. It is suggested to upgrade "
+                    "your index to support normalized names as the name in "
+                    "/simple/{name}." % (req.name, main_index_url),
                     RemovedInPip8Warning,
                 )
 


### PR DESCRIPTION
and display a little more info about the index used.
##### Before

```
$ pip install thispackagedoesntexist
Collecting thispackagedoesntexist
  DEPRECATION: One or more of your dependencies required using a deprecated fallback to looking at /simple/ to discover it's real name. It is suggested to upgrade your index to  support normalized names as the name in /simple/{name}.
  Could not find any downloads that satisfy the requirement thispackagedoesntexist
  No distributions at all found for thispackagedoesntexist
```
##### After

```
$ pip install thispackagedoesntexist
Collecting thispackagedoesntexist
  Could not find any downloads that satisfy the requirement thispackagedoesntexist
  No distributions at all found for thispackagedoesntexist
```

With a custom index:

```
$ pip install -i https://devpi.mycompany.com/simple thispackagedoesntexist
Downloading/unpacking thispackagedoesntexist
  DEPRECATION: Failed to find 'thispackagedoesntexist' at https://devpi.mycompany.com/simple/thispackagedoesntexist/. It is suggested to upgrade your index to support normalized names as the name in /simple/{name}.
  Could not find any downloads that satisfy the requirement thispackagedoesntexist
  No distributions at all found for thispackagedoesntexist
```

Arguably, the last case is still not ideal, as it didn't find the package even after looking at `/simple/` so the deprecation message is kind of useless and distracting. Maybe that can be solved later.
