### PR TITLE
Default to downloading to the current directory

### DIFF
--- a/docs/reference/pip_download.rst
+++ b/docs/reference/pip_download.rst
@@ -25,8 +25,8 @@ which is now deprecated and will be removed in pip 10.
 
 ``pip download`` does the same resolution and downloading as ``pip install``,
 but instead of installing the dependencies, it collects the downloaded
-distributions into the directory provided (defaulting to ``./pip_downloads``).
-This directory can later be passed as the value to
+distributions into the directory provided (defaulting to the current
+directory). This directory can later be passed as the value to
 ``pip install --find-links`` to facilitate offline or locked down package
 installation.
 
@@ -46,8 +46,8 @@ Examples
 
   ::
 
-    $ pip download -d ./pip_downloads SomePackage
-    $ pip download SomePackage  # equivalent to above
+    $ pip download SomePackage
+    $ pip download -d . SomePackage  # equivalent to above
     $ pip download --no-index --find-links=/tmp/wheelhouse -d /tmp/otherwheelhouse SomePackage
 
 

--- a/pip/commands/download.py
+++ b/pip/commands/download.py
@@ -11,9 +11,6 @@ from pip.utils.build import BuildDirectory
 from pip.utils.filesystem import check_path_owner
 
 
-DEFAULT_DOWNLOAD_DIR = os.path.join(normalize_path(os.curdir), 'pip_downloads')
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +59,7 @@ class DownloadCommand(RequirementCommand):
             '-d', '--dest', '--destination-dir', '--destination-directory',
             dest='download_dir',
             metavar='dir',
-            default=DEFAULT_DOWNLOAD_DIR,
+            default=os.curdir,
             help=("Download packages into <dir>."),
         )
 
@@ -77,6 +74,8 @@ class DownloadCommand(RequirementCommand):
     def run(self, options, args):
         options.ignore_installed = True
         options.src_dir = os.path.abspath(options.src_dir)
+        options.download_dir = normalize_path(options.download_dir)
+
         ensure_dir(options.download_dir)
 
         with self._build_session(options) as session:

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -11,9 +11,10 @@ def test_download_if_requested(script):
     It should download (in the scratch path) and not install if requested.
     """
     result = script.pip(
-        'download', '-d', '.', 'INITools==0.1', expect_error=True
+        'download', '-d', 'pip_downloads', 'INITools==0.1', expect_error=True
     )
-    assert Path('scratch') / 'INITools-0.1.tar.gz' in result.files_created
+    assert Path('scratch') / 'pip_downloads' / 'INITools-0.1.tar.gz' \
+        in result.files_created
     assert script.site_packages / 'initools' not in result.files_created
 
 
@@ -23,9 +24,7 @@ def test_download_setuptools(script):
     It should download (in the scratch path) and not install if requested.
     """
     result = script.pip('download', 'setuptools')
-    setuptools_prefix = str(
-        Path('scratch') / 'pip_downloads' / 'setuptools'
-    )
+    setuptools_prefix = str(Path('scratch') / 'setuptools')
     assert any(
         path.startswith(setuptools_prefix) for path in result.files_created
     )


### PR DESCRIPTION
Looking at other tools that do similar things, and asking around it appears people generally expect this to just dump things into ``os.curdir``.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3378)
<!-- Reviewable:end -->
