### PR TITLE
ntlm authentication

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 **8.1.0 (unreleased)**
 
+* Added support for ntlm authentication using ``--auth-ntlm``
+
 
 **8.0.2 (2016-01-21)**
 

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -94,7 +94,12 @@ class Command(object):
             }
 
         if options.auth_ntlm:
-            session.auth = MultiDomainNtlmAuth()
+            try:
+                session.auth = MultiDomainNtlmAuth()
+            except InstallationError:
+                # Needed to allow pip to check for updates
+                options.auth_ntlm = False
+                raise
 
         # Determine if we can prompt the user for authentication or not
         session.auth.prompting = not options.no_input

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -10,7 +10,7 @@ import warnings
 from pip import cmdoptions
 from pip.index import PackageFinder
 from pip.locations import running_under_virtualenv
-from pip.download import PipSession
+from pip.download import PipSession, MultiDomainNtlmAuth
 from pip.exceptions import (BadCommand, InstallationError, UninstallationError,
                             CommandError, PreviousBuildDirError)
 
@@ -92,6 +92,9 @@ class Command(object):
                 "http": options.proxy,
                 "https": options.proxy,
             }
+
+        if options.auth_ntlm:
+            session.auth = MultiDomainNtlmAuth()
 
         # Determine if we can prompt the user for authentication or not
         session.auth.prompting = not options.no_input

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -565,6 +565,14 @@ require_hashes = partial(
          'requirements file has a --hash option.')
 
 
+auth_ntlm = partial(
+    Option,
+    '--auth-ntlm',
+    dest='auth_ntlm',
+    action='store_true',
+    default=False,
+    help='Authenticate on host using NTLM.')
+
 ##########
 # groups #
 ##########
@@ -592,6 +600,7 @@ general_group = {
         cache_dir,
         no_cache,
         disable_pip_version_check,
+        auth_ntlm,
     ]
 }
 

--- a/pip/download.py
+++ b/pip/download.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     HAS_TLS = False
 
+try:
+    from requests_ntlm import HttpNtlmAuth  # noqa
+except ImportError:
+    HttpNtlmAuth = None
+
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib import request as urllib_request
 
@@ -213,7 +218,11 @@ class MultiDomainBasicAuth(MultiDomainAuth):
 class MultiDomainNtlmAuth(MultiDomainAuth):
     @classmethod
     def authlib(cls):
-        from requests_ntlm import HttpNtlmAuth  # noqa
+        if HttpNtlmAuth is None:
+            raise ImportError(
+                "Dependencies for Ntlm authentication are missing. Install "
+                "dependencies via the `pip install pip['ntlm']` command."
+            )
         return HttpNtlmAuth
 
 

--- a/pip/download.py
+++ b/pip/download.py
@@ -220,7 +220,7 @@ class MultiDomainNtlmAuth(MultiDomainAuth):
         if HttpNtlmAuth is None:
             raise InstallationError(
                 "Dependencies for Ntlm authentication are missing. Install "
-                "dependencies via the `pip install pip['ntlm']` command."
+                "dependencies via the 'pip install pip[ntlm]' command."
             )
         super(MultiDomainNtlmAuth, self).__init__(*args, **kwargs)
 

--- a/pip/download.py
+++ b/pip/download.py
@@ -216,13 +216,16 @@ class MultiDomainBasicAuth(MultiDomainAuth):
 
 
 class MultiDomainNtlmAuth(MultiDomainAuth):
-    @classmethod
-    def authlib(cls):
+    def __init__(self, *args, **kwargs):
         if HttpNtlmAuth is None:
