### PR TITLE
Speed up _filter_install function

### DIFF
--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -14,7 +14,7 @@ from pip.download import PipSession
 from pip.index import PackageFinder
 from pip.req import (InstallRequirement, RequirementSet,
                      Requirements, parse_requirements)
-from pip.req.req_install import parse_editable
+from pip.req.req_install import parse_editable, _filter_install
 from pip.utils import read_text_file
 from pip._vendor import pkg_resources
 from tests.lib import assert_raises_regexp
@@ -439,3 +439,24 @@ def test_req_file_no_finder(tmpdir):
         """)
 
     parse_requirements(tmpdir.join("req.txt"), session=PipSession())
+
+
+def test_filter_install():
+    from logging import DEBUG, INFO
+
+    assert _filter_install('running setup.py install') == (
+        DEBUG, 'running setup.py install')
+    assert _filter_install('writing foo.bar') == (
+        DEBUG, 'writing foo.bar')
+    assert _filter_install('creating foo.bar') == (
+        DEBUG, 'creating foo.bar')
+    assert _filter_install('copying foo.bar') == (
+        DEBUG, 'copying foo.bar')
+    assert _filter_install('SyntaxError: blah blah') == (
+        DEBUG, 'SyntaxError: blah blah')
+    assert _filter_install('This should not be filtered') == (
+        INFO, 'This should not be filtered')
+    assert _filter_install('foo bar') == (
+        INFO, 'foo bar')
+    assert _filter_install('I made a SyntaxError') == (
+        INFO, 'I made a SyntaxError')


### PR DESCRIPTION
This speeds up the `_filter_install` function that is used to filter the output of `python setup.py install` when installing packages. It does this by using a single regex which is pre-compiled and thus avoiding a `for` loop over 15 different regexes.

Before:

    $ python
    Python 2.7.9 (v2.7.9:648dcafa7e5f, Dec 10 2014, 10:10:46)
    [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import timeit
    >>> timeit.timeit("""_filter_install("if we've already set distribute as a conflict to setuptools blah blah blah blah")""", setup='from pip.req.req_install import InstallRequirement; ir = InstallRequirement("foo", None, None); _filter_install = ir._filter_install')
    21.220640897750854

After:

    $ python
    Python 2.7.9 (v2.7.9:648dcafa7e5f, Dec 10 2014, 10:10:46)
    [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import timeit
    >>> timeit.timeit("""_filter_install("if we've already set distribute as a conflict to setuptools blah blah blah blah")""", setup='from pip.req.req_install import InstallRequirement; ir = InstallRequirement("foo", None, None); _filter_install = ir._filter_install')
    0.9454500675201416