### PR TITLE
From RequirementSet to Resolver - Part 1

### DIFF
--- a/news/4546.trivial
+++ b/news/4546.trivial
@@ -1,0 +1,1 @@
+Move attributes from RequirementSet to Resolver

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -297,6 +297,9 @@ class RequirementCommand(Command):
                     finder=finder, options=options, session=session,
                     wheel_cache=wheel_cache):
                 requirement_set.add_requirement(req)
+        # If --require-hashes was a line in a requirements file, tell
+        # RequirementSet about it:
+        requirement_set.require_hashes = options.require_hashes
 
         if not (args or options.editables or options.requirements):
             opts = {'name': name}

--- a/pip/basecommand.py
+++ b/pip/basecommand.py
@@ -19,7 +19,6 @@ from pip.exceptions import (
 from pip.index import PackageFinder
 from pip.locations import running_under_virtualenv
 from pip.req import InstallRequirement, parse_requirements
-from pip.resolve import Resolver
 from pip.status_codes import (
     ERROR, PREVIOUS_BUILD_DIR_ERROR, SUCCESS, UNKNOWN_ERROR,
     VIRTUALENV_NOT_FOUND
@@ -266,6 +265,8 @@ class RequirementCommand(Command):
         """
         Marshal cmd line args into a requirement set.
         """
+        # NOTE: As a side-effect, options.require_hashes may be updated
+
         for filename in options.constraints:
             for req in parse_requirements(
                     filename,
@@ -296,9 +297,6 @@ class RequirementCommand(Command):
                     finder=finder, options=options, session=session,
                     wheel_cache=wheel_cache):
                 requirement_set.add_requirement(req)
-        # If --require-hashes was a line in a requirements file, tell
-        # RequirementSet about it:
-        requirement_set.require_hashes = options.require_hashes
 
         if not (args or options.editables or options.requirements):
             opts = {'name': name}
@@ -352,15 +350,4 @@ class RequirementCommand(Command):
             versions=python_versions,
             abi=abi,
             implementation=implementation,
-        )
-
-    def _build_resolver(self, options, finder):
-        strategy = getattr(options, "upgrade_strategy", "not-allowed")
-        upgrade = getattr(options, "upgrade", False)
-        if not upgrade:
-            strategy = "not-allowed"
-
-        return Resolver(
-            upgrade_strategy=strategy,
-            finder=finder,
         )

--- a/pip/commands/download.py
+++ b/pip/commands/download.py
@@ -181,6 +181,7 @@ class DownloadCommand(RequirementCommand):
                     src_dir=options.src_dir,
                     download_dir=options.download_dir,
                     require_hashes=options.require_hashes,
+                    progress_bar=options.progress_bar,
                 )
                 self.populate_requirement_set(
                     requirement_set,
@@ -202,7 +203,6 @@ class DownloadCommand(RequirementCommand):
                     ignore_requires_python=False,
                     ignore_installed=True,
                     isolated=options.isolated_mode,
-                    progress_bar=options.progress_bar,
                 )
                 resolver.resolve(requirement_set)
 

--- a/pip/commands/download.py
+++ b/pip/commands/download.py
@@ -196,7 +196,7 @@ class DownloadCommand(RequirementCommand):
                     finder=finder,
                     session=session,
                     use_user_site=False,
-                    upgrade_strategy="not-allowed",
+                    upgrade_strategy="to-satisfy-only",
                     force_reinstall=False,
                     ignore_dependencies=options.ignore_dependencies,
                     ignore_requires_python=False,

--- a/pip/commands/download.py
+++ b/pip/commands/download.py
@@ -180,7 +180,7 @@ class DownloadCommand(RequirementCommand):
                     build_dir=directory.path,
                     src_dir=options.src_dir,
                     download_dir=options.download_dir,
