### PR TITLE
Issue 2675

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,6 +25,9 @@
 * Build Wheels prior to installing from sdist, caching them in the pip cache
   directory to speed up subsequent installs. (:pull:`2618`)
 
+* Allow fine grained control over the use of wheels and source builds.
+  (:pull:`2699`)
+
 **6.1.1 (2015-04-07)**
 
 * No longer ignore dependencies which have been added to the standard library,

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -112,7 +112,8 @@ Additionally, the following Package Index Options are supported:
   *  :ref:`--allow-external <--allow-external>`
   *  :ref:`--allow-all-external <--allow-external>`
   *  :ref:`--allow-unverified <--allow-unverified>`
-  *  :ref:`--no-use-wheel <install_--no-use-wheel>`
+  *  :ref:`--no-binary <install_--no-binary>`
+  *  :ref:`--only-binary <install_--only-binary>`
 
 For example, to specify :ref:`--no-index <--no-index>` and 2 :ref:`--find-links <--find-links>` locations:
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -123,7 +123,7 @@ to building and installing from source archives. For more information, see the
 `PEP425 <http://www.python.org/dev/peps/pep-0425>`_
 
 Pip prefers Wheels where they are available. To disable this, use the
-:ref:`--no-use-wheel <install_--no-use-wheel>` flag for :ref:`pip install`.
+:ref:`--no-binary <install_--no-binary>` flag for :ref:`pip install`.
 
 If no satisfactory wheels are found, pip will default to finding source archives.
 

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import sys
 
+import pip
 from pip.basecommand import Command
 from pip.operations.freeze import freeze
 from pip.wheel import WheelCache
