### PR TITLE
Support pip install --prefix

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -139,6 +139,14 @@ class InstallCommand(RequirementCommand):
                  "directory.")
 
         cmd_opts.add_option(
+            '--prefix',
+            dest='prefix_path',
+            metavar='dir',
+            default=None,
+            help="Installation prefix where lib, bin and other top-level "
+                 "folders are placed")
+
+        cmd_opts.add_option(
             "--compile",
             action="store_true",
             dest="compile",
@@ -309,6 +317,7 @@ class InstallCommand(RequirementCommand):
                             install_options,
                             global_options,
                             root=options.root_path,
+                            prefix=options.prefix_path,
                         )
                         reqs = sorted(
                             requirement_set.successfully_installed,

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -215,6 +215,11 @@ class InstallCommand(RequirementCommand):
         options.src_dir = os.path.abspath(options.src_dir)
         install_options = options.install_options or []
         if options.use_user_site:
+            if options.prefix_path:
+                raise CommandError(
+                    "Can not combine '--user' and '--prefix' as they imply "
+                    "different installation locations"
+                )
             if virtualenv_no_global():
                 raise InstallationError(
                     "Can not perform a '--user' install. User site-packages "

--- a/pip/locations.py
+++ b/pip/locations.py
@@ -184,11 +184,9 @@ def distutils_scheme(dist_name, user=False, home=None, root=None,
     # NOTE: setting user or home has the side-effect of creating the home dir
     # or user base for installations during finalize_options()
     # ideally, we'd prefer a scheme class that has no side-effects.
+    assert not (user and prefix), "Got user and prefix {}".format(user, prefix)
     i.user = user or i.user
-    if user:
-        i.prefix = ""
-    else:
-        i.prefix = prefix or i.prefix
+    i.prefix = prefix or i.prefix
     i.home = home or i.home
     i.root = root or i.root
     i.finalize_options()

--- a/pip/locations.py
+++ b/pip/locations.py
@@ -163,7 +163,7 @@ site_config_files = [
 
 
 def distutils_scheme(dist_name, user=False, home=None, root=None,
-                     isolated=False):
+                     isolated=False, prefix=None):
     """
     Return a distutils install scheme
     """
@@ -187,6 +187,8 @@ def distutils_scheme(dist_name, user=False, home=None, root=None,
     i.user = user or i.user
     if user:
         i.prefix = ""
+    else:
+        i.prefix = prefix or i.prefix
     i.home = home or i.home
     i.root = root or i.root
     i.finalize_options()

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -792,7 +792,8 @@ exec(compile(
         else:
             return True
 
-    def install(self, install_options, global_options=[], root=None):
+    def install(self, install_options, global_options=[], root=None,
+                prefix=None):
         if self.editable:
             self.install_editable(install_options, global_options)
             return
@@ -800,7 +801,7 @@ exec(compile(
             version = pip.wheel.wheel_version(self.source_dir)
             pip.wheel.check_compatibility(version, self.name)
 
-            self.move_wheel_files(self.source_dir, root=root)
+            self.move_wheel_files(self.source_dir, root=root, prefix=prefix)
             self.install_succeeded = True
             return
 
@@ -833,6 +834,8 @@ exec(compile(
 
             if root is not None:
                 install_args += ['--root', root]
+            if prefix is not None:
+                install_args += ['--prefix', prefix]
 
             if self.pycompile:
                 install_args += ["--compile"]
@@ -988,12 +991,13 @@ exec(compile(
     def is_wheel(self):
         return self.link and self.link.is_wheel
 
-    def move_wheel_files(self, wheeldir, root=None):
+    def move_wheel_files(self, wheeldir, root=None, prefix=None):
         move_wheel_files(
             self.name, self.req, wheeldir,
             user=self.use_user_site,
             home=self.target_dir,
             root=root,
+            prefix=prefix,
             pycompile=self.pycompile,
             isolated=self.isolated,
         )

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -795,7 +795,8 @@ exec(compile(
     def install(self, install_options, global_options=[], root=None,
                 prefix=None):
         if self.editable:
-            self.install_editable(install_options, global_options)
+            self.install_editable(
+                install_options, global_options, prefix=prefix)
             return
         if self.is_wheel:
             version = pip.wheel.wheel_version(self.source_dir)
@@ -929,11 +930,16 @@ exec(compile(
             rmtree(self._temp_build_dir)
         self._temp_build_dir = None
 
-    def install_editable(self, install_options, global_options=()):
+    def install_editable(self, install_options,
+                         global_options=(), prefix=None):
         logger.info('Running setup.py develop for %s', self.name)
 
         if self.isolated:
             global_options = list(global_options) + ["--no-user-cfg"]
+
+        if prefix:
+            prefix_param = ['--prefix={0}'.format(prefix)]
+            install_options = list(install_options) + prefix_param
 
         with indent_log():
             # FIXME: should we do --install-headers here too?

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -234,12 +234,13 @@ def get_entrypoints(filename):
 
 
 def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
-                     pycompile=True, scheme=None, isolated=False):
+                     pycompile=True, scheme=None, isolated=False, prefix=None):
     """Install a wheel"""
 
     if not scheme:
         scheme = distutils_scheme(
-            name, user=user, home=home, root=root, isolated=isolated
+            name, user=user, home=home, root=root, isolated=isolated,
+            prefix=prefix,
         )
 
     if root_is_purelib(name, wheeldir):

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 import glob
 
@@ -125,6 +126,22 @@ def test_install_wheel_with_root(script, data):
         '--no-index', '--find-links=' + data.find_links,
     )
     assert Path('scratch') / 'root' in result.files_created
+
+
+def test_install_wheel_with_prefix(script, data):
+    """
+    Test installing a wheel using pip install --prefix
+    """
+    prefix_dir = script.scratch_path / 'prefix'
+    result = script.pip(
+        'install', 'simple.dist==0.1', '--prefix', prefix_dir,
+        '--no-index', '--find-links=' + data.find_links,
+    )
+    if hasattr(sys, "pypy_version_info"):
+        lib = Path('scratch') / 'prefix' / 'site-packages'
+    else:
+        lib = Path('scratch') / 'prefix' / 'lib'
+    assert lib in result.files_created
 
 
 def test_install_from_wheel_installs_deps(script, data):

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -373,6 +373,20 @@ class TestMoveWheelFiles(object):
             self.name, self.req, self.src, scheme=self.scheme)
         self.assert_installed()
 
+    def test_install_prefix(self, data, tmpdir):
+        prefix = os.path.join(os.path.sep, 'some', 'path')
+        self.prep(data, tmpdir)
+        wheel.move_wheel_files(
+            self.name,
+            self.req,
+            self.src,
+            root=tmpdir,
+            prefix=prefix,
+        )
+
+        assert os.path.exists(os.path.join(tmpdir, 'some', 'path', 'bin'))
+        assert os.path.exists(os.path.join(tmpdir, 'some', 'path', 'my_data'))
+
     def test_dist_info_contains_empty_dir(self, data, tmpdir):
         """
         Test that empty dirs are not installed


### PR DESCRIPTION
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3252)
<!-- Reviewable:end -->

Currently `pip` supports only `--root` for installing packages relative to a folder (with the whole prefix, which is extracted from `sys.prefix`.

This PR adds support for `--prefix` to denote the prefix path relative to `lib`, `bin`, etc.

Example:

```
$ mkdir tmp
$ pip install --prefix /usr/local/ --root tmp/ Django
$ ls tmp/usr/local/
bin  lib
```

This is needed for Nix package manager to be able to install packages to separate folders. It is possible to specify prefix to install command with `--install-option="--prefix=..."`, but that doesn't work for wheels at all so hence this PR.
