### PR TITLE
Travis: Try running with 4 workers

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -44,7 +44,7 @@ if [[ $TOXENV == py* ]]; then
     # Run unit tests
     tox -- -m unit
     # Run integration tests
-    tox -- -m integration -n 8 --duration=5
+    tox -- -m integration -n 4 --duration=5
 else
     # Run once
     tox


### PR DESCRIPTION
It seems that when we use less number of workers, it is harder to hit the Heisenbug that causes failure of the PyPy test. I just tried this 3 times on https://travis-ci.org/pradyunsg/pip/builds/266822913.

In favour of keeping life simple, I'm making all jobs use 4 workers. Further, it seems that Travis only gives 2 cores on the machines... 2 cores*2 threads = 4 workers seems like a reasonable thing to me.
