### PR TITLE
Speed up unpack_file_url

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -632,7 +632,10 @@ def unpack_file_url(link, location, download_dir=None):
     if os.path.isdir(link_path):
         if os.path.isdir(location):
             rmtree(location)
-        shutil.copytree(link_path, location, symlinks=True)
+        shutil.copytree(
+            link_path, location, symlinks=True,
+            ignore=shutil.ignore_patterns(
+                '.tox', '.git', '.hg', '.bzr', '.svn'))
         if download_dir:
             logger.info('Link is a directory, ignoring download_dir')
         return


### PR DESCRIPTION
by ignoring ('.tox', '.git', 'build') when doing `shutil.copytree`.

Fixes: GH-2195
##### Before

```
$ time pip install --no-install ~/dev/git-repos/pip
DEPRECATION: --no-install and --no-download are deprecated. See https://github.com/pypa/pip/issues/906.
Processing /Users/marca/dev/git-repos/pip
  Requirement already satisfied (use --upgrade to upgrade): pip==6.0.dev1 from file:///Users/marca/dev/git-repos/pip in /Users/marca/dev/git-repos/pip
pip install --no-install ~/dev/git-repos/pip  2.80s user 5.86s system 50% cpu 17.205 total
```
##### After

```
$ time pip install --no-install ~/dev/git-repos/pip
DEPRECATION: --no-install and --no-download are deprecated. See https://github.com/pypa/pip/issues/906.
Processing /Users/marca/dev/git-repos/pip
  Requirement already satisfied (use --upgrade to upgrade): pip==6.0.dev1 from file:///Users/marca/dev/git-repos/pip in /Users/marca/dev/git-repos/pip
pip install --no-install ~/dev/git-repos/pip  0.80s user 0.87s system 70% cpu 2.392 total
```

From 17 seconds to less than 3 seconds; not bad! :smile: 
