### PR TITLE
Help UX - do not show global options for subcommands by default

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -101,6 +101,11 @@ class Command(object):
         # factored out for testability
         return self.parser.parse_args(args)
 
+    def print_help(self):
+        # factored out for uniform handling
+        # of 'help <command>' and '<command> --help' cases
+        self.parser.print_help()
+
     def main(self, args):
         options, args = self.parse_args(args)
 
@@ -115,6 +120,10 @@ class Command(object):
             level = "DEBUG"
         else:
             level = "INFO"
+
+        if options.help:
+            self.print_help()
+            sys.exit(0)
 
         logging_dictConfig({
             "version": 1,

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -55,11 +55,11 @@ class Command(object):
         self.cmd_opts = optparse.OptionGroup(self.parser, optgroup_name)
 
         # Add the general options
-        gen_opts = cmdoptions.make_option_group(
+        self.gen_opts = cmdoptions.make_option_group(
             cmdoptions.general_group,
             self.parser,
         )
-        self.parser.add_option_group(gen_opts)
+        self.parser.add_option_group(self.gen_opts)
 
     def _build_session(self, options, retries=None, timeout=None):
         session = PipSession(
@@ -122,6 +122,15 @@ class Command(object):
             level = "INFO"
 
         if options.help:
+            if not options.verbose:
+                # hide General Options
+                self.parser.epilog = "\nAdd '-v' flag to show general "\
+                                     "options.\n"
+                self.parser.option_groups.remove(self.gen_opts)
+
+                # 'pip --help' is handled by pip.__init__.parseopt(),
+                # so it is not affected by absence of --verbose
+
             self.print_help()
             sys.exit(0)
 

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -67,7 +67,7 @@ help_ = partial(
     Option,
     '-h', '--help',
     dest='help',
-    action='help',
+    action='store_true',
     help='Show help.')
 
 isolated_mode = partial(

--- a/pip/commands/help.py
+++ b/pip/commands/help.py
@@ -30,6 +30,6 @@ class HelpCommand(Command):
             raise CommandError(' - '.join(msg))
 
         command = commands_dict[cmd_name]()
-        command.parser.print_help()
+        command.print_help()
 
         return SUCCESS


### PR DESCRIPTION
'list -h' help is too long to fit one screen, so this PR omits global options for subcommands help unless explicitly requested with `--verbose` flag.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3319)
<!-- Reviewable:end -->
