### PR TITLE
Reduce duplication of "pypi.python.org"

### DIFF
--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 
 import copy
 from optparse import OptionGroup, SUPPRESS_HELP, Option
+from pip.index import PyPI
 from pip.locations import CA_BUNDLE_PATH, USER_CACHE_DIR, src_prefix
 
 
@@ -192,7 +193,7 @@ index_url = OptionMaker(
     '-i', '--index-url', '--pypi-url',
     dest='index_url',
     metavar='URL',
-    default='https://pypi.python.org/simple/',
+    default=PyPI.simple_url,
     help='Base URL of Python Package Index (default %default).')
 
 extra_index_url = OptionMaker(

--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -6,6 +6,7 @@ import textwrap
 
 from pip.basecommand import Command, SUCCESS
 from pip.download import PipXmlrpcTransport
+from pip.index import PyPI
 from pip.utils import get_terminal_size
 from pip.utils.logging import indent_log
 from pip.exceptions import CommandError
@@ -30,7 +31,7 @@ class SearchCommand(Command):
             '--index',
             dest='index',
             metavar='URL',
-            default='https://pypi.python.org/pypi',
+            default=PyPI.pypi_url,
             help='Base URL of Python Package Index (default %default)')
 
         self.parser.insert_option_group(0, self.cmd_opts)

--- a/pip/index.py
+++ b/pip/index.py
@@ -47,6 +47,21 @@ SECURE_ORIGINS = [
 logger = logging.getLogger(__name__)
 
 
+class Index(object):
+    def __init__(self, url):
+        self.url = url
+        self.netloc = urllib_parse.urlsplit(url).netloc
+        self.simple_url = self.url_to_path('simple')
+        self.pypi_url = self.url_to_path('pypi')
+        self.pip_json_url = self.url_to_path('pypi/pip/json')
+
+    def url_to_path(self, path):
+        return urllib_parse.urljoin(self.url, path)
+
+
+PyPI = Index('https://pypi.python.org/')
+
+
 class PackageFinder(object):
     """This finds packages.
 
@@ -302,7 +317,7 @@ class PackageFinder(object):
             )
 
             page = self._get_page(main_index_url, req)
-            if page is None and 'pypi.python.org' not in str(main_index_url):
+            if page is None and PyPI.netloc not in str(main_index_url):
                 warnings.warn(
                     "Failed to find %r at %s. It is suggested to upgrade "
                     "your index to support normalized names as the name in "
@@ -703,7 +718,7 @@ class PackageFinder(object):
                         and comes_from is not None
                         and urllib_parse.urlparse(
                             comes_from.url
-                        ).netloc.endswith("pypi.python.org")):
+                        ).netloc.endswith(PyPI.netloc)):
                     if not wheel.supported(tags=supported_tags_noarch):
                         logger.debug(
                             "Skipping %s because it is a pypi-hosted binary "

--- a/pip/utils/outdated.py
+++ b/pip/utils/outdated.py
@@ -10,6 +10,7 @@ from pip._vendor import lockfile
 from pip._vendor import pkg_resources
 
 from pip.compat import total_seconds
+from pip.index import PyPI
 from pip.locations import USER_CACHE_DIR, running_under_virtualenv
 
 
@@ -104,7 +105,7 @@ def pip_version_check(session):
         # Refresh the version if we need to or just see if we need to warn
         if pypi_version is None:
             resp = session.get(
-                "https://pypi.python.org/pypi/pip/json",
+                PyPI.pip_json_url,
                 headers={"Accept": "application/json"},
             )
             resp.raise_for_status()


### PR DESCRIPTION
by creating a `PyPI` object (of class `Index`)

Inspired by [comment](https://github.com/pypa/pip/pull/2183#issuecomment-66967168) from @xavfernandez:

> I'm surprised "pypi.python.org" is not a constant defined somewhere in pip's code, just like distlib seems to do

Before:

```
$ ag --ignore=_vendor 'pypi.python.org' pip
pip/cmdoptions.py
195:    default='https://pypi.python.org/simple/',

pip/commands/search.py
33:            default='https://pypi.python.org/pypi',

pip/index.py
305:            if page is None and 'pypi.python.org' not in str(main_index_url):
706:                        ).netloc.endswith("pypi.python.org")):

pip/utils/outdated.py
107:                "https://pypi.python.org/pypi/pip/json",
```

After:

```
$ ag --ignore=_vendor 'pypi.python.org' pip
pip/index.py
77:PyPI = Index(url='https://pypi.python.org/', trusted=True)
```
