### PR TITLE
install: ignore stdlib pkgs like wsgiref

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import os
 
+from pip.compat import stdlib_pkgs
 from pip._vendor import pkg_resources
 from pip._vendor import requests
 
@@ -147,6 +148,13 @@ class RequirementSet(object):
                          install_req.name, install_req.markers)
             return
 
+        if install_req.name in stdlib_pkgs:
+            logger.warning(
+                'Skipping requirement: %s '
+                'because %s is a stdlib package',
+                install_req, install_req.name)
+            return
+
         name = install_req.name
         install_req.as_egg = self.as_egg
         install_req.use_user_site = self.use_user_site
@@ -214,6 +222,12 @@ class RequirementSet(object):
             list(self.unnamed_requirements), list(self.requirements.values()),
             discovered_reqs)
         for req_to_install in reqs:
+            if req_to_install.name in stdlib_pkgs:
+                logger.warning(
+                    'Skipping requirement: %s '
+                    'because %s is a stdlib package',
+                    req_to_install, req_to_install.name)
+                continue
             more_reqs = handler(req_to_install)
             if more_reqs:
                 discovered_reqs.extend(more_reqs)


### PR DESCRIPTION
in requirements files

This allows a `pip install -r requirements.txt` to succeed even if it was generated with an older version of pip that included stuff like `wsgiref==0.1.2` in it.

```
$ .tox/py34/bin/pip install -r requirements.txt
Skipping requirement: wsgiref==0.1.2 (from -r requirements.txt (line 17)) because wsgiref is a stdlib package
...
  Skipping requirement: wsgiref (from static==0.4->-r requirements.txt (line 16)) because wsgiref is a stdlib package
Skipping requirement: wsgiref (from static==0.4->-r requirements.txt (line 16)) because wsgiref is a stdlib package
Installing collected packages: nose, mccabe, gunicorn, flake8, django-toolbelt, django-nose, dj-static, dj-database-url, coverage, South, Django
...
```