### PR TITLE
Backport fixes for 6.0.7

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,9 @@
 * Fix an issue where switching between Python 3 and Python 2 would evict cached
   items.
 
+* Fix a regression where pip would be unable to successfully uninstall a
+  project without a normalized version.
+
 
 **6.0.6 (2015-01-03)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,9 @@
 * Fix a regression where Numpy requires a build path without symlinks to
   properly build.
 
+* Fix a broken log message when running ``pip wheel`` without a requirement.
+
+
 **6.0.6 (2015-01-03)**
 
 * Continue the regression fix from 6.0.5 which was not a complete fix.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+**6.0.7 (2015-01-28)**
+
 **6.0.6 (2015-01-03)**
 
 * Continue the regression fix from 6.0.5 which was not a complete fix.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,9 @@
 * Properly create the state file for the pip version check so it only happens
   once a week.
 
+* Fix an issue where switching between Python 3 and Python 2 would evict cached
+  items.
+
 
 **6.0.6 (2015-01-03)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@
 
 * Fix a broken log message when running ``pip wheel`` without a requirement.
 
+* Don't mask network errors while downloading the file as a hash failure.
+
 
 **6.0.6 (2015-01-03)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@
 
 * Don't mask network errors while downloading the file as a hash failure.
 
+* Properly create the state file for the pip version check so it only happens
+  once a week.
+
 
 **6.0.6 (2015-01-03)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 **6.0.7 (2015-01-28)**
 
+* Fix a regression where Numpy requires a build path without symlinks to
+  properly build.
+
 **6.0.6 (2015-01-03)**
 
 * Continue the regression fix from 6.0.5 which was not a complete fix.

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -30,7 +30,7 @@ import pip.cmdoptions
 cmdoptions = pip.cmdoptions
 
 # The version as used in the setup.py and the docs conf.py
-__version__ = "6.0.6"
+__version__ = "6.0.7.dev0"
 
 
 logger = logging.getLogger(__name__)

--- a/pip/_vendor/cachecontrol/__init__.py
+++ b/pip/_vendor/cachecontrol/__init__.py
@@ -2,6 +2,10 @@
 
 Make it easy to import from cachecontrol without long namespaces.
 """
+__author__ = 'Eric Larson'
+__email__ = 'eric@ionrock.org'
+__version__ = '0.11.1'
+
 from .wrapper import CacheControl
 from .adapter import CacheControlAdapter
 from .controller import CacheController

--- a/pip/_vendor/cachecontrol/controller.py
+++ b/pip/_vendor/cachecontrol/controller.py
@@ -112,15 +112,19 @@ class CacheController(object):
         current_age = max(0, now - date)
 
         # TODO: There is an assumption that the result will be a
-        # urllib3 response object. This may not be best since we
-        # could probably avoid instantiating or constructing the
-        # response until we know we need it.
+        #       urllib3 response object. This may not be best since we
+        #       could probably avoid instantiating or constructing the
+        #       response until we know we need it.
         resp_cc = self.parse_cache_control(headers)
 
         # determine freshness
         freshness_lifetime = 0
+
+        # Check the max-age pragma in the cache control header
         if 'max-age' in resp_cc and resp_cc['max-age'].isdigit():
             freshness_lifetime = int(resp_cc['max-age'])
+
+        # If there isn't a max-age, check for an expires header
         elif 'expires' in headers:
             expires = parsedate_tz(headers['expires'])
             if expires is not None:

--- a/pip/_vendor/cachecontrol/heuristics.py
+++ b/pip/_vendor/cachecontrol/heuristics.py
@@ -5,11 +5,24 @@ from email.utils import formatdate, parsedate
 from datetime import datetime, timedelta
 
 
+def expire_after(delta, date=None):
+    date = date or datetime.now()
+    return date + delta
+
+
+def datetime_to_header(dt):
+    return formatdate(calendar.timegm(dt.timetuple()))
+
+
 class BaseHeuristic(object):
 
-    def warning(self):
+    def warning(self, response):
         """
         Return a valid 1xx warning header value describing the cache adjustments.
+
+        The response is provided too allow warnings like 113
+        http://tools.ietf.org/html/rfc7234#section-5.5.4 where we need
+        to explicitly say response is over 24 hours old.
         """
         return '110 - "Response is Stale"'
 
@@ -17,15 +30,15 @@ class BaseHeuristic(object):
         """Update the response headers with any new headers.
 
         NOTE: This SHOULD always include some Warning header to
