### PR TITLE
Dont raise on #egg metadata mismatch, just warn

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,10 +11,6 @@
 * **BACKWARD INCOMPATIBLE** Remove the ``--log-explicit-levels`` which had been
   deprecated in 6.0.
 
-* **BACKWARD INCOMPATIBLE** Abort installation of editable if the
-  provided #egg=name part does not match the metadata produced by
-  `setup.py egg_info`. :issue:`3143`.
-
 * Deprecate and no-op the ``--allow-external``, ``--allow-all-external``, and
   ``--allow-unverified`` functionality that was added as part of PEP 438. With
   changes made to the repository protocol made in PEP 470, these options are no
@@ -113,6 +109,9 @@
 
 * Improve message when an unexisting path is passed to --find-links option
   (:issue:`2968`).
+
+* Warn on installation of editable if the provided #egg=name part does not
+  match the metadata produced by `setup.py egg_info`. :issue:`3143`.
 
 
 **7.1.2 (2015-08-22)**

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -450,11 +450,13 @@ class InstallRequirement(object):
         else:
             metadata_name = canonicalize_name(self.pkg_info()["Name"])
             if canonicalize_name(self.req.project_name) != metadata_name:
-                raise InstallationError(
+                logger.warning(
                     'Running setup.py (path:%s) egg_info for package %s '
-                    'produced metadata for project name %s' % (
-                        self.setup_py, self.name, metadata_name)
+                    'produced metadata for project name %s. Fix your '
+                    '#egg=%s fragments.',
+                    self.setup_py, self.name, metadata_name, self.name
                 )
+                self.req = pkg_resources.Requirement.parse(metadata_name)
 
     def egg_info_data(self, filename):
         if self.satisfied_by is not None:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -911,4 +911,6 @@ def test_install_editable_with_wrong_egg_name(script):
         'install', '--editable', 'file://%s#egg=pkgb' % pkga_path,
         expect_error=True)
     assert ("egg_info for package pkgb produced metadata "
-            "for project name pkga") in result.stderr
+            "for project name pkga. Fix your #egg=pkgb "
+            "fragments.") in result.stderr
+    assert "Successfully installed pkga" in str(result), str(result)


### PR DESCRIPTION
Since pip 7, via pip freeze, is producing such mismatching #egg
fragment, forbidding them in pip 8 would be too strongly
backward-incompatible.

It is a partial rollback of 1a012bb6 (#3153).

cc @qwcode and @dstufft

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3347)
<!-- Reviewable:end -->
