### PR TITLE
Breakup method in pip.operations.prepare

### DIFF
--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -150,7 +150,6 @@ class RequirementPreparer(object):
 
     def prepare_requirement(self, req, resolver):
         # TODO: Remove circular dependency on resolver
-        # TODO: Breakup into smaller functions
         # TODO: Add a nice docstring
         assert resolver.require_hashes is not None, (
             "require_hashes should have been set in Resolver.resolve()"
@@ -170,6 +169,10 @@ class RequirementPreparer(object):
                 req, resolver, skip_reason
             )
 
+        return self._prepare_linked_requirement(req, resolver)
+
+    def _prepare_linked_requirement(self, req, resolver):
+        # TODO: Breakup into smaller functions
         if req.link and req.link.scheme == 'file':
             path = url_to_path(req.link.url)
             logger.info('Processing %s', display_path(path))

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -188,8 +188,7 @@ class RequirementPreparer(object):
             # FIXME: this won't upgrade when there's an existing
             # package unpacked in `req.source_dir`
             # package unpacked in `req.source_dir`
-            if os.path.exists(
-                    os.path.join(req.source_dir, 'setup.py')):
+            if os.path.exists(os.path.join(req.source_dir, 'setup.py')):
                 raise PreviousBuildDirError(
                     "pip can't proceed with requirements '%s' due to a"
                     " pre-existing build directory (%s). This is "
@@ -227,8 +226,7 @@ class RequirementPreparer(object):
                     raise VcsHashUnsupported()
                 elif is_file_url(link) and is_dir_url(link):
                     raise DirectoryUrlHashUnsupported()
-                if (not req.original_link and
-                        not req.is_pinned):
+                if not req.original_link and not req.is_pinned:
                     # Unpinned packages are asking for trouble when a new
                     # version is uploaded. This isn't a security check, but
                     # it saves users a surprising hash mismatch in the
@@ -237,8 +235,7 @@ class RequirementPreparer(object):
                     # file:/// URLs aren't pinnable, so don't complain
                     # about them not being pinned.
                     raise HashUnpinned()
-            hashes = req.hashes(
-                trust_internet=not resolver.require_hashes)
+            hashes = req.hashes(trust_internet=not resolver.require_hashes)
             if resolver.require_hashes and not hashes:
                 # Known-good hashes are missing for this requirement, so
                 # shim it with a facade object that will provoke hash
@@ -250,8 +247,7 @@ class RequirementPreparer(object):
                 download_dir = self.download_dir
                 # We always delete unpacked sdists after pip ran.
                 autodelete_unpacked = True
-                if req.link.is_wheel \
-                        and self.wheel_download_dir:
+                if req.link.is_wheel and self.wheel_download_dir:
                     # when doing 'pip wheel` we download wheels to a
                     # dedicated dir.
                     download_dir = self.wheel_download_dir
@@ -268,17 +264,17 @@ class RequirementPreparer(object):
                     req.link, req.source_dir,
                     download_dir, autodelete_unpacked,
                     session=resolver.session, hashes=hashes,
-                    progress_bar=self.progress_bar)
+                    progress_bar=self.progress_bar
+                )
             except requests.HTTPError as exc:
                 logger.critical(
-                    'Could not install requirement %s because '
-                    'of error %s',
+                    'Could not install requirement %s because of error %s',
                     req,
                     exc,
                 )
                 raise InstallationError(
-                    'Could not install requirement %s because '
-                    'of HTTP error %s for URL %s' %
+                    'Could not install requirement %s because of HTTP '
+                    'error %s for URL %s' %
                     (req, exc, req.link)
                 )
             abstract_dist = make_abstract_dist(req)
@@ -300,10 +296,9 @@ class RequirementPreparer(object):
                 if should_modify:
                     # don't uninstall conflict if user install and
                     # conflict is not user install
