### PR TITLE
Added missing space

### DIFF
--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -247,7 +247,7 @@ def find_links():
         default=[],
         metavar='url',
         help="If a url or path to an html file, then parse for links to "
-             "archives. If a local path or file:// url that's a directory,"
+             "archives. If a local path or file:// url that's a directory, "
              "then look for archives in the directory listing.")
 
 


### PR DESCRIPTION
Added a space missing in multi-line help text string. Replaces #3567

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3570)
<!-- Reviewable:end -->
