### PR TITLE
Abort install if Requires-Python do not match the running version

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -52,6 +52,8 @@
 
 * Normalize package names before using in ``pip show`` (:issue:`3976`)
 
+* Raises when Requires-Python do not match the running version.
+
 
 **8.1.2 (2016-05-10)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -53,6 +53,7 @@
 * Normalize package names before using in ``pip show`` (:issue:`3976`)
 
 * Raises when Requires-Python do not match the running version.
+  Add ``--ignore-requires-python`` escape hatch.
 
 
 **8.1.2 (2016-05-10)**

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -477,6 +477,13 @@ build_dir = partial(
     help='Directory to unpack packages into and build in.'
 )
 
+ignore_requires_python = partial(
+    Option,
+    '--ignore-requires-python',
+    dest='ignore_requires_python',
+    action='store_true',
+    help='Ignore the Requires-Python information.')
+
 install_options = partial(
     Option,
     '--install-option',

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -118,6 +118,7 @@ class InstallCommand(RequirementCommand):
             action='store_true',
             help='Ignore the installed packages (reinstalling instead).')
 
+        cmd_opts.add_option(cmdoptions.ignore_requires_python())
         cmd_opts.add_option(cmdoptions.no_deps())
 
         cmd_opts.add_option(cmdoptions.install_options())
@@ -295,6 +296,7 @@ class InstallCommand(RequirementCommand):
                     as_egg=options.as_egg,
                     ignore_installed=options.ignore_installed,
                     ignore_dependencies=options.ignore_dependencies,
+                    ignore_requires_python=options.ignore_requires_python,
                     force_reinstall=options.force_reinstall,
                     use_user_site=options.use_user_site,
                     target_dir=temp_target_dir,

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -70,6 +70,7 @@ class WheelCommand(RequirementCommand):
         cmd_opts.add_option(cmdoptions.editable())
         cmd_opts.add_option(cmdoptions.requirements())
         cmd_opts.add_option(cmdoptions.src())
+        cmd_opts.add_option(cmdoptions.ignore_requires_python())
         cmd_opts.add_option(cmdoptions.no_deps())
         cmd_opts.add_option(cmdoptions.build_dir())
 
@@ -171,6 +172,7 @@ class WheelCommand(RequirementCommand):
                     download_dir=None,
                     ignore_dependencies=options.ignore_dependencies,
                     ignore_installed=True,
+                    ignore_requires_python=options.ignore_requires_python,
                     isolated=options.isolated_mode,
                     session=session,
                     wheel_cache=wheel_cache,

--- a/pip/exceptions.py
+++ b/pip/exceptions.py
@@ -237,3 +237,7 @@ class HashMismatch(HashError):
                          self.gots[hash_name].hexdigest())
             prefix = '    or'
         return '\n'.join(lines)
+
+
+class UnsupportedPythonVersion(InstallationError):
+    """Unsupported python version (related to PEP 345 Requires-Python)."""

--- a/pip/exceptions.py
+++ b/pip/exceptions.py
@@ -240,4 +240,5 @@ class HashMismatch(HashError):
 
 
 class UnsupportedPythonVersion(InstallationError):
-    """Unsupported python version (related to PEP 345 Requires-Python)."""
+    """Unsupported python version according to Requires-Python package
+    metadata."""

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -20,6 +20,7 @@ from pip.utils import (
     display_path, dist_in_usersite, ensure_dir, normalize_path)
 from pip.utils.hashes import MissingHashes
 from pip.utils.logging import indent_log
+from pip.utils.packaging import check_dist_requires_python
 from pip.vcs import vcs
 from pip.wheel import Wheel
 
@@ -655,6 +656,7 @@ class RequirementSet(object):
             # # parse dependencies # #
             # ###################### #
             dist = abstract_dist.dist(finder)
+            check_dist_requires_python(dist)
             more_reqs = []
 
             def add_req(subreq):

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -665,6 +665,7 @@ class RequirementSet(object):
                 if self.ignore_requires_python:
                     logger.warning(e.args[0])
                 else:
+                    req_to_install.remove_temporary_source()
                     raise
             more_reqs = []
 

--- a/pip/utils/packaging.py
+++ b/pip/utils/packaging.py
@@ -1,9 +1,15 @@
 from __future__ import absolute_import
+
+from email.parser import FeedParser
+
 import logging
 import sys
 
 from pip._vendor.packaging import specifiers
 from pip._vendor.packaging import version
+from pip._vendor import pkg_resources
+
+from pip import exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -26,3 +32,32 @@ def check_requires_python(requires_python):
     # We only use major.minor.micro
     python_version = version.parse('.'.join(map(str, sys.version_info[:3])))
     return python_version in requires_python_specifier
+
+
+def get_metadata(dist):
+    if (isinstance(dist, pkg_resources.DistInfoDistribution) and
+            dist.has_metadata('METADATA')):
+        return dist.get_metadata('METADATA')
+    elif dist.has_metadata('PKG-INFO'):
+        return dist.get_metadata('PKG-INFO')
+
+
+def check_dist_requires_python(dist):
+    metadata = get_metadata(dist)
+    feed_parser = FeedParser()
+    feed_parser.feed(metadata)
+    pkg_info_dict = feed_parser.close()
+    requires_python = pkg_info_dict.get('Requires-Python')
+    try:
+        if not check_requires_python(requires_python):
+            raise exceptions.UnsupportedPythonVersion(
+                "%s requires Python '%s' but the running Python is %s" % (
+                    dist.project_name,
+                    requires_python,
+                    '.'.join(map(str, sys.version_info[:3])),)
+            )
+    except specifiers.InvalidSpecifier as e:
+        logger.debug(
+            "Package %s has an invalid Requires-Python entry %s - %s" % (
+                dist.project_name, requires_python, e))
+        return

--- a/pip/utils/packaging.py
+++ b/pip/utils/packaging.py
@@ -57,7 +57,7 @@ def check_dist_requires_python(dist):
                     '.'.join(map(str, sys.version_info[:3])),)
             )
     except specifiers.InvalidSpecifier as e:
-        logger.debug(
+        logger.warning(
             "Package %s has an invalid Requires-Python entry %s - %s" % (
                 dist.project_name, requires_python, e))
         return


### PR DESCRIPTION
Once https://github.com/pypa/setuptools/pull/631 is merged, it should be easier to add functionnal tests

I'm wondering wheither pip should provide an escape hatch via some `--ignore-requires-python` or not.