### PR TITLE
Add --save and --save-to options to install

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 import logging
 import operator
 import os
-import tempfile
 import shutil
+import tempfile
 import warnings
+
 try:
     import wheel
 except ImportError:
@@ -157,6 +158,20 @@ class InstallCommand(RequirementCommand):
             action="store_false",
             dest="compile",
             help="Do not compile py files to pyc",
+        )
+
+        cmd_opts.add_option(
+            '--save',
+            action='store_true',
+            dest='save',
+            default=False,
+            help='Add package(s) to requirements file'
+        )
+
+        cmd_opts.add_option(
+            '--save-to',
+            dest='save_to',
+            help='Path to the requirements file'
         )
 
         cmd_opts.add_option(cmdoptions.use_wheel())
@@ -394,4 +409,19 @@ class InstallCommand(RequirementCommand):
                         target_item_dir
                     )
             shutil.rmtree(temp_target_dir)
+
+        if options.save:
+            if options.save_to:
+                requirements_fpath = options.save_to
+            else:
+                requirements_fpath = 'requirements.txt'
+
+            with open(requirements_fpath, 'a') as requirements_file:
+                for requirement in requirement_set.requirements.values():
+                    if not requirement.comes_from:  # not a dependency of smth
+                        requirements_file.write(
+                            '{pkg}=={pkg_version}\n'.format(
+                                pkg=requirement.name,
+                                pkg_version=requirement.installed_version))
+
         return requirement_set

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1026,3 +1026,11 @@ def test_double_install_fail(script, data):
     msg = ("Double requirement given: pip==7.1.2 (already in pip==*, "
            "name='pip')")
     assert msg in result.stderr
+
+
+def test_save_installed_package_in_requirements(script, tmpdir):
+    requirements_fpath = tmpdir.join('requirements.txt')
+    script.pip('install', '--save',
+               '--save-to', requirements_fpath, 'pip')
+    with open(requirements_fpath, 'r') as requirements_file:
+        assert 'pip==' in requirements_file.read()

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1026,11 +1026,3 @@ def test_double_install_fail(script, data):
     msg = ("Double requirement given: pip==7.1.2 (already in pip==*, "
            "name='pip')")
     assert msg in result.stderr
-
-
-def test_save_installed_package_in_requirements(script, tmpdir):
-    requirements_fpath = tmpdir.join('requirements.txt')
-    script.pip('install', '--save',
-               '--save-to', requirements_fpath, 'pip')
-    with open(requirements_fpath, 'r') as requirements_file:
-        assert 'pip==' in requirements_file.read()

--- a/tests/functional/test_install_save.py
+++ b/tests/functional/test_install_save.py
@@ -1,0 +1,56 @@
+def test_save_installed_package_in_requirements(script):
+    freezed_requests = 'requests==1.0.0'
+    script.pip('install', '--save', freezed_requests)
+
+    requirements_fpath = script.cwd.join('requirements.txt')
+    with open(requirements_fpath, 'r') as requirements_file:
+        assert freezed_requests in requirements_file.read()
+
+
+def test_save_can_specify_save_to_file(script, tmpdir):
+    requirements_fpath = tmpdir.join('base.txt')
+    freezed_requests = 'requests==1.0.0'
+    script.pip('install', '--save',
+               '--save-to', requirements_fpath, freezed_requests)
+
+    with open(requirements_fpath, 'r') as requirements_file:
+        assert freezed_requests in requirements_file.read()
+
+
+def test_save_fails_if_base_directory_not_exists(script, tmpdir):
+    requirements_fpath = tmpdir.join('base/requirements.txt')
+    freezed_requests = 'requests==1.0.0'
+    result = script.pip('install', '--save',
+                        '--save-to', requirements_fpath, freezed_requests,
+                        expect_error=True)
+    assert result.returncode == 2
+    assert 'FileNotFoundError' in result.stderr
+
+
+def test_save_only_updates_package_line_if_already_exists(script, tmpdir):
+    requirements_fpath = tmpdir.join('requirements.txt')
+    existing_requests_line = 'requests==1.0.0'
+    with open(requirements_fpath, 'w') as requirements_file:
+        requirements_file.write(existing_requests_line)
+
+    updated_requests_line = 'requests==1.0.1'
+    script.pip('install', '--save',
+               '--save-to', requirements_fpath, updated_requests_line)
+
+    with open(requirements_fpath, 'r') as requirements_file:
+        assert updated_requests_line in requirements_file.read()
+
+
+def test_save_preserves_original_content_of_requirements_file(script, tmpdir):
+    requirements_fpath = tmpdir.join('dev-requirements.txt')
+    original_line = '-r requirements.txt'
+    with open(requirements_fpath, 'w') as requirements_file:
+        requirements_file.write(original_line + '\n')
+
+    requests_line = 'requests==1.0.1'
+    script.pip('install', '--save',
+               '--save-to', requirements_fpath, requests_line)
+    with open(requirements_fpath, 'r') as requirements_file:
+        file_contents = requirements_file.read()
+        assert original_line in file_contents
+        assert requests_line in file_contents


### PR DESCRIPTION
Resolves #1479.

`--save` is a boolean flag to save a `name==version` line to the requirements file, and `--save-to` specifies which requirements file to use.

Features:
- updates package line in the requirements file if package already exists in the file
- fails with `FileNotFoundError` if base directory for the requirements file does not exist
- preserves file content (i.e. `-r requirements.txt` in the beginning of the file)