### PR TITLE
Simplify code for handling Git branches and tags

### DIFF
--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -103,14 +103,19 @@ class Git(VersionControl):
                                   show_stdout=False, on_returncode='ignore')
         refs = {}
         for line in output.strip().splitlines():
-            sha, ref = line.split(None, 1)
+            try:
+                sha, ref = line.split()
+            except ValueError:
+                # Include the offending line to simplify troubleshooting if
+                # this error ever occurs.
+                raise ValueError('unexpected show-ref line: {!r}'.format(line))
+
             refs[ref] = sha
 
-        sha = refs.get('refs/remotes/origin/{}'.format(rev))
-        if sha is not None:
-            return sha
+        branch_ref = 'refs/remotes/origin/{}'.format(rev)
+        tag_ref = 'refs/tags/{}'.format(rev)
 
-        return refs.get('refs/tags/{}'.format(rev))
+        return refs.get(branch_ref) or refs.get(tag_ref)
 
     def check_rev_options(self, dest, rev_options):
         """Check the revision options before checkout.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -38,7 +38,7 @@ class Git(VersionControl):
     # Prevent the user's environment variables from interfering with pip:
     # https://github.com/pypa/pip/issues/1130
     unset_environ = ('GIT_DIR', 'GIT_WORK_TREE')
-    default_arg_rev = 'origin/HEAD'
+    default_arg_rev = 'HEAD'
 
     def __init__(self, url=None, *args, **kwargs):
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -89,6 +89,29 @@ class Git(VersionControl):
                 show_stdout=False, cwd=temp_dir.path
             )
 
+    def get_revision_sha(self, dest, rev):
+        """
+        Return a commit hash for the given revision if it names a remote
+        branch or tag.  Otherwise, return None.
+
+        Args:
+          dest: the repository directory.
+          rev: the revision name.
+        """
+        # Pass rev to pre-filter the list.
+        output = self.run_command(['show-ref', rev], cwd=dest,
+                                  show_stdout=False, on_returncode='ignore')
+        refs = {}
+        for line in output.strip().splitlines():
+            sha, ref = line.split(None, 1)
+            refs[ref] = sha
+
+        sha = refs.get('refs/remotes/origin/{}'.format(rev))
+        if sha is not None:
+            return sha
+
+        return refs.get('refs/tags/{}'.format(rev))
+
     def check_rev_options(self, dest, rev_options):
         """Check the revision options before checkout to compensate that tags
         and branches may need origin/ as a prefix.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -223,10 +223,6 @@ class Git(VersionControl):
             self.is_ref_tag(ref),
         ))
 
-    # Should deprecate `get_refs` since it's ambiguous
-    def get_refs(self, location):
-        return self.get_short_refs(location)
-
     def get_short_refs(self, location):
         """Return map of named refs (branches or tags) to commit hashes."""
         rv = {}

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -129,17 +129,17 @@ class Git(VersionControl):
         rev = rev_options.arg_rev
         sha = self.get_revision_sha(dest, rev)
 
+        if sha is not None:
+            return rev_options.make_new(sha)
+
         # Do not show a warning for the common case of something that has
         # the form of a Git commit hash.
-        if sha is None:
-            if not looks_like_hash(rev):
-                logger.warning(
-                    "Did not find branch or tag '%s', assuming revision or ref",
-                    rev,
-                )
-            return rev_options
-
-        return rev_options.make_new(sha)
+        if not looks_like_hash(rev):
+            logger.warning(
+                "Did not find branch or tag '%s', assuming revision or ref",
+                rev,
+            )
+        return rev_options
 
     def is_commit_id_equal(self, dest, name):
         """

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -136,7 +136,7 @@ class Git(VersionControl):
         # the form of a Git commit hash.
         if not looks_like_hash(rev):
             logger.warning(
-                "Did not find branch or tag '%s', assuming revision or ref",
+                "Did not find branch or tag '%s', assuming revision or ref.",
                 rev,
             )
         return rev_options

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -215,14 +215,6 @@ class Git(VersionControl):
     def is_ref_tag(self, ref):
         return ref.startswith('refs/tags/')
 
-    def is_ref_commit(self, ref):
-        """A ref is a commit sha if it is not anything else"""
-        return not any((
-            self.is_ref_remote(ref),
-            self.is_ref_branch(ref),
-            self.is_ref_tag(ref),
-        ))
-
     def get_short_refs(self, location):
         """Return map of named refs (branches or tags) to commit hashes."""
         rv = {}

--- a/tests/functional/test_install_vcs.py
+++ b/tests/functional/test_install_vcs.py
@@ -25,7 +25,6 @@ def _install_version_pkg(script, path, rev=None):
     return version
 
 
-@pytest.mark.network
 def test_git_install_again_after_changes(script):
     """
     Test installing a repository a second time without specifying a revision,
