### PR TITLE
allow ability to ignore path prefixes in the wheel cache for locally hosted packages

### DIFF
--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -463,6 +463,15 @@ no_cache = partial(
     help="Disable the cache.",
 )
 
+def cache_ignore_prefix():
+    return Option(
+        "--cache-ignore-prefix",
+        dest="cache_ignore_prefix",
+        action="append",
+        default=[],
+        metavar="url",
+        help="Ignore this prefix on cached files.")
+
 download_cache = partial(
     Option,
     '--download-cache',
@@ -560,6 +569,7 @@ general_group = {
         client_cert,
         cache_dir,
         no_cache,
+        cache_ignore_prefix,
         disable_pip_version_check,
     ]
 }

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -463,6 +463,7 @@ no_cache = partial(
     help="Disable the cache.",
 )
 
+
 def cache_ignore_prefix():
     return Option(
         "--cache-ignore-prefix",

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -244,7 +244,8 @@ class InstallCommand(RequirementCommand):
 
             finder = self._build_package_finder(options, index_urls, session)
             build_delete = (not (options.no_clean or options.build_dir))
-            wheel_cache = WheelCache(options.cache_dir, options.format_control)
+            wheel_cache = WheelCache(options.cache_dir, options.format_control,
+                                     options.cache_ignore_prefix)
             with BuildDirectory(options.build_dir,
                                 delete=build_delete) as build_dir:
                 requirement_set = RequirementSet(

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -63,7 +63,8 @@ class WheelCache(object):
 
     def cached_wheel(self, link, package_name):
         return cached_wheel(
-            self._cache_dir, link, self._format_control, package_name, self._cache_ignore_prefix)
+            self._cache_dir, link, self._format_control, package_name,
+            self._cache_ignore_prefix)
 
 
 def _cache_for_link(cache_dir, link, cache_ignore_prefix=[]):
@@ -120,7 +121,8 @@ def _cache_for_link(cache_dir, link, cache_ignore_prefix=[]):
     return base_dir
 
 
-def cached_wheel(cache_dir, link, format_control, package_name, cache_ignore_prefix=[]):
+def cached_wheel(cache_dir, link, format_control, package_name,
+                 cache_ignore_prefix=[]):
     if not cache_dir:
         return link
     if not link:
@@ -666,7 +668,8 @@ class WheelBuilder(object):
         self.requirement_set = requirement_set
         self.finder = finder
         self._cache_root = requirement_set._wheel_cache._cache_dir
-        self._cache_ignore_prefix = requirement_set._wheel_cache._cache_ignore_prefix
+        self._cache_ignore_prefix = requirement_set._wheel_cache \
+                                                   ._cache_ignore_prefix
         self._wheel_dir = requirement_set.wheel_download_dir
         self.build_options = build_options or []
         self.global_options = global_options or []

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -115,7 +115,9 @@ def _cache_for_link(cache_dir, link, cache_ignore_prefix=[]):
 
     # Inside of the base location for cached wheels, expand our parts and join
     # them all together.
-    return os.path.join(cache_dir, "wheels", *parts)
+    base_dir = os.path.join(cache_dir, "wheels", *parts)
+    logger.debug('Link %s cache info: key %s dir %s', link, key_url, base_dir)
+    return base_dir
 
 
 def cached_wheel(cache_dir, link, format_control, package_name, cache_ignore_prefix=[]):


### PR DESCRIPTION
The new wheel caching is great, but one issue I've been having is that it, for local packages found via --find-links file: URLs, the caching is based on the absolute path. In my usage, I have multiple local repositories with packages downloaded from pypi, these wheel builds from these packages should be identical and cached, however they are not recognized as such since they have different absolute paths.

My solution was to add a `--cache-ignore-prefix` option. This can be used as follows:

```pip install install --no-index --find-links file://foo/ --cache-ignore-prefix file://foo/ bar```

Then, if the package bar exists as `foo/bar.tar.gz`, it's key in the wheel cache is set to be `/bar.tar.gz` and not `/absolute_path_to/foo/bar.tar.gz` as is the current behavior.

If you don't like this patch, a simpler option would be to have an command-line option that sets wheel cache keys on only the file name ignoring the rest of the path, rather that allowing arbitrarty path prefixes to be ignored as in the patch. I'm happy to do that also, however it would be great to have some type of flexibility in terms of how wheel cache keys are computed for local packages.