-              signify that the response was cached by the client, not by way
-              of the provided headers.
-              return response.
+              signify that the response was cached by the client, not
+              by way of the provided headers.
         """
         return {}
 
     def apply(self, response):
+        warning_header = {'warning': self.warning(response)}
         response.headers.update(self.update_headers(response))
-        response.headers.update({'warning': self.warning()})
+        response.headers.update(warning_header)
         return response
 
 
@@ -39,7 +52,28 @@ class OneDayCache(BaseHeuristic):
 
         if 'expires' not in response.headers:
             date = parsedate(response.headers['date'])
-            expires = datetime(*date[:6]) + timedelta(days=1)
-            headers['expires'] = formatdate(calendar.timegm(expires.timetuple()))
-
+            expires = expire_after(timedelta(days=1),
+                                   date=datetime(*date[:6]))
+            headers['expires'] = datetime_to_header(expires)
+            headers['cache-control'] = 'public'
         return headers
+
+
+class ExpiresAfter(BaseHeuristic):
+    """
+    Cache **all** requests for a defined time period.
+    """
+
+    def __init__(self, **kw):
+        self.delta = timedelta(**kw)
+
+    def update_headers(self, response):
+        expires = expire_after(self.delta)
+        return {
+            'expires': datetime_to_header(expires),
+            'cache-control': 'public',
+        }
+
+    def warning(self, response):
+        tmpl = '110 - Automatically cached for %s. Response might be stale'
+        return tmpl % self.delta

--- a/pip/_vendor/cachecontrol/serialize.py
+++ b/pip/_vendor/cachecontrol/serialize.py
@@ -1,8 +1,27 @@
+import base64
 import io
+import json
+import zlib
 
 from pip._vendor.requests.structures import CaseInsensitiveDict
 
 from .compat import HTTPResponse, pickle
+
+
+def _b64_encode_bytes(b):
+    return base64.b64encode(b).decode("ascii")
+
+
+def _b64_encode_str(s):
+    return _b64_encode_bytes(s.encode("utf8"))
+
+
+def _b64_decode_bytes(b):
+    return base64.b64decode(b.encode("ascii"))
+
+
+def _b64_decode_str(s):
+    return _b64_decode_bytes(s).decode("utf8")
 
 
 class Serializer(object):
@@ -12,15 +31,29 @@ class Serializer(object):
 
         if body is None:
             body = response.read(decode_content=False)
+
+            # NOTE: 99% sure this is dead code. I'm only leaving it
+            #       here b/c I don't have a test yet to prove
+            #       it. Basically, before using
+            #       `cachecontrol.filewrapper.CallbackFileWrapper`,
+            #       this made an effort to reset the file handle. The
+            #       `CallbackFileWrapper` short circuits this code by
+            #       setting the body as the content is consumed, the
+            #       result being a `body` argument is *always* passed
+            #       into cache_response, and in turn,
+            #       `Serializer.dump`.
             response._fp = io.BytesIO(body)
 
         data = {
             "response": {
-                "body": body,
-                "headers": response.headers,
+                "body": _b64_encode_bytes(body),
+                "headers": dict(
+                    (_b64_encode_str(k), _b64_encode_str(v))
+                    for k, v in response.headers.items()
+                ),
                 "status": response.status,
                 "version": response.version,
-                "reason": response.reason,
+                "reason": _b64_encode_str(response.reason),
                 "strict": response.strict,
                 "decode_content": response.decode_content,
             },
@@ -34,7 +67,20 @@ class Serializer(object):
                 header = header.strip()
                 data["vary"][header] = request.headers.get(header, None)
 
-        return b"cc=1," + pickle.dumps(data, pickle.HIGHEST_PROTOCOL)
+        # Encode our Vary headers to ensure they can be serialized as JSON
+        data["vary"] = dict(
+            (_b64_encode_str(k), _b64_encode_str(v) if v is not None else v)
+            for k, v in data["vary"].items()
+        )
+
+        return b",".join([
+            b"cc=2",
+            zlib.compress(
+                json.dumps(
+                    data, separators=(",", ":"), sort_keys=True,
+                ).encode("utf8"),
+            ),
+        ])
 
     def loads(self, request, data):
         # Short circuit if we've been given an empty set of data
@@ -65,18 +111,10 @@ class Serializer(object):
             # just treat it as a miss and return None
             return
 
-    def _loads_v0(self, request, data):
-        # The original legacy cache data. This doesn't contain enough
-        # information to construct everything we need, so we'll treat this as
-        # a miss.
-        return
-
-    def _loads_v1(self, request, data):
-        try:
-            cached = pickle.loads(data)
-        except ValueError:
-            return
-
+    def prepare_response(self, request, cached):
+        """Verify our vary headers match and construct a real urllib3
+        HTTPResponse object.
+        """
         # Special case the '*' Vary value as it means we cannot actually
         # determine if the cached response is suitable for this request.
         if "*" in cached.get("vary", {}):
@@ -94,3 +132,41 @@ class Serializer(object):
             preload_content=False,
             **cached["response"]
         )
+
+    def _loads_v0(self, request, data):
+        # The original legacy cache data. This doesn't contain enough
+        # information to construct everything we need, so we'll treat this as
+        # a miss.
+        return
+
+    def _loads_v1(self, request, data):
+        try:
+            cached = pickle.loads(data)
+        except ValueError:
+            return
+
+        return self.prepare_response(request, cached)
+
+    def _loads_v2(self, request, data):
+        try:
+            cached = json.loads(zlib.decompress(data).decode("utf8"))
+        except ValueError:
+            return
+
+        # We need to decode the items that we've base64 encoded
+        cached["response"]["body"] = _b64_decode_bytes(
+            cached["response"]["body"]
+        )
+        cached["response"]["headers"] = dict(
+            (_b64_decode_str(k), _b64_decode_str(v))
+            for k, v in cached["response"]["headers"].items()
+        )
+        cached["response"]["reason"] = _b64_decode_str(
+            cached["response"]["reason"],
+        )
+        cached["vary"] = dict(
+            (_b64_decode_str(k), _b64_decode_str(v) if v is not None else v)
+            for k, v in cached["vary"].items()
+        )
+
+        return self.prepare_response(request, cached)

--- a/pip/_vendor/colorama/__init__.py
+++ b/pip/_vendor/colorama/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 from .initialise import init, deinit, reinit
-from .ansi import Fore, Back, Style
+from .ansi import Fore, Back, Style, Cursor
 from .ansitowin32 import AnsiToWin32
 
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 

--- a/pip/_vendor/colorama/ansi.py
+++ b/pip/_vendor/colorama/ansi.py
@@ -5,9 +5,13 @@ See: http://en.wikipedia.org/wiki/ANSI_escape_code
 '''
 
 CSI = '\033['
+OSC = '\033]'
+BEL = '\007'
+
 
 def code_to_chars(code):
     return CSI + str(code) + 'm'
+
 
 class AnsiCodes(object):
     def __init__(self, codes):
@@ -16,27 +20,72 @@ class AnsiCodes(object):
                 value = getattr(codes, name)
                 setattr(self, name, code_to_chars(value))
 
+
+class AnsiCursor(object):
+    def UP(self, n=1):
+        return CSI + str(n) + "A"
+    def DOWN(self, n=1):
+        return CSI + str(n) + "B"
+    def FORWARD(self, n=1):
+        return CSI + str(n) + "C"
+    def BACK(self, n=1):
+        return CSI + str(n) + "D"
+    def POS(self, x=1, y=1):
+        return CSI + str(y) + ";" + str(x) + "H"
+
+def set_title(title):
+    return OSC + "2;" + title + BEL
+
+def clear_screen(mode=2):
+    return CSI + str(mode) + "J"
+
+def clear_line(mode=2):
+    return CSI + str(mode) + "K"
+
+
 class AnsiFore:
-    BLACK   = 30
-    RED     = 31
-    GREEN   = 32
-    YELLOW  = 33
-    BLUE    = 34
-    MAGENTA = 35
-    CYAN    = 36
-    WHITE   = 37
-    RESET   = 39
+    BLACK           = 30
+    RED             = 31
+    GREEN           = 32
+    YELLOW          = 33
+    BLUE            = 34
+    MAGENTA         = 35
+    CYAN            = 36
+    WHITE           = 37
+    RESET           = 39
+
+    # These are fairly well supported, but not part of the standard.
+    LIGHTBLACK_EX   = 90
+    LIGHTRED_EX     = 91
+    LIGHTGREEN_EX   = 92
+    LIGHTYELLOW_EX  = 93
+    LIGHTBLUE_EX    = 94
+    LIGHTMAGENTA_EX = 95
+    LIGHTCYAN_EX    = 96
+    LIGHTWHITE_EX   = 97
+
 
 class AnsiBack:
-    BLACK   = 40
-    RED     = 41
-    GREEN   = 42
-    YELLOW  = 43
-    BLUE    = 44
-    MAGENTA = 45
-    CYAN    = 46
-    WHITE   = 47
-    RESET   = 49
+    BLACK           = 40
+    RED             = 41
+    GREEN           = 42
+    YELLOW          = 43
+    BLUE            = 44
+    MAGENTA         = 45
+    CYAN            = 46
+    WHITE           = 47
+    RESET           = 49
+
+    # These are fairly well supported, but not part of the standard.
+    LIGHTBLACK_EX   = 100
+    LIGHTRED_EX     = 101
+    LIGHTGREEN_EX   = 102
+    LIGHTYELLOW_EX  = 103
+    LIGHTBLUE_EX    = 104
+    LIGHTMAGENTA_EX = 105
+    LIGHTCYAN_EX    = 106
+    LIGHTWHITE_EX   = 107
+
 
 class AnsiStyle:
     BRIGHT    = 1
@@ -47,4 +96,4 @@ class AnsiStyle:
 Fore = AnsiCodes( AnsiFore )
 Back = AnsiCodes( AnsiBack )
 Style = AnsiCodes( AnsiStyle )
-
+Cursor = AnsiCursor()

--- a/pip/_vendor/colorama/ansitowin32.py
+++ b/pip/_vendor/colorama/ansitowin32.py
@@ -1,6 +1,7 @@
 # Copyright Jonathan Hartley 2013. BSD 3-Clause license, see LICENSE file.
 import re
 import sys
+import os
 
 from .ansi import AnsiFore, AnsiBack, AnsiStyle, Style
 from .winterm import WinTerm, WinColor, WinStyle
@@ -41,7 +42,8 @@ class AnsiToWin32(object):
     sequences from the text, and if outputting to a tty, will convert them into
     win32 function calls.
     '''
-    ANSI_RE = re.compile('\033\[((?:\d|;)*)([a-zA-Z])')
+    ANSI_CSI_RE = re.compile('\033\[((?:\d|;)*)([a-zA-Z])')     # Control Sequence Introducer
+    ANSI_OSC_RE = re.compile('\033\]((?:.|;)*?)(\x07)')         # Operating System Command
 
     def __init__(self, wrapped, convert=None, strip=None, autoreset=False):
         # The wrapped stream (normally sys.stdout or sys.stderr)
@@ -53,16 +55,17 @@ class AnsiToWin32(object):
         # create the proxy wrapping our output stream
         self.stream = StreamWrapper(wrapped, self)
 
-        on_windows = sys.platform.startswith('win')
+        on_windows = os.name == 'nt'
+        on_emulated_windows = on_windows and 'TERM' in os.environ
 
         # should we strip ANSI sequences from our output?
         if strip is None:
-            strip = on_windows
+            strip = on_windows and not on_emulated_windows
         self.strip = strip
 
         # should we should convert ANSI sequences into win32 calls?
         if convert is None:
-            convert = on_windows and not wrapped.closed and is_a_tty(wrapped)
+            convert = on_windows and not wrapped.closed and not on_emulated_windows and is_a_tty(wrapped)
         self.convert = convert
 
         # dict of ansi codes to win32 functions and parameters
@@ -70,7 +73,6 @@ class AnsiToWin32(object):
 
         # are we wrapping stderr?
         self.on_stderr = self.wrapped is sys.stderr
-
 
     def should_wrap(self):
         '''
@@ -81,7 +83,6 @@ class AnsiToWin32(object):
         autoreset has been requested using kwargs to init()
         '''
         return self.convert or self.strip or self.autoreset
-
 
     def get_win32_calls(self):
         if self.convert and winterm:
@@ -99,6 +100,14 @@ class AnsiToWin32(object):
                 AnsiFore.CYAN: (winterm.fore, WinColor.CYAN),
                 AnsiFore.WHITE: (winterm.fore, WinColor.GREY),
                 AnsiFore.RESET: (winterm.fore, ),
+                AnsiFore.LIGHTBLACK_EX: (winterm.fore, WinColor.BLACK, True),
+                AnsiFore.LIGHTRED_EX: (winterm.fore, WinColor.RED, True),
+                AnsiFore.LIGHTGREEN_EX: (winterm.fore, WinColor.GREEN, True),
+                AnsiFore.LIGHTYELLOW_EX: (winterm.fore, WinColor.YELLOW, True),
+                AnsiFore.LIGHTBLUE_EX: (winterm.fore, WinColor.BLUE, True),
+                AnsiFore.LIGHTMAGENTA_EX: (winterm.fore, WinColor.MAGENTA, True),
+                AnsiFore.LIGHTCYAN_EX: (winterm.fore, WinColor.CYAN, True),
+                AnsiFore.LIGHTWHITE_EX: (winterm.fore, WinColor.GREY, True),
                 AnsiBack.BLACK: (winterm.back, WinColor.BLACK),
                 AnsiBack.RED: (winterm.back, WinColor.RED),
                 AnsiBack.GREEN: (winterm.back, WinColor.GREEN),
@@ -108,9 +117,16 @@ class AnsiToWin32(object):
                 AnsiBack.CYAN: (winterm.back, WinColor.CYAN),
                 AnsiBack.WHITE: (winterm.back, WinColor.GREY),
                 AnsiBack.RESET: (winterm.back, ),
+                AnsiBack.LIGHTBLACK_EX: (winterm.back, WinColor.BLACK, True),
+                AnsiBack.LIGHTRED_EX: (winterm.back, WinColor.RED, True),
+                AnsiBack.LIGHTGREEN_EX: (winterm.back, WinColor.GREEN, True),
+                AnsiBack.LIGHTYELLOW_EX: (winterm.back, WinColor.YELLOW, True),
+                AnsiBack.LIGHTBLUE_EX: (winterm.back, WinColor.BLUE, True),
+                AnsiBack.LIGHTMAGENTA_EX: (winterm.back, WinColor.MAGENTA, True),
+                AnsiBack.LIGHTCYAN_EX: (winterm.back, WinColor.CYAN, True),
+                AnsiBack.LIGHTWHITE_EX: (winterm.back, WinColor.GREY, True),
             }
         return dict()
-
 
     def write(self, text):
         if self.strip or self.convert:
@@ -136,7 +152,8 @@ class AnsiToWin32(object):
         calls.
         '''
         cursor = 0
-        for match in self.ANSI_RE.finditer(text):
+        text = self.convert_osc(text)
+        for match in self.ANSI_CSI_RE.finditer(text):
             start, end = match.span()
             self.write_plain_text(text, cursor, start)
             self.convert_ansi(*match.groups())
@@ -152,21 +169,29 @@ class AnsiToWin32(object):
 
     def convert_ansi(self, paramstring, command):
         if self.convert:
-            params = self.extract_params(paramstring)
+            params = self.extract_params(command, paramstring)
             self.call_win32(command, params)
 
 
-    def extract_params(self, paramstring):
-        def split(paramstring):
-            for p in paramstring.split(';'):
-                if p != '':
-                    yield int(p)
-        return tuple(split(paramstring))
+    def extract_params(self, command, paramstring):
+        if command in 'Hf':
+            params = tuple(int(p) if len(p) != 0 else 1 for p in paramstring.split(';'))
+            while len(params) < 2:
+                # defaults:
+                params = params + (1,)
+        else:
+            params = tuple(int(p) for p in paramstring.split(';') if len(p) != 0)
+            if len(params) == 0:
+                # defaults:
+                if command in 'JKm':
+                    params = (0,)
+                elif command in 'ABCD':
+                    params = (1,)
+
+        return params
 
 
     def call_win32(self, command, params):
-        if params == []:
-            params = [0]
         if command == 'm':
             for param in params:
                 if param in self.win32_calls:
@@ -175,17 +200,29 @@ class AnsiToWin32(object):
                     args = func_args[1:]
                     kwargs = dict(on_stderr=self.on_stderr)
                     func(*args, **kwargs)
-        elif command in ('H', 'f'): # set cursor position
-            func = winterm.set_cursor_position
-            func(params, on_stderr=self.on_stderr)
-        elif command in ('J'):
-            func = winterm.erase_data
-            func(params, on_stderr=self.on_stderr)
-        elif command == 'A':
-            if params == () or params == None:
-                num_rows = 1
-            else:
-                num_rows = params[0]
-            func = winterm.cursor_up
-            func(num_rows, on_stderr=self.on_stderr)
+        elif command in 'J':
+            winterm.erase_screen(params[0], on_stderr=self.on_stderr)
+        elif command in 'K':
+            winterm.erase_line(params[0], on_stderr=self.on_stderr)
+        elif command in 'Hf':     # cursor position - absolute
+            winterm.set_cursor_position(params, on_stderr=self.on_stderr)
+        elif command in 'ABCD':   # cursor position - relative
+            n = params[0]
+            # A - up, B - down, C - forward, D - back
+            x, y = {'A': (0, -n), 'B': (0, n), 'C': (n, 0), 'D': (-n, 0)}[command]
+            winterm.cursor_adjust(x, y, on_stderr=self.on_stderr)
 
+
+    def convert_osc(self, text):
+        for match in self.ANSI_OSC_RE.finditer(text):
+            start, end = match.span()
+            text = text[:start] + text[end:]
+            paramstring, command = match.groups()
+            if command in '\x07':       # \x07 = BEL
+                params = paramstring.split(";")
+                # 0 - change title and icon (we will only change title)
+                # 1 - change icon (we don't support this)
+                # 2 - change title
+                if params[0] in '02':
+                    winterm.set_title(params[1])
+        return text

--- a/pip/_vendor/colorama/winterm.py
+++ b/pip/_vendor/colorama/winterm.py
@@ -15,9 +15,9 @@ class WinColor(object):
 
 # from wincon.h
 class WinStyle(object):
-    NORMAL = 0x00 # dim text, dim background
-    BRIGHT = 0x08 # bright text, dim background
-
+    NORMAL              = 0x00 # dim text, dim background
+    BRIGHT              = 0x08 # bright text, dim background
+    BRIGHT_BACKGROUND   = 0x80 # dim text, bright background
 
 class WinTerm(object):
 
@@ -34,22 +34,26 @@ class WinTerm(object):
     def set_attrs(self, value):
         self._fore = value & 7
         self._back = (value >> 4) & 7
-        self._style = value & WinStyle.BRIGHT
+        self._style = value & (WinStyle.BRIGHT | WinStyle.BRIGHT_BACKGROUND)
 
     def reset_all(self, on_stderr=None):
         self.set_attrs(self._default)
         self.set_console(attrs=self._default)
 
-    def fore(self, fore=None, on_stderr=False):
+    def fore(self, fore=None, light=False, on_stderr=False):
         if fore is None:
             fore = self._default_fore
         self._fore = fore
+        if light:
+            self._style |= WinStyle.BRIGHT
         self.set_console(on_stderr=on_stderr)
 
-    def back(self, back=None, on_stderr=False):
+    def back(self, back=None, light=False, on_stderr=False):
         if back is None:
             back = self._default_back
         self._back = back
+        if light:
+            self._style |= WinStyle.BRIGHT_BACKGROUND
         self.set_console(on_stderr=on_stderr)
 
     def style(self, style=None, on_stderr=False):
@@ -73,7 +77,7 @@ class WinTerm(object):
         position.X += 1
         position.Y += 1
         return position
-    
+
     def set_cursor_position(self, position=None, on_stderr=False):
         if position is None:
             #I'm not currently tracking the position, so there is no default.
@@ -84,37 +88,64 @@ class WinTerm(object):
             handle = win32.STDERR
         win32.SetConsoleCursorPosition(handle, position)
 
-    def cursor_up(self, num_rows=0, on_stderr=False):
-        if num_rows == 0:
-            return
+    def cursor_adjust(self, x, y, on_stderr=False):
         handle = win32.STDOUT
         if on_stderr:
             handle = win32.STDERR
         position = self.get_position(handle)
-        adjusted_position = (position.Y - num_rows, position.X)
-        self.set_cursor_position(adjusted_position, on_stderr)
+        adjusted_position = (position.Y + y, position.X + x)
+        win32.SetConsoleCursorPosition(handle, adjusted_position, adjust=False)
 
-    def erase_data(self, mode=0, on_stderr=False):
-        # 0 (or None) should clear from the cursor to the end of the screen.
+    def erase_screen(self, mode=0, on_stderr=False):
+        # 0 should clear from the cursor to the end of the screen.
         # 1 should clear from the cursor to the beginning of the screen.
-        # 2 should clear the entire screen. (And maybe move cursor to (1,1)?)
-        #
-        # At the moment, I only support mode 2. From looking at the API, it
-        #    should be possible to calculate a different number of bytes to clear,
-        #    and to do so relative to the cursor position.
-        if mode[0] not in (2,):
-            return
+        # 2 should clear the entire screen, and move cursor to (1,1)
         handle = win32.STDOUT
         if on_stderr:
             handle = win32.STDERR
-        # here's where we'll home the cursor
-        coord_screen = win32.COORD(0,0)
         csbi = win32.GetConsoleScreenBufferInfo(handle)
         # get the number of character cells in the current buffer
-        dw_con_size = csbi.dwSize.X * csbi.dwSize.Y
+        cells_in_screen = csbi.dwSize.X * csbi.dwSize.Y
+        # get number of character cells before current cursor position
+        cells_before_cursor = csbi.dwSize.X * csbi.dwCursorPosition.Y + csbi.dwCursorPosition.X
+        if mode == 0:
+            from_coord = csbi.dwCursorPosition
+            cells_to_erase = cells_in_screen - cells_before_cursor
+        if mode == 1:
+            from_coord = win32.COORD(0, 0)
+            cells_to_erase = cells_before_cursor
+        elif mode == 2:
+            from_coord = win32.COORD(0, 0)
+            cells_to_erase = cells_in_screen
         # fill the entire screen with blanks
-        win32.FillConsoleOutputCharacter(handle, ' ', dw_con_size, coord_screen)
+        win32.FillConsoleOutputCharacter(handle, ' ', cells_to_erase, from_coord)
         # now set the buffer's attributes accordingly
-        win32.FillConsoleOutputAttribute(handle, self.get_attrs(), dw_con_size, coord_screen );
-        # put the cursor at (0, 0)
-        win32.SetConsoleCursorPosition(handle, (coord_screen.X, coord_screen.Y))
+        win32.FillConsoleOutputAttribute(handle, self.get_attrs(), cells_to_erase, from_coord)
+        if mode == 2:
+            # put the cursor where needed
+            win32.SetConsoleCursorPosition(handle, (1, 1))
+
+    def erase_line(self, mode=0, on_stderr=False):
+        # 0 should clear from the cursor to the end of the line.
+        # 1 should clear from the cursor to the beginning of the line.
+        # 2 should clear the entire line.
+        handle = win32.STDOUT
+        if on_stderr:
+            handle = win32.STDERR
+        csbi = win32.GetConsoleScreenBufferInfo(handle)
+        if mode == 0:
+            from_coord = csbi.dwCursorPosition
+            cells_to_erase = csbi.dwSize.X - csbi.dwCursorPosition.X
+        if mode == 1:
+            from_coord = win32.COORD(0, csbi.dwCursorPosition.Y)
+            cells_to_erase = csbi.dwCursorPosition.X
+        elif mode == 2:
+            from_coord = win32.COORD(0, csbi.dwCursorPosition.Y)
+            cells_to_erase = csbi.dwSize.X
+        # fill the entire screen with blanks
+        win32.FillConsoleOutputCharacter(handle, ' ', cells_to_erase, from_coord)
+        # now set the buffer's attributes accordingly
+        win32.FillConsoleOutputAttribute(handle, self.get_attrs(), cells_to_erase, from_coord)
+
+    def set_title(self, title):
+        win32.SetConsoleTitle(title)

--- a/pip/_vendor/requests/__init__.py
+++ b/pip/_vendor/requests/__init__.py
@@ -42,8 +42,8 @@ is at <http://python-requests.org>.
 """
 
 __title__ = 'requests'
