### PR TITLE
Do not show global options for subcommands by default

### DIFF
--- a/news/4433.feature
+++ b/news/4433.feature
@@ -1,0 +1,2 @@
+Global options are not shown for subcommands unless explicitly requested with
+`--verbose`.

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -105,6 +105,11 @@ class Command(object):
         # factored out for testability
         return self.parser.parse_args(args)
 
+    def print_help(self):
+        # factored out for uniform handling
+        # of 'help <command>' and '<command> --help' cases
+        self.parser.print_help()
+
     def main(self, args):
         options, args = self.parse_args(args)
 
@@ -125,6 +130,10 @@ class Command(object):
         root_level = level
         if options.log:
             root_level = "DEBUG"
+
+        if options.help:
+            self.print_help()
+            sys.exit(0)
 
         logging.config.dictConfig({
             "version": 1,

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -59,11 +59,11 @@ class Command(object):
         self.cmd_opts = optparse.OptionGroup(self.parser, optgroup_name)
 
         # Add the general options
-        gen_opts = cmdoptions.make_option_group(
+        self.gen_opts = cmdoptions.make_option_group(
             cmdoptions.general_group,
             self.parser,
         )
-        self.parser.add_option_group(gen_opts)
+        self.parser.add_option_group(self.gen_opts)
 
     def _build_session(self, options, retries=None, timeout=None):
         session = PipSession(
@@ -132,6 +132,15 @@ class Command(object):
             root_level = "DEBUG"
 
         if options.help:
+            if not options.verbose:
+                # hide General Options
+                self.parser.epilog = "\nAdd '-v' flag to show general "\
+                                     "options.\n"
+                self.parser.option_groups.remove(self.gen_opts)
+
+                # 'pip --help' is handled by pip.__init__.parseopt(),
+                # so it is not affected by absence of --verbose
+
             self.print_help()
             sys.exit(0)
 

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -105,10 +105,25 @@ class Command(object):
         # factored out for testability
         return self.parser.parse_args(args)
 
-    def print_help(self):
-        # factored out for uniform handling
-        # of 'help <command>' and '<command> --help' cases
-        self.parser.print_help()
+    def print_help(self, verbose=False):
+        """
+        Process 'help <command>' and '<command> --help' to hide global
+        options unless --verbose flag is specified.
+
+        'pip --help' is handled separately by pip.__init__.parseopt()
+        """
+        if verbose:
+            self.parser.print_help()
+        else:
+            # remove General Options group and restore after print
+            saveepy = self.parser.epilog
+            saveogr = self.parser.option_groups  # it is a list
+            self.parser.epilog = "\nAdd '-v' flag to show general "\
+                                 "options.\n"
+            self.parser.option_groups.remove(self.gen_opts)
+            self.parser.print_help()
+            self.parser.epilog = saveepy
+            self.parser.option_groups = saveogr
 
     def main(self, args):
         options, args = self.parse_args(args)
@@ -132,16 +147,7 @@ class Command(object):
             root_level = "DEBUG"
 
         if options.help:
-            if not options.verbose:
-                # hide General Options
-                self.parser.epilog = "\nAdd '-v' flag to show general "\
-                                     "options.\n"
-                self.parser.option_groups.remove(self.gen_opts)
-
-                # 'pip --help' is handled by pip.__init__.parseopt(),
-                # so it is not affected by absence of --verbose
-
-            self.print_help()
+            self.print_help(options.verbose)
             sys.exit(0)
 
         logging.config.dictConfig({

--- a/pip/cmdoptions.py
+++ b/pip/cmdoptions.py
@@ -63,7 +63,7 @@ help_ = partial(
     Option,
     '-h', '--help',
     dest='help',
-    action='help',
+    action='store_true',
     help='Show help.')
 
 isolated_mode = partial(

--- a/pip/commands/help.py
+++ b/pip/commands/help.py
@@ -31,6 +31,6 @@ class HelpCommand(Command):
             raise CommandError(' - '.join(msg))
 
         command = commands_dict[cmd_name]()
-        command.parser.print_help()
+        command.print_help()
 
         return SUCCESS


### PR DESCRIPTION
Rebased #3319, which got bitrotten.

'list -h' help is too long to fit one screen, so this PR omits global options for subcommands help unless explicitly requested with --verbose flag.