### PR TITLE
macOS: use ~/.config/pip/pip.conf as default as well (#4100)

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -280,7 +280,9 @@ all users) configuration:
 * On Unix the default configuration file is: :file:`$HOME/.config/pip/pip.conf`
   which respects the ``XDG_CONFIG_HOME`` environment variable.
 * On macOS the configuration file is
-  :file:`$HOME/Library/Application Support/pip/pip.conf`.
+  :file:`$HOME/Library/Application Support/pip/pip.conf`
+  if directory ``$HOME/Library/Application Support/pip`` exists
+  else :file:`$HOME/.config/pip/pip.conf`.
 * On Windows the configuration file is :file:`%APPDATA%\\pip\\pip.ini`.
 
 There are also a legacy per-user configuration file which is also respected,

--- a/pip/utils/appdirs.py
+++ b/pip/utils/appdirs.py
@@ -74,6 +74,7 @@ def user_data_dir(appname, roaming=False):
 
     Typical user data directories are:
         macOS:                  ~/Library/Application Support/<AppName>
+                                if it exists, else ~/.config/<AppName>
         Unix:                   ~/.local/share/<AppName>    # or in
                                 $XDG_DATA_HOME, if defined
         Win XP (not roaming):   C:\Documents and Settings\<username>\ ...
@@ -92,6 +93,13 @@ def user_data_dir(appname, roaming=False):
     elif sys.platform == "darwin":
         path = os.path.join(
             expanduser('~/Library/Application Support/'),
+            appname,
+        ) if os.path.isdir(os.path.join(
+            expanduser('~/Library/Application Support/'),
+            appname,
+        )
+        ) else os.path.join(
+            expanduser('~/.config/'),
             appname,
         )
     else:

--- a/tests/unit/test_appdirs.py
+++ b/tests/unit/test_appdirs.py
@@ -184,8 +184,12 @@ class TestUserDataDir:
         monkeypatch.setenv("HOME", "/home/test")
         monkeypatch.setattr(sys, "platform", "darwin")
 
-        assert (appdirs.user_data_dir("pip") ==
-                "/home/test/Library/Application Support/pip")
+        if os.path.isdir('/home/test/Library/Application Support/'):
+                assert (appdirs.user_data_dir("pip") ==
+                        "/home/test/Library/Application Support/pip")
+        else:
+                assert (appdirs.user_data_dir("pip") ==
+                        "/home/test/.config/pip")
 
     def test_user_data_dir_linux(self, monkeypatch):
         monkeypatch.setattr(appdirs, "WINDOWS", False)
@@ -262,8 +266,12 @@ class TestUserConfigDir:
         monkeypatch.setenv("HOME", "/home/test")
         monkeypatch.setattr(sys, "platform", "darwin")
 
-        assert (appdirs.user_config_dir("pip") ==
-                "/home/test/Library/Application Support/pip")
+        if os.path.isdir('/home/test/Library/Application Support/'):
+                assert (appdirs.user_data_dir("pip") ==
+                        "/home/test/Library/Application Support/pip")
+        else:
+                assert (appdirs.user_data_dir("pip") ==
+                        "/home/test/.config/pip")
 
     def test_user_config_dir_linux(self, monkeypatch):
         monkeypatch.setattr(appdirs, "WINDOWS", False)


### PR DESCRIPTION
This commit will use `~/.config/pip` as config directory if `~/Library/Application Support/pip` directory does not exist on macOS.
Updated doc as well.

Tested by adding a logger that lists all config files in get_config_files method - 

```
$ ls ~/Library/Application\ Support/pip
ls: /Users/anish/Library/Application Support/pip: No such file or directory
$ pip 1>/dev/null
WARNING:pip.baseparser:get_config_files - ['/Library/Application Support/pip/pip.conf', '/Users/anish/.pip/pip.conf', '/Users/anish/.config/pip/pip.conf']
$ mkdir ~/Library/Application\ Support/pip
$ pip 1>/dev/null
WARNING:pip.baseparser:get_config_files - ['/Library/Application Support/pip/pip.conf', '/Users/anish/.pip/pip.conf', '/Users/anish/Library/Application Support/pip/pip.conf']
$ rm -rf ~/Library/Application\ Support/pip/
$ pip 1>/dev/null
WARNING:pip.baseparser:get_config_files - ['/Library/Application Support/pip/pip.conf', '/Users/anish/.pip/pip.conf', '/Users/anish/.config/pip/pip.conf']
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4124)
<!-- Reviewable:end -->
