### PR TITLE
fixes pip install freezing when using cache dir which doesn't support hard links

### DIFF
--- a/pip/_vendor/cachecontrol/caches/file_cache.py
+++ b/pip/_vendor/cachecontrol/caches/file_cache.py
@@ -1,8 +1,7 @@
 import hashlib
 import os
 
-from pip._vendor.lockfile import FileLock
-
+from pip._vendor.lockfile.mkdirlockfile import MkdirLockFile
 from ..cache import BaseCache
 from ..controller import CacheController
 
@@ -83,7 +82,7 @@ class FileCache(BaseCache):
         except (IOError, OSError):
             pass
 
-        with FileLock(name) as lock:
+        with MkdirLockFile(name) as lock:
             # Write our actual file
             with _secure_open_write(lock.path, self.filemode) as fh:
                 fh.write(value)


### PR DESCRIPTION
This fixes a bug when a user specifies a cache directory in a filesystem, that does not support creating hard links. 
LockFile only checks if OS has hard link support, but not the target filesystem.
This leads to pip freezing forever under specified conditions.
Fixes below solve the problem:
* don't use LinkLockFile for caching as we don't know if the target filesystem supports hard links
* if someone will ever use LinkLockFile - make sure it raises exeption for unsupported file system, but not fall into infinite loop