### PR TITLE
Added the possibility to follow symlinks on copytree also for py3

### DIFF
--- a/news/3707.bugfix
+++ b/news/3707.bugfix
@@ -1,2 +1,3 @@
 1. Revert previous fix that disable symlinks dereference.
 2. Fixed shutil.copytree for py3 when a symlink points to a directory (python version > 2 and < 3.5).
+3. Ignored circular symbolic links for copytree execution.

--- a/news/3707.bugfix
+++ b/news/3707.bugfix
@@ -1,1 +1,2 @@
 1. Revert previous fix that disable symlinks dereference.
+2. Fixed shutil.copytree for py3 when a symlink points to a directory (python version > 2 and < 3.5).

--- a/news/3707.bugfix
+++ b/news/3707.bugfix
@@ -1,0 +1,1 @@
+1. Revert previous fix that disable symlinks dereference.

--- a/pip/compat.py
+++ b/pip/compat.py
@@ -6,6 +6,7 @@ import codecs
 import locale
 import logging
 import os
+import shutil
 import sys
 
 from pip._vendor.six import text_type
@@ -123,6 +124,63 @@ else:
         if isinstance(s, text_type):
             return s.encode('utf-8')
         return s
+
+if sys.version_info >= (3,) and sys.version_info < (3, 5):
+    def copytree(source, location, symlinks=False, ignore=None):
+        # The py3k version of `shutil.copytree` fails when symlinks point on
+        # directories.
+        follow_symlinks = not symlinks
+        copying = []
+
+        def copy_callback(src, dst, follow_symlinks=follow_symlinks):
+            if not follow_symlinks and os.path.islink(src):
+                linkto = os.readlink(src)
+                if not os.path.isabs(linkto):
+                    linkto = os.path.join(os.path.dirname(src), linkto)
+                try:
+                    os.symlink(linkto, dst)
+                    return dst
+                except OSError:
+                    # catch the OSError when the os.symlink function is called
+                    # on Windows by an unprivileged user. In that case we pass
+                    # follow_symlinks to True
+                    follow_symlinks = True
+            src = os.path.normcase(os.path.realpath(src))
+            if src in copying:
+                # Already seen this path, so we must have a symlink loop
+                raise Exception(
+                    'Circular reference detected in "%s" ("%s" > "%s").'
+                    '' % (copying[0], '" > "'.join(copying), copying[0])
+                )
+            copying.append(src)
+            if os.path.isdir(src):
+                shutil.copytree(
+                    src,
+                    dst,
+                    symlinks=not follow_symlinks,
+                    ignore=ignore,
+                    copy_function=copy_callback,
+                )
+            else:
+                shutil.copy2(src, dst)
+            copying.remove(src)
+            return dst
+        return shutil.copytree(
+            source,
+            location,
+            symlinks=symlinks,
+            ignore=ignore,
+            copy_function=copy_callback,
+        )
+
+else:
+    def copytree(source, location, symlinks=False, ignore=None):
+        return shutil.copytree(
+            source,
+            location,
+            symlinks=symlinks,
+            ignore=ignore,
+        )
 
 
 def get_path_uid(path):

--- a/pip/download.py
+++ b/pip/download.py
@@ -691,7 +691,7 @@ def unpack_file_url(link, location, download_dir=None, hashes=None):
     if is_dir_url(link):
         if os.path.isdir(location):
             rmtree(location)
-        shutil.copytree(link_path, location, symlinks=True)
+        shutil.copytree(link_path, location)
         if download_dir:
             logger.info('Link is a directory, ignoring download_dir')
         return

--- a/pip/download.py
+++ b/pip/download.py
@@ -28,15 +28,13 @@ from pip._vendor.six.moves.urllib import request as urllib_request
 from pip._vendor.six.moves.urllib.parse import unquote as urllib_unquote
 
 import pip
-# For copytree as when using from an import exception is thrown.
-import pip.compat as compat
 from pip.exceptions import HashMismatch, InstallationError
 from pip.locations import write_delete_marker_file
 from pip.models import PyPI
 from pip.utils import (
     ARCHIVE_EXTENSIONS, ask_path_exists, backup_dir, call_subprocess, consume,
-    display_path, format_size, get_installed_version, rmtree, splitext,
-    unpack_file
+    copytree, display_path, format_size, get_installed_version, rmtree,
+    splitext, unpack_file
 )
 from pip.utils.encoding import auto_decode
 from pip.utils.filesystem import check_path_owner
@@ -693,7 +691,7 @@ def unpack_file_url(link, location, download_dir=None, hashes=None):
     if is_dir_url(link):
         if os.path.isdir(location):
             rmtree(location)
-        compat.copytree(link_path, location)
+        copytree(link_path, location)
         if download_dir:
             logger.info('Link is a directory, ignoring download_dir')
         return

--- a/pip/download.py
+++ b/pip/download.py
@@ -28,6 +28,8 @@ from pip._vendor.six.moves.urllib import request as urllib_request
 from pip._vendor.six.moves.urllib.parse import unquote as urllib_unquote
 
 import pip
+# For copytree as when using from an import exception is thrown.
+import pip.compat as compat
 from pip.exceptions import HashMismatch, InstallationError
 from pip.locations import write_delete_marker_file
 from pip.models import PyPI
@@ -691,7 +693,7 @@ def unpack_file_url(link, location, download_dir=None, hashes=None):
     if is_dir_url(link):
         if os.path.isdir(location):
             rmtree(location)
-        shutil.copytree(link_path, location)
+        compat.copytree(link_path, location)
         if download_dir:
             logger.info('Link is a directory, ignoring download_dir')
         return

--- a/pip/exceptions.py
+++ b/pip/exceptions.py
@@ -246,3 +246,13 @@ class HashMismatch(HashError):
 class UnsupportedPythonVersion(InstallationError):
     """Unsupported python version according to Requires-Python package
     metadata."""
+
+
+class CircularSymlinkException(PipError):
+    """When a circular symbolic link is detected."""
+    def __init__(self, resources):
+        message = (
+            'Circular reference detected in "%s" ("%s" > "%s").'
+            '' % (resources[0], '" > "'.join(resources), resources[0]),
+        )
+        PipError.__init__(self, message)


### PR DESCRIPTION
Hello,

Reply to #1311

It's an answer of https://github.com/pypa/pip/pull/1311/files#r7640350

If a project contains true NTFS symlinks it require elevated privileges indeed (source: @docs.python: os.symlink and @wikipedia: NTFS_symbolic_link)

 Fix shutil.copytree for py3 when a symlink points to a directory

 Prevent circular symbolic links

 Add test with circular symbolic links

 revert pypa/pip@f579c17

It should be also update tests.lib.path.Path.copytree method (e.g. git revert pypa/pip@99a4f6f) but it will add a dependency to pip.util module.

All comments are welcome

---

_This was migrated from pypa/pip#1329 to reparent it to the `master` branch. Please see original pull request for any previous discussion._
- [x] rebase it against master

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3707)
<!-- Reviewable:end -->
