### PR TITLE
Fix example package name in user_guide.rst

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -478,7 +478,7 @@ satisfy the new parent requirements.
 E.g. supposing:
 
 * `SomePackage-1.0` requires `AnotherPackage>=1.0`
-* `SomePackage-2.0` requires `AnotherPackage>=1.0` and `OneMorePoject==1.0`
+* `SomePackage-2.0` requires `AnotherPackage>=1.0` and `OneMorePackage==1.0`
 * `SomePackage-1.0` and `AnotherPackage-1.0` are currently installed
 * `SomePackage-2.0` and `AnotherPackage-2.0` are the latest versions available on PyPI.
 


### PR DESCRIPTION
Make it consistent with the next occurrence:
```
The 2nd line will fill in new dependencies like `OneMorePackage`.
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3456)
<!-- Reviewable:end -->
