### PR TITLE
Ignore distutils prefix when using --user

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -212,6 +212,7 @@ class InstallCommand(RequirementCommand):
                     "are not visible in this virtualenv."
                 )
             install_options.append('--user')
+            install_options.append('--prefix=')
 
         temp_target_dir = None
         if options.target_dir:

--- a/pip/locations.py
+++ b/pip/locations.py
@@ -185,6 +185,8 @@ def distutils_scheme(dist_name, user=False, home=None, root=None,
     # or user base for installations during finalize_options()
     # ideally, we'd prefer a scheme class that has no side-effects.
     i.user = user or i.user
+    if user:
+        i.prefix = ""
     i.home = home or i.home
     i.root = root or i.root
     i.finalize_options()

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -191,6 +191,34 @@ def test_install_local_editable_with_subdirectory(script):
     result.assert_installed('version-subpkg', sub_dir='version_subdir')
 
 
+def test_user_with_prefix_in_pydistutils_cfg(script, data, virtualenv):
+    virtualenv.system_site_packages = True
+    homedir = script.environ["HOME"]
+    script.scratch_path.join("bin").mkdir()
+    with open(os.path.join(homedir, ".pydistutils.cfg"), "w") as cfg:
+        cfg.write(textwrap.dedent("""
+            [install]
+            prefix=%s""" % script.scratch_path))
+
+    result = script.pip('install', '--user', '--no-index', '-f',
+                        data.find_links, 'requiresupper')
+    assert 'installed requiresupper' in result.stdout
+
+
+def test_nowheel_user_with_prefix_in_pydistutils_cfg(script, data, virtualenv):
+    virtualenv.system_site_packages = True
+    homedir = script.environ["HOME"]
+    script.scratch_path.join("bin").mkdir()
+    with open(os.path.join(homedir, ".pydistutils.cfg"), "w") as cfg:
+        cfg.write(textwrap.dedent("""
+            [install]
+            prefix=%s""" % script.scratch_path))
+
+    result = script.pip('install', '--no-use-wheel', '--user', '--no-index',
+                        '-f', data.find_links, 'requiresupper')
+    assert 'installed requiresupper' in result.stdout
+
+
 def test_install_option_in_requirements_file(script, data, virtualenv):
     """
     Test --install-option in requirements file overrides same option in cli


### PR DESCRIPTION
Fixes bug #2683

There are two changes here; one to fix the using-wheels codepath and one
to fix the no-wheels codepath. Two tests are introduced, one to test
each codepath.