### PR TITLE
Find all versions by project name

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -375,7 +375,7 @@ class PackageFinder(object):
         ))
 
         page_versions = []
-        for page in self._get_pages(locations, req):
+        for page in self._get_pages(locations, req.name):
             logger.debug('Analyzing links from page %s', page.url)
             with indent_log():
                 page_versions.extend(
@@ -561,13 +561,14 @@ class PackageFinder(object):
                 return base
         return None
 
-    def _get_pages(self, locations, req):
+    def _get_pages(self, locations, req_name):
         """
         Yields (page, page_url) from the given locations, skipping
         locations that have errors, and adding download/homepage links
         """
         all_locations = list(locations)
         seen = set()
+        normalized = normalize_name(req_name)
 
         while all_locations:
             location = all_locations.pop(0)
@@ -582,7 +583,6 @@ class PackageFinder(object):
             yield page
 
             for link in page.rel_links():
-                normalized = normalize_name(req.name).lower()
 
                 if (normalized not in self.allow_external and not
                         self.allow_all_external):

--- a/pip/index.py
+++ b/pip/index.py
@@ -291,7 +291,7 @@ class PackageFinder(object):
                 RemovedInPip7Warning,
             )
 
-    def _get_index_urls_locations(self, req_name):
+    def _get_index_urls_locations(self, project_name):
         """Returns the locations found via self.index_urls
 
         Checks the url_name on the main (first in the list) index and
@@ -299,7 +299,7 @@ class PackageFinder(object):
         """
 
         def mkurl_pypi_url(url):
-            loc = posixpath.join(url, req_url_name)
+            loc = posixpath.join(url, project_url_name)
             # For maximum compatibility with easy_install, ensure the path
             # ends in a trailing slash.  Although this isn't in the spec
             # (and PyPI can handle it without the slash) some other index
@@ -309,7 +309,7 @@ class PackageFinder(object):
                 loc = loc + '/'
             return loc
 
-        req_url_name = urllib_parse.quote(req_name.lower())
+        project_url_name = urllib_parse.quote(project_name.lower())
 
         if self.index_urls:
             # Check that we have the url_name correctly spelled:
@@ -325,16 +325,16 @@ class PackageFinder(object):
                 warnings.warn(
                     "Failed to find %r at %s. It is suggested to upgrade "
                     "your index to support normalized names as the name in "
-                    "/simple/{name}." % (req_name, main_index_url),
+                    "/simple/{name}." % (project_name, main_index_url),
                     RemovedInPip8Warning,
                 )
 
-                req_url_name = self._find_url_name(
+                project_url_name = self._find_url_name(
                     Link(self.index_urls[0], trusted=True),
-                    req_url_name,
-                ) or req_url_name
+                    project_url_name,
+                ) or project_url_name
 
-        if req_url_name is not None:
+        if project_url_name is not None:
             return [mkurl_pypi_url(url) for url in self.index_urls]
         return []
 
@@ -561,14 +561,14 @@ class PackageFinder(object):
                 return base
         return None
 
-    def _get_pages(self, locations, req_name):
+    def _get_pages(self, locations, project_name):
         """
         Yields (page, page_url) from the given locations, skipping
         locations that have errors, and adding download/homepage links
         """
         all_locations = list(locations)
         seen = set()
-        normalized = normalize_name(req_name)
+        normalized = normalize_name(project_name)
 
         while all_locations:
             location = all_locations.pop(0)

--- a/pip/index.py
+++ b/pip/index.py
@@ -291,7 +291,7 @@ class PackageFinder(object):
                 RemovedInPip7Warning,
             )
 
-    def _get_index_urls_locations(self, req):
+    def _get_index_urls_locations(self, req_name):
         """Returns the locations found via self.index_urls
 
         Checks the url_name on the main (first in the list) index and
@@ -299,7 +299,7 @@ class PackageFinder(object):
         """
 
         def mkurl_pypi_url(url):
-            loc = posixpath.join(url, url_name)
+            loc = posixpath.join(url, req_url_name)
             # For maximum compatibility with easy_install, ensure the path
             # ends in a trailing slash.  Although this isn't in the spec
             # (and PyPI can handle it without the slash) some other index
