### PR TITLE
Ignore DoctestTextfile when collecting

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from tests.lib.venv import VirtualEnvironment
 
 def pytest_collection_modifyitems(items):
     for item in items:
+        if not hasattr(item, 'module'):  # e.g.: DoctestTextfile
+            continue
         module_path = os.path.relpath(
             item.module.__file__,
             os.path.commonprefix([__file__, item.module.__file__]),


### PR DESCRIPTION
Prevents this error:

    $ tox -e py27 -- -m unit
    ...
    INTERNALERROR>   File "/Users/marca/dev/git-repos/pip/tests/conftest.py", line 16, in pytest_collection_modifyitems
    INTERNALERROR>     item.module.__file__,
    INTERNALERROR> AttributeError: 'DoctestTextfile' object has no attribute 'module'