### PR TITLE
Mention all 4 TopoRequires packages

### DIFF
--- a/tests/data/packages/README.txt
+++ b/tests/data/packages/README.txt
@@ -71,7 +71,7 @@ priority-*
 ----------
 used for testing wheel priority over sdists
 
-TopoRequires[123][-0.0.1.tar.gz]
+TopoRequires[1234][-0.0.1.tar.gz]
 --------------------------------
 
 These are used for testing topological handling of requirements: we have


### PR DESCRIPTION
TopoRequires4 is mentioned in the body text but not the header.