### PR TITLE
Fixed #3569 inability to load credentials from .netrc files

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -199,6 +199,13 @@ class MultiDomainBasicAuth(AuthBase):
             return userinfo, None
         return None, None
 
+    def __nonzero__(self):
+       # needed in order to evalue authentication object to False when we have no credentials, prevents failure to load .netrc files
+       print("FATAL: %s" % self.passwords)
+       return bool(self.passwords)
+
+    def __bool__(self):
+       return self.__nonzero__()
 
 class LocalFSAdapter(BaseAdapter):
 

--- a/pip/download.py
+++ b/pip/download.py
@@ -200,12 +200,13 @@ class MultiDomainBasicAuth(AuthBase):
         return None, None
 
     def __nonzero__(self):
-       # needed in order to evalue authentication object to False when we have no credentials, prevents failure to load .netrc files
-       print("FATAL: %s" % self.passwords)
-       return bool(self.passwords)
+        # needed in order to evalue authentication object to False when we have
+        # no credentials, prevents failure to load .netrc files
+        return bool(self.passwords)
 
     def __bool__(self):
-       return self.__nonzero__()
+        return self.__nonzero__()
+
 
 class LocalFSAdapter(BaseAdapter):
 
@@ -756,6 +757,7 @@ class PipXmlrpcTransport(xmlrpc_client.Transport):
     """Provide a `xmlrpclib.Transport` implementation via a `PipSession`
     object.
     """
+
     def __init__(self, index_url, session, use_datetime=False):
         xmlrpc_client.Transport.__init__(self, use_datetime)
         index_parts = urllib_parse.urlparse(index_url)


### PR DESCRIPTION
Explanation: because the MultiDomainBasicAuth object was always evaluating as true the condition for loading the .netrc was never met so that's why it was not working.

Now I added code to evaluate the object as true/false based on the existence of some secrets being loaded inside the internal dictionary and now the code works well, values from the .netrc are loaded and used.

This change is
---

*This was migrated from pypa/pip#3637 to reparent it to the ``master`` branch. Please see original pull request for any previous discussion.*