### PR TITLE
Add support for command plugins

### DIFF
--- a/pip/commands/__init__.py
+++ b/pip/commands/__init__.py
@@ -3,6 +3,8 @@ Package containing all pip commands
 """
 from __future__ import absolute_import
 
+import logging
+
 from pip.commands.completion import CompletionCommand
 from pip.commands.freeze import FreezeCommand
 from pip.commands.help import HelpCommand
@@ -14,6 +16,10 @@ from pip.commands.uninstall import UninstallCommand
 from pip.commands.unzip import UnzipCommand
 from pip.commands.zip import ZipCommand
 from pip.commands.wheel import WheelCommand
+from pip._vendor import pkg_resources
+
+
+logger = logging.getLogger(__name__)
 
 
 commands_dict = {
@@ -43,6 +49,16 @@ commands_order = [
     UnzipCommand,
     HelpCommand,
 ]
+
+
+for ep in pkg_resources.iter_entry_points('pip.command.v1'):
+    try:
+        command = ep.load()
+        logger.debug('from entry point %r loaded command = %r' % (ep, command))
+        commands_dict[command.name] = command
+    except Exception as e:
+        logger.warning('Failed to load command plugin: %r (%r): %s'
+                       % (ep, command, e))
 
 
 def get_summaries(ignore_hidden=True, ordered=True):


### PR DESCRIPTION
This introduces a new concept to pip called **"command plugins"**. This allows a user to implement new features but do them **outside pip** itself. This means that people can do interesting experimental and/or custom features and implement these features **outside of pip** so that it doesn't clutter up the core code of pip and it doesn't require the time of pip maintainers to review it.

This might also be an alternative to simply ripping out features of pip that maybe aren't used a ton and are deemed not worth the effort to maintain them (e.g.: `pip [un]zip`, `pip bundle`, etc.). Perhaps even `pip wheel` could be made into a plugin (although I feel that it is probably used much more than the previously mentioned commands, but maybe since `pip wheel` requires the `wheel` package anyway, maybe it makes sense to just have the `wheel` package implement a pip plugin?). Such features could be removed from pip itself, but put into a separate plugin package and maintained by a 3rd party, so that they are not a time burden on PyPA developers.

To create a plugin command, simply:

- Create a third-party Python distribution. It does not have to be on PyPI. It just needs to be installable.
- Create a class that subclasses the `pip.basecommand.Command` class ([example](https://github.com/msabramo/pipdeptree/blob/pip_plugin/pipdeptree.py#L209)).
- Register your new class with the new `pip.command.v1` entry point in the `setup.py` of your distribution ([example](https://github.com/msabramo/pipdeptree/blob/pip_plugin/setup.py#L24)).

An example plugin is available at https://github.com/msabramo/pipdeptree/tree/pip_plugin -- in this branch I've forked an [already existing `pipdeptree` project](https://github.com/naiquevin/pipdeptree) that implements a separate `pipdeptree` command -- in my fork I've put in the necessary bits so that `pipdeptree` is a pip plugin.

Showing how it works...

```
[marca@marca-mac2 ~WORKON_HOME]$ mktmpenv
New python executable in tmp-4adc64ecf8c6ac9e/bin/python
Please make sure you remove any previous custom paths from your /Users/marca/.pydistutils.cfg file.
Installing setuptools, pip...done.
This is a temporary environment. It will be deleted when you run 'deactivate'.

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip install https://github.com/msabramo/pip/archive/command_plugins.zip
...
Successfully installed pip-6.1.0.dev0

# Install the pipdeptree plugin
[marca@marca-mac2 ~VIRTUAL_ENV]$ pip install https://github.com/msabramo/pipdeptree/archive/pip_plugin.zip
Collecting https://github.com/msabramo/pipdeptree/archive/pip_plugin.zip
  Downloading https://github.com/msabramo/pipdeptree/archive/pip_plugin.zip
     - 20kB 85kB/s
Requirement already satisfied (use --upgrade to upgrade): pip>=1.4.1 in ./lib/python2.7/site-packages (from pipdeptree==0.4.2)
Installing collected packages: pipdeptree
  Running setup.py install for pipdeptree
    Installing pipdeptree script to /Users/marca/python/virtualenvs/tmp-4adc64ecf8c6ac9e/bin
Successfully installed pipdeptree-0.4.2

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip

Usage:
  pip <command> [options]

Commands:
  ...
  deptree                     Display a dependency tree of the installed python packages

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip deptree --help

Usage:
  pip deptree [options]

Deptree Options:
  -f, --freeze                Print names so as to write freeze files
  -a, --all                   list all deps at top level
  -l, --local-only            If in a virtualenv that has global access donot show globally installed packages
  -w, --nowarn                Inhibit warnings about possibly confusing packages
...

# Just installing a few packages so that the output of `pip deptree` is more interesting...
[marca@marca-mac2 ~VIRTUAL_ENV]$ pip install flask ipython
...

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip deptree
wsgiref==0.1.2
Flask==0.10.1
  - Werkzeug [required: >=0.7, installed: 0.9.6]
  - Jinja2 [required: >=2.4, installed: 2.7.3]
    - MarkupSafe [installed: 0.23]
  - itsdangerous [required: >=0.21, installed: 0.24]
ipython==2.3.1
  - gnureadline [installed: 6.3.3]
wheel==0.24.0
```

Cc: @dstufft, @pfmoore, @naiquevin, @therealprologic

Refs: https://github.com/naiquevin/pipdeptree/issues/1

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/2329)
<!-- Reviewable:end -->
