### PR TITLE
Update search.py

### DIFF
--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -52,7 +52,7 @@ class SearchCommand(Command):
         if sys.stdout.isatty():
             terminal_width = get_terminal_size()[0]
 
-        print_results(hits, terminal_width=terminal_width)
+        print_results(hits, query, terminal_width=terminal_width)
         if pypi_hits:
             return SUCCESS
         return NO_MATCHES_FOUND
@@ -94,7 +94,7 @@ def transform_hits(hits):
     return list(packages.values())
 
 
-def print_results(hits, name_column_width=None, terminal_width=None):
+def print_results(hits, query, name_column_width=None, terminal_width=None):
     if not hits:
         return
     if name_column_width is None:
@@ -127,6 +127,9 @@ def print_results(hits, name_column_width=None, terminal_width=None):
                     else:
                         logger.info('INSTALLED: %s', dist.version)
                         logger.info('LATEST:    %s', latest)
+            elif name in query:
+                with indent_log():
+                    logger.info('NOT INSTALLED')
         except UnicodeEncodeError:
             pass
 


### PR DESCRIPTION
Modification for printing 'NOT INSTALLED' modules.

Usage:
```console
$ pip search opt | grep INSTALLED -B 1
cvxopt (1.1.9)                   - Convex optimization package
  INSTALLED: 1.1.9 (latest)
--
docopt (0.6.2)                   - Pythonic argument parser, that will make you smile
  INSTALLED: 0.6.2 (latest)
--
opt (0.1)                        - 
  NOT INSTALLED
--
Theano (1.0.1)                   - Optimizing compiler for evaluating mathematical expressions on CPUs and GPUs.
  INSTALLED: 1.0.1 (latest)
$ pip search opt | wc -l
     937
```

```console
$ pip3 search matplotlib | grep INSTALLED -B 1
matplotlib (2.1.1)                  - Python plotting package
  NOT INSTALLED
$ pip  search matplotlib | grep INSTALLED -B 1
matplotlib (2.1.1)                  - Python plotting package
  INSTALLED: 2.1.1 (latest)
```

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
