### PR TITLE
Fix ``pip list`` when there is an invalid PEP 440 version installed

### DIFF
--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -253,7 +253,7 @@ class FrozenRequirement(object):
             editable = False
             req = dist.as_requirement()
             specs = req.specs
-            assert len(specs) == 1 and specs[0][0] == '=='
+            assert len(specs) == 1 and specs[0][0] in ["==", "==="]
             version = specs[0][1]
             ver_match = cls._rev_re.search(version)
             date_match = cls._date_re.search(version)


### PR DESCRIPTION
Fixes #2208
