### PR TITLE
Fix Python 3.3 jobs on AppVeyor/Travis

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 freezegun
 pretend
-pytest
+pytest<=3.2.5
 pytest-catchlog
 pytest-cov
 pytest-rerunfailures


### PR DESCRIPTION
Pytest 3.3.0 dropped support for Python 3.3: https://docs.pytest.org/en/latest/changelog.html#deprecations-and-removals