### PR TITLE
Add support for command plugins

### DIFF
--- a/pip/commands/__init__.py
+++ b/pip/commands/__init__.py
@@ -3,6 +3,8 @@ Package containing all pip commands
 """
 from __future__ import absolute_import
 
+import logging
+
 from pip.commands.completion import CompletionCommand
 from pip.commands.download import DownloadCommand
 from pip.commands.freeze import FreezeCommand
@@ -15,6 +17,10 @@ from pip.commands.show import ShowCommand
 from pip.commands.install import InstallCommand
 from pip.commands.uninstall import UninstallCommand
 from pip.commands.wheel import WheelCommand
+from pip._vendor import pkg_resources
+
+
+logger = logging.getLogger(__name__)
 
 
 commands_dict = {
@@ -47,6 +53,16 @@ commands_order = [
     CompletionCommand,
     HelpCommand,
 ]
+
+
+for ep in pkg_resources.iter_entry_points('pip.command.v1'):
+    try:
+        command = ep.load()
+        logger.debug('from entry point %r loaded command = %r' % (ep, command))
+        commands_dict[command.name] = command
+    except Exception as e:
+        logger.warning('Failed to load command plugin: %r (%r): %s'
+                       % (ep, command, e))
 
 
 def get_summaries(ordered=True):


### PR DESCRIPTION
(Reopening change in PR #2329)

Simply register a Command class with the new `pip.command.v1` entry point.

Cc: @pfmoore, @dstufft, @szepeviktor