### PR TITLE
Use container builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+sudo: false
+
 matrix:
   include:
     - env: TOXENV=docs


### PR DESCRIPTION
https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments says that repositories enabled before 2015 use the slower and bulkier full VM build, instead of the container based one.

This PR is an experiment to see if switching has any benefits; even minor. 