### PR TITLE
Use a realpath for the temporary build directory.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,9 @@
 
 * Added optional column formatting to ``pip list`` (:issue:`3651`).
 
+* Fix the build on systems with symlinked /tmp directory for custom
+  builds such as numpy.
+
 
 **8.1.2 (2016-05-10)**
 

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -307,7 +307,12 @@ class InstallRequirement(object):
             # package is not available yet so we create a temp directory
             # Once run_egg_info will have run, we'll be able
             # to fix it via _correct_build_location
-            self._temp_build_dir = tempfile.mkdtemp('-build', 'pip-')
+            # Some systems have /tmp as a symlink which confuses custom
+            # builds (such as numpy). Thus, we ensure that the real path
+            # is returned.
+            self._temp_build_dir = os.path.realpath(
+                tempfile.mkdtemp('-build', 'pip-')
+            )
             self._ideal_build_dir = build_dir
             return self._temp_build_dir
         if self.editable:

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+
+import pytest
+
+from pip.req.req_install import InstallRequirement
+
+
+class TestInstallRequirementBuildDirectory(object):
+    # no need to test symlinks on Windows
+    @pytest.mark.skipif("sys.platform == 'win32'")
+    def test_tmp_build_directory(self):
+        # when req is None, we can produce a temporary directory
+        # Make sure we're handling it correctly with real path.
+        requirement = InstallRequirement(None, None)
+        tmp_dir = tempfile.mkdtemp('-build', 'pip-')
+        tmp_build_dir = requirement.build_location(tmp_dir)
+        assert (
+            os.path.dirname(tmp_build_dir) ==
+            os.path.realpath(os.path.dirname(tmp_dir))
+        )
+        # are we on a system where /tmp is a symlink
+        if os.path.realpath(tmp_dir) != os.path.abspath(tmp_dir):
+            assert os.path.dirname(tmp_build_dir) != os.path.dirname(tmp_dir)
+        else:
+            assert os.path.dirname(tmp_build_dir) == os.path.dirname(tmp_dir)
+        os.rmdir(tmp_dir)
+        assert not os.path.exists(tmp_dir)


### PR DESCRIPTION
Some systems have /tmp symlinked which confuses custom builds, such as
numpy. This ensures that real path is passed and that such builds
resolve their paths correctly during build and install.

Added test for the change and also for the previous related fix:
https://github.com/pypa/pip/issues/707

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3079)
<!-- Reviewable:end -->
