### PR TITLE
Add pre-released package upgrade hints

### DIFF
--- a/news/5408.feature
+++ b/news/5408.feature
@@ -1,0 +1,1 @@
+Update latest package version message to include reminder on how to install pre-releases.

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -126,7 +126,11 @@ def print_results(hits, name_column_width=None, terminal_width=None):
                         logger.info('INSTALLED: %s (latest)', dist.version)
                     else:
                         logger.info('INSTALLED: %s', dist.version)
-                        logger.info('LATEST:    %s', latest)
+                        if parse_version(latest).pre:
+                            logger.info('LATEST:    %s (pre-release; install'
+                                        ' with "pip install --pre")', latest)
+                        else:
+                            logger.info('LATEST:    %s', latest)
         except UnicodeEncodeError:
             pass
 

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -142,6 +142,27 @@ def test_search_exit_status_code_when_finds_no_package(script):
     assert result.returncode == NO_MATCHES_FOUND, result.returncode
 
 
+def test_latest_prerelease_install_message(caplog):
+    """
+    Test documentation for installing pre-release packages is displayed
+    """
+    hits = [
+        {
+            'name': 'ni',
+            'summary': 'For knights who say Ni!',
+            'versions': ['1.0.0', '1.0.1.dev']
+        }
+    ]
+    print_results(hits)
+    print(dir(caplog))
+    print(caplog.text)
+    records = sorted([r.getMessage() for r in caplog.records])
+    print(records)
+    print(dir(records))
+    lines = records[0].splitlines()
+    assert 'pre-release; install with "pip install --pre"' in lines[-1]
+
+
 def test_search_print_results_should_contain_latest_versions(caplog):
     """
     Test that printed search results contain the latest package versions


### PR DESCRIPTION
Before this commit when querying for an installed package using pip if
the package that was returned contained a pre-released version of the
package it was not intuitive that the pre-released version of the
package could not be directly upgraded to without the `--pre` flag.

This commit shows additional information on how to upgrade to
pre-released versions of a package if one is found in the search.

Fixes #5169.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
