### PR TITLE
fix AttributeError: 'thread._local' object has no attribute 'indentatation'

### DIFF
--- a/pip/utils/logging.py
+++ b/pip/utils/logging.py
@@ -31,11 +31,11 @@ def indent_log(num=2):
     A context manager which will cause the log output to be indented for any
     log messages emited inside it.
     """
-    _log_state.indentation += num
+    _log_state.indentation = get_indentation() + num
     try:
         yield
     finally:
-        _log_state.indentation -= num
+        _log_state.indentation = get_indentation() - num
 
 
 def get_indentation():


### PR DESCRIPTION

when i run main command from python under Django, logging fails with this error because threadig state has no attribute indentation, this solution uses helper for optional indentation
    
    import pip
    pip.main(['install', 'leonardo-translations'])

        Exception:
        Traceback (most recent call last):
          File "/srv/leonardo/sites/majklk/local/lib/python2.7/site-packages/pip/basecommand.py", line 211, in main
            status = self.run(options, args)
          File "/srv/leonardo/sites/majklk/local/lib/python2.7/site-packages/pip/commands/install.py", line 344, in run
            requirement_set.cleanup_files()
          File "/srv/leonardo/sites/majklk/local/lib/python2.7/site-packages/pip/req/req_set.py", line 589, in cleanup_files
            with indent_log():
          File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__
            return self.gen.next()
          File "/srv/leonardo/sites/majklk/local/lib/python2.7/site-packages/pip/utils/logging.py", line 38, in indent_log
            _log_state.indentation -= num
        AttributeError: 'thread._local' object has no attribute 'indentation'