### PR TITLE
Limit progress updates to avoid swamping the TTY

### DIFF
--- a/news/5124.trivial
+++ b/news/5124.trivial
@@ -1,0 +1,1 @@
+Limit progress bar update interval to 200 ms.

--- a/src/pip/_internal/utils/ui.py
+++ b/src/pip/_internal/utils/ui.py
@@ -137,6 +137,7 @@ class DownloadProgressMixin(object):
     def __init__(self, *args, **kwargs):
         super(DownloadProgressMixin, self).__init__(*args, **kwargs)
         self.message = (" " * (get_indentation() + 2)) + self.message
+        self.last_update = 0.0
 
     @property
     def downloaded(self):
@@ -160,6 +161,15 @@ class DownloadProgressMixin(object):
             yield x
             self.next(n)
         self.finish()
+
+    def update(self):
+        # limit updates to avoid swamping the TTY
+        now = time.time()
+        if now < self.last_update + 0.2:
+            return
+        self.last_update = now
+
+        super(DownloadProgressMixin, self).update()
 
 
 class WindowsMixin(object):


### PR DESCRIPTION
This makes the values more readable for large downloads on fast
connections.  200 ms value chosen from wget.