### PR TITLE
Try to build wheels for directories/VCS

### DIFF
--- a/news/4501.feature
+++ b/news/4501.feature
@@ -1,0 +1,3 @@
+Installing from a local directory or a VCS URL now builds a wheel to install,
+rather than running ``setup.py install``. Wheels from these sources are not
+cached.

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -88,5 +88,8 @@ class FreezeCommand(Command):
             skip=skip,
             exclude_editable=options.exclude_editable)
 
-        for line in freeze(**freeze_kwargs):
-            sys.stdout.write(line + '\n')
+        try:
+            for line in freeze(**freeze_kwargs):
+                sys.stdout.write(line + '\n')
+        finally:
+            wheel_cache.cleanup()

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -248,12 +248,12 @@ class InstallCommand(RequirementCommand):
                     progress_bar=options.progress_bar,
                 )
 
-                self.populate_requirement_set(
-                    requirement_set, args, options, finder, session, self.name,
-                    wheel_cache
-                )
-
                 try:
+                    self.populate_requirement_set(
+                        requirement_set, args, options, finder, session,
+                        self.name, wheel_cache
+                    )
+
                     if (not wheel or not options.cache_dir):
                         # on -d don't do complex things like building
                         # wheels, and don't try to build wheels when wheel is

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -152,12 +152,12 @@ class WheelCommand(RequirementCommand):
                     progress_bar=options.progress_bar
                 )
 
-                self.populate_requirement_set(
-                    requirement_set, args, options, finder, session, self.name,
-                    wheel_cache
-                )
-
                 try:
+                    self.populate_requirement_set(
+                        requirement_set, args, options, finder, session,
+                        self.name, wheel_cache
+                    )
+
                     # build wheels
                     wb = WheelBuilder(
                         requirement_set,

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -719,6 +719,9 @@ class RequirementSet(object):
             for req in self.reqs_to_cleanup:
                 req.remove_temporary_source()
 
+            if self._wheel_cache:
+                self._wheel_cache.cleanup()
+
     def _to_install(self):
         """Create the installation order.
 

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -62,7 +62,7 @@ class WheelCache(object):
         """
         self._cache_dir = expanduser(cache_dir) if cache_dir else None
         # Ephemeral cache: store wheels just for this run
-        self._ephem_cache_dir = tempfile.mkdtemp()
+        self._ephem_cache_dir = tempfile.mkdtemp(suffix='-pip-ephem-cache')
         self._format_control = format_control
 
     def cached_wheel(self, link, package_name):

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -71,7 +71,8 @@ class WheelCache(object):
             self._cache_dir, link, self._format_control, package_name)
         if link is orig_link:
             link = cached_wheel(
-                self._ephem_cache_dir, link, self._format_control, package_name)
+                self._ephem_cache_dir, link, self._format_control,
+                package_name)
         return link
 
     def cleanup(self):
@@ -890,11 +891,9 @@ class WheelBuilder(object):
                 python_tag = None
                 if autobuilding:
                     python_tag = pep425tags.implementation_tag
