### PR TITLE
Update installing.rst

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -65,12 +65,7 @@ On Linux or OS X:
 
  pip install -U pip
 
-
-<<<<<<< HEAD
-On Windows [5]_:
-=======
 On Windows [6]_:
->>>>>>> develop
 
 ::
 


### PR DESCRIPTION
Fixes unresolved conflict caused by footnote bump. Windows should point to 6(https://github.com/pypa/pip/issues/1299)
