### PR TITLE
Fixes 4893 - error handling for malformed configurations

### DIFF
--- a/news/4893.bugfix
+++ b/news/4893.bugfix
@@ -1,1 +1,1 @@
-Add handling for configparser errors when conf is malformed.
+Malformed configuration files now show helpful error messages, instead of tracebacks.

--- a/news/4893.bugfix
+++ b/news/4893.bugfix
@@ -1,0 +1,1 @@
+Add handling for configparser errors when conf is malformed.

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -292,6 +292,20 @@ class Configuration(object):
                     "Configuration file contains invalid %s characters.\n"
                     "Please fix your configuration, located at %s\n"
                 ) % (locale.getpreferredencoding(False), fname))
+            except configparser.MissingSectionHeaderError as e:
+                raise ConfigurationError((
+                    "ERROR: "
+                    "Configuration file headers cannot be parsed. \n"
+                    "Please fix the section formatting of the "
+                    "configuration located at line %s of file %s\n"
+                ) % (e.lineno, fname))
+            except configparser.ParsingError as e:
+                raise ConfigurationError(
+                    "ERROR: "
+                    "Configuration file cannot be parsed. \n"
+                    "%s\n" % str(e)
+                )
+
         return parser
 
     def _load_environment_vars(self):

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -76,12 +76,12 @@ class TestConfigurationLoading(ConfigurationMixin):
         with self.tmpfile(contents) as config_file:
             os.environ["PIP_CONFIG_FILE"] = config_file
 
-            with pytest.raises(ConfigurationError):
+            with pytest.raises(ConfigurationError) as err:
                 self.configuration.load()
 
-            assert "malformed" in str(err)
-            assert lineno in str(err)
-            assert filepath in str(err)
+        assert "malformed" in str(err)
+        assert lineno in str(err)
+        assert filepath in str(err)
 
 
 class TestConfigurationPrecedence(ConfigurationMixin):

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -68,8 +68,6 @@ class TestConfigurationLoading(ConfigurationMixin):
         with pytest.raises(ConfigurationError):
             self.configuration.get_value(":env:.version")
 
-
-class TestConfigurationLoadingErrors(ConfigurationMixin):
     def test_environment_config_errors_if_malformed(self):
         contents = """
             test]
@@ -80,6 +78,10 @@ class TestConfigurationLoadingErrors(ConfigurationMixin):
 
             with pytest.raises(ConfigurationError):
                 self.configuration.load()
+
+            assert "malformed" in str(err)
+            assert lineno in str(err)
+            assert filepath in str(err)
 
 
 class TestConfigurationPrecedence(ConfigurationMixin):

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -69,6 +69,19 @@ class TestConfigurationLoading(ConfigurationMixin):
             self.configuration.get_value(":env:.version")
 
 
+class TestConfigurationLoadingErrors(ConfigurationMixin):
+    def test_environment_config_errors_if_malformed(self):
+        contents = """
+            test]
+            hello = 4
+        """
+        with self.tmpfile(contents) as config_file:
+            os.environ["PIP_CONFIG_FILE"] = config_file
+
+            with pytest.raises(ConfigurationError):
+                self.configuration.load()
+
+
 class TestConfigurationPrecedence(ConfigurationMixin):
     # Tests for methods to that determine the order of precedence of
     # configuration options


### PR DESCRIPTION
This fixes #4893 . In the event that a pip conf has malformed headers, it will handle the error and raise a specific message. Previously, pip would exit with a traceback.

Two things I'm uncertain about:
1. This is a very specific error case, modeled after the original problem referenced in the ticket. Would it be better to handle more generic ConfigParser errors, or perhaps to add additional excepts for other parser exceptions? 
2. Not sure if I put the test in the right location!