### PR TITLE
Add --json flag to print download information

### DIFF
--- a/news/5398.feature
+++ b/news/5398.feature
@@ -1,0 +1,1 @@
+Add machine readable --json to pip download and add --log-stderr

--- a/src/pip/_internal/cmdoptions.py
+++ b/src/pip/_internal/cmdoptions.py
@@ -274,6 +274,15 @@ no_index = partial(
     help='Ignore package index (only looking at --find-links URLs instead).',
 )  # type: Any
 
+log_stderr = partial(
+    Option,
+    '--log-stderr',
+    dest='log_stderr',
+    action='store_true',
+    default=False,
+    help="Log logger warnings to stderr",
+)
+
 
 def find_links():
     return Option(
@@ -604,6 +613,7 @@ general_group = {
         no_cache,
         disable_pip_version_check,
         no_color,
+        log_stderr,
     ]
 }
 

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -486,7 +486,7 @@ class PackageFinder(object):
         """Try to find a Link matching req
 
         Expects req, an InstallRequirement and upgrade, a boolean
-        Returns a Link if found,
+        Returns an InstallationCandidate if found,
         Raises DistributionNotFound or BestVersionAlreadyInstalled otherwise
         """
         all_candidates = self.find_all_candidates(req.name)
@@ -579,7 +579,7 @@ class PackageFinder(object):
             best_candidate.version,
             ', '.join(sorted(compatible_versions, key=parse_version))
         )
-        return best_candidate.location
+        return best_candidate
 
     def _get_pages(self, locations, project_name):
         """

--- a/src/pip/_internal/resolve.py
+++ b/src/pip/_internal/resolve.py
@@ -352,3 +352,10 @@ class Resolver(object):
         for install_req in req_set.requirements.values():
             schedule(install_req)
         return order
+
+    def get_dependencies(self):
+        """ Gets dependencies discovered after resolution
+
+        Returns a mapping of package names to lists of requirement objects
+        """
+        return self._discovered_dependencies


### PR DESCRIPTION
This adds a --json flag to pip download. This prints out some basic information about packages resolved by pip download (acknowledging that it may not be 100% correct because pip) such as name, version, url and dependencies.

Also added a --log-stderr to force info messages to go to stderr so that machine readable output is not clobbered by human readable text.

Added and updated unit tests to make sure it worked. Sample run through jq here: https://gist.github.com/philipjameson/88580962e0fed1ad9ec75f1733c0a625

Fixes #5398 
