### PR TITLE
Backport fixes for 6.0.8

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@
 * Fix an issue where pip did not properly unquote quoted URLs which contain
   characters like PEP 440's epoch separator (``!``).
 
+* Fix an issue where distutils installed projects were not actually uninstalled
+  and deprecate attempting to uninstall them altogether.
+
 
 **6.0.7 (2015-01-28)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+**6.0.8 (2015-02-04)**
+
 **6.0.7 (2015-01-28)**
 
 * Fix a regression where Numpy requires a build path without symlinks to

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,9 @@
 * Retry deleting directories incase a process like an antivirus is holding the
   directory open temporarily.
 
+* Fix an issue where pip would hide the cursor on Windows but would not reshow
+  it.
+
 
 **6.0.7 (2015-01-28)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,9 @@
 * Fix an issue where the ``--download`` flag would cause pip to no longer use
   randomized build directories.
 
+* Fix an issue where pip did not properly unquote quoted URLs which contain
+  characters like PEP 440's epoch separator (``!``).
+
 
 **6.0.7 (2015-01-28)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 **6.0.8 (2015-02-04)**
 
+* Fix an issue where the ``--download`` flag would cause pip to no longer use
+  randomized build directories.
+
+
 **6.0.7 (2015-01-28)**
 
 * Fix a regression where Numpy requires a build path without symlinks to

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@
 * Fix an issue where distutils installed projects were not actually uninstalled
   and deprecate attempting to uninstall them altogether.
 
+* Retry deleting directories incase a process like an antivirus is holding the
+  directory open temporarily.
+
 
 **6.0.7 (2015-01-28)**
 

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -30,7 +30,7 @@ import pip.cmdoptions
 cmdoptions = pip.cmdoptions
 
 # The version as used in the setup.py and the docs conf.py
-__version__ = "6.0.7"
+__version__ = "6.0.8.dev0"
 
 
 logger = logging.getLogger(__name__)

