### PR TITLE
Pip freeze of editable git repos reports repo path

### DIFF
--- a/news/4759.bugfix
+++ b/news/4759.bugfix
@@ -1,2 +1,2 @@
-Rather than report an error for git repositories with no remotes in
-pip freeze output report the filesystem location with a file:// url.
+Pip freeze now reports URL based on file system location for git
+repositories with no remotes.

--- a/news/4759.bugfix
+++ b/news/4759.bugfix
@@ -1,0 +1,2 @@
+Rather than report an error for git repositories with no remotes in
+pip freeze output report the filesystem location with a file:// url.

--- a/news/4759.bugfix
+++ b/news/4759.bugfix
@@ -1,2 +1,2 @@
-Pip freeze now reports URL based on file system location for git
+pip freeze now reports URL based on file system location for git
 repositories with no remotes.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -208,7 +208,7 @@ class Git(VersionControl):
                 ['config', '--get-regexp', r'remote\..*\.url'],
                 show_stdout=False, cwd=location,
             )
-        except InstallationError as e:
+        except InstallationError:
             # If the above command fails we have no git remotes or cannot
             # determine what they are. Just use the local repo path in that
             # case instead.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -208,6 +208,12 @@ class Git(VersionControl):
                 ['config', '--get-regexp', r'remote\..*\.url'],
                 show_stdout=False, cwd=location,
             )
+        except InstallationError as e:
+            # If the above command fails we have no git remotes or cannot
+            # determine what they are. Just use the local repo path in that
+            # case instead.
+            url = 'file://' + location
+        else:
             remotes = remotes.splitlines()
             found_remote = remotes[0]
             for remote in remotes:
@@ -215,10 +221,6 @@ class Git(VersionControl):
                     found_remote = remote
                     break
             url = found_remote.split(' ')[1]
-        except InstallationError:
-            # If the above command fails we have no git remotes. Just use the
-            # local repo path in that case instead.
-            url = 'file://' + location
         return url.strip()
 
     def get_revision(self, location):

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -331,7 +331,6 @@ def test_freeze_git_remote(script, tmpdir):
         """
     ).format(remote='file://' + repo_dir).strip()
     _check_output(result.stdout, expected)
-    # check when there are no remotes. Should report local file path.
 
 
 @need_mercurial

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -329,7 +329,7 @@ def test_freeze_git_remote(script, tmpdir):
             ...-e git+{remote}@...#egg=version_pkg
             ...
         """
-    ).format(remote='file://' + repo_dir).strip()
+    ).format(remote='file://' + os.path.normcase(repo_dir)).strip()
     _check_output(result.stdout, expected)
 
 

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -320,6 +320,18 @@ def test_freeze_git_remote(script, tmpdir):
         """
     ).format(remote=origin_remote).strip()
     _check_output(result.stdout, expected)
+    # check when there are no remotes. Should report local file path.
+    script.run('git', 'remote', 'remove', 'origin', cwd=repo_dir)
+    script.run('git', 'remote', 'remove', 'other', cwd=repo_dir)
+    result = script.pip('freeze', expect_stderr=True)
+    expected = textwrap.dedent(
+        """
+            ...-e git+{remote}@...#egg=version_pkg
+            ...
+        """
+    ).format(remote='file://' + repo_dir).strip()
+    _check_output(result.stdout, expected)
+    # check when there are no remotes. Should report local file path.
 
 
 @need_mercurial

--- a/tests/functional/test_install_vcs.py
+++ b/tests/functional/test_install_vcs.py
@@ -292,21 +292,6 @@ def test_git_with_ambiguous_revs(script):
 
 
 @pytest.mark.network
-def test_git_works_with_editable_non_origin_repo(script):
-    # set up, create a git repo and install it as editable from a local
-    # directory path
-    version_pkg_path = _create_test_package(script)
-    script.pip('install', '-e', version_pkg_path.abspath)
-
-    # 'freeze'ing this should not fall over, but should result in stderr output
-    # warning
-    result = script.pip('freeze', expect_stderr=True)
-    assert "Error when trying to get requirement" in result.stderr
-    assert "Could not determine repository location" in result.stdout
-    assert "version-pkg==0.1" in result.stdout
-
-
-@pytest.mark.network
 def test_reinstalling_works_with_editible_non_master_branch(script):
     """
     Reinstalling an editable installation should not assume that the "master"


### PR DESCRIPTION
Rather than report an error for git repositories with no remotes in
pip freeze output report the filesystem location with a file:// url.

Edit by @pradyunsg: Fixes #4759