@@ -309,7 +309,7 @@ class PackageFinder(object):
                 loc = loc + '/'
             return loc
 
-        url_name = req.url_name
+        req_url_name = urllib_parse.quote(req_name.lower())
 
         if self.index_urls:
             # Check that we have the url_name correctly spelled:
@@ -325,16 +325,16 @@ class PackageFinder(object):
                 warnings.warn(
                     "Failed to find %r at %s. It is suggested to upgrade "
                     "your index to support normalized names as the name in "
-                    "/simple/{name}." % (req.name, main_index_url),
+                    "/simple/{name}." % (req_name, main_index_url),
                     RemovedInPip8Warning,
                 )
 
-                url_name = self._find_url_name(
+                req_url_name = self._find_url_name(
                     Link(self.index_urls[0], trusted=True),
-                    url_name,
-                ) or req.url_name
+                    req_url_name,
+                ) or req_url_name
 
-        if url_name is not None:
+        if req_url_name is not None:
             return [mkurl_pypi_url(url) for url in self.index_urls]
         return []
 
@@ -346,7 +346,7 @@ class PackageFinder(object):
 
         See _link_package_versions for details on which files are accepted
         """
-        index_locations = self._get_index_urls_locations(req)
+        index_locations = self._get_index_urls_locations(req.name)
         file_locations, url_locations = self._sort_locations(index_locations)
         fl_file_loc, fl_url_loc = self._sort_locations(self.find_links)
         file_locations.extend(fl_file_loc)

--- a/pip/index.py
+++ b/pip/index.py
@@ -320,7 +320,7 @@ class PackageFinder(object):
                 trusted=True,
             )
 
-            page = self._get_page(main_index_url, req)
+            page = self._get_page(main_index_url)
             if page is None and PyPI.netloc not in str(main_index_url):
                 warnings.warn(
                     "Failed to find %r at %s. It is suggested to upgrade "
@@ -547,7 +547,7 @@ class PackageFinder(object):
             # Vaguely part of the PyPI API... weird but true.
             # FIXME: bad to modify this?
             index_url.url += '/'
-        page = self._get_page(index_url, req)
+        page = self._get_page(index_url)
         if page is None:
             logger.critical('Cannot fetch index base URL %s', index_url)
             return
@@ -575,7 +575,7 @@ class PackageFinder(object):
                 continue
             seen.add(location)
 
-            page = self._get_page(location, req)
+            page = self._get_page(location)
             if page is None:
                 continue
 
@@ -785,7 +785,7 @@ class PackageFinder(object):
         else:
             return None
 
-    def _get_page(self, link, req):
+    def _get_page(self, link):
         return HTMLPage.get_page(link, session=self.session)
 
 

--- a/pip/index.py
+++ b/pip/index.py
@@ -331,7 +331,7 @@ class PackageFinder(object):
 
                 url_name = self._find_url_name(
                     Link(self.index_urls[0], trusted=True),
-                    url_name, req
+                    url_name,
                 ) or req.url_name
 
         if url_name is not None:
@@ -537,7 +537,7 @@ class PackageFinder(object):
 
         return selected_version
 
-    def _find_url_name(self, index_url, url_name, req):
+    def _find_url_name(self, index_url, url_name):
         """
         Finds the true URL name of a package, when the given name isn't quite
         correct.
@@ -551,7 +551,7 @@ class PackageFinder(object):
         if page is None:
             logger.critical('Cannot fetch index base URL %s', index_url)
             return
-        norm_name = normalize_name(req.url_name)
+        norm_name = normalize_name(url_name)
         for link in page.links:
             base = posixpath.basename(link.path.rstrip('/'))
             if norm_name == normalize_name(base):

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -16,7 +16,6 @@ from email.parser import FeedParser
 from pip._vendor import pkg_resources, six
 from pip._vendor.distlib.markers import interpret as markers_interpret
 from pip._vendor.six.moves import configparser
-from pip._vendor.six.moves.urllib import parse as urllib_parse
 
 import pip.wheel
 
@@ -316,12 +315,6 @@ class InstallRequirement(object):
         if self.req is None:
             return None
         return native_str(self.req.project_name)
