### PR TITLE
Add cache command

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -14,4 +14,5 @@ Reference Guide
    pip_show
    pip_search
    pip_wheel
+   pip_cache
    pip_hash

--- a/docs/reference/pip_cache.rst
+++ b/docs/reference/pip_cache.rst
@@ -1,0 +1,24 @@
+.. _`pip cache`:
+
+pip cache
+---------
+
+.. contents::
+
+
+Usage
+*****
+
+.. pip-command-usage:: cache
+
+
+Description
+***********
+
+.. pip-command-description:: cache
+
+
+Options
+*******
+
+.. pip-command-options:: cache

--- a/pip/commands/__init__.py
+++ b/pip/commands/__init__.py
@@ -15,6 +15,7 @@ from pip.commands.show import ShowCommand
 from pip.commands.install import InstallCommand
 from pip.commands.uninstall import UninstallCommand
 from pip.commands.wheel import WheelCommand
+from pip.commands.cache import CacheCommand
 
 
 commands_dict = {
@@ -30,6 +31,7 @@ commands_dict = {
     ListCommand.name: ListCommand,
     CheckCommand.name: CheckCommand,
     WheelCommand.name: WheelCommand,
+    CacheCommand.name: CacheCommand,
 }
 
 
@@ -45,6 +47,7 @@ commands_order = [
     WheelCommand,
     HashCommand,
     CompletionCommand,
+    CacheCommand,
     HelpCommand,
 ]
 

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -76,7 +76,7 @@ class CacheCommand(Command):
                 (name[cache_type], location, stats["files"],
                  format_size(stats["size"]))
             ))
-        logger.info("\n\n".join(result))
+        logger.info((os.linesep * 2).join(result))
         return SUCCESS
 
     def action_list(self, options, args):
@@ -87,7 +87,7 @@ class CacheCommand(Command):
         wheels = [os.path.basename(f) for f in
                   find_files(cache_location, "*.whl")]
         wheels.sort()
-        logger.info("\n".join(wheels))
+        logger.info(os.linesep.join(wheels))
 
     def action_rm(self, options, args):
         if options.type != "wheel":

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -46,10 +46,10 @@ class CacheCommand(Command):
 
     def run(self, options, args):
         if not args or args[0] not in self.actions:
-            logger.warning(
-                "ERROR: Please provide one of these subcommands: %s" %
-                ", ".join(self.actions))
-            return ERROR
+            raise CommandError(
+                "Please provide one of these subcommands: %s" %
+                ", ".join(self.actions)
+            )
         method = getattr(self, "action_%s" % args[0])
         return method(options, args[1:])
 
@@ -81,9 +81,8 @@ class CacheCommand(Command):
 
     def action_list(self, options, args):
         if options.type != "wheel":
-            logger.warning(
-                "ERROR: pip cache list only operates on the wheel cache.")
-            return ERROR
+            raise CommandError(
+                "pip cache list only operates on the wheel cache.")
         cache_location = self.get_cache_location(options.cache_dir, "wheel")
         wheels = [os.path.basename(f) for f in
                   find_files(cache_location, "*.whl")]

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -28,7 +28,7 @@ class CacheCommand(Command):
                 "ERROR: Please provide one of these subcommands: %s" %
                 ", ".join(self.actions))
             return ERROR
-        method = self.__getattribute__("action_%s" % args[0])
+        method = getattr(self, "action_%s" % args[0])
         return method(options, args[1:])
 
     def action_location(self, options, args):

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -27,13 +27,13 @@ class CacheCommand(Command):
             Show information about the caches.
         list (wheel cache only):
             List filenames of wheels stored in the cache.
