### PR TITLE
Add the ability to autocorrect a user's command

### DIFF
--- a/news/4193.feature
+++ b/news/4193.feature
@@ -1,0 +1,5 @@
+Add ability to suggest commands and also to autocorrect mistyped commands.
+
+A new "autocorrect" configuration key is now supported. It can be set to a
+numerical value. If it is set, pip will wait for the specified seconds and then
+autocorrect your command and continue, if a replacement is similar enough.

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import
 
 import locale
 import logging
-import optparse
 import os
-import sys
-import time
+import optparse
 import warnings
+
+import sys
 
 # 2016-06-17 barry@debian.org: urllib3 1.14 added optional support for socks,
 # but if invoked (i.e. imported), it will issue a warning to stderr if socks
@@ -17,24 +17,7 @@ import warnings
 # to add socks as yet another dependency for pip, nor do I want to allow-stder
 # in the DEP-8 tests, so just suppress the warning.  pdb tells me this has to
 # be done before the import of pip.vcs.
-from pip._vendor.requests.packages.urllib3.exceptions import (
-    DependencyWarning, InsecureRequestWarning
-)
-
-# This fixes a peculiarity when importing via __import__ - as we are
-# initialising the pip module, "from pip import cmdoptions" is recursive
-# and appears not to work properly in that situation.
-import pip.cmdoptions
-import pip.status_codes
-from pip.baseparser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
-from pip.commands import commands_dict, get_closest_command, get_summaries
-from pip.exceptions import CommandError, ConfigurationError, PipError
-from pip.utils import deprecation, get_installed_distributions, get_prog
-from pip.vcs import bazaar, git, mercurial, subversion  # noqa
-
-# The version as used in the setup.py and the docs conf.py
-__version__ = "10.0.0.dev0"
-
+from pip._vendor.requests.packages.urllib3.exceptions import DependencyWarning
 warnings.filterwarnings("ignore", category=DependencyWarning)  # noqa
 
 # We want to inject the use of SecureTransport as early as possible so that any
@@ -57,8 +40,29 @@ else:
         else:
             securetransport.inject_into_urllib3()
 
+from pip.exceptions import CommandError, ConfigurationError, PipError
+from pip.utils import get_installed_distributions, get_prog
+from pip.utils import deprecation
+from pip.vcs import git, mercurial, subversion, bazaar  # noqa
+from pip.baseparser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
+from pip.commands import get_summaries, get_closest_command
+from pip.commands import commands_dict
+from pip._vendor.requests.packages.urllib3.exceptions import (
+    InsecureRequestWarning,
+)
+
+
 # assignment for flake8 to be happy
+
+# This fixes a peculiarity when importing via __import__ - as we are
+# initialising the pip module, "from pip import cmdoptions" is recursive
+# and appears not to work properly in that situation.
+import pip.cmdoptions
 cmdoptions = pip.cmdoptions
+
+# The version as used in the setup.py and the docs conf.py
+__version__ = "10.0.0.dev0"
+
 
 logger = logging.getLogger(__name__)
 

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -215,6 +215,13 @@ def parseopts(args):
         except ConfigurationError:
             autocorrect_delay = None
 
+        try:
+            autocorrect_delay = float(autocorrect_delay)
+        except ValueError:
+            raise ConfigurationError(
+                "autocorrect needs to be a numerical value"
+            )
+
         guess, score = get_closest_command(cmd_name)
 
         # Decide what message has to be shown to user

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -3,11 +3,10 @@ from __future__ import absolute_import
 
 import locale
 import logging
-import os
 import optparse
-import warnings
-
+import os
 import sys
+import warnings
 
 # 2016-06-17 barry@debian.org: urllib3 1.14 added optional support for socks,
 # but if invoked (i.e. imported), it will issue a warning to stderr if socks
@@ -17,7 +16,24 @@ import sys
 # to add socks as yet another dependency for pip, nor do I want to allow-stder
 # in the DEP-8 tests, so just suppress the warning.  pdb tells me this has to
 # be done before the import of pip.vcs.
