### PR TITLE
updated distlib to 0.2.2

### DIFF
--- a/pip/_vendor/distlib/__init__.py
+++ b/pip/_vendor/distlib/__init__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2012-2014 Vinay Sajip.
+# Copyright (C) 2012-2016 Vinay Sajip.
 # Licensed to the Python Software Foundation under a contributor agreement.
 # See LICENSE.txt and CONTRIBUTORS.txt.
 #
 import logging
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 class DistlibException(Exception):
     pass

--- a/pip/_vendor/distlib/compat.py
+++ b/pip/_vendor/distlib/compat.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2013-2014 Vinay Sajip.
+# Copyright (C) 2013-2016 Vinay Sajip.
 # Licensed to the Python Software Foundation under a contributor agreement.
 # See LICENSE.txt and CONTRIBUTORS.txt.
 #

--- a/pip/_vendor/distlib/locators.py
+++ b/pip/_vendor/distlib/locators.py
@@ -14,7 +14,7 @@ import posixpath
 import re
 try:
     import threading
-except ImportError:
+except ImportError:  # pragma: no cover
     import dummy_threading as threading
 import zlib
 
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 HASHER_HASH = re.compile('^(\w+)=([a-f0-9]+)')
 CHARSET = re.compile(r';\s*charset\s*=\s*(.*)\s*$', re.I)
 HTML_CONTENT_TYPE = re.compile('text/html|application/x(ht)?ml')
-DEFAULT_INDEX = 'http://python.org/pypi'
+DEFAULT_INDEX = 'https://pypi.python.org/pypi'
 
 def get_all_distribution_names(url=None):
     """
@@ -354,7 +354,7 @@ class Locator(object):
                         else:
                             logger.debug('skipping pre-release '
                                          'version %s of %s', k, matcher.name)
-                except Exception:
+                except Exception:  # pragma: no cover
                     logger.warning('error matching %s with %r', matcher, k)
                     pass # slist.append(k)
             if len(slist) > 1:
@@ -763,18 +763,18 @@ class SimpleScrapingLocator(Locator):
                             encoding = m.group(1)
                         try:
                             data = data.decode(encoding)
-                        except UnicodeError:
+                        except UnicodeError:  # pragma: no cover
                             data = data.decode('latin-1')    # fallback
                         result = Page(data, final_url)
                         self._page_cache[final_url] = result
                 except HTTPError as e:
                     if e.code != 404:
                         logger.exception('Fetch failed: %s: %s', url, e)
-                except URLError as e:
+                except URLError as e:  # pragma: no cover
                     logger.exception('Fetch failed: %s: %s', url, e)
                     with self._lock:
                         self._bad_hosts.add(host)
-                except Exception as e:
+                except Exception as e:  # pragma: no cover
                     logger.exception('Fetch failed: %s: %s', url, e)
                 finally:
                     self._page_cache[url] = result   # even if None (failure)
@@ -812,7 +812,7 @@ class DirectoryLocator(Locator):
         self.recursive = kwargs.pop('recursive', True)
         super(DirectoryLocator, self).__init__(**kwargs)
         path = os.path.abspath(path)
-        if not os.path.isdir(path):
+        if not os.path.isdir(path):  # pragma: no cover
             raise DistlibException('Not a directory: %r' % path)
         self.base_dir = path
 
@@ -1083,7 +1083,7 @@ class DependencyFinder(object):
         """
         try:
             matcher = self.scheme.matcher(reqt)
-        except UnsupportedVersionError:
+        except UnsupportedVersionError:  # pragma: no cover
             # XXX compat-mode if cannot read the version
             name = reqt.split()[0]
             matcher = self.scheme.matcher(name)

--- a/pip/_vendor/distlib/metadata.py
+++ b/pip/_vendor/distlib/metadata.py
@@ -50,7 +50,8 @@ PKG_INFO_ENCODING = 'utf-8'
 # to 1.2 once PEP 345 is supported everywhere
 PKG_INFO_PREFERRED_VERSION = '1.1'
 
