### PR TITLE
pip list: reenable prereleases filter

### DIFF
--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -159,6 +159,11 @@ class ListCommand(Command):
             for dist in installed_packages:
                 typ = 'unknown'
                 all_candidates = finder.find_all_candidates(dist.key)
+                if not options.pre:
+                    # Remove prereleases
+                    all_candidates = [candidate for candidate in all_candidates
+                                      if not candidate.version.is_prerelease]
+
                 if not all_candidates:
                     continue
                 best_candidate = max(all_candidates,

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -147,3 +147,22 @@ def test_outdated_editables_flag(script, data):
     assert os.path.join('src', 'pip-test-package') in result.stdout, (
         str(result)
     )
+
+
+def test_outdated_pre(script, data):
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+
+    # Let's build a fake wheelhouse
+    script.scratch_path.join("wheelhouse").mkdir()
+    wheelhouse_path = script.scratch_path / 'wheelhouse'
+    wheelhouse_path.join('simple-1.1-py2.py3-none-any.whl').write('')
+    wheelhouse_path.join('simple-2.0.dev0-py2.py3-none-any.whl').write('')
+    result = script.pip('list', '--no-index', '--find-links', wheelhouse_path)
+    assert 'simple (1.0)' in result.stdout
+    result = script.pip('list', '--no-index', '--find-links', wheelhouse_path,
+                        '--outdated')
+    assert 'simple (1.0) - Latest: 1.1 [wheel]' in result.stdout
+    result_pre = script.pip('list', '--no-index',
+                            '--find-links', wheelhouse_path,
+                            '--outdated', '--pre')
+    assert 'simple (1.0) - Latest: 2.0.dev0 [wheel]' in result_pre.stdout


### PR DESCRIPTION
according to --pre option

broken in 7fcf75bb6198f3a7d339290b62c106cc3326ceb0

closes #3385

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3398)
<!-- Reviewable:end -->
