### PR TITLE
Added a command to view source of package.

### DIFF
--- a/pip/commands/__init__.py
+++ b/pip/commands/__init__.py
@@ -12,6 +12,7 @@ from pip.commands.show import ShowCommand
 from pip.commands.install import InstallCommand
 from pip.commands.uninstall import UninstallCommand
 from pip.commands.wheel import WheelCommand
+from pip.commands.view import ViewCommand
 
 
 commands_dict = {
@@ -24,6 +25,7 @@ commands_dict = {
     UninstallCommand.name: UninstallCommand,
     ListCommand.name: ListCommand,
     WheelCommand.name: WheelCommand,
+    ViewCommand.name: ViewCommand,
 }
 
 
@@ -35,6 +37,7 @@ commands_order = [
     ShowCommand,
     SearchCommand,
     WheelCommand,
+    ViewCommand,
     HelpCommand,
 ]
 

--- a/pip/commands/view.py
+++ b/pip/commands/view.py
@@ -1,0 +1,59 @@
+import logging
+import os
+import subprocess
+
+from pip.basecommand import Command
+from pip.commands.show import search_packages_info
+from pip.status_codes import SUCCESS, ERROR
+from pip._vendor import pkg_resources
+
+logger = logging.getLogger(__name__)
+
+
+class ViewCommand(Command):
+
+    """
+    Views the package source directory with the editor defined in
+    $PIP_EDITOR.
+    """
+    name = 'view'
+    usage = """
+      %prog <package>"""
+    summary = 'View installed package in the editor'
+
+    def __init__(self, *args, **kw):
+        super(ViewCommand, self).__init__(*args, **kw)
+
+    def run(self, options, args):
+        if not args:
+            logger.warning('ERROR: Please provide a package name or names.')
+            return ERROR
+        if not os.getenv('PIP_EDITOR'):
+            logger.warning(
+                'ERROR: Please set $PIP_EDITOR to open the package.')
+            return ERROR
+        query = args
+        shell_command = os.getenv('PIP_EDITOR').split()
+        results = list(search_packages_info(query))
+        installed = dict(
+            [(p.project_name.lower(), p) for p in pkg_resources.working_set])
+        if len(results) is 0:
+            logger.warning("ERROR: Could not find package(s).")
+            return ERROR
+        for dist in results:
+            pkg = installed[dist['name'].lower()]
+            names = list(pkg.get_metadata_lines('top_level.txt'))
+            for i in range(len(names)):
+                fullpath = os.path.join(dist['location'], names[i])
+                if os.path.isdir(fullpath):
+                    names[i] = fullpath
+                elif os.path.isfile(fullpath + '.py'):
+                    names[i] = fullpath + '.py'
+                elif os.path.isfile(fullpath + '.so'):
+                    names[i] = fullpath + '.so'
+                else:
+                    return ERROR
+            status_code = subprocess.call(shell_command + names)
+            if status_code is not 0:
+                return ERROR
+        return SUCCESS


### PR DESCRIPTION
Hi, I'd like to open a discussion on a feature I'd really like to see in pip.

I do quite a bit of work in Ruby in my spare time and the pip equivalent in Ruby is [bundler](http://bundler.io/) which has a really cool command that is invoked by typing `bundle open <gemname>`. What it does is it opens up the source code of gem (that's the Ruby terminology for a library) using an editor defined in an environment variable (see http://bundler.io/v1.10/bundle_open.html)

I do Django development at my day job and I'd love to open up libraries in my editor of choice. I notice that pip already has the `show` command which lists the location of the library and even an option to display the flags. Would a patch to add an additional "view" command be something that sounds like a good idea? 

This particular patch I'm proposing requires $PIP_EDITOR to be set. Perhaps I could also add an option to specify the editor (say, pip view --editor vim). It seems to work for all the libraries I currently use.

Any thoughts?

P.S - I would have loved make this pull request with some tests, but it's difficult to know a priori the output of the system call would be without mocking everything (the editor, the location, the virtualenv location, etc). If anyone has a good idea on how I'd be able to go about with the test I'd be glad to add them.