### PR TITLE
Introduce pip.cache.Cache base class for pip's caches

### DIFF
--- a/pip/cache.py
+++ b/pip/cache.py
@@ -5,7 +5,6 @@ import errno
 import hashlib
 import logging
 import os
-import sys
 
 from pip._vendor.packaging.utils import canonicalize_name
 
@@ -75,7 +74,7 @@ class Cache(object):
         formats = pip.index.fmt_ctl_formats(
             self.format_control, canonical_name
         )
-        if self.allowed_formats.intersection(formats):
+        if not self.allowed_formats.intersection(formats):
             return []
 
         root = self.get_path_for_link(link)

--- a/pip/cache.py
+++ b/pip/cache.py
@@ -96,6 +96,12 @@ class Cache(object):
         """
         raise NotImplementedError()
 
+    def _link_for_candidate(self, link, candidate):
+        root = self.get_path_for_link(link)
+        path = os.path.join(root, candidate)
+
+        return pip.index.Link(path_to_url(path))
+
 
 class WheelCache(Cache):
     """A cache of wheels for future installs.
@@ -141,7 +147,4 @@ class WheelCache(Cache):
         if not candidates:
             return link
 
-        root = self.get_path_for_link(link)
-        path = os.path.join(root, min(candidates)[1])
-
-        return pip.index.Link(path_to_url(path))
+        return self._link_for_candidate(link, min(candidates)[1])

--- a/pip/req/req_install.py
+++ b/pip/req/req_install.py
@@ -298,7 +298,7 @@ class InstallRequirement(object):
             self.link = finder.find_requirement(self, upgrade)
         if self._wheel_cache is not None and not require_hashes:
             old_link = self.link
-            self.link = self._wheel_cache.cached_wheel(self.link, self.name)
+            self.link = self._wheel_cache.get(self.link, self.name)
             if old_link != self.link:
                 logger.debug('Using cached wheel link: %s', self.link)
 

--- a/pip/wheel.py
+++ b/pip/wheel.py
@@ -727,7 +727,7 @@ class WheelBuilder(object):
         :return: True if all the wheels built correctly.
         """
         building_is_possible = self._wheel_dir or (
-            autobuilding and self.wheel_cache._cache_dir
+            autobuilding and self.wheel_cache.cache_dir
         )
         assert building_is_possible
 
@@ -778,9 +778,7 @@ class WheelBuilder(object):
                 python_tag = None
                 if autobuilding:
                     python_tag = pep425tags.implementation_tag
-                    output_dir = self.wheel_cache.get_cache_path_for_link(
-                        req.link
-                    )
+                    output_dir = self.wheel_cache.get_path_for_link(req.link)
                     try:
                         ensure_dir(output_dir)
                     except OSError as e:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -6,8 +6,8 @@ class TestWheelCache:
 
     def test_expands_path(self):
         wc = WheelCache("~/.foo/", None)
-        assert wc._cache_dir == expanduser("~/.foo/")
+        assert wc.cache_dir == expanduser("~/.foo/")
 
     def test_falsey_path_none(self):
         wc = WheelCache(False, None)
-        assert wc._cache_dir is None
+        assert wc.cache_dir is None


### PR DESCRIPTION
`Cache` class would serve as a common base class for the (future) `SDistCache` and `WheelCache` {all caches in pip}.

---

I am not sure if this change should be made with or without the rest of the changes - introduction of `SDistCache` and making pip use it. I felt like this is okay as a standalone change hence a separate PR.