### PR TITLE
Use SecureTransport on macOS

### DIFF
--- a/news/4454.bugfix
+++ b/news/4454.bugfix
@@ -1,0 +1,2 @@
+Fallback to using SecureTransport on macOS when the linked OpenSSL is too old to
+support TLSv1.2.

--- a/pip/__init__.py
+++ b/pip/__init__.py
@@ -20,6 +20,25 @@ import sys
 from pip._vendor.requests.packages.urllib3.exceptions import DependencyWarning
 warnings.filterwarnings("ignore", category=DependencyWarning)  # noqa
 
+# We want to inject the use of SecureTransport as early as possible so that any
+# references or sessions or what have you are ensured to have it, however we
+# only want to do this in the case that we're running on macOS and the linked
+# OpenSSL is too old to handle TLSv1.2
+try:
+    import ssl
+except ImportError:
+    pass
+else:
+    if (sys.platform == "darwin" and
+            ssl.OPENSSL_VERSION_NUMBER < 0x1000100f):  # OpenSSL 1.0.1
+        try:
+            from pip._vendor.requests.packages.urllib3.contrib import (
+                securetransport,
+            )
+        except (ImportError, OSError):
+            pass
+        else:
+            securetransport.inject_into_urllib3()
 
 from pip.exceptions import CommandError, PipError
 from pip.utils import get_installed_distributions, get_prog


### PR DESCRIPTION
The OpenSSL available on macOS is really old, so old in fact that in the future it will no longer be able to talk to PyPI. Thanks to the great work of @Lukasa we can utilize the SecureTransport library instead of OpenSSL which is new enough to support this.

Ideally this should not change any user visible behavior, but that cannot be guaranteed. In addition this really only matters for people using a Python that is linking against the system OpenSSL library, which is ``/usr/bin/python`` and Python.org prior to 3.6. Homebrew and Python.org 3.6+ installers use their own OpenSSL which is fine.

So that means we have a few options here:

* We can just unambiguously use SecureTransport on macOS to have guaranteed consistent behavior on all Python installs regardless of what OpenSSL they link to. The downside to this is that the securetransport bindings is written in ctypes (because we can't use a C compiler) and isn't as battle tested as the OpenSSL code so it may run into more errors. Obviously there is also a risk of behavior changing between OpenSSL and SecureTransport.
* We can detect if the OpenSSL is the ancient old one shipped by macOS and only enable the securetransport library in that case. The downside here is that if there are behavior diffrences, you can get different behaviors depending on if you're using a Python that links against the system OpenSSL or not. The upside is that if you're not using one of those Pythons linked against the system OpenSSL, then this PR is effectively a no-op for you.

Thoughts @pypa/pip-committers?

Note: This is a WIP because I pulled in the branch to test it, this wouldn't actually be merged until both urllib3 and requests are released.
