### PR TITLE
Make get_dist handle egg_info_path w/ slash at end

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -989,7 +989,7 @@ exec(compile(
 
     def get_dist(self):
         """Return a pkg_resources.Distribution built from self.egg_info_path"""
-        egg_info = self.egg_info_path('')
+        egg_info = self.egg_info_path('').rstrip('/')
         base_dir = os.path.dirname(egg_info)
         metadata = pkg_resources.PathMetadata(base_dir, egg_info)
         dist_name = os.path.splitext(os.path.basename(egg_info))[0]

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -66,7 +66,7 @@ def test_nonexistent_extra_warns_user_no_wheel(script, data):
         'simple[nonexistent]', expect_stderr=True,
     )
     assert (
-        "Unknown 3.0 does not provide the extra 'nonexistent'"
+        "simple 3.0 does not provide the extra 'nonexistent'"
         in result.stdout
     )
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -136,6 +136,23 @@ class TestInstallRequirement(object):
         req = InstallRequirement.from_editable(url)
         assert req.link.url == url
 
+    def test_get_dist(self):
+        req = InstallRequirement.from_line('foo')
+        req.egg_info_path = Mock(return_value='/path/to/foo.egg-info')
+        dist = req.get_dist()
+        assert isinstance(dist, pkg_resources.Distribution)
+        assert dist.project_name == 'foo'
+        assert dist.location == '/path/to'
+
+    def test_get_dist_trailing_slash(self):
+        # Tests issue fixed by https://github.com/pypa/pip/pull/2530
+        req = InstallRequirement.from_line('foo')
+        req.egg_info_path = Mock(return_value='/path/to/foo.egg-info/')
+        dist = req.get_dist()
+        assert isinstance(dist, pkg_resources.Distribution)
+        assert dist.project_name == 'foo'
+        assert dist.location == '/path/to'
+
     def test_markers(self):
         for line in (
             # recommanded syntax


### PR DESCRIPTION
Without this, I was getting:

    $ pip install -U 'sentry[lol]'
    ...
      UnknownExtra: Unknown 7.4.1 has no such extra feature 'lol'

With this, I get:

    $ pip install -U 'sentry[lol]'
    ...
      UnknownExtra: sentry 7.4.1 has no such extra feature 'lol'

Mentioned in https://github.com/pypa/pip/pull/2142#issuecomment-78591467

Cc: @derwolfe, @dcramer