### PR TITLE
fix regression with environment markers handling

### DIFF
--- a/pip/_vendor/packaging/markers.py
+++ b/pip/_vendor/packaging/markers.py
@@ -56,11 +56,15 @@ class Node(object):
 
 
 class Variable(Node):
-    pass
+
+    def __str__(self):
+        return self.value
 
 
 class Value(Node):
-    pass
+
+    def __str__(self):
+        return repr(str(self.value))
 
 
 VARIABLE = (
@@ -151,7 +155,7 @@ def _format_marker(marker, first=True):
         else:
             return "(" + " ".join(inner) + ")"
     elif isinstance(marker, tuple):
-        return '{0} {1} "{2}"'.format(*marker)
+        return '{0} {1} {2}'.format(*marker)
     else:
         return marker
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -607,3 +607,26 @@ def test_exclusive_environment_markers():
     req_set.add_requirement(eq26)
     req_set.add_requirement(ne26)
     assert req_set.has_requirement('Django')
+
+
+def test_requirement_str():
+    for req_str, req_cannonical_str in (
+        ('pywin32 (>1.0); sys.platform == "win32"',
+         "pywin32>1.0; sys_platform == 'win32'"),
+        ("pywin31; sys.platform == 'win32'",
+         "pywin31; sys_platform == 'win32'"),
+        ("foo != 1.3; platform.machine=='i386'",
+         "foo!=1.3; platform_machine == 'i386'"),
+        ("bar; python_version=='2.4'or python_version==\"2.5\"",
+         "bar; python_version == '2.4' or python_version == '2.5'"),
+        ("bar; ('3.2' <= python_version and python_version <= '3.5')",
+         "bar; '3.2' <= python_version and python_version <= '3.5'"),
+        ("libxslt; 'linux' in sys.platform",
+         "libxslt; 'linux' in sys_platform"),
+        ("foobar; '\"' in sys_platform",
+         "foobar; '\"' in sys_platform"),
+        ("foobar; \"'\" in sys_platform",
+         "foobar; \"'\" in sys_platform"),
+    ):
+        req = Requirement(req_str)
+        assert str(req) == req_cannonical_str


### PR DESCRIPTION
This fix #3781. Turn out the problem was not with the parsing code but how a `Requirement` is converted back to a string:
```python
In [1]: import pip

In [2]: pip.__version__
Out[2]: '8.1.2'

In [3]: str(pip._vendor.packaging.requirements.Requirement("python-xlib>=0.16; 'linux' in sys_platform"))
Out[3]: 'python-xlib>=0.16; linux in "sys_platform"'
```

The patch ensure the result of `str(Requirement())` is itself a valid requirement line that can be parsed back.
