### PR TITLE
check that wheel cache dir is writable

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -22,6 +22,7 @@ from pip import cmdoptions
 from pip.utils import ensure_dir
 from pip.utils.build import BuildDirectory
 from pip.utils.deprecation import RemovedInPip8Warning
+from pip.utils.filesystem import check_path_owner
 from pip.wheel import WheelCache, WheelBuilder
 
 
@@ -246,6 +247,17 @@ class InstallCommand(RequirementCommand):
             finder = self._build_package_finder(options, index_urls, session)
             build_delete = (not (options.no_clean or options.build_dir))
             wheel_cache = WheelCache(options.cache_dir, options.format_control)
+            if options.cache_dir and not check_path_owner(options.cache_dir):
+                logger.warning(
+                    "The directory '%s' or its parent directory is not owned "
+                    "by the current user and caching wheels has been "
+                    "disabled. check the permissions and owner of that "
+                    "directory. If executing pip with sudo, you may want "
+                    "sudo's -H flag.",
+                    options.cache_dir,
+                )
+                options.cache_dir = None
+
             with BuildDirectory(options.build_dir,
                                 delete=build_delete) as build_dir:
                 requirement_set = RequirementSet(

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -753,7 +753,13 @@ class WheelBuilder(object):
             for req in buildset:
                 if autobuilding:
                     output_dir = _cache_for_link(self._cache_root, req.link)
-                    ensure_dir(output_dir)
+                    try:
+                        ensure_dir(output_dir)
+                    except OSError as e:
+                        logger.warn("Building wheel for %s failed: %s",
+                                    req.name, e)
+                        build_failure.append(req)
+                        continue
                 else:
                     output_dir = self._wheel_dir
                 wheel_file = self._build_one(req, output_dir)


### PR DESCRIPTION
before building wheels. Warning is copied from http cache check.

HTTP cache has a similar check and warning, but wheels would still try and fail to build.