### PR TITLE
Declarative setuptools dependencies.

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -633,6 +633,7 @@ exec(compile(
                     paths_to_remove.add(path)
                     paths_to_remove.add(path + '.py')
                     paths_to_remove.add(path + '.pyc')
+                    paths_to_remove.add(path + '.pyo')
 
         elif distutils_egg_info:
             raise UninstallationError(


### PR DESCRIPTION
This adds support per the discussion we had on distutils-sig for
declarative requirements in setup.cfg.
    
Supported are requires-setup (the problem to be solved). requires-dist
(defined by d2to1, and needed as a consequences of supporting setup
requirements, because we can't run egg_info during the
pre-installation phase to detect requires. Similarly extras are
supported, for the same reason.
    
Neither setup-requires nor extras are defined by d2to1, so we may want
to bikeshed a little over the syntax there, but the basic structure works.
