### PR TITLE
Add expansion of environment variables in requirement files

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -433,6 +433,44 @@ Tags or revisions can be installed like so::
     [-e] bzr+http://bzr.example.com/MyProject/trunk@v1.0#egg=MyProject
 
 
+.. _`Environment Variable Expansion`:
+
+Environment Variable Expansion
+++++++++++++++++++++++++++++++
+
+Since version 10, pip supports environment variables inside the requirements
+file. This makes it possible to specify a package using a URL that requires
+authentication but without storing the credential in the requirement file
+itself.
+
+For instance, the ZIP files available for a Github repository require basic
+auth when the repository is private. Previously, the token used for
+authenication had to be saved to the requirements file...which is a security
+concern::
+
+   https://a-not-so-secret-token:x-oauth-basic@github.com/user/repo/archive/master.zip
+
+Pip now supports the use of environment variables within the requirement file
+which makes it possible to provide credentials (and other values) as environment
+variables. They are then evaluated by pip at run time. This approach aligns
+with the `12-factor configuration approach <https://12factor.net/config>`_  and
+is widely used by continuous integration and deployment services.
+
+For a robust evaluation of variables, the format is limited to a specific
+POSIX-style version: wrapping an uppercase name in `${}`. For instance a valid
+variable name would be `${GITHUB_TOKEN}`. This turns the example above into::
+
+   https://${GITHUB_TOKEN}:x-oauth-basic@github.com/user/repo/archive/master.zip
+
+All you have to do now is export a variable `GITHUB_TOKEN` on your host system
+that contains the actual value and pip will use it when attempting to download
+this package from Github.
+
+Please be aware that pip doesn't support all variable formats supported by other
+systems! THere's no support for `$GITHUB_TOKEN` or `%GITHUB_TOKEN%` inside
+a requirements file, although they are valid names on their respective systems.
+
+
 Finding Packages
 ++++++++++++++++
 

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -171,6 +171,28 @@ You can also refer to :ref:`constraints files <Constraints Files>`, like this::
 
     -c some_constraints.txt
 
+.. _`Using Environment Variables`:
+
+Using Environment Variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since version 10, pip supports the use of environment variables inside the
+requirements file. You can now store sensitive data (tokens, keys, etc.) in
+environment variables and only specify the variable name for your requirements,
+letting pip lookup the value at runtime. This approach aligns with the commonly
+used `12-factor configuration pattern <https://12factor.net/config>`_.
+
+You have to use the POSIX format for variable names including brackets around
+the uppercase name as shown in this example: ``${API_TOKEN}``. pip will attempt
+to find the corresponding environment variable defined on the host system at
+runtime.
+
+.. note::
+
+   There is no support for other variable expansion syntaxes such as
+   ``$VARIABLE`` and ``%VARIABLE%``.
+
+
 .. _`Example Requirements File`:
 
 Example Requirements File
@@ -432,44 +454,21 @@ Tags or revisions can be installed like so::
     [-e] bzr+https://bzr.example.com/MyProject/trunk@2019#egg=MyProject
     [-e] bzr+http://bzr.example.com/MyProject/trunk@v1.0#egg=MyProject
 
+Using Environment Variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _`Environment Variable Expansion`:
+Since version 10, pip also makes it possible to use environment variables which
+makes it possible to reference private repositories without having to store
+access tokens in the requirements file. For example, a private git repository
+allowing Basic Auth for authentication can be refenced like this::
 
-Environment Variable Expansion
-++++++++++++++++++++++++++++++
+    [-e] git+http://${AUTH_USER}:${AUTH_PASSWORD}@git.example.com/MyProject#egg=MyProject
+    [-e] git+https://${AUTH_USER}:${AUTH_PASSWORD}@git.example.com/MyProject#egg=MyProject
 
-Since version 10, pip supports environment variables inside the requirements
-file. This makes it possible to specify a package using a URL that requires
-authentication but without storing the credential in the requirement file
-itself.
+.. note::
 
-For instance, the ZIP files available for a Github repository require basic
-auth when the repository is private. Previously, the token used for
-authenication had to be saved to the requirements file...which is a security
-concern::
-
-   https://a-not-so-secret-token:x-oauth-basic@github.com/user/repo/archive/master.zip
-
-Pip now supports the use of environment variables within the requirement file
-which makes it possible to provide credentials (and other values) as environment
-variables. They are then evaluated by pip at run time. This approach aligns
-with the `12-factor configuration approach <https://12factor.net/config>`_  and
-is widely used by continuous integration and deployment services.
-
-For a robust evaluation of variables, the format is limited to a specific
-POSIX-style version: wrapping an uppercase name in `${}`. For instance a valid
-variable name would be `${GITHUB_TOKEN}`. This turns the example above into::
-
-   https://${GITHUB_TOKEN}:x-oauth-basic@github.com/user/repo/archive/master.zip
-
-All you have to do now is export a variable `GITHUB_TOKEN` on your host system
-that contains the actual value and pip will use it when attempting to download
-this package from Github.
-
-Please be aware that pip doesn't support all variable formats supported by other
-systems! THere's no support for `$GITHUB_TOKEN` or `%GITHUB_TOKEN%` inside
-a requirements file, although they are valid names on their respective systems.
-
+   Only ``${VARIABLE}`` is supported, other formats like ``$VARIABLE`` or
+   ``%VARIABLE%`` won't work.
 
 Finding Packages
 ++++++++++++++++

