### PR TITLE
refactor PackageFinder.find_requirement into smaller methods

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -642,13 +642,7 @@ class PackageFinder(object):
         return extensions
 
     def _link_package_versions(self, link, search_name):
-        """
-        Return an iterable of triples (pkg_resources_version_key,
-        link, python_version) that can be extracted from the given
-        link.
-
-        Meant to be overridden by subclasses, not called by clients.
-        """
+        """Return an InstallationCandidate or None"""
         platform = get_platform()
 
         version = None

--- a/pip/index.py
+++ b/pip/index.py
@@ -360,7 +360,7 @@ class PackageFinder(object):
 
         find_links_versions = list(self._package_versions(
             # We trust every directly linked archive in find_links
-            [Link(url, '-f', trusted=True) for url in self.find_links],
+            (Link(url, '-f', trusted=True) for url in self.find_links),
             req.name.lower()
         ))
 
@@ -373,7 +373,8 @@ class PackageFinder(object):
                 )
 
         dependency_versions = list(self._package_versions(
-            [Link(url) for url in self.dependency_links], req.name.lower()))
+            (Link(url) for url in self.dependency_links), req.name.lower()
+        ))
         if dependency_versions:
             logger.debug(
                 'dependency_links found: %s',
@@ -384,7 +385,7 @@ class PackageFinder(object):
 
         file_versions = list(
             self._package_versions(
-                [Link(url) for url in file_locations],
+                (Link(url) for url in file_locations),
                 req.name.lower()
             )
         )

--- a/pip/index.py
+++ b/pip/index.py
@@ -339,6 +339,13 @@ class PackageFinder(object):
         return []
 
     def _find_all_versions(self, req):
+        """Find all available versions for req.project_name
+
+        This checks index_urls, find_links and dependency_links
+        All versions are returned regardless of req.specifier
+
+        See _link_package_versions for details on which files are accepted
+        """
         index_locations = self._get_index_urls_locations(req)
         file_locations, url_locations = self._sort_locations(index_locations)
         fl_file_loc, fl_url_loc = self._sort_locations(self.find_links)

--- a/pip/index.py
+++ b/pip/index.py
@@ -408,9 +408,11 @@ class PackageFinder(object):
         )
 
     def find_requirement(self, req, upgrade):
-        """Expects req, an InstallRequirement and upgrade, a boolean
-           Returns an InstallationCandidate or None
-           May raise DistributionNotFound or BestVersionAlreadyInstalled"""
+        """Try to find an InstallationCandidate for req
+
+        Expects req, an InstallRequirement and upgrade, a boolean
+        Returns an InstallationCandidate or None
+        May raise DistributionNotFound or BestVersionAlreadyInstalled"""
         all_versions = self._find_all_versions(req)
         if not all_versions:
             logger.critical(

--- a/pip/index.py
+++ b/pip/index.py
@@ -423,6 +423,9 @@ class PackageFinder(object):
         )
 
     def find_requirement(self, req, upgrade):
+        """Expects req, an InstallRequirement and upgrade, a boolean
+           Returns an InstallationCandidate or None
+           May raise DistributionNotFound or BestVersionAlreadyInstalled"""
         all_versions = self._find_all_versions(req)
         # Filter out anything which doesn't match our specifier
         _versions = set(

--- a/pip/index.py
+++ b/pip/index.py
@@ -291,9 +291,11 @@ class PackageFinder(object):
                 RemovedInPip7Warning,
             )
 
-    def _get_indexes_locations(self, req):
-        """Returns locations found via self.index_urls
-           with the url_name checked on the main index
+    def _get_index_urls_locations(self, req):
+        """Returns the locations found via self.index_urls
+
+        Checks the url_name on the main (first in the list) index and
+        use this url_name to produce all locations
         """
 
         def mkurl_pypi_url(url):
@@ -337,7 +339,7 @@ class PackageFinder(object):
         return []
 
     def _find_all_versions(self, req):
-        index_locations = self._get_indexes_locations(req)
+        index_locations = self._get_index_urls_locations(req)
         file_locations, url_locations = self._sort_locations(index_locations)
         fl_file_loc, fl_url_loc = self._sort_locations(self.find_links)
         file_locations.extend(fl_file_loc)

--- a/pip/index.py
+++ b/pip/index.py
@@ -352,14 +352,11 @@ class PackageFinder(object):
             logger.debug('* %s', location)
             self._validate_secure_origin(logger, location)
 
-        found_versions = []
-        found_versions.extend(
-            self._package_versions(
-                # We trust every directly linked archive in find_links
-                [Link(url, '-f', trusted=True) for url in self.find_links],
-                req.name.lower()
-            )
-        )
+        find_links_versions = list(self._package_versions(
+            # We trust every directly linked archive in find_links
+            [Link(url, '-f', trusted=True) for url in self.find_links],
+            req.name.lower()
+        ))
         page_versions = []
         for page in self._get_pages(locations, req):
             logger.debug('Analyzing links from page %s', page.url)
@@ -382,7 +379,7 @@ class PackageFinder(object):
                 req.name.lower()
             )
         )
-        if (not found_versions and not
+        if (not find_links_versions and not
                 page_versions and not
                 dependency_versions and not
                 file_versions):
@@ -430,7 +427,7 @@ class PackageFinder(object):
 
         # This is an intentional priority ordering
         all_versions = (
-            file_versions + found_versions + page_versions +
+            file_versions + find_links_versions + page_versions +
             dependency_versions
         )
 

--- a/pip/index.py
+++ b/pip/index.py
@@ -448,12 +448,11 @@ class PackageFinder(object):
                     INSTALLED_VERSION,
                 )
             )
+            existing_applicable = True
+        else:
+            existing_applicable = False
 
         applicable_versions = self._sort_versions(applicable_versions)
-        existing_applicable = any(
-            i.location is INSTALLED_VERSION
-            for i in applicable_versions
-        )
 
         if not upgrade and existing_applicable:
             if applicable_versions[0].location is INSTALLED_VERSION:

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -715,11 +715,11 @@ class test_link_package_versions(object):
         assert result == [], result
 
 
-def test_get_indexes_location():
+def test_get_index_urls_locations():
     """Check that the canonical name is on all indexes"""
     finder = PackageFinder(
         [], ['file://index1/', 'file://index2'], session=PipSession())
-    locations = finder._get_indexes_locations(
+    locations = finder._get_index_urls_locations(
         InstallRequirement.from_line('Complex_Name'))
     assert locations == ['file://index1/complex-name/',
                          'file://index2/complex-name/']


### PR DESCRIPTION
It chops the find_requirement method into smaller pieces that should enable easier testing.