### PR TITLE
Proposal: --auth (--netloc-credentials) global option

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -95,6 +95,16 @@ class Command(object):
                 "https": options.proxy,
             }
 
+        # Handle configured credentials
+        if len(options.credentials):
+            for netloc_cred in options.credentials:
+                if netloc_cred.find("@") == -1 or netloc_cred.find(":") == -1:
+                    logger.warn("Invalid credentials format: %s", netloc_cred)
+                else:
+                    username_password, netloc = netloc_cred.split("@")
+                    username, password = username_password.split(":")
+                    session.auth.passwords[netloc] = (username, password)
+
         # Determine if we can prompt the user for authentication or not
         session.auth.prompting = not options.no_input
 

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -148,6 +148,15 @@ proxy = partial(
     default='',
     help="Specify a proxy in the form [user:passwd@]proxy.server:port.")
 
+netloc_credentials = partial(
+    Option,
+    '--auth', '--netloc-credentials',
+    dest='credentials',
+    action='append',
+    type='str',
+    default=[],
+    help="Specify credentials in the form user:passwd@private.server[:port].")
+
 retries = partial(
     Option,
     '--retries',
@@ -539,6 +548,7 @@ general_group = {
         log_explicit_levels,
         no_input,
         proxy,
+        netloc_credentials,
         retries,
         timeout,
         default_vcs,


### PR DESCRIPTION
# Adding one global option
```
  --auth <credentials>        Specify credentials in the form
                              user:passwd@private.server[:port].
```

This option enables you to do direct installation of archive exported from private repository in Bitbucket, Stash (with exporting plugin) and hopefully GitHub.

## What situation this will solve
To install archive with downloading from some private space over HTTP(s), pip requires 1) server returns HTTP 401 status code and then 2) human needs to enter credentials on his/her console if you don't want to put credentials into URL.

When you do automation without requirements.txt, putting credentials into URL is good but when you want to use requirements.txt, writing credentials into the file is not feasible because it's most probably supposed to be committed into somewhere and shared.

## How to use
```
pip --auth username:password@private.stash.local install http://private.stash.local/path/to/archive
pip --auth username:password@bitbucket.org install http://bitbucket.org /path/to/archive
```

## TODOs
- Manual tests with private repositories in other Git services such as GitHub.
- Write test code if required.
