### PR TITLE
Add `--dependencies-only` sub-command.

### DIFF
--- a/news/5054.feature
+++ b/news/5054.feature
@@ -1,0 +1,1 @@
+Add sub-command called --dependencies-only to install command that will install only dependencies of given package.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -138,6 +138,13 @@ class InstallCommand(RequirementCommand):
             action='store_true',
             help='Ignore the installed packages (reinstalling instead).')
 
+        cmd_opts.add_option(
+            '-D', '--dependencies-only',
+            dest='dependencies_only',
+            action='store_true',
+            help='Install only dependencies of given packages.'
+        )
+
         cmd_opts.add_option(cmdoptions.ignore_requires_python())
 
         cmd_opts.add_option(cmdoptions.install_options())
@@ -298,6 +305,7 @@ class InstallCommand(RequirementCommand):
                         root=options.root_path,
                         prefix=options.prefix_path,
                         warn_script_location=options.warn_script_location,
+                        dependencies_only=options.dependencies_only,
                     )
 
                     possible_lib_locations = get_lib_location_guesses(

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -203,6 +203,11 @@ class RequirementSet(object):
         """
         to_install = self._to_install()
 
+        if kwargs.pop("dependencies_only"):
+            to_install = [
+                req for req in to_install if req.comes_from is None
+            ]
+
         if to_install:
             logger.info(
                 'Installing collected packages: %s',


### PR DESCRIPTION
### Problem
There is package `foo` with install dependencies `bar` and `baz`. Testing given package using docker is quite cumbersome because introduced changes invalidate docker cache and we are ending with installing the same requirements each time.

```docker
COPY . /app  # this layer gets invalidated on each change
RUN pip install /app  # we are installing the `bar` and `baz` on each build
```
### Solution
Introducing  sub-command called `--dependencies-only` to `install` command that will  install only dependencies of given package.
```docker
COPY setup.py /app/setup.py
RUN pip install --dependencies-only /app/setup.py

RUN pip install /app
```