### PR TITLE
tox.ini: Add "cover" target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,10 @@ install_command = python -m pip install --pre {opts} {packages}
 [testenv:py26]
 install_command = pip install --pre {opts} {packages}
 
+[testenv:cover]
+basepython = python3.4
+commands = py.test --timeout 300 --cov=pip --cov-report=term-missing --cov-report=xml --cov-report=html tests/unit {posargs}
+
 [testenv:docs]
 deps = sphinx
 basepython = python2.7


### PR DESCRIPTION
that measures coverage for unit tests only. Functional tests are slow
enough already and a lot of them fail when coverage is measured, because
they fork processes and them emit warnings to stderr that the tests are
not expecting.

I think it's a good thing to try to increase unit test coverage and this
lets us measure and see where the gaps are. And it will help folks
realize if they increased or decreased coverage with their changes.

---

_This was automatically migrated from pypa/pip#2546 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @msabramo_
