### PR TITLE
Fix for svn related bug #1062

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -51,6 +51,7 @@ Dave Abrahams <dave@boostpro.com>
 David Aguilar <davvid@gmail.com>
 David Black <db@d1b.org>
 David Evans <d@drhevans.com>
+David Linke <dalito@users.noreply.github.com>
 David Pursehouse <david.pursehouse@gmail.com>
 David Wales <daviewales@gmail.com>
 Davidovich <david.genest@gmail.com>

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -44,6 +44,9 @@
 * Fixed :issue:`3009`, correct reporting of requirements file line numbers
   (:pull:`3125`)
 
+* Fixed :issue:`1062`, Exception(IOError) for ``pip freeze`` and ``pip list`` 
+  commands with subversion >= 1.7. (:pull:`3346`)
+
 * Provide a spinner showing that progress is happening when installing or
   building a package via ``setup.py``. This will alleviate concerns that
   projects with unusually long build times have with pip appearing to stall.

--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -163,8 +163,13 @@ class Subversion(VersionControl):
     def _get_svn_url_rev(self, location):
         from pip.exceptions import InstallationError
 
-        with open(os.path.join(location, self.dirname, 'entries')) as f:
-            data = f.read()
+        entries_path = os.path.join(location, self.dirname, 'entries')
+        if os.path.exists(entries_path):
+            with open(entries_path) as f:
+                data = f.read()
+        else:  # subversion >= 1.7 does not have the 'entries' file
+            data = ''
+
         if (data.startswith('8') or
                 data.startswith('9') or
                 data.startswith('10')):


### PR DESCRIPTION
This avoids an exception(IOError) for "pip freeze" and "pip list" commands that is related to subversion >= 1.7. The issue was reported a while ago and is still present in pip 7.1.2 (#1062).

The fix is simple and may not require a test. I would have added a test but I could not find tests for subversion to build upon. I only saw tests for the subversion command line interface but no tests related to the subversion repository structure which changed between subversion 1.6 and 1.7.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3346)
<!-- Reviewable:end -->
