### PR TITLE
Refactor InstallRequirement instantiation

### DIFF
--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -674,7 +674,7 @@ class RequirementSet(object):
             more_reqs = []
 
             def add_req(subreq, extras_requested):
-                sub_install_req = InstallRequirement(
+                sub_install_req = InstallRequirement.from_req(
                     str(subreq),
                     req_to_install,
                     isolated=self.isolated,

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -468,7 +468,7 @@ class TestInstallRequirement(object):
             'sys_platform == %r' % sys.platform,
         ):
             line = 'name; ' + markers
-            req = InstallRequirement(line, comes_from='')
+            req = InstallRequirement.from_line(line, comes_from='')
             assert str(req.markers) == str(Marker(markers))
             assert req.match_markers()
 
@@ -478,7 +478,7 @@ class TestInstallRequirement(object):
             'sys_platform != %r' % sys.platform,
         ):
             line = 'name; ' + markers
-            req = InstallRequirement(line, comes_from='')
+            req = InstallRequirement.from_line(line, comes_from='')
             assert str(req.markers) == str(Marker(markers))
             assert not req.match_markers()
 


### PR DESCRIPTION
Move the logic out of `__init__`, it should ease the way of PEP 518 implementation.