### PR TITLE
Add short flag for --process-dependency-links

### DIFF
--- a/news/5112.feature
+++ b/news/5112.feature
@@ -1,0 +1,2 @@
+Add ``-L`` flag to ``pip install``, as a short alternative to
+``--process-dependency-links``.

--- a/src/pip/_internal/cmdoptions.py
+++ b/src/pip/_internal/cmdoptions.py
@@ -303,7 +303,7 @@ def trusted_host():
 # Remove after 1.5
 process_dependency_links = partial(
     Option,
-    "--process-dependency-links",
+    "-L", "--process-dependency-links",
     dest="process_dependency_links",
     action="store_true",
     default=False,

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -415,6 +415,9 @@ class TestProcessLine(object):
             "--process-dependency-links", "file", 1, finder=finder))
         assert finder.process_dependency_links
 
+        list(process_line("-L", "file", 1, finder=finder))
+        assert finder.process_dependency_links
+
 
 class TestBreakOptionsArgs(object):
 


### PR DESCRIPTION
Adds `-L` as a short alternative for `--process-dependency-links`.

Closes #5112 