### PR TITLE
add wheel tag for py2-none-[arch] / py3-none-[arch]

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -113,6 +113,9 @@ def get_supported(versions=None, noarch=False):
             for arch in arches:
                 supported.append(('%s%s' % (impl, versions[0]), abi, arch))
 
+        # Major Python version + platform; e.g. binaries not using the Python API
+        supported.append(('py%s' % (versions[0][0]), 'none', arch))
+
     # No abi / arch, but requires our implementation:
     for i, version in enumerate(versions):
         supported.append(('%s%s' % (impl, version), 'none', 'any'))

--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -113,7 +113,7 @@ def get_supported(versions=None, noarch=False):
             for arch in arches:
                 supported.append(('%s%s' % (impl, versions[0]), abi, arch))
 
-        # Major Python version + platform; e.g. binaries not using the Python API
+        # Has binaries, does not use the Python API:
         supported.append(('py%s' % (versions[0][0]), 'none', arch))
 
     # No abi / arch, but requires our implementation:


### PR DESCRIPTION
To support platform-specific but not Python ABI specific wheels.