### PR TITLE
Replace wheel cache cache_dir with an object.

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -281,7 +281,7 @@ class RequirementCommand(Command):
 
     @staticmethod
     def populate_requirement_set(requirement_set, args, options, finder,
-                                 session, name):
+                                 session, name, wheel_cache):
         """
         Marshal cmd line args into a requirement set.
         """
@@ -289,7 +289,7 @@ class RequirementCommand(Command):
             requirement_set.add_requirement(
                 InstallRequirement.from_line(
                     name, None, isolated=options.isolated_mode,
-                    cache_root=options.cache_dir
+                    wheel_cache=wheel_cache
                 )
             )
 
@@ -299,14 +299,15 @@ class RequirementCommand(Command):
                     name,
                     default_vcs=options.default_vcs,
                     isolated=options.isolated_mode,
-                    cache_root=options.cache_dir
+                    wheel_cache=wheel_cache
                 )
             )
 
         for filename in options.requirements:
             for req in parse_requirements(
                     filename,
-                    finder=finder, options=options, session=session):
+                    finder=finder, options=options, session=session,
+                    wheel_cache=wheel_cache):
                 requirement_set.add_requirement(req)
 
         if not requirement_set.has_requirements:

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -4,6 +4,7 @@ import sys
 
 from pip.basecommand import Command
 from pip.operations.freeze import freeze
+from pip.wheel import WheelCache
 
 
 class FreezeCommand(Command):
@@ -54,6 +55,7 @@ class FreezeCommand(Command):
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
+        wheel_cache = WheelCache(options.cache_dir)
         freeze_kwargs = dict(
             requirement=options.requirement,
             find_links=options.find_links,
@@ -61,7 +63,7 @@ class FreezeCommand(Command):
             user_only=options.user,
             skip_regex=options.skip_requirements_regex,
             isolated=options.isolated_mode,
-            cache_root=options.cache_dir)
+            wheel_cache=wheel_cache)
 
         for line in freeze(**freeze_kwargs):
             sys.stdout.write(line + '\n')

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -22,7 +22,7 @@ from pip import cmdoptions
 from pip.utils import ensure_dir
 from pip.utils.build import BuildDirectory
 from pip.utils.deprecation import RemovedInPip8Warning
-from pip.wheel import WheelBuilder
+from pip.wheel import WheelCache, WheelBuilder
 
 
 logger = logging.getLogger(__name__)
@@ -239,11 +239,11 @@ class InstallCommand(RequirementCommand):
 
             finder = self._build_package_finder(options, index_urls, session)
             build_delete = (not (options.no_clean or options.build_dir))
+            wheel_cache = WheelCache(options.cache_dir)
             with BuildDirectory(options.build_dir,
                                 delete=build_delete) as build_dir:
                 requirement_set = RequirementSet(
                     build_dir=build_dir,
-                    cache_root=options.cache_dir,
                     src_dir=options.src_dir,
                     download_dir=options.download_dir,
                     upgrade=options.upgrade,
@@ -256,10 +256,12 @@ class InstallCommand(RequirementCommand):
                     session=session,
                     pycompile=options.compile,
                     isolated=options.isolated_mode,
+                    wheel_cache=wheel_cache,
                 )
 
                 self.populate_requirement_set(
                     requirement_set, args, options, finder, session, self.name,
+                    wheel_cache
                 )
 
                 if not requirement_set.has_requirements:

--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -9,6 +9,7 @@ from pip.exceptions import DistributionNotFound
 from pip.index import PackageFinder, Search
 from pip.req import InstallRequirement
 from pip.utils import get_installed_distributions, dist_is_editable
+from pip.wheel import WheelCache
 from pip.cmdoptions import make_option_group, index_group
 
 
@@ -130,10 +131,11 @@ class ListCommand(Command):
                 user_only=options.user,
                 include_editables=False,
             )
+            wheel_cache = WheelCache(options.cache_dir)
             for dist in installed_packages:
                 req = InstallRequirement.from_line(
                     dist.key, None, isolated=options.isolated_mode,
-                    cache_root=options.cache_dir,
+                    wheel_cache=wheel_cache
                 )
                 typ = 'unknown'
                 try:

--- a/pip/commands/uninstall.py
+++ b/pip/commands/uninstall.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from pip.wheel import WheelCache
 from pip.req import InstallRequirement, RequirementSet, parse_requirements
 from pip.basecommand import Command
 from pip.exceptions import InstallationError
