### PR TITLE
Switch pip to use Warehouse by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ pip
 The `PyPA recommended`_ tool for installing Python packages.
 
 .. image:: https://img.shields.io/pypi/v/pip.svg
-   :target: https://pypi.python.org/pypi/pip
+   :target: https://pypi.org/project/pip/
 
 .. image:: https://img.shields.io/travis/pypa/pip/master.svg
    :target: http://travis-ci.org/pypa/pip

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ pip
 `User list <http://groups.google.com/group/python-virtualenv>`_ |
 `Dev list <http://groups.google.com/group/pypa-dev>`_ |
 `Github <https://github.com/pypa/pip>`_ |
-`PyPI <https://pypi.python.org/pypi/pip/>`_ |
+`PyPI <https://pypi.org/project/pip/>`_ |
 User IRC: #pypa |
 Dev IRC: #pypa-dev
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -63,4 +63,4 @@ Uninstall a package:
   Successfully uninstalled SomePackage
 
 
-.. _PyPI: http://pypi.python.org/pypi/
+.. _PyPI: https://pypi.org/

--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -474,7 +474,7 @@ Finding Packages
 ++++++++++++++++
 
 pip searches for packages on `PyPI`_ using the
-`http simple interface <http://pypi.python.org/simple>`_,
+`http simple interface <https://pypi.org/simple/>`_,
 which is documented `here <https://setuptools.readthedocs.io/en/latest/easy_install.html#package-index-api>`_
 and `there <http://www.python.org/dev/peps/pep-0301/>`_
 
@@ -774,7 +774,7 @@ No other build system commands are invoked by the ``pip install`` command.
 
 Installing a package from a wheel does not invoke the build system at all.
 
-.. _PyPI: http://pypi.python.org/pypi/
+.. _PyPI: https://pypi.org/
 .. _setuptools extras: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
 
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -46,7 +46,7 @@ Specifiers`
 
 For more information and examples, see the :ref:`pip install` reference.
 
-.. _PyPI: http://pypi.python.org/pypi
+.. _PyPI: https://pypi.org/
 
 
 .. _`Requirements Files`:
@@ -197,7 +197,7 @@ For the cases where wheels are not available, pip offers :ref:`pip wheel` as a
 convenience, to build wheels for all your requirements and dependencies.
 
 :ref:`pip wheel` requires the `wheel package
-<https://pypi.python.org/pypi/wheel>`_ to be installed, which provides the
+<https://pypi.org/project/wheel/>`_ to be installed, which provides the
 "bdist_wheel" setuptools extension that it uses.
 
 To build wheels for your requirements and all their dependencies to a local directory:

--- a/news/5214.feature
+++ b/news/5214.feature
@@ -1,0 +1,1 @@
+Switch the default repository to the new "PyPI 2.0" running at https://pypi.org/.

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -903,7 +903,7 @@ class Link(object):
 
     def __init__(self, url, comes_from=None, requires_python=None):
         """
-        Object representing a parsed link from https://pypi.python.org/simple/*
+        Object representing a parsed link from https://pypi.org/simple/*
 
         url:
             url of the resource pointed to (href of the link)

--- a/src/pip/_internal/models/index.py
+++ b/src/pip/_internal/models/index.py
@@ -12,4 +12,4 @@ class Index(object):
         return urllib_parse.urljoin(self.url, path)
 
 
-PyPI = Index('https://pypi.python.org/')
+PyPI = Index('https://pypi.org/')

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -24,10 +24,10 @@ def test_command_line_options_override_env_vars(script, virtualenv):
     Test that command line options override environmental variables.
 
     """
-    script.environ['PIP_INDEX_URL'] = 'https://b.pypi.python.org/simple/'
+    script.environ['PIP_INDEX_URL'] = 'https://example.com/simple/'
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
     assert (
-        "Getting page https://b.pypi.python.org/simple/initools"
+        "Getting page https://example.com/simple/initools"
         in result.stdout
     )
     virtualenv.clear()
@@ -36,7 +36,7 @@ def test_command_line_options_override_env_vars(script, virtualenv):
         'INITools',
         expect_error=True,
     )
