### PR TITLE
Make indentation work with multiple threads

### DIFF
--- a/news/4654.bugfix
+++ b/news/4654.bugfix
@@ -1,0 +1,1 @@
+Made `pip.utils.logging.indent_log` work with multiple threads.

--- a/pip/utils/logging.py
+++ b/pip/utils/logging.py
@@ -32,6 +32,11 @@ def indent_log(num=2):
     A context manager which will cause the log output to be indented for any
     log messages emitted inside it.
     """
+
+    # Make sure this thread has "indentation" attribute initialized.
+    if not hasattr(_log_state, 'indentation'):
+        _log_state.indentation = 0
+
     _log_state.indentation += num
     try:
         yield


### PR DESCRIPTION
When using `indent_log` log with multiple threads (like subprocessing) then `indent_log` does not really work in other threads because `_log_state.indentation` is initialized only in initial thread. Importing module again does not work either (to initialize the value in the new thread), because information about which modules have been imported is shared between threads.

In our case we use `pip.utils.logging.indent_log` outside of just pip, because we found it useful.

This check makes sure that value is always initialized.

See #3889 and #2553 for more information.