### PR TITLE
Removed commented out calls to `pdb.set_trace`.

### DIFF
--- a/pip/_vendor/distlib/locators.py
+++ b/pip/_vendor/distlib/locators.py
@@ -1178,7 +1178,6 @@ class DependencyFinder(object):
             if name not in self.dists_by_name:
                 self.add_distribution(dist)
             else:
-                #import pdb; pdb.set_trace()
                 other = self.dists_by_name[name]
                 if other != dist:
                     self.try_to_replace(dist, other, problems)

--- a/pip/_vendor/distlib/metadata.py
+++ b/pip/_vendor/distlib/metadata.py
@@ -668,7 +668,6 @@ class Metadata(object):
         self._legacy = None
         self._data = None
         self.scheme = scheme
-        #import pdb; pdb.set_trace()
         if mapping is not None:
             try:
                 self._validate_mapping(mapping, scheme)

--- a/pip/_vendor/distlib/util.py
+++ b/pip/_vendor/distlib/util.py
@@ -1166,7 +1166,6 @@ class Progress(object):
         if self.done:
             prefix = 'Done'
             t = self.elapsed
-            #import pdb; pdb.set_trace()
         else:
             prefix = 'ETA '
             if self.max is None:
@@ -1174,7 +1173,6 @@ class Progress(object):
             elif self.elapsed == 0 or (self.cur == self.min):
                 t = 0
             else:
-                #import pdb; pdb.set_trace()
                 t = float(self.max - self.min)
                 t /= self.cur - self.min
                 t = (t - 1) * self.elapsed

--- a/pip/_vendor/distlib/version.py
+++ b/pip/_vendor/distlib/version.py
@@ -422,7 +422,6 @@ def _suggest_semantic_version(s):
 
     # Now look for numeric prefix, and separate it out from
     # the rest.
-    #import pdb; pdb.set_trace()
     m = _NUMERIC_PREFIX.match(result)
     if not m:
         prefix = '0.0.0'
@@ -440,7 +439,6 @@ def _suggest_semantic_version(s):
         prefix = '.'.join([str(i) for i in prefix])
         suffix = suffix.strip()
     if suffix:
-        #import pdb; pdb.set_trace()
         # massage the suffix.
         for pat, repl in _SUFFIX_REPLACEMENTS:
             suffix = pat.sub(repl, suffix)


### PR DESCRIPTION
I found some commented-out `set_trace()` calls, with nothing saying if they should be kept, so I guess they can probably be removed.

There are also 2 other calls which **aren’t** commented out:

* https://github.com/pypa/pip/blob/develop/pip/_vendor/distlib/database.py#L528
* https://github.com/pypa/pip/blob/develop/pip/_vendor/distlib/database.py#L550

which were added in https://github.com/pypa/pip/commit/a797cafd8b837e3b03814023161d1eaa24b6214a. Again, no comments explaining why, but they can’t trivially be removed without changing behaviour.

Can these be removed too, and if so what should happen in those nested blocks? (`if finder is None` and `except AttributeError`)

I’d guess `if finder is None` we’d want to throw an exception… if so, what? And we could just let `AttributeError` propagate?