--- a/pip/_vendor/retrying.py
+++ b/pip/_vendor/retrying.py
@@ -1,0 +1,267 @@
+## Copyright 2013-2014 Ray Holder
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+import random
+from pip._vendor import six
+import sys
+import time
+import traceback
+
+
+# sys.maxint / 2, since Python 3.2 doesn't have a sys.maxint...
+MAX_WAIT = 1073741823
+
+
+def retry(*dargs, **dkw):
+    """
+    Decorator function that instantiates the Retrying object
+    @param *dargs: positional arguments passed to Retrying object
+    @param **dkw: keyword arguments passed to the Retrying object
+    """
+    # support both @retry and @retry() as valid syntax
+    if len(dargs) == 1 and callable(dargs[0]):
+        def wrap_simple(f):
+
+            @six.wraps(f)
+            def wrapped_f(*args, **kw):
+                return Retrying().call(f, *args, **kw)
+
+            return wrapped_f
+
+        return wrap_simple(dargs[0])
+
+    else:
+        def wrap(f):
+
+            @six.wraps(f)
+            def wrapped_f(*args, **kw):
+                return Retrying(*dargs, **dkw).call(f, *args, **kw)
+
+            return wrapped_f
+
+        return wrap
+
+
+class Retrying(object):
+
+    def __init__(self,
+                 stop=None, wait=None,
+                 stop_max_attempt_number=None,
+                 stop_max_delay=None,
+                 wait_fixed=None,
+                 wait_random_min=None, wait_random_max=None,
+                 wait_incrementing_start=None, wait_incrementing_increment=None,
+                 wait_exponential_multiplier=None, wait_exponential_max=None,
+                 retry_on_exception=None,
+                 retry_on_result=None,
+                 wrap_exception=False,
+                 stop_func=None,
+                 wait_func=None,
+                 wait_jitter_max=None):
+
+        self._stop_max_attempt_number = 5 if stop_max_attempt_number is None else stop_max_attempt_number
+        self._stop_max_delay = 100 if stop_max_delay is None else stop_max_delay
+        self._wait_fixed = 1000 if wait_fixed is None else wait_fixed
+        self._wait_random_min = 0 if wait_random_min is None else wait_random_min
+        self._wait_random_max = 1000 if wait_random_max is None else wait_random_max
+        self._wait_incrementing_start = 0 if wait_incrementing_start is None else wait_incrementing_start
+        self._wait_incrementing_increment = 100 if wait_incrementing_increment is None else wait_incrementing_increment
+        self._wait_exponential_multiplier = 1 if wait_exponential_multiplier is None else wait_exponential_multiplier
+        self._wait_exponential_max = MAX_WAIT if wait_exponential_max is None else wait_exponential_max
+        self._wait_jitter_max = 0 if wait_jitter_max is None else wait_jitter_max
+
+        # TODO add chaining of stop behaviors
+        # stop behavior
+        stop_funcs = []
+        if stop_max_attempt_number is not None:
+            stop_funcs.append(self.stop_after_attempt)
+
+        if stop_max_delay is not None:
+            stop_funcs.append(self.stop_after_delay)
+
+        if stop_func is not None:
+            self.stop = stop_func
+
+        elif stop is None:
+            self.stop = lambda attempts, delay: any(f(attempts, delay) for f in stop_funcs)
+
+        else:
+            self.stop = getattr(self, stop)
+
+        # TODO add chaining of wait behaviors
+        # wait behavior
+        wait_funcs = [lambda *args, **kwargs: 0]
+        if wait_fixed is not None:
+            wait_funcs.append(self.fixed_sleep)
+
+        if wait_random_min is not None or wait_random_max is not None:
+            wait_funcs.append(self.random_sleep)
+
+        if wait_incrementing_start is not None or wait_incrementing_increment is not None:
+            wait_funcs.append(self.incrementing_sleep)
+
+        if wait_exponential_multiplier is not None or wait_exponential_max is not None:
+            wait_funcs.append(self.exponential_sleep)
+
+        if wait_func is not None:
+            self.wait = wait_func
+
+        elif wait is None:
+            self.wait = lambda attempts, delay: max(f(attempts, delay) for f in wait_funcs)
+
+        else:
+            self.wait = getattr(self, wait)
+
+        # retry on exception filter
+        if retry_on_exception is None:
+            self._retry_on_exception = self.always_reject
+        else:
+            self._retry_on_exception = retry_on_exception
+
+        # TODO simplify retrying by Exception types
+        # retry on result filter
+        if retry_on_result is None:
+            self._retry_on_result = self.never_reject
+        else:
+            self._retry_on_result = retry_on_result
+
+        self._wrap_exception = wrap_exception
+
+    def stop_after_attempt(self, previous_attempt_number, delay_since_first_attempt_ms):
+        """Stop after the previous attempt >= stop_max_attempt_number."""
+        return previous_attempt_number >= self._stop_max_attempt_number
+
+    def stop_after_delay(self, previous_attempt_number, delay_since_first_attempt_ms):
+        """Stop after the time from the first attempt >= stop_max_delay."""
+        return delay_since_first_attempt_ms >= self._stop_max_delay
+
+    def no_sleep(self, previous_attempt_number, delay_since_first_attempt_ms):
+        """Don't sleep at all before retrying."""
+        return 0
+
+    def fixed_sleep(self, previous_attempt_number, delay_since_first_attempt_ms):
+        """Sleep a fixed amount of time between each retry."""
+        return self._wait_fixed
+
+    def random_sleep(self, previous_attempt_number, delay_since_first_attempt_ms):
+        """Sleep a random amount of time between wait_random_min and wait_random_max"""
+        return random.randint(self._wait_random_min, self._wait_random_max)
+
+    def incrementing_sleep(self, previous_attempt_number, delay_since_first_attempt_ms):
+        """
+        Sleep an incremental amount of time after each attempt, starting at
+        wait_incrementing_start and incrementing by wait_incrementing_increment
+        """
+        result = self._wait_incrementing_start + (self._wait_incrementing_increment * (previous_attempt_number - 1))
+        if result < 0:
+            result = 0
+        return result
+
+    def exponential_sleep(self, previous_attempt_number, delay_since_first_attempt_ms):
+        exp = 2 ** previous_attempt_number
+        result = self._wait_exponential_multiplier * exp
+        if result > self._wait_exponential_max:
+            result = self._wait_exponential_max
+        if result < 0:
+            result = 0
+        return result
+
+    def never_reject(self, result):
+        return False
+
+    def always_reject(self, result):
+        return True
+
+    def should_reject(self, attempt):
+        reject = False
+        if attempt.has_exception:
+            reject |= self._retry_on_exception(attempt.value[1])
+        else:
+            reject |= self._retry_on_result(attempt.value)
+
+        return reject
+
+    def call(self, fn, *args, **kwargs):
+        start_time = int(round(time.time() * 1000))
+        attempt_number = 1
+        while True:
+            try:
+                attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
+            except:
+                tb = sys.exc_info()
+                attempt = Attempt(tb, attempt_number, True)
+
+            if not self.should_reject(attempt):
+                return attempt.get(self._wrap_exception)
+
+            delay_since_first_attempt_ms = int(round(time.time() * 1000)) - start_time
+            if self.stop(attempt_number, delay_since_first_attempt_ms):
+                if not self._wrap_exception and attempt.has_exception:
+                    # get() on an attempt with an exception should cause it to be raised, but raise just in case
+                    raise attempt.get()
+                else:
+                    raise RetryError(attempt)
+            else:
+                sleep = self.wait(attempt_number, delay_since_first_attempt_ms)
+                if self._wait_jitter_max:
+                    jitter = random.random() * self._wait_jitter_max
+                    sleep = sleep + max(0, jitter)
+                time.sleep(sleep / 1000.0)
+
+            attempt_number += 1
+
+
+class Attempt(object):
+    """
+    An Attempt encapsulates a call to a target function that may end as a
+    normal return value from the function or an Exception depending on what
+    occurred during the execution.
+    """
+
+    def __init__(self, value, attempt_number, has_exception):
+        self.value = value
+        self.attempt_number = attempt_number
+        self.has_exception = has_exception
+
+    def get(self, wrap_exception=False):
+        """
+        Return the return value of this Attempt instance or raise an Exception.
+        If wrap_exception is true, this Attempt is wrapped inside of a
+        RetryError before being raised.
+        """
+        if self.has_exception:
+            if wrap_exception:
+                raise RetryError(self)
+            else:
+                six.reraise(self.value[0], self.value[1], self.value[2])
+        else:
+            return self.value
+
+    def __repr__(self):
+        if self.has_exception:
+            return "Attempts: {0}, Error:\n{1}".format(self.attempt_number, "".join(traceback.format_tb(self.value[2])))
+        else:
+            return "Attempts: {0}, Value: {1}".format(self.attempt_number, self.value)
+
+
+class RetryError(Exception):
+    """
+    A RetryError encapsulates the last Attempt instance right before giving up.
+    """
+
+    def __init__(self, last_attempt):
+        self.last_attempt = last_attempt
+
+    def __str__(self):
+        return "RetryError[{0}]".format(self.last_attempt)

