### PR TITLE
Allow -py3 (or -py2) suffix on filenames

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -636,7 +636,7 @@ class PackageFinder(object):
         if match:
             version = version[:match.start()]
             py_version = match.group(1)
-            if py_version != sys.version[:3]:
+            if not sys.version.startswith(py_version):
                 self._log_skipped_link(
                     link, 'Python version is incorrect')
                 return


### PR DESCRIPTION
pip already finds and installs packages with a suffix like `-py3.5`, if it's running on the relevant version of Python.

The regex controlling this (`r'-py([123]\.?[0-9]?)$'`) will already match a shorter tag like '-py3', but the code that checks the Python version will always decide that doesn't match the current Python version. This changes from checking the first three characters of `sys.version` to using `.startswith()` to match as much as the regex has found.

I want this so I can release new versions of packages which support only Python 3, while pip will continue to install older versions on Python 2. There are better ways to indicate compatibility (classifiers, or even the requires-python metadata), but using those in pip would involve much bigger changes. This is a very simple solution using the machinery already in place.

See also gh-3182. Pinging @hgrecco and @Carreau.