### PR TITLE
[Py3] Remove package containing entry points names with colons

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,9 @@
 
 * Make ``install --quiet`` really quiet. See #3418.
 
+* Fix a bug when removing packages in python 3: disable INI-style parsing of the
+  entry_point.txt file to allow entry point names with colons (:pull:`3434`)
+
 
 **8.0.2 (2016-01-21)**
 

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -727,7 +727,11 @@ class InstallRequirement(object):
 
         # find console_scripts
         if dist.has_metadata('entry_points.txt'):
-            config = configparser.SafeConfigParser()
+            if six.PY2:
+                options = {}
+            else:
+                options = {"delimiters": ('=')}
+            config = configparser.SafeConfigParser(**options)
             config.readfp(
                 FakeFile(dist.get_metadata_lines('entry_points.txt'))
             )

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -730,7 +730,7 @@ class InstallRequirement(object):
             if six.PY2:
                 options = {}
             else:
-                options = {"delimiters": ('=')}
+                options = {"delimiters": ('=', )}
             config = configparser.SafeConfigParser(**options)
             config.readfp(
                 FakeFile(dist.get_metadata_lines('entry_points.txt'))

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ def find_version(*file_paths):
 
 long_description = read('README.rst')
 
-tests_require = ['pytest', 'virtualenv>=1.10', 'scripttest>=1.3', 'mock']
+tests_require = ['pytest', 'virtualenv>=1.10', 'scripttest>=1.3', 'mock',
+                 'pretend']
 
 
 setup(

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -175,7 +175,7 @@ def test_uninstall_entry_point(script):
     result = script.pip('install', pkg_path)
     result = script.pip('list')
     assert "ep-install (0.1)" in result.stdout
-    script.pip('uninstall', 'ep_install', '-y', expect_stderr=True)
+    script.pip('uninstall', 'ep_install', '-y')
     result2 = script.pip('list')
     assert "ep-install (0.1)" not in result2.stdout
 

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -154,6 +154,32 @@ def test_uninstall_overlapping_package(script, data):
     assert_all_changes(result2, result3, [])
 
 
+def test_uninstall_entry_point(script):
+    """
+    Test uninstall package with two or more entry points in the same section,
+    whose name contain a colon.
+    """
+    script.scratch_path.join("ep_install").mkdir()
+    pkg_path = script.scratch_path / 'ep_install'
+    pkg_path.join("setup.py").write(textwrap.dedent("""
+        from setuptools import setup
+        setup(
+            name='ep-install',
+            version='0.1',
+            entry_points={"pip_test.ep":
+                          ["ep:name1 = distutils_install",
+                           "ep:name2 = distutils_install"]
+                          }
+        )
+    """))
+    result = script.pip('install', pkg_path)
+    result = script.pip('list')
+    assert "ep-install (0.1)" in result.stdout
+    script.pip('uninstall', 'ep_install', '-y', expect_stderr=True)
+    result2 = script.pip('list')
+    assert "ep-install (0.1)" not in result2.stdout
+
+
 @pytest.mark.network
 def test_uninstall_console_scripts(script):
     """


### PR DESCRIPTION
Entry points names containing colons are legit, or at least ``pkg_resources`` can deal with them without any issue.

Unfortunately, in python 3 ``pip uninstall`` choke on them when removing a package.
This is because ConfigParser supports by defaults also the "INI" format, in which the delimiter is a colon. This is not a problem for python 2.

This PR force the delimiter to be only ``=`` to fix this issue.

I haven't add a test as now. I should have to dig into the test suite (which is huge).
In theory would be enough to add an entry point somewhere called e.g.:

    entry:point = path.to.package:function

If someone would be so kind as to point me to the correct place to add it, I would be very happy to add it and check if everything is fine.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3434)
<!-- Reviewable:end -->
