### PR TITLE
ENH added external dependency resolution

### DIFF
--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -172,6 +172,18 @@ class InstallCommand(RequirementCommand):
             help="Do not compile py files to pyc",
         )
 
+        cmd_opts.add_option(
+            "--dependency-resolver", "--dep-resolver",
+            dest="dependency_resolver",
+            type='str',
+            default=None,
+            help="Use this command to resolve dependencies. The command is "
+                 "called with the requirement string `req` as the first argument "
+                 "using `subprocess.run([cmd, req], shell=True, check=True)`. If "
+                 "the command is unable to resolve a dependency or encounters an "
+                 "error, pip's dependency resolution is used instead."
+        )
+
         cmd_opts.add_option(cmdoptions.use_wheel())
         cmd_opts.add_option(cmdoptions.no_use_wheel())
         cmd_opts.add_option(cmdoptions.no_binary())
@@ -305,6 +317,7 @@ class InstallCommand(RequirementCommand):
                     wheel_cache=wheel_cache,
                     require_hashes=options.require_hashes,
                     progress_bar=options.progress_bar,
+                    dependency_resolver=options.dependency_resolver,
                 )
 
                 self.populate_requirement_set(

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -178,10 +178,11 @@ class InstallCommand(RequirementCommand):
             type='str',
             default=None,
             help="Use this command to resolve dependencies. The command is "
-                 "called with the requirement string `req` as the first argument "
-                 "using `subprocess.run([cmd, req], shell=True, check=True)`. If "
-                 "the command is unable to resolve a dependency or encounters an "
-                 "error, pip's dependency resolution is used instead."
+                 "called with the requirement string `req` as the first "
+                 "argument using `subprocess.run([cmd, req], shell=True, "
+                 "check=True)`. If the command is unable to resolve a "
+                 "dependency or encounters an error, pip's dependency "
+                 "resolution is used instead."
         )
 
         cmd_opts.add_option(cmdoptions.use_wheel())


### PR DESCRIPTION
This PR adds a switch to allow users to pass a path to an executable that will resolve dependencies before `pip` attempts to do so. 

Reasons to include this feature:

1. This feature would allow users to integrate pip into custom build environments where they would like to pull packages from another source.
2. It would let them do this without having to setup their on pypi server, which is a big overhead in maintenance and technical know-how.

Reasons not to include this feature:

1. People could just setup their on pypi server.
2. It is ugly.
3. It is easy to abuse.

To Do:
 - [ ] As it stands now, this feature does not address uninstalls, upgrades or other possible pip commands.
 - [ ] Tests need to be added.

I would say that right now as this PR stands, this is not ready for merging, mostly due to a lack of sophistication in handling all of the possible edge cases for installs, upgrades and uninstalls.

I am opening this PR to stimulate discussion for a feature of this kind and get contributions and/or feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4325)
<!-- Reviewable:end -->
