### PR TITLE
Disable vendor C libraries only on Windows

### DIFF
--- a/news/4098.bugfix
+++ b/news/4098.bugfix
@@ -1,0 +1,1 @@
+Limit the disabling of requests' pyopenssl to Windows only. Fixes "SNIMissingWarning / InsecurePlatformWarning not fixable with pip 9.0 / 9.0.1" (for non-Windows)

--- a/pip/_vendor/README.rst
+++ b/pip/_vendor/README.rst
@@ -97,7 +97,7 @@ Modifications
 * ``pkg_resources`` has been modified to import its dependencies from ``pip._vendor``
 * ``CacheControl`` has been modified to import its dependencies from ``pip._vendor``
 * ``packaging`` has been modified to import its dependencies from ``pip._vendor``
-* ``requests`` has been modified *not* to optionally load any C dependencies
+* ``requests`` has been modified to *not* load C dependencies: ``simplejson`` (all platforms) and ``pyopenssl`` (Windows)
 * Modified distro to delay importing ``argparse`` to avoid errors on 2.6
 
 

--- a/pip/_vendor/requests/__init__.py
+++ b/pip/_vendor/requests/__init__.py
@@ -47,14 +47,19 @@ __author__ = 'Kenneth Reitz'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2016 Kenneth Reitz'
 
+
+from pip.compat import WINDOWS
+
+
 # Attempt to enable urllib3's SNI support, if possible
-# Note: Patched by pip to prevent using the PyOpenSSL module. On Windows this
-#       prevents upgrading cryptography.
-# try:
-#     from .packages.urllib3.contrib import pyopenssl
-#     pyopenssl.inject_into_urllib3()
-# except ImportError:
-#     pass
+# Note: Patched by pip to prevent using the PyOpenSSL module when OS is Windows.
+#       Otherwise on Windows this would prevent upgrading cryptography.
+if not WINDOWS:
+    try:
+        from .packages.urllib3.contrib import pyopenssl
+        pyopenssl.inject_into_urllib3()
+    except ImportError:
+        pass
 
 import warnings
 

--- a/tasks/vendoring/patches/requests.patch
+++ b/tasks/vendoring/patches/requests.patch
@@ -1,24 +1,30 @@
 diff --git a/pip/_vendor/requests/__init__.py b/pip/_vendor/requests/__init__.py
-index 9c3b769..44f6836 100644
+index 9c3b769..36a4ef40 100644
 --- a/pip/_vendor/requests/__init__.py
 +++ b/pip/_vendor/requests/__init__.py
-@@ -48,11 +48,13 @@ __license__ = 'Apache 2.0'
+@@ -47,12 +47,19 @@ __author__ = 'Kenneth Reitz'
+ __license__ = 'Apache 2.0'
  __copyright__ = 'Copyright 2016 Kenneth Reitz'
- 
+
++
++from pip.compat import WINDOWS
++
++
  # Attempt to enable urllib3's SNI support, if possible
 -try:
 -    from .packages.urllib3.contrib import pyopenssl
 -    pyopenssl.inject_into_urllib3()
 -except ImportError:
 -    pass
-+# Note: Patched by pip to prevent using the PyOpenSSL module. On Windows this
-+#       prevents upgrading cryptography.
-+# try:
-+#     from .packages.urllib3.contrib import pyopenssl
-+#     pyopenssl.inject_into_urllib3()
-+# except ImportError:
-+#     pass
- 
++# Note: Patched by pip to prevent using the PyOpenSSL module when OS is Windows.
++#       Otherwise on Windows this would prevent upgrading cryptography.
++if not WINDOWS:
++    try:
++        from .packages.urllib3.contrib import pyopenssl
++        pyopenssl.inject_into_urllib3()
++    except ImportError:
++        pass
+
  import warnings
  
 diff --git a/pip/_vendor/requests/compat.py b/pip/_vendor/requests/compat.py


### PR DESCRIPTION
### Overview
This PR attempts to implement solution (3) from this issue: https://github.com/pypa/pip/issues/4098, which amounts to:
- limiting the existing disabling of vendor c libraries (specifically `requests`' `pyopenssl`) to Windows only (currently disabled for all)
- restoring the ability to fix the `SNIMissingWarning`/`InsecurePlatformWarning` generated during `pip install` on non-Windows platforms.

On that issue @dstufft had commented:

> So this is a bit of a sticky issue. We've modified our bundled copies of the libraries so that they will not load any of the C libraries because on some OSs (particularly Windows) if pip imports the C library then it becomes impossible for pip to actually upgrade or uninstall that library (because importing locks the .dll from deletion). The downside of this is that it means you're stuck with what your Python is able to provide.
> 
> I see a few ways around this:
> 
> Do nothing, let the warning's stand to try and push people to upgrade their Python to one that has a better SSL module.
> Disable the warnings completely, the warnings don't matter much for PyPI's own usage (although they could for non PyPI repositories) and just live with it.
> Adjust our disable of C libraries to only disable them on platforms where they cause problems (e.g. Windows).
> If we pick (3) we'd still need to pick which of (1) or (2) we want to happen on platforms where our C libraries support is disabled.
> 

Solution (3) had the most traction from the comments on the issue, and seemed like a reasonable compromise between backward- and forward-compatibility concerns.

### Todo
- discussion:
  - [ ] is this approach sufficient?
  - [ ] is there anything big missing?
- [x] did not yet deal with `tasks/vendoring/patches`
- [x] ~some failing tests when run locally~
- [x] ~(more?)~