### PR TITLE
fix for AttributeError when installing a cached wheel

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -746,6 +746,7 @@ class PackageFinder(object):
                             platform == 'cli'
                         ) and
                         comes_from is not None and
+                        hasattr(comes_from, 'url') and
                         urllib_parse.urlparse(
                             comes_from.url
                         ).netloc.endswith(PyPI.netloc)):


### PR DESCRIPTION
pip install crashes with an AttributeError under the following combination of circumstances:

1. attempting to install a cached wheel
2. using --no-index and specifying individual package files with --find-links
3. not on OS X or Windows

Here's a simple fix, which tests for the attribute before using it.