### PR TITLE
Resolves result obj in req_constraints

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -249,11 +249,10 @@ class RequirementSet(object):
                     self.requirement_aliases[name.lower()] = name
                 result = [install_req]
             else:
-                if not existing_req.constraint:
-                    # No need to scan, we've already encountered this for
-                    # scanning.
-                    result = []
-                elif not install_req.constraint:
+                # Assume there's no need to scan, and that we've already
+                # encountered this for scanning.
+                result = []
+                if not install_req.constraint and existing_req.constraint:
                     if (install_req.link and not (existing_req.link and
                        install_req.link.path == existing_req.link.path)):
                         self.reqs_to_cleanup.append(install_req)


### PR DESCRIPTION
The changes resolves a condition that can lead to a stacktrace due to the 
use of constraint files. There are conditions where the result object may be
left undefined which causes the problems

**Example of the traceback**
``` traceback
  Exception:
  Traceback (most recent call last):
    File "/usr/local/lib/python2.7/dist-packages/pip/basecommand.py", line 211, in main
      status = self.run(options, args)
    File "/usr/local/lib/python2.7/dist-packages/pip/commands/wheel.py", line 180, in run
      wheel_cache
    File "/usr/local/lib/python2.7/dist-packages/pip/basecommand.py", line 266, in populate_requirement_set
      requirement_set.add_requirement(req)
    File "/usr/local/lib/python2.7/dist-packages/pip/req/req_set.py", line 267, in add_requirement
      return result
  UnboundLocalError: local variable 'result' referenced before assignment
```

This change simply ensures that the 'result' object is a defined
when the method returns

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>