### PR TITLE
Invert osx priority

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -92,7 +92,7 @@ def get_supported(versions=None, noarch=False):
                 if actual_arch in ('i386', 'x86_64'):
                     actual_arches.append('intel')
                 if actual_arch in ('i386', 'ppc', 'x86_64'):
-                    actual_arches.append('fat3')
+                    actual_arches.append('fat32')
                 if actual_arch in ('ppc64', 'x86_64'):
                     actual_arches.append('fat64')
                 if actual_arch in ('i386', 'x86_64', 'intel', 'ppc', 'ppc64'):

--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -91,10 +91,10 @@ def get_supported(versions=None, noarch=False):
                     actual_arches.append('fat')
                 if actual_arch in ('i386', 'x86_64'):
                     actual_arches.append('intel')
-                if actual_arch in ('i386', 'ppc', 'x86_64'):
-                    actual_arches.append('fat32')
                 if actual_arch in ('ppc64', 'x86_64'):
                     actual_arches.append('fat64')
+                if actual_arch in ('i386', 'ppc', 'x86_64'):
+                    actual_arches.append('fat32')
                 if actual_arch in ('i386', 'x86_64', 'intel', 'ppc', 'ppc64'):
                     actual_arches.append('universal')
                 tpl = '{0}_{1}_%i_%s'.format(name, major)

--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -99,7 +99,7 @@ def get_supported(versions=None, noarch=False):
                     actual_arches.append('universal')
                 tpl = '{0}_{1}_%i_%s'.format(name, major)
                 arches = []
-                for m in range(int(minor) + 1):
+                for m in reversed(range(int(minor) + 1)):
                     for a in actual_arches:
                         arches.append(tpl % (m, a))
             else:


### PR DESCRIPTION
* Fixes ``fat3`` -> ``fat32``
* Prefers ``fat64`` wheels over ``fat32`` as they will be smaller.
* Prefers a wheel built with a newer SDK over one built with an older SDK.