### PR TITLE
Add a RevOptions class

### DIFF
--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -17,7 +17,7 @@ from pip._internal.utils.misc import (
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Dict, Tuple
+    from typing import Dict, Optional, Tuple
     from pip._internal.basecommand import Command
 
 __all__ = ['vcs', 'get_src_requirement']
@@ -167,7 +167,7 @@ class VersionControl(object):
     dirname = ''
     # List of supported schemes for this Version Control
     schemes = ()  # type: Tuple[str, ...]
-    default_arg_rev = None
+    default_arg_rev = None  # type: Optional[str]
 
     def __init__(self, url=None, *args, **kwargs):
         self.url = url

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -263,12 +263,18 @@ class VersionControl(object):
     def switch(self, dest, url, rev_options):
         """
         Switch the repo at ``dest`` to point to ``URL``.
+
+        Args:
+          rev_options: a RevOptions object.
         """
         raise NotImplementedError
 
     def update(self, dest, rev_options):
         """
         Update an already-existing repo to the given ``rev_options``.
+
+        Args:
+          rev_options: a RevOptions object.
         """
         raise NotImplementedError
 
@@ -279,15 +285,19 @@ class VersionControl(object):
         """
         raise NotImplementedError
 
-    def check_destination(self, dest, url, rev_options, rev_display):
+    def check_destination(self, dest, url, rev_options):
         """
         Prepare a location to receive a checkout/clone.
 
         Return True if the location is ready for (and requires) a
         checkout/clone, False otherwise.
+
+        Args:
+          rev_options: a RevOptions object.
         """
         checkout = True
         prompt = False
+        rev_display = rev_options.to_display()
         if os.path.exists(dest):
             checkout = False
             if os.path.exists(os.path.join(dest, self.dirname)):

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -49,6 +49,9 @@ class RevOptions(object):
         self.rev = rev
         self.vcs = vcs
 
+    def __repr__(self):
+        return '<RevOptions {}: rev={!r}>'.format(self.vcs.name, self.rev)
+
     @property
     def arg_rev(self):
         if self.rev is None:
@@ -56,19 +59,15 @@ class RevOptions(object):
 
         return self.rev
 
-    def to_args(self, start_args, end_args=None):
+    def to_args(self):
         """
-        Return VCS-specific command arguments.
+        Return the VCS-specific command arguments.
         """
-        if end_args is None:
-            end_args = []
-
-        args = copy.copy(start_args)
+        args = []
         rev = self.arg_rev
         if rev is not None:
             args += self.vcs.get_base_rev_args(rev)
         args += self.extra_args
-        args += end_args
 
         return args
 
@@ -282,6 +281,9 @@ class VersionControl(object):
         """
         Return True if the version is identical to what exists and
         doesn't need to be updated.
+
+        Args:
+          rev_options: a RevOptions object.
         """
         raise NotImplementedError
 

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -52,24 +52,22 @@ class Bazaar(VersionControl):
         self.run_command(['switch', url], cwd=dest)
 
     def update(self, dest, rev_options):
-        self.run_command(['pull', '-q'] + rev_options, cwd=dest)
+        cmd_args = rev_options.to_args(['pull', '-q'])
+        self.run_command(cmd_args, cwd=dest)
 
     def obtain(self, dest):
         url, rev = self.get_url_rev()
-        if rev:
-            rev_options = ['-r', rev]
-            rev_display = ' (to revision %s)' % rev
-        else:
-            rev_options = []
-            rev_display = ''
-        if self.check_destination(dest, url, rev_options, rev_display):
+        rev_options = self.make_rev_options(rev)
+        if self.check_destination(dest, url, rev_options):
+            rev_display = rev_options.to_display()
             logger.info(
                 'Checking out %s%s to %s',
                 url,
                 rev_display,
                 display_path(dest),
             )
-            self.run_command(['branch', '-q'] + rev_options + [url, dest])
+            cmd_args = rev_options.to_args(['branch', '-q'], [url, dest])
+            self.run_command(cmd_args)
 
     def get_url_rev(self):
         # hotfix the URL scheme after removing bzr+ from bzr+ssh:// readd it

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -52,7 +52,7 @@ class Bazaar(VersionControl):
         self.run_command(['switch', url], cwd=dest)
 
     def update(self, dest, rev_options):
-        cmd_args = rev_options.to_args(['pull', '-q'])
+        cmd_args = ['pull', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 
     def obtain(self, dest):
@@ -66,7 +66,7 @@ class Bazaar(VersionControl):
                 rev_display,
                 display_path(dest),
             )
-            cmd_args = rev_options.to_args(['branch', '-q'], [url, dest])
+            cmd_args = ['branch', '-q'] + rev_options.to_args() + [url, dest]
             self.run_command(cmd_args)
 
     def get_url_rev(self):

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -29,6 +29,9 @@ class Bazaar(VersionControl):
         if getattr(urllib_parse, 'uses_fragment', None):
             urllib_parse.uses_fragment.extend(['lp'])
 
+    def get_base_rev_args(self, rev):
+        return ['-r', rev]
+
     def export(self, location):
         """
         Export the Bazaar repository at the url to the destination location

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -27,6 +27,7 @@ class Git(VersionControl):
     schemes = (
         'git', 'git+http', 'git+https', 'git+ssh', 'git+git', 'git+file',
     )
+    default_arg_rev = 'origin/master'
 
     def __init__(self, url=None, *args, **kwargs):
 
@@ -48,6 +49,9 @@ class Git(VersionControl):
                 )
 
         super(Git, self).__init__(url, *args, **kwargs)
