### PR TITLE
Autocomplete installed dists in `pip show ...`.

### DIFF
--- a/news/4749.feature
+++ b/news/4749.feature
@@ -1,0 +1,2 @@
+The command-line autocompletion engine ``pip show`` now autocompletes installed
+distribution names.

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -87,8 +87,9 @@ def autocomplete():
         # special case: 'help' subcommand has no options
         if subcommand_name == 'help':
             sys.exit(1)
-        # special case: list locally installed dists for uninstall command
-        if subcommand_name == 'uninstall' and not current.startswith('-'):
+        # special case: list locally installed dists for show and uninstall
+        if (subcommand_name in ['show', 'uninstall']
+                and not current.startswith('-')):
             installed = []
             lc = current.lower()
             for dist in get_installed_distributions(local_only=True):

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -88,8 +88,11 @@ def autocomplete():
         if subcommand_name == 'help':
             sys.exit(1)
         # special case: list locally installed dists for show and uninstall
-        if (subcommand_name in ['show', 'uninstall']
-                and not current.startswith('-')):
+        should_list_installed = (
+            subcommand_name in ['show', 'uninstall'] and
+            not current.startswith('-')
+        )
+        if should_list_installed:
             installed = []
             lc = current.lower()
             for dist in get_installed_distributions(local_only=True):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->

Fixes the second half of https://github.com/pypa/pip/issues/3849.