### PR TITLE
Give markers chance to remove incompat wheel links

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -209,11 +209,6 @@ class InstallRequirement(object):
             # wheel file
             if link.is_wheel:
                 wheel = Wheel(link.filename)  # can raise InvalidWheelFilename
-                if not wheel.supported():
-                    raise UnsupportedWheel(
-                        "%s is not a supported wheel on this platform." %
-                        wheel.filename
-                    )
                 req = "%s==%s" % (wheel.name, wheel.version)
             else:
                 # set the req to the egg fragment.  when it's not there, this

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -457,3 +457,16 @@ def test_install_distribution_union_conflicting_extras(script, data):
                                       expect_error=True)
     assert 'installed' not in result.stdout
     assert "Conflict" in result.stderr
+
+def test_install_unsupported_wheel_with_marker(script, data):
+    script.scratch_path.join("with-marker.txt").write(textwrap.dedent("""\
+        https://github.com/a/b/c/asdf-1.5.2-cp27-none-xyz.whl; sys_platform == "xyz"
+        """))
+    result = script.pip(
+        'install', '-r', script.scratch_path / 'with-marker.txt',
+        expect_error=False,
+        expect_stderr=True,
+    )
+    assert ("Ignoring asdf: markers u'sys_platform == \"xyz\"' don't " +
+        "match your environment" in result.stderr)
+    assert len(result.files_created) == 0


### PR DESCRIPTION
`pip install -r reqs.txt` was failing when the requirements file includes
an unsupported wheel, regardless of whether it is conditionally removed
by a marker. This patch fixes that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3556)
<!-- Reviewable:end -->
