### PR TITLE
Fix typos in mailing list links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,6 @@ rooms and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 .. _Changelog: https://pip.pypa.io/en/stable/news.html
 .. _GitHub Page: https://github.com/pypa/pip
 .. _Issue Tracking: https://github.com/pypa/pip/issues
-.. _User mailing list: http://groups.google.com/group/python-virtualenv>
-.. _Dev mailing list: http://groups.google.com/group/pypa-dev>
+.. _User mailing list: http://groups.google.com/group/python-virtualenv
+.. _Dev mailing list: http://groups.google.com/group/pypa-dev
 .. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/


### PR DESCRIPTION
The links to the mailing lists contained a trailing '>', resulting in a 404 error.
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
