### PR TITLE
3905 pip version check cache dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
     - env: TOXENV=py36
       python: 3.6
     # All the other Py3 versions
-    - env: TOXENV=py33
-      python: 3.3
     - env: TOXENV=py34
       python: 3.4
     - env: TOXENV=py35

--- a/news/3905.bugfix
+++ b/news/3905.bugfix
@@ -1,8 +1,1 @@
-Changed rules on where pip version lock file selfcheck.json is stored.
-
-Previously, the lock file was either stored at ``USER_CACHE``/selfcheck.json,
-or for vitual enviorments it is stored at ``sys.prefix``\pip-selfcheck.json
-
-Now regardless of whether the user is in a virtual environment, the lock file
-is stored either in selfcheck.json in the path specified in cache-dir in
-pip.conf, or if none is specified it is stored at``USER_CACHE``/selfcheck.json 
+Adjust path to selfcheck.json - remove virtualenv specific path and honor cache-dir in pip.conf

--- a/news/3905.bugfix
+++ b/news/3905.bugfix
@@ -1,0 +1,8 @@
+Changed rules on where pip version lock file selfcheck.json is stored.
+
+Previously, the lock file was either stored at ``USER_CACHE``/selfcheck.json,
+or for vitual enviorments it is stored at ``sys.prefix``\pip-selfcheck.json
+
+Now regardless of whether the user is in a virtual environment, the lock file
+is stored either in selfcheck.json in the path specified in cache-dir in
+pip.conf, or if none is specified it is stored at``USER_CACHE``/selfcheck.json 

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -21,31 +21,6 @@ SELFCHECK_DATE_FMT = "%Y-%m-%dT%H:%M:%SZ"
 logger = logging.getLogger(__name__)
 
 
-class VirtualenvSelfCheckState(object):
-    def __init__(self):
-        self.statefile_path = os.path.join(sys.prefix, "pip-selfcheck.json")
-
-        # Load the existing state
-        try:
-            with open(self.statefile_path) as statefile:
-                self.state = json.load(statefile)
-        except (IOError, ValueError):
-            self.state = {}
-
-    def save(self, pypi_version, current_time):
-        # Attempt to write out our version check file
-        with open(self.statefile_path, "w") as statefile:
-            json.dump(
-                {
-                    "last_check": current_time.strftime(SELFCHECK_DATE_FMT),
-                    "pypi_version": pypi_version,
-                },
-                statefile,
-                sort_keys=True,
-                separators=(",", ":")
-            )
-
-
 class GlobalSelfCheckState(object):
     def __init__(self):
         self.statefile_path = os.path.join(USER_CACHE_DIR, "selfcheck.json")
@@ -84,13 +59,6 @@ class GlobalSelfCheckState(object):
                           separators=(",", ":"))
 
 
