### PR TITLE
Strip usage in the documentation

### DIFF
--- a/docs/pipext.py
+++ b/docs/pipext.py
@@ -17,7 +17,7 @@ class PipCommandUsage(rst.Directive):
     def run(self):
         cmd = commands[self.arguments[0]]
         prog = '%s %s' % (get_prog(), cmd.name)
-        usage = dedent(cmd.usage.replace('%prog', prog))
+        usage = dedent(cmd.usage.replace('%prog', prog)).strip()
         node = nodes.literal_block(usage, usage)
         return [node]
 


### PR DESCRIPTION
This removes a useless empty line in the output.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