-from pip._vendor.requests.packages.urllib3.exceptions import DependencyWarning
+from pip._vendor.requests.packages.urllib3.exceptions import (
+    DependencyWarning, InsecureRequestWarning
+)
+
+# This fixes a peculiarity when importing via __import__ - as we are
+# initialising the pip module, "from pip import cmdoptions" is recursive
+# and appears not to work properly in that situation.
+import pip.cmdoptions
+import pip.status_codes
+from pip.baseparser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
+from pip.commands import commands_dict, get_closest_command, get_summaries
+from pip.exceptions import CommandError, PipError
+from pip.utils import deprecation, get_installed_distributions, get_prog
+from pip.vcs import bazaar, git, mercurial, subversion  # noqa
+
+# The version as used in the setup.py and the docs conf.py
+__version__ = "10.0.0.dev0"
+
 warnings.filterwarnings("ignore", category=DependencyWarning)  # noqa
 
 # We want to inject the use of SecureTransport as early as possible so that any
@@ -40,29 +56,8 @@ else:
         else:
             securetransport.inject_into_urllib3()
 
-from pip.exceptions import CommandError, PipError
-from pip.utils import get_installed_distributions, get_prog
-from pip.utils import deprecation
-from pip.vcs import git, mercurial, subversion, bazaar  # noqa
-from pip.baseparser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
-from pip.commands import get_summaries, get_similar_commands
-from pip.commands import commands_dict
-from pip._vendor.requests.packages.urllib3.exceptions import (
-    InsecureRequestWarning,
-)
-
-
 # assignment for flake8 to be happy
-
-# This fixes a peculiarity when importing via __import__ - as we are
-# initialising the pip module, "from pip import cmdoptions" is recursive
-# and appears not to work properly in that situation.
-import pip.cmdoptions
 cmdoptions = pip.cmdoptions
-
-# The version as used in the setup.py and the docs conf.py
-__version__ = "10.0.0.dev0"
-
 
 logger = logging.getLogger(__name__)
 

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -40,16 +40,16 @@ else:
         else:
             securetransport.inject_into_urllib3()
 
+from pip.exceptions import CommandError, ConfigurationError, PipError
+from pip.utils import get_installed_distributions, get_prog
+from pip.utils import deprecation
+from pip.vcs import git, mercurial, subversion, bazaar  # noqa
+from pip.baseparser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
+from pip.commands import get_summaries, get_closest_command
+from pip.commands import commands_dict
 from pip._vendor.requests.packages.urllib3.exceptions import (
     InsecureRequestWarning,
 )
-
-from pip.baseparser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
-from pip.commands import commands_dict, get_closest_command, get_summaries
-from pip.exceptions import CommandError, ConfigurationError, PipError
-from pip.utils import deprecation
-from pip.utils import get_installed_distributions, get_prog
-from pip.vcs import bazaar, git, mercurial, subversion  # noqa
 
 
 # assignment for flake8 to be happy

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -6,6 +6,7 @@ import logging
 import optparse
 import os
 import sys
+import time
 import warnings
 
 # 2016-06-17 barry@debian.org: urllib3 1.14 added optional support for socks,

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -3,11 +3,10 @@ from __future__ import absolute_import
 
 import locale
 import logging
-import os
 import optparse
-import warnings
-
+import os
 import sys
+import warnings
 
 # 2016-06-17 barry@debian.org: urllib3 1.14 added optional support for socks,
 # but if invoked (i.e. imported), it will issue a warning to stderr if socks
@@ -40,16 +39,16 @@ else:
         else:
             securetransport.inject_into_urllib3()
 
-from pip.exceptions import CommandError, ConfigurationError, PipError
-from pip.utils import get_installed_distributions, get_prog
-from pip.utils import deprecation
-from pip.vcs import git, mercurial, subversion, bazaar  # noqa
-from pip.baseparser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
-from pip.commands import get_summaries, get_closest_command
-from pip.commands import commands_dict
 from pip._vendor.requests.packages.urllib3.exceptions import (
     InsecureRequestWarning,
 )
+
+from pip.baseparser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
+from pip.commands import commands_dict, get_closest_command, get_summaries
+from pip.exceptions import CommandError, ConfigurationError, PipError
+from pip.utils import deprecation
+from pip.utils import get_installed_distributions, get_prog
+from pip.vcs import bazaar, git, mercurial, subversion  # noqa
 
 
 # assignment for flake8 to be happy