+
+    def get_base_rev_args(self, rev):
+        return [rev]
 
     def get_git_version(self):
         VERSION_PFX = 'git version '

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -27,7 +27,7 @@ class Git(VersionControl):
     schemes = (
         'git', 'git+http', 'git+https', 'git+ssh', 'git+git', 'git+file',
     )
-    default_arg_rev = 'origin/master'
+    default_arg_rev = 'origin/HEAD'
 
     def __init__(self, url=None, *args, **kwargs):
 
@@ -78,20 +78,25 @@ class Git(VersionControl):
                 show_stdout=False, cwd=temp_dir.path
             )
 
-    def check_rev_options(self, rev, dest, rev_options):
+    def check_rev_options(self, dest, rev_options):
         """Check the revision options before checkout to compensate that tags
         and branches may need origin/ as a prefix.
-        Returns the SHA1 of the branch or tag if found.
+        Returns a new RevOptions object for the SHA1 of the branch or tag
+        if found.
+
+        Args:
+          rev_options: a RevOptions object.
         """
         revisions = self.get_short_refs(dest)
 
+        rev = rev_options.arg_rev
         origin_rev = 'origin/%s' % rev
         if origin_rev in revisions:
             # remote branch
-            return [revisions[origin_rev]]
+            return rev_options.make_new(revisions[origin_rev])
         elif rev in revisions:
             # a local tag or branch name
