### PR TITLE
Add example requirements.txt file to pip_install.rst

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -164,7 +164,7 @@ Use ``pip install -r dev-requirements.txt`` to install::
     rejected
     green
     #
-    ###### a particular file ######
+    ###### A particular file ######
     ./downloads/numpy-1.9.2-cp34-none-win32.whl
     http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
 

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -128,6 +128,46 @@ You can also refer to constraints files, like this::
 
     -c some_constraints.txt
 
+.. _`Example Requirements File`:
+
+Example Requirements File
+=========================
+
+Use ``pip install -r dev-requirements.txt`` to install::
+
+    #
+    ####### dev-requirements.txt #######
+    #
+    # Standard installs
+    nose
+    nose-cov
+    beautifulsoup4
+    #
+    ###### Getting Specific Versions ######
+    #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
+    docopt == 0.6.1             # Version Matching. Must be version 0.6.1
+    keyring >= 4.1.1            # Minimum version 4.1.1
+    coverage != 3.5             # Version Exclusion. Anything except version 3.5
+    Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.1.*
+    #
+    ###### Allowing external and unverified Packages ######
+    #   must explicitly tell pip which packages are external and unverified.
+    #   CMD line equivalent: 'pip install pyPdf --allow-external pyPdf --allow-unverified pyPdf'
+    --allow-external pyPdf
+    --allow-unverified pyPdf
+    pyPdf
+    #
+    ###### Refer to other requirements files ######
+    -r other-requirements.txt
+    #
+    ###### Other standard installs ######
+    rejected
+    green
+    #
+    ###### a particular file ######
+    ./downloads/numpy-1.9.2-cp34-none-win32.whl
+    http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
+
 .. _`Requirement Specifiers`:
 
 Requirement Specifiers

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -131,7 +131,7 @@ You can also refer to constraints files, like this::
 .. _`Example Requirements File`:
 
 Example Requirements File
-=========================
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use ``pip install -r dev-requirements.txt`` to install::
 

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -133,26 +133,26 @@ You can also refer to constraints files, like this::
 Example Requirements File
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use ``pip install -r dev-requirements.txt`` to install::
+Use ``pip install -r example-requirements.txt`` to install::
 
     #
-    ####### dev-requirements.txt #######
+    ####### example-requirements.txt #######
     #
-    # Standard installs
+    ###### Requirements without Version Specifiers ######
     nose
     nose-cov
     beautifulsoup4
     #
-    ###### Getting Specific Versions ######
+    ###### Requirements with Version Specifiers ######
     #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
     docopt == 0.6.1             # Version Matching. Must be version 0.6.1
     keyring >= 4.1.1            # Minimum version 4.1.1
     coverage != 3.5             # Version Exclusion. Anything except version 3.5
     Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.1.*
     #
-    ###### Allowing external and unverified Packages ######
-    #   must explicitly tell pip which packages are external and unverified.
-    #   CMD line equivalent: 'pip install pyPdf --allow-external pyPdf --allow-unverified pyPdf'
+    ###### Allowing External and Unverified Packages ######
+    #   Must explicitly tell pip which packages are external and unverified.
+    #   Command-line equivalent: 'pip install pyPdf --allow-external pyPdf --allow-unverified pyPdf'
     --allow-external pyPdf
     --allow-unverified pyPdf
     pyPdf
@@ -160,13 +160,16 @@ Use ``pip install -r dev-requirements.txt`` to install::
     ###### Refer to other requirements files ######
     -r other-requirements.txt
     #
-    ###### Other standard installs ######
-    rejected
-    green
     #
     ###### A particular file ######
     ./downloads/numpy-1.9.2-cp34-none-win32.whl
     http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
+    #
+    ###### Additional Requirements without Version Specifiers ######
+    #   Same as 1st section, just here to show that you can put things in any order.
+    rejected
+    green
+    #
 
 .. _`Requirement Specifiers`:
 

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -150,13 +150,6 @@ Use ``pip install -r example-requirements.txt`` to install::
     coverage != 3.5             # Version Exclusion. Anything except version 3.5
     Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.1.*
     #
-    ###### Allowing External and Unverified Packages ######
-    #   Must explicitly tell pip which packages are external and unverified.
-    #   Command-line equivalent: 'pip install pyPdf --allow-external pyPdf --allow-unverified pyPdf'
-    --allow-external pyPdf
-    --allow-unverified pyPdf
-    pyPdf
-    #
     ###### Refer to other requirements files ######
     -r other-requirements.txt
     #


### PR DESCRIPTION
I find that some of the docs for ``pip install`` are lacking a bit. One of the main areas which I thought was confusing was the Requirements File Format section.

I thought that this section could use an example of a requirements file, so I've added one.

Please take a look. I didn't put every option in the example since I either a) don't know how to use those options or b) never have had a need for them.