-                    if ephem:
-                        output_dir = _cache_for_link(self._ephem_cache_root,
-                                                     req.link)
-                    else:
-                        output_dir = _cache_for_link(self._cache_root, req.link)
+                    cache_root = (self._ephem_cache_root if ephem
+                                  else self._cache_root)
+                    output_dir = _cache_for_link(cache_root, req.link)
                     try:
                         ensure_dir(output_dir)
                     except OSError as e:

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -882,7 +882,7 @@ class WheelBuilder(object):
         # Build the wheels.
         logger.info(
             'Building wheels for collected packages: %s',
-            ', '.join([req.name for req in buildset]),
+            ', '.join([req.name for (req, _) in buildset]),
         )
         with indent_log():
             build_success, build_failure = [], []

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -61,11 +61,21 @@ class WheelCache(object):
             binaries being read from the cache.
         """
         self._cache_dir = expanduser(cache_dir) if cache_dir else None
+        # Ephemeral cache: store wheels just for this run
+        self._ephem_cache_dir = tempfile.mkdtemp()
         self._format_control = format_control
 
     def cached_wheel(self, link, package_name):
-        return cached_wheel(
+        orig_link = link
+        link = cached_wheel(
             self._cache_dir, link, self._format_control, package_name)
+        if link is orig_link:
+            link = cached_wheel(
+                self._ephem_cache_dir, link, self._format_control, package_name)
+        return link
+
+    def cleanup(self):
+        rmtree(self._ephem_cache_dir)
 
 
 def _cache_for_link(cache_dir, link):
@@ -693,6 +703,7 @@ class WheelBuilder(object):
         self.requirement_set = requirement_set
         self.finder = finder
         self._cache_root = requirement_set._wheel_cache._cache_dir
+        self._ephem_cache_root = requirement_set._wheel_cache._ephem_cache_dir
         self._wheel_dir = requirement_set.wheel_download_dir
         self.build_options = build_options or []
         self.global_options = global_options or []
@@ -835,6 +846,7 @@ class WheelBuilder(object):
 
         buildset = []
         for req in reqset:
+            ephem_cache = False
             if req.constraint:
                 continue
             if req.is_wheel:
@@ -844,7 +856,8 @@ class WheelBuilder(object):
             elif autobuilding and req.editable:
                 pass
             elif autobuilding and req.link and not req.link.is_artifact:
-                pass
+                # VCS checkout. Build wheel just for this run.
+                ephem_cache = True
             elif autobuilding and not req.source_dir:
                 pass
             else:
@@ -852,17 +865,16 @@ class WheelBuilder(object):
                     link = req.link
                     base, ext = link.splitext()
                     if pip.index.egg_info_matches(base, None, link) is None:
-                        # Doesn't look like a package - don't autobuild a wheel
-                        # because we'll have no way to lookup the result sanely
-                        continue
-                    if "binary" not in pip.index.fmt_ctl_formats(
+                        # E.g. local directory. Build wheel just for this run.
+                        ephem_cache = True
+                    elif "binary" not in pip.index.fmt_ctl_formats(
                             self.finder.format_control,
                             canonicalize_name(req.name)):
                         logger.info(
                             "Skipping bdist_wheel for %s, due to binaries "
                             "being disabled for it.", req.name)
                         continue
-                buildset.append(req)
+                buildset.append((req, ephem_cache))
 
         if not buildset:
             return True
@@ -874,11 +886,15 @@ class WheelBuilder(object):
         )
         with indent_log():
             build_success, build_failure = [], []
-            for req in buildset:
+            for req, ephem in buildset:
                 python_tag = None
                 if autobuilding:
                     python_tag = pep425tags.implementation_tag
-                    output_dir = _cache_for_link(self._cache_root, req.link)
+                    if ephem:
+                        output_dir = _cache_for_link(self._ephem_cache_root,
+                                                     req.link)
+                    else:
+                        output_dir = _cache_for_link(self._cache_root, req.link)
                     try:
                         ensure_dir(output_dir)
                     except OSError as e:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1005,16 +1005,15 @@ def test_install_no_binary_disables_building_wheels(script, data):
         wheels.extend(files)
     # and built wheels for wheelbroken only
     assert "Running setup.py bdist_wheel for wheelb" in str(res), str(res)
-    # But not requires_wheel... which is a local dir and thus uncachable.
-    assert "Running setup.py bdist_wheel for requir" not in str(res), str(res)
+    # Wheels are built for local directories, but not cached
+    assert "Running setup.py bdist_wheel for requir" in str(res), str(res)
     # Nor upper, which was blacklisted
     assert "Running setup.py bdist_wheel for upper" not in str(res), str(res)
     # wheelbroken has to run install
     # into the cache
     assert wheels != [], str(res)
-    # the local tree can't build a wheel (because we can't assume that every
-    # build will have a suitable unique key to cache on).
-    assert "Running setup.py install for requires-wheel" in str(res), str(res)
+    # Wheels are built for local directories, but not cached
+    assert "Running setup.py install for requir" not in str(res), str(res)
     # And these two fell back to sdist based installed.
     assert "Running setup.py install for wheelb" in str(res), str(res)
     assert "Running setup.py install for upper" in str(res), str(res)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -970,16 +970,15 @@ def test_install_builds_wheels(script, data):
     # and built wheels for upper and wheelbroken
     assert "Running setup.py bdist_wheel for upper" in str(res), str(res)
     assert "Running setup.py bdist_wheel for wheelb" in str(res), str(res)
-    # But not requires_wheel... which is a local dir and thus uncachable.
-    assert "Running setup.py bdist_wheel for requir" not in str(res), str(res)
+    # Wheels are built for local directories, but not cached.
+    assert "Running setup.py bdist_wheel for requir" in str(res), str(res)
     # wheelbroken has to run install
     # into the cache
     assert wheels != [], str(res)
     # and installed from the wheel
     assert "Running setup.py install for upper" not in str(res), str(res)
-    # the local tree can't build a wheel (because we can't assume that every
-    # build will have a suitable unique key to cache on).
-    assert "Running setup.py install for requires-wheel" in str(res), str(res)
+    # Wheels are built for local directories, but not cached.
+    assert "Running setup.py install for requir" not in str(res), str(res)
     # wheelbroken has to run install
     assert "Running setup.py install for wheelb" in str(res), str(res)
     # We want to make sure we used the correct implementation tag

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -131,7 +131,7 @@ def test_cleanup_prevented_upon_build_dir_exception(script, data):
     result = script.pip(
         'install', '-f', data.find_links, '--no-index', 'simple',
         '--build', build,
-        expect_error=True,
+        expect_error=True, expect_temp=True,
     )
 
     assert result.returncode == PREVIOUS_BUILD_DIR_ERROR

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -29,7 +29,7 @@ def test_no_clean_option_blocks_cleaning_after_install(script, data):
     build = script.base_path / 'pip-build'
     script.pip(
         'install', '--no-clean', '--no-index', '--build', build,
-        '--find-links=%s' % data.find_links, 'simple',
+        '--find-links=%s' % data.find_links, 'simple', expect_temp=True,
     )
     assert exists(build)
 

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -79,12 +79,12 @@ class Tests_UserSite:
             expect_error=False,
         )
         fspkg_folder = script.user_site / 'fspkg'
-        egg_info_folder = (
-            script.user_site / 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
+        dist_info_folder = (
+            script.user_site / 'FSPkg-0.1.dev0.dist-info' % pyversion
         )
         assert fspkg_folder in result.files_created, result.stdout
 
-        assert egg_info_folder in result.files_created
+        assert dist_info_folder in result.files_created
 
     def test_install_user_venv_nositepkgs_fails(self, script, data):
         """

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -80,7 +80,7 @@ class Tests_UserSite:
         )
         fspkg_folder = script.user_site / 'fspkg'
         dist_info_folder = (
-            script.user_site / 'FSPkg-0.1.dev0.dist-info' % pyversion
+            script.user_site / 'FSPkg-0.1.dev0.dist-info'
         )
         assert fspkg_folder in result.files_created, result.stdout
 

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -67,11 +67,13 @@ class Tests_UserSite:
         )
         result.assert_installed('INITools', use_user_site=True)
 
+    @pytest.mark.network
     def test_install_curdir_usersite(self, script, virtualenv, data):
         """
         Test installing current directory ('.') into usersite
         """
         virtualenv.system_site_packages = True
+        script.pip("install", "wheel")
         run_from = data.packages.join("FSPkg")
         result = script.pip(
             'install', '-vvv', '--user', curdir,

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -189,7 +189,7 @@ def test_pip_wheel_fail_cause_of_previous_build_dir(script, data):
     result = script.pip(
         'wheel', '--no-index', '--find-links=%s' % data.find_links,
         '--build', script.venv_path / 'build',
-        'simple==3.0', expect_error=True,
+        'simple==3.0', expect_error=True, expect_temp=True,
     )
 
     # Then I see that the error code is the right one


### PR DESCRIPTION
Follow up from gh-4144

To allow build system abstractions, we want installation to go through wheels in more cases. In particular, installing packages from a local directory or a VCS URL currently runs 'setup.py install'. The aim of this PR is to have it build a wheel, which is stored in an ephemeral cache directory, used for installation, and then discarded.

We can't cache it permanently based on the path/URL, because the code there might change, but our cache wouldn't be invalidated.
