### PR TITLE
tox: fix handling of flaky tests during CI builds

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py27, py33, py34, py35, py36, py37, pypy
 
 [testenv]
-passenv = GIT_SSL_CAINFO
+passenv = CI GIT_SSL_CAINFO
 setenv =
     # This is required in order to get UTF-8 output inside of the subprocesses
     # that our tests use.


### PR DESCRIPTION
Pass the `CI` environment variable to the testsuite so flaky tests are automatically re-run on failure.