### PR TITLE
Use log level info when ignoring packages due to environment markers

### DIFF
--- a/news/4876.bugfix
+++ b/news/4876.bugfix
@@ -1,0 +1,1 @@
+Use log level `info` instead of `warning` when ignoring packages due to environment markers.

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -59,16 +59,16 @@ class RequirementSet(object):
             already be added. Note that None implies that this is a user
             supplied requirement, vs an inferred one.
         :param extras_requested: an iterable of extras used to evaluate the
-            environement markers.
+            environment markers.
         :return: Additional requirements to scan. That is either [] if
             the requirement is not applicable, or [install_req] if the
             requirement is applicable and has just been added.
         """
         name = install_req.name
         if not install_req.match_markers(extras_requested):
-            logger.warning("Ignoring %s: markers '%s' don't match your "
-                           "environment", install_req.name,
-                           install_req.markers)
+            logger.info("Ignoring %s: markers '%s' don't match your "
+                        "environment", install_req.name,
+                        install_req.markers)
             return []
 
         # This check has to come after we filter requirements with the

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1202,10 +1202,10 @@ def test_basic_install_environment_markers(script):
         )
     """))
 
-    res = script.pip('install', '--no-index', pkga_path, expect_stderr=True)
+    res = script.pip('install', '--no-index', pkga_path)
     # missing_pkg should be ignored
     assert ("Ignoring missing-pkg: markers 'python_version == \"1.0\"' don't "
-            "match your environment") in res.stderr, str(res)
+            "match your environment") in res.stdout, str(res)
     assert "Successfully installed pkga-0.1" in res.stdout, str(res)
 
 

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -484,11 +484,10 @@ def test_install_unsupported_wheel_link_with_marker(script):
     result = script.pip(
         'install', '-r', script.scratch_path / 'with-marker.txt',
         expect_error=False,
-        expect_stderr=True,
     )
 
     assert ("Ignoring asdf: markers 'sys_platform == \"xyz\"' don't match "
-            "your environment") in result.stderr
+            "your environment") in result.stdout
     assert len(result.files_created) == 0
 
 


### PR DESCRIPTION
The use of environment markers implies that the user expects the packages to not be installed in some cases (eg depending on version of Python), so the log output shouldn't be classed as a warning, particularly since this results in it being sent to `stderr` rather than `stdout`.

Fixes #4876.