### PR TITLE
Correct package hash line suggestions for URL requirements

### DIFF
--- a/pip/exceptions.py
+++ b/pip/exceptions.py
@@ -160,13 +160,16 @@ class HashMissing(HashError):
     def body(self):
         from pip.utils.hashes import FAVORITE_HASH  # Dodge circular import.
 
-        package_name = (self.req.req if self.req and
-                        # In case someone feeds something
-                        # downright stupid to
-                        # InstallRequirement's constructor:
-                        getattr(self.req, 'req', None)
-                        else 'unknown package')
-        return '    %s --hash=%s:%s' % (package_name,
+        package = None
+        if self.req:
+            # In the case of URL-based requirements, display the original URL
+            # seen in the requirements file rather than the package name,
+            # so the output can be directly copied into the requirements file.
+            package = (self.req.original_link if self.req.original_link
+                       # In case someone feeds something downright stupid
+                       # to InstallRequirement's constructor.
+                       else getattr(self.req, 'req', None))
+        return '    %s --hash=%s:%s' % (package or 'unknown package',
                                         FAVORITE_HASH,
                                         self.gotten_hash)
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -93,6 +93,12 @@ class TestRequirementSet(object):
             list(process_line('https://pypi.python.org/packages/source/m/more-'
                               'itertools/more-itertools-1.0.tar.gz#md5=b21850c'
                               '3cfa7efbb70fd662ab5413bdd', 'file', 3))[0])
+        # The error text should list this as a URL and not `peep==3.1.1`:
+        reqset.add_requirement(
+            list(process_line('https://pypi.python.org/packages/source/p/peep/'
+                              'peep-3.1.1.tar.gz',
+                              'file',
+                              4))[0])
         finder = PackageFinder([],
                                ['https://pypi.python.org/simple'],
                                session=PipSession())
@@ -100,6 +106,8 @@ class TestRequirementSet(object):
             HashErrors,
             r'Hashes are required in --require-hashes mode, but they are '
             r'missing .*\n'
+            r'    https://pypi\.python\.org/packages/source/p/peep/peep'
+            r'-3\.1\.1\.tar\.gz --hash=sha256:[0-9a-f]+\n'
             r'    blessings==1.0 --hash=sha256:[0-9a-f]+\n'
             r'THESE PACKAGES DO NOT MATCH THE HASHES.*\n'
             r'    tracefront==0.1 .*:\n'


### PR DESCRIPTION
When require hashes mode is enabled, if any packages defined in the requirements file are missing a hash, installation fails with a message suggesting the appropriate lines that should be copied into the requirements file.

This worked fine for requirement specifiers such as `requests==2.9.1`, however for packages specified by URL, the resultant output did not match that originally in the requirements file.

For example a requirements file containing:
```
--require-hashes
https://github.com/benoitc/gunicorn/archive/19.4.5.zip
https://github.com/kennethreitz/requests/archive/v2.9.1.zip#egg=requests==2.9.1
```

Would result in:
```
Hashes are required in ...
    unknown package --hash=sha256:399347c0a7272fb70b45d5840027c372f...
    requests==2.9.1 --hash=sha256:89839b1698243e232780d1fc808ae8730...
```

Now the original URL line is correctly shown:
```
Hashes are required in ...
    https://github.com/benoitc/gunicorn/archive/19.4.5.zip --hash=...
    https://github.com/kennethreitz/requests/archive/v2.9.1.zip#egg=requests==2.9.1 --hash=...
```

Fixes #3362.

CC @erikrose

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3496)
<!-- Reviewable:end -->
