### PR TITLE
retest on precise infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ install: .travis/install.sh
 
 script: .travis/run.sh
 
+dist: precise
+
 
 notifications:
   irc:


### PR DESCRIPTION
Used to debug tests fails on py26 and py33 on develop with the new travis infrastructure ( https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future)

Only tests with `virtualenv.system_site_packages = True` seem to fail.

And all tests calling `_patch_dist_in_site_packages` fails (5 of the 6 failing tests).
Most `virtualenv.system_site_packages = True` seems ok, the failing one contains `_patch_dist_in_site_packages`.

Replace #3295

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3305)
<!-- Reviewable:end -->
