### PR TITLE
place manylinux1 after linux tag

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -282,7 +282,7 @@ def get_supported(versions=None, noarch=False, platform=None,
                 # arch pattern didn't match (?!)
                 arches = [arch]
         elif platform is None and is_manylinux1_compatible():
-            arches = [arch.replace('linux', 'manylinux1'), arch]
+            arches = [arch, arch.replace('linux', 'manylinux1')]
         else:
             arches = [arch]
 

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -143,9 +143,9 @@ class TestManylinux1Tags(object):
     @patch('pip.pep425tags.get_platform', lambda: 'linux_x86_64')
     @patch('pip.utils.glibc.have_compatible_glibc', lambda major, minor: True)
     @patch('sys.platform', 'linux2')
-    def test_manylinux1_tag_is_first(self):
+    def test_manylinux1_tag_is_second(self):
         """
-        Test that the more specific tag manylinux1 comes first.
+        Test that the less specific tag manylinux1 comes second.
         """
         groups = {}
         for pyimpl, abi, arch in pep425tags.get_supported():
@@ -156,6 +156,6 @@ class TestManylinux1Tags(object):
                 continue
             # Expect the most specific arch first:
             if len(arches) == 3:
-                assert arches == ['manylinux1_x86_64', 'linux_x86_64', 'any']
+                assert arches == ['linux_x86_64', 'manylinux1_x86_64', 'any']
             else:
-                assert arches == ['manylinux1_x86_64', 'linux_x86_64']
+                assert arches == ['linux_x86_64', 'manylinux1_x86_64']


### PR DESCRIPTION
PEP 425 tags are designed to score 'the one most specific to the
installation environment' above more general tags. Although linux_x86_64
does not mean much _globally_, within the confines of a given machine
it means _compiled for this machine_.

Placing linux above manylinux1 lets you compile a wheel on your local
machine, for your local machine, and have it get picked above the
manylinux1 wheel from pypi without disabling manylinux1 completely.
