### PR TITLE
Add one more fail-safe when decoding console to str in Py3

### DIFF
--- a/news/4310.bugfix
+++ b/news/4310.bugfix
@@ -1,0 +1,2 @@
+Works around UnicodeDecodeError using ``repr()`` in decoding console output on
+Python 3.

--- a/pip/compat.py
+++ b/pip/compat.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division
 
 import os
 import sys
+import warnings
 
 from pip._vendor.six import text_type
 
@@ -44,6 +45,9 @@ if sys.version_info >= (3,):
             try:
                 return s.decode('utf_8')
             except UnicodeDecodeError:
+                warnings.warn(
+                    'Could not detect stdout encoding - falling back to repr',
+                    category=RuntimeWarning, stacklevel=2)
                 # Decode at least line breaks manually
                 return repr(s)[2:-1].replace('\\r', '\r').replace('\\n', '\n')
 

--- a/pip/compat.py
+++ b/pip/compat.py
@@ -41,7 +41,11 @@ if sys.version_info >= (3,):
         try:
             return s.decode(sys.__stdout__.encoding)
         except UnicodeDecodeError:
-            return s.decode('utf_8')
+            try:
+                return s.decode('utf_8')
+            except UnicodeDecodeError:
+                # Decode at least line breaks manually
+                return repr(s)[2:-1].replace('\\r', '\r').replace('\\n', '\n')
 
     def native_str(s, replace=False):
         if isinstance(s, bytes):


### PR DESCRIPTION
Here's one suggestion of fix for https://github.com/pypa/pip/issues/4110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4310)
<!-- Reviewable:end -->
