### PR TITLE
[WIP] Implement --global and try to default to --user when it makes sense

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -15,6 +15,7 @@ from pip.exceptions import (
     InstallationError, CommandError, PreviousBuildDirError,
 )
 from pip import cmdoptions
+from pip.utils import default_user_site
 from pip.utils.build import BuildDirectory
 from pip.utils.deprecation import RemovedInPip7Warning, RemovedInPip8Warning
 
@@ -127,6 +128,12 @@ class InstallCommand(Command):
             help='Install using the user scheme.')
 
         cmd_opts.add_option(
+            '--global',
+            dest='use_user_site',
+            action='store_false',
+            help='Install into the global site packages.')
+
+        cmd_opts.add_option(
             '--egg',
             dest='as_egg',
             action='store_true',
@@ -224,6 +231,13 @@ class InstallCommand(Command):
 
         options.src_dir = os.path.abspath(options.src_dir)
         install_options = options.install_options or []
+
+        # If we don't have an explicitly selected --user or --global then we
+        # want to execute our fallback code to determine what we're going to
+        # use.
+        if options.use_user_site is None:
+            options.use_user_site = default_user_site()
+
         if options.use_user_site:
             if virtualenv_no_global():
                 raise InstallationError(


### PR DESCRIPTION
Fixes #1668 by implementing:

* [x] When ``--user`` is passed we always install into the user site packages.
* [x] When ``--global`` is passed we always install into the global site packages.
* [ ] When neither is passed we implement a fallback method which:
  1. [x] Detects if we're in a virtual environment and if so acts as if ``--global`` was passed.
  2. [x] Detects if user site-packages is disabled and if so acts as if ``--global`` was passed.
  3. [ ] Looks at ``default-install`` and if that exists uses ``--user`` or ``-global`` based on it.
  4. [x] Detects if the effective user does not have write permissions to global site packages, and if they do not act as if ``--user`` was passed.
  5. [x] Finally, if all other detection methods failed, act as if ``--global`` was passed.
* [ ] Display a warning when installing a script into ``--user`` and the user bin isn't on ``$PATH``.

Implementation TODOs:

* [ ] Make sure that our detection logic works when one of the directories does not exist.
* [ ] Figure out what our detection logic should do when things like ``--root`` and such are passed.
* [ ] Write tests.

This is currently untested and is just a first pass but I figured I'd throw it up here for people to see.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/2418)
<!-- Reviewable:end -->
