### PR TITLE
Python 3.6 invalid escape sequence deprecation fixes

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -289,7 +289,7 @@ class PackageFinder(object):
                 )
             pri = -(wheel.support_index_min(self.valid_tags))
             if wheel.build_tag is not None:
-                match = re.match('^(\d+)(.*)$', wheel.build_tag)
+                match = re.match(r'^(\d+)(.*)$', wheel.build_tag)
                 build_tag_groups = match.groups()
                 build_tag = (int(build_tag_groups[0]), build_tag_groups[1])
         else:  # sdist

--- a/tests/functional/test_yaml.py
+++ b/tests/functional/test_yaml.py
@@ -12,7 +12,7 @@ from tests.lib.yaml_helpers import generate_yaml_tests, id_func
 _conflict_finder_re = re.compile(
     # Conflicting Requirements: \
     # A 1.0.0 requires B == 2.0.0, C 1.0.0 requires B == 1.0.0.
-    """
+    r"""
         (?P<package>[\w\-_]+?)
         [ ]
         (?P<version>\S+?)


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior