### PR TITLE
tests: do not mark `test_unsupported_hashes` as xfailed

### DIFF
--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -165,10 +165,6 @@ class TestRequirementSet(object):
                 wheel_cache=None)
         assert req_set.require_hashes
 
-    # This test doesn't appear to handle URL-encoded Windows paths
-    # correctly. Needs reviewing by someone who understands the logic.
-    @pytest.mark.xfail("sys.platform == 'win32'",
-                       reason="Code doesn't handle url-encoded Windows paths")
     def test_unsupported_hashes(self, data):
         """VCS and dir links should raise errors when --require-hashes is
         on.


### PR DESCRIPTION
The test got fixed in f1d0939d (between 9.0 and 9.0.1).