### PR TITLE
Allow passing arguments to tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
     # that our tests use.
     LC_CTYPE = en_US.UTF-8
 deps = -r{toxinidir}/dev-requirements.txt
-commands = py.test --timeout 300 []
+commands = py.test --timeout 300 {posargs}
 install_command = python -m pip install --pre {opts} {packages}
 
 [testenv:py26]
@@ -26,12 +26,12 @@ commands = check-manifest
 [testenv:pep8]
 basepython = python2.7
 deps = flake8==2.3.0
-commands = flake8 .
+commands = flake8 {posargs}
 
 [testenv:py3pep8]
 basepython = python3.3
 deps = flake8==2.3.0
-commands = flake8 .
+commands = flake8 {posargs}
 
 [flake8]
 exclude = .tox,*.egg,build,_vendor,data


### PR DESCRIPTION
Let you invokes the tox env with additional parameters being passed to
the underlying command ie:

tox -epy27 -- tests/unit/test_vcs.py
tox -epep8 -- --statistics

Drop '[]' argument passed to py.test, that is the default.
Drop '.' argument passed to flake8, that is the default.