### PR TITLE
Fixes #2483: pip install --user option un(der)documented

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -124,7 +124,10 @@ class InstallCommand(Command):
             '--user',
             dest='use_user_site',
             action='store_true',
-            help='Install using the user scheme.')
+            help="Install to the Python user install directory for your "
+                 "platform. Typically ~/.local/, or %APPDATA%\Python on "
+                 "Windows. (See the Python documentation for site.USER_BASE "
+                 "for full details.)")
 
         cmd_opts.add_option(
             '--egg',


### PR DESCRIPTION
Now `pip install --help` gives more hints as to what `--user` does.