### PR TITLE
add a simple order strategy for result of search command

### DIFF
--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -137,12 +137,13 @@ def highest_version(versions):
 
 def sort_hits(query, hits):
     if len(query) != 1:
-        #Now only handle the easiest condition, which is possibly the most frequent condition
+#   Now only handle the easiest condition,
+#   which is possibly the most frequent condition
         return hits
     query = query[0]
     p = re.compile(query)
     p_ignorecase = re.compile(query, re.IGNORECASE)
-    for index,item in enumerate(hits):
+    for index, item in enumerate(hits):
         hits[index]['match_score'] = 0
         name = item['name']
         summary = item['summary']
@@ -153,7 +154,7 @@ def sort_hits(query, hits):
         m3 = p_ignorecase.findall(name)
         m4 = p_ignorecase.findall(summary)
 
-        #Ordering strategy
+        # Ordering strategy
         if name == query:
             hits[index]['match_score'] += 10000
         elif name.lower() == query.lower():

--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -135,10 +135,11 @@ def print_results(hits, name_column_width=None, terminal_width=None):
 def highest_version(versions):
     return max(versions, key=parse_version)
 
+
 def sort_hits(query, hits):
     if len(query) != 1:
-#   Now only handle the easiest condition,
-#   which is possibly the most frequent condition
+        # Now only handle the easiest condition,
+        # which is possibly the most frequent condition
         return hits
     query = query[0]
     p = re.compile(query)
@@ -168,5 +169,5 @@ def sort_hits(query, hits):
         if m4 is not None:
             hits[index]['match_score'] += len(m3)
 
-    hits.sort(key = lambda i: i['match_score'], reverse=True)
+    hits.sort(key=lambda i: i['match_score'], reverse=True)
     return hits

--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -1,8 +1,10 @@
+
 from __future__ import absolute_import
 
 import logging
 import sys
 import textwrap
+import re
 
 from pip.basecommand import Command, SUCCESS
 from pip.compat import OrderedDict
@@ -44,6 +46,7 @@ class SearchCommand(Command):
         query = args
         pypi_hits = self.search(query, options)
         hits = transform_hits(pypi_hits)
+        hits = sort_hits(query, hits)
 
         terminal_width = None
         if sys.stdout.isatty():
@@ -131,3 +134,38 @@ def print_results(hits, name_column_width=None, terminal_width=None):
 
 def highest_version(versions):
     return max(versions, key=parse_version)
+
+def sort_hits(query, hits):
+    if len(query) != 1:
+        #Now only handle the easiest condition, which is possibly the most frequent condition
+        return hits
+    query = query[0]
+    p = re.compile(query)
+    p_ignorecase = re.compile(query, re.IGNORECASE)
+    for index,item in enumerate(hits):
+        hits[index]['match_score'] = 0
+        name = item['name']
+        summary = item['summary']
+        if summary is None:
+            summary = ''
+        m1 = p.match(name)
+        m2 = p_ignorecase.match(name)
+        m3 = p_ignorecase.findall(name)
+        m4 = p_ignorecase.findall(summary)
+
+        #Ordering strategy
+        if name == query:
+            hits[index]['match_score'] += 10000
+        elif name.lower() == query.lower():
+            hits[index]['match_score'] += 9000
+        if m1 is not None:
+            hits[index]['match_score'] += 1000
+        elif m2 is not None:
+            hits[index]['match_score'] += 900
+        elif m3 is not None:
+            hits[index]['match_score'] += 800
+        if m4 is not None:
+            hits[index]['match_score'] += len(m3)
+
+    hits.sort(key = lambda i: i['match_score'], reverse=True)
+    return hits

--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -144,12 +144,10 @@ def sort_hits(query, hits):
     query = query[0]
     p = re.compile(query)
     p_ignorecase = re.compile(query, re.IGNORECASE)
-    for index, item in enumerate(hits):
-        hits[index]['match_score'] = 0
+    for item in hits:
+        item['match_score'] = 0
         name = item['name']
-        summary = item['summary']
-        if summary is None:
-            summary = ''
+        summary = item['summary'] or ''
         m1 = p.match(name)
         m2 = p_ignorecase.match(name)
         m3 = p_ignorecase.findall(name)
@@ -157,17 +155,17 @@ def sort_hits(query, hits):
 
         # Ordering strategy
         if name == query:
-            hits[index]['match_score'] += 10000
+            item['match_score'] += 10000
         elif name.lower() == query.lower():
-            hits[index]['match_score'] += 9000
+            item['match_score'] += 9000
         if m1 is not None:
-            hits[index]['match_score'] += 1000
+            item['match_score'] += 1000
         elif m2 is not None:
-            hits[index]['match_score'] += 900
+            item['match_score'] += 900
         elif m3 is not None:
-            hits[index]['match_score'] += 800
+            item['match_score'] += 800
         if m4 is not None:
-            hits[index]['match_score'] += len(m3)
+            item['match_score'] += len(m3) + len(m4)
 
     hits.sort(key=lambda i: i['match_score'], reverse=True)
     return hits

--- a/pip/commands/search.py
+++ b/pip/commands/search.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import
 
 import logging
+import re
 import sys
 import textwrap
-import re
 
 from pip.basecommand import Command, SUCCESS
 from pip.compat import OrderedDict


### PR DESCRIPTION
Mostly, I use "pip search" just with a package name that I want to install. I just want to make sure that the name is correct. But most of the time, the result is very confused. I add a small ordering strategy on search result by giving them a score. The solution is very elementary. But, at least, if I did search with the exactly package name, that package would come at the very first line. I'm using this version of pip search on my own laptop for a while. Till now, it works fine. :-)