### PR TITLE
Use travis_retry on `pip install`s

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -5,5 +5,7 @@ set -x
 git config --global user.email "pypa-dev@googlegroups.com"
 git config --global user.name "pip"
 
-pip install --upgrade setuptools
-pip install coverage diff_cover tox
+# Use travis_retry to prevent intermittent failures from external factors like
+# networking problems or PyPI issues
+travis_retry pip install --upgrade setuptools
+travis_retry pip install coverage diff_cover tox


### PR DESCRIPTION
to hopefully prevent intermittent failures from external factors like temporary networking problems or PyPI issues.