### PR TITLE
Use a nicer progress bar if possible

### DIFF
--- a/pip/utils/ui.py
+++ b/pip/utils/ui.py
@@ -7,7 +7,8 @@ import sys
 from pip.compat import WINDOWS
 from pip.utils import format_size
 from pip.utils.logging import get_indentation
-from pip._vendor.progress.bar import Bar
+from pip._vendor import six
+from pip._vendor.progress.bar import Bar, IncrementalBar
 from pip._vendor.progress.helpers import WritelnMixin
 from pip._vendor.progress.spinner import Spinner
 
@@ -17,6 +18,36 @@ try:
 # ImportError.
 except Exception:
     colorama = None
+
+
+def _select_progress_class(preferred, fallback):
+    encoding = getattr(preferred.file, "encoding", None)
+
+    # If we don't know what encoding this file is in, then we'll just assume
+    # that it doesn't support unicode and use the ASCII bar.
+    if not encoding:
+        return fallback
+
+    # Collect all of the possible characters we want to use with the preferred
+    # bar.
+    characters = [
+        getattr(preferred, "empty_fill", six.text_type()),
+        getattr(preferred, "fill", six.text_type()),
+    ]
+    characters += list(getattr(preferred, "phases", []))
+
+    # Try to decode the characters we're using for the bar using the encoding
+    # of the given file, if this works then we'll assume that we can use the
+    # fancier bar and if not we'll fall back to the plaintext bar.
+    try:
+        six.text_type().join(characters).encode(encoding)
+    except UnicodeEncodeError:
+        return fallback
+    else:
+        return preferred
+
+
+_BaseBar = _select_progress_class(IncrementalBar, Bar)
 
 
 class DownloadProgressMixin(object):
@@ -74,7 +105,7 @@ class WindowsMixin(object):
             self.hide_cursor = False
 
 
-class DownloadProgressBar(WindowsMixin, DownloadProgressMixin, Bar):
+class DownloadProgressBar(WindowsMixin, DownloadProgressMixin, _BaseBar):
 
     file = sys.stdout
     message = "%(percent)d%%"


### PR DESCRIPTION
Here's an alternative to #2229 which detects which bar to use based on the capabilities of stdout. This I think gives us the best of both worlds since it will attempt to use the nicer bar by default, but will fallback and assume that it won't work unless it can successfully encode characters using the encoding of the file the progress bar is printing to.

I have no idea if this works on Windows (or if Windows even shows the progress bar at all) so hopefully @pfmoore can be insightful here.

Example:

![pip-progress](https://cloud.githubusercontent.com/assets/145979/5506895/49b49fc4-876c-11e4-8849-0398a53a33d0.png)

Closes #2229 
