### PR TITLE
Add a --disable-urllib3-warnings option

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -177,6 +177,14 @@ class Command(object):
             ),
         })
 
+        if options.disable_urllib3_warnings:
+            from pip._vendor.requests.packages import urllib3
+            category = getattr(urllib3.exceptions,
+                               options.disable_urllib3_warnings,
+                               urllib3.exceptions.HTTPWarning)
+            logger.debug('Disabling urllib3 warnings: %r' % category)
+            urllib3.disable_warnings(category)
+
         # TODO: try to get these passing down from the command?
         #      without resorting to os.environ to hold these.
 

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -513,6 +513,15 @@ disable_pip_version_check = partial(
     help="Don't periodically check PyPI to determine whether a new version "
          "of pip is available for download. Implied with --no-index.")
 
+disable_urllib3_warnings = partial(
+    Option,
+    "--disable-urllib3-warnings",
+    dest="disable_urllib3_warnings",
+    metavar='warnings_class',
+    default=False,
+    help="Suppress warnings from urllib3; e.g.: InsecurePlatformWarning "
+         "(see https://urllib3.readthedocs.org/en/latest/security.html)")
+
 # Deprecated, Remove later
 always_unzip = partial(
     Option,
@@ -550,6 +559,7 @@ general_group = {
         cache_dir,
         no_cache,
         disable_pip_version_check,
+        disable_urllib3_warnings,
     ]
 }
 


### PR DESCRIPTION
Fixes: GH-2681

I'm sorry to beat a dead horse, but...

## Rationale

This warning might be useful in some cases, if it convinces folks to upgrade their Python to a version that supports more secure SSL. However, a lot of folks can't upgrade for various reasons, including that they want to use the standard packages from their distro and their distro bundles an older version.

In my case, we have a CI server that has Ubuntu 14.04 and hence Python 2.7.3. We'd rather not upgrade to a later version at this time, because we'd have to use an unofficial repo like deadsnakes and upgrading even a minor version of Python can often break existing virtualenvs built with an older version. Developers are frequently confused by this warning and think that it has something to do with their build failing. We will upgrade to a later version of Python, but in the meantime we want developers to have clean build logs.

Without:

    [marca@marca-mac2 pip]$ pip list -o --no-cache-dir
    /Users/marca/dev/git-repos/pip/pip/_vendor/requests/packages/urllib3/util/ssl_.py:90: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
      InsecurePlatformWarning
    path.py (Current: 7.6.1 Latest: 8.1.1 [wheel])
    setuptools (Current: 12.0.5 Latest: 18.3.1 [wheel])

With:

    [marca@marca-mac2 pip]$ pip list -o --no-cache-dir --disable-urllib3-warnings
    path.py (Current: 7.6.1 Latest: 8.1.1 [wheel])
    setuptools (Current: 12.0.5 Latest: 18.3.1 [wheel])

    [marca@marca-mac2 pip]$ PIP_DISABLE_URLLIB3_WARNINGS=1 pip list -o --no-cache-dir
    path.py (Current: 7.6.1 Latest: 8.1.1 [wheel])
    setuptools (Current: 12.0.5 Latest: 18.3.1 [wheel])

Cc: @georges, @aconrad, @sontek