### PR TITLE
Optionally load C dependencies based on platform

### DIFF
--- a/pip/_vendor/requests/__init__.py
+++ b/pip/_vendor/requests/__init__.py
@@ -50,11 +50,14 @@ __copyright__ = 'Copyright 2016 Kenneth Reitz'
 # Attempt to enable urllib3's SNI support, if possible
 # Note: Patched by pip to prevent using the PyOpenSSL module. On Windows this
 #       prevents upgrading cryptography.
-# try:
-#     from .packages.urllib3.contrib import pyopenssl
-#     pyopenssl.inject_into_urllib3()
-# except ImportError:
-#     pass
+from pip.compat import LOAD_C_DEPENDENCIES
+if LOAD_C_DEPENDENCIES:
+    try:
+        from .packages.urllib3.contrib import pyopenssl
+        pyopenssl.inject_into_urllib3()
+    except ImportError:
+        pass
+del LOAD_C_DEPENDENCIES
 
 import warnings
 

--- a/pip/_vendor/requests/compat.py
+++ b/pip/_vendor/requests/compat.py
@@ -27,12 +27,17 @@ is_py3 = (_ver[0] == 3)
 
 # Note: We've patched out simplejson support in pip because it prevents
 #       upgrading simplejson on Windows.
-# try:
-#     import simplejson as json
-# except (ImportError, SyntaxError):
-#     # simplejson does not support Python 3.2, it throws a SyntaxError
-#     # because of u'...' Unicode literals.
-import json
+from pip.compat import LOAD_C_DEPENDENCIES
+if LOAD_C_DEPENDENCIES:
+    try:
+        import simplejson as json
+    except (ImportError, SyntaxError):
+        # simplejson does not support Python 3.2, it throws a SyntaxError
+        # because of u'...' Unicode literals.
+        import json
+else:
+    import json
+del LOAD_C_DEPENDENCIES
 
 # ---------
 # Specifics

--- a/pip/_vendor/requests/packages/urllib3/util/ssl_.py
+++ b/pip/_vendor/requests/packages/urllib3/util/ssl_.py
@@ -112,15 +112,32 @@ except ImportError:
             self.ciphers = cipher_suite
 
         def wrap_socket(self, socket, server_hostname=None, server_side=False):
