### PR TITLE
Remove trailing os.sep to avoid false negatives

### DIFF
--- a/news/5293.bugfix
+++ b/news/5293.bugfix
@@ -1,0 +1,1 @@
+Remove trailing os.sep from PATH directories to avoid false negatives

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -164,7 +164,8 @@ def message_about_scripts_not_on_PATH(scripts):
 
     # We don't want to warn for directories that are on PATH.
     not_warn_dirs = [
-        os.path.normcase(i) for i in os.environ["PATH"].split(os.pathsep)
+        os.path.normcase(i).rstrip(os.sep) for i in
+        os.environ["PATH"].split(os.pathsep)
     ]
     # If an executable sits with sys.executable, we don't warn for it.
     #     This covers the case of venv invocations without activating the venv.


### PR DESCRIPTION
When we look the dirs in PATH, we don't remove the trailing os.sep, and since we are using a set to do the checking, we get false negatives.

Example:

![image](https://user-images.githubusercontent.com/34587441/38966126-f66e1b4c-4356-11e8-88f0-bf4a95d8c1e6.png)