### PR TITLE
Update supported Mercurial schemes with hg+file

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -382,6 +382,7 @@ Here are the supported forms::
     [-e] hg+http://hg.myproject.org/MyProject#egg=MyProject
     [-e] hg+https://hg.myproject.org/MyProject#egg=MyProject
     [-e] hg+ssh://hg.myproject.org/MyProject#egg=MyProject
+    [-e] hg+file:///home/user/projects/MyProject#egg=MyProject
 
 You can also specify a revision number, a revision hash, a tag name or a local
 branch name like so::


### PR DESCRIPTION
Empirically, pip supports pip [-e] hg+file:///path/to/repo