### PR TITLE
Fix pip install -v fails

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -505,7 +505,7 @@ class PackageFinder(object):
         if applicable_versions[0].location is INSTALLED_VERSION:
             # We have an existing version, and its the best version
             logger.debug(
-                'Installed version (%s) is most up-to-date (past versions: ',
+                'Installed version (%s) is most up-to-date (past versions: '
                 '%s)',
                 req.satisfied_by.version,
                 ', '.join(str(i.version) for i in applicable_versions[1:])


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/var/lib/jenkins/.pyenv/versions/3.4.2/lib/python3.4/logging/__init__.py", line 978, in emit
    msg = self.format(record)
  File "/var/lib/jenkins/venv/lib/python3.4/site-packages/pip/utils/logging.py", line 103, in format

▽
    msg = logging.StreamHandler.format(self, record)
  File "/var/lib/jenkins/.pyenv/versions/3.4.2/lib/python3.4/logging/__init__.py", line 828, in format
    return fmt.format(record)
  File "/var/lib/jenkins/venv/lib/python3.4/site-packages/pip/utils/logging.py", line 49, in format
    formatted = logging.Formatter.format(self, record)
  File "/var/lib/jenkins/.pyenv/versions/3.4.2/lib/python3.4/logging/__init__.py", line 565, in format
    record.message = record.getMessage()
  File "/var/lib/jenkins/.pyenv/versions/3.4.2/lib/python3.4/logging/__init__.py", line 328, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "venv/bin/pip", line 11, in <module>
    sys.exit(main())
  File "/var/lib/jenkins/venv/lib/python3.4/site-packages/pip/__init__.py", line 217, in main
    return command.main(cmd_args)
  File "/var/lib/jenkins/venv/lib/python3.4/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/var/lib/jenkins/venv/lib/python3.4/site-packages/pip/commands/install.py", line 339, in run
    requirement_set.prepare_files(finder)
  File "/var/lib/jenkins/venv/lib/python3.4/site-packages/pip/req/req_set.py", line 235, in prepare_files
    req_to_install, self.upgrade)
  File "/var/lib/jenkins/venv/lib/python3.4/site-packages/pip/index.py", line 512, in find_requirement
    or "none",
Message: 'Installed version (%s) is most up-to-date (past versions: '
Arguments: ('%s)', '2.3.1', '2.3.1, 2.3.1, 2.3.1, 2.3.0, 2.3.0, 2.3.0, 2.2.0, 2.2.0, 2.2.0, 2.1.0, 2.1.0, 2.1.0, 2.0.0, 2.0.0, 2.0.0, 1.2.1, 1.2.1, 1.2.0, 1.2.0, 1.1.0, 1.1.0, 1.0.0, 1.0.0, 0.13.2, 0.13.2, 0.13.1, 0.13.1, 0.13, 0.13, 0.12.1, 0.12.1, 0.12, 0.12, 0.11, 0.11, 0.10.2, 0.10.2, 0.10.1, 0.10.1, 0.10')
```