-                    require_hashes=options.require_hashes
+                    require_hashes=options.require_hashes,
                 )
                 self.populate_requirement_set(
                     requirement_set,

--- a/pip/commands/download.py
+++ b/pip/commands/download.py
@@ -8,6 +8,7 @@ from pip.basecommand import RequirementCommand
 from pip.exceptions import CommandError
 from pip.index import FormatControl
 from pip.req import RequirementSet
+from pip.resolve import Resolver
 from pip.utils import ensure_dir, normalize_path
 from pip.utils.filesystem import check_path_owner
 from pip.utils.temp_dir import TempDirectory
@@ -179,12 +180,7 @@ class DownloadCommand(RequirementCommand):
                     build_dir=directory.path,
                     src_dir=options.src_dir,
                     download_dir=options.download_dir,
-                    ignore_installed=True,
-                    ignore_dependencies=options.ignore_dependencies,
-                    session=session,
-                    isolated=options.isolated_mode,
-                    require_hashes=options.require_hashes,
-                    progress_bar=options.progress_bar
+                    require_hashes=options.require_hashes
                 )
                 self.populate_requirement_set(
                     requirement_set,
@@ -196,7 +192,18 @@ class DownloadCommand(RequirementCommand):
                     None
                 )
 
-                resolver = self._build_resolver(options, finder)
+                resolver = Resolver(
+                    finder=finder,
+                    session=session,
+                    use_user_site=False,
+                    upgrade_strategy="not-allowed",
+                    force_reinstall=False,
+                    ignore_dependencies=options.ignore_dependencies,
+                    ignore_requires_python=False,
+                    ignore_installed=True,
+                    isolated=options.isolated_mode,
+                    progress_bar=options.progress_bar,
+                )
                 resolver.resolve(requirement_set)
 
                 downloaded = ' '.join([

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -246,6 +246,7 @@ class InstallCommand(RequirementCommand):
                     pycompile=options.compile,
                     wheel_cache=wheel_cache,
                     require_hashes=options.require_hashes,
+                    use_user_site=options.use_user_site,
                 )
 
                 self.populate_requirement_set(

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -14,6 +14,7 @@ from pip.exceptions import (
 )
 from pip.locations import distutils_scheme, virtualenv_no_global
 from pip.req import RequirementSet
+from pip.resolve import Resolver
 from pip.status_codes import ERROR
 from pip.utils import ensure_dir, get_installed_version
 from pip.utils.filesystem import check_path_owner
@@ -179,6 +180,10 @@ class InstallCommand(RequirementCommand):
     def run(self, options, args):
         cmdoptions.check_install_build_global(options)
 
+        upgrade_strategy = "not-allowed"
+        if options.upgrade:
+            upgrade_strategy = options.upgrade_strategy
+
         if options.build_dir:
             options.build_dir = os.path.abspath(options.build_dir)
 
@@ -235,22 +240,9 @@ class InstallCommand(RequirementCommand):
                 options.build_dir, delete=build_delete, kind="install"
             ) as directory:
                 requirement_set = RequirementSet(
-                    build_dir=directory.path,
-                    src_dir=options.src_dir,
-                    upgrade=options.upgrade,
-                    upgrade_strategy=options.upgrade_strategy,
-                    ignore_installed=options.ignore_installed,
-                    ignore_dependencies=options.ignore_dependencies,
-                    ignore_requires_python=options.ignore_requires_python,
-                    force_reinstall=options.force_reinstall,
-                    use_user_site=options.use_user_site,
                     target_dir=target_temp_dir.path,
-                    session=session,
                     pycompile=options.compile,
-                    isolated=options.isolated_mode,
                     wheel_cache=wheel_cache,
-                    require_hashes=options.require_hashes,
-                    progress_bar=options.progress_bar,
                 )
 
                 self.populate_requirement_set(
@@ -259,7 +251,21 @@ class InstallCommand(RequirementCommand):
                 )
 
                 try:
-                    resolver = self._build_resolver(options, finder)
+                    resolver = Resolver(
+                        build_dir=directory.path,
+                        src_dir=options.src_dir,
+                        finder=finder,
+                        session=session,
+                        use_user_site=options.use_user_site,
+                        upgrade_strategy=upgrade_strategy,
+                        force_reinstall=options.force_reinstall,
+                        ignore_dependencies=options.ignore_dependencies,
+                        ignore_requires_python=options.ignore_requires_python,
+                        ignore_installed=options.ignore_installed,
+                        isolated=options.isolated_mode,
+                        require_hashes=options.require_hashes,
+                        progress_bar=options.progress_bar,
+                    )
                     resolver.resolve(requirement_set)
 
                     # on -d don't do complex things like building
@@ -275,7 +281,9 @@ class InstallCommand(RequirementCommand):
                         )
                         # Ignore the result: a failed wheel will be
                         # installed from the sdist/vcs whatever.
