### PR TITLE
[FIX] help tests fail if PIP_INDEX_URL set

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,6 +160,9 @@ def isolate(tmpdir):
 
     # We want to disable the version check from running in the tests
     os.environ["PIP_DISABLE_PIP_VERSION_CHECK"] = "true"
+    
+    # Tox will pass PIP_INDEX_URL, ensure it's not set.
+    os.environ.pop('PIP_INDEX_URL', None)
 
     # Make sure tests don't share a requirements tracker.
     os.environ.pop('PIP_REQ_TRACKER', None)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -171,6 +171,8 @@ def test_basic_install_from_pypi(script):
     """
     Test installing a package from PyPI.
     """
+    if 'PIP_INDEX_URL' in script.environ:
+        del script.environ['PIP_INDEX_URL']
     result = script.pip('install', '-vvv', 'INITools==0.2')
     egg_info_folder = (
         script.site_packages / 'INITools-0.2-py%s.egg-info' % pyversion

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -148,6 +148,8 @@ def test_config_file_override_stack(script, virtualenv):
 
 def _test_config_file_override_stack(script, virtualenv, config_file):
     # set this to make pip load it
+    if 'PIP_INDEX_URL' in script.environ:
+        del script.environ['PIP_INDEX_URL']
     script.environ['PIP_CONFIG_FILE'] = config_file
     (script.scratch_path / config_file).write(textwrap.dedent("""\
         [global]

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -11,11 +11,13 @@ def test_basic_show(script):
     """
     Test end to end test for show command.
     """
+    if 'PIP_INDEX_URL' in script.environ:
+        del script.environ['PIP_INDEX_URL']
     result = script.pip('show', 'pip')
     lines = result.stdout.splitlines()
     assert len(lines) == 10
     assert 'Name: pip' in lines
-    assert 'Version: %s' % __version__ in lines
+    assert 'Version: {}'.format(__version__) in lines
     assert any(line.startswith('Location: ') for line in lines)
     assert 'Requires: ' in lines
 


### PR DESCRIPTION
The repo out of box tests fails to run if the developer has PIP_INDEX_URL set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/5397)
<!-- Reviewable:end -->