-    assert "b.pypi.python.org" not in result.stdout
+    assert "example.com" not in result.stdout
     assert "Getting page https://download.zope.org/ppix" in result.stdout
 
 
@@ -85,24 +85,24 @@ def test_command_line_append_flags(script, virtualenv, data):
     variables.
 
     """
-    script.environ['PIP_FIND_LINKS'] = 'https://testpypi.python.org'
+    script.environ['PIP_FIND_LINKS'] = 'https://test.pypi.org'
     result = script.pip(
         'install', '-vvv', 'INITools', '--trusted-host',
-        'testpypi.python.org',
+        'test.pypi.org',
         expect_error=True,
     )
     assert (
-        "Analyzing links from page https://testpypi.python.org"
+        "Analyzing links from page https://test.pypi.org"
         in result.stdout
     ), str(result)
     virtualenv.clear()
     result = script.pip(
         'install', '-vvv', '--find-links', data.find_links, 'INITools',
-        '--trusted-host', 'testpypi.python.org',
+        '--trusted-host', 'test.pypi.org',
         expect_error=True,
     )
     assert (
-        "Analyzing links from page https://testpypi.python.org"
+        "Analyzing links from page https://test.pypi.org"
         in result.stdout
     )
     assert "Skipping link %s" % data.find_links in result.stdout
@@ -115,16 +115,16 @@ def test_command_line_appends_correctly(script, data):
 
     """
     script.environ['PIP_FIND_LINKS'] = (
-        'https://testpypi.python.org %s' % data.find_links
+        'https://test.pypi.org %s' % data.find_links
     )
     result = script.pip(
         'install', '-vvv', 'INITools', '--trusted-host',
-        'testpypi.python.org',
+        'test.pypi.org',
         expect_error=True,
     )
 
     assert (
-        "Analyzing links from page https://testpypi.python.org"
+        "Analyzing links from page https://test.pypi.org"
         in result.stdout
     ), result.stdout
     assert "Skipping link %s" % data.find_links in result.stdout
@@ -167,7 +167,7 @@ def _test_config_file_override_stack(script, virtualenv, config_file):
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
     assert "Getting page https://pypi.gocept.com/initools" in result.stdout
     result = script.pip(
-        'install', '-vvv', '--index-url', 'https://pypi.python.org/simple',
+        'install', '-vvv', '--index-url', 'https://pypi.org/simple/',
         'INITools',
         expect_error=True,
     )
@@ -177,7 +177,7 @@ def _test_config_file_override_stack(script, virtualenv, config_file):
     )
     assert "Getting page https://pypi.gocept.com/INITools" not in result.stdout
     assert (
-        "Getting page https://pypi.python.org/simple/initools" in result.stdout
+        "Getting page https://pypi.org/simple/initools" in result.stdout
     )
 
 

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -221,7 +221,7 @@ def test_uninstall_before_upgrade_from_url(script):
     )
     result2 = script.pip(
         'install',
-        'https://pypi.python.org/packages/source/I/INITools/INITools-'
+        'https://files.pythonhosted.org/packages/source/I/INITools/INITools-'
         '0.3.tar.gz',
         expect_error=True,
     )
@@ -243,7 +243,7 @@ def test_upgrade_to_same_version_from_url(script):
     )
     result2 = script.pip(
         'install',
-        'https://pypi.python.org/packages/source/I/INITools/INITools-'
+        'https://files.pythonhosted.org/packages/source/I/INITools/INITools-'
         '0.3.tar.gz',
         expect_error=True,
     )
@@ -373,7 +373,7 @@ def test_upgrade_vcs_req_with_dist_found(script):
     )
     script.pip("install", req, expect_stderr=True)
     result = script.pip("install", "-U", req, expect_stderr=True)