-                    if not (resolver.use_user_site and not
-                            dist_in_usersite(req.satisfied_by)):
-                        req.conflicts_with = \
-                            req.satisfied_by
+                    if not (resolver.use_user_site and
+                            not dist_in_usersite(req.satisfied_by)):
+                        req.conflicts_with = req.satisfied_by
                     req.satisfied_by = None
                 else:
                     logger.info(
@@ -323,7 +318,8 @@ class RequirementPreparer(object):
                 raise InstallationError(
                     'The editable requirement %s cannot be installed when '
                     'requiring hashes, because there is no single file to '
-                    'hash.' % req)
+                    'hash.' % req
+                )
             req.ensure_has_source_dir(self.src_dir)
             req.update_editable(not self._download_should_save)
 

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -149,6 +149,7 @@ class RequirementPreparer(object):
         return False
 
     def prepare_requirement(self, req, resolver):
+        # TODO: Remove circular dependency on resolver
         # TODO: Breakup into smaller functions
         # TODO: Add a nice docstring
         if req.editable:

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -157,7 +157,7 @@ class RequirementPreparer(object):
         )
 
         if req.editable:
-            abstract_dist = self._prepare_editable_requirement(req)
+            abstract_dist = self._prepare_editable_requirement(req, resolver)
         else:
             # satisfied_by is only evaluated by calling _check_skip_installed,
             # so it must be None here.
@@ -322,7 +322,7 @@ class RequirementPreparer(object):
                         )
         return abstract_dist
 
-    def _prepare_editable_requirement(self, req):
+    def _prepare_editable_requirement(self, req, resolver):
         assert req.editable, "cannot prepare a non-editable req as editable"
 
         logger.info('Obtaining %s', req)

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -152,6 +152,10 @@ class RequirementPreparer(object):
         # TODO: Remove circular dependency on resolver
         # TODO: Breakup into smaller functions
         # TODO: Add a nice docstring
+        assert resolver.require_hashes is not None, (
+            "require_hashes should have been set in Resolver.resolve()"
+        )
+
         if req.editable:
             abstract_dist = self._prepare_editable_requirement(req)
         else:
@@ -172,9 +176,6 @@ class RequirementPreparer(object):
                     logger.info('Processing %s', display_path(path))
                 else:
                     logger.info('Collecting %s', req)
-
-        assert resolver.require_hashes is not None, \
-            "This should have been set in resolve()"
 
         with indent_log():
             # ################################ #

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -149,8 +149,11 @@ class RequirementPreparer(object):
         return False
 
     def prepare_requirement(self, req, resolver):
+        """Prepare a requirement for installation
+
+        Returns an AbstractDist that can be used to install the package
+        """
         # TODO: Remove circular dependency on resolver
-        # TODO: Add a nice docstring
         assert resolver.require_hashes is not None, (
             "require_hashes should have been set in Resolver.resolve()"
         )
@@ -172,6 +175,8 @@ class RequirementPreparer(object):
         return self._prepare_linked_requirement(req, resolver)
 
     def _prepare_linked_requirement(self, req, resolver):
+        """Prepare a requirement that would be obtained from req.link
+        """
         # TODO: Breakup into smaller functions
         if req.link and req.link.scheme == 'file':
             path = url_to_path(req.link.url)
@@ -312,6 +317,8 @@ class RequirementPreparer(object):
         return abstract_dist
 
     def _prepare_editable_requirement(self, req, resolver):
+        """Prepare an editable requirement
+        """
         assert req.editable, "cannot prepare a non-editable req as editable"
 
         logger.info('Obtaining %s', req)
@@ -336,6 +343,8 @@ class RequirementPreparer(object):
         return abstract_dist
 
     def _prepare_installed_requirement(self, req, resolver, skip_reason):
+        """Prepare an already-installed requirement
+        """
         assert req.satisfied_by, "req should have been satisfied but isn't"
         assert skip_reason is not None, (
             "did not get skip reason skipped but req.satisfied_by "


### PR DESCRIPTION
The one-big-function `RequirementPreparer.prepare_requirements` has been broken up into smaller functions.


s/function/method/
