### PR TITLE
Use shutil.move instead of os.rename

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -641,7 +641,7 @@ class WheelBuilder(object):
                 try:
                     wheel_name = os.listdir(tempd)[0]
                     wheel_path = os.path.join(output_dir, wheel_name)
-                    os.rename(os.path.join(tempd, wheel_name), wheel_path)
+                    shutil.move(os.path.join(tempd, wheel_name), wheel_path)
                     logger.info('Stored in directory: %s', output_dir)
                     return wheel_path
                 except:


### PR DESCRIPTION
``os.rename`` causes errors to happen whenever the temporary location is on a different device than the wheel cache directory. Using ``shutil.move`` instead will cause it to use ``os.rename`` when it can and fallback to copying otherwise.