### PR TITLE
Add --no-deps support for use in requirements files

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -153,6 +153,7 @@ The following options are supported:
   *  :ref:`--no-binary <install_--no-binary>`
   *  :ref:`--only-binary <install_--only-binary>`
   *  :ref:`--require-hashes <--require-hashes>`
+  *  :ref:`--no-deps <install_--no-deps>`
 
 For example, to specify :ref:`--no-index <--no-index>` and 2 :ref:`--find-links <--find-links>` locations:
 

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -295,9 +295,10 @@ class RequirementCommand(Command):
                     wheel_cache=wheel_cache):
                 found_req_in_file = True
                 requirement_set.add_requirement(req)
-        # If --require-hashes was a line in a requirements file, tell
-        # RequirementSet about it:
+        # If --require-hashes or --no-deps was a line in a requirements file,
+        # tell RequirementSet about it:
         requirement_set.require_hashes = options.require_hashes
+        requirement_set.ignore_dependencies = options.ignore_dependencies
 
         if not (args or options.editables or found_req_in_file):
             opts = {'name': name}

--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -48,6 +48,7 @@ SUPPORTED_OPTIONS = [
     cmdoptions.process_dependency_links,
     cmdoptions.trusted_host,
     cmdoptions.require_hashes,
+    cmdoptions.no_deps
 ]
 
 # options to be passed to requirements
@@ -195,6 +196,10 @@ def process_line(line, filename, line_number, finder=None, comes_from=None,
     # percolate hash-checking option upward
     elif opts.require_hashes:
         options.require_hashes = opts.require_hashes
+
+    # percolate ignore dependencies option upward
+    elif opts.ignore_dependencies:
+        options.ignore_dependencies = opts.ignore_dependencies
 
     # set finder options
     elif finder:

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -518,3 +518,16 @@ def test_install_unsupported_wheel_file(script, data):
     assert ("simple.dist-0.1-py1-none-invalid.whl is not a supported " +
             "wheel on this platform" in result.stderr)
     assert len(result.files_created) == 0
+
+
+@pytest.mark.network
+def test_no_deps_option_in_requirements_file(script):
+    script.scratch_path.join("jinja2-req.txt").write(textwrap.dedent("""\
+        --no-deps\n
+        Flask==0.11.1
+        """))
+    result = script.pip(
+        'install', '-r', script.scratch_path / 'jinja2-req.txt'
+    )
+    assert script.site_packages / 'flask' in result.files_created
+    assert script.site_packages / 'jinja2' not in result.files_created

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -288,7 +288,7 @@ class TestRequirementSet(object):
         with pytest.raises(InstallationError):
             reqset.prepare_files(finder)
 
-    def test_missing_hash_with_require_hashes_in_reqs_file(self, data, tmpdir):
+    def test_no_deps_in_reqs_file(self, data, tmpdir):
         """--no-deps in a requirements file should make its way to the
         RequirementSet.
         """
@@ -622,5 +622,3 @@ def test_exclusive_environment_markers():
     req_set.add_requirement(eq26)
     req_set.add_requirement(ne26)
     assert req_set.has_requirement('Django')
-
-

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -288,6 +288,21 @@ class TestRequirementSet(object):
         with pytest.raises(InstallationError):
             reqset.prepare_files(finder)
 
+    def test_missing_hash_with_require_hashes_in_reqs_file(self, data, tmpdir):
+        """--no-deps in a requirements file should make its way to the
+        RequirementSet.
+        """
+        req_set = self.basic_reqset(ignore_dependencies=False)
+        session = PipSession()
+        finder = PackageFinder([data.find_links], [], session=session)
+        command = InstallCommand()
+        with requirements_file('--no-deps', tmpdir) as reqs_file:
+            options, args = command.parse_args(['-r', reqs_file])
+            command.populate_requirement_set(
+                req_set, args, options, finder, session, command.name,
+                wheel_cache=None)
+        assert req_set.ignore_dependencies
+
 
 @pytest.mark.parametrize(('file_contents', 'expected'), [
     (b'\xf6\x80', b'\xc3\xb6\xe2\x82\xac'),  # cp1252
@@ -607,3 +622,5 @@ def test_exclusive_environment_markers():
     req_set.add_requirement(eq26)
     req_set.add_requirement(ne26)
     assert req_set.has_requirement('Django')
+
+


### PR DESCRIPTION
This adds the possibility to use `--no-deps` in a requirements file.
This feature was requested in #3933.
