### PR TITLE
Display spinner during long setup.py calls

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -34,6 +34,7 @@ from pip.utils import (
     get_installed_version, canonicalize_name
 )
 from pip.utils.logging import indent_log
+from pip.utils.ui import open_spinner
 from pip.req.req_uninstall import UninstallPathSet
 from pip.vcs import vcs
 from pip.wheel import move_wheel_files, Wheel
@@ -828,7 +829,7 @@ exec(compile(
         temp_location = tempfile.mkdtemp('-record', 'pip-')
         record_filename = os.path.join(temp_location, 'install-record.txt')
         try:
-            install_args = [sys.executable]
+            install_args = [sys.executable, "-u"]
             install_args.append('-c')
             install_args.append(
                 "import setuptools, tokenize;__file__=%r;"
@@ -854,13 +855,15 @@ exec(compile(
                 install_args += ['--install-headers',
                                  os.path.join(sys.prefix, 'include', 'site',
                                               py_ver_str, self.name)]
-            logger.info('Running setup.py install for %s', self.name)
-            with indent_log():
-                call_subprocess(
-                    install_args + install_options,
-                    cwd=self.source_dir,
-                    show_stdout=False,
-                )
+            msg = 'Running setup.py install for %s' % (self.name,)
+            with open_spinner(msg) as spinner:
+                with indent_log():
+                    call_subprocess(
+                        install_args + install_options,
+                        cwd=self.source_dir,
+                        show_stdout=False,
+                        spinner=spinner,
+                    )
 
             if not os.path.exists(record_filename):
                 logger.debug('Record file %s not found', record_filename)

--- a/pip/utils/ui.py
+++ b/pip/utils/ui.py
@@ -4,13 +4,17 @@ from __future__ import division
 import itertools
 import sys
 from signal import signal, SIGINT, default_int_handler
+import time
+import contextlib
+import logging
 
 from pip.compat import WINDOWS
 from pip.utils import format_size
 from pip.utils.logging import get_indentation
 from pip._vendor import six
 from pip._vendor.progress.bar import Bar, IncrementalBar
-from pip._vendor.progress.helpers import WritelnMixin
+from pip._vendor.progress.helpers import (WritelnMixin,
+                                          HIDE_CURSOR, SHOW_CURSOR)
 from pip._vendor.progress.spinner import Spinner
 
 try:
@@ -19,6 +23,8 @@ try:
 # ImportError.
 except Exception:
     colorama = None
+
+logger = logging.getLogger(__name__)
 
 
 def _select_progress_class(preferred, fallback):
@@ -197,3 +203,137 @@ class DownloadProgressSpinner(WindowsMixin, InterruptibleMixin,
         ])
 
         self.writeln(line)
+
+
+################################################################
+# Generic "something is happening" spinners
+#
+# We don't even try using progress.spinner.Spinner here because it's actually
+# simpler to reimplement from scratch than to coerce their code into doing
+# what we need.
+################################################################
+
+@contextlib.contextmanager
+def hidden_cursor(file):
+    # The Windows terminal does not support the hide/show cursor ANSI codes,
+    # even via colorama. So don't even try.
+    if WINDOWS:
+        yield
+    else:
+        file.write(HIDE_CURSOR)
+        try:
+            yield
+        finally:
+            file.write(SHOW_CURSOR)
+
+
+class RateLimiter(object):
+    def __init__(self, min_update_interval_seconds):
+        self._min_update_interval_seconds = min_update_interval_seconds
+        self._last_update = 0
+
+    def ready(self):
+        now = time.time()
+        delta = now - self._last_update
+        return delta >= self._min_update_interval_seconds
+
+    def reset(self):
+        self._last_update = time.time()
+
+
+class InteractiveSpinner(object):
+    def __init__(self, message, file=None, spin_chars="-\\|/",
+                 # Empirically, 8 updates/second looks nice
+                 min_update_interval_seconds=0.125):
+        self._message = message
+        if file is None:
+            file = sys.stdout
+        self._file = file
+        self._rate_limiter = RateLimiter(min_update_interval_seconds)
+        self._finished = False
+
+        self._spin_cycle = itertools.cycle(spin_chars)
+
+        self._file.write(" " * get_indentation() + self._message + " ... ")
+        self._width = 0
+
+    def _write(self, status):
+        assert not self._finished
+        # Erase what we wrote before by backspacing to the beginning, writing
+        # spaces to overwrite the old text, and then backspacing again
+        backup = "\b" * self._width
+        self._file.write(backup + " " * self._width + backup)
+        # Now we have a blank slate to add our status
+        self._file.write(status)
+        self._width = len(status)
+        self._file.flush()
+        self._rate_limiter.reset()
+
+    def spin(self):
+        if self._finished:
+            return
+        if not self._rate_limiter.ready():
+            return
+        self._write(next(self._spin_cycle))
+
+    def finish(self, final_status):
+        if self._finished:
+            return
+        self._write(final_status)
+        self._file.write("\n")
+        self._file.flush()
+        self._finished = True
+
+
+# Used for dumb terminals, non-interactive installs (no tty), etc.
+# We still print updates occasionally (once every 60 seconds by default) to
+# act as a keep-alive for systems like Travis-CI that take lack-of-output as
+# an indication that a task has frozen.
+class NonInteractiveSpinner(object):
+    def __init__(self, message, min_update_interval_seconds=60):
+        self._message = message
+        self._finished = False
+        self._rate_limiter = RateLimiter(min_update_interval_seconds)
+        self._update("started")
+
+    def _update(self, status):
+        assert not self._finished
+        self._rate_limiter.reset()
+        logger.info("%s: %s", self._message, status)
+
+    def spin(self):
+        if self._finished:
+            return
+        if not self._rate_limiter.ready():
+            return
+        self._update("still running...")
+
+    def finish(self, final_status):
+        if self._finished:
+            return
+        self._update("finished with status '%s'" % (final_status,))
+        self._finished = True
+
+
+@contextlib.contextmanager
+def open_spinner(message):
+    # Interactive spinner goes directly to sys.stdout rather than being routed
+    # through the logging system, but it acts like it has level INFO,
+    # i.e. it's only displayed if we're at level INFO or better.
+    # Non-interactive spinner goes through the logging system, so it is always
+    # in sync with logging configuration.
+    if sys.stdout.isatty() and logger.getEffectiveLevel() <= logging.INFO:
+        spinner = InteractiveSpinner(message)
+    else:
+        spinner = NonInteractiveSpinner(message)
+    try:
+        with hidden_cursor(sys.stdout):
+            yield spinner
+    except KeyboardInterrupt:
+        spinner.finish("canceled")
+        raise
+    except Exception:
+        spinner.finish("error")
+        raise
+    else:
+        spinner.finish("done")


### PR DESCRIPTION
One of the downsides of pip's new hiding of build chatter is that for
packages that take a very long time to build (e.g. scipy) the user gets
no indication that anything is happening for a very long time (e.g. tens
of minutes), and is likely to get frustrated and hit Control-C.

Here's a proof of concept of an idea discussed here:

  https://github.com/pypa/pip/issues/2732#issuecomment-153215371

where we put up a spinner that rotates whenever the underlying build
produces output. I tried it on scipy, and it the experience was quite
pleasant! It spun around, sometimes fast and sometimes slow, and then
there was one uncomfortable pause for ~1 minute while a very gnarly C++
file got compiled, but that's okay because it was actually providing
accurate feedback.

Reasons this is only a proof of concept:
- no rate-limiting
- the current UI is unacceptable -- try it and you'll see what I mean,
  but basically it puts the spinner in a weird place and then leaves
  detritus behind.

The underlying reason for both of these is that I find the progress
bar/spinner system totally incomprehensible (you are lost in a maze of
twisty mixins, all different...), and am also uncertain how to integrate
it with the existing messages that go via logger.info... If I knew how
I'd have made it produce output like:
```
  Running setup.py install for scipy ... /
  Running setup.py install for scipy ... -
  Running setup.py install for scipy ... \
  Running setup.py install for scipy ... done.
```
...but I don't.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3224)
<!-- Reviewable:end -->
