### PR TITLE
tox.ini: Pin pep8<1.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 env:
   - TOXENV=pep8
   - TOXENV=py3pep8
+  - TOXENV=pep8_latest
+  - TOXENV=py3pep8_latest
   - TOXENV=docs
   - TOXENV=packaging
   - TOXENV=py26
@@ -15,6 +17,15 @@ env:
   - TOXENV=py34 VENDOR=no
   - TOXENV=py27 VENDOR=no WHEELS=yes
   - TOXENV=py34 VENDOR=no WHEELS=yes
+
+matrix:
+  # Allow these targets to fail because they might bring in a new version of
+  # pep8 with new checks that fail and it isn't fair to people submitting
+  # PRs to fail their builds for things outside of their control.
+  allow_failures:
+    - env: TOXENV=pep8_latest
+    - env: TOXENV=py3pep8_latest
+  fast_finish: true
 
 install: .travis/install.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs, packaging, pep8, py3pep8, py26, py27, py32, py33, py34, pypy
+envlist = docs, packaging, pep8, pep8_latest, py3pep8, py3pep8_latest, py26, py27, py32, py33, py34, pypy
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt
@@ -19,11 +19,31 @@ deps = check-manifest
 commands = check-manifest
 
 [testenv:pep8]
+# This target pins pep8 so that we don't suddenly get failures when there are
+# new pep8 versions with new checks
+basepython = python2.7
+deps = flake8
+       pep8<1.6.2
+commands = flake8 .
+
+[testenv:py3pep8]
+# This target pins pep8 so that we don't suddenly get failures when there are
+# new pep8 versions with new checks
+basepython = python3.3
+deps = flake8
+       pep8<1.6.2
+commands = flake8 .
+
+[testenv:pep8_latest]
+# This target does NOT pin pep8 so that we are aware of when there are new pep8
+# versions with new checks that we fail
 basepython = python2.7
 deps = flake8
 commands = flake8 .
 
-[testenv:py3pep8]
+[testenv:py3pep8_latest]
+# This target does NOT pin pep8 so that we are aware of when there are new pep8
+# versions with new checks that we fail
 basepython = python3.3
 deps = flake8
 commands = flake8 .


### PR DESCRIPTION
Because pep8 keeps adding new checks and causing Travis CI to fail.