### PR TITLE
Fix GH-2249: not listing candidate versions

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -431,10 +431,10 @@ class PackageFinder(object):
                 ),
             )
         )
-        all_versions = [x for x in all_versions if x.version in _versions]
+        applicable_versions = [x for x in all_versions if x.version in _versions]
 
         # Finally add our existing versions to the front of our versions.
-        applicable_versions = installed_version + all_versions
+        applicable_versions = installed_version + applicable_versions
 
         applicable_versions = self._sort_versions(applicable_versions)
         existing_applicable = any(
@@ -459,6 +459,7 @@ class PackageFinder(object):
             return None
 
         if not applicable_versions:
+            # import pdb; pdb.set_trace()
             logger.critical(
                 'Could not find a version that satisfies the requirement %s '
                 '(from versions: %s)',


### PR DESCRIPTION
all_versions => applicable_versions

Fixes: #2249
