### PR TITLE
fix un-vendored support; add missing entry for urllib3

### DIFF
--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -107,3 +107,4 @@ if DEBUNDLED:
     vendored("requests.packages.urllib3.util.ssl_")
     vendored("requests.packages.urllib3.util.timeout")
     vendored("requests.packages.urllib3.util.url")
+    vendored("urllib3")


### PR DESCRIPTION
I'm assuming since you don't "officially" support this, I don't need to
create a news entry?

OTOH I'm working on pulling in all system modules needed for pip so I
can get Arch Linux to provide a devendored pip, so this may get some
better testing anyway. ;)