### PR TITLE
updated installation docs

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -30,7 +30,8 @@ Then run the following (which may require sudo or administrator access):
 
 
 get-pip.py will also intall :ref:`pypug:setuptools` [3]_ and :ref:`pypug:wheel`,
-if it's not already.
+if it's not already. Both are required to be able to build a :ref:`Wheel
+cache`, which improves installation speed.
 
 
 get-pip.py options

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -66,20 +66,67 @@ Install behind a proxy::
   python get-pip.py --proxy="[user:passwd@]proxy.server:port"
 
 
-Installing with OS Package Managers
------------------------------------
+Installing with Linux Package Managers
+--------------------------------------
 
-On Linux, pip will generally be available for the system install of python using
-the system package manager, although often the latest version will be
-unavailable.
+Fedora
+~~~~~~
 
-On Debian/Ubuntu::
+To get the version supplied by the distribution:
+
+* < Fedora 23:
+
+ * Python 2: ``sudo yum install python-pip``
+ * Python 3: ``sudo yum install python3-pip``
+
+* >= Fedora 23:
+
+ * Python 2: ``sudo dnf install python-pip``
+ * Python 3: ``sudo dnf install python3-pip``
+
+To get newer versions of pip (and also setuptools and wheel), you can enable the
+"unofficial" `PyPA Copr Repo <https://copr.fedoraproject.org/coprs/pypa/pypa/>`_
+using `these instructions
+<https://fedorahosted.org/copr/wiki/HowToEnableRepo>`__, and run the same
+commands as above.
+
+
+CentOS/RHEL
+~~~~~~~~~~~
+
+CentOS and RHEL don't offer ``python-pip`` in their core repositories.
+
+It's common practice to install pip from the `EPEL repository
+<https://fedoraproject.org/wiki/EPEL>`_. Enable EPEL using `these instructions
+<https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F>`__,
+and install like so::
+
+   sudo yum install python-pip
+
+You can also use the "unofficial" `PyPA Copr Repo
+<https://copr.fedoraproject.org/coprs/pypa/pypa/>`_ using `these instructions
+<https://fedorahosted.org/copr/wiki/HowToEnableRepo>`__ [5]_, and run the same
+command as above.  The Copr repository has an advantage over EPEL in that it
+also maintains packages of ``python-wheel`` and newer versions of
+``python-setuptools``.
+
+Lastly, If you're using the `IUS repository
+<https://iuscommunity.org/pages/Repos.html>`_ to install alternative Python
+versions, be aware that IUS also maintains packages for newer versions of pip,
+setuptools, and wheel that are consistent with the alternative Python versions.
+The IUS packages will not work with the system Python.
+
+
+
+Debian/Ubuntu
+~~~~~~~~~~~~~
+
+To get the version supplied by the distribution:
+
+::
 
    sudo apt-get install python-pip
 
-On Fedora/CentOS/RHEL::
-
-   sudo yum install python-pip
 
 Upgrading
 ---------
@@ -129,4 +176,7 @@ pip works on Unix/Linux, OS X, and Windows.
        tested or endorsed. For discussion, see `Issue 1668
        <https://github.com/pypa/pip/issues/1668>`_.
 
-.. [5] https://github.com/pypa/pip/issues/1299
+.. [5] Currently, there is no "copr" yum plugin available for CentOS/RHEL, so
+       the only option is to manually place the repo files as described.
+
+.. [6] https://github.com/pypa/pip/issues/1299

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -74,7 +74,7 @@ Installing with Linux Package Managers
 Fedora
 ~~~~~~
 
-To get the version supplied by the distribution:
+To install the supported version of pip:
 
 * < Fedora 23:
 
@@ -96,7 +96,7 @@ commands as above.
 CentOS/RHEL
 ~~~~~~~~~~~
 
-CentOS and RHEL don't offer ``python-pip`` in their core repositories.
+CentOS and RHEL don't offer pip in their core repositories.
 
 It's common practice to install pip from the `EPEL repository
 <https://fedoraproject.org/wiki/EPEL>`_. Enable EPEL using `these instructions
@@ -119,11 +119,10 @@ setuptools, and wheel that are consistent with the alternative Python versions.
 The IUS packages will not work with the system Python.
 
 
-
 Debian/Ubuntu
 ~~~~~~~~~~~~~
 
-To get the version supplied by the distribution:
+To install the supported version of pip:
 
 ::
 
@@ -140,7 +139,7 @@ On Linux or OS X:
  pip install -U pip
 
 
-On Windows [5]_:
+On Windows [6]_:
 
 ::
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -12,7 +12,8 @@ pip works on Unix/Linux, OS X, and Windows.
 
 .. note::
 
-  Python 2.5 was supported through v1.3.1, and Python 2.4 was supported through v1.1.
+  Python 2.5 was supported through v1.3.1, and Python 2.4 was supported through
+  v1.1.
 
 
 Do I need to install pip?
