### PR TITLE
Displays info about [un]installed versions

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import operator
 import os
 import tempfile
 import shutil
@@ -345,10 +346,20 @@ class InstallCommand(Command):
                             global_options,
                             root=options.root_path,
                         )
-                        installed = ' '.join([
-                            req.name for req in
-                            requirement_set.successfully_installed
-                        ])
+                        reqs = sorted(
+                            requirement_set.successfully_installed,
+                            key=operator.attrgetter('name'))
+                        items = []
+                        for req in reqs:
+                            item = req.name
+                            try:
+                                if hasattr(req, 'installed_version'):
+                                    if req.installed_version:
+                                        item += '-' + req.installed_version
+                            except Exception:
+                                pass
+                            items.append(item)
+                        installed = ' '.join(items)
                         if installed:
                             logger.info('Successfully installed %s', installed)
                     else:

--- a/pip/req/req_uninstall.py
+++ b/pip/req/req_uninstall.py
@@ -98,7 +98,10 @@ class UninstallPathSet(object):
                 self.dist.project_name,
             )
             return
-        logger.info('Uninstalling %s:', self.dist.project_name)
+        logger.info(
+            'Uninstalling %s-%s:',
+            self.dist.project_name, self.dist.version
+        )
 
         with indent_log():
             paths = sorted(self.compact(self.paths))
@@ -124,7 +127,8 @@ class UninstallPathSet(object):
                 for pth in self.pth.values():
                     pth.remove()
                 logger.info(
-                    'Successfully uninstalled %s', self.dist.project_name
+                    'Successfully uninstalled %s-%s',
+                    self.dist.project_name, self.dist.version
                 )
 
     def rollback(self):


### PR DESCRIPTION
This is a variation on https://github.com/pypa/pip/pull/2207 that doesn't write the output in `package_name==version` format, because @dstufft had some reservations about using that format and then people getting accustomed to it.

Displays version when installing and uninstalling -- e.g.:

```
Successfully installed pyrepl-0.8.4 pytest-2.6.4
```

and:

```
Uninstalling pyrepl-0.8.4:
  Successfully uninstalled pyrepl-0.8.4
Uninstalling pytest-2.6.4:
  Successfully uninstalled pytest-2.6.4
```
