### PR TITLE
Only warn on final releases with different base versions

### DIFF
--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -26,7 +26,7 @@ def test_pip_version_check(monkeypatch, stored_time, newver, check, warn):
 
     resp = pretend.stub(
         raise_for_status=pretend.call_recorder(lambda: None),
-        json=pretend.call_recorder(lambda: {"info": {"version": newver}}),
+        json=pretend.call_recorder(lambda: {"releases": {newver: {}}}),
     )
     session = pretend.stub(
         get=pretend.call_recorder(lambda u, headers=None: resp),


### PR DESCRIPTION
We only want to prompt people to upgrade their pip version if the newer version is not a post release of the version they have and it's not a pre-release version.

Fixes #2647