### PR TITLE
add PEP 425 tags for abi3 / Py_LIMITED_API wheels

### DIFF
--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -294,7 +294,8 @@ def get_supported(versions=None, noarch=False, platform=None,
         # abi3 modules compatible with older version of Python
         for version in versions[1:]:
             # abi3 was introduced in Python 3.2
-            if version in ('31', '30'): break
+            if version in ('31', '30'):
+                break
             for abi in abi3s:   # empty set if not Python 3
                 for arch in arches:
                     supported.append(("%s%s" % (impl, version), abi, arch))

--- a/pip/pep425tags.py
+++ b/pip/pep425tags.py
@@ -291,6 +291,14 @@ def get_supported(versions=None, noarch=False, platform=None,
             for arch in arches:
                 supported.append(('%s%s' % (impl, versions[0]), abi, arch))
 
+        # abi3 modules compatible with older version of Python
+        for version in versions[1:]:
+            # abi3 was introduced in Python 3.2
+            if version in ('31', '30'): break
+            for abi in abi3s:   # empty set if not Python 3
+                for arch in arches:
+                    supported.append(("%s%s" % (impl, version), abi, arch))
+
         # Has binaries, does not use the Python API:
         for arch in arches:
             supported.append(('py%s' % (versions[0][0]), 'none', arch))


### PR DESCRIPTION
Python 3.2 and above have Py_LIMITED_API to build extensions compatible
with a particular version of CPython and greater. Add tags cpXX-abi3-arch
to support wheels with these C extensions.

For example, on Python 3.5
```

[('cp35', 'cp35m', 'manylinux1_x86_64'),
 ('cp35', 'cp35m', 'linux_x86_64'),
 ('cp35', 'abi3', 'manylinux1_x86_64'),
 ('cp35', 'abi3', 'linux_x86_64'),
 ('cp35', 'none', 'manylinux1_x86_64'),
 ('cp35', 'none', 'linux_x86_64'),
 ('cp34', 'abi3', 'manylinux1_x86_64'),
 ('cp34', 'abi3', 'linux_x86_64'),
 ('cp33', 'abi3', 'manylinux1_x86_64'),
 ('cp33', 'abi3', 'linux_x86_64'),
 ('cp32', 'abi3', 'manylinux1_x86_64'),
 ('cp32', 'abi3', 'linux_x86_64'),
 ('py3', 'none', 'manylinux1_x86_64'),
 ('py3', 'none', 'linux_x86_64'),
 ('cp35', 'none', 'any'),
 ('cp3', 'none', 'any'),
 ('py35', 'none', 'any'),
 ('py3', 'none', 'any'),
 ('py34', 'none', 'any'),
 ('py33', 'none', 'any'),
 ('py32', 'none', 'any'),
 ('py31', 'none', 'any'),
 ('py30', 'none', 'any')]

```
Unchanged on Python 2.7

```
[('cp27', 'cp27mu', 'manylinux1_x86_64'),
 ('cp27', 'cp27mu', 'linux_x86_64'),
 ('cp27', 'none', 'manylinux1_x86_64'),
 ('cp27', 'none', 'linux_x86_64'),
 ('py2', 'none', 'manylinux1_x86_64'),
 ('py2', 'none', 'linux_x86_64'),
 ('cp27', 'none', 'any'),
 ('cp2', 'none', 'any'),
 ('py27', 'none', 'any'),
 ('py2', 'none', 'any'),
 ('py26', 'none', 'any'),
 ('py25', 'none', 'any'),
 ('py24', 'none', 'any'),
 ('py23', 'none', 'any'),
 ('py22', 'none', 'any'),
 ('py21', 'none', 'any'),
 ('py20', 'none', 'any')]
```
