### PR TITLE
Example for installation of multiple extras

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -801,6 +801,7 @@ Examples
       $ pip install git+https://git.repo/some_pkg.git#egg=SomePackage[PDF]
       $ pip install SomePackage[PDF]==3.0
       $ pip install -e .[PDF]==3.0  # editable project in current directory
+      $ pip install SomePackage[PDF,EPUB]  # multiple extras
 
 
 #. Install a particular source archive file.


### PR DESCRIPTION
Documention did not have an example for installation of multiple extras.
To the reader it is not clear if SomePackage[extra1,extra2] works or
SomePackage[extra1] SomePackage[extra2].

(Spoiler alert: Donald told me, it's SomePackage[extra1,extra2].)

Signed-off-by: Christian Heimes <christian@python.org>

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