--- a/pip/commands/__init__.py
+++ b/pip/commands/__init__.py
@@ -64,9 +64,9 @@ def _sort_commands(cmddict, order):
 def _get_closest_match(word, possibilities):
     """Get the closest match of word in possibilities.
 
-    Returns a tuple of (similarity, possibility) where possibility has the
-    highest similarity.
-    Returns (0, None) if there is no such possibility in possibilities.
+    Returns a tuple of (name, similarity) where possibility has the
+    highest similarity, where 0 <= similarity <= 1.
+    Returns (None, 0) as a fallback, if no possibility matches.
 
     If more than one possibilities have the highest similarity, the first
     matched is returned.
@@ -98,9 +98,9 @@ def get_closest_command(name):
     """Command name auto-correction
 
     If there are any commands with a similarity greater than cutoff, returns
-    (similarity, name) of the command with highest similarity.
+    (command_name, similarity) of the command_name with highest similarity.
 
-    If there is no such command, returns (0, None).
+    If there is no such command, returns (None, 0).
 
     If more than one commands have the highest similarity, the alphabetically
     first is returned.

--- a/pip/commands/__init__.py
+++ b/pip/commands/__init__.py
@@ -3,6 +3,8 @@ Package containing all pip commands
 """
 from __future__ import absolute_import
 
+from difflib import SequenceMatcher
+
 from pip.commands.completion import CompletionCommand
 from pip.commands.configuration import ConfigurationCommand
 from pip.commands.download import DownloadCommand
@@ -48,20 +50,6 @@ def get_summaries(ordered=True):
         yield (name, command_class.summary)
 
 
-def get_similar_commands(name):
-    """Command name auto-correct."""
-    from difflib import get_close_matches
-
-    name = name.lower()
-
-    close_commands = get_close_matches(name, commands_dict.keys())
-
-    if close_commands:
-        return close_commands[0]
-    else:
-        return False
-
-
 def _sort_commands(cmddict, order):
     def keyfn(key):
         try:
@@ -71,3 +59,50 @@ def _sort_commands(cmddict, order):
             return 0xff
 
     return sorted(cmddict.items(), key=keyfn)
+
+
+def _get_closest_match(word, possibilities):
+    """Get the closest match of word in possibilities.
+
+    Returns a tuple of (similarity, possibility) where possibility has the
+    highest similarity.
+    Returns (0, None) if there is no such possibility in possibilities.
+
+    If more than one possibilities have the highest similarity, the first
+    matched is returned.
+    """
+    guess, best_score = None, 0
+
+    matcher = SequenceMatcher()
+    matcher.set_seq2(word)
+
+    for trial in possibilities:
+        matcher.set_seq1(trial)
+
+        # These are upper limits.
+        if matcher.real_quick_ratio() < best_score:
+            continue
+        if matcher.quick_ratio() < best_score:
+            continue
+
+        # Select the first best match
+        score = matcher.ratio()
+        if score > best_score:
+            guess = trial
+            best_score = score
+
+    return guess, best_score
+
+
+def get_closest_command(name):
+    """Command name auto-correction
+
+    If there are any commands with a similarity greater than cutoff, returns
+    (similarity, name) of the command with highest similarity.
+
+    If there is no such command, returns (0, None).
+
+    If more than one commands have the highest similarity, the alphabetically
+    first is returned.
+    """
+    return _get_closest_match(name.lower(), sorted(commands_dict.keys()))

--- a/pip/commands/help.py
+++ b/pip/commands/help.py
@@ -13,7 +13,7 @@ class HelpCommand(Command):
     ignore_require_venv = True
 
     def run(self, options, args):
-        from pip.commands import commands_dict, get_similar_commands
+        from pip.commands import commands_dict, get_closest_command
 
         try:
             # 'pip help' with no args is handled by pip.__init__.parseopt()
@@ -22,10 +22,11 @@ class HelpCommand(Command):
             return SUCCESS
 
         if cmd_name not in commands_dict:
-            guess = get_similar_commands(cmd_name)
+            guess, score = get_closest_command(cmd_name)
+            suggest_cut_off = 0.6
 
             msg = ['unknown command "%s"' % cmd_name]
-            if guess:
+            if guess and score > suggest_cut_off:
                 msg.append('maybe you meant "%s"' % guess)
 
             raise CommandError(' - '.join(msg))

--- a/pip/configuration.py
+++ b/pip/configuration.py
@@ -24,7 +24,6 @@ from pip.locations import (
 )
 from pip.utils import ensure_dir, enum
 
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Fixes #1737

Essentially, this adds the ability to:
- provide suggestions when the user mistypes
- auto-correct the user, if they opt-in, using the best matching command name
