### PR TITLE
Implement pep 503 data-requires-python

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,10 @@
 * Fix regression in pip freeze: when there is more than one git remote,
   priority is given to the remote named origin (:issue:`3616`)
 
+* Implementation of pep-503 ``data-requires-python``. When this field is
+  present for a release link, pip will ignore the download when
+  installing to a Python version that doesn't satisfy the requirement.
+
 * Pip wheel now works on editable packages too (it was only working on
   editable dependencies before); this allows running pip wheel on the result
   of pip freeze in presence of editable requirements (:issue:`3291`)

--- a/pip/baseparser.py
+++ b/pip/baseparser.py
@@ -113,6 +113,7 @@ class UpdatingDefaultsHelpFormatter(PrettyHelpFormatter):
 
 
 class CustomOptionParser(optparse.OptionParser):
+
     def insert_option_group(self, idx, *args, **kwargs):
         """Insert an OptionGroup at a given position."""
         group = self.add_option_group(*args, **kwargs)

--- a/pip/index.py
+++ b/pip/index.py
@@ -644,7 +644,9 @@ class PackageFinder(object):
                 return
 
         if not check_requires_python(link.requires_python):
-            logger.debug('The package ', link, "is incompatible with the python version in use. Acceptable python versions are:", link.requires_python)
+            logger.debug("The package %s is incompatible with the python"
+                         "version in use. Acceptable python versions are:%s",
+                         link, link.requires_python)
             return
         logger.debug('Found link %s, version: %s', link, version)
 
@@ -834,7 +836,8 @@ class HTMLPage(object):
                 url = self.clean_link(
                     urllib_parse.urljoin(self.base_url, href)
                 )
-                yield Link(url, self, requires_python=anchor.get('data-requires-python'))
+                pyrequire = anchor.get('data-requires-python')
+                yield Link(url, self, requires_python=pyrequire)
 
     _clean_re = re.compile(r'[^a-z0-9$&+,/:;=?@.#%_\\|-]', re.I)
 
@@ -850,7 +853,7 @@ class Link(object):
 
     def __init__(self, url, comes_from=None, requires_python=None):
         """
-        Object representing a parsed link from https://pypi.python.org/simple/<packagename>/
+        Object representing a parsed link from https://pypi.python.org/simple/*
 
         url:
             url of the resource pointed to (href of the link)

--- a/pip/index.py
+++ b/pip/index.py
@@ -644,9 +644,8 @@ class PackageFinder(object):
                 return
 
         if not check_requires_python(link.requires_python):
-            print('check on ', link, "Showed it's not compatible with python version in use:", link.requires_python)
+            logger.debug('The package ', link, "is incompatible with the python version in use. Acceptable python versions are:", link.requires_python)
             return
-        #import ipdb; ipdb.set_trace()
         logger.debug('Found link %s, version: %s', link, version)
 
         return InstallationCandidate(search.supplied, version, link)

--- a/pip/index.py
+++ b/pip/index.py
@@ -849,6 +849,19 @@ class HTMLPage(object):
 class Link(object):
 
     def __init__(self, url, comes_from=None, requires_python=None):
+        """
+        Object representing a parsed link from https://pypi.python.org/simple/<packagename>/
+
+        url:
+            url of the resource pointed to (href of the link)
+        comes_form:
+            <Not sure>
+        requires_python:
+            String containing the `Requires-Python` metadata field, specified
+            in PEP 345. This is to understand pep 503. The `requires_python`
+            string will be unescaped as pep 503 requires `<` and `>` to be
+            escaped, then stored under the `requires_python` attribute.
+        """
 
         # url can be a UNC windows share
         if url.startswith('\\\\'):

--- a/pip/utils/packaging.py
+++ b/pip/utils/packaging.py
@@ -7,13 +7,15 @@ from pip._vendor.packaging import version
 
 logger = logging.getLogger(__name__)
 
+
 def check_requires_python(requires_python):
     """
-    Check if the python version in used match the `requires_python` specifier passed.
+    Check if the python version in used match the `requires_python` specifier.
 
     Return `True` if the version of python in use matches the requirement.
