### PR TITLE
SOABI support for Python 2.X and PyPy

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -30,7 +30,11 @@ def get_abbr_impl():
 
 def get_impl_ver():
     """Return implementation version."""
-    impl_ver = sysconfig.get_config_var("py_version_nodot")
+    try:
+        impl_ver = sysconfig.get_config_var("py_version_nodot")
+    except IOError as e:  # Issue #1074
+        warnings.warn("{0}".format(e), RuntimeWarning)
+        impl_ver = None
     if not impl_ver or get_abbr_impl() == 'pp':
         impl_ver = ''.join(map(str, get_impl_version_info()))
     return impl_ver
@@ -62,9 +66,9 @@ def get_abi_tag():
         u = 'u' if sys.maxunicode == 0x10ffff else ''
         abi = '%s%s%s%s%s' % (impl, get_impl_ver(), d, m, u)
     elif soabi and soabi.startswith('cpython-'):
-        abi = 'cp' + soabi.split('-', 1)[-1]
+        abi = 'cp' + soabi.split('-')[1]
     elif soabi:
-        abi = soabi
+        abi = soabi.replace('.', '_').replace('-', '_')
     else:
         abi = None
     return abi

--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -63,7 +63,7 @@ def get_abi_tag():
     if not soabi and impl in ('cp', 'pp'):
         d = 'd' if get_config_var('Py_DEBUG') else ''
         m = 'm' if get_config_var('WITH_PYMALLOC') else ''
-        u = 'u' if sys.maxunicode == 0x10ffff else ''
+        u = 'u' if get_config_var('Py_UNICODE_SIZE') == 4 else ''
         abi = '%s%s%s%s%s' % (impl, get_impl_ver(), d, m, u)
     elif soabi and soabi.startswith('cpython-'):
         abi = 'cp' + soabi.split('-')[1]

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -294,6 +294,50 @@ class TestWheelFile(object):
 
 class TestPEP425Tags(object):
 
+    def mock_get_config_var(self, **kwd):
+        """
+        Patch sysconfig.get_config_var for arbitrary keys.
+        """
+        import pip.pep425tags
+
+        get_config_var = pip.pep425tags.sysconfig.get_config_var
+
+        def _mock_get_config_var(var):
+            if var in kwd:
+                return kwd[var]
+            return get_config_var(var)
+        return _mock_get_config_var
+
+    def abi_tag_unicode(self, flags, config_vars):
+        """
+        Used to test ABI tags, verify correct use of the `u` flag
+        """
+        import pip.pep425tags
+
+        config_vars.update({'SOABI': None})
+        base = pip.pep425tags.get_abbr_impl() + pip.pep425tags.get_impl_ver()
+
+        config_vars.update({'Py_UNICODE_SIZE': 2})
+        mock_gcf = self.mock_get_config_var(**config_vars)
+        with patch('pip.pep425tags.sysconfig.get_config_var', mock_gcf):
+            abi_tag = pip.pep425tags.get_abi_tag()
+            assert abi_tag == base + flags
+
+        config_vars.update({'Py_UNICODE_SIZE': 4})
+        mock_gcf = self.mock_get_config_var(**config_vars)
+        with patch('pip.pep425tags.sysconfig.get_config_var', mock_gcf):
+            abi_tag = pip.pep425tags.get_abi_tag()
+            assert abi_tag == base + flags + 'u'
+
+        # On Python >= 3.3, UCS-4 is essentially permanently enabled, and
+        # Py_UNICODE_SIZE is None. SOABI on these builds does not include the
+        # 'u' so manual SOABI detection should not do so either.
+        config_vars.update({'Py_UNICODE_SIZE': None})
+        mock_gcf = self.mock_get_config_var(**config_vars)
+        with patch('pip.pep425tags.sysconfig.get_config_var', mock_gcf):
+            abi_tag = pip.pep425tags.get_abi_tag()
+            assert abi_tag == base + flags
+
     def test_broken_sysconfig(self):
         """
         Test that pep425tags still works when sysconfig is broken.
@@ -314,20 +358,39 @@ class TestPEP425Tags(object):
         """
         import pip.pep425tags
 
-        get_config_var = pip.pep425tags.sysconfig.get_config_var
+        mock_gcf = self.mock_get_config_var(SOABI='cpython-35m-darwin')
 
-        def mock_soabi(var):
-            if var == 'SOABI':
-                return 'cpython-35m-darwin'
-            return get_config_var(var)
-
-        with patch('pip.pep425tags.sysconfig.get_config_var', mock_soabi):
+        with patch('pip.pep425tags.sysconfig.get_config_var', mock_gcf):
             supported = pip.pep425tags.get_supported()
 
         for (py, abi, plat) in supported:
             assert '-' not in py
             assert '-' not in abi
             assert '-' not in plat
+
+    def test_manual_abi_noflags(self):
+        """
+        Test that no flags are set on a non-PyDebug, non-Pymalloc ABI tag.
+        """
+        self.abi_tag_unicode('', {'Py_DEBUG': False, 'WITH_PYMALLOC': False})
+
+    def test_manual_abi_d_flag(self):
+        """
+        Test that the `d` flag is set on a PyDebug, non-Pymalloc ABI tag.
+        """
+        self.abi_tag_unicode('d', {'Py_DEBUG': True, 'WITH_PYMALLOC': False})
+
+    def test_manual_abi_m_flag(self):
+        """
+        Test that the `m` flag is set on a non-PyDebug, Pymalloc ABI tag.
+        """
+        self.abi_tag_unicode('m', {'Py_DEBUG': False, 'WITH_PYMALLOC': True})
+
+    def test_manual_abi_dm_flags(self):
+        """
+        Test that the `dm` flags are set on a PyDebug, Pymalloc ABI tag.
+        """
+        self.abi_tag_unicode('dm', {'Py_DEBUG': True, 'WITH_PYMALLOC': True})
 
 
 class TestMoveWheelFiles(object):


### PR DESCRIPTION
Additionally, fix the version portion of the Python tag on wheels built with PyPy that use the Python API. It will now be the Python major version concatenated with the PyPy major and minor versions.

Fixes #2671, #2882.

xrefs:
- [wheel pull request #55](https://bitbucket.org/pypa/wheel/pull-requests/55/soabi-support-for-python-2x-and-pypy/diff)
- [pypi-meatdata-formats issue #25](https://bitbucket.org/pypa/pypi-metadata-formats/issues/25)
- [wheel issue #63](https://bitbucket.org/pypa/wheel/issues/63/backport-soabi-to-python-2)
- [wheel issue #101](https://bitbucket.org/pypa/wheel/issues/101/python-wheels-need-ucs-tag-on-2x)