### PR TITLE
Alias imports for vendored requests deps

### DIFF
--- a/pip/_vendor/__init__.py
+++ b/pip/_vendor/__init__.py
@@ -64,3 +64,37 @@ if DEBUNDLED:
     vendored("progress")
     vendored("retrying")
     vendored("requests")
+    vendored("requests.packages")
+    vendored("requests.packages.urllib3")
+    vendored("requests.packages.urllib3._collections")
+    vendored("requests.packages.urllib3.connection")
+    vendored("requests.packages.urllib3.connectionpool")
+    vendored("requests.packages.urllib3.contrib")
+    try:
+        vendored("requests.packages.urllib3.contrib.ntlmpool")
+    except ImportError:
+        pass
+    try:
+        vendored("requests.packages.urllib3.contrib.pyopenssl")
+    except ImportError:
+        pass
+    vendored("requests.packages.urllib3.exceptions")
+    vendored("requests.packages.urllib3.fields")
+    vendored("requests.packages.urllib3.filepost")
+    vendored("requests.packages.urllib3.packages")
+    vendored("requests.packages.urllib3.packages.ordered_dict")
+    vendored("requests.packages.urllib3.packages.six")
+    vendored("requests.packages.urllib3.packages.ssl_match_hostname")
+    vendored("requests.packages.urllib3.packages.ssl_match_hostname."
+             "_implementation")
+    vendored("requests.packages.urllib3.poolmanager")
+    vendored("requests.packages.urllib3.request")
+    vendored("requests.packages.urllib3.response")
+    vendored("requests.packages.urllib3.util")
+    vendored("requests.packages.urllib3.util.connection")
+    vendored("requests.packages.urllib3.util.request")
+    vendored("requests.packages.urllib3.util.response")
+    vendored("requests.packages.urllib3.util.retry")
+    vendored("requests.packages.urllib3.util.ssl_")
+    vendored("requests.packages.urllib3.util.timeout")
+    vendored("requests.packages.urllib3.util.url")


### PR DESCRIPTION
Some distributions unvendor pip while leaving other packages vendored.
In the case of this bug, pip's dependencies were unvendored while
requests did not have its dependencies unvendored. This caused a
problem where urllib3 was receiving a
pip._vendor.requests.packages.urllib3.Retry instance but expecting a
requests.packages.urllib3.Retry instance. Since they aren't the same,
urllib3 assumed it was an integer and we received a TypeError as
described in the bug report.

Creating aliases for urllib3 and it's submodules should fix this
(similar to how we specify six, six.moves, six.moves.urllib, packaging,
packaging.version, and packaging.specifiers)

Closes #3282

---

I'm not sure the easiest way to test this currently, any suggestions?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3287)
<!-- Reviewable:end -->
