### PR TITLE
Changed show not to break on first empty line processing metadata for classifiers

### DIFF
--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -109,9 +109,9 @@ def search_packages_info(query):
         classifiers = []
         for line in metadata.splitlines():
             if not line:
-                break
+                pass  # The Problem SJB
             # Classifier: License :: OSI Approved :: MIT License
-            if line.startswith('Classifier: '):
+            elif line.startswith('Classifier: '):
                 classifiers.append(line[len('Classifier: '):])
         package['classifiers'] = classifiers
 

--- a/pip/commands/show.py
+++ b/pip/commands/show.py
@@ -108,10 +108,7 @@ def search_packages_info(query):
         # It looks like FeedParser cannot deal with repeated headers
         classifiers = []
         for line in metadata.splitlines():
-            if not line:
-                pass  # The Problem SJB
-            # Classifier: License :: OSI Approved :: MIT License
-            elif line.startswith('Classifier: '):
+            if line.startswith('Classifier: '):
                 classifiers.append(line[len('Classifier: '):])
         package['classifiers'] = classifiers
 


### PR DESCRIPTION
Changed show not to break on first empty line processing metadata for classifiers. Addresses #4027

Tested with Python 2.7.12 & Python 3.5.2 `pip show -v folium` now shows Classifiers:

```
Name: folium
Version: 0.2.1
Summary: Make beautiful maps with Leaflet.js & Python
Home-page: https://github.com/python-visualization/folium
Author: Rob Story
Author-email: wrobstory@gmail.com
License: Copyright (C) 2013, Rob Story
Location: c:\python35-32\lib\site-packages
Requires: Jinja2
Metadata-Version: 1.1
Installer:
Classifiers:
  Programming Language :: Python :: 2.7
  Programming Language :: Python :: 3.3
  Programming Language :: Python :: 3.4
  Programming Language :: Python :: 3.5
  License :: OSI Approved :: MIT License
  Development Status :: 5 - Production/Stable
Entry-points:
```