### PR TITLE
Use --depth=1 when checking out git repositories

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -180,11 +180,10 @@ Here are the supported forms::
     [-e] git+ssh://git.myproject.org/MyProject#egg=MyProject
     -e git+git@git.myproject.org:MyProject#egg=MyProject
 
-Passing branch names, a commit hash or a tag name is possible like so::
+Passing branch names or a tag name is possible like so::
 
     [-e] git://git.myproject.org/MyProject.git@master#egg=MyProject
     [-e] git://git.myproject.org/MyProject.git@v1.0#egg=MyProject
-    [-e] git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef95601890afd80709#egg=MyProject
 
 Mercurial
 ~~~~~~~~~
@@ -506,5 +505,3 @@ Examples
  ::
 
   $ pip install --pre SomePackage
-
-

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -96,8 +96,10 @@ def test_check_submodule_addition(script):
     """
     module_path, submodule_path = _create_test_package_with_submodule(script)
 
+    # expect error because git may write to stderr
     install_result = script.pip(
-        'install', '-e', 'git+' + module_path + '#egg=version_pkg'
+        'install', '-e', 'git+' + module_path + '#egg=version_pkg',
+        expect_error=True,
     )
     assert (
         script.venv / 'src/version-pkg/testpkg/static/testfile'

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -34,7 +34,7 @@ def test_git_get_src_requirements():
 
     assert ret == ''.join([
         'git+http://github.com/pypa/pip-test-package',
-        '@5547fa909e83df8bd743d3978d6667497983a4b7',
+        '@bar',
         '#egg=pip_test_package-bar'
     ])
 


### PR DESCRIPTION
In most uses of pip's git backend, we don't need the full git history -
only the target head/branch/tag.  This change adds --depth=1 to git
fetch and clone commands.

Fixes #2432

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/2439)
<!-- Reviewable:end -->
