### PR TITLE
improve message when installing requirements file (#4127)

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -240,23 +240,7 @@ class InstallRequirement(object):
             except InvalidRequirement:
                 if os.path.sep in req:
                     add_msg = "It looks like a path."
-                    if os.path.exists(req):
-                        add_msg += " It does exist."
-                        # Try to parse and check if it is a requirements file.
-                        try:
-                            with open(req, 'r') as fp:
-                                # parse first line only
-                                parse_requirements(fp.read()).next()
-                                add_msg += " The argument you provided " + \
-                                    "(%s) appears to be a" % (req) + \
-                                    " requirements file. If that is the" + \
-                                    " case, use the '-r' flag to install" + \
-                                    " the packages specified within it."
-                        except RequirementParseError:
-                            logger.debug("Cannot parse '%s' as requirements \
-                                file" % (req), exc_info=1)
-                    else:
-                        add_msg += " File '%s' does not exist." % (req)
+                    add_msg += deduce_helpful_msg(req)
                 elif '=' in req and not any(op in req for op in operators):
                     add_msg = "= is not a valid operator. Did you mean == ?"
                 else:
@@ -1067,3 +1051,30 @@ def parse_editable(editable_req, default_vcs=None):
             "with #egg=your_package_name" % editable_req
         )
     return _strip_postfix(package_name), url, None
+
+
+def deduce_helpful_msg(req):
+    """Returns helpful msg in case requirements file does not exist,
+    or cannot be parsed.
+
+    :params req: Requirements file path
+    """
+    msg = ""
+    if os.path.exists(req):
+        msg = " It does exist."
+        # Try to parse and check if it is a requirements file.
+        try:
+            with open(req, 'r') as fp:
+                # parse first line only
+                parse_requirements(fp.read()).next()
+                msg += " The argument you provided " + \
+                    "(%s) appears to be a" % (req) + \
+                    " requirements file. If that is the" + \
+                    " case, use the '-r' flag to install" + \
+                    " the packages specified within it."
+        except RequirementParseError:
+            logger.debug("Cannot parse '%s' as requirements \
+            file" % (req), exc_info=1)
+    else:
+        msg += " File '%s' does not exist." % (req)
+    return msg

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -520,7 +520,7 @@ class TestInstallRequirement(object):
                 os.path.join('this', 'path', 'does', 'not', 'exist'))
         err_msg = e.value.args[0]
         assert "Invalid requirement" in err_msg
-        assert "It looks like a path. Does it exist ?" in err_msg
+        assert "It looks like a path." in err_msg
 
     def test_single_equal_sign(self):
         with pytest.raises(InstallationError) as e:


### PR DESCRIPTION
Before - 
```
$ pip install requirements/dev.txt
Invalid requirement: 'requirements/dev.txt'
It looks like a path. Does it exist ?
```

After - 
```
$ pip install ./dev-requirements.txt
Invalid requirement: './dev-requirements.txt'
It looks like a path. It does exist. The argument you provided (./dev-requirements.txt) appears to be a requirements file. If that is the case, use the '-r' flag to install the packages specified within it.
$ pip install ./setup.py
Invalid requirement: './setup.py'
It looks like a path. It does exist.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4211)
<!-- Reviewable:end -->
