### PR TITLE
Join extras from constraints and requests

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -263,6 +263,8 @@ class RequirementSet(object):
                     # If we're now installing a constraint, mark the existing
                     # object for real installation.
                     existing_req.constraint = False
+                    existing_req.extras = tuple(set(existing_req.extras).union(
+                                                set(install_req.extras)))
                     # And now we need to scan this.
                     result = [existing_req]
                 # Canonicalise to the already-added object for the backref

--- a/tests/data/packages/LocalExtras/setup.py
+++ b/tests/data/packages/LocalExtras/setup.py
@@ -24,6 +24,6 @@ setup(
     name='LocalExtras',
     version='0.0.1',
     packages=find_packages(),
-    extras_require={ 'bar': ['simple'] },
+    extras_require={ 'bar': ['simple'], 'baz': ['singlemodule'] },
     dependency_links=[DEP_URL]
 )

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -313,3 +313,46 @@ def test_constrained_to_url_install_same_url(script, data):
         'install', '--no-index', '-f', data.find_links, '-c',
         script.scratch_path / 'constraints.txt', to_install)
     assert 'Running setup.py install for singlemodule' in result.stdout
+
+
+def test_install_with_extras_from_constraints(script, data):
+    to_install = data.packages.join("LocalExtras")
+    script.scratch_path.join("constraints.txt").write(
+        "file://%s#egg=LocalExtras[bar]" % to_install
+    )
+    result = script.pip_install_local(
+        '-c', script.scratch_path / 'constraints.txt', 'LocalExtras')
+    assert script.site_packages / 'simple' in result.files_created
+
+
+def test_install_with_extras_from_install(script, data):
+    to_install = data.packages.join("LocalExtras")
+    script.scratch_path.join("constraints.txt").write(
+        "file://%s#egg=LocalExtras" % to_install
+    )
+    result = script.pip_install_local(
+        '-c', script.scratch_path / 'constraints.txt', 'LocalExtras[baz]')
+    assert script.site_packages / 'singlemodule.py'in result.files_created
+
+
+def test_install_with_extras_joined(script, data):
+    to_install = data.packages.join("LocalExtras")
+    script.scratch_path.join("constraints.txt").write(
+        "file://%s#egg=LocalExtras[bar]" % to_install
+    )
+    result = script.pip_install_local(
+        '-c', script.scratch_path / 'constraints.txt', 'LocalExtras[baz]'
+    )
+    assert script.site_packages / 'simple' in result.files_created
+    assert script.site_packages / 'singlemodule.py'in result.files_created
+
+
+def test_install_with_extras_editable_joined(script, data):
+    to_install = data.packages.join("LocalExtras")
+    script.scratch_path.join("constraints.txt").write(
+        "-e file://%s#egg=LocalExtras[bar]" % to_install
+    )
+    result = script.pip_install_local(
+        '-c', script.scratch_path / 'constraints.txt', 'LocalExtras[baz]')
+    assert script.site_packages / 'simple' in result.files_created
+    assert script.site_packages / 'singlemodule.py'in result.files_created


### PR DESCRIPTION
If a dep is mentioned in constraints we just take that version, meaning we
will completely ignore any extras requested on the command line or in a
requirements file.  This takes a union of the two before installing.

Following commits are being handled in PR #2937
 - Attempt to install editable packge defined in constraints should error
 - Attempt to get name for editable file:// URLs

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3105)
<!-- Reviewable:end -->
