### PR TITLE
Move the test for local items to earlier in uninstall process

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -752,7 +752,7 @@ class InstallRequirement(object):
             self.uninstalled.rollback()
         else:
             logger.error(
-                "Can't rollback %s, nothing uninstalled.", self.project_name,
+                "Can't rollback %s, nothing uninstalled.", self.name,
             )
 
     def commit_uninstall(self):

--- a/pip/req/req_uninstall.py
+++ b/pip/req/req_uninstall.py
@@ -2,13 +2,11 @@ from __future__ import absolute_import
 
 import logging
 import os
-import sys
 import tempfile
 
 from pip.compat import uses_pycache, WINDOWS, cache_from_source
 from pip.exceptions import UninstallationError
-from pip.utils import (rmtree, ask, is_local, dist_is_local, renames,
-                       normalize_path)
+from pip.utils import rmtree, ask, is_local, renames, normalize_path
 from pip.utils.logging import indent_log
 
 
@@ -33,17 +31,6 @@ class UninstallPathSet(object):
 
         """
         return is_local(path)
-
-    def _can_uninstall(self):
-        if not dist_is_local(self.dist):
-            logger.info(
-                "Not uninstalling %s at %s, outside environment %s",
-                self.dist.project_name,
-                normalize_path(self.dist.location),
-                sys.prefix,
-            )
-            return False
-        return True
 
     def add(self, path):
         head, tail = os.path.split(path)
@@ -94,8 +81,6 @@ class UninstallPathSet(object):
     def remove(self, auto_confirm=False):
         """Remove paths in ``self.paths`` with confirmation (unless
         ``auto_confirm`` is True)."""
-        if not self._can_uninstall():
-            return
         if not self.paths:
             logger.info(
                 "Can't uninstall '%s'. No files were found to uninstall.",


### PR DESCRIPTION
I think this will fix some of the breakage from #3384, specifically the parts where you attempt to upgrade a library inside of a virtual environment, when that virtual environment has system site packages enabled *and* the library you're attempting to upgrade is outside of the virtual environment *and* it was originally installed using distutils.

Fixes #3404

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3401)
<!-- Reviewable:end -->