-                        wb.build(autobuilding=True)
+                        wb.build(
+                            session, src_dir=directory.path, autobuilding=True
+                        )
 
                     requirement_set.install(
                         install_options,

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -247,6 +247,7 @@ class InstallCommand(RequirementCommand):
                     wheel_cache=wheel_cache,
                     require_hashes=options.require_hashes,
                     use_user_site=options.use_user_site,
+                    progress_bar=options.progress_bar,
                 )
 
                 self.populate_requirement_set(
@@ -265,7 +266,6 @@ class InstallCommand(RequirementCommand):
                         ignore_requires_python=options.ignore_requires_python,
                         ignore_installed=options.ignore_installed,
                         isolated=options.isolated_mode,
-                        progress_bar=options.progress_bar,
                     )
                     resolver.resolve(requirement_set)
 

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -281,9 +281,7 @@ class InstallCommand(RequirementCommand):
                         )
                         # Ignore the result: a failed wheel will be
                         # installed from the sdist/vcs whatever.
-                        wb.build(
-                            session, autobuilding=True
-                        )
+                        wb.build(session=session, autobuilding=True)
 
                     requirement_set.install(
                         install_options,

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -240,9 +240,12 @@ class InstallCommand(RequirementCommand):
                 options.build_dir, delete=build_delete, kind="install"
             ) as directory:
                 requirement_set = RequirementSet(
+                    build_dir=directory.path,
+                    src_dir=options.src_dir,
                     target_dir=target_temp_dir.path,
                     pycompile=options.compile,
                     wheel_cache=wheel_cache,
+                    require_hashes=options.require_hashes,
                 )
 
                 self.populate_requirement_set(
@@ -252,8 +255,6 @@ class InstallCommand(RequirementCommand):
 
                 try:
                     resolver = Resolver(
-                        build_dir=directory.path,
-                        src_dir=options.src_dir,
                         finder=finder,
                         session=session,
                         use_user_site=options.use_user_site,
@@ -263,7 +264,6 @@ class InstallCommand(RequirementCommand):
                         ignore_requires_python=options.ignore_requires_python,
                         ignore_installed=options.ignore_installed,
                         isolated=options.isolated_mode,
-                        require_hashes=options.require_hashes,
                         progress_bar=options.progress_bar,
                     )
                     resolver.resolve(requirement_set)
@@ -282,7 +282,7 @@ class InstallCommand(RequirementCommand):
                         # Ignore the result: a failed wheel will be
                         # installed from the sdist/vcs whatever.
                         wb.build(
-                            session, src_dir=directory.path, autobuilding=True
+                            session, autobuilding=True
                         )
 
                     requirement_set.install(

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -180,7 +180,7 @@ class InstallCommand(RequirementCommand):
     def run(self, options, args):
         cmdoptions.check_install_build_global(options)
 
-        upgrade_strategy = "not-allowed"
+        upgrade_strategy = "to-satisfy-only"
         if options.upgrade:
             upgrade_strategy = options.upgrade_strategy
 

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -9,6 +9,7 @@ from pip.basecommand import RequirementCommand
 from pip.cache import WheelCache
 from pip.exceptions import CommandError, PreviousBuildDirError
 from pip.req import RequirementSet
+from pip.resolve import Resolver
 from pip.utils import import_or_raise
 from pip.utils.temp_dir import TempDirectory
 from pip.wheel import WheelBuilder
@@ -144,15 +145,9 @@ class WheelCommand(RequirementCommand):
                     build_dir=directory.path,
                     src_dir=options.src_dir,
                     download_dir=None,
-                    ignore_dependencies=options.ignore_dependencies,
-                    ignore_installed=True,
-                    ignore_requires_python=options.ignore_requires_python,
-                    isolated=options.isolated_mode,
-                    session=session,
                     wheel_cache=wheel_cache,
                     wheel_download_dir=options.wheel_dir,
-                    require_hashes=options.require_hashes,
-                    progress_bar=options.progress_bar
+                    require_hashes=options.require_hashes
                 )
 
                 self.populate_requirement_set(
@@ -160,7 +155,19 @@ class WheelCommand(RequirementCommand):
                     wheel_cache
                 )
 
-                resolver = self._build_resolver(options, finder)
+
+                resolver = Resolver(
+                    finder=finder,
+                    session=session,
+                    use_user_site=False,
+                    upgrade_strategy="not-allowed",
+                    force_reinstall=False,
+                    ignore_dependencies=options.ignore_dependencies,
+                    ignore_requires_python=options.ignore_requires_python,
+                    ignore_installed=True,
+                    isolated=options.isolated_mode,
+                    progress_bar=options.progress_bar,
+                )
                 resolver.resolve(requirement_set)
 
                 try:

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -159,7 +159,7 @@ class WheelCommand(RequirementCommand):
                     finder=finder,
                     session=session,
                     use_user_site=False,
-                    upgrade_strategy="not-allowed",
+                    upgrade_strategy="to-satisfy-only",
                     force_reinstall=False,
                     ignore_dependencies=options.ignore_dependencies,
                     ignore_requires_python=options.ignore_requires_python,

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -147,7 +147,8 @@ class WheelCommand(RequirementCommand):
                     download_dir=None,
                     wheel_cache=wheel_cache,
                     wheel_download_dir=options.wheel_dir,
-                    require_hashes=options.require_hashes
+                    require_hashes=options.require_hashes,
+                    progress_bar=options.progress_bar,
                 )
 
                 self.populate_requirement_set(
@@ -165,7 +166,6 @@ class WheelCommand(RequirementCommand):
                     ignore_requires_python=options.ignore_requires_python,
                     ignore_installed=True,
                     isolated=options.isolated_mode,
-                    progress_bar=options.progress_bar,
                 )
                 resolver.resolve(requirement_set)
 

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -172,10 +172,7 @@ class WheelCommand(RequirementCommand):
                         global_options=options.global_options or [],
                         no_clean=options.no_clean,
                     )
