### PR TITLE
Add `pip.main` as func raising clean error

### DIFF
--- a/src/pip/__init__.py
+++ b/src/pip/__init__.py
@@ -1,1 +1,17 @@
 __version__ = "10.0.0"
+
+
+def main(*args, **kwargs):
+    """
+    This is an importable main func.
+    Its only purpose is to raise a clean error for users who call `pip.main()`
+    -- a usage which was never supported.
+    """
+    raise RuntimeError(
+        "pip.main() is unsupported and should not be used. "
+        "If you want to invoke pip from within your program, see the "
+        "documentation here: "
+        "https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program"
+        "\n"
+        "You may find that pip.main() works on pip<10, but pip cannot and "
+        "does not support or condone such usage.")


### PR DESCRIPTION
This is follow-up/an alternative to #5149

This has upsides and downsides. It improves the errors and guidance for those who invoke `pip.main`, but it changes the time of failure for some modules attempting to import and use `pip.main`. Instead of failing at import time, they'll fail when they invoke `pip.main()`.
On the plus side, it means that modules which import pip.main but only use it in some of their functions/classes may remain otherwise functional, so the scope of breakage is reduced.

Modules using `pip.main()` are going to be broken one way or another, and although ImportErrors will be superior for a number of users, it forbids us from sending good and clear messaging about what to do to remediate.

Advertising pip<10 as "maybe working" is probably a bit controversial, but it's practical/useful info. Whether or not pip takes a hardline stance on this is a matter for discussion/debate.