### PR TITLE
Custom skip freeze

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@
 * Fix a bug when removing packages in python 3: disable INI-style parsing of the
   entry_point.txt file to allow entry point names with colons (:pull:`3434`)
 
+* Add a --freeze-with option to include usually skipped package (like pip or
+  setuptools) to the freeze output. Also add wheel to the skipped packages list.
+  :issue:`1610`, :issue:`2989`
+
 
 **8.0.2 (2016-01-21)**
 

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -58,7 +58,7 @@ class FreezeCommand(Command):
             help='Only output packages installed in user-site.')
         self.cmd_opts.add_option(
             '--with',
-            dest='whitelist',
+            dest='freeze_whitelist',
             action='append',
             default=[],
             help='Do not skip those packages.')
@@ -70,7 +70,7 @@ class FreezeCommand(Command):
         wheel_cache = WheelCache(options.cache_dir, format_control)
         skip = set()
         for pkg in stdlib_pkgs + DEV_PKGS:
-            if pkg not in options.whitelist:
+            if pkg not in options.freeze_whitelist:
                 skip.add(pkg)
 
         freeze_kwargs = dict(

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -9,7 +9,7 @@ from pip.operations.freeze import freeze
 from pip.wheel import WheelCache
 
 
-DEV_PKGS = ('pip', 'setuptools', 'distribute')
+DEV_PKGS = ('pip', 'setuptools', 'distribute', 'wheel')
 
 
 class FreezeCommand(Command):

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -57,7 +57,7 @@ class FreezeCommand(Command):
             default=False,
             help='Only output packages installed in user-site.')
         self.cmd_opts.add_option(
-            '--with',
+            '--freeze-with',
             dest='freeze_whitelist',
             action='append',
             default=[],

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -3,9 +3,13 @@ from __future__ import absolute_import
 import sys
 
 import pip
+from pip.compat import stdlib_pkgs
 from pip.basecommand import Command
 from pip.operations.freeze import freeze
 from pip.wheel import WheelCache
+
+
+DEV_PKGS = ('pip', 'setuptools', 'distribute')
 
 
 class FreezeCommand(Command):
@@ -52,12 +56,23 @@ class FreezeCommand(Command):
             action='store_true',
             default=False,
             help='Only output packages installed in user-site.')
+        self.cmd_opts.add_option(
+            '--with',
+            dest='whitelist',
+            action='append',
+            default=[],
+            help='Do not skip those packages.')
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
         format_control = pip.index.FormatControl(set(), set())
         wheel_cache = WheelCache(options.cache_dir, format_control)
+        skip = set()
+        for pkg in stdlib_pkgs + DEV_PKGS:
+            if pkg not in options.whitelist:
+                skip.add(pkg)
+
         freeze_kwargs = dict(
             requirement=options.requirement,
             find_links=options.find_links,
@@ -65,7 +80,8 @@ class FreezeCommand(Command):
             user_only=options.user,
             skip_regex=options.skip_requirements_regex,
             isolated=options.isolated_mode,
-            wheel_cache=wheel_cache)
+            wheel_cache=wheel_cache,
+            skip=skip)
 
         for line in freeze(**freeze_kwargs):
             sys.stdout.write(line + '\n')

--- a/pip/compat/__init__.py
+++ b/pip/compat/__init__.py
@@ -138,9 +138,9 @@ def expanduser(path):
 # dist.location (py27:`sysconfig.get_paths()['stdlib']`,
 # py26:sysconfig.get_config_vars('LIBDEST')), but fear platform variation may
 # make this ineffective, so hard-coding
-stdlib_pkgs = ['python', 'wsgiref']
+stdlib_pkgs = ('python', 'wsgiref')
 if sys.version_info >= (2, 7):
-    stdlib_pkgs.extend(['argparse'])
+    stdlib_pkgs += ('argparse',)
 
 
 # windows detection, covers cpython and ironpython