-        rm <pattern|packagename> (wheel cache only):
-            Remove one or more wheels from the cache. `rm` accepts one or more
+        remove <pattern|packagename> (wheel cache only):
+            Remove one or more wheels from the cache. `remove` accepts one or more
             package names, filenames, or shell glob expressions matching filenames.
         purge:
             Remove all items from the cache.
     """  # noqa
-    actions = ["info", "list", "rm", "purge"]
+    actions = ["info", "list", "remove", "purge"]
     name = "cache"
     usage = """
       %%prog [options] %s""" % "|".join(actions)
@@ -126,10 +126,10 @@ class CacheCommand(Command):
             logger.info(os.linesep.join(wheels))
         return SUCCESS
 
-    def action_rm(self, options, args):
+    def action_remove(self, options, args):
         if options.type != "wheel":
             raise CommandError(
-                "pip cache rm only operates on the wheel cache.")
+                "pip cache remove only operates on the wheel cache.")
         if len(args) == 0:
             raise CommandError(
                 "Must specify the filename of (a) wheel(s) to remove.")

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import
 
 import logging
 import os
+from os.path import realpath
 import textwrap
 
 from pip.basecommand import Command
+from pip.exceptions import CommandError
 from pip.status_codes import SUCCESS, ERROR
 from pip.utils import format_size
 from pip.utils.filesystem import tree_statistics, find_files
@@ -19,8 +21,10 @@ class CacheCommand(Command):
 
     Subcommands:
         info: Show information about the caches.
-        list (wheel cache only): List wheels stored in the cache."""
-    actions = ["info", "list"]
+        list (wheel cache only): List wheels stored in the cache.
+        rm <filename> (wheel cache only): Remove one or more wheels from the cache.
+    """  # noqa
+    actions = ["info", "list", "rm"]
     name = "cache"
     usage = """
       %%prog [options] %s""" % "|".join(actions)
@@ -85,3 +89,39 @@ class CacheCommand(Command):
                   find_files(cache_location, "*.whl")]
         wheels.sort()
         logger.info("\n".join(wheels))
+
+    def action_rm(self, options, args):
+        if options.type != "wheel":
+            raise CommandError(
+                "pip cache rm only operates on the wheel cache.")
+        if len(args) == 0:
+            raise CommandError(
+                "Must specify the filename of (a) wheel(s) to remove.")
+        cache_location = self.get_cache_location(options.cache_dir, "wheel")
+        cache_realpath = realpath(cache_location)
+        value = SUCCESS
+        for target in args:
+            matches = find_files(cache_location, target)
+            if not matches:
+                logger.warning("No match found for %s" % target)
+                value = ERROR
+                continue
+            for match in matches:
+                # protect against symlink attacks
+                if (os.path.commonprefix([cache_realpath, realpath(match)]) !=
+                        cache_realpath):
+                    logger.warning(
+                        "Did not remove %s because it is not a child of the "
+                        "wheel cache." % realpath(match))
+                    value = ERROR
+                    continue
+                try:
+                    os.unlink(match)
+                except OSError as e:
+                    logger.warning(
+                        "Could not remove %s; %s" % (match, e))
+                    value = ERROR
+                else:
+                    logger.info("Removed %s" % match)
+
+        return value

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+import logging
+import os
+
+from pip.basecommand import Command
+from pip.status_codes import SUCCESS, ERROR
+
+
+logger = logging.getLogger(__name__)
+
+
+class CacheCommand(Command):
+    """\
+    Show information about pip's wheel cache.
+
+    Subcommands:
+        location: Print the location of the wheel cache."""
+    actions = ["location"]
+    name = "cache"
+    usage = """
+      %%prog [options] %s""" % "|".join(actions)
+    summary = "Show information about pip's wheel cache."
+
+    def run(self, options, args):
+        if not args or args[0] not in self.actions:
+            logger.warning(
+                "ERROR: Please provide one of these subcommands: %s" %
+                ", ".join(self.actions))
+            return ERROR
+        method = self.__getattribute__("action_%s" % args[0])
+        return method(options, args[1:])
+
+    def action_location(self, options, args):
+        logger.info(os.path.join(options.cache_dir, "wheels"))
+        return SUCCESS

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -67,7 +67,7 @@ class CacheCommand(Command):
                 """\
                 %s info:
                    Location: %s
-                   Number of files: %s
+                   Files: %s
                    Size: %s""" %
                 (name[cache_type], location, stats["files"],
                  format_size(stats["size"]))

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -12,15 +12,29 @@ logger = logging.getLogger(__name__)
 
 class CacheCommand(Command):
     """\
