### PR TITLE
Do not swallow all exceptions during wheel building

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -58,6 +58,7 @@ Cody <Purring@users.noreply.github.com>
 Cody Soyland <codysoyland@gmail.com>
 Colin Watson <cjwatson@debian.org>
 Connor Osborn <cdosborn@email.arizona.edu>
+Cooper Lees <me@cooperlees.com>
 Cory Benfield <lukasaoz@gmail.com>
 Cory Wright <corywright@gmail.com>
 Craig Kerstiens <craig.kerstiens@gmail.com>

--- a/news/4829.bugfix
+++ b/news/4829.bugfix
@@ -1,0 +1,2 @@
+Stop a key part of wheel.py swallowing useful debug exception information
+during a wheel build

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -733,10 +733,12 @@ class WheelBuilder(object):
                     shutil.move(
                         os.path.join(temp_dir.path, wheel_name), wheel_path
                     )
+                except BaseException as exc:
+                    logger.critical('Failed to build: %s', exc)
+                    logger.debug('Exception information:', exc_info=True)
+                else:
                     logger.info('Stored in directory: %s', output_dir)
                     return wheel_path
-                except:
-                    pass
             # Ignore return, we can't do anything else useful.
             self._clean_one(req)
             return None


### PR DESCRIPTION
- Due to swallowing all the exceptions (even in logging.DEBUG mode) it took longer than desired to workout why pip would not work in my chroot build environment
- It was a simple PermissionsError - If that had been printed I would of fixed my chroot creation code in seconds and moved on with life
- I would like to save future `pip` debuggers time and effort :D

Tested: Copied over wheel.py in a virtualenv and used this code to see my very simple problem