### PR TITLE
Add Perforce as supported VCS

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -7,3 +7,10 @@ git config --global user.name "pip"
 
 pip install --upgrade setuptools
 pip install --upgrade tox
+
+wget -N -P "$HOME/.p4/bin" \
+    "http://ftp.perforce.com/perforce/r17.2/bin.linux26x86_64/p4" \
+    "http://ftp.perforce.com/perforce/r17.2/bin.linux26x86_64/p4d"
+chmod +x \
+    "$HOME/.p4/bin/p4" \
+    "$HOME/.p4/bin/p4d"

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,6 +2,8 @@
 set -e
 set -x
 
+export PATH="$PATH:$HOME/.p4/bin"
+
 if [[ $TOXENV == py* ]]; then
     # Run unit tests
     tox -- -m unit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    # Unit and integration tests. 
+    # Unit and integration tests.
     - PYTHON: "C:\\Python27"
       RUN_INTEGRATION_TESTS: "True"
     - PYTHON: "C:\\Python36-x64"
@@ -23,6 +23,12 @@ install:
   - "python -m certifi >cacert.txt"
   - "set /p GIT_SSL_CAINFO=<cacert.txt"
   - "set GIT_SSL_CAINFO"
+  # Install Helix Core.
+  - ps: mkdir .p4\bin
+  - ps: pushd .p4\bin
+  - ps: Start-FileDownload "http://ftp.perforce.com/perforce/r17.2/bin.ntx86/p4.exe"
+  - ps: Start-FileDownload "http://ftp.perforce.com/perforce/r17.2/bin.ntx86/p4d.exe"
+  - ps: popd
 
 build: off
 
@@ -31,6 +37,7 @@ test_script:
   - "subst T: %TEMP%"
   - "set TEMP=T:\\"
   - "set TMP=T:\\"
+  - "set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\\.p4\\bin"
   - "tox -e py -- -m unit -n 3"
   - "if \"%RUN_INTEGRATION_TESTS%\" == \"True\" (
     tox -e py -- -m integration -n 3 --duration=5 )"

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -50,7 +50,7 @@ We also have Jenkins CI that runs regularly for certain python versions on windo
 Running tests
 =============
 
-OS Requirements: subversion, bazaar, git, and mercurial.
+OS Requirements: subversion, bazaar, git, mercurial, and helix core.
 
 Python Requirements: tox or pytest, virtualenv, scripttest, and mock
 

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -308,10 +308,11 @@ that will enable installing pre-releases and development releases.
 VCS Support
 +++++++++++
 
-pip supports installing from Git, Mercurial, Subversion and Bazaar, and detects
-the type of VCS using url prefixes: "git+", "hg+", "bzr+", "svn+".
+pip supports installing from Git, Mercurial, Subversion, Bazaar and Helix Core,
+and detects the type of VCS using url prefixes: "git+", "hg+", "bzr+", "svn+",
+"p4+".
 
-pip requires a working VCS command on your path: git, hg, svn, or bzr.
+pip requires a working VCS command on your path: git, hg, svn, bzr, or p4.
 
 VCS projects can be installed in :ref:`editable mode <editable-installs>` (using
 the :ref:`--editable <install_--editable>` option) or not.
@@ -432,6 +433,25 @@ Tags or revisions can be installed like so::
     [-e] bzr+https://bzr.example.com/MyProject/trunk@2019#egg=MyProject
     [-e] bzr+http://bzr.example.com/MyProject/trunk@v1.0#egg=MyProject
 
+Helix Core
+~~~~~~~~~~
+
+pip supports Helix Core (also known as Perforce) URL schemes beginning with
+``p4+``. The second part of the scheme may be any valid ``P4PORT``
+protocol, such as ``ssl6``. A special value, ``p4``, may be used to express
+no preference.
+
+The URL may optionally include the username, password, hostname and port. For
+example::
+
+    [-e] p4+ssl6://user:p4ssw0rd@perforce1:1667/depot/myproject@2019
+
+pip consults the ``P4PORT``, ``P4USER`` and ``P4PASSWD`` environment variables
+for any information not given in the URL. In single-server environments these
+variables are typically set in the user's shell, and therefore the following
+form can be used (note the triple-slash)::
+
+    [-e] p4+p4:///depot/myproject
 
 Finding Packages
 ++++++++++++++++

