### PR TITLE
Reduce the number of workers to 4

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -44,7 +44,7 @@ if [[ $TOXENV == py* ]]; then
     # Run unit tests
     tox -- -m unit
     # Run integration tests
-    tox -- -m integration -n 8 --duration=5
+    tox -- -m integration -n 4 --duration=5
 else
     # Run once
     tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,4 +13,4 @@ install:
     cmd: "%PYTHON%\\python.exe -m pip install tox"
 build: off
 test_script:
-    - "%PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 8"
+    - "%PYTHON%\\Scripts\\tox.exe -e py -- -m unit -n 4"


### PR DESCRIPTION
There are 2 cores per CI enviroment - so assuming 2 threads per core (as is usual on many modern processors) - we should have 4 workers.

https://www.appveyor.com/docs/build-environment/#build-vm-configurations
https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments

Might speed up things, if it doesn't, can we merge it anyway?