### PR TITLE
Deprecate SVN specific code based on dependency links

### DIFF
--- a/news/4449.removal
+++ b/news/4449.removal
@@ -1,0 +1,1 @@
+Deprecate SVN detection based on dependency links in ``pip freeze``.

--- a/pip/operations/freeze.py
+++ b/pip/operations/freeze.py
@@ -3,11 +3,13 @@ from __future__ import absolute_import
 import logging
 import os
 import re
+import warnings
 
 from pip.exceptions import InstallationError
 from pip.req import InstallRequirement
 from pip.req.req_file import COMMENT_RE
 from pip.utils import get_installed_distributions, dist_is_editable
+from pip.utils.deprecation import RemovedInPip11Warning
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.pkg_resources import RequirementParseError
@@ -193,6 +195,11 @@ class FrozenRequirement(object):
                         'for this package:'
                     )
                 else:
+                    warnings.warn(
+                        "SVN editable detection based on dependency links "
+                        "will be dropped in the future.",
+                        RemovedInPip11Warning,
+                    )
                     comments.append(
                         '# Installing as editable to satisfy requirement %s:' %
                         req


### PR DESCRIPTION
This seems to have around since forever (c2000d7de68 at least) for an
undocumented, untested and quite specific corner case based on the
deprecated dependency links.
