### PR TITLE
Fix change log comment, with reference to #4194

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,8 +16,10 @@
 * Add `--exclude-editable` to ``pip list`` to exclude editable packages
   from installed package list.
 
-* Add `--progress-bar <progress_bar>` to ``pip download``, ``pip install``
-  and ``pip wheel`` to suppress progress bar in the console (:pull:`4194`)
+* Add `--progress-bar <progress_bar>` to ``pip download``, ``pip install`` and
+  ``pip wheel`` commands, to allow selecting a specific progress indicator
+  type (:pull:`4194`). To completely suppress (for example in a CI environment)
+  use ``--progress-bar off```.
 
 
 **9.0.1 (2016-11-06)**


### PR DESCRIPTION
Originally the plan was to have a boolean value, the resulting changelog was a mix of the two implementations. Updated, including a focus on the main use case - CI progress bar suppression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4257)
<!-- Reviewable:end -->
