### PR TITLE
Allow pip install with entrypoint names with colons

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 **9.1.0 (UNRELEASED)**
 
+* Use pkg_resources to parse the entry points file to allow names with
+  colons (:pull:`3901`)
 
 **9.0.1 (2016-11-06)**
 
@@ -110,9 +112,6 @@
 
 * Restore the ability to use inline comments in requirements files passed to
   ``pip freeze`` (:issue:`3680`).
-
-* Python 3: disable INI-style parsing of the entry points file to allow names
-  with colons (:pull:`3901`)
 
 **8.1.2 (2016-05-10)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -111,6 +111,8 @@
 * Restore the ability to use inline comments in requirements files passed to
   ``pip freeze`` (:issue:`3680`).
 
+* Python 3: disable INI-style parsing of the entry points file to allow names
+  with colons (:pull:`3901`)
 
 **8.1.2 (2016-05-10)**
 

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -20,7 +20,6 @@ from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version, parse as parse_version
-from pip._vendor.six.moves import configparser
 
 import pip.wheel
 
@@ -35,7 +34,7 @@ from pip.locations import (
 from pip.utils import (
     display_path, rmtree, ask_path_exists, backup_dir, is_installable_dir,
     dist_in_usersite, dist_in_site_packages, egg_link_path,
-    call_subprocess, read_text_file, FakeFile, _make_build_dir, ensure_dir,
+    call_subprocess, read_text_file, _make_build_dir, ensure_dir,
     get_installed_version, normalize_path, dist_is_local,
 )
 
@@ -724,32 +723,18 @@ class InstallRequirement(object):
                     paths_to_remove.add(os.path.join(bin_dir, script) + '.bat')
 
         # find console_scripts
-        if dist.has_metadata('entry_points.txt'):
-            if six.PY2:
-                options = {}
+        console_scripts = dist.get_entry_map(group='console_scripts')
+        for name in console_scripts.keys():
+            if dist_in_usersite(dist):
+                bin_dir = bin_user
             else:
-                options = {"delimiters": ('=', )}
-            config = configparser.SafeConfigParser(**options)
-            config.readfp(
-                FakeFile(dist.get_metadata_lines('entry_points.txt'))
-            )
-            if config.has_section('console_scripts'):
-                for name, value in config.items('console_scripts'):
-                    if dist_in_usersite(dist):
-                        bin_dir = bin_user
-                    else:
-                        bin_dir = bin_py
-                    paths_to_remove.add(os.path.join(bin_dir, name))
-                    if WINDOWS:
-                        paths_to_remove.add(
-                            os.path.join(bin_dir, name) + '.exe'
-                        )
-                        paths_to_remove.add(
-                            os.path.join(bin_dir, name) + '.exe.manifest'
-                        )
-                        paths_to_remove.add(
-                            os.path.join(bin_dir, name) + '-script.py'
-                        )
+                bin_dir = bin_py
+            exe_name = os.path.join(bin_dir, name)
+            paths_to_remove.add(exe_name)
+            if WINDOWS:
+                paths_to_remove.add(exe_name + '.exe')
+                paths_to_remove.add(exe_name + '.exe.manifest')
+                paths_to_remove.add(exe_name + '-script.py')
 
         paths_to_remove.remove(auto_confirm)
         self.uninstalled = paths_to_remove

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -39,8 +39,6 @@ from pip.utils.setuptools_build import SETUPTOOLS_SHIM
 from pip._vendor.distlib.scripts import ScriptMaker
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor import six
-from pip._vendor.six.moves import configparser
 
 
 wheel_ext = '.whl'

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -225,20 +225,19 @@ def get_entrypoints(filename):
             data.write("\n")
         data.seek(0)
 
-    if six.PY2:
-        options = {}
-    else:
-        options = {"delimiters": ('=', )}
-    cp = configparser.RawConfigParser(**options)
-    cp.optionxform = lambda option: option
-    cp.readfp(data)
+    # get the entry points and then the script names
+    entry_points = pkg_resources.EntryPoint.parse_map(data)
+    console = entry_points.get('console_scripts', {})
+    gui = entry_points.get('gui_scripts', {})
 
-    console = {}
-    gui = {}
-    if cp.has_section('console_scripts'):
-        console = dict(cp.items('console_scripts'))
-    if cp.has_section('gui_scripts'):
-        gui = dict(cp.items('gui_scripts'))
+    def _split_ep(s):
+        """get the string representation of EntryPoint, remove space and split
+        on '='"""
+        return str(s).replace(" ", "").split("=")
+
+    # convert the EntryPoint objects into strings with module:function
+    console = dict(_split_ep(v) for v in console.values())
+    gui = dict(_split_ep(v) for v in gui.values())
     return console, gui
 
 

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -39,6 +39,7 @@ from pip.utils.setuptools_build import SETUPTOOLS_SHIM
 from pip._vendor.distlib.scripts import ScriptMaker
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor import six
 from pip._vendor.six.moves import configparser
 
 
@@ -224,7 +225,11 @@ def get_entrypoints(filename):
             data.write("\n")
         data.seek(0)
 
-    cp = configparser.RawConfigParser()
+    if six.PY2:
+        options = {}
+    else:
+        options = {"delimiters": ('=', )}
+    cp = configparser.RawConfigParser(**options)
     cp.optionxform = lambda option: option
     cp.readfp(data)
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def find_version(*file_paths):
 long_description = read('README.rst')
 
 tests_require = ['pytest', 'virtualenv>=1.10', 'scripttest>=1.3', 'mock',
-                 'pretend', 'pytest-catchlog', 'freezegun']
+                 'pretend']
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def find_version(*file_paths):
 long_description = read('README.rst')
 
 tests_require = ['pytest', 'virtualenv>=1.10', 'scripttest>=1.3', 'mock',
-                 'pretend']
+                 'pretend', 'pytest-catchlog', 'freezegun']
 
 
 setup(

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -9,6 +9,7 @@ import pretend
 from os.path import join, normpath
 from tempfile import mkdtemp
 from tests.lib import assert_all_changes, pyversion
+from tests.lib import create_test_package_with_setup
 from tests.lib.local_repos import local_repo, local_checkout
 
 from pip.req import InstallRequirement
@@ -162,20 +163,17 @@ def test_uninstall_entry_point(script, console_scripts):
     Test uninstall package with two or more entry points in the same section,
     whose name contain a colon.
     """
-    script.scratch_path.join("ep_install").mkdir()
-    pkg_path = script.scratch_path / 'ep_install'
-    pkg_path.join("setup.py").write(textwrap.dedent("""
-        from setuptools import setup
-        setup(
-            name='ep-install',
+    pkg_name = 'ep_install'
+    pkg_path = create_test_package_with_setup(
+            script,
+            name=pkg_name,
             version='0.1',
-            entry_points={{"console_scripts": ["{0}", ],
-                           "pip_test.ep":
-                           ["ep:name1 = distutils_install",
-                            "ep:name2 = distutils_install"]
-                          }}
-        )
-    """.format(console_scripts)))
+            entry_points={"console_scripts": [console_scripts, ],
+                          "pip_test.ep":
+                          ["ep:name1 = distutils_install",
+                           "ep:name2 = distutils_install"]
+                          }
+    )
     script_name = script.bin_path.join(console_scripts.split('=')[0].strip())
     result = script.pip('install', pkg_path)
     assert script_name.exists
@@ -192,17 +190,12 @@ def test_uninstall_gui_scripts(script):
     Make sure that uninstall removes gui scripts
     """
     pkg_name = "gui_pkg"
-    script.scratch_path.join(pkg_name).mkdir()
-    pkg_path = script.scratch_path / pkg_name
-    pkg_path.join("setup.py").write(textwrap.dedent("""
-        from setuptools import setup
-        setup(
-            name='{0}',
+    pkg_path = create_test_package_with_setup(
+            script,
+            name=pkg_name,
             version='0.1',
-            entry_points={{"gui_scripts": ["test_ = distutils_install", ],
-                          }}
-        )
-    """.format(pkg_name)))
+            entry_points={"gui_scripts": ["test_ = distutils_install", ], }
+    )
     script_name = script.bin_path.join('test_')
     script.pip('install', pkg_path)
     assert script_name.exists

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -165,14 +165,14 @@ def test_uninstall_entry_point(script, console_scripts):
     """
     pkg_name = 'ep_install'
     pkg_path = create_test_package_with_setup(
-            script,
-            name=pkg_name,
-            version='0.1',
-            entry_points={"console_scripts": [console_scripts, ],
-                          "pip_test.ep":
-                          ["ep:name1 = distutils_install",
-                           "ep:name2 = distutils_install"]
-                          }
+        script,
+        name=pkg_name,
+        version='0.1',
+        entry_points={"console_scripts": [console_scripts, ],
+                      "pip_test.ep":
+                      ["ep:name1 = distutils_install",
+                       "ep:name2 = distutils_install"]
+                      }
     )
     script_name = script.bin_path.join(console_scripts.split('=')[0].strip())
     result = script.pip('install', pkg_path)
@@ -191,10 +191,10 @@ def test_uninstall_gui_scripts(script):
     """
     pkg_name = "gui_pkg"
     pkg_path = create_test_package_with_setup(
-            script,
-            name=pkg_name,
-            version='0.1',
-            entry_points={"gui_scripts": ["test_ = distutils_install", ], }
+        script,
+        name=pkg_name,
+        version='0.1',
+        entry_points={"gui_scripts": ["test_ = distutils_install", ], }
     )
     script_name = script.bin_path.join('test_')
     script.pip('install', pkg_path)

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -187,6 +187,29 @@ def test_uninstall_entry_point(script, console_scripts):
     assert "ep-install (0.1)" not in result2.stdout
 
 
+def test_uninstall_gui_scripts(script):
+    """
+    Make sure that uninstall removes gui scripts
+    """
+    pkg_name = "gui_pkg"
+    script.scratch_path.join(pkg_name).mkdir()
+    pkg_path = script.scratch_path / pkg_name
+    pkg_path.join("setup.py").write(textwrap.dedent("""
+        from setuptools import setup
+        setup(
+            name='{0}',
+            version='0.1',
+            entry_points={{"gui_scripts": ["test_ = distutils_install", ],
+                          }}
+        )
+    """.format(pkg_name)))
+    script_name = script.bin_path.join('test_')
+    script.pip('install', pkg_path)
+    assert script_name.exists
+    script.pip('uninstall', pkg_name, '-y')
+    assert not script_name.exists
+
+
 @pytest.mark.network
 def test_uninstall_console_scripts(script):
     """

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -11,15 +11,21 @@ from pip.exceptions import InvalidWheelFilename, UnsupportedWheel
 from pip.utils import unpack_file
 
 
-def test_get_entrypoints(tmpdir):
+@pytest.mark.parametrize("console_scripts",
+                         ["pip = pip.main:pip", "pip:pip = pip.main:pip"])
+def test_get_entrypoints(tmpdir, console_scripts):
     with open(str(tmpdir.join("entry_points.txt")), "w") as fp:
         fp.write("""
             [console_scripts]
-            pip = pip.main:pip
-        """)
+            {}
+            [section]
+            common:one = module:func
+            common:two = module:other_func
+        """.format(console_scripts))
+        fp.write(console_scripts + '\n')
 
     assert wheel.get_entrypoints(str(tmpdir.join("entry_points.txt"))) == (
-        {"pip": "pip.main:pip"},
+        dict([console_scripts.split(' = ')]),
         {},
     )
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -17,7 +17,7 @@ def test_get_entrypoints(tmpdir, console_scripts):
     with open(str(tmpdir.join("entry_points.txt")), "w") as fp:
         fp.write("""
             [console_scripts]
-            {}
+            {0}
             [section]
             common:one = module:func
             common:two = module:other_func

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -14,7 +14,8 @@ from pip.utils import unpack_file
 @pytest.mark.parametrize("console_scripts",
                          ["pip = pip.main:pip", "pip:pip = pip.main:pip"])
 def test_get_entrypoints(tmpdir, console_scripts):
-    with open(str(tmpdir.join("entry_points.txt")), "w") as fp:
+    entry_points = tmpdir.join("entry_points.txt")
+    with open(str(entry_points), "w") as fp:
         fp.write("""
             [console_scripts]
             {0}
@@ -22,9 +23,8 @@ def test_get_entrypoints(tmpdir, console_scripts):
             common:one = module:func
             common:two = module:other_func
         """.format(console_scripts))
-        fp.write(console_scripts + '\n')
 
-    assert wheel.get_entrypoints(str(tmpdir.join("entry_points.txt"))) == (
+    assert wheel.get_entrypoints(str(entry_points)) == (
         dict([console_scripts.split(' = ')]),
         {},
     )


### PR DESCRIPTION
I did try to install a package (from a local pypi-like server) containing colons in entry point names and the installation crashed after copying all the files to the site-packages directory but before creating the entry points:

```
Exception:
Traceback (most recent call last):
  File "lib/python3.4/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "lib/python3.4/site-packages/pip/commands/install.py", line 317, in run
    prefix=options.prefix_path,
  File "lib/python3.4/site-packages/pip/req/req_set.py", line 742, in install
    **kwargs
  File "lib/python3.4/site-packages/pip/req/req_install.py", line 831, in install
    self.move_wheel_files(self.source_dir, root=root, prefix=prefix)
  File "lib/python3.4/site-packages/pip/req/req_install.py", line 1032, in move_wheel_files
    isolated=self.isolated,
  File "lib/python3.4/site-packages/pip/wheel.py", line 352, in move_wheel_files
    console, gui = get_entrypoints(ep_file)
  File "lib/python3.4/site-packages/pip/wheel.py", line 229, in get_entrypoints
    cp.readfp(data)
  File "/usr/lib/python3.4/configparser.py", line 735, in readfp
    self.read_file(fp, source=filename)
  File "/usr/lib/python3.4/configparser.py", line 690, in read_file
    self._read(f, source)
  File "/usr/lib/python3.4/configparser.py", line 1069, in _read
    fpname, lineno)
configparser.DuplicateOptionError: While reading from '<???>' [line 10]: option 'common' in section 'section' already exists
```

the entry points look like

```
[section]
common:one = module:func
common:two = module:other_func
```

This is a similar issue to #3434.
If you accept this change I'll add tests and change logs.

As a temporary work around, is there are way to avoid going through `pip/wheel.py`?

Also if I run `pip install -e .` in the source code directory it works fine (because it doesn't use the wheel.py module).
