### PR TITLE
tox.ini: Pin pep8<1.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,13 @@ commands = check-manifest
 [testenv:pep8]
 basepython = python2.7
 deps = flake8
+       pep8<1.6
 commands = flake8 .
 
 [testenv:py3pep8]
 basepython = python3.3
 deps = flake8
+       pep8<1.6
 commands = flake8 .
 
 [flake8]


### PR DESCRIPTION
[pep8 1.6](https://pypi.python.org/pypi/pep8/1.6.1) added some additional checks that pip currently fails.

This prevents Travis CI failures until folks can evaluate whether the issues should be fixed in the code or ignored.