### PR TITLE
Don't use toxenv on appveyor, as it has no way of coping with 64-bit …

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,31 +1,16 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-      TOXENV: "py27"
-
     - PYTHON: "C:\\Python33"
-      TOXENV: "py33"
-
     - PYTHON: "C:\\Python34"
-      TOXENV: "py34"
-
     - PYTHON: "C:\\Python35"
-      TOXENV: "py35"
-
     - PYTHON: "C:\\Python27-x64"
-      TOXENV: "py27"
-
     - PYTHON: "C:\\Python33-x64"
-      TOXENV: "py33"
-
     - PYTHON: "C:\\Python34-x64"
-      TOXENV: "py34"
-
     - PYTHON: "C:\\Python35-x64"
-      TOXENV: "py35"
 
 install:
     cmd: "%PYTHON%\\python.exe -m pip install tox"
 build: off
 test_script:
-    - "%PYTHON%\\Scripts\\tox.exe -e %TOXENV% -- -m unit -n 8"
+    - "%PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8"


### PR DESCRIPTION
…Python versions

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3280)
<!-- Reviewable:end -->