-__version__ = '2.5.0'
-__build__ = 0x020500
+__version__ = '2.5.1'
+__build__ = 0x020501
 __author__ = 'Kenneth Reitz'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2014 Kenneth Reitz'

--- a/pip/_vendor/requests/auth.py
+++ b/pip/_vendor/requests/auth.py
@@ -67,6 +67,7 @@ class HTTPDigestAuth(AuthBase):
         self.nonce_count = 0
         self.chal = {}
         self.pos = None
+        self.num_401_calls = 1
 
     def build_digest_header(self, method, url):
 
@@ -154,7 +155,7 @@ class HTTPDigestAuth(AuthBase):
     def handle_redirect(self, r, **kwargs):
         """Reset num_401_calls counter on redirects."""
         if r.is_redirect:
-            setattr(self, 'num_401_calls', 1)
+            self.num_401_calls = 1
 
     def handle_401(self, r, **kwargs):
         """Takes the given response and tries digest-auth, if needed."""
@@ -168,7 +169,7 @@ class HTTPDigestAuth(AuthBase):
 
         if 'digest' in s_auth.lower() and num_401_calls < 2:
 
-            setattr(self, 'num_401_calls', num_401_calls + 1)
+            self.num_401_calls += 1
             pat = re.compile(r'digest ', flags=re.IGNORECASE)
             self.chal = parse_dict_header(pat.sub('', s_auth, count=1))
 
