### PR TITLE
Travis: Improve build speeds and upgrade PyPy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+sudo: false
+
 matrix:
   include:
     - env: TOXENV=docs
@@ -20,7 +22,6 @@ matrix:
       python: nightly
     - env: TOXENV=pypy
       python: pypy-5.4
-      sudo: false
     - env: "TOXENV=py27 VENDOR=no WHEELS=yes"
       python: 2.7
     - env: "TOXENV=py36 VENDOR=no WHEELS=yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,8 @@ matrix:
     - env: TOXENV=py37
       python: nightly
     - env: TOXENV=pypy
-      python: pypy-5.3
-    - env: TOXENV=pypy
       python: pypy-5.4
-    - env: TOXENV=pypy
-      python: pypy-5.5
-    - env: TOXENV=pypy
-      python: pypy-5.6
-    - env: TOXENV=pypy
-      python: pypy-5.7
-    - env: TOXENV=pypy
-      python: pypy-5.8
+      sudo: false
     - env: "TOXENV=py27 VENDOR=no WHEELS=yes"
       python: 2.7
     - env: "TOXENV=py36 VENDOR=no WHEELS=yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,17 @@ matrix:
     - env: TOXENV=py37
       python: nightly
     - env: TOXENV=pypy
-      python: pypy
+      python: pypy2.7-5.8.0
+    - env: TOXENV=pypy
+      python: pypy3.5-5.8.0
     - env: "TOXENV=py27 VENDOR=no WHEELS=yes"
       python: 2.7
     - env: "TOXENV=py36 VENDOR=no WHEELS=yes"
       python: 3.6
   allow_failures:
     - python: nightly
+    - env: TOXENV=pypy
+      python: pypy-dev
 
 install: travis_retry .travis/install.sh
 script: .travis/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ matrix:
       python: 3.6
   allow_failures:
     - python: nightly
-    - env: TOXENV=pypy
-      python: pypy-dev
 
 install: travis_retry .travis/install.sh
 script: .travis/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,29 +19,17 @@ matrix:
     - env: TOXENV=py37
       python: nightly
     - env: TOXENV=pypy
-      python: pypy2.7-5.3
+      python: pypy-5.3
     - env: TOXENV=pypy
-      python: pypy3.5-5.3
+      python: pypy-5.4
     - env: TOXENV=pypy
-      python: pypy2.7-5.4
+      python: pypy-5.5
     - env: TOXENV=pypy
-      python: pypy3.5-5.4
+      python: pypy-5.6
     - env: TOXENV=pypy
-      python: pypy2.7-5.5
+      python: pypy-5.7
     - env: TOXENV=pypy
-      python: pypy3.5-5.5
-    - env: TOXENV=pypy
-      python: pypy2.7-5.6
-    - env: TOXENV=pypy
-      python: pypy3.5-5.6
-    - env: TOXENV=pypy
-      python: pypy2.7-5.7
-    - env: TOXENV=pypy
-      python: pypy3.5-5.7
-    - env: TOXENV=pypy
-      python: pypy2.7-5.8
-    - env: TOXENV=pypy
-      python: pypy3.5-5.8
+      python: pypy-5.8
     - env: "TOXENV=py27 VENDOR=no WHEELS=yes"
       python: 2.7
     - env: "TOXENV=py36 VENDOR=no WHEELS=yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,29 @@ matrix:
     - env: TOXENV=py37
       python: nightly
     - env: TOXENV=pypy
-      python: pypy2.7-5.8.0
+      python: pypy2.7-5.3
     - env: TOXENV=pypy
-      python: pypy3.5-5.8.0
+      python: pypy3.5-5.3
+    - env: TOXENV=pypy
+      python: pypy2.7-5.4
+    - env: TOXENV=pypy
+      python: pypy3.5-5.4
+    - env: TOXENV=pypy
+      python: pypy2.7-5.5
+    - env: TOXENV=pypy
+      python: pypy3.5-5.5
+    - env: TOXENV=pypy
+      python: pypy2.7-5.6
+    - env: TOXENV=pypy
+      python: pypy3.5-5.6
+    - env: TOXENV=pypy
+      python: pypy2.7-5.7
+    - env: TOXENV=pypy
+      python: pypy3.5-5.7
+    - env: TOXENV=pypy
+      python: pypy2.7-5.8
+    - env: TOXENV=pypy
+      python: pypy3.5-5.8
     - env: "TOXENV=py27 VENDOR=no WHEELS=yes"
       python: 2.7
     - env: "TOXENV=py36 VENDOR=no WHEELS=yes"


### PR DESCRIPTION
Firstly, sorry for the mess I created with #4584, #4585, #4586. Won't happen again.
Secondly, thanks @xoviat for pointing out that the default PyPy on Travis CI was very old.

Closes #4587, since this is a cleaner approach.

---

With that out of the way, this PR:
- switches to Container Based infrastructure to speed up all build jobs
- upgrades the version of PyPy to the newest that Travis seems to provide [[1]]

These 2 combined seem to bring down the CI time from what's a 45 minute CI today [[2]].

[1]: https://travis-ci.org/pradyunsg/pip/builds/249051079
[2]: https://travis-ci.org/pypa/pip/builds/249101236
