### PR TITLE
Fix indented log.

### DIFF
--- a/pip/utils/logging.py
+++ b/pip/utils/logging.py
@@ -32,8 +32,10 @@ def indent_log(num=2):
     log messages emited inside it.
     """
     _log_state.indentation += num
-    yield
-    _log_state.indentation -= num
+    try:
+        yield
+    finally:
+        _log_state.indentation -= num
 
 
 def get_indentation():


### PR DESCRIPTION
If exception occur the log stays indented. Oops.