### PR TITLE
Move WheelCache to a new pip.cache

### DIFF
--- a/news/4545.trivial
+++ b/news/4545.trivial
@@ -1,0 +1,1 @@
+Add a new pip.cache module.

--- a/pip/cache.py
+++ b/pip/cache.py
@@ -1,17 +1,17 @@
 """Cache Management
 """
 
-import os
 import errno
 import logging
+import os
 
 from pip._vendor.packaging.utils import canonicalize_name
 
 import pip.index
 from pip.compat import expanduser
 from pip.download import path_to_url
-from pip.wheel import Wheel, InvalidWheelFilename
 from pip.utils.cache import get_cache_path_for_link
+from pip.wheel import InvalidWheelFilename, Wheel
 
 logger = logging.getLogger(__name__)
 

--- a/pip/cache.py
+++ b/pip/cache.py
@@ -1,0 +1,71 @@
+"""Cache Management
+"""
+
+import os
+import errno
+import logging
+
+from pip._vendor.packaging.utils import canonicalize_name
+
+import pip.index
+from pip.compat import expanduser
+from pip.download import path_to_url
+from pip.wheel import Wheel, InvalidWheelFilename
+from pip.utils.cache import get_cache_path_for_link
+
+logger = logging.getLogger(__name__)
+
+
+class WheelCache(object):
+    """A cache of wheels for future installs."""
+
+    def __init__(self, cache_dir, format_control):
+        """Create a wheel cache.
+
+        :param cache_dir: The root of the cache.
+        :param format_control: A pip.index.FormatControl object to limit
+            binaries being read from the cache.
+        """
+        self._cache_dir = expanduser(cache_dir) if cache_dir else None
+        self._format_control = format_control
+
+    def cached_wheel(self, link, package_name):
+        not_cached = (
+            not self._cache_dir or
+            not link or
+            link.is_wheel or
+            not link.is_artifact or
+            not package_name
+        )
+
+        if not_cached:
+            return link
+
+        canonical_name = canonicalize_name(package_name)
+        formats = pip.index.fmt_ctl_formats(
+            self._format_control, canonical_name
+        )
+        if "binary" not in formats:
+            return link
+        root = get_cache_path_for_link(self._cache_dir, link)
+        try:
+            wheel_names = os.listdir(root)
+        except OSError as err:
+            if err.errno in {errno.ENOENT, errno.ENOTDIR}:
+                return link
+            raise
+        candidates = []
+        for wheel_name in wheel_names:
+            try:
+                wheel = Wheel(wheel_name)
+            except InvalidWheelFilename:
+                continue
+            if not wheel.supported():
+                # Built for a different python/arch/etc
+                continue
+            candidates.append((wheel.support_index_min(), wheel_name))
+        if not candidates:
+            return link
+        candidates.sort()
+        path = os.path.join(root, candidates[0][1])
+        return pip.index.Link(path_to_url(path))

--- a/pip/commands/freeze.py
+++ b/pip/commands/freeze.py
@@ -4,9 +4,9 @@ import sys
 
 import pip
 from pip.basecommand import Command
+from pip.cache import WheelCache
 from pip.compat import stdlib_pkgs
 from pip.operations.freeze import freeze
-from pip.wheel import WheelCache
 
 DEV_PKGS = {'pip', 'setuptools', 'distribute', 'wheel'}
 

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -8,6 +8,7 @@ import shutil
 
 from pip import cmdoptions
 from pip.basecommand import RequirementCommand
+from pip.cache import WheelCache
 from pip.exceptions import (
     CommandError, InstallationError, PreviousBuildDirError
 )
@@ -17,7 +18,7 @@ from pip.status_codes import ERROR
 from pip.utils import ensure_dir, get_installed_version
 from pip.utils.filesystem import check_path_owner
 from pip.utils.temp_dir import TempDirectory
-from pip.wheel import WheelBuilder, WheelCache
+from pip.wheel import WheelBuilder
 
 try:
     import wheel

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -6,11 +6,12 @@ import os
 
 from pip import cmdoptions
 from pip.basecommand import RequirementCommand
+from pip.cache import WheelCache
 from pip.exceptions import CommandError, PreviousBuildDirError
 from pip.req import RequirementSet
 from pip.utils import import_or_raise
 from pip.utils.temp_dir import TempDirectory
-from pip.wheel import WheelBuilder, WheelCache
+from pip.wheel import WheelBuilder
 
 logger = logging.getLogger(__name__)
 

