### PR TITLE
Fix  Pip install Error on windows("The directory is not empty") #306

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -619,13 +619,14 @@ def unpack_http_url(link, location, download_dir=None, session=None):
 
     if not already_downloaded_path:
         os.unlink(from_path)
-	
-    # remove directory can fail with oserror due virus canner locking, try and notify user if it fails
+
+    """remove directory can fail with oserror due virus scanner locking,
+    try and notify user if it fails"""
     try:
         os.rmdir(temp_dir)
     except OSError:
-        logger.warn('Sorry, clearing our temp files fails. You may do it manually for %s', temp_dir)
-
+        logger.warn('Sorry, clearing our temp files fails. '
+        'You may do it manually for %s', temp_dir)
 
 def unpack_file_url(link, location, download_dir=None):
     """Unpack link into location.

--- a/pip/download.py
+++ b/pip/download.py
@@ -626,7 +626,7 @@ def unpack_http_url(link, location, download_dir=None, session=None):
         os.rmdir(temp_dir)
     except OSError:
         logger.warn('Sorry, clearing our temp files fails. '
-        'You may do it manually for %s', temp_dir)
+                    'You may do it manually for %s', temp_dir)
 
 
 def unpack_file_url(link, location, download_dir=None):

--- a/pip/download.py
+++ b/pip/download.py
@@ -628,6 +628,7 @@ def unpack_http_url(link, location, download_dir=None, session=None):
         logger.warn('Sorry, clearing our temp files fails. '
         'You may do it manually for %s', temp_dir)
 
+
 def unpack_file_url(link, location, download_dir=None):
     """Unpack link into location.
     If download_dir is provided and link points to a file, make a copy

--- a/pip/download.py
+++ b/pip/download.py
@@ -619,7 +619,12 @@ def unpack_http_url(link, location, download_dir=None, session=None):
 
     if not already_downloaded_path:
         os.unlink(from_path)
-    os.rmdir(temp_dir)
+	
+    # remove directory can fail with oserror due virus canner locking, try and notify user if it fails
+    try:
+        os.rmdir(temp_dir)
+    except OSError:
+        logger.warn('Sorry, clearing our temp files fails. You may do it manually for %s', temp_dir)
 
 
 def unpack_file_url(link, location, download_dir=None):


### PR DESCRIPTION
https://github.com/pypa/pip/issues/306

Maybe not the best solution, but this bug is annoying for so long. Please commit this solution.
It is a waste of time it the bug treats a user to install manually.