### PR TITLE
Demand the correct exception be raised in assert_raises_regexp().

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -567,7 +567,7 @@ def assert_raises_regexp(exception, reg, run, *args, **kwargs):
     try:
         run(*args, **kwargs)
         assert False, "%s should have been thrown" % exception
-    except Exception:
+    except exception:
         e = sys.exc_info()[1]
         p = re.compile(reg)
         assert p.search(str(e)), str(e)


### PR DESCRIPTION
Previously, it would accept any type of exception; the `exception` arg was used only in an error message.