### PR TITLE
Add shorthand -i for index flag in search subcommand

### DIFF
--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -29,7 +29,7 @@ class SearchCommand(Command):
     def __init__(self, *args, **kw):
         super(SearchCommand, self).__init__(*args, **kw)
         self.cmd_opts.add_option(
-            '--index',
+            '-i', '--index',
             dest='index',
             metavar='URL',
             default=PyPI.pypi_url,


### PR DESCRIPTION
The install subcommand has a shorthand flag '-i but I noticed search does not.





This change is

---

*This was automatically migrated from pypa/pip#3579 to reparent it to the ``master`` branch. Please see original pull request for any previous discussion.*

*Original Submitter: @MichaelAquilina*