### PR TITLE
write only relative path in 'RECORD'

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -517,9 +517,10 @@ if __name__ == '__main__':
                 if row[0] in changed:
                     row[1], row[2] = rehash(row[0])
                 writer.writerow(row)
+            tmp_p = os.path.join(os.path.dirname(sys.executable),"Lib", "site-packages")    
             for f in generated:
                 h, l = rehash(f)
-                writer.writerow((f, h, l))
+                writer.writerow((normpath(f, tmp_p), h, l))
             for f in installed:
                 writer.writerow((installed[f], '', ''))
     shutil.move(temp_record, record)

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -517,7 +517,8 @@ if __name__ == '__main__':
                 if row[0] in changed:
                     row[1], row[2] = rehash(row[0])
                 writer.writerow(row)
-            tmp_p = os.path.join(os.path.dirname(sys.executable),"Lib", "site-packages")    
+            tmp_p = os.path.join(os.path.dirname(sys.executable),
+                                 "Lib", "site-packages")    
             for f in generated:
                 h, l = rehash(f)
                 writer.writerow((normpath(f, tmp_p), h, l))

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -517,11 +517,9 @@ if __name__ == '__main__':
                 if row[0] in changed:
                     row[1], row[2] = rehash(row[0])
                 writer.writerow(row)
-            tmp_p = os.path.join(os.path.dirname(sys.executable),
-                                 "Lib", "site-packages")
             for f in generated:
                 h, l = rehash(f)
-                writer.writerow((normpath(f, tmp_p), h, l))
+                writer.writerow((normpath(f, lib_dir), h, l))
             for f in installed:
                 writer.writerow((installed[f], '', ''))
     shutil.move(temp_record, record)

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -518,7 +518,7 @@ if __name__ == '__main__':
                     row[1], row[2] = rehash(row[0])
                 writer.writerow(row)
             tmp_p = os.path.join(os.path.dirname(sys.executable),
-                                 "Lib", "site-packages")    
+                                 "Lib", "site-packages")
             for f in generated:
                 h, l = rehash(f)
                 writer.writerow((normpath(f, tmp_p), h, l))


### PR DESCRIPTION
RECORD now contains only relative path.
some bugs triggered by a bleeding edge usage of python may disappear a result (https://github.com/pypa/pip/issues/3433)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3448)
<!-- Reviewable:end -->
