### PR TITLE
fix for Issue 2734

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,9 @@
   disable the use of wheels, and the autobuilding of wheels. (:pull:`2711`)
   Fixes :issue:`2677`
 
+* Improve logging when a requirement marker doesn't match your environment
+  (:pull:`2735`)
+
 **6.1.1 (2015-04-07)**
 
 * No longer ignore dependencies which have been added to the standard library,

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -290,32 +290,34 @@ class RequirementCommand(Command):
         """
         Marshal cmd line args into a requirement set.
         """
-        for name in args:
+        for req in args:
             requirement_set.add_requirement(
                 InstallRequirement.from_line(
-                    name, None, isolated=options.isolated_mode,
+                    req, None, isolated=options.isolated_mode,
                     wheel_cache=wheel_cache
                 )
             )
 
-        for name in options.editables:
+        for req in options.editables:
             requirement_set.add_requirement(
                 InstallRequirement.from_editable(
-                    name,
+                    req,
                     default_vcs=options.default_vcs,
                     isolated=options.isolated_mode,
                     wheel_cache=wheel_cache
                 )
             )
 
+        found_req_in_file = False
         for filename in options.requirements:
             for req in parse_requirements(
                     filename,
                     finder=finder, options=options, session=session,
                     wheel_cache=wheel_cache):
+                found_req_in_file = True
                 requirement_set.add_requirement(req)
 
-        if not requirement_set.has_requirements:
+        if not (args or options.editables or found_req_in_file):
             opts = {'name': name}
             if options.find_links:
                 msg = ('You must give at least one requirement to '

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -217,8 +217,8 @@ class RequirementSet(object):
         """
         name = install_req.name
         if not install_req.match_markers():
-            logger.debug("Ignore %s: markers %r don't match",
-                         install_req.name, install_req.markers)
+            logger.warning("Ignoring %s: markers %r don't match your "
+                           "environment", install_req.name, install_req.markers)
             return []
 
         install_req.as_egg = self.as_egg

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -218,7 +218,8 @@ class RequirementSet(object):
         name = install_req.name
         if not install_req.match_markers():
             logger.warning("Ignoring %s: markers %r don't match your "
-                           "environment", install_req.name, install_req.markers)
+                           "environment", install_req.name,
+                           install_req.markers)
             return []
 
         install_req.as_egg = self.as_egg


### PR DESCRIPTION
fix for #2734

* remove overlapping variables from `populate_requirement_set`
* warn about not specifying requirements, when they're not specified, not when the RequirementSet happens to turn up empty
*  warn when requirements are ignored due to non-matching markers