### PR TITLE
Fix pip install --target

### DIFF
--- a/news/4111.bugfix
+++ b/news/4111.bugfix
@@ -1,0 +1,1 @@
+Fix ``pip install --target`` by making ``--target``, ``--user``, and ``--prefix`` mutually exclusive.

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -181,6 +181,11 @@ class InstallCommand(RequirementCommand):
                     "Can not combine '--user' and '--prefix' as they imply "
                     "different installation locations"
                 )
+            if options.target_dir:
+                raise CommandError(
+                    "Can not combine '--user' and '--target' as they imply "
+                    "different installation locations"
+                )
             if virtualenv_no_global():
                 raise InstallationError(
                     "Can not perform a '--user' install. User site-packages "
@@ -191,6 +196,11 @@ class InstallCommand(RequirementCommand):
 
         temp_target_dir = None
         if options.target_dir:
+            if options.prefix_path:
+                raise CommandError(
+                    "Can not combine '--target' and '--prefix' as they imply "
+                    "different installation locations"
+                )
             options.ignore_installed = True
             temp_target_dir = tempfile.mkdtemp()
             options.target_dir = os.path.abspath(options.target_dir)
@@ -201,6 +211,7 @@ class InstallCommand(RequirementCommand):
                     "continue."
                 )
             install_options.append('--home=' + temp_target_dir)
+            install_options.append('--prefix=')
 
         global_options = options.global_options or []
 

--- a/pip/locations.py
+++ b/pip/locations.py
@@ -151,9 +151,11 @@ def distutils_scheme(dist_name, user=False, home=None, root=None,
     # or user base for installations during finalize_options()
     # ideally, we'd prefer a scheme class that has no side-effects.
     assert not (user and prefix), "user={0} prefix={1}".format(user, prefix)
-    i.user = user or i.user
-    if user:
+    assert not (home and prefix), "home={0} prefix={1}".format(home, prefix)
+    assert not (home and user), "home={0} user={1}".format(home, user)
+    if user or home:
         i.prefix = ""
+    i.user = user or i.user
     i.prefix = prefix or i.prefix
     i.home = home or i.home
     i.root = root or i.root

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -663,6 +663,37 @@ def test_install_package_conflict_prefix_and_user(script, data):
     )
 
 
+def test_install_package_conflict_target_and_user(script, data):
+    """
+    Test installing a package using pip install --target --user errors out
+    """
+    target_path = script.scratch_path / 'target'
+    result = script.pip(
+        'install', '-f', data.find_links, '--no-index', '--user',
+        '--target', target_path, 'simple==1.0',
+        expect_error=True, quiet=True,
+    )
+    assert (
+        "Can not combine '--user' and '--target'" in result.stderr
+    )
+
+
+def test_install_package_conflict_prefix_and_target(script, data):
+    """
+    Test installing a package using pip install --prefix --targetx errors out
+    """
+    prefix_path = script.scratch_path / 'prefix'
+    target_path = script.scratch_path / 'target'
+    result = script.pip(
+        'install', '-f', data.find_links, '--no-index', '--target',
+        target_path, '--prefix', prefix_path, 'simple==1.0',
+        expect_error=True, quiet=True,
+    )
+    assert (
+        "Can not combine '--target' and '--prefix'" in result.stderr
+    )
+
+
 # skip on win/py3 for now, see issue #782
 @pytest.mark.skipif("sys.platform == 'win32' and sys.version_info >= (3,)")
 def test_install_package_that_emits_unicode(script, data):

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -222,6 +222,65 @@ def test_wheel_user_with_prefix_in_pydistutils_cfg(script, data, virtualenv):
     assert 'installed requiresupper' in result.stdout
 
 
