### PR TITLE
Root logger should use debug level

### DIFF
--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -117,6 +117,12 @@ class Command(object):
         else:
             level = "INFO"
 
+        # The root logger should match the "console" level *unless* we
+        # specified "--log" to send debug logs to a file.
+        root_level = level
+        if options.log:
+            root_level = "DEBUG"
+
         logging_dictConfig({
             "version": 1,
             "disable_existing_loggers": False,
@@ -155,7 +161,7 @@ class Command(object):
                 },
             },
             "root": {
-                "level": level,
+                "level": root_level,
                 "handlers": list(filter(None, [
                     "console",
                     "console_errors",

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -846,6 +846,18 @@ def test_install_subprocess_output_handling(script, data):
     assert 1 == result.stdout.count("I DIE, I DIE")
 
 
+def test_install_log(script, data, tmpdir):
+    # test that verbose logs go to "--log" file
+    f = tmpdir.join("log.txt")
+    args = ['--log=%s' % f,
+            'install', data.src.join('chattymodule')]
+    result = script.pip(*args)
+    assert 0 == result.stdout.count("HELLO FROM CHATTYMODULE")
+    with open(f, 'r') as fp:
+        # one from egg_info, one from install
+        assert 2 == fp.read().count("HELLO FROM CHATTYMODULE")
+
+
 def test_install_topological_sort(script, data):
     args = ['install', 'TopoRequires4', '-f', data.packages]
     res = str(script.pip(*args, expect_error=False))


### PR DESCRIPTION
We want the root logger to output debug level logs when we have specified "--log".  The log-file handler then sends this to our file, and the other handlers (console) filter out at their appropriate level.

This restores the intended behaviour of "--log" argument, which is supposed to output verbose logs to a file always.

A test-case is added

Closes: #3351

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3586)
<!-- Reviewable:end -->
