### PR TITLE
fix for #2828:  handling marker syntax using `pip freeze -r`

### DIFF
--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import re
+import shlex
 
 import pip
 from pip.compat import stdlib_pkgs
@@ -66,6 +67,10 @@ def freeze(
                             '--extra-index-url'))):
                     yield line.rstrip()
                     continue
+
+                # as of pip v7, using markers in requirements files requires
+                # quoting, which requires shlex to parse correctly.
+                line = ' '.join(shlex.split(line))
 
                 if line.startswith('-e') or line.startswith('--editable'):
                     if line.startswith('-e'):

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -292,6 +292,7 @@ def test_freeze_with_requirement_option(script):
     script.scratch_path.join("hint.txt").write(textwrap.dedent("""\
         INITools==0.1
         NoExist==4.2
+        "simple==3.0; python_version > '1.0'"
         """) + ignores)
     result = script.pip_install_local('initools==0.2')
     result = script.pip_install_local('simple')
@@ -306,6 +307,7 @@ Requirement file contains NoExist==4.2, but that package is not installed
 
 -- stdout: --------------------
 INITools==0.2
+simple==3.0
 """ + ignores + "## The following requirements were added by pip freeze:..."
     _check_output(result, expected)
 


### PR DESCRIPTION
This is the minimal change to fix #2828.  I updated the test for this as well.

Later, we should come back and refactor this block to be consistent with the new parsing in `pip.req.req_file` (vs the manual parsing it's doing)
