### PR TITLE
Get rid of (upcoming) pytest 3.0 warnings

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 freezegun
 pretend
 pytest
-pytest-capturelog
+pytest-catchlog
 pytest-timeout
 pytest-xdist
 mock<1.1

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -4,13 +4,14 @@ import pytest
 import glob
 
 from tests.lib.path import Path
-from tests.lib import TestFailure
 
 
 def test_install_from_future_wheel_version(script, data):
     """
     Test installing a future wheel
     """
+    from tests.lib import TestFailure
+
     package = data.packages.join("futurewheel-3.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=True)
     with pytest.raises(TestFailure):
@@ -30,6 +31,7 @@ def test_install_from_broken_wheel(script, data):
     """
     Test that installing a broken wheel fails properly
     """
+    from tests.lib import TestFailure
     package = data.packages.join("brokenwheel-1.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=True)
     with pytest.raises(TestFailure):


### PR DESCRIPTION
Hi,

I [tested pip with the upcoming pytest 3.0 release branch](https://travis-ci.org/nicoddemus/pip/builds/148189001) and I'm glad to report it worked fine with no modifications. :smile: :+1: 

Pytest 3.0 will now print warnings by default, and I noticed those warnings for pip:

```
============================ pytest-warning summary ============================
WI1 /home/travis/build/nicoddemus/pip/.tox/py35/lib/python3.5/site-packages/pytest_capturelog.py:171 'pytest_runtest_makereport' hook uses deprecated __multicall__ argument
WC1 None pytest_funcarg__caplog: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.
WC1 None pytest_funcarg__capturelog: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.
WC1 /home/travis/build/nicoddemus/pip/tests/functional/test_install_wheel.py cannot collect test class 'TestFailure' because it has a __init__ constructor
===================== 335 tests deselected by "-m 'unit'" ======================
== 343 passed, 5 skipped, 335 deselected, 4 pytest-warnings in 12.83 seconds ===
___________________________________ summary ____________________________________
```

* The first 3 are related to using [pytest-capturelog](https://pypi.python.org/pypi/pytest-capturelog) because it still uses the `pytest_funcarg__` function prefix to declare fixtures, which has been deprecated for a long time in favor of the `@pytest.fixture` decorator; unfortunately `pytest-capturelog` has not being maintained for a long time, so a fork [pytest-catchlog](https://pypi.python.org/pypi/pytest-catchlog) is now recommended. The functionality is the same, so I just switched one for the other.
* The last one is related to an import of `TestFailure` in one of the tests; moving it to a local import fixes it.

These changes could be applied right away because they are compatible with pytest 2.9, and will produce no warnings on pytest 3.0.