### PR TITLE
Ignore the .idea directory when running flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -41,5 +41,5 @@ deps = isort==4.2.5
 commands = isort --recursive --check-only --diff pip tests
 
 [flake8]
-exclude = .tox,*.egg,build,_vendor,data
+exclude = .tox,.idea,*.egg,build,_vendor,data
 select = E,W,F


### PR DESCRIPTION
It's ignored through `.gitignore`, which meant that I started using it as a scratchpad. flake8 is the only thing that doesn't seem to ignore that directory.

/request-tag trivial