--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -26,7 +26,7 @@ def freeze(
     skip_match = None
 
     if skip_regex:
-        skip_match = re.compile(skip_regex)
+        skip_match = re.compile(skip_regex).search
 
     dependency_links = []
 
@@ -55,7 +55,7 @@ def freeze(
             for line in req_file:
                 if (not line.strip() or
                         line.strip().startswith('#') or
-                        (skip_match and skip_match.search(line)) or
+                        (skip_match and skip_match(line)) or
                         line.startswith((
                             '-r', '--requirement',
                             '-Z', '--always-unzip',

--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -13,7 +13,7 @@ from pip._vendor import pkg_resources
 logger = logging.getLogger(__name__)
 
 # packages to exclude from freeze output
-freeze_excludes = stdlib_pkgs + ['setuptools', 'pip', 'distribute']
+freeze_excludes = stdlib_pkgs + ('setuptools', 'pip', 'distribute')
 
 
 def freeze(

--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -4,16 +4,12 @@ import logging
 import re
 
 import pip
-from pip.compat import stdlib_pkgs
 from pip.req import InstallRequirement
-from pip.utils import get_installed_distributions
+from pip.utils import canonicalize_name, get_installed_distributions
 from pip._vendor import pkg_resources
 
 
 logger = logging.getLogger(__name__)
-
-# packages to exclude from freeze output
-freeze_excludes = stdlib_pkgs + ('setuptools', 'pip', 'distribute')
 
 
 def freeze(
@@ -21,7 +17,8 @@ def freeze(
         find_links=None, local_only=None, user_only=None, skip_regex=None,
         default_vcs=None,
         isolated=False,
-        wheel_cache=None):
+        wheel_cache=None,
+        skip=()):
     find_links = find_links or []
     skip_match = None
 
@@ -42,7 +39,7 @@ def freeze(
         yield '-f %s' % link
     installations = {}
     for dist in get_installed_distributions(local_only=local_only,
-                                            skip=freeze_excludes,
+                                            skip=(),
                                             user_only=user_only):
         req = pip.FrozenRequirement.from_dist(
             dist,
@@ -112,4 +109,5 @@ def freeze(
         )
     for installation in sorted(
             installations.values(), key=lambda x: x.name.lower()):
-        yield str(installation).rstrip()
+        if canonicalize_name(installation.name) not in skip:
+            yield str(installation).rstrip()

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -63,6 +63,12 @@ def test_freeze_basic(script):
     _check_output(result.stdout, expected)
 
 
+def test_freeze_with_pip(script):
+    """Test pip shows itself"""
+    result = script.pip('freeze', '--with=pip')
+    assert 'pip==' in result.stdout
+
+
 @pytest.mark.svn
 def test_freeze_svn(script, tmpdir):
     """Test freezing a svn checkout"""

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -65,7 +65,7 @@ def test_freeze_basic(script):
 
 def test_freeze_with_pip(script):
     """Test pip shows itself"""
-    result = script.pip('freeze', '--with=pip')
+    result = script.pip('freeze', '--freeze-with=pip')
     assert 'pip==' in result.stdout
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,7 +16,6 @@ from pip.exceptions import HashMismatch, HashMissing, InstallationError
 from pip.utils import (egg_link_path, get_installed_distributions,
                        untar_file, unzip_file, rmtree, normalize_path)
 from pip.utils.hashes import Hashes, MissingHashes
-from pip.operations.freeze import freeze_excludes
 from pip._vendor.six import BytesIO
 
 
@@ -261,7 +260,8 @@ class Tests_get_installed_distributions:
         mock_dist_is_editable.side_effect = self.dist_is_editable
         mock_dist_is_local.side_effect = self.dist_is_local
         mock_dist_in_usersite.side_effect = self.dist_in_usersite
-        dists = get_installed_distributions(skip=freeze_excludes)
+        dists = get_installed_distributions(
+            skip=('setuptools', 'pip', 'distribute'))
         assert len(dists) == 0
 
 


### PR DESCRIPTION
- Also skip wheel package in freeze by default
- Adds a `--freeze-with` option to whitelist normally skipped packages:

    $ pip freeze --freeze-with=setuptools --freeze-with=argparse
    argparse==1.2.1
    setuptools==18.3.2

(or putting `freeze_with = argparse setuptools` in your pip.conf)

Not sure about the option name...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3173)
<!-- Reviewable:end -->
