### PR TITLE
Issue #2677: Disable wheels for setup.py options.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,10 @@
 * Allow fine grained control over the use of wheels and source builds.
   (:pull:`2699`)
 
+* The use of ``--install-option``, ``--global-option`` or ``--build-option``
+  disable the use of wheels, and the autobuilding of wheels. (:pull:`2711`))
+  Fixes :issue:`2677`
+
 **6.1.1 (2015-04-07)**
 
 * No longer ignore dependencies which have been added to the standard library,

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -194,6 +194,7 @@ class InstallCommand(RequirementCommand):
 
     def run(self, options, args):
         cmdoptions.resolve_wheel_no_use_binary(options)
+        cmdoptions.check_install_build_global(options)
 
         if options.download_dir:
             options.ignore_installed = True

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -125,6 +125,7 @@ class WheelCommand(RequirementCommand):
     def run(self, options, args):
         self.check_required_packages()
         cmdoptions.resolve_wheel_no_use_binary(options)
+        cmdoptions.check_install_build_global(options)
 
         index_urls = [options.index_url] + options.extra_index_urls
         if options.no_index:

--- a/pip/index.py
+++ b/pip/index.py
@@ -1243,12 +1243,17 @@ def fmt_ctl_formats(fmt_ctl, canonical_name):
     return frozenset(result)
 
 
-def fmt_ctl_no_use_wheel(fmt_ctl):
+def fmt_ctl_no_binary(fmt_ctl):
     fmt_ctl_handle_mutual_exclude(
         ':all:', fmt_ctl.no_binary, fmt_ctl.only_binary)
+
+
+def fmt_ctl_no_use_wheel(fmt_ctl):
+    fmt_ctl_no_binary(fmt_ctl)
     warnings.warn(
         '--no-use-wheel is deprecated and will be removed in the future. '
-        ' Please use --no-binary :all: instead.')
+        ' Please use --no-binary :all: instead.', DeprecationWarning,
+        stacklevel=2)
 
 
 Search = namedtuple('Search', 'supplied canonical formats')

--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -140,6 +140,8 @@ def process_line(line, filename, line_number, finder=None, comes_from=None,
         args_line = ' '.join(args)
         comes_from = '-r %s (line %s)' % (filename, line_number)
         isolated = options.isolated_mode if options else False
+        if options:
+            cmdoptions.check_install_build_global(options, opts)
         # trim the None items
         keys = [opt for opt in opts.__dict__ if getattr(opts, opt) is None]
         for key in keys:
@@ -215,8 +217,8 @@ def build_parser():
     parser = optparse.OptionParser(add_help_option=False)
 
     options = SUPPORTED_OPTIONS + SUPPORTED_OPTIONS_REQ
-    for option in options:
-        option = option()
+    for option_factory in options:
+        option = option_factory()
         # we want no default values; defaults are handled in `pip install`
         # parsing. just concerned with values that are specifically set.
         option.default = None

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -304,7 +304,7 @@ def test_install_global_option(script):
     """
     result = script.pip(
         'install', '--global-option=--version', "INITools==0.1",
-    )
+        expect_stderr=True)
     assert '0.1\n' in result.stdout
 
 
@@ -335,8 +335,8 @@ def test_install_using_install_option_and_editable(script, tmpdir):
     result = script.pip(
         'install', '-e', '%s#egg=pip-test-package' %
         local_checkout(url, tmpdir.join("cache")),
-        '--install-option=--script-dir=%s' % folder
-    )
+        '--install-option=--script-dir=%s' % folder,
+        expect_stderr=True)
     script_file = (
         script.venv / 'src' / 'pip-test-package' /
         folder / 'pip-test-package' + script.exe
@@ -352,8 +352,8 @@ def test_install_global_option_using_editable(script, tmpdir):
     url = 'hg+http://bitbucket.org/runeh/anyjson'
     result = script.pip(
         'install', '--global-option=--version', '-e',
-        '%s@0.2.5#egg=anyjson' % local_checkout(url, tmpdir.join("cache"))
-    )
+        '%s@0.2.5#egg=anyjson' % local_checkout(url, tmpdir.join("cache")),
+        expect_stderr=True)
     assert 'Successfully installed anyjson' in result.stdout
 
 

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -187,7 +187,8 @@ def test_install_option_in_requirements_file(script, data, virtualenv):
     result = script.pip(
         'install', '--no-index', '-f', data.find_links, '-r',
         script.scratch_path / 'reqs.txt',
-        '--install-option=--home=%s' % script.scratch_path.join("home2"))
+        '--install-option=--home=%s' % script.scratch_path.join("home2"),
+        expect_stderr=True)
 
     package_dir = script.scratch / 'home1' / 'lib' / 'python' / 'simple'
     assert package_dir in result.files_created


### PR DESCRIPTION
Using --install-options, --build-options, --global-options changes
the way that setup.py behaves, and isn't honoured by the wheel code.
The new wheel autobuilding code made this very obvious - disable
the use of wheels when these options are supplied.
