### PR TITLE
don't require environment marker specifiers to be quoted in requirement files

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 **7.1.0 (unreleased)**
 
+**7.0.2 (unreleased)**
+
+* Revert the change (released in v7.0.0) that required quoting in requirements
+  around specifiers containing environment markers.
 
 **7.0.1 (2015-05-22)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,7 @@
 **7.0.2 (unreleased)**
 
 * Revert the change (released in v7.0.0) that required quoting in requirements
-  around specifiers containing environment markers.
+  files around specifiers containing environment markers.
 
 **7.0.1 (2015-05-22)**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,15 @@ sys.path.insert(0, os.path.abspath(os.pardir))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 # extensions = ['sphinx.ext.autodoc']
-extensions = ['sphinx.ext.extlinks', 'docs.pipext']
+extensions = ['sphinx.ext.extlinks', 'docs.pipext', 'sphinx.ext.intersphinx']
+
+# intersphinx
+intersphinx_cache_limit = 0
+intersphinx_mapping = {
+    'pypug': ('https://packaging.python.org/en/latest/', None),
+    'pypa': ('https://pypa.io/en/latest/', None),
+}
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = []

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -82,20 +82,12 @@ Requirements File Format
 Each line of the requirements file indicates something to be installed,
 and like arguments to :ref:`pip install`, the following forms are supported::
 
-    <requirement specifier>
     <requirement specifier> [--install-option="..."] [--global-option="..."]
     <archive url/path>
     [-e] <local project path>
     [-e] <vcs project url>
 
-Since version 6.0, pip also supports markers using the "; " separator.
-Examples::
-
-    "futures; python_version < '2.7'"
-    "http://my.package.repo/SomePackage-1.0.4.zip; python_version >= '3.4'"
-
-Requirements with markers must be quoted. For example, use ``"SomeProject;
-python_version < '2.7'"``, not simply ``SomeProject; python_version < '2.7'``.
+For details on requirement specifiers, see :ref:`Requirement Specifiers`.
 
 See the :ref:`pip install Examples<pip install Examples>` for examples of all these forms.
 
@@ -136,23 +128,38 @@ Lastly, if you wish, you can refer to other requirements files, like this::
 Requirement Specifiers
 ++++++++++++++++++++++
 
-pip supports installing from "requirement specifiers" as implemented in
-`pkg_resources Requirements <http://packages.python.org/setuptools/pkg_resources.html#requirement-objects>`_
+pip supports installing from a package index using a :term:`requirement
+specifier <pypug:Requirement Specifier>`. Generally speaking, a requirement
+specifier is composed of a project name followed by an optional :term:`version
+specifier <pypug:Version Specifier>`.  :ref:`PEP440 <pypa:PEP440s>` contains a
+`full specification
+<https://www.python.org/dev/peps/pep-0440/#version-specifiers>`_ of the
+currently supported specifiers.
 
-Some Examples:
+Below are some examples:
 
  ::
 
-  'FooProject >= 1.2'
-  Fizzy [foo, bar]
-  'PickyThing<1.6,>1.9,!=1.9.6,<2.0a0,==2.4c1'
-  SomethingWhoseVersionIDontCareAbout
+  SomeProject
+  SomeProject==1.3
+  SomeProject>=1.2,<.2.0
+  SomeProject[foo, bar]
+  SomeProject~=1.4.2
+
+Since version 6.0, pip also supports specifers containing `environment markers
+<https://www.python.org/dev/peps/pep-0426/#environment-markers>`_ like so:
+
+ ::
+
+  SomeProject; python_version < '2.7'
+  SomeProject; sys.platform == 'win32'
+
+Environment markers are supported in the command line and in requirements files.
 
 .. note::
 
-  Use single or double quotes around specifiers when using them in a shell to avoid ``>`` and ``<`` being
-  interpreted as shell redirects. e.g. ``pip install 'FooProject>=1.2'``.
-  Don't use single or double quotes in a ``requirements.txt`` file.
+   Use quotes around specifiers in the shell when using ``>``, ``<``, or when
+   using environment markers. Don't use quotes in requirement files. [1]_
 
 
 .. _`Per-requirement Overrides`:
@@ -631,3 +638,8 @@ Examples
  ::
 
   $ pip install --pre SomePackage
+
+----
+
+.. [1] This is true with the exception that pip v7.0 and v7.0.1 required quotes
+       around specifiers containing environment markers in requirement files.

