### PR TITLE
Quickstart doc: improve the grammar

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,8 +11,9 @@ Install a package from `PyPI`_:
   [...]
   Successfully installed SomePackage
 
-Install a package already downloaded from `PyPI`_ or got elsewhere.
-This is useful if the target machine does not have a network connection:
+Install a package that's already been downloaded from `PyPI`_ or
+obtained from elsewhere. This is useful if the target machine does not have a
+network connection:
 
 ::
 


### PR DESCRIPTION
"got elsewhere" sounds odd. Rephrased to: "obtained from elsewhere".