### PR TITLE
Column formatting for "pip list"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 **8.2.0 (unreleased)**
 
+* Added optional column formatting to ``pip list`` (:issue:`3651`).
+
 
 **8.1.2 (2016-05-10)**
 

--- a/docs/reference/pip_list.rst
+++ b/docs/reference/pip_list.rst
@@ -44,3 +44,35 @@ Examples
   $ pip list --outdated
   docutils (Current: 0.10 Latest: 0.11)
   Sphinx (Current: 1.2.1 Latest: 1.2.2)
+
+3) List installed packages with column formatting.
+
+ ::
+
+  $ pip list --columns
+  Package Version
+  ------- -------
+  docopt  0.6.2
+  idlex   1.13
+  jedi    0.9.0
+
+4) List outdated packages with column formatting.
+
+ ::
+
+  $ pip list -o --columns
+  Package    Version Latest Type
+  ---------- ------- ------ -----
+  retry      0.8.1   0.9.1  wheel
+  setuptools 20.6.7  21.0.0 wheel
+
+5) Do not use column formatting.
+
+ ::
+
+  $ pip list --no-columns
+  DEPRECATION: The --no-columns option will be removed in the future.
+  colorama (0.3.7)
+  docopt (0.6.2)
+  idlex (1.13)
+  jedi (0.9.0)

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -1,6 +1,9 @@
 import os
 import pytest
 
+WARN_NOCOL = ("DEPRECATION: The --no-columns option will be "
+              "removed in the future.")
+
 
 def test_list_command(script, data):
     """
@@ -16,6 +19,75 @@ def test_list_command(script, data):
     assert 'simple2 (3.0)' in result.stdout, str(result)
 
 
+def test_columns_flag(script, data):
+    """
+    Test the list command with the '--columns' option
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
+        'simple2==3.0',
+    )
+    result = script.pip('list', '--columns')
+    assert 'Package' in result.stdout, str(result)
+    assert 'Version' in result.stdout, str(result)
+    assert 'simple (1.0)' not in result.stdout, str(result)
+    assert 'simple     1.0' in result.stdout, str(result)
+    assert 'simple2    3.0' in result.stdout, str(result)
+
+
+def test_nocolumns_flag(script, data):
+    """
+    Test that --no-columns raises the deprecation warning and still outputs
+    the old-style formatting.
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
+        'simple2==3.0',
+    )
+    result = script.pip('list', '--no-columns', expect_stderr=True)
+    assert WARN_NOCOL in result.stderr, str(result)
+    assert 'simple (1.0)' in result.stdout, str(result)
+    assert 'simple2 (3.0)' in result.stdout, str(result)
+
+
+def test_columns_nocolumns(script, data):
+    """
+    Test that --no-columns has priority in --columns --no-columns.
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
+        'simple2==3.0',
+    )
+    result = script.pip(
+        'list', '--columns', '--no-columns',
+        expect_error=True,
+    )
+    assert WARN_NOCOL in result.stderr, str(result)
+    assert 'simple (1.0)' in result.stdout, str(result)
+    assert 'simple2 (3.0)' in result.stdout, str(result)
+    assert 'simple     1.0' not in result.stdout, str(result)
+    assert 'simple2    3.0' not in result.stdout, str(result)
+
+
+def test_nocolumns_columns(script, data):
+    """
+    Test that --columns has priority in --no-columns --columns.
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
+        'simple2==3.0',
+    )
+    result = script.pip(
+        'list', '--no-columns', '--columns',
+    )
+    assert 'Package' in result.stdout, str(result)
+    assert 'Version' in result.stdout, str(result)
+    assert 'simple (1.0)' not in result.stdout, str(result)
+    assert 'simple2 (3.0)' not in result.stdout, str(result)
+    assert 'simple     1.0' in result.stdout, str(result)
+    assert 'simple2    3.0' in result.stdout, str(result)
+
+
 def test_local_flag(script, data):
     """
     Test the behavior of --local flag in the list command