-            return [revisions[rev]]
+            return rev_options.make_new(revisions[rev])
         else:
             logger.warning(
                 "Could not find a tag or branch '%s', assuming commit or ref",
@@ -105,12 +110,16 @@ class Git(VersionControl):
         but current rev will always point to a sha. This means that a branch
         or tag will never compare as True. So this ultimately only matches
         against exact shas.
+
+        Args:
+          rev_options: a RevOptions object.
         """
-        return self.get_revision(dest).startswith(rev_options[0])
+        return self.get_revision(dest).startswith(rev_options.arg_rev)
 
     def switch(self, dest, url, rev_options):
         self.run_command(['config', 'remote.origin.url', url], cwd=dest)
-        self.run_command(['checkout', '-q'] + rev_options, cwd=dest)
+        cmd_args = rev_options.to_args(['checkout', '-q'])
+        self.run_command(cmd_args, cwd=dest)
 
         self.update_submodules(dest)
 
@@ -122,36 +131,28 @@ class Git(VersionControl):
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
         # Then reset to wanted revision (maybe even origin/master)
-        if rev_options:
-            rev_options = self.check_rev_options(
-                rev_options[0], dest, rev_options,
-            )
-        self.run_command(['reset', '--hard', '-q'] + rev_options, cwd=dest)
+        rev_options = self.check_rev_options(dest, rev_options)
+        cmd_args = rev_options.to_args(['reset', '--hard', '-q'])
+        self.run_command(cmd_args, cwd=dest)
         #: update submodules
         self.update_submodules(dest)
 
     def obtain(self, dest):
         url, rev = self.get_url_rev()
-        if rev:
-            rev_options = [rev]
-            rev_display = ' (to %s)' % rev
-        else:
-            rev_options = ['origin/HEAD']
-            rev_display = ''
-        if self.check_destination(dest, url, rev_options, rev_display):
+        rev_options = self.make_rev_options(rev)
+        if self.check_destination(dest, url, rev_options):
+            rev_display = rev_options.to_display()
             logger.info(
                 'Cloning %s%s to %s', url, rev_display, display_path(dest),
             )
             self.run_command(['clone', '-q', url, dest])
 
             if rev:
-                rev_options = self.check_rev_options(rev, dest, rev_options)
+                rev_options = self.check_rev_options(dest, rev_options)
                 # Only do a checkout if rev_options differs from HEAD
                 if not self.check_version(dest, rev_options):
-                    self.run_command(
-                        ['fetch', '-q', url] + rev_options,
-                        cwd=dest,
-                    )
+                    cmd_args = rev_options.to_args(['fetch', '-q', url])
+                    self.run_command(cmd_args, cwd=dest,)
                     self.run_command(
                         ['checkout', '-q', 'FETCH_HEAD'],
                         cwd=dest,

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -118,7 +118,7 @@ class Git(VersionControl):
 
     def switch(self, dest, url, rev_options):
         self.run_command(['config', 'remote.origin.url', url], cwd=dest)
-        cmd_args = rev_options.to_args(['checkout', '-q'])
+        cmd_args = ['checkout', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 
         self.update_submodules(dest)
@@ -132,7 +132,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q'], cwd=dest)
         # Then reset to wanted revision (maybe even origin/master)
         rev_options = self.check_rev_options(dest, rev_options)
-        cmd_args = rev_options.to_args(['reset', '--hard', '-q'])
+        cmd_args = ['reset', '--hard', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
         #: update submodules
         self.update_submodules(dest)
@@ -151,7 +151,7 @@ class Git(VersionControl):
                 rev_options = self.check_rev_options(dest, rev_options)
                 # Only do a checkout if rev_options differs from HEAD
                 if not self.check_version(dest, rev_options):
-                    cmd_args = rev_options.to_args(['fetch', '-q', url])
+                    cmd_args = ['fetch', '-q', url] + rev_options.to_args()
                     self.run_command(cmd_args, cwd=dest,)
                     self.run_command(
                         ['checkout', '-q', 'FETCH_HEAD'],

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -19,6 +19,9 @@ class Mercurial(VersionControl):
     repo_name = 'clone'
     schemes = ('hg', 'hg+http', 'hg+https', 'hg+ssh', 'hg+static-http')
 
+    def get_base_rev_args(self, rev):
+        return [rev]
+
     def export(self, location):
         """Export the Hg repository at the url to the destination location"""
         with TempDirectory(kind="export") as temp_dir:

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -44,12 +44,12 @@ class Mercurial(VersionControl):
                 'Could not switch Mercurial repository to %s: %s', url, exc,
             )
         else:
-            cmd_args = rev_options.to_args(['update', '-q'])
+            cmd_args = ['update', '-q'] + rev_options.to_args()
             self.run_command(cmd_args, cwd=dest)
 
     def update(self, dest, rev_options):
         self.run_command(['pull', '-q'], cwd=dest)
-        cmd_args = rev_options.to_args(['update', '-q'])
+        cmd_args = ['update', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 
     def obtain(self, dest):
@@ -64,7 +64,7 @@ class Mercurial(VersionControl):
                 display_path(dest),
             )
             self.run_command(['clone', '--noupdate', '-q', url, dest])
-            cmd_args = rev_options.to_args(['update', '-q'])
+            cmd_args = ['update', '-q'] + rev_options.to_args()
             self.run_command(cmd_args, cwd=dest)
 
     def get_url(self, location):

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -44,21 +44,19 @@ class Mercurial(VersionControl):
                 'Could not switch Mercurial repository to %s: %s', url, exc,
             )
         else:
-            self.run_command(['update', '-q'] + rev_options, cwd=dest)
+            cmd_args = rev_options.to_args(['update', '-q'])
+            self.run_command(cmd_args, cwd=dest)
 
     def update(self, dest, rev_options):
         self.run_command(['pull', '-q'], cwd=dest)
-        self.run_command(['update', '-q'] + rev_options, cwd=dest)
+        cmd_args = rev_options.to_args(['update', '-q'])
+        self.run_command(cmd_args, cwd=dest)
 
     def obtain(self, dest):
         url, rev = self.get_url_rev()
-        if rev:
-            rev_options = [rev]
-            rev_display = ' (to revision %s)' % rev
-        else:
-            rev_options = []
-            rev_display = ''
-        if self.check_destination(dest, url, rev_options, rev_display):
+        rev_options = self.make_rev_options(rev)
+        if self.check_destination(dest, url, rev_options):
+            rev_display = rev_options.to_display()
             logger.info(
                 'Cloning hg %s%s to %s',
                 url,
@@ -66,7 +64,8 @@ class Mercurial(VersionControl):
                 display_path(dest),
             )
             self.run_command(['clone', '--noupdate', '-q', url, dest])
-            self.run_command(['update', '-q'] + rev_options, cwd=dest)
+            cmd_args = rev_options.to_args(['update', '-q'])
+            self.run_command(cmd_args, cwd=dest)
 
     def get_url(self, location):
         url = self.run_command(

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -28,6 +28,9 @@ class Subversion(VersionControl):
     repo_name = 'checkout'
     schemes = ('svn', 'svn+ssh', 'svn+http', 'svn+https', 'svn+svn')
 
+    def get_base_rev_args(self, rev):
+        return ['-r', rev]
+
     def get_info(self, location):
         """Returns (url, revision), where both are strings"""
         assert not location.rstrip('/').endswith(self.dirname), \

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -70,15 +70,15 @@ class Subversion(VersionControl):
                 # Subversion doesn't like to check out over an existing
                 # directory --force fixes this, but was only added in svn 1.5
                 rmtree(location)
-            cmd_args = rev_options.to_args(['export'], [url, location])
+            cmd_args = ['export'] + rev_options.to_args() + [url, location]
             self.run_command(cmd_args, show_stdout=False)
 
     def switch(self, dest, url, rev_options):
-        cmd_args = rev_options.to_args(['switch'], [url, dest])
+        cmd_args = ['switch'] + rev_options.to_args() + [url, dest]
         self.run_command(cmd_args)
 
     def update(self, dest, rev_options):
-        cmd_args = rev_options.to_args(['update'], [dest])
+        cmd_args = ['update'] + rev_options.to_args() + [dest]
         self.run_command(cmd_args)
 
     def obtain(self, dest):
@@ -93,7 +93,7 @@ class Subversion(VersionControl):
                 rev_display,
                 display_path(dest),
             )
-            cmd_args = rev_options.to_args(['checkout', '-q'], [url, dest])
+            cmd_args = ['checkout', '-q'] + rev_options.to_args() + [url, dest]
             self.run_command(cmd_args)
 
     def get_location(self, dist, dependency_links):

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -62,7 +62,7 @@ class Subversion(VersionControl):
     def export(self, location):
         """Export the svn repository at the url to the destination location"""
         url, rev = self.get_url_rev()
-        rev_options = get_rev_options(url, rev)
+        rev_options = get_rev_options(self, url, rev)
         url = self.remove_auth_from_url(url)
         logger.info('Exporting svn repository %s to %s', url, location)
         with indent_log():
@@ -70,32 +70,31 @@ class Subversion(VersionControl):
                 # Subversion doesn't like to check out over an existing
                 # directory --force fixes this, but was only added in svn 1.5
                 rmtree(location)
-            self.run_command(
-                ['export'] + rev_options + [url, location],
-                show_stdout=False)
+            cmd_args = rev_options.to_args(['export'], [url, location])
+            self.run_command(cmd_args, show_stdout=False)
 
     def switch(self, dest, url, rev_options):
-        self.run_command(['switch'] + rev_options + [url, dest])
+        cmd_args = rev_options.to_args(['switch'], [url, dest])
+        self.run_command(cmd_args)
 
     def update(self, dest, rev_options):
-        self.run_command(['update'] + rev_options + [dest])
+        cmd_args = rev_options.to_args(['update'], [dest])
+        self.run_command(cmd_args)
 
     def obtain(self, dest):
         url, rev = self.get_url_rev()
-        rev_options = get_rev_options(url, rev)
+        rev_options = get_rev_options(self, url, rev)
         url = self.remove_auth_from_url(url)
-        if rev:
-            rev_display = ' (to revision %s)' % rev
-        else:
-            rev_display = ''
-        if self.check_destination(dest, url, rev_options, rev_display):
+        if self.check_destination(dest, url, rev_options):
+            rev_display = rev_options.to_display()
             logger.info(
                 'Checking out %s%s to %s',
                 url,
                 rev_display,
                 display_path(dest),
             )
-            self.run_command(['checkout', '-q'] + rev_options + [url, dest])
+            cmd_args = rev_options.to_args(['checkout', '-q'], [url, dest])
+            self.run_command(cmd_args)
 
     def get_location(self, dist, dependency_links):
         for url in dependency_links:
@@ -241,12 +240,10 @@ class Subversion(VersionControl):
         return surl
 
 
-def get_rev_options(url, rev):
-    if rev:
-        rev_options = ['-r', rev]
-    else:
-        rev_options = []
-
+def get_rev_options(vcs, url, rev):
+    """
+    Return a RevOptions object.
+    """
     r = urllib_parse.urlsplit(url)
     if hasattr(r, 'username'):
         # >= Python-2.5
@@ -262,11 +259,13 @@ def get_rev_options(url, rev):
         else:
             username, password = None, None
 
+    extra_args = []
     if username:
-        rev_options += ['--username', username]
+        extra_args += ['--username', username]
     if password:
-        rev_options += ['--password', password]
-    return rev_options
+        extra_args += ['--password', password]
+
+    return vcs.make_rev_options(rev, extra_args=extra_args)
 
 
 vcs.register(Subversion)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -140,7 +140,8 @@ def test_git_get_src_requirements(git, dist):
     ('foo', False),
 ))
 def test_git_check_version(git, ref, result):
-    assert git.check_version('foo', ref) is result
+    rev_options = git.make_rev_options(ref)
+    assert git.check_version('foo', rev_options) is result
 
 
 def test_translate_egg_surname():

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -29,7 +29,7 @@ def test_rev_options_to_args():
     """
     # Check VCS-specific RevOptions behavior.
     check_to_args(Bazaar(), ['cmd'], ['cmd', '-r', '123'])
-    check_to_args(Git(), ['cmd', 'origin/master'], ['cmd', '123'])
+    check_to_args(Git(), ['cmd', 'origin/HEAD'], ['cmd', '123'])
     check_to_args(Mercurial(), ['cmd'], ['cmd', '123'])
     check_to_args(Subversion(), ['cmd'], ['cmd', '-r', '123'])
 


### PR DESCRIPTION
This PR adds a `RevOptions` class to encapsulate the argument information needed to run VCS commands for a revision.

Currently, the code base requires passing around at least three distinct, closely related pieces of information: the `rev` (revision to install), the `rev_options` (list of VCS command arguments), and `rev_display` (how to display the revision to the end-user). It would be easier if this information can be passed around as a single unit.

Also, in some cases the code "recomputes" the `rev` from the `rev_options` argument list. The `Git` class does this [here](https://github.com/pypa/pip/blob/a9d56c7734fd465d01437d61f632749a293e7805/src/pip/_internal/vcs/git.py#L105):

```python
return self.get_revision(dest).startswith(rev_options[0])
```

And [here](https://github.com/pypa/pip/blob/a9d56c7734fd465d01437d61f632749a293e7805/src/pip/_internal/vcs/git.py#L122):

```python
rev_options = self.check_rev_options(
    rev_options[0], dest, rev_options,
)
```

Accessing `rev_options[0]` is somewhat of a hack because it is brittle and VCS-specific. This can be done for the Git case because `rev_options` happens always to be `[rev]` (at least when `rev_options` is non-empty). For Subversion though, `rev_options` can take the form:

    ['-r', rev, '--username`, `John`]

The `RevOptions` class allows the `rev` to be accessed programmatically by storing this value as an attribute (e.g. letting us remove some Git-specific hacks like above).

Another advantage of adding a `RevOptions` class is that more code can be moved into a class that can be unit-tested in a stand-alone fashion (and without using mocks, etc).  This PR adds such tests for the `RevOptions` class.
