### PR TITLE
Move InstallationCandidate to pip.index

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -24,9 +24,9 @@ from pip.exceptions import (
 )
 from pip.download import url_to_path, path_to_url
 from pip.models import PyPI
+from pip.models.installationcandidate import InstallationCandidate
 from pip.wheel import Wheel, wheel_ext
 from pip.pep425tags import supported_tags, supported_tags_noarch, get_platform
-from pip.req.req_requirement import InstallationCandidate
 from pip._vendor import html5lib, requests, pkg_resources, six
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.requests.exceptions import SSLError

--- a/pip/models/installationcandidate.py
+++ b/pip/models/installationcandidate.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from pip._vendor.packaging.version import parse as parse_version
 
 
@@ -18,7 +20,6 @@ class InstallationCandidate(object):
         return hash(self._key)
 
     def __lt__(self, other):
-
         return self._compare(other, lambda s, o: s < o)
 
     def __le__(self, other):

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -25,6 +25,7 @@ from pip.download import is_url, url_to_path, path_to_url, is_archive_file
 from pip.exceptions import (
     InstallationError, UninstallationError, UnsupportedWheel,
 )
+from pip.index import Link
 from pip.locations import (
     bin_py, running_under_virtualenv, PIP_DELETE_MARKER_FILENAME, bin_user,
 )
@@ -94,8 +95,6 @@ class InstallRequirement(object):
     @classmethod
     def from_editable(cls, editable_req, comes_from=None, default_vcs=None,
                       isolated=False):
-        from pip.index import Link
-
         name, url, extras_override, editable_options = parse_editable(
             editable_req, default_vcs)
         if url.startswith('file:'):
@@ -119,8 +118,6 @@ class InstallRequirement(object):
         """Creates an InstallRequirement from a name, which might be a
         requirement, directory containing 'setup.py', filename, or URL.
         """
-        from pip.index import Link
-
         if is_url(name):
             marker_sep = '; '
         else:

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -5,13 +5,12 @@ import pip.pep425tags
 
 from pkg_resources import parse_version, Distribution
 from pip.req import InstallRequirement
-from pip.index import PackageFinder, Link
+from pip.index import PackageFinder, Link, InstallationCandidate
 from pip.exceptions import (
     BestVersionAlreadyInstalled, DistributionNotFound, InstallationError,
 )
 from pip.utils import Inf
 from pip.download import PipSession
-from pip.req.req_requirement import InstallationCandidate
 
 from mock import Mock, patch
 


### PR DESCRIPTION
because it's only used by `pip.index` and having it live inside `pip.req`, made `pip.index` depend on `pip.req`, thereby creating a circular dependency.

By moving `InstallationCandidate` from `pip.req.req_requirement` to `pip.index`, we can:

1. Delete the somewhat confusingly named `pip.req.req_requirement` altogether, as it only contained this one class.

2. Eliminate imports inside functions in `pip.req.req_install`, which were necessary because of the circular dependency, which is now gone.