### PR TITLE
Make install --quiet really quiet

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 **8.1.0 (unreleased)**
 
+* Make ``install --quiet`` really quiet. See #3418.
+
 
 **8.0.2 (2016-01-21)**
 

--- a/pip/utils/ui.py
+++ b/pip/utils/ui.py
@@ -219,6 +219,11 @@ def hidden_cursor(file):
     # even via colorama. So don't even try.
     if WINDOWS:
         yield
+    # We don't want to clutter the output with control characters if we're
+    # writing to a file, or if the user is running with --quiet.
+    # See https://github.com/pypa/pip/issues/3418
+    elif not file.isatty() or logger.getEffectiveLevel() > logging.INFO:
+        yield
     else:
         file.write(HIDE_CURSOR)
         try:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -235,6 +235,20 @@ def test_install_from_local_directory(script, data):
     assert egg_info_folder in result.files_created, str(result)
 
 
+def test_install_quiet(script, data):
+    """
+    Test that install -q is actually quiet.
+    """
+    # Apparently if pip install -q is not actually quiet, then it breaks
+    # everything. See:
+    #   https://github.com/pypa/pip/issues/3418
+    #   https://github.com/docker-library/python/issues/83
+    to_install = data.packages.join("FSPkg")
+    result = script.pip('install', '-q', to_install, expect_error=False)
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
 def test_hashed_install_success(script, data, tmpdir):
     """
     Test that installing various sorts of requirements with correct hashes


### PR DESCRIPTION
Commit 5bb989993 added some code for hiding/showing the cursor when
running on the terminal, but accidentally made it so that it always
printed the invisible control codes, even when not on a tty or when
--quiet was specified. This turns out to be surprisingly bad (e.g. it
breaks the official docker python builds). So, let's not do that.

Fixes gh-3418

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3444)
<!-- Reviewable:end -->