--- a/news/2754.feature
+++ b/news/2754.feature
@@ -1,0 +1,3 @@
+Add initial support for the Helix Core VCS, also known as Perforce. Packages
+can be installed from a Helix Core depot by using
+``pip install p4+p4:///depot/path/to/package``.

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -43,7 +43,7 @@ from pip._internal import cmdoptions
 from pip._internal.exceptions import CommandError, PipError
 from pip._internal.utils.misc import get_installed_distributions, get_prog
 from pip._internal.utils import deprecation
-from pip._internal.vcs import git, mercurial, subversion, bazaar  # noqa
+from pip._internal.vcs import git, mercurial, subversion, bazaar, helix_core  # noqa
 from pip._internal.baseparser import (
     ConfigOptionParser, UpdatingDefaultsHelpFormatter,
 )

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -1074,7 +1074,7 @@ def parse_editable(editable_req):
     if '+' not in url:
         raise InstallationError(
             '%s should either be a path to a local project or a VCS url '
-            'beginning with svn+, git+, hg+, or bzr+' %
+            'beginning with svn+, git+, hg+, bzr+ or p4+' %
             editable_req
         )
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -679,12 +679,9 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
         env.pop(name, None)
     try:
         proc = subprocess.Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=stdout,
-            stderr=subprocess.STDOUT,
-            cwd=cwd,
-            env=env)
+            cmd, stderr=subprocess.STDOUT, stdin=subprocess.PIPE,
+            stdout=stdout, cwd=cwd, env=env,
+        )
         if stdin:
             proc.stdin.write(stdin)
         proc.stdin.close()

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -630,7 +630,8 @@ def unpack_file(filename, location, content_type, link):
 def call_subprocess(cmd, show_stdout=True, cwd=None,
                     on_returncode='raise',
                     command_desc=None,
-                    extra_environ=None, unset_environ=None, spinner=None):
+                    extra_environ=None, unset_environ=None, spinner=None,
+                    stdin=None):
     """
     Args:
       unset_environ: an iterable of environment variable names to unset
@@ -678,9 +679,14 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
         env.pop(name, None)
     try:
         proc = subprocess.Popen(
-            cmd, stderr=subprocess.STDOUT, stdin=subprocess.PIPE,
-            stdout=stdout, cwd=cwd, env=env,
-        )
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=stdout,
+            stderr=subprocess.STDOUT,
+            cwd=cwd,
+            env=env)
+        if stdin:
+            proc.stdin.write(stdin)
         proc.stdin.close()
     except Exception as exc:
         logger.critical(

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -89,7 +89,7 @@ class RevOptions(object):
 
 class VcsSupport(object):
     _registry = {}  # type: Dict[str, Command]
-    schemes = ['ssh', 'git', 'hg', 'bzr', 'sftp', 'svn']
+    schemes = ['ssh', 'git', 'hg', 'bzr', 'sftp', 'svn', 'p4']
 
     def __init__(self):
         # Register more schemes with urlparse for various version control
@@ -304,7 +304,7 @@ class VersionControl(object):
         rev_display = rev_options.to_display()
         if os.path.exists(dest):
             checkout = False
-            if os.path.exists(os.path.join(dest, self.dirname)):
+            if self.controls_location(dest):
                 existing_url = self.get_url(dest)
                 if self.compare_urls(existing_url, url):
                     logger.debug(
@@ -412,7 +412,7 @@ class VersionControl(object):
     def run_command(self, cmd, show_stdout=True, cwd=None,
                     on_returncode='raise',
                     command_desc=None,
-                    extra_environ=None, spinner=None):
+                    extra_environ=None, spinner=None, stdin=None):
         """
         Run a VCS subcommand
         This is simply a wrapper around call_subprocess that adds the VCS
@@ -424,7 +424,8 @@ class VersionControl(object):
                                    on_returncode,
                                    command_desc, extra_environ,
                                    unset_environ=self.unset_environ,
-                                   spinner=spinner)
+                                   spinner=spinner,
+                                   stdin=stdin)
         except OSError as e:
             # errno.ENOENT = no such file or directory
             # In other words, the VCS executable isn't available

