### PR TITLE
Fix test_sort_locations_file_not_find_link test

### DIFF
--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -23,7 +23,7 @@ def test_sort_locations_file_not_find_link(data):
     run
     """
     finder = PackageFinder([], [], session=PipSession())
-    files, urls = finder._sort_locations(data.index_url("empty_with_pkg"))
+    files, urls = finder._sort_locations([data.index_url("empty_with_pkg")])
     assert urls and not files, "urls, but not files should have been found"
 
 


### PR DESCRIPTION
_sort_locations expects a list

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3288)
<!-- Reviewable:end -->
