### PR TITLE
Added --changed / -c option to pip freeze

### DIFF
--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -50,6 +50,13 @@ class FreezeCommand(Command):
             action='store_true',
             default=False,
             help='Only output packages installed in user-site.')
+        self.parser.add_option(
+            '-c', '--changed',
+            dest='changed_only',
+            action='store_true',
+            default=False,
+            help='Only list packages that are new or have changed relative '
+                  'to a provided requirements file (-r).')
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -59,6 +66,7 @@ class FreezeCommand(Command):
             find_links=options.find_links,
             local_only=options.local,
             user_only=options.user,
+            changed_only=options.changed_only,
             skip_regex=options.skip_requirements_regex,
             isolated=options.isolated_mode)
 

--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -19,6 +19,7 @@ freeze_excludes = stdlib_pkgs + ['setuptools', 'pip', 'distribute']
 def freeze(
         requirement=None,
         find_links=None, local_only=None, user_only=None, skip_regex=None,
+        changed_only=False,
         find_tags=False,
         default_vcs=None,
         isolated=False):
@@ -63,7 +64,8 @@ def freeze(
                             '-f', '--find-links',
                             '-i', '--index-url',
                             '--extra-index-url'))):
-                    yield line.rstrip()
+                    if not changed_only:
+                        yield line.rstrip()
                     continue
 
                 if line.startswith('-e') or line.startswith('--editable'):
@@ -99,13 +101,15 @@ def freeze(
                         line.strip(),
                     )
                 else:
-                    yield str(installations[line_req.name]).rstrip()
+                    if not changed_only:
+                        yield str(installations[line_req.name]).rstrip()
                     del installations[line_req.name]
 
-        yield(
-            '## The following requirements were added by '
-            'pip freeze:'
-        )
+        if installations:
+            yield(
+                '## The following requirements were added by '
+                'pip freeze:'
+            )
     for installation in sorted(
             installations.values(), key=lambda x: x.name.lower()):
         yield str(installation).rstrip()

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -311,6 +311,46 @@ INITools==0.2
     _check_output(result, expected)
 
 
+def test_freeze_with_changed_option(script):
+    """
+    Test that pip only reports new/changed packages with the --changed option.
+
+    """
+    # First install something
+    script.scratch_path.join('initools-req.txt').write(textwrap.dedent("""\
+        INITools==0.2
+        """))
+    result = script.pip_install_local('-r', 'initools-req.txt')
+
+    # Now install something else and check that only that is reported
+    result = script.pip_install_local('pip-test-package')
+    result = script.pip('freeze', '--changed',
+                        '-r', 'initools-req.txt', expect_stderr=True)
+    expected = textwrap.dedent("""\
+        Script result: pip freeze --changed...
+        -- stdout: --------------------
+        ## The following requirements were added by pip freeze...
+        pip-test-package==0.1.1...
+        <BLANKLINE>""")
+    _check_output(result, expected)
+
+    # Check that upgraded packages are shown as changed
+    script.scratch_path.join('initools-req.txt').write(textwrap.dedent("""\
+        INITools==0.2
+        wsgiref==0.1.1
+        """))
+    result = script.pip_install_local('pip-test-package')
+    result = script.pip('freeze', '--changed',
+                        '-r', 'initools-req.txt', expect_stderr=True)
+    expected = textwrap.dedent("""\
+        Script result: pip freeze --changed...
+        -- stdout: --------------------
+        ## The following requirements were added by pip freeze...
+        pip-test-package==0.1.1...
+        <BLANKLINE>""")
+    _check_output(result, expected)
+
+
 def test_freeze_user(script, virtualenv):
     """
     Testing freeze with --user, first we have to install some stuff.


### PR DESCRIPTION
Fixes: #341

Rebased on to develop by @msabramo on 2015-03-12

This is a resurrection of https://github.com/pypa/pip/pull/378 by @ulope in 2011.

If we close this because we don't want the feature, we should also close #378.

```
[marca@marca-mac2 ~VIRTUAL_ENV]$ cat requirements.txt
ipython
requests
WebOb

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip freeze -r requirements.txt
ipython==3.0.0
requests==2.5.3
WebOb==1.4
## The following requirements were added by pip freeze:
blessings==1.6
bpython==0.14.1
curtsies==0.1.19
gnureadline==6.3.3
greenlet==0.4.5
Pygments==2.0.2
six==1.9.0

[marca@marca-mac2 ~VIRTUAL_ENV]$ pip freeze -r requirements.txt -c
## The following requirements were added by pip freeze:
blessings==1.6
bpython==0.14.1
curtsies==0.1.19
gnureadline==6.3.3
greenlet==0.4.5
Pygments==2.0.2
six==1.9.0
```