### PR TITLE
Display distribution name in assertion error

### DIFF
--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -259,7 +259,7 @@ class FrozenRequirement(object):
             editable = False
             req = dist.as_requirement()
             specs = req.specs
-            assert len(specs) == 1 and specs[0][0] in ["==", "==="]
+            assert len(specs) == 1 and specs[0][0] in ["==", "==="], dist
             version = specs[0][1]
             ver_match = cls._rev_re.search(version)
             date_match = cls._date_re.search(version)

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -259,7 +259,9 @@ class FrozenRequirement(object):
             editable = False
             req = dist.as_requirement()
             specs = req.specs
-            assert len(specs) == 1 and specs[0][0] in ["==", "==="], dist
+            assert len(specs) == 1 and specs[0][0] in ["==", "==="], \
+                'Expected 1 spec with == or ===; specs = %r; dist = %r' % \
+                (specs, dist)
             version = specs[0][1]
             ver_match = cls._rev_re.search(version)
             date_match = cls._date_re.search(version)


### PR DESCRIPTION
When specs of distribution aren't correct, display the faulty distribution in for easier debugging