--- a/news/3728.feature
+++ b/news/3728.feature
@@ -1,0 +1,7 @@
+Add support for variable expansion in URLs in the requirement file. This allows
+the use of URLs that require credentials to be used without storing the
+credential as plain text in the requirement file. The variable format used is
+limited to the POSIX-style `${MY_CREDENTIAL}`. An example pointing to an
+installable artifact in a private Github repository looks like this::
+
+    https://${GITHUB_TOKEN}:x-oauth-basic@github.com/the-user/my-repo/archive/master.zip

--- a/news/3728.feature
+++ b/news/3728.feature
@@ -1,7 +1,2 @@
-Add support for variable expansion in URLs in the requirement file. This allows
-the use of URLs that require credentials to be used without storing the
-credential as plain text in the requirement file. The variable format used is
-limited to the POSIX-style `${MY_CREDENTIAL}`. An example pointing to an
-installable artifact in a private Github repository looks like this::
-
-    https://${GITHUB_TOKEN}:x-oauth-basic@github.com/the-user/my-repo/archive/master.zip
+pip now supports environment variable expansion in requirement files using
+only ``${VARIABLE}`` syntax on all platforms.

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -313,7 +313,7 @@ def skip_regex(lines_enum, options):
 
 
 def expand_env_variables(lines_enum):
-    """ Replace all environment variables that can be retrieved via `os.getenv`.
+    """Replace all environment variables that can be retrieved via `os.getenv`.
 
     The only allowed format for environment variables defined in the
     requirement file is `${MY_VARIABLE_1}` to ensure two things:
@@ -329,10 +329,8 @@ def expand_env_variables(lines_enum):
     to uppercase letter, digits and the `_` (underscore).
     """
     for line_number, line in lines_enum:
-
         for env_var, var_name in ENV_VAR_RE.findall(line):
             value = os.getenv(var_name)
-
             if not value:
                 continue
 

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -23,6 +23,12 @@ __all__ = ['parse_requirements']
 SCHEME_RE = re.compile(r'^(http|https|file):', re.I)
 COMMENT_RE = re.compile(r'(^|\s)+#.*$')
 
+# Matches environment variable-style values in '${MY_VARIABLE_1}' with the
+# variable name consisting of only uppercase letters, digits or the '_'
+# (underscore). This follows the POSIX standard defined in IEEE Std 1003.1,
+# 2013 Edition.
+ENV_VAR_RE = re.compile(r'(?P<var>\$\{(?P<name>[A-Z0-9_]+)\})')
+
 SUPPORTED_OPTIONS = [
     cmdoptions.constraints,
     cmdoptions.editable,
@@ -307,9 +313,29 @@ def skip_regex(lines_enum, options):
 
 
 def expand_env_variables(lines_enum):
+    """ Replace all environment variables that can be retrieved via `os.getenv`.
+
+    The only allowed format for environment variables defined in the
+    requirement file is `${MY_VARIABLE_1}` to ensure two things:
+
+    1. Strings that contain a `$` aren't accidentally (partially) expanded.
+    2. Ensure consistency across platforms for requirement files.
+
+    These points are the result of a discusssion on the `github pull
+    request #3514 <https://github.com/pypa/pip/pull/3514>`_.
+
+    Valid characters in variable names follow the `POSIX standard
+    <http://pubs.opengroup.org/onlinepubs/9699919799/>`_ and are limited
+    to uppercase letter, digits and the `_` (underscore).
     """
-    Replace environment variables in requirement if it's defined.
-    """
-    for line in lines_enum:
-        line = os.path.expandvars(line)
-        yield line
+    for line_number, line in lines_enum:
+
+        for env_var, var_name in ENV_VAR_RE.findall(line):
+            value = os.getenv(var_name)
+
+            if not value:
+                continue
+
+            line = line.replace(env_var, value)
+
+        yield line_number, line

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -94,6 +94,7 @@ def preprocess(content, options):
     lines_enum = join_lines(lines_enum)
     lines_enum = ignore_comments(lines_enum)
     lines_enum = skip_regex(lines_enum, options)
+    lines_enum = expand_env_variables(lines_enum)
     return lines_enum
 
 
@@ -303,3 +304,12 @@ def skip_regex(lines_enum, options):
             lambda e: pattern.search(e[1]),
             lines_enum)
     return lines_enum
+
+
+def expand_env_variables(lines_enum):
+    """
+    Replace environment variables in requirement if it's defined.
+    """
+    for line in lines_enum:
+        line = os.path.expandvars(line)
+        yield line

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -495,6 +495,40 @@ class TestParseRequirements(object):
 
         assert finder.index_urls == ['Good']
 