@@ -188,7 +189,7 @@ class HTTPDigestAuth(AuthBase):
 
             return _r
 
-        setattr(self, 'num_401_calls', num_401_calls + 1)
+        self.num_401_calls = 1
         return r
 
     def __call__(self, r):

--- a/pip/_vendor/requests/compat.py
+++ b/pip/_vendor/requests/compat.py
@@ -76,7 +76,7 @@ is_solaris = ('solar==' in str(sys.platform).lower())   # Complete guess.
 try:
     import simplejson as json
 except (ImportError, SyntaxError):
-    # simplejson does not support Python 3.2, it thows a SyntaxError
+    # simplejson does not support Python 3.2, it throws a SyntaxError
     # because of u'...' Unicode literals.
     import json
 

--- a/pip/_vendor/requests/utils.py
+++ b/pip/_vendor/requests/utils.py
@@ -115,7 +115,7 @@ def get_netrc_auth(url):
 def guess_filename(obj):
     """Tries to guess the filename of the given object."""
     name = getattr(obj, 'name', None)
-    if name and name[0] != '<' and name[-1] != '>':
+    if name and isinstance(name, builtin_str) and name[0] != '<' and name[-1] != '>':
         return os.path.basename(name)
 
 

--- a/pip/_vendor/six.py
+++ b/pip/_vendor/six.py
@@ -1,6 +1,6 @@
 """Utilities for writing code that runs on Python 2 and 3"""
 
