### PR TITLE
Don't follow symlinks when uninstalling files

### DIFF
--- a/pip/req/req_uninstall.py
+++ b/pip/req/req_uninstall.py
@@ -47,7 +47,7 @@ class UninstallPathSet(object):
         return True
 
     def add(self, path):
-        path = normalize_path(path)
+        path = os.path.normcase(os.path.expanduser(path))
         if not os.path.exists(path):
             return
         if self._permitted(path):

--- a/pip/req/req_uninstall.py
+++ b/pip/req/req_uninstall.py
@@ -47,7 +47,7 @@ class UninstallPathSet(object):
         return True
 
     def add(self, path):
-        path = os.path.normcase(os.path.expanduser(path))
+        path = normalize_path(path, resolve_symlinks=False)
         if not os.path.exists(path):
             return
         if self._permitted(path):

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -268,6 +268,8 @@ def normalize_path(path, resolve_symlinks=True):
     path = os.path.expanduser(path)
     if resolve_symlinks:
         path = os.path.realpath(path)
+    else:
+        path = os.path.abspath(path)
     return os.path.normcase(path)
 
 

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -260,12 +260,15 @@ def make_path_relative(path, rel_to):
     return os.path.sep.join(full_parts)
 
 
-def normalize_path(path):
+def normalize_path(path, resolve_symlinks=True):
     """
     Convert a path to its canonical, case-normalized, absolute version.
 
     """
-    return os.path.normcase(os.path.realpath(os.path.expanduser(path)))
+    path = os.path.expanduser(path)
+    if resolve_symlinks:
+        path = os.path.realpath(path)
+    return os.path.normcase(path)
 
 
 def splitext(path):

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+import sys
+import tempfile
+
+import pytest
+from mock import Mock
+
+from pip.locations import running_under_virtualenv
+from pip.req.req_uninstall import UninstallPathSet
+
+class TestUninstallPathSet(object):
+    def setup(self):
+        if running_under_virtualenv():
+            # Construct tempdir in sys.prefix, otherwise UninstallPathSet
+            # will reject paths.
+            self.tempdir = tempfile.mkdtemp(prefix=sys.prefix)
+        else:
+            self.tempdir = tempfile.mkdtemp()
+
+    def teardown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def test_add(self):
+        file_extant = os.path.join(self.tempdir, 'foo')
+        file_nonexistant = os.path.join(self.tempdir, 'nonexistant')
+        with open(file_extant, 'w'): pass
+
+        ups = UninstallPathSet(dist=Mock())
+        assert ups.paths == set()
+        ups.add(file_extant)
+        assert ups.paths == set([file_extant])
+
+        ups.add(file_nonexistant)
+        assert ups.paths == set([file_extant])
+
+    @pytest.mark.skipif("sys.platform == 'win32'")
+    def test_add_symlink(self):
+        f = os.path.join(self.tempdir, 'foo')
+        with open(f, 'w'): pass
+        l = os.path.join(self.tempdir, 'foo_link')
+        os.symlink(f, l)
+
+        ups = UninstallPathSet(dist=Mock())
+        ups.add(l)
+        assert ups.paths == set([l])

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -1,18 +1,17 @@
 import os
-import shutil
-import sys
-import tempfile
 
 import pytest
 from mock import Mock
 
-import pip.utils
+import pip.req.req_uninstall
 from pip.req.req_uninstall import UninstallPathSet
+
 
 # Pretend all files are local, so UninstallPathSet accepts files in the tmpdir,
 # outside the virtualenv
 def mock_is_local(path):
     return True
+
 
 class TestUninstallPathSet(object):
     def test_add(self, tmpdir, monkeypatch):

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -15,7 +15,7 @@ def mock_is_local(path):
 
 class TestUninstallPathSet(object):
     def test_add(self, tmpdir, monkeypatch):
-        monkeypatch.setattr(pip.utils, 'is_local', mock_is_local)
+        monkeypatch.setattr(pip.req.req_uninstall, 'is_local', mock_is_local)
         file_extant = os.path.join(tmpdir, 'foo')
         file_nonexistant = os.path.join(tmpdir, 'nonexistant')
         with open(file_extant, 'w'):
@@ -31,7 +31,7 @@ class TestUninstallPathSet(object):
 
     @pytest.mark.skipif("sys.platform == 'win32'")
     def test_add_symlink(self, tmpdir, monkeypatch):
-        monkeypatch.setattr(pip.utils, 'is_local', mock_is_local)
+        monkeypatch.setattr(pip.req.req_uninstall, 'is_local', mock_is_local)
         f = os.path.join(tmpdir, 'foo')
         with open(f, 'w'):
             pass

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -9,6 +9,7 @@ from mock import Mock
 from pip.locations import running_under_virtualenv
 from pip.req.req_uninstall import UninstallPathSet
 
+
 class TestUninstallPathSet(object):
     def setup(self):
         if running_under_virtualenv():
@@ -24,7 +25,8 @@ class TestUninstallPathSet(object):
     def test_add(self):
         file_extant = os.path.join(self.tempdir, 'foo')
         file_nonexistant = os.path.join(self.tempdir, 'nonexistant')
-        with open(file_extant, 'w'): pass
+        with open(file_extant, 'w'):
+            pass
 
         ups = UninstallPathSet(dist=Mock())
         assert ups.paths == set()
@@ -37,7 +39,8 @@ class TestUninstallPathSet(object):
     @pytest.mark.skipif("sys.platform == 'win32'")
     def test_add_symlink(self):
         f = os.path.join(self.tempdir, 'foo')
