### PR TITLE
add support for returning setuptools version for bigquery statistics

### DIFF
--- a/news/4209.feature
+++ b/news/4209.feature
@@ -1,0 +1,1 @@
+Add setuptools version to the statistics sent to BigQuery.

--- a/pip/download.py
+++ b/pip/download.py
@@ -120,7 +120,9 @@ def user_agent():
     if HAS_TLS:
         data["openssl_version"] = ssl.OPENSSL_VERSION
 
-    data["setuptools_version"] = get_installed_version("setuptools")
+    setuptools_version = get_installed_version("setuptools")
+    if setuptools_version is not None:
+        data["setuptools_version"] = setuptools_version
 
     return "{data[installer][name]}/{data[installer][version]} {json}".format(
         data=data,

--- a/pip/download.py
+++ b/pip/download.py
@@ -28,7 +28,8 @@ from pip.exceptions import InstallationError, HashMismatch
 from pip.models import PyPI
 from pip.utils import (splitext, rmtree, format_size, display_path,
                        backup_dir, ask_path_exists, unpack_file,
-                       ARCHIVE_EXTENSIONS, consume, call_subprocess)
+                       ARCHIVE_EXTENSIONS, consume, call_subprocess,
+                       get_installed_version)
 from pip.utils.encoding import auto_decode
 from pip.utils.filesystem import check_path_owner
 from pip.utils.logging import indent_log
@@ -118,6 +119,8 @@ def user_agent():
 
     if HAS_TLS:
         data["openssl_version"] = ssl.OPENSSL_VERSION
+
+    data["setuptools_version"] = get_installed_version("setuptools")
 
     return "{data[installer][name]}/{data[installer][version]} {json}".format(
         data=data,


### PR DESCRIPTION
setuptools is a common runtime dependency (especially for packages that use entry points). Unfortunately pip is frequently used in scenarios where it can't successfully upgrade setuptools due to system restrictions. Being able to see what version of setuptools is actually installed would greatly assist in decisions regarding minimum versions (and when workarounds can be removed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4209)
<!-- Reviewable:end -->