@@ -34,16 +35,28 @@ Installing pip
 To install pip, securely download `get-pip.py
 <https://bootstrap.pypa.io/get-pip.py>`_. [2]_
 
-Then run the following (which may require administrator access):
+Then run the following (which may require sudo or administrator access):
 
 ::
 
  python get-pip.py
 
-If `setuptools`_ is not already installed, ``get-pip.py`` will install
-`setuptools`_ for you. [3]_
 
-To upgrade an existing `setuptools`_, run ``pip install -U setuptools``.
+`get-pip.py` will also intall :ref:`pypug:setuptools` and :ref:`pypug:wheel`, if
+it's not already.
+
+
+get-pip.py options
+~~~~~~~~~~~~~~~~~~~
+
+.. option:: --no-setuptools
+
+    If set, don't attempt to install :ref:`pypug:setuptools`
+
+.. option:: --no-wheel
+
+    If set, don't attempt to install :ref:`pypug:wheel`
+
 
 Additionally, ``get-pip.py`` supports using the :ref:`pip install options <pip
 install Options>` and the :ref:`general options <General Options>`. Below are
@@ -115,6 +128,3 @@ On Fedora::
        <https://github.com/pypa/pip/issues/1668>`_.
 
 .. [5] https://github.com/pypa/pip/issues/1299
-
-.. _setuptools: https://pypi.python.org/pypi/setuptools
-.. _distribute: https://pypi.python.org/pypi/distribute

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -14,15 +14,22 @@ pip works on Unix/Linux, OS X, and Windows.
 
   Python 2.5 was supported through v1.3.1, and Python 2.4 was supported through v1.1.
 
-pip included with Python
-------------------------
-Python 2.7.9 and later (on the python2 series), and Python 3.4
-and later include pip by default [1]_, so you may have pip already.
+
+Do I need to install pip?
+-------------------------
+
+Distributions of Python 2.7.9 and later (in the Python 2 series), and
+Python 3.4 and later (in the Python 3 series) may already include pip by
+default. [1]_
+
+Additionally, it's common to be using a tool like :ref:`pypug:virtualenv` or
+:ref:`pyvenv <pypug:venv>`, which installs pip for you.
+
 
 .. _`get-pip`:
 
-Install pip
------------
+Installing pip
+--------------
 
 To install pip, securely download `get-pip.py
 <https://bootstrap.pypa.io/get-pip.py>`_. [2]_
@@ -55,8 +62,8 @@ Install behind a proxy::
   python get-pip.py --proxy="[user:passwd@]proxy.server:port"
 
 
-Upgrade pip
------------
+Upgrading pip
+-------------
 
 On Linux or OS X:
 
@@ -91,7 +98,8 @@ On Fedora::
 
 ----
 
-.. [1] https://docs.python.org/3/installing/
+.. [1] For Python 2, see https://docs.python.org/2/installing, and for Python3,
+       see https://docs.python.org/3/installing.
 
 .. [2] "Secure" in this context means using a modern browser or a
        tool like `curl` that verifies SSL certificates when downloading from

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -30,8 +30,11 @@ Then run the following (which may require sudo or administrator access):
 
 
 get-pip.py will also intall :ref:`pypug:setuptools` [3]_ and :ref:`pypug:wheel`,
-if it's not already. Both are required to be able to build a :ref:`Wheel
-cache`, which improves installation speed.
+if they're not already. :ref:`pypug:setuptools` is required to install
+:term:`source distributions <pypug:Source Distribution (or "sdist")>`.  Both are
+required to be able to build a :ref:`Wheel cache` (which improves installation
+speed), although neither are required to install pre-built :term:`wheels
+<pypug:Wheel>`.
 
 
 get-pip.py options

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -10,8 +10,10 @@ Distributions of Python 2.7.9 and later (in the Python 2 series), and
 Python 3.4 and later (in the Python 3 series) may already include pip by
 default. [1]_
 
-Additionally, it's common to be using a tool like :ref:`pypug:virtualenv` or
-:ref:`pyvenv <pypug:venv>`, which installs pip for you.
+Additionally, it's common to be working in a :ref:`Virtual Envionment
+<pypug:Creating and using Virtual Environments>` created by a tool like
+:ref:`pypug:virtualenv` or :ref:`pyvenv <pypug:venv>`, which handles installing
+pip for you.
 
 
 .. _`get-pip`:

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -3,19 +3,6 @@
 Installation
 ============
 
-Python & OS Support
--------------------
-
-pip works with CPython versions 2.6, 2.7, 3.2, 3.3, 3.4, 3.5 and also pypy.
-
-pip works on Unix/Linux, OS X, and Windows.
-
-.. note::
-
-  Python 2.5 was supported through v1.3.1, and Python 2.4 was supported through
-  v1.1.
-
-
 Do I need to install pip?
 -------------------------
 
@@ -29,8 +16,8 @@ Additionally, it's common to be using a tool like :ref:`pypug:virtualenv` or
 
 .. _`get-pip`:
 
-Installing pip
---------------
+Installing with get-pip.py
+--------------------------
 
 To install pip, securely download `get-pip.py
 <https://bootstrap.pypa.io/get-pip.py>`_. [2]_