--- a/pip/_vendor/vendor.txt
+++ b/pip/_vendor/vendor.txt
@@ -9,3 +9,4 @@ lockfile==0.10.2
 progress==1.2
 ipaddress==1.0.7  # Only needed on 2.6, 2.7, and 3.2
 packaging==15.0
+retrying==1.3.3

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -209,15 +209,15 @@ class InstallCommand(Command):
                 RemovedInPip7Warning,
             )
 
-        if options.download_dir:
-            options.no_install = True
-            options.ignore_installed = True
-
         # If we have --no-install or --no-download and no --build we use the
         # legacy static build dir
         if (options.build_dir is None
                 and (options.no_install or options.no_download)):
             options.build_dir = build_prefix
+
+        if options.download_dir:
+            options.no_install = True
+            options.ignore_installed = True
 
         if options.build_dir:
             options.build_dir = os.path.abspath(options.build_dir)

--- a/pip/download.py
+++ b/pip/download.py
@@ -676,7 +676,7 @@ def unpack_http_url(link, location, download_dir=None, session=None):
 
     if not already_downloaded_path:
         os.unlink(from_path)
-    os.rmdir(temp_dir)
+    rmtree(temp_dir)
 
 
 def unpack_file_url(link, location, download_dir=None):

--- a/pip/index.py
+++ b/pip/index.py
@@ -1114,7 +1114,7 @@ class Link(object):
 
     @property
     def path(self):
-        return urllib_parse.urlsplit(self.url)[2]
+        return urllib_parse.unquote(urllib_parse.urlsplit(self.url)[2])
 
     def splitext(self):
         return splitext(posixpath.basename(self.path.rstrip('/')))

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import sys
 import tempfile
+import warnings
 import zipfile
 
 from distutils.util import change_root
@@ -32,6 +33,7 @@ from pip.utils import (
     dist_in_usersite, dist_in_site_packages, egg_link_path, make_path_relative,
     call_subprocess, read_text_file, FakeFile, _make_build_dir,
 )
+from pip.utils.deprecation import RemovedInPip8Warning
 from pip.utils.logging import indent_log
 from pip.req.req_uninstall import UninstallPathSet
 from pip.vcs import vcs