--- a/src/pip/_internal/vcs/helix_core.py
+++ b/src/pip/_internal/vcs/helix_core.py
@@ -1,0 +1,286 @@
+from __future__ import absolute_import
+
+import logging
+import os
+import random
+import re
+import socket
+import string
+
+from pip._vendor.six.moves.urllib import parse as urllib_parse
+from pip._internal.vcs import VersionControl, vcs
+
+logger = logging.getLogger(__name__)
+
+client_spec_template = """
+Owner:   {user}
+Host:    {host}
+Client:  {name}
+Root:    {client_path}
+View:    /{server_path}/... //{name}/...
+Options: allwrite rmdir
+"""
+
+
+def split_url(url, environ=os.environ):
+    """
+    Parses a URL and returns a 5-tuple of
+    ``(port, depot_path, revision, username, password)``. Where fields are not
+    present in the given URL, information from Helix Core environment variables
+    (``P4PORT``, ``P4USER``, ``P4PASSWD``) is used.
+
+    URL examples::
+
+        ssl://me:p4ssw0rd@perforce1/depot/myproject
+        p4://perforce1:1667/depot/myproject
+        p4:///depot/myproject
+    """
+
+    if url.startswith("p4+"):
+        url = url[3:]
+    url = urllib_parse.urlsplit(url)
+
+    p4path = url.path
+    if '@' in p4path:
+        p4path, p4rev = p4path.split("@")
+    else:
+        p4rev = None
+
+    p4user = (
+        url.username or
+        environ.get("P4USER") or
+        environ.get("USER") or
+        environ.get("USERNAME") or
+        '')
+    p4passwd = (
+        url.password or
+        environ.get("P4PASSWD") or
+        '')
+
+    p4port = ["tcp", "perforce", "1666"]
+    p4port_old = environ.get("P4PORT")
+    if p4port_old:
+        for i, v in enumerate(reversed(p4port_old.split(":"))):
+            if v:
+                p4port[-i - 1] = v
+    if url.scheme != "p4":
+        p4port[0] = url.scheme
+    if url.hostname:
+        p4port[1] = url.hostname
+    if url.port:
+        p4port[2] = str(url.port)
+    p4port = ":".join(p4port)
+
+    return p4port, p4path, p4rev, p4user, p4passwd
+
+
+def join_url(p4port, p4path):
+    """
+    Return a Helix Core URL. Information that does not contribute to the
+    uniqueness of the resource - i.e. username, password, protocol and
+    revision - is not required by this function.
+    """
+
+    p4port = p4port or 'p4:'
+    return urllib_parse.urlunsplit((
+        'p4',
+        p4port.split(":", 1)[1],
+        p4path,
+        '',
+        ''))
+
+
+class HelixCoreClient(object):
+    """
+    Represents a Helix Core client (a.k.a. workspace). Stores the local
+    filesystem location of the client and a number of environment variables
+    used by the ``p4`` executable to configure communication with the Helix
+    Core server. These include:
+
+    - ``P4CLIENT``: Name of the client.
+    - ``P4PORT``: Protocol, hostname and port of the Helix Core server.
+    - ``P4USER``
+    - ``P4PASSWD``
+    - ``P4PATH``: Depot path being mapped. This is a pip-specific extension
+      that is unused by the ``p4`` executable.
+
+    This class has methods for saving and loading the environment to a
+    ``.p4pip/environ.txt`` file. The ``run()`` method can be used to execute
+    a ``p4`` command within the client's environment.
+    """
+
+    def __init__(self, run_command, client_path, environ=None):
+        self._run_command = run_command
+        self.client_path = client_path
+        self.environ = environ or {}
+        self.p4pip_path = os.path.join(client_path, ".p4pip")
+        self.environ_path = os.path.join(self.p4pip_path, "environ.txt")
+
+        if environ is None:
+            self.load_environ()
+
+    def load_environ(self):
+        """
+        Load environment from ``.p4pip/environ.txt`` file.
+        """
+
+        self.environ.clear()
+
+        with open(self.environ_path) as fd:
+            for line in fd:
+                name, value = line.strip().split("=", 2)
+                self.environ[name] = value
+
+    def save_environ(self):
+        """
+        Save environment to ``.p4pip/environ.txt`` file.
+        """
+
+        if not os.path.exists(self.p4pip_path):
+            os.mkdir(self.p4pip_path)
+
+        with open(self.environ_path, "w") as fd:
+            for name, value in sorted(self.environ.items()):
+                fd.write("%s=%s\n" % (name, value))
+
+    def delete_environ(self):
+        """
+        Delete the ``.p4pip/environ.txt`` file.
+        """
+
+        os.remove(self.environ_path)
+        os.rmdir(self.p4pip_path)
+
+    def save(self):
+        """
+        Create or update the Helix Core client.
+        """
+
+        spec = client_spec_template.format(
+            user=self.environ['P4USER'],
+            host=socket.gethostname(),
+            name=self.environ['P4CLIENT'],
+            client_path=self.client_path,
+            server_path=self.environ['P4PATH'])
+
+        self.run('client', '-i', stdin=spec.encode('ascii'))
+
+    def delete(self):
+        """
+        Delete the Helix Core client.
+        """
+
+        self.run('client', '-d', self.environ['P4CLIENT'])
+
+    def run(self, *cmd, **kwargs):
+        """
+        Run a Helix Core command.
+        """
+
+        return self._run_command(
+            cmd=list(cmd),
+            cwd=self.client_path,
+            extra_environ=self.environ,
+            show_stdout=False,
+            **kwargs)
+
+
+class HelixCore(VersionControl):
+    name = 'p4'
+    dirname = '.p4pip'
+    repo_name = 'workspace'
+    schemes = (
+        'p4+p4',
+        'p4+tcp',
+        'p4+tcp4',
+        'p4+tcp6',
+        'p4+tcp46',
+        'p4+tcp64',
+        'p4+ssl',
+        'p4+ssl4',
+        'p4+ssl6',
+        'p4+ssl46',
+        'p4+ssl64')
+
+    def get_client(self, path, environ=None):
+        return HelixCoreClient(self.run_command, path, environ)
+
+    def get_base_rev_args(self, rev):
+        return ['@%s' % rev]
+
+    # Informational -----------------------------------------------------------
+
+    def get_url(self, location):
+        client = self.get_client(location)
+        return join_url(client.environ['P4PORT'], client.environ['P4PATH'])
+
+    def get_revision(self, location):
+        client = self.get_client(location)
+        havelist = re.findall(
+            r"\.\.\. change (\d+)\n\.\.\. status have\n",
+            client.run('cstat'))
+        if havelist:
+            return havelist[-1]
+        else:
+            return 0
+
+    def is_commit_id_equal(self, dest, name):
+        if not name:
+            return False
+
+        return self.get_revision(dest) == name
+
+    def get_src_requirement(self, dist, location):
+        return 'p4+%s@%s#egg=%s' % (
+            self.get_url(location),
+            self.get_revision(location),
+            dist.egg_name().split('-', 1)[0])
+
+    # Operations --------------------------------------------------------------
+
+    def obtain(self, dest):
+        p4port, p4path, p4rev, p4user, p4passwd = split_url(self.url)
+        rev_options = self.make_rev_options(p4rev)
+        url = join_url(p4port, p4path)
+
+        environ = {
+            'P4PORT': p4port,
+            'P4PATH': p4path,
+            'P4USER': p4user,
+            'P4PASSWD': p4passwd,
+            'P4CLIENT': 'pip-%s' % ''.join(
+                random.choice(string.digits + string.ascii_lowercase)
+                for _ in range(32))
+        }
+
+        if self.check_destination(dest, url, rev_options):
+            logger.info('Syncing "%s"' % url)
+
+            if not os.path.exists(dest):
+                os.mkdir(dest)
+            client = self.get_client(dest, environ)
+            client.save_environ()
+            client.save()
+            client.run('sync', '-f', *rev_options.to_args())
+
+    def update(self, dest, rev_options):
+        client = self.get_client(dest)
+        client.run('sync', '-f', *rev_options.to_args())
+
+    def switch(self, dest, url, rev_options):
+        p4port, p4path = split_url(url)[:2]
+        client = self.get_client(dest)
+        client.environ['P4PORT'] = p4port
+        client.environ['P4PATH'] = p4path
+        client.save_environ()
+        client.save()
+        client.run('sync', '-f', *rev_options.to_args())
+
+    def export(self, location):
+        self.obtain(location)
+        client = self.get_client(location)
+        client.delete()
+        client.delete_environ()
+
+
+vcs.register(HelixCore)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 
 import pytest
 import six
