### PR TITLE
handle missing trailing newline when looking to uninstall entries in pth

### DIFF
--- a/pip/req/req_uninstall.py
+++ b/pip/req/req_uninstall.py
@@ -174,6 +174,9 @@ class UninstallPthEntries(object):
             endline = '\r\n'
         else:
             endline = '\n'
+        # handle missing trailing newline
+        if lines and not lines[-1].endswith(endline.encode("utf-8")):
+            lines[-1] = lines[-1] + endline.encode("utf-8")
         for entry in self.entries:
             try:
                 logger.debug('Removing entry: %s', entry)


### PR DESCRIPTION
If a pth file lacks a trailing newline, the last entry will not be recognized and removed.