-    Show information about pip's wheel cache.
+    Operate on pip's caches.
 
     Subcommands:
-        location: Print the location of the wheel cache."""
+        location: Print the location of the cache."""
     actions = ["location"]
     name = "cache"
     usage = """
       %%prog [options] %s""" % "|".join(actions)
-    summary = "Show information about pip's wheel cache."
+    summary = "Operate on pip's caches."
+
+    def __init__(self, *args, **kw):
+        super(CacheCommand, self).__init__(*args, **kw)
+
+        cache_types = ["all", "http", "wheel"]
+
+        self.cmd_opts.add_option(
+            "--type", "-t",
+            choices=cache_types,
+            default="wheel",
+            help="The cache upon which to operate: %s (default: %%default)" %
+                 ", ".join(cache_types)
+        )
+        self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
         if not args or args[0] not in self.actions:
@@ -32,5 +46,9 @@ class CacheCommand(Command):
         return method(options, args[1:])
 
     def action_location(self, options, args):
-        logger.info(os.path.join(options.cache_dir, "wheels"))
+        location = options.cache_dir
+        suffix = {"wheel": "wheels", "http": "http"}
+        if options.type != "all":
+            location = os.path.join(location, suffix[options.type])
+        logger.info(location)
         return SUCCESS

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -86,8 +86,7 @@ class CacheCommand(Command):
             raise CommandError(
                 "pip cache list only operates on the wheel cache.")
         cache_location = self.get_cache_location(options.cache_dir, "wheel")
-        wheels = [os.path.basename(f) for f in
-                  find_files(cache_location, "*.whl")]
+        wheels = [basename(f) for f in find_files(cache_location, "*.whl")]
         wheels.sort()
         logger.info(os.linesep.join(wheels))
 

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -20,7 +20,7 @@ class CacheCommand(Command):
     Subcommands:
         location: Print the location of the cache.
         info: Show statistics on the cache."""
-    actions = ["location", "info"]
+    actions = ["info"]
     name = "cache"
     usage = """
       %%prog [options] %s""" % "|".join(actions)
@@ -55,10 +55,6 @@ class CacheCommand(Command):
         if cache_type != "all":
             location = os.path.join(location, suffix[cache_type])
         return location
-
-    def action_location(self, options, args):
-        logger.info(self.get_cache_location(options.cache_dir, options.type))
-        return SUCCESS
 
     def action_info(self, options, args):
         caches = ["http", "wheel"] if options.type == "all" else [options.type]

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -18,7 +18,6 @@ class CacheCommand(Command):
     Operate on pip's caches.
 
     Subcommands:
-        location: Print the location of the cache.
         info: Show statistics on the cache."""
     actions = ["info"]
     name = "cache"

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -95,7 +95,9 @@ class CacheCommand(Command):
         cache_location = self.get_cache_location(options.cache_dir, "wheel")
         wheels = [basename(f) for f in find_files(cache_location, "*.whl")]
         wheels.sort()
-        logger.info(os.linesep.join(wheels))
+        if wheels:
+            logger.info(os.linesep.join(wheels))
+        return SUCCESS
 
     def action_rm(self, options, args):
         if options.type != "wheel":

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -6,7 +6,8 @@ import textwrap
 
 from pip.basecommand import Command
 from pip.status_codes import SUCCESS, ERROR
-from pip.utils.filesystem import tree_statistics, human_size
+from pip.utils import format_size
+from pip.utils.filesystem import tree_statistics
 
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ class CacheCommand(Command):
                    Number of files: %s
                    Size: %s""" %
                 (name[cache_type], location, stats["files"],
-                 human_size(stats["size"]))
+                 format_size(stats["size"]))
             ))
         logger.info("\n\n".join(result))
         return SUCCESS

--- a/pip/commands/cache.py
+++ b/pip/commands/cache.py
@@ -22,7 +22,7 @@ class CacheCommand(Command):
 
     Subcommands:
         info: Show information about the caches.
-        list (wheel cache only): List wheels stored in the cache.
+        list (wheel cache only): List filenames of wheels stored in the cache.
         rm <filename> (wheel cache only): Remove one or more wheels from the cache.
         purge: Remove all items from the cache.
     """  # noqa

