### PR TITLE
_create_test_package use path_to_url for svn; makes test_freeze_svn work on Windows

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -484,8 +484,8 @@ def _create_test_package(script, vcs='git'):
             '-am', 'initial version', cwd=version_pkg_path,
         )
     elif vcs == 'svn':
-        repo_url = ('file://' +
-                    script.scratch_path / 'pip-test-package-repo' / 'trunk')
+        repo_url = path_to_url(
+            script.scratch_path / 'pip-test-package-repo' / 'trunk')
         script.run(
             'svnadmin', 'create', 'pip-test-package-repo',
             cwd=script.scratch_path


### PR DESCRIPTION
because `path_to_url` is smarter than the ad-hoc code I hacked together.
In particular, it works on Windows, whereas my code didn't. This
prevents the following error on Windows:

    Script result: svn import c:\users\admini~1\appdata\local\temp\pytest-27\test_freeze_svn0\workspace\scratch\version_pkg file://c:\users\admini~1\appdata\local\temp\pytest-27\test_freeze_svn0\workspace\scratch\pip-test-package-repo\trunk -m Initial import of pip-test-package
      return code: 1
    -- stderr: --------------------
    svn: E170000: Illegal repository URL 'file://c:%5cusers%5cadmini~1%5cappdata%5clocal%5ctemp%5cpytest-27%5ctest_freeze_svn0%5cworkspace%5cscratch%5cpip-test-package-repo%5ctrunk'

Cc: @pfmoore, because this makes the `test_freeze_svn` test work on Windows.

```
(pip) C:\Users\Administrator\Development\Python\pip>tox -e py27 -- tests/functional/test_freeze.py -k test_freeze_svn --tb=short
GLOB sdist-make: C:\Users\Administrator\Development\Python\pip\setup.py
py27 inst-nodeps: C:\Users\Administrator\Development\Python\pip\.tox\dist\pip-6.1.0.dev0.zip
py27 runtests: PYTHONHASHSEED='864'
py27 runtests: commands[0] | py.test --timeout 300 tests\functional\test_freeze.py -k test_freeze_svn --tb=short
============================= test session starts =============================
platform win32 -- Python 2.7.5 -- py-1.4.26 -- pytest-2.6.4
plugins: capturelog, cov, timeout, xdist
collected 8 items

tests/functional/test_freeze.py .

================== 7 tests deselected by '-ktest_freeze_svn' ==================
=================== 1 passed, 7 deselected in 10.62 seconds ===================
____________________________________________________________ summary _____________________________________________________________
  py27: commands succeeded
  congratulations :)
```

See also: https://github.com/pypa/pip/issues/2520