### PR TITLE
Handle missing case from bug #2888

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -102,6 +102,8 @@ class InstallRequirement(object):
         self.target_dir = None
         self.options = options if options else {}
         self.pycompile = pycompile
+        # Set to True after successful preparation of this requirement
+        self.prepared = False
 
         self.isolated = isolated
 

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -393,8 +393,10 @@ class RequirementSet(object):
         # Tell user what we are doing for this requirement:
         # obtain (editable), skipping, processing (local url), collecting
         # (remote url or package name)
-        if req_to_install.constraint:
+        if req_to_install.constraint or req_to_install.prepared:
             return []
+
+        req_to_install.prepared = True
 
         if req_to_install.editable:
             logger.info('Obtaining %s', req_to_install)

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -106,6 +106,16 @@ def test_multiple_requirements_files(script, tmpdir):
     assert script.venv / 'src' / 'initools' in result.files_created
 
 
+def test_package_in_constraints_and_dependencies(script, data):
+    script.scratch_path.join("constraints.txt").write(
+        "TopoRequires2==0.0.1\nTopoRequires==0.0.1"
+    )
+    result = script.pip('install', '--no-index', '-f',
+                        data.find_links, '-c', script.scratch_path /
+                        'constraints.txt', 'TopoRequires2')
+    assert 'installed TopoRequires-0.0.1' in result.stdout
+
+
 def test_multiple_constraints_files(script, data):
     script.scratch_path.join("outer.txt").write("-c inner.txt")
     script.scratch_path.join("inner.txt").write(


### PR DESCRIPTION
If a single package is listed as a constraint; is a dependency of a
package being installed; *and* is already installed, we end up
processing it multiple times. This change adds a new "prepared" flag
which we set the first time the package is processed, to prevent
multiple handling.

Fixes bug #2888