### PR TITLE
[WIP] Added --save option to install command

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -165,6 +165,20 @@ class InstallCommand(RequirementCommand):
             help="Include pre-release and development versions. By default, "
                  "pip only finds stable versions.")
 
+        cmd_opts.add_option(
+            '--save',
+            action='store_true',
+            dest='save',
+            default=False,
+            help='Add package(s) to requirements.txt'
+        )
+
+        cmd_opts.add_option(
+            '--save-dest',
+            dest='save',
+            help='Specify file to add package in requirements format'
+        )
+
         cmd_opts.add_option(cmdoptions.no_clean())
 
         index_opts = cmdoptions.make_option_group(
@@ -377,4 +391,16 @@ class InstallCommand(RequirementCommand):
                     target_item_dir
                 )
             shutil.rmtree(temp_target_dir)
+        if options.save:
+            if isinstance(options.save, bool):
+                req_file = 'requirements.txt'
+            else:
+                req_file = options.save
+            with open(req_file, 'a') as requirements_file:
+                for requirement in requirement_set.requirements.values():
+                    if not requirement.comes_from:
+                        requirements_file.write(
+                            '{pkg}=={pkg_version}\n'
+                            .format(pkg=requirement.name,
+                                    pkg_version=requirement.installed_version))
         return requirement_set


### PR DESCRIPTION
I added a pair of new command options to the install command. --save
will append the specified packages to the end of the 'requirements.txt'
file. --save-dest will take a filename or path argument and the
specified packages will be appended to the given file.

I am opening this pull request to see if there is any interest in adding this to pip and if so to gather any feedback about things that I may be doing wrong.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/2988)
<!-- Reviewable:end -->
