### PR TITLE
vendor: Don't discard traces when an ImportError occurs

### DIFF
--- a/pip/_vendor/__init__.py
+++ b/pip/_vendor/__init__.py
@@ -85,11 +85,8 @@ class VendorAlias(object):
             # We can't import the vendor name, so we'll try to import the
             # "real" name.
             real_name = name[len(self._vendor_pkg):]
-            try:
-                __import__(real_name)
-                module = sys.modules[real_name]
-            except ImportError:
-                raise ImportError("No module named '%s'" % (name,))
+            __import__(real_name)
+            module = sys.modules[real_name]
 
         # If we've gotten here we've found the module we're looking for, either
         # as part of our vendored package, or as the real name, so we'll add


### PR DESCRIPTION
In Homebrew, we ran into [an issue](https://github.com/Homebrew/homebrew/issues/40516) where an ImportError raised when pip failed to import a module from within `_vendor`. The trace was unhelpful, and after a bit of digging I noticed that the original trace is being discarded and a new `ImportError` raised that masks the actual location of the exception.

For example, the provided trace looked like this:

```
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/pip-7.0.1-py2.7.egg/pip/__init__.py", line 15, in <module>
    from pip.vcs import git, mercurial, subversion, bazaar  # noqa
  File "/usr/local/lib/python2.7/site-packages/pip-7.0.1-py2.7.egg/pip/vcs/subversion.py", line 9, in <module>
    from pip.index import Link
  File "/usr/local/lib/python2.7/site-packages/pip-7.0.1-py2.7.egg/pip/index.py", line 30, in <module>
    from pip.wheel import Wheel, wheel_ext
  File "/usr/local/lib/python2.7/site-packages/pip-7.0.1-py2.7.egg/pip/wheel.py", line 34, in <module>
    from pip._vendor.distlib.scripts import ScriptMaker
  File "/usr/local/lib/python2.7/site-packages/pip-7.0.1-py2.7.egg/pip/_vendor/__init__.py", line 92, in load_module
    raise ImportError("No module named '%s'" % (name,))
ImportError: No module named 'pip._vendor.distlib.scripts'
```

However, the actual `ImportError` was being raised [here](https://github.com/pypa/pip/blob/develop/pip/_vendor/distlib/compat.py#L31-L34) (Python was built without `_ssl`, and so one of the constants is unavailable).

I think it would make debugging easier to let the original `ImportError` propagate.