### PR TITLE
Clarify default for --upgrade-strategy is eager

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -98,8 +98,8 @@ class InstallCommand(RequirementCommand):
             default='eager',
             choices=['only-if-needed', 'eager'],
             help='Determines how dependency upgrading should be handled. '
-                 '"eager" (default) - dependencies are upgraded regardless '
-                 'of whether the currently installed version satisfies the '
+                 '"eager" - dependencies are upgraded regardless of '
+                 'whether the currently installed version satisfies the '
                  'requirements of the upgraded package(s). '
                  '"only-if-needed" -  are upgraded only when they do not '
                  'satisfy the requirements of the upgraded package(s).'

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -98,6 +98,7 @@ class InstallCommand(RequirementCommand):
             default='eager',
             choices=['only-if-needed', 'eager'],
             help='Determines how dependency upgrading should be handled. '
+                 '(default: %(default)s) '
                  '"eager" - dependencies are upgraded regardless of '
                  'whether the currently installed version satisfies the '
                  'requirements of the upgraded package(s). '

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -98,8 +98,8 @@ class InstallCommand(RequirementCommand):
             default='eager',
             choices=['only-if-needed', 'eager'],
             help='Determines how dependency upgrading should be handled. '
-                 '"eager" - dependencies are upgraded regardless of '
-                 'whether the currently installed version satisfies the '
+                 '"eager" (default) - dependencies are upgraded regardless '
+                 'of whether the currently installed version satisfies the '
                  'requirements of the upgraded package(s). '
                  '"only-if-needed" -  are upgraded only when they do not '
                  'satisfy the requirements of the upgraded package(s).'

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -97,8 +97,8 @@ class InstallCommand(RequirementCommand):
             dest='upgrade_strategy',
             default='eager',
             choices=['only-if-needed', 'eager'],
-            help='Determines how dependency upgrading should be handled. '
-                 '(default: %(default)s) '
+            help='Determines how dependency upgrading should be handled '
+                 '(default: %(default)s). '
                  '"eager" - dependencies are upgraded regardless of '
                  'whether the currently installed version satisfies the '
                  'requirements of the upgraded package(s). '


### PR DESCRIPTION
When reading the docs or looking at `pip install --help`, it wasn't clear what the default for `--upgrade-strategy` is. I had to go to the code and confirm. This should be specific in the flag documentation (which looks like it makes it's way to the [online documentation](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption--upgrade-strategy) too). This patch simply notes that the default is "eager" in the help text for that argument.