### PR TITLE
Better traceback on venv pip install fail

### DIFF
--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -65,10 +65,9 @@ class VirtualEnvironment(object):
         )
         p.communicate()
         if p.returncode != 0:
-            raise Exception(p.stderr)
             raise subprocess.CalledProcessError(
                 p.returncode,
-                cmd[0],
+                cmd,
                 output=p.stdout,
             )
 


### PR DESCRIPTION
Instead of:

    tests/conftest.py:146: in virtualenv
        pip_source_dir=pip_src,
    tests/lib/venv.py:45: in create
        obj._create(clear=clear)
    tests/lib/venv.py:68: in _create
        raise Exception(p.stderr)
    E   Exception: None

We get the more informative:

    tests/conftest.py:146: in virtualenv
        pip_source_dir=pip_src,
    tests/lib/venv.py:45: in create
        obj._create(clear=clear)
    tests/lib/venv.py:71: in _create
        output=p.stdout,
    E   CalledProcessError: Command '[Path(u'/private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pytest-675/test_freeze_basic0/workspace/venv/bin/python'), 'setup.py', 'installxx']' returned non-zero exit status 1

The two `raise`s are weird. I wonder if that was the result of a merge. Looks like @dstufft and @qwcode both touched that area in around Jan. of 2014.