### PR TITLE
Make test_freeze_bazaar_clone not depend on bazaar.launchpad.net

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -505,6 +505,17 @@ def _create_test_package(script, vcs='git'):
         checkout_path = checkout_path.replace('c:', 'C:')
 
         version_pkg_path = checkout_path
+    elif vcs == 'bazaar':
+        script.run('bzr', 'init', cwd=version_pkg_path)
+        script.run('bzr', 'add', '.', cwd=version_pkg_path)
+        script.run(
+            'bzr', 'whoami', 'pip <pypa-dev@googlegroups.com>',
+            cwd=version_pkg_path)
+        script.run(
+            'bzr', 'commit', '-q',
+            '--author', 'pip <pypa-dev@googlegroups.com>',
+            '-m', 'initial version', cwd=version_pkg_path,
+        )
     else:
         raise ValueError('Unknown vcs: %r' % vcs)
     return version_pkg_path


### PR DESCRIPTION
Instead of checking out bzr+http://bazaar.launchpad.net/%7Edjango-wikiapp/django-wikiapp/, we create a bzr repo on the fly by calling `tests.lib._create_test_package` which has been enhanced to be able to create bzr repos:

```python
checkout_path = _create_test_package(script, vcs='bazaar')
```

The test is no longer marked as `network` (because it doesn't require the network -- yay!), but it is marked `bzr`. This allows for skipping the test in environments where `bzr` is not installed -- e.g.:

```
py.test tests/functional/test_freeze.py -k 'not bzr'
```