### PR TITLE
Update uninstall tests to cover pkgutil namespace packages

### DIFF
--- a/tests/data/src/pkgutil-namespace-pkgs/pkg_a/example_pkg/__init__.py
+++ b/tests/data/src/pkgutil-namespace-pkgs/pkg_a/example_pkg/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/tests/data/src/pkgutil-namespace-pkgs/pkg_a/example_pkg/a/__init__.py
+++ b/tests/data/src/pkgutil-namespace-pkgs/pkg_a/example_pkg/a/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name = 'a'

--- a/tests/data/src/pkgutil-namespace-pkgs/pkg_a/setup.py
+++ b/tests/data/src/pkgutil-namespace-pkgs/pkg_a/setup.py
@@ -1,0 +1,32 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import setup, find_packages
+
+
+setup(
+    name='example_pkg_a',
+
+    version='1',
+
+    description='',
+    long_description='',
+
+    author='Jon Wayne Parrott',
+    author_email='jonwayne@google.com',
+
+    license='Apache Software License',
+
+    packages=find_packages(),
+)

--- a/tests/data/src/pkgutil-namespace-pkgs/pkg_b/example_pkg/__init__.py
+++ b/tests/data/src/pkgutil-namespace-pkgs/pkg_b/example_pkg/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/tests/data/src/pkgutil-namespace-pkgs/pkg_b/example_pkg/b/__init__.py
+++ b/tests/data/src/pkgutil-namespace-pkgs/pkg_b/example_pkg/b/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name = 'b'

--- a/tests/data/src/pkgutil-namespace-pkgs/pkg_b/setup.py
+++ b/tests/data/src/pkgutil-namespace-pkgs/pkg_b/setup.py
@@ -1,0 +1,32 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import setup, find_packages
+
+
+setup(
+    name='example_pkg_b',
+
+    version='1',
+
+    description='',
+    long_description='',
+
+    author='Jon Wayne Parrott',
+    author_email='jonwayne@google.com',
+
+    license='Apache Software License',
+
+    packages=find_packages(),
+)


### PR DESCRIPTION
See https://github.com/pypa/python-packaging-user-guide/issues/314

This PR is mostly just to demonstrate that this case fails because pip uninstalls the namespace package's `__init__.py` file. I can try to fix this behavior, but I'm hoping someone else can be kind enough to take that on.