### PR TITLE
Added --prefer-binary flag.

### DIFF
--- a/news/3785.feature
+++ b/news/3785.feature
@@ -1,0 +1,1 @@
+Add the --prefer-binary flag, to prefer older wheels over newer source packages.

--- a/news/3785.feature
+++ b/news/3785.feature
@@ -1,1 +1,1 @@
-Add the --prefer-binary flag, to prefer older wheels over newer source packages.
+Introduce a new --prefer-binary flag, to prefer older wheels over newer source packages.

--- a/src/pip/_internal/basecommand.py
+++ b/src/pip/_internal/basecommand.py
@@ -370,4 +370,5 @@ class RequirementCommand(Command):
             versions=python_versions,
             abi=abi,
             implementation=implementation,
+            prefer_binary=options.prefer_binary,
         )

--- a/src/pip/_internal/cmdoptions.py
+++ b/src/pip/_internal/cmdoptions.py
@@ -406,6 +406,16 @@ def only_binary():
     )
 
 
+def prefer_binary():
+    return Option(
+        "--prefer-binary",
+        dest="prefer_binary",
+        action="store_true",
+        default=False,
+        help="Prefer older binary packages over newer source packages."
+    )
+
+
 cache_dir = partial(
     Option,
     "--cache-dir",

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -52,6 +52,7 @@ class DownloadCommand(RequirementCommand):
         cmd_opts.add_option(cmdoptions.global_options())
         cmd_opts.add_option(cmdoptions.no_binary())
         cmd_opts.add_option(cmdoptions.only_binary())
+        cmd_opts.add_option(cmdoptions.prefer_binary())
         cmd_opts.add_option(cmdoptions.src())
         cmd_opts.add_option(cmdoptions.pre())
         cmd_opts.add_option(cmdoptions.no_clean())

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -183,6 +183,7 @@ class InstallCommand(RequirementCommand):
 
         cmd_opts.add_option(cmdoptions.no_binary())
         cmd_opts.add_option(cmdoptions.only_binary())
+        cmd_opts.add_option(cmdoptions.prefer_binary())
         cmd_opts.add_option(cmdoptions.no_clean())
         cmd_opts.add_option(cmdoptions.require_hashes())
         cmd_opts.add_option(cmdoptions.progress_bar())

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -57,6 +57,7 @@ class WheelCommand(RequirementCommand):
         )
         cmd_opts.add_option(cmdoptions.no_binary())
         cmd_opts.add_option(cmdoptions.only_binary())
+        cmd_opts.add_option(cmdoptions.prefer_binary())
         cmd_opts.add_option(
             '--build-option',
             dest='build_options',

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -108,7 +108,8 @@ class PackageFinder(object):
     def __init__(self, find_links, index_urls, allow_all_prereleases=False,
                  trusted_hosts=None, process_dependency_links=False,
                  session=None, format_control=None, platform=None,
-                 versions=None, abi=None, implementation=None, prefer_binary=False):
+                 versions=None, abi=None, implementation=None,
+                 prefer_binary=False):
         """Create a PackageFinder.
 
         :param format_control: A FormatControl object or None. Used to control

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -625,12 +625,17 @@ def test_download_prefer_binary_when_tarball_higher_than_wheel(script, data):
 
 def test_download_prefer_binary_when_wheel_doesnt_satisfy_req(script, data):
     fake_wheel(data, 'source-0.8-py2.py3-none-any.whl')
+    script.scratch_path.join("test-req.txt").write(textwrap.dedent("""
+        source>0.9
+        """))
+
     result = script.pip(
         'download',
         '--prefer-binary',
         '--no-index',
         '-f', data.packages,
-        '-d', '.', 'source>=0.9'
+        '-d', '.',
+        '-r', script.scratch_path / 'test-req.txt'
     )
     assert (
         Path('scratch') / 'source-1.0.tar.gz'


### PR DESCRIPTION
Hi,

I ran into  #3785, and I need this feature, because c/cpp compilation is cumbersome, so if there is a wheel, even an old one (but still valid for the requirements), i'd rather use it than attempt to compile the source package. I can't use `--only-binary :all:`, because then python-only package that provide only source distribution won't be installed.
This PR adds the needed feature.

Thanks.

Fixes #3785