### PR TITLE
Improve dependency links log message

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -669,7 +669,7 @@ class PackageFinder(object):
             version = egg_info_matches(egg_info, search.supplied, link)
         if version is None:
             self._log_skipped_link(
-                link, 'wrong project name (not %s)' % search.supplied)
+                link, 'Missing project version for %s' % search.supplied)
             return
 
         match = self._py_version_re.search(version)


### PR DESCRIPTION
This a fairly misleading log message. If the version cannot be parsed from the user provided string then pip currently will print `wrong project name (not <given-project-name>)`. I ran into this when I did not add a version at the end of a dependency link, although the project name was correct.