### PR TITLE
Raise log level for output of failed commands

### DIFF
--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -685,10 +685,10 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
     if proc.returncode:
         if raise_on_returncode:
             if all_output:
-                logger.info(
+                logger.critical(
                     'Complete output from command %s:', command_desc,
                 )
-                logger.info(
+                logger.critical(
                     ''.join(all_output) +
                     '\n----------------------------------------'
                 )


### PR DESCRIPTION
The detailed motivation for this is discussed in https://github.com/pantsbuild/pants/issues/2161 but I will summarize it here.

The `pants` tool currently runs `pip` with the `--quiet` flag in order to avoid noisy output that is produced at log level `INFO`.  However, if you silence log level `INFO` then you also silences the really useful output of failed commands that can help debug why they failed.  This pull request raises the log level for the failed command's output in order to differentiate it from less important information.