### PR TITLE
setup.py: Add setuptools extra for "wheel"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(
     zip_safe=False,
     extras_require={
         'testing': tests_require,
+        'wheel': ['wheel'],
     },
     cmdclass={'test': PyTest},
 )


### PR DESCRIPTION
So folks can do `easy_install pip[wheel]` and such.