### PR TITLE
Correct compatible release clause example

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -191,7 +191,7 @@ Use ``pip install -r example-requirements.txt`` to install::
     docopt == 0.6.1             # Version Matching. Must be version 0.6.1
     keyring >= 4.1.1            # Minimum version 4.1.1
     coverage != 3.5             # Version Exclusion. Anything except version 3.5
-    Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.1.*
+    Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.*
     #
     ###### Refer to other requirements files ######
     -r other-requirements.txt


### PR DESCRIPTION
According to PEP 0440, ~= V.N is the same as >= V.N, == V.* , not >= V.N, == V.N.*

https://www.python.org/dev/peps/pep-0440/#compatible-release

Thank you.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3529)
<!-- Reviewable:end -->
