### PR TITLE
Quickstart doc: lowercase the i in Install.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==========
 
-First, :doc:`Install pip <installing>`.
+First, :doc:`install pip <installing>`.
 
 Install a package from `PyPI`_:
 


### PR DESCRIPTION
Seems to be more grammatically correct that way.
