### PR TITLE
Allow download with specific platform and --no-deps

### DIFF
--- a/docs/reference/pip_download.rst
+++ b/docs/reference/pip_download.rst
@@ -28,8 +28,8 @@ directory). This directory can later be passed as the value to ``pip install
 ``pip download`` with the ``--platform``, ``--python-version``,
 ``--implementation``, and ``--abi`` options provides the ability to fetch
 dependencies for an interpreter and system other than the ones that pip is
-running on. ``--only-binary=:all:`` is required when using any of these
-options. It is important to note that these options all default to the
+running on. ``--only-binary=:all:`` or ``--no-deps`` is required when using any
+of these options. It is important to note that these options all default to the
 current system/interpreter, and not to the most restrictive constraints (e.g.
 platform any, abi none, etc). To avoid fetching dependencies that happen to
 match the constraint of the current interpreter (but not your target one), it

--- a/news/4289.feature
+++ b/news/4289.feature
@@ -1,0 +1,2 @@
+Allow ``pip download`` to be used with a specific platform when ``--no-deps`` is
+set.

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -139,12 +139,17 @@ class DownloadCommand(RequirementCommand):
             options.implementation,
         ])
         binary_only = FormatControl(set(), {':all:'})
-        if dist_restriction_set and options.format_control != binary_only:
+        no_sdist_dependencies = (
+            options.format_control != binary_only and
+            not options.ignore_dependencies
+        )
+        if dist_restriction_set and no_sdist_dependencies:
             raise CommandError(
-                "--only-binary=:all: must be set and --no-binary must not "
-                "be set (or must be set to :none:) when restricting platform "
-                "and interpreter constraints using --python-version, "
-                "--platform, --abi, or --implementation."
+                "When restricting platform and interpreter constraints using "
+                "--python-version, --platform, --abi, or --implementation, "
+                "either --no-deps must be set, or --only-binary=:all: must be "
+                "set and --no-binary must not be set (or must be set to "
+                ":none:)."
             )
 
         options.src_dir = os.path.abspath(options.src_dir)

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -167,10 +167,10 @@ def test_download_vcs_link(script):
     assert script.site_packages / 'piptestpackage' not in result.files_created
 
 
-def test_download_specify_platform_only_binary(script, data):
+def test_only_binary_set_then_download_specific_platform(script, data):
     """
     Confirm that specifying an interpreter/platform constraint
-    enforces that ``--only-binary=:all:`` is set.
+    is allowed when ``--only-binary=:all:`` is set.
     """
     fake_wheel(data, 'fake-1.0-py2.py3-none-any.whl')
 
@@ -186,6 +186,14 @@ def test_download_specify_platform_only_binary(script, data):
         in result.files_created
     )
 
+
+def test_not_only_binary_then_download_specific_platform_fails(script, data):
+    """
+    Confirm that specifying an interpreter/platform constraint
+    enforces that ``--only-binary=:all:`` is set.
+    """
+    fake_wheel(data, 'fake-1.0-py2.py3-none-any.whl')
+
     result = script.pip(
         'download', '--no-index', '--find-links', data.find_links,
         '--dest', '.',
@@ -194,6 +202,14 @@ def test_download_specify_platform_only_binary(script, data):
         expect_error=True,
     )
     assert '--only-binary=:all:' in result.stderr
+
+
+def test_no_binary_set_then_download_specific_platform_fails(script, data):
+    """
+    Confirm that specifying an interpreter/platform constraint
+    enforces that ``--only-binary=:all:`` is set without ``--no-binary``.
+    """
+    fake_wheel(data, 'fake-1.0-py2.py3-none-any.whl')
 
     result = script.pip(
         'download', '--no-index', '--find-links', data.find_links,

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -187,10 +187,30 @@ def test_only_binary_set_then_download_specific_platform(script, data):
     )
 
 
-def test_not_only_binary_then_download_specific_platform_fails(script, data):
+def test_no_deps_set_then_download_specific_platform(script, data):
     """
     Confirm that specifying an interpreter/platform constraint
-    enforces that ``--only-binary=:all:`` is set.
+    is allowed when ``--no-deps`` is set.
+    """
+    fake_wheel(data, 'fake-1.0-py2.py3-none-any.whl')
+
+    result = script.pip(
+        'download', '--no-index', '--find-links', data.find_links,
+        '--no-deps',
+        '--dest', '.',
+        '--platform', 'linux_x86_64',
+        'fake'
+    )
+    assert (
+        Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
+        in result.files_created
+    )
+
+
+def test_download_specific_platform_fails(script, data):
+    """
+    Confirm that specifying an interpreter/platform constraint
+    enforces that ``--no-deps`` or ``--only-binary=:all:`` is set.
     """
     fake_wheel(data, 'fake-1.0-py2.py3-none-any.whl')
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -197,15 +197,6 @@ def test_download_specify_platform_only_binary(script, data):
 
     result = script.pip(
         'download', '--no-index', '--find-links', data.find_links,
-        '--dest', '.',
-        '--platform', 'linux_x86_64',
-        'fake',
-        expect_error=True,
-    )
-    assert '--only-binary=:all:' in result.stderr
-
-    result = script.pip(
-        'download', '--no-index', '--find-links', data.find_links,
         '--only-binary=:all:',
         '--no-binary=fake',
         '--dest', '.',


### PR DESCRIPTION
Addresses #4289: allow a specific platform when calling `pip download` when `--no-deps` is set. I only touched the code that checked the arguments before actually starting the download, meaning that `setup.py egg_info` is still called when `--no-deps` is set. This might cause some issues if the `setup.py` checks the platform for something other than dependencies. Is this something worth addressing (assuming that this change is sensible in the first place)?

This doesn't fully address #4289, but given that `setup.py` needs to be run to find dependencies for sdists, it seems to me that this is the best that can be done.