### PR TITLE
Make installed_version work for wheel

### DIFF
--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -8,6 +8,7 @@ import pytest
 from mock import Mock, patch, mock_open
 from pip.exceptions import (
     PreviousBuildDirError, InvalidWheelFilename, UnsupportedWheel,
+    DistributionNotFound,
 )
 from pip.download import PipSession
 from pip.index import PackageFinder
@@ -84,6 +85,11 @@ class TestInstallRequirement(object):
             InstallRequirement.from_line(
                 'peppercorn-0.4-py2.py3-bogus-any.whl',
             )
+
+    def test_installed_version_not_installed(self):
+        req = InstallRequirement.from_line('simple-0.1-py2.py3-none-any.whl')
+        with pytest.raises(DistributionNotFound):
+            req.installed_version
 
     def test_invalid_wheel_requirement_raises(self):
         with pytest.raises(InvalidWheelFilename):


### PR DESCRIPTION
by using `pkg_resources.get_distribution` instead of calling `pkg_info` method. Wheels don't have a `.pip-egg-info` folder.

See: GH-2202