@@ -23,6 +95,30 @@ def test_local_flag(script, data):
     """
     script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
     result = script.pip('list', '--local')
+    assert 'simple (1.0)' in result.stdout
+
+
+def test_local_columns_flag(script, data):
+    """
+    Test the behavior of --local --columns flags in the list command
+
+    """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    result = script.pip('list', '--local', '--columns')
+    assert 'Package' in result.stdout
+    assert 'Version' in result.stdout
+    assert 'simple (1.0)' not in result.stdout
+    assert 'simple     1.0' in result.stdout, str(result)
+
+
+def test_local_nocolumns_flag(script, data):
+    """
+    Test the behavior of --local --no-columns flags in the list
+    command.
+    """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    result = script.pip('list', '--local', '--no-columns', expect_stderr=True)
+    assert WARN_NOCOL in result.stderr, str(result)
     assert 'simple (1.0)' in result.stdout
 
 
@@ -38,6 +134,37 @@ def test_user_flag(script, data, virtualenv):
     result = script.pip('list', '--user')
     assert 'simple (1.0)' not in result.stdout
     assert 'simple2 (2.0)' in result.stdout
+
+
+def test_user_columns_flag(script, data, virtualenv):
+    """
+    Test the behavior of --user --columns flags in the list command
+
+    """
+    virtualenv.system_site_packages = True
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    script.pip('install', '-f', data.find_links, '--no-index',
+               '--user', 'simple2==2.0')
+    result = script.pip('list', '--user', '--columns')
+    assert 'Package' in result.stdout
+    assert 'Version' in result.stdout
+    assert 'simple2 (2.0)' not in result.stdout
+    assert 'simple2 2.0' in result.stdout, str(result)
+
+
+def test_user_nocolumns_flag(script, data, virtualenv):
+    """
+    Test the behavior of --user flag in the list command
+
+    """
+    virtualenv.system_site_packages = True
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    script.pip('install', '-f', data.find_links, '--no-index',
+               '--user', 'simple2==2.0')
+    result = script.pip('list', '--user', '--no-columns', expect_stderr=True)
+    assert WARN_NOCOL in result.stderr, str(result)
+    assert 'simple (1.0)' not in result.stdout
+    assert 'simple2 (2.0)' in result.stdout, str(result)
 
 
 @pytest.mark.network
@@ -58,6 +185,56 @@ def test_uptodate_flag(script, data):
         'list', '-f', data.find_links, '--no-index', '--uptodate',
         expect_stderr=True,
     )
+    assert 'simple (1.0)' not in result.stdout  # 3.0 is latest
+    assert 'pip-test-package (0.1.1,' in result.stdout  # editables included
+    assert 'simple2 (3.0)' in result.stdout, str(result)
+
+
+@pytest.mark.network
+def test_uptodate_columns_flag(script, data):
+    """
+    Test the behavior of --uptodate --columns flag in the list command
+
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
+        'simple2==3.0',
+    )
+    script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git#egg=pip-test-package'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index', '--uptodate',
+        '--columns',
+    )
+    assert 'Package' in result.stdout
+    assert 'Version' in result.stdout
+    assert 'Location' in result.stdout      # editables included
+    assert 'pip-test-package (0.1.1,' not in result.stdout
+    assert 'pip-test-package 0.1.1' in result.stdout, str(result)
+    assert 'simple2          3.0' in result.stdout, str(result)
+
+
+@pytest.mark.network
+def test_uptodate_nocolumns_flag(script, data):
+    """
+    Test the behavior of --uptodate --no-columns flag in the list command
+
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
+        'simple2==3.0',
+    )
+    script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git#egg=pip-test-package'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index', '--uptodate',
+        '--no-columns', expect_stderr=True,
+    )
+    assert WARN_NOCOL in result.stderr, str(result)
     assert 'simple (1.0)' not in result.stdout  # 3.0 is latest
     assert 'pip-test-package (0.1.1,' in result.stdout  # editables included
     assert 'simple2 (3.0)' in result.stdout, str(result)
@@ -90,6 +267,67 @@ def test_outdated_flag(script, data):
 
 
 @pytest.mark.network
+def test_outdated_columns_flag(script, data):
+    """
+    Test the behavior of --outdated --columns flag in the list command
+
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
+        'simple2==3.0', 'simplewheel==1.0',
+    )
+    script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git'
+        '@0.1#egg=pip-test-package'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index', '--outdated',
+        '--columns',
+    )
+    assert 'Package' in result.stdout
+    assert 'Version' in result.stdout
+    assert 'Latest' in result.stdout
+    assert 'Type' in result.stdout
+    assert 'simple (1.0) - Latest: 3.0 [sdist]' not in result.stdout
+    assert 'simplewheel (1.0) - Latest: 2.0 [wheel]' not in result.stdout
+    assert 'simple           1.0     3.0    sdist' in result.stdout, (
+        str(result)
+    )
+    assert 'simplewheel      1.0     2.0    wheel' in result.stdout, (
+        str(result)
+    )
+    assert 'simple2' not in result.stdout, str(result)  # 3.0 is latest
+
+
+@pytest.mark.network
+def test_outdated_nocolumns_flag(script, data):
+    """
+    Test the behavior of --outdated --no-columns flag in the list command
+
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
+        'simple2==3.0', 'simplewheel==1.0',
+    )
+    script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git'
+        '@0.1#egg=pip-test-package'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index', '--outdated',
+        '--no-columns', expect_stderr=True,
+    )
+    assert WARN_NOCOL in result.stderr, str(result)
+    assert 'simple (1.0) - Latest: 3.0 [sdist]' in result.stdout
+    assert 'simplewheel (1.0) - Latest: 2.0 [wheel]' in result.stdout
+    assert 'pip-test-package (0.1, ' in result.stdout
+    assert ' Latest: 0.1.1 [sdist]' in result.stdout
+    assert 'simple2' not in result.stdout, str(result)  # 3.0 is latest
+
+
+@pytest.mark.network
 def test_editables_flag(script, data):
     """
     Test the behavior of --editables flag in the list command