-    assert "pypi.python.org" not in result.stdout, result.stdout
+    assert "pypi.org" not in result.stdout, result.stdout
 
 
 class TestUpgradeDistributeToSetuptools(object):

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -8,10 +8,10 @@ def test_timeout(script):
         expect_error=True,
     )
     assert (
-        "Could not fetch URL https://pypi.python.org/simple/INITools/: "
+        "Could not fetch URL https://pypi.org/simple/INITools/: "
         "timed out" in result.stdout
     )
     assert (
-        "Could not fetch URL https://pypi.python.org/simple/: "
+        "Could not fetch URL https://pypi.org/simple/: "
         "timed out" in result.stdout
     )

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -100,7 +100,7 @@ def test_run_method_should_return_success_when_find_packages():
     Test SearchCommand.run for found package
     """
     command = SearchCommand()
-    cmdline = "--index=https://pypi.python.org/pypi pip"
+    cmdline = "--index=https://pypi.org/pypi pip"
     options, args = command.parse_args(cmdline.split())
     status = command.run(options, args)
     assert status == SUCCESS
@@ -112,7 +112,7 @@ def test_run_method_should_return_no_matches_found_when_does_not_find_pkgs():
     Test SearchCommand.run for no matches
     """
     command = SearchCommand()
-    cmdline = "--index=https://pypi.python.org/pypi nonexistentpackage"
+    cmdline = "--index=https://pypi.org/pypi nonexistentpackage"
     options, args = command.parse_args(cmdline.split())
     status = command.run(options, args)
     assert status == NO_MATCHES_FOUND

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -73,6 +73,12 @@ def test_basic_search(script):
 
 
 @pytest.mark.network
