### PR TITLE
Remove the wheel-less vendor tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ matrix:
     - python: pypy
       env: TOXENV=pypy
     - python: 2.7
-      env: TOXENV=py27 VENDOR=no
-    - python: 3.6
-      env: TOXENV=py36 VENDOR=no
-    - python: 2.7
       env: TOXENV=py27 VENDOR=no WHEELS=yes
     - python: 3.6
       env: TOXENV=py36 VENDOR=no WHEELS=yes


### PR DESCRIPTION
The wheel based vendor tests should get us the same testing without the issue of trying to upgrade something that setuptools itself is depending on. It also matches the mechanism that downstream are currently using better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/4341)
<!-- Reviewable:end -->
