### PR TITLE
Add the ability to short circuit CI builds for docs-only changes

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,6 +2,28 @@
 set -e
 set -x
 
+# Short circuit tests and linting jobs if there are no code changes involved.
+if [[ $TOXENV != docs ]]; then
+    if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
+    then
+        echo "This is not a PR -- will do a complete build."
+    else
+        # Pull requests are slightly complicated because $TRAVIS_COMMIT_RANGE
+        # may include more changes than desired if the history is convoluted.
+        # Instead, explicitly fetch the base branch and compare against the
+        # merge-base commit.
+        git fetch -q origin +refs/heads/$TRAVIS_BRANCH
+        changes=$(git diff --name-only HEAD $(git merge-base HEAD FETCH_HEAD))
+        echo "Files changed:"
+        echo "$changes"
+        if ! echo "$changes" | grep -qvE '(\.rst$)|(^docs)|(^news)|(^\.github)'
+        then
+            echo "Only Documentation was updated -- skipping build."
+            exit
+        fi
+    fi
+fi
+
 if [[ $TOXENV == py* ]]; then
     # Run unit tests
     tox -- -m unit


### PR DESCRIPTION
Closes #5185

Based on CPython's code, linked in the mentioned issue. This doesn't really help us with the news-only commits but this is an improvement regardless.
