### PR TITLE
tox.ini: Add py34fast target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,12 @@ deps = -r{toxinidir}/dev-requirements.txt
 commands = py.test --timeout 300 []
 install_command = python -m pip install --pre {opts} {packages}
 
+[testenv:py34fast]
+basepython = python3.4
+deps = -r{toxinidir}/dev-requirements.txt
+commands = py.test --timeout 300 tests/unit -k 'not network' []
+install_command = python -m pip install --pre {opts} {packages}
+
 [testenv:py26]
 install_command = pip install --pre {opts} {packages}
 


### PR DESCRIPTION
This runs just the unit tests which don't need the network, so it could
be useful for doing a quick sanity check of some changes.

The regular tox targets take so long that they are not conducive to TDD
and I am often tempted to skip them and that's not good.

inspired in part by seeing how fast the unit tests were (and that you can
filter out the ones that require network access) in
https://github.com/pypa/pip/issues/2498

```
[marca@marca-mac2 pip]$ tox -e py34fast
GLOB sdist-make: /Users/marca/dev/git-repos/pip/setup.py
py34fast inst-nodeps: /Users/marca/dev/git-repos/pip/.tox/dist/pip-6.1.0.dev0.zip
py34fast runtests: PYTHONHASHSEED='3841935332'
py34fast runtests: commands[0] | py.test --timeout 300 tests/unit -k not network
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.4.2 -- py-1.4.26 -- pytest-2.6.4
plugins: capturelog, cov, timeout, xdist
collected 261 items

tests/unit/test_appdirs.py ......................
tests/unit/test_basecommand.py ....
tests/unit/test_compat.py .....
tests/unit/test_download.py .....sss..............
tests/unit/test_download_hashes.py ....................
tests/unit/test_finder.py ...............................
tests/unit/test_index.py .....................
tests/unit/test_locations.py .........
tests/unit/test_options.py ............................
tests/unit/test_proxy.py .
tests/unit/test_req.py .............................
tests/unit/test_unit_outdated.py ......
tests/unit/test_utils.py ..................s..........
tests/unit/test_vcs.py ...
tests/unit/test_wheel.py ...................s.......

==================================================================== 4 tests deselected by '-knot network' =====================================================================
============================================================= 252 passed, 5 skipped, 4 deselected in 10.95 seconds =============================================================
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py34fast: commands succeeded
  congratulations :)
```