-                    wheels_built_successfully = wb.build(
-                        # Names are a little messed up
-                        session=session, src_dir=resolver.build_dir
-                    )
+                    wheels_built_successfully = wb.build(session=session)
                     if not wheels_built_successfully:
                         raise CommandError(
                             "Failed to build one or more wheels"

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -155,7 +155,6 @@ class WheelCommand(RequirementCommand):
                     wheel_cache
                 )
 
-
                 resolver = Resolver(
                     finder=finder,
                     session=session,

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -172,7 +172,11 @@ class WheelCommand(RequirementCommand):
                         global_options=options.global_options or [],
                         no_clean=options.no_clean,
                     )
-                    if not wb.build():
+                    wheels_built_successfully = wb.build(
+                        # Names are a little messed up
+                        session=session, src_dir=resolver.build_dir
+                    )
+                    if not wheels_built_successfully:
                         raise CommandError(
                             "Failed to build one or more wheels"
                         )

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -43,61 +43,36 @@ class Requirements(object):
 
 class RequirementSet(object):
 
-    def __init__(self, build_dir, src_dir, download_dir=None, upgrade=False,
-                 upgrade_strategy=None, ignore_installed=False,
-                 target_dir=None, ignore_dependencies=False,
-                 force_reinstall=False, use_user_site=False, session=None,
-                 pycompile=True, isolated=False, wheel_download_dir=None,
-                 wheel_cache=None, require_hashes=False,
-                 ignore_requires_python=False, progress_bar="on"):
+    def __init__(self, download_dir=None,
+                 target_dir=None, use_user_site=False,
+                 pycompile=True, wheel_download_dir=None,
+                 wheel_cache=None):
         """Create a RequirementSet.
 
-        :param wheel_download_dir: Where still-packed .whl files should be
-            written to. If None they are written to the download_dir parameter.
-            Separate to download_dir to permit only keeping wheel archives for
-            pip wheel.
         :param download_dir: Where still packed archives should be written to.
             If None they are not saved, and are deleted immediately after
             unpacking.
         :param wheel_cache: The pip wheel cache, for passing to
             InstallRequirement.
         """
-        if session is None:
-            raise TypeError(
-                "RequirementSet() missing 1 required keyword argument: "
-                "'session'"
-            )
-
-        self.build_dir = build_dir
-        self.src_dir = src_dir
         # XXX: download_dir and wheel_download_dir overlap semantically and may
         # be combined if we're willing to have non-wheel archives present in
         # the wheelhouse output by 'pip wheel'.
         self.download_dir = download_dir
