### PR TITLE
Add {posargs} to py.test command in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
     # that our tests use.
     LC_CTYPE = en_US.UTF-8
 deps = -r{toxinidir}/dev-requirements.txt
-commands = py.test --timeout 300 []
+commands = py.test --timeout 300 [] {posargs}
 install_command = python -m pip install --pre {opts} {packages}
 
 [testenv:py26]


### PR DESCRIPTION
Allow for user to call py.test with "positional arguments" to allow
easier debugging.

```
tox -e py34 -- -k test_egg_info_data
```
instead of
```
source .tox/py34/bin/activate
py.test -k test_egg_info_data
deactivate
```