### PR TITLE
Don't say "Unpacking" if installing from directory

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -280,10 +280,8 @@ class RequirementSet(object):
             elif install:
                 if (req_to_install.url
                         and req_to_install.url.lower().startswith('file:')):
-                    logger.info(
-                        'Unpacking %s',
-                        display_path(url_to_path(req_to_install.url)),
-                    )
+                    path = url_to_path(req_to_install.url)
+                    logger.info('Processing %s', display_path(path))
                 else:
                     logger.info('Downloading/unpacking %s', req_to_install)
 


### PR DESCRIPTION
##### Before

```
$ pip install ~/dev/git-repos/pip
Unpacking /Users/marca/dev/git-repos/pip
...
```
##### After

```
$ pip install ~/dev/git-repos/pip
Processing directory /Users/marca/dev/git-repos/pip
...
```

Fixes: GH-2187

Cc: @dstufft, @tomprince
