### PR TITLE
Stop trying to locate system trust stores

### DIFF
--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -17,7 +17,7 @@ from pip.index import (
     FormatControl, fmt_ctl_handle_mutual_exclude, fmt_ctl_no_binary,
     fmt_ctl_no_use_wheel)
 from pip.models import PyPI
-from pip.locations import CA_BUNDLE_PATH, USER_CACHE_DIR, src_prefix
+from pip.locations import USER_CACHE_DIR, src_prefix
 from pip.utils.hashes import STRONG_HASHES
 
 
@@ -197,7 +197,6 @@ cert = partial(
     '--cert',
     dest='cert',
     type='str',
-    default=CA_BUNDLE_PATH,
     metavar='path',
     help="Path to alternate CA bundle.")
 

--- a/pip/locations.py
+++ b/pip/locations.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import os
 import os.path
 import site
-import ssl
 import sys
 
 from distutils import sysconfig
@@ -12,52 +11,6 @@ from distutils.command.install import install, SCHEME_KEYS  # noqa
 
 from pip.compat import WINDOWS, expanduser
 from pip.utils import appdirs
-
-
-# if the Python we're running on is new enough to have the needed API then
-# we'll ask OpenSSL to give us the path to the default CA Bundle. If this API
-# doesn't exist or we cannot resolve the path to an existing file, then we will
-# simply set this to None. Setting this to None will have requests fall back
-# and use it's default CA Bundle logic.
-# Ever since requests 2.9.0, requests has supported a CAPath in addition to a
-# CAFile, because some systems (such as Debian) have a broken CAFile currently
-# we'll go ahead and support both, prefering CAPath over CAfile.
-if getattr(ssl, "get_default_verify_paths", None):
-    _ssl_paths = ssl.get_default_verify_paths()
-
-    # Ok, this is a little hairy because system trust stores are randomly
-    # broken in different and exciting ways and this should help fix that.
-    # Ideally we'd just not trust the system store, however that leads end
-    # users to be confused on systems like Debian that patch python-pip, even
-    # inside of a virtual environment, to support the system store. This would
-    # lead to pip trusting the system store when creating the virtual
-    # environment, but then switching to not doing that when upgraded to a
-    # version from PyPI. However, we can't *only* rely on the system store
-    # because not all systems actually have one, so at the end of the day we
-    # still need to fall back to trusting the bundled copy.
-    #
-    # Resolution Method:
-    #
-    # 1. We prefer a CAPath, however we will *only* prefer a CAPath if the
-    #    directory exists and it is not empty. This works around systems like
-    #    Homebrew which have an empty CAPath but a populated CAFile.
-    # 2. Failing that, we prefer a CAFile, however again we will *only* prefer
-    #    it if it exists on disk and if it is not empty. This will work around
-    #    systems that have an empty CAFile sitting around for no good reason.
-    # 3. Finally, we'll just fall back to letting requests use it's bundled
-    #    CAFile, which can of course be overriden by the end user installing
-    #    certifi.
-    if _ssl_paths.capath is not None and os.listdir(_ssl_paths.capath):
-        CA_BUNDLE_PATH = _ssl_paths.capath
-    elif _ssl_paths.cafile is not None and os.path.getsize(_ssl_paths.cafile):
-        CA_BUNDLE_PATH = _ssl_paths.cafile
-    else:
-        CA_BUNDLE_PATH = None
-else:
-    # If we aren't running on a copy of Python that is new enough to be able
-    # to query OpenSSL for it's default locations, then we'll only support
-    # using the built in CA Bundle by default.
-    CA_BUNDLE_PATH = None
 
 
 # Application Directories


### PR DESCRIPTION
We started trying to locate the system trust stores, because downstream was patching out our bundled copies anyways and it would provide a smoother experience when people upgraded their pip inside of their system.

However, if we just use OpenSSL's CAFile then we're broken on systems like Debian which currently ship a broken CAFile configuration. If we just use OpenSSL's CAPath then we're broken on systems like CentOS and Fedora that currently are shipping a broken OpenSSL CAPath.

So basically, none of the major distributions seem to be capable of shipping an OpenSSL that isn't broken, so we're going back to relying on our own CA bundle exclusively.

Fixes #3415

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3416)
<!-- Reviewable:end -->
