### PR TITLE
Add abort option if existing files are found

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 **8.2.0 (unreleased)**
 
+* Added option to allow user to abort pip operation if file/directory exists
+
 * **DEPRECATION** ``pip install --egg`` have been deprecated and will be
   removed in the future. This "feature" has a long list of drawbacks where it
   breaks almost all of pip's other features in subtle and hard to diagnose

--- a/docs/reference/pip.rst
+++ b/docs/reference/pip.rst
@@ -61,6 +61,8 @@ when decision is needed.
     Rename the file or checkout to ``{name}{'.bak' * n}``, where n is some number
     of ``.bak`` extensions, such that the file didn't exist at some point.
     So the most recent backup will be the one with the largest number after ``.bak``.
+*(a)abort*
+    Abort pip and return non-zero exit status.
 
 .. _`build-interface`:
 

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -187,12 +187,12 @@ def exists_action():
         '--exists-action',
         dest='exists_action',
         type='choice',
-        choices=['s', 'i', 'w', 'b'],
+        choices=['s', 'i', 'w', 'b', 'a'],
         default=[],
         action='append',
         metavar='action',
         help="Default action when a path already exists: "
-        "(s)witch, (i)gnore, (w)ipe, (b)ackup.")
+        "(s)witch, (i)gnore, (w)ipe, (b)ackup, (a)bort.")
 
 
 cert = partial(

--- a/pip/download.py
+++ b/pip/download.py
@@ -610,8 +610,8 @@ def _copy_file(filename, location, link):
     download_location = os.path.join(location, link.filename)
     if os.path.exists(download_location):
         response = ask_path_exists(
-            'The file %s exists. (i)gnore, (w)ipe, (b)ackup ' %
-            display_path(download_location), ('i', 'w', 'b'))
+            'The file %s exists. (i)gnore, (w)ipe, (b)ackup, (a)abort' %
+            display_path(download_location), ('i', 'w', 'b', 'a'))
         if response == 'i':
             copy = False
         elif response == 'w':
@@ -625,6 +625,8 @@ def _copy_file(filename, location, link):
                 display_path(dest_file),
             )
             shutil.move(download_location, dest_file)
+        elif response == 'a':
+            sys.exit(-1)
     if copy:
         shutil.copy(filename, download_location)
         logger.info('Saved %s', display_path(download_location))

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -766,8 +766,8 @@ class InstallRequirement(object):
         archive_path = os.path.join(build_dir, archive_name)
         if os.path.exists(archive_path):
             response = ask_path_exists(
-                'The file %s exists. (i)gnore, (w)ipe, (b)ackup ' %
-                display_path(archive_path), ('i', 'w', 'b'))
+                'The file %s exists. (i)gnore, (w)ipe, (b)ackup, (a)bort ' %
+                display_path(archive_path), ('i', 'w', 'b', 'a'))
             if response == 'i':
                 create_archive = False
             elif response == 'w':
@@ -781,6 +781,8 @@ class InstallRequirement(object):
                     display_path(dest_file),
                 )
                 shutil.move(archive_path, dest_file)
+            elif response == 'a':
+                sys.exit(-1)
         if create_archive:
             zip = zipfile.ZipFile(
                 archive_path, 'w', zipfile.ZIP_DEFLATED,

--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -5,6 +5,7 @@ import errno
 import logging
 import os
 import shutil
+import sys
 
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
@@ -271,6 +272,8 @@ class VersionControl(object):
                 )
                 shutil.move(dest, dest_dir)
                 checkout = True
+            elif response == 'a':
+                sys.exit(-1)
         return checkout
 
     def unpack(self, location):


### PR DESCRIPTION
We give users the option to abort pip if a file/directory exists when they try to install.

This is useful when running `pip install` as part of a CI step and one wants the CI step to fail if pip can not complete due to existing file/directory.