### PR TITLE
fix(pip/req/req_set): Dont err on double reqs of the same spec

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -242,7 +242,8 @@ class RequirementSet(object):
                 existing_req = None
             if (parent_req_name is None and existing_req and not
                     existing_req.constraint and
-                    existing_req.extras == install_req.extras):
+                    existing_req.extras == install_req.extras and not
+                    existing_req.req.specs == install_req.req.specs):
                 raise InstallationError(
                     'Double requirement given: %s (already in %s, name=%r)'
                     % (install_req, existing_req, name))

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -932,3 +932,22 @@ def test_install_tar_lzma(script, data):
         pytest.skip("No lzma support")
     res = script.pip('install', data.packages / 'singlemodule-0.0.1.tar.lzma')
     assert "Successfully installed singlemodule-0.0.1" in res.stdout, res
+
+
+def test_double_install(script, data):
+    """
+    Test double install passing with two same version requirements
+    """
+    result = script.pip('install', 'pip', 'pip', expect_error=False)
+    msg = "Double requirement given: pip (already in pip, name='pip')"
+    assert msg not in result.stderr
+
+
+def test_double_install_fail(script, data):
+    """
+    Test double install failing with two different version requirements
+    """
+    result = script.pip('install', 'pip==*', 'pip==7.1.2', expect_error=True)
+    msg = ("Double requirement given: pip==7.1.2 (already in pip==*, "
+           "name='pip')")
+    assert msg in result.stderr


### PR DESCRIPTION
If double requirements exist with the same specs, dont raise a double requirement given error.

My reasoning is that if the user has the same version specified in more than one place this is an unnecessary level of hand holding and this error prevents people from writing more modular requirements.txts more than it prevents bugs. 
If separate versions exist multiple times it makes sense to error out/ use a dependency resolver as discussed in #988 .

Fixes #993.

This does not affect #2367.
This is not related to #1658. I've noticed that if two git+... links are given with different egg names this code block doesn't affect them and it will happily install them even without the req.specs check. Checked on py 3.5.1 and 2.7.10.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3372)
<!-- Reviewable:end -->
