### PR TITLE
Update installing.rst example proxy URI

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -70,7 +70,7 @@ Install to the user site [4]_::
 
 Install behind a proxy::
 
-  python get-pip.py --proxy="[user:passwd@]proxy.server:port"
+  python get-pip.py --proxy="http://[user:passwd@]proxy.server:port"
 
 
 Using Linux Package Managers


### PR DESCRIPTION
for Install behind a proxy added missing "http://" proxyScheme

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3631)
<!-- Reviewable:end -->
