### PR TITLE
Add warning if python classifiers do not match the running version

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+
+* Add warning when python version classifiers do not match the running version.
+
 **8.1.1 (2016-03-17)**
 
 * Fix regression with non-ascii requirement files on Python 2 and add support

--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -6,6 +6,7 @@ import os
 
 from pip.basecommand import Command
 from pip.status_codes import SUCCESS, ERROR
+from pip.utils.packaging import get_classifiers
 from pip._vendor import pkg_resources
 
 
@@ -102,15 +103,7 @@ def search_packages_info(query):
                     'home-page', 'author', 'author-email', 'license'):
             package[key] = pkg_info_dict.get(key)
 
-        # It looks like FeedParser can not deal with repeated headers
-        classifiers = []
-        for line in metadata.splitlines():
-            if not line:
-                break
-            # Classifier: License :: OSI Approved :: MIT License
-            if line.startswith('Classifier: '):
-                classifiers.append(line[len('Classifier: '):])
-        package['classifiers'] = classifiers
+        package['classifiers'] = get_classifiers(metadata)
 
         if file_list:
             package['files'] = sorted(file_list)

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -20,6 +20,7 @@ from pip.utils import (
     display_path, dist_in_usersite, ensure_dir, normalize_path)
 from pip.utils.hashes import MissingHashes
 from pip.utils.logging import indent_log
+from pip.utils.packaging import check_python_classifiers
 from pip.vcs import vcs
 
 
@@ -619,6 +620,7 @@ class RequirementSet(object):
             # # parse dependencies # #
             # ###################### #
             dist = abstract_dist.dist(finder)
+            check_python_classifiers(dist)
             more_reqs = []
 
             def add_req(subreq):

--- a/pip/utils/packaging.py
+++ b/pip/utils/packaging.py
@@ -1,0 +1,71 @@
+from __future__ import absolute_import
+
+import logging
+import sys
+
+from pip._vendor import pkg_resources
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_metadata(dist):
+    if (isinstance(dist, pkg_resources.DistInfoDistribution) and
+            dist.has_metadata('METADATA')):
+        return dist.get_metadata('METADATA')
+    elif dist.has_metadata('PKG-INFO'):
+        return dist.get_metadata('PKG-INFO')
+
+
+def get_classifiers(metadata):
+    # It looks like FeedParser can not deal with repeated headers
+    classifiers = []
+    for line in metadata.splitlines():
+        if not line:
+            break
+        # Classifier: License :: OSI Approved :: MIT License
+        if line.startswith('Classifier: '):
+            classifiers.append(line[len('Classifier: '):])
+    return classifiers
+
+
+def check_python_classifiers(dist):
+    classifiers = get_classifiers(get_metadata(dist))
+    # Catch:
+    # Programming Language :: Python :: 3.6
+    # but not:
+    # Programming Language :: Python :: Implementation :: PyPy
+    # TODO: deal with "Programming Language :: Python :: 2 :: Only"
+    supported_versions = [
+        # 34 == len('Programming Language :: Python :: ')
+        classifier[34:] for classifier in classifiers
+        if (
+            classifier.startswith('Programming Language :: Python :: ') and
+            '::' not in classifier[34:] and
+            classifier[34:35].isdigit()
+        )
+    ]
+    if not supported_versions:
+        # The package provides no information
+        return
+    major_versions, minor_versions = [], []
+    for version in supported_versions:
+        if '.' in version:
+            minor_versions.append(tuple(map(int, version.split('.'))))
+        else:
+            major_versions.append(int(version))
+    if major_versions and sys.version_info[0] not in major_versions:
+        logger.warning(
+            "%s is advertised as supporting %s but not Python %s",
+            dist.project_name,
+            ", ".join(["Python %s" % (version,)
+                       for version in major_versions]),
+            sys.version_info[0])
+    if (minor_versions and sys.version_info[0:2] not in minor_versions and
+            sys.version_info[0:2] < max(minor_versions)):
+        logger.warning(
+            "%s is advertised as supporting %s but not Python %s",
+            dist.project_name,
+            ", ".join(["Python %s" % ('.'.join(map(str, version)),)
+                       for version in minor_versions]),
+            '.'.join(map(str, sys.version_info[0:2])),)


### PR DESCRIPTION
I'm looking for feedback before starting to add tests :)

cc @pypa/pip-committers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3640)
<!-- Reviewable:end -->
