### PR TITLE
test_freeze_svn: No dep on bitbucket

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -65,6 +65,13 @@ Ways to run the tests locally:
  $ py.test               # Using py.test directly
  $ tox                   # Using tox against pip's tox.ini
 
+If you are missing one of the VCS tools, you can tell ``py.test`` to skip it:
+
+::
+
+ $ py.test -k 'not bzr'
+ $ py.test -k 'not svn'
+
 
 Getting Involved
 ================

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -4,6 +4,7 @@ import textwrap
 import pytest
 from doctest import OutputChecker, ELLIPSIS
 
+from tests.lib import _create_test_package
 from tests.lib.local_repos import local_checkout, local_repo
 
 
@@ -65,39 +66,23 @@ def test_freeze_basic(script):
     _check_output(result, expected)
 
 
-@pytest.mark.network
+@pytest.mark.svn
 def test_freeze_svn(script, tmpdir):
     """Test freezing a svn checkout"""
 
-    checkout_path = local_checkout(
-        'svn+http://svn.colorstudy.com/INITools/trunk',
-        tmpdir.join("cache"),
-    )
-    # svn internally stores windows drives as uppercase; we'll match that.
-    checkout_path = checkout_path.replace('c:', 'C:')
+    checkout_path = _create_test_package(script, vcs='svn')
 
-    # Checkout
-    script.run(
-        'svn', 'co', '-r10',
-        local_repo(
-            'svn+http://svn.colorstudy.com/INITools/trunk',
-            tmpdir.join("cache"),
-        ),
-        'initools-trunk',
-    )
     # Install with develop
     script.run(
         'python', 'setup.py', 'develop',
-        cwd=script.scratch_path / 'initools-trunk',
-        expect_stderr=True,
+        cwd=checkout_path, expect_stderr=True
     )
     result = script.pip('freeze', expect_stderr=True)
-
     expected = textwrap.dedent("""\
         Script result: pip freeze
         -- stdout: --------------------
-        ...-e %s@10#egg=INITools-0.3.1dev...-dev_r10
-        ...""" % checkout_path)
+        ...-e svn+...#egg=version_pkg-0.1-...
+        ...""")
     _check_output(result, expected)
 
 


### PR DESCRIPTION
Instead of using local_checkout, which downloads a 204 KB dump file from
http://bitbucket.org/hltbra/pip-initools-dump/raw/8b55c908a320/INITools_modified.dump,
use `svnadmin create` and `svn import` to create an svn repo on the fly.