### PR TITLE
Correct link and add docs badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,11 +17,13 @@ tool for installing Python packages.
 
 
 .. image:: https://img.shields.io/pypi/v/pip.svg
-        :target: https://pypi.python.org/pypi/pip
+   :target: https://pypi.python.org/pypi/pip
 
 .. image:: https://img.shields.io/travis/pypa/pip/develop.svg
    :target: http://travis-ci.org/pypa/pip
 
+.. image:: https://readthedocs.org/projects/pip/badge/?version=stable
+   :target: https://pip.pypa.io/en/stable
 
 Code of Conduct
 ---------------


### PR DESCRIPTION
@dstufft The current link in README.rst to pypa recommended tools was broken.

Corrected the link and added a docs badge to indicate successful doc builds.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3169)
<!-- Reviewable:end -->
