### PR TITLE
Fix distro support on non-linux OS

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -37,7 +37,6 @@ from pip.utils.glibc import libc_ver
 from pip.utils.ui import DownloadProgressBar, DownloadProgressSpinner
 from pip.locations import write_delete_marker_file
 from pip.vcs import vcs
-from pip._vendor import distro
 from pip._vendor import requests, six
 from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
 from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
@@ -48,6 +47,10 @@ from pip._vendor.cachecontrol import CacheControlAdapter
 from pip._vendor.cachecontrol.caches import FileCache
 from pip._vendor.lockfile import LockError
 from pip._vendor.six.moves import xmlrpc_client
+
+IS_LINUX = sys.platform.startswith("linux")
+if IS_LINUX:
+    from pip._vendor import distro
 
 
 __all__ = ['get_file_content',
@@ -89,7 +92,7 @@ def user_agent():
         # Complete Guess
         data["implementation"]["version"] = platform.python_version()
 
-    if sys.platform.startswith("linux"):
+    if IS_LINUX:
         distro_infos = dict(filter(
             lambda x: x[1],
             zip(["name", "version", "id"], distro.linux_distribution()),


### PR DESCRIPTION
This only import `distro` on linux.
The alternative is to actually use the check distro comes with and ignore the import error (don't quite understand why that check was removed from the vendored distro).