### PR TITLE
Don't reset purelib/platlib when install-dir not set

### DIFF
--- a/pip/locations.py
+++ b/pip/locations.py
@@ -237,8 +237,12 @@ def distutils_scheme(dist_name, user=False, home=None, root=None,
     for key in SCHEME_KEYS:
         scheme[key] = getattr(i, 'install_' + key)
 
-    if i.install_lib is not None:
-        # install_lib takes precedence over purelib and platlib
+    # install_lib specified in setup.cfg should install *everything*
+    # into there (i.e. it takes precedence over both purelib and
+    # platlib).  Note, i.install_lib is *always* set after
+    # finalize_options(); we only want to override here if the user
+    # has explicitly requested it hence going back to the config
+    if 'install_lib' in d.get_option_dict('install'):
         scheme.update(dict(purelib=i.install_lib, platlib=i.install_lib))
 
     if running_under_virtualenv():

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -181,6 +181,9 @@ class TestDisutilsScheme:
         scheme = distutils_scheme('example')
         assert scheme['scripts'] == '/somewhere/else'
 
+    # when we request install-lib, we should install everything (.py &
+    # .so) into that path; i.e. ensure platlib & purelib are set to
+    # this path
     def test_install_lib_takes_precedence(self, tmpdir, monkeypatch):
         f = tmpdir.mkdir("config").join("setup.cfg")
         f.write("[install]\ninstall-lib=/somewhere/else/")


### PR DESCRIPTION
Change 3affcaa2b8dc29e34643c4c60db6ab9e6f9becd1 attempts to reset
purelib & platlib to any "install-dir" specified by the user in
setup.cfg.  This code is used when we are installing wheels.

The problem with this is that distutils is *always* setting
"i.install_lib" -- even when the user specifies nothing.  This has the
result of unconditionally setting purelib == platlib.

On some systems this results in .so's from the wheel getting installed
into /usr/lib/python2.7 (purelib) rather than /usr/lib64/python
(platlib).  Because distribution-packaged libraries have installed
their .so into platlib, we can now have a situation where the new
pip-installed library is picking up an old .so from the distro package
... with predictably bad results.

This takes the approach of checking the configuration to see if the
user has overridden install-dir and only resetting the paths if they
have.  The override case is covered by existing test-cases

Closes #2940