+    def test_expand_existing_env_variables(self, tmpdir, finder):
+        template = ('https://%s:x-oauth-basic@'
+                    'github.com/user/repo/archive/master.zip')
+
+        with open(tmpdir.join('req1.txt'), 'w') as fp:
+            fp.write(template % ('$GITHUB_TOKEN',))
+
+        with patch('pip.req.req_file.os.path.expandvars') as expandvars:
+            expandvars.return_value = (1, template % ('notarealtoken',))
+
+            reqs = list(parse_requirements(tmpdir.join('req1.txt'),
+                                           finder=finder,
+                                           session=PipSession()))
+
+            assert len(reqs) == 1
+            assert reqs[0].link.url == template % ('notarealtoken',)
+
+    def test_expand_missing_env_variables(self, tmpdir, finder):
+        req_url = ('https://$NON_EXISTING_VARIABLE:x-oauth-basic@'
+                   'github.com/user/repo/archive/master.zip')
+
+        with open(tmpdir.join('req1.txt'), 'w') as fp:
+            fp.write(req_url)
+
+        with patch('pip.req.req_file.os.path.expandvars') as expandvars:
+            expandvars.return_value = (1, req_url)
+
+            reqs = list(parse_requirements(tmpdir.join('req1.txt'),
+                                           finder=finder,
+                                           session=PipSession()))
+
+            assert len(reqs) == 1
+            assert reqs[0].link.url == req_url
+
     def test_join_lines(self, tmpdir, finder):
         with open(tmpdir.join("req1.txt"), "w") as fp:
             fp.write("--extra-index-url url1 \\\n--extra-index-url url2")

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -497,30 +497,37 @@ class TestParseRequirements(object):
 
     def test_expand_existing_env_variables(self, tmpdir, finder):
         template = ('https://%s:x-oauth-basic@'
-                    'github.com/user/repo/archive/master.zip')
+                    'github.com/user/%s/archive/master.zip')
+
+        env_vars = (
+            ('GITHUB_TOKEN', 'notarealtoken'),
+            ('DO_12_FACTOR', 'awwyeah'),
+        )
 
         with open(tmpdir.join('req1.txt'), 'w') as fp:
-            fp.write(template % ('$GITHUB_TOKEN',))
+            fp.write(template % tuple(['${%s}' % k for k, _ in env_vars]))
 
-        with patch('pip.req.req_file.os.path.expandvars') as expandvars:
-            expandvars.return_value = (1, template % ('notarealtoken',))
+        with patch('pip._internal.req.req_file.os.getenv') as getenv:
+            getenv.side_effect = lambda n: dict(env_vars)[n]
 
             reqs = list(parse_requirements(tmpdir.join('req1.txt'),
                                            finder=finder,
                                            session=PipSession()))
 
             assert len(reqs) == 1
-            assert reqs[0].link.url == template % ('notarealtoken',)
+
+            expected_url = template % tuple([v for _, v in env_vars])
+            assert reqs[0].link.url == expected_url
 
     def test_expand_missing_env_variables(self, tmpdir, finder):
-        req_url = ('https://$NON_EXISTING_VARIABLE:x-oauth-basic@'
-                   'github.com/user/repo/archive/master.zip')
+        req_url = ('https://${NON_EXISTING_VARIABLE}:$WRONG_FORMAT@'
+                   '%WINDOWS_FORMAT%github.com/user/repo/archive/master.zip')
 
         with open(tmpdir.join('req1.txt'), 'w') as fp:
             fp.write(req_url)
 
-        with patch('pip.req.req_file.os.path.expandvars') as expandvars:
-            expandvars.return_value = (1, req_url)
+        with patch('pip._internal.req.req_file.os.getenv') as getenv:
+            getenv.return_value = ''
 
             reqs = list(parse_requirements(tmpdir.join('req1.txt'),
                                            finder=finder,


### PR DESCRIPTION
I really like pip and have been using it for quite some time. One scenario that I've come across several times that doesn't seem to be covered is installing from private git (or other) repos without having to store private API keys or other authentication artifacts in the requirements file.

In a 12-factor fashion, I've started thinking about how pip could support private repos by keeping secrets in environment variables. And it turned out that supporting the expansion of environment variables is pretty trivial. Adding a line like this in a requirement file:

https://$GITHUB_TOKEN:x-oauth-basic@github.com/user/repo/archive/master.zip

can easily be expanded to by extracting the actual API key from the $GITHUB_TOKEN variable using os.path.expandvars, turning it into:

https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:x-oauth-basic@github.com/user/repo/archive/master.zip

I'm not sure if there are any caveats with this implementation around cross-platform support, security or whatever else. But I think this would be a great feature to add to pip and would love to know how to improve on this PR to get it added. 

I'm also aware that the tests could be improved since they are not really testing if this actually work. However, mocking the environment for this specific test is not really straight forward. I'd appreciate any input on how this can be tested properly.

---

_This was automatically migrated from pypa/pip#3514 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @elbaschid_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3728)
<!-- Reviewable:end -->