@@ -260,3 +261,14 @@ class InMemoryPip(object):
 @pytest.fixture
 def in_memory_pip():
     return InMemoryPip()
+
+
+@pytest.yield_fixture
+def helix_core_server(tmpdir_factory, worker_id):
+    port = "localhost:%d" % (10000 + hash(worker_id) % 10000)
+    tmpdir = str(tmpdir_factory.mktemp('p4d-server'))
+    proc = subprocess.Popen(['p4d', '-p', port, '-r', tmpdir])
+    time.sleep(5)
+    yield port
+    subprocess.check_call(['p4', '-p', port, 'admin', 'stop'])
+    proc.wait()

--- a/tests/functional/test_vcs_helix_core.py
+++ b/tests/functional/test_vcs_helix_core.py
@@ -1,0 +1,86 @@
+from tests.lib import _create_test_package, need_helix_core
+
+
+@need_helix_core
+def test_install(script, helix_core_server):
+    """Test checking out from Helix Core."""
+
+    p4port = helix_core_server
+    _create_test_package(script, name='testpackage', vcs='p4', p4port=p4port)
+    url = 'p4+p4://%s/depot/pip-test-package-0#egg=testpackage' % p4port
+    result = script.pip('install', '-e', url, **{"expect_error": True})
+    result.assert_installed('testpackage')
+
+
+@need_helix_core
+def test_install_at_rev(script, helix_core_server):
+    """Test checking out from Helix Core at a particular revision."""
+
+    p4port = helix_core_server
+    _create_test_package(script, name='testpackage', vcs='p4', p4port=p4port)
+    url = 'p4+p4://%s/depot/pip-test-package-0@1#egg=testpackage' % p4port
+    result = script.pip('install', '-e', url, **{"expect_error": True})
+    result.assert_installed(
+        'testpackage', with_files=['.p4pip'], without_files=['canary0.py'])
+
+
+@need_helix_core
+def test_install_with_update(script, helix_core_server):
+    """
+    Test checking out from Helix Core at a particular revision, then updating
+    the installation to a different revision.
+    """
+
+    p4port = helix_core_server
+    pkg_path = script.venv / 'src' / 'testpackage'
+    _create_test_package(script, name='testpackage', vcs='p4', p4port=p4port)
+
+    # Initial installation at revision 1
+    url = 'p4+p4://%s/depot/pip-test-package-0@1#egg=testpackage' % p4port
+    result = script.pip('install', '-e', url, **{"expect_error": True})
+    result.assert_installed(
+        'testpackage', with_files=['.p4pip'], without_files=['canary0.py'])
+
+    # Second installation at revision 2
+    url = 'p4+p4://%s/depot/pip-test-package-0@2#egg=testpackage' % p4port
+    result = script.pip('install', '-e', url, **{"expect_error": True})
+    assert (pkg_path / "canary0.py") in result.files_created
+
+
+@need_helix_core
+def test_install_with_switch(script, helix_core_server):
+    """
+    Test checking out from Helix Core from a particular URL, then switching
+    the installation to a different URL.
+    """
+
+    p4port = helix_core_server
+    pkg_path = script.venv / 'src' / 'testpackage'
+    _create_test_package(script, name='testpackage', vcs='p4', p4port=p4port)
+    script.environ['PIP_EXISTS_ACTION'] = 's'
+
+    # Initial installation at depot path /pip-test-package-0
+    url = 'p4+p4://%s/depot/pip-test-package-0#egg=testpackage' % p4port
+    result = script.pip('install', '-e', url, **{"expect_error": True})
+    result.assert_installed(
+        'testpackage', with_files=['canary0.py'], without_files=['canary1.py'])
+
+    # Second installation at depot path /pip-test-package-1
+    url = 'p4+p4://%s/depot/pip-test-package-1#egg=testpackage' % p4port
+    result = script.pip('install', '-e', url, **{"expect_error": True})
+    assert (pkg_path / "canary0.py") in result.files_deleted
+    assert (pkg_path / "canary1.py") in result.files_created
+
+
+@need_helix_core
+def test_freeze(script, helix_core_server):
+    """Test freezing an editable installation from Helix Core."""
+
+    p4port = helix_core_server
+    _create_test_package(script, name='testpackage', vcs='p4', p4port=p4port)
+    url = 'p4+p4://%s/depot/pip-test-package-0@1#egg=testpackage' % p4port
+    result = script.pip('install', '-e', url, **{"expect_error": True})
+    result.assert_installed('testpackage')
+
+    result = script.pip('freeze')
+    assert ("-e %s" % url) in result.stdout

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -536,7 +536,7 @@ def _create_test_package_with_srcdir(script, name='version_pkg', vcs='git'):
     return _vcs_add(script, version_pkg_path, vcs)
 
 