-    Return `False` if the version of python in use does not matches the requirement.
-    Raises an InvalidSpecifier if `requires_python` have an invalid format.
+    Return `False` if the version of python in use does not matches the
+    requirement. Raises an InvalidSpecifier if `requires_python` have an
+    invalid format.
     """
     if requires_python is None:
         # The package provides no information
@@ -23,10 +25,9 @@ def check_requires_python(requires_python):
     except specifiers.InvalidSpecifier as e:
         logger.debug(
             "Package %s has an invalid Requires-Python entry - %s" % (
-                 requires_python, e))
-        raise specifiers.InvalidSpecifier(*e.args)
+                requires_python, e))
+        raise
 
     # We only use major.minor.micro
     python_version = version.parse('.'.join(map(str, sys.version_info[:3])))
     return python_version in requires_python_specifier
-

--- a/pip/utils/packaging.py
+++ b/pip/utils/packaging.py
@@ -1,22 +1,11 @@
 from __future__ import absolute_import
-
 import logging
 import sys
 
-from pip._vendor import pkg_resources
 from pip._vendor.packaging import specifiers
 from pip._vendor.packaging import version
 
 logger = logging.getLogger(__name__)
-
-
-def get_metadata(dist):
-    if (isinstance(dist, pkg_resources.DistInfoDistribution) and
-            dist.has_metadata('METADATA')):
-        return dist.get_metadata('METADATA')
-    elif dist.has_metadata('PKG-INFO'):
-        return dist.get_metadata('PKG-INFO')
-
 
 def check_requires_python(requires_python):
     """

--- a/pip/utils/packaging.py
+++ b/pip/utils/packaging.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+import logging
+import sys
+
+from pip._vendor import pkg_resources
+from pip._vendor.packaging import specifiers
+from pip._vendor.packaging import version
+
+logger = logging.getLogger(__name__)
+
+
+def get_metadata(dist):
+    if (isinstance(dist, pkg_resources.DistInfoDistribution) and
+            dist.has_metadata('METADATA')):
+        return dist.get_metadata('METADATA')
+    elif dist.has_metadata('PKG-INFO'):
+        return dist.get_metadata('PKG-INFO')
+
+
+def check_requires_python(requires_python):
+    if requires_python is None:
+        # The package provides no information
+        return True
+    try:
+        requires_python_specifier = specifiers.SpecifierSet(requires_python)
+    except specifiers.InvalidSpecifier as e:
+        logger.debug(
+            "Package %s has an invalid Requires-Python entry - %s" % (
+                 requires_python, e))
+        return ValueError('Wrong Specifier')
+
+    # We only use major.minor.micro
+    python_version = version.parse('.'.join(map(str, sys.version_info[:3])))
+    if python_version not in requires_python_specifier:
+        return False

--- a/pip/utils/packaging.py
+++ b/pip/utils/packaging.py
@@ -19,6 +19,13 @@ def get_metadata(dist):
 
 
 def check_requires_python(requires_python):
+    """
+    Check if the python version in used match the `requires_python` specifier passed.
+
+    Return `True` if the version of python in use matches the requirement.
+    Return `False` if the version of python in use does not matches the requirement.
+    Raises an InvalidSpecifier if `requires_python` have an invalid format.
+    """
     if requires_python is None:
         # The package provides no information
         return True
@@ -28,9 +35,9 @@ def check_requires_python(requires_python):
         logger.debug(
             "Package %s has an invalid Requires-Python entry - %s" % (
                  requires_python, e))
-        return ValueError('Wrong Specifier')
+        raise specifiers.InvalidSpecifier(*e.args)
 
     # We only use major.minor.micro
     python_version = version.parse('.'.join(map(str, sys.version_info[:3])))
-    if python_version not in requires_python_specifier:
-        return False
+    return python_version in requires_python_specifier
+

--- a/pip/utils/packaging.py
+++ b/pip/utils/packaging.py
@@ -10,23 +10,18 @@ logger = logging.getLogger(__name__)
 
 def check_requires_python(requires_python):
     """
-    Check if the python version in used match the `requires_python` specifier.
+    Check if the python version in use match the `requires_python` specifier.
 
-    Return `True` if the version of python in use matches the requirement.
-    Return `False` if the version of python in use does not matches the
-    requirement. Raises an InvalidSpecifier if `requires_python` have an
-    invalid format.
+    Returns `True` if the version of python in use matches the requirement.
+    Returns `False` if the version of python in use does not matches the
+    requirement.
+
+    Raises an InvalidSpecifier if `requires_python` have an invalid format.
     """
     if requires_python is None:
         # The package provides no information
         return True
-    try:
-        requires_python_specifier = specifiers.SpecifierSet(requires_python)
-    except specifiers.InvalidSpecifier as e:
-        logger.debug(
-            "Package %s has an invalid Requires-Python entry - %s" % (
-                requires_python, e))
-        raise
+    requires_python_specifier = specifiers.SpecifierSet(requires_python)
 
     # We only use major.minor.micro
     python_version = version.parse('.'.join(map(str, sys.version_info[:3])))