@@ -559,6 +561,8 @@ exec(compile(
         paths_to_remove = UninstallPathSet(dist)
         develop_egg_link = egg_link_path(dist)
         egg_info_exists = dist.egg_info and os.path.exists(dist.egg_info)
+        # Special case for distutils installed package
+        distutils_egg_info = getattr(dist._provider, 'path', None)
         if develop_egg_link:
             # develop egg
             with open(develop_egg_link, 'r') as fh:
@@ -596,6 +600,16 @@ exec(compile(
                     paths_to_remove.add(path)
                     paths_to_remove.add(path + '.py')
                     paths_to_remove.add(path + '.pyc')
+
+        elif distutils_egg_info:
+            warnings.warn(
+                "Uninstalling a distutils installed project ({0}) has been "
+                "deprecated and will be removed in a future version. This is "
+                "due to the fact that uninstalling a distutils project will "
+                "only partially uninstall the project.".format(self.name),
+                RemovedInPip8Warning,
+            )
+            paths_to_remove.add(distutils_egg_info)
 
         elif dist.location.endswith('.egg'):
             # package installed by easy_install

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -845,7 +845,7 @@ exec(compile(
         finally:
             if os.path.exists(record_filename):
                 os.remove(record_filename)
-            os.rmdir(temp_location)
+            rmtree(temp_location)
 
     def remove_temporary_source(self):
         """Remove the source files from this requirement, if they are marked

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -23,6 +23,7 @@ from pip._vendor import pkg_resources, six
 from pip._vendor.six.moves import input
 from pip._vendor.six.moves import cStringIO
 from pip._vendor.six import PY2
+from pip._vendor.retrying import retry
 
 if PY2:
     from io import BytesIO as StringIO
@@ -53,6 +54,8 @@ def get_prog():
     return 'pip'
 
 
+# Retry every half second for up to 3 seconds
+@retry(stop_max_delay=3000, wait_fixed=500)
 def rmtree(dir, ignore_errors=False):
     shutil.rmtree(dir, ignore_errors=ignore_errors,
                   onerror=rmtree_errorhandler)

--- a/pip/utils/ui.py
+++ b/pip/utils/ui.py
@@ -52,6 +52,16 @@ class DownloadProgressMixin(object):
 class WindowsMixin(object):
 
     def __init__(self, *args, **kwargs):
+        # The Windows terminal does not support the hide/show cursor ANSI codes
+        # even with colorama. So we'll ensure that hide_cursor is False on
+        # Windows.
+        # This call neds to go before the super() call, so that hide_cursor
+        # is set in time. The base progress bar class writes the "hide cursor"
+        # code to the terminal in its init, so if we don't set this soon
+        # enough, we get a "hide" with no corresponding "show"...
+        if WINDOWS and self.hide_cursor:
+            self.hide_cursor = False
+
         super(WindowsMixin, self).__init__(*args, **kwargs)
 
         # Check if we are running on Windows and we have the colorama module,
@@ -66,12 +76,6 @@ class WindowsMixin(object):
             # but the colorama.AnsiToWin32() object doesn't have that, so we'll
             # add it.
             self.file.flush = lambda: self.file.wrapped.flush()
-
-        # The Windows terminal does not support the hide/show cursor ANSI codes
-        # even with colorama. So we'll ensure that hide_cursor is False on
-        # Windows.
-        if WINDOWS and self.hide_cursor:
-            self.hide_cursor = False
 
 
 class DownloadProgressBar(WindowsMixin, DownloadProgressMixin, Bar):

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -123,7 +123,8 @@ def test_freeze_git_clone(script, tmpdir):
     )
     result = script.run(
         'python', 'setup.py', 'develop',
-        cwd=repo_dir
+        cwd=repo_dir,
+        expect_stderr=True,
     )
     result = script.pip('freeze', expect_stderr=True)
     expected = textwrap.dedent(
@@ -279,6 +280,7 @@ def test_freeze_bazaar_clone(script, tmpdir):
     result = script.run(
         'python', 'setup.py', 'develop',
         cwd=script.scratch_path / 'django-wikiapp',
+        expect_stderr=True,
     )
     result = script.pip('freeze', expect_stderr=True)
     expected = textwrap.dedent("""\

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -28,6 +28,28 @@ def test_simple_uninstall(script):
     assert_all_changes(result, result2, [script.venv / 'build', 'cache'])
 
 
+def test_simple_uninstall_distutils(script):
+    """
+    Test simple install and uninstall.
+
+    """
+    script.scratch_path.join("distutils_install").mkdir()
+    pkg_path = script.scratch_path / 'distutils_install'
+    pkg_path.join("setup.py").write(textwrap.dedent("""
+        from distutils.core import setup
+        setup(
+            name='distutils-install',
+            version='0.1',
+        )
+    """))
+    result = script.run('python', pkg_path / 'setup.py', 'install')
+    result = script.pip('list')
+    assert "distutils-install (0.1)" in result.stdout
+    script.pip('uninstall', 'distutils_install', '-y')
+    result2 = script.pip('list')
+    assert "distutils-install (0.1)" not in result2.stdout
+
+
 def test_uninstall_with_scripts(script):
     """
     Uninstall an easy_installed package with scripts.


### PR DESCRIPTION
* Fix an issue where the ``--download`` flag would cause pip to no longer use randomized build directories.
* Fix an issue where pip did not properly unquote quoted URLs which contain characters like PEP 440's epoch separator (``!``).
* Fix an issue where distutils installed projects were not actually uninstalled and deprecate attempting to uninstall them altogether.
* Retry deleting directories incase a process like an antivirus is holding the directory open temporarily.
* Fix an issue where pip would hide the cursor on Windows but would not reshow it.
