### PR TITLE
Show package version for already-up-to-date/installed (#828) (#1414)

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -489,8 +489,9 @@ class RequirementSet(object):
                     'req_to_install.satisfied_by is set to %r'
                     % (req_to_install.satisfied_by,))
                 logger.info(
-                    'Requirement %s: %s', skip_reason,
-                    req_to_install)
+                    'Requirement %s: %s (%s)', skip_reason,
+                    req_to_install,
+                    req_to_install.satisfied_by.version)
             else:
                 if (req_to_install.link and
                         req_to_install.link.scheme == 'file'):


### PR DESCRIPTION
Show package version for already-up-to-date/ installed (#828) (#1414)
Shows up like this - 
```
$ pip install wheel
Requirement already satisfied: wheel in ./venv/lib/python2.7/site-packages (0.30.0a0)
$  pip install --upgrade wheel
Requirement already up-to-date: wheel in ./venv/lib/python2.7/site-packages (0.30.0a0)
```