### PR TITLE
Fix git+file example in Documentation

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -365,7 +365,7 @@ Here are the supported forms::
     [-e] git+https://git.example.com/MyProject#egg=MyProject
     [-e] git+ssh://git.example.com/MyProject#egg=MyProject
     [-e] git+git://git.example.com/MyProject#egg=MyProject
-    [-e] git+file://git.example.com/MyProject#egg=MyProject
+    [-e] git+file:///home/user/projects/MyProject#egg=MyProject
     -e git+git@git.example.com:MyProject#egg=MyProject
 
 Passing branch names, a commit hash or a tag name is possible like so::


### PR DESCRIPTION
- Went to use this `pip` SCM option and was surprised when there was not an example to his a local repo in the documentation
- Replace git+file:// example to include a POSIX path after testing