### PR TITLE
Add package version in InstallRequirement representation

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -235,6 +235,8 @@ class InstallRequirement(object):
                 s += ' from %s' % self.link.url
         else:
             s = self.link.url if self.link else None
+        if self.installed_version:
+            s += ' (%s)' % self.installed_version
         if self.satisfied_by is not None:
             s += ' in %s' % display_path(self.satisfied_by.location)
         if self.comes_from:


### PR DESCRIPTION
According to #828 and #1414 issues, I just add version in `InstallRequirement` string representation.

For example:

```
$ pip install pip
Requirement already satisfied: pip (8.2.0.dev0) in [...]
```
