### PR TITLE
More robust passing of egg_info --egg-base argument

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -340,9 +340,10 @@ class InstallRequirement(object):
                 egg_base_option = []
             else:
                 egg_info_dir = os.path.join(self.source_dir, 'pip-egg-info')
+                egg_info_dir = os.path.abspath(egg_info_dir)
                 if not os.path.exists(egg_info_dir):
                     os.makedirs(egg_info_dir)
-                egg_base_option = ['--egg-base', 'pip-egg-info']
+                egg_base_option = ['--egg-base', egg_info_dir]
             cwd = self.source_dir
             if self.editable_options and \
                     'subdirectory' in self.editable_options:


### PR DESCRIPTION
A custom package setup.py can be arranged in a way that it changes
current working directory on its own (perhaps because pip doesn't
currently support specifying subdirectory for non-editable installs).
As a consequence, relative path of directory passed as --egg-base
argument of "setup.py egg_info" invocation when installing such
a package could result in a failure.

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>