### PR TITLE
get only first part of SOABI for ABI tag

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -67,7 +67,7 @@ def get_supported(versions=None, noarch=False):
         soabi = None
 
     if soabi and soabi.startswith('cpython-'):
-        abis[0:0] = ['cp' + soabi.split('-', 1)[-1]]
+        abis[0:0] = ['cp' + soabi.split('-')[1]]
 
     abi3s = set()
     import imp

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -307,6 +307,27 @@ class TestPEP425Tags(object):
         with patch('pip.pep425tags.sysconfig.get_config_var', raises_ioerror):
             assert len(pip.pep425tags.get_supported())
 
+    def test_no_hyphen_tag(self):
+        """
+        Test that no tag contains a hyphen.
+        """
+        import pip.pep425tags
+
+        get_config_var = pip.pep425tags.sysconfig.get_config_var
+
+        def mock_soabi(var):
+            if var == 'SOABI':
+                return 'cpython-35m-darwin'
+            return get_config_var(var)
+
+        with patch('pip.pep425tags.sysconfig.get_config_var', mock_soabi):
+            supported = pip.pep425tags.get_supported()
+
+        for (py, abi, plat) in supported:
+            assert '-' not in py
+            assert '-' not in abi
+            assert '-' not in plat
+
 
 class TestMoveWheelFiles(object):
     """


### PR DESCRIPTION
after `cpython-`

CPython 3.5 has SOABI='cpython-35m-darwin'

This now returns the expected 'cp35m'

The alternate fix is to add a `.replace('-', '_')`, so that the ABI tag would be `cp35m_darwin`, but right now there is a hyphen in the tag, which I believe is not valid in pep425.

[Related PR on wheel](https://bitbucket.org/pypa/wheel/pull-request/53/use-split-instead-of-rsplit-to-create/diff)