@@ -42,20 +43,20 @@ class UninstallCommand(Command):
 
     def run(self, options, args):
         with self._build_session(options) as session:
-
+            wheel_cache = WheelCache(options.cache_dir)
             requirement_set = RequirementSet(
                 build_dir=None,
-                cache_root=options.cache_dir,
                 src_dir=None,
                 download_dir=None,
                 isolated=options.isolated_mode,
                 session=session,
+                wheel_cache=wheel_cache,
             )
             for name in args:
                 requirement_set.add_requirement(
                     InstallRequirement.from_line(
                         name, isolated=options.isolated_mode,
-                        cache_root=options.cache_dir,
+                        wheel_cache=wheel_cache
                     )
                 )
             for filename in options.requirements:
@@ -63,7 +64,7 @@ class UninstallCommand(Command):
                         filename,
                         options=options,
                         session=session,
-                        cache_root=options.cache_dir):
+                        wheel_cache=wheel_cache):
                     requirement_set.add_requirement(req)
             if not requirement_set.has_requirements:
                 raise InstallationError(

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -12,7 +12,7 @@ from pip.req import RequirementSet
 from pip.utils import import_or_raise, normalize_path
 from pip.utils.build import BuildDirectory
 from pip.utils.deprecation import RemovedInPip8Warning
-from pip.wheel import WheelBuilder
+from pip.wheel import WheelCache, WheelBuilder
 from pip import cmdoptions
 
 DEFAULT_WHEEL_DIR = os.path.join(normalize_path(os.curdir), 'wheelhouse')
@@ -155,22 +155,24 @@ class WheelCommand(RequirementCommand):
             )
 
             build_delete = (not (options.no_clean or options.build_dir))
+            wheel_cache = WheelCache(options.cache_dir)
             with BuildDirectory(options.build_dir,
                                 delete=build_delete) as build_dir:
                 requirement_set = RequirementSet(
                     build_dir=build_dir,
-                    cache_root=options.cache_dir,
                     src_dir=options.src_dir,
                     download_dir=None,
                     ignore_dependencies=options.ignore_dependencies,
                     ignore_installed=True,
                     isolated=options.isolated_mode,
                     session=session,
+                    wheel_cache=wheel_cache,
                     wheel_download_dir=options.wheel_dir
                 )
 
                 self.populate_requirement_set(
                     requirement_set, args, options, finder, session, self.name,
+                    wheel_cache
                 )
 
                 if not requirement_set.has_requirements:

--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -22,7 +22,7 @@ def freeze(
         find_tags=False,
         default_vcs=None,
         isolated=False,
-        cache_root=None):
+        wheel_cache=None):
     find_links = find_links or []
     skip_match = None
 
@@ -76,13 +76,13 @@ def freeze(
                         line,
                         default_vcs=default_vcs,
                         isolated=isolated,
-                        cache_root=cache_root,
+                        wheel_cache=wheel_cache,
                     )
                 else:
                     line_req = InstallRequirement.from_line(
                         line,
                         isolated=isolated,
-                        cache_root=cache_root,
+                        wheel_cache=wheel_cache,
                     )
 
                 if not line_req.name:

