### PR TITLE
[WIP] AppVeyor: Timeout tests after 5 minutes

### DIFF
--- a/.appveyor/run.cmd
+++ b/.appveyor/run.cmd
@@ -1,0 +1,18 @@
+@echo on
+setlocal enableextensions disabledelayedexpansion
+
+start "" %PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8
+call :timeoutProcess "%PYTHON%\\Scripts\\tox.exe" 300
+
+exit /b
+
+:timeoutProcess process timeout [leave]
+    rem process = name of process to monitor
+    rem timeout = timeout in seconds to wait for process to end
+    rem leave   = 1 if process should not be killed on timeout
+    for /l %%t in (1 1 %~2) do (
+        timeout /t 1 >nul
+        tasklist | find /i "%~1" >nul || exit /b 0
+    )
+    if not "%~3"=="1" taskkill /f /im "%~1" >nul 2>nul
+    if %errorlevel% equ 128 ( exit /b 0 ) else ( exit /b 1 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,4 +13,13 @@ install:
     cmd: "%PYTHON%\\python.exe -m pip install tox"
 build: off
 test_script:
-    - "%PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8"
+    # Run for 300 seconds max
+    - ps: |
+        $p = Start-Process "cmd.exe" '/c %PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8' -PassThru
+        Wait-Process -id $p.ID -timeout 300
+
+        # Kill the process if it didn't exit after a Wait-Process
+        if(!$p.hasExited) {
+            echo "Killing the process"
+            taskkill /T /F /PID $p.ID
+        }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build: off
 test_script:
     # Run for 300 seconds max
     - ps: |
-        $p = Start-Process "cmd.exe" '/c %PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8' -PassThru
+        $p = Start-Process "cmd.exe" '/c %PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8' -PassThru  -NoNewWindow
         Wait-Process -id $p.ID -timeout 300
 
         # Kill the process if it didn't exit after a Wait-Process

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,4 @@ install:
 build: off
 test_script:
     # Run for 300 seconds max
-    - cmd: |
-        start %PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8
-        timeout /nobreak /t 300
-        taskkill /im %PYTHON%\\Scripts\\tox.exe /f
+    - cmd: ./.appveyor/run.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,7 @@ install:
 build: off
 test_script:
     # Run for 300 seconds max
-    - ps: |
-        $p = Start-Process "cmd.exe" '/c %PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8' -PassThru  -NoNewWindow
-        Wait-Process -id $p.ID -timeout 300
-
-        # Kill the process if it didn't exit after a Wait-Process
-        if(!$p.hasExited) {
-            echo "Killing the process"
-            taskkill /T /F /PID $p.ID
-        }
+    - cmd: |
+        start %PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8
+        timeout /nobreak /t 300
+        taskkill /im %PYTHON%\\Scripts\\tox.exe /f


### PR DESCRIPTION
Idea inspired by #4589 holding up the AppVeyor build queue for a long time.

@pfmoore Thoughts?

---

I feel this is simpler than #4591 and better serves our purpose (preventing long builds from holding up the build queue) by timing out the test process itself in 5 minutes on one job. 

Since the tests currently finish in around 2 minutes, the timeout has a buffer of 150% of the current run time, which I think is a safe enough size to know that something got stuck.