### PR TITLE
Make --no-clean work in tox

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -671,6 +671,5 @@ class RequirementSet(object):
                     if (requirement.conflicts_with and
                             requirement.install_succeeded):
                         requirement.commit_uninstall()
-                requirement.remove_temporary_source()
 
         self.successfully_installed = to_install

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -32,7 +32,7 @@ def test_no_clean_option_blocks_cleaning_after_install(script, data):
         'install', '--no-clean', '--no-index', '--build', build,
         '--find-links=%s' % data.find_links, 'simple',
     )
-    assert exists(build)
+    assert exists(build / 'simple' / 'setup.py')
 
 
 @pytest.mark.network


### PR DESCRIPTION
Right now, --no-clean will preserve the build directory that pip created during the installation, but everything in the directory is deleted. It's not useful to keep the build directory if there's nothing in it, so this fixes the issue by not deleting things inside the build directory unconditionally.

---

_This was automatically migrated from pypa/pip#2689 to reparent it to the `master` branch. Please see original pull request for any previous discussion._

_Original Submitter: @habnabit_
