### PR TITLE
Fix #5059: Replace SafeConfigParser with ConfigParser

### DIFF
--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -33,7 +33,7 @@ class Mercurial(VersionControl):
 
     def switch(self, dest, url, rev_options):
         repo_config = os.path.join(dest, self.dirname, 'hgrc')
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         try:
             config.read(repo_config)
             config.set('paths', 'default', url)


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
Fix https://github.com/pypa/pip/issues/5059


Here's a local test result:

```sh
test_vcs.py ....................                                         [100%]

========================== 20 passed in 0.28 seconds ==========================
```


Notes:

```
class SafeConfigParser(ConfigParser):
    """ConfigParser alias for backwards compatibility purposes."""

    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        warnings.warn(
            "The SafeConfigParser class has been renamed to ConfigParser "
            "in Python 3.2. This alias will be removed in future versions."
            " Use ConfigParser directly instead.",
            DeprecationWarning, stacklevel=2
        )
```