### PR TITLE
Ensure all tags are fetched when updating git repo

### DIFF
--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -99,7 +99,7 @@ class Git(VersionControl):
 
     def update(self, dest, rev_options):
         # First fetch changes from the default remote
-        self.run_command(['fetch', '-q'], cwd=dest)
+        self.run_command(['fetch', '--tags', '-q'], cwd=dest)
         # Then reset to wanted revision (maybe even origin/master)
         if rev_options:
             rev_options = self.check_rev_options(


### PR DESCRIPTION
We ran into a case in which we had a `requirements.txt` like:
```
...
-e git+ssh://git@github.com/foobar/foobar.git@v0.4.0#egg=foobar
...
```

And, when upgrading *foobar*, `requirements.txt` becomes:
```
...
-e git+ssh://git@github.com/foobar/foobar.git@v0.4.1#egg=foobar
...
```

Then `pip install --upgrade -r requirements.txt` fails with these lines in our logs:
```
[10:50:53] Command /usr/bin/git reset --hard -q v0.4.1 failed with error code 128 in ...
[10:50:53] Storing debug log for failure in /home/ubuntu/.pip/pip.log
[10:50:54]   Could not find a tag or branch 'v0.4.1', assuming commit.
[10:50:54] fatal: ambiguous argument 'v0.4.1': unknown revision or path not in the working tree.
[10:50:54] Use '--' to separate paths from revisions
```

So it seems that `git fetch` didn't fetch the v0.4.1 tag.

What about having an explicit `git fetch --tags` to ensure all tags will be fetched?