### PR TITLE
Error out on encoding issues with configuration loading

### DIFF
--- a/news/4976.bugfix
+++ b/news/4976.bugfix
@@ -1,0 +1,1 @@
+Abort if reading configuration causes encoding errors.

--- a/src/pip/_internal/baseparser.py
+++ b/src/pip/_internal/baseparser.py
@@ -9,7 +9,7 @@ from distutils.util import strtobool
 
 from pip._vendor.six import string_types
 
-from pip._internal.configuration import Configuration
+from pip._internal.configuration import Configuration, ConfigurationError
 from pip._internal.utils.misc import get_terminal_size
 
 logger = logging.getLogger(__name__)
@@ -177,9 +177,6 @@ class ConfigOptionParser(CustomOptionParser):
         the environ. Does a little special handling for certain types of
         options (lists)."""
 
-        # Load the configuration
-        self.config.load()
-
         # Accumulate complex default state.
         self.values = optparse.Values(self.defaults)
         late_eval = set()
@@ -223,6 +220,12 @@ class ConfigOptionParser(CustomOptionParser):
         if not self.process_default_values:
             # Old, pre-Optik 1.5 behaviour.
             return optparse.Values(self.defaults)
+
+        # Load the configuration, or error out in case of an error
+        try:
+            self.config.load()
+        except ConfigurationError as err:
+            self.exit(2, err.args[0])
 
         defaults = self._update_defaults(self.defaults.copy())  # ours
         for option in self._get_all_options():

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -288,7 +288,8 @@ class Configuration(object):
                 parser.read(fname)
             except UnicodeDecodeError:
                 raise ConfigurationError((
-                    "ERROR: Configuration file contains invalid %s characters.\n"
+                    "ERROR: "
+                    "Configuration file contains invalid %s characters.\n"
                     "Please fix your configuration, located at %s\n"
                 ) % (locale.getpreferredencoding(False), fname))
         return parser

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -11,6 +11,7 @@ Some terminology:
   A single word describing where the configuration key-value pair came from
 """
 
+import locale
 import logging
 import os
 
@@ -283,8 +284,13 @@ class Configuration(object):
         # Doing this is useful when modifying and saving files, where we don't
         # need to construct a parser.
         if os.path.exists(fname):
-            parser.read(fname)
-
+            try:
+                parser.read(fname)
+            except UnicodeDecodeError:
+                raise ConfigurationError((
+                    "ERROR: Configuration file contains invalid %s characters.\n"
+                    "Please fix your configuration, located at %s\n"
+                ) % (locale.getpreferredencoding(False), fname))
         return parser
 
     def _load_environment_vars(self):


### PR DESCRIPTION
Fixes #4963 by printing a relevant error message when an error occurs and aborting.

Note that the logging infrastructure of pip is not really set-up at this stage of the initialisation process. 
I'm not sure if this needs tests or how they would work.

PS: I have an exam. I should really be studying.