### PR TITLE
Force the --python-tag when autobuilding wheels

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -55,6 +55,13 @@ def get_impl_version_info():
         return sys.version_info[0], sys.version_info[1]
 
 
+def get_impl_tag():
+    """
+    Returns the Tag for this specific implementation.
+    """
+    return "{0}{1}".format(get_abbr_impl(), get_impl_ver())
+
+
 def get_flag(var, fallback, expected=True, warn=True):
     """Use a fallback method for determining SOABI flags if the needed config
     var is unset or unavailable."""
@@ -198,3 +205,5 @@ def get_supported(versions=None, noarch=False):
 
 supported_tags = get_supported()
 supported_tags_noarch = get_supported(noarch=True)
+
+implementation_tag = get_impl_tag()

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -7,6 +7,7 @@ from os.path import join, curdir, pardir
 
 import pytest
 
+from pip import pep425tags
 from pip.utils import appdirs, rmtree
 from tests.lib import (pyversion, pyversion_tuple,
                        _create_test_package, _create_svn_repo, path_to_url)
@@ -737,7 +738,7 @@ def test_install_builds_wheels(script, data):
     assert expected in str(res), str(res)
     root = appdirs.user_cache_dir('pip')
     wheels = []
-    for top, dirs, files in os.walk(root):
+    for top, dirs, files in os.walk(os.path.join(root, "wheels")):
         wheels.extend(files)
     # and built wheels for upper and wheelbroken
     assert "Running setup.py bdist_wheel for upper" in str(res), str(res)
@@ -754,6 +755,10 @@ def test_install_builds_wheels(script, data):
     assert "Running setup.py install for requires-wheel" in str(res), str(res)
     # wheelbroken has to run install
     assert "Running setup.py install for wheelb" in str(res), str(res)
+    # We want to make sure we used the correct implementation tag
+    assert wheels == [
+        "Upper-2.0-{0}-none-any.whl".format(pep425tags.implementation_tag),
+    ]
 
 
 def test_install_no_binary_disables_building_wheels(script, data):


### PR DESCRIPTION
A lot of existing tarballs will successfully build a wheel, but the wheel will be implicitly broken because they will have dynamically adjusted the install_requires inside of their ``setup.py``. Typically this is done for things like Python version, implementation, or what OS this is being installed on. We don't consider cache directories to be OS agnostic but we do consider them to be Python version and implementation agnostic. To solve this, we'll force the cached wheel to use a more specific Python tag that includes the major version and the implementation.

Fixes #3025 
