### PR TITLE
Fix user directory expansion when HOME=/

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,9 @@
 * When installing, if building a wheel fails, clear up the build directory
   before falling back to a source install. :issue:`3047`.
 
+* Fix user directory expansion when ``HOME=/``. Workaround for Python bug
+  http://bugs.python.org/issue14768, reported in :issue:`2996`.
+
 
 **7.1.2 (2015-08-22)**
 

--- a/pip/compat/__init__.py
+++ b/pip/compat/__init__.py
@@ -101,6 +101,18 @@ def get_path_uid(path):
     return file_uid
 
 
+def expanduser(path):
+    """
+    Expand ~ and ~user constructions.
+
+    Includes a workaround for http://bugs.python.org/issue14768
+    """
+    expanded = os.path.expanduser(path)
+    if path.startswith('~/') and expanded.startswith('//'):
+        expanded = expanded[1:]
+    return expanded
+
+
 # packages in the stdlib that may have installation metadata, but should not be
 # considered 'installed'.  this theoretically could be determined based on
 # dist.location (py27:`sysconfig.get_paths()['stdlib']`,

--- a/pip/locations.py
+++ b/pip/locations.py
@@ -9,7 +9,7 @@ import sys
 from distutils import sysconfig
 from distutils.command.install import install, SCHEME_KEYS  # noqa
 
-from pip.compat import WINDOWS
+from pip.compat import WINDOWS, expanduser
 from pip.utils import appdirs
 
 
@@ -114,7 +114,7 @@ src_prefix = os.path.abspath(src_prefix)
 
 site_packages = sysconfig.get_python_lib()
 user_site = site.USER_SITE
-user_dir = os.path.expanduser('~')
+user_dir = expanduser('~')
 if WINDOWS:
     bin_py = os.path.join(sys.prefix, 'Scripts')
     bin_user = os.path.join(user_site, 'Scripts')

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -9,6 +9,7 @@ import os
 from pip._vendor import pkg_resources
 from pip._vendor import requests
 
+from pip.compat import expanduser
 from pip.download import (url_to_path, unpack_url)
 from pip.exceptions import (InstallationError, BestVersionAlreadyInstalled,
                             DistributionNotFound, PreviousBuildDirError)
@@ -290,7 +291,7 @@ class RequirementSet(object):
     @property
     def is_download(self):
         if self.download_dir:
-            self.download_dir = os.path.expanduser(self.download_dir)
+            self.download_dir = expanduser(self.download_dir)
             if os.path.exists(self.download_dir):
                 return True
             else:

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -15,7 +15,7 @@ import tarfile
 import zipfile
 
 from pip.exceptions import InstallationError
