### PR TITLE
Refactor in preparation for issue #1139 fix.

### DIFF
--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -14,7 +14,7 @@ from pip.exceptions import (
     DirectoryUrlHashUnsupported, HashUnpinned, InstallationError,
     PreviousBuildDirError, VcsHashUnsupported
 )
-from pip.utils import display_path, dist_in_usersite, normalize_path
+from pip.utils import display_path, normalize_path
 from pip.utils.hashes import MissingHashes
 from pip.utils.logging import indent_log
 from pip.vcs import vcs
@@ -302,12 +302,7 @@ class RequirementPreparer(object):
                     resolver.ignore_installed
                 )
                 if should_modify:
-                    # don't uninstall conflict if user install and
-                    # conflict is not user install
-                    if not (resolver.use_user_site and
-                            not dist_in_usersite(req.satisfied_by)):
-                        req.conflicts_with = req.satisfied_by
-                    req.satisfied_by = None
+                    resolver._set_req_to_reinstall(req)
                 else:
                     logger.info(
                         'Requirement already satisfied (use '

--- a/pip/operations/prepare.py
+++ b/pip/operations/prepare.py
@@ -164,8 +164,7 @@ class RequirementPreparer(object):
         # satisfied_by is only evaluated by calling _check_skip_installed,
         # so it must be None here.
         assert req.satisfied_by is None
-        if not resolver.ignore_installed:
-            skip_reason = resolver._check_skip_installed(req)
+        skip_reason = resolver._check_skip_installed(req)
 
         if req.satisfied_by:
             return self._prepare_installed_requirement(

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -149,12 +149,10 @@ class Resolver(object):
         if not req_to_install.satisfied_by:
             return None
 
-        upgrade_allowed = self._is_upgrade_allowed(req_to_install)
-
         # Is the best version is installed.
         best_installed = False
 
-        if upgrade_allowed:
+        if self._is_upgrade_allowed(req_to_install):
             # For link based requirements we have to pull the
             # tree down and inspect to assess the version #, so
             # its handled way down.
@@ -163,8 +161,7 @@ class Resolver(object):
             )
             if should_check_possibility_for_upgrade:
                 try:
-                    self.finder.find_requirement(
-                        req_to_install, upgrade_allowed)
+                    self.finder.find_requirement(req_to_install, upgrade=True)
                 except BestVersionAlreadyInstalled:
                     best_installed = True
                 except DistributionNotFound:

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -144,7 +144,9 @@ class Resolver(object):
 
         :return: A text reason for why it was skipped, or None.
         """
-        # Check whether to upgrade/reinstall this req or not.
+        if self.ignore_installed:
+            return None
+
         req_to_install.check_if_exists()
         if not req_to_install.satisfied_by:
             return None

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -176,6 +176,9 @@ class Resolver(object):
 
             if not best_installed:
                 self._set_req_to_reinstall(req_to_install)
+                return None
+
+            # If we got here, best_installed is true.
 
         # Figure out a nice message to say why we're skipping this.
         if best_installed:

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -114,6 +114,17 @@ class Resolver(object):
             assert self.upgrade_strategy == "only-if-needed"
             return req.is_direct
 
+    def _set_req_to_reinstall(self, req):
+        """
+        Set a requirement to be installed.
+        """
+        # Don't uninstall the conflict if doing a user install and the
+        # conflict is not a user install.
+        if not (self.use_user_site and
+                not dist_in_usersite(req.satisfied_by)):
+            req.conflicts_with = req.satisfied_by
+        req.satisfied_by = None
+
     # XXX: Stop passing requirement_set for options
     def _check_skip_installed(self, req_to_install):
         """Check if req_to_install should be skipped.
@@ -162,13 +173,7 @@ class Resolver(object):
                         pass
 
                 if not best_installed:
-                    # don't uninstall conflict if user install and
-                    # conflict is not user install
-                    if not (self.use_user_site and not
-                            dist_in_usersite(req_to_install.satisfied_by)):
-                        req_to_install.conflicts_with = \
-                            req_to_install.satisfied_by
-                    req_to_install.satisfied_by = None
+                    self._set_req_to_reinstall(req_to_install)
 
             # Figure out a nice message to say why we're skipping this.
             if best_installed:

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -178,12 +178,9 @@ class Resolver(object):
                 self._set_req_to_reinstall(req_to_install)
                 return None
 
-            # If we got here, best_installed is true.
+            return 'already up-to-date'
 
-        # Figure out a nice message to say why we're skipping this.
-        if best_installed:
-            skip_reason = 'already up-to-date'
-        elif self.upgrade_strategy == "only-if-needed":
+        if self.upgrade_strategy == "only-if-needed":
             skip_reason = 'not upgraded as not directly required'
         else:
             skip_reason = 'already satisfied'

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -146,46 +146,46 @@ class Resolver(object):
         """
         # Check whether to upgrade/reinstall this req or not.
         req_to_install.check_if_exists()
-        if req_to_install.satisfied_by:
-            upgrade_allowed = self._is_upgrade_allowed(req_to_install)
-
-            # Is the best version is installed.
-            best_installed = False
-
-            if upgrade_allowed:
-                # For link based requirements we have to pull the
-                # tree down and inspect to assess the version #, so
-                # its handled way down.
-                should_check_possibility_for_upgrade = not (
-                    self.force_reinstall or req_to_install.link
-                )
-                if should_check_possibility_for_upgrade:
-                    try:
-                        self.finder.find_requirement(
-                            req_to_install, upgrade_allowed)
-                    except BestVersionAlreadyInstalled:
-                        best_installed = True
-                    except DistributionNotFound:
-                        # No distribution found, so we squash the
-                        # error - it will be raised later when we
-                        # re-try later to do the install.
-                        # Why don't we just raise here?
-                        pass
-
-                if not best_installed:
-                    self._set_req_to_reinstall(req_to_install)
-
-            # Figure out a nice message to say why we're skipping this.
-            if best_installed:
-                skip_reason = 'already up-to-date'
-            elif self.upgrade_strategy == "only-if-needed":
-                skip_reason = 'not upgraded as not directly required'
-            else:
-                skip_reason = 'already satisfied'
-
-            return skip_reason
-        else:
+        if not req_to_install.satisfied_by:
             return None
+
+        upgrade_allowed = self._is_upgrade_allowed(req_to_install)
+
+        # Is the best version is installed.
+        best_installed = False
+
+        if upgrade_allowed:
+            # For link based requirements we have to pull the
+            # tree down and inspect to assess the version #, so
+            # its handled way down.
+            should_check_possibility_for_upgrade = not (
+                self.force_reinstall or req_to_install.link
+            )
+            if should_check_possibility_for_upgrade:
+                try:
+                    self.finder.find_requirement(
+                        req_to_install, upgrade_allowed)
+                except BestVersionAlreadyInstalled:
+                    best_installed = True
+                except DistributionNotFound:
+                    # No distribution found, so we squash the
+                    # error - it will be raised later when we
+                    # re-try later to do the install.
+                    # Why don't we just raise here?
+                    pass
+
+            if not best_installed:
+                self._set_req_to_reinstall(req_to_install)
+
+        # Figure out a nice message to say why we're skipping this.
+        if best_installed:
+            skip_reason = 'already up-to-date'
+        elif self.upgrade_strategy == "only-if-needed":
+            skip_reason = 'not upgraded as not directly required'
+        else:
+            skip_reason = 'already satisfied'
+
+        return skip_reason
 
     def _resolve_one(self, requirement_set, req_to_install):
         """Prepare a single requirements file.

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -149,9 +149,6 @@ class Resolver(object):
         if not req_to_install.satisfied_by:
             return None
 
-        # Is the best version is installed.
-        best_installed = False
-
         if self._is_upgrade_allowed(req_to_install):
             # For link based requirements we have to pull the
             # tree down and inspect to assess the version #, so
@@ -163,7 +160,8 @@ class Resolver(object):
                 try:
                     self.finder.find_requirement(req_to_install, upgrade=True)
                 except BestVersionAlreadyInstalled:
-                    best_installed = True
+                    # Then the best version is installed.
+                    return 'already up-to-date'
                 except DistributionNotFound:
                     # No distribution found, so we squash the
                     # error - it will be raised later when we
@@ -171,11 +169,9 @@ class Resolver(object):
                     # Why don't we just raise here?
                     pass
 
-            if not best_installed:
-                self._set_req_to_reinstall(req_to_install)
-                return None
+            self._set_req_to_reinstall(req_to_install)
+            return None
 
-            return 'already up-to-date'
 
         if self.upgrade_strategy == "only-if-needed":
             skip_reason = 'not upgraded as not directly required'

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -154,12 +154,10 @@ class Resolver(object):
                 return 'not upgraded as not directly required'
             return 'already satisfied'
 
-        # For link-based requirements we have to pull the tree down and
-        # inspect to assess the version #, so it's handled way down.
-        should_check_possibility_for_upgrade = not (
-            self.force_reinstall or req_to_install.link
-        )
-        if should_check_possibility_for_upgrade:
+        # Check for the possibility of an upgrade.  For link-based
+        # requirements we have to pull the tree down and inspect to assess
+        # the version #, so it's handled way down.
+        if not (self.force_reinstall or req_to_install.link):
             try:
                 self.finder.find_requirement(req_to_install, upgrade=True)
             except BestVersionAlreadyInstalled:

--- a/pip/resolve.py
+++ b/pip/resolve.py
@@ -120,8 +120,7 @@ class Resolver(object):
         """
         # Don't uninstall the conflict if doing a user install and the
         # conflict is not a user install.
-        if not (self.use_user_site and
-                not dist_in_usersite(req.satisfied_by)):
+        if not self.use_user_site or dist_in_usersite(req.satisfied_by):
             req.conflicts_with = req.satisfied_by
         req.satisfied_by = None
 


### PR DESCRIPTION
[This PR was requested [here](https://github.com/pypa/pip/pull/4432#issuecomment-319947833) by @pradyunsg to be broken out as a separate PR.]

This PR does some minor refactoring in preparation for the patch proposed in PR #4432 to address issue #1139.

Collectively, the changes in this PR make the affected portion of the code easier to check and reason about, as well as the PR #4432 patch.  It does things like create a separate function called `_set_req_to_reinstall()` that will be used in the later patch and that makes the existing code more DRY. It also simplifies the implementation of `_check_skip_installed()` by reducing the deeply nested if structure and the need for temporary variables. This is mostly made possible by the use of guard clauses.
