### PR TITLE
Fix a ResourceWarning in setuptools_build

### DIFF
--- a/pip/utils/setuptools_build.py
+++ b/pip/utils/setuptools_build.py
@@ -1,6 +1,8 @@
 # Shim to wrap setup.py invocation with setuptools
 SETUPTOOLS_SHIM = (
     "import setuptools, tokenize;__file__=%r;"
-    "exec(compile(getattr(tokenize, 'open', open)(__file__).read()"
-    ".replace('\\r\\n', '\\n'), __file__, 'exec'))"
+    "f=getattr(tokenize, 'open', open)(__file__);"
+    "code=f.read().replace('\\r\\n', '\\n');"
+    "f.close();"
+    "exec(compile(code, __file__, 'exec'))"
 )


### PR DESCRIPTION
Running setup.py using SETUPTOOLS_SHIM logs a ResourceWarning on
Python 3 when using python3 -Wd command line option. This change
fixes the warning by close the setup.py file before running it.

Example of warning with Python 3.5 and pip:

```
$ python3 -m venv py3
$ py3/bin/python -m pip install -U pip
$ py3/bin/python -Wd -m pip install PrettyTable python-editor
...

Collecting PrettyTable
  Using cached prettytable-0.7.2.zip
/home/haypo/prog/openstack/nova/py36/lib/python3.6/site-packages/pip/req/req_install.py:425: ResourceWarning: unclosed file <_io.BufferedReader name=5>
  command_desc='python setup.py egg_info')

Collecting python-editor
  Using cached python-editor-1.0.1.tar.gz
Installing collected packages: PrettyTable, python-editor
  Running setup.py install for PrettyTable ... done
/home/haypo/prog/openstack/nova/py36/lib/python3.6/site-packages/pip/req/req_install.py:880: ResourceWarning: unclosed file <_io.BufferedReader name=5>
  spinner=spinner,
  Running setup.py install for python-editor ... done

...
```