-from pip.compat import console_to_str, stdlib_pkgs
+from pip.compat import console_to_str, expanduser, stdlib_pkgs
 from pip.locations import (
     site_packages, user_site, running_under_virtualenv, virtualenv_no_global,
     write_delete_marker_file,
@@ -252,7 +252,7 @@ def normalize_path(path, resolve_symlinks=True):
     Convert a path to its canonical, case-normalized, absolute version.
 
     """
-    path = os.path.expanduser(path)
+    path = expanduser(path)
     if resolve_symlinks:
         path = os.path.realpath(path)
     else:

--- a/pip/utils/appdirs.py
+++ b/pip/utils/appdirs.py
@@ -45,7 +45,11 @@ def user_cache_dir(appname):
         path = os.path.join(path, appname)
     else:
         # Get the base path
-        path = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+        path = os.getenv(
+            "XDG_CACHE_HOME",
+            # Workaround for http://bugs.python.org/issue14768
+            os.path.join(os.path.expanduser("~"), ".cache")
+        )
 
         # Add our app name to it
         path = os.path.join(path, appname)
@@ -90,7 +94,11 @@ def user_data_dir(appname, roaming=False):
         )
     else:
         path = os.path.join(
-            os.getenv('XDG_DATA_HOME', os.path.expanduser("~/.local/share")),
+            os.getenv(
+                'XDG_DATA_HOME',
+                # Workaround for http://bugs.python.org/issue14768
+                os.path.join(os.path.expanduser("~"), ".local/share")
+            ),
             appname,
         )
 
@@ -122,7 +130,11 @@ def user_config_dir(appname, roaming=True):
     elif sys.platform == "darwin":
         path = user_data_dir(appname)
     else:
-        path = os.getenv('XDG_CONFIG_HOME', os.path.expanduser("~/.config"))
+        path = os.getenv(
+            'XDG_CONFIG_HOME',
+            # Workaround for http://bugs.python.org/issue14768
+            os.path.join(os.path.expanduser("~"), ".config")
+        )
         path = os.path.join(path, appname)
 
     return path

--- a/pip/utils/appdirs.py
+++ b/pip/utils/appdirs.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 import os
 import sys
 
-from pip.compat import WINDOWS
+from pip.compat import WINDOWS, expanduser
 
 
 def user_cache_dir(appname):
@@ -39,17 +39,13 @@ def user_cache_dir(appname):
         path = os.path.join(path, appname, "Cache")
     elif sys.platform == "darwin":
         # Get the base path
-        path = os.path.expanduser("~/Library/Caches")
+        path = expanduser("~/Library/Caches")
 
         # Add our app name to it
         path = os.path.join(path, appname)
     else:
         # Get the base path
-        path = os.getenv(
-            "XDG_CACHE_HOME",
-            # Workaround for http://bugs.python.org/issue14768
-            os.path.join(os.path.expanduser("~"), ".cache")
-        )
+        path = os.getenv("XDG_CACHE_HOME", expanduser("~/.cache"))
 
         # Add our app name to it
         path = os.path.join(path, appname)
@@ -89,16 +85,12 @@ def user_data_dir(appname, roaming=False):
         path = os.path.join(os.path.normpath(_get_win_folder(const)), appname)
     elif sys.platform == "darwin":
         path = os.path.join(
-            os.path.expanduser('~/Library/Application Support/'),
+            expanduser('~/Library/Application Support/'),
             appname,
         )
     else:
         path = os.path.join(
-            os.getenv(
-                'XDG_DATA_HOME',
-                # Workaround for http://bugs.python.org/issue14768
-                os.path.join(os.path.expanduser("~"), ".local/share")
-            ),
+            os.getenv('XDG_DATA_HOME', expanduser("~/.local/share")),
             appname,
         )
 
@@ -130,11 +122,7 @@ def user_config_dir(appname, roaming=True):
     elif sys.platform == "darwin":
         path = user_data_dir(appname)
     else:
-        path = os.getenv(
-            'XDG_CONFIG_HOME',
-            # Workaround for http://bugs.python.org/issue14768
-            os.path.join(os.path.expanduser("~"), ".config")
-        )
+        path = os.getenv('XDG_CONFIG_HOME', expanduser("~/.config"))
         path = os.path.join(path, appname)
 
     return path
@@ -168,7 +156,7 @@ def site_config_dirs(appname):
         xdg_config_dirs = os.getenv('XDG_CONFIG_DIRS', '/etc/xdg')
         if xdg_config_dirs:
             pathlist = [
-                os.sep.join([os.path.expanduser(x), appname])
+                os.sep.join([expanduser(x), appname])
                 for x in xdg_config_dirs.split(os.pathsep)
             ]
         else:

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -24,6 +24,7 @@ from email.parser import Parser
 from pip._vendor.six import StringIO
 
 import pip
+from pip.compat import expanduser
 from pip.download import path_to_url, unpack_url
 from pip.exceptions import (
     InstallationError, InvalidWheelFilename, UnsupportedWheel)
@@ -55,7 +56,7 @@ class WheelCache(object):
         :param format_control: A pip.index.FormatControl object to limit
             binaries being read from the cache.
         """
-        self._cache_dir = os.path.expanduser(cache_dir) if cache_dir else None
+        self._cache_dir = expanduser(cache_dir) if cache_dir else None
         self._format_control = format_control
 
     def cached_wheel(self, link, package_name):

--- a/tests/unit/test_appdirs.py
+++ b/tests/unit/test_appdirs.py
@@ -44,6 +44,14 @@ class TestUserCacheDir:
 
         assert appdirs.user_cache_dir("pip") == "/home/test/.other-cache/pip"
 
+    def test_user_cache_dir_linux_home_slash(self, monkeypatch):
+        # Verify that we are not affected by http://bugs.python.org/issue14768
+        monkeypatch.delenv("XDG_CACHE_HOME")
+        monkeypatch.setenv("HOME", "/")
+        monkeypatch.setattr(sys, "platform", "linux2")
+
+        assert appdirs.user_cache_dir("pip") == "/.cache/pip"
+
 
 class TestSiteConfigDirs:
 
@@ -154,6 +162,14 @@ class TestUserDataDir:
 
         assert appdirs.user_data_dir("pip") == "/home/test/.other-share/pip"
 
+    def test_user_data_dir_linux_home_slash(self, monkeypatch):
+        # Verify that we are not affected by http://bugs.python.org/issue14768
+        monkeypatch.delenv("XDG_DATA_HOME")
+        monkeypatch.setenv("HOME", "/")
+        monkeypatch.setattr(sys, "platform", "linux2")
+
+        assert appdirs.user_data_dir("pip") == "/.local/share/pip"
+
 
 class TestUserConfigDir:
 
@@ -213,3 +229,11 @@ class TestUserConfigDir:
         monkeypatch.setattr(sys, "platform", "linux2")
 
         assert appdirs.user_config_dir("pip") == "/home/test/.other-config/pip"
+
+    def test_user_config_dir_linux_home_slash(self, monkeypatch):
+        # Verify that we are not affected by http://bugs.python.org/issue14768
+        monkeypatch.delenv("XDG_CONFIG_HOME")
+        monkeypatch.setenv("HOME", "/")
+        monkeypatch.setattr(sys, "platform", "linux2")
+
+        assert appdirs.user_config_dir("pip") == "/.config/pip"

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,5 +1,5 @@
 import os
-from pip.compat import get_path_uid, native_str
+from pip.compat import expanduser, get_path_uid, native_str
 import pytest
 
 
@@ -42,3 +42,15 @@ def test_to_native_str_type():
     some_unicode = b"test\xE9 et approuv\xE9".decode('iso-8859-15')
     assert isinstance(native_str(some_bytes, True), str)
     assert isinstance(native_str(some_unicode, True), str)
+
+
+@pytest.mark.parametrize("home,path,expanded", [
+    ("/Users/test", "~", "/Users/test"),
+    ("/Users/test", "~/.cache", "/Users/test/.cache"),
+    # Verify that we are not affected by http://bugs.python.org/issue14768
+    ("/", "~", "/"),
+    ("/", "~/.cache", "/.cache"),
+])
+def test_expanduser(home, path, expanded, monkeypatch):
+    monkeypatch.setenv("HOME", home)
+    assert expanduser(path) == expanded

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -6,6 +6,7 @@ from mock import patch, Mock
 
 from pip._vendor import pkg_resources
 from pip import pep425tags, wheel
+from pip.compat import expanduser
 from pip.exceptions import InvalidWheelFilename, UnsupportedWheel
 from pip.utils import unpack_file
 
@@ -417,7 +418,7 @@ class TestWheelCache:
 
     def test_expands_path(self):
         wc = wheel.WheelCache("~/.foo/", None)
-        assert wc._cache_dir == os.path.expanduser("~/.foo/")
+        assert wc._cache_dir == expanduser("~/.foo/")
 
     def test_falsey_path_none(self):
         wc = wheel.WheelCache(False, None)


### PR DESCRIPTION
On versions of CPython affected by <http://bugs.python.org/issue14768> (Python 2.6, some versions of Python 2.7 and 3.3), `os.path.expanduser('~/path')` returns `//path` rather than `/path` when `HOME=/`. This affects pip when `os.path.expanduser('~/.cache/pip')` is expanded to `/\\\\.cache/pip`. Although `HOME=/` is probably uncommon on most Linux systems, it is extremely common in Docker images.

Fixes #2996.