### PR TITLE
Fixed support for Jython 2.7 in wheel.py.

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -123,7 +123,7 @@ def cached_wheel(cache_dir, link, format_control, package_name):
     try:
         wheel_names = os.listdir(root)
     except OSError as e:
-        if e.errno == errno.ENOENT:
+        if e.errno in (errno.ENOENT, errno.ENOTDIR):
             return link
         raise
     candidates = []


### PR DESCRIPTION
Jython 2.7 doesn't emit the same OSError code as CPython when a directory doesn't exist. This is a one-line fix.