@@ -44,7 +43,6 @@ def test_git_install_again_after_changes(script):
     assert version == 'some different version'
 
 
-@pytest.mark.network
 def test_git_install_branch_again_after_branch_changes(script):
     """
     Test installing a branch again after the branch is updated in the remote

--- a/tests/functional/test_install_vcs.py
+++ b/tests/functional/test_install_vcs.py
@@ -6,6 +6,38 @@ from tests.lib import (
 from tests.lib.local_repos import local_checkout
 
 
+def _install_version_pkg(script, path):
+    """
+    Install the version_pkg package, and return the version installed.
+
+    Args:
+      path: a tests.lib.path.Path object pointing to a Git repository
+        containing the package.
+    """
+    abs_path = path.abspath.replace('\\', '/')
+    project_url = 'git+file://{}@master#egg=version_pkg'.format(abs_path)
+    script.pip('install', '-e', project_url)
+    result = script.run('version_pkg')
+    version = result.stdout.strip()
+
+    return version
+
+
+@pytest.mark.network
+def test_git_install_branch_again_after_branch_changes(script):
+    """
+    Test installing a branch again after the branch is updated in the remote
+    repository.
+    """
+    version_pkg_path = _create_test_package(script)
+    version = _install_version_pkg(script, version_pkg_path)
+    assert version == '0.1'
+
+    _change_test_package_version(script, version_pkg_path)
+    version = _install_version_pkg(script, version_pkg_path)
+    assert version == 'some different version'
+
+
 @pytest.mark.network
 def test_install_editable_from_git_with_https(script, tmpdir):
     """

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -49,9 +49,9 @@ def test_check_rev_options_ref_not_found(get_sha_mock):
     assert new_options.rev == 'develop'
 
 
-@patch('pip._internal.vcs.git.Git.get_short_refs')
-def test_check_rev_options_not_found_warning(get_refs_mock, caplog):
-    get_refs_mock.return_value = {}
+@patch('pip._internal.vcs.git.Git.get_revision_sha')
+def test_check_rev_options_not_found_warning(get_sha_mock, caplog):
+    get_sha_mock.return_value = None
     git = Git()
 
     sha = 40 * 'a'