--- a/pip/utils/filesystem.py
+++ b/pip/utils/filesystem.py
@@ -26,3 +26,31 @@ def check_path_owner(path):
                 return os.access(path, os.W_OK)
         else:
             previous, path = path, os.path.dirname(path)
+
+
+def tree_statistics(path):
+    """Computes statistics on a filesystem tree.
+    Returns a dictionary with keys:
+        files: number of files
+        size: total size in bytes
+    """
+    result = {"files": 0, "size": 0}
+    for root, dirs, files in os.walk(path):
+        result["files"] += len(files)
+        abs_paths = (os.path.join(root, f) for f in files)
+        result["size"] += sum(os.path.getsize(f) for f in abs_paths)
+    return result
+
+
+def human_size(n_bytes):
+    units = ["B", "KiB", "MiB", "GiB", "TiB"]
+    size = n_bytes
+    for unit in units:
+        if size <= 1024:
+            if unit == "B":
+                result = "%d %s" % (size, unit)
+            else:
+                result = "%.1f %s" % (size, unit)
+            return result
+        size /= 1024.
+    return "%.1f %s" % (size, "PiB")

--- a/pip/utils/filesystem.py
+++ b/pip/utils/filesystem.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 import os.path
 
@@ -39,4 +40,14 @@ def tree_statistics(path):
         result["files"] += len(files)
         abs_paths = (os.path.join(root, f) for f in files)
         result["size"] += sum(os.path.getsize(f) for f in abs_paths)
+    return result
+
+
+def find_files(path, pattern):
+    """Returns a list of absolute paths of files beneath path, recursively,
+    with filenames which match the UNIX-style shell glob pattern."""
+    result = []
+    for root, dirs, files in os.walk(path):
+        matches = fnmatch.filter(files, pattern)
+        result.extend(os.path.join(root, f) for f in matches)
     return result

--- a/pip/utils/filesystem.py
+++ b/pip/utils/filesystem.py
@@ -40,17 +40,3 @@ def tree_statistics(path):
         abs_paths = (os.path.join(root, f) for f in files)
         result["size"] += sum(os.path.getsize(f) for f in abs_paths)
     return result
-
-
-def human_size(n_bytes):
-    units = ["B", "KiB", "MiB", "GiB", "TiB"]
-    size = n_bytes
-    for unit in units:
-        if size <= 1024:
-            if unit == "B":
-                result = "%d %s" % (size, unit)
-            else:
-                result = "%.1f %s" % (size, unit)
-            return result
-        size /= 1024.
-    return "%.1f %s" % (size, "PiB")

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -3,7 +3,7 @@ import os
 from pip.utils import appdirs
 
 
-def test_cache(script, monkeypatch):
+def test_wheel_cache_location(script, monkeypatch):
     result = script.pip("cache", "location")
     lines = result.stdout.splitlines()
     assert len(lines) == 1
@@ -12,3 +12,9 @@ def test_cache(script, monkeypatch):
         monkeypatch.setenv(k, v)
     cache_dir = os.path.join(appdirs.user_cache_dir("pip"), "wheels")
     assert cache_dir in lines
+
+
+def test_cache_rejects_invalid_cache_type(script):
+    result = script.pip("cache", "--type", "wombat", "location",
+                        expect_error=True)
+    assert "invalid choice" in result.stderr

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -5,24 +5,29 @@ import pytest
 from pip.utils import appdirs
 
 
-def test_wheel_cache_location(script, monkeypatch):
-    result = script.pip("cache", "location")
-    lines = result.stdout.splitlines()
-    assert len(lines) == 1
-
-    for k, v in script.environ.items():
-        monkeypatch.setenv(k, v)
-    cache_dir = os.path.join(appdirs.user_cache_dir("pip"), "wheels")
-    assert cache_dir in lines
-
-
 def test_cache_rejects_invalid_cache_type(script):