-            raise ImportError(
+            raise InstallationError(
                 "Dependencies for Ntlm authentication are missing. Install "
                 "dependencies via the `pip install pip['ntlm']` command."
             )
+        super(MultiDomainNtlmAuth, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def authlib(cls):
         return HttpNtlmAuth
 
 

--- a/pip/download.py
+++ b/pip/download.py
@@ -210,6 +210,13 @@ class MultiDomainBasicAuth(MultiDomainAuth):
         return HTTPBasicAuth
 
 
+class MultiDomainNtlmAuth(MultiDomainAuth):
+    @classmethod
+    def authlib(cls):
+        from requests_ntlm import HttpNtlmAuth  # noqa
+        return HttpNtlmAuth
+
+
 class LocalFSAdapter(BaseAdapter):
 
     def send(self, request, stream=None, timeout=None, verify=None, cert=None,

--- a/pip/download.py
+++ b/pip/download.py
@@ -201,7 +201,7 @@ class MultiDomainAuth(AuthBase):
     @classmethod
     def authlib(cls):
         # Place holder for Authentication Class
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class MultiDomainBasicAuth(MultiDomainAuth):

--- a/pip/download.py
+++ b/pip/download.py
@@ -154,7 +154,7 @@ class MultiDomainAuth(AuthBase):
             self.passwords[netloc] = (username, password)
 
             # Send the basic auth with this request
-            req = self.authlib()(username or "", password or "")(req)
+            req = self.authlib(username or "", password or "")(req)
 
         # Attach a hook to handle 401 responses
         req.register_hook("response", self.handle_401)
@@ -187,7 +187,7 @@ class MultiDomainAuth(AuthBase):
         resp.raw.release_conn()
 
         # Add our new username and password to the request
-        req = self.authlib()(username or "", password or "")(resp.request)
+        req = self.authlib(username or "", password or "")(resp.request)
 
         # Send our new request
         new_resp = resp.connection.send(req, **kwargs)
@@ -203,15 +203,15 @@ class MultiDomainAuth(AuthBase):
             return userinfo, None
         return None, None
 
-    @classmethod
-    def authlib(cls):
+    @property
+    def authlib(self):
         # Place holder for Authentication Class
         raise NotImplementedError
 
 
 class MultiDomainBasicAuth(MultiDomainAuth):
-    @classmethod
-    def authlib(cls):
+    @property
+    def authlib(self):
         return HTTPBasicAuth
 
 
@@ -224,8 +224,8 @@ class MultiDomainNtlmAuth(MultiDomainAuth):
             )
         super(MultiDomainNtlmAuth, self).__init__(*args, **kwargs)
 
-    @classmethod
-    def authlib(cls):
+    @property
+    def authlib(self):
         return HttpNtlmAuth
 
 

--- a/pip/download.py
+++ b/pip/download.py
@@ -122,7 +122,7 @@ def user_agent():
     )
 
 
-class MultiDomainBasicAuth(AuthBase):
+class MultiDomainAuth(AuthBase):
 
     def __init__(self, prompting=True):
         self.prompting = prompting
@@ -149,7 +149,7 @@ class MultiDomainBasicAuth(AuthBase):
             self.passwords[netloc] = (username, password)
 
             # Send the basic auth with this request
-            req = HTTPBasicAuth(username or "", password or "")(req)
+            req = self.authlib()(username or "", password or "")(req)
 
         # Attach a hook to handle 401 responses
         req.register_hook("response", self.handle_401)
@@ -182,7 +182,7 @@ class MultiDomainBasicAuth(AuthBase):
         resp.raw.release_conn()
 
         # Add our new username and password to the request
-        req = HTTPBasicAuth(username or "", password or "")(resp.request)
+        req = self.authlib()(username or "", password or "")(resp.request)
 
         # Send our new request
         new_resp = resp.connection.send(req, **kwargs)
@@ -197,6 +197,17 @@ class MultiDomainBasicAuth(AuthBase):
                 return userinfo.split(":", 1)
             return userinfo, None
         return None, None
+
+    @classmethod
+    def authlib(cls):
+        # Place holder for Authentication Class
+        raise NotImplemented
+
+
+class MultiDomainBasicAuth(MultiDomainAuth):
+    @classmethod
+    def authlib(cls):
+        return HTTPBasicAuth
 
 
 class LocalFSAdapter(BaseAdapter):

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
     zip_safe=False,
     extras_require={
         'testing': tests_require,
+        'ntlm': ['requests_ntlm'],
     },
     cmdclass={'test': PyTest},
 )

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -60,6 +60,23 @@ def test_with_setuptools_and_import_error(script, data):
     assert "ImportError: toto" in result.stderr
 
 
+def test_without_ntlm(script, data):
+    result = script.run(
+        "python", "-c",
+        "import pip; pip.main(["
+        "'install', "
+        "'INITools==0.2', "
+        "'-f', '%s', "
+        "'--auth-ntlm'])" % data.packages,
+        expect_error=True,
+    )
+    assert (
+        "Dependencies for Ntlm authentication are missing. Install "
+        "dependencies via the 'pip install pip[ntlm]' command."
+        in result.stderr
+    )
+
+
 def test_pip_second_command_line_interface_works(script, data):
     """
     Check if ``pip<PYVERSION>`` commands behaves equally

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -5,6 +5,7 @@ from shutil import rmtree, copy
 from tempfile import mkdtemp
 
 from pip._vendor.six.moves.urllib import request as urllib_request
+from pip._vendor.requests.auth import HTTPBasicAuth
 
 from mock import Mock, patch
 import pytest
@@ -13,7 +14,7 @@ import pip
 from pip.exceptions import HashMismatch
 from pip.download import (
     PipSession, SafeFileCache, path_to_url, unpack_http_url, url_to_path,
-    unpack_file_url,
+    unpack_file_url, MultiDomainBasicAuth,
 )
 from pip.index import Link
 from pip.utils.hashes import Hashes
@@ -312,6 +313,11 @@ class TestPipSession:
 
         assert not hasattr(session.adapters["http://"], "cache")
         assert not hasattr(session.adapters["https://"], "cache")
+
+    def test_authlib_returns_HTTPBasicAuth(self):
+        session = PipSession()
+        assert isinstance(session.auth, MultiDomainBasicAuth)
+        assert session.auth.authlib == HTTPBasicAuth
 
     def test_cache_is_enabled(self, tmpdir):
         session = PipSession(cache=tmpdir.join("test-cache"))


### PR DESCRIPTION
Adding ntlm for #1182. Other authentication libraries can be added the same way (ie, kerberos)
The import statement was placed inside the method to only import when needed, and not cause an `ImportError` if package isn't installed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3419)
<!-- Reviewable:end -->
