### PR TITLE
Differentiate Between Quiet Flag Counts

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -109,7 +109,10 @@ class Command(object):
         options, args = self.parse_args(args)
 
         if options.quiet:
-            level = "WARNING"
+            if options.quiet == 1:
+                level = "WARNING"
+            else:
+                level = "ERROR"
         elif options.verbose:
             level = "DEBUG"
         else:

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -111,8 +111,10 @@ class Command(object):
         if options.quiet:
             if options.quiet == 1:
                 level = "WARNING"
-            else:
+            if options.quiet == 2:
                 level = "ERROR"
+            else:
+                level = "CRITICAL"
         elif options.verbose:
             level = "DEBUG"
         else:

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -200,6 +200,10 @@ class TestGeneralOptions(object):
         options4, args4 = main(['fake', '--quiet', '--quiet'])
         assert options3.quiet == options4.quiet == 2
 
+        options5, args5 = main(['--quiet', '--quiet', '--quiet', 'fake'])
+        options6, args6 = main(['fake', '--quiet', '--quiet', '--quiet'])
+        assert options5.quiet == options6.quiet == 3
+
     def test_log(self):
         options1, args1 = main(['--log', 'path', 'fake'])
         options2, args2 = main(['fake', '--log', 'path'])

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -196,6 +196,10 @@ class TestGeneralOptions(object):
         options2, args2 = main(['fake', '--quiet'])
         assert options1.quiet == options2.quiet == 1
 
+        options3, args3 = main(['--quiet', '--quiet', 'fake'])
+        options4, args4 = main(['fake', '--quiet', '--quiet'])
+        assert options3.quiet == options4.quiet == 2
+
     def test_log(self):
         options1, args1 = main(['--log', 'path', 'fake'])
         options2, args2 = main(['fake', '--log', 'path'])


### PR DESCRIPTION
This fixes issue #2670 which notes that

> there's no difference between `-q`, `-qq`, or `-qqq`

The suggested behavior is

> - `-qq`: `ERROR`
> - `-qqq`: Disable all output (maybe? Does it ever make sense to allow squashing the errors even?).

This change makes it so that `-q` maps to the `WARNING` log level and anything more maps to the `ERROR` level.