### PR TITLE
get-pip: add notes to docs for specifying versions

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -76,6 +76,11 @@ Install behind a proxy::
 
   python get-pip.py --proxy="http://[user:passwd@]proxy.server:port"
 
+``get-pip.py`` can also be used to install a specified combination of ``pip``,
+``setuptools``, and ``wheel`` using the same requirements syntax as ``pip``::
+
+  python get-pip.py pip==9.0.2 wheel==0.30.0 setuptools==28.8.0
+
 
 Using Linux Package Managers
 ----------------------------


### PR DESCRIPTION
get-pip.py supports installing specified versions of pip, wheel, setuptools...
and any dependency for that matter, but this is not clearly exposed in
the documentation at https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py