### PR TITLE
Fix OS X platform detection for pep425tags

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import re
 import sys
 import warnings
+import platform
 
 try:
     import sysconfig
@@ -110,6 +111,13 @@ def get_abi_tag():
 
 def get_platform():
     """Return our platform name 'win32', 'linux_x86_64'"""
+    if sys.platform == 'darwin':
+        # distutils.util.get_platform() returns the release based on the value
+        # of MACOSX_DEPLOYMENT_TARGET on which Python was built, which may
+        # be signficantly older than the user's current machine.
+        release, _, machine = platform.mac_ver()
+        major, minor, micro = release.split('.')
+        return 'macosx_{0}_{1}_{2}'.format(major, minor, machine)
     # XXX remove distutils dependency
     return distutils.util.get_platform().replace('.', '_').replace('-', '_')
 


### PR DESCRIPTION
For the purpose of detecting the user's platform to determine which wheels are compatible, this switches `pep425tags.get_platform()` to avoid `distutils.util.get_platform()` on OS X, because that method returns the release on which the interpreter was built (often but not always 10.5 or 10.6) as opposed to the platform on which the interpreter is running.

see also: https://mail.python.org/pipermail/distutils-sig/2015-November/027578.html

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3232)
<!-- Reviewable:end -->
