### PR TITLE
BUG: finish fix for speeding up "pip install ."

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,12 +2,12 @@
 set -e
 set -x
 
-# If we're running under Python 3.5, we can't use anything but --asert=plain
+# If we're running under Python 3.5, we can't use anything but --assert=plain
 if [[ $TOXENV = "py35" ]]; then
     export TOXARGS="--assert=plain"
 fi
 
-# If we're running under Python 3.6, we can't use anything but --asert=plain
+# If we're running under Python 3.6, we can't use anything but --assert=plain
 if [[ $TOXENV = "py36" ]]; then
     export TOXARGS="--assert=plain"
 fi

--- a/pip/download.py
+++ b/pip/download.py
@@ -694,9 +694,7 @@ def unpack_file_url(link, location, download_dir=None):
 
     # If it's a url to a local directory
     if os.path.isdir(link_path):
-        if os.path.isdir(location):
-            rmtree(location)
-        shutil.copytree(link_path, location, symlinks=True)
+        _copy_dist_from_dir(link_path, location)
         if download_dir:
             logger.info('Link is a directory, ignoring download_dir')
         return
@@ -736,12 +734,6 @@ def _copy_dist_from_dir(link_path, location):
         pip install ~/dev/git-repos/python-prompt-toolkit
 
     """
-
-    # Note: This is currently VERY SLOW if you have a lot of data in the
-    # directory, because it copies everything with `shutil.copytree`.
-    # What it should really do is build an sdist and install that.
-    # See https://github.com/pypa/pip/issues/2195
-
     if os.path.isdir(location):
         rmtree(location)
 

--- a/pip/download.py
+++ b/pip/download.py
@@ -752,6 +752,13 @@ def _copy_dist_from_dir(link_path, location):
     with indent_log():
         call_subprocess(sdist_args, cwd=link_path, show_stdout=False)
 
+    # determine what .egg-info/ was created and delete it again.  otherwise
+    # it is found on the path for `pip install .` and mistaken for an installed
+    # version
+    egg_info_dirs = [s for s in os.listdir(link_path) if s.endswith('.egg-info')]
+    for dirname in egg_info_dirs:
+        rmtree(os.path.join(link_path, dirname))
+
     # unpack sdist into `location`
     sdist = os.path.join(location, os.listdir(location)[0])
     logger.info('Unpacking sdist %s into %s', sdist, location)


### PR DESCRIPTION
This is a follow-up to gh-2535, which added the code to copy via
(sdist + unpack) instead of shutil.copytree, but forgot to actually
call that function.

Fixes gh-2195 (slow pip install of a dir).

I've tested that this works (on scipy), but since gh-2535 refers to some issues with ``pbr`` / OpenStack and the previous PR didn't change pip's behavior the ``pbr`` test should be redone.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3219)
<!-- Reviewable:end -->
