### PR TITLE
Bug correction for script case naming when install a wheel with pip

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -224,6 +224,8 @@ def get_entrypoints(filename):
         data.seek(0)
 
     cp = configparser.RawConfigParser()
+    # Replace optionxform with str to preserve the case of console and gui scripts
+    cp.optionxform = str
     cp.readfp(data)
 
     console = {}


### PR DESCRIPTION
When pip install a wheel that create scripts declared in console_scripts entry_points the case of the name of the script is actually lost. This patch only replace the optionxform attribute by str to preserve orignial name.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3358)
<!-- Reviewable:end -->
