### PR TITLE
workaround for a Windows 'already removed' rmtree problem

### DIFF
--- a/news/4910.bugfix
+++ b/news/4910.bugfix
@@ -1,0 +1,6 @@
+Workaround for a Windows issue (encountered for example on Windows 10 machines,
+even with no anti-virus software installed) where a folder removal operation may
+fail while it actually does remove the folder or at least parts of it and a
+repeated operation then completes successfully. This used to cause pip to report
+failures on repeated operations due to the target folder not existing. Now such
+use-cases are treated as successful folder removals.


### PR DESCRIPTION
This is a fix for issue #4910.

On Windows, we can get an Access Denied error as a result of our `rmtree()` operation, but with the original operation actually removing the target folder. This can cause problems with the repeated operation failing due to the target folder (or some part of it) not existing.

Workaround is to treat any 'does not exist` errors as success.

(edit by @pradyunsg: Fixes #4910)