-        self.upgrade = upgrade
-        self.upgrade_strategy = upgrade_strategy
-        self.ignore_installed = ignore_installed
-        self.force_reinstall = force_reinstall
         self.requirements = Requirements()
         # Mapping of alias: real_name
         self.requirement_aliases = {}
         self.unnamed_requirements = []
-        self.ignore_dependencies = ignore_dependencies
-        self.ignore_requires_python = ignore_requires_python
-        self.progress_bar = progress_bar
         self.successfully_downloaded = []
         self.successfully_installed = []
         self.reqs_to_cleanup = []
         self.use_user_site = use_user_site
         self.target_dir = target_dir  # set from --target option
-        self.session = session
         self.pycompile = pycompile
-        self.isolated = isolated
         if wheel_download_dir:
             wheel_download_dir = normalize_path(wheel_download_dir)
         self.wheel_download_dir = wheel_download_dir
         self._wheel_cache = wheel_cache
-        self.require_hashes = require_hashes
         # Maps from install_req -> dependencies_of_install_req
         self._dependencies = defaultdict(list)
 

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -45,7 +45,8 @@ class RequirementSet(object):
 
     def __init__(self, build_dir, src_dir, download_dir=None,
                  require_hashes=False, target_dir=None, use_user_site=False,
-                 pycompile=True, wheel_download_dir=None, wheel_cache=None):
+                 pycompile=True, wheel_download_dir=None, wheel_cache=None,
+                 progress_bar="on"):
         """Create a RequirementSet.
 
 
@@ -70,6 +71,8 @@ class RequirementSet(object):
         self.requirements = Requirements()
 
         self.require_hashes = require_hashes
+
+        self.progress_bar = progress_bar
 
         # Mapping of alias: real_name
         self.requirement_aliases = {}

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -48,6 +48,11 @@ class RequirementSet(object):
                  pycompile=True, wheel_download_dir=None, wheel_cache=None):
         """Create a RequirementSet.
 
+
+        :param wheel_download_dir: Where still-packed .whl files should be
+            written to. If None they are written to the download_dir parameter.
+            Separate to download_dir to permit only keeping wheel archives for
+            pip wheel.
         :param download_dir: Where still packed archives should be written to.
             If None they are not saved, and are deleted immediately after
             unpacking.

--- a/pip/req/req_set.py
+++ b/pip/req/req_set.py
@@ -43,10 +43,9 @@ class Requirements(object):
 
 class RequirementSet(object):
 
-    def __init__(self, download_dir=None,
-                 target_dir=None, use_user_site=False,
-                 pycompile=True, wheel_download_dir=None,
-                 wheel_cache=None):
+    def __init__(self, build_dir, src_dir, download_dir=None,
+                 require_hashes=False, target_dir=None, use_user_site=False,
+                 pycompile=True, wheel_download_dir=None, wheel_cache=None):
         """Create a RequirementSet.
 
         :param download_dir: Where still packed archives should be written to.
@@ -55,11 +54,18 @@ class RequirementSet(object):
         :param wheel_cache: The pip wheel cache, for passing to
             InstallRequirement.
         """
+
+        self.build_dir = build_dir
+        self.src_dir = src_dir
+
         # XXX: download_dir and wheel_download_dir overlap semantically and may
         # be combined if we're willing to have non-wheel archives present in
         # the wheelhouse output by 'pip wheel'.
         self.download_dir = download_dir
         self.requirements = Requirements()
+
+        self.require_hashes = require_hashes
+
         # Mapping of alias: real_name
         self.requirement_aliases = {}
         self.unnamed_requirements = []

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -127,7 +127,7 @@ class Resolver(object):
                  ignore_dependencies, ignore_installed, ignore_requires_python,
                  force_reinstall, isolated, upgrade_strategy):
         super(Resolver, self).__init__()
-        assert upgrade_strategy in ["eager", "only-if-needed", "not-allowed"]
+        assert upgrade_strategy in ["eager", "only-if-needed", "to-satisfy-only"]
 
         self.finder = finder
         self.session = session
@@ -187,7 +187,7 @@ class Resolver(object):
             raise hash_errors
 
     def _is_upgrade_allowed(self, req):