--- a/tests/data/indexes/datarequire/fakepackage/index.html
+++ b/tests/data/indexes/datarequire/fakepackage/index.html
@@ -1,0 +1,8 @@
+<html><head><title>Links for fakepackage</title><meta name="api-version" value="2" /></head><body><h1>Links for fakepackage</h1>
+    <a data-requires-python=''                href="/fakepackage-1.0.0.tar.gz#md5=00000000000000000000000000000000" rel="internal">fakepackage-1.0.0.tar.gz</a><br/>
+    <a data-requires-python='&lt;2.7'         href="/fakepackage-2.6.0.tar.gz#md5=00000000000000000000000000000000" rel="internal">fakepackage-2.6.0.tar.gz</a><br/>
+    <a data-requires-python='&gt;=2.7,&lt;3'  href="/fakepackage-2.7.0.tar.gz#md5=00000000000000000000000000000000" rel="internal">fakepackage-2.7.0.tar.gz</a><br/>
+    <a data-requires-python='&gt;=3.3'        href="/fakepackage-3.3.0.tar.gz#md5=00000000000000000000000000000000" rel="internal">fakepackage-3.3.0.tar.gz</a><br/>
+    <a data-requires-python='&gt;&lt;X.y.z'   href="/fakepackage-9.9.9.tar.gz#md5=00000000000000000000000000000000" rel="internal">fakepackage-9.9.9.tar.gz</a><br/>
+</body></html>
+

--- a/tests/scripts/test_all_pip.py
+++ b/tests/scripts/test_all_pip.py
@@ -38,10 +38,9 @@ def main(args=None):
         print('Downloading pending list')
         projects = all_projects()
         print('Found %s projects' % len(projects))
-        f = open(pending_fn, 'w')
-        for name in projects:
-            f.write(name + '\n')
-        f.close()
+        with open(pending_fn, 'w') as f:
+            for name in projects:
+                f.write(name + '\n')
     print('Starting testing...')
     while os.stat(pending_fn).st_size:
         _test_packages(output, pending_fn)

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 import pip.wheel
 import pip.pep425tags
@@ -363,6 +364,27 @@ def test_finder_only_installs_stable_releases(data):
     with patch.object(finder, "_get_pages", lambda x, y: []):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-1.0.tar.gz"
+
+
+def test_finder_only_installs_data_require(data):
+    """
+    """
+
+    # using a local index (that has pre & dev releases)
+    finder = PackageFinder([],
+                           [data.index_url("datarequire")],
+                           session=PipSession())
+    links = finder.find_all_candidates("fakepackage")
+
+    expected = ['1.0.0', '9.9.9']
+    if sys.version_info < (2, 7):
+        expected.append('2.6.0')
+    elif (2, 7) < sys.version_info < (3,):
+        expected.append('2.7.0')
+    elif sys.version_info > (3, 3):
+        expected.append('3.3.0')
+
+    assert set([str(v.version) for v in links]) == set(expected)
 
 
 def test_finder_installs_pre_releases(data):

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -368,6 +368,13 @@ def test_finder_only_installs_stable_releases(data):
 
 def test_finder_only_installs_data_require(data):
     """
+    Test whether the PackageFinder understand data-python-requires
+
+    This can optionally be exposed by a simple-repository to tell which
+    distribution are compatible with which version of Python by adding a
+    data-python-require to the anchor links.
+
+    See pep 503 for more informations.
     """
 
     # using a local index (that has pre & dev releases)


### PR DESCRIPTION
Allows pip to understand the `data-requires-python` metadata
information that can be set on a simple repository. This allows pip to
ignore any release or file that would not be compatible with the current
Python version even before trying to download and install this version.

Relevant extract of pep 503 at the time of this writing.

    A repository MAY include a data-requires-python attribute on a file
    link. This exposes the Requires-Python metadata field, specified in PEP
    345 , for the corresponding release. Where this is present, installer
    tools SHOULD ignore the download when installing to a Python version
    that doesn't satisfy the requirement. For example:

    <a href="..." data-requires-python="&gt;=3">...</a>
    In the attribute value, < and > have to be HTML encoded as &lt; and &gt;
    , respectively.

This can mostly be used to, for example, mark a new sdist of a new
package version as requires-python >3.4, and not  fail to install or
upgrade on users systems.

This will require extra patches to PyPI-legacy and warehouse to be
usable. Though releasing a version of pip that understand this feature
is necessary to have wide adoption at the time when these metadata get
actually published.


---- 

This will partially replace https://github.com/pypa/pip/pull/3847 (from @takluyver ) once pypi-legacy and warehouse support exposing this metadata as well. I suppose this will be of interest for @astrofrog. 

@michaelpacer and I are trying to get a the data-requires-python into pypi-legacy, though we have issue to run it locally.  So we tested with a "Fake" local PyPI that just exposes static webpages that we editted by hand to include 'date-requires-python'.