### PR TITLE
tests: install pip w/ --no-compile

### DIFF
--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -56,7 +56,7 @@ class VirtualEnvironment(object):
 
         # Install our development version of pip install the virtual
         # environment
-        cmd = [self.bin.join("python"), "setup.py", "install"]
+        cmd = [self.bin.join("python"), "setup.py", "install", "--no-compile"]
         p = subprocess.Popen(
             cmd,
             cwd=self.pip_source_dir,


### PR DESCRIPTION
For me, this speeds up `py.test tests/functional/test_freeze.py` from 62 seconds to 54 seconds (about a 13% speedup). It should theoretically speed up all functional tests. 