### PR TITLE
Add RequirementSet.__repr__

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -141,6 +141,13 @@ class RequirementSet(object):
         reqs.sort(key=lambda req: req.name.lower())
         return ' '.join([str(req.req) for req in reqs])
 
+    def __repr__(self):
+        reqs = [req for req in self.requirements.values()]
+        reqs.sort(key=lambda req: req.name.lower())
+        reqs_str = ', '.join([str(req.req) for req in reqs])
+        return ('<%s object; %d requirement(s): %s>'
+                % (self.__class__.__name__, len(reqs), reqs_str))
+
     def add_requirement(self, install_req):
         if not install_req.match_markers():
             logger.debug("Ignore %s: markers %r don't match",


### PR DESCRIPTION
This is useful when exploring with pdb -- e.g.:

    (Pdb++) requirement_set
    <RequirementSet object; 17 requirement(s): coverage==3.7.1, dj-database-url==0.2.2, dj-static==0.0.5, Django==1.6.2, django-nose==1.2, django-toolbelt==0.0.1, flake8==2.1.0, gunicorn==18.0, mccabe==0.2.1, nose==1.3.0, pep8==1.4.6, psycopg2==2.5.2, pyflakes==0.7.3, selenium==2.39.0, South==0.8.4, static==0.4, wsgiref==0.1.2>