### PR TITLE
Fix split_leading_dir, no need to cast to str

### DIFF
--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -221,7 +221,6 @@ def file_contents(filename):
 
 
 def split_leading_dir(path):
-    path = str(path)
     path = path.lstrip('/').lstrip('\\')
     if '/' in path and (('\\' in path and path.find('/') < path.find('\\')) or
                         '\\' not in path):


### PR DESCRIPTION
closes #2729 

I see no reason for this casting, and installing https://github.com/django/django/archive/master.zip worked fine on this branch...