@@ -67,7 +67,7 @@ def test_check_rev_options_not_found_warning(get_refs_mock, caplog):
     messages = [r.getMessage() for r in caplog.records]
     messages = [msg for msg in messages if msg.startswith('Did not find ')]
     assert messages == [
-        "Did not find branch or tag 'aaaaaa', assuming ref or revision."
+        "Did not find branch or tag 'aaaaaa', assuming revision or ref."
     ]
 
 

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -10,55 +10,6 @@ from tests.lib.git_submodule_helpers import (
 
 
 @pytest.mark.network
-def test_get_short_refs_should_return_tag_name_and_commit_pair(script):
-    version_pkg_path = _create_test_package(script)
-    script.run('git', 'tag', '0.1', cwd=version_pkg_path)
-    script.run('git', 'tag', '0.2', cwd=version_pkg_path)
-    commit = script.run(
-        'git', 'rev-parse', 'HEAD',
-        cwd=version_pkg_path
-    ).stdout.strip()
-    git = Git()
-    result = git.get_short_refs(version_pkg_path)
-    assert result['0.1'] == commit, result
-    assert result['0.2'] == commit, result
-
-
-@pytest.mark.network
-def test_get_short_refs_should_return_branch_name_and_commit_pair(script):
-    version_pkg_path = _create_test_package(script)
-    script.run('git', 'branch', 'branch0.1', cwd=version_pkg_path)
-    commit = script.run(
-        'git', 'rev-parse', 'HEAD',
-        cwd=version_pkg_path
-    ).stdout.strip()
-    git = Git()
-    result = git.get_short_refs(version_pkg_path)
-    assert result['master'] == commit, result
-    assert result['branch0.1'] == commit, result
-
-
-@pytest.mark.network
-def test_get_short_refs_should_ignore_no_branch(script):
-    version_pkg_path = _create_test_package(script)
-    script.run('git', 'branch', 'branch0.1', cwd=version_pkg_path)
-    commit = script.run(
-        'git', 'rev-parse', 'HEAD',
-        cwd=version_pkg_path
-    ).stdout.strip()
-    # current branch here is "* (nobranch)"
-    script.run(
-        'git', 'checkout', commit,
-        cwd=version_pkg_path,
-        expect_stderr=True,
-    )
-    git = Git()
-    result = git.get_short_refs(version_pkg_path)
-    assert result['master'] == commit, result
-    assert result['branch0.1'] == commit, result
-
-
-@pytest.mark.network
 def test_is_commit_id_equal(script):
     """
     Test Git.is_commit_id_equal().
@@ -78,34 +29,24 @@ def test_is_commit_id_equal(script):
     assert not git.is_commit_id_equal(version_pkg_path, None)
 
 
-@patch('pip._internal.vcs.git.Git.get_short_refs')
-def test_check_rev_options_should_handle_branch_name(get_refs_mock):
-    get_refs_mock.return_value = {'master': '123456', '0.1': 'abc123'}
+@patch('pip._internal.vcs.git.Git.get_revision_sha')
+def test_check_rev_options_ref_exists(get_sha_mock):
+    get_sha_mock.return_value = '123456'
     git = Git()
-    rev_options = git.make_rev_options('master')
+    rev_options = git.make_rev_options('develop')
 
     new_options = git.check_rev_options('.', rev_options)
     assert new_options.rev == '123456'
 
 
-@patch('pip._internal.vcs.git.Git.get_short_refs')
-def test_check_rev_options_should_handle_tag_name(get_refs_mock):
-    get_refs_mock.return_value = {'master': '123456', '0.1': 'abc123'}
+@patch('pip._internal.vcs.git.Git.get_revision_sha')
+def test_check_rev_options_ref_not_found(get_sha_mock):
+    get_sha_mock.return_value = None
     git = Git()
-    rev_options = git.make_rev_options('0.1')
+    rev_options = git.make_rev_options('develop')
 
     new_options = git.check_rev_options('.', rev_options)
-    assert new_options.rev == 'abc123'
-
-
-@patch('pip._internal.vcs.git.Git.get_short_refs')
-def test_check_rev_options_should_handle_ambiguous_commit(get_refs_mock):
-    get_refs_mock.return_value = {'master': '123456', '0.1': '123456'}
-    git = Git()
-    rev_options = git.make_rev_options('0.1')
-
-    new_options = git.check_rev_options('.', rev_options)
-    assert new_options.rev == '123456'
+    assert new_options.rev == 'develop'
 
 
 @patch('pip._internal.vcs.git.Git.get_short_refs')

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -7,11 +7,10 @@ from pip.vcs.git import Git
 
 
 def get_head_sha(script, dest):
-    """
-    Return the HEAD sha.
-    """
+    """Return the HEAD sha."""
     result = script.run('git', 'rev-parse', 'HEAD', cwd=dest)
     sha = result.stdout.strip()
+
     return sha
 
 
@@ -20,15 +19,11 @@ def do_commit(script, dest):
         'git', 'commit', '-q', '--author', 'pip <pypa-dev@googlegroups.com>',
         '--allow-empty', '-m', 'test commit', cwd=dest
     )
-    sha = get_head_sha(script, dest)
-
-    return sha
+    return get_head_sha(script, dest)
 
 
 def add_commits(script, dest, count):
-    """
-    Return a list of the commit hashes from oldest to newest.
-    """
+    """Return a list of the commit hashes from oldest to newest."""
     shas = []
     for index in range(count):
         sha = do_commit(script, dest)
@@ -46,46 +41,52 @@ def test_get_revision_sha(script):
     with TempDirectory(kind="testing") as temp:
         repo_dir = temp.path
         script.run('git', 'init', cwd=repo_dir)
-        shas = add_commits(script, repo_dir, count=6)
+        shas = add_commits(script, repo_dir, count=3)
 
-        local_branch_sha = shas[0]
-        tag_sha = shas[1]
-        origin_branch_sha = shas[2]
-        upstream_branch_sha = shas[3]
-        ref_sha = shas[4]
-        head_sha = shas[5]
+        tag_sha = shas[0]
+        origin_sha = shas[1]
+        head_sha = shas[2]
         assert head_sha == shas[-1]
 
+        origin_ref = 'refs/remotes/origin/origin-branch'
+        generic_ref = 'refs/generic-ref'
+
         script.run(
-            'git', 'branch', 'local-branch', local_branch_sha, cwd=repo_dir
+            'git', 'branch', 'local-branch', head_sha, cwd=repo_dir
         )
         script.run('git', 'tag', 'v1.0', tag_sha, cwd=repo_dir)
-        script.run(
-            'git', 'update-ref', 'refs/remotes/origin/origin-branch',
-            origin_branch_sha, cwd=repo_dir
-        )
+        script.run('git', 'update-ref', origin_ref, origin_sha, cwd=repo_dir)
         script.run(
             'git', 'update-ref', 'refs/remotes/upstream/upstream-branch',
-            upstream_branch_sha, cwd=repo_dir
+            head_sha, cwd=repo_dir
         )
-        script.run(
-            'git', 'update-ref', 'refs/generic-ref', ref_sha, cwd=repo_dir
-        )
+        script.run('git', 'update-ref', generic_ref, head_sha, cwd=repo_dir)
 
         # Test two tags pointing to the same sha.
         script.run('git', 'tag', 'v2.0', tag_sha, cwd=repo_dir)
         # Test tags sharing the same suffix as another tag, both before and
-        # after alphabetically.
+        # after the suffix alphabetically.
         script.run('git', 'tag', 'aaa/v1.0', head_sha, cwd=repo_dir)
         script.run('git', 'tag', 'zzz/v1.0', head_sha, cwd=repo_dir)
 
-        check_rev(repo_dir, 'local-branch', None)
         check_rev(repo_dir, 'v1.0', tag_sha)
         check_rev(repo_dir, 'v2.0', tag_sha)
-        check_rev(repo_dir, 'origin-branch', origin_branch_sha)
-        check_rev(repo_dir, 'upstream-branch', None)
-        check_rev(repo_dir, 'generic-ref', None)
-        # Test passing a valid commit hash.
-        check_rev(repo_dir, tag_sha, None)
-        # Test passing a non-existent name.
-        check_rev(repo_dir, 'does-not-exist', None)
+        check_rev(repo_dir, 'origin-branch', origin_sha)
+
+        ignored_names = [
+            # Local branches should be ignored.
+            'local-branch',
+            # Non-origin remote branches should be ignored.
+            'upstream-branch',
+            # Generic refs should be ignored.
+            'generic-ref',
+            # Fully spelled-out refs should be ignored.
+            origin_ref,
+            generic_ref,
+            # Test passing a valid commit hash.
+            tag_sha,
+            # Test passing a non-existent name.
+            'does-not-exist',
+        ]
+        for name in ignored_names:
+            check_rev(repo_dir, name, None)

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -2,8 +2,8 @@
 Contains functional tests of the Git class.
 """
 
-from pip.utils.temp_dir import TempDirectory
-from pip.vcs.git import Git
+from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.vcs.git import Git
 
 
 def get_head_sha(script, dest):

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -1,0 +1,91 @@
+"""
+Contains functional tests of the Git class.
+"""
+
+from pip.utils.temp_dir import TempDirectory
+from pip.vcs.git import Git
+
+
+def get_head_sha(script, dest):
+    """
+    Return the HEAD sha.
+    """
+    result = script.run('git', 'rev-parse', 'HEAD', cwd=dest)
+    sha = result.stdout.strip()
+    return sha
+
+
+def do_commit(script, dest):
+    script.run(
+        'git', 'commit', '-q', '--author', 'pip <pypa-dev@googlegroups.com>',
+        '--allow-empty', '-m', 'test commit', cwd=dest
+    )
+    sha = get_head_sha(script, dest)
+
+    return sha
+
+
+def add_commits(script, dest, count):
+    """
+    Return a list of the commit hashes from oldest to newest.
+    """
+    shas = []
+    for index in range(count):
+        sha = do_commit(script, dest)
+        shas.append(sha)
+
+    return shas
+
+
+def check_rev(repo_dir, rev, expected_sha):
+    git = Git()
+    assert git.get_revision_sha(repo_dir, rev) == expected_sha
+
+
+def test_get_revision_sha(script):
+    with TempDirectory(kind="testing") as temp:
+        repo_dir = temp.path
+        script.run('git', 'init', cwd=repo_dir)
+        shas = add_commits(script, repo_dir, count=6)
+
+        local_branch_sha = shas[0]
+        tag_sha = shas[1]
+        origin_branch_sha = shas[2]
+        upstream_branch_sha = shas[3]
+        ref_sha = shas[4]
+        head_sha = shas[5]
+        assert head_sha == shas[-1]
+
+        script.run(
+            'git', 'branch', 'local-branch', local_branch_sha, cwd=repo_dir
+        )
+        script.run('git', 'tag', 'v1.0', tag_sha, cwd=repo_dir)
+        script.run(
+            'git', 'update-ref', 'refs/remotes/origin/origin-branch',
+            origin_branch_sha, cwd=repo_dir
+        )
+        script.run(
+            'git', 'update-ref', 'refs/remotes/upstream/upstream-branch',
+            upstream_branch_sha, cwd=repo_dir
+        )
+        script.run(
+            'git', 'update-ref', 'refs/generic-ref', ref_sha, cwd=repo_dir
+        )
+
+        # Test two tags pointing to the same sha.
+        script.run('git', 'tag', 'v2.0', tag_sha, cwd=repo_dir)
+        # Test tags sharing the same suffix as another tag, both before and
+        # after alphabetically.
+        script.run('git', 'tag', 'aaa/v1.0', head_sha, cwd=repo_dir)
+        script.run('git', 'tag', 'zzz/v1.0', head_sha, cwd=repo_dir)
+
+        check_rev(repo_dir, 'local-branch', None)
+        check_rev(repo_dir, 'v1.0', tag_sha)
+        check_rev(repo_dir, 'v2.0', tag_sha)
+        check_rev(repo_dir, 'origin-branch', origin_branch_sha)
+        check_rev(repo_dir, 'upstream-branch', None)
+        check_rev(repo_dir, 'generic-ref', None)
+        # Test passing a valid commit hash.
+        check_rev(repo_dir, tag_sha, None)
+        # Test passing a non-existent name.
+        check_rev(repo_dir, 'does-not-exist', None)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -73,17 +73,17 @@ def test_rev_options_make_new():
 @pytest.fixture
 def git():
     git_url = 'http://github.com/pypa/pip-test-package'
+    sha = '5547fa909e83df8bd743d3978d6667497983a4b7'
     refs = {
         '0.1': 'a8992fc7ee17e5b9ece022417b64594423caca7c',
         '0.1.1': '7d654e66c8fa7149c165ddeffa5b56bc06619458',
         '0.1.2': 'f1c1020ebac81f9aeb5c766ff7a772f709e696ee',
-        'foo': '5547fa909e83df8bd743d3978d6667497983a4b7',
-        'bar': '5547fa909e83df8bd743d3978d6667497983a4b7',
-        'master': '5547fa909e83df8bd743d3978d6667497983a4b7',
-        'origin/master': '5547fa909e83df8bd743d3978d6667497983a4b7',
-        'origin/HEAD': '5547fa909e83df8bd743d3978d6667497983a4b7',
+        'foo': sha,
+        'bar': sha,
+        'master': sha,
+        'origin/master': sha,
+        'origin/HEAD': sha,
     }
-    sha = refs['foo']
 
     git = Git()
     git.get_url = Mock(return_value=git_url)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -23,11 +23,11 @@ def test_rev_options_repr():
 @pytest.mark.parametrize(('vcs', 'expected1', 'expected2', 'kwargs'), [
     # First check VCS-specific RevOptions behavior.
     (Bazaar(), [], ['-r', '123'], {}),
-    (Git(), ['origin/HEAD'], ['123'], {}),
+    (Git(), ['HEAD'], ['123'], {}),
     (Mercurial(), [], ['123'], {}),
     (Subversion(), [], ['-r', '123'], {}),
     # Test extra_args.  For this, test using a single VersionControl class.
-    (Git(), ['origin/HEAD', 'opt1', 'opt2'], ['123', 'opt1', 'opt2'],
+    (Git(), ['HEAD', 'opt1', 'opt2'], ['123', 'opt1', 'opt2'],
         dict(extra_args=['opt1', 'opt2'])),
 ])
 def test_rev_options_to_args(vcs, expected1, expected2, kwargs):

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -74,21 +74,9 @@ def test_rev_options_make_new():
 def git():
     git_url = 'http://github.com/pypa/pip-test-package'
     sha = '5547fa909e83df8bd743d3978d6667497983a4b7'
-    refs = {
-        '0.1': 'a8992fc7ee17e5b9ece022417b64594423caca7c',
-        '0.1.1': '7d654e66c8fa7149c165ddeffa5b56bc06619458',
-        '0.1.2': 'f1c1020ebac81f9aeb5c766ff7a772f709e696ee',
-        'foo': sha,
-        'bar': sha,
-        'master': sha,
-        'origin/master': sha,
-        'origin/HEAD': sha,
-    }
-
     git = Git()
     git.get_url = Mock(return_value=git_url)
     git.get_revision = Mock(return_value=sha)
-    git.get_short_refs = Mock(return_value=refs)
     return git
 
 


### PR DESCRIPTION
This PR significantly simplifies the code responsible for looking up Git refs. It replaces 7 functions with one function (`Git.get_revision_sha()`) that is easier to understand, can be tested independently of any packaging-related code, and simplifies the implementation of `Git.check_rev_options()`.

I noticed this could be done while working on PR #4674 for issue #4507.

