### PR TITLE
allow development on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ docs/_build/
 pip.egg-info/
 MANIFEST
 .tox
+.cache
 *.egg
 *.py[cod]
 *~

--- a/pip/vcs/git.py
+++ b/pip/vcs/git.py
@@ -54,7 +54,7 @@ class Git(VersionControl):
         VERSION_PFX = 'git version '
         version = self.run_command(['version'], show_stdout=False)
         if version.startswith(VERSION_PFX):
-            version = version[len(VERSION_PFX):]
+            version = version[len(VERSION_PFX):].split()[0]
         else:
             version = ''
         # get first 3 positions of the git version becasue


### PR DESCRIPTION
On Yosemite (with homebrew/Python 3.5), attempting to run `tox -e py35 -- -n auto` will fail thusly:
```
test_get_git_version:
[gw6] darwin -- Python 3.5.2 /Users/curtis/src/github/pip/.tox/py35/bin/python
def test_get_git_version():
        git_version = Git().get_git_version()
>       assert git_version >= parse_version('1.0.0')
E       assert <LegacyVersion('2.5.4 (Apple Git-61)\n')> >= <Version('1.0.0')>
E        +  where <Version('1.0.0')> = parse_version('1.0.0')

tests/unit/test_vcs.py:145: AssertionError
```

Here's the fix!

Also included a patch to tell git to ignore more dev junk in .cache/