### PR TITLE
Do case-insensitive matching of env-vars for configuration

### DIFF
--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -313,7 +313,7 @@ class Configuration(object):
         """Returns a generator with all environmental vars with prefix PIP_"""
         for key, val in os.environ.items():
             should_be_yielded = (
-                key.startswith("PIP_") and
+                key.upper().startswith("PIP_") and
                 key[4:].lower() not in self._ignore_env_names
             )
             if should_be_yielded:

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -52,13 +52,11 @@ class TestConfigurationLoading(ConfigurationMixin):
         self.configuration.load()
         assert self.configuration.get_value(":env:.hello") == "5"
 
-    @pytest.mark.skipif("sys.platform == 'win32'")
-    def test_environment_var_does_not_load_lowercase(self):
+    def test_environment_var_does_load_lowercase(self):
         os.environ["pip_hello"] = "5"
 
         self.configuration.load()
-        with pytest.raises(ConfigurationError):
-            self.configuration.get_value(":env:.hello")
+        assert self.configuration.get_value(":env:.hello") == "5"
 
     def test_environment_var_does_not_load_version(self):
         os.environ["PIP_VERSION"] = "True"


### PR DESCRIPTION
@pfmoore My notes say that you'd asked for this (at some point in the past).
