### PR TITLE
Fix python version check

### DIFF
--- a/pip/index.py
+++ b/pip/index.py
@@ -658,8 +658,8 @@ class PackageFinder(object):
         match = self._py_version_re.search(version)
         if match:
             version = version[:match.start()]
-            py_version = match.group(1)
-            if py_version != sys.version[:3]:
+            py_version = tuple(int(i) for i in match.group(1).split('.'))
+            if py_version != sys.version_info[:len(py_version)]:
                 self._log_skipped_link(
                     link, 'Python version is incorrect')
                 return

--- a/pip/index.py
+++ b/pip/index.py
@@ -571,7 +571,7 @@ class PackageFinder(object):
 
             yield page
 
-    _py_version_re = re.compile(r'-py([123]\.?[0-9]?)$')
+    _py_version_re = re.compile(r'-py([123](?:\.\d+)?)$')
 
     def _sort_links(self, links):
         """


### PR DESCRIPTION
I have noticed that pip does not recognize `-py3` source archives when present at PyPI.  For example installation of the [pycifrw](https://pypi.python.org/pypi/PyCifRW/4.2.1) package with Python 3 pip produced the following output and went on to install the Python 2 version.

```sh
$ pip install -vvv --no-cache-dir pycifrw               
Collecting pycifrw
...
  Analyzing links from page https://pypi.python.org/simple/pycifrw/
    Skipping link https://pypi.python.org/packages/01/68/b75a924883f1b1b7b3c2d0c1fdc2cede03d255ce5287c4d9d8d17f6d517e/PyCifRW-4.2.1-py3.tar.gz#md5=3bc6b0d2f23b170546dc7c194bc2991c (from https://pypi.python.org/simple/pycifrw/); Python version is incorrect
...
```

This is because version checking code compared both major and minor versions, however `-py3` provides only the major version.  After this PR `pip` finds and installs the correct `-py3` archive:

```sh
$ pip install -vvv --no-cache-dir pycifrw
Collecting pycifrw
  1 location(s) to search for versions of pycifrw:
  * https://pypi.python.org/simple/pycifrw/
  Getting page https://pypi.python.org/simple/pycifrw/
  Starting new HTTPS connection (1): pypi.python.org
  "GET /simple/pycifrw/ HTTP/1.1" 200 1232
  Analyzing links from page https://pypi.python.org/simple/pycifrw/
    Found link https://pypi.python.org/packages/01/68/b75a924883f1b1b7b3c2d0c1fdc2cede03d255ce5287c4d9d8d17f6d517e/PyCifRW-4.2.1-py3.tar.gz#md5=3bc6b0d2f23b170546dc7c194bc2991c (from https://pypi.python.org/simple/pycifrw/), version: 4.2.1
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4254)
<!-- Reviewable:end -->
