### PR TITLE
Revert "Revert "#2414: parse SSH repositories url with a commit hash""

### DIFF
--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -144,9 +144,17 @@ class VersionControl(object):
         url = self.url.split('+', 1)[1]
         scheme, netloc, path, query, frag = urllib_parse.urlsplit(url)
         rev = None
-        if '@' in path:
-            path, rev = path.rsplit('@', 1)
-        url = urllib_parse.urlunsplit((scheme, netloc, path, query, ''))
+        if scheme == 'ssh' and not path:  # Fix urllib_parse parsing
+            url_splitted = url.split('@')
+            if len(url_splitted) == 3:
+                url = '%s@%s' % (url_splitted[0], url_splitted[1])
+                rev = url_splitted[2].split('#')[0]
+            assert len(url_splitted) < 4,\
+                "You can't have more than two @ in VCS url."
+        else:
+            if '@' in path:
+                path, rev = path.rsplit('@', 1)
+            url = urllib_parse.urlunsplit((scheme, netloc, path, query, ''))
         return url, rev
 
     def get_info(self, location):

--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -195,6 +195,8 @@ class Git(VersionControl):
             url = url.replace('ssh://', '')
         else:
             url, rev = super(Git, self).get_url_rev()
+            # For explicit SSH URLs, remove 'ssh://' to clone
+            url = url.replace('ssh://', '')
 
         return url, rev
 

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -39,6 +39,40 @@ def test_git_get_src_requirements():
     ])
 
 
+def test_git_urls():
+    """
+    Test git url support.
+
+    SSH has special handling.
+    """
+    https_repo = Git(
+        url='git+https://github.com/Eyepea/pip.git'
+            '@8cf54fff31b650847e0cddc2cd2951c34e0b4822#egg=pip'
+    )
+    implicit_ssh_repo = Git(
+        url='git+git@github.com:Eyepea/pip.git'
+            '@8cf54fff31b650847e0cddc2cd2951c34e0b4822#egg=pip'
+    )
+
+    explicit_ssh_repo = Git(
+        url='git+ssh://git@github.com:Eyepea/pip.git'
+            '@8cf54fff31b650847e0cddc2cd2951c34e0b4822#egg=pip'
+    )
+
+    assert https_repo.get_url_rev() == (
+        'https://github.com/Eyepea/pip.git',
+        '8cf54fff31b650847e0cddc2cd2951c34e0b4822',
+    )
+    assert implicit_ssh_repo.get_url_rev() == (
+        'git@github.com:Eyepea/pip.git',
+        '8cf54fff31b650847e0cddc2cd2951c34e0b4822',
+    )
+    assert explicit_ssh_repo.get_url_rev() == (
+        'git@github.com:Eyepea/pip.git',
+        '8cf54fff31b650847e0cddc2cd2951c34e0b4822',
+    )
+
+
 def test_translate_egg_surname():
     vc = VersionControl()
     assert vc.translate_egg_surname("foo") == "foo"


### PR DESCRIPTION
Reverting the revert so we can look at it and see what broke.

From https://github.com/pypa/pip/pull/2547#issuecomment-81848695

> Here are snippets from tracebacks, sorry, I censored some things.
> 
> With `pip@HEAD`:
> 
> ```
>     File "/home/vagrant/workspace/hadoop-DEVELOP/.venv/lib/python2.6/site-packages/pip/utils/__init__.py", > line 728, in call_subprocess
>       % (command_desc, proc.returncode, cwd))
>   InstallationError: Command "git clone -q git@github.com/Me/MyPackage.git /tmp/pip-build-UXqGMZ/mypackage" failed with error code 128 in None
> ```
> 
> With `pip@6.0.8`:
> ```
> Collecting mypackage from git+ssh://git@github.com/Me/MyPackage.git#egg=mypackage
>   Cloning ssh://git@github.com/Me/MyPackage.git to /tmp/pip-build-o8EO3S/mypackage
> ```
> 
> Notice that the former (HEAD) lacks a scheme.
> 
> `git --version` is 1.7.1, and in fact does not support URLs like that without SSH scheme. (Trying quickly with my local git which is `2.3.2` shows that it doesn't like that either, so I suspect no versions actually work without the ssh there unless you use the `:` style thing, `git@github.com:Me/MyProject.git`, which works on 1.7.1 as well)