### PR TITLE
Issue #3622 Add new option --archive-extension for right calculate hash

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 **8.1.2 (unreleased)**
 
+* Fix wrong calculate hash if package is available in multiple formats. The
+  validation will fail because pip may pick different format than was used to
+  calculate hash. (:issue: `3622`).
+
 * Fix a regression on systems with uninitialized locale (:issue:`3575`).
 
 * Use environment markers to filter packages before determining if a

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -614,6 +614,16 @@ Hash-checking mode also works with :ref:`pip download` and :ref:`pip wheel`. A
 
         pip install --no-deps .
 
+.. _`--archive-extension`:
+
+The `--hash` and `--require-hashes` options allow to validate archive that was
+downloaded from PyPI. However, if package is available in multiple formats
+the validation will fail because pip may pick different format than was used
+to calculate hash. To determine what kind of archive you need to use the
+option to specify::
+
+    FooProject == 1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 --archive-extension=tar.gz
+
 
 Hashes from PyPI
 ~~~~~~~~~~~~~~~~

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -564,6 +564,16 @@ require_hashes = partial(
          'repeatable installs. This option is implied when any package in a '
          'requirements file has a --hash option.')
 
+archive_extension = partial(
+    Option,
+    '--archive-extension',
+    dest='archive-extension',
+    action='store',
+    type='string',
+    default='',
+    help='Extra param for select package where used --hash in requirements. '
+         'Select packages only with this extension.')
+
 
 ##########
 # groups #

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -166,6 +166,7 @@ class InstallCommand(RequirementCommand):
         cmd_opts.add_option(cmdoptions.pre())
         cmd_opts.add_option(cmdoptions.no_clean())
         cmd_opts.add_option(cmdoptions.require_hashes())
+        cmd_opts.add_option(cmdoptions.archive_extension())
 
         index_opts = cmdoptions.make_option_group(
             cmdoptions.index_group,

--- a/pip/index.py
+++ b/pip/index.py
@@ -463,6 +463,14 @@ class PackageFinder(object):
             c for c in all_candidates if str(c.version) in compatible_versions
         ]
 
+        archive_extension = req.options.get('archive-extension')
+        # If identified archive-extension, select only this extension packages
+        if archive_extension:
+            applicable_candidates = [
+                candidate for candidate in applicable_candidates
+                if candidate.location.ext.endswith(archive_extension)
+            ]
+
         if applicable_candidates:
             best_candidate = max(applicable_candidates,
                                  key=self._candidate_sort_key)

--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -55,6 +55,7 @@ SUPPORTED_OPTIONS_REQ = [
     cmdoptions.install_options,
     cmdoptions.global_options,
     cmdoptions.hash,
+    cmdoptions.archive_extension,
 ]
 
 # the 'dest' string values


### PR DESCRIPTION
Add new option --archive-extension for right calculate hash where package is availabe multiple extensions.

This change is

---

_This was automatically migrated from pypa/pip#3639 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @robin0371_
