### PR TITLE
Don't assume master branch exists when reinstalling editable package from Git

### DIFF
--- a/news/4448.bugfix
+++ b/news/4448.bugfix
@@ -1,0 +1,2 @@
+Reinstalling an editable package from Git no longer assumes that the ``master``
+branch exists.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -132,7 +132,7 @@ class Git(VersionControl):
             rev_options = [rev]
             rev_display = ' (to %s)' % rev
         else:
-            rev_options = ['origin/master']
+            rev_options = ['refs/remotes/origin/HEAD']
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.info(

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -132,7 +132,7 @@ class Git(VersionControl):
             rev_options = [rev]
             rev_display = ' (to %s)' % rev
         else:
-            rev_options = ['refs/remotes/origin/HEAD']
+            rev_options = ['origin/HEAD']
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.info(

--- a/tests/functional/test_install_vcs.py
+++ b/tests/functional/test_install_vcs.py
@@ -270,7 +270,6 @@ def test_reinstalling_works_with_editible_non_master_branch(script):
         'install', '-e',
         '%s#egg=version_pkg' %
         ('git+file://' + version_pkg_path.abspath.replace('\\', '/')),
-        expect_stderr=True,
     )
     version = script.run('version_pkg')
     assert '0.1' in version.stdout
@@ -280,7 +279,6 @@ def test_reinstalling_works_with_editible_non_master_branch(script):
         'install', '-e',
         '%s#egg=version_pkg' %
         ('git+file://' + version_pkg_path.abspath.replace('\\', '/')),
-        expect_stderr=True,
     )
     version = script.run('version_pkg')
     assert 'some different version' in version.stdout


### PR DESCRIPTION
Fixes #4448, fixes #647.