### PR TITLE
Unbreak on non-Linux platforms

### DIFF
--- a/pip/download.py
+++ b/pip/download.py
@@ -37,7 +37,11 @@ from pip.utils.glibc import libc_ver
 from pip.utils.ui import DownloadProgressBar, DownloadProgressSpinner
 from pip.locations import write_delete_marker_file
 from pip.vcs import vcs
-from pip._vendor import distro
+
+# Fails at import time.
+if sys.platform.startswith("linux"):
+    from pip._vendor import distro
+
 from pip._vendor import requests, six
 from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
 from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth

--- a/pip/download.py
+++ b/pip/download.py
@@ -38,10 +38,6 @@ from pip.utils.ui import DownloadProgressBar, DownloadProgressSpinner
 from pip.locations import write_delete_marker_file
 from pip.vcs import vcs
 
-# Fails at import time.
-if sys.platform.startswith("linux"):
-    from pip._vendor import distro
-
 from pip._vendor import requests, six
 from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
 from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
@@ -52,6 +48,10 @@ from pip._vendor.cachecontrol import CacheControlAdapter
 from pip._vendor.cachecontrol.caches import FileCache
 from pip._vendor.lockfile import LockError
 from pip._vendor.six.moves import xmlrpc_client
+
+# Fails at import time.
+if sys.platform.startswith("linux"):
+    from pip._vendor import distro
 
 
 __all__ = ['get_file_content',


### PR DESCRIPTION
Replacing platform.linux_distribution() with distro made pip unusable on all non-Linux platforms, because distro does not work anywhere but on Linux and fails on import.

Fixes #3941.