### PR TITLE
Separate pip search command from operation

### DIFF
--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -5,14 +5,14 @@ import sys
 import textwrap
 
 from pip.basecommand import Command, SUCCESS
-from pip.download import PipXmlrpcTransport
 from pip.index import PyPI
 from pip.utils import get_terminal_size
 from pip.utils.logging import indent_log
 from pip.exceptions import CommandError
 from pip.status_codes import NO_MATCHES_FOUND
 from pip._vendor import pkg_resources
-from pip._vendor.six.moves import xmlrpc_client
+
+from pip.operations.search import highest_version, search, transform_hits
 
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,8 @@ class SearchCommand(Command):
         if not args:
             raise CommandError('Missing required argument (search query).')
         query = args
-        pypi_hits = self.search(query, options)
+        with self._build_session(options) as session:
+            pypi_hits = search(query, options.index, session)
         hits = transform_hits(pypi_hits)
 
         terminal_width = None
@@ -51,54 +52,6 @@ class SearchCommand(Command):
         if pypi_hits:
             return SUCCESS
         return NO_MATCHES_FOUND
-
-    def search(self, query, options):
-        index_url = options.index
-        with self._build_session(options) as session:
-            transport = PipXmlrpcTransport(index_url, session)
-            pypi = xmlrpc_client.ServerProxy(index_url, transport)
-            hits = pypi.search({'name': query, 'summary': query}, 'or')
-            return hits
-
-
-def transform_hits(hits):
-    """
-    The list from pypi is really a list of versions. We want a list of
-    packages with the list of versions stored inline. This converts the
-    list from pypi into one we can use.
-    """
-    packages = {}
-    for hit in hits:
-        name = hit['name']
-        summary = hit['summary']
-        version = hit['version']
-        score = hit['_pypi_ordering']
-        if score is None:
-            score = 0
-
-        if name not in packages.keys():
-            packages[name] = {
-                'name': name,
-                'summary': summary,
-                'versions': [version],
-                'score': score,
-            }
-        else:
-            packages[name]['versions'].append(version)
-
-            # if this is the highest version, replace summary and score
-            if version == highest_version(packages[name]['versions']):
-                packages[name]['summary'] = summary
-                packages[name]['score'] = score
-
-    # each record has a unique name now, so we will convert the dict into a
-    # list sorted by score
-    package_list = sorted(
-        packages.values(),
-        key=lambda x: x['score'],
-        reverse=True,
-    )
-    return package_list
 
 
 def print_results(hits, name_column_width=None, terminal_width=None):
@@ -131,9 +84,3 @@ def print_results(hits, name_column_width=None, terminal_width=None):
                         logger.info('LATEST:    %s', latest)
         except UnicodeEncodeError:
             pass
-
-
-def highest_version(versions):
-    return next(iter(
-        sorted(versions, key=pkg_resources.parse_version, reverse=True)
-    ))

--- a/pip/operations/search.py
+++ b/pip/operations/search.py
@@ -1,0 +1,58 @@
+# The guts of search
+
+from pip.download import PipXmlrpcTransport
+from pip._vendor.six.moves import xmlrpc_client
+from pip._vendor import pkg_resources
+
+
+def search(query, index_url, session):
+    transport = PipXmlrpcTransport(index_url, session)
+    pypi = xmlrpc_client.ServerProxy(index_url, transport)
+    hits = pypi.search({'name': query, 'summary': query}, 'or')
+    return hits
+
+
+def transform_hits(hits):
+    """
+    The list from pypi is really a list of versions. We want a list of
+    packages with the list of versions stored inline. This converts the
+    list from pypi into one we can use.
+    """
+    packages = {}
+    for hit in hits:
+        name = hit['name']
+        summary = hit['summary']
+        version = hit['version']
+        score = hit['_pypi_ordering']
+        if score is None:
+            score = 0
+
+        if name not in packages.keys():
+            packages[name] = {
+                'name': name,
+                'summary': summary,
+                'versions': [version],
+                'score': score,
+            }
+        else:
+            packages[name]['versions'].append(version)
+
+            # if this is the highest version, replace summary and score
+            if version == highest_version(packages[name]['versions']):
+                packages[name]['summary'] = summary
+                packages[name]['score'] = score
+
+    # each record has a unique name now, so we will convert the dict into a
+    # list sorted by score
+    package_list = sorted(
+        packages.values(),
+        key=lambda x: x['score'],
+        reverse=True,
+    )
+    return package_list
+
+
+def highest_version(versions):
+    return next(iter(
+        sorted(versions, key=pkg_resources.parse_version, reverse=True)
+    ))

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,13 @@ commands = check-manifest
 [testenv:pep8]
 basepython = python2.7
 deps = flake8
+       pep8<1.6
 commands = flake8 .
 
 [testenv:py3pep8]
 basepython = python3.3
 deps = flake8
+       pep8<1.6
 commands = flake8 .
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -21,13 +21,11 @@ commands = check-manifest
 [testenv:pep8]
 basepython = python2.7
 deps = flake8
-       pep8<1.6
 commands = flake8 .
 
 [testenv:py3pep8]
 basepython = python3.3
 deps = flake8
-       pep8<1.6
 commands = flake8 .
 
 [flake8]


### PR DESCRIPTION
By extracting the logic into `pip.operations.search`, the hope is that
folks could do a `search` programmatically more easily.

It also has greater separation of concerns and should allow people to
work in parallel with less chance of merge conflicts.

Continuing work started in #2173 and #2404.