### PR TITLE
InstallRequirement.__repr__ show editable

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -198,7 +198,8 @@ class InstallRequirement(object):
         return s
 
     def __repr__(self):
-        return '<%s object: %s>' % (self.__class__.__name__, str(self))
+        return '<%s object: %s editable=%r>' % (
+            self.__class__.__name__, str(self), self.editable)
 
     @property
     def specifier(self):


### PR DESCRIPTION
This is handy to have when debugging with pdb.

```
(Pdb++) req_to_install
<InstallRequirement object: file:///Users/marca/dev/git-repos/pip editable=False>
```