### PR TITLE
Move dev reqs from tox.ini to dev-requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ exclude .mailmap
 exclude .travis.yml
 exclude pip/_vendor/Makefile
 exclude tox.ini
+exclude dev-requirements.txt
 
 recursive-include pip/_vendor *.pem
 recursive-include docs Makefile *.rst *.py *.bat

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,10 @@
+https://github.com/spulec/freezegun/archive/master.zip#egg=freezegun
+pretend
+pytest
+pytest-capturelog
+pytest-cov
+pytest-timeout
+pytest-xdist
+mock
+scripttest>=1.3
+https://github.com/pypa/virtualenv/archive/develop.zip#egg=virtualenv

--- a/tox.ini
+++ b/tox.ini
@@ -1,38 +1,22 @@
 [tox]
-envlist =
-    docs,packaging,pep8,py3pep8,py26,py27,py32,py33,py34,pypy
+envlist = docs, packaging, pep8, py3pep8, py26, py27, py32, py33, py34, pypy
 
 [testenv]
-deps =
-    https://github.com/spulec/freezegun/archive/master.zip#egg=freezegun
-    pretend
-    pytest
-    pytest-capturelog
-    pytest-cov
-    pytest-timeout
-    pytest-xdist
-    mock
-    scripttest>=1.3
-    https://github.com/pypa/virtualenv/archive/develop.zip#egg=virtualenv
-commands =
-    py.test --timeout 300 []
-install_command =
-    python -m pip install --pre {opts} {packages}
+deps = -r{toxinidir}/dev-requirements.txt
+commands = py.test --timeout 300 []
+install_command = python -m pip install --pre {opts} {packages}
 
 [testenv:py26]
-install_command =
-    pip install --pre {opts} {packages}
+install_command = pip install --pre {opts} {packages}
 
 [testenv:docs]
 deps = sphinx
 basepython = python2.7
-commands =
-    sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
+commands = sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
 [testenv:packaging]
 deps = check-manifest
-commands =
-    check-manifest
+commands = check-manifest
 
 [testenv:pep8]
 basepython = python2.7
@@ -43,7 +27,6 @@ commands = flake8 .
 basepython = python3.3
 deps = flake8
 commands = flake8 .
-
 
 [flake8]
 exclude = .tox,*.egg,build,_vendor,data


### PR DESCRIPTION
Then folks who don't use tox can do `pip install -r dev-requirements.txt`

Since this is pip, which created the idea of requirements files, it seems nice for the project to have one to showcase the idea.

Also cleaned up the tox.ini and made it more compact (fits now on my laptop screen) and consistent.
