### PR TITLE
Fixing _NamespacePath sort method - #4935 error

### DIFF
--- a/src/pip/_vendor/pkg_resources/__init__.py
+++ b/src/pip/_vendor/pkg_resources/__init__.py
@@ -2227,8 +2227,9 @@ def _rebuild_mod_path(orig_path, package_name, module):
         # Is this behavior useful when module.__path__ is not a list?
         return
 
-    orig_path.sort(key=position_in_sys_path)
-    module.__path__[:] = [_normalize_cached(p) for p in orig_path]
+    orig_path_t = list(orig_path)
+    orig_path_t.sort(key=position_in_sys_path)
+    module.__path__[:] = [_normalize_cached(p) for p in orig_path_t]
 
 
 def declare_namespace(packageName):


### PR DESCRIPTION
Fixing the error "_NamespacePath object has no attribute sort", cited in #4935, by transforming the object NameSpace into a list to permit sorting by `position_in_sys_path`.

The changes was tested to certify the order and datatypes are correct.

Since it is a very trivial change, only two lines of code added, I think probably it is not necessary to create a NEWS.rst, but please let me know if it is not the case.