### PR TITLE
Show # of locations to be searched in debug log

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -362,7 +362,8 @@ class PackageFinder(object):
         # We explicitly do not trust links that came from dependency_links
         locations.extend([Link(url) for url in _ulocations])
 
-        logger.debug('URLs to search for versions for %s:', req)
+        logger.debug('%d location(s) to search for versions of %s:',
+                     len(locations), req)
         for location in locations:
             logger.debug('* %s', location)
             self._validate_secure_origin(logger, location)


### PR DESCRIPTION
Because I saw this:

      URLs to search for versions for setuptools:
      Skipping link . (from -f); not a file
      Skipping link /Users/marca/dev/git-repos/virtualenv (from -f); not a file
      Skipping link /Users/marca/dev/git-repos/virtualenv/virtualenv_support (from -f); not a file

and I didn't know if there were no URLs to search or if the code was buggy and it was forgetting to list them (it turned out to be the former).

Now it looks like this, which is a little less confusing to me and perhaps other people delving into pip:

      0 location(s) to search for versions of setuptools:
      Skipping link . (from -f); not a file
      Skipping link /Users/marca/dev/git-repos/virtualenv (from -f); not a file
      Skipping link /Users/marca/dev/git-repos/virtualenv/virtualenv_support (from -f); not a file