### PR TITLE
Drop the --pre option when installing environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,10 @@ setenv =
     LC_CTYPE = en_US.UTF-8
 deps = -r{toxinidir}/dev-requirements.txt
 commands = py.test --timeout 300 []
-install_command = python -m pip install --pre {opts} {packages}
+install_command = python -m pip install {opts} {packages}
 
 [testenv:py26]
-install_command = pip install --pre {opts} {packages}
+install_command = pip install {opts} {packages}
 
 [testenv:docs]
 deps = sphinx


### PR DESCRIPTION
It currently causes our docs build to install sphinx==1.4a1 and to crash

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3490)
<!-- Reviewable:end -->
