### PR TITLE
`session` is only needed for URLs in requirements

### DIFF
--- a/news/4555.bugfix
+++ b/news/4555.bugfix
@@ -1,0 +1,1 @@
+Fail requirements parsing without `session` only if it is needed

--- a/pip/download.py
+++ b/pip/download.py
@@ -399,11 +399,6 @@ def get_file_content(url, comes_from=None, session=None):
     :param comes_from:  Origin description of requirements.
     :param session:     Instance of pip.download.PipSession.
     """
-    if session is None:
-        raise TypeError(
-            "get_file_content() missing 1 required keyword argument: 'session'"
-        )
-
     match = _scheme_re.search(url)
     if match:
         scheme = match.group(1).lower()
@@ -423,6 +418,11 @@ def get_file_content(url, comes_from=None, session=None):
                 path = '/' + path.lstrip('/')
             url = path
         else:
+            if session is None:
+                raise TypeError(
+                    "get_file_content() requires `session` for fetching URLs"
+                )
+
             # FIXME: catch some errors
             resp = session.get(url)
             resp.raise_for_status()

--- a/pip/req/req_file.py
+++ b/pip/req/req_file.py
@@ -64,12 +64,6 @@ def parse_requirements(filename, finder=None, comes_from=None, options=None,
         requirements file.
     :param wheel_cache: Instance of pip.wheel.WheelCache
     """
-    if session is None:
-        raise TypeError(
-            "parse_requirements() missing 1 required keyword argument: "
-            "'session'"
-        )
-
     _, content = get_file_content(
         filename, comes_from=comes_from, session=session
     )


### PR DESCRIPTION
Fixes #4555.

This should make some 157 people happy in 
https://stackoverflow.com/questions/14399534/how-can-i-reference-requirements-txt-for-the-install-requires-kwarg-in-setuptool for a while. https://github.com/pypa/pip/commit/7037443975ee5706ef829f14a52ac2fba7dbfff2 
