### PR TITLE
Clearer msg for already installed deps when updating

### DIFF
--- a/news/5319.feature
+++ b/news/5319.feature
@@ -1,0 +1,1 @@
+Improve status message when upgrade is skipped due to only-if-needed strategy

--- a/src/pip/_internal/resolve.py
+++ b/src/pip/_internal/resolve.py
@@ -160,7 +160,7 @@ class Resolver(object):
 
         if not self._is_upgrade_allowed(req_to_install):
             if self.upgrade_strategy == "only-if-needed":
-                return 'not upgraded as not directly required'
+                return 'already satisfied, skipping upgrade'
             return 'already satisfied'
 
         # Check for the possibility of an upgrade.  For link-based

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -53,6 +53,10 @@ def test_only_if_needed_does_not_upgrade_deps_when_satisfied(script):
         (script.site_packages / 'simple-2.0-py%s.egg-info' % pyversion)
         not in result.files_deleted
     ), "should not have uninstalled simple==2.0"
+    assert (
+        "Requirement already satisfied, skipping upgrade: simple"
+        in result.stdout
+    ), "did not print correct message for not-upgraded requirement"
 
 
 def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(script):


### PR DESCRIPTION
I went for "Requirement already satisfied, not checking version" after discussion in #5302 

Maybe this message is a bit long, but I can't find anything shorter that conveys the same info.

Fixes #5302 