### PR TITLE
Abort installation on metadata mismatch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,10 @@
 * **BACKWARD INCOMPATIBLE** Remove the ``--log-explicit-levels`` which had been
   deprecated in 6.0.
 
+* **BACKWARD INCOMPATIBLE** Abort installation of editable if the
+  provided #egg=name part does not match the metadata produced by
+  `setup.py egg_info`. :issue:`3143`.
+
 * Deprecate and no-op the ``--allow-external``, ``--allow-all-external``, and
   ``--allow-unverified`` functionality that was added as part of PEP 438. With
   changes made to the repository protocol made in PEP 470, these options are no
@@ -33,9 +37,6 @@
 
 * Fix user directory expansion when ``HOME=/``. Workaround for Python bug
   http://bugs.python.org/issue14768, reported in :issue:`2996`.
-
-* Abort installation of editable if the provided #egg=name part does not
-  match the metadata produced by `setup.py egg_info`. :issue:`3143`.
 
 
 **7.1.2 (2015-08-22)**

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,6 +34,9 @@
 * Fix user directory expansion when ``HOME=/``. Workaround for Python bug
   http://bugs.python.org/issue14768, reported in :issue:`2996`.
 
+* Abort installation of editable if the provided #egg=name part does not
+  match the metadata produced by `setup.py egg_info`. :issue:`3143`.
+
 
 **7.1.2 (2015-08-22)**
 

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -30,7 +30,7 @@ from pip.utils import (
     display_path, rmtree, ask_path_exists, backup_dir, is_installable_dir,
     dist_in_usersite, dist_in_site_packages, egg_link_path,
     call_subprocess, read_text_file, FakeFile, _make_build_dir, ensure_dir,
-    get_installed_version
+    get_installed_version, canonicalize_name
 )
 from pip.utils.logging import indent_log
 from pip.req.req_uninstall import UninstallPathSet
@@ -421,6 +421,14 @@ class InstallRequirement(object):
                     self.pkg_info()["Version"],
                 ]))
             self._correct_build_location()
+        else:
+            metadata_name = canonicalize_name(self.pkg_info()["Name"])
+            if canonicalize_name(self.req.project_name) != metadata_name:
+                raise InstallationError(
+                    'Running setup.py (path:%s) egg_info for package %s '
+                    'produced metadata for project name %s' % (
+                        self.setup_py, self.name, metadata_name)
+                )
 
     # FIXME: This is a lame hack, entirely for PasteScript which has
     # a self-provided entry point that causes this awkwardness

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -775,3 +775,18 @@ def test_install_no_binary_disables_cached_wheels(script, data):
     assert "Running setup.py bdist_wheel for upper" not in str(res), str(res)
     # Must have used source, not a cached wheel to install upper.
     assert "Running setup.py install for upper" in str(res), str(res)
+
+
+def test_install_editable_with_wrong_egg_name(script):
+    script.scratch_path.join("pkga").mkdir()
+    pkga_path = script.scratch_path / 'pkga'
+    pkga_path.join("setup.py").write(textwrap.dedent("""
+        from setuptools import setup
+        setup(name='pkga',
+              version='0.1')
+    """))
+    result = script.pip(
+        'install', '--editable', 'file://%s#egg=pkgb' % pkga_path,
+        expect_error=True)
+    assert ("egg_info for package pkgb produced metadata "
+            "for project name pkga") in result.stderr


### PR DESCRIPTION
If setup.py egg_info produces metadata for a different project name than
self.req.project_name, abort the installation.
Fixes #3143