### PR TITLE
Fix name normalization used for install warnings

### DIFF
--- a/news/5134.bugfix
+++ b/news/5134.bugfix
@@ -1,0 +1,1 @@
+Prevent false-positive installation warnings due to incomplete name normalizaton.

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -99,4 +99,5 @@ def _simulate_installation_of(to_install, state):
     # Modify it as installing requirement_set would (assuming no errors)
     for inst_req in to_install:
         dist = make_abstract_dist(inst_req).dist(finder=None)
-        state[dist.key] = PackageDetails(dist.version, dist.requires())
+        name = canonicalize_name(dist.key)
+        state[name] = PackageDetails(dist.version, dist.requires())

--- a/tests/functional/test_install_check.py
+++ b/tests/functional/test_install_check.py
@@ -1,0 +1,59 @@
+from tests.lib import create_test_package_with_setup
+
+
+def matches_expected_lines(string, expected_lines):
+    def predicate(line):
+        return line and not line.startswith('DEPRECATION')
+
+    output_lines = set(filter(predicate, string.splitlines()))
+    # Match regardless of order
+    return set(output_lines) == set(expected_lines)
+
+
+def test_check_install_warnings(script):
+    pkga_path = create_test_package_with_setup(
+        script,
+        name='pkga',
+        version='1.0',
+        install_requires=['normal-missing', 'special.missing'],
+    )
+    # Let's install pkga without its dependency
+    result = script.pip('install', '--no-index', pkga_path, '--no-deps')
+    assert "Successfully installed pkga-1.0" in result.stdout, str(result)
+
+    # Install the first missing dependency. Only an error for the
+    # second dependency should remain.
+    normal_path = create_test_package_with_setup(
+        script,
+        name='normal-missing', version='0.1',
+    )
+    result = script.pip(
+        'install', '--no-index', normal_path, '--quiet', expect_error=True
+    )
+    expected_lines = (
+        "pkga 1.0 requires special.missing, which is not installed.",
+    )
+    assert matches_expected_lines(result.stderr, expected_lines)
+    assert result.returncode == 0
+
+    # Install the second missing package and expect that there is no warning
+    # during the installation. This is special as the package name requires
+    # name normalization (as in https://github.com/pypa/pip/issues/5134)
+    missing_path = create_test_package_with_setup(
+        script,
+        name='special.missing', version='0.1',
+    )
+    result = script.pip(
+        'install', '--no-index', missing_path, '--quiet',
+    )
+    assert matches_expected_lines(result.stdout, [])
+    assert matches_expected_lines(result.stderr, [])
+    assert result.returncode == 0
+
+    # Double check that all errors are resolved in the end
+    result = script.pip('check')
+    expected_lines = (
+        "No broken requirements found.",
+    )
+    assert matches_expected_lines(result.stdout, expected_lines)
+    assert result.returncode == 0


### PR DESCRIPTION
This fixes #5134. 

Writing a unit test for this turned to be quite involved. I have therefore opted for a simple integration test.