### PR TITLE
Another attempt to fix encoding issues

### DIFF
--- a/docs/reference/pip.rst
+++ b/docs/reference/pip.rst
@@ -98,7 +98,7 @@ user if requested). In order to correctly read the build system output, pip
 requires that the output is written in a well-defined encoding, specifically
 the encoding the user has configured for text output (which can be obtained in
 Python using ``locale.getpreferredencoding``). If the configured encoding is
-ASCII, pip assumes UTF-8 (to match the behaviour of some Unix systems).
+ASCII, pip assumes UTF-8 (to account for the behaviour of some Unix systems).
 
 Build systems should ensure that any tools they invoke (compilers, etc) produce
 output in the correct encoding. In practice - and in particular on Windows,
@@ -106,7 +106,7 @@ where tools are inconsistent in their use of the "OEM" and "ANSI" codepages -
 this may not always be possible. Pip will therefore attempt to recover cleanly
 if presented with incorrectly encoded build tool output, by translating
 unexpected byte sequences to Python-style hexadecimal escape sequences
-(\x80\xff, etc). However, it is still possible for output to be displayed
+(``"\x80\xff"``, etc). However, it is still possible for output to be displayed
 using an incorrect encoding (mojibake).
 
 Future Developments

--- a/docs/reference/pip.rst
+++ b/docs/reference/pip.rst
@@ -90,6 +90,28 @@ before invoking ``setup.py``. The injection should be transparent to
 ``setup.py`` emulating the commands pip requires may need to be aware that it
 takes place.
 
+Build System Output
+~~~~~~~~~~~~~~~~~~~
+
+Any output produced by the build system will be read by pip (for display to
+the user if requested). In order to correctly read the build system output,
+pip requires that the output is written in a well-defined encoding:
+
+* On Windows, the build system must produce all output in the "OEM"
+  encoding.
+* On non-Windows systems, the build system should use the encoding
+  returned by python's ``locale.getpreferredencoding`` function, or
+  "utf8" if ``getpreferredencoding`` does not return a value.
+
+Build systems should ensure that any tools they invoke (compilers, etc)
+produce output in the correct encoding. In practice - and in particular
+on Windows, where tools are inconsistent in their use of the "OEM" and
+"ANSI" codepages - this may not always be possible, so pip will attempt to
+recover cleanly if presented with incorrectly encoded build tool output.
+However, pip cannot guarantee in that case that the displayed output will
+not be corrupted (mojibake, or characters replaced with the standard
+replacement character, often a question mark).
+
 Future Developments
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/reference/pip.rst
+++ b/docs/reference/pip.rst
@@ -96,18 +96,18 @@ Build System Output
 Any output produced by the build system will be read by pip (for display to the
 user if requested). In order to correctly read the build system output, pip
 requires that the output is written in a well-defined encoding, specifically
-the encoding returned by python's ``locale.getpreferredencoding`` function, or
-"utf8" if ``getpreferredencoding`` does not return a value (or returns "ASCII",
-which ).
+the encoding the user has configured for text output (which can be obtained in
+Python using ``locale.getpreferredencoding``). If the configured encoding is
+ASCII, pip assumes UTF-8 (to match the behaviour of some Unix systems).
 
-Build systems should ensure that any tools they invoke (compilers, etc)
-produce output in the correct encoding. In practice - and in particular
-on Windows, where tools are inconsistent in their use of the "OEM" and
-"ANSI" codepages - this may not always be possible, so pip will attempt to
-recover cleanly if presented with incorrectly encoded build tool output.
-However, pip cannot guarantee in that case that the displayed output will
-not be corrupted (mojibake, or characters replaced with the standard
-replacement character, often a question mark).
+Build systems should ensure that any tools they invoke (compilers, etc) produce
+output in the correct encoding. In practice - and in particular on Windows,
+where tools are inconsistent in their use of the "OEM" and "ANSI" codepages -
+this may not always be possible. Pip will therefore attempt to recover cleanly
+if presented with incorrectly encoded build tool output, by translating
+unexpected byte sequences to Python-style hexadecimal escape sequences
+(\x80\xff, etc). However, it is still possible for output to be displayed
+using an incorrect encoding (mojibake).
 
 Future Developments
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/reference/pip.rst
+++ b/docs/reference/pip.rst
@@ -93,15 +93,12 @@ takes place.
 Build System Output
 ~~~~~~~~~~~~~~~~~~~
 
-Any output produced by the build system will be read by pip (for display to
-the user if requested). In order to correctly read the build system output,
-pip requires that the output is written in a well-defined encoding:
-
-* On Windows, the build system must produce all output in the "OEM"
-  encoding.
-* On non-Windows systems, the build system should use the encoding
-  returned by python's ``locale.getpreferredencoding`` function, or
-  "utf8" if ``getpreferredencoding`` does not return a value.
+Any output produced by the build system will be read by pip (for display to the
+user if requested). In order to correctly read the build system output, pip
+requires that the output is written in a well-defined encoding, specifically
+the encoding returned by python's ``locale.getpreferredencoding`` function, or
+"utf8" if ``getpreferredencoding`` does not return a value (or returns "ASCII",
+which ).
 
 Build systems should ensure that any tools they invoke (compilers, etc)
 produce output in the correct encoding. In practice - and in particular