-    result = script.pip("cache", "--type", "wombat", "location",
+    result = script.pip("cache", "--type", "wombat", "info",
                         expect_error=True)
     assert "invalid choice" in result.stderr
 
 
 @pytest.mark.parametrize("cache_type", ["all", "wheel", "http"])
-def test_cache_info(script, cache_type):
+def test_cache_info(script, monkeypatch, cache_type):
     result = script.pip("cache", "-t", cache_type, "info")
+
+    for k, v in script.environ.items():
+        monkeypatch.setenv(k, v)
+    cache_base = appdirs.user_cache_dir("pip")
+    wheel_cache_dir = os.path.join(cache_base, "wheels")
+    http_cache_dir = os.path.join(cache_base, "http")
+
     assert "Size:" in result.stdout
+    if cache_type == "wheel":
+        assert "Location: %s" % wheel_cache_dir in result.stdout
+        assert http_cache_dir not in result.stdout
+    elif cache_type == "http":
+        assert "Location: %s" % http_cache_dir in result.stdout
+        assert wheel_cache_dir not in result.stdout
+    else:
+        assert "Location: %s" % wheel_cache_dir in result.stdout
+        assert "Location: %s" % http_cache_dir in result.stdout

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -1,0 +1,14 @@
+import os
+
+from pip.utils import appdirs
+
+
+def test_cache(script, monkeypatch):
+    result = script.pip("cache", "location")
+    lines = result.stdout.splitlines()
+    assert len(lines) == 1
+
+    for k, v in script.environ.items():
+        monkeypatch.setenv(k, v)
+    cache_dir = os.path.join(appdirs.user_cache_dir("pip"), "wheels")
+    assert cache_dir in lines

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from pip.utils import appdirs
 
 
@@ -18,3 +20,9 @@ def test_cache_rejects_invalid_cache_type(script):
     result = script.pip("cache", "--type", "wombat", "location",
                         expect_error=True)
     assert "invalid choice" in result.stderr
+
+
+@pytest.mark.parametrize("cache_type", ["all", "wheel", "http"])
+def test_cache_info(script, cache_type):
+    result = script.pip("cache", "-t", cache_type, "info")
+    assert "Size:" in result.stdout

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -47,7 +47,7 @@ def test_cache_list(script, monkeypatch):
     assert "zzz.whl" in result.stdout
 
 
-def test_cache_rm(script, monkeypatch):
+def test_cache_remove(script, monkeypatch):
     for k, v in script.environ.items():
         monkeypatch.setenv(k, v)
     cache_base = appdirs.user_cache_dir("pip")
@@ -56,6 +56,6 @@ def test_cache_rm(script, monkeypatch):
     with open(os.path.join(wheel_cache_dir, "zzz.whl"), "w"):
         pass
 
-    script.pip("cache", "rm", expect_error=True)
-    result = script.pip("cache", "rm", "zzz.whl")
+    script.pip("cache", "remove", expect_error=True)
+    result = script.pip("cache", "remove", "zzz.whl")
     assert re.match(r"^Removed.*zzz\.whl$", result.stdout)

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -53,9 +53,9 @@ def test_cache_rm(script, monkeypatch):
     cache_base = appdirs.user_cache_dir("pip")
     wheel_cache_dir = os.path.join(cache_base, "wheels")
     os.makedirs(wheel_cache_dir)
-    with open(os.path.join(wheel_cache_dir, "zzz"), "w"):
+    with open(os.path.join(wheel_cache_dir, "zzz.whl"), "w"):
         pass
 
     script.pip("cache", "rm", expect_error=True)
-    result = script.pip("cache", "rm", "zzz")
-    assert re.match("^Removed.*zzz$", result.stdout)
+    result = script.pip("cache", "rm", "zzz.whl")
+    assert re.match(r"^Removed.*zzz\.whl$", result.stdout)


### PR DESCRIPTION
Adds an option that prints the configured location of the cache directory and
exits. This is useful if users want to know where the cache is so that they can
delete stale or poisoned wheels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3968)
<!-- Reviewable:end -->
