### PR TITLE
Create a Search object.

### DIFF
--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import
 
 import logging
 
+from pip._vendor import pkg_resources
+
 from pip.basecommand import Command
 from pip.exceptions import DistributionNotFound
-from pip.index import PackageFinder
+from pip.index import PackageFinder, Search
 from pip.req import InstallRequirement
 from pip.utils import get_installed_distributions, dist_is_editable
 from pip.cmdoptions import make_option_group, index_group
@@ -144,9 +146,12 @@ class ListCommand(Command):
                 except DistributionNotFound:
                     continue
                 else:
+                    search = Search(
+                        req.name,
+                        pkg_resources.safe_name(req.name).lower(),
+                        ["source", "binary"])
                     remote_version = finder._link_package_versions(
-                        link, req.name
-                    ).version
+                        link, search).version
                     if link.is_wheel:
                         typ = 'wheel'
                     else:


### PR DESCRIPTION
We currently recalculate safe_name on every archive we assess, and
with the upcoming per-package check for binary and source use we
either need to recalculate that too, or - as this patch does - hoist
this essentially static data out of the helper function innards into a
static data structure.