### PR TITLE
Accept non-ASCII setup.py when running on Python 3

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -675,11 +675,15 @@ class WheelBuilder(object):
             rmtree(tempd)
 
     def __build_one(self, req, tempd):
+        if sys.hexversion < 0x03000000:
+            replacing = ").read().replace('\\r\\n', '\\n'), "
+        else:
+            replacing = ", 'rb').read().replace(b'\\r\\n', b'\\n'), "
         base_args = [
             sys.executable, '-c',
-            "import setuptools;__file__=%r;"
-            "exec(compile(open(__file__).read().replace('\\r\\n', '\\n'), "
-            "__file__, 'exec'))" % req.setup_py
+            ("import setuptools;__file__=%r;" % req.setup_py) + \
+            "exec(compile(open(__file__" + replacing + \
+            "__file__, 'exec'))"
         ] + list(self.global_options)
 
         logger.info('Running setup.py bdist_wheel for %s', req.name)

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -681,8 +681,8 @@ class WheelBuilder(object):
             replacing = ", 'rb').read().replace(b'\\r\\n', b'\\n'), "
         base_args = [
             sys.executable, '-c',
-            ("import setuptools;__file__=%r;" % req.setup_py) + \
-            "exec(compile(open(__file__" + replacing + \
+            ("import setuptools;__file__=%r;" % req.setup_py) +
+            "exec(compile(open(__file__" + replacing +
             "__file__, 'exec'))"
         ] + list(self.global_options)
 


### PR DESCRIPTION
When running on Python 3 and setup.py includes non-ASCII characters,
'pip install xxx' will fail at building the wheel infomation.

This patch will fix the problem.
Thanks!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/2916)
<!-- Reviewable:end -->
