### PR TITLE
Packaging requirements

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -335,7 +335,9 @@ class PackageFinder(object):
         """
 
         def mkurl_pypi_url(url):
-            loc = posixpath.join(url, urllib_parse.quote(project_name.lower()))
+            loc = posixpath.join(
+                url,
+                urllib_parse.quote(canonicalize_name(project_name)))
             # For maximum compatibility with easy_install, ensure the path
             # ends in a trailing slash.  Although this isn't in the spec
             # (and PyPI can handle it without the slash) some other index

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -17,7 +17,9 @@ from email.parser import FeedParser
 from pip._vendor import pkg_resources, six
 from pip._vendor.distlib.markers import interpret as markers_interpret
 from pip._vendor.packaging import specifiers
+from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import Version
 from pip._vendor.six.moves import configparser
 
 import pip.wheel
@@ -45,7 +47,6 @@ from pip.utils.ui import open_spinner
 from pip.req.req_uninstall import UninstallPathSet
 from pip.vcs import vcs
 from pip.wheel import move_wheel_files, Wheel
-from pip._vendor.packaging.version import Version
 
 
 logger = logging.getLogger(__name__)
@@ -74,8 +75,8 @@ class InstallRequirement(object):
         self.extras = ()
         if isinstance(req, six.string_types):
             try:
-                req = pkg_resources.Requirement.parse(req)
-            except pkg_resources.RequirementParseError:
+                req = Requirement(req)
+            except InvalidRequirement:
                 if os.path.sep in req:
                     add_msg = "It looks like a path. Does it exist ?"
                 elif '=' in req and not any(op in req for op in operators):
@@ -230,8 +231,7 @@ class InstallRequirement(object):
                   wheel_cache=wheel_cache, constraint=constraint)
 
         if extras:
-            res.extras = pkg_resources.Requirement.parse('__placeholder__' +
-                                                         extras).extras
+            res.extras = Requirement('placeholder' + extras).extras
 
         return res
 
@@ -362,7 +362,7 @@ class InstallRequirement(object):
     def name(self):
         if self.req is None:
             return None
-        return native_str(self.req.project_name)
+        return native_str(pkg_resources.safe_name(self.req.name))
 
     @property
     def setup_py_dir(self):
@@ -436,23 +436,24 @@ class InstallRequirement(object):
                 op = "=="
             else:
                 op = "==="
-            self.req = pkg_resources.Requirement.parse(
+            self.req = Requirement(
                 "".join([
                     self.pkg_info()["Name"],
                     op,
                     self.pkg_info()["Version"],
-                ]))
+                ])
+            )
             self._correct_build_location()
         else:
             metadata_name = canonicalize_name(self.pkg_info()["Name"])
-            if canonicalize_name(self.req.project_name) != metadata_name:
+            if canonicalize_name(self.req.name) != metadata_name:
                 logger.warning(
                     'Running setup.py (path:%s) egg_info for package %s '
                     'produced metadata for project name %s. Fix your '
                     '#egg=%s fragments.',
                     self.setup_py, self.name, metadata_name, self.name
                 )
-                self.req = pkg_resources.Requirement.parse(metadata_name)
+                self.req = Requirement(metadata_name)
 
     def egg_info_data(self, filename):
         if self.satisfied_by is not None:
@@ -540,7 +541,7 @@ class InstallRequirement(object):
     def assert_source_matches_version(self):
         assert self.source_dir
         version = self.pkg_info()['version']
-        if version not in self.req:
+        if self.req.specifier and version not in self.req.specifier:
             logger.warning(
                 'Requested %s, but installing version %s',
                 self,
@@ -994,12 +995,12 @@ class InstallRequirement(object):
         if self.req is None:
             return False
         try:
-            self.satisfied_by = pkg_resources.get_distribution(self.req)
+            self.satisfied_by = pkg_resources.get_distribution(str(self.req))
         except pkg_resources.DistributionNotFound:
             return False
         except pkg_resources.VersionConflict:
             existing_dist = pkg_resources.get_distribution(
-                self.req.project_name
+                self.req.name
             )
             if self.use_user_site:
                 if dist_in_usersite(existing_dist):
@@ -1142,9 +1143,7 @@ def parse_editable(editable_req, default_vcs=None):
             return (
                 package_name,
                 url_no_extras,
-                pkg_resources.Requirement.parse(
-                    '__placeholder__' + extras
-                ).extras,
+                Requirement("placeholder" + extras).extras,
             )
         else:
             return package_name, url_no_extras, None

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -243,7 +243,7 @@ class RequirementSet(object):
             if (parent_req_name is None and existing_req and not
                     existing_req.constraint and
                     existing_req.extras == install_req.extras and not
-                    existing_req.req.specs == install_req.req.specs):
+                    existing_req.req.specifier == install_req.req.specifier):
                 raise InstallationError(
                     'Double requirement given: %s (already in %s, name=%r)'
                     % (install_req, existing_req, name))

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -300,7 +300,7 @@ def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
                         s.endswith('.dist-info') and
                         # is self.req.project_name case preserving?
                         s.lower().startswith(
-                            req.project_name.replace('-', '_').lower())):
+                            req.name.replace('-', '_').lower())):
                     assert not info_dir, 'Multiple .dist-info directories'
                     info_dir.append(destsubdir)
             for f in files:

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -196,7 +196,7 @@ class TestProcessLine(object):
         comes_from = '-r %s (line %s)' % (filename, 1)
         req = InstallRequirement.from_line(line, comes_from=comes_from)
         assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
-        assert req.req.specs == [('>=', '2')]
+        assert str(req.req.specifier) == '>=2'
 
     def test_yield_editable_requirement(self):
         url = 'git+https://url#egg=SomeProject'

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from mock import patch, Mock
 
-from pip._vendor import pkg_resources
+from pip._vendor.packaging.requirements import Requirement
 from pip import pep425tags, wheel
 from pip.compat import expanduser, WINDOWS
 from pip.exceptions import InvalidWheelFilename, UnsupportedWheel
@@ -301,7 +301,7 @@ class TestMoveWheelFiles(object):
         self.name = 'sample'
         self.wheelpath = data.packages.join(
             'sample-1.2.0-py2.py3-none-any.whl')
-        self.req = pkg_resources.Requirement.parse('sample')
+        self.req = Requirement('sample')
         self.src = os.path.join(tmpdir, 'src')
         self.dest = os.path.join(tmpdir, 'dest')
         unpack_file(self.wheelpath, self.src, None, None)


### PR DESCRIPTION
Stop using pkg_resources.Requirements inside pip to represent parsed requirements, instead make use of packaging.requirements.Requirement to do so.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3307)
<!-- Reviewable:end -->