--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -198,13 +198,15 @@ def break_args_options(line):
     (and then optparse) the options, not the args.  args can contain markers
     which are corrupted by shlex.
     """
-    tokens = shlex.split(line)
+    tokens = line.split(' ')
     args = []
-    options = tokens
+    options = tokens[:]
     for token in tokens:
         if token.startswith('-') or token.startswith('--'):
             break
-        args.append(options.pop(0))
+        else:
+            args.append(token)
+            options.pop(0)
     return ' '.join(args), ' '.join(options)
 
 

--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -111,11 +111,11 @@ def process_line(line, filename, line_number, finder=None, comes_from=None,
     if finder:
         # `finder.format_control` will be updated during parsing
         defaults.format_control = finder.format_control
-    opts, args = parser.parse_args(shlex.split(line), defaults)
+    args_str, options_str = break_args_options(line)
+    opts, _ = parser.parse_args(shlex.split(options_str), defaults)
 
     # yield a line requirement
-    if args:
-        args_line = ' '.join(args)
+    if args_str:
         comes_from = '-r %s (line %s)' % (filename, line_number)
         isolated = options.isolated_mode if options else False
         if options:
@@ -126,7 +126,7 @@ def process_line(line, filename, line_number, finder=None, comes_from=None,
             if dest in opts.__dict__ and opts.__dict__[dest]:
                 req_options[dest] = opts.__dict__[dest]
         yield InstallRequirement.from_line(
-            args_line, comes_from, isolated=isolated, options=req_options,
+            args_str, comes_from, isolated=isolated, options=req_options,
             wheel_cache=wheel_cache
         )
 
@@ -191,6 +191,21 @@ def process_line(line, filename, line_number, finder=None, comes_from=None,
             if os.path.exists(relative_to_reqs_file):
                 value = relative_to_reqs_file
             finder.find_links.append(value)
+
+
+def break_args_options(line):
+    """Break up the line into an args and options string.  We only want to shlex
+    (and then optparse) the options, not the args.  args can contain markers
+    which are corrupted by shlex.
+    """
+    tokens = shlex.split(line)
+    args = []
+    options = tokens
+    for token in tokens:
+        if token.startswith('-') or token.startswith('--'):
+            break
+        args.append(options.pop(0))
+    return ' '.join(args), ' '.join(options)
 
 
 def build_parser():

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -292,6 +292,7 @@ def test_freeze_with_requirement_option(script):
     script.scratch_path.join("hint.txt").write(textwrap.dedent("""\
         INITools==0.1
         NoExist==4.2
+        simple==3.0; python_version > '1.0'
         """) + ignores)
     result = script.pip_install_local('initools==0.2')
     result = script.pip_install_local('simple')
@@ -306,6 +307,7 @@ Requirement file contains NoExist==4.2, but that package is not installed
 
 -- stdout: --------------------
 INITools==0.2
+simple==3.0
 """ + ignores + "## The following requirements were added by pip freeze:..."
     _check_output(result, expected)
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -312,18 +312,18 @@ class TestProcessLine(object):
 class TestBreakOptionsArgs(object):
 
     def test_no_args(self):
-        assert ['', '--option'] == break_args_options('--option')
+        assert ('', '--option') == break_args_options('--option')
 
     def test_no_options(self):
-        assert ['arg arg', ''] == break_args_options('arg arg')
+        assert ('arg arg', '') == break_args_options('arg arg')
 
     def test_args_short_options(self):
         result = break_args_options('arg arg -s')
-        assert ['arg arg', '-s'] == result
+        assert ('arg arg', '-s') == result
 
     def test_args_long_options(self):
         result = break_args_options('arg arg --long')
-        assert ['arg arg', '--long'] == result
+        assert ('arg arg', '--long') == result
 
 
 class TestOptionVariants(object):

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -12,7 +12,7 @@ from pip.download import PipSession
 from pip.index import PackageFinder
 from pip.req.req_install import InstallRequirement
 from pip.req.req_file import (parse_requirements, process_line, join_lines,
-                              ignore_comments)
+                              ignore_comments, break_args_options)
 
 
 @pytest.fixture
@@ -300,6 +300,30 @@ class TestProcessLine(object):
         assert len(req.extras) == 2
         assert req.extras[0] == 'ex1'
         assert req.extras[1] == 'ex2'
+
+    def test_options_and_markers(self):
+        line = 'SomeProject ; python_version=="2.6" --install-option "yo"'
+        filename = 'filename'
+        req = list(process_line(line, filename, 1))[0]
+        assert req.options == {'install_options': ['yo']}
+        assert req.markers == 'python_version=="2.6"'
+
+
+class TestBreakOptionsArgs(object):
+
+    def test_no_args(self):
+        assert ['', '--option'] == break_args_options('--option')
+
+    def test_no_options(self):
+        assert ['arg arg', ''] == break_args_options('arg arg')
+
+    def test_args_short_options(self):
+        result = break_args_options('arg arg -s')
+        assert ['arg arg', '-s'] == result
+
+    def test_args_long_options(self):
+        result = break_args_options('arg arg --long')
+        assert ['arg arg', '--long'] == result
 
 
 class TestOptionVariants(object):


### PR DESCRIPTION
the alternate idea mentioned in #2841 

the advantage over #2841 is that allows markers and `--install-option` to work together properly, i.e w/o having to tack the ";" portion at the end of line, where it's not supposed to go.
