### PR TITLE
Update installing.rst example proxy URI

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -70,7 +70,7 @@ Install to the user site [4]_::
 
 Install behind a proxy::
 
-  python get-pip.py --proxy="[user:passwd@]proxy.server:port"
+  python get-pip.py --proxy="http://[user:passwd@]proxy.server:port"
 
 
 Using Linux Package Managers


### PR DESCRIPTION
for Install behind a proxy added missing "http://" proxyScheme

This change is

---

_This was automatically migrated from pypa/pip#3631 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @gdanielson_
