### PR TITLE
Moved the Auth part before doing the split on /, ? and #, those can be in passwords

### DIFF
--- a/pip/_vendor/requests/packages/urllib3/util/url.py
+++ b/pip/_vendor/requests/packages/urllib3/util/url.py
@@ -156,6 +156,13 @@ def parse_url(url):
     if '://' in url:
         scheme, url = url.split('://', 1)
 
+    # FIX PE2MBS: 10 Aug 2015 Marc Bertens-Nguyen  <m.bertens@pe2mbs.nl>
+    # Moved the Auth part before doing the split on /, ? and #, those can be in passwords
+    # Auth
+    if '@' in url:
+        # Last '@' denotes end of auth part
+        auth, url = url.rsplit('@', 1)
+
     # Find the earliest Authority Terminator
     # (http://tools.ietf.org/html/rfc3986#section-3.2)
     url, path_, delim = split_first(url, ['/', '?', '#'])
@@ -163,11 +170,6 @@ def parse_url(url):
     if delim:
         # Reassemble the path
         path = delim + path_
-
-    # Auth
-    if '@' in url:
-        # Last '@' denotes end of auth part
-        auth, url = url.rsplit('@', 1)
 
     # IPv6
     if url and url[0] == '[':


### PR DESCRIPTION
Moved splitting up the auth section of the url to above the finding the 'Authority Terminator'. This corrects the problem that slash, question mark and hash can be in passwords.