### PR TITLE
Add support for pip freeze to use multiple --requirement files

### DIFF
--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -29,12 +29,13 @@ class FreezeCommand(Command):
 
         self.cmd_opts.add_option(
             '-r', '--requirement',
-            dest='requirement',
-            action='store',
-            default=None,
+            dest='requirements',
+            action='append',
+            default=[],
             metavar='file',
             help="Use the order in the given requirements file and its "
-                 "comments when generating output.")
+                 "comments when generating output. This option can be "
+                 "used multiple times.")
         self.cmd_opts.add_option(
             '-f', '--find-links',
             dest='find_links',
@@ -73,7 +74,7 @@ class FreezeCommand(Command):
             skip.update(DEV_PKGS)
 
         freeze_kwargs = dict(
-            requirement=options.requirement,
+            requirement=options.requirements,
             find_links=options.find_links,
             local_only=options.local,
             user_only=options.user,

--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -49,60 +49,69 @@ def freeze(
         installations[req.name] = req
 
     if requirement:
-        with open(requirement) as req_file:
-            for line in req_file:
-                if (not line.strip() or
-                        line.strip().startswith('#') or
-                        (skip_match and skip_match(line)) or
-                        line.startswith((
-                            '-r', '--requirement',
-                            '-Z', '--always-unzip',
-                            '-f', '--find-links',
-                            '-i', '--index-url',
-                            '--pre',
-                            '--trusted-host',
-                            '--process-dependency-links',
-                            '--extra-index-url'))):
-                    yield line.rstrip()
-                    continue
+        # the options that don't get turned into an InstallRequirement
+        # should only be emitted once, even if the same option is in multiple
+        # requirements files, so we need to keep track of what has been emitted
+        # so that we don't emit it again if it's seen again
+        emitted_options = set()
+        for req_file_path in requirement:
+            with open(req_file_path) as req_file:
+                for line in req_file:
+                    if (not line.strip() or
+                            line.strip().startswith('#') or
+                            (skip_match and skip_match(line)) or
+                            line.startswith((
+                                '-r', '--requirement',
+                                '-Z', '--always-unzip',
+                                '-f', '--find-links',
+                                '-i', '--index-url',
+                                '--pre',
+                                '--trusted-host',
+                                '--process-dependency-links',
+                                '--extra-index-url'))):
+                        line = line.rstrip()
+                        if line not in emitted_options:
+                            emitted_options.add(line)
+                            yield line
+                        continue
 
-                if line.startswith('-e') or line.startswith('--editable'):
-                    if line.startswith('-e'):
-                        line = line[2:].strip()
+                    if line.startswith('-e') or line.startswith('--editable'):
+                        if line.startswith('-e'):
+                            line = line[2:].strip()
+                        else:
+                            line = line[len('--editable'):].strip().lstrip('=')
+                        line_req = InstallRequirement.from_editable(
+                            line,
+                            default_vcs=default_vcs,
+                            isolated=isolated,
+                            wheel_cache=wheel_cache,
+                        )
                     else:
-                        line = line[len('--editable'):].strip().lstrip('=')
-                    line_req = InstallRequirement.from_editable(
-                        line,
-                        default_vcs=default_vcs,
-                        isolated=isolated,
-                        wheel_cache=wheel_cache,
-                    )
-                else:
-                    line_req = InstallRequirement.from_line(
-                        line,
-                        isolated=isolated,
-                        wheel_cache=wheel_cache,
-                    )
+                        line_req = InstallRequirement.from_line(
+                            line,
+                            isolated=isolated,
+                            wheel_cache=wheel_cache,
+                        )
 
-                if not line_req.name:
-                    logger.info(
-                        "Skipping line because it's not clear what it "
-                        "would install: %s",
-                        line.strip(),
-                    )
-                    logger.info(
-                        "  (add #egg=PackageName to the URL to avoid"
-                        " this warning)"
-                    )
-                elif line_req.name not in installations:
-                    logger.warning(
-                        "Requirement file contains %s, but that package is"
-                        " not installed",
-                        line.strip(),
-                    )
-                else:
-                    yield str(installations[line_req.name]).rstrip()
-                    del installations[line_req.name]
+                    if not line_req.name:
+                        logger.info(
+                            "Skipping line in requirement file [%s] because "
+                            "it's not clear what it would install: %s",
+                            req_file_path, line.strip(),
+                        )
+                        logger.info(
+                            "  (add #egg=PackageName to the URL to avoid"
+                            " this warning)"
+                        )
+                    elif line_req.name not in installations:
+                        logger.warning(
+                            "Requirement file [%s] contains %s, but that "
+                            "package is not installed",
+                            req_file_path, line.strip(),
+                        )
+                    else:
+                        yield str(installations[line_req.name]).rstrip()
+                        del installations[line_req.name]
 
         yield(
             '## The following requirements were added by '


### PR DESCRIPTION
- updated freeze command to accept multiple --requirement
- added test that uses multiple --requirement params and refactored
  existing test to reuse the boilerplate requirements options
- modified warning and info message to include which requirement
  file a message is for now that there can be multiple
- see issue #3599 for motivation

This is a resubmission based on master of pull request #3600 (based on develop), originally submitted on April 03, 2016. See ticket #3599 for discussion and an example.