### PR TITLE
Add a warning about order of processing requirements.

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -42,7 +42,8 @@ installed using :ref:`pip install` like so:
 Details on the format of the files are here: :ref:`Requirements File Format`.
 
 Logically, a Requirements file is just a list of :ref:`pip install` arguments
-placed in a file.
+placed in a file. Note that you should not rely on the items in the file being
+installed by pip in any particular order.
 
 In practice, there are 4 common uses of Requirements files:
 


### PR DESCRIPTION
As per https://github.com/pypa/pip/issues/3480#issuecomment-183010917 there is no guarantee over the order in which items in a requirements.txt file might be installed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3481)
<!-- Reviewable:end -->
