### PR TITLE
Refactor/move preparation logic out

### DIFF
--- a/pip/commands/download.py
+++ b/pip/commands/download.py
@@ -7,6 +7,7 @@ from pip import cmdoptions
 from pip.basecommand import RequirementCommand
 from pip.exceptions import CommandError
 from pip.index import FormatControl
+from pip.operations.prepare import RequirementPreparer
 from pip.req import RequirementSet
 from pip.resolve import Resolver
 from pip.utils import ensure_dir, normalize_path
@@ -194,6 +195,7 @@ class DownloadCommand(RequirementCommand):
                 )
 
                 resolver = Resolver(
+                    preparer=RequirementPreparer(),
                     finder=finder,
                     session=session,
                     use_user_site=False,

--- a/pip/commands/install.py
+++ b/pip/commands/install.py
@@ -13,6 +13,7 @@ from pip.exceptions import (
     CommandError, InstallationError, PreviousBuildDirError
 )
 from pip.locations import distutils_scheme, virtualenv_no_global
+from pip.operations.prepare import RequirementPreparer
 from pip.req import RequirementSet
 from pip.resolve import Resolver
 from pip.status_codes import ERROR
@@ -257,6 +258,7 @@ class InstallCommand(RequirementCommand):
 
                 try:
                     resolver = Resolver(
+                        preparer=RequirementPreparer(),
                         finder=finder,
                         session=session,
                         use_user_site=options.use_user_site,

--- a/pip/commands/wheel.py
+++ b/pip/commands/wheel.py
@@ -8,6 +8,7 @@ from pip import cmdoptions
 from pip.basecommand import RequirementCommand
 from pip.cache import WheelCache
 from pip.exceptions import CommandError, PreviousBuildDirError
+from pip.operations.prepare import RequirementPreparer
 from pip.req import RequirementSet
 from pip.resolve import Resolver
 from pip.utils import import_or_raise
@@ -157,6 +158,7 @@ class WheelCommand(RequirementCommand):
                 )
 
                 resolver = Resolver(
+                    preparer=RequirementPreparer(),
                     finder=finder,
                     session=session,
                     use_user_site=False,

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -99,7 +99,7 @@ class RequirementPreparer(object):
     def __init__(self):
         super(RequirementPreparer, self).__init__()
 
-    def prepare_requirement(self, req_to_install, resolver):
+    def prepare_requirement(self, req_to_install, resolver, requirement_set):
         # ###################### #
         # # print log messages # #
         # ###################### #

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -1,0 +1,297 @@
+"""Prepares a distribution for installation
+"""
+
+import logging
+
+import pkg_resources
+
+
+logger = logging.getLogger(__name__)
+
+
+def make_abstract_dist(req_to_install):
+    """Factory to make an abstract dist object.
+
+    Preconditions: Either an editable req with a source_dir, or satisfied_by or
+    a wheel link, or a non-editable req with a source_dir.
+
+    :return: A concrete DistAbstraction.
+    """
+    if req_to_install.editable:
+        return IsSDist(req_to_install)
+    elif req_to_install.link and req_to_install.link.is_wheel:
+        return IsWheel(req_to_install)
+    else:
+        return IsSDist(req_to_install)
+
+
+class DistAbstraction(object):
+    """Abstracts out the wheel vs non-wheel Resolver.resolve() logic.
+
+    The requirements for anything installable are as follows:
+     - we must be able to determine the requirement name
+       (or we can't correctly handle the non-upgrade case).
+     - we must be able to generate a list of run-time dependencies
+       without installing any additional packages (or we would
+       have to either burn time by doing temporary isolated installs
+       or alternatively violate pips 'don't start installing unless
+       all requirements are available' rule - neither of which are
+       desirable).
+     - for packages with setup requirements, we must also be able
+       to determine their requirements without installing additional
+       packages (for the same reason as run-time dependencies)
+     - we must be able to create a Distribution object exposing the
+       above metadata.
+    """
+
+    def __init__(self, req_to_install):
+        self.req_to_install = req_to_install
+
+    def dist(self, finder):
+        """Return a setuptools Dist object."""
+        raise NotImplementedError(self.dist)
+
+    def prep_for_dist(self):
+        """Ensure that we can get a Dist for this requirement."""
+        raise NotImplementedError(self.dist)
+
+
+class IsWheel(DistAbstraction):
+
+    def dist(self, finder):
+        return list(pkg_resources.find_distributions(
+            self.req_to_install.source_dir))[0]
+
+    def prep_for_dist(self):
+        # FIXME:https://github.com/pypa/pip/issues/1112
+        pass
+
+
+class IsSDist(DistAbstraction):
+
+    def dist(self, finder):
+        dist = self.req_to_install.get_dist()
+        # FIXME: shouldn't be globally added.
+        if dist.has_metadata('dependency_links.txt'):
+            finder.add_dependency_links(
+                dist.get_metadata_lines('dependency_links.txt')
+            )
+        return dist
+
+    def prep_for_dist(self):
+        self.req_to_install.run_egg_info()
+        self.req_to_install.assert_source_matches_version()
+
+
+class Installed(DistAbstraction):
+
+    def dist(self, finder):
+        return self.req_to_install.satisfied_by
+
+    def prep_for_dist(self):
+        pass
+
+
+class RequirementPreparer(object):
+    """Prepares a Requirement
+    """
+
+    def __init__(self):
+        super(RequirementPreparer, self).__init__()
+
+    def prepare_requirement(self, req_to_install, resolver):
+        # ###################### #
+        # # print log messages # #
+        # ###################### #
+        if req_to_install.editable:
+            logger.info('Obtaining %s', req_to_install)
+        else:
+            # satisfied_by is only evaluated by calling _check_skip_installed,
+            # so it must be None here.
+            assert req_to_install.satisfied_by is None
+            if not self.ignore_installed:
+                skip_reason = self._check_skip_installed(
+                    req_to_install, requirement_set
+                )
+
+            if req_to_install.satisfied_by:
+                assert skip_reason is not None, (
+                    '_check_skip_installed returned None but '
+                    'req_to_install.satisfied_by is set to %r'
+                    % (req_to_install.satisfied_by,))
+                logger.info(
+                    'Requirement %s: %s (%s)', skip_reason,
+                    req_to_install,
+                    req_to_install.satisfied_by.version)
+            else:
+                if (req_to_install.link and
+                        req_to_install.link.scheme == 'file'):
+                    path = url_to_path(req_to_install.link.url)
+                    logger.info('Processing %s', display_path(path))
+                else:
+                    logger.info('Collecting %s', req_to_install)
+
+        assert self.require_hashes is not None, \
+            "This should have been set in resolve()"
+
+        with indent_log():
+            # ################################ #
+            # # vcs update or unpack archive # #
+            # ################################ #
+            if req_to_install.editable:
+                if self.require_hashes:
+                    raise InstallationError(
+                        'The editable requirement %s cannot be installed when '
+                        'requiring hashes, because there is no single file to '
+                        'hash.' % req_to_install)
+                req_to_install.ensure_has_source_dir(requirement_set.src_dir)
+                req_to_install.update_editable(not requirement_set.is_download)
+                abstract_dist = make_abstract_dist(req_to_install)
+                abstract_dist.prep_for_dist()
+                if requirement_set.is_download:
+                    req_to_install.archive(requirement_set.download_dir)
+                req_to_install.check_if_exists()
+            elif req_to_install.satisfied_by:
+                if self.require_hashes:
+                    logger.debug(
+                        'Since it is already installed, we are trusting this '
+                        'package without checking its hash. To ensure a '
+                        'completely repeatable environment, install into an '
+                        'empty virtualenv.')
+                abstract_dist = Installed(req_to_install)
+            else:
+                # @@ if filesystem packages are not marked
+                # editable in a req, a non deterministic error
+                # occurs when the script attempts to unpack the
+                # build directory
+                req_to_install.ensure_has_source_dir(requirement_set.build_dir)
+                # If a checkout exists, it's unwise to keep going.  version
+                # inconsistencies are logged later, but do not fail the
+                # installation.
+                # FIXME: this won't upgrade when there's an existing
+                # package unpacked in `req_to_install.source_dir`
+                # package unpacked in `req_to_install.source_dir`
+                if os.path.exists(
+                        os.path.join(req_to_install.source_dir, 'setup.py')):
+                    raise PreviousBuildDirError(
+                        "pip can't proceed with requirements '%s' due to a"
+                        " pre-existing build directory (%s). This is "
+                        "likely due to a previous installation that failed"
+                        ". pip is being responsible and not assuming it "
+                        "can delete this. Please delete it and try again."
+                        % (req_to_install, req_to_install.source_dir)
+                    )
+                req_to_install.populate_link(
+                    self.finder,
+                    self._is_upgrade_allowed(req_to_install),
+                    self.require_hashes
+                )
+                # We can't hit this spot and have populate_link return None.
+                # req_to_install.satisfied_by is None here (because we're
+                # guarded) and upgrade has no impact except when satisfied_by
+                # is not None.
+                # Then inside find_requirement existing_applicable -> False
+                # If no new versions are found, DistributionNotFound is raised,
+                # otherwise a result is guaranteed.
+                assert req_to_install.link
+                link = req_to_install.link
+
+                # Now that we have the real link, we can tell what kind of
+                # requirements we have and raise some more informative errors
+                # than otherwise. (For example, we can raise VcsHashUnsupported
+                # for a VCS URL rather than HashMissing.)
+                if self.require_hashes:
+                    # We could check these first 2 conditions inside
+                    # unpack_url and save repetition of conditions, but then
+                    # we would report less-useful error messages for
+                    # unhashable requirements, complaining that there's no
+                    # hash provided.
+                    if is_vcs_url(link):
+                        raise VcsHashUnsupported()
+                    elif is_file_url(link) and is_dir_url(link):
+                        raise DirectoryUrlHashUnsupported()
+                    if (not req_to_install.original_link and
+                            not req_to_install.is_pinned):
+                        # Unpinned packages are asking for trouble when a new
+                        # version is uploaded. This isn't a security check, but
+                        # it saves users a surprising hash mismatch in the
+                        # future.
+                        #
+                        # file:/// URLs aren't pinnable, so don't complain
+                        # about them not being pinned.
+                        raise HashUnpinned()
+                hashes = req_to_install.hashes(
+                    trust_internet=not self.require_hashes)
+                if self.require_hashes and not hashes:
+                    # Known-good hashes are missing for this requirement, so
+                    # shim it with a facade object that will provoke hash
+                    # computation and then raise a HashMissing exception
+                    # showing the user what the hash should be.
+                    hashes = MissingHashes()
+
+                try:
+                    download_dir = requirement_set.download_dir
+                    # We always delete unpacked sdists after pip ran.
+                    autodelete_unpacked = True
+                    if req_to_install.link.is_wheel \
+                            and requirement_set.wheel_download_dir:
+                        # when doing 'pip wheel` we download wheels to a
+                        # dedicated dir.
+                        download_dir = requirement_set.wheel_download_dir
+                    if req_to_install.link.is_wheel:
+                        if download_dir:
+                            # When downloading, we only unpack wheels to get
+                            # metadata.
+                            autodelete_unpacked = True
+                        else:
+                            # When installing a wheel, we use the unpacked
+                            # wheel.
+                            autodelete_unpacked = False
+                    unpack_url(
+                        req_to_install.link, req_to_install.source_dir,
+                        download_dir, autodelete_unpacked,
+                        session=self.session, hashes=hashes,
+                        progress_bar=requirement_set.progress_bar)
+                except requests.HTTPError as exc:
+                    logger.critical(
+                        'Could not install requirement %s because '
+                        'of error %s',
+                        req_to_install,
+                        exc,
+                    )
+                    raise InstallationError(
+                        'Could not install requirement %s because '
+                        'of HTTP error %s for URL %s' %
+                        (req_to_install, exc, req_to_install.link)
+                    )
+                abstract_dist = make_abstract_dist(req_to_install)
+                abstract_dist.prep_for_dist()
+                if requirement_set.is_download:
+                    # Make a .zip of the source_dir we already created.
+                    if req_to_install.link.scheme in vcs.all_schemes:
+                        req_to_install.archive(requirement_set.download_dir)
+                # req_to_install.req is only avail after unpack for URL
+                # pkgs repeat check_if_exists to uninstall-on-upgrade
+                # (#14)
+                if not self.ignore_installed:
+                    req_to_install.check_if_exists()
+                if req_to_install.satisfied_by:
+                    should_modify = (
+                        self.upgrade_strategy != "to-satisfy-only" or
+                        self.ignore_installed
+                    )
+                    if should_modify:
+                        # don't uninstall conflict if user install and
+                        # conflict is not user install
+                        if not (self.use_user_site and not
+                                dist_in_usersite(req_to_install.satisfied_by)):
+                            req_to_install.conflicts_with = \
+                                req_to_install.satisfied_by
+                        req_to_install.satisfied_by = None
+                    else:
+                        logger.info(
+                            'Requirement already satisfied (use '
+                            '--upgrade to upgrade): %s',
+                            req_to_install,
+                        )
+        return abstract_dist

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -1,24 +1,22 @@
 """Prepares a distribution for installation
 """
 
-import os
 import logging
+import os
 
+from pip._vendor import pkg_resources, requests
 
 from pip.download import (
     is_dir_url, is_file_url, is_vcs_url, unpack_url, url_to_path
 )
 from pip.exceptions import (
-    HashUnpinned, InstallationError, PreviousBuildDirError, VcsHashUnsupported,
-    DirectoryUrlHashUnsupported
+    DirectoryUrlHashUnsupported, HashUnpinned, InstallationError,
+    PreviousBuildDirError, VcsHashUnsupported
 )
 from pip.utils import display_path, dist_in_usersite
 from pip.utils.hashes import MissingHashes
 from pip.utils.logging import indent_log
 from pip.vcs import vcs
-
-from pip._vendor import pkg_resources, requests
-
 
 logger = logging.getLogger(__name__)
 

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -110,9 +110,7 @@ class RequirementPreparer(object):
             # so it must be None here.
             assert req_to_install.satisfied_by is None
             if not resolver.ignore_installed:
-                skip_reason = resolver._check_skip_installed(
-                    req_to_install, requirement_set
-                )
+                skip_reason = resolver._check_skip_installed(req_to_install)
 
             if req_to_install.satisfied_by:
                 assert skip_reason is not None, (

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -1,9 +1,23 @@
 """Prepares a distribution for installation
 """
 
+import os
 import logging
 
-import pkg_resources
+
+from pip.download import (
+    is_dir_url, is_file_url, is_vcs_url, unpack_url, url_to_path
+)
+from pip.exceptions import (
+    HashUnpinned, InstallationError, PreviousBuildDirError, VcsHashUnsupported,
+    DirectoryUrlHashUnsupported
+)
+from pip.utils import display_path, dist_in_usersite
+from pip.utils.hashes import MissingHashes
+from pip.utils.logging import indent_log
+from pip.vcs import vcs
+
+from pip._vendor import pkg_resources, requests
 
 
 logger = logging.getLogger(__name__)

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -1,4 +1,3 @@
-
 """Dependency Resolution
 
 The dependency resolution in pip is performed as follows:
@@ -197,10 +196,7 @@ class Resolver(object):
         # register tmp src for cleanup in case something goes wrong
         requirement_set.reqs_to_cleanup.append(req_to_install)
 
-        # ###################### #
-        # # parse dependencies # #
-        # ###################### #
-
+        # Parse and return dependencies
         dist = abstract_dist.dist(self.finder)
         try:
             check_dist_requires_python(dist)
@@ -209,6 +205,7 @@ class Resolver(object):
                 logger.warning(err.args[0])
             else:
                 raise
+
         more_reqs = []
 
         def add_req(subreq, extras_requested):

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -33,12 +33,13 @@ class Resolver(object):
 
     _allowed_strategies = {"eager", "only-if-needed", "to-satisfy-only"}
 
-    def __init__(self, session, finder, use_user_site,
+    def __init__(self, preparer, session, finder, use_user_site,
                  ignore_dependencies, ignore_installed, ignore_requires_python,
                  force_reinstall, isolated, upgrade_strategy):
         super(Resolver, self).__init__()
         assert upgrade_strategy in self._allowed_strategies
 
+        self.preparer = preparer
         self.finder = finder
         self.session = session
 

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -231,26 +231,26 @@ class Resolver(object):
                 # 'unnamed' requirements will get added here
                 requirement_set.add_requirement(req_to_install, None)
 
-                if not self.ignore_dependencies:
-                    if req_to_install.extras:
-                        logger.debug(
-                            "Installing extra requirements: %r",
-                            ','.join(req_to_install.extras),
-                        )
-                    missing_requested = sorted(
-                        set(req_to_install.extras) - set(dist.extras)
+            if not self.ignore_dependencies:
+                if req_to_install.extras:
+                    logger.debug(
+                        "Installing extra requirements: %r",
+                        ','.join(req_to_install.extras),
                     )
-                    for missing in missing_requested:
-                        logger.warning(
-                            '%s does not provide the extra \'%s\'',
-                            dist, missing
-                        )
+                missing_requested = sorted(
+                    set(req_to_install.extras) - set(dist.extras)
+                )
+                for missing in missing_requested:
+                    logger.warning(
+                        '%s does not provide the extra \'%s\'',
+                        dist, missing
+                    )
 
-                    available_requested = sorted(
-                        set(dist.extras) & set(req_to_install.extras)
-                    )
-                    for subreq in dist.requires(available_requested):
-                        add_req(subreq, extras_requested=available_requested)
+                available_requested = sorted(
+                    set(dist.extras) & set(req_to_install.extras)
+                )
+                for subreq in dist.requires(available_requested):
+                    add_req(subreq, extras_requested=available_requested)
 
             if not req_to_install.editable and not req_to_install.satisfied_by:
                 # XXX: --no-install leads this to report 'Successfully

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -1,3 +1,4 @@
+
 """Dependency Resolution
 
 The dependency resolution in pip is performed as follows:
@@ -33,89 +34,6 @@ from pip.utils.packaging import check_dist_requires_python
 from pip.vcs import vcs
 
 logger = logging.getLogger(__name__)
-
-
-def make_abstract_dist(req_to_install):
-    """Factory to make an abstract dist object.
-
-    Preconditions: Either an editable req with a source_dir, or satisfied_by or
-    a wheel link, or a non-editable req with a source_dir.
-
-    :return: A concrete DistAbstraction.
-    """
-    if req_to_install.editable:
-        return IsSDist(req_to_install)
-    elif req_to_install.link and req_to_install.link.is_wheel:
-        return IsWheel(req_to_install)
-    else:
-        return IsSDist(req_to_install)
-
-
-class DistAbstraction(object):
-    """Abstracts out the wheel vs non-wheel Resolver.resolve() logic.
-
-    The requirements for anything installable are as follows:
-     - we must be able to determine the requirement name
-       (or we can't correctly handle the non-upgrade case).
-     - we must be able to generate a list of run-time dependencies
-       without installing any additional packages (or we would
-       have to either burn time by doing temporary isolated installs
-       or alternatively violate pips 'don't start installing unless
-       all requirements are available' rule - neither of which are
-       desirable).
-     - for packages with setup requirements, we must also be able
-       to determine their requirements without installing additional
-       packages (for the same reason as run-time dependencies)
-     - we must be able to create a Distribution object exposing the
-       above metadata.
-    """
-
-    def __init__(self, req_to_install):
-        self.req_to_install = req_to_install
-
-    def dist(self, finder):
-        """Return a setuptools Dist object."""
-        raise NotImplementedError(self.dist)
-
-    def prep_for_dist(self):
-        """Ensure that we can get a Dist for this requirement."""
-        raise NotImplementedError(self.dist)
-
-
-class IsWheel(DistAbstraction):
-
-    def dist(self, finder):
-        return list(pkg_resources.find_distributions(
-            self.req_to_install.source_dir))[0]
-
-    def prep_for_dist(self):
-        # FIXME:https://github.com/pypa/pip/issues/1112
-        pass
-
-
-class IsSDist(DistAbstraction):
-
-    def dist(self, finder):
-        dist = self.req_to_install.get_dist()
-        # FIXME: shouldn't be globally added:
-        if dist.has_metadata('dependency_links.txt'):
-            finder.add_dependency_links(
-                dist.get_metadata_lines('dependency_links.txt')
-            )
-        return dist
-
-    def prep_for_dist(self):
-        self.req_to_install.run_egg_info()
-        self.req_to_install.assert_source_matches_version()
-
-
-class Installed(DistAbstraction):
-
-    def dist(self, finder):
-        return self.req_to_install.satisfied_by
-
-    def prep_for_dist(self):
-        pass
 
 
 class Resolver(object):
@@ -281,238 +199,44 @@ class Resolver(object):
             return []
 
         req_to_install.prepared = True
+        self.preparer.prepare_requirement(req_to_install, self)
+
+        # register tmp src for cleanup in case something goes wrong
+        requirement_set.reqs_to_cleanup.append(req_to_install)
 
         # ###################### #
-        # # print log messages # #
+        # # parse dependencies # #
         # ###################### #
-        if req_to_install.editable:
-            logger.info('Obtaining %s', req_to_install)
-        else:
-            # satisfied_by is only evaluated by calling _check_skip_installed,
-            # so it must be None here.
-            assert req_to_install.satisfied_by is None
-            if not self.ignore_installed:
-                skip_reason = self._check_skip_installed(
-                    req_to_install, requirement_set
-                )
 
-            if req_to_install.satisfied_by:
-                assert skip_reason is not None, (
-                    '_check_skip_installed returned None but '
-                    'req_to_install.satisfied_by is set to %r'
-                    % (req_to_install.satisfied_by,))
-                logger.info(
-                    'Requirement %s: %s (%s)', skip_reason,
-                    req_to_install,
-                    req_to_install.satisfied_by.version)
+        dist = abstract_dist.dist(self.finder)
+        try:
+            check_dist_requires_python(dist)
+        except UnsupportedPythonVersion as err:
+            if self.ignore_requires_python:
+                logger.warning(err.args[0])
             else:
-                if (req_to_install.link and
-                        req_to_install.link.scheme == 'file'):
-                    path = url_to_path(req_to_install.link.url)
-                    logger.info('Processing %s', display_path(path))
-                else:
-                    logger.info('Collecting %s', req_to_install)
+                raise
+        more_reqs = []
 
-        assert self.require_hashes is not None, \
-            "This should have been set in resolve()"
-
-        with indent_log():
-            # ################################ #
-            # # vcs update or unpack archive # #
-            # ################################ #
-            if req_to_install.editable:
-                if self.require_hashes:
-                    raise InstallationError(
-                        'The editable requirement %s cannot be installed when '
-                        'requiring hashes, because there is no single file to '
-                        'hash.' % req_to_install)
-                req_to_install.ensure_has_source_dir(requirement_set.src_dir)
-                req_to_install.update_editable(not requirement_set.is_download)
-                abstract_dist = make_abstract_dist(req_to_install)
-                abstract_dist.prep_for_dist()
-                if requirement_set.is_download:
-                    req_to_install.archive(requirement_set.download_dir)
-                req_to_install.check_if_exists()
-            elif req_to_install.satisfied_by:
-                if self.require_hashes:
-                    logger.debug(
-                        'Since it is already installed, we are trusting this '
-                        'package without checking its hash. To ensure a '
-                        'completely repeatable environment, install into an '
-                        'empty virtualenv.')
-                abstract_dist = Installed(req_to_install)
-            else:
-                # @@ if filesystem packages are not marked
-                # editable in a req, a non deterministic error
-                # occurs when the script attempts to unpack the
-                # build directory
-                req_to_install.ensure_has_source_dir(requirement_set.build_dir)
-                # If a checkout exists, it's unwise to keep going.  version
-                # inconsistencies are logged later, but do not fail the
-                # installation.
-                # FIXME: this won't upgrade when there's an existing
-                # package unpacked in `req_to_install.source_dir`
-                # package unpacked in `req_to_install.source_dir`
-                if os.path.exists(
-                        os.path.join(req_to_install.source_dir, 'setup.py')):
-                    raise PreviousBuildDirError(
-                        "pip can't proceed with requirements '%s' due to a"
-                        " pre-existing build directory (%s). This is "
-                        "likely due to a previous installation that failed"
-                        ". pip is being responsible and not assuming it "
-                        "can delete this. Please delete it and try again."
-                        % (req_to_install, req_to_install.source_dir)
-                    )
-                req_to_install.populate_link(
-                    self.finder,
-                    self._is_upgrade_allowed(req_to_install),
-                    self.require_hashes
+        def add_req(subreq, extras_requested):
+            sub_install_req = InstallRequirement.from_req(
+                str(subreq),
+                req_to_install,
+                isolated=self.isolated,
+                wheel_cache=requirement_set._wheel_cache,
+            )
+            more_reqs.extend(
+                requirement_set.add_requirement(
+                    sub_install_req, req_to_install.name,
+                    extras_requested=extras_requested
                 )
-                # We can't hit this spot and have populate_link return None.
-                # req_to_install.satisfied_by is None here (because we're
-                # guarded) and upgrade has no impact except when satisfied_by
-                # is not None.
-                # Then inside find_requirement existing_applicable -> False
-                # If no new versions are found, DistributionNotFound is raised,
-                # otherwise a result is guaranteed.
-                assert req_to_install.link
-                link = req_to_install.link
+            )
 
-                # Now that we have the real link, we can tell what kind of
-                # requirements we have and raise some more informative errors
-                # than otherwise. (For example, we can raise VcsHashUnsupported
-                # for a VCS URL rather than HashMissing.)
-                if self.require_hashes:
-                    # We could check these first 2 conditions inside
-                    # unpack_url and save repetition of conditions, but then
-                    # we would report less-useful error messages for
-                    # unhashable requirements, complaining that there's no
-                    # hash provided.
-                    if is_vcs_url(link):
-                        raise VcsHashUnsupported()
-                    elif is_file_url(link) and is_dir_url(link):
-                        raise DirectoryUrlHashUnsupported()
-                    if (not req_to_install.original_link and
-                            not req_to_install.is_pinned):
-                        # Unpinned packages are asking for trouble when a new
-                        # version is uploaded. This isn't a security check, but
-                        # it saves users a surprising hash mismatch in the
-                        # future.
-                        #
-                        # file:/// URLs aren't pinnable, so don't complain
-                        # about them not being pinned.
-                        raise HashUnpinned()
-                hashes = req_to_install.hashes(
-                    trust_internet=not self.require_hashes)
-                if self.require_hashes and not hashes:
-                    # Known-good hashes are missing for this requirement, so
-                    # shim it with a facade object that will provoke hash
-                    # computation and then raise a HashMissing exception
-                    # showing the user what the hash should be.
-                    hashes = MissingHashes()
-
-                try:
-                    download_dir = requirement_set.download_dir
-                    # We always delete unpacked sdists after pip ran.
-                    autodelete_unpacked = True
-                    if req_to_install.link.is_wheel \
-                            and requirement_set.wheel_download_dir:
-                        # when doing 'pip wheel` we download wheels to a
-                        # dedicated dir.
-                        download_dir = requirement_set.wheel_download_dir
-                    if req_to_install.link.is_wheel:
-                        if download_dir:
-                            # When downloading, we only unpack wheels to get
-                            # metadata.
-                            autodelete_unpacked = True
-                        else:
-                            # When installing a wheel, we use the unpacked
-                            # wheel.
-                            autodelete_unpacked = False
-                    unpack_url(
-                        req_to_install.link, req_to_install.source_dir,
-                        download_dir, autodelete_unpacked,
-                        session=self.session, hashes=hashes,
-                        progress_bar=requirement_set.progress_bar)
-                except requests.HTTPError as exc:
-                    logger.critical(
-                        'Could not install requirement %s because '
-                        'of error %s',
-                        req_to_install,
-                        exc,
-                    )
-                    raise InstallationError(
-                        'Could not install requirement %s because '
-                        'of HTTP error %s for URL %s' %
-                        (req_to_install, exc, req_to_install.link)
-                    )
-                abstract_dist = make_abstract_dist(req_to_install)
-                abstract_dist.prep_for_dist()
-                if requirement_set.is_download:
-                    # Make a .zip of the source_dir we already created.
-                    if req_to_install.link.scheme in vcs.all_schemes:
-                        req_to_install.archive(requirement_set.download_dir)
-                # req_to_install.req is only avail after unpack for URL
-                # pkgs repeat check_if_exists to uninstall-on-upgrade
-                # (#14)
-                if not self.ignore_installed:
-                    req_to_install.check_if_exists()
-                if req_to_install.satisfied_by:
-                    should_modify = (
-                        self.upgrade_strategy != "to-satisfy-only" or
-                        self.ignore_installed
-                    )
-                    if should_modify:
-                        # don't uninstall conflict if user install and
-                        # conflict is not user install
-                        if not (self.use_user_site and not
-                                dist_in_usersite(req_to_install.satisfied_by)):
-                            req_to_install.conflicts_with = \
-                                req_to_install.satisfied_by
-                        req_to_install.satisfied_by = None
-                    else:
-                        logger.info(
-                            'Requirement already satisfied (use '
-                            '--upgrade to upgrade): %s',
-                            req_to_install,
-                        )
-
-            # register tmp src for cleanup in case something goes wrong
-            requirement_set.reqs_to_cleanup.append(req_to_install)
-
-            # ###################### #
-            # # parse dependencies # #
-            # ###################### #
-
-            dist = abstract_dist.dist(self.finder)
-            try:
-                check_dist_requires_python(dist)
-            except UnsupportedPythonVersion as err:
-                if self.ignore_requires_python:
-                    logger.warning(err.args[0])
-                else:
-                    raise
-            more_reqs = []
-
-            def add_req(subreq, extras_requested):
-                sub_install_req = InstallRequirement.from_req(
-                    str(subreq),
-                    req_to_install,
-                    isolated=self.isolated,
-                    wheel_cache=requirement_set._wheel_cache,
-                )
-                more_reqs.extend(
-                    requirement_set.add_requirement(
-                        sub_install_req, req_to_install.name,
-                        extras_requested=extras_requested
-                    )
-                )
-
-            # We add req_to_install before its dependencies, so that we
-            # can refer to it when adding dependencies.
-            if not requirement_set.has_requirement(req_to_install.name):
-                # 'unnamed' requirements will get added here
-                requirement_set.add_requirement(req_to_install, None)
+        # We add req_to_install before its dependencies, so that we
+        # can refer to it when adding dependencies.
+        if not requirement_set.has_requirement(req_to_install.name):
+            # 'unnamed' requirements will get added here
+            requirement_set.add_requirement(req_to_install, None)
 
             if not self.ignore_dependencies:
                 if req_to_install.extras:

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -199,7 +199,9 @@ class Resolver(object):
             return []
 
         req_to_install.prepared = True
-        self.preparer.prepare_requirement(req_to_install, self)
+        self.preparer.prepare_requirement(
+            req_to_install, self, requirement_set
+        )
 
         # register tmp src for cleanup in case something goes wrong
         requirement_set.reqs_to_cleanup.append(req_to_install)

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -120,7 +120,7 @@ class Resolver(object):
             return req.is_direct
 
     # XXX: Stop passing requirement_set for options
-    def _check_skip_installed(self, req_to_install, requirement_set):
+    def _check_skip_installed(self, req_to_install):
         """Check if req_to_install should be skipped.
 
         This will check if the req is installed, and whether we should upgrade

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -15,6 +15,7 @@ from pip.exceptions import (
     HashErrors, InstallationError, InvalidWheelFilename, PreviousBuildDirError
 )
 from pip.index import PackageFinder
+from pip.operations.prepare import RequirementPreparer
 from pip.req import InstallRequirement, Requirements, RequirementSet
 from pip.req.req_file import process_line
 from pip.req.req_install import parse_editable
@@ -42,6 +43,7 @@ class TestRequirementSet(object):
 
     def _basic_resolver(self, finder):
         return Resolver(
+            preparer=RequirementPreparer(),
             session=PipSession(), finder=finder,
             use_user_site=False, upgrade_strategy="to-satisfy-only",
             ignore_dependencies=False, ignore_installed=False,


### PR DESCRIPTION
This change moves out all the preparation logic out of `pip.resolve` into a new `pip.operations.prepare`; `pip.resolve` now handles only things directly related to dependency determination.

Additionally, both `Resolver` and `RequirementPreparer` can then be incrementally improved more easily.

No new functionality has been added, so no new tests.

---

Just a copy-paste change. Moving of attributes to RequirementPreparer, breaking down of big functions bodies etc would happen in more PRs. :)