### PR TITLE
don't assume egg-link corresponds to dist to uninstall

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -679,6 +679,10 @@ class InstallRequirement(object):
                                             'easy-install.pth')
             paths_to_remove.add_pth(easy_install_pth, './' + easy_install_egg)
 
+        elif egg_info_exists and dist.egg_info.endswith('.dist-info'):
+            for path in pip.wheel.uninstallation_paths(dist):
+                paths_to_remove.add(path)
+
         elif develop_egg_link:
             # develop egg
             with open(develop_egg_link, 'r') as fh:
@@ -691,10 +695,6 @@ class InstallRequirement(object):
             easy_install_pth = os.path.join(os.path.dirname(develop_egg_link),
                                             'easy-install.pth')
             paths_to_remove.add_pth(easy_install_pth, dist.location)
-
-        elif egg_info_exists and dist.egg_info.endswith('.dist-info'):
-            for path in pip.wheel.uninstallation_paths(dist):
-                paths_to_remove.add(path)
 
         else:
             logger.debug(


### PR DESCRIPTION
by checking if develop_egg_link exists prior to checking dist_info,
the `.egg-link` file is attempted to be uninstalled,
without checking whether it corresponds to the dist scheduled to be uninstalled.

Lowering the priority of the egg-link uninstall fixes this.

To reproduce, use setuptools 25, or SETUPTOOLS_SYS_PATH_TECHNIQUE=raw, and:

```python
pip install .
pip install -e . # doesn't remove previous installation (pending #3898)
pip uninstall packagename
```

With SETUPTOOLS_SYS_PATH_TECHNIQUE=raw, and without #3898, both installations are present and the 'regular' install has higher priority, and is the dist found to be uninstalled. The order of the `elifs` meant that the egg-link would attempt to be uninstalled, even though it doesn't correspond to that dist.

By lowering the priority, the egg-link is only removed if the dist to be removed isn't wheel-installed, which I think is more consistent with the other conditions in this switch.

A more rigorous fix, perhaps, would be to check directly that the egg-link corresponds to the dist-to-be-removed, and remove it from consideration if not. I'm not 100% sure how to do that, though. I suppose this would be approximately promoting the `assert` that's currently failing to a condition, which if met means the egg-link matches the dist, otherwise it should not be included in the uninstall.