### PR TITLE
Make search name column width dynamic

### DIFF
--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -101,7 +101,11 @@ def transform_hits(hits):
     return package_list
 
 
-def print_results(hits, name_column_width=25, terminal_width=None):
+def print_results(hits, name_column_width=None, terminal_width=None):
+    if not hits:
+        return
+    if name_column_width is None:
+        name_column_width = max((len(hit['name']) for hit in hits)) + 4
     installed_packages = [p.project_name for p in pkg_resources.working_set]
     for hit in hits:
         name = hit['name']


### PR DESCRIPTION
Before:

```
$ pip search pytest | egrep 'bytecode|template|cache|cpp'
pytest-cpp                - Use pytest's runner to discover and execute C++ tests
pytest-cache              - pytest plugin with mechanisms for caching across test runs
python_boilerplate_template - PasteScript template for initializing a new buildout/pytest/travis/setuptools-enabled Python project
pytest-remove-stale-bytecode - py.test plugin to remove stale byte code files.
```

After:

```
$ pip search pytest | egrep 'bytecode|template|cache|cpp'
pytest-cpp                       - Use pytest's runner to discover and execute C++ tests
pytest-cache                     - pytest plugin with mechanisms for caching across test runs
python_boilerplate_template      - PasteScript template for initializing a new buildout/pytest/travis/setuptools-enabled Python project
pytest-remove-stale-bytecode     - py.test plugin to remove stale byte code files.
```

This might help with https://github.com/pypa/pip/pull/1415 (although it might also cause a merge conflict).
