### PR TITLE
Add fallback to filename completion to Zsh completion, like for Bash

### DIFF
--- a/news/4916.bugfix
+++ b/news/4916.bugfix
@@ -1,0 +1,1 @@
+Add fallback to filename completion to Zsh completion, like for Bash.

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -29,7 +29,7 @@ COMPLETION_SCRIPTS = {
                      COMP_CWORD=$(( cword-1 )) \\
                      PIP_AUTO_COMPLETE=1 $words[1] ) )
         }
-        compctl -K _pip_completion %(prog)s
+        compctl -K _pip_completion + -f %(prog)s
     """,
     'fish': """
         function __fish_complete_pip

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -34,7 +34,7 @@ function _pip_completion {
              COMP_CWORD=$(( cword-1 )) \\
              PIP_AUTO_COMPLETE=1 $words[1] ) )
 }
-compctl -K _pip_completion pip"""
+compctl -K _pip_completion + -f pip"""
 
     result = script.pip('completion', '--zsh')
     assert zsh_completion in result.stdout, 'zsh completion is wrong'


### PR DESCRIPTION
## The Issue
### Bash 😃 
```sh
$ pip install -r de<tab>
# You get:
$ pip install -r dev-requirements.txt
```


### Zsh 😖
```sh
$ pip install -r de<tab><tab><tab><tab>
# ...
```

## Description
This is an equivalent for the "-o default" in Bash's complete builtin, Which will complete file names if no other completion matches. Otherwise it's quite painful to try and pass file names to pip, like requirements
files.

Hopefully this is the right way to do this... 😛

Reference: [Completion-Using-compctl - Alternative-Completion](http://zsh.sourceforge.net/Doc/Release/Completion-Using-compctl.html#Alternative-Completion)

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
