### PR TITLE
.travis.yml: travis_retry .travis/install.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   - TOXENV=py27 VENDOR=no WHEELS=yes
   - TOXENV=py34 VENDOR=no WHEELS=yes
 
-install: .travis/install.sh
+install: travis_retry .travis/install.sh
 
 script: .travis/run.sh
 


### PR DESCRIPTION
so we will retry if an install fails because of a networking blip, like for instance this one with setuptools:

https://travis-ci.org/pypa/pip/jobs/58362989

I had an earlier PR that did retry on the tests, but that's a bad idea because if the tests legitimately fail they will get run repeatedly.

I think `install` is generally expected to succeed and if it fails, it is most likely a transient problem.