### PR TITLE
Bugfix: Fixes #3763, #3830, and #4453

### DIFF
--- a/news/5010.bugfix
+++ b/news/5010.bugfix
@@ -1,0 +1,2 @@
+Prevent '--install-option' and '--global-option' from leaking into the next
+dependencies in the 'requirements.txt' file.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -769,8 +769,10 @@ class InstallRequirement(object):
         # Options specified in requirements file override those
         # specified on the command line, since the last option given
         # to setup.py is the one that is used.
-        global_options += self.options.get('global_options', [])
-        install_options += self.options.get('install_options', [])
+        global_options = \
+            global_options + self.options.get('global_options', [])
+        install_options = \
+            install_options + self.options.get('install_options', [])
 
         if self.isolated:
             global_options = list(global_options) + ["--no-user-cfg"]


### PR DESCRIPTION
Prevent `--install-option` and `--global-option` from leaking into the next dependencies in the `requirements.txt` file.

You should not mutate the parameters provided by the caller unless you are aware of what you're doing.

```python
# BAD! Mutating the parameter!
def bad(param):
    param += ['a']

# OK. Binding a new object to the name.
def good(param):
    param = param + ['a']
```

Fixes #3763, #3830, and #4453.

###### Reference
- https://github.com/simnalamburt/snippets/blob/master/python/pip-4453.py

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
