### PR TITLE
Update to use new GitHub support for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+#### Environment Information
+
+* pip version:
+* Python version:
+* OS:
+
+#### Describe the bug
+
+A clear and concise description of what the bug is; what you were trying, what happened, what went wrong and so on. Provide any context that you feel is helpful here.
+
+#### How to Reproduce
+
+Describe what steps need to be followed to bump into this bug.
+
+1. Run '...'
+2. Then run '...'
+3. See error
+
+#### Output
+
+```
+Paste the output of the steps above, including the commands themselves and pip's output/traceback etc.
+```
+
+#### Expected behavior
+
+A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+#### Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is.
+
+#### Describe the solution you'd like
+
+A clear and concise description of what you want to happen. If it's possible to achieve this today, also describe how this solution is compared to the status quo.
+
+#### Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+#### Additional context
+
+Add any other context or details, related to the feature request here.


### PR DESCRIPTION
https://blog.github.com/2018-05-02-issue-template-improvements/

- Create new, dedicated issue templates for:
  - bug reports
  - feature requests
  - @pypa/pip-committers Any other kind of template we might want to add to this list?
- Improve bug report template to include steps to reproduce
- Slightly smaller headings
