### PR TITLE
Fix tests when wheel is available in global site packages

### DIFF
--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -113,9 +113,10 @@ class Tests_UserSite:
         """
         virtualenv.system_site_packages = True
 
-        script.pip('install', '--user', 'INITools==0.3')
+        script.pip('install', '--user', 'INITools==0.3', '--no-binary=:all:')
 
-        result2 = script.pip('install', '--user', 'INITools==0.1')
+        result2 = script.pip(
+            'install', '--user', 'INITools==0.1', '--no-binary=:all:')
 
         # usersite has 0.1
         egg_info_folder = (
@@ -151,9 +152,10 @@ class Tests_UserSite:
         script.environ["PYTHONPATH"] = script.base_path / script.user_site
         _patch_dist_in_site_packages(script)
 
-        script.pip('install', 'INITools==0.2')
+        script.pip('install', 'INITools==0.2', '--no-binary=:all:')
 
-        result2 = script.pip('install', '--user', 'INITools==0.1')
+        result2 = script.pip(
+            'install', '--user', 'INITools==0.1', '--no-binary=:all:')
 
         # usersite has 0.1
         egg_info_folder = (
@@ -194,8 +196,9 @@ class Tests_UserSite:
         script.environ["PYTHONPATH"] = script.base_path / script.user_site
         _patch_dist_in_site_packages(script)
 
-        script.pip('install', 'INITools==0.2')
-        result2 = script.pip('install', '--user', '--upgrade', 'INITools')
+        script.pip('install', 'INITools==0.2', '--no-binary=:all:')
+        result2 = script.pip(
+            'install', '--user', '--upgrade', 'INITools', '--no-binary=:all:')
 
         # usersite has 0.3.1
         egg_info_folder = (
@@ -237,10 +240,11 @@ class Tests_UserSite:
         script.environ["PYTHONPATH"] = script.base_path / script.user_site
         _patch_dist_in_site_packages(script)
 
-        script.pip('install', 'INITools==0.2')
-        script.pip('install', '--user', 'INITools==0.3')
+        script.pip('install', 'INITools==0.2', '--no-binary=:all:')
+        script.pip('install', '--user', 'INITools==0.3', '--no-binary=:all:')
 
-        result3 = script.pip('install', '--user', 'INITools==0.1')
+        result3 = script.pip(
+            'install', '--user', 'INITools==0.1', '--no-binary=:all:')
 
         # usersite has 0.1
         egg_info_folder = (

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -41,9 +41,10 @@ class Tests_UninstallUserSite:
         script.environ["PYTHONPATH"] = script.base_path / script.user_site
         _patch_dist_in_site_packages(script)
 
-        script.pip_install_local('pip-test-package==0.1')
+        script.pip_install_local('pip-test-package==0.1', '--no-binary=:all:')
 
-        result2 = script.pip_install_local('--user', 'pip-test-package==0.1.1')
+        result2 = script.pip_install_local(
+            '--user', 'pip-test-package==0.1.1', '--no-binary=:all:')
         result3 = script.pip('uninstall', '-vy', 'pip-test-package')
 
         # uninstall console is mentioning user scripts, but not global scripts


### PR DESCRIPTION
Make sure we are installing via setuptools and not wheels so that we get
egg-info directories.

This solves 5 of the 6 test failures on new travis infra (or on my laptop).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3306)
<!-- Reviewable:end -->
