### PR TITLE
Compare revisions for remote git branches/tags

### DIFF
--- a/pip/vcs/__init__.py
+++ b/pip/vcs/__init__.py
@@ -184,7 +184,7 @@ class VersionControl(object):
         """
         raise NotImplementedError
 
-    def check_version(self, dest, rev_options):
+    def check_version(self, dest, rev_options, url=None):
         """
         Return True if the version is identical to what exists and
         doesn't need to be updated.
@@ -211,7 +211,7 @@ class VersionControl(object):
                         display_path(dest),
                         url,
                     )
-                    if not self.check_version(dest, rev_options):
+                    if not self.check_version(dest, rev_options, url=url):
                         logger.info(
                             'Updating %s %s%s',
                             display_path(dest),

--- a/pip/vcs/bazaar.py
+++ b/pip/vcs/bazaar.py
@@ -108,7 +108,7 @@ class Bazaar(VersionControl):
         current_rev = self.get_revision(location)
         return '%s@%s#egg=%s' % (repo, current_rev, egg_project_name)
 
-    def check_version(self, dest, rev_options):
+    def check_version(self, dest, rev_options, url=None):
         """Always assume the versions don't match"""
         return False
 

--- a/pip/vcs/mercurial.py
+++ b/pip/vcs/mercurial.py
@@ -96,7 +96,7 @@ class Mercurial(VersionControl):
         current_rev_hash = self.get_revision_hash(location)
         return '%s@%s#egg=%s' % (repo, current_rev_hash, egg_project_name)
 
-    def check_version(self, dest, rev_options):
+    def check_version(self, dest, rev_options, url=None):
         """Always assume the versions don't match"""
         return False
 

--- a/pip/vcs/subversion.py
+++ b/pip/vcs/subversion.py
@@ -215,7 +215,7 @@ class Subversion(VersionControl):
         rev = self.get_revision(location)
         return 'svn+%s@%s#egg=%s' % (repo, rev, egg_project_name)
 
-    def check_version(self, dest, rev_options):
+    def check_version(self, dest, rev_options, url=None):
         """Always assume the versions don't match"""
         return False
 


### PR DESCRIPTION
Adds a simple check if the local revision is the same as the remote revision, even if the ref is a tag or branch name.

Until now branches or tags would always try to update the repository.