### PR TITLE
pytest: enable report

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ follow_imports = skip
 ignore_errors = True
 
 [tool:pytest]
-addopts = --ignore src/pip/_vendor --ignore tests/tests_cache
+addopts = --ignore src/pip/_vendor --ignore tests/tests_cache -r aR
 
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
Rational: easier to read, show xpassed tests and rerun failures.

On that subject: `test_unsupported_hashes` does show has xpassed on Windows:
```
XPASS tests/unit/test_req.py::TestRequirementSet::()::test_unsupported_hashes Code doesn't handle url-encoded Windows paths
```