### PR TITLE
Drop INSTALLED_VERSION

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -463,7 +463,12 @@ class PackageFinder(object):
 
         applicable_candidates = self._sort_versions(applicable_candidates)
 
-        if req.satisfied_by is None and not applicable_candidates:
+        if req.satisfied_by is not None:
+            installed_version = parse_version(req.satisfied_by.version)
+        else:
+            installed_version = None
+
+        if installed_version is None and not applicable_candidates:
             logger.critical(
                 'Could not find a version that satisfies the requirement %s '
                 '(from versions: %s)',
@@ -481,23 +486,23 @@ class PackageFinder(object):
             )
 
         best_installed = False
-        if req.satisfied_by and (
+        if installed_version and (
                 not applicable_candidates or
-                applicable_candidates[0].version <= req.satisfied_by.version):
+                applicable_candidates[0].version <= installed_version):
             best_installed = True
 
-        if not upgrade and req.satisfied_by is not None:
+        if not upgrade and installed_version is not None:
             if best_installed:
                 logger.debug(
                     'Existing installed version (%s) is most up-to-date and '
                     'satisfies requirement',
-                    req.satisfied_by.version,
+                    installed_version,
                 )
             else:
                 logger.debug(
                     'Existing installed version (%s) satisfies requirement '
                     '(most up-to-date version is %s)',
-                    req.satisfied_by.version,
+                    installed_version,
                     applicable_candidates[0].version,
                 )
             return None
@@ -507,7 +512,7 @@ class PackageFinder(object):
             logger.debug(
                 'Installed version (%s) is most up-to-date (past versions: '
                 '%s)',
-                req.satisfied_by.version,
+                installed_version,
                 ', '.join(str(c.version) for c in applicable_candidates) or
                 "none",
             )

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -31,7 +31,7 @@ else:
     from io import StringIO
 
 __all__ = ['rmtree', 'display_path', 'backup_dir',
-           'ask', 'Inf', 'splitext',
+           'ask', 'splitext',
            'format_size', 'is_installable_dir',
            'is_svn_page', 'file_contents',
            'split_leading_dir', 'has_leading_dir',
@@ -152,38 +152,6 @@ def ask(message, options):
             )
         else:
             return response
-
-
-class _Inf(object):
-    """I am bigger than everything!"""
-
-    def __eq__(self, other):
-        if self is other:
-            return True
-        else:
-            return False
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __lt__(self, other):
-        return False
-
-    def __le__(self, other):
-        return False
-
-    def __gt__(self, other):
-        return True
-
-    def __ge__(self, other):
-        return True
-
-    def __repr__(self):
-        return 'Inf'
-
-
-Inf = _Inf()  # this object is not currently used as a sortable in our code
-del _Inf
 
 
 def format_size(bytes):

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -11,7 +11,6 @@ from pip.index import (
 from pip.exceptions import (
     BestVersionAlreadyInstalled, DistributionNotFound, InstallationError,
 )
-from pip.utils import Inf
 from pip.download import PipSession
 
 from mock import Mock, patch
@@ -225,7 +224,6 @@ class TestWheel:
         Test link sorting
         """
         links = [
-            InstallationCandidate("simple", "2.0", Link(Inf)),
             InstallationCandidate("simple", "2.0", Link('simple-2.0.tar.gz')),
             InstallationCandidate(
                 "simple",

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -2,7 +2,7 @@ import pytest
 
 from pip.download import PipSession
 from pip.index import HTMLPage
-from pip.index import PackageFinder, Link, INSTALLED_VERSION
+from pip.index import PackageFinder, Link
 
 
 def test_sort_locations_file_expand_dir(data):
@@ -25,11 +25,6 @@ def test_sort_locations_file_not_find_link(data):
     finder = PackageFinder([], [], session=PipSession())
     files, urls = finder._sort_locations(data.index_url("empty_with_pkg"))
     assert urls and not files, "urls, but not files should have been found"
-
-
-def test_INSTALLED_VERSION_greater():
-    """Test INSTALLED_VERSION compares greater."""
-    assert INSTALLED_VERSION > Link("some link")
 
 
 class TestLink(object):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -12,7 +12,7 @@ import tempfile
 import pytest
 
 from mock import Mock, patch
-from pip.utils import (egg_link_path, Inf, get_installed_distributions,
+from pip.utils import (egg_link_path, get_installed_distributions,
                        untar_file, unzip_file, rmtree, normalize_path)
 from pip.operations.freeze import freeze_excludes
 
@@ -149,16 +149,6 @@ class Tests_EgglinkPath:
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.return_value = False
         assert egg_link_path(self.mock_dist) is None
-
-
-def test_Inf_greater():
-    """Test Inf compares greater."""
-    assert Inf > object()
-
-
-def test_Inf_equals_Inf():
-    """Test Inf compares greater."""
-    assert Inf == Inf
 
 
 @patch('pip.utils.dist_in_usersite')


### PR DESCRIPTION
closes #703

This refactor is a first step to ease the transition to a simpler `Finder`, only returning a list of `InstallationCandidate` (or alternatively only the best/None) from a req_name and a version specifier (i.e. something like `django>=1.5,<1.7`).

The logic of satisfied_by/upgrade could/should be performed in an other place.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3211)
<!-- Reviewable:end -->
