### PR TITLE
Add auto completion of short options

### DIFF
--- a/news/4954.feature
+++ b/news/4954.feature
@@ -1,0 +1,1 @@
+Add auto completion of short options.

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -105,9 +105,11 @@ def autocomplete():
                 sys.exit(1)
 
         subcommand = commands_dict[subcommand_name]()
-        options += [(opt.get_opt_string(), opt.nargs)
-                    for opt in subcommand.parser.option_list_all
-                    if opt.help != optparse.SUPPRESS_HELP]
+
+        for opt in subcommand.parser.option_list_all:
+            if opt.help != optparse.SUPPRESS_HELP:
+                for opt_str in opt._long_opts + opt._short_opts:
+                    options.append((opt_str, opt.nargs))
 
         # filter out previously specified options from available options
         prev_opts = [x.split('=')[0] for x in cwords[1:cword - 1]]
@@ -117,7 +119,7 @@ def autocomplete():
         for option in options:
             opt_label = option[0]
             # append '=' to options which require args
-            if option[1]:
+            if option[1] and option[0][:2] == "--":
                 opt_label += '='
             print(opt_label)
     else:
@@ -127,8 +129,9 @@ def autocomplete():
             opts.append(parser.option_list)
             opts = (o for it in opts for o in it)
 
-            subcommands += [i.get_opt_string() for i in opts
-                            if i.help != optparse.SUPPRESS_HELP]
+            for opt in opts:
+                if opt.help != optparse.SUPPRESS_HELP:
+                    subcommands += opt._long_opts + opt._short_opts
 
         print(' '.join([x for x in subcommands if x.startswith(current)]))
     sys.exit(1)

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -121,6 +121,29 @@ def test_completion_option_for_command(script):
            "autocomplete function could not complete ``--``"
 
 
+def test_completion_short_option(script):
+    """
+    Test getting completion for short options after ``-`` (eg. pip -)
+    """
+
+    res, env = setup_completion(script, 'pip -', '1')
+
+    assert '-h' in res.stdout.split(),\
+           "autocomplete function could not complete short options after ``-``"
+
+
+def test_completion_short_option_for_command(script):
+    """
+    Test getting completion for short options after ``-`` in command
+    (eg. pip search -)
+    """
+
+    res, env = setup_completion(script, 'pip search -', '2')
+
+    assert '-h' in res.stdout.split(),\
+           "autocomplete function could not complete short options after ``-``"
+
+
 @pytest.mark.parametrize('flag', ['--bash', '--zsh', '--fish'])
 def test_completion_uses_same_executable_name(script, flag):
     expect_stderr = sys.version_info[:2] == (3, 3)


### PR DESCRIPTION
Fixes #4954

P.S. Pip's auto completion is still quite messy regardless, not completing file names (#4842), not recognizing (At least in Zsh) that it shouldn't add a space after `=` for a long option. So Pip's builtin auto completion is not really all that usable currently regardless.