### PR TITLE
fix PEP 518 support

### DIFF
--- a/news/5188.bugfix
+++ b/news/5188.bugfix
@@ -1,0 +1,1 @@
+Fix PEP 518 support.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -2,6 +2,7 @@
 """
 
 import os
+from distutils.sysconfig import get_python_lib
 from sysconfig import get_paths
 
 from pip._internal.utils.temp_dir import TempDirectory
@@ -38,11 +39,14 @@ class BuildEnvironment(object):
         else:
             os.environ['PATH'] = scripts + os.pathsep + os.defpath
 
-        if install_dirs['purelib'] == install_dirs['platlib']:
-            lib_dirs = install_dirs['purelib']
+        # Note: prefer distutils' sysconfig to get the
+        # library paths so PyPy is correctly supported.
+        purelib = get_python_lib(plat_specific=0, prefix=self.path)
+        platlib = get_python_lib(plat_specific=1, prefix=self.path)
+        if purelib == platlib:
+            lib_dirs = purelib
         else:
-            lib_dirs = install_dirs['purelib'] + os.pathsep + \
-                install_dirs['platlib']
+            lib_dirs = purelib + os.pathsep + platlib
         if self.save_pythonpath:
             os.environ['PYTHONPATH'] = lib_dirs + os.pathsep + \
                 self.save_pythonpath

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -11,7 +11,6 @@ from pip._internal.exceptions import CommandError, PreviousBuildDirError
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req import RequirementSet
 from pip._internal.resolve import Resolver
-from pip._internal.utils.misc import import_or_raise
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.wheel import WheelBuilder
 
@@ -102,28 +101,7 @@ class WheelCommand(RequirementCommand):
         self.parser.insert_option_group(0, index_opts)
         self.parser.insert_option_group(0, cmd_opts)
 
-    def check_required_packages(self):
-        import_or_raise(
-            'wheel.bdist_wheel',
-            CommandError,
-            "'pip wheel' requires the 'wheel' package. To fix this, run: "
-            "pip install wheel"
-        )
-
-        need_setuptools_message = (
-            "'pip wheel' requires setuptools >= 0.8 for dist-info support. "
-            "To fix this, run: pip install --upgrade setuptools>=0.8"
-        )
-        pkg_resources = import_or_raise(
-            'pkg_resources',
-            CommandError,
-            need_setuptools_message
-        )
-        if not hasattr(pkg_resources, 'DistInfoDistribution'):
-            raise CommandError(need_setuptools_message)
-
     def run(self, options, args):
-        self.check_required_packages()
         cmdoptions.check_install_build_global(options)
 
         index_urls = [options.index_url] + options.extra_index_urls

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -9,17 +9,6 @@ from pip._internal.status_codes import ERROR, PREVIOUS_BUILD_DIR_ERROR
 from tests.lib import pyversion
 
 
-def test_basic_pip_wheel_fails_without_wheel(script, data):
-    """
-    Test 'pip wheel' fails without wheel
-    """
-    result = script.pip(
-        'wheel', '--no-index', '-f', data.find_links, 'simple==3.0',
-        expect_error=True,
-    )
-    assert "'pip wheel' requires the 'wheel' package" in result.stderr
-
-
 def test_wheel_exit_status_code_when_no_requirements(script, common_wheels):
     """
     Test wheel exit status code when no requirements specified


### PR DESCRIPTION
* fix build environment handling when using PyPy
* do use the build environment for all build commands
* allow installing and building a wheel of a PEP 518 enabled package without prior installation of setuptools and/or wheels
* fix check for minimum supported requirements for PEP 518 support:
  - correctly handle complex requirements
  - both setuptools and wheels are needed

Fix #5188.