### PR TITLE
Do not suggest upgrading pip when I am upgrading pip

### DIFF
--- a/pip/utils/outdated.py
+++ b/pip/utils/outdated.py
@@ -135,12 +135,14 @@ def pip_version_check(session):
 
         # Determine if our pypi_version is older
         if pip_version < pkg_resources.parse_version(pypi_version):
-            logger.warning(
-                "You are using pip version %s, however version %s is "
-                "available.\nYou should consider upgrading via the "
-                "'pip install --upgrade pip' command." % (pip.__version__,
-                                                          pypi_version)
-            )
+            # Check to make sure we reminding someone already upgrading
+            if " ".join(sys.argv) == "pip install --upgrade pip":
+                logger.warning(
+                    "You are using pip version %s, however version %s is "
+                    "available.\nYou should consider upgrading via the "
+                    "'pip install --upgrade pip' command." % (pip.__version__,
+                                                            pypi_version)
+                )
 
     except Exception:
         logger.debug(


### PR DESCRIPTION
Noticed that pip will remind users to upgrade while they are upgrading.
I find this mildly annoying, so I added an addition check to not warn in this case.