### PR TITLE
fix PEP 518 support when pip is installed in the user site

### DIFF
--- a/news/5524.bugfix
+++ b/news/5524.bugfix
@@ -1,0 +1,1 @@
+Fix PEP 518 support when pip is installed in the user site.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -144,8 +144,10 @@ class IsSDist(DistAbstraction):
             )
 
         if should_isolate:
-            with self.req.build_env as prefix:
-                _install_build_reqs(finder, prefix, build_requirements)
+            with self.req.build_env:
+                pass
+            _install_build_reqs(finder, self.req.build_env.path,
+                                build_requirements)
         else:
             self.req.build_env = NoOpBuildEnvironment(no_clean=False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,20 +137,24 @@ def isolate(tmpdir):
         )
 
 
-@pytest.yield_fixture(scope='session')
-def virtualenv_template(tmpdir_factory):
-    tmpdir = Path(str(tmpdir_factory.mktemp('virtualenv')))
-    # Copy over our source tree so that each virtual environment is self
-    # contained
-    pip_src = tmpdir.join("pip_src").abspath
+@pytest.fixture(scope='session')
+def pip_src(tmpdir_factory):
+    pip_src = Path(str(tmpdir_factory.mktemp('pip_src'))).join('pip_src')
+    # Copy over our source tree so that each use is self contained
     shutil.copytree(
         SRC_DIR,
-        pip_src,
+        pip_src.abspath,
         ignore=shutil.ignore_patterns(
             "*.pyc", "__pycache__", "contrib", "docs", "tasks", "*.txt",
             "tests", "pip.egg-info", "build", "dist", ".tox", ".git",
         ),
     )
+    return pip_src
+
+
+@pytest.yield_fixture(scope='session')
+def virtualenv_template(tmpdir_factory, pip_src):
+    tmpdir = Path(str(tmpdir_factory.mktemp('virtualenv')))
     # Create the virtual environment
     venv = VirtualEnvironment.create(
         tmpdir.join("venv_orig"),


### PR DESCRIPTION
Do not use the build environment isolation during the build dependencies installation.

Note: included are the changes originally proposed in #5189 as well as an additional patch fixing the virtualenvs used by the testsuite so user site packages are correctly handled.

Fix #5224.