### PR TITLE
Workaround for docker overlayfs bug

### DIFF
--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -116,17 +116,17 @@ def rmtree_errorhandler(func, path, exc_info):
     the overlayfs folks to fix this issue, we need to handle the OSError that
     happens when we try to delete a file that "isn't there" according to the
     overlay backend."""
+    if not os.path.exists(path):
+        # no issues with trying to delete a file/directory that isn't there
+        msg = "{}({}) failed because {} does not exist.".format(func, path)
+        logger.warn(msg)
+        return
     # if file type currently read only
-    if os.stat(path).st_mode & stat.S_IREAD:
+    elif os.stat(path).st_mode & stat.S_IREAD:
         # convert to read/write
         os.chmod(path, stat.S_IWRITE)
         # use the original function to repeat the operation
         func(path)
-        return
-    elif not os.path.exists(path):
-        # no issues with trying to delete a file/directory that isn't there
-        msg = "{}({}) failed because {} does not exist.".format(func, path)
-        logger.warn(msg)
         return
     else:
         raise

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -123,9 +123,10 @@ def rmtree_errorhandler(func, path, exc_info):
         # use the original function to repeat the operation
         func(path)
         return
-    elif not os.path.exists(path) and func is shutil.rmtree:
+    elif not os.path.exists(path):
         # no issues with trying to delete a file/directory that isn't there
-        logger.debug("Can't find {} when trying to remove it".format(path))
+        msg = "{}({}) failed because {} does not exist.".format(func, path)
+        logger.warn(msg)
         return
     else:
         raise

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -118,7 +118,19 @@ def rmtree_errorhandler(func, path, exc_info):
     overlay backend."""
     if not os.path.exists(path):
         # no issues with trying to delete a file/directory that isn't there
-        msg = "{}({}) failed because {} does not exist.".format(func, path)
+        msg = "{}({}) failed because {} does not exist. Ignoring.".format(
+            func, path)
+        logger.warn(msg)
+        return
+    elif os.path.isdir(path):
+        # I want to look and see if this is empty
+        logger.info(os.path.listdir(path))
+        # This is sketchier, but when we ignore all of the non-existent deletes
+        # because of the overlay problem, we then get to the directory level,
+        # where the system is confused about whether it is non-empty or
+        # not.
+        msg = "{}({}) failed because it is a non-empty directory.".format(
+            func, path)
         logger.warn(msg)
         return
     # if file type currently read only

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -118,17 +118,17 @@ def rmtree_errorhandler(func, path, exc_info):
     overlay backend."""
     if not os.path.exists(path):
         # no issues with trying to delete a file/directory that isn't there
-        logger.warn("%s(%s) failed because %s does not exist. Ignoring.",
-                    func.__name__, path, path)
+        logger.warning("%s(%s) failed because %s does not exist. Ignoring.",
+                       func.__name__, path, path)
         return
     elif os.path.isdir(path):
         # This is sketchier, but when we ignore all of the non-existent deletes
         # because of the overlay problem, we then get to the directory level,
         # where the system is confused about whether it is non-empty or
         # not.
-        logger.warn("%s(%s) failed because it is a non-empty directory. You "
-                    "may need to clean this up manually. Ignoring.",
-                    func.__name__, path)
+        logger.warning("%s(%s) failed because it is a non-empty directory. "
+                       "You may need to clean this up manually. Ignoring.",
+                       func.__name__, path)
         return
     # if file type currently read only
     elif os.stat(path).st_mode & stat.S_IREAD:

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -124,13 +124,13 @@ def rmtree_errorhandler(func, path, exc_info):
         return
     elif os.path.isdir(path):
         # I want to look and see if this is empty
-        logger.info(os.path.listdir(path))
+        logger.info(os.listdir(path))
         # This is sketchier, but when we ignore all of the non-existent deletes
         # because of the overlay problem, we then get to the directory level,
         # where the system is confused about whether it is non-empty or
         # not.
-        msg = "{}({}) failed because it is a non-empty directory.".format(
-            func, path)
+        msg = ("{}({}) failed because it is a non-empty directory. "
+               "Ignoring.".format(func, path))
         logger.warn(msg)
         return
     # if file type currently read only

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -118,20 +118,17 @@ def rmtree_errorhandler(func, path, exc_info):
     overlay backend."""
     if not os.path.exists(path):
         # no issues with trying to delete a file/directory that isn't there
-        msg = "{}({}) failed because {} does not exist. Ignoring.".format(
-            func, path)
-        logger.warn(msg)
+        logger.warn("%s(%s) failed because %s does not exist. Ignoring.",
+                    func.__name__, path, path)
         return
     elif os.path.isdir(path):
-        # I want to look and see if this is empty
-        logger.info(os.listdir(path))
         # This is sketchier, but when we ignore all of the non-existent deletes
         # because of the overlay problem, we then get to the directory level,
         # where the system is confused about whether it is non-empty or
         # not.
-        msg = ("{}({}) failed because it is a non-empty directory. "
-               "Ignoring.".format(func, path))
-        logger.warn(msg)
+        logger.warn("%s(%s) failed because it is a non-empty directory. You "
+                    "may need to clean this up manually. Ignoring.",
+                    func.__name__, path)
         return
     # if file type currently read only
     elif os.stat(path).st_mode & stat.S_IREAD:


### PR DESCRIPTION
This patch aims to fix Issue #2953

In Docker containers with the overlayfs backend, when a package is installed at one layer, and then upgraded or downgraded at another, such that pip uninstalls the previously installed version, an error can occur when files are copied to /tmp (so that they can be rolled back) and then deleted on successful uninstall. See discussion about this issue at https://github.com/docker/docker/issues/9572 and https://github.com/docker/docker/issues/12327. While we are waiting for the overlayfs folks to fix this issue, we need to handle the OSError that happens when we try to delete a file that "isn't there" according to the overlay backend.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3425)
<!-- Reviewable:end -->