-# Copyright (c) 2010-2014 Benjamin Peterson
+# Copyright (c) 2010-2015 Benjamin Peterson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,13 @@
 from __future__ import absolute_import
 
 import functools
+import itertools
 import operator
 import sys
 import types
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 
 # Useful for very coarse version differentiation.
@@ -88,8 +89,12 @@ class _LazyDescr(object):
     def __get__(self, obj, tp):
         result = self._resolve()
         setattr(obj, self.name, result) # Invokes __set__.
-        # This is a bit ugly, but it avoids running this again.
-        delattr(obj.__class__, self.name)
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
         return result
 
 
@@ -554,6 +559,12 @@ if PY3:
 
     def iterlists(d, **kw):
         return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
 else:
     def iterkeys(d, **kw):
         return iter(d.iterkeys(**kw))
@@ -566,6 +577,12 @@ else:
 
     def iterlists(d, **kw):
         return iter(d.iterlists(**kw))
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
 
 _add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
 _add_doc(itervalues, "Return an iterator over the values of a dictionary.")
@@ -593,6 +610,9 @@ if PY3:
     import io
     StringIO = io.StringIO
     BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    _assertRaisesRegex = "assertRaisesRegex"
+    _assertRegex = "assertRegex"
 else:
     def b(s):
         return s
