### PR TITLE
Minor README updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ tool for installing Python packages.
 .. image:: https://img.shields.io/appveyor/ci/pypa/pip.svg
    :target: https://ci.appveyor.com/project/pypa/pip/history
 
-.. image:: https://readthedocs.org/projects/pip/badge/?version=stable
-   :target: https://pip.pypa.io/en/stable
+.. image:: https://readthedocs.org/projects/pip/badge/?version=latest
+   :target: https://pip.pypa.io/en/latest
 
 * `Installation <https://pip.pypa.io/en/stable/installing.html>`_
 * `Documentation <https://pip.pypa.io/>`_

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,7 @@
 pip
 ===
 
-The `PyPA recommended
-<https://packaging.python.org/en/latest/current/>`_
-tool for installing Python packages.
+The `PyPA recommended`_ tool for installing Python packages.
 
 .. image:: https://img.shields.io/pypi/v/pip.svg
    :target: https://pypi.python.org/pypi/pip
@@ -17,21 +15,28 @@ tool for installing Python packages.
 .. image:: https://readthedocs.org/projects/pip/badge/?version=latest
    :target: https://pip.pypa.io/en/latest
 
-* `Installation <https://pip.pypa.io/en/stable/installing.html>`_
-* `Documentation <https://pip.pypa.io/>`_
-* `Changelog <https://pip.pypa.io/en/stable/news.html>`_
-* `GitHub Page <https://github.com/pypa/pip>`_
-* `Issue Tracking <https://github.com/pypa/pip/issues>`_
-* `User mailing list <http://groups.google.com/group/python-virtualenv>`_
-* `Dev mailing list <http://groups.google.com/group/pypa-dev>`_
+* `Installation`_
+* `Documentation`_
+* `Changelog`_
+* `GitHub Page`_
+* `Issue Tracking`_
+* `User mailing list`_
+* `Dev mailing list`_
 * User IRC: #pypa on Freenode.
 * Dev IRC: #pypa-dev on Freenode.
-
 
 Code of Conduct
 ---------------
 
 Everyone interacting in the pip project's codebases, issue trackers, chat
-rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
+rooms and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 
+.. _PyPA recommended: https://packaging.python.org/en/latest/current/
+.. _Installation: https://pip.pypa.io/en/stable/installing.html
+.. _Documentation: https://pip.pypa.io/en/stable/
+.. _Changelog: https://pip.pypa.io/en/stable/news.html
+.. _GitHub Page: https://github.com/pypa/pip
+.. _Issue Tracking: https://github.com/pypa/pip/issues
+.. _User mailing list: http://groups.google.com/group/python-virtualenv>
+.. _Dev mailing list: http://groups.google.com/group/pypa-dev>
 .. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/


### PR DESCRIPTION
- Updates documentation badge to refer to master instead of the previous release
  - stable build is currently failing due to changes in documentation build config in #4778
- Moves all links to the end of the document
