### PR TITLE
Backport a number of fixed to 6.0.4

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@
 **6.0.3 (2014-12-23)**
 
 * Fix an issue where the implicit version check new in pip 6.0 could cause pip
-  to block for up to 75 seconds if PyPI was not accessable.
+  to block for up to 75 seconds if PyPI was not accessible.
 
 * Make ``--no-index`` imply ``--disable-pip-version-check``.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+**6.0.4 (2015-01-03)**
+
+* Fix an issue where ANSI escape codes would be used on Windows even though the
+  Windows shell does not support them, causing odd characters to appear with
+  the progress bar.
+
+
 **6.0.3 (2014-12-23)**
 
 * Fix an issue where the implicit version check new in pip 6.0 could cause pip

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,8 @@
 * Update PEP 440 support to handle the latest changes to PEP 440, particularly
   the changes to ``>V`` and ``<V`` so that they no longer imply ``!=V.*``.
 
+* Document the default cache directories for each operating system.
+
 
 **6.0.3 (2014-12-23)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@
   Windows shell does not support them, causing odd characters to appear with
   the progress bar.
 
+* Fix an issue where using -v would cause an exception saying "TypeError: not
+  all arguments converted during string formatting".
+
 
 **6.0.3 (2014-12-23)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,10 @@
 * Fix an issue where upgrading distribute would cause an exception saying
   ``TypeError: expected string or buffer``.
 
+* Show a warning and disable the use of the cache directory when the cache
+  directory is not owned by the current use, commonly caused by using ``sudo``
+  without the ``-H`` flag.
+
 
 **6.0.3 (2014-12-23)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,9 @@
 * Fix an issue where using -v with dependency links would cause an exception
   saying ``TypeError: 'InstallationCandidate' object is not iterable``.
 
+* Fix an issue where upgrading distribute would cause an exception saying
+  ``TypeError: expected string or buffer``.
+
 
 **6.0.3 (2014-12-23)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,8 @@
   Windows shell does not support them, causing odd characters to appear with
   the progress bar.
 
-* Fix an issue where using -v would cause an exception saying "TypeError: not
-  all arguments converted during string formatting".
+* Fix an issue where using -v would cause an exception saying
+  ``TypeError: not all arguments converted during string formatting``.
 
 * Fix an issue where using -v with dependency links would cause an exception
   saying ``TypeError: 'InstallationCandidate' object is not iterable``.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,9 @@
 
 * Document the default cache directories for each operating system.
 
+* Create the cache directory when the pip version check needs to save to it
+  instead of silently logging an error.
+
 
 **6.0.3 (2014-12-23)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,9 @@
   directory is not owned by the current use, commonly caused by using ``sudo``
   without the ``-H`` flag.
 
+* Update PEP 440 support to handle the latest changes to PEP 440, particularly
+  the changes to ``>V`` and ``<V`` so that they no longer imply ``!=V.*``.
+
 
 **6.0.3 (2014-12-23)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@
 * Fix an issue where using -v would cause an exception saying "TypeError: not
   all arguments converted during string formatting".
 
+* Fix an issue where using -v with dependency links would cause an exception
+  saying ``TypeError: 'InstallationCandidate' object is not iterable``.
+
 
 **6.0.3 (2014-12-23)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,6 +25,9 @@
 * Create the cache directory when the pip version check needs to save to it
   instead of silently logging an error.
 
+* Fix a regression where the ``-q`` flag would not properly suppress the
+  display of the progress bars.
+
 
 **6.0.3 (2014-12-23)**
 

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -291,6 +291,15 @@ While this cache attempts to minimize network activity, it does not prevent
 network access all together. If you want a fast/local install solution that
 circumvents accessing PyPI, see :ref:`Fast & Local Installs`.
 
+The default location for the cache directory depends on the Operating System:
+
+Unix
+  :file:`~/.cache/pip` and it respects the ``XDG_CACHE_HOME`` directory.
+OS X
+  :file:`~/Library/Caches/pip`.
+Windows
+  :file:`<CSIDL_LOCAL_APPDATA>\pip\Cache`
+
 
 Hash Verification
 +++++++++++++++++

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -30,7 +30,7 @@ import pip.cmdoptions
 cmdoptions = pip.cmdoptions
 
 # The version as used in the setup.py and the docs conf.py
