### PR TITLE
Fix broken PyPA Code of Conduct link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,4 +31,4 @@ Code of Conduct
 Everyone interacting in the pip project's codebases, issue trackers, chat
 rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 
-.. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/
+.. _PyPA Code of Conduct: http://pypaio.readthedocs.org/en/latest/code-of-conduct/


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3493)
<!-- Reviewable:end -->