-        if self.upgrade_strategy == "not-allowed":
+        if self.upgrade_strategy == "to-satisfy-only":
             return False
         elif self.upgrade_strategy == "eager":
             return True
@@ -452,7 +452,7 @@ class Resolver(object):
                     req_to_install.check_if_exists()
                 if req_to_install.satisfied_by:
                     should_modify = (
-                        self.upgrade_strategy != "not-allowed" or
+                        self.upgrade_strategy != "to-satisfy-only" or
                         self.ignore_installed
                     )
                     if should_modify:

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -123,7 +123,7 @@ class Resolver(object):
     the requested operation without breaking the requirements of any package.
     """
 
-    _allowed_strategies = ["eager", "only-if-needed", "to-satisfy-only"]
+    _allowed_strategies = {"eager", "only-if-needed", "to-satisfy-only"}
 
     def __init__(self, session, finder, use_user_site,
                  ignore_dependencies, ignore_installed, ignore_requires_python,
@@ -308,7 +308,8 @@ class Resolver(object):
                 else:
                     logger.info('Collecting %s', req_to_install)
 
-        assert self.require_hashes is not None
+        assert self.require_hashes is not None, \
+            "This should have been set in resolve()"
 
         with indent_log():
             # ################################ #

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -125,7 +125,7 @@ class Resolver(object):
 
     _allowed_strategies = ["eager", "only-if-needed", "to-satisfy-only"]
 
-    def __init__(self, session, finder, progress_bar, use_user_site,
+    def __init__(self, session, finder, use_user_site,
                  ignore_dependencies, ignore_installed, ignore_requires_python,
                  force_reinstall, isolated, upgrade_strategy):
         super(Resolver, self).__init__()
@@ -133,7 +133,6 @@ class Resolver(object):
 
         self.finder = finder
         self.session = session
-        self.progress_bar = progress_bar
 
         self.require_hashes = None  # This is set in resolve
 
@@ -428,7 +427,7 @@ class Resolver(object):
                         req_to_install.link, req_to_install.source_dir,
                         download_dir, autodelete_unpacked,
                         session=self.session, hashes=hashes,
-                        progress_bar=self.progress_bar)
+                        progress_bar=requirement_set.progress_bar)
                 except requests.HTTPError as exc:
                     logger.critical(
                         'Could not install requirement %s because '

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -123,11 +123,13 @@ class Resolver(object):
     the requested operation without breaking the requirements of any package.
     """
 
+    _allowed_strategies = ["eager", "only-if-needed", "to-satisfy-only"]
+
     def __init__(self, session, finder, progress_bar, use_user_site,
                  ignore_dependencies, ignore_installed, ignore_requires_python,
                  force_reinstall, isolated, upgrade_strategy):
         super(Resolver, self).__init__()
-        assert upgrade_strategy in ["eager", "only-if-needed", "to-satisfy-only"]
+        assert upgrade_strategy in self._allowed_strategies
 
         self.finder = finder
         self.session = session

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -717,7 +717,7 @@ class WheelBuilder(object):
             logger.error('Failed cleaning build dir for %s', req.name)
             return False
 
-    def build(self, session, src_dir, autobuilding=False):
+    def build(self, session, autobuilding=False):
         """Build wheels.
 
         :param unpack: If True, replace the sdist we built from with the
@@ -804,7 +804,9 @@ class WheelBuilder(object):
                         req.remove_temporary_source()
                         # set the build directory again - name is known from
                         # the work prepare_files did.
-                        req.source_dir = req.build_location(src_dir)
+                        req.source_dir = req.build_location(
+                            self.requirement_set.build_dir
+                        )
                         # Update the link for this.
                         req.link = pip.index.Link(
                             path_to_url(wheel_file))

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -717,7 +717,7 @@ class WheelBuilder(object):
             logger.error('Failed cleaning build dir for %s', req.name)
             return False
 
-    def build(self, autobuilding=False):
+    def build(self, session, src_dir, autobuilding=False):
         """Build wheels.
 
         :param unpack: If True, replace the sdist we built from with the
@@ -804,8 +804,7 @@ class WheelBuilder(object):
                         req.remove_temporary_source()
                         # set the build directory again - name is known from
                         # the work prepare_files did.
