### PR TITLE
fix for nested requirements files

### DIFF
--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -142,16 +142,19 @@ def process_line(line, filename, line_number, finder=None, comes_from=None,
 
     # parse a nested requirements file
     elif opts.requirements:
-        req_file = opts.requirements[0]
+        req_path = opts.requirements[0]
+        # original file is over http
         if SCHEME_RE.search(filename):
-            # Relative to an URL.
-            req_url = urllib_parse.urljoin(filename, req_file)
-        elif not SCHEME_RE.search(req_file):
+            # do a url join so relative paths work
+            req_path = urllib_parse.urljoin(filename, req_path)
+        # original file and nested file are paths
+        elif not SCHEME_RE.search(req_path):
+            # do a join so relative paths work
             req_dir = os.path.dirname(filename)
-            req_url = os.path.join(os.path.dirname(filename), req_file)
+            req_path = os.path.join(os.path.dirname(filename), req_path)
         # TODO: Why not use `comes_from='-r {} (line {})'` here as well?
         parser = parse_requirements(
-            req_url, finder, comes_from, options, session,
+            req_path, finder, comes_from, options, session,
             wheel_cache=wheel_cache
         )
         for req in parser:

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -245,7 +245,8 @@ class TestProcessLine(object):
         mock_parse = Mock()
         mock_parse.side_effect = parse
         monkeypatch.setattr(pip.req.req_file, 'parse_requirements', mock_parse)
-        list(process_line("-r http://me.com/me/reqs.txt", req_file, 1, finder=finder))
+        list(process_line("-r http://me.com/me/reqs.txt", req_file, 1,
+                          finder=finder))
         call = mock_parse.mock_calls[0]
         assert call[1][0] == 'http://me.com/me/reqs.txt'
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -187,6 +187,9 @@ class TestProcessLine(object):
         list(process_line("--no-allow-insecure", "file", 1, finder=finder))
 
     def test_relative_local_find_links(self, finder, monkeypatch):
+        """
+        Test a relative find_links path is joined with the req file directory
+        """
         req_file = '/path/req_file.txt'
         nested_link = '/path/rel_path'
         exists_ = os.path.exists
@@ -202,6 +205,9 @@ class TestProcessLine(object):
         assert finder.find_links == [nested_link]
 
     def test_relative_http_nested_req_files(self, finder, monkeypatch):
+        """
+        Test a relative nested req file path is joined with the req file url
+        """
         req_file = 'http://me.com/me/req_file.txt'
 
         def parse(*args, **kwargs):
@@ -214,6 +220,9 @@ class TestProcessLine(object):
         assert call[1][0] == 'http://me.com/me/reqs.txt'
 
     def test_relative_local_nested_req_files(self, finder, monkeypatch):
+        """
+        Test a relative nested req file path is joined with the req file dir
+        """
         req_file = '/path/req_file.txt'
 
         def parse(*args, **kwargs):
@@ -226,6 +235,9 @@ class TestProcessLine(object):
         assert call[1][0] == '/path/reqs.txt'
 
     def test_absolute_local_nested_req_files(self, finder, monkeypatch):
+        """
+        Test an absolute nested req file path
+        """
         req_file = '/path/req_file.txt'
 
         def parse(*args, **kwargs):
@@ -238,6 +250,9 @@ class TestProcessLine(object):
         assert call[1][0] == '/other/reqs.txt'
 
     def test_absolute_http_nested_req_file_in_local(self, finder, monkeypatch):
+        """
+        Test a nested req file url in a local req file
+        """
         req_file = '/path/req_file.txt'
 
         def parse(*args, **kwargs):


### PR DESCRIPTION
fixes a bug for the case where the original requirements file is a local path and the nested file is over http.

the error:
```
 File "/home/qwcode/p/pypa/pip3/pip/req/req_file.py", line 154, in process_line
    req_url, finder, comes_from, options, session,
UnboundLocalError: local variable 'req_url' referenced before assignment
```

this bug came from #2537 

added 5 new tests.
