### PR TITLE
The parameter include_editables of pip.get_installed_distributions() is desribed as editables in the docstring

### DIFF
--- a/news/4974.trivial
+++ b/news/4974.trivial
@@ -1,0 +1,1 @@
+Fix the mismatched parameter name in ``get_installed_distributions()``.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -344,7 +344,7 @@ def get_installed_distributions(local_only=True,
     ``skip`` argument is an iterable of lower-case project names to
     ignore; defaults to stdlib_pkgs
 
-    If ``editables`` is False, don't report editables.
+    If ``include_editables`` is False, don't report editables.
 
     If ``editables_only`` is True , only report editables.
 


### PR DESCRIPTION
Hello,

I created an issue at #4974 . This is a trivial point but I found the parameter `include_editables` of `pip.get_installed_distributions()` is described as `editables` in the docstring when I tried to use the function. If it makes sense, I'd like this to be handled. Thank you in advance.

(I read the comment in the PR template and https://pip.pypa.io/en/latest/development/#adding-a-news-entry but this is my first contribution to the repository and I may be wrong. If there's anything wrong with this PR, please let me know.)