-                        req.source_dir = req.build_location(
-                            self.requirement_set.build_dir)
+                        req.source_dir = req.build_location(src_dir)
                         # Update the link for this.
                         req.link = pip.index.Link(
                             path_to_url(wheel_file))
@@ -813,7 +812,7 @@ class WheelBuilder(object):
                         # extract the wheel into the dir
                         unpack_url(
                             req.link, req.source_dir, None, False,
-                            session=self.requirement_set.session)
+                            session=session)
                 else:
                     build_failure.append(req)
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -37,12 +37,17 @@ class TestRequirementSet(object):
             build_dir=os.path.join(self.tempdir, 'build'),
             src_dir=os.path.join(self.tempdir, 'src'),
             download_dir=None,
-            session=PipSession(),
             **kwargs
         )
 
     def _basic_resolver(self, finder):
-        return Resolver("not-allowed", finder)
+        return Resolver(
+            session=PipSession(), finder=finder,
+            progress_bar="on", use_user_site=False,
+            ignore_dependencies=False, ignore_installed=False,
+            ignore_requires_python=False, force_reinstall=False,
+            isolated=False, upgrade_strategy="not-allowed"
+        )
 
     def test_no_reuse_existing_build_dir(self, data):
         """Test prepare_files raise exception with previous build dir"""
@@ -318,7 +323,6 @@ class TestInstallRequirement(object):
             build_dir=os.path.join(self.tempdir, 'build'),
             src_dir=os.path.join(self.tempdir, 'src'),
             download_dir=None,
-            session=PipSession(),
             **kwargs
         )
 
@@ -630,7 +634,7 @@ def test_exclusive_environment_markers():
     ne26 = InstallRequirement.from_line(
         "Django>=1.6.10,<1.8 ; python_version != '2.6'")
 
-    req_set = RequirementSet('', '', '', session=PipSession())
+    req_set = RequirementSet('', '', '')
     req_set.add_requirement(eq26)
     req_set.add_requirement(ne26)
     assert req_set.has_requirement('Django')

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -43,10 +43,10 @@ class TestRequirementSet(object):
     def _basic_resolver(self, finder):
         return Resolver(
             session=PipSession(), finder=finder,
-            progress_bar="on", use_user_site=False,
+            use_user_site=False, upgrade_strategy="to-satisfy-only",
             ignore_dependencies=False, ignore_installed=False,
             ignore_requires_python=False, force_reinstall=False,
-            isolated=False, upgrade_strategy="to-satisfy-only"
+            isolated=False,
         )
 
     def test_no_reuse_existing_build_dir(self, data):

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -46,7 +46,7 @@ class TestRequirementSet(object):
             progress_bar="on", use_user_site=False,
             ignore_dependencies=False, ignore_installed=False,
             ignore_requires_python=False, force_reinstall=False,
-            isolated=False, upgrade_strategy="not-allowed"
+            isolated=False, upgrade_strategy="to-satisfy-only"
         )
 
     def test_no_reuse_existing_build_dir(self, data):

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -363,6 +363,6 @@ class TestWheelBuilder(object):
             reqset = Mock(requirements=Mock(values=lambda: [wheel_req]),
                           wheel_download_dir='/wheel/dir')
             wb = wheel.WheelBuilder(reqset, Mock())
-            wb.build()
+            wb.build(Mock(), Mock())
             assert "due to already being wheel" in caplog.text
             assert mock_build_one.mock_calls == []

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -363,6 +363,6 @@ class TestWheelBuilder(object):
             reqset = Mock(requirements=Mock(values=lambda: [wheel_req]),
                           wheel_download_dir='/wheel/dir')
             wb = wheel.WheelBuilder(reqset, Mock())
-            wb.build(Mock(), Mock())
+            wb.build(Mock())
             assert "due to already being wheel" in caplog.text
             assert mock_build_one.mock_calls == []


### PR DESCRIPTION
Follows #4526.

This PR moves certain responsibilities (read attributes) out from `RequirementSet` to `Resolver`. As such, there's no major logic change that has been made.

`use_user_site` is used in both `RequirementSet` and `Resolver`. It can be moved out to a different part of the codebase in another PR.

---

Certain attributes that should move out of `RequirementSet` but not into `Resolver` (like `src_dir` and `build_dir`) which would be another PR.

<sub><b>Edit</b>: Reflect current state of PR.</sub>