### PR TITLE
Better git detection mechanism for pip freeze and pip list -e

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -78,6 +78,10 @@
 * Correctly freeze Git develop packages in presence of the &subdirectory
   option (:pull:`3258`)
 
+* The detection of editable packages now relies on the presence of ``.egg-link``
+  instead of looking for a VCS, so ``pip list -e`` is more reliable
+  (:pull:`3258`)
+
 
 **7.1.2 (2015-08-22)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -75,6 +75,9 @@
   and when ``package_dir`` is used, so ``pip freeze`` works in more
   cases (:pull:`3258`)
 
+* Correctly freeze Git develop packages in presence of the &subdirectory
+  option (:pull:`3258`)
+
 
 **7.1.2 (2015-08-22)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -68,6 +68,9 @@
 * Allow combination of pip list options --editable with --outdated/--updtodate.
   (:issue:`933`)
 
+* Gives VCS implementations control over saying whether a project 
+  is under their control (:pull:`3258`)
+
 
 **7.1.2 (2015-08-22)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -71,6 +71,10 @@
 * Gives VCS implementations control over saying whether a project 
   is under their control (:pull:`3258`)
 
+* Git detection now works when ``setup.py`` is not at the Git repo root
+  and when ``package_dir`` is used, so ``pip freeze`` works in more
+  cases (:pull:`3258`)
+
 
 **7.1.2 (2015-08-22)**
 

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -11,7 +11,7 @@ import re
 
 from pip.exceptions import InstallationError, CommandError, PipError
 from pip.utils import get_installed_distributions, get_prog
-from pip.utils import deprecation
+from pip.utils import deprecation, dist_is_editable
 from pip.vcs import git, mercurial, subversion, bazaar  # noqa
 from pip.baseparser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
 from pip.commands import get_summaries, get_similar_commands
@@ -236,7 +236,7 @@ class FrozenRequirement(object):
         location = os.path.normcase(os.path.abspath(dist.location))
         comments = []
         from pip.vcs import vcs, get_src_requirement
-        if vcs.get_backend_name(location):
+        if dist_is_editable(dist) and vcs.get_backend_name(location):
             editable = True
             try:
                 req = get_src_requirement(dist, location, find_tags)

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -307,10 +307,11 @@ def dist_in_site_packages(dist):
 
 def dist_is_editable(dist):
     """Is distribution an editable install?"""
-    # TODO: factor out determining editableness out of FrozenRequirement
-    from pip import FrozenRequirement
-    req = FrozenRequirement.from_dist(dist, [])
-    return req.editable
+    for path_item in sys.path:
+        egg_link = os.path.join(path_item, dist.project_name + '.egg-link')
+        if os.path.isfile(egg_link):
+            return True
+    return False
 
 
 def get_installed_distributions(local_only=True,

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -621,9 +621,9 @@ def remove_tracebacks(output):
 
 
 def call_subprocess(cmd, show_stdout=True, cwd=None,
-                    raise_on_returncode=True,
+                    on_returncode='raise',
                     command_level=std_logging.DEBUG, command_desc=None,
-                    extra_environ=None, spinner=None, warn_on_returncode=True):
+                    extra_environ=None, spinner=None):
     if command_desc is None:
         cmd_parts = []
         for part in cmd:
@@ -662,7 +662,7 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
         else:
             spinner.finish("done")
     if proc.returncode:
