### PR TITLE
Fix broken link to setup tools documentation

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -633,7 +633,7 @@ local hash.
 +++++++++++++++++++
 
 "Editable" installs are fundamentally `"setuptools develop mode"
-<http://packages.python.org/setuptools/setuptools.html#development-mode>`_
+<http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode>`_
 installs.
 
 You can install local projects or VCS projects in "editable" mode::


### PR DESCRIPTION
Original link results in 404 as setuptools documentation has now been moved to readthedocs, I believe this is the correct location