### PR TITLE
Upgrade requests to 2.6.0.

### DIFF
--- a/pip/_vendor/requests/__init__.py
+++ b/pip/_vendor/requests/__init__.py
@@ -42,7 +42,7 @@ is at <http://python-requests.org>.
 """
 
 __title__ = 'requests'
-__version__ = '2.5.3'
+__version__ = '2.6.0'
 __build__ = 0x020503
 __author__ = 'Kenneth Reitz'
 __license__ = 'Apache 2.0'

--- a/pip/_vendor/requests/adapters.py
+++ b/pip/_vendor/requests/adapters.py
@@ -11,10 +11,10 @@ and maintain connections.
 import socket
 
 from .models import Response
-from .packages.urllib3 import Retry
 from .packages.urllib3.poolmanager import PoolManager, proxy_from_url
 from .packages.urllib3.response import HTTPResponse
 from .packages.urllib3.util import Timeout as TimeoutSauce
+from .packages.urllib3.util.retry import Retry
 from .compat import urlparse, basestring
 from .utils import (DEFAULT_CA_BUNDLE_PATH, get_encoding_from_headers,
                     prepend_scheme_if_needed, get_auth_from_url, urldefragauth)

--- a/pip/_vendor/requests/api.py
+++ b/pip/_vendor/requests/api.py
@@ -16,7 +16,6 @@ from . import sessions
 
 def request(method, url, **kwargs):
     """Constructs and sends a :class:`Request <Request>`.
-    Returns :class:`Response <Response>` object.
 
     :param method: method for the new :class:`Request` object.
     :param url: URL for the new :class:`Request` object.
@@ -37,6 +36,8 @@ def request(method, url, **kwargs):
     :param verify: (optional) if ``True``, the SSL cert will be verified. A CA_BUNDLE path can also be provided.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
     :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
 
     Usage::
 
@@ -55,10 +56,12 @@ def request(method, url, **kwargs):
 
 
 def get(url, **kwargs):
-    """Sends a GET request. Returns :class:`Response` object.
+    """Sends a GET request.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
     """
 
     kwargs.setdefault('allow_redirects', True)
@@ -66,10 +69,12 @@ def get(url, **kwargs):
 
 
 def options(url, **kwargs):
-    """Sends a OPTIONS request. Returns :class:`Response` object.
+    """Sends a OPTIONS request.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
     """
 
     kwargs.setdefault('allow_redirects', True)
@@ -77,10 +82,12 @@ def options(url, **kwargs):
 
 
 def head(url, **kwargs):
-    """Sends a HEAD request. Returns :class:`Response` object.
+    """Sends a HEAD request.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
     """
 
     kwargs.setdefault('allow_redirects', False)
@@ -88,44 +95,52 @@ def head(url, **kwargs):
 
 
 def post(url, data=None, json=None, **kwargs):
-    """Sends a POST request. Returns :class:`Response` object.
+    """Sends a POST request.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, bytes, or file-like object to send in the body of the :class:`Request`.
     :param json: (optional) json data to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
     """
 
     return request('post', url, data=data, json=json, **kwargs)
 
 
 def put(url, data=None, **kwargs):
-    """Sends a PUT request. Returns :class:`Response` object.
+    """Sends a PUT request.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, bytes, or file-like object to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
     """
 
     return request('put', url, data=data, **kwargs)
 
 
 def patch(url, data=None, **kwargs):
-    """Sends a PATCH request. Returns :class:`Response` object.
+    """Sends a PATCH request.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, bytes, or file-like object to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
     """
 
     return request('patch', url,  data=data, **kwargs)
 
 
 def delete(url, **kwargs):
-    """Sends a DELETE request. Returns :class:`Response` object.
+    """Sends a DELETE request.
 
     :param url: URL for the new :class:`Request` object.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