@@ -55,7 +56,8 @@ class FreezeCommand(Command):
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
-        wheel_cache = WheelCache(options.cache_dir)
+        format_control = pip.index.FormatControl(set(), set())
+        wheel_cache = WheelCache(options.cache_dir, format_control)
         freeze_kwargs = dict(
             requirement=options.requirement,
             find_links=options.find_links,

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -153,6 +153,8 @@ class InstallCommand(RequirementCommand):
 
         cmd_opts.add_option(cmdoptions.use_wheel())
         cmd_opts.add_option(cmdoptions.no_use_wheel())
+        cmd_opts.add_option(cmdoptions.no_binary())
+        cmd_opts.add_option(cmdoptions.only_binary())
 
         cmd_opts.add_option(
             '--pre',
@@ -179,8 +181,8 @@ class InstallCommand(RequirementCommand):
         """
         return PackageFinder(
             find_links=options.find_links,
+            format_control=options.format_control,
             index_urls=index_urls,
-            use_wheel=options.use_wheel,
             allow_external=options.allow_external,
             allow_unverified=options.allow_unverified,
             allow_all_external=options.allow_all_external,
@@ -191,6 +193,7 @@ class InstallCommand(RequirementCommand):
         )
 
     def run(self, options, args):
+        cmdoptions.resolve_wheel_no_use_binary(options)
 
         if options.download_dir:
             options.ignore_installed = True
@@ -239,7 +242,7 @@ class InstallCommand(RequirementCommand):
 
             finder = self._build_package_finder(options, index_urls, session)
             build_delete = (not (options.no_clean or options.build_dir))
-            wheel_cache = WheelCache(options.cache_dir)
+            wheel_cache = WheelCache(options.cache_dir, options.format_control)
             with BuildDirectory(options.build_dir,
                                 delete=build_delete) as build_dir:
                 requirement_set = RequirementSet(

--- a/pip/commands/uninstall.py
+++ b/pip/commands/uninstall.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import pip
 from pip.wheel import WheelCache
 from pip.req import InstallRequirement, RequirementSet, parse_requirements
 from pip.basecommand import Command
@@ -43,7 +44,8 @@ class UninstallCommand(Command):
 
     def run(self, options, args):
         with self._build_session(options) as session:
-            wheel_cache = WheelCache(options.cache_dir)
+            format_control = pip.index.FormatControl(set(), set())
+            wheel_cache = WheelCache(options.cache_dir, format_control)
             requirement_set = RequirementSet(
                 build_dir=None,
                 src_dir=None,

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -61,6 +61,8 @@ class WheelCommand(RequirementCommand):
         )
         cmd_opts.add_option(cmdoptions.use_wheel())
         cmd_opts.add_option(cmdoptions.no_use_wheel())
+        cmd_opts.add_option(cmdoptions.no_binary())
+        cmd_opts.add_option(cmdoptions.only_binary())
         cmd_opts.add_option(
             '--build-option',
             dest='build_options',
@@ -122,6 +124,7 @@ class WheelCommand(RequirementCommand):
 
     def run(self, options, args):
         self.check_required_packages()
+        cmdoptions.resolve_wheel_no_use_binary(options)
 
         index_urls = [options.index_url] + options.extra_index_urls
         if options.no_index:
@@ -143,8 +146,8 @@ class WheelCommand(RequirementCommand):
 
             finder = PackageFinder(
                 find_links=options.find_links,
+                format_control=options.format_control,
                 index_urls=index_urls,
-                use_wheel=options.use_wheel,
                 allow_external=options.allow_external,
                 allow_unverified=options.allow_unverified,
                 allow_all_external=options.allow_all_external,
@@ -155,7 +158,7 @@ class WheelCommand(RequirementCommand):
             )
 
             build_delete = (not (options.no_clean or options.build_dir))
-            wheel_cache = WheelCache(options.cache_dir)
+            wheel_cache = WheelCache(options.cache_dir, options.format_control)
             with BuildDirectory(options.build_dir,
                                 delete=build_delete) as build_dir:
                 requirement_set = RequirementSet(

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -257,7 +257,7 @@ class InstallRequirement(object):
         if self._wheel_cache is None:
             self._link = link
         else:
-            self._link = self._wheel_cache.cached_wheel(link)
+            self._link = self._wheel_cache.cached_wheel(link, self.name)
 
     @property
     def specifier(self):

--- a/tests/data/reqfiles/README.txt
+++ b/tests/data/reqfiles/README.txt
@@ -1,0 +1,9 @@
+supported_options.txt
+---------------------
+
+Contains --no-use-wheel.
+
+supported_options2.txt
+----------------------
+
+Contains --no-binary and --only-binary options.

--- a/tests/data/reqfiles/supported_options2.txt
+++ b/tests/data/reqfiles/supported_options2.txt
@@ -1,0 +1,5 @@
+# default is no constraints
+# We're not testing the format control logic here, just that the options are
+# accepted
+--no-binary fred
+--only-binary wilma

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -61,7 +61,7 @@ def test_nonexistent_extra_warns_user_no_wheel(script, data):
     This exercises source installs.
     """
     result = script.pip(
-        'install', '--no-use-wheel', '--no-index',
+        'install', '--no-binary=:all:', '--no-index',
         '--find-links=' + data.find_links,
         'simple[nonexistent]', expect_stderr=True,
     )

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -333,7 +333,7 @@ class TestUpgradeSetuptools(object):
             self, script, data, virtualenv):
         self.prep_ve(script, '1.9.1', virtualenv.pip_source_dir)
         result = self.script.run(
-            self.ve_bin / 'pip', 'install', '--no-use-wheel', '--no-index',
+            self.ve_bin / 'pip', 'install', '--no-binary=:all:', '--no-index',
             '--find-links=%s' % data.find_links, '-U', 'setuptools'
         )
         assert (

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -51,6 +51,15 @@ def test_pip_wheel_downloads_wheels(script, data):
 
 
 @pytest.mark.network
+def test_pip_wheel_builds_when_no_binary_set(script, data):
+    script.pip('install', 'wheel')
+    res = script.pip(
+        'wheel', '--no-index', '--no-binary', ':all:', '-f', data.find_links,
+        'setuptools==0.9.8')
+    assert "Running setup.py bdist_wheel for setuptools" in str(res), str(res)
+
+
+@pytest.mark.network
 def test_pip_wheel_builds_editable_deps(script, data):
     """
     Test 'pip wheel' finds and builds dependencies of editables

--- a/tests/unit/test_cmdoptions.py
+++ b/tests/unit/test_cmdoptions.py
@@ -1,0 +1,62 @@
+import pip
+from pip.basecommand import Command
+from pip import cmdoptions
+
+
+class SimpleCommand(Command):
+    name = 'fake'
+    summary = name
+
+    def __init__(self):
+        super(SimpleCommand, self).__init__()
+        self.cmd_opts.add_option(cmdoptions.no_use_wheel())
+        self.cmd_opts.add_option(cmdoptions.no_binary())
+        self.cmd_opts.add_option(cmdoptions.only_binary())
+
+    def run(self, options, args):
+        cmdoptions.resolve_wheel_no_use_binary(options)
+        self.options = options
+
+
+def test_no_use_wheel_sets_no_binary_all():
+    cmd = SimpleCommand()
+    cmd.main(['fake', '--no-use-wheel'])
+    expected = pip.index.FormatControl(set([':all:']), set([]))
+    assert cmd.options.format_control == expected
+
+
+def test_no_binary_overrides():
+    cmd = SimpleCommand()
+    cmd.main(['fake', '--only-binary=:all:', '--no-binary=fred'])
+    expected = pip.index.FormatControl(set(['fred']), set([':all:']))
+    assert cmd.options.format_control == expected
+
+
+def test_only_binary_overrides():
+    cmd = SimpleCommand()
+    cmd.main(['fake', '--no-binary=:all:', '--only-binary=fred'])
+    expected = pip.index.FormatControl(set([':all:']), set(['fred']))
+    assert cmd.options.format_control == expected
+
+
+def test_none_resets():
+    cmd = SimpleCommand()
+    cmd.main(['fake', '--no-binary=:all:', '--no-binary=:none:'])
+    expected = pip.index.FormatControl(set([]), set([]))
+    assert cmd.options.format_control == expected
+
+
+def test_none_preserves_other_side():
+    cmd = SimpleCommand()
+    cmd.main(
+        ['fake', '--no-binary=:all:', '--only-binary=fred',
+         '--no-binary=:none:'])
+    expected = pip.index.FormatControl(set([]), set(['fred']))
+    assert cmd.options.format_control == expected
+
+
+def test_comma_separated_values():
+    cmd = SimpleCommand()
+    cmd.main(['fake', '--no-binary=1,2,3'])
+    expected = pip.index.FormatControl(set(['1', '2', '3']), set([]))
+    assert cmd.options.format_control == expected

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -5,7 +5,9 @@ import pip.pep425tags
 
 from pkg_resources import parse_version, Distribution
 from pip.req import InstallRequirement
-from pip.index import InstallationCandidate, PackageFinder, Link
+from pip.index import (
+    InstallationCandidate, PackageFinder, Link, FormatControl,
+    fmt_ctl_formats)
 from pip.exceptions import (
     BestVersionAlreadyInstalled, DistributionNotFound, InstallationError,
 )
@@ -760,3 +762,16 @@ def test_find_all_versions_find_links_and_index(data):
     versions = finder._find_all_versions('simple')
     # first the find-links versions then the page versions
     assert [str(v.version) for v in versions] == ['3.0', '2.0', '1.0', '1.0']
+
+
+def test_fmt_ctl_matches():
+    fmt = FormatControl(set(), set())
+    assert fmt_ctl_formats(fmt, "fred") == frozenset(["source", "binary"])
+    fmt = FormatControl(set(["fred"]), set())
+    assert fmt_ctl_formats(fmt, "fred") == frozenset(["source"])
+    fmt = FormatControl(set(["fred"]), set([":all:"]))
+    assert fmt_ctl_formats(fmt, "fred") == frozenset(["source"])
+    fmt = FormatControl(set(), set(["fred"]))
+    assert fmt_ctl_formats(fmt, "fred") == frozenset(["binary"])
+    fmt = FormatControl(set([":all:"]), set(["fred"]))
+    assert fmt_ctl_formats(fmt, "fred") == frozenset(["binary"])


### PR DESCRIPTION
Issue #2675: Granular control over wheels/sdists
    
With wheel autobuilding in place a release blocker is having some granular way to opt-out of wheels for known-bad packages. This patch introduces two new options: --no-binary and --only-binary to control what archives we are willing to use on both a global and per-package basis.
    
This also closes #2084
