### PR TITLE
Some new helpful search arguments

### DIFF
--- a/news/5333.feature
+++ b/news/5333.feature
@@ -1,0 +1,7 @@
+Added some search arguments(limit, operator, name-only).
+'limit' argument allows users to limit the  search results.
+'operator' argument allows users to apply union and intersection
+on result set of querystring in name and result set of querystring
+in summary.
+'name-only' argument allows users to apply search on package name
+only.

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -37,7 +37,17 @@ class SearchCommand(Command):
             dest='index',
             metavar='URL',
             default=PyPI.pypi_url,
-            help='Base URL of Python Package Index (default %default)')
+            help='Base URL of Python Package Index (default %default)'
+        )
+        self.cmd_opts.add_option(
+            '-l', '--limit',
+            dest='limit',
+            metavar='number',
+            type=int,
+            default=None,
+            help='Show only limited number of results. '
+                 'By default this will show all results.'
+        )
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -46,7 +56,7 @@ class SearchCommand(Command):
             raise CommandError('Missing required argument (search query).')
         query = args
         pypi_hits = self.search(query, options)
-        hits = transform_hits(pypi_hits)
+        hits = transform_hits(pypi_hits, options.limit)
 
         terminal_width = None
         if sys.stdout.isatty():
@@ -66,14 +76,14 @@ class SearchCommand(Command):
             return hits
 
 
-def transform_hits(hits):
+def transform_hits(hits, limit):
     """
     The list from pypi is really a list of versions. We want a list of
     packages with the list of versions stored inline. This converts the
     list from pypi into one we can use.
     """
     packages = OrderedDict()
-    for hit in hits:
+    for hit in hits[:limit]:
         name = hit['name']
         summary = hit['summary']
         version = hit['version']

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -48,6 +48,13 @@ class SearchCommand(Command):
             help='Show only limited number of results. '
                  'By default this will show all results.'
         )
+        self.cmd_opts.add_option(
+            '-o', '--operator',
+            dest='operator',
+            metavar='or/and',
+            default='or',
+            help='Show results with query string in name or/and summary.'
+        )
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -72,7 +79,7 @@ class SearchCommand(Command):
         with self._build_session(options) as session:
             transport = PipXmlrpcTransport(index_url, session)
             pypi = xmlrpc_client.ServerProxy(index_url, transport)
-            hits = pypi.search({'name': query, 'summary': query}, 'or')
+            hits = pypi.search({'name': '', 'summary': query}, options.operator)
             return hits
 
 

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -60,7 +60,8 @@ class SearchCommand(Command):
             action='store_true',
             dest='name_only',
             default=False,
-            help='Show only results with query string in package name (default %default) '
+            help='Show only results with query string in package name.'
+                 'By default shows all results.'
         )
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -94,7 +95,7 @@ class SearchCommand(Command):
             return hits
 
 
-def transform_hits(hits, limit):
+def transform_hits(hits, limit=None):
     """
     The list from pypi is really a list of versions. We want a list of
     packages with the list of versions stored inline. This converts the

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -55,7 +55,13 @@ class SearchCommand(Command):
             default='or',
             help='Show results with query string in name or/and summary.'
         )
-
+        self.cmd_opts.add_option(
+            '-n', '--name-only',
+            action='store_true',
+            dest='name_only',
+            default=False,
+            help='Show only results with query string in package name (default %default) '
+        )
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
@@ -79,7 +85,12 @@ class SearchCommand(Command):
         with self._build_session(options) as session:
             transport = PipXmlrpcTransport(index_url, session)
             pypi = xmlrpc_client.ServerProxy(index_url, transport)
-            hits = pypi.search({'name': '', 'summary': query}, options.operator)
+            hits = pypi.search(
+                {
+                    'name': query,
+                    'summary': '' if options.name_only else query
+                }, options.operator
+            )
             return hits
 
 


### PR DESCRIPTION
**Description**
As the search command shows a lot of results, I have added some arguments which can be pretty useful for the users.
**limit argument**
Limits the number of results.
**operator argument**
Changes the server query operator which is a hard coded or.
**name only argument**
Shows only results with query string in name. 

Example queries to see the difference with and without the arguments:
**limit argument**
pip search pypi
pip search -l 10 pypi
**operator argument**
pip search pypi
pip search -o or pypi
pip search -o and pypi
**name only argument**
pip search pypi
pip search -n pypi
