### PR TITLE
Fix some tests on Windows

### DIFF
--- a/tests/functional/test_install_download.py
+++ b/tests/functional/test_install_download.py
@@ -90,9 +90,9 @@ def test_download_should_download_wheel_deps(script, data):
     """
     wheel_filename = 'colander-0.9.9-py2.py3-none-any.whl'
     dep_filename = 'translationstring-1.1.tar.gz'
-    wheel_path = os.path.join(data.find_links, wheel_filename)
+    wheel_file_uri = '/'.join([data.find_links, wheel_filename])
     result = script.pip(
-        'install', wheel_path,
+        'install', wheel_file_uri,
         '-d', '.', '--find-links', data.find_links, '--no-index',
         expect_stderr=True,
     )

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -172,10 +172,11 @@ class TestPipResult(object):
                 )
 
             egg_link_file = self.files_created[egg_link_path]
+            normalized_newline_bytes = egg_link_file.bytes.replace('\r\n', '\n')
 
             # FIXME: I don't understand why there's a trailing . here
-            if not (egg_link_file.bytes.endswith('\n.') and
-                    egg_link_file.bytes[:-2].endswith(pkg_dir)):
+            if not (normalized_newline_bytes.endswith('\n.') and
+                    normalized_newline_bytes[:-2].endswith(pkg_dir)):
                 raise TestFailure(textwrap.dedent(u('''\
                     Incorrect egg_link file %r
                     Expected ending: %r


### PR DESCRIPTION
test_install_download: URI shouldn't be os specific.  Renamed for clarity.
**init**.py: account for difference in Windows line endings

---

_This was automatically migrated from pypa/pip#3133 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @ChristopherHogan_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3735)
<!-- Reviewable:end -->
