### PR TITLE
switch 'pip install .' to use sdists, not copytree

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -717,11 +717,6 @@ def _copy_dist_from_dir(link_path, location):
 
     """
 
-    # Note: This is currently VERY SLOW if you have a lot of data in the
-    # directory, because it copies everything with `shutil.copytree`.
-    # What it should really do is build an sdist and install that.
-    # See https://github.com/pypa/pip/issues/2195
-
     if os.path.isdir(location):
         rmtree(location)
 
@@ -741,6 +736,13 @@ def _copy_dist_from_dir(link_path, location):
     sdist = os.path.join(location, os.listdir(location)[0])
     logger.info('Unpacking sdist %s into %s', sdist, location)
     unpack_file(sdist, location, content_type=None, link=None)
+
+    # copy the original setup.py into `location`, since the shim's
+    # sys.argv[0] confuses distutils.command.sdist.add_defaults() into not
+    # automatically adding setup.py to the tarball
+    logger.info('Copying setup.py from original into %s', location)
+    shutil.copy(os.path.join(link_path, setup_py),
+                os.path.join(location, "setup.py"))
 
 
 class PipXmlrpcTransport(xmlrpc_client.Transport):

--- a/pip/download.py
+++ b/pip/download.py
@@ -671,9 +671,7 @@ def unpack_file_url(link, location, download_dir=None, hashes=None):
 
     # If it's a url to a local directory
     if is_dir_url(link):
-        if os.path.isdir(location):
-            rmtree(location)
-        shutil.copytree(link_path, location, symlinks=True)
+        _copy_dist_from_dir(link_path, location)
         if download_dir:
             logger.info('Link is a directory, ignoring download_dir')
         return


### PR DESCRIPTION
This has an updated (mergeable) version of the original #2535 missing patch (to actually use the new copy function), and a workaround for the missing-setup.py problem that I found during testing.

refs #2195, #2535, #3176

This change is

---

_This was automatically migrated from pypa/pip#3615 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @warner_
