### PR TITLE
Do not break built-in logging module when pip embedded in script

### DIFF
--- a/pip/utils/logging.py
+++ b/pip/utils/logging.py
@@ -39,7 +39,7 @@ def indent_log(num=2):
 
 
 def get_indentation():
-    return _log_state.indentation
+    return getattr(_log_state, 'indentation', 0)
 
 
 class IndentingFormatter(logging.Formatter):


### PR DESCRIPTION
Fixes #2553.

When a Python script embeds pip and tries to log something from a different thread, an AttributeError is raised.