### PR TITLE
Record pip in INSTALLER file

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -496,6 +496,15 @@ if __name__ == '__main__':
             )
         )
 
+    # Record pip as the installer
+    installer = os.path.join(info_dir[0], 'INSTALLER')
+    temp_installer = os.path.join(info_dir[0], 'INSTALLER.pip')
+    with open(temp_installer, 'wb') as installer_file:
+        installer_file.write(b'pip\n')
+    shutil.move(temp_installer, installer)
+    generated.append(installer)
+
+    # Record details of all files installed
     record = os.path.join(info_dir[0], 'RECORD')
     temp_record = os.path.join(info_dir[0], 'RECORD.pip')
     with open_for_csv(record, 'r') as record_in:

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -83,6 +83,17 @@ def test_install_from_wheel_file(script, data):
     assert dist_info_folder in result.files_created, (dist_info_folder,
                                                       result.files_created,
                                                       result.stdout)
+    installer = dist_info_folder / 'INSTALLER'
+    assert installer in result.files_created, (dist_info_folder,
+                                               result.files_created,
+                                               result.stdout)
+    with open(script.base_path / installer, 'rb') as installer_file:
+        installer_details = installer_file.read()
+        assert installer_details == b'pip\n'
+    installer_temp = dist_info_folder / 'INSTALLER.pip'
+    assert installer_temp not in result.files_created, (dist_info_folder,
+                                                        result.files_created,
+                                                        result.stdout)
 
 
 # header installs are broke in pypy virtualenvs


### PR DESCRIPTION
When installing from a wheel archive (whether directly, or by building a wheel file from a source format), generate and install an INSTALLER metadata file indicating that "pip" handled the installation.

This initial implementation is hardcoded to use "pip\n" as the identifier.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3284)
<!-- Reviewable:end -->