@@ -605,12 +625,26 @@ else:
         return ord(bs[0])
     def indexbytes(buf, i):
         return ord(buf[i])
-    def iterbytes(buf):
-        return (ord(byte) for byte in buf)
+    iterbytes = functools.partial(itertools.imap, ord)
     import StringIO
     StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
 _add_doc(b, """Byte literal""")
 _add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
 
 
 if PY3:
@@ -641,6 +675,21 @@ else:
     exec_("""def reraise(tp, value, tb=None):
     raise tp, value, tb
 """)
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    if from_value is None:
+        raise value
+    raise value from from_value
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    raise value from from_value
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
 
 
 print_ = getattr(moves.builtins, "print", None)
@@ -697,6 +746,14 @@ if print_ is None:
                 write(sep)
             write(arg)
         write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
 
 _add_doc(reraise, """Reraise an exception.""")
 
@@ -704,7 +761,7 @@ if sys.version_info[0:2] < (3, 4):
     def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
               updated=functools.WRAPPER_UPDATES):
         def wrapper(f):
-            f = functools.wraps(wrapped)(f)
+            f = functools.wraps(wrapped, assigned, updated)(f)
             f.__wrapped__ = wrapped
             return f
         return wrapper
@@ -736,6 +793,25 @@ def add_metaclass(metaclass):
         orig_vars.pop('__weakref__', None)
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
     return wrapper
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
 
 # Complete the moves implementation.
 # This code is at the end of this module to speed up module loading.

