### PR TITLE
Revendoring script not to rewrite binascii import

### DIFF
--- a/news/5347.bugfix
+++ b/news/5347.bugfix
@@ -1,0 +1,1 @@
+Fix the revendoring script no to rewrite unrelated import that starts suspicious. 

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -17,8 +17,8 @@ FILE_WHITE_LIST = (
 )
 
 
-def drop_dir(path):
-    shutil.rmtree(str(path))
+def drop_dir(path, **kwargs):
+    shutil.rmtree(str(path), **kwargs)
 
 
 def remove_all(paths):
@@ -113,6 +113,10 @@ def vendor(ctx, vendor_dir):
     drop_dir(vendor_dir / 'setuptools')
     drop_dir(vendor_dir / 'pkg_resources' / '_vendor')
     drop_dir(vendor_dir / 'pkg_resources' / 'extern')
+
+    # Drop the bin directory (contains easy_install, distro, chardetect etc.)
+    # Might not appear on all OSes, so ignoring errors
+    drop_dir(vendor_dir / 'bin', ignore_errors=True)
 
     # Drop interpreter and OS specific msgpack libs.
     # Pip will rely on the python-only fallback instead.

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -83,8 +83,8 @@ def rewrite_file_imports(item, vendored_libs):
             text,
         )
         text = re.sub(
-            r'(\n\s*)from %s' % lib,
-            r'\1from pip._vendor.%s' % lib,
+            r'(\n\s*)from %s(\.|\s+)' % lib,
+            r'\1from pip._vendor.%s\2' % lib,
             text,
         )
     item.write_text(text, encoding='utf-8')


### PR DESCRIPTION
Both the commits would fix the issue, but I suppose keeping them both makes this not kick us later.