### PR TITLE
Use container builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+sudo: false
+
 matrix:
   include:
     - env: TOXENV=docs

--- a/news/4586.trivial
+++ b/news/4586.trivial
@@ -1,0 +1,1 @@
+Speed up CI by using container builds.


### PR DESCRIPTION
https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments says that repositories enabled before 2015 use the slower and bulkier full VM build, instead of the container based one.

This PR is an experiment to see if switching has any benefits; even minor one.
