### PR TITLE
failed upgrade doesn't properly rollback

### DIFF
--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -264,6 +264,8 @@ def renames(old, new):
     if head and tail and not os.path.exists(head):
         os.makedirs(head)
 
+    if os.path.isdir(new):
+        shutil.rmtree(new)
     shutil.move(old, new)
 
     head, tail = os.path.split(old)


### PR DESCRIPTION
### Summary:
When an upgrade fails, the rollback doesn't move the old version back where it was.

### Discuss and Reproduce:
On a vanilla macOS system:

`sudo python2.7 -m ensurepip`
`brew install python3`
`ls -oh /usr/local/bin/pip*`
```
-rwxr-xr-x  1 root     288B Nov 11 17:04 /usr/local/bin/pip
-rwxr-xr-x  1 root     288B Nov 11 17:04 /usr/local/bin/pip2
-rwxr-xr-x  1 root     288B Nov 11 17:04 /usr/local/bin/pip2.7
lrwxr-xr-x  1 curtis    34B Nov 11 17:09 /usr/local/bin/pip3 -> ../Cellar/python3/3.5.2_3/bin/pip3
lrwxr-xr-x  1 curtis    36B Nov 11 17:09 /usr/local/bin/pip3.5 -> ../Cellar/python3/3.5.2_3/bin/pip3.5
```

Notice how system python2/pip is owned by root. But brew python3/pip is owned by user. This will cause the following to fail.

`pip3.5 install --upgrade pip`

However, when it does, the rollback doesn't work properly! Thus we are left with the new pip incompletely installed, and the old pip lingering inside--useless.

`grep ^__ver /usr/local/lib/python3.5/site-packages/pip/{,pip/}__init__.py`
```
/usr/local/lib/python3.5/site-packages/pip/__init__.py:__version__ = "9.0.1"
/usr/local/lib/python3.5/site-packages/pip/pip/__init__.py:__version__ = "8.1.2"
```
