### PR TITLE
Change "tmpdir" fixture to work with latest pytest

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,16 +2,6 @@
 set -e
 set -x
 
-# If we're running under Python 3.5, we can't use anything but --asert=plain
-if [[ $TOXENV = "py35" ]]; then
-    export TOXARGS="--assert=plain"
-fi
-
-# If we're running under Python 3.6, we can't use anything but --asert=plain
-if [[ $TOXENV = "py36" ]]; then
-    export TOXARGS="--assert=plain"
-fi
-
 # We want to create the virtual environment here, but not actually run anything
 tox --notest
 
@@ -51,7 +41,7 @@ if [[ $VENDOR = "no" ]]; then
 fi
 
 # Run the unit tests
-tox -- -m unit $TOXARGS
+tox -- -m unit
 
 # Run our integration tests
-tox -- -m integration -n 8 $TOXARGS
+tox -- -m integration -n 8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,8 @@
 freezegun
 pretend
-# Pinned to 2.7.2 to avoid an issue with parallel builds
-pytest==2.7.2
+pytest
 pytest-capturelog
-# Pinned to 0.5 to stay compatible with pytest==2.7.2
-pytest-timeout==0.5
+pytest-timeout
 pytest-xdist
 mock<1.1
 scripttest>=1.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 
-import py
 import pytest
 
 from pip.utils import appdirs
@@ -42,27 +41,23 @@ def pytest_collection_modifyitems(items):
             )
 
 
-@pytest.fixture
-def tmpdir(request):
+@pytest.yield_fixture
+def tmpdir(tmpdir):
     """
     Return a temporary directory path object which is unique to each test
     function invocation, created as a sub directory of the base temporary
     directory. The returned object is a ``tests.lib.path.Path`` object.
 
-    This is taken from pytest itself but modified to return our typical
-    path object instead of py.path.local as well as deleting the temporary
-    directories at the end of each test case.
+    This uses the built-in tmpdir fixture from pytest itself but modified
+    to return our typical path object instead of py.path.local as well as
+    deleting the temporary directories at the end of each test case.
     """
-    name = request.node.name
-    name = py.std.re.sub("[\W]", "_", name)
-    tmp = request.config._tmpdirhandler.mktemp(name, numbered=True)
-
+    assert tmpdir.isdir()
+    yield Path(str(tmpdir))
     # Clear out the temporary directory after the test has finished using it.
     # This should prevent us from needing a multiple gigabyte temporary
     # directory while running the tests.
-    request.addfinalizer(lambda: shutil.rmtree(str(tmp), ignore_errors=True))
-
-    return Path(str(tmp))
+    tmpdir.remove(ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Re-using the built-in `tmpdir` fixture fixes pytest-dev/pytest#1083

Also with latest pytest there's no need to use `--assert=plain` on py35 anymore

Fixes #3699
Fixes pytest-dev/pytest#1083