--- a/pip/_vendor/vendor.txt
+++ b/pip/_vendor/vendor.txt
@@ -1,7 +1,7 @@
 distlib==0.2.0
 html5lib==0.999  # See: https://github.com/html5lib/html5lib-python/issues/161
 six==1.9.0
-colorama==0.3.2
+colorama==0.3.3
 requests==2.5.1
 certifi==14.05.14
 CacheControl==0.11.1

--- a/pip/_vendor/vendor.txt
+++ b/pip/_vendor/vendor.txt
@@ -2,7 +2,7 @@ distlib==0.2.0
 html5lib==0.999  # See: https://github.com/html5lib/html5lib-python/issues/161
 six==1.8.0
 colorama==0.3.2
-requests==2.5.0
+requests==2.5.1
 certifi==14.05.14
 CacheControl==0.10.7
 lockfile==0.10.2

--- a/pip/_vendor/vendor.txt
+++ b/pip/_vendor/vendor.txt
@@ -1,6 +1,6 @@
 distlib==0.2.0
 html5lib==0.999  # See: https://github.com/html5lib/html5lib-python/issues/161
-six==1.8.0
+six==1.9.0
 colorama==0.3.2
 requests==2.5.1
 certifi==14.05.14

--- a/pip/_vendor/vendor.txt
+++ b/pip/_vendor/vendor.txt
@@ -4,7 +4,7 @@ six==1.9.0
 colorama==0.3.2
 requests==2.5.1
 certifi==14.05.14
-CacheControl==0.10.7
+CacheControl==0.11.1
 lockfile==0.10.2
 progress==1.2
 ipaddress==1.0.7  # Only needed on 2.6, 2.7, and 3.2

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -222,7 +222,7 @@ class WheelCommand(Command):
                     logger.error(
                         "You must give at least one requirement to %s "
                         "(see \"pip help %s\")",
-                        self.name,
+                        self.name, self.name,
                     )
                     return
 

