### PR TITLE
Fix unknown encoding utf8 in file headers

### DIFF
--- a/pip/_vendor/webencodings/__init__.py
+++ b/pip/_vendor/webencodings/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
 
     webencodings

--- a/pip/_vendor/webencodings/tests.py
+++ b/pip/_vendor/webencodings/tests.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
 
     webencodings.tests

--- a/pip/_vendor/webencodings/x_user_defined.py
+++ b/pip/_vendor/webencodings/x_user_defined.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
 
     webencodings.x_user_defined


### PR DESCRIPTION
Avoids warnings like this when processing Django messages with gettext:
```
gettext: ./env/lib/python2.7/site-packages/pip/_vendor/webencodings/x_user_defined.py:1:
Unknown encoding "utf8". Proceeding with ASCII instead.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4312)
<!-- Reviewable:end -->
