### PR TITLE
Normalize file URLs

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -980,6 +980,16 @@ class Link(object):
 
         return True
 
+    def normalize(self):
+        parsed = urllib_parse.urlsplit(self.url)
+        if parsed.scheme == 'file':
+            path = urllib_request.url2pathname(parsed.path)
+            path = normalize_path(path)
+            path = urllib_request.pathname2url(path)
+            self.url = urllib_parse.urlunsplit(
+                (parsed.scheme, parsed.netloc,
+                 path, parsed.query, parsed.fragment))
+
 
 FormatControl = namedtuple('FormatControl', 'no_binary only_binary')
 """This object has two fields, no_binary and only_binary.

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -202,10 +202,8 @@ class InstallRequirement(object):
 
         # it's a local file, dir, or url
         if link:
-            # Handle relative file URLs
-            if link.scheme == 'file' and re.search(r'\.\./', link.url):
-                link = Link(
-                    path_to_url(os.path.normpath(os.path.abspath(link.path))))
+            # Normalize URLs
+            link.normalize()
             # wheel file
             if link.is_wheel:
                 wheel = Wheel(link.filename)  # can raise InvalidWheelFilename

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -337,6 +337,29 @@ def test_constrained_to_url_install_same_url(script, data):
     assert 'Running setup.py install for singlemodule' in result.stdout
 
 
+def test_constraints_constrain_to_local_dotdot(script, data):
+    to_install = data.src.join("singlemodule/subdir/..")
+    script.scratch_path.join("constraints.txt").write(
+        "file://%s#egg=singlemodule" % to_install
+    )
+    result = script.pip(
+        'install', '--no-index', '-f', data.find_links, '-c',
+        script.scratch_path / 'constraints.txt', to_install)
+    assert 'Running setup.py install for singlemodule' in result.stdout
+
+
+def test_constraints_constrain_to_local_extraslash(script, data):
+    to_install = data.src.join("singlemodule")
+    to_install = '//'.join(to_install.rsplit('/', 1))
+    script.scratch_path.join("constraints.txt").write(
+        "file://%s#egg=singlemodule" % to_install
+    )
+    result = script.pip(
+        'install', '--no-index', '-f', data.find_links, '-c',
+        script.scratch_path / 'constraints.txt', to_install)
+    assert 'Running setup.py install for singlemodule' in result.stdout
+
+
 @pytest.mark.network
 def test_double_install_spurious_hash_mismatch(script, tmpdir):
     """Make sure installing the same hashed sdist twice doesn't throw hash


### PR DESCRIPTION
It seems pip distinguishes paths with .. or extra / for constraints.
For example, the following directories are considered different.

    /path/to/dir
    /path/to//dir
    /path/to/dir/subdir/..

It can lead "Could not satisfy constraints for 'xxxx':
installation from path or url cannot be constrained to a version"
error, whose cause is not obvious to users. [1]

This commit tries to normalize the given directory name to avoid
the error.

[1] https://bugs.launchpad.net/devstack/+bug/1542545

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3582)
<!-- Reviewable:end -->
