### PR TITLE
Add a global option to disable colors

### DIFF
--- a/docs/reference/pip.rst
+++ b/docs/reference/pip.rst
@@ -24,7 +24,9 @@ Console logging
 ~~~~~~~~~~~~~~~
 
 pip offers :ref:`-v, --verbose <--verbose>` and :ref:`-q, --quiet <--quiet>`
-to control the console log level.
+to control the console log level. By default, some messages (error and warnnings)
+are colored in the terminal. If you want to suppress the colored output use
+:ref:`--no-color <--no-color>`.
 
 
 .. _`FileLogging`:

--- a/docs/reference/pip.rst
+++ b/docs/reference/pip.rst
@@ -24,7 +24,7 @@ Console logging
 ~~~~~~~~~~~~~~~
 
 pip offers :ref:`-v, --verbose <--verbose>` and :ref:`-q, --quiet <--quiet>`
-to control the console log level. By default, some messages (error and warnnings)
+to control the console log level. By default, some messages (error and warnings)
 are colored in the terminal. If you want to suppress the colored output use
 :ref:`--no-color <--no-color>`.
 

--- a/news/2449.feature
+++ b/news/2449.feature
@@ -1,0 +1,2 @@
+Add `--no-color` to `pip`. All colored output is disabled
+if this flag is detected.

