### PR TITLE
Add support for '#' in git branch names (as git does not disallow them)

### DIFF
--- a/news/handle-#-in-branch-names.feature
+++ b/news/handle-#-in-branch-names.feature
@@ -1,0 +1,1 @@
+Properly handle Git VCS branch names which contain '#'

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -226,7 +226,9 @@ class VersionControl(object):
         )
         assert '+' in self.url, error_message % self.url
         url = self.url.split('+', 1)[1]
-        scheme, netloc, path, query, frag = urllib_parse.urlsplit(url)
+        scheme, netloc, path, query, frag = urllib_parse.urlsplit(url, allow_framents=False)
+        if '#' in path:
+            path, frag = path.rsplit('#', 1)
         rev = None
         if '@' in path:
             path, rev = path.rsplit('@', 1)

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -381,6 +381,12 @@ class TestInstallRequirement(object):
         req = InstallRequirement.from_editable(url)
         assert req.link.url == url
 
+    def test_url_with_pound_sign_in_the_branch_name_req(self):
+        """Confirm that an URL which contains # in the branch name is correctly parsed"""
+        url = 'git+ssh://git@github.com/owner/reponame.git@issue#2035#egg=Reponame'
+        req = InstallRequirement.from_editable(url)
+        assert req.link.url == url
+
     @pytest.mark.parametrize('path', (
         '/path/to/foo.egg-info'.replace('/', os.path.sep),
         # Tests issue fixed by https://github.com/pypa/pip/pull/2530


### PR DESCRIPTION
Considering the following URL 'git+ssh://git@github.com/owner/reponame.git@issue#2035#egg=Reponame', previously we'd get an error similar to:
```
Collecting Reponame from git+ssh://git@github.com/owner/reponame.git@issue#2035#egg=Reponame
  Cloning ssh://git@github.com/owner/reponame.git (to issue) to /tmp/vampas/pip-build-ftjipp8c/Reponame
  Could not find a tag or branch 'issue', assuming commit.
error: pathspec 'issue' did not match any file(s) known to git.
```

With this change, we check for an existing '#' in the frag part of the
parsed URL and add back the remaining of the path in such case.

We now get something like:
```
Collecting Reponame from git+ssh://git@github.com/owner/reponame.git@issue#2035#egg=Reponame
  Cloning ssh://git@github.com/owner/reponame.git (to revision issue#2035) to /tmp/vampas/pip-install-jjs7njl1/Reponame
Installing collected packages: Reponame
  Running setup.py install for Reponame ... done
Successfully installed Reponame-5.2
```

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
