### PR TITLE
Improve tests for remote requirements files

### DIFF
--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -106,6 +106,33 @@ def test_multiple_requirements_files(script, tmpdir):
     assert script.venv / 'src' / 'initools' in result.files_created
 
 
+@pytest.mark.network
+def test_remote_requirements_file_stuff(script):
+    """
+    Test installing from a simple remote requirements file
+    """
+    # this requirements file just contains a comment
+    url = ('https://raw.githubusercontent.com/pypa/pip/6.0.8/'
+           'dev-requirements.txt')
+    result = script.pip('install', '-r', url)
+    assert result.files_created[script.site_packages / 'pretend.py'].file
+    assert result.files_created[script.site_packages / '_pytest'].dir
+    assert result.files_created[script.site_packages / 'dateutil'].dir
+    assert result.files_created[script.site_packages / 'freezegun'].dir
+
+
+@pytest.mark.network
+def test_remote_requirements_file_empty(script):
+    """
+    Test installing from a remote requirements file with only a comment
+    """
+    # this requirements file just contains a comment
+    url = ('https://raw.githubusercontent.com/pypa/pip-test-package/master/'
+           'tests/req_just_comment.txt')
+    result = script.pip('install', '-r', url)
+    assert result.files_created == {}
+
+
 def test_respect_order_in_requirements_file(script, data):
     script.scratch_path.join("frameworks-req.txt").write(textwrap.dedent("""\
         parent

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -352,17 +352,20 @@ def test_parse_editable_local_extras(
     )
 
 
-@pytest.mark.network
-def test_remote_reqs_parse():
+@patch('pip.req.req_file.get_file_content')
+def test_remote_reqs_parse(get_file_content):
     """
     Test parsing a simple remote requirements file
     """
     # this requirements file just contains a comment
     # previously this has failed in py3: https://github.com/pypa/pip/issues/760
-    for req in parse_requirements(
-            'https://raw.githubusercontent.com/pypa/pip-test-package/master/'
-            'tests/req_just_comment.txt', session=PipSession()):
-        pass
+    get_file_content.return_value = ('requirements.txt', '# just a comment\n')
+    session = PipSession()
+    reqs = list(
+        parse_requirements(
+            'https://raw.githubusercontent.com/pypa/pip-test-package/'
+            'master/tests/req_just_comment.txt', session=session))
+    assert reqs == []
 
 
 def test_req_file_parse_no_use_wheel(data):


### PR DESCRIPTION
- Make the unit test not use the network by mocking.
- Add 2 functional tests to fully exercise without mocking.

The new functional tests are better tests I think than existing unit test, which used the network and didn't assert anything about the results.

Note that there before this PR there were only 4 unit tests using `@pytest.mark.network`:

```
$ ag pytest.mark.network tests/unit
tests/unit/test_req.py
355:@pytest.mark.network

tests/unit/test_finder.py
79:@pytest.mark.network
97:@pytest.mark.network
313:@pytest.mark.network
```

and this PR removes the `tests/unit/test_req.py` one so that there are only 3 remaining and all in a single file, `tests/unit/test_finder.py`.