### PR TITLE
quickstart: Installing already downloaded package

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,7 +11,7 @@ Install a package from `PyPI`_:
     [...]
     Successfully installed SomePackage
 
-Install a distribution already downloaded from `PyPI`_ or got elsewhere.
+Install a package already downloaded from `PyPI`_ or got elsewhere.
 This is useful if the target machine does not have a network connection:
 
 ::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,6 +11,15 @@ Install a package from `PyPI`_:
     [...]
     Successfully installed SomePackage
 
+Install a distribution already downloaded from `PyPI`_ or got elsewhere.
+This is useful if the target machine does not have a network connection:
+
+::
+
+  $ pip install SomePackage-1.0-py2.py3-none-any.whl
+    [...]
+    Successfully installed SomePackage
+
 Show what files were installed:
 
 ::


### PR DESCRIPTION
Document how to install a package if the target machine has no network connection.

I have been working with clients who have environments without network connection (or with annoying proxies that require special configuration). In such situations the capability to install an already downloaded package is very convenient. Showing how to do it in the Quickstart would be nice.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3431)
<!-- Reviewable:end -->
