### PR TITLE
newbies need reminder: pip runs inside python

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,6 +7,8 @@ Install a package from `PyPI`_:
 
 ::
 
+pip runs in Python. (To start pip from the OS command line, type: python -m pip)
+
   $ pip install SomePackage
     [...]
     Successfully installed SomePackage

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,7 +7,7 @@ Install a package from `PyPI`_:
 
 ::
 
-pip runs in Python. (To start pip from the OS command line, type: python -m pip)
+(Windows users: To start pip from the command line, type: python -m pip)
 
   $ pip install SomePackage
     [...]


### PR DESCRIPTION
New Python users on Windows are asking why typing "pip" at command line doesn't work. e.g. http://stackoverflow.com/questions/4750806/how-do-i-install-pip-on-windows .  They aren't clear that pip runs inside Python because they're brand-new to Python.  

Many newbie tutorials require using pip to begin learning Python, so newbies land here before they have much experience with Python.  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4218)
<!-- Reviewable:end -->
