### PR TITLE
Re-order Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,28 +8,31 @@ matrix:
     - env: TOXENV=lint-py2
     - env: TOXENV=lint-py3
     - env: TOXENV=packaging
-
+    # PyPy jobs start first -- they are the slowest
     - env: TOXENV=pypy
       python: pypy
     - env: TOXENV=pypy3
       python: pypy3
-
+    # Latest Stable CPython jobs
     - env: TOXENV=py27
       python: 2.7
+    - env: TOXENV=py36
+      python: 3.6
+    # Unvendored
+    - env: "TOXENV=py27 VENDOR=no WHEELS=yes"
+      python: 2.7
+    - env: "TOXENV=py36 VENDOR=no WHEELS=yes"
+      python: 3.6
+    # All the other Py3 versions
     - env: TOXENV=py33
       python: 3.3
     - env: TOXENV=py34
       python: 3.4
     - env: TOXENV=py35
       python: 3.5
-    - env: TOXENV=py36
-      python: 3.6
+    # Nightly Python goes last
     - env: TOXENV=py37
       python: nightly
-    - env: "TOXENV=py27 VENDOR=no WHEELS=yes"
-      python: 2.7
-    - env: "TOXENV=py36 VENDOR=no WHEELS=yes"
-      python: 3.6
   allow_failures:
     - python: nightly
     - python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ matrix:
     - env: TOXENV=lint-py3
     - env: TOXENV=packaging
 
+    - env: TOXENV=pypy
+      python: pypy
+    - env: TOXENV=pypy3
+      python: pypy3
+
     - env: TOXENV=py27
       python: 2.7
     - env: TOXENV=py33
@@ -21,10 +26,6 @@ matrix:
       python: 3.6
     - env: TOXENV=py37
       python: nightly
-    - env: TOXENV=pypy
-      python: pypy
-    - env: TOXENV=pypy3
-      python: pypy3
     - env: "TOXENV=py27 VENDOR=no WHEELS=yes"
       python: 2.7
     - env: "TOXENV=py36 VENDOR=no WHEELS=yes"


### PR DESCRIPTION
Basically, reorder the jobs so as to get the information about whether the build is good more quickly than the current order.