### PR TITLE
Warn about `>` being an exclusive operator now.

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -459,6 +459,18 @@ class PackageFinder(object):
             return None
 
         if not applicable_versions:
+            # The following check for '>' is designed to prevent confusion like
+            # that in
+            # https://bitbucket.org/pypa/setuptools/issue/301/101-in-requirementparse-foo-10-results
+            str_specifier = str(req.specifier)
+            if '>' in str_specifier and '>=' not in str_specifier:
+                logger.warning(
+                    "The behavior of the `>` version specifier has changed in "
+                    "PEP 440. `>` is now an exclusive operator, meaning that "
+                    "%s does not match %s. "
+                    "Perhaps you want `>=` instead of `>`?",
+                    str_specifier, str_specifier + '.*'
+                )
             logger.critical(
                 'Could not find a version that satisfies the requirement %s '
                 '(from versions: %s)',


### PR DESCRIPTION
E.g.: `pip install 'prettytable>0.7'` will no longer install
`prettytable==0.7.2`, because of PEP 440.

```
$ pip install 'prettytable>0.7'
Collecting prettytable>0.7
  The behavior of the `>` version specifier has changed in PEP 440. `>` is now an exclusive operator, meaning that >0.7 does not match >0.7.*.
  Perhaps you want `>=` instead of `>`?
  Could not find a version that satisfies the requirement prettytable>0.7 (from versions: )
  No distributions matching the version for prettytable>0.7
```
