### PR TITLE
Manylinux2010

### DIFF
--- a/news/5008.feature
+++ b/news/5008.feature
@@ -1,0 +1,3 @@
+Implement manylinux2 platform tag support.  manylinux2 is the successor
+to manylinux1.  It allows carefully compiled binary wheels to be installed
+on compatible Linux platforms.

--- a/news/5008.feature
+++ b/news/5008.feature
@@ -1,3 +1,3 @@
-Implement manylinux2 platform tag support.  manylinux2 is the successor
+Implement manylinux2010 platform tag support.  manylinux2010 is the successor
 to manylinux1.  It allows carefully compiled binary wheels to be installed
 on compatible Linux platforms.

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -281,7 +281,7 @@ def get_supported(versions=None, noarch=False, platform=None,
     if not noarch:
         arch = platform or get_platform()
         arch_prefix, arch_sep, arch_suffix = arch.partition('_')
-        if arch_prefix == 'macosx':
+        if arch.startswith('macosx'):
             # support macosx-10.6-intel on macosx-10.9-x86_64
             match = _osx_arch_pat.match(arch)
             if match:

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -295,7 +295,10 @@ def get_supported(versions=None, noarch=False, platform=None,
                 # arch pattern didn't match (?!)
                 arches = [arch]
         elif arch_prefix == 'manylinux2010':
-            # manylinux1 wheels run on manylinux2010 systems.
+            # manylinux1 wheels run on most manylinux2010 systems with the
+            # exception of wheels depending on ncurses. PEP 571 states
+            # manylinux1 wheels should be considered manylinux2010 wheels:
+            # https://www.python.org/dev/peps/pep-0571/#backwards-compatibility-with-manylinux1-wheels
             arches = [arch, 'manylinux1' + arch_sep + arch_suffix]
         elif platform is None:
             arches = []

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -157,7 +157,7 @@ def is_manylinux1_compatible():
     return pip._internal.utils.glibc.have_compatible_glibc(2, 5)
 
 
-def is_manylinux2_compatible():
+def is_manylinux2010_compatible():
     # Only Linux, and only x86-64 / i686
     if get_platform() not in {"linux_x86_64", "linux_i686"}:
         return False
@@ -165,7 +165,7 @@ def is_manylinux2_compatible():
     # Check for presence of _manylinux module
     try:
         import _manylinux
-        return bool(_manylinux.manylinux2_compatible)
+        return bool(_manylinux.manylinux2010_compatible)
     except (ImportError, AttributeError):
         # Fall through to heuristic check below
         pass
@@ -293,13 +293,13 @@ def get_supported(versions=None, noarch=False, platform=None,
             else:
                 # arch pattern didn't match (?!)
                 arches = [arch]
-        elif arch.startswith('manylinux2'):
-            # manylinux1 wheels run on manylinux2 systems.
-            arches = [arch, arch.replace('manylinux2', 'manylinux1')]
+        elif arch.startswith('manylinux2010'):
+            # manylinux1 wheels run on manylinux2010 systems.
+            arches = [arch, arch.replace('manylinux2010', 'manylinux1')]
         elif platform is None:
             arches = []
-            if is_manylinux2_compatible():
-                arches.append(arch.replace('linux', 'manylinux2'))
+            if is_manylinux2010_compatible():
+                arches.append(arch.replace('linux', 'manylinux2010'))
             if is_manylinux1_compatible():
                 arches.append(arch.replace('linux', 'manylinux1'))
             arches.append(arch)

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -280,7 +280,8 @@ def get_supported(versions=None, noarch=False, platform=None,
 
     if not noarch:
         arch = platform or get_platform()
-        if arch.startswith('macosx'):
+        arch_prefix, arch_sep, arch_suffix = arch.partition('_')
+        if arch_prefix == 'macosx':
             # support macosx-10.6-intel on macosx-10.9-x86_64
             match = _osx_arch_pat.match(arch)
             if match:
@@ -293,15 +294,15 @@ def get_supported(versions=None, noarch=False, platform=None,
             else:
                 # arch pattern didn't match (?!)
                 arches = [arch]
-        elif arch.startswith('manylinux2010'):
+        elif arch_prefix == 'manylinux2010':
             # manylinux1 wheels run on manylinux2010 systems.
-            arches = [arch, arch.replace('manylinux2010', 'manylinux1')]
+            arches = [arch, 'manylinux1' + arch_sep + arch_suffix]
         elif platform is None:
             arches = []
             if is_manylinux2010_compatible():
-                arches.append(arch.replace('linux', 'manylinux2010'))
+                arches.append('manylinux2010' + arch_sep + arch_suffix)
             if is_manylinux1_compatible():
-                arches.append(arch.replace('linux', 'manylinux1'))
+                arches.append('manylinux1' + arch_sep + arch_suffix)
             arches.append(arch)
         else:
             arches = [arch]

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -331,7 +331,7 @@ class TestDownloadPlatformManylinuxes(object):
     @pytest.mark.parametrize("platform", [
         "linux_x86_64",
         "manylinux1_x86_64",
-        "manylinux2_x86_64",
+        "manylinux2010_x86_64",
     ])
     def test_download_universal(self, platform, script, data):
         """
@@ -352,8 +352,8 @@ class TestDownloadPlatformManylinuxes(object):
 
     @pytest.mark.parametrize("wheel_abi,platform", [
         ("manylinux1_x86_64", "manylinux1_x86_64"),
-        ("manylinux1_x86_64", "manylinux2_x86_64"),
-        ("manylinux2_x86_64", "manylinux2_x86_64"),
+        ("manylinux1_x86_64", "manylinux2010_x86_64"),
+        ("manylinux2010_x86_64", "manylinux2010_x86_64"),
     ])
     def test_download_compatible_manylinuxes(
             self, wheel_abi, platform, script, data,

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -322,54 +322,71 @@ def test_download_specify_platform(script, data):
     )
 
 
-def test_download_platform_manylinux(script, data):
+class TestDownloadPlatformManylinuxes(object):
     """
-    Test using "pip download --platform" to download a .whl archive
-    supported for a specific platform.
+    "pip download --platform" downloads a .whl archive supported for
+    manylinux platforms.
     """
-    fake_wheel(data, 'fake-1.0-py2.py3-none-any.whl')
-    # Confirm that universal wheels are returned even for specific
-    # platforms.
-    result = script.pip(
-        'download', '--no-index', '--find-links', data.find_links,
-        '--only-binary=:all:',
-        '--dest', '.',
-        '--platform', 'linux_x86_64',
-        'fake',
-    )
-    assert (
-        Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
-        in result.files_created
-    )
 
-    data.reset()
-    fake_wheel(data, 'fake-1.0-py2.py3-none-manylinux1_x86_64.whl')
-    result = script.pip(
-        'download', '--no-index', '--find-links', data.find_links,
-        '--only-binary=:all:',
-        '--dest', '.',
-        '--platform', 'manylinux1_x86_64',
-        'fake',
-    )
-    assert (
-        Path('scratch') /
-        'fake-1.0-py2.py3-none-manylinux1_x86_64.whl'
-        in result.files_created
-    )
+    @pytest.mark.parametrize("platform", [
+        "linux_x86_64",
+        "manylinux1_x86_64",
+        "manylinux2_x86_64",
+    ])
+    def test_download_universal(self, platform, script, data):
+        """
+        Universal wheels are returned even for specific platforms.
+        """
+        fake_wheel(data, 'fake-1.0-py2.py3-none-any.whl')
+        result = script.pip(
+            'download', '--no-index', '--find-links', data.find_links,
+            '--only-binary=:all:',
+            '--dest', '.',
+            '--platform', platform,
+            'fake',
+        )
+        assert (
+            Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
+            in result.files_created
+        )
 
-    # When specifying the platform, manylinux1 needs to be the
-    # explicit platform--it won't ever be added to the compatible
-    # tags.
-    data.reset()
-    fake_wheel(data, 'fake-1.0-py2.py3-none-linux_x86_64.whl')
-    result = script.pip(
-        'download', '--no-index', '--find-links', data.find_links,
-        '--only-binary=:all:',
-        '--dest', '.',
-        '--platform', 'linux_x86_64',
-        'fake',
-        expect_error=True,
-    )
+    @pytest.mark.parametrize("wheel_abi,platform", [
+        ("manylinux1_x86_64", "manylinux1_x86_64"),
+        ("manylinux1_x86_64", "manylinux2_x86_64"),
+        ("manylinux2_x86_64", "manylinux2_x86_64"),
+    ])
+    def test_download_compatible_manylinuxes(
+            self, wheel_abi, platform, script, data,
+    ):
+        """
+        Earlier manylinuxes are compatible with later manylinuxes.
+        """
+        wheel = 'fake-1.0-py2.py3-none-{}.whl'.format(wheel_abi)
+        fake_wheel(data, wheel)
+        result = script.pip(
+            'download', '--no-index', '--find-links', data.find_links,
+            '--only-binary=:all:',
+            '--dest', '.',
+            '--platform', platform,
+            'fake',
+        )
+        assert Path('scratch') / wheel in result.files_created
+
+    def test_explicit_platform_only(self, data, script):
+        """
+        When specifying the platform, manylinux1 needs to be the
+        explicit platform--it won't ever be added to the compatible
+        tags.
+        """
+        fake_wheel(data, 'fake-1.0-py2.py3-none-linux_x86_64.whl')
+        script.pip(
+            'download', '--no-index', '--find-links', data.find_links,
+            '--only-binary=:all:',
+            '--dest', '.',
+            '--platform', 'linux_x86_64',
+            'fake',
+            expect_error=True,
+        )
 
 
 def test_download_specify_python_version(script, data):

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -118,11 +118,11 @@ class TestPEP425Tags(object):
 
 @pytest.mark.parametrize('is_manylinux_compatible', [
     pep425tags.is_manylinux1_compatible,
-    pep425tags.is_manylinux2_compatible,
+    pep425tags.is_manylinux2010_compatible,
 ])
 class TestManylinuxTags(object):
     """
-    Tests common to all manylinux tags (e.g. manylinux1, manylinux2,
+    Tests common to all manylinux tags (e.g. manylinux1, manylinux2010,
     ...)
     """
     @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
@@ -166,7 +166,8 @@ class TestManylinuxTags(object):
 
 class TestManylinux1Tags(object):
 
-    @patch('pip._internal.pep425tags.is_manylinux2_compatible', lambda: False)
+    @patch('pip._internal.pep425tags.is_manylinux2010_compatible',
+           lambda: False)
     @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
     @patch('pip._internal.utils.glibc.have_compatible_glibc',
            lambda major, minor: True)
@@ -189,15 +190,15 @@ class TestManylinux1Tags(object):
                 assert arches == ['manylinux1_x86_64', 'linux_x86_64']
 
 
-class TestManylinux2Tags(object):
+class TestManylinux2010Tags(object):
 
     @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
     @patch('pip._internal.utils.glibc.have_compatible_glibc',
            lambda major, minor: True)
     @patch('sys.platform', 'linux2')
-    def test_manylinux2_tag_is_first(self):
+    def test_manylinux2010_tag_is_first(self):
         """
-        Test that the more specific tag manylinux2 comes first.
+        Test that the more specific tag manylinux2010 comes first.
         """
         groups = {}
         for pyimpl, abi, arch in pep425tags.get_supported():
@@ -208,28 +209,29 @@ class TestManylinux2Tags(object):
                 continue
             # Expect the most specific arch first:
             if len(arches) == 4:
-                assert arches == ['manylinux2_x86_64',
+                assert arches == ['manylinux2010_x86_64',
                                   'manylinux1_x86_64',
                                   'linux_x86_64',
                                   'any']
             else:
-                assert arches == ['manylinux2_x86_64',
+                assert arches == ['manylinux2010_x86_64',
                                   'manylinux1_x86_64',
                                   'linux_x86_64']
 
-    @pytest.mark.parametrize("manylinux2,manylinux1", [
-        ("manylinux2_x86_64", "manylinux1_x86_64"),
-        ("manylinux2_i686", "manylinux1_i686"),
+    @pytest.mark.parametrize("manylinux2010,manylinux1", [
+        ("manylinux2010_x86_64", "manylinux1_x86_64"),
+        ("manylinux2010_i686", "manylinux1_i686"),
     ])
-    def test_manylinux2_implies_manylinux1(self, manylinux2, manylinux1):
+    def test_manylinux2010_implies_manylinux1(self, manylinux2010, manylinux1):
         """
-        Specifying manylinux2 implies manylinux1.
+        Specifying manylinux2010 implies manylinux1.
         """
         groups = {}
-        for pyimpl, abi, arch in pep425tags.get_supported(platform=manylinux2):
+        supported = pep425tags.get_supported(platform=manylinux2010)
+        for pyimpl, abi, arch in supported:
             groups.setdefault((pyimpl, abi), []).append(arch)
 
         for arches in groups.values():
             if arches == ['any']:
                 continue
-            assert arches[:2] == [manylinux2, manylinux1]
+            assert arches[:2] == [manylinux2010, manylinux1]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -539,7 +539,7 @@ class TestTempDirectory(object):
 
 
 class TestGlibc(object):
-    def test_manylinux1_check_glibc_version(self):
+    def test_manylinux_check_glibc_version(self):
         """
         Test that the check_glibc_version function is robust against weird
         glibc version strings.


### PR DESCRIPTION
This is an update of @markrwilliams merge request pypa/pip#5008. Updates the tag from manylinux2 to manylinux2010 to reflect the changes in [PEP 571](https://www.python.org/dev/peps/pep-0571/#id45). Also addresses @dstufft's suggestion to not use `startswith` to detect the arch. Thanks to @ncoghlan for the help!