### PR TITLE
add exclude-editable option to freeze command

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,10 @@
 * Return a failing exit status when `pip install`, `pip download`, or
   `pip wheel` is called with no requirements. (:issue:`2720`, :pull:`2721`)
 
+
+* Add `--exclude-editable` to ``pip freeze`` to exclude editable packages
+  from installed package list.
+
 **9.0.1 (2016-11-06)**
 
 * Correct the deprecation message when not specifying a --format so that it
@@ -115,9 +119,6 @@
 
 * Restore the ability to use inline comments in requirements files passed to
   ``pip freeze`` (:issue:`3680`).
-
-* Add `--exclude-editable` to ``pip freeze`` to exclude editable packages
-  from installed package list.
 
 **8.1.2 (2016-05-10)**
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -116,6 +116,9 @@
 * Restore the ability to use inline comments in requirements files passed to
   ``pip freeze`` (:issue:`3680`).
 
+* Add `--exclude-editable` to ``pip freeze`` to exclude editable packages
+  from installed package list.
+
 **8.1.2 (2016-05-10)**
 
 * Fix a regression on systems with uninitialized locale (:issue:`3575`).

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -69,7 +69,6 @@ class FreezeCommand(Command):
             action='store_true',
             help='Exclude editable package from output.')
 
-
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -63,6 +63,12 @@ class FreezeCommand(Command):
             action='store_true',
             help='Do not skip these packages in the output:'
                  ' %s' % ', '.join(DEV_PKGS))
+        self.cmd_opts.add_option(
+            '--exclude-editable',
+            dest='exclude_editable',
+            action='store_true',
+            help='Exclude editable package from output.')
+
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -81,7 +87,8 @@ class FreezeCommand(Command):
             skip_regex=options.skip_requirements_regex,
             isolated=options.isolated_mode,
             wheel_cache=wheel_cache,
-            skip=skip)
+            skip=skip,
+            exclude_editable=options.exclude_editable)
 
         for line in freeze(**freeze_kwargs):
             sys.stdout.write(line + '\n')

--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -21,6 +21,7 @@ def freeze(
         default_vcs=None,
         isolated=False,
         wheel_cache=None,
+        exclude_editable=False,
         skip=()):
     find_links = find_links or []
     skip_match = None
@@ -54,6 +55,8 @@ def freeze(
                 "Could not parse requirement: %s",
                 dist.project_name
             )
+            continue
+        if exclude_editable and req.editable:
             continue
         installations[req.name] = req
 

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -135,7 +135,7 @@ def test_freeze_svn(script, tmpdir):
 @pytest.mark.xfail
 def test_freeze_exclude_editable(script, tmpdir):
     """
-    Test excluding editable from freezing list. 
+    Test excluding editable from freezing list.
     """
     # Returns path to a generated package called "version_pkg"
     pkg_version = _create_test_package(script)

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -132,6 +132,35 @@ def test_freeze_svn(script, tmpdir):
 
 
 @pytest.mark.git
+@pytest.mark.xfail
+def test_freeze_exclude_editable(script, tmpdir):
+    """
+    Test excluding editable from freezing list. 
+    """
+    # Returns path to a generated package called "version_pkg"
+    pkg_version = _create_test_package(script)
+
+    result = script.run(
+        'git', 'clone', pkg_version, 'pip-test-package',
+        expect_stderr=True,
+    )
+    repo_dir = script.scratch_path / 'pip-test-package'
+    result = script.run(
+        'python', 'setup.py', 'develop',
+        cwd=repo_dir,
+        expect_stderr=True,
+    )
+    result = script.pip('freeze', '--exclude-editable', expect_stderr=True)
+    expected = textwrap.dedent(
+        """
+            ...-e git+...#egg=version_pkg
+            ...
+        """
+    ).strip()
+    _check_output(result.stdout, expected)
+
+
+@pytest.mark.git
 def test_freeze_git_clone(script, tmpdir):
     """
     Test freezing a Git clone.


### PR DESCRIPTION
The project that using setup.py to manage dependency uses `pip freeze` to constraints versions, editable line is not necessary.

I use `pip freeze` to create versions constraints list as bellow::

```
pip install -e . 
pip freeze > constraints.txt
```

I have deleted editable line from constraints.txt when that ran.

`--exclude-editable` option can exclude from editable package from that output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4015)
<!-- Reviewable:end -->
