### PR TITLE
Fix ssl compatibility for Python2.6

### DIFF
--- a/news/5093.bugfix
+++ b/news/5093.bugfix
@@ -1,0 +1,1 @@
+Prevent pip from raising exception if ssl does not have OPENSSL_VERSION_NUMBER. (ssl in python2.6 does not have this attribute)

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -30,7 +30,9 @@ except ImportError:
     pass
 else:
     # Checks for OpenSSL 1.0.1 on MacOS
-    if sys.platform == "darwin" and ssl.OPENSSL_VERSION_NUMBER < 0x1000100f:
+    if (sys.platform == "darwin" and\
+            hasattr(ssl, "OPENSSL_VERSION_NUMBER") and\
+            ssl.OPENSSL_VERSION_NUMBER < 0x1000100f):
         try:
             from pip._vendor.urllib3.contrib import securetransport
         except (ImportError, OSError):


### PR DESCRIPTION
Prevent pip from raising exception if ssl does not have OPENSSL_VERSION_NUMBER. (ssl in python2.6 does not have this attribute)

This problem breaks pip 9.0.2 in python2.6, and it affects get-pip.py, virtualenv, and tox.

Fixes #5093.