### PR TITLE
Issue #2723: Restore the use of git clones

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -459,12 +459,9 @@ def is_archive_file(name):
     return False
 
 
-def unpack_vcs_link(link, location, only_download=False):
+def unpack_vcs_link(link, location):
     vcs_backend = _get_used_vcs_backend(link)
-    if only_download:
-        vcs_backend.export(location)
-    else:
-        vcs_backend.unpack(location)
+    vcs_backend.unpack(location)
 
 
 def _get_used_vcs_backend(link):
@@ -804,13 +801,11 @@ def unpack_url(link, location, download_dir=None,
     """
     # non-editable vcs urls
     if is_vcs_url(link):
-        unpack_vcs_link(link, location, only_download)
+        unpack_vcs_link(link, location)
 
     # file urls
     elif is_file_url(link):
         unpack_file_url(link, location, download_dir)
-        if only_download:
-            write_delete_marker_file(location)
 
     # http urls
     else:
@@ -823,8 +818,8 @@ def unpack_url(link, location, download_dir=None,
             download_dir,
             session,
         )
-        if only_download:
-            write_delete_marker_file(location)
+    if only_download:
+        write_delete_marker_file(location)
 
 
 def _download_http_url(link, session, temp_dir):


### PR DESCRIPTION
6.1.1 and before use git clones when installing a git+ url. 7.0.0.dev
didn't temporarily because the internal flag for controlling whether
to do a clone or an export was tied into the behaviour for whether
something will be deleted or not - which is arguably different. Remove
the confounded behaviour and just unpack always, using the same marker
flag to delete directories as used for file and non-vcs urls.