### PR TITLE
Display warning when 'SUDO_COMMAND' in os.environ

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import logging
 import os
 import sys
+import textwrap
 import traceback
 import optparse
 import warnings
@@ -210,6 +211,27 @@ class Command(object):
 
         if options.exists_action:
             os.environ['PIP_EXISTS_ACTION'] = ' '.join(options.exists_action)
+
+        if 'SUDO_COMMAND' in os.environ:
+            logger.warning(
+                textwrap.dedent("""\
+                ******************************************************
+                Are you using sudo?  Using pip with sudo can be tricky.
+
+                If you're using a virtualenv:
+
+                  Sudo usually won't pass the environment variables
+                  that are set by virtualenv's `activate` scripts, so
+                  a `sudo pip install` may not run in the virtualenv.
+
+                If you're installing to the system python:
+
+                  This is risky and can lead to system breakage.
+                  Usually it is better to use your OS package manager
+                  to manage your system python and to use pip in a
+                  virtualenv or with the --user option.
+                ******************************************************""")
+            )
 
         if options.require_venv:
             # If a venv is required check if it can really be found


### PR DESCRIPTION
Because using sudo with pip is often a mistake; often people either:

- don't realize that `sudo` won't honor their activated virtualenv
- are trying to use `pip` to manage packages in their system python, which can break
  systems and is often better left to the system package manager.

This is a **warning** rather than a fatal error, so that it is less likely to break someone's workflow or tools.

This is inspired by:

- frequent occurrences of people on systems of ours doing `source /path/to/virtualenv/bin/activate; sudo -u appuser pip install foobar` and installing cruft in the system Python.
- @pfmoore's comment: https://github.com/pypa/pip/pull/2401#issuecomment-73103207

Cc: @aconrad, @sudarkoff, @sontek