### PR TITLE
Fix ResourceWarning in call_subprocess()

### DIFF
--- a/pip/utils/__init__.py
+++ b/pip/utils/__init__.py
@@ -685,7 +685,11 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
                 # Update the spinner
                 if spinner is not None:
                     spinner.spin()
-    proc.wait()
+    try:
+        proc.wait()
+    finally:
+        if proc.stdout:
+            proc.stdout.close()
     if spinner is not None:
         if proc.returncode:
             spinner.finish("error")


### PR DESCRIPTION
Close explicitly proc.stdout to prevent ResourceWarning warning.