### PR TITLE
Do not break built-in logging module when pip embedded in script

### DIFF
--- a/pip/utils/logging.py
+++ b/pip/utils/logging.py
@@ -31,7 +31,7 @@ def indent_log(num=2):
     A context manager which will cause the log output to be indented for any
     log messages emitted inside it.
     """
-    _log_state.indentation += num
+    _log_state.indentation = get_indentation() + num
     try:
         yield
     finally:


### PR DESCRIPTION
I got ``AttributeError`` when pip embedded in script and used with ``concurrent.futures.ThreadPoolExecutor``. Traceback:

```python
/Users/messense/workspace/bosondata/badwolf/lib/python2.7/site-packages/pip/index.pyc in find_all_candidates(self, project_name)
    398         for page in self._get_pages(url_locations, project_name):
    399             logger.debug('Analyzing links from page %s', page.url)
--> 400             with indent_log():
    401                 page_versions.extend(
    402                     self._package_versions(page.links, search)

/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.pyc in __enter__(self)
     15     def __enter__(self):
     16         try:
---> 17             return self.gen.next()
     18         except StopIteration:
     19             raise RuntimeError("generator didn't yield")

/Users/messense/workspace/bosondata/badwolf/lib/python2.7/site-packages/pip/utils/logging.pyc in indent_log(num)
     32     log messages emitted inside it.
     33     """
---> 34     _log_state.indentation += num
     35     try:
     36         yield

AttributeError: 'thread._local' object has no attribute 'indentation'
```

Ref #2553 #2977

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3632)
<!-- Reviewable:end -->
