### PR TITLE
pip freeze no more assumes git remote is 'origin'

### DIFF
--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -124,9 +124,12 @@ class Git(VersionControl):
             self.update_submodules(dest)
 
     def get_url(self, location):
-        url = self.run_command(
-            ['config', 'remote.origin.url'],
+        """Return URL of the first remote encountered."""
+        remotes = self.run_command(
+            ['config', '--get-regexp', 'remote\..*\.url'],
             show_stdout=False, cwd=location)
+        first_remote = remotes.splitlines()[0]
+        url = first_remote.split(' ')[1]
         return url.strip()
 
     def get_revision(self, location):


### PR DESCRIPTION
OpenStack and Wikimedia foundations are using Gerrit as a review system
and both uses an utility named git-review.  It will create a git remote
named 'gerrit' for all interactions and hence some people remove the
remote named 'origin'.

Running pip freeze, it fails to find the remote URL since
vcs.git.get_url() is hardcoded to use 'origin'.

Use a git config regex to find the list of remotes, extract the URL from
the first remote found.

Fixes #1853