### PR TITLE
Fix manylinux1 have_compatible_glibc for rare platform

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -184,7 +184,11 @@ def have_compatible_glibc(major, minimum_minor):
         version_str = version_str.decode("ascii")
 
     # Parse string and check against requested version.
-    version = [int(piece) for piece in version_str.split(".")]
+    try:
+        version = [int(piece) for piece in version_str.split(".")]
+    except ValueError:
+        return False
+    
     if len(version) < 2:
         warnings.warn("Expected glibc version with 2 components major.minor,"
                       " got: %s" % version_str, RuntimeWarning)


### PR DESCRIPTION
This is a fix for #3588. If the value returned by glibc's `gnu_get_libc_version` doesn't follow the expected pattern, I think we should probably just assume that the platform isn't manylinux compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3589)
<!-- Reviewable:end -->
