### PR TITLE
add snippet for installing extras from git repo urls

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -791,6 +791,7 @@ Examples
     ::
 
       $ pip install SomePackage[PDF]
+      $ pip install git+https://git.repo/some_pkg.git#egg=SomePackage[PDF]
       $ pip install SomePackage[PDF]==3.0
       $ pip install -e .[PDF]==3.0  # editable project in current directory
 


### PR DESCRIPTION
# 4030 suggested the line be added somewhere to the docs because it's came up in previous issues, and it was sort of a little secret.

Now, it's there, but is it enough? Should we add a section as to why this is needed (since you **technically** can use square brackets in urls). I don't think people would really care about the reasoning, but who knows.
