### PR TITLE
Skip the ownership check if we don't have os.geteuid()

### DIFF
--- a/pip/utils/filesystem.py
+++ b/pip/utils/filesystem.py
@@ -1,9 +1,15 @@
+import os
 import os.path
 
 from pip.compat import get_path_uid
 
 
 def check_path_owner(path, uid):
+    # If we don't have a way to check the effective uid of this process, then
+    # we'll just assume that we own the directory.
+    if not hasattr(os, "geteuid"):
+        return True
+
     previous = None
     while path != previous:
         if os.path.lexists(path):


### PR DESCRIPTION
Fixes #2307