### PR TITLE
Mark network tests as flaky and do reruns on fail

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ freezegun
 pretend
 pytest
 pytest-catchlog
+pytest-rerunfailures
 pytest-timeout
 pytest-xdist
 mock<1.1

--- a/news/4492.trivial
+++ b/news/4492.trivial
@@ -1,0 +1,1 @@
+Re-Run network tests if they fail, up to 3 times

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,11 @@ def pytest_collection_modifyitems(items):
     for item in items:
         if not hasattr(item, 'module'):  # e.g.: DoctestTextfile
             continue
+
+        # Mark network tests as flaky
+        if item.get_marker('network') is not None:
+            item.add_marker(pytest.mark.flaky(reruns=3))
+
         module_path = os.path.relpath(
             item.module.__file__,
             os.path.commonprefix([__file__, item.module.__file__]),


### PR DESCRIPTION
An attempt to make CI builds more robust but this'll also make them run longer on average.