### PR TITLE
Add test_finder.test_tilde unit test

### DIFF
--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -34,6 +34,18 @@ def test_no_partial_name_match(data):
     assert found.url.endswith("gmpy-1.15.tar.gz"), found
 
 
+@patch(
+    'pip.index.os.path.exists',
+    return_value=True  # b/c we only use tilde expanded version if it exists
+)
+def test_tilde(data):
+    """Finder can accept a path with ~ in it and will normalize it."""
+    finder = PackageFinder(['~/python-pkgs'], [], session=PipSession())
+    req = InstallRequirement.from_line("gmpy")
+    with pytest.raises(DistributionNotFound):
+        finder.find_requirement(req, False)
+
+
 def test_duplicates_sort_ok(data):
     """Finder successfully finds one of a set of duplicates in different
     locations"""


### PR DESCRIPTION
Adds a `test_tilde` test to augment @pfmoore's work in https://github.com/pypa/pip/pull/2455 ("Normalize paths starting with ~ in find-links")

This would've caught the missing import problem we had (https://github.com/pfmoore/pip/pull/1).

Cc: @pfmoore 