### PR TITLE
Add shorthand -i for index flag in search subcommand

### DIFF
--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -28,7 +28,7 @@ class SearchCommand(Command):
     def __init__(self, *args, **kw):
         super(SearchCommand, self).__init__(*args, **kw)
         self.cmd_opts.add_option(
-            '--index',
+            '-i', '--index',
             dest='index',
             metavar='URL',
             default=PyPI.pypi_url,


### PR DESCRIPTION
The `install` subcommand has a shorthand flag `'-i` but I noticed `search` does not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3579)
<!-- Reviewable:end -->
