### PR TITLE
Install wheel with a non-PEP 440 version in the filename.

### DIFF
--- a/news/4169.bugfix
+++ b/news/4169.bugfix
@@ -1,0 +1,1 @@
+Support the installation of wheels with non-PEP 440 version in their filenames.

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -187,7 +187,7 @@ def fix_script(path):
             script.write(rest)
         return True
 
-dist_info_re = re.compile(r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)
+dist_info_re = re.compile(r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>.+?))?)
                                 \.dist-info$""", re.VERBOSE)
 
 
@@ -582,7 +582,7 @@ class Wheel(object):
     # TODO: maybe move the install code into this class
 
     wheel_file_re = re.compile(
-        r"""^(?P<namever>(?P<name>.+?)-(?P<ver>\d.*?))
+        r"""^(?P<namever>(?P<name>.+?)-(?P<ver>.*?))
         ((-(?P<build>\d.*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
         \.whl|\.dist-info)$""",
         re.VERBOSE

--- a/tests/data/packages/plat_wheel-_invalidversion_/plat_wheel-_invalidversion_.dist-info/WHEEL
+++ b/tests/data/packages/plat_wheel-_invalidversion_/plat_wheel-_invalidversion_.dist-info/WHEEL
@@ -1,0 +1,4 @@
+Wheel-Version: 0.1
+Packager: bdist_wheel
+Root-Is-Purelib: false
+

--- a/tests/data/packages/pure_wheel-_invalidversion_/pure_wheel-_invalidversion_.dist-info/WHEEL
+++ b/tests/data/packages/pure_wheel-_invalidversion_/pure_wheel-_invalidversion_.dist-info/WHEEL
@@ -1,0 +1,4 @@
+Wheel-Version: 0.1
+Packager: bdist_wheel
+Root-Is-Purelib: true
+

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -100,6 +100,10 @@ class TestWheelFile(object):
         w = wheel.Wheel('simple-1-py2-none-any.whl')
         assert w.version == '1'
 
+    def test_non_pep440_version(self):
+        w = wheel.Wheel('simple-_invalid_-py2-none-any.whl')
+        assert w.version == '-invalid-'
+
     def test_missing_version_raises(self):
         with pytest.raises(InvalidWheelFilename):
             wheel.Wheel('Cython-cp27-none-linux_x86_64.whl')
@@ -257,6 +261,10 @@ class TestWheelFile(object):
         packages = [
             ("pure_wheel", data.packages.join("pure_wheel-1.7"), True),
             ("plat_wheel", data.packages.join("plat_wheel-1.7"), False),
+            ("pure_wheel", data.packages.join(
+                "pure_wheel-_invalidversion_"), True),
+            ("plat_wheel", data.packages.join(
+                "plat_wheel-_invalidversion_"), False),
         ]
 
         for name, path, expected in packages:


### PR DESCRIPTION
Fixes #4169
PEP 427 has no specific requirements for the format of the version.
As pip wheel allows to create a wheel with a non-PEP 440 version, it should also be able to install that same wheel.