### PR TITLE
Drop PasteScript specific hack

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,6 +63,8 @@
 * Fixed :issue:`2042` regarding wheel building with setup.py using a different
   encoding than the system.
 
+* Drop PasteScript specific egg_info hack. (:pull:`3270`)
+
 
 **7.1.2 (2015-08-22)**
 

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -408,7 +408,7 @@ class InstallRequirement(object):
             )
 
         with indent_log():
-            script = self._run_setup_py % self.setup_py
+            script = SETUPTOOLS_SHIM % self.setup_py
             base_cmd = [sys.executable, '-c', script]
             if self.isolated:
                 base_cmd += ["--no-user-cfg"]
@@ -455,24 +455,6 @@ class InstallRequirement(object):
                     'produced metadata for project name %s' % (
                         self.setup_py, self.name, metadata_name)
                 )
-
-    # FIXME: This is a lame hack, entirely for PasteScript which has
-    # a self-provided entry point that causes this awkwardness
-    _run_setup_py = """
-from setuptools.command import egg_info
-import pkg_resources
-import os
-def replacement_run(self):
-    self.mkpath(self.egg_info)
-    installer = self.distribution.fetch_build_egg
-    for ep in pkg_resources.iter_entry_points('egg_info.writers'):
-        # require=False is the change we're making:
-        writer = ep.load(require=False)
-        if writer:
-            writer(self, ep.name, os.path.join(self.egg_info,ep.name))
-    self.find_sources()
-egg_info.egg_info.run = replacement_run
-""" + SETUPTOOLS_SHIM
 
     def egg_info_data(self, filename):
         if self.satisfied_by is not None:


### PR DESCRIPTION
With or without this hack, pip works the same with PasteScript latest version and
crashes the same with versions 0.3/0.3.1
It was added in c2000d7 (7 years from now)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3270)
<!-- Reviewable:end -->
