### PR TITLE
Fix --quiet option logging levels

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -96,6 +96,8 @@
 
 * Added ``pip completion`` support for the ``fish`` shell.
 
+* ``-q`` specified once correctly sets logging level to WARNING, instead of CRITICAL.
+
 * Fix problems on Windows on Python 2 when username or hostname contains
   non-ASCII characters (:issue:`3463`, :pull:`3970`, :pull:`4000`).
 

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -108,7 +108,7 @@ class Command(object):
         if options.quiet:
             if options.quiet == 1:
                 level = "WARNING"
-            if options.quiet == 2:
+            elif options.quiet == 2:
                 level = "ERROR"
             else:
                 level = "CRITICAL"


### PR DESCRIPTION
Before, `-q` meant `CRITICAL` and `-qq` meant `ERROR`.

UPD. @xavfernandez Does this PR actually make sense, or it will break everything everywhere?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/3994)
<!-- Reviewable:end -->
