### PR TITLE
add exclude-editable option to list command

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,9 @@
 * Add `--exclude-editable` to ``pip freeze`` to exclude editable packages
   from installed package list.
 
+* Add `--exclude-editable` to ``pip list`` to exclude editable packages
+  from installed package list.
+
 * Add `--progress-bar <progress_bar>` to ``pip download``, ``pip install``
   and ``pip wheel`` to suppress progress bar in the console (:pull:`4194`)
 

--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -91,6 +91,13 @@ class ListCommand(Command):
                  "installed packages.",
         )
 
+        cmd_opts.add_option(
+            '--exclude-editable',
+            action='store_true',
+            dest='exclude_editable',
+            help='Exclude editable package from output.',
+        )
+
         index_opts = make_option_group(index_group, self.parser)
 
         self.parser.insert_option_group(0, index_opts)
@@ -151,6 +158,7 @@ class ListCommand(Command):
             local_only=options.local,
             user_only=options.user,
             editables_only=options.editable,
+            include_editables=not options.exclude_editable,
         )
 
         if options.outdated:

--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -93,11 +93,17 @@ class ListCommand(Command):
 
         cmd_opts.add_option(
             '--exclude-editable',
-            action='store_true',
-            dest='exclude_editable',
+            action='store_false',
+            dest='include_editable',
             help='Exclude editable package from output.',
         )
-
+        cmd_opts.add_option(
+            '--include-editable',
+            action='store_true',
+            dest='include_editable',
+            help='Include editable package from output.',
+            default=True,
+        )
         index_opts = make_option_group(index_group, self.parser)
 
         self.parser.insert_option_group(0, index_opts)
@@ -158,7 +164,7 @@ class ListCommand(Command):
             local_only=options.local,
             user_only=options.user,
             editables_only=options.editable,
-            include_editables=not options.exclude_editable,
+            include_editables=options.include_editable,
         )
 
         if options.outdated:

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -329,6 +329,21 @@ def test_editables_flag(script, data):
 
 
 @pytest.mark.network
+def test_exclude_editable_flag(script, data):
+    """
+    Test the behavior of --editables flag in the list command
+    """
+    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
+    result = script.pip(
+        'install', '-e',
+        'git+https://github.com/pypa/pip-test-package.git#egg=pip-test-package'
+    )
+    result = script.pip('list', '--exclude-editable', '--format=legacy')
+    assert 'simple (1.0)' in result.stdout, str(result)
+    assert 'pip-test-package (0.1, ' not in result.stdout
+
+
+@pytest.mark.network
 def test_editables_columns_flag(script, data):
     """
     Test the behavior of --editables flag in the list command


### PR DESCRIPTION
this PR motivated from #4015.
I've needed `exclude-editable` option to `freeze` command,  but that may be to be alias of `list` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4016)
<!-- Reviewable:end -->
