### PR TITLE
Ignore the absence of a requirement and print a warning when uninstalling

### DIFF
--- a/news/3016.feature
+++ b/news/3016.feature
@@ -1,0 +1,1 @@
+pip uninstall now ignores the absence of a requirement and prints a warning.

--- a/news/4642.feature
+++ b/news/4642.feature
@@ -1,0 +1,1 @@
+pip uninstall now ignores the absence of a requirement and prints a warning.

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -64,7 +64,8 @@ class UninstallCommand(Command):
                     '"pip help %(name)s")' % dict(name=self.name)
                 )
             for req in reqs_to_uninstall.values():
-                req.uninstall(
+                uninstall_pathset = req.uninstall(
                     auto_confirm=options.yes, verbose=options.verbose != 0
                 )
-                req.uninstalled_pathset.commit()
+                if uninstall_pathset:
+                    uninstall_pathset.commit()

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -648,9 +648,8 @@ class InstallRequirement(object):
 
         """
         if not self.check_if_exists():
-            raise UninstallationError(
-                "Cannot uninstall requirement %s, not installed" % (self.name,)
-            )
+            logger.warning("Skipping %s as it is not installed.", self.name)
+            return
         dist = self.satisfied_by or self.conflicts_with
 
         uninstalled_pathset = UninstallPathSet.from_dist(dist)

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -653,8 +653,9 @@ class InstallRequirement(object):
             )
         dist = self.satisfied_by or self.conflicts_with
 
-        self.uninstalled_pathset = UninstallPathSet.from_dist(dist)
-        self.uninstalled_pathset.remove(auto_confirm, verbose)
+        uninstalled_pathset = UninstallPathSet.from_dist(dist)
+        uninstalled_pathset.remove(auto_confirm, verbose)
+        return uninstalled_pathset
 
     def archive(self, build_dir):
         assert self.source_dir

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -216,7 +216,9 @@ class RequirementSet(object):
                         requirement.conflicts_with,
                     )
                     with indent_log():
-                        requirement.uninstall(auto_confirm=True)
+                        uninstalled_pathset = requirement.uninstall(
+                            auto_confirm=True
+                        )
                 try:
                     requirement.install(
                         install_options,
@@ -231,7 +233,7 @@ class RequirementSet(object):
                     )
                     # if install did not succeed, rollback previous uninstall
                     if should_rollback:
-                        requirement.uninstalled_pathset.rollback()
+                        uninstalled_pathset.rollback()
                     raise
                 else:
                     should_commit = (
@@ -239,7 +241,7 @@ class RequirementSet(object):
                         requirement.install_succeeded
                     )
                     if should_commit:
-                        requirement.uninstalled_pathset.commit()
+                        uninstalled_pathset.commit()
                 requirement.remove_temporary_source()
 
         return to_install

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -468,3 +468,25 @@ def test_uninstall_editable_and_pip_install(script, data):
     ) in uninstall2.files_deleted, list(uninstall2.files_deleted.keys())
     list_result2 = script.pip('list', '--format=json')
     assert "FSPkg" not in {p["name"] for p in json.loads(list_result2.stdout)}
+
+
+def test_uninstall_ignores_missing_packages(script, data):
+    """Uninstall of a non existent package prints a warning and exits cleanly
+    """
+    result = script.pip(
+        'uninstall', '-y', 'non-existent-pkg', expect_stderr=True,
+    )
+
+    assert "Skipping non-existent-pkg as it is not installed." in result.stderr
+    assert result.returncode == 0, "Expected clean exit"
+
+
+def test_uninstall_ignores_missing_packages_and_uninstalls_rest(script, data):
+    script.pip_install_local('simple')
+    result = script.pip(
+        'uninstall', '-y', 'non-existent-pkg', 'simple', expect_stderr=True,
+    )
+
+    assert "Skipping non-existent-pkg as it is not installed." in result.stderr
+    assert "Successfully uninstalled simple" in result.stdout
+    assert result.returncode == 0, "Expected clean exit"


### PR DESCRIPTION
Resolves #3016.

