### PR TITLE
Only update VCS when things have actually changed

### DIFF
--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -186,6 +186,13 @@ class VersionControl(object):
         """
         raise NotImplementedError
 
+    def check_version(self, dest, rev_options):
+        """
+        Return True if the version is identical to what exists and
+        doesn't need to be updated.
+        """
+        raise NotImplementedError
+
     def check_destination(self, dest, url, rev_options, rev_display):
         """
         Prepare a location to receive a checkout/clone.
@@ -206,13 +213,17 @@ class VersionControl(object):
                         display_path(dest),
                         url,
                     )
-                    logger.info(
-                        'Updating %s %s%s',
-                        display_path(dest),
-                        self.repo_name,
-                        rev_display,
-                    )
-                    self.update(dest, rev_options)
+                    if not self.check_version(dest, rev_options):
+                        logger.info(
+                            'Updating %s %s%s',
+                            display_path(dest),
+                            self.repo_name,
+                            rev_display,
+                        )
+                        self.update(dest, rev_options)
+                    else:
+                        logger.info(
+                            'Skipping because already up-to-date.')
                 else:
                     logger.warning(
                         '%s %s in %s exists with URL %s',

--- a/pip/vcs/bazaar.py
+++ b/pip/vcs/bazaar.py
@@ -128,5 +128,9 @@ class Bazaar(VersionControl):
             full_egg_name = '%s-dev_r%s' % (dist.egg_name(), current_rev)
         return '%s@%s#egg=%s' % (repo, current_rev, full_egg_name)
 
+    def check_version(self, dest, rev_options):
+        """Always assume the versions don't match"""
+        return False
+
 
 vcs.register(Bazaar)

--- a/pip/vcs/mercurial.py
+++ b/pip/vcs/mercurial.py
@@ -136,4 +136,8 @@ class Mercurial(VersionControl):
             full_egg_name = '%s-dev' % egg_project_name
         return '%s@%s#egg=%s' % (repo, current_rev_hash, full_egg_name)
 
+    def check_version(self, dest, rev_options):
+        """Always assume the versions don't match"""
+        return False
+
 vcs.register(Mercurial)

--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -259,6 +259,10 @@ class Subversion(VersionControl):
             full_egg_name = '%s-dev_r%s' % (egg_project_name, rev)
         return 'svn+%s@%s#egg=%s' % (repo, rev, full_egg_name)
 
+    def check_version(self, dest, rev_options):
+        """Always assume the versions don't match"""
+        return False
+
 
 def get_rev_options(url, rev):
     if rev:

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -12,7 +12,7 @@ from tests.lib.git_submodule_helpers import (
 
 
 @pytest.mark.network
-def test_get_refs_should_return_tag_name_and_commit_pair(script):
+def test_get_short_refs_should_return_tag_name_and_commit_pair(script):
     version_pkg_path = _create_test_package(script)
     script.run('git', 'tag', '0.1', cwd=version_pkg_path)
     script.run('git', 'tag', '0.2', cwd=version_pkg_path)
@@ -21,13 +21,13 @@ def test_get_refs_should_return_tag_name_and_commit_pair(script):
         cwd=version_pkg_path
     ).stdout.strip()
     git = Git()
-    result = git.get_refs(version_pkg_path)
+    result = git.get_short_refs(version_pkg_path)
     assert result['0.1'] == commit, result
     assert result['0.2'] == commit, result
 
 
 @pytest.mark.network
-def test_get_refs_should_return_branch_name_and_commit_pair(script):
+def test_get_short_refs_should_return_branch_name_and_commit_pair(script):
     version_pkg_path = _create_test_package(script)
     script.run('git', 'branch', 'branch0.1', cwd=version_pkg_path)
     commit = script.run(
@@ -35,13 +35,13 @@ def test_get_refs_should_return_branch_name_and_commit_pair(script):
         cwd=version_pkg_path
     ).stdout.strip()
     git = Git()
-    result = git.get_refs(version_pkg_path)
+    result = git.get_short_refs(version_pkg_path)
     assert result['master'] == commit, result
     assert result['branch0.1'] == commit, result
 
 
 @pytest.mark.network
-def test_get_refs_should_ignore_no_branch(script):
+def test_get_short_refs_should_ignore_no_branch(script):
     version_pkg_path = _create_test_package(script)
     script.run('git', 'branch', 'branch0.1', cwd=version_pkg_path)
     commit = script.run(
@@ -55,12 +55,27 @@ def test_get_refs_should_ignore_no_branch(script):
         expect_stderr=True,
     )
     git = Git()
-    result = git.get_refs(version_pkg_path)
+    result = git.get_short_refs(version_pkg_path)
     assert result['master'] == commit, result
     assert result['branch0.1'] == commit, result
 
 
-@patch('pip.vcs.git.Git.get_refs')
+@pytest.mark.network
+def test_check_version(script):
+    version_pkg_path = _create_test_package(script)
+    script.run('git', 'branch', 'branch0.1', cwd=version_pkg_path)
+    commit = script.run(
+        'git', 'rev-parse', 'HEAD',
+        cwd=version_pkg_path
+    ).stdout.strip()
+    git = Git()
+    assert git.check_version(version_pkg_path, [commit])
+    assert git.check_version(version_pkg_path, [commit[:7]])
+    assert not git.check_version(version_pkg_path, ['branch0.1'])
+    assert not git.check_version(version_pkg_path, ['abc123'])
+
+
+@patch('pip.vcs.git.Git.get_short_refs')
 def test_check_rev_options_should_handle_branch_name(get_refs_mock):
     get_refs_mock.return_value = {'master': '123456', '0.1': '123456'}
     git = Git()
@@ -69,7 +84,7 @@ def test_check_rev_options_should_handle_branch_name(get_refs_mock):
     assert result == ['123456']
 
 
-@patch('pip.vcs.git.Git.get_refs')
+@patch('pip.vcs.git.Git.get_short_refs')
 def test_check_rev_options_should_handle_tag_name(get_refs_mock):
     get_refs_mock.return_value = {'master': '123456', '0.1': '123456'}
     git = Git()
@@ -78,7 +93,7 @@ def test_check_rev_options_should_handle_tag_name(get_refs_mock):
     assert result == ['123456']
 
 
-@patch('pip.vcs.git.Git.get_refs')
+@patch('pip.vcs.git.Git.get_short_refs')
 def test_check_rev_options_should_handle_ambiguous_commit(get_refs_mock):
     get_refs_mock.return_value = {'master': '123456', '0.1': '123456'}
     git = Git()


### PR DESCRIPTION
**NOTE: Only implemented for `git` backend.**

This saves a network hop when using git and passing an explicit sha
as a ref by comparing the version that's already checked out.

Yields a ~4x speedup on my local machine

Before:
```
$ /usr/local/bin/pip --version
pip 7.1.0 from /usr/local/lib/python2.7/site-packages (python 2.7)
$ time /usr/local/bin/pip install --disable-pip-version-check -e git+https://github.com/getsentry/raven-python.git@56fc6f7beecf445843d0ec7052bb8c6f0ea80a2e#egg=raven_dev
Obtaining raven-dev from git+https://github.com/getsentry/raven-python.git@56fc6f7beecf445843d0ec7052bb8c6f0ea80a2e#egg=raven_dev
  Updating ./src/raven-dev clone (to 56fc6f7beecf445843d0ec7052bb8c6f0ea80a2e)
  Could not find a tag or branch '56fc6f7beecf445843d0ec7052bb8c6f0ea80a2e', assuming commit.
Installing collected packages: raven-dev
  Running setup.py develop for raven-dev
Successfully installed raven-dev
/usr/local/bin/pip install --disable-pip-version-check -e   0.84s user 0.48s system 39% cpu 3.300 total
```

After:
```
$ /Users/matt/.virtualenvs/pip/bin/pip --version
pip 7.2.0.dev0 from /Users/matt/code/pip (python 2.7)
$ time /Users/matt/.virtualenvs/pip/bin/pip install --disable-pip-version-check -e git+https://github.com/getsentry/raven-python.git@56fc6f7beecf445843d0ec7052bb8c6f0ea80a2e#egg=raven_dev
Obtaining raven-dev from git+https://github.com/getsentry/raven-python.git@56fc6f7beecf445843d0ec7052bb8c6f0ea80a2e#egg=raven_dev
checking version
  Skipping because already up-to-date.
Installing collected packages: raven-dev
  Running setup.py develop for raven-dev
Successfully installed raven-dev
/Users/matt/.virtualenvs/pip/bin/pip install --disable-pip-version-check -e   0.59s user 0.22s system 98% cpu 0.824 total
```