### PR TITLE
Document behavior of boolean config file variables (--no-cache and --no-compile)

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -321,6 +321,17 @@ set like this:
     ignore-installed = true
     no-dependencies = yes
 
+To enable the boolean options ``--no-compile`` and ``--no-cache-dir``, falsy
+values have to be used:
+
+.. code-block:: ini
+
+    [global]
+    no-cache-dir = false
+
+    [install]
+    no-compile = no
+
 Appending options like ``--find-links`` can be written on multiple lines:
 
 .. code-block:: ini


### PR DESCRIPTION
I had to do a deep dive to find out that arguments that have `store_false` as their action need to be specified as a Falsy value in a config file. There are two more deprecated options that work this way.

I'd be happy to rework the code so that it works in a less surprising manner, but that would break some people's `pip.conf` files, or at least mine.