### PR TITLE
Disable sphinx's smartypants to fix -- being replaced with – in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,7 +148,7 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-html_use_smartypants = True
+html_use_smartypants = False
 
 # Custom sidebar templates, maps document names to template names.
 # html_sidebars = {}


### PR DESCRIPTION
This setting was replacing every single instance of `--` (which comes up a lot when describing arguments) with an en dash. See [this example](https://pip.pypa.io/en/latest/user_guide.html#installing-from-wheels):

>Pip prefers Wheels where they are available. To disable this, use the –no-use-wheel flag for pip install.

Grepping through the docs I saw no intentional use of this feature, so the only downside is that quotes will now all revert to `"` instead of the typographically correct `“` and `”` characters. I assume no one will miss those too much.