### PR TITLE
Handle stdin correctly when calling subprocesses

### DIFF
--- a/news/2732.bugfix
+++ b/news/2732.bugfix
@@ -1,0 +1,1 @@
+Interactive setup.py files will no longer hang indefinitely.

--- a/news/4982.bugfix
+++ b/news/4982.bugfix
@@ -1,0 +1,1 @@
+Interactive setup.py files will no longer hang indefinitely.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -678,9 +678,10 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
         env.pop(name, None)
     try:
         proc = subprocess.Popen(
-            cmd, stderr=subprocess.STDOUT, stdin=None, stdout=stdout,
-            cwd=cwd, env=env,
+            cmd, stderr=subprocess.STDOUT, stdin=subprocess.PIPE,
+            stdout=stdout, cwd=cwd, env=env,
         )
+        proc.stdin.close()
     except Exception as exc:
         logger.critical(
             "Error %s while executing command %s", exc, command_desc,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -23,8 +23,8 @@ from pip._internal.utils.encoding import auto_decode
 from pip._internal.utils.glibc import check_glibc_version
 from pip._internal.utils.hashes import Hashes, MissingHashes
 from pip._internal.utils.misc import (
-    egg_link_path, ensure_dir, get_installed_distributions, get_prog,
-    normalize_path, rmtree, untar_file, unzip_file,
+    call_subprocess, egg_link_path, ensure_dir, get_installed_distributions,
+    get_prog, normalize_path, rmtree, untar_file, unzip_file,
 )
 from pip._internal.utils.packaging import check_dist_requires_python
 from pip._internal.utils.temp_dir import TempDirectory
@@ -612,3 +612,15 @@ class TestGetProg(object):
             executable
         )
         assert get_prog() == expected
+
+
+def test_call_subprocess_works_okay_when_just_given_nothing():
+    try:
+        call_subprocess([sys.executable, '-c', 'print("Hello")'])
+    except Exception:
+        assert False, "Expected subprocess call to succeed"
+
+
+def test_call_subprocess_closes_stdin():
+    with pytest.raises(InstallationError):
+        call_subprocess([sys.executable, '-c', 'input()'])


### PR DESCRIPTION
Fixes #2732

Instead of not doing anything with stdin, we're now creating a pipe and closing it immediately. This should render a subprocess unable to read from stdin.
