### PR TITLE
Fix unassigned variable.

### DIFF
--- a/news/4811.bugfix
+++ b/news/4811.bugfix
@@ -1,0 +1,2 @@
+Fix an issue where a variable assigned in a try clause was accessed in the except clause, resulting in an undefined
+variable error in the except clause.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -139,7 +139,7 @@ class InstallRequirement(object):
             try:
                 req = Requirement(name)
             except InvalidRequirement:
-                raise InstallationError("Invalid requirement: '%s'" % req)
+                raise InstallationError("Invalid requirement: '%s'" % name)
         else:
             req = None
         return cls(


### PR DESCRIPTION
In the event of an error, 'req' will be unassigned. This will cause another error in the exception.

Replace 'req' with 'name.'

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
