### PR TITLE
pip show: Normalize package names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,6 +32,9 @@
 * Upgrade ipaddress to 1.0.13.
 
 
+* ``pip show`` now normalize package names. :issue:`2899`.
+
+
 **7.1.0 (2015-06-30)**
 
 * Allow constraining versions globally without having to know exactly what will

--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -51,7 +51,7 @@ def search_packages_info(query):
     """
     installed = dict(
         [(p.project_name.lower(), p) for p in pkg_resources.working_set])
-    query_names = [name.lower() for name in query]
+    query_names = [pkg_resources.safe_name(name).lower() for name in query]
     for dist in [installed[pkg] for pkg in query_names if pkg in installed]:
         package = {
             'name': dist.project_name,

--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -6,6 +6,7 @@ import os
 
 from pip.basecommand import Command
 from pip.status_codes import SUCCESS, ERROR
+from pip.utils import canonicalize_name
 from pip._vendor import pkg_resources
 
 
@@ -51,7 +52,7 @@ def search_packages_info(query):
     """
     installed = dict(
         [(p.project_name.lower(), p) for p in pkg_resources.working_set])
-    query_names = [pkg_resources.safe_name(name).lower() for name in query]
+    query_names = [canonicalize_name(name) for name in query]
     for dist in [installed[pkg] for pkg in query_names if pkg in installed]:
         package = {
             'name': dist.project_name,

--- a/tests/data/packages/normalize_name/setup.py
+++ b/tests/data/packages/normalize_name/setup.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+from distutils.core import setup
+
+setup(name='normalize_name',
+      version='0.1',
+      py_modules=['normalize_name'],
+      )

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -96,3 +96,15 @@ def test_more_than_one_package():
     """
     result = list(search_packages_info(['Pip', 'pytest', 'Virtualenv']))
     assert len(result) == 3
+
+
+def test_show_normalize_name(script, data):
+    """
+    Normalize package names before querying.
+
+    """
+    editable = data.packages.join('normalize_name')
+    script.pip('install', '-e', editable)
+    result = script.pip('show', 'normalize_name')
+    lines = result.stdout.split('\n')
+    assert "Name: normalize-name" in lines


### PR DESCRIPTION
This makes "pip show"'s behavior same as "pip install".

Fixes #2899