### PR TITLE
Make `pip show` show much more metadata

### DIFF
--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from email.parser import FeedParser
 import logging
 import os
 
@@ -59,6 +60,7 @@ def search_packages_info(query):
             'requires': [dep.project_name for dep in dist.requires()],
         }
         file_list = None
+        metadata = None
         if isinstance(dist, pkg_resources.DistInfoDistribution):
             # RECORDs should be part of .dist-info metadatas
             if dist.has_metadata('RECORD'):
@@ -66,12 +68,30 @@ def search_packages_info(query):
                 paths = [l.split(',')[0] for l in lines]
                 paths = [os.path.join(dist.location, p) for p in paths]
                 file_list = [os.path.relpath(p, dist.location) for p in paths]
+
+            if dist.has_metadata('METADATA'):
+                metadata = dist.get_metadata('METADATA')
         else:
             # Otherwise use pip's log for .egg-info's
             if dist.has_metadata('installed-files.txt'):
                 paths = dist.get_metadata_lines('installed-files.txt')
                 paths = [os.path.join(dist.egg_info, p) for p in paths]
                 file_list = [os.path.relpath(p, dist.location) for p in paths]
+            if dist.has_metadata('entry_points.txt'):
+                entry_points = dist.get_metadata_lines('entry_points.txt')
+                package['entry_points'] = entry_points
+
+            if dist.has_metadata('PKG-INFO'):
+                metadata = dist.get_metadata('PKG-INFO')
+
+        # @todo: Should pkg_resources.Distribution have a
+        # `get_pkg_info` method?
+        feed_parser = FeedParser()
+        feed_parser.feed(metadata)
+        pkg_info_dict = feed_parser.close()
+        for key in ('metadata-version', 'summary',
+                    'home-page', 'author', 'author-email', 'license'):
+            package[key] = pkg_info_dict.get(key)
 
         # use and short-circuit to check for None
         package['files'] = file_list and sorted(file_list)
@@ -86,8 +106,14 @@ def print_results(distributions, list_all_files):
     for dist in distributions:
         results_printed = True
         logger.info("---")
+        logger.info("Metadata-Version: %s" % dist.get('metadata-version'))
         logger.info("Name: %s" % dist['name'])
         logger.info("Version: %s" % dist['version'])
+        logger.info("Summary: %s" % dist.get('summary'))
+        logger.info("Home-page: %s" % dist.get('home-page'))
+        logger.info("Author: %s" % dist.get('author'))
+        logger.info("Author-email: %s" % dist.get('author-email'))
+        logger.info("License: %s" % dist.get('license'))
         logger.info("Location: %s" % dist['location'])
         logger.info("Requires: %s" % ', '.join(dist['requires']))
         if list_all_files:
@@ -97,4 +123,8 @@ def print_results(distributions, list_all_files):
                     logger.info("  %s" % line.strip())
             else:
                 logger.info("Cannot locate installed-files.txt")
+        if 'entry_points' in dist:
+            logger.info("Entry-points:")
+            for line in dist['entry_points']:
+                logger.info("  %s" % line.strip())
     return results_printed

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -9,12 +9,12 @@ def test_show(script):
     """
     result = script.pip('show', 'pip')
     lines = result.stdout.split('\n')
-    assert len(lines) == 6
+    assert len(lines) == 17
     assert lines[0] == '---', lines[0]
-    assert lines[1] == 'Name: pip', lines[1]
-    assert lines[2] == 'Version: %s' % __version__, lines[2]
-    assert lines[3].startswith('Location: '), lines[3]
-    assert lines[4] == 'Requires: '
+    assert 'Name: pip' in lines
+    assert 'Version: %s' % __version__ in lines
+    assert any(line.startswith('Location: ') for line in lines)
+    assert 'Requires: ' in lines
 
 
 def test_show_with_files_not_found(script, data):
@@ -26,14 +26,14 @@ def test_show_with_files_not_found(script, data):
     script.pip('install', '-e', editable)
     result = script.pip('show', '-f', 'SetupPyUTF8')
     lines = result.stdout.split('\n')
-    assert len(lines) == 8
+    assert len(lines) == 14
     assert lines[0] == '---', lines[0]
-    assert lines[1] == 'Name: SetupPyUTF8', lines[1]
-    assert lines[2] == 'Version: 0.0.0', lines[2]
-    assert lines[3].startswith('Location: '), lines[3]
-    assert lines[4] == 'Requires: ', lines[4]
-    assert lines[5] == 'Files:', lines[5]
-    assert lines[6] == 'Cannot locate installed-files.txt', lines[6]
+    assert 'Name: SetupPyUTF8' in lines
+    assert 'Version: 0.0.0' in lines
+    assert any(line.startswith('Location: ') for line in lines)
+    assert 'Requires: ' in lines
+    assert 'Files:' in lines
+    assert 'Cannot locate installed-files.txt' in lines
 
 
 def test_show_with_files_from_wheel(script, data):
@@ -44,7 +44,7 @@ def test_show_with_files_from_wheel(script, data):
     script.pip('install', '--no-index', wheel_file)
     result = script.pip('show', '-f', 'simple.dist')
     lines = result.stdout.split('\n')
-    assert lines[1] == 'Name: simple.dist', lines[1]
+    assert 'Name: simple.dist' in lines
     assert 'Cannot locate installed-files.txt' not in lines[6], lines[6]
     assert re.search(r"Files:\n(  .+\n)+", result.stdout)
 


### PR DESCRIPTION
New fields:
- `Metadata-Version`
- `Summary`
- `Home-Page`
- `Author`
- `Author-email`
- `License`
- `Entry-points`

Sample output:

```
$ pip show pytest

---
Metadata-Version: 1.1
Name: pytest
Version: 2.6.4
Summary: pytest: simple powerful testing with Python
Home-page: http://pytest.org
Author: Holger Krekel, Benjamin Peterson, Ronny Pfannschmidt, Floris Bruynooghe and others
Author-email: holger at merlinux.eu
License: MIT license
Location: /Users/marca/python/virtualenvs/tmp-4e2169280f5cbd16/lib/python3.4/site-packages
Requires: py
Entry points:
  [console_scripts]
  py.test = pytest:main
  py.test-3.4 = pytest:main
```
