### PR TITLE
Fixed #3682 : pip install --target ignores platlib directories

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -352,35 +352,46 @@ class InstallCommand(RequirementCommand):
         if options.target_dir:
             ensure_dir(options.target_dir)
 
-            lib_dir = distutils_scheme('', home=temp_target_dir)['purelib']
+            # Checking both purelib and platlib directories for installed
+            # packages to be moved to target directory
+            lib_dir_list = []
 
-            for item in os.listdir(lib_dir):
-                target_item_dir = os.path.join(options.target_dir, item)
-                if os.path.exists(target_item_dir):
-                    if not options.upgrade:
-                        logger.warning(
-                            'Target directory %s already exists. Specify '
-                            '--upgrade to force replacement.',
-                            target_item_dir
-                        )
-                        continue
-                    if os.path.islink(target_item_dir):
-                        logger.warning(
-                            'Target directory %s already exists and is '
-                            'a link. Pip will not automatically replace '
-                            'links, please remove if replacement is '
-                            'desired.',
-                            target_item_dir
-                        )
-                        continue
-                    if os.path.isdir(target_item_dir):
-                        shutil.rmtree(target_item_dir)
-                    else:
-                        os.remove(target_item_dir)
+            purelib_dir = distutils_scheme('', home=temp_target_dir)['purelib']
+            platlib_dir = distutils_scheme('', home=temp_target_dir)['platlib']
 
-                shutil.move(
-                    os.path.join(lib_dir, item),
-                    target_item_dir
-                )
+            if os.path.exists(purelib_dir):
+                lib_dir_list.append(purelib_dir)
+            if os.path.exists(platlib_dir) and platlib_dir != purelib_dir:
+                lib_dir_list.append(platlib_dir)
+
+            for lib_dir in lib_dir_list:
+                for item in os.listdir(lib_dir):
+                    target_item_dir = os.path.join(options.target_dir, item)
+                    if os.path.exists(target_item_dir):
+                        if not options.upgrade:
+                            logger.warning(
+                                'Target directory %s already exists. Specify '
+                                '--upgrade to force replacement.',
+                                target_item_dir
+                            )
+                            continue
+                        if os.path.islink(target_item_dir):
+                            logger.warning(
+                                'Target directory %s already exists and is '
+                                'a link. Pip will not automatically replace '
+                                'links, please remove if replacement is '
+                                'desired.',
+                                target_item_dir
+                            )
+                            continue
+                        if os.path.isdir(target_item_dir):
+                            shutil.rmtree(target_item_dir)
+                        else:
+                            os.remove(target_item_dir)
+
+                    shutil.move(
+                        os.path.join(lib_dir, item),
+                        target_item_dir
+                    )
             shutil.rmtree(temp_target_dir)
         return requirement_set


### PR DESCRIPTION
*This was migrated from pypa/pip#3684 to reparent it to the ``master`` branch. Please see original pull request for any previous discussion.*