### PR TITLE
Fall back to sys.getdefaultencoding in auto_decode

### DIFF
--- a/news/4184.bugfix
+++ b/news/4184.bugfix
@@ -1,0 +1,1 @@
+Fall back to sys.getdefaultencoding() if locale.getpreferredencoding() returns None in `pip.utils.encoding.auto_decode`.

--- a/pip/utils/encoding.py
+++ b/pip/utils/encoding.py
@@ -1,6 +1,7 @@
 import codecs
 import locale
 import re
+import sys
 
 
 BOMS = [
@@ -28,4 +29,6 @@ def auto_decode(data):
         if line[0:1] == b'#' and ENCODING_RE.search(line):
             encoding = ENCODING_RE.search(line).groups()[0].decode('ascii')
             return data.decode(encoding)
-    return data.decode(locale.getpreferredencoding(False))
+    return data.decode(
+        locale.getpreferredencoding(False) or sys.getdefaultencoding(),
+    )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -461,6 +461,16 @@ class TestEncoding(object):
         latin1_req = u'# coding=latin1\n# Pas trop de café'
         assert auto_decode(latin1_req.encode('latin1')) == latin1_req
 
+    def test_auto_decode_no_preferred_encoding(self):
+        om, em = Mock(), Mock()
+        om.return_value = 'ascii'
+        em.return_value = None
+        data = u'data'
+        with patch('sys.getdefaultencoding', om):
+            with patch('locale.getpreferredencoding', em):
+                ret = auto_decode(data.encode(sys.getdefaultencoding()))
+        assert ret == data
+
 
 class TestBuildDirectory(object):
     # No need to test symlinked directories on Windows


### PR DESCRIPTION
Fixes #4184 

`test_auto_decode_no_preferred_encoding` fails against master:
``` python
=========================================================== test session starts ============================================================
platform linux2 -- Python 2.7.9, pytest-3.0.7, py-1.4.33, pluggy-0.4.0 -- /media/dtucker/SSD/projects/pip/venv-pip/bin/python2
cachedir: .cache
rootdir: /media/dtucker/SSD/projects/pip, inifile: setup.cfg
plugins: xdist-1.15.0, timeout-1.2.0, catchlog-1.2.2
collected 6 items 

tests/unit/test_utils.py::TestEncoding::test_auto_decode_utf16_le PASSED
tests/unit/test_utils.py::TestEncoding::test_auto_decode_no_bom PASSED
tests/unit/test_utils.py::TestEncoding::test_auto_decode_pep263_headers PASSED
tests/unit/test_utils.py::TestEncoding::test_auto_decode_no_preferred_encoding FAILED

================================================================= FAILURES =================================================================
___________________________________________ TestEncoding.test_auto_decode_no_preferred_encoding ____________________________________________

self = <tests.unit.test_utils.TestEncoding object at 0x7f167d409110>

    def test_auto_decode_no_preferred_encoding(self):
        om, em = Mock(), Mock()
        om.return_value = 'ascii'
        em.return_value = None
        data = u'data'
        with patch('sys.getdefaultencoding', om):
            with patch('locale.getpreferredencoding', em):
>               ret = auto_decode(data.encode(sys.getdefaultencoding()))

tests/unit/test_utils.py:471: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

data = 'data'

    def auto_decode(data):
        """Check a bytes string for a BOM to correctly detect the encoding
    
        Fallback to locale.getpreferredencoding(False) like open() on Python3"""
        for bom, encoding in BOMS:
            if data.startswith(bom):
                return data[len(bom):].decode(encoding)
        # Lets check the first two lines as in PEP263
        for line in data.split(b'\n')[:2]:
            if line[0:1] == b'#' and ENCODING_RE.search(line):
                encoding = ENCODING_RE.search(line).groups()[0].decode('ascii')
                return data.decode(encoding)
>       return data.decode(locale.getpreferredencoding(False))
E       TypeError: decode() argument 1 must be string, not None

pip/utils/encoding.py:31: TypeError
==================================================== 1 failed, 3 passed in 0.09 seconds ====================================================
```