### PR TITLE
Fix example of using setuptools find_links

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -513,7 +513,7 @@ To have the dependency located from a local directory and not crawl PyPI, add th
 
   [easy_install]
   allow_hosts = ''
-  find_links = file:///path/to/local/archives
+  find_links = file:///path/to/local/archives/
 
 
 Build System Interface


### PR DESCRIPTION
setuptools.package_index.local_open is used for file: URLs, and only
handles directories if the URL ends with a slash.  Add the trailing
slash to pip's documentation to reduce confusion.