@@ -42,8 +29,8 @@ Then run the following (which may require sudo or administrator access):
  python get-pip.py
 
 
-`get-pip.py` will also intall :ref:`pypug:setuptools` and :ref:`pypug:wheel`, if
-it's not already.
+get-pip.py will also intall :ref:`pypug:setuptools` [3]_ and :ref:`pypug:wheel`,
+if it's not already.
 
 
 get-pip.py options
@@ -75,8 +62,23 @@ Install behind a proxy::
   python get-pip.py --proxy="[user:passwd@]proxy.server:port"
 
 
-Upgrading pip
--------------
+Installing with OS Package Managers
+-----------------------------------
+
+On Linux, pip will generally be available for the system install of python using
+the system package manager, although often the latest version will be
+unavailable.
+
+On Debian and Ubuntu::
+
+   sudo apt-get install python-pip
+
+On Fedora::
+
+   sudo yum install python-pip
+
+Upgrading
+---------
 
 On Linux or OS X:
 
@@ -92,21 +94,17 @@ On Windows [5]_:
  python -m pip install -U pip
 
 
+Python and OS Compatibility
+---------------------------
 
-Using OS Package Managers
--------------------------
+pip works with CPython versions 2.6, 2.7, 3.2, 3.3, 3.4, 3.5 and also pypy.
 
-On Linux, pip will generally be available for the system install of python using
-the system package manager, although often the latest version will be
-unavailable.
+pip works on Unix/Linux, OS X, and Windows.
 
-On Debian and Ubuntu::
+.. note::
 
-   sudo apt-get install python-pip
-
-On Fedora::
-
-   sudo yum install python-pip
+  Python 2.5 was supported through v1.3.1, and Python 2.4 was supported through
+  v1.1.
 
 
 ----

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -70,11 +70,11 @@ On Linux, pip will generally be available for the system install of python using
 the system package manager, although often the latest version will be
 unavailable.
 
-On Debian and Ubuntu::
+On Debian/Ubuntu::
 
    sudo apt-get install python-pip
 
-On Fedora::
+On Fedora/CentOS/RHEL::
 
    sudo yum install python-pip
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -24,12 +24,18 @@ Installing with get-pip.py
 To install pip, securely download `get-pip.py
 <https://bootstrap.pypa.io/get-pip.py>`_. [2]_
 
-Then run the following (which may require sudo or administrator access):
+Then run the following:
 
 ::
 
  python get-pip.py
 
+
+.. warning::
+
+   If you're using a Python install that's managed by your operating system or
+   another package manager, then be cautious. "get-pip.py" does not coordinate
+   with those tools, and may leave your system in an inconsistent state.
 
 get-pip.py will also intall :ref:`pypug:setuptools` [3]_ and :ref:`pypug:wheel`,
 if they're not already. :ref:`pypug:setuptools` is required to install
@@ -74,7 +80,7 @@ Installing with Linux Package Managers
 Fedora
 ~~~~~~
 
-To install the supported version of pip:
+To install the Fedora supported version of pip:
 
 * < Fedora 23:
 
@@ -122,7 +128,7 @@ The IUS packages will not work with the system Python.
 Debian/Ubuntu
 ~~~~~~~~~~~~~
 
-To install the supported version of pip:
+To install the Debian or Ubuntu supported version of pip:
 
 ::
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -6,7 +6,7 @@ Installation
 Python & OS Support
 -------------------
 
-pip works with CPython versions 2.6, 2.7, 3.2, 3.3, 3.4 and also pypy.
+pip works with CPython versions 2.6, 2.7, 3.2, 3.3, 3.4, 3.5 and also pypy.
 
 pip works on Unix/Linux, OS X, and Windows.
 

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -415,6 +415,8 @@ Windows
   :file:`<CSIDL_LOCAL_APPDATA>\\pip\\Cache`
 
 
+.. _`Wheel cache`:
+
 Wheel cache
 ***********
 


### PR DESCRIPTION
- a new "Do I need to install pip?" section
- a better "Installing with Linux Package Managers" section that mentions EPEL, Copr, and IUS
- a new subsection for the get-pip options (which now mentions `--no-wheel` and `--no-setuptools`)
- explain that get-pip.py installs setuptools and wheel, and why.
- mention support for Python3.5
- miscellaneous re-wording...