### PR TITLE
pip freeze: handle new requirements options.

### DIFF
--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -61,6 +61,9 @@ def freeze(
                             '-Z', '--always-unzip',
                             '-f', '--find-links',
                             '-i', '--index-url',
+                            '--pre',
+                            '--trusted-host',
+                            '--process-dependency-links',
                             '--extra-index-url'))):
                     yield line.rstrip()
                     continue

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -305,6 +305,9 @@ def test_freeze_with_requirement_option(script):
         --always-unzip ignore
         -f http://ignore
         -i http://ignore
+        --pre
+        --trusted-host url
+        --process-dependency-links
         --extra-index-url http://ignore
         --find-links http://ignore
         --index-url http://ignore


### PR DESCRIPTION
pip 8.0.0 added support for `--pre`, `--trusted-host`, and `--process-dependency-links` to requirements files, but they were not handled by `pip freeze -r`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3412)
<!-- Reviewable:end -->
