### PR TITLE
Updates to the handling of news files

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -3,7 +3,7 @@
          fix problems like typo corrections or such.
 
          To add a new change log entry, please see
-             https://pip.pypa.io/en/latest/development/#adding-news
+             https://pip.pypa.io/en/latest/development/#adding-a-news-entry
 
 .. towncrier release notes start
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -125,6 +125,12 @@ like operating system, one can be added by running
 ``touch news/$(uuidgen).trivial``. Core committers may also add a "trivial"
 label to the PR which will accomplish the same thing.
 
+Upgrading, removing, or adding a new vendored library gets a special mention
+using a ``news/<library>.vendor`` file. This is in addition to any features,
+bugfixes, or other kinds of news that pulling in this library may have. This
+uses the library name as the key so that updating the same library twice doesn't
+produce two news file entries.
+
 
 Release Process
 ===============

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -88,26 +88,42 @@ Later, when you think you're ready, get in touch with one of the maintainers,
 and they will initiate a vote.
 
 
-Adding News
-===========
+Adding a NEWS Entry
+===================
 
-The pip project manages its changelog/news file using
-`towncrier <https://pypi.org/project/towncrier/>`_. To add a new item to the
-news file, you must create a file inside of the ``news/`` directory.
+The ``NEWS.rst`` file is managed using
+`towncrier <https://pypi.org/project/towncrier/>`_ and all non trivial changes
+must be accompanied by a news entry.
 
-This file must be named as ``<issue>.<ext>``, where ``<issue>`` is the issue
-number on GitHub (if it's important enough to have a news entry, it should be
-important enough to have a bug describing the desired change) and ``<ext>`` is
-one of ``removal``, ``feature``, ``bugfix``, ``doc``. Thus a file might be named
-something like ``news/1234.bugfix``.
+To add an entry to the news file, first you need to have created an issue
+describing the change you want to make. A Pull Request itself *may* function as
+such, but it is preferred to have a dedicated issue (for example, in case the
+PR ends up rejected due to code quality reasons).
 
-The contents of this file is the news file entry that you wish to add WITHOUT
-referencing the issue number (the reference will be added automatically). These
-contents can include reStructuredText formatting.
+Once you have an issue or pull request, you take the number and you create a
+file inside of the ``news/`` directory named after that issue number with an
+extension of ``removal``, ``feature``, ``bugfix``, or ``doc``. Thus if your
+issue or PR number is ``1234`` and this change is fixing a bug, then you would
+create a file ``news/1234.bugfix``. PRs can span multiple categories by creating
+multiple files (for instance, if you added a feature and deprecated/removed the
+old feature at the same time, you would create ``news/NNNN.feature`` and
+``news/NNNN.removal``). Likewise if a PR touches multiple issues/PRs you may
+create a file for each of them with the exact same contents and Towncrier will
+deduplicate them.
 
-If you wish to reference multiple issues with the same news file entry, then
-simply create multiple files with the exact same contents and towncrier will
-deduplicate them and reference all of the specified issues.
+The contents of this file are reStructuredText formatted text that will be used
+as the content of the news file entry. You do not need to reference the issue
+or PR numbers here as towncrier will automatically add a reference to all of
+the affected issues when rendering the news file.
+
+A trivial change is anything that does not warrant an entry in the news file.
+Some examples are: Code refactors that don't change anything as far as the
+public is concerned, typo fixes, white space modification, etc. To mark a PR
+as trivial a contributor simply needs to add a randomly named, empty file to the
+``news/`` directory with the extension of ``.trivial``. If you are on a POSIX
+like operating system, one can be added by running
+``touch news/$(uuidgen).trivial``. Core committers may also add a "trivial"
+label to the PR which will accomplish the same thing.
 
 
 Release Process

--- a/news/_template.rst
+++ b/news/_template.rst
@@ -6,7 +6,7 @@
 
 {% endif %}
 {% if sections[section] %}
-{% for category, val in definitions.items() if category in sections[section]%}
+{% for category, val in definitions.items() if category in sections[section] and category != 'trivial' %}
 
 {{ definitions[category]['name'] }}
 {{ underline * definitions[category]['name']|length }}

--- a/news/_template.rst
+++ b/news/_template.rst
@@ -13,7 +13,8 @@
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category]|dictsort(by='value') %}
-- {{ text }} ({{ values|sort|join(', ') }})
+- {{ text }}{% if category != 'vendor' %} ({{ values|sort|join(', ') }}){% endif %}
+
 {% endfor %}
 {% else %}
 - {{ sections[section][category]['']|sort|join(', ') }}

--- a/news/appdirs.vendor
+++ b/news/appdirs.vendor
@@ -1,0 +1,1 @@
+Upgraded appdirs to 1.4.3.

--- a/news/cachecontrol.vendor
+++ b/news/cachecontrol.vendor
@@ -1,0 +1,1 @@
+Upgraded CacheControl to 0.12.1.

--- a/news/distro.vendor
+++ b/news/distro.vendor
@@ -1,0 +1,1 @@
+Upgraded distro to 1.0.2.

--- a/news/ipaddress.vendor
+++ b/news/ipaddress.vendor
@@ -1,0 +1,1 @@
+Upgraded ipaddress to 1.0.18.

--- a/news/msgpack-python.vendor
+++ b/news/msgpack-python.vendor
@@ -1,0 +1,1 @@
+Vendored msgpack-python at 0.4.8.

--- a/news/ordereddict.vendor
+++ b/news/ordereddict.vendor
@@ -1,0 +1,1 @@
+Removed the vendored ordereddict.

--- a/news/pyparsing.vendor
+++ b/news/pyparsing.vendor
@@ -1,0 +1,1 @@
+Upgraded pyparsing to 2.2.0.

--- a/news/requests.vendor
+++ b/news/requests.vendor
@@ -1,0 +1,1 @@
+Upgraded requests to 2.13.0.

--- a/news/setuptools.vendor
+++ b/news/setuptools.vendor
@@ -1,0 +1,1 @@
+Upgraded pkg_resources (via setuptools) to 34.3.2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,8 @@ template = "news/_template.rst"
   directory = "doc"
   name = "Improved Documentation"
   showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "trivial"
+  name = "Trivial Changes"
+  showcontent = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ template = "news/_template.rst"
 
   [[tool.towncrier.type]]
   directory = "removal"
-  name = "Removal"
+  name = "Deprecations and Removals"
   showcontent = true
 
   [[tool.towncrier.type]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ template = "news/_template.rst"
   showcontent = true
 
   [[tool.towncrier.type]]
+  directory = "vendor"
+  name = "Vendored Libraries"
+  showcontent = true
+
+  [[tool.towncrier.type]]
   directory = "doc"
   name = "Improved Documentation"
   showcontent = true


### PR DESCRIPTION
* Added the "trivial" mechanism to hide a PR from the news file completely.
* Added the "vendor" mechanism to call out updates, removals, and additions to the vendored libraries.
* Rewrote the documentation to (hopefully) be more clear.
* Clean up the name for removals.