-        if raise_on_returncode:
+        if on_returncode == 'raise':
             if all_output:
                 logger.info(
                     'Complete output from command %s:', command_desc,
@@ -674,12 +674,16 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
             raise InstallationError(
                 'Command "%s" failed with error code %s in %s'
                 % (command_desc, proc.returncode, cwd))
+        elif on_returncode == 'warn':
+            logger.warning(
+                'Command "%s" had error code %s in %s',
+                command_desc, proc.returncode, cwd,
+            )
+        elif on_returncode == 'ignore':
+            pass
         else:
-            if warn_on_returncode:
-                logger.warning(
-                    'Command "%s" had error code %s in %s',
-                    command_desc, proc.returncode, cwd,
-                )
+            raise ValueError('Invalid value: on_returncode=%s' %
+                             repr(on_returncode))
     if not show_stdout:
         return remove_tracebacks(''.join(all_output))
 

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -622,7 +622,7 @@ def remove_tracebacks(output):
 def call_subprocess(cmd, show_stdout=True, cwd=None,
                     raise_on_returncode=True,
                     command_level=std_logging.DEBUG, command_desc=None,
-                    extra_environ=None, spinner=None):
+                    extra_environ=None, spinner=None, warn_on_returncode=True):
     if command_desc is None:
         cmd_parts = []
         for part in cmd:
@@ -674,10 +674,11 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
                 'Command "%s" failed with error code %s in %s'
                 % (command_desc, proc.returncode, cwd))
         else:
-            logger.warning(
-                'Command "%s" had error code %s in %s',
-                command_desc, proc.returncode, cwd,
-            )
+            if warn_on_returncode:
+                logger.warning(
+                    'Command "%s" had error code %s in %s',
+                    command_desc, proc.returncode, cwd,
+                )
     if not show_stdout:
         return remove_tracebacks(''.join(all_output))
 

--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -309,7 +309,7 @@ class VersionControl(object):
     def run_command(self, cmd, show_stdout=True, cwd=None,
                     raise_on_returncode=True,
                     command_level=logging.DEBUG, command_desc=None,
-                    extra_environ=None):
+                    extra_environ=None, spinner=None, warn_on_returncode=True):
         """
         Run a VCS subcommand
         This is simply a wrapper around call_subprocess that adds the VCS
@@ -319,7 +319,8 @@ class VersionControl(object):
         try:
             return call_subprocess(cmd, show_stdout, cwd,
                                    raise_on_returncode, command_level,
-                                   command_desc, extra_environ)
+                                   command_desc, extra_environ,
+                                   spinner, warn_on_returncode)
         except OSError as e:
             # errno.ENOENT = no such file or directory
             # In other words, the VCS executable isn't available

--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -307,9 +307,9 @@ class VersionControl(object):
         raise NotImplementedError
 
     def run_command(self, cmd, show_stdout=True, cwd=None,
-                    raise_on_returncode=True,
+                    on_returncode='raise',
                     command_level=logging.DEBUG, command_desc=None,
-                    extra_environ=None, spinner=None, warn_on_returncode=True):
+                    extra_environ=None, spinner=None):
         """
         Run a VCS subcommand
         This is simply a wrapper around call_subprocess that adds the VCS
@@ -318,9 +318,9 @@ class VersionControl(object):
         cmd = [self.name] + cmd
         try:
             return call_subprocess(cmd, show_stdout, cwd,
-                                   raise_on_returncode, command_level,
+                                   on_returncode, command_level,
                                    command_desc, extra_environ,
-                                   spinner, warn_on_returncode)
+                                   spinner)
         except OSError as e:
             # errno.ENOENT = no such file or directory
             # In other words, the VCS executable isn't available

