### PR TITLE
quickstart: How to install downloaded package

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,6 +11,14 @@ Install a package from `PyPI`_:
     [...]
     Successfully installed SomePackage
 
+Install a package downloaded from `PyPI`_ or got elsewhere. This is useful if the target machine does not have a network connection:
+
+::
+
+  $ pip install SomePackage.tar.gz
+    [...]
+    Successfully installed SomePackage
+
 Show what files were installed:
 
 ::


### PR DESCRIPTION
I have been working with clients who have environments without network connection (or with annoying proxies that require special configuration). In such situations the capability to install an already downloaded package is very convenient. Showing it in the Quickstart would be nice.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3429)
<!-- Reviewable:end -->
