### PR TITLE
Fix issue #3233

### DIFF
--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -419,7 +419,7 @@ import sys
 from %(module)s import %(import_name)s
 
 if __name__ == '__main__':
-    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
     sys.exit(%(func)s())
 """
 


### PR DESCRIPTION
Made ending 'w' optional as generated entry points rarely, if ever, will end in one.

This will remedy #3233 and this change has fixed a similar issue in setuptools pypa/setuptools/pull/736