### PR TITLE
Cleanup now use_wheel is the default.

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -576,4 +576,4 @@ Once you have a bundle, you can then install it using::
 
     $ tempdir=$(mktemp -d /tmp/wheelhouse-XXXXX)
     $ (cd $tempdir; tar -xvf /path/to/bundled.tar.bz2)
-    $ pip install --force-reinstall --ignore-installed --upgrade --no-index --use-wheel --no-deps $tempdir/*
+    $ pip install --force-reinstall --ignore-installed --upgrade --no-index --no-deps $tempdir/*

--- a/pip/index.py
+++ b/pip/index.py
@@ -235,24 +235,21 @@ class PackageFinder(object):
               comparison operators, but then different sdist links
               with the same version, would have to be considered equal
         """
-        if self.use_wheel:
-            support_num = len(supported_tags)
-            if candidate.location == INSTALLED_VERSION:
-                pri = 1
-            elif candidate.location.is_wheel:
-                # can raise InvalidWheelFilename
-                wheel = Wheel(candidate.location.filename)
-                if not wheel.supported():
-                    raise UnsupportedWheel(
-                        "%s is not a supported wheel for this platform. It "
-                        "can't be sorted." % wheel.filename
-                    )
-                pri = -(wheel.support_index_min())
-            else:  # sdist
-                pri = -(support_num)
-            return (candidate.version, pri)
-        else:
-            return candidate.version
+        support_num = len(supported_tags)
+        if candidate.location == INSTALLED_VERSION:
+            pri = 1
+        elif candidate.location.is_wheel:
+            # can raise InvalidWheelFilename
+            wheel = Wheel(candidate.location.filename)
+            if not wheel.supported():
+                raise UnsupportedWheel(
+                    "%s is not a supported wheel for this platform. It "
+                    "can't be sorted." % wheel.filename
+                )
+            pri = -(wheel.support_index_min())
+        else:  # sdist
+            pri = -(support_num)
+        return (candidate.version, pri)
 
     def _sort_versions(self, applicable_versions):
         """

--- a/tests/functional/test_install_download.py
+++ b/tests/functional/test_install_download.py
@@ -25,7 +25,7 @@ def test_download_wheel(script):
            --find-links has a bug https://github.com/pypa/pip/issues/1111
     """
     result = script.pip(
-        'install', '--use-wheel',
+        'install',
         '-f', 'https://bitbucket.org/pypa/pip-test-package/downloads',
         '-d', '.', 'pip-test-package'
     )

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -79,7 +79,7 @@ def test_nonexistent_extra_warns_user_with_wheel(script, data):
     This exercises wheel installs.
     """
     result = script.pip(
-        'install', '--use-wheel', '--no-index',
+        'install', '--no-index',
         '--find-links=' + data.find_links,
         'simplewheel[nonexistent]', expect_stderr=True,
     )
@@ -94,7 +94,7 @@ def test_nonexistent_options_listed_in_order(script, data):
     Warn the user for each extra that doesn't exist.
     """
     result = script.pip(
-        'install', '--use-wheel', '--no-index',
+        'install', '--no-index',
         '--find-links=' + data.find_links,
         'simplewheel[nonexistent, nope]', expect_stderr=True,
     )

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -372,7 +372,7 @@ class TestUpgradeSetuptools(object):
             self, script, data, virtualenv):
         self.prep_ve(script, '1.10', virtualenv.pip_source_dir)
         result = self.script.run(
-            self.ve_bin / 'pip', 'install', '--use-wheel', '--no-index',
+            self.ve_bin / 'pip', 'install', '--no-index',
             '--find-links=%s' % data.find_links, '-U', 'setuptools'
         )
         assert "Found existing installation: setuptools 0.9.7" in result.stdout

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -41,7 +41,7 @@ def test_install_from_wheel(script, data):
     Test installing from a wheel (that has a script)
     """
     result = script.pip(
-        'install', 'has.script==1.0', '--use-wheel', '--no-index',
+        'install', 'has.script==1.0', '--no-index',
         '--find-links=' + data.find_links,
         expect_error=False,
     )
@@ -58,7 +58,7 @@ def test_install_from_wheel_with_extras(script, data):
     Test installing from a wheel with extras.
     """
     result = script.pip(
-        'install', 'complex-dist[simple]', '--use-wheel', '--no-index',
+        'install', 'complex-dist[simple]', '--no-index',
         '--find-links=' + data.find_links,
         expect_error=False,
     )
@@ -107,7 +107,7 @@ def test_install_wheel_with_target(script, data):
     script.pip('install', 'wheel')
     target_dir = script.scratch_path / 'target'
     result = script.pip(
-        'install', 'simple.dist==0.1', '-t', target_dir, '--use-wheel',
+        'install', 'simple.dist==0.1', '-t', target_dir,
         '--no-index', '--find-links=' + data.find_links,
     )
     assert Path('scratch') / 'target' / 'simpledist' in result.files_created, (
@@ -121,7 +121,7 @@ def test_install_wheel_with_root(script, data):
     """
     root_dir = script.scratch_path / 'root'
     result = script.pip(
-        'install', 'simple.dist==0.1', '--root', root_dir, '--use-wheel',
+        'install', 'simple.dist==0.1', '--root', root_dir,
         '--no-index', '--find-links=' + data.find_links,
     )
     assert Path('scratch') / 'root' in result.files_created
@@ -161,7 +161,7 @@ def test_install_user_wheel(script, virtualenv, data):
     virtualenv.system_site_packages = True
     script.pip('install', 'wheel')
     result = script.pip(
-        'install', 'has.script==1.0', '--user', '--use-wheel', '--no-index',
+        'install', 'has.script==1.0', '--user', '--no-index',
         '--find-links=' + data.find_links,
     )
     egg_info_folder = script.user_site / 'has.script-1.0.dist-info'
@@ -175,7 +175,7 @@ def test_install_from_wheel_gen_entrypoint(script, data):
     Test installing scripts (entry points are generated)
     """
     result = script.pip(
-        'install', 'script.wheel1a==0.1', '--use-wheel', '--no-index',
+        'install', 'script.wheel1a==0.1', '--no-index',
         '--find-links=' + data.find_links,
         expect_error=False,
     )
@@ -194,7 +194,7 @@ def test_install_from_wheel_with_legacy(script, data):
     Test installing scripts (legacy scripts are preserved)
     """
     result = script.pip(
-        'install', 'script.wheel2a==0.1', '--use-wheel', '--no-index',
+        'install', 'script.wheel2a==0.1', '--no-index',
         '--find-links=' + data.find_links,
         expect_error=False,
     )
@@ -212,7 +212,7 @@ def test_install_from_wheel_no_setuptools_entrypoint(script, data):
     the wheel are skipped.
     """
     result = script.pip(
-        'install', 'script.wheel1==0.1', '--use-wheel', '--no-index',
+        'install', 'script.wheel1==0.1', '--no-index',
         '--find-links=' + data.find_links,
         expect_error=False,
     )
@@ -237,7 +237,7 @@ def test_skipping_setuptools_doesnt_skip_legacy(script, data):
     setuptools wrappers)
     """
     result = script.pip(
-        'install', 'script.wheel2==0.1', '--use-wheel', '--no-index',
+        'install', 'script.wheel2==0.1', '--no-index',
         '--find-links=' + data.find_links,
         expect_error=False,
     )
@@ -256,7 +256,7 @@ def test_install_from_wheel_gui_entrypoint(script, data):
     Test installing scripts (gui entry points are generated)
     """
     result = script.pip(
-        'install', 'script.wheel3==0.1', '--use-wheel', '--no-index',
+        'install', 'script.wheel3==0.1', '--no-index',
         '--find-links=' + data.find_links,
         expect_error=False,
     )

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -104,14 +104,13 @@ def test_no_clean_option_blocks_cleaning_after_wheel(script, data):
 @pytest.mark.network
 def test_pip_wheel_source_deps(script, data):
     """
-    Test 'pip wheel --use-wheel' finds and builds source archive dependencies
+    Test 'pip wheel' finds and builds source archive dependencies
     of wheels
     """
     # 'requires_source' is a wheel that depends on the 'source' project
     script.pip('install', 'wheel')
     result = script.pip(
-        'wheel', '--use-wheel', '--no-index', '-f', data.find_links,
-        'requires_source',
+        'wheel', '--no-index', '-f', data.find_links, 'requires_source',
     )
     wheel_file_name = 'source-1.0-py%s-none-any.whl' % pyversion[0]
     wheel_file_path = script.scratch / 'wheelhouse' / wheel_file_name

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -126,7 +126,6 @@ class TestWheel:
         finder = PackageFinder(
             [data.find_links],
             [],
-            use_wheel=True,
             session=PipSession(),
         )
         with pytest.raises(DistributionNotFound):
@@ -151,7 +150,6 @@ class TestWheel:
         finder = PackageFinder(
             [data.find_links],
             [],
-            use_wheel=True,
             session=PipSession(),
         )
 
@@ -172,7 +170,6 @@ class TestWheel:
         finder = PackageFinder(
             [data.find_links],
             [],
-            use_wheel=True,
             session=PipSession(),
         )
         found = finder.find_requirement(req, True)
@@ -189,7 +186,6 @@ class TestWheel:
         finder = PackageFinder(
             [data.find_links],
             [],
-            use_wheel=True,
             session=PipSession(),
         )
         found = finder.find_requirement(req, True)
@@ -211,7 +207,6 @@ class TestWheel:
         finder = PackageFinder(
             [data.find_links],
             [],
-            use_wheel=True,
             session=PipSession(),
         )
 
@@ -253,7 +248,6 @@ class TestWheel:
         ]
 
         finder = PackageFinder([], [], session=PipSession())
-        finder.use_wheel = True
 
         results = finder._sort_versions(links)
         results2 = finder._sort_versions(reversed(links))
@@ -269,7 +263,7 @@ class TestWheel:
                 Link('simple-1.0-py2.py3-none-TEST.whl'),
             ),
         ]
-        finder = PackageFinder([], [], use_wheel=True, session=PipSession())
+        finder = PackageFinder([], [], session=PipSession())
         with pytest.raises(InstallationError):
             finder._sort_versions(links)
 
@@ -698,7 +692,6 @@ class test_link_package_versions(object):
         self.finder = PackageFinder(
             [],
             [],
-            use_wheel=True,
             session=PipSession(),
         )
 


### PR DESCRIPTION
There were a bunch of tests passing use_wheel unnecessarily, this
makes the change to remove use_wheel larger than it needs to be.