### PR TITLE
handle missing trailing newline when looking to uninstall entries in pth

### DIFF
--- a/news/3741.bugfix
+++ b/news/3741.bugfix
@@ -1,0 +1,1 @@
+Fix ``pip uninstall`` when ``easy-install.pth`` lacks a trailing newline.

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -430,6 +430,9 @@ class UninstallPthEntries(object):
             endline = '\r\n'
         else:
             endline = '\n'
+        # handle missing trailing newline
+        if lines and not lines[-1].endswith(endline.encode("utf-8")):
+            lines[-1] = lines[-1] + endline.encode("utf-8")
         for entry in self.entries:
             try:
                 logger.debug('Removing entry: %s', entry)

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -101,6 +101,39 @@ def test_uninstall_easy_install_after_import(script):
 
 
 @pytest.mark.network
+def test_uninstall_trailing_newline(script):
+    """
+    Uninstall behaves appropriately if easy-install.pth
+    lacks a trailing newline
+
+    """
+    script.run('easy_install', 'INITools==0.2', expect_stderr=True)
+    script.run('easy_install', 'PyLogo', expect_stderr=True)
+    easy_install_pth = script.site_packages_path / 'easy-install.pth'
+
+    # trim trailing newline from easy-install.pth
+    with open(easy_install_pth) as f:
+        pth_before = f.read()
+
+    with open(easy_install_pth, 'w') as f:
+        f.write(pth_before.rstrip())
+
+    # uninstall initools
+    script.pip('uninstall', 'INITools', '-y')
+    with open(easy_install_pth) as f:
+        pth_after = f.read()
+
+    # verify that only initools is removed
+    before_without_initools = [
+        line for line in pth_before.splitlines()
+        if 'initools' not in line.lower()
+    ]
+    lines_after = pth_after.splitlines()
+
+    assert lines_after == before_without_initools
+
+
+@pytest.mark.network
 def test_uninstall_namespace_package(script):
     """
     Uninstall a distribution with a namespace package without clobbering


### PR DESCRIPTION
If a pth file lacks a trailing newline, the last entry will not be recognized and removed.

---

_This was automatically migrated from pypa/pip#2957 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @minrk_
