### PR TITLE
fix for 'pretend' and 'scripttest>=1.3' getting concatenated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ long_description = read('README.rst')
 tests_require = [
     'pytest',
     'mock',
-    'pretend'
+    'pretend',
     'scripttest>=1.3',
     'virtualenv>=1.10',
     'freezegun',


### PR DESCRIPTION
Basically a missing `,`