### PR TITLE
Fix CI for Python 3.7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ pytest-cov
 pytest-rerunfailures
 pytest-timeout
 pytest-xdist
-pyyaml
+https://github.com/yaml/pyyaml/archive/master.zip#egg=pyyaml
 mock
 scripttest>=1.3
 https://github.com/pypa/virtualenv/archive/master.zip#egg=virtualenv


### PR DESCRIPTION
The currently latest available version of PyYAML does not have support for Python 3.7.

We're switching to using the latest master for PyYAML.
