### PR TITLE
Support wildcards for uninstall and freeze

### DIFF
--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -95,15 +95,18 @@ class FreezeCommand(Command):
         for link in find_links:
             f.write('-f %s\n' % link)
         installations = {}
-        for dist in get_installed_distributions(local_only=local_only,
-                                                skip=freeze_excludes,
-                                                user_only=user_only):
-            req = pip.FrozenRequirement.from_dist(
-                dist,
-                dependency_links,
-                find_tags=find_tags,
-            )
-            installations[req.name] = req
+        glob_patterns = args or ['*']
+        for glob_pattern in glob_patterns:
+            for dist in get_installed_distributions(glob_pattern=glob_pattern,
+                                                    local_only=local_only,
+                                                    skip=freeze_excludes,
+                                                    user_only=user_only):
+                req = pip.FrozenRequirement.from_dist(
+                    dist,
+                    dependency_links,
+                    find_tags=find_tags,
+                )
+                installations[req.name] = req
 
         if requirement:
             with open(requirement) as req_file:

--- a/pip/commands/uninstall.py
+++ b/pip/commands/uninstall.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from pip.req import InstallRequirement, RequirementSet, parse_requirements
 from pip.basecommand import Command
 from pip.exceptions import InstallationError
+from pip.utils import get_installed_distributions
 
 
 class UninstallCommand(Command):
@@ -50,7 +51,17 @@ class UninstallCommand(Command):
                 isolated=options.isolated_mode,
                 session=session,
             )
-            for name in args:
+
+            names = []
+
+            for arg in args:
+                if '*' in arg:
+                    matches = get_installed_distributions(glob_pattern=arg)
+                    names.extend([distro.project_name for distro in matches])
+                else:
+                    names.append(arg)
+
+            for name in names:
                 requirement_set.add_requirement(
                     InstallRequirement.from_line(
                         name, isolated=options.isolated_mode,

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import contextlib
+import fnmatch
 import locale
 import logging
 import re
@@ -369,7 +370,8 @@ def dist_is_editable(dist):
     return req.editable
 
 
-def get_installed_distributions(local_only=True,
+def get_installed_distributions(glob_pattern='*',
+                                local_only=True,
                                 skip=stdlib_pkgs,
                                 include_editables=True,
                                 editables_only=False,
@@ -417,6 +419,7 @@ def get_installed_distributions(local_only=True,
             and editable_test(d)
             and editables_only_test(d)
             and user_test(d)
+            and fnmatch.fnmatch(str(d), glob_pattern)
             ]
 
 


### PR DESCRIPTION
e.g.:

```
[marca@marca-mac2 pip]$ pip freeze 'py*' 'zope*'
py==1.4.26
pyramid==1.5.2
pyramid-chameleon==0.3
pyrepl==0.8.4
pytest==2.6.4
zope.deprecation==4.1.1
zope.interface==4.1.1
```

and

```
[marca@marca-mac2 pip]$ noglob pip uninstall 'zope.*'
Uninstalling zope.deprecation:
  Successfully uninstalled zope.deprecation
Uninstalling zope.interface:
  Successfully uninstalled zope.interface
```

This will require some doc updates if we're okay with going this way...
