### PR TITLE
Indicate where we are looking for packages

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -187,6 +187,12 @@ class PackageFinder(object):
                     )
                     break
 
+    def __str__(self):
+        sources = list(self.index_urls)
+        if self.find_links:
+            sources += self.find_links
+        return str(sources)
+
     def add_dependency_links(self, links):
         # # FIXME: this shouldn't be global list this, it should only
         # # apply to requirements of the package that specifies the
@@ -560,7 +566,8 @@ class PackageFinder(object):
                 )
 
             raise DistributionNotFound(
-                'No matching distribution found for %s' % req
+                'No matching distribution found for %s from %s'
+                % (req, self)
             )
 
         if applicable_versions[0].location is INSTALLED_VERSION:

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -400,7 +400,11 @@ class RequirementSet(object):
                     path = url_to_path(req_to_install.link.url)
                     logger.info('Processing %s', display_path(path))
                 else:
-                    logger.info('Collecting %s', req_to_install)
+                    if req_to_install.link:
+                        logger.info('Collecting %s', req_to_install)
+                    else:
+                        logger.info(
+                            'Collecting %s from %s', req_to_install, finder)
 
         with indent_log():
             # ################################ #

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -305,7 +305,7 @@ def test_install_global_option(script):
     result = script.pip(
         'install', '--global-option=--version', "INITools==0.1",
         expect_stderr=True)
-    assert '0.1\n' in result.stdout
+    assert 'Collecting INITools==0.1' in result.stdout
 
 
 def test_install_with_pax_header(script, data):


### PR DESCRIPTION
If you frequently edit your ~/.pip/pip.conf to add and remove indexes, then it's easy to forget what state you've left it in and it's useful to be able to see where pip is searching for packages. E.g.:

$ pip install --download=. --find-links=/tmp/wheels 'smlib.web>=3.0'
Collecting smlib.web>=3.0 from ['https://pypi.python.org/simple', '/tmp/wheels']
...
No matching distribution found for smlib.web>=3.0 from ['https://pypi.python.org/simple', '/tmp/wheels']

---

_This was automatically migrated from pypa/pip#2790 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @msabramo_
