### PR TITLE
Fixes to vendoring scripts so they work on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Patches must have Unix-style line endings, even on Windows
+tasks/vendoring/patches/* eol=lf

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -73,7 +73,7 @@ def rewrite_imports(package_dir, vendored_libs):
 
 def rewrite_file_imports(item, vendored_libs):
     """Rewrite 'import xxx' and 'from xxx import' for vendored_libs"""
-    text = item.read_text()
+    text = item.read_text(encoding='utf-8')
     # Revendor pkg_resources.extern first
     text = re.sub(r'pkg_resources.extern', r'pip._vendor', text)
     for lib in vendored_libs:
@@ -87,7 +87,7 @@ def rewrite_file_imports(item, vendored_libs):
             r'\1from pip._vendor.%s' % lib,
             text,
         )
-    item.write_text(text)
+    item.write_text(text, encoding='utf-8')
 
 
 def apply_patch(ctx, patch_file_path):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
