### PR TITLE
Update link to PyPA doc in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ pip
 ===
 
 The `PyPA recommended
-<https://python-packaging-user-guide.readthedocs.org/en/latest/current.html>`_
+<https://packaging.python.org/en/latest/current/>`_
 tool for installing Python packages.
 
 * `Installation <https://pip.pypa.io/en/stable/installing.html>`_


### PR DESCRIPTION
Updates README link for "PyPA recommended" documentation. Addresses #3272 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3273)
<!-- Reviewable:end -->
