### PR TITLE
update for processing continuations/comments for req files

### DIFF
--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -98,8 +98,8 @@ def preprocess(content, options):
     :param options: cli options
     """
     lines_enum = enumerate(content.splitlines(), start=1)
-    lines_enum = ignore_comments(lines_enum)
     lines_enum = join_lines(lines_enum)
+    lines_enum = ignore_comments(lines_enum)
     lines_enum = skip_regex(lines_enum, options)
     return lines_enum
 
@@ -278,13 +278,16 @@ def build_parser():
 
 
 def join_lines(lines_enum):
-    """Joins a line ending in '\' with the previous line.  The joined line takes on
-    the index of the first line.
+    """Joins a line ending in '\' with the previous line (except when following
+    comments).  The joined line takes on the index of the first line.
     """
     primary_line_number = None
     new_line = []
     for line_number, line in lines_enum:
-        if not line.endswith('\\'):
+        if not line.endswith('\\') or COMMENT_RE.match(line):
+            if COMMENT_RE.match(line):
+                # this ensures comments are always matched later
+                line = ' ' + line
             if new_line:
                 new_line.append(line)
                 yield primary_line_number, ''.join(new_line)

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -37,16 +37,16 @@ def options(session):
 class TestPreprocess(object):
     """tests for `preprocess`"""
 
-    def test_comments_processed_before_joining_case1(self):
+    def test_comments_and_joins_case1(self):
         content = textwrap.dedent("""\
           req1 \\
           # comment \\
           req2
         """)
         result = preprocess(content, None)
-        assert list(result) == [(1, 'req1 req2')]
+        assert list(result) == [(1, 'req1'), (3, 'req2')]
 
-    def test_comments_processed_before_joining_case2(self):
+    def test_comments_and_joins_case2(self):
         content = textwrap.dedent("""\
           req1\\
           # comment
@@ -54,14 +54,14 @@ class TestPreprocess(object):
         result = preprocess(content, None)
         assert list(result) == [(1, 'req1')]
 
-    def test_comments_processed_before_joining_case3(self):
+    def test_comments_and_joins_case3(self):
         content = textwrap.dedent("""\
           req1 \\
           # comment
           req2
         """)
         result = preprocess(content, None)
-        assert list(result) == [(1, 'req1 req2')]
+        assert list(result) == [(1, 'req1'), (3, 'req2')]
 
     def test_skip_regex_after_joining_case1(self, options):
         content = textwrap.dedent("""\


### PR DESCRIPTION
this modifies the behavior for processing comments and line continuations in req files.

this case:
```
req1 \
# comment
req2
```

now processes to
```
req1
req2
```

not
```
req1 req2
```

although @pfmoore mentioned his idea of "process comments first, but leave an empty line", I chose to handle this by doing continuations first, but with some special handling for comments. this seemed clearer to me and more consistent with Python.