-def _create_test_package(script, name='version_pkg', vcs='git'):
+def _create_test_package(script, name='version_pkg', vcs='git', p4port=None):
     script.scratch_path.join(name).mkdir()
     version_pkg_path = script.scratch_path / name
     version_pkg_path.join("%s.py" % name).write(textwrap.dedent("""
@@ -553,10 +553,10 @@ def _create_test_package(script, name='version_pkg', vcs='git'):
             entry_points=dict(console_scripts=['{name}={name}:main'])
         )
     """.format(name=name)))
-    return _vcs_add(script, version_pkg_path, vcs)
+    return _vcs_add(script, version_pkg_path, vcs, p4port)
 
 
-def _vcs_add(script, version_pkg_path, vcs='git'):
+def _vcs_add(script, version_pkg_path, vcs='git', p4port=None):
     if vcs == 'git':
         script.run('git', 'init', cwd=version_pkg_path)
         script.run('git', 'add', '.', cwd=version_pkg_path)
@@ -596,6 +596,47 @@ def _vcs_add(script, version_pkg_path, vcs='git'):
             '--author', 'pip <pypa-dev@googlegroups.com>',
             '-m', 'initial version', cwd=version_pkg_path,
         )
+    elif vcs == 'p4':
+        def run_command(cmd, cwd, extra_environ, show_stdout, stdin=None):
+            """
+            Emulation of ``VersionControl.run_command()``.
+            """
+            old_environ = script.environ.copy()
+            script.environ.update(extra_environ)
+            script.run("p4", *cmd, cwd=cwd, stdin=stdin)
+            script.environ.clear()
+            script.environ.update(old_environ)
+
+        from pip._internal.vcs.helix_core import HelixCoreClient
+
+        for package_idx in range(2):
+            package = "pip-test-package-%d" % package_idx
+            canary = "canary%d.py" % package_idx
+
+            # Create client
+            client = HelixCoreClient(
+                run_command=run_command,
+                client_path=version_pkg_path,
+                environ={
+                    'P4PORT': p4port,
+                    'P4PATH': '/depot/%s' % package,
+                    'P4CLIENT': package,
+                    'P4USER': '',
+                })
+            client.save()
+
+            # First changelist
+            client.run('add', '//%s/...' % package)
+            client.run('submit', '-d', '%s first version' % package)
+
+            # Second changelist
+            version_pkg_path.join(canary).write("print 'hello world'")
+            client.run('add', '//%s/...' % package)
+            client.run('submit', '-d', '%s second version' % package)
+            os.remove(version_pkg_path.join(canary))
+
+            # Delete client
+            client.delete()
     else:
         raise ValueError('Unknown vcs: %r' % vcs)
     return version_pkg_path
