### PR TITLE
tox.ini: Add "fast" matrix targets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
-envlist = docs, packaging, pep8, py3pep8, py26, py27, py32, py33, py34, pypy
+envlist = docs, packaging, pep8, py3pep8, {py26,py27,py32,py33,py34,pypy}-{fast,slow}
 
 [testenv]
 deps = -r{toxinidir}/dev-requirements.txt
-commands = py.test --timeout 300 []
-install_command = python -m pip install --pre {opts} {packages}
-
-[testenv:py26]
 install_command = pip install --pre {opts} {packages}
+commands =
+    slow: py.test --timeout 300 {posargs:tests/}
+    fast: py.test -k 'not network' --timeout 300 {posargs:tests/unit/}
 
 [testenv:docs]
 deps = sphinx


### PR DESCRIPTION
This creates faster test targets like #2499, but that one only created a single target called `py34fast` and this one creates a fast target for each Python version using tox's new generative envlist declarations and "factor" specific settings.

The nice thing about this is that if I have no/poor network access or I'm in a hurry and want just a quick sanity check, I can do:

    $ tox -e '{py26,py27,py32,py33,py34,pypy}-fast'
    ...
      py26-fast: commands succeeded
      py27-fast: commands succeeded
      py32-fast: commands succeeded
      py33-fast: commands succeeded
      py34-fast: commands succeeded
      pypy-fast: commands succeeded
      congratulations :)
    >>> elapsed time 1m42s

and get a result in under 2 minutes.

Tox docs for generative envlist declarations and "factor" specific settings: http://tox.readthedocs.org/en/latest/config.html#generating-environments-conditional-settings