### PR TITLE
Added support for servers which do not support directory indexing.

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -757,7 +757,22 @@ class HTMLPage(object):
                     "Cache-Control": "max-age=600",
                 },
             )
-            resp.raise_for_status()
+            try:
+                resp.raise_for_status()
+            except IOError as e:
+                logger.debug(
+                    ' url %s raise %s: retrying with index.html', e, url)
+                resp = session.get(
+                    urllib_parse.urljoin(url, 'index.html'),
+                    headers={
+                        "Accept": "text/html",
+                        "Cache-Control": "max-age=600",
+                    },
+                )
+
+                resp.raise_for_status()
+
+
 
             # The check for archives above only works if the url ends with
             #   something that looks like an archive. However that is not a


### PR DESCRIPTION
Some servers do not support directory indexing automatically, nor can they
rewrite URLs with trailing / to fetch index.html. In these cases it would be
easier if PIP could retry the URL with a trailing index.html.

Specifically I am trying to set up a PyPi repository in Google Cloud Storage and it basically works well if I use HTTP but unfortunately they do not support directory indexing on the SSL enabled URL (which I really want to use).