### PR TITLE
Simpler user agent

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -97,19 +97,9 @@ def user_agent():
     if sys.platform.startswith("darwin") and platform.mac_ver()[0]:
         data["distro"] = {"name": "OS X", "version": platform.mac_ver()[0]}
 
-    if platform.system():
-        data.setdefault("system", {})["name"] = platform.system()
-
-    if platform.release():
-        data.setdefault("system", {})["release"] = platform.release()
-
-    if platform.machine():
-        data["cpu"] = platform.machine()
-
-    return "{data[installer][name]}/{data[installer][version]} {json}".format(
-        data=data,
-        json=json.dumps(data, separators=(",", ":"), sort_keys=True),
-    )
+    user_agent = ' '.join(["{item[name]}/{item[version]}".format(item=data[key])
+                  for key in ("installer", "implementation", "distro")])
+    return user_agent
 
 
 class MultiDomainBasicAuth(AuthBase):


### PR DESCRIPTION
Instead of a big blob of JSON, emit info in a more concise and way that is more typical of other user agents so that log analyzers are less likely to choke on it. E.g.:

    (Pdb++) user_agent
    'pip/6.1.0.dev0 CPython/2.7.9 OS X/10.9.5'