### PR TITLE
Disable version check on pip upgrade; closes #3130

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -116,6 +116,9 @@ class Command(object):
         else:
             level = "INFO"
 
+        if options.upgrade and 'pip' in args:
+            options.disable_pip_version_check = True
+
         logging_dictConfig({
             "version": 1,
             "disable_existing_loggers": False,


### PR DESCRIPTION
If the command arguments contain `--upgrade pip`, then the option
`--disable-pip-version-check` will be enabled.

This prevents the warning "... however version <newer> is available." as
described in issue #3130