### PR TITLE
exclude wheel from pip freeze

### DIFF
--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -13,7 +13,7 @@ from pip._vendor import pkg_resources
 logger = logging.getLogger(__name__)
 
 # packages to exclude from freeze output
-freeze_excludes = stdlib_pkgs + ['setuptools', 'pip', 'distribute']
+freeze_excludes = stdlib_pkgs + ['setuptools', 'pip', 'distribute', 'wheel']
 
 
 def freeze(


### PR DESCRIPTION
This change adds 'wheel' to the list of packages that are excluded from `$ pip freeze` output. 

This change was briefly discussed with @dstufft on IRC.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3453)
<!-- Reviewable:end -->
