### PR TITLE
Record installed files in a deterministic order

### DIFF
--- a/news/4667.bugfix
+++ b/news/4667.bugfix
@@ -1,0 +1,2 @@
+pip now records installed files in a deterministic manner improving
+reproducibility.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -802,6 +802,7 @@ class InstallRequirement(object):
                     new_lines.append(
                         os.path.relpath(prepend_root(filename), egg_info_dir)
                     )
+            new_lines.sort()
             ensure_dir(egg_info_dir)
             inst_files_path = os.path.join(egg_info_dir, 'installed-files.txt')
             with open(inst_files_path, 'w') as f:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1260,3 +1260,25 @@ def test_installing_scripts_on_path_does_not_print_warning(script):
     result = script.pip_install_local("script_wheel1")
     assert "Successfully installed script-wheel1" in result.stdout, str(result)
     assert "--no-warn-script-location" not in result.stderr
+
+
+def test_installed_files_recorded_in_deterministic_order(script, data):
+    """
+    Ensure that we record the files installed by a package in a deterministic
+    order, to make installs reproducible.
+    """
+    to_install = data.packages.join("FSPkg")
+    result = script.pip('install', to_install, expect_error=False)
+    fspkg_folder = script.site_packages / 'fspkg'
+    egg_info = 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
+    installed_files_path = (
+        script.site_packages / egg_info / 'installed-files.txt'
+    )
+    assert fspkg_folder in result.files_created, str(result.stdout)
+    assert installed_files_path in result.files_created, str(result)
+
+    installed_files_path = result.files_created[installed_files_path].full
+    installed_files_lines = [
+        p for p in Path(installed_files_path).read_text().split('\n') if p
+    ]
+    assert installed_files_lines == sorted(installed_files_lines)


### PR DESCRIPTION
Installed files are recorded by Pip in the order the underlying tool
(Distutils, Setuptools, ...) recorded them.

Unfortunately, at least Setuptools doesn't record them in a
deterministic order in the case of a directory being installed, as it
uses os.walk to find the list of files.

We could fix all those underlying tools to record their files in a
deterministic order in all situations. But fixing it once here in Pip
for all tools is certainly simpler and more future-proof.

This makes the installation more reproducible, and therefore more
verifiable.

---

Note: I did not add a NEWS file fragment because I'm not sure this deserves being mentioned. If you think it does, I'll be happy to add one. 😃 