@@ -772,4 +813,10 @@ def need_bzr(fn):
 def need_mercurial(fn):
     return pytest.mark.mercurial(need_executable(
         'Mercurial', ('hg', 'version')
+    )(fn))
+
+
+def need_helix_core(fn):
+    return pytest.mark.helix_core(need_executable(
+        'Helix Core', ('p4', '-V')
     )(fn))

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -536,7 +536,7 @@ def _create_test_package_with_srcdir(script, name='version_pkg', vcs='git'):
     return _vcs_add(script, version_pkg_path, vcs)
 
 
-def _create_test_package(script, name='version_pkg', vcs='git', p4port=None):
+def _create_test_package(script, name='version_pkg', vcs='git', **vcs_options):
     script.scratch_path.join(name).mkdir()
     version_pkg_path = script.scratch_path / name
     version_pkg_path.join("%s.py" % name).write(textwrap.dedent("""
@@ -553,10 +553,10 @@ def _create_test_package(script, name='version_pkg', vcs='git', p4port=None):
             entry_points=dict(console_scripts=['{name}={name}:main'])
         )
     """.format(name=name)))
-    return _vcs_add(script, version_pkg_path, vcs, p4port)
+    return _vcs_add(script, version_pkg_path, vcs, **vcs_options)
 
 
-def _vcs_add(script, version_pkg_path, vcs='git', p4port=None):
+def _vcs_add(script, version_pkg_path, vcs='git', **vcs_options):
     if vcs == 'git':
         script.run('git', 'init', cwd=version_pkg_path)
         script.run('git', 'add', '.', cwd=version_pkg_path)
