### PR TITLE
Loosen filter regexes slightly

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -916,9 +916,9 @@ exec(compile(
                 r'^byte-compiling ',
                 r'^SyntaxError:',
                 r'^SyntaxWarning:',
-                (r'^(warning: )?no previously-included (files|directories) '
-                 r'(found)? matching \'.*\''),
-                r'^warning: no files found matching \'.*\' under directory',
+                r'^\s*Skipping implicit fixer: ',
+                r'^\s*(warning: )?no previously-included (files|directories) ',
+                r'^\s*warning: no files found matching \'.*\'',
                 # Not sure what this warning is, but it seems harmless:
                 r"^warning: manifest_maker: standard file '-c' not found$"]:
             if not line or re.search(regex, line.strip()):


### PR DESCRIPTION
to catch a few messages that slipped through when I was installing `docutils` on Python 3.4:

```
warning: no files found matching 'MANIFEST'
warning: no previously-included files matching '.cvsignore' found under directory '*'
Skipping implicit fixer: buffer
```

Before:

```
$ pip install ~/src/docutils --upgrade
Processing /Users/marca/src/docutils
    warning: no files found matching 'MANIFEST'
    warning: no previously-included files matching '.cvsignore' found under directory '*'
    warning: no previously-included files matching '*~' found under directory '*'
    warning: no previously-included files matching '.DS_Store' found under directory '*'
Installing collected packages: docutils
  Found existing installation: docutils 0.13
    Uninstalling docutils:
      Successfully uninstalled docutils
  Running setup.py install for docutils
    Skipping implicit fixer: buffer
    Skipping implicit fixer: idioms
    Skipping implicit fixer: set_literal
    Skipping implicit fixer: ws_comma
  ...
```

After:

```
$ pip install ~/src/docutils --upgrade
Processing /Users/marca/src/docutils
Installing collected packages: docutils
  Found existing installation: docutils 0.13
    Uninstalling docutils:
      Successfully uninstalled docutils
  Running setup.py install for docutils
  ...
```
