### PR TITLE
fixes #3521

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 **8.1.0 (unreleased)**
 
+* Fixed an issue where ``call_subprocess`` would crash trying to print debug
+  data on child process failure (:issue:`3521`, :pull:`3522`).
+
 * Exclude the wheel package from the `pip freeze` output (like pip and setuptools).
   :issue:`2989`.
 

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -703,15 +703,15 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
             spinner.finish("done")
     if proc.returncode:
         if on_returncode == 'raise':
-            if logger.getEffectiveLevel() > std_logging.DEBUG:
-                if not show_stdout:
-                    logger.info(
-                        'Complete output from command %s:', command_desc,
-                    )
-                    logger.info(
-                        ''.join(all_output) +
-                        '\n----------------------------------------'
-                    )
+            if (logger.getEffectiveLevel() > std_logging.DEBUG and
+                    not show_stdout):
+                logger.info(
+                    'Complete output from command %s:', command_desc,
+                )
+                logger.info(
+                    ''.join(all_output) +
+                    '\n----------------------------------------'
+                )
             raise InstallationError(
                 'Command "%s" failed with error code %s in %s'
                 % (command_desc, proc.returncode, cwd))

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -704,13 +704,14 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
     if proc.returncode:
         if on_returncode == 'raise':
             if logger.getEffectiveLevel() > std_logging.DEBUG:
-                logger.info(
-                    'Complete output from command %s:', command_desc,
-                )
-                logger.info(
-                    ''.join(all_output) +
-                    '\n----------------------------------------'
-                )
+                if not show_stdout:
+                    logger.info(
+                        'Complete output from command %s:', command_desc,
+                    )
+                    logger.info(
+                        ''.join(all_output) +
+                        '\n----------------------------------------'
+                    )
             raise InstallationError(
                 'Command "%s" failed with error code %s in %s'
                 % (command_desc, proc.returncode, cwd))


### PR DESCRIPTION
https://github.com/pypa/pip/issues/3521

Only print `all_output` when process' stdout is not already printed to console.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3522)
<!-- Reviewable:end -->
