### PR TITLE
Rename a few tests to add the word "basic"

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -63,6 +63,11 @@ def _strip_extras(path):
 
 
 class InstallRequirement(object):
+    """
+    Represents something that may be installed later on, may have information
+    about where to fetch the relavant requirement and also contains logic for
+    installing the said requirement.
+    """
 
     def __init__(self, req, comes_from, source_dir=None, editable=False,
                  link=None, update=True, pycompile=True, markers=None,

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -8,7 +8,7 @@ def matches_expected_lines(string, expected_lines):
     return set(output_lines) == set(expected_lines)
 
 
-def test_check_clean(script):
+def test_basic_check_clean(script):
     """On a clean environment, check should print a helpful message.
 
     """
@@ -20,7 +20,7 @@ def test_check_clean(script):
     assert matches_expected_lines(result.stdout, expected_lines)
 
 
-def test_check_missing_dependency(script):
+def test_basic_check_missing_dependency(script):
     # Setup a small project
     pkga_path = create_test_package_with_setup(
         script,
@@ -39,7 +39,7 @@ def test_check_missing_dependency(script):
     assert result.returncode == 1
 
 
-def test_check_broken_dependency(script):
+def test_basic_check_broken_dependency(script):
     # Setup pkga depending on pkgb>=1.0
     pkga_path = create_test_package_with_setup(
         script,
@@ -67,7 +67,7 @@ def test_check_broken_dependency(script):
     assert result.returncode == 1
 
 
-def test_check_broken_dependency_and_missing_dependency(script):
+def test_basic_check_broken_dependency_and_missing_dependency(script):
     pkga_path = create_test_package_with_setup(
         script,
         name='pkga', version='1.0', install_requires=['broken>=1.0'],

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -28,7 +28,7 @@ class TestBasicLoading(ConfigurationMixin):
 
         assert "test.hello=1" in result.stdout
 
-    def test_modification_pipeline(self, script):
+    def test_basic_modification_pipeline(self, script):
         script.pip("config", "get", "test.blah", expect_error=True)
         script.pip("config", "set", "test.blah", "1")
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -27,7 +27,7 @@ def test_download_if_requested(script):
 
 
 @pytest.mark.network
-def test_download_setuptools(script):
+def test_basic_download_setuptools(script):
     """
     It should download (in the scratch path) and not install if requested.
     """
@@ -73,7 +73,7 @@ def test_single_download_from_requirements_file(script):
 
 
 @pytest.mark.network
-def test_download_should_download_dependencies(script):
+def test_basic_download_should_download_dependencies(script):
     """
     It should download dependencies (in the scratch path)
     """

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -42,7 +42,7 @@ def _check_output(result, expected):
     )
 
 
-def test_freeze_basic(script):
+def test_basic_freeze(script):
     """
     Some tests of freeze, first we have to install some stuff.  Note that
     the test is a little crude at the end because Python 2.5+ adds egg

--- a/tests/functional/test_hash.py
+++ b/tests/functional/test_hash.py
@@ -1,7 +1,7 @@
 """Tests for the ``pip hash`` command"""
 
 
-def test_basic(script, tmpdir):
+def test_basic_hash(script, tmpdir):
     """Run 'pip hash' through its default behavior."""
     expected = ('--hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425'
                 'e73043362938b9824')
@@ -20,9 +20,9 @@ def test_good_algo_option(script, tmpdir):
 
 def test_bad_algo_option(script, tmpdir):
     """Make sure the -a option raises an error when given a bad operand."""
-    result = script.pip('hash', '-a', 'poppycock', _hello_file(tmpdir),
+    result = script.pip('hash', '-a', 'invalidname', _hello_file(tmpdir),
                         expect_error=True)
-    assert "invalid choice: 'poppycock'" in str(result)
+    assert "invalid choice: 'invalidname'" in str(result)
 
 
 def _hello_file(tmpdir):

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -104,7 +104,7 @@ def test_install_exit_status_code_when_blank_requirements_file(script):
 
 
 @pytest.mark.network
-def test_install_from_pypi(script):
+def test_basic_install_from_pypi(script):
     """
     Test installing a package from PyPI.
     """
@@ -121,7 +121,7 @@ def test_install_from_pypi(script):
     assert "Looking in links: " not in result.stdout
 
 
-def test_editable_install(script):
+def test_basic_editable_install(script):
     """
     Test editable installation.
     """
@@ -135,7 +135,7 @@ def test_editable_install(script):
 
 
 @pytest.mark.svn
-def test_install_editable_from_svn(script):
+def test_basic_install_editable_from_svn(script):
     """
     Test checking out from svn.
     """
@@ -156,7 +156,7 @@ def _test_install_editable_from_git(script, tmpdir):
     result.assert_installed('testpackage', with_files=['.git'])
 
 
-def test_install_editable_from_git(script, tmpdir):
+def test_basic_install_editable_from_git(script, tmpdir):
     _test_install_editable_from_git(script, tmpdir)
 
 
@@ -219,7 +219,7 @@ def test_install_editable_uninstalls_existing_from_path(script, data):
 
 
 @need_mercurial
-def test_install_editable_from_hg(script, tmpdir):
+def test_basic_install_editable_from_hg(script, tmpdir):
     """Test cloning from Mercurial."""
     pkg_path = _create_test_package(script, name='testpackage', vcs='hg')
     args = ['install', '-e', 'hg+%s#egg=testpackage' % path_to_url(pkg_path)]
@@ -264,7 +264,7 @@ def test_vcs_url_urlquote_normalization(script, tmpdir):
     )
 
 
-def test_install_from_local_directory(script, data):
+def test_basic_install_from_local_directory(script, data):
     """
     Test installing from a local directory.
     """
@@ -278,7 +278,7 @@ def test_install_from_local_directory(script, data):
     assert egg_info_folder in result.files_created, str(result)
 
 
-def test_install_relative_directory(script, data):
+def test_basic_install_relative_directory(script, data):
     """
     Test installing a requirement using a relative path.
     """
@@ -1190,7 +1190,7 @@ def test_install_compatible_python_requires(script, common_wheels):
     assert "Successfully installed pkga-0.1" in res.stdout, res
 
 
-def test_install_environment_markers(script):
+def test_basic_install_environment_markers(script):
     # make a dummy project
     pkga_path = script.scratch_path / 'pkga'
     pkga_path.mkdir()

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -41,7 +41,7 @@ def test_install_from_broken_wheel(script, data):
                                 editable=False)
 
 
-def test_install_from_wheel(script, data):
+def test_basic_install_from_wheel(script, data):
     """
     Test installing from a wheel (that has a script)
     """
@@ -58,7 +58,7 @@ def test_install_from_wheel(script, data):
     assert script_file in result.files_created
 
 
-def test_install_from_wheel_with_extras(script, data):
+def test_basic_install_from_wheel_with_extras(script, data):
     """
     Test installing from a wheel with extras.
     """
@@ -77,7 +77,7 @@ def test_install_from_wheel_with_extras(script, data):
                                                       result.stdout)
 
 
-def test_install_from_wheel_file(script, data):
+def test_basic_install_from_wheel_file(script, data):
     """
     Test installing directly from a wheel file.
     """

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 
-def test_list_command(script, data):
+def test_basic_list(script, data):
     """
     Test default behavior of list command without format specifier.
 

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -60,7 +60,7 @@ def test_pypi_xml_transformation():
 
 
 @pytest.mark.network
-def test_search(script):
+def test_basic_search(script):
     """
     End to end test of search command.
 

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -7,7 +7,7 @@ from pip import __version__
 from pip._internal.commands.show import search_packages_info
 
 
-def test_show(script):
+def test_basic_show(script):
     """
     Test end to end test for show command.
     """

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -17,9 +17,9 @@ from tests.lib.local_repos import local_checkout, local_repo
 
 
 @pytest.mark.network
-def test_simple_uninstall(script):
+def test_basic_uninstall(script):
     """
-    Test simple install and uninstall.
+    Test basic install and uninstall.
 
     """
     result = script.pip('install', 'INITools==0.2')
@@ -33,9 +33,9 @@ def test_simple_uninstall(script):
     assert_all_changes(result, result2, [script.venv / 'build', 'cache'])
 
 
-def test_simple_uninstall_distutils(script):
+def test_basic_uninstall_distutils(script):
     """
-    Test simple install and uninstall.
+    Test basic install and uninstall.
 
     """
     script.scratch_path.join("distutils_install").mkdir()
@@ -61,7 +61,7 @@ def test_simple_uninstall_distutils(script):
 
 
 @pytest.mark.network
-def test_uninstall_with_scripts(script):
+def test_basic_uninstall_with_scripts(script):
     """
     Uninstall an easy_installed package with scripts.
 
@@ -134,7 +134,7 @@ def test_uninstall_trailing_newline(script):
 
 
 @pytest.mark.network
-def test_uninstall_namespace_package(script):
+def test_basic_uninstall_namespace_package(script):
     """
     Uninstall a distribution with a namespace package without clobbering
     the namespace and everything in it.

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -9,7 +9,7 @@ from pip._internal.status_codes import ERROR, PREVIOUS_BUILD_DIR_ERROR
 from tests.lib import pyversion
 
 
-def test_pip_wheel_fails_without_wheel(script, data):
+def test_basic_pip_wheel_fails_without_wheel(script, data):
     """
     Test 'pip wheel' fails without wheel
     """
@@ -57,7 +57,7 @@ def test_pip_wheel_success(script, data, common_wheels):
 
 
 @pytest.mark.network
-def test_pip_wheel_downloads_wheels(script, data, common_wheels):
+def test_basic_pip_wheel_downloads_wheels(script, data, common_wheels):
     """
     Test 'pip wheel' downloads wheels
     """


### PR DESCRIPTION
This essentially allows me to do an overall check general check by running the tests using pytest's `-k basic` syntax. Given that I like running tests often and that, in general, I make typos more often than changes that break core functionality, I think this will reduce cycle times for me.
