### PR TITLE
Add --upload-to-index option to wheel command

### DIFF
--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -52,6 +52,12 @@ class WheelCommand(RequirementCommand):
         cmd_opts = self.cmd_opts
 
         cmd_opts.add_option(
+            '--upload-to-index',
+            dest='upload_to_index',
+            metavar='index_url',
+            help=("Upload built wheels to package index at <index_url>"),
+        )
+        cmd_opts.add_option(
             '-w', '--wheel-dir',
             dest='wheel_dir',
             metavar='dir',
@@ -123,6 +129,12 @@ class WheelCommand(RequirementCommand):
             )
 
     def run(self, options, args):
+        if options.upload_to_index:
+            if options.build_options is None:
+                options.build_options = []
+            options.build_options.extend(
+                ['upload', '-r', options.upload_to_index])
+
         self.check_required_packages()
         cmdoptions.resolve_wheel_no_use_binary(options)
         cmdoptions.check_install_build_global(options)


### PR DESCRIPTION
Gives an easy way to build a wheel and upload it to a package index. E.g.:

```
$ pip wheel requests --upload-to-index=http://some-nonexistent-index.com
/Users/marca/dev/git-repos/pip/pip/commands/wheel.py:140: UserWarning: Disabling all use of wheels due to the use of --build-options / --global-options / --install-options.
  cmdoptions.check_install_build_global(options)
Collecting requests
  Using cached requests-2.7.0.tar.gz
Building wheels for collected packages: requests
  Running setup.py bdist_wheel for requests
  Complete output from command /Users/marca/python/virtualenvs/devpi-server-dev/bin/python -c "import setuptools;__file__='/private/var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/pip-build-G8FwFj/requests/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /var/f>
...
  running upload
  Submitting /var/folders/gw/w0clrs515zx9x_55zgtpv4mm0000gp/T/tmpLFipt2pip-wheel-/requests-2.7.0-py2.py3-none-any.whl 
to http://some-nonexistent-index.com
  error: <urlopen error [Errno 8] nodename nor servname provided, or not known>

  ----------------------------------------
  Failed building wheel for requests
Failed to build requests
```