### PR TITLE
Make filter regex more inclusive

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -912,7 +912,8 @@ exec(compile(
                 r'^byte-compiling ',
                 r'^SyntaxError:',
                 r'^SyntaxWarning:',
-                r'^warning: no previously-included files matching \'.*\'',
+                (r'^(warning: )?no previously-included (files|directories) '
+                 r'(found)? matching \'.*\''),
                 r'^warning: no files found matching \'.*\' under directory',
                 # Not sure what this warning is, but it seems harmless:
                 r"^warning: manifest_maker: standard file '-c' not found$"]:


### PR DESCRIPTION
so that it filters out more `"no previously-included..."` warnings from distutils while installing.
##### Before:

```
$ pip install -e ~/dev/git-repos/pip
Obtaining file:///Users/marca/dev/git-repos/pip
    warning: no previously-included files found matching '.coveragerc'
    warning: no previously-included files found matching '.mailmap'
    warning: no previously-included files found matching '.travis.yml'
    warning: no previously-included files found matching 'pip/_vendor/Makefile'
    warning: no previously-included files found matching 'tox.ini'
    no previously-included directories found matching '.travis'
    no previously-included directories found matching 'docs/_build'
    no previously-included directories found matching 'contrib'
    no previously-included directories found matching 'tasks'
    no previously-included directories found matching 'tests'
Installing collected packages: pip
  Running setup.py develop for pip
    warning: no previously-included files found matching '.coveragerc'
    warning: no previously-included files found matching '.mailmap'
    warning: no previously-included files found matching '.travis.yml'
    warning: no previously-included files found matching 'pip/_vendor/Makefile'
    warning: no previously-included files found matching 'tox.ini'
    no previously-included directories found matching '.travis'
    no previously-included directories found matching 'docs/_build'
    no previously-included directories found matching 'contrib'
    no previously-included directories found matching 'tasks'
    no previously-included directories found matching 'tests'
...
```
##### After:

```
$ pip install -e ~/dev/git-repos/pip
Obtaining file:///Users/marca/dev/git-repos/pip
Installing collected packages: pip
  Running setup.py develop for pip
...
```