-__version__ = "6.0.3"
+__version__ = "6.0.4.dev0"
 
 
 logger = logging.getLogger(__name__)

--- a/pip/_vendor/README.rst
+++ b/pip/_vendor/README.rst
@@ -15,10 +15,10 @@ Modifications
 * progress has been modified to not use unicode literals for support for Python 3.2
 
 
-Markerlib and pkg_resources
-===========================
+_markerlib and pkg_resources
+============================
 
-Markerlib and pkg_resources has been pulled in from setuptools 8.2.1
+_markerlib and pkg_resources has been pulled in from setuptools 11.0
 
 
 Note to Downstream Distributors

--- a/pip/_vendor/packaging/__about__.py
+++ b/pip/_vendor/packaging/__about__.py
@@ -22,7 +22,7 @@ __title__ = "packaging"
 __summary__ = "Core utilities for Python packages"
 __uri__ = "https://github.com/pypa/packaging"
 
-__version__ = "14.5"
+__version__ = "15.0"
 
 __author__ = "Donald Stufft"
 __email__ = "donald@stufft.io"

--- a/pip/_vendor/packaging/version.py
+++ b/pip/_vendor/packaging/version.py
@@ -96,11 +96,19 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     @property
+    def base_version(self):
+        return self._version
+
+    @property
     def local(self):
         return None
 
     @property
     def is_prerelease(self):
+        return False
+
+    @property
+    def is_postrelease(self):
         return False
 
 
@@ -270,6 +278,19 @@ class Version(_BaseVersion):
         return str(self).split("+", 1)[0]
 
     @property
+    def base_version(self):
+        parts = []
+
+        # Epoch
+        if self._version.epoch != 0:
+            parts.append("{0}!".format(self._version.epoch))
+
+        # Release segment
+        parts.append(".".join(str(x) for x in self._version.release))
+
+        return "".join(parts)
+
+    @property
     def local(self):
         version_string = str(self)
         if "+" in version_string:
@@ -278,6 +299,10 @@ class Version(_BaseVersion):
     @property
     def is_prerelease(self):
         return bool(self._version.dev or self._version.pre)
+
+    @property
+    def is_postrelease(self):
+        return bool(self._version.post)
 
 
 def _parse_letter_version(letter, number):

--- a/pip/_vendor/pkg_resources/__init__.py
+++ b/pip/_vendor/pkg_resources/__init__.py
@@ -2250,14 +2250,20 @@ class EntryPoint(object):
     def load(self, require=True, env=None, installer=None):
         if require:
             self.require(env, installer)
-        entry = __import__(self.module_name, globals(), globals(),
-            ['__name__'])
-        for attr in self.attrs:
-            try:
-                entry = getattr(entry, attr)
-            except AttributeError:
-                raise ImportError("%r has no %r attribute" % (entry, attr))
-        return entry
+        else:
+            warnings.warn(
+                "`require` parameter is deprecated. Use "
+                "EntryPoint._load instead.",
+                DeprecationWarning,
+            )
+        return self._load()
+
+    def _load(self):
+        module = __import__(self.module_name, fromlist=['__name__'], level=0)
+        try:
+            return functools.reduce(getattr, self.attrs, module)
+        except AttributeError as exc:
+            raise ImportError(str(exc))
 
     def require(self, env=None, installer=None):
         if self.extras and not self.dist:
@@ -2265,6 +2271,15 @@ class EntryPoint(object):
         reqs = self.dist.requires(self.extras)
         items = working_set.resolve(reqs, env, installer)
         list(map(working_set.add, items))
+
+    pattern = re.compile(
+        r'\s*'
+        r'(?P<name>[+\w. -]+?)\s*'
+        r'=\s*'
+        r'(?P<module>[\w.]+)\s*'
+        r'(:\s*(?P<attr>[\w.]+))?\s*'
+        r'(?P<extras>\[.*\])?\s*$'
+    )
 
     @classmethod
     def parse(cls, src, dist=None):
