### PR TITLE
Speedup printing of installed package versions

### DIFF
--- a/news/5127.bugfix
+++ b/news/5127.bugfix
@@ -1,0 +1,1 @@
+Speed up printing of newly installed package versions

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -7,6 +7,8 @@ import os
 import shutil
 from optparse import SUPPRESS_HELP
 
+from pip._vendor import pkg_resources
+
 from pip._internal import cmdoptions
 from pip._internal.basecommand import RequirementCommand
 from pip._internal.cache import WheelCache
@@ -343,20 +345,22 @@ class InstallCommand(RequirementCommand):
                         use_user_site=options.use_user_site,
                     )
 
-                    possible_lib_locations = get_lib_location_guesses(
+                    lib_locations = get_lib_location_guesses(
                         user=options.use_user_site,
                         home=target_temp_dir.path,
                         root=options.root_path,
                         prefix=options.prefix_path,
                         isolated=options.isolated_mode,
                     )
+                    working_set = pkg_resources.WorkingSet(lib_locations)
+
                     reqs = sorted(installed, key=operator.attrgetter('name'))
                     items = []
                     for req in reqs:
                         item = req.name
                         try:
                             installed_version = get_installed_version(
-                                req.name, possible_lib_locations
+                                req.name, working_set=working_set
                             )
                             if installed_version:
                                 item += '-' + installed_version

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -821,17 +821,15 @@ class cached_property(object):
         return value
 
 
-def get_installed_version(dist_name, lookup_dirs=None):
+def get_installed_version(dist_name, working_set=None):
     """Get the installed version of dist_name avoiding pkg_resources cache"""
     # Create a requirement that we'll look for inside of setuptools.
     req = pkg_resources.Requirement.parse(dist_name)
 
-    # We want to avoid having this cached, so we need to construct a new
-    # working set each time.
-    if lookup_dirs is None:
+    if working_set is None:
+        # We want to avoid having this cached, so we need to construct a new
+        # working set each time.
         working_set = pkg_resources.WorkingSet()
-    else:
-        working_set = pkg_resources.WorkingSet(lookup_dirs)
 
     # Get the installed distribution from our working set
     dist = working_set.find(req)


### PR DESCRIPTION
Profiling indicates a large amount of time is spend in `get_installed_version`. 

![install-profile](https://user-images.githubusercontent.com/483730/38156701-398ed780-3480-11e8-9c06-352a82caa53e.png)


When printing all installed package versions, the installed set is already fixed and no longer changing. It is therefore safe to reuse a single `pkg_resources.WorkingSet` for all invocations of `get_installed_version`.

This yields a small performance improvement:

    # Before this patch (hot cache)
    $ time pip install "apache-airflow[doc,dask,azure]" --no-compile --ignore-installed --no-warn-conflicts
    11.163    

    # With this patch (hot cache)
    $ time pip install "apache-airflow[doc,dask,azure]" --no-compile --ignore-installed --no-warn-conflicts
    8.967




