### PR TITLE
Fix crash on systems with uninitialized locale

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+**8.1.2 (unreleased)**
+
+* Fix a regression on systems with uninitialized locale (:issue:`3575`).
+
+
 **8.1.1 (2016-03-17)**
 
 * Fix regression with non-ascii requirement files on Python 2 and add support

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -212,7 +212,11 @@ def main(args=None):
 
     # Needed for locale.getpreferredencoding(False) to work
     # in pip.utils.encoding.auto_decode
-    locale.setlocale(locale.LC_ALL, '')
+    try:
+        locale.setlocale(locale.LC_ALL, '')
+    except locale.Error as e:
+        # setlocale can apparently crash if locale are uninitialized
+        logger.debug("Ignoring error %s when setting locale", e)
     command = commands_dict[cmd_name](isolated=check_isolated(cmd_args))
     return command.main(cmd_args)
 


### PR DESCRIPTION
locale.setlocale(locale.LC_ALL, '') apparently crashes in such case.
The raised exception can be safely ignored as locale loading is only
used to automatically detect the default encoding for requirements.txt
files.
Closes #3575

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3598)
<!-- Reviewable:end -->
