### PR TITLE
fix for issue #5375

### DIFF
--- a/news/5375.bugfix
+++ b/news/5375.bugfix
@@ -1,0 +1,1 @@
+Fix to manage svn+ssh scheme case for authentication


### PR DESCRIPTION
svn checkout svn+ssh:// does not recognize --username option, so auth should not be extracted from URL.

Fixes #5375