-            warnings.warn(
-                'A true SSLContext object is not available. This prevents '
-                'urllib3 from configuring SSL appropriately and may cause '
-                'certain SSL connections to fail. You can upgrade to a newer '
-                'version of Python to solve this. For more information, see '
-                'https://urllib3.readthedocs.io/en/latest/security.html'
-                '#insecureplatformwarning.',
-                InsecurePlatformWarning
-            )
+            from pip.compat import LOAD_C_DEPENDENCIES
+            if LOAD_C_DEPENDENCIES:
+                warnings.warn(
+                    'A true SSLContext object is not available. This prevents '
+                    'urllib3 from configuring SSL appropriately and may cause '
+                    'certain SSL connections to fail. You can upgrade to a newer '
+                    'version of Python to solve this. For more information, see '
+                    'https://urllib3.readthedocs.io/en/latest/security.html'
+                    '#insecureplatformwarning.',
+                    InsecurePlatformWarning
+                )
+            else:
+                warnings.warn(
+                    'A true SSLContext object is not available. This prevents '
+                    'urllib3 from configuring SSL appropriately and may cause '
+                    'certain SSL connections to fail. You can upgrade to a newer '
+                    'version of Python to solve this. For more information, see '
+                    'https://urllib3.readthedocs.io/en/latest/security.html'
+                    '#insecureplatformwarning. '
+                    'NOTE: Since pip uses vendored versions of '
+                    'requests and urllib3 and cannot load C dependencies based '
+                    'on the current platform, installing additional security '
+                    'packages will NOT resolve this warning.',
+                    InsecurePlatformWarning
+                )
+
             kwargs = {
                 'keyfile': self.keyfile,
                 'certfile': self.certfile,
@@ -307,14 +324,31 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
     if HAS_SNI:  # Platform-specific: OpenSSL with enabled SNI
         return context.wrap_socket(sock, server_hostname=server_hostname)
 
-    warnings.warn(
-        'An HTTPS request has been made, but the SNI (Subject Name '
-        'Indication) extension to TLS is not available on this platform. '
-        'This may cause the server to present an incorrect TLS '
-        'certificate, which can cause validation failures. You can upgrade to '
-        'a newer version of Python to solve this. For more information, see '
-        'https://urllib3.readthedocs.io/en/latest/security.html'
-        '#snimissingwarning.',
-        SNIMissingWarning
-    )
+    from pip.compat import LOAD_C_DEPENDENCIES
+    if LOAD_C_DEPENDENCIES:
+        warnings.warn(
+            'An HTTPS request has been made, but the SNI (Subject Name '
+            'Indication) extension to TLS is not available on this platform. '
+            'This may cause the server to present an incorrect TLS '
+            'certificate, which can cause validation failures. You can upgrade to '
+            'a newer version of Python to solve this. For more information, see '
+            'https://urllib3.readthedocs.io/en/latest/security.html'
+            '#snimissingwarning.',
+            SNIMissingWarning
+        )
+    else:
+        warnings.warn(
+            'An HTTPS request has been made, but the SNI (Subject Name '
+            'Indication) extension to TLS is not available on this platform. '
+            'This may cause the server to present an incorrect TLS '
+            'certificate, which can cause validation failures. You can upgrade to '
+            'a newer version of Python to solve this. For more information, see '
+            'https://urllib3.readthedocs.io/en/latest/security.html'
+            '#snimissingwarning. '
+            'NOTE: Since pip uses vendored versions of '
+            'requests and urllib3 and cannot load C dependencies based '
+            'on the current platform, installing additional security '
+            'packages will NOT resolve this warning.',
+            SNIMissingWarning
+        )
     return context.wrap_socket(sock)

--- a/pip/compat/__init__.py
+++ b/pip/compat/__init__.py
@@ -51,7 +51,7 @@ except ImportError:
 __all__ = [
     "logging_dictConfig", "ipaddress", "uses_pycache", "console_to_str",
     "native_str", "get_path_uid", "stdlib_pkgs", "WINDOWS", "samefile",
-    "OrderedDict",
+    "OrderedDict", "LOAD_C_DEPENDENCIES",
 ]
 
 
@@ -152,6 +152,13 @@ if sys.version_info >= (2, 7):
 # windows detection, covers cpython and ironpython
 WINDOWS = (sys.platform.startswith("win") or
            (sys.platform == 'cli' and os.name == 'nt'))
+
+
+# pip should attempt to load C dependencies from packages on all platforms
+# where they do not cause problems when attempting to upgrade/delete said
+# packages; e.g. importing on Windows locks .dll files preventing deletion,
+# so do not load C dependencies if on Windows
+LOAD_C_DEPENDENCIES = not WINDOWS
 
 
 def samefile(file1, file2):

--- a/tasks/vendoring/patches/requests.patch
+++ b/tasks/vendoring/patches/requests.patch
@@ -1,8 +1,8 @@
 diff --git a/pip/_vendor/requests/__init__.py b/pip/_vendor/requests/__init__.py
-index 9c3b769..44f6836 100644
+index 9c3b7695..a041ca73 100644
 --- a/pip/_vendor/requests/__init__.py
 +++ b/pip/_vendor/requests/__init__.py
-@@ -48,11 +48,13 @@ __license__ = 'Apache 2.0'
+@@ -48,11 +48,16 @@ __license__ = 'Apache 2.0'
  __copyright__ = 'Copyright 2016 Kenneth Reitz'
  
  # Attempt to enable urllib3's SNI support, if possible
@@ -13,19 +13,22 @@ index 9c3b769..44f6836 100644
 -    pass
 +# Note: Patched by pip to prevent using the PyOpenSSL module. On Windows this
 +#       prevents upgrading cryptography.
-+# try:
-+#     from .packages.urllib3.contrib import pyopenssl
-+#     pyopenssl.inject_into_urllib3()
-+# except ImportError:
-+#     pass
++from pip.compat import LOAD_C_DEPENDENCIES
++if LOAD_C_DEPENDENCIES:
++    try:
++        from .packages.urllib3.contrib import pyopenssl
++        pyopenssl.inject_into_urllib3()
++    except ImportError:
++        pass
++del LOAD_C_DEPENDENCIES
  
  import warnings
  
 diff --git a/pip/_vendor/requests/compat.py b/pip/_vendor/requests/compat.py
-index eb6530d..353ec29 100644
+index eb6530d6..ea328f63 100644
 --- a/pip/_vendor/requests/compat.py
 +++ b/pip/_vendor/requests/compat.py
-@@ -25,12 +25,14 @@ is_py2 = (_ver[0] == 2)
+@@ -25,12 +25,19 @@ is_py2 = (_ver[0] == 2)
  #: Python 3.x?
  is_py3 = (_ver[0] == 3)
  
@@ -34,15 +37,107 @@ index eb6530d..353ec29 100644
 -except (ImportError, SyntaxError):
 -    # simplejson does not support Python 3.2, it throws a SyntaxError
 -    # because of u'...' Unicode literals.
--    import json
 +# Note: We've patched out simplejson support in pip because it prevents
 +#       upgrading simplejson on Windows.
-+# try:
-+#     import simplejson as json
-+# except (ImportError, SyntaxError):
-+#     # simplejson does not support Python 3.2, it throws a SyntaxError
-+#     # because of u'...' Unicode literals.
-+import json
++from pip.compat import LOAD_C_DEPENDENCIES
++if LOAD_C_DEPENDENCIES:
++    try:
++        import simplejson as json
++    except (ImportError, SyntaxError):
++        # simplejson does not support Python 3.2, it throws a SyntaxError
++        # because of u'...' Unicode literals.
++        import json
++else:
+     import json
++del LOAD_C_DEPENDENCIES
  
  # ---------
  # Specifics
+diff --git a/pip/_vendor/requests/packages/urllib3/util/ssl_.py b/pip/_vendor/requests/packages/urllib3/util/ssl_.py
+index 4a64d7ef..4fb3047f 100644
+--- a/pip/_vendor/requests/packages/urllib3/util/ssl_.py
++++ b/pip/_vendor/requests/packages/urllib3/util/ssl_.py
+@@ -112,15 +112,32 @@ except ImportError:
+             self.ciphers = cipher_suite
+ 
+         def wrap_socket(self, socket, server_hostname=None, server_side=False):
+-            warnings.warn(
+-                'A true SSLContext object is not available. This prevents '
+-                'urllib3 from configuring SSL appropriately and may cause '
+-                'certain SSL connections to fail. You can upgrade to a newer '
+-                'version of Python to solve this. For more information, see '
+-                'https://urllib3.readthedocs.io/en/latest/security.html'
+-                '#insecureplatformwarning.',
+-                InsecurePlatformWarning
+-            )
++            from pip.compat import LOAD_C_DEPENDENCIES
++            if LOAD_C_DEPENDENCIES:
++                warnings.warn(
++                    'A true SSLContext object is not available. This prevents '
++                    'urllib3 from configuring SSL appropriately and may cause '
++                    'certain SSL connections to fail. You can upgrade to a newer '
++                    'version of Python to solve this. For more information, see '
++                    'https://urllib3.readthedocs.io/en/latest/security.html'
++                    '#insecureplatformwarning.',
++                    InsecurePlatformWarning
++                )
++            else:
++                warnings.warn(
++                    'A true SSLContext object is not available. This prevents '
++                    'urllib3 from configuring SSL appropriately and may cause '
++                    'certain SSL connections to fail. You can upgrade to a newer '
++                    'version of Python to solve this. For more information, see '
++                    'https://urllib3.readthedocs.io/en/latest/security.html'
++                    '#insecureplatformwarning. '
++                    'NOTE: Since pip uses vendored versions of '
++                    'requests and urllib3 and cannot load C dependencies based '
++                    'on the current platform, installing additional security '
++                    'packages will NOT resolve this warning.',
++                    InsecurePlatformWarning
++                )
++
+             kwargs = {
+                 'keyfile': self.keyfile,
+                 'certfile': self.certfile,
+@@ -307,14 +324,31 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
+     if HAS_SNI:  # Platform-specific: OpenSSL with enabled SNI
+         return context.wrap_socket(sock, server_hostname=server_hostname)
+ 
+-    warnings.warn(
+-        'An HTTPS request has been made, but the SNI (Subject Name '
+-        'Indication) extension to TLS is not available on this platform. '
+-        'This may cause the server to present an incorrect TLS '
+-        'certificate, which can cause validation failures. You can upgrade to '
+-        'a newer version of Python to solve this. For more information, see '
+-        'https://urllib3.readthedocs.io/en/latest/security.html'
+-        '#snimissingwarning.',
+-        SNIMissingWarning
+-    )
++    from pip.compat import LOAD_C_DEPENDENCIES
++    if LOAD_C_DEPENDENCIES:
++        warnings.warn(
++            'An HTTPS request has been made, but the SNI (Subject Name '
++            'Indication) extension to TLS is not available on this platform. '
++            'This may cause the server to present an incorrect TLS '
++            'certificate, which can cause validation failures. You can upgrade to '
++            'a newer version of Python to solve this. For more information, see '
++            'https://urllib3.readthedocs.io/en/latest/security.html'
++            '#snimissingwarning.',
++            SNIMissingWarning
++        )
++    else:
++        warnings.warn(
++            'An HTTPS request has been made, but the SNI (Subject Name '
++            'Indication) extension to TLS is not available on this platform. '
++            'This may cause the server to present an incorrect TLS '
++            'certificate, which can cause validation failures. You can upgrade to '
++            'a newer version of Python to solve this. For more information, see '
++            'https://urllib3.readthedocs.io/en/latest/security.html'
++            '#snimissingwarning. '
++            'NOTE: Since pip uses vendored versions of '
++            'requests and urllib3 and cannot load C dependencies based '
++            'on the current platform, installing additional security '
++            'packages will NOT resolve this warning.',
++            SNIMissingWarning
++        )
+     return context.wrap_socket(sock)


### PR DESCRIPTION
PR for #4098.

I'm not thrilled importing from `pip.compat` to detect windows since it requires a `del` statement to leave no trace. Could of course duplicate the same logic to avoid the import + del, but that seems even worse.