### PR TITLE
Fix InterpreterNotFound: python3.5 error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
           env: TOXENV=py33
         - python: 3.4
           env: TOXENV=py34
-        - python: nightly
+        - python: 3.5-dev
           env: TOXENV=py35
         - python: pypy
           env: TOXENV=pypy


### PR DESCRIPTION
nightly now installs Python 3.6, so switched to use 3.5-dev.

See http://docs.travis-ci.com/user/languages/python/#On-demand-installations
for more information.