### PR TITLE
Extract get_install_args from install

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -836,33 +836,10 @@ exec(compile(
 
         temp_location = tempfile.mkdtemp('-record', 'pip-')
         record_filename = os.path.join(temp_location, 'install-record.txt')
+        install_args = self.get_install_args(
+            global_options, record_filename, root)
+
         try:
-            install_args = [sys.executable]
-            install_args.append('-c')
-            install_args.append(
-                "import setuptools, tokenize;__file__=%r;"
-                "exec(compile(getattr(tokenize, 'open', open)(__file__).read()"
-                ".replace('\\r\\n', '\\n'), __file__, 'exec'))" % self.setup_py
-            )
-            install_args += list(global_options) + \
-                ['install', '--record', record_filename]
-
-            if not self.as_egg:
-                install_args += ['--single-version-externally-managed']
-
-            if root is not None:
-                install_args += ['--root', root]
-
-            if self.pycompile:
-                install_args += ["--compile"]
-            else:
-                install_args += ["--no-compile"]
-
-            if running_under_virtualenv():
-                py_ver_str = 'python' + sysconfig.get_python_version()
-                install_args += ['--install-headers',
-                                 os.path.join(sys.prefix, 'include', 'site',
-                                              py_ver_str, self.name)]
             logger.info('Running setup.py install for %s', self.name)
             with indent_log():
                 call_subprocess(
@@ -933,6 +910,36 @@ exec(compile(
         if self.source_dir is None:
             self.source_dir = self.build_location(parent_dir)
         return self.source_dir
+
+    def get_install_args(self, global_options, record_filename, root):
+        install_args = [sys.executable]
+        install_args.append('-c')
+        install_args.append(
+            "import setuptools, tokenize;__file__=%r;"
+            "exec(compile(getattr(tokenize, 'open', open)(__file__).read()"
+            ".replace('\\r\\n', '\\n'), __file__, 'exec'))" % self.setup_py
+        )
+        install_args += list(global_options) + \
+            ['install', '--record', record_filename]
+
+        if not self.as_egg:
+            install_args += ['--single-version-externally-managed']
+
+        if root is not None:
+            install_args += ['--root', root]
+
+        if self.pycompile:
+            install_args += ["--compile"]
+        else:
+            install_args += ["--no-compile"]
+
+        if running_under_virtualenv():
+            py_ver_str = 'python' + sysconfig.get_python_version()
+            install_args += ['--install-headers',
+                             os.path.join(sys.prefix, 'include', 'site',
+                                          py_ver_str, self.name)]
+
+        return install_args
 
     def remove_temporary_source(self):
         """Remove the source files from this requirement, if they are marked


### PR DESCRIPTION
in `InstallRequirement` class. `pip/req/req_install.py` has some big classes and methods and it would be nice to start making things more modular.

This is a drop in the bucket, but you have to start somewhere...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/2579)
<!-- Reviewable:end -->
