### PR TITLE
Remove python 3.3 from package classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ matrix:
     - env: TOXENV=py36
       python: 3.6
     # All the other Py3 versions
-    - env: TOXENV=py33
-      python: 3.3
     - env: TOXENV=py34
       python: 3.4
     - env: TOXENV=py35

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ environment:
       RUN_INTEGRATION_TESTS: "True"
     # Unit tests only.
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python33"
-    - PYTHON: "C:\\Python33-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35"

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -102,7 +102,7 @@ On Windows [4]_::
 Python and OS Compatibility
 ---------------------------
 
-pip works with CPython versions 2.7, 3.3, 3.4, 3.5, 3.6 and also pypy.
+pip works with CPython versions 2.7, 3.4, 3.5, 3.6 and also pypy.
 
 This means pip works on the latest patch version of each of these minor
 versions. Previous patch versions are supported on a best effort approach.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     docs, packaging, lint-py2, lint-py3, mypy,
-    py27, py33, py34, py35, py36, py37, pypy
+    py27, py34, py35, py36, py37, pypy
 
 [testenv]
 passenv = GIT_SSL_CAINFO


### PR DESCRIPTION
Hello, this seems to have been missed in #4355.