### PR TITLE
Add "--no-progress" option

### DIFF
--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -119,6 +119,15 @@ quiet = partial(
           ' levels).')
 )
 
+no_progress = partial(
+    Option,
+    '--no-progress',
+    dest='no_progress',
+    action='store_true',
+    default=False,
+    help=('Disable progress bar.')
+)
+
 log = partial(
     Option,
     "--log", "--log-file", "--local-log",

--- a/pip/commands/download.py
+++ b/pip/commands/download.py
@@ -56,6 +56,7 @@ class DownloadCommand(RequirementCommand):
         cmd_opts.add_option(cmdoptions.pre())
         cmd_opts.add_option(cmdoptions.no_clean())
         cmd_opts.add_option(cmdoptions.require_hashes())
+        cmd_opts.add_option(cmdoptions.no_progress())
 
         cmd_opts.add_option(
             '-d', '--dest', '--destination-dir', '--destination-directory',
@@ -180,7 +181,8 @@ class DownloadCommand(RequirementCommand):
                     ignore_dependencies=options.ignore_dependencies,
                     session=session,
                     isolated=options.isolated_mode,
-                    require_hashes=options.require_hashes
+                    require_hashes=options.require_hashes,
+                    no_progress=options.no_progress,
                 )
                 self.populate_requirement_set(
                     requirement_set,

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -60,6 +60,7 @@ class InstallCommand(RequirementCommand):
         cmd_opts.add_option(cmdoptions.editable())
         cmd_opts.add_option(cmdoptions.requirements())
         cmd_opts.add_option(cmdoptions.build_dir())
+        cmd_opts.add_option(cmdoptions.no_progress())
 
         cmd_opts.add_option(
             '-t', '--target',
@@ -306,6 +307,7 @@ class InstallCommand(RequirementCommand):
                     isolated=options.isolated_mode,
                     wheel_cache=wheel_cache,
                     require_hashes=options.require_hashes,
+                    no_progress=options.no_progress,
                 )
 
                 self.populate_requirement_set(
@@ -330,6 +332,7 @@ class InstallCommand(RequirementCommand):
                             finder,
                             build_options=[],
                             global_options=[],
+                            no_progress=options.no_progress,
                         )
                         # Ignore the result: a failed wheel will be
                         # installed from the sdist/vcs whatever.

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -73,6 +73,7 @@ class WheelCommand(RequirementCommand):
         cmd_opts.add_option(cmdoptions.ignore_requires_python())
         cmd_opts.add_option(cmdoptions.no_deps())
         cmd_opts.add_option(cmdoptions.build_dir())
+        cmd_opts.add_option(cmdoptions.no_progress())
 
         cmd_opts.add_option(
             '--global-option',
@@ -177,7 +178,8 @@ class WheelCommand(RequirementCommand):
                     session=session,
                     wheel_cache=wheel_cache,
                     wheel_download_dir=options.wheel_dir,
-                    require_hashes=options.require_hashes
+                    require_hashes=options.require_hashes,
+                    no_progress=options.no_progress,
                 )
 
                 self.populate_requirement_set(
@@ -195,6 +197,7 @@ class WheelCommand(RequirementCommand):
                         finder,
                         build_options=options.build_options or [],
                         global_options=options.global_options or [],
+                        no_progress=options.no_progress,
                     )
                     if not wb.build():
                         raise CommandError(

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -147,7 +147,7 @@ class RequirementSet(object):
                  force_reinstall=False, use_user_site=False, session=None,
                  pycompile=True, isolated=False, wheel_download_dir=None,
                  wheel_cache=None, require_hashes=False,
-                 ignore_requires_python=False):
+                 ignore_requires_python=False, no_progress=False):
         """Create a RequirementSet.
 
         :param wheel_download_dir: Where still-packed .whl files should be
@@ -196,6 +196,7 @@ class RequirementSet(object):
         self.wheel_download_dir = wheel_download_dir
         self._wheel_cache = wheel_cache
         self.require_hashes = require_hashes
+        self.no_progress = no_progress
         # Maps from install_req -> dependencies_of_install_req
         self._dependencies = defaultdict(list)
 
@@ -618,7 +619,8 @@ class RequirementSet(object):
                     unpack_url(
                         req_to_install.link, req_to_install.source_dir,
                         download_dir, autodelete_unpacked,
-                        session=self.session, hashes=hashes)
+                        session=self.session, hashes=hashes,
+                        no_progress=self.no_progress)
                 except requests.HTTPError as exc:
                     logger.critical(
                         'Could not install requirement %s because '

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -635,13 +635,14 @@ class WheelBuilder(object):
     """Build wheels from a RequirementSet."""
 
     def __init__(self, requirement_set, finder, build_options=None,
-                 global_options=None):
+                 global_options=None, no_progress=False):
         self.requirement_set = requirement_set
         self.finder = finder
         self._cache_root = requirement_set._wheel_cache._cache_dir
         self._wheel_dir = requirement_set.wheel_download_dir
         self.build_options = build_options or []
         self.global_options = global_options or []
+        self.no_progress = no_progress
 
     def _build_one(self, req, output_dir, python_tag=None):
         """Build one wheel.
@@ -801,7 +802,8 @@ class WheelBuilder(object):
                         # extract the wheel into the dir
                         unpack_url(
                             req.link, req.source_dir, None, False,
-                            session=self.requirement_set.session)
+                            session=self.requirement_set.session,
+                            no_progress=self.no_progress)
                 else:
                     build_failure.append(req)
 


### PR DESCRIPTION
This PR addresses the same issue #4194 does (#2756 and #2369). I had this one almost ready when I noticed #4194, so I decided to send it anyway.

Here's a list of differences I discovered between this PR and #4194:

 - option is called `--no-progress` here, but in #4194 it's called `--no-progress-bar`;
 - seems like in #4194 the option is added only to `install` command; this PR also adds the option to `wheel` and `download` commands;

`uninstall` command uses `pip.req.req_set.RequirementSet` too, but it does not download anything (if I understand the code correctly), so I did not add the option to this command.