### PR TITLE
Emit a warning when pip is used on Python 2.6

### DIFF
--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -206,14 +206,6 @@ def main(args=None):
 
     autocomplete()
 
-    if sys.version_info[:2] == (2, 6):
-        warnings.warn(
-            "Python 2.6 is no longer supported by the Python core team, "
-            "please upgrade your Python. A future version of pip will drop "
-            "support for Python 2.6",
-            DeprecationWarning
-        )
-
     try:
         cmd_name, cmd_args = parseopts(args)
     except PipError as exc:

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -206,6 +206,14 @@ def main(args=None):
 
     autocomplete()
 
+    if sys.version_info[:2] == (2, 6):
+        warnings.warn(
+            "Python 2.6 is no longer supported by the Python core team, "
+            "please upgrade your Python. A future version of pip will drop "
+            "support for Python 2.6",
+            DeprecationWarning
+        )
+
     try:
         cmd_name, cmd_args = parseopts(args)
     except PipError as exc:

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -183,8 +183,8 @@ class Command(object):
         if sys.version_info[:2] == (2, 6):
             warnings.warn(
                 "Python 2.6 is no longer supported by the Python core team, "
-                "please upgrade your Python. A future version of pip will drop "
-                "support for Python 2.6",
+                "please upgrade your Python. A future version of pip will "
+                "drop support for Python 2.6",
                 deprecation.Python26DeprecationWarning
             )
 

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import optparse
+import warnings
 
 from pip import cmdoptions
 from pip.index import PackageFinder
@@ -20,7 +21,7 @@ from pip.status_codes import (
     SUCCESS, ERROR, UNKNOWN_ERROR, VIRTUALENV_NOT_FOUND,
     PREVIOUS_BUILD_DIR_ERROR,
 )
-from pip.utils import get_prog, normalize_path
+from pip.utils import deprecation, get_prog, normalize_path
 from pip.utils.logging import IndentingFormatter
 from pip.utils.outdated import pip_version_check
 
@@ -178,6 +179,14 @@ class Command(object):
                 for name in ["pip._vendor", "distlib", "requests", "urllib3"]
             ),
         })
+
+        if sys.version_info[:2] == (2, 6):
+            warnings.warn(
+                "Python 2.6 is no longer supported by the Python core team, "
+                "please upgrade your Python. A future version of pip will drop "
+                "support for Python 2.6",
+                deprecation.Python26DeprecationWarning
+            )
 
         # TODO: try to get these passing down from the command?
         #      without resorting to os.environ to hold these.

--- a/pip/utils/deprecation.py
+++ b/pip/utils/deprecation.py
@@ -19,7 +19,13 @@ class RemovedInPip10Warning(PipDeprecationWarning, PendingDeprecationWarning):
     pass
 
 
-DEPRECATIONS = [RemovedInPip9Warning, RemovedInPip10Warning]
+class Python26DeprecationWarning(PipDeprecationWarning, PendingDeprecationWarning):
+    pass
+
+
+DEPRECATIONS = [
+    RemovedInPip9Warning, RemovedInPip10Warning, Python26DeprecationWarning
+]
 
 
 # Warnings <-> Logging Integration

--- a/pip/utils/deprecation.py
+++ b/pip/utils/deprecation.py
@@ -19,7 +19,9 @@ class RemovedInPip10Warning(PipDeprecationWarning, PendingDeprecationWarning):
     pass
 
 
-class Python26DeprecationWarning(PipDeprecationWarning, PendingDeprecationWarning):
+class Python26DeprecationWarning(
+    PipDeprecationWarning, PendingDeprecationWarning
+):
     pass
 
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -334,6 +334,9 @@ class PipTestEnvironment(scripttest.TestFileEnvironment):
         if (pyversion_tuple < (2, 7, 9) and
                 args and args[0] in ('search', 'install', 'download')):
             kwargs['expect_stderr'] = True
+        # Python 2.6 is deprecated and we emit a warning on it.
+        if pyversion_tuple[:2] == (2, 6):
+            kwargs['expect_stderr'] = True
 
         return self.run("pip", *args, **kwargs)
 


### PR DESCRIPTION
Python 2.6 is unmaintained by the Python core team, we should encourage users to upgrade.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3329)
<!-- Reviewable:end -->
