### PR TITLE
Allow local package installations with forward slashes on Windows.

### DIFF
--- a/news/4024.bugfix
+++ b/news/4024.bugfix
@@ -1,0 +1,1 @@
+Allow forward slashes in local packages on Windows.

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -195,7 +195,7 @@ class InstallRequirement(object):
         else:
             p, extras = _strip_extras(path)
             if (os.path.isdir(p) and
-                    (os.path.sep in name or name.startswith('.'))):
+                    (os.path.sep in name or os.path.altsep in name or name.startswith('.'))):
 
                 if not is_installable_dir(p):
                     raise InstallationError(

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -239,7 +239,6 @@ class InstallRequirement(object):
             try:
                 req = Requirement(req)
             except InvalidRequirement:
-                print("ERROR")
                 if os.path.sep in req:
                     add_msg = "It looks like a path."
                     add_msg += deduce_helpful_msg(req)

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -239,6 +239,7 @@ class InstallRequirement(object):
             try:
                 req = Requirement(req)
             except InvalidRequirement:
+                print("ERROR")
                 if os.path.sep in req:
                     add_msg = "It looks like a path."
                     add_msg += deduce_helpful_msg(req)

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -515,6 +515,12 @@ class TestInstallRequirement(object):
         assert len(req.extras) == 2
         assert req.extras == set(['ex1', 'ex2'])
 
+    def test_path_with_forward_slashes(self):
+        # Don't normalize this to test that Windows recognizes that this is a directory.
+        req = InstallRequirement.from_line('tests/data/src/sample')
+        assert req.link.url.startswith('file://')
+        assert req.link.url.endswith('sample')
+
     def test_unexisting_path(self):
         with pytest.raises(InstallationError) as e:
             InstallRequirement.from_line(


### PR DESCRIPTION
Now you can do `pip install path/to/local/package` on Windows.