--- a/pip/utils/build.py
+++ b/pip/utils/build.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import os.path
 import tempfile
 
 from pip.utils import rmtree
@@ -14,7 +15,11 @@ class BuildDirectory(object):
             delete = True
 
         if name is None:
-            name = tempfile.mkdtemp(prefix="pip-build-")
+            # We realpath here because some systems have their default tmpdir
+            # symlinked to another directory.  This tends to confuse build
+            # scripts, so we canonicalize the path by traversing potential
+            # symlinks here.
+            name = os.path.realpath(tempfile.mkdtemp(prefix="pip-build-"))
             # If we were not given an explicit directory, and we were not given
             # an explicit delete option, then we'll default to deleting.
             if delete is None:

--- a/pip/utils/outdated.py
+++ b/pip/utils/outdated.py
@@ -73,8 +73,11 @@ class GlobalSelfCheckState(object):
 
         # Attempt to write out our version check file
         with lockfile.LockFile(self.statefile_path):
-            with open(self.statefile_path) as statefile:
-                state = json.load(statefile)
+            if os.path.exists(self.statefile_path):
+                with open(self.statefile_path) as statefile:
+                    state = json.load(statefile)
+            else:
+                state = {}
 
             state[sys.prefix] = {
                 "last_check": current_time.strftime(SELFCHECK_DATE_FMT),

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -329,7 +329,7 @@ class TestUpgradeSetuptools(object):
             "Found existing installation: setuptools 0.6rc11" in result.stdout
         )
         result = self.script.run(self.ve_bin / 'pip', 'list')
-        "setuptools (0.9.8)" in result.stdout
+        assert "setuptools (0.9.8)" in result.stdout
 
     def test_py2_py3_from_distribute_6_to_setuptools_7(
             self, script, data, virtualenv):
@@ -344,8 +344,8 @@ class TestUpgradeSetuptools(object):
             "Found existing installation: distribute 0.6.34" in result.stdout
         )
         result = self.script.run(self.ve_bin / 'pip', 'list')
-        "setuptools (0.9.8)" in result.stdout
-        "distribute (0.7.3)" in result.stdout
+        assert "setuptools (0.9.8)" in result.stdout
+        assert "distribute (0.7.3)" not in result.stdout
 
     def test_from_setuptools_7_to_setuptools_7(self, script, data, virtualenv):
         self.prep_ve(script, '1.10', virtualenv.pip_source_dir)
@@ -355,7 +355,7 @@ class TestUpgradeSetuptools(object):
         )
         assert "Found existing installation: setuptools 0.9.7" in result.stdout
         result = self.script.run(self.ve_bin / 'pip', 'list')
-        "setuptools (0.9.8)" in result.stdout
+        assert "setuptools (0.9.8)" in result.stdout
 
     def test_from_setuptools_7_to_setuptools_7_using_wheel(
             self, script, data, virtualenv):
@@ -368,7 +368,7 @@ class TestUpgradeSetuptools(object):
         # only wheels use dist-info
         assert 'setuptools-0.9.8.dist-info' in str(result.files_created)
         result = self.script.run(self.ve_bin / 'pip', 'list')
-        "setuptools (0.9.8)" in result.stdout
+        assert "setuptools (0.9.8)" in result.stdout
 
     # disabling intermittent travis failure:
     #   https://github.com/pypa/pip/issues/1379
@@ -387,13 +387,12 @@ class TestUpgradeSetuptools(object):
             '--find-links=%s' % data.find_links, 'setuptools==0.9.6'
         )
         result = self.script.run(self.ve_bin / 'pip', 'list')
-        "setuptools (0.9.6)" in result.stdout
-        "distribute (0.7.3)" in result.stdout
+        assert "setuptools (0.9.6)" in result.stdout
+        assert "distribute (0.7.3)" not in result.stdout
         result = self.script.run(
             self.ve_bin / 'pip', 'install', '--no-index',
             '--find-links=%s' % data.find_links, '-U', 'setuptools'
         )
         assert "Found existing installation: setuptools 0.9.6" in result.stdout
         result = self.script.run(self.ve_bin / 'pip', 'list')
-        "setuptools (0.9.8)" in result.stdout
-        "distribute (0.7.3)" in result.stdout
+        assert "setuptools (0.9.8)" in result.stdout

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -131,6 +131,7 @@ def test_global_state(monkeypatch):
     monkeypatch.setattr(outdated, "check_path_owner", lambda p: True)
 
     monkeypatch.setattr(lockfile, 'LockFile', fake_lock)
+    monkeypatch.setattr(os.path, "exists", lambda p: True)
 
     monkeypatch.setattr(outdated, 'running_under_virtualenv',
                         pretend.call_recorder(lambda: False))


### PR DESCRIPTION
* Fix a regression where Numpy requires a build path without symlinks to properly build.
* Fix a broken log message when running ``pip wheel`` without a requirement.
* Don't mask network errors while downloading the file as a hash failure.
* Properly create the state file for the pip version check so it only happens once a week.
* Fix an issue where switching between Python 3 and Python 2 would evict cached items.
* Fix a regression where pip would be unable to successfully uninstall a project without a normalized version.