### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -944,7 +944,7 @@
 * Fixed :issue:`32` - pip fails when server does not send content-type header.
   Thanks Hugo Lopes Tavares and Kelsey Hightower (:pull:`872`).
 
-* "Vendorized" distlib as pip.vendor.distlib (https://distlib.readthedocs.org/).
+* "Vendorized" distlib as pip.vendor.distlib (https://distlib.readthedocs.io/).
 
 * Fixed git VCS backend with git 1.8.3. (:pull:`967`)
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -153,7 +153,7 @@ Installing from Wheels
 
 "Wheel" is a built, archive format that can greatly speed installation compared
 to building and installing from source archives. For more information, see the
-`Wheel docs <http://wheel.readthedocs.org>`_ ,
+`Wheel docs <https://wheel.readthedocs.io>`_ ,
 `PEP427 <http://www.python.org/dev/peps/pep-0427>`_, and
 `PEP425 <http://www.python.org/dev/peps/pep-0425>`_
 

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -24,7 +24,7 @@ class WheelCommand(RequirementCommand):
 
     Wheel is a built-package format, and offers the advantage of not
     recompiling your software during every install. For more details, see the
-    wheel docs: http://wheel.readthedocs.org/en/latest.
+    wheel docs: https://wheel.readthedocs.io/en/latest/
 
     Requirements: setuptools>=0.8, and wheel.
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.