--- a/pip/configuration.py
+++ b/pip/configuration.py
@@ -24,7 +24,6 @@ from pip.locations import (
 )
 from pip.utils import ensure_dir, enum
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/pip/utils/cache.py
+++ b/pip/utils/cache.py
@@ -1,0 +1,46 @@
+"""Helpers for caches
+"""
+
+import os.path
+import hashlib
+
+
+def get_cache_path_for_link(cache_dir, link):
+    """
+    Return a directory to store cached wheels in for link.
+
+    Because there are M wheels for any one sdist, we provide a directory
+    to cache them in, and then consult that directory when looking up
+    cache hits.
+
+    We only insert things into the cache if they have plausible version
+    numbers, so that we don't contaminate the cache with things that were not
+    unique. E.g. ./package might have dozens of installs done for it and build
+    a version of 0.0...and if we built and cached a wheel, we'd end up using
+    the same wheel even if the source has been edited.
+
+    :param cache_dir: The cache_dir being used by pip.
+    :param link: The link of the sdist for which this will cache wheels.
+    """
+
+    # We want to generate an url to use as our cache key, we don't want to just
+    # re-use the URL because it might have other items in the fragment and we
+    # don't care about those.
+    key_parts = [link.url_without_fragment]
+    if link.hash_name is not None and link.hash is not None:
+        key_parts.append("=".join([link.hash_name, link.hash]))
+    key_url = "#".join(key_parts)
+
+    # Encode our key url with sha224, we'll use this because it has similar
+    # security properties to sha256, but with a shorter total output (and thus
+    # less secure). However the differences don't make a lot of difference for
+    # our use case here.
+    hashed = hashlib.sha224(key_url.encode()).hexdigest()
+
+    # We want to nest the directories some to prevent having a ton of top level
+    # directories where we might run out of sub directories on some FS.
+    parts = [hashed[:2], hashed[2:4], hashed[4:6], hashed[6:]]
+
+    # Inside of the base location for cached wheels, expand our parts and join
+    # them all together.
+    return os.path.join(cache_dir, "wheels", *parts)

--- a/pip/utils/cache.py
+++ b/pip/utils/cache.py
@@ -1,8 +1,8 @@
 """Helpers for caches
 """
 
-import os.path
 import hashlib
+import os.path
 
 
 def get_cache_path_for_link(cache_dir, link):

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,6 +1,7 @@
 from pip.cache import WheelCache
 from pip.compat import expanduser
 
+
 class TestWheelCache:
 
     def test_expands_path(self):

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,5 +1,5 @@
 from pip.cache import WheelCache
-
+from pip.compat import expanduser
 
 class TestWheelCache:
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,12 @@
+from pip.cache import WheelCache
+
+
+class TestWheelCache:
+
+    def test_expands_path(self):
+        wc = WheelCache("~/.foo/", None)
+        assert wc._cache_dir == expanduser("~/.foo/")
+
+    def test_falsey_path_none(self):
+        wc = WheelCache(False, None)
+        assert wc._cache_dir is None

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -6,7 +6,7 @@ from mock import Mock, patch
 from pip._vendor.packaging.requirements import Requirement
 
 from pip import pep425tags, wheel
-from pip.compat import WINDOWS, expanduser
+from pip.compat import WINDOWS
 from pip.exceptions import InvalidWheelFilename, UnsupportedWheel
 from pip.utils import unpack_file
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -366,14 +366,3 @@ class TestWheelBuilder(object):
             wb.build()
             assert "due to already being wheel" in caplog.text
             assert mock_build_one.mock_calls == []
-
-
-class TestWheelCache:
-
-    def test_expands_path(self):
-        wc = wheel.WheelCache("~/.foo/", None)
-        assert wc._cache_dir == expanduser("~/.foo/")
-
-    def test_falsey_path_none(self):
-        wc = wheel.WheelCache(False, None)
-        assert wc._cache_dir is None


### PR DESCRIPTION
Eventually, another class `EggInfoCache` will be added to this new module, for #988. 

Until that is written, `WheelCache` can live alone in the new module.

---

There are a few changes I wanted to make to `WheelCache` and `pip.wheel`, to eliminate the need for having a `pip.utils.cache` (which exists because the function is used in both `pip.cache` and `pip.wheel`). To keep this PR small, for now I've done this.

I think a later PR will eliminate the need for `pip.utils.cache`.