--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -72,10 +72,7 @@ class VcsSupport(object):
         location, e.g. vcs.get_backend_name('/path/to/vcs/checkout')
         """
         for vc_type in self._registry.values():
-            logger.debug('Checking in %s for %s (%s)...',
-                         location, vc_type.dirname, vc_type.name)
-            path = os.path.join(location, vc_type.dirname)
-            if os.path.exists(path):
+            if vc_type.controls_location(location):
                 logger.debug('Determine that %s uses VCS: %s',
                              location, vc_type.name)
                 return vc_type.name
@@ -330,6 +327,18 @@ class VersionControl(object):
                 raise BadCommand('Cannot find command %r' % self.name)
             else:
                 raise  # re-raise exception if a different error occured
+
+    @classmethod
+    def controls_location(cls, location):
+        """
+        Check if a location is controlled by the vcs.
+        It is meant to be overridden to implement smarter detection
+        mechanisms for specific vcs.
+        """
+        logger.debug('Checking in %s for %s (%s)...',
+                     location, cls.dirname, cls.name)
+        path = os.path.join(location, cls.dirname)
+        return os.path.exists(path)
 
 
 def get_src_requirement(dist, location, find_tags):

--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -280,8 +280,7 @@ class Git(VersionControl):
             r = cls().run_command(['rev-parse'],
                                   cwd=location,
                                   show_stdout=False,
-                                  raise_on_returncode=False,
-                                  warn_on_returncode=False)
+                                  on_returncode='ignore')
             return not r
         except BadCommand:
             logger.debug("could not determine if %s is under git control "

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -139,10 +139,9 @@ def test_freeze_git_clone(script, tmpdir):
     # Create a new commit to ensure that the commit has only one branch
     # or tag name associated to it (to avoid the non-determinism reported
     # in issue #1867).
-    script.run(
-        'git', 'revert', '--no-edit', 'HEAD',
-        cwd=repo_dir,
-    )
+    script.run('touch', 'newfile', cwd=repo_dir)
+    script.run('git', 'add', 'newfile', cwd=repo_dir)
+    script.run('git', 'commit', '-m', '...', cwd=repo_dir)
     result = script.pip('freeze', expect_stderr=True)
     expected = textwrap.dedent(
         """

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -376,7 +376,7 @@ def test_uninstall_setuptools_develop_install(script, data):
     script.run('python', 'setup.py', 'install',
                expect_stderr=True, cwd=pkg_path)
     list_result = script.pip('list')
-    assert "FSPkg (0.1.dev0)" in list_result.stdout
+    assert "FSPkg (0.1.dev0, " in list_result.stdout
     # Uninstall both develop and install
     uninstall = script.pip('uninstall', 'FSPkg', '-y')
     assert any(filename.endswith('.egg')

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -486,6 +486,10 @@ def _create_test_package(script, name='version_pkg', vcs='git'):
             entry_points=dict(console_scripts=['{name}={name}:main'])
         )
     """.format(name=name)))
+    return _vcs_add(script, version_pkg_path, vcs)
+
+
+def _vcs_add(script, version_pkg_path, vcs='git'):
     if vcs == 'git':
         script.run('git', 'init', cwd=version_pkg_path)
         script.run('git', 'add', '.', cwd=version_pkg_path)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -469,6 +469,28 @@ setup(name='version_subpkg',
     return version_pkg_path
 
 
+def _create_test_package_with_srcdir(script, name='version_pkg', vcs='git'):
+    script.scratch_path.join(name).mkdir()
+    version_pkg_path = script.scratch_path / name
+    subdir_path = version_pkg_path.join('subdir')
+    subdir_path.mkdir()
+    src_path = subdir_path.join('src')
+    src_path.mkdir()
+    pkg_path = src_path.join('pkg')
+    pkg_path.mkdir()
+    pkg_path.join('__init__.py').write('')
+    subdir_path.join("setup.py").write(textwrap.dedent("""
+        from setuptools import setup, find_packages
+        setup(
+            name='{name}',
+            version='0.1',
+            packages=find_packages(),
+            package_dir={{'': 'src'}},
+        )
+    """.format(name=name)))
+    return _vcs_add(script, version_pkg_path, vcs)
+
+
 def _create_test_package(script, name='version_pkg', vcs='git'):
     script.scratch_path.join(name).mkdir()
     version_pkg_path = script.scratch_path / name


### PR DESCRIPTION
`pip freeze` and `pip list -e` do not correctly detect the source is under git control when setup.py is not at the repo root and/or the package_dir setup option is used.

This PR should fix https://github.com/pypa/pip/issues/713 and #3186 at least in editable mode. This also complements #717.

The first commit refactors the vcs detection mechanism to let specific vcs implementations hook their own algorithm.

The second commit implements it for git using git rev-parse.

The third commit implements subdirectory support.

The last one adds the test.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3258)
<!-- Reviewable:end -->