@@ -597,49 +597,53 @@ def _vcs_add(script, version_pkg_path, vcs='git', p4port=None):
             '-m', 'initial version', cwd=version_pkg_path,
         )
     elif vcs == 'p4':
-        def run_command(cmd, cwd, extra_environ, show_stdout, stdin=None):
-            """
-            Emulation of ``VersionControl.run_command()``.
-            """
-            old_environ = script.environ.copy()
-            script.environ.update(extra_environ)
-            script.run("p4", *cmd, cwd=cwd, stdin=stdin)
-            script.environ.clear()
-            script.environ.update(old_environ)
-
-        from pip._internal.vcs.helix_core import HelixCoreClient
-
-        for package_idx in range(2):
-            package = "pip-test-package-%d" % package_idx
-            canary = "canary%d.py" % package_idx
-
-            # Create client
-            client = HelixCoreClient(
-                run_command=run_command,
-                client_path=version_pkg_path,
-                environ={
-                    'P4PORT': p4port,
-                    'P4PATH': '/depot/%s' % package,
-                    'P4CLIENT': package,
-                    'P4USER': '',
-                })
-            client.save()
-
-            # First changelist
-            client.run('add', '//%s/...' % package)
-            client.run('submit', '-d', '%s first version' % package)
-
-            # Second changelist
-            version_pkg_path.join(canary).write("print 'hello world'")
-            client.run('add', '//%s/...' % package)
-            client.run('submit', '-d', '%s second version' % package)
-            os.remove(version_pkg_path.join(canary))
-
-            # Delete client
-            client.delete()
+        _create_p4_repo(script, version_pkg_path, vcs_options["p4port"])
     else:
         raise ValueError('Unknown vcs: %r' % vcs)
     return version_pkg_path
+
+
+def _create_p4_repo(script, version_pkg_path, p4port):
+    def run_command(cmd, cwd, extra_environ, show_stdout, stdin=None):
+        """
+        Emulation of ``VersionControl.run_command()``.
+        """
+        old_environ = script.environ.copy()
+        script.environ.update(extra_environ)
+        script.run("p4", *cmd, cwd=cwd, stdin=stdin)
+        script.environ.clear()
+        script.environ.update(old_environ)
+
+    from pip._internal.vcs.helix_core import HelixCoreClient
+
+    for package_idx in range(2):
+        package = "pip-test-package-%d" % package_idx
+        canary = "canary%d.py" % package_idx
+
+        # Create client
+        client = HelixCoreClient(
+            run_command=run_command,
+            client_path=version_pkg_path,
+            environ={
+                'P4PORT': p4port,
+                'P4PATH': '/depot/%s' % package,
+                'P4CLIENT': package,
+                'P4USER': '',
+            })
+        client.save()
+
+        # First changelist
+        client.run('add', '//%s/...' % package)
+        client.run('submit', '-d', '%s first version' % package)
+
+        # Second changelist
+        version_pkg_path.join(canary).write("print 'hello world'")
+        client.run('add', '//%s/...' % package)
+        client.run('submit', '-d', '%s second version' % package)
+        os.remove(version_pkg_path.join(canary))
+
+        # Delete client
+        client.delete()
 
 
 def _create_svn_repo(script, version_pkg_path):

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -5,6 +5,7 @@ from pip._vendor.packaging.version import parse as parse_version
 from pip._internal.vcs import RevOptions, VersionControl
 from pip._internal.vcs.bazaar import Bazaar
 from pip._internal.vcs.git import Git, looks_like_hash
