### PR TITLE
Rationalise wheel_dir usage.

### DIFF
--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -9,7 +9,7 @@ from pip.basecommand import RequirementCommand
 from pip.index import PackageFinder
 from pip.exceptions import CommandError, PreviousBuildDirError
 from pip.req import RequirementSet
-from pip.utils import import_or_raise, ensure_dir, normalize_path
+from pip.utils import import_or_raise, normalize_path
 from pip.utils.build import BuildDirectory
 from pip.utils.deprecation import RemovedInPip8Warning
 from pip.wheel import WheelBuilder
@@ -168,10 +168,6 @@ class WheelCommand(RequirementCommand):
                     wheel_download_dir=options.wheel_dir
                 )
 
-                # make the wheelhouse
-                options.wheel_dir = normalize_path(options.wheel_dir)
-                ensure_dir(options.wheel_dir)
-
                 self.populate_requirement_set(
                     requirement_set, args, options, finder, session, self.name,
                 )
@@ -184,7 +180,6 @@ class WheelCommand(RequirementCommand):
                     wb = WheelBuilder(
                         requirement_set,
                         finder,
-                        options.wheel_dir,
                         build_options=options.build_options or [],
                         global_options=options.global_options or [],
                     )

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -13,7 +13,8 @@ from pip.download import (url_to_path, unpack_url)
 from pip.exceptions import (InstallationError, BestVersionAlreadyInstalled,
                             DistributionNotFound, PreviousBuildDirError)
 from pip.req.req_install import InstallRequirement
-from pip.utils import display_path, dist_in_usersite, normalize_path
+from pip.utils import (
+    display_path, dist_in_usersite, ensure_dir, normalize_path)
 from pip.utils.logging import indent_log
 from pip.vcs import vcs
 
@@ -294,6 +295,10 @@ class RequirementSet(object):
         """
         Prepare process. Create temp directories, download and/or unpack files.
         """
+        # make the wheelhouse
+        if self.wheel_download_dir:
+            ensure_dir(self.wheel_download_dir)
+
         self._walk_req_to_install(
             functools.partial(self._prepare_file, finder))
 

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -24,9 +24,7 @@ from pip.exceptions import InvalidWheelFilename, UnsupportedWheel
 from pip.locations import distutils_scheme
 from pip import pep425tags
 from pip.utils import (
-    call_subprocess, ensure_dir, normalize_path, make_path_relative,
-    captured_stdout,
-)
+    call_subprocess, ensure_dir, make_path_relative, captured_stdout)
 from pip.utils.logging import indent_log
 from pip._vendor.distlib.scripts import ScriptMaker
 from pip._vendor import pkg_resources
@@ -543,11 +541,11 @@ class Wheel(object):
 class WheelBuilder(object):
     """Build wheels from a RequirementSet."""
 
-    def __init__(self, requirement_set, finder, wheel_dir, build_options=None,
+    def __init__(self, requirement_set, finder, build_options=None,
                  global_options=None):
         self.requirement_set = requirement_set
         self.finder = finder
-        self.wheel_dir = normalize_path(wheel_dir)
+        self.wheel_dir = requirement_set.wheel_download_dir
         self.build_options = build_options or []
         self.global_options = global_options or []
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -374,8 +374,9 @@ class TestWheelBuilder(object):
     def test_skip_building_wheels(self, caplog):
         with patch('pip.wheel.WheelBuilder._build_one') as mock_build_one:
             wheel_req = Mock(is_wheel=True, editable=False)
-            reqset = Mock(requirements=Mock(values=lambda: [wheel_req]))
-            wb = wheel.WheelBuilder(reqset, Mock(), '/wheel/dir')
+            reqset = Mock(requirements=Mock(values=lambda: [wheel_req]),
+                          wheel_download_dir='/wheel/dir')
+            wb = wheel.WheelBuilder(reqset, Mock())
             wb.build()
             assert "due to already being wheel" in caplog.text()
             assert mock_build_one.mock_calls == []
@@ -383,8 +384,9 @@ class TestWheelBuilder(object):
     def test_skip_building_editables(self, caplog):
         with patch('pip.wheel.WheelBuilder._build_one') as mock_build_one:
             editable_req = Mock(editable=True, is_wheel=False)
-            reqset = Mock(requirements=Mock(values=lambda: [editable_req]))
-            wb = wheel.WheelBuilder(reqset, Mock(), '/wheel/dir')
+            reqset = Mock(requirements=Mock(values=lambda: [editable_req]),
+                          wheel_download_dir='/wheel/dir')
+            wb = wheel.WheelBuilder(reqset, Mock())
             wb.build()
             assert "due to being editable" in caplog.text()
             assert mock_build_one.mock_calls == []


### PR DESCRIPTION
We we normalising it right before making it, after passing it
RequirementSet, which means RequirementSet also had to normalise it.

And then we passed it to WheelBuilder which as a result had to
normalise it too.

Instead, pass it as-is to RequirementSet, have that normalise it, and
then pull it back out in WheelBuilder.