### PR TITLE
Display versions of uninstalled distributions

### DIFF
--- a/pip/req/req_uninstall.py
+++ b/pip/req/req_uninstall.py
@@ -98,7 +98,7 @@ class UninstallPathSet(object):
                 self.dist.project_name,
             )
             return
-        logger.info('Uninstalling %s:', self.dist.project_name)
+        logger.info('Uninstalling %s:', self.dist)
 
         with indent_log():
             paths = sorted(self.compact(self.paths))
@@ -123,9 +123,7 @@ class UninstallPathSet(object):
                     renames(path, new_path)
                 for pth in self.pth.values():
                     pth.remove()
-                logger.info(
-                    'Successfully uninstalled %s', self.dist.project_name
-                )
+                logger.info('Successfully uninstalled %s', self.dist)
 
     def rollback(self):
         """Rollback the changes previously made by remove()."""


### PR DESCRIPTION
It's helpful to see the versions uninstalled for auditing purposes and
if the user realizes they broke something and they want to restore
things back to exactly how they were.

Before:

```
$ pip uninstall pyrepl pytest
Uninstalling pyrepl:
  Successfully uninstalled pyrepl
Uninstalling pytest:
  Successfully uninstalled pytest
```

After:

```
$ pip uninstall pyrepl pytest
Uninstalling pyrepl 0.8.4:
  Successfully uninstalled pyrepl 0.8.4
Uninstalling pytest 2.6.4:
  Successfully uninstalled pytest 2.6.4
```
