### PR TITLE
Fix ResourceWarning generated by setup.py when warnings are enabled

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ here = os.path.abspath(os.path.dirname(__file__))
 def read(*parts):
     # intentionally *not* adding an encoding option to open, See:
     #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
-    return codecs.open(os.path.join(here, *parts), 'r').read()
+    with codecs.open(os.path.join(here, *parts), 'r') as fp:
+        return fp.read()
 
 
 def find_version(*file_paths):


### PR DESCRIPTION
Appears as:

```
  ResourceWarning: unclosed file ...
```

Always explicitly close open files. Use context manager to make this easier.