### PR TITLE
Improve Environment Variable configuration handling

### DIFF
--- a/pip/configuration.py
+++ b/pip/configuration.py
@@ -276,7 +276,7 @@ class Configuration(object):
     def _get_environ_vars(self):
         """Returns a generator with all environmental vars with prefix PIP_"""
         for key, val in os.environ.items():
-            if key.startswith("PIP_"):
+            if key.upper().startswith("PIP_"):
                 yield key[4:].lower(), val
 
     # XXX: This is patched in the tests.

--- a/pip/configuration.py
+++ b/pip/configuration.py
@@ -84,6 +84,8 @@ class Configuration(object):
             kinds.GLOBAL, kinds.USER, kinds.VENV, kinds.ENV, kinds.ENV_VAR
         ]
 
+        self._ignore_env_names = ["version", "help"]
+
         # Because we keep track of where we got the data from
         self._parsers = {variant: [] for variant in self._override_order}
         self._config = {variant: {} for variant in self._override_order}
@@ -276,7 +278,11 @@ class Configuration(object):
     def _get_environ_vars(self):
         """Returns a generator with all environmental vars with prefix PIP_"""
         for key, val in os.environ.items():
-            if key.upper().startswith("PIP_"):
+            should_be_yielded = (
+                key.upper().startswith("PIP_") and
+                key[4:].lower() not in self._ignore_env_names
+            )
+            if should_be_yielded:
                 yield key[4:].lower(), val
 
     # XXX: This is patched in the tests.

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -3,6 +3,7 @@
 
 import os
 
+import pytest
 from mock import MagicMock
 
 from pip.exceptions import ConfigurationError
@@ -54,6 +55,14 @@ class TestConfigurationLoading(ConfigurationMixin):
 
         self.configuration.load()
         assert self.configuration.get_value(":env:.hello") == "5"
+
+    def test_environment_var_does_not_load_version(self):
+        os.environ["PIP_VERSION"] = "True"
+
+        self.configuration.load()
+
+        with pytest.raises(ConfigurationError):
+            self.configuration.get_value(":env:.version")
 
 
 class TestConfigurationPrecedence(ConfigurationMixin):

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -49,6 +49,12 @@ class TestConfigurationLoading(ConfigurationMixin):
         self.configuration.load()
         assert self.configuration.get_value(":env:.hello") == "5"
 
+    def test_environment_var_loading_lowercase(self):
+        os.environ["pip_hello"] = "5"
+
+        self.configuration.load()
+        assert self.configuration.get_value(":env:.hello") == "5"
+
 
 class TestConfigurationPrecedence(ConfigurationMixin):
     # Tests for methods to that determine the order of precedence of


### PR DESCRIPTION
This also kinda addresses #4528, by ignoring `PIP_VERSION` environment variable.

An actual fix coming soon.