### PR TITLE
When pip was not installed by pip, don't show the upgrade warning

### DIFF
--- a/news/5346.bugfix
+++ b/news/5346.bugfix
@@ -1,0 +1,5 @@
+Disable pip's version check (and upgrade message) when installed by a different package manager.
+
+This works better with Linux distributions where pip's upgrade message may
+result in users running pip in a manner that modifies files that should be
+managed by the OS's package manager.


### PR DESCRIPTION
Implements behavior as discussed in https://github.com/pypa/pip/issues/5346.
