### PR TITLE
Fix per-requirement global options. fixes #3830

### DIFF
--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -694,8 +694,9 @@ class InstallRequirement(object):
         else:
             return True
 
-    def install(self, install_options, global_options=[], root=None,
+    def install(self, install_options, global_options=None, root=None,
                 prefix=None):
+        global_options = list(global_options) if global_options else []
         if self.editable:
             self.install_editable(
                 install_options, global_options, prefix=prefix)

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -598,3 +598,40 @@ class TestParseRequirements(object):
                 call.index(global_option) > 0
         assert options.format_control.no_binary == set([':all:'])
         assert options.format_control.only_binary == set([])
+
+    def test_global_options(self, tmpdir, finder, session, options):
+        global_options = [
+            '--dry-run',
+            '--without-libyaml',
+            ''
+        ]
+
+        content = '''
+        INITools==2.0 --global-option="{global_options[0]}"
+        requests==2.12.4 --global-option="{global_options[1]}"
+        jsonschema==2.5.1
+        '''.format(global_options=global_options)
+
+        with requirements_file(content, tmpdir) as reqs_file:
+            install_requirements = list(parse_requirements(reqs_file.abspath,
+                                        finder=finder,
+                                        options=options,
+                                        session=session))
+
+        for req_num, req in enumerate(install_requirements):
+            req.source_dir = os.curdir
+            with patch.object(subprocess, 'Popen') as popen:
+                popen.return_value.stdout.readline.return_value = ""
+                try:
+                    req.install([])
+                except:
+                    pass
+
+                call = popen.call_args_list[0][0][0]
+                for opt_num, opt in enumerate(global_options):
+                    if not opt:
+                        continue
+                    if opt_num == req_num:
+                        assert opt in call
+                    else:
+                        assert opt not in call


### PR DESCRIPTION
This fixes the problem described in #3830 but I am not sure if that problem should be fixed.
However, something is definitely wrong with per-requirement `--global-option`'s:
1) If it is intended to add a custom option to one and only one requirement, then #3830 needs to be solved, but the name "global option" is a bit confusing because it is not actually global, it's per-requirement.
2) If global options are intended to be applied to all requirements, then they should be listed separately from any particular requirement and also there is a bug, because global options are applied only to requirements that are listed after. So global options are not really global again.

In this pull request I address the first problem and make global options from different requirements not to interfere with each other.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4217)
<!-- Reviewable:end -->
