### PR TITLE
[WIP] Implement working scheme

### DIFF
--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -203,7 +203,7 @@ class DownloadCommand(RequirementCommand):
                     finder=finder,
                     session=session,
                     wheel_cache=None,
-                    use_user_site=False,
+                    working_scheme="global",
                     upgrade_strategy="to-satisfy-only",
                     force_reinstall=False,
                     ignore_dependencies=options.ignore_dependencies,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -14,7 +14,7 @@ from pip._internal.exceptions import (
     CommandError, InstallationError, PreviousBuildDirError
 )
 from pip._internal.locations import (
-    distutils_scheme, running_under_virtualenv, virtualenv_no_global,
+    distutils_scheme, running_under_virtualenv, virtualenv_no_global
 )
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req import RequirementSet
@@ -22,7 +22,7 @@ from pip._internal.resolve import Resolver
 from pip._internal.status_codes import ERROR
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.misc import (
-    ensure_dir, get_installed_version, guess_correct_working_scheme,
+    ensure_dir, get_installed_version, guess_correct_working_scheme
 )
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.wheel import WheelBuilder

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -164,7 +164,7 @@ class WheelCommand(RequirementCommand):
                     finder=finder,
                     session=session,
                     wheel_cache=wheel_cache,
-                    use_user_site=False,
+                    working_scheme="global",
                     upgrade_strategy="to-satisfy-only",
                     force_reinstall=False,
                     ignore_dependencies=options.ignore_dependencies,

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -115,7 +115,7 @@ class InstallRequirement(object):
         self.install_succeeded = None
         # UninstallPathSet of uninstalled distribution (for possible rollback)
         self.uninstalled_pathset = None
-        self.use_user_site = False
+        self.working_scheme = "global"
         self.target_dir = None
         self.options = options if options else {}
         self.pycompile = pycompile
@@ -840,7 +840,7 @@ class InstallRequirement(object):
         else:
             install_args += ["--no-compile"]
 
-        if running_under_virtualenv():
+        if self.working_scheme == "venv":
             py_ver_str = 'python' + sysconfig.get_python_version()
             install_args += ['--install-headers',
                              os.path.join(sys.prefix, 'include', 'site',
@@ -913,7 +913,7 @@ class InstallRequirement(object):
             existing_dist = pkg_resources.get_distribution(
                 self.req.name
             )
-            if self.use_user_site:
+            if self.working_scheme == "user":
                 if dist_in_usersite(existing_dist):
                     self.conflicts_with = existing_dist
                 elif (running_under_virtualenv() and
@@ -935,7 +935,7 @@ class InstallRequirement(object):
                          warn_script_location=True):
         move_wheel_files(
             self.name, self.req, wheeldir,
-            user=self.use_user_site,
+            user=self.working_scheme == "user",
             home=self.target_dir,
             root=root,
             prefix=prefix,

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 class RequirementSet(object):
 
     def __init__(self,
-                 require_hashes=False, target_dir=None, use_user_site=False,
-                 pycompile=True):
+                 require_hashes=False, target_dir=None,
+                 working_scheme="global", pycompile=True):
         """Create a RequirementSet.
 
         :param wheel_cache: The pip wheel cache, for passing to
@@ -29,7 +29,7 @@ class RequirementSet(object):
         self.unnamed_requirements = []
         self.successfully_downloaded = []
         self.reqs_to_cleanup = []
-        self.use_user_site = use_user_site
+        self.working_scheme = working_scheme
         self.target_dir = target_dir  # set from --target option
         self.pycompile = pycompile
         # Maps from install_req -> dependencies_of_install_req
@@ -81,7 +81,7 @@ class RequirementSet(object):
                     wheel.filename
                 )
 
-        install_req.use_user_site = self.use_user_site
+        install_req.working_scheme = self.working_scheme
         install_req.target_dir = self.target_dir
         install_req.pycompile = self.pycompile
         install_req.is_direct = (parent_req_name is None)

--- a/src/pip/_internal/resolve.py
+++ b/src/pip/_internal/resolve.py
@@ -32,7 +32,7 @@ class Resolver(object):
 
     _allowed_strategies = {"eager", "only-if-needed", "to-satisfy-only"}
 
-    def __init__(self, preparer, session, finder, wheel_cache, use_user_site,
+    def __init__(self, preparer, session, finder, wheel_cache, working_scheme,
                  ignore_dependencies, ignore_installed, ignore_requires_python,
                  force_reinstall, isolated, upgrade_strategy):
         super(Resolver, self).__init__()
@@ -54,7 +54,7 @@ class Resolver(object):
         self.ignore_dependencies = ignore_dependencies
         self.ignore_installed = ignore_installed
         self.ignore_requires_python = ignore_requires_python
-        self.use_user_site = use_user_site
+        self.working_scheme = working_scheme
 
     def resolve(self, requirement_set):
         """Resolve what operations need to be done
@@ -120,7 +120,7 @@ class Resolver(object):
         """
         # Don't uninstall the conflict if doing a user install and the
         # conflict is not a user install.
-        if not self.use_user_site or dist_in_usersite(req.satisfied_by):
+        if self.working_scheme != "user" or dist_in_usersite(req.satisfied_by):
             req.conflicts_with = req.satisfied_by
         req.satisfied_by = None
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -30,7 +30,7 @@ from pip._internal.compat import console_to_str, expanduser, stdlib_pkgs
 from pip._internal.exceptions import InstallationError
 from pip._internal.locations import (
     distutils_scheme, running_under_virtualenv, site_packages, user_site,
-    virtualenv_no_global, write_delete_marker_file,
+    virtualenv_no_global, write_delete_marker_file
 )
 
 if PY2:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -708,7 +708,7 @@ def test_install_package_conflict_prefix_and_user(script, data):
         expect_error=True, quiet=True,
     )
     assert (
-        "Can not combine '--user' and '--prefix'" in result.stderr
+        "Can not combine '--scheme user' and '--prefix'" in result.stderr
     )
 
 

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -66,7 +66,7 @@ class Tests_UserSite:
                 tmpdir.join("cache"),
             )
         )
-        result.assert_installed('INITools', use_user_site=True)
+        result.assert_installed('INITools', in_user_site=True)
 
     def test_install_curdir_usersite(self, script, virtualenv, data):
         """

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -98,8 +98,8 @@ class Tests_UserSite:
             expect_error=True,
         )
         assert (
-            "Can not perform a '--user' install. User site-packages are not "
-            "visible in this virtualenv." in result.stderr
+            "Can not perform a user scheme install. User site-packages are "
+            "not visible in this virtualenv." in result.stderr
         )
 
     @pytest.mark.network

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -170,7 +170,7 @@ class TestPipResult(object):
 
     def assert_installed(self, pkg_name, editable=True, with_files=[],
                          without_files=[], without_egg_link=False,
-                         use_user_site=False, sub_dir=False):
+                         in_user_site=False, sub_dir=False):
         e = self.test_env
 
         if editable:
