### PR TITLE
Case-insensitive match secure origin names

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -291,7 +291,9 @@ class PackageFinder(object):
             except ValueError:
                 # We don't have both a valid address or a valid network, so
                 # we'll check this origin against hostnames.
-                if origin[1] != secure_origin[1] and secure_origin[1] != "*":
+                if (origin[1] and
+                        origin[1].lower() != secure_origin[1].lower() and
+                        secure_origin[1] != "*"):
                     continue
             else:
                 # We have a valid address and network, so see if the address

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -120,6 +120,7 @@ class MockLogger(object):
         ("http://127.0.0.1", [], False),
         ("http://example.com/something/", [], True),
         ("http://example.com/something/", ["example.com"], False),
+        ("http://eXample.com/something/", ["example.cOm"], False),
     ],
 )
 def test_secure_origin(location, trusted, expected):


### PR DESCRIPTION
DNS is non-case-sensitive, so case mismatches between origin names
and any declared trusted hosts are also irrelevant.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3435)
<!-- Reviewable:end -->
