### PR TITLE
Failing exit status when no requirements specified

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,9 @@
 * Use pkg_resources to parse the entry points file to allow names with
   colons (:pull:`3901`)
 
+* Return a failing exit status when `pip install`, `pip download`, or
+  `pip wheel` is called with no requirements. (:issue:`2720`, :pull:`2721`)
+
 **9.0.1 (2016-11-06)**
 
 * Correct the deprecation message when not specifying a --format so that it

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -302,14 +302,14 @@ class RequirementCommand(Command):
         if not (args or options.editables or found_req_in_file):
             opts = {'name': name}
             if options.find_links:
-                msg = ('You must give at least one requirement to '
-                       '%(name)s (maybe you meant "pip %(name)s '
-                       '%(links)s"?)' %
-                       dict(opts, links=' '.join(options.find_links)))
+                raise CommandError(
+                    'You must give at least one requirement to %(name)s '
+                    '(maybe you meant "pip %(name)s %(links)s"?)' %
+                    dict(opts, links=' '.join(options.find_links)))
             else:
-                msg = ('You must give at least one requirement '
-                       'to %(name)s (see "pip help %(name)s")' % opts)
-            logger.warning(msg)
+                raise CommandError(
+                    'You must give at least one requirement to %(name)s '
+                    '(see "pip help %(name)s")' % opts)
 
     def _build_package_finder(self, options, session,
                               platform=None, python_versions=None,

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -287,19 +287,17 @@ class RequirementCommand(Command):
                 )
             )
 
-        found_req_in_file = False
         for filename in options.requirements:
             for req in parse_requirements(
                     filename,
                     finder=finder, options=options, session=session,
                     wheel_cache=wheel_cache):
-                found_req_in_file = True
                 requirement_set.add_requirement(req)
         # If --require-hashes was a line in a requirements file, tell
         # RequirementSet about it:
         requirement_set.require_hashes = options.require_hashes
 
-        if not (args or options.editables or found_req_in_file):
+        if not (args or options.editables or options.requirements):
             opts = {'name': name}
             if options.find_links:
                 raise CommandError(

--- a/pip/commands/download.py
+++ b/pip/commands/download.py
@@ -192,9 +192,6 @@ class DownloadCommand(RequirementCommand):
                     None
                 )
 
-                if not requirement_set.has_requirements:
-                    return
-
                 requirement_set.prepare_files(finder)
 
                 downloaded = ' '.join([

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -313,9 +313,6 @@ class InstallCommand(RequirementCommand):
                     wheel_cache
                 )
 
-                if not requirement_set.has_requirements:
-                    return
-
                 try:
                     if (options.download_dir or not wheel or not
                             options.cache_dir):

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -185,9 +185,6 @@ class WheelCommand(RequirementCommand):
                     wheel_cache
                 )
 
-                if not requirement_set.has_requirements:
-                    return
-
                 try:
                     # build wheels
                     wb = WheelBuilder(

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -566,3 +566,11 @@ def test_download_exit_status_code_when_no_requirements(script):
         "You must give at least one requirement to download" in result.stderr
     )
     assert result.returncode == ERROR
+
+
+def test_download_exit_status_code_when_blank_requirements_file(script):
+    """
+    Test download exit status code when blank requirements file specified
+    """
+    script.scratch_path.join("blank.txt").write("\n")
+    script.pip('download', '-r', 'blank.txt')

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -2,6 +2,7 @@ import os
 import textwrap
 import pytest
 
+from pip.status_codes import ERROR
 from tests.lib.path import Path
 
 
@@ -554,3 +555,14 @@ def test_download_specify_implementation(script, data):
         'fake',
         expect_error=True,
     )
+
+
+def test_download_exit_status_code_when_no_requirements(script):
+    """
+    Test download exit status code when no requirements specified
+    """
+    result = script.pip('download', expect_error=True)
+    assert (
+        "You must give at least one requirement to download" in result.stderr
+    )
+    assert result.returncode == ERROR

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -9,6 +9,7 @@ import pytest
 
 from pip import pep425tags
 from pip.utils import appdirs, rmtree
+from pip.status_codes import ERROR
 from tests.lib import (pyversion, pyversion_tuple,
                        _create_test_package, _create_svn_repo, path_to_url,
                        requirements_file)
@@ -81,6 +82,15 @@ def test_pip_second_command_line_interface_works(script, data):
     initools_folder = script.site_packages / 'initools'
     assert egg_info_folder in result.files_created, str(result)
     assert initools_folder in result.files_created, str(result)
+
+
+def test_install_exit_status_code_when_no_requirements(script):
+    """
+    Test install exit status code when no requirements specified
+    """
+    result = script.pip('install', expect_error=True)
+    assert "You must give at least one requirement to install" in result.stderr
+    assert result.returncode == ERROR
 
 
 @pytest.mark.network

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -93,6 +93,14 @@ def test_install_exit_status_code_when_no_requirements(script):
     assert result.returncode == ERROR
 
 
+def test_install_exit_status_code_when_blank_requirements_file(script):
+    """
+    Test install exit status code when blank requirements file specified
+    """
+    script.scratch_path.join("blank.txt").write("\n")
+    script.pip('install', '-r', 'blank.txt')
+
+
 @pytest.mark.network
 def test_install_from_pypi(script):
     """

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -5,7 +5,7 @@ import pytest
 from os.path import exists
 
 from pip.locations import write_delete_marker_file
-from pip.status_codes import PREVIOUS_BUILD_DIR_ERROR
+from pip.status_codes import ERROR, PREVIOUS_BUILD_DIR_ERROR
 from tests.lib import pyversion
 
 
@@ -18,6 +18,16 @@ def test_pip_wheel_fails_without_wheel(script, data):
         expect_error=True,
     )
     assert "'pip wheel' requires the 'wheel' package" in result.stderr
+
+
+def test_wheel_exit_status_code_when_no_requirements(script):
+    """
+    Test wheel exit status code when no requirements specified
+    """
+    script.pip('install', 'wheel')
+    result = script.pip('wheel', expect_error=True)
+    assert "You must give at least one requirement to wheel" in result.stderr
+    assert result.returncode == ERROR
 
 
 @pytest.mark.network

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -30,6 +30,15 @@ def test_wheel_exit_status_code_when_no_requirements(script):
     assert result.returncode == ERROR
 
 
+def test_wheel_exit_status_code_when_blank_requirements_file(script):
+    """
+    Test wheel exit status code when blank requirements file specified
+    """
+    script.pip('install', 'wheel')
+    script.scratch_path.join("blank.txt").write("\n")
+    script.pip('wheel', '-r', 'blank.txt')
+
+
 @pytest.mark.network
 def test_pip_wheel_success(script, data):
     """


### PR DESCRIPTION
This is an update of PR #3832, which was in turn an update of PR #2721, to finally fix issue #2720. Sorry for the years-long delay!

@xavfernandez @pfmoore this adds the requested change to allow blank requirements files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4210)
<!-- Reviewable:end -->
