### PR TITLE
Give markers chance to remove incompat wheel links

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -209,11 +209,6 @@ class InstallRequirement(object):
             # wheel file
             if link.is_wheel:
                 wheel = Wheel(link.filename)  # can raise InvalidWheelFilename
-                if not wheel.supported():
-                    raise UnsupportedWheel(
-                        "%s is not a supported wheel on this platform." %
-                        wheel.filename
-                    )
                 req = "%s==%s" % (wheel.name, wheel.version)
             else:
                 # set the req to the egg fragment.  when it's not there, this

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -21,7 +21,7 @@ from pip.utils import (
 from pip.utils.hashes import MissingHashes
 from pip.utils.logging import indent_log
 from pip.vcs import vcs
-
+from pip.wheel import Wheel
 
 logger = logging.getLogger(__name__)
 
@@ -226,6 +226,16 @@ class RequirementSet(object):
                            "environment", install_req.name,
                            install_req.markers)
             return []
+
+        # This check has to come after we filter requirements with the
+        # environment markers.
+        if install_req.link and install_req.link.is_wheel:
+            wheel = Wheel(install_req.link.filename)
+            if not wheel.supported():
+                raise InstallationError(
+                    "%s is not a supported wheel on this platform." %
+                    wheel.filename
+                )
 
         install_req.as_egg = self.as_egg
         install_req.use_user_site = self.use_user_site

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -300,6 +300,20 @@ def test_egg_info_data(file_contents, expected):
 
 
 class TestInstallRequirement(object):
+    def setup(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def teardown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def basic_reqset(self, **kwargs):
+        return RequirementSet(
+            build_dir=os.path.join(self.tempdir, 'build'),
+            src_dir=os.path.join(self.tempdir, 'src'),
+            download_dir=None,
+            session=PipSession(),
+            **kwargs
+        )
 
     def test_url_with_query(self):
         """InstallRequirement should strip the fragment, but not the query."""
@@ -308,11 +322,29 @@ class TestInstallRequirement(object):
         req = InstallRequirement.from_line(url + fragment)
         assert req.link.url == url + fragment, req.link
 
-    def test_unsupported_wheel_requirement_raises(self):
-        with pytest.raises(UnsupportedWheel):
-            InstallRequirement.from_line(
-                'peppercorn-0.4-py2.py3-bogus-any.whl',
-            )
+    def test_unsupported_wheel_link_requirement_raises(self):
+        reqset = self.basic_reqset()
+        req = InstallRequirement.from_line(
+            'https://whatever.com/peppercorn-0.4-py2.py3-bogus-any.whl',
+        )
+        assert req.link is not None
+        assert req.link.is_wheel is True
+        assert req.link.scheme == "https"
+
+        with pytest.raises(InstallationError):
+            reqset.add_requirement(req)
+
+    def test_unsupported_wheel_local_file_requirement_raises(self, data):
+        reqset = self.basic_reqset()
+        req = InstallRequirement.from_line(
+            data.packages.join('simple.dist-0.1-py1-none-invalid.whl'),
+        )
+        assert req.link is not None
+        assert req.link.is_wheel is True
+        assert req.link.scheme == "file"
+
+        with pytest.raises(InstallationError):
+            reqset.add_requirement(req)
 
     def test_installed_version_not_installed(self):
         req = InstallRequirement.from_line('simple-0.1-py2.py3-none-any.whl')


### PR DESCRIPTION
`pip install -r reqs.txt` was failing when the requirements file includes
an unsupported wheel, regardless of whether it is conditionally removed
by a marker. This patch fixes that issue.

Additionally, this patch makes pip check local file wheels for
compatibility. Previously, a requirements file could include a path
to a valid wheel for any platform and pip would happily install it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3558)
<!-- Reviewable:end -->
