### PR TITLE
Pin pytest-timeout==0.5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,8 @@ pretend
 # Pinned to 2.7.2 to avoid an issue with parallel builds
 pytest==2.7.2
 pytest-capturelog
-pytest-timeout
+# Pinned to 0.5 to stay compatible with pytest==2.7.2
+pytest-timeout==0.5
 pytest-xdist
 mock<1.1
 scripttest>=1.3


### PR DESCRIPTION
Version 1.0 requires pytest>=2.8 which contains a regression on parallel
tests (cf e78df3e069e4)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3249)
<!-- Reviewable:end -->
