### PR TITLE
Deprecate the _strip_postfix function

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -41,7 +41,7 @@ from pip.utils import (
 )
 
 from pip.utils.hashes import Hashes
-from pip.utils.deprecation import RemovedInPip10Warning
+from pip.utils.deprecation import RemovedInPip10Warning, RemovedInPip11Warning
 from pip.utils.logging import indent_log
 from pip.utils.setuptools_build import SETUPTOOLS_SHIM
 from pip.utils.ui import open_spinner
@@ -984,6 +984,10 @@ def _strip_postfix(req):
     match = re.search(r'^(.*?)(?:-dev|-\d.*)$', req)
     if match:
         # Strip off -dev, -0.2, etc.
+        warnings.warn(
+            "#egg cleanup for editable urls will be dropped in the future",
+            RemovedInPip11Warning,
+        )
         req = match.group(1)
     return req
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -152,7 +152,7 @@ def test_download_editable_to_custom_path(script, tmpdir):
     result = script.pip(
         'install',
         '-e',
-        '%s#egg=initools-dev' %
+        '%s#egg=initools' %
         local_checkout(
             'svn+http://svn.colorstudy.com/INITools/trunk',
             tmpdir.join("cache")

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -83,7 +83,7 @@ def test_multiple_requirements_files(script, tmpdir):
     other_lib_name, other_lib_version = 'anyjson', '0.3'
     script.scratch_path.join("initools-req.txt").write(
         textwrap.dedent("""
-            -e %s@10#egg=INITools-dev
+            -e %s@10#egg=INITools
             -r %s-req.txt
         """) %
         (

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -61,7 +61,7 @@ class Tests_UserSite:
         virtualenv.system_site_packages = True
         result = script.pip(
             'install', '--user', '-e',
-            '%s#egg=initools-dev' %
+            '%s#egg=initools' %
             local_checkout(
                 'svn+http://svn.colorstudy.com/INITools/trunk',
                 tmpdir.join("cache"),

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -249,7 +249,7 @@ def test_uninstall_editable_from_svn(script, tmpdir):
     """
     result = script.pip(
         'install', '-e',
-        '%s#egg=initools-dev' % local_checkout(
+        '%s#egg=initools' % local_checkout(
             'svn+http://svn.colorstudy.com/INITools/trunk',
             tmpdir.join("cache"),
         ),
@@ -320,7 +320,7 @@ def test_uninstall_from_reqs_file(script, tmpdir):
     """
     script.scratch_path.join("test-req.txt").write(
         textwrap.dedent("""
-            -e %s#egg=initools-dev
+            -e %s#egg=initools
             # and something else to test out:
             PyLogo<0.4
         """) %
@@ -337,7 +337,7 @@ def test_uninstall_from_reqs_file(script, tmpdir):
             -i http://www.example.com
             --extra-index-url http://www.example.com
 
-            -e %s#egg=initools-dev
+            -e %s#egg=initools
             # and something else to test out:
             PyLogo<0.4
         """) %


### PR DESCRIPTION
It only happens for editable-non-file URLs and is an untested and
undocumented behavior.

cc @dstufft @pfmoore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4174)
<!-- Reviewable:end -->
