### PR TITLE
Fix for svn issue #1062

### DIFF
--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -163,8 +163,13 @@ class Subversion(VersionControl):
     def _get_svn_url_rev(self, location):
         from pip.exceptions import InstallationError
 
-        with open(os.path.join(location, self.dirname, 'entries')) as f:
-            data = f.read()
+        entries_path = os.path.join(location, self.dirname, 'entries')
+        if os.path.exists(entries_path):
+            with open(entries_path) as f:
+                data = f.read()
+        else:  # subversion >= 1.7 does not have the 'entries' file
+            data = ''
+
         if (data.startswith('8') or
                 data.startswith('9') or
                 data.startswith('10')):


### PR DESCRIPTION
This avoids an exception(IOError) for "pip freeze" and "pip list" commands that is related to subversion >= 1.7. The issue was reported a while ago and is still present in pip 7.1.2 (#1062).

The fix is simple and may not require a test. I would have added a test but I could not find tests for subversion to build upon. I only saw tests for the subversion command line interface but no tests related to the subversion repository structure which changed between subversion 1.6 and 1.7.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3345)
<!-- Reviewable:end -->