-_LINE_PREFIX = re.compile('\n       \|')
+_LINE_PREFIX_1_2 = re.compile('\n       \|')
+_LINE_PREFIX_PRE_1_2 = re.compile('\n        ')
 _241_FIELDS = ('Metadata-Version', 'Name', 'Version', 'Platform',
                'Summary', 'Description',
                'Keywords', 'Home-page', 'Author', 'Author-email',
@@ -295,7 +296,10 @@ class LegacyMetadata(object):
         return 'UNKNOWN'
 
     def _remove_line_prefix(self, value):
-        return _LINE_PREFIX.sub('\n', value)
+        if self.metadata_version in ('1.0', '1.1'):
+            return _LINE_PREFIX_PRE_1_2.sub('\n', value)
+        else:
+            return _LINE_PREFIX_1_2.sub('\n', value)
 
     def __getattr__(self, name):
         if name in _ATTR2FIELD:
@@ -374,7 +378,10 @@ class LegacyMetadata(object):
                 continue
             if field not in _LISTFIELDS:
                 if field == 'Description':
-                    values = values.replace('\n', '\n       |')
+                    if self.metadata_version in ('1.0', '1.1'):
+                        values = values.replace('\n', '\n        ')
+                    else:
+                        values = values.replace('\n', '\n       |')
                 values = [values]
 
             if field in _LISTTUPLEFIELDS:
@@ -548,7 +555,7 @@ class LegacyMetadata(object):
             ('description', 'Description'),
             ('keywords', 'Keywords'),
             ('platform', 'Platform'),
-            ('classifier', 'Classifier'),
+            ('classifiers', 'Classifier'),
             ('download_url', 'Download-URL'),
         )
 
@@ -617,6 +624,7 @@ class LegacyMetadata(object):
 
 
 METADATA_FILENAME = 'pydist.json'
+WHEEL_METADATA_FILENAME = 'metadata.json'
 
 
 class Metadata(object):

--- a/pip/_vendor/distlib/resources.py
+++ b/pip/_vendor/distlib/resources.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2013 Vinay Sajip.
+# Copyright (C) 2013-2016 Vinay Sajip.
 # Licensed to the Python Software Foundation under a contributor agreement.
 # See LICENSE.txt and CONTRIBUTORS.txt.
 #

--- a/pip/_vendor/distlib/version.py
+++ b/pip/_vendor/distlib/version.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2012-2014 The Python Software Foundation.
+# Copyright (C) 2012-2016 The Python Software Foundation.
 # See LICENSE.txt and CONTRIBUTORS.txt.
 #
 """
-Implementation of a flexible versioning scheme providing support for PEP-386,
-distribute-compatible and semantic versioning.
+Implementation of a flexible versioning scheme providing support for PEP-440,
+setuptools-compatible and semantic versioning.
 """
 
 import logging

--- a/pip/_vendor/distlib/wheel.py
+++ b/pip/_vendor/distlib/wheel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2013-2014 Vinay Sajip.
+# Copyright (C) 2013-2016 Vinay Sajip.
 # Licensed to the Python Software Foundation under a contributor agreement.
 # See LICENSE.txt and CONTRIBUTORS.txt.
 #

--- a/pip/_vendor/vendor.txt
+++ b/pip/_vendor/vendor.txt
@@ -1,4 +1,4 @@
-distlib==0.2.1
+distlib==0.2.2
 html5lib==1.0b8
 six==1.10.0
 colorama==0.3.6


### PR DESCRIPTION
This fixes an issue with tox/virtualenv/pip where the pip and wheel
shebang lines were wrapped with a quote " that prevents the command
from executing.

https://bitbucket.org/vinay.sajip/distlib/src/66e48052714fc7060999c9b5bea12cf59edeb3b7/distlib/scripts.py?at=default&fileviewer=file-view-default#scripts.py-66

I confirmed that with the updated distlib I was able to create a
virtualenv, and then install the updated `pip` into it.

Pip is extremely hard to test due to multiple independent code paths for installation (pip and setuptools) along with pip's mechanism for attempting to pull from the network. 

setuptools has a similar bug where it has a bare shebang line that also breaks installed scripts by *not* prefixing `/usr/bin/env` infront of calls to the jython launcher script.

```
virtualenv --no-wheel --no-pip --no-setuptools --python=jython jython.env
jython -c 'import sys, pip; sys.exit(pip.main(["install", "--ignore-installed"] + sys.argv[1:]))' pip
```

```
$ pip list
decorator (4.0.9)
ipython (4.1.1)
ipython-genutils (0.1.0)
path.py (8.1.2)
pexpect (4.0.1)
pickleshare (0.6)
pip (8.0.2)
ptyprocess (0.5.1)
py (1.4.31)
pytest (2.8.7)
requests (2.9.1)
setuptools (20.0)
simplegeneric (0.8.1)
simplejson (3.8.1)
six (1.10.0)
traitlets (4.1.0)
wheel (0.29.0)
```

Aside: The process for tracking and updating _vendor libs should be streamlined.
The Makefile blows away modified code, making it a manual process to update
vendored libs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3468)
<!-- Reviewable:end -->
