### PR TITLE
Add a requirement's come_from to user agent's telemetry data.

### DIFF
--- a/news/4885.feature
+++ b/news/4885.feature
@@ -1,0 +1,1 @@
+The distribution that's caused a download is sent in that download's telemetry to PyPI.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -241,12 +241,13 @@ class RequirementPreparer(object):
                         # When installing a wheel, we use the unpacked
                         # wheel.
                         autodelete_unpacked = False
-                unpack_url(
-                    req.link, req.source_dir,
-                    download_dir, autodelete_unpacked,
-                    session=session, hashes=hashes,
-                    progress_bar=self.progress_bar
-                )
+                with session.set_comes_from(req.comes_from):
+                    unpack_url(
+                        req.link, req.source_dir,
+                        download_dir, autodelete_unpacked,
+                        session=session, hashes=hashes,
+                        progress_bar=self.progress_bar
+                    )
             except requests.HTTPError as exc:
                 logger.critical(
                     'Could not install requirement %s because of error %s',

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -886,9 +886,10 @@ class WheelBuilder(object):
                         req.link = index.Link(path_to_url(wheel_file))
                         assert req.link.is_wheel
                         # extract the wheel into the dir
-                        unpack_url(
-                            req.link, req.source_dir, None, False,
-                            session=session)
+                        with session.set_comes_from(req.comes_from):
+                            unpack_url(
+                                req.link, req.source_dir, None, False,
+                                session=session)
                 else:
                     build_failure.append(req)
 

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -50,10 +50,6 @@ def test_unpack_http_url_with_urllib_response_without_content_type(data):
         rmtree(temp_dir)
 
 
-def test_user_agent():
-    PipSession().headers["User-Agent"].startswith("pip/%s" % pip.__version__)
-
-
 class FakeStream(object):
 
     def __init__(self, contents):
@@ -301,6 +297,24 @@ class TestSafeFileCache:
 
 
 class TestPipSession:
+    PREAMBLE = "pip/%s" % pip.__version__
+
+    def parse_user_agent_telemetry(self, user_agent):
+        """
+        Parse out the telemetry JSON blob from a PipSession's user
+        agent.
+        """
+        telemetry_blob = user_agent.replace(self.PREAMBLE, "")
+        return json.loads(telemetry_blob)
+
+    def test_user_agent_format(self):
+        """
+        The user agent starts with the installer name and its version and
+        ends with a JSON blob of telemetry data.
+        """
+        user_agent = PipSession().headers["User-Agent"]
+        assert user_agent.startswith(self.PREAMBLE)
+        assert self.parse_user_agent_telemetry(user_agent)
 
     def test_cache_defaults_off(self):
         session = PipSession()


### PR DESCRIPTION
[`pip`'s telemetry data is super useful to project developers trying to make maintenance decisions](https://langui.sh/2016/12/09/data-driven-decisions/).  Sometimes we want to know if we can raise the lowest version constraint for a dependency based on how users install our project (are most [Twisted](twisted/twisted) downloads installing the latest version of pyOpenSSL?)  Other times we want to know who our most popular downstreams are so we can test against them ([Twisted](twisted/twisted) would like to not break [Synapse](matrix-org/synapse)).  We could answer these questions if we knew what distribution a download is a _dependency_  of.

`pip` records a distribution's provenance in `InstallRequirement`'s `comes_from` attribute so it can log a useful message:

`Collecting pyopenssl>=16.0.0; extra == "tls" (from Twisted[tls])`

This PR attempts to forward `comes_from` to PyPI so it can be queried against in BigQuery and used to answer these questions.