+from pip._internal.vcs.helix_core import HelixCore
 from pip._internal.vcs.mercurial import Mercurial
 from pip._internal.vcs.subversion import Subversion
 from tests.lib import pyversion
@@ -26,6 +27,7 @@ def test_rev_options_repr():
     (Git(), ['HEAD'], ['123'], {}),
     (Mercurial(), [], ['123'], {}),
     (Subversion(), [], ['-r', '123'], {}),
+    (HelixCore(), [], ['@123'], {}),
     # Test extra_args.  For this, test using a single VersionControl class.
     (Git(), ['HEAD', 'opt1', 'opt2'], ['123', 'opt1', 'opt2'],
         dict(extra_args=['opt1', 'opt2'])),

--- a/tests/unit/test_vcs_helix_core.py
+++ b/tests/unit/test_vcs_helix_core.py
@@ -2,22 +2,15 @@ from pip._internal.vcs.helix_core import join_url, split_url
 
 url1 = "p4+p4:///foo/bar"
 url2 = "p4+ssl://myname:p4ssw0rd@myserver:1234/baz/zyz@456"
+parts1 = ('tcp:perforce:1666', '/foo/bar', None, '', '')
+parts2 = ('ssl:myserver:1234', '/baz/zyz', '456', 'myname', 'p4ssw0rd')
 
 
-def test_parse_url():
-    parts = split_url(url1, {})
-    assert parts[0] == 'tcp:perforce:1666'
-    assert parts[1] == '/foo/bar'
-    assert parts[2] is None
-
-    parts = split_url(url2, {})
-    assert parts[0] == 'ssl:myserver:1234'
-    assert parts[1] == '/baz/zyz'
-    assert parts[2] == '456'
-    assert parts[3] == 'myname'
-    assert parts[4] == 'p4ssw0rd'
+def test_split_url():
+    assert split_url(url1, {}) == parts1
+    assert split_url(url2, {}) == parts2
 
 
 def test_join_url():
-    assert join_url(*split_url(url1, {})[:2]) == "p4://perforce:1666/foo/bar"
-    assert join_url(*split_url(url2, {})[:2]) == "p4://myserver:1234/baz/zyz"
+    assert join_url(*parts1[:2]) == "p4://perforce:1666/foo/bar"
+    assert join_url(*parts2[:2]) == "p4://myserver:1234/baz/zyz"

--- a/tests/unit/test_vcs_helix_core.py
+++ b/tests/unit/test_vcs_helix_core.py
@@ -1,0 +1,23 @@
+from pip._internal.vcs.helix_core import join_url, split_url
+
+url1 = "p4+p4:///foo/bar"
+url2 = "p4+ssl://myname:p4ssw0rd@myserver:1234/baz/zyz@456"
+
+
+def test_parse_url():
+    parts = split_url(url1, {})
+    assert parts[0] == 'tcp:perforce:1666'
+    assert parts[1] == '/foo/bar'
+    assert parts[2] is None
+
+    parts = split_url(url2, {})
+    assert parts[0] == 'ssl:myserver:1234'
+    assert parts[1] == '/baz/zyz'
+    assert parts[2] == '456'
+    assert parts[3] == 'myname'
+    assert parts[4] == 'p4ssw0rd'
+
+
+def test_join_url():
+    assert join_url(*split_url(url1, {})[:2]) == "p4://perforce:1666/foo/bar"
+    assert join_url(*split_url(url2, {})[:2]) == "p4://myserver:1234/baz/zyz"


### PR DESCRIPTION
This PR is a first pass on supporting the Perforce VCS, as described in #2754.

Still to-do:

- [x] Better client name generation
- [x] Testing on Windows and Mac
- [x] Automated tests

Notes:

- `controls_location()` always returns `False`, and hence installations from the local filesystem are impossible. As such every installation is a fresh sync from the remote depot. I *think* this makes sense for perforce - keen to hear usecases for anything else.
- `p4 client` won't accept a client specification using a command-line argument. It *can* accept one on stdin, but `pip`'s command-runner doesn't currently support passing data to stdin. For the timebeing I've worked around this by writing the client spec to a temporary file, and then setting `P4EDITOR` to copy that file. Happy to consider other approaches.

I hope this is along the right lines?