### PR TITLE
Ignores invalid urls with warning

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -108,6 +108,9 @@
 
 * Show entry points for projects installed via wheel (:pull:`3122`).
 
+* Improve message when an unexisting path is passed to --find-links option
+  (:issue:`2968`).
+
 
 **7.1.2 (2015-08-22)**
 

--- a/pip/index.py
+++ b/pip/index.py
@@ -25,7 +25,7 @@ from pip.exceptions import (
     DistributionNotFound, BestVersionAlreadyInstalled, InvalidWheelFilename,
     UnsupportedWheel,
 )
-from pip.download import HAS_TLS, url_to_path, path_to_url
+from pip.download import HAS_TLS, is_url, path_to_url, url_to_path
 from pip.models import PyPI
 from pip.wheel import Wheel, wheel_ext
 from pip.pep425tags import supported_tags, supported_tags_noarch, get_platform
@@ -214,8 +214,17 @@ class PackageFinder(object):
                         urls.append(url)
                 elif os.path.isfile(path):
                     sort_path(path)
-            else:
+                else:
+                    logger.warning(
+                        "Url '%s' is ignored: it is neither a file "
+                        "nor a directory.", url)
+            elif is_url(url):
+                # Only add url with clear scheme
                 urls.append(url)
+            else:
+                logger.warning(
+                    "Url '%s' is ignored. It is either a non-existing "
+                    "path or lacks a specific scheme.", url)
 
         return files, urls
 

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,3 +1,4 @@
+import os.path
 import pytest
 
 from pip.download import PipSession
@@ -25,6 +26,16 @@ def test_sort_locations_file_not_find_link(data):
     finder = PackageFinder([], [], session=PipSession())
     files, urls = finder._sort_locations([data.index_url("empty_with_pkg")])
     assert urls and not files, "urls, but not files should have been found"
+
+
+def test_sort_locations_non_existing_path():
+    """
+    Test that a non-existing path is ignored.
+    """
+    finder = PackageFinder([], [], session=PipSession())
+    files, urls = finder._sort_locations(
+        [os.path.join('this', 'doesnt', 'exist')])
+    assert not urls and not files, "nothing should have been found"
 
 
 class TestLink(object):


### PR DESCRIPTION
for non-existing paths or url without scheme

closes #2968

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3289)
<!-- Reviewable:end -->
