### PR TITLE
Add __repr__ to InstallRequirement

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -198,6 +198,9 @@ class InstallRequirement(object):
                 s += ' (from %s)' % comes_from
         return s
 
+    def __repr__(self):
+        return '<%s object: %s>' % (self.__class__.__name__, str(self))
+
     @property
     def specifier(self):
         return self.req.specifier


### PR DESCRIPTION
This makes it easier to inspect with pdb.

Instead of:

    (Pdb++) req_to_install
    <pip.req.req_install.InstallRequirement object at 0x10459f7d0>

we get the much friendlier:

    (Pdb++) req_to_install
    <InstallRequirement object: wheel==0.24.0 in /Users/marca/python/virtualenvs/pip/lib/python2.7/site-packages>