### PR TITLE
Allow all wheels from PyPI

### DIFF
--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -14,8 +14,9 @@ from optparse import OptionGroup, SUPPRESS_HELP, Option
 import warnings
 
 from pip.index import (
-    PyPI, FormatControl, fmt_ctl_handle_mutual_exclude, fmt_ctl_no_binary,
+    FormatControl, fmt_ctl_handle_mutual_exclude, fmt_ctl_no_binary,
     fmt_ctl_no_use_wheel)
+from pip.models import PyPI
 from pip.locations import CA_BUNDLE_PATH, USER_CACHE_DIR, src_prefix
 from pip.utils.hashes import STRONG_HASHES
 

--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -6,7 +6,7 @@ import textwrap
 
 from pip.basecommand import Command, SUCCESS
 from pip.download import PipXmlrpcTransport
-from pip.index import PyPI
+from pip.models import PyPI
 from pip.utils import get_terminal_size
 from pip.utils.logging import indent_log
 from pip.exceptions import CommandError

--- a/pip/index.py
+++ b/pip/index.py
@@ -26,9 +26,8 @@ from pip.exceptions import (
     UnsupportedWheel,
 )
 from pip.download import HAS_TLS, is_url, path_to_url, url_to_path
-from pip.models import PyPI
 from pip.wheel import Wheel, wheel_ext
-from pip.pep425tags import supported_tags, supported_tags_noarch, get_platform
+from pip.pep425tags import supported_tags
 from pip._vendor import html5lib, requests, six
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.requests.exceptions import SSLError
@@ -585,7 +584,6 @@ class PackageFinder(object):
 
     def _link_package_versions(self, link, search):
         """Return an InstallationCandidate or None"""
-        platform = get_platform()
 
         version = None
         if link.egg_fragment:
@@ -621,30 +619,7 @@ class PackageFinder(object):
                     self._log_skipped_link(
                         link, 'it is not compatible with this Python')
                     return
-                # This is a dirty hack to prevent installing Binary Wheels from
-                # PyPI unless it is a Windows or Mac Binary Wheel. This is
-                # paired with a change to PyPI disabling uploads for the
-                # same. Once we have a mechanism for enabling support for
-                # binary wheels on linux that deals with the inherent problems
-                # of binary distribution this can be removed.
-                comes_from = getattr(link, "comes_from", None)
-                if (
-                        (
-                            not platform.startswith('win') and not
-                            platform.startswith('macosx') and not
-                            platform == 'cli'
-                        ) and
-                        comes_from is not None and
-                        urllib_parse.urlparse(
-                            comes_from.url
-                        ).netloc.endswith(PyPI.netloc)):
-                    if not wheel.supported(tags=supported_tags_noarch):
-                        self._log_skipped_link(
-                            link,
-                            "it is a pypi-hosted binary "
-                            "Wheel on an unsupported platform",
-                        )
-                        return
+
                 version = wheel.version
 
         # This should be up by the search.ok_binary check, but see issue 2700.

--- a/pip/utils/outdated.py
+++ b/pip/utils/outdated.py
@@ -10,7 +10,7 @@ from pip._vendor import lockfile
 from pip._vendor.packaging import version as packaging_version
 
 from pip.compat import total_seconds, WINDOWS
-from pip.index import PyPI
+from pip.models import PyPI
 from pip.locations import USER_CACHE_DIR, running_under_virtualenv
 from pip.utils import ensure_dir, get_installed_version
 from pip.utils.filesystem import check_path_owner


### PR DESCRIPTION
It's unlikely that we're going to need any changes in pip itself to support linux enabled wheels except for maybe a more specific platform tag. If a more specific platform tag is needed then older pip's won't install that anyways. This should allow experimentation with some possible solutions to linux enabled wheels.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3338)
<!-- Reviewable:end -->
