### PR TITLE
BUG: ioctl(fd, termios.TIOCGWINSZ, ...) returns 8 bytes

### DIFF
--- a/news/5150.bugfix
+++ b/news/5150.bugfix
@@ -1,0 +1,1 @@
+`ioctl(fd, termios.TIOCGWINSZ, ...)` needs 8 bytes of data

--- a/src/pip/_internal/compat.py
+++ b/src/pip/_internal/compat.py
@@ -213,9 +213,9 @@ else:
                 import fcntl
                 import termios
                 import struct
-                cr = struct.unpack(
+                cr = struct.unpack_from(
                     'hh',
-                    fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234')
+                    fcntl.ioctl(fd, termios.TIOCGWINSZ, '12345678')
                 )
             except:
                 return None


### PR DESCRIPTION
fixes issue #5150