### PR TITLE
install: Less output on success; once on failure

### DIFF
--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -727,23 +727,25 @@ def call_subprocess(cmd, show_stdout=True,
     if stdout is not None:
         stdout = remove_tracebacks(console_to_str(proc.stdout.read()))
         stdout = cStringIO(stdout)
-        while 1:
-            line = stdout.readline()
-            if not line:
-                break
-            line = line.rstrip()
-            all_output.append(line + '\n')
-            if filter_stdout:
-                level = filter_stdout(line)
-                if isinstance(level, tuple):
-                    level, line = level
-                logger.log(level, line)
-                # if not logger.stdout_level_matches(level) and False:
-                #     # TODO(dstufft): Handle progress bar.
-                #     logger.show_progress()
-            else:
-                logger.debug(line)
-    else:
+        all_output = stdout.readlines()
+        if show_stdout:
+            while 1:
+                line = stdout.readline()
+                if not line:
+                    break
+                line = line.rstrip()
+                all_output.append(line + '\n')
+                if filter_stdout:
+                    level = filter_stdout(line)
+                    if isinstance(level, tuple):
+                        level, line = level
+                    logger.log(level, line)
+                    # if not logger.stdout_level_matches(level) and False:
+                    #     # TODO(dstufft): Handle progress bar.
+                    #     logger.show_progress()
+                else:
+                    logger.debug(line)
+    if not all_output:
         returned_stdout, returned_stderr = proc.communicate()
         all_output = [returned_stdout or '']
     proc.wait()

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -454,7 +454,7 @@ def test_install_global_option_using_editable(script, tmpdir):
         'install', '--global-option=--version', '-e',
         '%s@0.2.5#egg=anyjson' % local_checkout(url, tmpdir.join("cache"))
     )
-    assert '0.2.5\n' in result.stdout
+    assert 'Successfully installed anyjson' in result.stdout
 
 
 @pytest.mark.network


### PR DESCRIPTION
This fixes 2 aspects of `pip install output`:

1. When `pip install` succeeds, it's still printing a lot of output from the package's `setup.py`. The average consumer of Python packages, when they do `pip install lxml`, probably doesn't care to see a bunch of output about:

   - copying files to a `build` directory
   - installing and running Cython
   - compiling C code

   This is noise to most when the `pip install` succeeds. It's useful to see all the output when the install fails, which is the subject of #2 below. On success, the output is now very clean with 5 short lines:

   ```
   $ pip install lxml
   Collecting lxml
     Using cached lxml-3.4.2.tar.gz
   Installing collected packages: lxml
     Running setup.py install for lxml
   Successfully installed lxml-3.4.2
   ```

2. When there's an error from `pip install`, it's annoying to have to scroll through 2 different copies of the failure output (especially when one is filtered and one is unfiltered so one might have stuff that the other doesn't). This makes it not print the filtered version so that there is just the unfiltered version and nothing is repeated.

   ```
   $ pip install ~/dev/git-repos/lxml
   Processing /Users/marca/dev/git-repos/lxml
   Installing collected packages: lxml
     Running setup.py install for lxml
       Complete output from command ...
       cc -c /var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/xmlCheckVersion4tBaVV.c -o var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/xmlCheckVersion4tBaVV.o
       /var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/xmlCheckVersion4tBaVV.c:1:10: fatal error: 'libxml/xmlversion.h' file not found
       #include "libxml/xmlversion.h"
                ^
       1 error generated.
       ----------------------------------------
       Command "/Users/marca/python/virtualenvs/pip/bin/python -c ...
   ```
   None of the lines above are repeated.

Cc: @sudarkoff, @aconrad 