### PR TITLE
#2414: parse SSH repositories url with a commit hash

### DIFF
--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -148,9 +148,17 @@ class VersionControl(object):
         url = self.url.split('+', 1)[1]
         scheme, netloc, path, query, frag = urllib_parse.urlsplit(url)
         rev = None
-        if '@' in path:
-            path, rev = path.rsplit('@', 1)
-        url = urllib_parse.urlunsplit((scheme, netloc, path, query, ''))
+        if scheme == 'ssh' and not path:  # Fix urllib_parse parsing
+            url_splitted = url.split('@')
+            if len(url_splitted) == 3:
+                url = '%s@%s' % (url_splitted[0], url_splitted[1])
+                rev = url_splitted[2].split('#')[0]
+            assert len(url_splitted) < 4, "You can't have more than two @ in VCS url."
+                
+        else:
+            if '@' in path:
+                path, rev = path.rsplit('@', 1)
+            url = urllib_parse.urlunsplit((scheme, netloc, path, query, ''))
         return url, rev
 
     def get_info(self, location):

--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -153,8 +153,8 @@ class VersionControl(object):
             if len(url_splitted) == 3:
                 url = '%s@%s' % (url_splitted[0], url_splitted[1])
                 rev = url_splitted[2].split('#')[0]
-            assert len(url_splitted) < 4, "You can't have more than two @ in VCS url."
-                
+            assert len(url_splitted) < 4,\
+                "You can't have more than two @ in VCS url."
         else:
             if '@' in path:
                 path, rev = path.rsplit('@', 1)

--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -201,6 +201,8 @@ class Git(VersionControl):
             url = url.replace('ssh://', '')
         else:
             url, rev = super(Git, self).get_url_rev()
+            # For explicit SSH URLs, remove 'ssh://' to clone
+            url = url.replace('ssh://', '')
 
         return url, rev
 

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -39,6 +39,37 @@ def test_git_get_src_requirements():
     ])
 
 
+def test_git_urls():
+    """
+    Test git url support.
+
+    SSH has special handling.
+    """
+    https_repo = Git(
+        url='git+https://github.com/Eyepea/pip.git@8cf54fff31b650847e0cddc2cd2951c34e0b4822#egg=pip'
+    )
+    implicit_ssh_repo = Git(
+        url='git+git@github.com:Eyepea/pip.git@8cf54fff31b650847e0cddc2cd2951c34e0b4822#egg=pip'
+    )
+
+    explicit_ssh_repo = Git(
+        url='git+ssh://git@github.com:Eyepea/pip.git@8cf54fff31b650847e0cddc2cd2951c34e0b4822#egg=pip'
+    )
+
+    assert https_repo.get_url_rev() == (
+        'https://github.com/Eyepea/pip.git',
+        '8cf54fff31b650847e0cddc2cd2951c34e0b4822',
+    )
+    assert implicit_ssh_repo.get_url_rev() == (
+        'git@github.com:Eyepea/pip.git',
+        '8cf54fff31b650847e0cddc2cd2951c34e0b4822',
+    )
+    assert explicit_ssh_repo.get_url_rev() == (
+        'git@github.com:Eyepea/pip.git',
+        '8cf54fff31b650847e0cddc2cd2951c34e0b4822',
+    )
+
+
 def test_translate_egg_surname():
     vc = VersionControl()
     assert vc.translate_egg_surname("foo") == "foo"


### PR DESCRIPTION
When you have a VCS repository with SSH, and you want to clone a specific commit, like you have in `requirements.txt` (ex: `git@github.com:Eyepea/pip.git@8cf54fff31b650847e0cddc2cd2951c34e0b4822`) you have a git command error, as described in #2414 issue.
This commit fixes that.