### PR TITLE
pip/wheel clobber: Log file copies

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -212,6 +212,7 @@ def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
                 # directories) as well as to ensure that we are not copying
                 # over any metadata because we want more control over what
                 # metadata we actually copy over.
+                logger.debug('Copying %s to %s ...', srcfile, destfile)
                 shutil.copyfile(srcfile, destfile)
 
                 # Copy over the metadata for the file, currently this only


### PR DESCRIPTION
This is because I was looking at improving the speed of the tests and at one point this morning, I was seeing significant latency (a half second per file perhaps?) when this code was asked to copy the files for the setuptools wheel and it copied some largish Windows .exe files:

```
  Copying /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-UUQsAq/setuptools/setuptools/cli-32.exe to /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-343/test_freeze_basic0/workspace/venv/lib/python2.7/site-packages/setuptools/cli-32.exe ...
  Copying /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-UUQsAq/setuptools/setuptools/cli-64.exe to /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-343/test_freeze_basic0/workspace/venv/lib/python2.7/site-packages/setuptools/cli-64.exe ...
  Copying /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-UUQsAq/setuptools/setuptools/cli-arm-32.exe to /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-343/test_freeze_basic0/workspace/venv/lib/python2.7/site-packages/setuptools/cli-arm-32.exe ...
  Copying /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-UUQsAq/setuptools/setuptools/cli.exe to /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-343/test_freeze_basic0/workspace/venv/lib/python2.7/site-packages/setuptools/cli.exe ...
  Copying /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-UUQsAq/setuptools/setuptools/gui-32.exe to /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-343/test_freeze_basic0/workspace/venv/lib/python2.7/site-packages/setuptools/gui-32.exe ...
  Copying /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-UUQsAq/setuptools/setuptools/gui-64.exe to /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-343/test_freeze_basic0/workspace/venv/lib/python2.7/site-packages/setuptools/gui-64.exe ...
  Copying /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-UUQsAq/setuptools/setuptools/gui-arm-32.exe to /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-343/test_freeze_basic0/workspace/venv/lib/python2.7/site-packages/setuptools/gui-arm-32.exe ...
  Copying /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-UUQsAq/setuptools/setuptools/gui.exe to /private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-343/test_freeze_basic0/workspace/venv/lib/python2.7/site-packages/setuptools/gui.exe ...
```

For unknown reasons, these files copies are no longer super slow like they were before, but I thought adding the logging would be a good idea anyway.

I wouldn't have guessed that installing setuptools on a Mac OS X system would copy Windows `.exe` files - sort of an interesting discovery. Maybe we can rebuild the setuptools wheel to not include these...?