### PR TITLE
pip completion for fish shell

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,8 @@
 * Skip scanning virtual environments even when venv/bin/python is a dangling
   symlink.
 
+* Added pip completion support for fish shell.
+
 
 **8.1.2 (2016-05-10)**
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -424,7 +424,7 @@ Examples:
 Command Completion
 ------------------
 
-pip comes with support for command line completion in bash and zsh.
+pip comes with support for command line completion in bash, zsh and fish.
 
 To setup for bash::
 
@@ -433,6 +433,10 @@ To setup for bash::
 To setup for zsh::
 
     $ pip completion --zsh >> ~/.zprofile
+
+To setup for fish::
+
+$ pip completion --fish > ~/.config/fish/completions/pip.fish
 
 Alternatively, you can use the result of the ``completion`` command
 directly with the eval function of your shell, e.g. by adding the following to your startup file::

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -44,7 +44,7 @@ def autocomplete():
     """Command and option completion for the main option parser (and options)
     and its subcommands (and options).
 
-    Enable by sourcing one of the completion shell scripts (bash or zsh).
+    Enable by sourcing one of the completion shell scripts (bash, zsh or fish).
     """
     # Don't complete if user hasn't sourced bash_completion file.
     if 'PIP_AUTO_COMPLETE' not in os.environ:

--- a/pip/commands/completion.py
+++ b/pip/commands/completion.py
@@ -26,6 +26,14 @@ function _pip_completion {
              PIP_AUTO_COMPLETE=1 $words[1] ) )
 }
 compctl -K _pip_completion pip
+""", 'fish': """
+function __fish_complete_pip
+    set -lx COMP_WORDS (commandline -o) ""
+    set -lx COMP_CWORD (math (contains -i -- (commandline -t) $COMP_WORDS)-1)
+    set -lx PIP_AUTO_COMPLETE 1
+    string split \  -- (eval $COMP_WORDS[1])
+end
+complete -fa "(__fish_complete_pip)" -c pip
 """}
 
 
@@ -51,6 +59,12 @@ class CompletionCommand(Command):
             const='zsh',
             dest='shell',
             help='Emit completion code for zsh')
+        cmd_opts.add_option(
+            '--fish', '-f',
+            action='store_const',
+            const='fish',
+            dest='shell',
+            help='Emit completion code for fish')
 
         self.parser.insert_option_group(0, cmd_opts)
 

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -37,6 +37,23 @@ compctl -K _pip_completion pip"""
     assert zsh_completion in result.stdout, 'zsh completion is wrong'
 
 
+def test_completion_for_fish(script):
+    """
+    Test getting completion for fish shell
+    """
+    fish_completion = """\
+    function __fish_complete_pip
+        set -lx COMP_WORDS (commandline -o) ""
+        set -lx COMP_CWORD (math (contains -i -- (commandline -t) $COMP_WORDS)-1)
+        set -lx PIP_AUTO_COMPLETE 1
+        string split \  -- (eval $COMP_WORDS[1])
+    end
+    complete -fa "(__fish_complete_pip)" -c pip"""
+
+    result = script.pip('completion', '--fish')
+    assert fish_completion in result.stdout, 'fish completion is wrong'
+
+
 def test_completion_for_unknown_shell(script):
     """
     Test getting completion for an unknown shell

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -68,7 +68,7 @@ def test_completion_alone(script):
     Test getting completion for none shell, just pip completion
     """
     result = script.pip('completion', expect_error=True)
-    assert 'ERROR: You must pass --bash or --zsh' in result.stderr, \
+    assert 'ERROR: You must pass --bash or --fish or --zsh' in result.stderr, \
            'completion alone failed -- ' + result.stderr
 
 

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -42,13 +42,13 @@ def test_completion_for_fish(script):
     Test getting completion for fish shell
     """
     fish_completion = """\
-    function __fish_complete_pip
-        set -lx COMP_WORDS (commandline -o) ""
-        set -lx COMP_CWORD (math (contains -i -- (commandline -t) $COMP_WORDS)-1)
-        set -lx PIP_AUTO_COMPLETE 1
-        string split \  -- (eval $COMP_WORDS[1])
-    end
-    complete -fa "(__fish_complete_pip)" -c pip"""
+function __fish_complete_pip
+    set -lx COMP_WORDS (commandline -o) ""
+    set -lx COMP_CWORD (math (contains -i -- (commandline -t) $COMP_WORDS)-1)
+    set -lx PIP_AUTO_COMPLETE 1
+    string split \  -- (eval $COMP_WORDS[1])
+end
+complete -fa "(__fish_complete_pip)" -c pip"""
 
     result = script.pip('completion', '--fish')
     assert fish_completion in result.stdout, 'fish completion is wrong'


### PR DESCRIPTION
PR to address #652

Note that fish completions can be much more in-depth than what's here, but I intentionally tried to keep things in line with the same level of "out of the box" pip completions you get with bash and zsh.

Function name is slightly different to that of bash/zsh to follow fish conventions.