### PR TITLE
Print cache_dir value in help.

### DIFF
--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -450,7 +450,8 @@ cache_dir = partial(
     dest="cache_dir",
     default=USER_CACHE_DIR,
     metavar="dir",
-    help="Store the cache data in <dir>."
+    help="Store the cache data in <dir>. Current cache directory is set to %s"%\
+            repr(USER_CACHE_DIR)
 )
 
 no_cache = partial(


### PR DESCRIPTION
This simplify finding the cache location (a bit). And avoid having to
reach for the doc to remember where it is.

We could also run the path to compress-user to make it a tiny bit
shorter on some systems.

Step toward #4157