### PR TITLE
Print the test environment on run failures

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -360,10 +360,15 @@ class PipTestEnvironment(scripttest.TestFileEnvironment):
         if sys.platform == 'win32':
             # Partial fix for ScriptTest.run using `shell=True` on Windows.
             args = [str(a).replace('^', '^^').replace('&', '^&') for a in args]
-        return TestPipResult(
-            super(PipTestEnvironment, self).run(cwd=cwd, *args, **kw),
-            verbose=self.verbose,
-        )
+
+        super_obj = super(PipTestEnvironment, self)
+        try:
+            result = super_obj.run(cwd=cwd, *args, **kw)
+        except Exception:
+            print(super_obj)
+            raise
+        else:
+            return TestPipResult(result, verbose=self.verbose)
 
     def pip(self, *args, **kwargs):
         # On old versions of Python, urllib3/requests will raise a warning


### PR DESCRIPTION
Intended to help debug failures such as [this](https://ci.appveyor.com/project/pypa/pip/build/1.0.1823/job/kg3dknp7e5coly71) which are happening on CI.

I'm not sure how and why they happen since they should be re-run and having this output when tests run on various PRs would likely make easier to locate the cause of this hiesenbug.
