### PR TITLE
Allow specification of alternative pip version

### DIFF
--- a/contrib/get-pip.py
+++ b/contrib/get-pip.py
@@ -95,8 +95,9 @@ def bootstrap(tmpdir=None):
 
     pip.commands_dict["install"] = CertInstallCommand
 
-    # We always want to install pip
-    packages = ["pip"]
+    # We always want to install pip, but let people specify an
+    # alternative version
+    packages = ["pip" + os.environ.get("PIP_VERSION_PIN", "")]
 
     # Check if the user has requested us not to install setuptools
     if "--no-setuptools" in sys.argv or os.environ.get("PIP_NO_SETUPTOOLS"):

--- a/tasks/generate.py
+++ b/tasks/generate.py
@@ -138,8 +138,9 @@ def bootstrap(tmpdir=None):
 
     pip.commands_dict["install"] = CertInstallCommand
 
-    # We always want to install pip
-    packages = ["pip"]
+    # We always want to install pip, but let people specify an
+    # alternative version
+    packages = ["pip" + os.environ.get("PIP_VERSION_PIN", "")]
 
     # Check if the user has requested us not to install setuptools
     if "--no-setuptools" in sys.argv or os.environ.get("PIP_NO_SETUPTOOLS"):


### PR DESCRIPTION
CI systems might be using get-pip.py, but if the latest release breaks
something it would be nice to be able to simply specify a standard
version string like PIP_VERSION_PIN="==X.Y.Z" to get a known-good
version until the issue is resolved.

contrib/get-pip.py is regenerated with this change