--- a/news/4486.bugfix
+++ b/news/4486.bugfix
@@ -1,1 +1,1 @@
-Improve handling of Unicode output from build tools under Python 3.
+Improve handling of text output from build tools (avoid Unicode errors)

--- a/news/4486.bugfix
+++ b/news/4486.bugfix
@@ -1,0 +1,1 @@
+Improve handling of Unicode output from build tools under Python 3.

--- a/pip/compat.py
+++ b/pip/compat.py
@@ -51,6 +51,9 @@ else:
     # backslash replacement for all versions.
     def backslashreplace_decode_fn(err):
         raw_bytes = (err.object[i] for i in range(err.start, err.end))
+        if sys.version_info[0] == 2:
+            # Python 2 gave us characters - convert to numeric bytes
+            raw_bytes = (ord(b) for b in raw_bytes)
         return u"".join(u"\\x%x" % c for c in raw_bytes), err.end
     codecs.register_error(
         "backslashreplace_decode",

--- a/pip/compat.py
+++ b/pip/compat.py
@@ -50,7 +50,7 @@ else:
     # situation, so that we can consistently use
     # backslash replacement for all versions.
     def backslashreplace_decode_fn(err):
-        raw_bytes = (ord(err.object[i]) for i in range(err.start, err.end))
+        raw_bytes = (err.object[i] for i in range(err.start, err.end))
         return u"".join(u"\\x%x" % c for c in raw_bytes), err.end
     codecs.register_error(
         "backslashreplace_decode",
@@ -80,7 +80,7 @@ def console_to_str(data):
     # decode with replacement.
     try:
         s = data.decode(encoding)
-    except UnicodeError:
+    except UnicodeDecodeError:
         logger.warning(
             "Subprocess output does not appear to be encoded as %s" %
             encoding)

--- a/pip/compat.py
+++ b/pip/compat.py
@@ -41,14 +41,22 @@ else:
         cache_from_source = None
 
 
-if sys.version_info > (3, 4):
+if sys.version_info >= (3, 5):
     backslashreplace_decode = "backslashreplace"
 else:
+    # In version 3.4 and older, backslashreplace exists
+    # but does not support use for decoding.
+    # We implement our own replace handler for this
+    # situation, so that we can consistently use
+    # backslash replacement for all versions.
     def backslashreplace_decode_fn(err):
         raw_bytes = (ord(err.object[i]) for i in range(err.start, err.end))
-        return u"".join(u"\\x%x" % c for c in raw_bytes), err.endP
-    codecs.register_error("backslashreplace_decode", backslashreplace_decode_fn)
+        return u"".join(u"\\x%x" % c for c in raw_bytes), err.end
+    codecs.register_error(
+        "backslashreplace_decode",
+        backslashreplace_decode_fn)
     backslashreplace_decode = "backslashreplace_decode"
+
 
 def console_to_str(data):
     """Return a string, safe for output, of subprocess output.

--- a/pip/compat.py
+++ b/pip/compat.py
@@ -41,6 +41,15 @@ else:
         cache_from_source = None
 
 
+if sys.version_info > (3, 4):
+    backslashreplace_decode = "backslashreplace"
+else:
+    def backslashreplace_decode_fn(err):
+        raw_bytes = (ord(err.object[i]) for i in range(err.start, err.end))
+        return u"".join(u"\\x%x" % c for c in raw_bytes), err.endP
+    codecs.register_error("backslashreplace_decode", backslashreplace_decode_fn)
+    backslashreplace_decode = "backslashreplace_decode"
+
 def console_to_str(data):
     """Return a string, safe for output, of subprocess output.
 
@@ -67,7 +76,7 @@ def console_to_str(data):
         logger.warning(
             "Subprocess output does not appear to be encoded as %s" %
             encoding)
-        s = data.decode(encoding, errors="replace")
+        s = data.decode(encoding, errors=backslashreplace_decode)
 
     # Make sure we can print the output, by encoding it to the output
     # encoding with replacement of unencodable characters, and then
@@ -78,7 +87,7 @@ def console_to_str(data):
     # that won't fail).
     output_encoding = sys.__stderr__.encoding
     if output_encoding:
-        s = s.encode(output_encoding, errors="replace")
+        s = s.encode(output_encoding, errors="backslashreplace")
         s = s.decode(output_encoding)
 
     return s


### PR DESCRIPTION
One more attempt to fix the various encoding issues we see. The main thing here is that we use the ```errors="replace"``` parameter when decoding subprocess output, so we should hopefully avoid many of the Unicode errors people are seeing.

There's also an attempt to choose (and document) a better encoding that we expect from build tools. There are known issues with this approach (see the comments under #4280) but it should at least improve things.

Partial fix for #4110, #4003, #4212, Note that this PR does *not* address any issues that are reported as happening on Python 2, this only changes Python 3 behaviour.