### PR TITLE
Ignore missing cffi on PyPy

### DIFF
--- a/pip/operations/check.py
+++ b/pip/operations/check.py
@@ -1,5 +1,13 @@
 from pip.utils import get_installed_distributions
 
+try:
+    import __pypy__  # NOQA
+    _ignore_missing = [
+        'cffi',  # cffi is built in to PyPy
+    ]
+except ImportError:
+    _ignore_missing = []
+
 
 def check_requirements():
     installed = get_installed_distributions(skip=())
@@ -26,6 +34,7 @@ def get_missing_reqs(dist, installed_dists):
 
     """
     installed_names = set(d.project_name.lower() for d in installed_dists)
+    installed_names.update(_ignore_missing)
     missing_requirements = set()
 
     for requirement in dist.requires():


### PR DESCRIPTION
Since PyPy includes `cffi`, things get a bit weird when using `pip check` with packages that use `cffi`:

```
$ pip check
psycopg2cffi 2.7.4 requires cffi, which is not installed.
bcrypt 3.1.1 requires cffi, which is not installed.
```

If a user were to try to install `cffi`, they would probably be confused:

```
$ pip install cffi
Requirement already satisfied: cffi in /Users/josh/.pyenv/versions/pypy-5.3.1/lib_pypy
```