### PR TITLE
 Detect x32 userspace ABI on 64-bit kernel (fixes #4962)

### DIFF
--- a/news/4962.bugfix
+++ b/news/4962.bugfix
@@ -1,0 +1,1 @@
+Detect x32 userspace ABI on 64-bit kernel

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -135,7 +135,12 @@ def get_platform():
     if result == "linux_x86_64" and _is_running_32bit():
         # 32 bit Python program (running on a 64 bit Linux): pip should only
         # install and run 32 bit compiled extensions in that case.
-        result = "linux_i686"
+        machine = platform.machine()
+
+        if machine == "x86_64":
+            result = "linux_x32"
+        else:
+            result = "linux_i686"  # and machine == "i686"
 
     return result
 


### PR DESCRIPTION
Closes #4962

I didn't see any unit tests for this particular logic, and the tests ran very slow on my old laptop, so I'm going to let Travis take a look at this for me.

See #4962 for more context and my reproduction of the bug/how to test the fix.

I chose this approach because it is almost the same as the current logic, with an exception for the x32 ABI. There are other possible approaches I could have taken (including throwing an exception for a case we haven't accounted for in order to avoid hitting this bug in the future), but I wanted to be conservative here. I'm open to other suggestions.