### PR TITLE
Do not use hardcoded slash separator for Windows support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,12 @@ def pytest_collection_modifyitems(items):
             os.path.commonprefix([__file__, item.module.__file__]),
         )
 
-        if (module_path.startswith("functional/")
-                or module_path.startswith("integration/")
-                or module_path.startswith("lib/")):
+        module_root_dir = module_path.split(os.pathsep)[0]
+        if (module_root_dir.startswith("functional")
+                or module_root_dir.startswith("integration")
+                or module_root_dir.startswith("lib")):
             item.add_marker(pytest.mark.integration)
-        elif module_path.startswith("unit/"):
+        elif module_root_dir.startswith("unit"):
             item.add_marker(pytest.mark.unit)
 
             # We don't want to allow using the script resource if this is a


### PR DESCRIPTION
The current conftest fails on Windows currently, which disables Windows testing.
This PR fixes the path separator expectations.

@pfmoore It seems that the Windows test suite is broken at the moment. Now it is a little less broken ;-)
