### PR TITLE
Fix pypy3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
       python: nightly
   allow_failures:
     - python: nightly
-    - python: pypy3
 
 install: travis_retry .travis/install.sh
 script: .travis/run.sh

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -9,6 +9,7 @@ import site
 import shutil
 
 import scripttest
+import six
 import virtualenv
 
 from tests.lib.path import Path, curdir
@@ -33,6 +34,15 @@ def path_to_url(path):
     if drive:
         return 'file:///' + drive + url
     return 'file://' + url
+
+
+# workaround for https://github.com/pypa/virtualenv/issues/306
+def virtualenv_lib_path(venv_home, venv_lib):
+    if not hasattr(sys, "pypy_version_info"):
+        return venv_lib
+    version_fmt = '{0}' if six.PY3 else '{0}.{1}'
+    version_dir = version_fmt.format(*sys.version_info)
+    return os.path.join(venv_home, 'lib-python', version_dir)
 
 
 def create_file(path, contents=None):
@@ -262,11 +272,8 @@ class PipTestEnvironment(scripttest.TestFileEnvironment):
         path_locations = virtualenv.path_locations(_virtualenv)
         # Make sure we have test.lib.path.Path objects
         venv, lib, include, bin = map(Path, path_locations)
-        # workaround for https://github.com/pypa/virtualenv/issues/306
-        if hasattr(sys, "pypy_version_info"):
-            lib = os.path.join(venv, 'lib-python', pyversion)
         self.venv_path = venv
-        self.lib_path = lib
+        self.lib_path = virtualenv_lib_path(venv, lib)
         self.include_path = include
         self.bin_path = bin
 

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 
 import os
 import subprocess
-import sys
 
 import virtualenv as _virtualenv
 
+from . import virtualenv_lib_path
 from .path import Path
 
 # On Python < 3.3 we don't have subprocess.DEVNULL
@@ -27,10 +27,7 @@ class VirtualEnvironment(object):
         self._system_site_packages = kwargs.pop("system_site_packages", False)
 
         home, lib, inc, bin = _virtualenv.path_locations(self.location)
-        # workaround for https://github.com/pypa/virtualenv/issues/306
-        if hasattr(sys, "pypy_version_info"):
-            lib = os.path.join(home, 'lib-python', sys.version[:3])
-        self.lib = Path(lib)
+        self.lib = Path(virtualenv_lib_path(home, lib))
         self.bin = Path(bin)
 
         super(VirtualEnvironment, self).__init__(*args, **kwargs)


### PR DESCRIPTION
The problem was the workaround for https://github.com/pypa/virtualenv/issues/306: using `[...]/workspace/venv/lib-python/3.5` as the virtualenv lib directory when `[...]/workspace/venv/lib-python/3` is the actual directory used when running with PyPy 3.
