### PR TITLE
Small tests related cleanups

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -344,7 +344,7 @@ def test_hashed_install_success(script, data, tmpdir):
         script.pip_install_local('-r', reqs_file.abspath, expect_error=False)
 
 
-def test_hashed_install_failure(script, data, tmpdir):
+def test_hashed_install_failure(script, tmpdir):
     """Test that wrong hashes stop installation.
 
     This makes sure prepare_files() is called in the course of installation
@@ -396,7 +396,7 @@ def test_editable_install_from_local_directory_with_no_setup_py(script, data):
 
 @pytest.mark.skipif("sys.version_info >= (3,4)")
 @pytest.mark.xfail
-def test_install_argparse_shadowed(script, data):
+def test_install_argparse_shadowed(script):
     # When argparse is in the stdlib, we support installing it
     # even though that's pretty useless because older packages did need to
     # depend on it, and not having its metadata will cause pkg_resources
@@ -409,7 +409,7 @@ def test_install_argparse_shadowed(script, data):
 
 
 @pytest.mark.skipif("sys.version_info < (3,4)")
-def test_upgrade_argparse_shadowed(script, data):
+def test_upgrade_argparse_shadowed(script):
     # If argparse is installed - even if shadowed for imported - we support
     # upgrading it and properly remove the older versions files.
     script.pip('install', 'argparse==1.3')
@@ -845,7 +845,7 @@ def test_compiles_pyc(script):
 
 
 @pytest.mark.network
-def test_no_compiles_pyc(script, data):
+def test_no_compiles_pyc(script):
     """
     Test installing from wheel with --compile on
     """
@@ -1081,7 +1081,7 @@ def test_install_tar_lzma(script, data):
     assert "Successfully installed singlemodule-0.0.1" in res.stdout, res
 
 
-def test_double_install(script, data):
+def test_double_install(script):
     """
     Test double install passing with two same version requirements
     """
@@ -1090,7 +1090,7 @@ def test_double_install(script, data):
     assert msg not in result.stderr
 
 
-def test_double_install_fail(script, data):
+def test_double_install_fail(script):
     """
     Test double install failing with two different version requirements
     """
@@ -1177,7 +1177,7 @@ def test_install_compatible_python_requires(script, common_wheels):
     assert "Successfully installed pkga-0.1" in res.stdout, res
 
 
-def test_install_environment_markers(script, data):
+def test_install_environment_markers(script):
     # make a dummy project
     pkga_path = script.scratch_path / 'pkga'
     pkga_path.mkdir()

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -107,7 +107,7 @@ def test_nonexistent_options_listed_in_order(script, data):
     assert msg in result.stderr
 
 
-def test_install_special_extra(script, data):
+def test_install_special_extra(script):
     # Check that uppercase letters and '-' are dealt with
     # make a dummy project
     pkga_path = script.scratch_path / 'pkga'

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -466,7 +466,7 @@ def test_install_distribution_union_conflicting_extras(script, data):
     assert "Conflict" in result.stderr
 
 
-def test_install_unsupported_wheel_link_with_marker(script, data):
+def test_install_unsupported_wheel_link_with_marker(script):
     script.scratch_path.join("with-marker.txt").write(
         textwrap.dedent("""\
             %s; %s

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -153,6 +153,6 @@ def test_search_print_results_should_contain_latest_versions(caplog):
         }
     ]
     print_results(hits)
-    log_messages = sorted([r.getMessage() for r in caplog.records()])
+    log_messages = sorted([r.getMessage() for r in caplog.records])
     assert log_messages[0].startswith('testlib1 (1.0.5)')
     assert log_messages[1].startswith('testlib2 (2.0.3)')

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -34,7 +34,7 @@ def test_no_partial_name_match(data):
     assert found.url.endswith("gmpy-1.15.tar.gz"), found
 
 
-def test_tilde(data):
+def test_tilde():
     """Finder can accept a path with ~ in it and will normalize it."""
     session = PipSession()
     with patch('pip._internal.index.os.path.exists', return_value=True):
@@ -551,7 +551,7 @@ def test_get_index_urls_locations():
                          'file://index2/complex-name/']
 
 
-def test_find_all_candidates_nothing(data):
+def test_find_all_candidates_nothing():
     """Find nothing without anything"""
     finder = PackageFinder([], [], session=PipSession())
     assert not finder.find_all_candidates('pip')

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -88,7 +88,7 @@ class TestRequirementSet(object):
             assert not reqset.has_requirement('simple')
 
     @pytest.mark.network
-    def test_missing_hash_checking(self, data):
+    def test_missing_hash_checking(self):
         """Make sure prepare_files() raises an error when a requirement has no
         hash in implicit hash-checking mode.
         """
@@ -275,7 +275,7 @@ class TestRequirementSet(object):
             resolver.resolve,
             reqset)
 
-    def test_hashed_deps_on_require_hashes(self, data):
+    def test_hashed_deps_on_require_hashes(self):
         """Make sure hashed dependencies get installed when --require-hashes
         is on.
 

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -139,7 +139,7 @@ def test_virtualenv_state(monkeypatch):
     assert len(fake_file.write.calls)
 
 
-def test_global_state(monkeypatch):
+def test_global_state(monkeypatch, tmpdir):
     CONTENT = '''{"pip_prefix": {"last_check": "1970-01-02T11:00:00Z",
         "pypi_version": "1.0"}}'''
     fake_file = pretend.stub(
@@ -167,15 +167,16 @@ def test_global_state(monkeypatch):
     monkeypatch.setattr(outdated, 'running_under_virtualenv',
                         pretend.call_recorder(lambda: False))
 
-    monkeypatch.setattr(outdated, 'USER_CACHE_DIR', 'cache_dir')
-    monkeypatch.setattr(sys, 'prefix', 'pip_prefix')
+    cache_dir = tmpdir / 'cache_dir'
+    monkeypatch.setattr(outdated, 'USER_CACHE_DIR', cache_dir)
+    monkeypatch.setattr(sys, 'prefix', tmpdir / 'pip_prefix')
 
     state = outdated.load_selfcheck_statefile()
     state.save('2.0', datetime.datetime.utcnow())
 
     assert len(outdated.running_under_virtualenv.calls) == 1
 
-    expected_path = os.path.join('cache_dir', 'selfcheck.json')
+    expected_path = cache_dir / 'selfcheck.json'
     assert fake_lock.calls == [pretend.call(expected_path)]
 
     assert fake_open.calls == [


### PR DESCRIPTION
* drop `data` fixture from tests that don't use it
* fix test not using temporary directory: avoid creating a `cache_dir` directory in the source tree
* fix pytest warning