### PR TITLE
imp deprecated on 3.4

### DIFF
--- a/pip/compat/__init__.py
+++ b/pip/compat/__init__.py
@@ -3,7 +3,6 @@ distributions."""
 from __future__ import absolute_import, division
 
 import os
-import imp
 import sys
 
 from pip._vendor.six import text_type
@@ -25,7 +24,16 @@ __all__ = [
 ]
 
 
-uses_pycache = hasattr(imp, 'cache_from_source')
+if sys.version_info >= (3, 4):
+    uses_pycache = True
+    from importlib.util import cache_from_source
+else:
+    import imp
+    uses_pycache = hasattr(imp, 'cache_from_source')
+    if uses_pycache:
+        cache_from_source = imp.cache_from_source
+    else:
+        cache_from_source = None
 
 
 if sys.version_info >= (3,):

--- a/pip/req/req_uninstall.py
+++ b/pip/req/req_uninstall.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
-import imp
 import logging
 import os
 import sys
 import tempfile
 
-from pip.compat import uses_pycache, WINDOWS
+from pip.compat import uses_pycache, WINDOWS, cache_from_source
 from pip.exceptions import UninstallationError
 from pip.utils import (rmtree, ask, is_local, dist_is_local, renames,
                        normalize_path)
@@ -58,7 +57,7 @@ class UninstallPathSet(object):
         # __pycache__ files can show up after 'installed-files.txt' is created,
         # due to imports
         if os.path.splitext(path)[1] == '.py' and uses_pycache:
-            self.add(imp.cache_from_source(path))
+            self.add(cache_from_source(path))
 
     def add_pth(self, pth_file, entry):
         pth_file = normalize_path(pth_file)

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -1,14 +1,13 @@
 """
 tests specific to "pip install --user"
 """
-import imp
 import os
 import textwrap
 import pytest
 
 from os.path import curdir, isdir, isfile
 
-from pip.compat import uses_pycache
+from pip.compat import uses_pycache, cache_from_source
 
 from tests.lib.local_repos import local_checkout
 from tests.lib import pyversion
@@ -29,7 +28,7 @@ def _patch_dist_in_site_packages(script):
     #   file to be sure
     #   See: https://github.com/pypa/pip/pull/893#issuecomment-16426701
     if uses_pycache:
-        cache_path = imp.cache_from_source(sitecustomize_path)
+        cache_path = cache_from_source(sitecustomize_path)
         if os.path.isfile(cache_path):
             os.remove(cache_path)
 


### PR DESCRIPTION
importing it prevent to debug other packages with `-W error` as the
deprecation warning will raise.

Though there is still imp imported from a few vendorized packages.