### PR TITLE
disable strict_optional mypy option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ select = E,W,F
 [mypy]
 follow_imports = silent
 ignore_missing_imports = True
+strict_optional = False
 
 [mypy-pip/_vendor/*]
 follow_imports = skip


### PR DESCRIPTION
mypy 0.600 changed the default for strict_optional. This PR changes it back to false for pip.
This is the reason all PRs in the last 2 days fail the mypy part in the travis build.