### PR TITLE
Allow things like "git+ssh" to count as secure in validate_secure_origin.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,9 @@
 
 * Allow ``--pre`` within a requirements file. :issue:`1273`.
 
+* Allow repository URLs with secure transports to count as trusted. (E.g.,
+  "git+ssh" is okay.) :issue:`2811`.
+
 
 **7.1.2 (2015-08-22)**
 

--- a/pip/index.py
+++ b/pip/index.py
@@ -37,15 +37,16 @@ from pip._vendor.requests.exceptions import SSLError
 __all__ = ['FormatControl', 'fmt_ctl_handle_mutual_exclude', 'PackageFinder']
 
 
-# Taken from Chrome's list of secure origins (See: http://bit.ly/1qrySKC)
 SECURE_ORIGINS = [
     # protocol, hostname, port
+    # Taken from Chrome's list of secure origins (See: http://bit.ly/1qrySKC)
     ("https", "*", "*"),
-    ("ssh", "*", "*"),
     ("*", "localhost", "*"),
     ("*", "127.0.0.0/8", "*"),
     ("*", "::1/128", "*"),
     ("file", "*", None),
+    # ssh is always secure.
+    ("ssh", "*", "*"),
 ]
 
 

--- a/pip/index.py
+++ b/pip/index.py
@@ -41,6 +41,7 @@ __all__ = ['FormatControl', 'fmt_ctl_handle_mutual_exclude', 'PackageFinder']
 SECURE_ORIGINS = [
     # protocol, hostname, port
     ("https", "*", "*"),
+    ("ssh", "*", "*"),
     ("*", "localhost", "*"),
     ("*", "127.0.0.0/8", "*"),
     ("*", "::1/128", "*"),

--- a/pip/index.py
+++ b/pip/index.py
@@ -269,7 +269,10 @@ class PackageFinder(object):
         # configured on this PackageFinder instance.
         for secure_origin in (SECURE_ORIGINS + self.secure_origins):
             # Check to see if the protocol matches
-            if origin[0] != secure_origin[0] and secure_origin[0] != "*":
+            # Don't count the repository type as part of the protocol, in
+            # things such as "git+ssh". (Only verify against the last scheme.)
+            protocol = origin[0].rsplit('+', 1)[-1]
+            if protocol != secure_origin[0] and secure_origin[0] != "*":
                 continue
 
             try:

--- a/pip/index.py
+++ b/pip/index.py
@@ -264,14 +264,16 @@ class PackageFinder(object):
         parsed = urllib_parse.urlparse(str(location))
         origin = (parsed.scheme, parsed.hostname, parsed.port)
 
+        # The protocol to use to see if the protocol matches.
+        # Don't count the repository type as part of the protocol: in
+        # cases such as "git+ssh", only use "ssh". (I.e., Only verify against
+        # the last scheme.)
+        protocol = origin[0].rsplit('+', 1)[-1]
+
         # Determine if our origin is a secure origin by looking through our
         # hardcoded list of secure origins, as well as any additional ones
         # configured on this PackageFinder instance.
         for secure_origin in (SECURE_ORIGINS + self.secure_origins):
-            # Check to see if the protocol matches
-            # Don't count the repository type as part of the protocol, in
-            # things such as "git+ssh". (Only verify against the last scheme.)
-            protocol = origin[0].rsplit('+', 1)[-1]
             if protocol != secure_origin[0] and secure_origin[0] != "*":
                 continue
 

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -107,6 +107,9 @@ class MockLogger(object):
     [
         ("http://pypi.python.org/something", [], True),
         ("https://pypi.python.org/something", [], False),
+        ("git+http://pypi.python.org/something", [], True),
+        ("git+https://pypi.python.org/something", [], False),
+        ("git+ssh://git@pypi.python.org/something", [], False),
         ("http://localhost", [], False),
         ("http://127.0.0.1", [], False),
         ("http://example.com/something/", [], True),


### PR DESCRIPTION
See issue #2811. (Couldn't figure out how to link this PR.)