### PR TITLE
Separate pip wheel command from operation

### DIFF
--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -6,14 +6,12 @@ import os
 import warnings
 
 from pip.basecommand import Command
-from pip.index import PackageFinder
-from pip.exceptions import CommandError, PreviousBuildDirError
-from pip.req import InstallRequirement, RequirementSet, parse_requirements
+from pip.exceptions import CommandError
 from pip.utils import normalize_path
-from pip.utils.build import BuildDirectory
 from pip.utils.deprecation import RemovedInPip7Warning, RemovedInPip8Warning
-from pip.wheel import WheelBuilder
 from pip import cmdoptions
+
+from pip.operations.wheel import build_wheel
 
 DEFAULT_WHEEL_DIR = os.path.join(normalize_path(os.curdir), 'wheelhouse')
 
@@ -101,12 +99,9 @@ class WheelCommand(Command):
         self.parser.insert_option_group(0, cmd_opts)
 
     def run(self, options, args):
-
         # confirm requirements
         try:
-            import wheel.bdist_wheel
-            # Hack to make flake8 not complain about an unused import
-            wheel.bdist_wheel
+            import wheel.bdist_wheel  # flake8: noqa
         except ImportError:
             raise CommandError(
                 "'pip wheel' requires the 'wheel' package. To fix this, run: "
@@ -161,87 +156,4 @@ class WheelCommand(Command):
         if options.build_dir:
             options.build_dir = os.path.abspath(options.build_dir)
 
-        with self._build_session(options) as session:
-
-            finder = PackageFinder(
-                find_links=options.find_links,
-                index_urls=index_urls,
-                use_wheel=options.use_wheel,
-                allow_external=options.allow_external,
-                allow_unverified=options.allow_unverified,
-                allow_all_external=options.allow_all_external,
-                allow_all_prereleases=options.pre,
-                trusted_hosts=options.trusted_hosts,
-                process_dependency_links=options.process_dependency_links,
-                session=session,
-            )
-
-            build_delete = (not (options.no_clean or options.build_dir))
-            with BuildDirectory(options.build_dir,
-                                delete=build_delete) as build_dir:
-                requirement_set = RequirementSet(
-                    build_dir=build_dir,
-                    src_dir=options.src_dir,
-                    download_dir=None,
-                    ignore_dependencies=options.ignore_dependencies,
-                    ignore_installed=True,
-                    isolated=options.isolated_mode,
-                    session=session,
-                    wheel_download_dir=options.wheel_dir
-                )
-
-                # make the wheelhouse
-                if not os.path.exists(options.wheel_dir):
-                    os.makedirs(options.wheel_dir)
-
-                # parse args and/or requirements files
-                for name in args:
-                    requirement_set.add_requirement(
-                        InstallRequirement.from_line(
-                            name, None, isolated=options.isolated_mode,
-                        )
-                    )
-                for name in options.editables:
-                    requirement_set.add_requirement(
-                        InstallRequirement.from_editable(
-                            name,
-                            default_vcs=options.default_vcs,
-                            isolated=options.isolated_mode,
-                        )
-                    )
-                for filename in options.requirements:
-                    for req in parse_requirements(
-                            filename,
-                            finder=finder,
-                            options=options,
-                            session=session):
-                        requirement_set.add_requirement(req)
-
-                # fail if no requirements
-                if not requirement_set.has_requirements:
-                    logger.error(
-                        "You must give at least one requirement to %s "
-                        "(see \"pip help %s\")",
-                        self.name, self.name,
-                    )
-                    return
-
-                try:
-                    # build wheels
-                    wb = WheelBuilder(
-                        requirement_set,
-                        finder,
-                        options.wheel_dir,
-                        build_options=options.build_options or [],
-                        global_options=options.global_options or [],
-                    )
-                    if not wb.build():
-                        raise CommandError(
-                            "Failed to build one or more wheels"
-                        )
-                except PreviousBuildDirError:
-                    options.no_clean = True
-                    raise
-                finally:
-                    if not options.no_clean:
-                        requirement_set.cleanup_files()
+        build_wheel(index_urls, options, args, self._build_session)

--- a/pip/operations/wheel.py
+++ b/pip/operations/wheel.py
@@ -1,0 +1,97 @@
+import logging
+import os
+
+from pip.exceptions import CommandError, PreviousBuildDirError
+from pip.index import PackageFinder
+from pip.req import InstallRequirement, RequirementSet, parse_requirements
+from pip.utils.build import BuildDirectory
+from pip.wheel import WheelBuilder
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_wheel(index_urls, options, args, build_session_func):
+    with build_session_func(options) as session:
+        finder = PackageFinder(
+            find_links=options.find_links,
+            index_urls=index_urls,
+            use_wheel=options.use_wheel,
+            allow_external=options.allow_external,
+            allow_unverified=options.allow_unverified,
+            allow_all_external=options.allow_all_external,
+            allow_all_prereleases=options.pre,
+            trusted_hosts=options.trusted_hosts,
+            process_dependency_links=options.process_dependency_links,
+            session=session,
+        )
+
+        build_delete = (not (options.no_clean or options.build_dir))
+        with BuildDirectory(options.build_dir,
+                            delete=build_delete) as build_dir:
+            requirement_set = RequirementSet(
+                build_dir=build_dir,
+                src_dir=options.src_dir,
+                download_dir=None,
+                ignore_dependencies=options.ignore_dependencies,
+                ignore_installed=True,
+                isolated=options.isolated_mode,
+                session=session,
+                wheel_download_dir=options.wheel_dir
+            )
+
+            # make the wheelhouse
+            if not os.path.exists(options.wheel_dir):
+                os.makedirs(options.wheel_dir)
+
+            # parse args and/or requirements files
+            for name in args:
+                requirement_set.add_requirement(
+                    InstallRequirement.from_line(
+                        name, None, isolated=options.isolated_mode,
+                    )
+                )
+            for name in options.editables:
+                requirement_set.add_requirement(
+                    InstallRequirement.from_editable(
+                        name,
+                        default_vcs=options.default_vcs,
+                        isolated=options.isolated_mode,
+                    )
+                )
+            for filename in options.requirements:
+                for req in parse_requirements(
+                        filename,
+                        finder=finder,
+                        options=options,
+                        session=session):
+                    requirement_set.add_requirement(req)
+
+            # fail if no requirements
+            if not requirement_set.has_requirements:
+                logger.error(
+                    "You must give at least one requirement to %s "
+                    "(see \"pip help %s\")",
+                    "wheel", "wheel",
+                )
+                return
+
+            try:
+                # build wheels
+                wb = WheelBuilder(
+                    requirement_set,
+                    finder,
+                    options.wheel_dir,
+                    build_options=options.build_options or [],
+                    global_options=options.global_options or [],
+                )
+                if not wb.build():
+                    raise CommandError(
+                        "Failed to build one or more wheels"
+                    )
+            except PreviousBuildDirError:
+                options.no_clean = True
+                raise
+            finally:
+                if not options.no_clean:
+                    requirement_set.cleanup_files()

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,13 @@ commands = check-manifest
 [testenv:pep8]
 basepython = python2.7
 deps = flake8
+       pep8<1.6
 commands = flake8 .
 
 [testenv:py3pep8]
 basepython = python3.3
 deps = flake8
+       pep8<1.6
 commands = flake8 .
 
 [flake8]


### PR DESCRIPTION
By extracting the logic into `pip.operations.wheel`, the hope is that
folks could do a `wheel` programmatically more easily.

It also has greater separation of concerns and should allow people to
work in parallel with less chance of merge conflicts.

Continuing work started in #2173, #2404, and #2410.