--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -77,15 +77,16 @@ IGNORE = 5
 
 
 def parse_requirements(filename, finder=None, comes_from=None, options=None,
-                       session=None, cache_root=None):
+                       session=None, wheel_cache=None):
     """
     Parse a requirements file and yield InstallRequirement instances.
 
-    :param filename:   Path or url of requirements file.
-    :param finder:     Instance of pip.index.PackageFinder.
-    :param comes_from: Origin description of requirements.
-    :param options:    Global options.
-    :param session:    Instance of pip.download.PipSession.
+    :param filename:    Path or url of requirements file.
+    :param finder:      Instance of pip.index.PackageFinder.
+    :param comes_from:  Origin description of requirements.
+    :param options:     Global options.
+    :param session:     Instance of pip.download.PipSession.
+    :param wheel_cache: Instance of pip.wheel.WheelCache
     """
     if session is None:
         raise TypeError(
@@ -98,7 +99,7 @@ def parse_requirements(filename, finder=None, comes_from=None, options=None,
     )
 
     parser = parse_content(
-        filename, content, finder, comes_from, options, session, cache_root
+        filename, content, finder, comes_from, options, session, wheel_cache
     )
 
     for item in parser:
@@ -106,7 +107,7 @@ def parse_requirements(filename, finder=None, comes_from=None, options=None,
 
 
 def parse_content(filename, content, finder=None, comes_from=None,
-                  options=None, session=None, cache_root=None):
+                  options=None, session=None, wheel_cache=None):
 
     # Split, sanitize and join lines with continuations.
     content = content.splitlines()
@@ -129,7 +130,7 @@ def parse_content(filename, content, finder=None, comes_from=None,
             isolated = options.isolated_mode if options else False
             yield InstallRequirement.from_line(
                 req, comes_from, isolated=isolated, options=opts,
-                cache_root=cache_root)
+                wheel_cache=wheel_cache)
 
         # ---------------------------------------------------------------------
         elif linetype == REQUIREMENT_EDITABLE:
@@ -139,7 +140,7 @@ def parse_content(filename, content, finder=None, comes_from=None,
             yield InstallRequirement.from_editable(
                 value, comes_from=comes_from,
                 default_vcs=default_vcs, isolated=isolated,
-                cache_root=cache_root)
+                wheel_cache=wheel_cache)
 
         # ---------------------------------------------------------------------
         elif linetype == REQUIREMENT_FILE:
@@ -152,7 +153,7 @@ def parse_content(filename, content, finder=None, comes_from=None,
             # TODO: Why not use `comes_from='-r {} (line {})'` here as well?
             parser = parse_requirements(
                 req_url, finder, comes_from, options, session,
-                cache_root=cache_root)
+                wheel_cache=wheel_cache)
             for req in parser:
                 yield req
 

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -140,7 +140,7 @@ class RequirementSet(object):
                  ignore_dependencies=False, force_reinstall=False,
                  use_user_site=False, session=None, pycompile=True,
                  isolated=False, wheel_download_dir=None,
-                 cache_root=None):
+                 wheel_cache=None):
         """Create a RequirementSet.
 
         :param wheel_download_dir: Where still-packed .whl files should be
@@ -150,7 +150,7 @@ class RequirementSet(object):
         :param download_dir: Where still packed archives should be written to.
             If None they are not saved, and are deleted immediately after
             unpacking.
-        :param cache_root: The root of the pip cache, for passing to
+        :param wheel_cache: The pip wheel cache, for passing to
             InstallRequirement.
         """
         if session is None:
@@ -185,7 +185,7 @@ class RequirementSet(object):
         if wheel_download_dir:
             wheel_download_dir = normalize_path(wheel_download_dir)
         self.wheel_download_dir = wheel_download_dir
-        self._cache_root = cache_root
+        self._wheel_cache = wheel_cache
         # Maps from install_req -> dependencies_of_install_req
         self._dependencies = defaultdict(list)
 
@@ -517,7 +517,7 @@ class RequirementSet(object):
                     str(subreq),
                     req_to_install,
                     isolated=self.isolated,
-                    cache_root=self._cache_root,
+                    wheel_cache=self._wheel_cache,
                 )
                 more_reqs.extend(self.add_requirement(
                     sub_install_req, req_to_install.name))

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -44,6 +44,20 @@ VERSION_COMPATIBLE = (1, 0)
 logger = logging.getLogger(__name__)
 
 
+class WheelCache(object):
+    """A cache of wheels for future installs."""
+
+    def __init__(self, cache_dir):
+        """Create a wheel cache.
+
+        :param cache_dir: The root of the cache.
+        """
+        self._cache_dir = cache_dir
+
+    def cached_wheel(self, link):
+        return cached_wheel(self._cache_dir, link)
+
+
 def _cache_for_filename(cache_dir, sdistfilename):
     """Return a directory to store cached wheels in for sdistfilename.
 
@@ -598,10 +612,10 @@ class WheelBuilder(object):
     """Build wheels from a RequirementSet."""
 
     def __init__(self, requirement_set, finder, build_options=None,
-                 global_options=None, cache_root=None):
+                 global_options=None):
         self.requirement_set = requirement_set
         self.finder = finder
-        self._cache_root = requirement_set._cache_root
+        self._cache_root = requirement_set._wheel_cache._cache_dir
         self._wheel_dir = requirement_set.wheel_download_dir
         self.build_options = build_options or []
         self.global_options = global_options or []


### PR DESCRIPTION
Wheel cache lookups become more complex when we wish to allow binary
blacklisting. Rather than passing more parameters around, replace
cache_root with wheel_cache, and create a wheel cache in all the
relevant command entry points.