-def load_selfcheck_statefile():
-    if running_under_virtualenv():
-        return VirtualenvSelfCheckState()
-    else:
-        return GlobalSelfCheckState()
-
-
 def pip_version_check(session, options):
     """Check for an update for pip.
 
@@ -106,7 +74,7 @@ def pip_version_check(session, options):
     pypi_version = None
 
     try:
-        state = load_selfcheck_statefile()
+        state = GlobalSelfCheckState()
 
         current_time = datetime.datetime.utcnow()
         # Determine if we need to refresh the state

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -11,7 +11,6 @@ from pip._vendor.packaging import version as packaging_version
 
 from pip._internal.compat import WINDOWS
 from pip._internal.index import PackageFinder
-from pip._internal.locations import USER_CACHE_DIR, running_under_virtualenv
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.misc import ensure_dir, get_installed_version
 
@@ -21,7 +20,7 @@ SELFCHECK_DATE_FMT = "%Y-%m-%dT%H:%M:%SZ"
 logger = logging.getLogger(__name__)
 
 
-class GlobalSelfCheckState(object):
+class SelfCheckState(object):
     def __init__(self, cache_dir):
         self.statefile_path = os.path.join(cache_dir, "selfcheck.json")
 
@@ -74,7 +73,7 @@ def pip_version_check(session, options):
     pypi_version = None
 
     try:
-        state = GlobalSelfCheckState(cache_dir=options.cache_dir)
+        state = SelfCheckState(cache_dir=options.cache_dir)
 
         current_time = datetime.datetime.utcnow()
         # Determine if we need to refresh the state

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 
 
 class GlobalSelfCheckState(object):
-    def __init__(self):
-        self.statefile_path = os.path.join(USER_CACHE_DIR, "selfcheck.json")
+    def __init__(self, cache_dir):
+        self.statefile_path = os.path.join(cache_dir, "selfcheck.json")
 
         # Load the existing state
         try:
@@ -74,7 +74,7 @@ def pip_version_check(session, options):
     pypi_version = None
 
     try:
-        state = GlobalSelfCheckState()
+        state = GlobalSelfCheckState(cache_dir=options.cache_dir)
 
         current_time = datetime.datetime.utcnow()
         # Determine if we need to refresh the state

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -83,7 +83,8 @@ def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,
             "six.moves",
             "pip._vendor.six.moves",
             "pip._vendor.requests.packages.urllib3.packages.six.moves",
-            ]):
+        ]
+    ):
         latest_pypi_version = outdated.pip_version_check(None, _options())
 
     # See we return None if not installed_version

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -3,6 +3,7 @@ import os
 import sys
 from contextlib import contextmanager
 
+
 import freezegun
 import pretend
 import pytest
@@ -37,6 +38,7 @@ def _options():
     return pretend.stub(
         find_links=False, extra_index_urls=[], index_url='default_url',
         pre=False, trusted_hosts=False, process_dependency_links=False,
+        cache_dir='',
     )
 
 
@@ -72,7 +74,7 @@ def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,
         save=pretend.call_recorder(lambda v, t: None),
     )
     monkeypatch.setattr(
-        outdated, 'GlobalSelfCheckState', lambda: fake_state
+        outdated, 'GlobalSelfCheckState', lambda **kw: fake_state
     )
 
     with freezegun.freeze_time(
@@ -135,7 +137,7 @@ def test_global_state(monkeypatch, tmpdir):
     monkeypatch.setattr(outdated, 'USER_CACHE_DIR', cache_dir)
     monkeypatch.setattr(sys, 'prefix', tmpdir / 'pip_prefix')
 
-    state = outdated.GlobalSelfCheckState()
+    state = outdated.GlobalSelfCheckState(cache_dir=cache_dir)
     state.save('2.0', datetime.datetime.utcnow())
 
     expected_path = cache_dir / 'selfcheck.json'

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -83,7 +83,7 @@ def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,
             "six.moves",
             "pip._vendor.six.moves",
             "pip._vendor.requests.packages.urllib3.packages.six.moves",
-        ]):
+            ]):
         latest_pypi_version = outdated.pip_version_check(None, _options())
 
     # See we return None if not installed_version
@@ -131,7 +131,6 @@ def test_self_check_state(monkeypatch, tmpdir):
 
     monkeypatch.setattr(lockfile, 'LockFile', fake_lock)
     monkeypatch.setattr(os.path, "exists", lambda p: True)
-
 
     cache_dir = tmpdir / 'cache_dir'
     monkeypatch.setattr(sys, 'prefix', tmpdir / 'pip_prefix')

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -78,12 +78,12 @@ def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,
     )
 
     with freezegun.freeze_time(
-            "1970-01-09 10:00:00",
-            ignore=[
-                "six.moves",
-                "pip._vendor.six.moves",
-                "pip._vendor.requests.packages.urllib3.packages.six.moves",
-            ]):
+        "1970-01-09 10:00:00",
+        ignore=[
+            "six.moves",
+            "pip._vendor.six.moves",
+            "pip._vendor.requests.packages.urllib3.packages.six.moves",
+        ]):
         latest_pypi_version = outdated.pip_version_check(None, _options())
 
     # See we return None if not installed_version

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -74,7 +74,7 @@ def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,
         save=pretend.call_recorder(lambda v, t: None),
     )
     monkeypatch.setattr(
-        outdated, 'GlobalSelfCheckState', lambda **kw: fake_state
+        outdated, 'SelfCheckState', lambda **kw: fake_state
     )
 
     with freezegun.freeze_time(
@@ -137,7 +137,7 @@ def test_global_state(monkeypatch, tmpdir):
     monkeypatch.setattr(outdated, 'USER_CACHE_DIR', cache_dir)
     monkeypatch.setattr(sys, 'prefix', tmpdir / 'pip_prefix')
 
-    state = outdated.GlobalSelfCheckState(cache_dir=cache_dir)
+    state = outdated.SelfCheckState(cache_dir=cache_dir)
     state.save('2.0', datetime.datetime.utcnow())
 
     expected_path = cache_dir / 'selfcheck.json'

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -107,7 +107,7 @@ def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,
         assert len(outdated.logger.warning.calls) == 0
 
 
-def test_global_state(monkeypatch, tmpdir):
+def test_self_check_state(monkeypatch, tmpdir):
     CONTENT = '''{"pip_prefix": {"last_check": "1970-01-02T11:00:00Z",
         "pypi_version": "1.0"}}'''
     fake_file = pretend.stub(
@@ -134,7 +134,6 @@ def test_global_state(monkeypatch, tmpdir):
 
 
     cache_dir = tmpdir / 'cache_dir'
-    monkeypatch.setattr(outdated, 'USER_CACHE_DIR', cache_dir)
     monkeypatch.setattr(sys, 'prefix', tmpdir / 'pip_prefix')
 
     state = outdated.SelfCheckState(cache_dir=cache_dir)


### PR DESCRIPTION
Fixes #3905 
Changed rules on where pip version lock file selfcheck.json is stored.

Previously, the lock file was either stored at ``USER_CACHE``/selfcheck.json,
or for vitual enviorments it is stored at ``sys.prefix``\pip-selfcheck.json

Now regardless of whether the user is in a virtual environment, the lock file
is stored either in selfcheck.json in the path specified in cache-dir in
pip.conf, or if none is specified it is stored at``USER_CACHE``/selfcheck.json