### PR TITLE
Deprecate _build_req_from_url

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -38,7 +38,7 @@ from pip.utils import (
 )
 
 from pip.utils.hashes import Hashes
-from pip.utils.deprecation import RemovedInPip10Warning
+from pip.utils.deprecation import RemovedInPip9Warning, RemovedInPip10Warning
 from pip.utils.logging import indent_log
 from pip.utils.setuptools_build import SETUPTOOLS_SHIM
 from pip.utils.ui import open_spinner
@@ -1094,6 +1094,12 @@ def _build_req_from_url(url):
         req = parts[-3]
     elif parts[-1] == 'trunk':
         req = parts[-2]
+    if req:
+        warnings.warn(
+            'Sniffing the requirement name from the url is deprecated and '
+            'will be removed in the future. Please specify an #egg segment '
+            'instead.', RemovedInPip9Warning,
+            stacklevel=2)
     return req
 
 


### PR DESCRIPTION
This should of very little use (basically guessing the requirement name from the url) and currently only works on editable requirements.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3495)
<!-- Reviewable:end -->
