### PR TITLE
Travis CI - Updates and Additions (sorted imports)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ script: .travis/run.sh
 notifications:
   irc:
     channels:
+      # This is set to a secure variable to prevent forks from notifying the
+      # IRC channel whenever they fail a build. This can be removed when travis
+      # implements https://github.com/travis-ci/travis-ci/issues/1094.
+      # The actual value here is: irc.freenode.org#pypa-dev
       - secure: zAlwcmrDThlRsZz7CPDGpj4ABTzf7bc/zQXYtvIuqmSj0yJMAwsO5Vx/+qdTGYBvmW/oHw2s/uUgtkZzntSQiVQToKMag2fs0d3wV5bLJQUE2Si2jnH2JOQo3JZWSo9HOqL6WYmlKGI8lH9FVTdVLgpeJmIpLy1bN4zx4/TiJjc=
     skip_join: true
     use_notice: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,38 @@
 language: python
 
-
 matrix:
   include:
     - env: TOXENV=docs
     - env: TOXENV=pep8
     - env: TOXENV=py3pep8
     - env: TOXENV=packaging
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
-    - python: 3.6
-      env: TOXENV=py36
-    - python: nightly
-      env: TOXENV=py37
-    - python: pypy
-      env: TOXENV=pypy
-    - python: 2.7
-      env: TOXENV=py27 VENDOR=no WHEELS=yes
-    - python: 3.6
-      env: TOXENV=py36 VENDOR=no WHEELS=yes
-
+    - env: TOXENV=py27
+      python: 2.7
+    - env: TOXENV=py33
+      python: 3.3
+    - env: TOXENV=py34
+      python: 3.4
+    - env: TOXENV=py35
+      python: 3.5
+    - env: TOXENV=py36
+      python: 3.6
+    - env: TOXENV=py37
+      python: nightly
+    - env: TOXENV=pypy
+      python: pypy
+    - env: "TOXENV=py27 VENDOR=no WHEELS=yes"
+      python: 2.7
+    - env: "TOXENV=py36 VENDOR=no WHEELS=yes"
+      python: 3.6
   allow_failures:
     - python: nightly
 
-
 install: travis_retry .travis/install.sh
-
-
 script: .travis/run.sh
-
 
 notifications:
   irc:
     channels:
-      # This is set to a secure variable to prevent forks from notifying the
-      # IRC channel whenever they fail a build. This can be removed when travis
-      # implements https://github.com/travis-ci/travis-ci/issues/1094.
-      # The actual value here is: irc.freenode.org#pypa-dev
-      - secure: "zAlwcmrDThlRsZz7CPDGpj4ABTzf7bc/zQXYtvIuqmSj0yJMAwsO5Vx/+qdTGYBvmW/oHw2s/uUgtkZzntSQiVQToKMag2fs0d3wV5bLJQUE2Si2jnH2JOQo3JZWSo9HOqL6WYmlKGI8lH9FVTdVLgpeJmIpLy1bN4zx4/TiJjc="
-    use_notice: true
+      - secure: zAlwcmrDThlRsZz7CPDGpj4ABTzf7bc/zQXYtvIuqmSj0yJMAwsO5Vx/+qdTGYBvmW/oHw2s/uUgtkZzntSQiVQToKMag2fs0d3wV5bLJQUE2Si2jnH2JOQo3JZWSo9HOqL6WYmlKGI8lH9FVTdVLgpeJmIpLy1bN4zx4/TiJjc=
     skip_join: true
+    use_notice: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
-
 matrix:
   include:
     - env: TOXENV=docs
     - env: TOXENV=pep8
     - env: TOXENV=py3pep8
+    - env: TOXENV=isort
     - env: TOXENV=packaging
     - env: TOXENV=py27
       python: 2.7

--- a/pip/utils/appdirs.py
+++ b/pip/utils/appdirs.py
@@ -231,6 +231,7 @@ def _get_win_folder_with_ctypes(csidl_name):
 
     return buf.value
 
+
 if WINDOWS:
     try:
         import ctypes

--- a/pip/vcs/mercurial.py
+++ b/pip/vcs/mercurial.py
@@ -99,4 +99,5 @@ class Mercurial(VersionControl):
         """Always assume the versions don't match"""
         return False
 
+
 vcs.register(Mercurial)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+[isort]
+skip =
+    _vendor
+    __main__.py
+
 [tool:pytest]
 addopts = --ignore pip/_vendor --ignore tests/tests_cache
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,13 @@
 skip =
     _vendor
     __main__.py
+multi_line_output = 5
+known_third_party =
+    pip._vendor
+known_first_party =
+    pip
+    tests
+default_section = THIRDPARTY
 
 [tool:pytest]
 addopts = --ignore pip/_vendor --ignore tests/tests_cache

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands = flake8 .
 [testenv:isort]
 basepython = python3.3
 deps = isort==4.2.5
-commands = isort --recursive --check-only --skip _vendor --diff pip tests
+commands = isort --recursive --check-only --diff pip tests
 
 [flake8]
 exclude = .tox,*.egg,build,_vendor,data

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands = flake8 .
 [testenv:isort]
 basepython = python3.3
 deps = isort==4.2.5
-commands = isort --recursive --check-only --diff pip tests
+commands = isort --recursive --check-only --skip _vendor --diff pip tests
 
 [flake8]
 exclude = .tox,*.egg,build,_vendor,data

--- a/tox.ini
+++ b/tox.ini
@@ -26,17 +26,17 @@ commands =
     python setup.py check -m -r -s
 
 [testenv:pep8]
-basepython = python2.7
+basepython = python2
 deps = flake8==3.3.0
 commands = flake8 .
 
 [testenv:py3pep8]
-basepython = python3.3
+basepython = python3
 deps = flake8==3.3.0
 commands = flake8 .
 
 [testenv:isort]
-basepython = python3.3
+basepython = python3
 deps = isort==4.2.5
 commands = isort --recursive --check-only --diff pip tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    docs, packaging, pep8, py3pep8, py27, py33, py34, py35, py36, py37, pypy
+    docs, packaging, pep8, py3pep8, isort,
+    py27, py33, py34, py35, py36, py37, pypy
 
 [testenv]
 setenv =
@@ -33,6 +34,11 @@ commands = flake8 .
 basepython = python3.3
 deps = flake8==3.3.0
 commands = flake8 .
+
+[testenv:isort]
+basepython = python3.3
+deps = isort==4.2.5
+commands = isort --recursive --check-only --diff pip tests
 
 [flake8]
 exclude = .tox,*.egg,build,_vendor,data

--- a/tox.ini
+++ b/tox.ini
@@ -26,12 +26,12 @@ commands =
 
 [testenv:pep8]
 basepython = python2.7
-deps = flake8==2.3.0
+deps = flake8==3.3.0
 commands = flake8 .
 
 [testenv:py3pep8]
 basepython = python3.3
-deps = flake8==2.3.0
+deps = flake8==3.3.0
 commands = flake8 .
 
 [flake8]


### PR DESCRIPTION
Changes:
- Format the `.travis.yml` file
- Add a new import order checking job (using isort)
- Remove lock-down on minor version of the interpreter when linting.
- Update flake8 version

Other PRs that need to merge before this:
 - [x]  #4485 
 - [x] #4488
 - [x] #4520