### PR TITLE
Fix typo in pip_install.rst

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -235,7 +235,7 @@ Since version 6.0, pip also supports specifers containing `environment markers
  ::
 
   SomeProject ==5.4 ; python_version < '2.7'
-  SomeProject; sys.platform == 'win32'
+  SomeProject; sys_platform == 'win32'
 
 Environment markers are supported in the command line and in requirements files.
 


### PR DESCRIPTION
It seems the requirement specifier must be `sys_platform` and not `sys.platform`. Tested with pip 8.0.0.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3410)
<!-- Reviewable:end -->
