### PR TITLE
Add a verbosity attribute to basecommand

### DIFF
--- a/src/pip/_internal/basecommand.py
+++ b/src/pip/_internal/basecommand.py
@@ -114,14 +114,16 @@ class Command(object):
     def main(self, args):
         options, args = self.parse_args(args)
 
-        verbosity = options.verbose - options.quiet
-        if verbosity >= 1:
+        # Set verbosity so that it can be used elsewhere.
+        self.verbosity = options.verbose - options.quiet
+
+        if self.verbosity >= 1:
             level = "DEBUG"
-        elif verbosity == -1:
+        elif self.verbosity == -1:
             level = "WARNING"
-        elif verbosity == -2:
+        elif self.verbosity == -2:
             level = "ERROR"
-        elif verbosity <= -3:
+        elif self.verbosity <= -3:
             level = "CRITICAL"
         else:
             level = "INFO"

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -339,7 +339,7 @@ class InstallCommand(RequirementCommand):
                         message_parts.append("\n")
 
                     logger.error(
-                        "".join(message_parts), exc_info=(options.verbose > 1)
+                        "".join(message_parts), exc_info=(self.verbosity > 1)
                     )
                     return ERROR
                 except PreviousBuildDirError:

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -65,7 +65,7 @@ class UninstallCommand(Command):
                 )
             for req in reqs_to_uninstall.values():
                 uninstall_pathset = req.uninstall(
-                    auto_confirm=options.yes, verbose=options.verbose != 0
+                    auto_confirm=options.yes, verbose=self.verbosity > 0,
                 )
                 if uninstall_pathset:
                     uninstall_pathset.commit()


### PR DESCRIPTION
This is the right thing to do to also account for `--quiet`.