### PR TITLE
get_src_requirement: always add the "vcs+" prefix

### DIFF
--- a/pip/vcs/bazaar.py
+++ b/pip/vcs/bazaar.py
@@ -115,8 +115,6 @@ class Bazaar(VersionControl):
         repo = self.get_url(location)
         if not repo:
             return None
-        if not repo.lower().startswith('bzr:'):
-            repo = 'bzr+' + repo
         egg_project_name = dist.egg_name().split('-', 1)[0]
         current_rev = self.get_revision(location)
         tag_revs = self.get_tag_revs(location)
@@ -126,7 +124,7 @@ class Bazaar(VersionControl):
             full_egg_name = '%s-%s' % (egg_project_name, tag_revs[current_rev])
         else:
             full_egg_name = '%s-dev_r%s' % (dist.egg_name(), current_rev)
-        return '%s@%s#egg=%s' % (repo, current_rev, full_egg_name)
+        return 'bzr+%s@%s#egg=%s' % (repo, current_rev, full_egg_name)
 
 
 vcs.register(Bazaar)

--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -155,8 +155,6 @@ class Git(VersionControl):
 
     def get_src_requirement(self, dist, location, find_tags):
         repo = self.get_url(location)
-        if not repo.lower().startswith('git:'):
-            repo = 'git+' + repo
         egg_project_name = dist.egg_name().split('-', 1)[0]
         if not repo:
             return None
@@ -179,7 +177,7 @@ class Git(VersionControl):
         else:
             full_egg_name = '%s-dev' % egg_project_name
 
-        return '%s@%s#egg=%s' % (repo, current_rev, full_egg_name)
+        return 'git+%s@%s#egg=%s' % (repo, current_rev, full_egg_name)
 
     def get_url_rev(self):
         """

--- a/pip/vcs/mercurial.py
+++ b/pip/vcs/mercurial.py
@@ -114,8 +114,6 @@ class Mercurial(VersionControl):
 
     def get_src_requirement(self, dist, location, find_tags):
         repo = self.get_url(location)
-        if not repo.lower().startswith('hg:'):
-            repo = 'hg+' + repo
         egg_project_name = dist.egg_name().split('-', 1)[0]
         if not repo:
             return None
@@ -134,6 +132,6 @@ class Mercurial(VersionControl):
             )
         else:
             full_egg_name = '%s-dev' % egg_project_name
-        return '%s@%s#egg=%s' % (repo, current_rev_hash, full_egg_name)
+        return 'hg+%s@%s#egg=%s' % (repo, current_rev_hash, full_egg_name)
 
 vcs.register(Mercurial)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -38,6 +38,16 @@ def test_git_get_src_requirements():
         '#egg=pip_test_package-bar'
     ])
 
+    git_url = 'git://github.com/pypa/pip-test-package'
+    git.get_url = Mock(return_value=git_url)
+    ret = git.get_src_requirement(dist, location='.', find_tags=None)
+
+    assert ret == ''.join([
+        'git+git://github.com/pypa/pip-test-package',
+        '@5547fa909e83df8bd743d3978d6667497983a4b7',
+        '#egg=pip_test_package-bar'
+    ])
+
 
 def test_translate_egg_surname():
     vc = VersionControl()


### PR DESCRIPTION
This got skipped previously for URLs starting with the protocol itself,
i.e. `git://`, `hg://` and `bzr://`, but not for `svn://`.

Leaving the `vcs+` prefix out does not allow for usage with `pip
install` or in a requirements file by default.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/2913)
<!-- Reviewable:end -->
