### PR TITLE
Prefer in-url credentials over cached credentials

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -137,12 +137,12 @@ class MultiDomainBasicAuth(AuthBase):
         # Set the url of the request to the url without any credentials
         req.url = urllib_parse.urlunparse(parsed[:1] + (netloc,) + parsed[2:])
 
-        # Use any stored credentials that we have for this netloc
-        username, password = self.passwords.get(netloc, (None, None))
-
         # Extract credentials embedded in the url if we have none stored
+        username, password = self.parse_credentials(parsed.netloc)
+
+        # Use any stored credentials that we have for this netloc
         if username is None:
-            username, password = self.parse_credentials(parsed.netloc)
+            username, password = self.passwords.get(netloc, (None, None))
 
         if username or password:
             # Store the username and password

--- a/pip/download.py
+++ b/pip/download.py
@@ -134,9 +134,6 @@ class MultiDomainBasicAuth(AuthBase):
         # Get the netloc without any embedded credentials
         netloc = parsed.netloc.rsplit("@", 1)[-1]
 
-        # Set the url of the request to the url without any credentials
-        req.url = urllib_parse.urlunparse(parsed[:1] + (netloc,) + parsed[2:])
-
         # Extract credentials embedded in the url if we have none stored
         username, password = self.parse_credentials(parsed.netloc)
 


### PR DESCRIPTION
When having multiple urls pointing to the same host with embedded
credentials for find-links/index-urls, prefer the embedded credentials
over cached credentials. This allows for different credentials on the
same host on different paths.

Don't know how to test this, I cannot seem to be able to find tests that test authentication.

---

_This was automatically migrated from pypa/pip#3483 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @siebz0r_
