### PR TITLE
Fixed issue#949

### DIFF
--- a/news/949.feature
+++ b/news/949.feature
@@ -1,0 +1,3 @@
+Added a way to distinguish between pip installed packages and those from
+the system package manager in 'pip list'. Specifically, 'pip list -vv' also
+shows the installer of package.

--- a/news/949.feature
+++ b/news/949.feature
@@ -1,3 +1,3 @@
 Added a way to distinguish between pip installed packages and those from
-the system package manager in 'pip list'. Specifically, 'pip list -vv' also
-shows the installer of package.
+the system package manager in 'pip list'. Specifically, 'pip list -v' also
+shows the installer of package if it has that meta data.

--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -210,7 +210,14 @@ class ListCommand(Command):
                 yield dist
 
     def output_legacy(self, dist, options):
-        if options.verbose >= 1 or dist_is_editable(dist):
+        if options.verbose >= 2:
+            return '%s (%s, %s, %s)' % (
+                dist.project_name,
+                dist.version,
+                dist.location,
+                dist.installer,
+            )
+        elif options.verbose >= 1 or dist_is_editable(dist):
             return '%s (%s, %s)' % (
                 dist.project_name,
                 dist.version,
@@ -236,6 +243,9 @@ class ListCommand(Command):
             self.output_package_listing_columns(data, header)
         elif options.list_format == 'freeze':
             for dist in packages:
+                if options.verbose >= 2:
+                    logger.info("%s==%s (%s) (%s)", dist.project_name,
+                                dist.version, dist.location, dist.installer)
                 if options.verbose >= 1:
                     logger.info("%s==%s (%s)", dist.project_name,
                                 dist.version, dist.location)
@@ -298,6 +308,8 @@ def format_for_columns(pkgs, options):
     data = []
     if options.verbose >= 1 or any(dist_is_editable(x) for x in pkgs):
         header.append("Location")
+    if options.verbose >= 2:
+        header.append("Installer")
 
     for proj in pkgs:
         # if we're working on the 'outdated' list, separate out the
@@ -310,6 +322,8 @@ def format_for_columns(pkgs, options):
 
         if options.verbose >= 1 or dist_is_editable(proj):
             row.append(proj.location)
+        if options.verbose >= 2:
+            row.append(proj.installer)
 
         data.append(row)
 
@@ -323,6 +337,8 @@ def format_for_json(packages, options):
             'name': dist.project_name,
             'version': six.text_type(dist.version),
         }
+        if options.verbose >= 2:
+            info['installer'] = dist.installer
         if options.verbose >= 1:
             info['location'] = dist.location
         if options.outdated:

--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -16,6 +16,7 @@ from pip.index import PackageFinder
 from pip.utils import (
     get_installed_distributions, dist_is_editable)
 from pip.utils.deprecation import RemovedInPip11Warning
+from pip.utils.packaging import get_installer
 from pip.cmdoptions import make_option_group, index_group
 
 logger = logging.getLogger(__name__)
@@ -342,11 +343,3 @@ def format_for_json(packages, options):
             info['latest_filetype'] = dist.latest_filetype
         data.append(info)
     return json.dumps(data)
-
-
-def get_installer(dist):
-    if dist.has_metadata('INSTALLER'):
-        for line in dist.get_metadata_lines('INSTALLER'):
-            if line.strip():
-                return line.strip()
-    return ''

--- a/pip/commands/list.py
+++ b/pip/commands/list.py
@@ -244,9 +244,8 @@ class ListCommand(Command):
         elif options.list_format == 'freeze':
             for dist in packages:
                 if options.verbose >= 1:
-                    logger.info("%s==%s (%s) (%s)", dist.project_name,
-                                dist.version, dist.location,
-                                get_installer(dist))
+                    logger.info("%s==%s (%s)", dist.project_name,
+                                dist.version, dist.location)
                 else:
                     logger.info("%s==%s", dist.project_name, dist.version)
         elif options.list_format == 'json':

--- a/pip/utils/packaging.py
+++ b/pip/utils/packaging.py
@@ -61,3 +61,11 @@ def check_dist_requires_python(dist):
             "Package %s has an invalid Requires-Python entry %s - %s" % (
                 dist.project_name, requires_python, e))
         return
+
+
+def get_installer(dist):
+    if dist.has_metadata('INSTALLER'):
+        for line in dist.get_metadata_lines('INSTALLER'):
+            if line.strip():
+                return line.strip()
+    return ''

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -29,13 +29,6 @@ def test_verbose_flag(script, data):
     assert 'Package' in result.stdout, str(result)
     assert 'Version' in result.stdout, str(result)
     assert 'Location' in result.stdout, str(result)
-    assert 'simple     1.0' in result.stdout, str(result)
-    assert 'simple2    3.0' in result.stdout, str(result)
-
-    result = script.pip('list', '-vv', '--format=columns')
-    assert 'Package' in result.stdout, str(result)
-    assert 'Version' in result.stdout, str(result)
-    assert 'Location' in result.stdout, str(result)
     assert 'Installer' in result.stdout, str(result)
     assert 'simple     1.0' in result.stdout, str(result)
     assert 'simple2    3.0' in result.stdout, str(result)

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -25,10 +25,18 @@ def test_verbose_flag(script, data):
         'install', '-f', data.find_links, '--no-index', 'simple==1.0',
         'simple2==3.0',
     )
-    result = script.pip('list', '-v')
+    result = script.pip('list', '-v', '--format=columns')
     assert 'Package' in result.stdout, str(result)
     assert 'Version' in result.stdout, str(result)
     assert 'Location' in result.stdout, str(result)
+    assert 'simple     1.0' in result.stdout, str(result)
+    assert 'simple2    3.0' in result.stdout, str(result)
+
+    result = script.pip('list', '-vv', '--format=columns')
+    assert 'Package' in result.stdout, str(result)
+    assert 'Version' in result.stdout, str(result)
+    assert 'Location' in result.stdout, str(result)
+    assert 'Installer' in result.stdout, str(result)
     assert 'simple     1.0' in result.stdout, str(result)
     assert 'simple2    3.0' in result.stdout, str(result)
 


### PR DESCRIPTION
Added a way to distinguish between pip installed packages and those from
the system package manager in 'pip list'. Specifically, 'pip list -vv' also
shows the installer of package.