@@ -2277,25 +2292,23 @@ class EntryPoint(object):
         The entry name and module name are required, but the ``:attrs`` and
         ``[extras]`` parts are optional
         """
-        try:
-            attrs = extras = ()
-            name, value = src.split('=', 1)
-            if '[' in value:
-                value, extras = value.split('[', 1)
-                req = Requirement.parse("x[" + extras)
-                if req.specs:
-                    raise ValueError
-                extras = req.extras
-            if ':' in value:
-                value, attrs = value.split(':', 1)
-                if not MODULE(attrs.rstrip()):
-                    raise ValueError
-                attrs = attrs.rstrip().split('.')
-        except ValueError:
+        m = cls.pattern.match(src)
+        if not m:
             msg = "EntryPoint must be in 'name=module:attrs [extras]' format"
             raise ValueError(msg, src)
-        else:
-            return cls(name.strip(), value.strip(), attrs, extras, dist)
+        res = m.groupdict()
+        extras = cls._parse_extras(res['extras'])
+        attrs = res['attr'].split('.') if res['attr'] else ()
+        return cls(res['name'], res['module'], attrs, extras, dist)
+
+    @classmethod
+    def _parse_extras(cls, extras_spec):
+        if not extras_spec:
+            return ()
+        req = Requirement.parse('x' + extras_spec)
+        if req.specs:
+            raise ValueError()
+        return req.extras
 
     @classmethod
     def parse_group(cls, group, lines, dist=None):

--- a/pip/_vendor/vendor.txt
+++ b/pip/_vendor/vendor.txt
@@ -8,4 +8,4 @@ CacheControl==0.10.7
 lockfile==0.10.2
 progress==1.2
 ipaddress==1.0.7  # Only needed on 2.6, 2.7, and 3.2
-packaging==14.5
+packaging==15.0

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -23,6 +23,7 @@ from pip.status_codes import (
 )
 from pip.utils import appdirs, get_prog, normalize_path
 from pip.utils.deprecation import RemovedInPip8Warning
+from pip.utils.filesystem import check_path_owner
 from pip.utils.logging import IndentingFormatter
 from pip.utils.outdated import pip_version_check
 
@@ -113,6 +114,13 @@ class Command(object):
         else:
             level = "INFO"
 
+        # Compute the path for our debug log.
+        debug_log_path = os.path.join(appdirs.user_log_dir("pip"), "debug.log")
+
+        # Ensure that the path for our debug log is owned by the current user
+        # and if it is not, disable the debug log.
+        write_debug_log = check_path_owner(debug_log_path, os.geteuid())
+
         logging_dictConfig({
             "version": 1,
             "disable_existing_loggers": False,
@@ -136,9 +144,7 @@ class Command(object):
                 "debug_log": {
                     "level": "DEBUG",
                     "class": "pip.utils.logging.BetterRotatingFileHandler",
-                    "filename": os.path.join(
-                        appdirs.user_log_dir("pip"), "debug.log",
-                    ),
+                    "filename": debug_log_path,
                     "maxBytes": 10 * 1000 * 1000,  # 10 MB
                     "backupCount": 1,
                     "delay": True,
@@ -156,7 +162,7 @@ class Command(object):
                 "level": level,
                 "handlers": list(filter(None, [
                     "console",
-                    "debug_log",
+                    "debug_log" if write_debug_log else None,
                     "user_log" if options.log else None,
                 ])),
             },
@@ -177,6 +183,17 @@ class Command(object):
                 for name in ["pip._vendor", "distlib", "requests", "urllib3"]
             ),
         })
+
+        # We add this warning here instead of up above, because the logger
+        # hasn't been configured until just now.
+        if not write_debug_log:
+            logger.warning(
+                "The directory '%s' or its parent directory is not owned by "
+                "the current user and the debug log has been disabled. Please "
+                "check the permissions and owner of that directory. If "
+                "executing pip with sudo, you may want the -H flag.",
+                os.path.dirname(debug_log_path),
+            )
 
         if options.log_explicit_levels:
             warnings.warn(

--- a/pip/download.py
+++ b/pip/download.py
@@ -537,7 +537,9 @@ def _download_url(resp, link, content_file):
 
     cached_resp = getattr(resp, "from_cache", False)
 
-    if cached_resp:
+    if logger.getEffectiveLevel() > logging.INFO:
+        show_progress = False
+    elif cached_resp:
         show_progress = False
     elif total_length > (40 * 1000):
         show_progress = True

--- a/pip/index.py
+++ b/pip/index.py
@@ -505,7 +505,7 @@ class PackageFinder(object):
         if applicable_versions[0].location is INSTALLED_VERSION:
             # We have an existing version, and its the best version
             logger.debug(
-                'Installed version (%s) is most up-to-date (past versions: ',
+                'Installed version (%s) is most up-to-date (past versions: '
                 '%s)',
                 req.satisfied_by.version,
                 ', '.join(str(i.version) for i in applicable_versions[1:])

--- a/pip/index.py
+++ b/pip/index.py
@@ -461,18 +461,6 @@ class PackageFinder(object):
             return None
 
         if not applicable_versions:
-            # The following check for '>' is designed to prevent confusion like
-            # that in
-            # https://bitbucket.org/pypa/setuptools/issue/301/101-in-requirementparse-foo-10-results
-            str_specifier = str(req.specifier)
-            if '>' in str_specifier and '>=' not in str_specifier:
-                logger.warning(
-                    "The behavior of the `>` version specifier has changed in "
-                    "PEP 440. `>` is now an exclusive operator, meaning that "
-                    "%s does not match %s. "
-                    "Perhaps you want `>=` instead of `>`?",
-                    str_specifier, str_specifier + '.*'
-                )
             logger.critical(
                 'Could not find a version that satisfies the requirement %s '
                 '(from versions: %s)',

--- a/pip/index.py
+++ b/pip/index.py
@@ -360,7 +360,7 @@ class PackageFinder(object):
             logger.debug(
                 'dependency_links found: %s',
                 ', '.join([
-                    link.url for p, link, version in dependency_versions
+                    version.location.url for version in dependency_versions
                 ])
             )
         file_versions = list(

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -494,6 +494,7 @@ class RequirementSet(object):
         distribute_req = pkg_resources.Requirement.parse("distribute>=0.7")
         for req in to_install:
             if (req.name == 'distribute'
+                    and req.installed_version is not None
                     and req.installed_version in distribute_req):
                 to_install.remove(req)
                 to_install.append(req)

--- a/pip/utils/filesystem.py
+++ b/pip/utils/filesystem.py
@@ -1,0 +1,18 @@
+import os.path
+
+from pip.compat import get_path_uid
+
+
+def check_path_owner(path, uid):
+    previous = None
+    while path != previous:
+        if os.path.lexists(path):
+            # Actually do the ownership check
+            try:
+                if get_path_uid(path) != os.geteuid():
+                    return False
+            except OSError:
+                return False
+            return True
+        else:
+            previous, path = path, os.path.dirname(path)

--- a/pip/utils/outdated.py
+++ b/pip/utils/outdated.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import datetime
+import errno
 import json
 import logging
 import os.path
@@ -12,6 +13,7 @@ from pip._vendor import pkg_resources
 from pip.compat import total_seconds
 from pip.index import PyPI
 from pip.locations import USER_CACHE_DIR, running_under_virtualenv
+from pip.utils.filesystem import check_path_owner
 
 
 SELFCHECK_DATE_FMT = "%Y-%m-%dT%H:%M:%SZ"
@@ -57,6 +59,19 @@ class GlobalSelfCheckState(object):
             self.state = {}
 
     def save(self, pypi_version, current_time):
+        # Check to make sure that we own the directory
+        if not check_path_owner(
+                os.path.dirname(self.statefile_path), os.geteuid()):
+            return
+
+        # Now that we've ensured the directory is owned by this user, we'll go
+        # ahead and make sure that all our directories are created.
+        try:
+            os.makedirs(os.path.dirname(self.statefile_path))
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
+
         # Attempt to write out our version check file
         with lockfile.LockFile(self.statefile_path):
             with open(self.statefile_path) as statefile:

--- a/pip/utils/ui.py
+++ b/pip/utils/ui.py
@@ -4,11 +4,19 @@ from __future__ import division
 import itertools
 import sys
 
+from pip.compat import WINDOWS
 from pip.utils import format_size
 from pip.utils.logging import get_indentation
 from pip._vendor.progress.bar import Bar
 from pip._vendor.progress.helpers import WritelnMixin
 from pip._vendor.progress.spinner import Spinner
+
+try:
+    from pip._vendor import colorama
+# Lots of different errors can come from this, including SystemError and
+# ImportError.
+except Exception:
+    colorama = None
 
 
 class DownloadProgressMixin(object):
@@ -41,14 +49,40 @@ class DownloadProgressMixin(object):
         self.finish()
 
 
-class DownloadProgressBar(DownloadProgressMixin, Bar):
+class WindowsMixin(object):
+
+    def __init__(self, *args, **kwargs):
+        super(WindowsMixin, self).__init__(*args, **kwargs)
+
+        # Check if we are running on Windows and we have the colorama module,
+        # if we do then wrap our file with it.
+        if WINDOWS and colorama:
+            self.file = colorama.AnsiToWin32(self.file)
+            # The progress code expects to be able to call self.file.isatty()
+            # but the colorama.AnsiToWin32() object doesn't have that, so we'll
+            # add it.
+            self.file.isatty = lambda: self.file.wrapped.isatty()
+            # The progress code expects to be able to call self.file.flush()
+            # but the colorama.AnsiToWin32() object doesn't have that, so we'll
+            # add it.
+            self.file.flush = lambda: self.file.wrapped.flush()
+
+        # The Windows terminal does not support the hide/show cursor ANSI codes
+        # even with colorama. So we'll ensure that hide_cursor is False on
+        # Windows.
+        if WINDOWS and self.hide_cursor:
+            self.hide_cursor = False
+
+
+class DownloadProgressBar(WindowsMixin, DownloadProgressMixin, Bar):
 
     file = sys.stdout
     message = "%(percent)d%%"
     suffix = "%(downloaded)s %(download_speed)s %(pretty_eta)s"
 
 
-class DownloadProgressSpinner(DownloadProgressMixin, WritelnMixin, Spinner):
+class DownloadProgressSpinner(WindowsMixin, DownloadProgressMixin,
+                              WritelnMixin, Spinner):
 
     file = sys.stdout
     suffix = "%(downloaded)s %(download_speed)s"

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -273,6 +273,23 @@ def test_finder_priority_file_over_page(data):
     assert link.url.startswith("file://")
 
 
+def test_finder_deplink():
+    """
+    Test PackageFinder with dependency links only
+    """
+    req = InstallRequirement.from_line('gmpy==1.15', None)
+    finder = PackageFinder(
+        [],
+        [],
+        process_dependency_links=True,
+        session=PipSession(),
+    )
+    finder.add_dependency_links(
+        ['https://pypi.python.org/packages/source/g/gmpy/gmpy-1.15.zip'])
+    link = finder.find_requirement(req, False)
+    assert link.url.startswith("https://pypi"), link
+
+
 def test_finder_priority_page_over_deplink():
     """
     Test PackageFinder prefers page links over equivalent dependency links

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -128,6 +128,8 @@ def test_global_state(monkeypatch):
     def fake_lock(filename):
         yield
 
+    monkeypatch.setattr(outdated, "check_path_owner", lambda p, u: True)
+
     monkeypatch.setattr(lockfile, 'LockFile', fake_lock)
 
     monkeypatch.setattr(outdated, 'running_under_virtualenv',


### PR DESCRIPTION
This includes https://github.com/pypa/pip/pull/2281, https://github.com/pypa/pip/pull/2283, https://github.com/pypa/pip/pull/2284, https://github.com/pypa/pip/pull/2288, https://github.com/pypa/pip/pull/2290, https://github.com/pypa/pip/pull/2291, https://github.com/pypa/pip/pull/2301, https://github.com/pypa/pip/pull/2302, https://github.com/pypa/pip/pull/2303, https://github.com/pypa/pip/pull/2304, https://github.com/pypa/pip/pull/2305.
