### PR TITLE
Only apply re-runs marker on CI runs

### DIFF
--- a/news/4541.trivial
+++ b/news/4541.trivial
@@ -1,0 +1,1 @@
+Re-Run tests only on CI

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def pytest_collection_modifyitems(items):
             continue
 
         # Mark network tests as flaky
-        if item.get_marker('network') is not None:
+        if item.get_marker('network') is not None and "CI" in os.environ:
             item.add_marker(pytest.mark.flaky(reruns=3))
 
         module_path = os.path.relpath(


### PR DESCRIPTION
On local systems, it's easy enough to re-run the test failures - it doesn't need to automatically happen.

We intended to re-run tests only on CI anyway. This actually does exactly that.