### PR TITLE
Do not log all versions when no distribution is found at all

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -496,17 +496,18 @@ class PackageFinder(object):
             return None
 
         if not applicable_versions:
-            logger.critical(
-                'Could not find a version that satisfies the requirement %s '
-                '(from versions: %s)',
-                req,
-                ', '.join(
-                    sorted(
-                        set(str(i.version) for i in all_versions),
-                        key=parse_version,
+            if all_versions:
+                logger.critical(
+                    'Could not find a version that satisfies the requirement %s '
+                    '(from versions: %s)',
+                    req,
+                    ', '.join(
+                        sorted(
+                            set(str(i.version) for i in all_versions),
+                            key=parse_version,
+                        )
                     )
                 )
-            )
 
             raise DistributionNotFound(
                 'No matching distribution found for %s' % req


### PR DESCRIPTION
Trying to install a non-existent package (e.g., `pyflac`) results in an error message of the following form:

      Could not find a version that satisfies the requirement pyflac (from versions: )
    No matching distribution found for pyflac

I think there is no need for the first line, since there is no package match in the first place.