-
-    @property
-    def url_name(self):
-        if self.req is None:
-            return None
-        return urllib_parse.quote(self.req.project_name.lower())
 
     @property
     def setup_py(self):

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -283,7 +283,7 @@ def test_finder_priority_file_over_page(data):
         ["http://pypi.python.org/simple"],
         session=PipSession(),
     )
-    all_versions = finder._find_all_versions(req)
+    all_versions = finder._find_all_versions(req.name)
     # 1 file InstallationCandidate followed by all https ones
     assert all_versions[0].location.scheme == 'file'
     assert all(version.location.scheme == 'https'
@@ -324,7 +324,7 @@ def test_finder_priority_page_over_deplink():
     )
     finder.add_dependency_links([
         'https://warehouse.python.org/packages/source/p/pip/pip-1.5.6.tar.gz'])
-    all_versions = finder._find_all_versions(req)
+    all_versions = finder._find_all_versions(req.name)
     # Check that the dependency_link is last
     assert all_versions[-1].location.url.startswith('https://warehouse')
     link = finder.find_requirement(req, False)
@@ -339,7 +339,7 @@ def test_finder_priority_nonegg_over_eggfragments():
     finder = PackageFinder(links, [], session=PipSession())
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
-        all_versions = finder._find_all_versions(req)
+        all_versions = finder._find_all_versions(req.name)
         assert all_versions[0].location.url.endswith('tar.gz')
         assert all_versions[1].location.url.endswith('#egg=bar-1.0')
 
@@ -351,7 +351,7 @@ def test_finder_priority_nonegg_over_eggfragments():
     finder = PackageFinder(links, [], session=PipSession())
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
-        all_versions = finder._find_all_versions(req)
+        all_versions = finder._find_all_versions(req.name)
         assert all_versions[0].location.url.endswith('tar.gz')
         assert all_versions[1].location.url.endswith('#egg=bar-1.0')
         link = finder.find_requirement(req, False)
@@ -745,29 +745,26 @@ def test_get_index_urls_locations():
 def test_find_all_versions_nothing(data):
     """Find nothing without anything"""
     finder = PackageFinder([], [], session=PipSession())
-    assert not finder._find_all_versions(InstallRequirement.from_line('pip'))
+    assert not finder._find_all_versions('pip')
 
 
 def test_find_all_versions_find_links(data):
     finder = PackageFinder(
         [data.find_links], [], session=PipSession())
-    versions = finder._find_all_versions(
-        InstallRequirement.from_line('simple'))
+    versions = finder._find_all_versions('simple')
     assert [str(v.version) for v in versions] == ['3.0', '2.0', '1.0']
 
 
 def test_find_all_versions_index(data):
     finder = PackageFinder(
         [], [data.index_url('simple')], session=PipSession())
-    versions = finder._find_all_versions(
-        InstallRequirement.from_line('simple'))
+    versions = finder._find_all_versions('simple')
     assert [str(v.version) for v in versions] == ['1.0']
 
 
 def test_find_all_versions_find_links_and_index(data):
     finder = PackageFinder(
         [data.find_links], [data.index_url('simple')], session=PipSession())
-    versions = finder._find_all_versions(
-        InstallRequirement.from_line('simple'))
+    versions = finder._find_all_versions('simple')
     # first the find-links versions then the page versions
     assert [str(v.version) for v in versions] == ['3.0', '2.0', '1.0', '1.0']

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -737,7 +737,7 @@ def test_get_index_urls_locations():
     finder = PackageFinder(
         [], ['file://index1/', 'file://index2'], session=PipSession())
     locations = finder._get_index_urls_locations(
-        InstallRequirement.from_line('Complex_Name'))
+        InstallRequirement.from_line('Complex_Name').name)
     assert locations == ['file://index1/complex-name/',
                          'file://index2/complex-name/']
 


### PR DESCRIPTION
This clears up a little what the finder does.

All we lose is the "Will skip URL %s when looking for download links for %s" log (but we still have "Could not fetch URL %s: %s - skipping" which should be enough).

This was suggested by @qwcode in #2505.