--- a/src/pip/_internal/basecommand.py
+++ b/src/pip/_internal/basecommand.py
@@ -151,7 +151,9 @@ class Command(object):
                 "console": {
                     "level": level,
                     "class":
-                        "pip._internal.utils.logging.ColorizedStreamHandler",
+                    "logging.StreamHandler"
+                        if options.no_color
+                        else "pip._internal.utils.logging.ColorizedStreamHandler",
                     "stream": self.log_streams[0],
                     "filters": ["exclude_warnings"],
                     "formatter": "indent",
@@ -159,7 +161,9 @@ class Command(object):
                 "console_errors": {
                     "level": "WARNING",
                     "class":
-                        "pip._internal.utils.logging.ColorizedStreamHandler",
+                    "logging.StreamHandler"
+                        if options.no_color
+                        else "pip._internal.utils.logging.ColorizedStreamHandler",
                     "stream": self.log_streams[1],
                     "formatter": "indent",
                 },

--- a/src/pip/_internal/basecommand.py
+++ b/src/pip/_internal/basecommand.py
@@ -132,6 +132,11 @@ class Command(object):
         if options.log:
             root_level = "DEBUG"
 
+        if options.no_color:
+            logger_class = "logging.StreamHandler"
+        else:
+            logger_class = "pip._internal.utils.logging.ColorizedStreamHandler"
+
         logging.config.dictConfig({
             "version": 1,
             "disable_existing_loggers": False,
@@ -150,22 +155,14 @@ class Command(object):
             "handlers": {
                 "console": {
                     "level": level,
-                    "class":
-                    "logging.StreamHandler"
-                        if options.no_color
-                        else ("pip._internal.utils.logging."
-                              "ColorizedStreamHandler"),
+                    "class": logger_class,
                     "stream": self.log_streams[0],
                     "filters": ["exclude_warnings"],
                     "formatter": "indent",
                 },
                 "console_errors": {
                     "level": "WARNING",
-                    "class":
-                    "logging.StreamHandler"
-                        if options.no_color
-                        else ("pip._internal.utils.logging"
-                              ".ColorizedStreamHandler"),
+                    "class": logger_class,
                     "stream": self.log_streams[1],
                     "formatter": "indent",
                 },

--- a/src/pip/_internal/basecommand.py
+++ b/src/pip/_internal/basecommand.py
@@ -153,7 +153,8 @@ class Command(object):
                     "class":
                     "logging.StreamHandler"
                         if options.no_color
-                        else "pip._internal.utils.logging.ColorizedStreamHandler",
+                        else ("pip._internal.utils.logging."
+                              "ColorizedStreamHandler"),
                     "stream": self.log_streams[0],
                     "filters": ["exclude_warnings"],
                     "formatter": "indent",
@@ -163,7 +164,8 @@ class Command(object):
                     "class":
                     "logging.StreamHandler"
                         if options.no_color
-                        else "pip._internal.utils.logging.ColorizedStreamHandler",
+                        else ("pip._internal.utils.logging"
+                              ".ColorizedStreamHandler"),
                     "stream": self.log_streams[1],
                     "formatter": "indent",
                 },

--- a/src/pip/_internal/cmdoptions.py
+++ b/src/pip/_internal/cmdoptions.py
@@ -102,6 +102,15 @@ verbose = partial(
     help='Give more output. Option is additive, and can be used up to 3 times.'
 )
 
+no_color = partial(
+    Option,
+    '--no-color',
+    dest='no_color',
+    action='store_true',
+    default=False,
+    help="Suppress colored output"
+)
+
 version = partial(
     Option,
     '-V', '--version',
@@ -566,6 +575,7 @@ general_group = {
         cache_dir,
         no_cache,
         disable_pip_version_check,
+        no_color
     ]
 }
 

--- a/src/pip/_internal/cmdoptions.py
+++ b/src/pip/_internal/cmdoptions.py
@@ -108,7 +108,7 @@ no_color = partial(
     dest='no_color',
     action='store_true',
     default=False,
-    help="Suppress colored output"
+    help="Suppress colored output",
 )
 
 version = partial(
@@ -575,7 +575,7 @@ general_group = {
         cache_dir,
         no_cache,
         disable_pip_version_check,
-        no_color
+        no_color,
     ]
 }
 

--- a/tests/functional/test_no_color.py
+++ b/tests/functional/test_no_color.py
@@ -26,12 +26,20 @@ def test_no_color(script):
              stdout=sp.PIPE, stderr=sp.PIPE).communicate()
 
     with open("/tmp/colored-output.txt", "r") as result:
-        output = result.read()
+
+        red_lines = 0
+        reset_lines = 0
+
+        for line in result.readlines():
+            if line.startswith("\x1b[31m"):
+                red_lines += 1
+            if line.endswith("\x1b[0m\n"):
+                reset_lines += 1
+
+        assert red_lines >= 1
+        assert reset_lines >= 1
 
     os.unlink("/tmp/colored-output.txt")
-
-    assert output.startswith("\x1b[31m")
-    assert output.endswith("\x1b[0m\n")
 
     sp.Popen("script --flush --quiet --return /tmp/no-color-output.txt"
              " --command \"pip --no-color uninstall noSuchPackage\"",
@@ -39,9 +47,15 @@ def test_no_color(script):
              stdout=sp.PIPE, stderr=sp.PIPE).communicate()
 
     with open("/tmp/no-color-output.txt", "r") as result:
-        output = result.read()
+        red_lines = 0
+        reset_lines = 0
+        for line in result.readlines():
+            if line.startswith("\x1b[31m"):
+                red_lines += 1
+            if line.endswith("\x1b[0m\n"):
+                reset_lines += 1
 
     os.unlink("/tmp/no-color-output.txt")
 
-    assert not output.startswith("\x1b[31m")
-    assert not output.endswith("\x1b[0m\n")
+    assert red_lines == 0
+    assert reset_lines == 0

--- a/tests/functional/test_no_color.py
+++ b/tests/functional/test_no_color.py
@@ -4,11 +4,12 @@ Test specific for the --no-color option
 import os
 import platform
 import subprocess as sp
+import sys
 
 import pytest
 
 
-@pytest.mark.skipif(platform.system() == 'Windows',
+@pytest.mark.skipif(sys.platform == 'win32',
                     reason="does not run on windows")
 def test_no_color(script):
 

--- a/tests/functional/test_no_color.py
+++ b/tests/functional/test_no_color.py
@@ -1,0 +1,46 @@
+"""
+Test specific for the --no-color option
+"""
+import os
+import platform
+import subprocess as sp
+
+import pytest
+
+
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason="does not run on windows")
+def test_no_color(script):
+
+    """
+    Test uninstalling an existing package - should out put red error
+
+    We must use subprocess with the script command, since redirection
+    in unix platform causes text coloring to disapper. Thus, we can't
+    use the testing infrastructure that other options has.
+    """
+
+    sp.Popen("script --flush --quiet --return /tmp/colored-output.txt"
+             " --command \"pip uninstall noSuchPackage\"", shell=True,
+             stdout=sp.PIPE, stderr=sp.PIPE).communicate()
+
+    with open("/tmp/colored-output.txt", "r") as result:
+        output = result.read()
+
+    os.unlink("/tmp/colored-output.txt")
+
+    assert output.startswith("\x1b[31m")
+    assert output.endswith("\x1b[0m\n")
+
+    sp.Popen("script --flush --quiet --return /tmp/no-color-output.txt"
+             " --command \"pip --no-color uninstall noSuchPackage\"",
+             shell=True,
+             stdout=sp.PIPE, stderr=sp.PIPE).communicate()
+
+    with open("/tmp/no-color-output.txt", "r") as result:
+        output = result.read()
+
+    os.unlink("/tmp/no-color-output.txt")
+
+    assert not output.startswith("\x1b[31m")
+    assert not output.endswith("\x1b[0m\n")

--- a/tests/functional/test_no_color.py
+++ b/tests/functional/test_no_color.py
@@ -26,18 +26,7 @@ def test_no_color(script):
              stdout=sp.PIPE, stderr=sp.PIPE).communicate()
 
     with open("/tmp/colored-output.txt", "r") as result:
-
-        red_lines = 0
-        reset_lines = 0
-
-        for line in result.readlines():
-            if line.startswith("\x1b[31m"):
-                red_lines += 1
-            if line.endswith("\x1b[0m\n"):
-                reset_lines += 1
-
-        assert red_lines >= 1
-        assert reset_lines >= 1
+        assert "\x1b[31m" in result.read()
 
     os.unlink("/tmp/colored-output.txt")
 
@@ -47,15 +36,6 @@ def test_no_color(script):
              stdout=sp.PIPE, stderr=sp.PIPE).communicate()
 
     with open("/tmp/no-color-output.txt", "r") as result:
-        red_lines = 0
-        reset_lines = 0
-        for line in result.readlines():
-            if line.startswith("\x1b[31m"):
-                red_lines += 1
-            if line.endswith("\x1b[0m\n"):
-                reset_lines += 1
+        assert "\x1b[31m" not in result.read()
 
     os.unlink("/tmp/no-color-output.txt")
-
-    assert red_lines == 0
-    assert reset_lines == 0


### PR DESCRIPTION
 This is a fix for issue #2449

 All it does is simply add a global option --no-color

 Internally it switches ColorizedStreamHandler to StreamHandler if
 this flag is detected.

![pip-fix](https://user-images.githubusercontent.com/1083045/30915270-8f69ab88-a396-11e7-82e2-85d0c42561c6.png)
