### PR TITLE
Explain how -e affects pip freeze.

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -325,6 +325,9 @@ the :ref:`--editable <install_--editable>` option) or not.
   already installed, the VCS source will not overwrite it without an `--upgrade`
   flag. VCS requirements pin the package version (specified in the `setup.py`
   file) of the target commit, not necessarily the commit itself.
+* The :ref:`pip freeze` subcomand will record the VCS requirement specifier
+  (referencing a specific commit) if and only if the install is done using the
+  editable option.
 
 The "project name" component of the url suffix "egg=<project name>-<version>"
 is used by pip in its dependency logic to identify the project prior


### PR DESCRIPTION
It took me a while to figure this out, even with help from existing stack overflow answers, and this seems like a reasonable place to document it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4273)
<!-- Reviewable:end -->
