### PR TITLE
test_freeze_mercurial_clone: no dep on bitbucket

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -483,6 +483,14 @@ def _create_test_package(script, vcs='git'):
             '--author', 'pip <pypa-dev@googlegroups.com>',
             '-am', 'initial version', cwd=version_pkg_path,
         )
+    elif vcs == 'hg':
+        script.run('hg', 'init', cwd=version_pkg_path)
+        script.run('hg', 'add', '.', cwd=version_pkg_path)
+        script.run(
+            'hg', 'commit', '-q',
+            '--user', 'pip <pypa-dev@googlegroups.com>',
+            '-m', 'initial version', cwd=version_pkg_path,
+        )
     elif vcs == 'svn':
         repo_url = ('file://' +
                     script.scratch_path / 'pip-test-package-repo' / 'trunk')


### PR DESCRIPTION
This removes the dependency on Bitbucket, or any network access for that matter. It also works on both UNIX and Windows systems:

#### UNIX:

```
$ tox -e py27 -- -k test_freeze_mercurial_clone
GLOB sdist-make: /Users/marca/dev/git-repos/pip/setup.py
py27 inst-nodeps: /Users/marca/dev/git-repos/pip/.tox/dist/pip-6.1.0.dev0.zip
py27 runtests: PYTHONHASHSEED='2132040743'
py27 runtests: commands[0] | py.test --timeout 300 -k test_freeze_mercurial_clone
============================================================================= test session starts ==============================================================================
platform darwin -- Python 2.7.9 -- py-1.4.26 -- pytest-2.6.4
plugins: capturelog, cov, timeout, xdist
collected 492 items

tests/functional/test_freeze.py .

=========================================================== 491 tests deselected by '-ktest_freeze_mercurial_clone' ============================================================
============================================================ 1 passed, 491 deselected, 1 warnings in 13.99 seconds =============================================================
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py27: commands succeeded
  congratulations :)
```

#### Windows

```
(pip) C:\Users\Administrator\Development\Python\pip>tox -e py27 -- -k test_freeze_mercurial_clone
GLOB sdist-make: C:\Users\Administrator\Development\Python\pip\setup.py
py27 inst-nodeps: C:\Users\Administrator\Development\Python\pip\.tox\dist\pip-6.1.0.dev0.zip
py27 runtests: PYTHONHASHSEED='465'
py27 runtests: commands[0] | py.test --timeout 300 -k test_freeze_mercurial_clone
============================= test session starts =============================
platform win32 -- Python 2.7.5 -- py-1.4.26 -- pytest-2.6.4
plugins: capturelog, cov, timeout, xdist
collected 492 items

tests/functional/test_freeze.py .

=========== 491 tests deselected by '-ktest_freeze_mercurial_clone' ===========
============ 1 passed, 491 deselected, 1 warnings in 14.91 seconds ============
____________________________________________________________ summary _____________________________________________________________
  py27: commands succeeded
  congratulations :)
```