@@ -100,6 +338,45 @@ def test_editables_flag(script, data):
         'git+https://github.com/pypa/pip-test-package.git#egg=pip-test-package'
     )
     result = script.pip('list', '--editable')
+    assert 'simple (1.0)' not in result.stdout, str(result)
+    assert os.path.join('src', 'pip-test-package') in result.stdout, (
+        str(result)
+    )
+
+
+@pytest.mark.network
+def test_editables_columns_flag(script, data):
+    """
+    Test the behavior of --editables flag in the list command
+    """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    result = script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git#egg=pip-test-package'
+    )
+    result = script.pip('list', '--editable', '--columns')
+    assert 'Package' in result.stdout
+    assert 'Version' in result.stdout
+    assert 'Location' in result.stdout
+    assert os.path.join('src', 'pip-test-package') in result.stdout, (
+        str(result)
+    )
+
+
+@pytest.mark.network
+def test_editables_nocolumns_flag(script, data):
+    """
+    Test the behavior of --editables flag in the list command
+    """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git#egg=pip-test-package'
+    )
+    result = script.pip(
+        'list', '--editable', '--no-columns', expect_stderr=True,
+    )
+    assert WARN_NOCOL in result.stderr, str(result)
     assert 'simple (1.0)' not in result.stdout, str(result)
     assert os.path.join('src', 'pip-test-package') in result.stdout, (
         str(result)
@@ -128,6 +405,51 @@ def test_uptodate_editables_flag(script, data):
 
 
 @pytest.mark.network
+def test_uptodate_editables_columns_flag(script, data):
+    """
+    test the behavior of --editable --uptodate --columns flag in the
+    list command
+    """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    result = script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git#egg=pip-test-package'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index',
+        '--editable', '--uptodate', '--columns',
+    )
+    assert 'Package' in result.stdout
+    assert 'Version' in result.stdout
+    assert 'Location' in result.stdout
+    assert os.path.join('src', 'pip-test-package') in result.stdout, (
+        str(result)
+    )
+
+
+@pytest.mark.network
+def test_uptodate_editables_nocolumns_flag(script, data):
+    """
+    test the behavior of --editable --uptodate --columns --no-columns flag
+    in the list command
+    """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git#egg=pip-test-package'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index', '--editable',
+        '--uptodate', '--no-columns', expect_stderr=True,
+    )
+    assert WARN_NOCOL in result.stderr, str(result)
+    assert 'simple (1.0)' not in result.stdout, str(result)
+    assert os.path.join('src', 'pip-test-package') in result.stdout, (
+        str(result)
+    )
+
+
+@pytest.mark.network
 def test_outdated_editables_flag(script, data):
     """
     test the behavior of --editable --outdated flag in the list command
@@ -143,6 +465,52 @@ def test_outdated_editables_flag(script, data):
         '--editable', '--outdated',
         expect_stderr=True,
     )
+    assert 'simple (1.0)' not in result.stdout, str(result)
+    assert os.path.join('src', 'pip-test-package') in result.stdout, (
+        str(result)
+    )
+
+
+@pytest.mark.network
+def test_outdated_editables_columns_flag(script, data):
+    """
+    test the behavior of --editable --outdated flag in the list command
+    """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    result = script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git'
+        '@0.1#egg=pip-test-package'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index',
+        '--editable', '--outdated', '--columns',
+    )
+    assert 'Package' in result.stdout
+    assert 'Version' in result.stdout
+    assert 'Location' in result.stdout
+    assert os.path.join('src', 'pip-test-package') in result.stdout, (
+        str(result)
+    )
+
+
+@pytest.mark.network
+def test_outdated_editables_nocolumns_flag(script, data):
+    """
+    test the behavior of --editable --outdated flag in the list command
+    """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git'
+        '@0.1#egg=pip-test-package'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index',
+        '--editable', '--outdated', '--no-columns',
+        expect_stderr=True,
+    )
+    assert WARN_NOCOL in result.stderr, str(result)
     assert 'simple (1.0)' not in result.stdout, str(result)
     assert os.path.join('src', 'pip-test-package') in result.stdout, (
         str(result)
@@ -166,3 +534,49 @@ def test_outdated_pre(script, data):
                             '--find-links', wheelhouse_path,
                             '--outdated', '--pre')
     assert 'simple (1.0) - Latest: 2.0.dev0 [wheel]' in result_pre.stdout
+
+
+def test_outdated_pre_columns(script, data):
+    """ Test of interaction behavior of --pre and --columns """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+
+    # Let's build a fake wheelhouse
+    script.scratch_path.join("wheelhouse").mkdir()
+    wheelhouse_path = script.scratch_path / 'wheelhouse'
+    wheelhouse_path.join('simple-1.1-py2.py3-none-any.whl').write('')
+    wheelhouse_path.join('simple-2.0.dev0-py2.py3-none-any.whl').write('')
+    result = script.pip('list', '--no-index', '--find-links', wheelhouse_path)
+    assert 'simple (1.0)' in result.stdout
+    result = script.pip('list', '--no-index', '--find-links', wheelhouse_path,
+                        '--outdated')
+    assert 'simple (1.0) - Latest: 1.1 [wheel]' in result.stdout
+    result_pre = script.pip(
+        'list', '--no-index', '--find-links', wheelhouse_path,
+        '--outdated', '--pre', '--columns',
+    )
+    assert 'Package' in result_pre.stdout
+    assert 'Version' in result_pre.stdout
+    assert 'Latest' in result_pre.stdout
+    assert 'Type' in result_pre.stdout
+
+
+def test_outdated_pre_nocolumns(script, data):
+    """ Test of interaction behavior of --pre and --no-columns """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+
+    # Let's build a fake wheelhouse
+    script.scratch_path.join("wheelhouse").mkdir()
+    wheelhouse_path = script.scratch_path / 'wheelhouse'
+    wheelhouse_path.join('simple-1.1-py2.py3-none-any.whl').write('')
+    wheelhouse_path.join('simple-2.0.dev0-py2.py3-none-any.whl').write('')
+    result = script.pip('list', '--no-index', '--find-links', wheelhouse_path)
+    assert 'simple (1.0)' in result.stdout
+    result = script.pip('list', '--no-index', '--find-links', wheelhouse_path,
+                        '--outdated')
+    assert 'simple (1.0) - Latest: 1.1 [wheel]' in result.stdout
+    result = script.pip(
+        'list', '--no-index',
+        '--find-links', wheelhouse_path,
+        '--outdated', '--pre', '--no-columns', expect_stderr=True
+    )
+    assert WARN_NOCOL in result.stderr, str(result)


### PR DESCRIPTION
# Summary
This PR adds optional column formatting to `pip list` via the commands `--columns` and `--no-header`.

Fixes #3651.

# Discussion
There is a lot of looping going on to accomplish this PR. I don't think it's a big deal because the list of installed packages is rarely large enough that having multiple loops would cause a significant slowdown. Where reasonable (for speed and readability), I've used list comprehensions instead.

While the call signature of `output_package_listing` was changed, it was not changed in a way that would effect other calls since the new `options` argument defaults to `None`.

If `output_package_listing` is called with `options=None` then there is no change to the previous behavior.

# Examples
Standard output of `pip list` is not changed. New output looks like so:
```
$ pip list --columns
Package        Version
-------------- ------------
docopt         0.6.2
idlex          1.13
jedi           0.9.0
pip            8.1.1
prompt-toolkit 0.60
ptpython       0.32
Pygments       2.1.3
pythonnet      2.1.0
retry          0.8.1
setuptools     20.6.7
six            1.10.0
sqlite-bro     0.8.11
wcwidth        0.1.6
winpython      1.5.20160402

$ pip list --columns -o
Package    Version Latest Type
---------- ------- ------ -----
retry      0.8.1   0.9.1  wheel
setuptools 20.6.7  21.0.0 wheel

$ pip list --columns
Package        Version      Location
-------------- ------------ -----------------------------------
colorama       0.3.7
docopt         0.6.2
idlex          1.13
jedi           0.9.0
pip            8.1.1
pluggy         0.3.1
prompt-toolkit 0.60
ptpython       0.32
py             1.4.31
Pygments       2.1.3
pytest         2.9.1
pythonnet      2.1.0
setuptools     20.6.7
six            1.10.0
sqlite-bro     0.8.11
tox            2.3.1
tqdm           4.5.0        c:\gitlab\temp\path with space\tqdm
virtualenv     15.0.1
wcwidth        0.1.6
winpython      1.5.20160402

$ pip list --no-columns
DEPRECATION: The --no-columns option will be removed in the future.
colorama (0.3.7)
docopt (0.6.2)
idlex (1.13)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3654)
<!-- Reviewable:end -->
