### PR TITLE
setup.cfg: Add --tb=short to pytest addopts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ignore pip/_vendor --ignore tests/tests_cache
+addopts = --ignore pip/_vendor --ignore tests/tests_cache --tb=short
 
 [wheel]
 universal=1


### PR DESCRIPTION
I find the default traceback format of pytest to be overly verbose and it's harder to look at test failures on Travis CI, because you have to scroll through a very long traceback to get the info you need.