### PR TITLE
Correct installation hash checking docs

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -521,8 +521,8 @@ Since version 8.0, pip can check downloaded package archives against local
 hashes to protect against remote tampering. To verify a package against one or
 more hashes, add them to the end of the line::
 
-    FooProject == 1.2 --hash:sha256=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 \
-                      --hash:sha256=486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7
+    FooProject == 1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 \
+                      --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7
 
 (The ability to use multiple hashes is important when a package has both
 binary and source distributions or when it offers binary distributions for a

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -621,7 +621,7 @@ Hash-checking Mode
 Beyond pinning version numbers, you can add hashes against which to verify
 downloaded packages::
 
-    FooProject == 1.2 --hash:sha256=2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    FooProject == 1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
 
 This protects against a compromise of PyPI or the HTTPS
 certificate chain. It also guards against a package changing


### PR DESCRIPTION
The docs currently show passing a package's hash(es) in the form of ``--hash:sha256=...``. When trying to install something using this format, pip fails with the error ``pip: error: no such option: --hash:sha256``. This should be changed to match the output of ``pip hash``.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3430)
<!-- Reviewable:end -->
