### PR TITLE
Catch misleading ImportError

### DIFF
--- a/src/pip/_vendor/cachecontrol/serialize.py
+++ b/src/pip/_vendor/cachecontrol/serialize.py
@@ -150,7 +150,7 @@ class Serializer(object):
     def _loads_v1(self, request, data):
         try:
             cached = pickle.loads(data)
-        except ValueError:
+        except (ValueError, ImportError):
             return
 
         return self.prepare_response(request, cached)

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+serializer error tests
+
+"""
+from __future__ import unicode_literals
+import unittest
+
+from mock import Mock, patch
+from pip._vendor.cachecontrol.serialize import Serializer
+
+
+class Tests_Serializer(unittest.TestCase):
+    "Test handling of cache loading errors"
+
+    serializer = Serializer()
+    mock_request = Mock(headers={})
+
+    @patch('pip._vendor.cachecontrol.serialize.pickle')
+    def test_serializer_import_error_returns(self, mock_pickle):
+        mock_pickle.loads.side_effect = ImportError()
+        self.assertIs(
+            self.serializer._loads_v1(self.mock_request, b'data'),
+            None)
+
+    @patch('pip._vendor.cachecontrol.serialize.pickle')
+    def test_serializer_value_error_returns(self, mock_pickle):
+        mock_pickle.loads.side_effect = ValueError()
+        self.assertIs(
+            self.serializer._loads_v1(self.mock_request, b'data'),
+            None)


### PR DESCRIPTION
If pip cache gets out of sync with the Python version used to create
it, it can cause a misleading pickling error.

When serialize.py tries to deserialize pickled cache data, packages
with an out-of-date path will generate an ImportError that may refer to
any number of imports that can look like missing external packages, 
such as urllib3 or requests. Example:

```
File "/Users/higgins/Projects/cfgov-refresh/.tox/unittest-fast/lib/python2.7/site-packages/pip/_vendor/cachecontrol/serialize.py",line 168, in _loads_v1
cached = pickle.loads(data)
ImportError: No module named urllib3._collections
```

In this state, attempting to load a cached package in any local virtual environment 
will hit an import error that doesn't seem related. Also, tox tests that generate
a new environment will also bomb if they try to install a cached package.

Adding ImportError as an exception lets a user escape this state 
by skipping the cache, the way a ValueError does.

It appears [this commenter](https://github.com/pypa/pip/issues/5079#issuecomment-374239659) on #5079 encountered the same pickling error.

Users who realize it's a cache problem can use `--no-cache-dir` on all
their installs, or clear the system pip cache, but a self-healing solution
would help toilers like me.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
