### PR TITLE
enable python -W with respect to PipDeprecationWarning

### DIFF
--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -197,10 +197,6 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
 
-    # Enable our Deprecation Warnings
-    for deprecation_warning in deprecation.DEPRECATIONS:
-        warnings.simplefilter("default", deprecation_warning, append=True)
-
     # Configure our deprecation warnings to be sent through loggers
     deprecation.install_warning_logger()
 

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -199,7 +199,7 @@ def main(args=None):
 
     # Enable our Deprecation Warnings
     for deprecation_warning in deprecation.DEPRECATIONS:
-        warnings.simplefilter("default", deprecation_warning)
+        warnings.simplefilter("default", deprecation_warning, append=True)
 
     # Configure our deprecation warnings to be sent through loggers
     deprecation.install_warning_logger()

--- a/pip/index.py
+++ b/pip/index.py
@@ -19,7 +19,7 @@ from pip.compat import ipaddress
 from pip.utils import (
     cached_property, splitext, normalize_path,
     ARCHIVE_EXTENSIONS, SUPPORTED_EXTENSIONS, canonicalize_name)
-from pip.utils.deprecation import RemovedInPip9Warning
+from pip.utils.deprecation import RemovedInPip9Warning, RemovedInPip10Warning
 from pip.utils.logging import indent_log
 from pip.exceptions import (
     DistributionNotFound, BestVersionAlreadyInstalled, InvalidWheelFilename,
@@ -1019,7 +1019,7 @@ def fmt_ctl_no_use_wheel(fmt_ctl):
     fmt_ctl_no_binary(fmt_ctl)
     warnings.warn(
         '--no-use-wheel is deprecated and will be removed in the future. '
-        ' Please use --no-binary :all: instead.', DeprecationWarning,
+        ' Please use --no-binary :all: instead.', RemovedInPip10Warning,
         stacklevel=2)
 
 

--- a/pip/utils/deprecation.py
+++ b/pip/utils/deprecation.py
@@ -27,11 +27,6 @@ class Python26DeprecationWarning(PipDeprecationWarning, Pending):
     pass
 
 
-DEPRECATIONS = [
-    RemovedInPip9Warning, RemovedInPip10Warning, Python26DeprecationWarning
-]
-
-
 # Warnings <-> Logging Integration
 
 
@@ -71,6 +66,9 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
 
 
 def install_warning_logger():
+    # Enable our Deprecation Warnings
+    warnings.simplefilter("default", PipDeprecationWarning, append=True)
+
     global _warnings_showwarning
 
     if _warnings_showwarning is None:

--- a/pip/utils/deprecation.py
+++ b/pip/utils/deprecation.py
@@ -11,17 +11,19 @@ class PipDeprecationWarning(Warning):
     pass
 
 
-class RemovedInPip9Warning(PipDeprecationWarning, DeprecationWarning):
+class Pending(object):
     pass
 
 
-class RemovedInPip10Warning(PipDeprecationWarning, PendingDeprecationWarning):
+class RemovedInPip9Warning(PipDeprecationWarning):
     pass
 
 
-class Python26DeprecationWarning(
-    PipDeprecationWarning, PendingDeprecationWarning
-):
+class RemovedInPip10Warning(PipDeprecationWarning, Pending):
+    pass
+
+
+class Python26DeprecationWarning(PipDeprecationWarning, Pending):
     pass
 
 
@@ -53,15 +55,15 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
             # want it to appear as if someone typed this entire message out.
             log_message = "DEPRECATION: %s" % message
 
-            # Things that are DeprecationWarnings will be removed in the very
-            # next version of pip. We want these to be more obvious so we
-            # use the ERROR logging level while the PendingDeprecationWarnings
-            # are still have at least 2 versions to go until they are removed
-            # so they can just be warnings.
-            if issubclass(category, DeprecationWarning):
-                logger.error(log_message)
-            else:
+            # PipDeprecationWarnings that are Pending still have at least 2
+            # versions to go until they are removed so they can just be
+            # warnings.  Otherwise, they will be removed in the very next
+            # version of pip. We want these to be more obvious so we use the
+            # ERROR logging level.
+            if issubclass(category, Pending):
                 logger.warning(log_message)
+            else:
+                logger.error(log_message)
         else:
             _warnings_showwarning(
                 message, category, filename, lineno, file, line,

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -220,8 +220,12 @@ def test_nowheel_user_with_prefix_in_pydistutils_cfg(script, data, virtualenv):
             prefix=%s""" % script.scratch_path))
 
     result = script.pip('install', '--no-use-wheel', '--user', '--no-index',
-                        '-f', data.find_links, 'requiresupper')
+                        '-f', data.find_links, 'requiresupper',
+                        expect_stderr=True)
     assert 'installed requiresupper' in result.stdout
+    assert ('DEPRECATION: --no-use-wheel is deprecated and will be removed '
+            'in the future.  Please use --no-binary :all: instead.\n'
+            ) in result.stderr
 
 
 def test_install_option_in_requirements_file(script, data, virtualenv):

--- a/tests/functional/test_warning.py
+++ b/tests/functional/test_warning.py
@@ -1,0 +1,36 @@
+import pytest
+
+PY26_WARNING = "Python 2.6 is no longer supported"
+
+
+@pytest.mark.skipif("sys.version_info >= (2,7)")
+def test_python26_options(script):
+    result = script.run(
+        'python', '-m', 'pip.__main__', 'list', expect_stderr=True,
+    )
+    assert PY26_WARNING in result.stderr
+    result = script.run('python', '-W', 'ignore', '-m', 'pip.__main__', 'list')
+    assert result.stderr == ''
+
+
+@pytest.mark.skipif("sys.version_info < (2,7)")
+def test_environ(script, tmpdir):
+    """$PYTHONWARNINGS was added in python2.7"""
+    demo = tmpdir.join('warnings_demo.py')
+    demo.write('''
+from pip.utils import deprecation
+deprecation.install_warning_logger()
+
+from logging import basicConfig
+basicConfig()
+
+from warnings import warn
+warn("deprecated!", deprecation.PipDeprecationWarning)
+''')
+
+    result = script.run('python', demo, expect_stderr=True)
+    assert result.stderr == 'ERROR:pip.deprecations:DEPRECATION: deprecated!\n'
+
+    script.environ['PYTHONWARNINGS'] = 'ignore'
+    result = script.run('python', demo)
+    assert result.stderr == ''


### PR DESCRIPTION
Before:

```
$ python2.6 -W ignore -m pip.__main__ list |& head
DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6
adns-python (1.2.1)
argparse (1.1)
Babel (0.9.4)
boto (2.34.0)
bounce-studio (3.7.0.570)
bpython (0.9.5.2)
buildbot (0.8.3-yelp6)
buildbot-slave (0.8.3-yelp6)
catbox (1.7.0)
```

After: (note warning is correctly ignored)
```
$ python2.6 -W ignore -m pip.__main__ list |& head
adns-python (1.2.1)
argparse (1.1)
Babel (0.9.4)
boto (2.34.0)
bounce-studio (3.7.0.570)
bpython (0.9.5.2)
buildbot (0.8.3-yelp6)
buildbot-slave (0.8.3-yelp6)
catbox (1.7.0)
Chameleon (2.10)
```

Implementation:

Default warning filters should be *appended* to the filter chain, to allow filters added by users via -W (et. al.) to have a chance to run. This has a problem when the Warnings are derived from DeprecationWarning. The docs state that the default behavior for DeprecationWarning is ignore. Appending to the filter chain won't change this. Since this isn't the desired behavior for PipDeprecationWarning, I believe it's incorrect to derive from this warning, albeit the names are similar.

Changing PipDeprecationWarning to derive directly from Warning allows the appended rule to be the default behavior, while also allowing rules prepended by users to have effect.

Testing:

I really can't see where a test for this would fit into the current test suite. Suggestions are very welcome. I should assert that:

1. The default behavior for PipDeprecation is to print a red error.
2. The behavior of (PipDeprecation, Pending) is to print a yellow warning.
2. Using -W (or PYTHONWARNINGS or similar) can change the behavior to ignore, or error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3455)
<!-- Reviewable:end -->
