### PR TITLE
allow creating wheels for editable packages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,10 @@
 * Fix regression in pip freeze: when there is more than one git remote,
   priority is given to the remote named origin (:issue:`3616`)
 
+* Pip wheel now works on editable packages too (it was only working on
+  editable dependencies before); this allows running pip wheel on the result
+  of pip freeze in presence of editable requirements (:issue:`3291`)
+
 
 **8.1.2 (2016-05-10)**
 

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -157,6 +157,8 @@ class WheelCommand(RequirementCommand):
         if options.build_dir:
             options.build_dir = os.path.abspath(options.build_dir)
 
+        options.src_dir = os.path.abspath(options.src_dir)
+
         with self._build_session(options) as session:
             finder = self._build_package_finder(options, session)
             build_delete = (not (options.no_clean or options.build_dir))

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -759,11 +759,8 @@ class WheelBuilder(object):
                 if not autobuilding:
                     logger.info(
                         'Skipping %s, due to already being wheel.', req.name)
-            elif req.editable:
-                if not autobuilding:
-                    logger.info(
-                        'Skipping bdist_wheel for %s, due to being editable',
-                        req.name)
+            elif autobuilding and req.editable:
+                pass
             elif autobuilding and req.link and not req.link.is_artifact:
                 pass
             elif autobuilding and not req.source_dir:

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -75,6 +75,21 @@ def test_pip_wheel_builds_editable_deps(script, data):
 
 
 @pytest.mark.network
+def test_pip_wheel_builds_editable(script, data):
+    """
+    Test 'pip wheel' builds an editable package
+    """
+    script.pip('install', 'wheel')
+    editable_path = os.path.join(data.src, 'simplewheel-1.0')
+    result = script.pip(
+        'wheel', '--no-index', '-e', editable_path
+    )
+    wheel_file_name = 'simplewheel-1.0-py%s-none-any.whl' % pyversion[0]
+    wheel_file_path = script.scratch / wheel_file_name
+    assert wheel_file_path in result.files_created, result.stdout
+
+
+@pytest.mark.network
 def test_pip_wheel_fail(script, data):
     """
     Test 'pip wheel' failure.

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -380,16 +380,6 @@ class TestWheelBuilder(object):
             assert "due to already being wheel" in caplog.text()
             assert mock_build_one.mock_calls == []
 
-    def test_skip_building_editables(self, caplog):
-        with patch('pip.wheel.WheelBuilder._build_one') as mock_build_one:
-            editable = Mock(editable=True, is_wheel=False, constraint=False)
-            reqset = Mock(requirements=Mock(values=lambda: [editable]),
-                          wheel_download_dir='/wheel/dir')
-            wb = wheel.WheelBuilder(reqset, Mock())
-            wb.build()
-            assert "due to being editable" in caplog.text()
-            assert mock_build_one.mock_calls == []
-
 
 class TestWheelCache:
 


### PR DESCRIPTION
Fixes #3291 

This lifts the restriction of not generating wheels for editable packages.

As explained in #3291 and #3379, there are legitimate scenarios for this, such as building wheels from frozen requirements.

---

*This was migrated from pypa/pip#3379 to reparent it to the ``master`` branch. Please see original pull request for any previous discussion.*