### PR TITLE
Make have_compatible_glibc more robust against unusual version strings

### DIFF
--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from mock import patch
 from pip import pep425tags
 
@@ -178,3 +179,16 @@ class TestManylinux1Tags(object):
             assert not pep425tags.check_glibc_version(two_twenty, 2, 21)
             assert not pep425tags.check_glibc_version(two_twenty, 3, 15)
             assert not pep425tags.check_glibc_version(two_twenty, 1, 15)
+
+        # For strings that we just can't parse at all, we should warn and
+        # return false
+        for bad_string in ["asdf", "", "foo.bar"]:
+            with warnings.catch_warnings(record=True) as ws:
+                warnings.filterwarnings("always")
+                assert not pep425tags.check_glibc_version(bad_string, 2, 5)
+                for w in ws:
+                    if "Expected glibc version with" in str(w.message):
+                        break
+                else:
+                    # Didn't find the warning we were expecting
+                    assert False

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -159,3 +159,22 @@ class TestManylinux1Tags(object):
                 assert arches == ['manylinux1_x86_64', 'linux_x86_64', 'any']
             else:
                 assert arches == ['manylinux1_x86_64', 'linux_x86_64']
+
+    def test_manylinux1_check_glibc_version(self):
+        """
+        Test that the check_glibc_version function is robust against weird
+        glibc version strings.
+        """
+        for two_twenty in ["2.20",
+                           # used by "linaro glibc", see gh-3588
+                           "2.20-2014.11",
+                           # weird possibilities that I just made up
+                           "2.20+dev",
+                           "2.20-custom",
+                           "2.20.1",
+                           ]:
+            assert pep425tags.check_glibc_version(two_twenty, 2, 15)
+            assert pep425tags.check_glibc_version(two_twenty, 2, 20)
+            assert not pep425tags.check_glibc_version(two_twenty, 2, 21)
+            assert not pep425tags.check_glibc_version(two_twenty, 3, 15)
+            assert not pep425tags.check_glibc_version(two_twenty, 1, 15)


### PR DESCRIPTION
Downstream forks/redistributors of glibc apparently sometimes add junk
onto the end of the version number -- e.g. Linaro glibc might have a
version number like "2.20-2014.11". This makes the glibc version number
parsing code ignore the rest of the string after the minor version
number, to be robust against Linaro's current usage, as well as whatever
exciting new weirdnesses that other redistributors might come up with
in the future.

Fixes: gh-3588

Alternative to: #3589

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3590)
<!-- Reviewable:end -->
#