+@pytest.mark.skip(
+    reason=("Warehouse search behavior is different and no longer returns "
+            "multiple results. See "
+            "https://github.com/pypa/warehouse/issues/3717 for more "
+            "information."),
+)
 def test_multiple_search(script):
     """
     Test searching for multiple packages at once.

--- a/tests/scripts/test_all_pip.py
+++ b/tests/scripts/test_all_pip.py
@@ -17,7 +17,7 @@ else:
 
 
 def all_projects():
-    data = urllib_request.urlopen('http://pypi.python.org/simple/').read()
+    data = urllib_request.urlopen('http://pypi.org/simple/').read()
     projects = [m.group(1) for m in re.finditer(r'<a.*?>(.+)</a>', data)]
     return projects
 

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -107,7 +107,7 @@ def test_finder_detects_latest_already_satisfied_pypi_links():
     req.satisfied_by = satisfied_by
     finder = PackageFinder(
         [],
-        ["http://pypi.python.org/simple"],
+        ["http://pypi.org/simple/"],
         session=PipSession(),
     )
 
@@ -287,7 +287,7 @@ def test_finder_priority_file_over_page(data):
     req = InstallRequirement.from_line('gmpy==1.15', None)
     finder = PackageFinder(
         [data.find_links],
-        ["http://pypi.python.org/simple"],
+        ["http://pypi.org/simple/"],
         session=PipSession(),
     )
     all_versions = finder.find_all_candidates(req.name)
@@ -312,9 +312,10 @@ def test_finder_deplink():
         session=PipSession(),
     )
     finder.add_dependency_links(
-        ['https://pypi.python.org/packages/source/g/gmpy/gmpy-1.15.zip'])
+        ['https://files.pythonhosted.org/packages/source/g/gmpy/gmpy-1.15.zip']
+    )
     link = finder.find_requirement(req, False)
-    assert link.url.startswith("https://pypi"), link
+    assert link.url.startswith("https://files.pythonhosted.org/"), link
 
 
 @pytest.mark.network
@@ -325,17 +326,22 @@ def test_finder_priority_page_over_deplink():
     req = InstallRequirement.from_line('pip==1.5.6', None)
     finder = PackageFinder(
         [],
-        ["https://pypi.python.org/simple"],
+        ["https://pypi.org/simple/"],
         process_dependency_links=True,
         session=PipSession(),
     )
     finder.add_dependency_links([
-        'https://warehouse.python.org/packages/source/p/pip/pip-1.5.6.tar.gz'])
+        'https://files.pythonhosted.org/packages/source/p/pip/pip-1.5.6.tar.gz'
+    ])
     all_versions = finder.find_all_candidates(req.name)
     # Check that the dependency_link is last
-    assert all_versions[-1].location.url.startswith('https://warehouse')
+    assert all_versions[-1].location.url.startswith(
+        'https://files.pythonhosted.org/'
+    )
     link = finder.find_requirement(req, False)
-    assert link.url.startswith("https://pypi"), link
+    assert link.url.startswith(
+        "https://files.pythonhosted.org/packages/3f/08/7347ca4"
+    ), link
 
 
 def test_finder_priority_nonegg_over_eggfragments():

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -122,11 +122,11 @@ class MockLogger(object):
 @pytest.mark.parametrize(
     ("location", "trusted", "expected"),
     [
-        ("http://pypi.python.org/something", [], True),
-        ("https://pypi.python.org/something", [], False),
-        ("git+http://pypi.python.org/something", [], True),
-        ("git+https://pypi.python.org/something", [], False),
-        ("git+ssh://git@pypi.python.org/something", [], False),
+        ("http://pypi.org/something", [], True),
+        ("https://pypi.org/something", [], False),
+        ("git+http://pypi.org/something", [], True),
+        ("git+https://pypi.org/something", [], False),
+        ("git+ssh://git@pypi.org/something", [], False),
         ("http://localhost", [], False),
         ("http://127.0.0.1", [], False),
         ("http://example.com/something/", [], True),

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -115,18 +115,19 @@ class TestRequirementSet(object):
         # This hash should be accepted because it came from the reqs file, not
         # from the internet:
         reqset.add_requirement(get_processed_req_from_line(
-            'https://pypi.python.org/packages/source/m/more-itertools/'
+            'https://files.pythonhosted.org/packages/source/m/more-itertools/'
             'more-itertools-1.0.tar.gz#md5=b21850c3cfa7efbb70fd662ab5413bdd',
             lineno=3,
         ))
         # The error text should list this as a URL and not `peep==3.1.1`:
         reqset.add_requirement(get_processed_req_from_line(
-            'https://pypi.python.org/packages/source/p/peep/peep-3.1.1.tar.gz',
+            'https://files.pythonhosted.org/'
+            'packages/source/p/peep/peep-3.1.1.tar.gz',
             lineno=4,
         ))
         finder = PackageFinder(
             [],
-            ['https://pypi.python.org/simple'],
+            ['https://pypi.org/simple/'],
             session=PipSession(),
         )
         resolver = self._basic_resolver(finder)
@@ -134,7 +135,7 @@ class TestRequirementSet(object):
             HashErrors,
             r'Hashes are required in --require-hashes mode, but they are '
             r'missing .*\n'
-            r'    https://pypi\.python\.org/packages/source/p/peep/peep'
+            r'    https://files\.pythonhosted\.org/packages/source/p/peep/peep'
             r'-3\.1\.1\.tar\.gz --hash=sha256:[0-9a-f]+\n'
             r'    blessings==1.0 --hash=sha256:[0-9a-f]+\n'
             r'THESE PACKAGES DO NOT MATCH THE HASHES.*\n'

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -14,7 +14,7 @@ from pip._internal.utils import outdated
 
 class MockPackageFinder(object):
 
-    BASE_URL = 'https://pypi.python.org/simple/pip-{0}.tar.gz'
+    BASE_URL = 'https://pypi.org/simple/pip-{0}.tar.gz'
     PIP_PROJECT_NAME = 'pip'
     INSTALLATION_CANDIDATES = [
         InstallationCandidate(PIP_PROJECT_NAME, '6.9.0',


### PR DESCRIPTION
Fixes #5214

I've made this PR against ``release/10.0.0``, I'd love to get this into the upcoming 10.0 release. I held off making this PR until we were 100% sure we were good to go on the PyPI side. Starting Monday we're going to be redirecting everything (and we've been running load tests where we start redirecting things in the interim to validate Warehouse).

The new code base is good to go, and this will let us get folks onto it without paying the cost of extra redirects sooner. It will also get pip 10 users onto the new code base for search, which we can't redirect and which is a much better experience.

I'm not tagging this as a release blocker, but @pfmoore if you don't have any objections, I'd love if you merged this prior to release.