### PR TITLE
fix safe_name behavior if package name includes dot

### DIFF
--- a/news/5021.bugfix
+++ b/news/5021.bugfix
@@ -1,0 +1,1 @@
+Fix safe_name behavior if package name includes dot.

--- a/src/pip/_vendor/pkg_resources/__init__.py
+++ b/src/pip/_vendor/pkg_resources/__init__.py
@@ -1393,7 +1393,7 @@ def safe_name(name):
 
     Any runs of non-alphanumeric/. characters are replaced with a single '-'.
     """
-    return re.sub('[^A-Za-z0-9.]+', '-', name)
+    return re.sub('[^A-Za-z0-9]+', '-', name)
 
 
 def safe_version(version):


### PR DESCRIPTION
Dot was not replaced with a single `-` in `pip._vendor.pkg_resources.safe_name`
This caused inconsistent behavior when installing package with dot in their name:
```
$ pip install fluent-logger
$ pip install fluent.logger
```
See #5021