@@ -182,7 +182,7 @@ class TestPipResult(object):
             without_egg_link = True
             pkg_dir = e.site_packages / pkg_name
 
-        if use_user_site:
+        if in_user_site:
             egg_link_path = e.user_site / pkg_name + '.egg-link'
         else:
             egg_link_path = e.site_packages / pkg_name + '.egg-link'
@@ -217,7 +217,7 @@ class TestPipResult(object):
                     repr(egg_link_contents))
                 ))
 
-        if use_user_site:
+        if in_user_site:
             pth_file = e.user_site / 'easy-install.pth'
         else:
             pth_file = e.site_packages / 'easy-install.pth'

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -44,7 +44,7 @@ class TestRequirementSet(object):
         return Resolver(
             preparer=preparer, wheel_cache=None,
             session=PipSession(), finder=finder,
-            use_user_site=False, upgrade_strategy="to-satisfy-only",
+            working_scheme="global", upgrade_strategy="to-satisfy-only",
             ignore_dependencies=False, ignore_installed=False,
             ignore_requires_python=False, force_reinstall=False,
             isolated=False,


### PR DESCRIPTION
Closes #4575 

This PR also:
- Builds upon fallback logic from #2418 that tries to use user-scheme whenever possible, which closes #1668
  - "ask for forgiveness, not permission"
     - try to write a file instead of using `os.access`
     - (good idea with computers, not people)
- Adds a `--global` flag, which closes #4865

I'm open to the idea of breaking this PR up but I think these changes are intertwined enough that we should consider them all in one bundle.

Since this is a topic that probably needs some discussion, I feel it'd be best to only discuss implementation related stuff here and have all the higher level discussion over at #4575.

I still need to make this refuse to install stuff in different schemes, write tests and documentation and probably more stuff. I'd appreciate some more eyeballs passing through this code though now.

<details>
<summary>TODO + self-notes</summary>

- [ ] Code
  - [x] First Pass
    - Implement stuff in the dumbest manner.
  - [ ] Second Pass
    - Start refusing different scheme installations. (would resolve #5176)
  - What about pip uninstall?
    - Think then bring up.
  - [ ] Changes based on feedback/reviews
  - [ ] Final Pass
- [ ] Tests
  - Ensure no existing tests need changing
  - Lots of tests? Just enough tests? Somewhere in the middle?
  - Think then bring up.
- [ ] Documentation
  - Options:
    - Rewrite the section "user installs"
    - Write a new "installation scheme"
  - Think then bring up.
- [ ] News
- pip config uses --global, --user, --venv; maybe they should be changed too?
  - Think then bring up.

</details>
