### PR TITLE
Fix typo in the user guide doc

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -434,7 +434,7 @@ To setup for zsh::
     $ pip completion --zsh >> ~/.zprofile
 
 Alternatively, you can use the result of the ``completion`` command
-directly with the eval function of you shell, e.g. by adding the following to your startup file::
+directly with the eval function of your shell, e.g. by adding the following to your startup file::
 
     eval "`pip completion --bash`"
 


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3428)
<!-- Reviewable:end -->