-        with open(f, 'w'): pass
+        with open(f, 'w'):
+            pass
         l = os.path.join(self.tempdir, 'foo_link')
         os.symlink(f, l)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -370,6 +370,7 @@ def test_rmtree_retries_for_3sec(tmpdir, monkeypatch):
     with pytest.raises(OSError):
         rmtree('foo')
 
+
 class Test_normalize_path(object):
     def setup(self):
         self.tempdir = tempfile.mkdtemp()
@@ -388,7 +389,8 @@ class Test_normalize_path(object):
         d = os.path.join('foo', 'bar')
         f = os.path.join(d, 'file1')
         os.makedirs(d)
-        with open(f, 'w'): pass  # Create the file
+        with open(f, 'w'):  # Create the file
+            pass
 
         os.symlink(d, 'dir_link')
         os.symlink(f, 'file_link')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -395,12 +395,16 @@ class Test_normalize_path(object):
         os.symlink(d, 'dir_link')
         os.symlink(f, 'file_link')
 
-        assert normalize_path('dir_link/file1', resolve_symlinks=True) \
-                == os.path.join(self.tempdir, f)
-        assert normalize_path('dir_link/file1', resolve_symlinks=False) \
-                == os.path.join(self.tempdir, 'dir_link', 'file1')
+        assert normalize_path(
+            'dir_link/file1', resolve_symlinks=True
+        ) == os.path.join(self.tempdir, f)
+        assert normalize_path(
+            'dir_link/file1', resolve_symlinks=False
+        ) == os.path.join(self.tempdir, 'dir_link', 'file1')
 
-        assert normalize_path('file_link', resolve_symlinks=True) \
-                == os.path.join(self.tempdir, f)
-        assert normalize_path('file_link', resolve_symlinks=False) \
-                == os.path.join(self.tempdir, 'file_link')
+        assert normalize_path(
+            'file_link', resolve_symlinks=True
+        ) == os.path.join(self.tempdir, f)
+        assert normalize_path(
+            'file_link', resolve_symlinks=False
+        ) == os.path.join(self.tempdir, 'file_link')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -372,39 +372,37 @@ def test_rmtree_retries_for_3sec(tmpdir, monkeypatch):
 
 
 class Test_normalize_path(object):
-    def setup(self):
-        self.tempdir = tempfile.mkdtemp()
-        self.orig_working_dir = os.getcwd()
-        os.chdir(self.tempdir)
-
-    def teardown(self):
-        os.chdir(self.orig_working_dir)
-        shutil.rmtree(self.tempdir, ignore_errors=True)
-
     # Technically, symlinks are possible on Windows, but you need a special
     # permission bit to create them, and Python 2 doesn't support it anyway, so
     # it's easiest just to skip this test on Windows altogether.
     @pytest.mark.skipif("sys.platform == 'win32'")
-    def test_resolve_symlinks(self):
-        d = os.path.join('foo', 'bar')
-        f = os.path.join(d, 'file1')
-        os.makedirs(d)
-        with open(f, 'w'):  # Create the file
-            pass
+    def test_resolve_symlinks(self, tmpdir):
+        print(type(tmpdir))
+        print(dir(tmpdir))
+        orig_working_dir = os.getcwd()
+        os.chdir(tmpdir)
+        try:
+            d = os.path.join('foo', 'bar')
+            f = os.path.join(d, 'file1')
+            os.makedirs(d)
+            with open(f, 'w'):  # Create the file
+                pass
 
-        os.symlink(d, 'dir_link')
-        os.symlink(f, 'file_link')
+            os.symlink(d, 'dir_link')
+            os.symlink(f, 'file_link')
 
-        assert normalize_path(
-            'dir_link/file1', resolve_symlinks=True
-        ) == os.path.join(self.tempdir, f)
-        assert normalize_path(
-            'dir_link/file1', resolve_symlinks=False
-        ) == os.path.join(self.tempdir, 'dir_link', 'file1')
+            assert normalize_path(
+                'dir_link/file1', resolve_symlinks=True
+            ) == os.path.join(tmpdir, f)
+            assert normalize_path(
+                'dir_link/file1', resolve_symlinks=False
+            ) == os.path.join(tmpdir, 'dir_link', 'file1')
 
-        assert normalize_path(
-            'file_link', resolve_symlinks=True
-        ) == os.path.join(self.tempdir, f)
-        assert normalize_path(
-            'file_link', resolve_symlinks=False
-        ) == os.path.join(self.tempdir, 'file_link')
+            assert normalize_path(
+                'file_link', resolve_symlinks=True
+            ) == os.path.join(tmpdir, f)
+            assert normalize_path(
+                'file_link', resolve_symlinks=False
+            ) == os.path.join(tmpdir, 'file_link')
+        finally:
+            os.chdir(orig_working_dir)


### PR DESCRIPTION
I'm developing a packaging tool that, among other things, symlinks things into site-packages for development installs (i.e. similar to `pip install -e`). When pip tries to uninstall those things, it erroneously removes the target of the symlink instead of the symlink itself. This has been tracked for some time as issue #40, and the comments on that issue seemed to agree that resolving the symlink when uninstalling was plain wrong.

I could have fixed this in `normalize_path()` itself, but it may be desirable in some other places to resolve the symlink, and in most cases it will at least not be harmful. Since that function is only one line, I opted to copy its contents, minus `realpath()`, to where it's used.

Fixes gh-40

Crosslink takluyver/flit#2.