### PR TITLE
Fix to work with relative paths, too

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -382,7 +382,7 @@ class InstallRequirement(object):
                 rmtree(os.path.join(self.source_dir, 'distribute.egg-info'))
 
             script = self._run_setup_py
-            script = script.replace('__SETUP_PY__', repr(self.setup_py))
+            script = script.replace('__SETUP_PY__', repr(os.path.abspath(self.setup_py)))
             script = script.replace('__PKG_NAME__', repr(self.name))
             base_cmd = [sys.executable, '-c', script]
             if self.isolated:


### PR DESCRIPTION
Replacing this placeholder with just the `setup_py` path (which is derived from the `source_dir` value), this breaks when the `source_dir` is a relative path, since this script is executed with `cwd` set to `source_dir`.

Example:

- `source_dir = './my-src'`
- `setup_py = './my-src/setup.py'`
- Then this script is run with cwd set to `'./my-src'`, trying to run `./my-src/setup.py`, which breaks.

By making this path absolute, the cwd will still be switched, but the absolute path `/abs/path/to/my-src/setup.py` will be run instead, succeeding again.
