### PR TITLE
Issue #2839: Revert syntax of requirement files.

### DIFF
--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 
 import os
 import re
-import shlex
 import optparse
 
 from pip._vendor.six.moves.urllib import parse as urllib_parse
@@ -111,7 +110,7 @@ def process_line(line, filename, line_number, finder=None, comes_from=None,
     if finder:
         # `finder.format_control` will be updated during parsing
         defaults.format_control = finder.format_control
-    opts, args = parser.parse_args(shlex.split(line), defaults)
+    opts, args = parser.parse_args(line.split(), defaults)
 
     # yield a line requirement
     if args:

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -120,12 +120,19 @@ class TestProcessLine(object):
 
     def test_options_on_a_requirement_line(self):
         line = 'SomeProject --install-option=yo1 --install-option yo2 '\
-               '--global-option="yo3" --global-option "yo4"'
+               '--global-option=yo3 --global-option yo4'
         filename = 'filename'
         req = list(process_line(line, filename, 1))[0]
         assert req.options == {
             'global_options': ['yo3', 'yo4'],
             'install_options': ['yo1', 'yo2']}
+
+    def test_options_and_markers(self):
+        line = 'SomeProject --install-option=yo1 ; python_version=="2.6"'
+        filename = 'filename'
+        req = list(process_line(line, filename, 1))[0]
+        assert req.options == {'install_options': ['yo1']}
+        assert req.markers == 'python_version=="2.6"'
 
     def test_set_isolated(self, options):
         line = 'SomeProject'
@@ -311,19 +318,11 @@ class TestOptionVariants(object):
         assert finder.index_urls == ['url']
 
     def test_variant2(self, finder):
-        list(process_line("-i 'url'", "file", 1, finder=finder))
-        assert finder.index_urls == ['url']
-
-    def test_variant3(self, finder):
         list(process_line("--index-url=url", "file", 1, finder=finder))
         assert finder.index_urls == ['url']
 
-    def test_variant4(self, finder):
+    def test_variant3(self, finder):
         list(process_line("--index-url url", "file", 1, finder=finder))
-        assert finder.index_urls == ['url']
-
-    def test_variant5(self, finder):
-        list(process_line("--index-url='url'", "file", 1, finder=finder))
         assert finder.index_urls == ['url']
 
 
@@ -444,8 +443,8 @@ class TestParseRequirements(object):
 
         content = '''
         --only-binary :all:
-        INITools==2.0 --global-option="{global_option}" \
-                        --install-option "{install_option}"
+        INITools==2.0 --global-option={global_option} \
+                        --install-option {install_option}
         '''.format(global_option=global_option, install_option=install_option)
 
         req_path = tmpdir.join('requirements.txt')


### PR DESCRIPTION
In < 7 requirements files did not need escaping for quotation marks.
7.0 accidentally introduced quoting (via the use of shlex.split) when
also introducing the feature of supporting local and global options.
Since we've only had a week while this has been public it should be
pretty safe to unwind the quoting aspect and restore previously
working requirements files to working order.