### PR TITLE
Updated Subversion vcs to strip auth info from url after collecting it for use as flags.

### DIFF
--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -224,8 +224,14 @@ class Subversion(VersionControl):
         # Return a copy of url with 'username:password@' stripped.
         # username/pass params are passed to subversion through flags & not recognized in
         #  the url.
-        url = re.sub('://.*?@', '://', url, count=1)
-        return url
+
+        # parsed url
+        purl = urllib_parse.urlsplit(url)
+        stripped_netloc = purl.netloc.split('@')[-1] if '@' in purl.netloc else purl.netloc
+
+        # stripped url
+        surl = urllib_parse.urlunsplit((purl.scheme, stripped_netloc, purl.path, purl.query, purl.fragment))
+        return surl
 
 
 def get_rev_options(url, rev):

--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -60,6 +60,7 @@ class Subversion(VersionControl):
         """Export the svn repository at the url to the destination location"""
         url, rev = self.get_url_rev()
         rev_options = get_rev_options(url, rev)
+        url = self.remove_auth_from_url(url)
         logger.info('Exporting svn repository %s to %s', url, location)
         with indent_log():
             if os.path.exists(location):
@@ -79,6 +80,7 @@ class Subversion(VersionControl):
     def obtain(self, dest):
         url, rev = self.get_url_rev()
         rev_options = get_rev_options(url, rev)
+        url = self.remove_auth_from_url(url)
         if rev:
             rev_display = ' (to revision %s)' % rev
         else:
@@ -216,6 +218,14 @@ class Subversion(VersionControl):
     def check_version(self, dest, rev_options):
         """Always assume the versions don't match"""
         return False
+
+    @staticmethod
+    def remove_auth_from_url(url):
+        # Return a copy of url with 'username:password@' stripped.
+        # username/pass params are passed to subversion through flags & not recognized in
+        #  the url.
+        url = re.sub('://.*?@', '://', url, count=1)
+        return url
 
 
 def get_rev_options(url, rev):

--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -221,16 +221,20 @@ class Subversion(VersionControl):
 
     @staticmethod
     def remove_auth_from_url(url):
-        # Return a copy of url with 'username:password@' stripped.
-        # username/pass params are passed to subversion through flags & not recognized in
-        #  the url.
+        # Return a copy of url with 'username:password@' removed.
+        # username/pass params are passed to subversion through flags
+        # and are not recognized in the url.
 
         # parsed url
         purl = urllib_parse.urlsplit(url)
-        stripped_netloc = purl.netloc.split('@')[-1] if '@' in purl.netloc else purl.netloc
+        stripped_netloc = \
+            purl.netloc.split('@')[-1]
 
         # stripped url
-        surl = urllib_parse.urlunsplit((purl.scheme, stripped_netloc, purl.path, purl.query, purl.fragment))
+        url_pieces = (
+            purl.scheme, stripped_netloc, purl.path, purl.query, purl.fragment
+        )
+        surl = urllib_parse.urlunsplit(url_pieces)
         return surl
 
 

--- a/tests/functional/test_install_vcs_svn.py
+++ b/tests/functional/test_install_vcs_svn.py
@@ -10,7 +10,7 @@ def test_obtain_should_recognize_auth_info_url(call_subprocess_mock, script):
     svn.obtain(script.scratch_path / 'test')
     assert call_subprocess_mock.call_args[0][0] == [
         svn.name, 'checkout', '-q', '--username', 'username', '--password',
-        'password', 'http://username:password@svn.example.com/',
+        'password', 'http://svn.example.com/',
         script.scratch_path / 'test',
     ]
 
@@ -22,6 +22,6 @@ def test_export_should_recognize_auth_info_url(call_subprocess_mock, script):
     svn.export(script.scratch_path / 'test')
     assert call_subprocess_mock.call_args[0][0] == [
         svn.name, 'export', '--username', 'username', '--password',
-        'password', 'http://username:password@svn.example.com/',
+        'password', 'http://svn.example.com/',
         script.scratch_path / 'test',
     ]

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -3,6 +3,7 @@ from tests.lib import pyversion
 from pip.vcs import VersionControl
 from pip.vcs.bazaar import Bazaar
 from pip.vcs.git import Git
+from pip.vcs.subversion import Subversion
 from mock import Mock
 
 if pyversion >= '3':
@@ -110,3 +111,17 @@ def test_bazaar_simple_urls():
     assert launchpad_bzr_repo.get_url_rev() == (
         'lp:MyLaunchpadProject', None,
     )
+
+
+def test_subversion_remove_auth_from_url():
+    # Check that the url is doctored appropriately to remove auth elements from the url
+    svn_auth_url = 'https://user:pass@svnrepo.org/svn/project/tags/v0.2'
+    expected_url = 'https://svnrepo.org/svn/project/tags/v0.2'
+    url = Subversion.remove_auth_from_url(svn_auth_url)
+    assert url == expected_url
+
+    # Check that this doesn't impact urls without authentication'
+    svn_noauth_url = 'https://svnrepo.org/svn/project/tags/v0.2'
+    expected_url = svn_noauth_url
+    url = Subversion.remove_auth_from_url(svn_noauth_url)
+    assert url == expected_url

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -125,3 +125,14 @@ def test_subversion_remove_auth_from_url():
     expected_url = svn_noauth_url
     url = Subversion.remove_auth_from_url(svn_noauth_url)
     assert url == expected_url
+
+    # Check that links to specific revisions are handled properly
+    svn_rev_url = 'https://user:pass@svnrepo.org/svn/project/trunk@8181'
+    expected_url = 'https://svnrepo.org/svn/project/trunk@8181'
+    url = Subversion.remove_auth_from_url(svn_rev_url)
+    assert url == expected_url
+
+    svn_rev_url = 'https://svnrepo.org/svn/project/trunk@8181'
+    expected_url = 'https://svnrepo.org/svn/project/trunk@8181'
+    url = Subversion.remove_auth_from_url(svn_rev_url)
+    assert url == expected_url

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -114,7 +114,8 @@ def test_bazaar_simple_urls():
 
 
 def test_subversion_remove_auth_from_url():
-    # Check that the url is doctored appropriately to remove auth elements from the url
+    # Check that the url is doctored appropriately to remove auth elements
+    #    from the url
     svn_auth_url = 'https://user:pass@svnrepo.org/svn/project/tags/v0.2'
     expected_url = 'https://svnrepo.org/svn/project/tags/v0.2'
     url = Subversion.remove_auth_from_url(svn_auth_url)


### PR DESCRIPTION
Updated Subversion vcs to strip auth info from url after collecting it for use as flags.
Allows straightforward use of Subversion repositories which require authentication in requirements files.
Fixes #3209

---

*This was migrated from pypa/pip#3210 to reparent it to the ``master`` branch. Please see original pull request for any previous discussion.*