### PR TITLE
report successfully installed versions of requirements even if existi…

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -18,7 +18,7 @@ from pip.exceptions import (
     InstallationError, CommandError, PreviousBuildDirError,
 )
 from pip import cmdoptions
-from pip.utils import ensure_dir
+from pip.utils import ensure_dir, get_installed_version
 from pip.utils.build import BuildDirectory
 from pip.utils.deprecation import RemovedInPip10Warning
 from pip.utils.filesystem import check_path_owner
@@ -316,6 +316,12 @@ class InstallCommand(RequirementCommand):
                             root=options.root_path,
                             prefix=options.prefix_path,
                         )
+
+                        possible_lib_locations = get_lib_location_guesses(
+                            user=options.use_user_site,
+                            home=temp_target_dir,
+                            prefix=options.prefix_path
+                        )
                         reqs = sorted(
                             requirement_set.successfully_installed,
                             key=operator.attrgetter('name'))
@@ -323,9 +329,11 @@ class InstallCommand(RequirementCommand):
                         for req in reqs:
                             item = req.name
                             try:
-                                if hasattr(req, 'installed_version'):
-                                    if req.installed_version:
-                                        item += '-' + req.installed_version
+                                installed_version = get_installed_version(
+                                    req.name, possible_lib_locations
+                                )
+                                if installed_version:
+                                    item += '-' + installed_version
                             except Exception:
                                 pass
                             items.append(item)
@@ -384,3 +392,10 @@ class InstallCommand(RequirementCommand):
                 )
             shutil.rmtree(temp_target_dir)
         return requirement_set
+
+
+def get_lib_location_guesses(user=False, home=None, root=None, prefix=None):
+    scheme = distutils_scheme(
+        '', user=user, home=home, root=root, prefix=prefix
+    )
+    return [scheme['purelib'], scheme['platlib']]

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -320,7 +320,8 @@ class InstallCommand(RequirementCommand):
                         possible_lib_locations = get_lib_location_guesses(
                             user=options.use_user_site,
                             home=temp_target_dir,
-                            prefix=options.prefix_path
+                            prefix=options.prefix_path,
+                            isolated=options.isolated_mode,
                         )
                         reqs = sorted(
                             requirement_set.successfully_installed,
@@ -394,8 +395,6 @@ class InstallCommand(RequirementCommand):
         return requirement_set
 
 
-def get_lib_location_guesses(user=False, home=None, root=None, prefix=None):
-    scheme = distutils_scheme(
-        '', user=user, home=home, root=root, prefix=prefix
-    )
+def get_lib_location_guesses(*args, **kwargs):
+    scheme = distutils_scheme('', *args, **kwargs)
     return [scheme['purelib'], scheme['platlib']]

--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -838,14 +838,17 @@ class cached_property(object):
         return value
 
 
-def get_installed_version(dist_name):
+def get_installed_version(dist_name, lookup_dirs=None):
     """Get the installed version of dist_name avoiding pkg_resources cache"""
     # Create a requirement that we'll look for inside of setuptools.
     req = pkg_resources.Requirement.parse(dist_name)
 
     # We want to avoid having this cached, so we need to construct a new
     # working set each time.
-    working_set = pkg_resources.WorkingSet()
+    if lookup_dirs is None:
+        working_set = pkg_resources.WorkingSet()
+    else:
+        working_set = pkg_resources.WorkingSet(lookup_dirs)
 
     # Get the installed distribution from our working set
     dist = working_set.find(req)


### PR DESCRIPTION
…ng installations have been ignored

currently, the "Successfully installed ..." message of a pip install can report a wrong version when either the -I or the --target options are in use: when another installation of the package exists on sys.path and the new installation goes to a location not on sys.path or in a later position, the pre-existing version will be reported. The patch fixes this for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3612)
<!-- Reviewable:end -->
