### PR TITLE
Fixes pip version check to use global configuration

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 freezegun
+setuptools_scm
 pretend
 pytest
 pytest-catchlog
@@ -6,4 +7,4 @@ pytest-timeout
 pytest-xdist
 mock<1.1
 scripttest>=1.3
-https://github.com/pypa/virtualenv/archive/master.zip#egg=virtualenv
+virtualenv

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -249,12 +249,18 @@ class Command(object):
                         options,
                         retries=0,
                         timeout=min(5, options.timeout)) as session:
-                    pip_version_check(session)
+                    pip_check_options = options
+                    # Thoseare hardsetted to make sure an install of an
+                    # unrelated package does not affect pip version check
+                    pip_check_options.find_links = []
+                    pip_check_options.format_control = None
+                    pip_check_options.extra_index_urls = []
+                    pip_check_options.process_dependency_links = False
+                    pip_check_options.pre = False
+                    finder = self._build_package_finder(options, session)
+                    pip_version_check(finder)
 
         return SUCCESS
-
-
-class RequirementCommand(Command):
 
     @staticmethod
     def populate_requirement_set(requirement_set, args, options, finder,

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -607,13 +607,13 @@ general_group = {
         cache_dir,
         no_cache,
         disable_pip_version_check,
+        index_url,
     ]
 }
 
 non_deprecated_index_group = {
     'name': 'Package Index Options',
     'options': [
-        index_url,
         extra_index_url,
         no_index,
         find_links,

--- a/pip/commands/download.py
+++ b/pip/commands/download.py
@@ -6,7 +6,7 @@ import os
 from pip.exceptions import CommandError
 from pip.index import FormatControl
 from pip.req import RequirementSet
-from pip.basecommand import RequirementCommand
+from pip.basecommand import Command
 from pip import cmdoptions
 from pip.utils import ensure_dir, normalize_path
 from pip.utils.build import BuildDirectory
@@ -16,7 +16,7 @@ from pip.utils.filesystem import check_path_owner
 logger = logging.getLogger(__name__)
 
 
-class DownloadCommand(RequirementCommand):
+class DownloadCommand(Command):
     """
     Download packages from:
 

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -12,7 +12,7 @@ except ImportError:
     wheel = None
 
 from pip.req import RequirementSet
-from pip.basecommand import RequirementCommand
+from pip.basecommand import Command
 from pip.locations import virtualenv_no_global, distutils_scheme
 from pip.exceptions import (
     InstallationError, CommandError, PreviousBuildDirError,
@@ -28,7 +28,7 @@ from pip.wheel import WheelCache, WheelBuilder
 logger = logging.getLogger(__name__)
 
 
-class InstallCommand(RequirementCommand):
+class InstallCommand(Command):
     """
     Install packages from:
 

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -5,7 +5,7 @@ import logging
 import os
 import warnings
 
-from pip.basecommand import RequirementCommand
+from pip.basecommand import Command
 from pip.exceptions import CommandError, PreviousBuildDirError
 from pip.req import RequirementSet
 from pip.utils import import_or_raise
@@ -18,7 +18,7 @@ from pip import cmdoptions
 logger = logging.getLogger(__name__)
 
 
-class WheelCommand(RequirementCommand):
+class WheelCommand(Command):
     """
     Build Wheel archives for your requirements and dependencies.
 

--- a/pip/index.py
+++ b/pip/index.py
@@ -552,7 +552,7 @@ class PackageFinder(object):
             best_candidate.version,
             ', '.join(sorted(compatible_versions, key=parse_version))
         )
-        return best_candidate.location
+        return best_candidate
 
     def _get_pages(self, locations, project_name):
         """

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -274,7 +274,8 @@ class InstallRequirement(object):
         to file modification times.
         """
         if self.link is None:
-            self.link = finder.find_requirement(self, upgrade)
+            self.link = getattr(finder.find_requirement(self, upgrade),
+                                'location', None)
         if self._wheel_cache is not None and not require_hashes:
             old_link = self.link
             self.link = self._wheel_cache.cached_wheel(self.link, self.name)


### PR DESCRIPTION
Pip use a hardcoded URL to check for new versions of pip available. This is an issue in environments where there is no direct internet access

This PR fixes this by leveraging on the mechanism already used to install package, to check for the last version of pip in the default repo configured (or pypi.org if unset)
