### PR TITLE
Release/7.0.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+**7.0.1 (2015-05-22)**
+
+* Don't build and cache wheels for non-editable installations from VCSs.
+
+* Allow ``--allow-all-external`` inside of a requirements.txt file, fixing a
+  regression in 7.0.
+
+
 **7.0.0 (2015-05-21)**
 
 * **BACKWARD INCOMPATIBLE** Removed the deprecated ``--mirror``,

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -30,7 +30,7 @@ import pip.cmdoptions
 cmdoptions = pip.cmdoptions
 
 # The version as used in the setup.py and the docs conf.py
-__version__ = "7.0.0"
+__version__ = "7.0.1.dev0"
 
 
 logger = logging.getLogger(__name__)

--- a/pip/index.py
+++ b/pip/index.py
@@ -1207,6 +1207,19 @@ class Link(object):
     def is_wheel(self):
         return self.ext == wheel_ext
 
+    @property
+    def is_artifact(self):
+        """
+        Determines if this points to an actual artifact (e.g. a tarball) or if
+        it points to an "abstract" thing like a path or a VCS location.
+        """
+        from pip.vcs import vcs
+
+        if self.scheme in vcs.all_schemes:
+            return False
+
+        return True
+
 
 # An object to represent the "link" for the installed version of a requirement.
 # Using Inf as the url makes it sort higher.

--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -32,6 +32,7 @@ SUPPORTED_OPTIONS = [
     cmdoptions.find_links,
     cmdoptions.extra_index_url,
     cmdoptions.allow_external,
+    cmdoptions.allow_all_external,
     cmdoptions.no_allow_external,
     cmdoptions.allow_unsafe,
     cmdoptions.no_allow_unsafe,

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -716,7 +716,7 @@ class WheelBuilder(object):
                     logger.info(
                         'Skipping bdist_wheel for %s, due to being editable',
                         req.name)
-            elif autobuilding and not req.link.is_artifact:
+            elif autobuilding and req.link and not req.link.is_artifact:
                 pass
             elif autobuilding and not req.source_dir:
                 pass

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -110,6 +110,8 @@ def cached_wheel(cache_dir, link, format_control, package_name):
         return link
     if link.is_wheel:
         return link
+    if not link.is_artifact:
+        return link
     if not package_name:
         return link
     canonical_name = pkg_resources.safe_name(package_name).lower()
@@ -714,6 +716,8 @@ class WheelBuilder(object):
                     logger.info(
                         'Skipping bdist_wheel for %s, due to being editable',
                         req.name)
+            elif autobuilding and not req.link.is_artifact:
+                pass
             elif autobuilding and not req.source_dir:
                 pass
             else:

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -52,6 +52,7 @@ class VirtualEnvironment(object):
             clear=clear,
             never_download=True,
             no_pip=True,
+            no_wheel=True,
         )
 
         # Install our development version of pip install the virtual

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -469,3 +469,13 @@ class TestParseRequirements(object):
                 call.index(global_option) > 0
         assert options.format_control.no_binary == set([':all:'])
         assert options.format_control.only_binary == set([])
+
+    def test_allow_all_external(self, tmpdir):
+        req_path = tmpdir.join("requirements.txt")
+        with open(req_path, "w") as fh:
+            fh.write("""
+        --allow-all-external
+        foo
+        """)
+
+        list(parse_requirements(req_path, session=PipSession()))


### PR DESCRIPTION
Backport changes to ``7.x``:

* Don't build and cache wheels for non-editable installations from VCSs.
* Allow ``--allow-all-external`` inside of a requirements.txt file, fixing a regression in 7.0.