### PR TITLE
allow creating wheels for editable packages

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -759,11 +759,8 @@ class WheelBuilder(object):
                 if not autobuilding:
                     logger.info(
                         'Skipping %s, due to already being wheel.', req.name)
-            elif req.editable:
-                if not autobuilding:
-                    logger.info(
-                        'Skipping bdist_wheel for %s, due to being editable',
-                        req.name)
+            elif autobuilding and req.editable:
+                pass
             elif autobuilding and req.link and not req.link.is_artifact:
                 pass
             elif autobuilding and not req.source_dir:

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -380,16 +380,6 @@ class TestWheelBuilder(object):
             assert "due to already being wheel" in caplog.text()
             assert mock_build_one.mock_calls == []
 
-    def test_skip_building_editables(self, caplog):
-        with patch('pip.wheel.WheelBuilder._build_one') as mock_build_one:
-            editable = Mock(editable=True, is_wheel=False, constraint=False)
-            reqset = Mock(requirements=Mock(values=lambda: [editable]),
-                          wheel_download_dir='/wheel/dir')
-            wb = wheel.WheelBuilder(reqset, Mock())
-            wb.build()
-            assert "due to being editable" in caplog.text()
-            assert mock_build_one.mock_calls == []
-
 
 class TestWheelCache:
 


### PR DESCRIPTION
Fixes #3291 

This lifts the restriction of not generating wheels for editable packages.

As explained in #3291, there are legitimate scenarios for this, such as building wheels from frozen requirements.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3379)
<!-- Reviewable:end -->
