### PR TITLE
monkeypatch os.path.exists over less code in test_tilde

### DIFF
--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -34,13 +34,11 @@ def test_no_partial_name_match(data):
     assert found.url.endswith("gmpy-1.15.tar.gz"), found
 
 
-@patch(
-    'pip.index.os.path.exists',
-    return_value=True  # b/c we only use tilde expanded version if it exists
-)
 def test_tilde(data):
     """Finder can accept a path with ~ in it and will normalize it."""
-    finder = PackageFinder(['~/python-pkgs'], [], session=PipSession())
+    session = PipSession()
+    with patch('pip.index.os.path.exists', return_value=True):
+        finder = PackageFinder(['~/python-pkgs'], [], session=session)
     req = InstallRequirement.from_line("gmpy")
     with pytest.raises(DistributionNotFound):
         finder.find_requirement(req, False)


### PR DESCRIPTION
PipSession attempts to create a user_agent which results in calls to
platform.linux_distribution being called, there is a chance this hits
platform._dist_try_harder, which calls os.path.exists("/a/bad/path")
then attempts to open and read from said path resulting in brekage.

This creates PipSession before mock patches os.path.exists then only
patches the call that requires os.path.exists to be patched.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3266)
<!-- Reviewable:end -->
