### PR TITLE
Eliminate blank lines from setup.py failure output

### DIFF
--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -754,7 +754,7 @@ def call_subprocess(cmd, show_stdout=True,
                     'Complete output from command %s:', command_desc,
                 )
                 logger.info(
-                    '\n'.join(all_output) +
+                    ''.join(all_output) +
                     '\n----------------------------------------'
                 )
             raise InstallationError(


### PR DESCRIPTION
Fixes a long-time annoyance that `setup.py` failure output has a blank line after every line -- e.g.:

    $ pip wheel ~/dev/git-repos/lxml
    Processing /Users/marca/dev/git-repos/lxml
      ...
      /usr/bin/clang -fno-strict-aliasing -fno-common -dynamic -arch i386 -arch x86_64 -g -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/usr/include/libxml2 -Isrc/lxml/includes -I/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c src/lxml/lxml.etree.c -o build/temp.macosx-10.6-intel-2.7/src/lxml/lxml.etree.o -w -flat_namespace

      In file included from src/lxml/lxml.etree.c:314:

      src/lxml/includes/etree_defs.h:14:10: fatal error: 'libxml/xmlversion.h' file not found

      #include "libxml/xmlversion.h"

               ^

      1 error generated.

      error: command '/usr/bin/clang' failed with exit status 1
      ...

Definitely @pfmoore should test this on Windows as I'm worried that removing that `'\n'` might mess something up on Windows, because line-endings are different.