### PR TITLE
Use os.path.lexists when checking for virtualenvs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,9 @@
   distributions for interpreters other than the one pip is being run on.
   (:pull:`3760`)
 
+* Skip scanning virtual environments even when venv/bin/python is a dangling
+  symlink.
+
 
 **8.1.2 (2016-05-10)**
 

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -483,7 +483,7 @@ class InstallRequirement(object):
                         # Don't search in anything that looks like a virtualenv
                         # environment
                         if (
-                                os.path.exists(
+                                os.path.lexists(
                                     os.path.join(root, dir, 'bin', 'python')
                                 ) or
                                 os.path.exists(


### PR DESCRIPTION
This is a fix for a fairly contrived situation I experience because of my particular development environment. For development, I run projects within a Vagrant virtual machine, with the source code living on my host machine (in `project/`), shared in to the virtual machine guest. I create a virtual environment on my host machine in this directory (`project/venv`) so that my editor can do code completion, etc. I run, test, and package the code on the the guest machine. When running `pip install -e .` or similar commands on the guest, the code within pip fails to detect the virtual environment created on the host machine as a virtual environment, causing the command to delve down through the virtual environment directories despite `pip` attempting to filter virtual environments out. This makes the `pip install -e .` command take about a minute to run, compared to the few seconds when the virtual environment is correctly ignored.

pip fails to detect the virtual environment in this particular case, as pip uses `os.path.exists()` to check that `project/venv/bin/python` exists. This file does exist, but is a symlink to the `python` executable provided by the system. On my host, the target file does exist, but in the guest (which may use a different version of Python, or structure its directories differently, or...), the target file does *not* exist. `os.path.exists()` returns `False` for dangling symlinks, causing the virtual environment detection code to fail.

This change uses `os.path.lexists()` instead of `os.path.exists()`, which returns True for dangling symlinks.