+def test_nowheel_user_with_prefix_in_pydistutils_cfg(script, data, virtualenv):
+    virtualenv.system_site_packages = True
+    homedir = script.environ["HOME"]
+    script.scratch_path.join("bin").mkdir()
+    with open(os.path.join(homedir, ".pydistutils.cfg"), "w") as cfg:
+        cfg.write(textwrap.dedent("""
+            [install]
+            prefix=%s""" % script.scratch_path))
+
+    result = script.pip('install', '--no-use-wheel', '--user', '--no-index',
+                        '-f', data.find_links, 'requiresupper',
+                        expect_stderr=True)
+    assert 'installed requiresupper' in result.stdout
+    assert ('DEPRECATION: --no-use-wheel is deprecated and will be removed '
+            'in the future.  Please use --no-binary :all: instead.\n'
+            ) in result.stderr
+
+
+@pytest.mark.network
+def test_wheel_target_with_prefix_in_pydistutils_cfg(script, data,
+                                                     virtualenv):
+    # Make sure wheel is available in the virtualenv
+    script.pip('install', 'wheel')
+    virtualenv.system_site_packages = True
+    homedir = script.environ["HOME"]
+    script.scratch_path.join("bin").mkdir()
+    with open(os.path.join(homedir, ".pydistutils.cfg"), "w") as cfg:
+        cfg.write(textwrap.dedent("""
+            [install]
+            prefix=%s""" % script.scratch_path))
+
+    target_path = script.scratch_path / 'target'
+    result = script.pip('install', '--target', target_path, '--no-index', '-f',
+                        data.find_links, 'requiresupper')
+    # Check that we are really installing a wheel
+    assert 'Running setup.py install for requiresupper' not in result.stdout
+    assert 'installed requiresupper' in result.stdout
+
+
+def test_nowheel_target_with_prefix_in_pydistutils_cfg(script, data,
+                                                       virtualenv):
+    virtualenv.system_site_packages = True
+    homedir = script.environ["HOME"]
+    script.scratch_path.join("bin").mkdir()
+    with open(os.path.join(homedir, ".pydistutils.cfg"), "w") as cfg:
+        cfg.write(textwrap.dedent("""
+            [install]
+            prefix=%s""" % script.scratch_path))
+
+    target_path = script.scratch_path / 'target'
+    result = script.pip('install', '--no-use-wheel', '--target', target_path,
+                        '--no-index', '-f', data.find_links, 'requiresupper',
+                        expect_stderr=True)
+    assert 'installed requiresupper' in result.stdout
+    assert ('DEPRECATION: --no-use-wheel is deprecated and will be removed '
+            'in the future.  Please use --no-binary :all: instead.\n'
+            ) in result.stderr
+
+
 def test_install_option_in_requirements_file(script, data, virtualenv):
     """
     Test --install-option in requirements file overrides same option in cli

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -235,9 +235,6 @@ def test_nowheel_user_with_prefix_in_pydistutils_cfg(script, data, virtualenv):
                         '-f', data.find_links, 'requiresupper',
                         expect_stderr=True)
     assert 'installed requiresupper' in result.stdout
-    assert ('DEPRECATION: --no-use-wheel is deprecated and will be removed '
-            'in the future.  Please use --no-binary :all: instead.\n'
-            ) in result.stderr
 
 
 @pytest.mark.network
@@ -272,13 +269,10 @@ def test_nowheel_target_with_prefix_in_pydistutils_cfg(script, data,
             prefix=%s""" % script.scratch_path))
 
     target_path = script.scratch_path / 'target'
-    result = script.pip('install', '--no-use-wheel', '--target', target_path,
+    result = script.pip('install', '--no-binary=:all:', '--target', target_path,
                         '--no-index', '-f', data.find_links, 'requiresupper',
                         expect_stderr=True)
     assert 'installed requiresupper' in result.stdout
-    assert ('DEPRECATION: --no-use-wheel is deprecated and will be removed '
-            'in the future.  Please use --no-binary :all: instead.\n'
-            ) in result.stderr
 
 
 def test_install_option_in_requirements_file(script, data, virtualenv):

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -269,7 +269,8 @@ def test_nowheel_target_with_prefix_in_pydistutils_cfg(script, data,
             prefix=%s""" % script.scratch_path))
 
     target_path = script.scratch_path / 'target'
-    result = script.pip('install', '--no-binary=:all:', '--target', target_path,
+    result = script.pip('install', '--no-binary=:all:',
+                        '--target', target_path,
                         '--no-index', '-f', data.find_links, 'requiresupper',
                         expect_stderr=True)
     assert 'installed requiresupper' in result.stdout

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -231,7 +231,7 @@ def test_nowheel_user_with_prefix_in_pydistutils_cfg(script, data, virtualenv):
             [install]
             prefix=%s""" % script.scratch_path))
 
-    result = script.pip('install', '--no-use-wheel', '--user', '--no-index',
+    result = script.pip('install', '--no-binary=:all:', '--user', '--no-index',
                         '-f', data.find_links, 'requiresupper',
                         expect_stderr=True)
     assert 'installed requiresupper' in result.stdout


### PR DESCRIPTION
As I messed up my branch, github force closed my last PR.
So this is a new, clean version of PR #4103 .

Sorry for the mess.

---
For reference: the original description of PR #4103:

> Currently `pip install --target` does fail when a prefix is set (e.g. in a .pydistutils.cfg).
> This is especially the case on macOS when Python is installed via Homebrew.
> It used to fail in the same way when using the `--user` flag. This was initially fixed in b227c45
> 
> Now I just replicated this fix for the usage of `--target`.
> 
> Interestingly, `--target` used to work when supplying `--install-option="--prefix="` at the command line as advised in [Homebrew-and-Python.md](https://github.com/Homebrew/brew/blob/master/docs/Homebrew-and-Python.md#note-on-pip-install---user), but now doesn't anymore.
> The error message changes though whether `--install-option="--prefix="` is set or not. - When the option is set, pip fails when `get_lib_location_guesses` calls `distutils_scheme`, so it seems the `--install-prefix` switch is ignored there.
> 
> Anyway, this pull request should fix it all by enforcing `prefix` to be empty when `--target` is used.
> Although this works fine for me, I am not yet sure if these changes would break anything else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4111)
<!-- Reviewable:end -->