+    :return: :class:`Response <Response>` object
+    :rtype: requests.Response
     """
 
     return request('delete', url, **kwargs)

--- a/pip/_vendor/requests/models.py
+++ b/pip/_vendor/requests/models.py
@@ -143,12 +143,13 @@ class RequestEncodingMixin(object):
             else:
                 fn = guess_filename(v) or k
                 fp = v
-            if isinstance(fp, str):
-                fp = StringIO(fp)
-            if isinstance(fp, bytes):
-                fp = BytesIO(fp)
 
-            rf = RequestField(name=k, data=fp.read(),
+            if isinstance(fp, (str, bytes, bytearray)):
+                fdata = fp
+            else:
+                fdata = fp.read()
+
+            rf = RequestField(name=k, data=fdata,
                               filename=fn, headers=fh)
             rf.make_multipart(content_type=ft)
             new_fields.append(rf)
@@ -688,6 +689,8 @@ class Response(object):
         """Iterates over the response data, one line at a time.  When
         stream=True is set on the request, this avoids reading the
         content at once into memory for large responses.
+
+        .. note:: This method is not reentrant safe.
         """
 
         pending = None

--- a/pip/_vendor/requests/packages/__init__.py
+++ b/pip/_vendor/requests/packages/__init__.py
@@ -27,9 +27,13 @@ import sys
 
 class VendorAlias(object):
 
-    def __init__(self):
+    def __init__(self, package_names):
+        self._package_names = package_names
         self._vendor_name = __name__
         self._vendor_pkg = self._vendor_name + "."
+        self._vendor_pkgs = [
+            self._vendor_pkg + name for name in self._package_names
+        ]
 
     def find_module(self, fullname, path=None):
         if fullname.startswith(self._vendor_pkg):
@@ -41,6 +45,14 @@ class VendorAlias(object):
             raise ImportError(
                 "Cannot import %s, must be a subpackage of '%s'." % (
                     name, self._vendor_name,
+                )
+            )
+
+        if not (name == self._vendor_name or
+                any(name.startswith(pkg) for pkg in self._vendor_pkgs)):
+            raise ImportError(
+                "Cannot import %s, must be one of %s." % (
+                    name, self._vendor_pkgs
                 )
             )
 
@@ -92,4 +104,4 @@ class VendorAlias(object):
         return module
 
 
-sys.meta_path.append(VendorAlias())
+sys.meta_path.append(VendorAlias(["urllib3", "chardet"]))

--- a/pip/_vendor/requests/packages/urllib3/__init__.py
+++ b/pip/_vendor/requests/packages/urllib3/__init__.py
@@ -4,7 +4,7 @@ urllib3 - Thread-safe connection pooling and re-using.
 
 __author__ = 'Andrey Petrov (andrey.petrov@shazow.net)'
 __license__ = 'MIT'
-__version__ = 'dev'
+__version__ = '1.10.2'
 
 
 from .connectionpool import (

--- a/pip/_vendor/requests/packages/urllib3/exceptions.py
+++ b/pip/_vendor/requests/packages/urllib3/exceptions.py
@@ -157,3 +157,8 @@ class InsecureRequestWarning(SecurityWarning):
 class SystemTimeWarning(SecurityWarning):
     "Warned when system time is suspected to be wrong"
     pass
+
+
+class InsecurePlatformWarning(SecurityWarning):
+    "Warned when certain SSL configuration is not available on a platform."
+    pass

--- a/pip/_vendor/requests/packages/urllib3/util/ssl_.py
+++ b/pip/_vendor/requests/packages/urllib3/util/ssl_.py
@@ -1,7 +1,7 @@
 from binascii import hexlify, unhexlify
 from hashlib import md5, sha1, sha256
 
-from ..exceptions import SSLError
+from ..exceptions import SSLError, InsecurePlatformWarning
 
 
 SSLContext = None
@@ -10,6 +10,7 @@ create_default_context = None
 
 import errno
 import ssl
+import warnings
 
 try:  # Test for SSL features
     from ssl import wrap_socket, CERT_NONE, PROTOCOL_SSLv23
@@ -69,6 +70,14 @@ except ImportError:
             self.ciphers = cipher_suite
 
         def wrap_socket(self, socket, server_hostname=None):
+            warnings.warn(
+                'A true SSLContext object is not available. This prevents '
+                'urllib3 from configuring SSL appropriately and may cause '
+                'certain SSL connections to fail. For more information, see '
+                'https://urllib3.readthedocs.org/en/latest/security.html'
+                '#insecureplatformwarning.',
+                InsecurePlatformWarning
+            )
             kwargs = {
                 'keyfile': self.keyfile,
                 'certfile': self.certfile,

--- a/pip/_vendor/requests/sessions.py
+++ b/pip/_vendor/requests/sessions.py
@@ -171,7 +171,10 @@ class SessionRedirectMixin(object):
             except KeyError:
                 pass
 
-            extract_cookies_to_jar(prepared_request._cookies, prepared_request, resp.raw)
+            # Extract any cookies sent on the response to the cookiejar
+            # in the new request. Because we've mutated our copied prepared
+            # request, use the old one that we haven't yet touched.
+            extract_cookies_to_jar(prepared_request._cookies, req, resp.raw)
             prepared_request._cookies.update(self.cookies)
             prepared_request.prepare_cookies(prepared_request._cookies)
 

--- a/pip/_vendor/vendor.txt
+++ b/pip/_vendor/vendor.txt
@@ -2,7 +2,7 @@ distlib==0.2.0
 html5lib==0.999  # See: https://github.com/html5lib/html5lib-python/issues/161
 six==1.9.0
 colorama==0.3.3
-requests==2.5.3
+requests==2.6.0
 CacheControl==0.11.1
 lockfile==0.10.2
 progress==1.2

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -32,9 +32,15 @@ def test_pip_second_command_line_interface_works(script):
     """
     Check if ``pip<PYVERSION>`` commands behaves equally
     """
+    # On old versions of Python, urllib3/requests will raise a warning about
+    # the lack of an SSLContext.
+    kwargs = {}
+    if pyversion < (2, 7, 9):
+        kwargs['expect_stderr'] = True
+
     args = ['pip%s' % pyversion]
     args.extend(['install', 'INITools==0.2'])
-    result = script.run(*args)
+    result = script.run(*args, **kwargs)
     egg_info_folder = (
         script.site_packages / 'INITools-0.2-py%s.egg-info' % pyversion
     )

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -8,7 +8,7 @@ from os.path import join, curdir, pardir
 import pytest
 
 from pip.utils import rmtree
-from tests.lib import pyversion
+from tests.lib import pyversion, pyversion_tuple
 from tests.lib.local_repos import local_checkout
 from tests.lib.path import Path
 
@@ -35,7 +35,7 @@ def test_pip_second_command_line_interface_works(script):
     # On old versions of Python, urllib3/requests will raise a warning about
     # the lack of an SSLContext.
     kwargs = {}
-    if pyversion < (2, 7, 9):
+    if pyversion_tuple < (2, 7, 9):
         kwargs['expect_stderr'] = True
 
     args = ['pip%s' % pyversion]

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -324,6 +324,12 @@ class PipTestEnvironment(scripttest.TestFileEnvironment):
         )
 
     def pip(self, *args, **kwargs):
+        # On old versions of Python, urllib3/requests will raise a warning
+        # about the lack of an SSLContext. Expect it when running commands
+        # that will touch the outside world.
+        if pyversion < (2, 7, 9) and args and args[0] in ('search', 'install'):
+            kwargs['expect_stderr'] = True
+
         return self.run("pip", *args, **kwargs)
 
     def pip_install_local(self, *args, **kwargs):

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -15,6 +15,7 @@ DATA_DIR = Path(__file__).folder.folder.join("data").abspath
 SRC_DIR = Path(__file__).abspath.folder.folder.folder
 
 pyversion = sys.version[:3]
+pyversion_tuple = sys.version_info
 
 
 def path_to_url(path):
@@ -327,7 +328,8 @@ class PipTestEnvironment(scripttest.TestFileEnvironment):
         # On old versions of Python, urllib3/requests will raise a warning
         # about the lack of an SSLContext. Expect it when running commands
         # that will touch the outside world.
-        if pyversion < (2, 7, 9) and args and args[0] in ('search', 'install'):
+        if (pyversion_tuple < (2, 7, 9) and
+                args and args[0] in ('search', 'install')):
             kwargs['expect_stderr'] = True
 
         return self.run("pip", *args, **kwargs)


### PR DESCRIPTION
requests 2.6.0 contains a number of bug fixes, but most importantly contains a fix for CVE-2015-2296, a regression that allows cookie leaking or session fixation in certain circumstances.

In the event that this is too extensive a change for rapid release, it should be trivial to backport just the fix for CVE-2015-2296, which can be found in [this commit](https://github.com/kennethreitz/requests/commit/3bd8afbff29e50b38f889b2f688785a669b9aafc).

Also brings urllib3 to 43b5b2b452e4344374de7d08ececcca495079b8d.