### PR TITLE
pip_install.rst: Fix backslashes in Windows path

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -298,7 +298,7 @@ Unix
 OS X
   :file:`~/Library/Caches/pip`.
 Windows
-  :file:`<CSIDL_LOCAL_APPDATA>\pip\Cache`
+  :file:`<CSIDL_LOCAL_APPDATA>\\pip\\Cache`
 
 
 Hash Verification


### PR DESCRIPTION
From PR #2564.