### PR TITLE
Reduce the API exposed by the configuration class

### DIFF
--- a/pip/baseparser.py
+++ b/pip/baseparser.py
@@ -128,8 +128,6 @@ class ConfigOptionParser(CustomOptionParser):
     """Custom option parser which updates its defaults by checking the
     configuration files and environmental variables"""
 
-    isolated = False
-
     def __init__(self, *args, **kwargs):
         self.name = kwargs.pop('name')
 

--- a/pip/baseparser.py
+++ b/pip/baseparser.py
@@ -150,7 +150,7 @@ class ConfigOptionParser(CustomOptionParser):
         options (lists)."""
 
         # Load the configuration
-        self.config.load()
+        self.config.load(self.name)
 
         # Accumulate complex default state.
         self.values = optparse.Values(self.defaults)

--- a/pip/baseparser.py
+++ b/pip/baseparser.py
@@ -133,7 +133,7 @@ class ConfigOptionParser(CustomOptionParser):
     def __init__(self, *args, **kwargs):
         self.name = kwargs.pop('name')
         self.isolated = kwargs.pop("isolated", False)
-        self.config = Configuration()
+        self.config = Configuration(self.isolated)
         assert self.name
         optparse.OptionParser.__init__(self, *args, **kwargs)
 
@@ -148,10 +148,9 @@ class ConfigOptionParser(CustomOptionParser):
         """Updates the given defaults with values from the config files and
         the environ. Does a little special handling for certain types of
         options (lists)."""
-        self.config.load_config_files(self.name, self.isolated)
-        # 2. environmental variables
-        if not self.isolated:
-            self.config.load_environment_vars()
+
+        # Load the configuration
+        self.config.load()
 
         # Accumulate complex default state.
         self.values = optparse.Values(self.defaults)

--- a/pip/baseparser.py
+++ b/pip/baseparser.py
@@ -132,8 +132,10 @@ class ConfigOptionParser(CustomOptionParser):
 
     def __init__(self, *args, **kwargs):
         self.name = kwargs.pop('name')
-        self.isolated = kwargs.pop("isolated", False)
-        self.config = Configuration(self.isolated)
+
+        isolated = kwargs.pop("isolated", False)
+        self.config = Configuration(isolated)
+
         assert self.name
         optparse.OptionParser.__init__(self, *args, **kwargs)
 

--- a/pip/configuration.py
+++ b/pip/configuration.py
@@ -26,10 +26,10 @@ class Configuration(object):
         self._config = {}
         self.isolated = isolated
 
-    def load(self, name):
+    def load(self, section):
         """Loads configuration
         """
-        self._load_config_files(name)
+        self._load_config_files(section)
         if not self.isolated:
             self._load_environment_vars()
 
@@ -39,7 +39,7 @@ class Configuration(object):
         """
         return self._config.items()
 
-    def _load_config_files(self, name):
+    def _load_config_files(self, section):
         """Loads configuration from configuration files
         """
         files = self._get_config_files()
@@ -47,7 +47,7 @@ class Configuration(object):
         if files:
             self._configparser.read(files)
 
-        for section in ('global', name):
+        for section in ('global', section):
             self._config.update(
                 self._normalize_keys(self._get_config_section(section))
             )
@@ -56,7 +56,6 @@ class Configuration(object):
         """Loads configuration from environment variables
         """
         self._config.update(self._normalize_keys(self._get_environ_vars()))
-
 
     def _normalize_keys(self, items):
         """Return a config dictionary with normalized keys regardless of

--- a/pip/configuration.py
+++ b/pip/configuration.py
@@ -21,14 +21,28 @@ class Configuration(object):
     accessing data within them.
     """
 
-    def __init__(self):
+    def __init__(self, isolated):
         self._configparser = configparser.RawConfigParser()
         self._config = {}
+        self.isolated = isolated
 
-    def load_config_files(self, name, isolated):
+    def load(self, name):
+        """Loads configuration
+        """
+        self._load_config_files(name)
+        if not self.isolated:
+            self._load_environment_vars()
+
+    def items(self):
+        """Returns key-value pairs like dict.values() representing the loaded
+        configuration
+        """
+        return self._config.items()
+
+    def _load_config_files(self, name):
         """Loads configuration from configuration files
         """
-        files = self._get_config_files(isolated)
+        files = self._get_config_files()
 
         if files:
             self._configparser.read(files)
@@ -38,16 +52,11 @@ class Configuration(object):
                 self._normalize_keys(self._get_config_section(section))
             )
 
-    def load_environment_vars(self):
+    def _load_environment_vars(self):
         """Loads configuration from environment variables
         """
         self._config.update(self._normalize_keys(self._get_environ_vars()))
 
-    def items(self):
-        """Returns key-value pairs like dict.values() representing the loaded
-        configuration
-        """
-        return self._config.items()
 
     def _normalize_keys(self, items):
         """Return a config dictionary with normalized keys regardless of
@@ -67,7 +76,7 @@ class Configuration(object):
             if _environ_prefix_re.search(key):
                 yield (_environ_prefix_re.sub("", key).lower(), val)
 
-    def _get_config_files(self, isolated):
+    def _get_config_files(self):
         """Returns configuration files in a defined order.
 
         The order is that the first files are overridden by the latter files;
@@ -84,7 +93,7 @@ class Configuration(object):
         files = list(site_config_files)
 
         # per-user configuration next
-        if not isolated:
+        if not self.isolated:
             if config_file and os.path.exists(config_file):
                 files.append(config_file)
             else:

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -278,5 +278,5 @@ class TestOptionsConfigFiles(object):
             lambda: True,
         )
         monkeypatch.setattr(os.path, 'exists', lambda filename: True)
-        cp = pip.configuration.Configuration()
-        assert len(cp._get_config_files(isolated=False)) == 4
+        cp = pip.configuration.Configuration(isolated=False)
+        assert len(cp._get_config_files()) == 4


### PR DESCRIPTION
Reduce the interface exposed by the Configuration class to a single method.

It now takes the isolated parameter on initialization, not loading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4200)
<!-- Reviewable:end -->
