### PR TITLE
Permit pipenv and other tools to report itself as the downloader in pip's user agent

### DIFF
--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -167,8 +167,14 @@ def user_agent():
     # value to make it easier to know that the check has been run.
     data["ci"] = True if looks_like_ci() else None
 
-    return "{data[installer][name]}/{data[installer][version]} {json}".format(
-        data=data,
+    installer = os.environ.get("PIP_USER_AGENT_INSTALLER_OVERRIDE")
+    if not installer:
+        installer = (
+            "{data[installer][name]}/{data[installer][version]}".format(
+                data=data))
+
+    return "{installer} {json}".format(
+        installer=installer,
         json=json.dumps(data, separators=(",", ":"), sort_keys=True),
     )
 

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -88,6 +88,11 @@ def test_user_agent__ci(monkeypatch, name, expected_like_ci):
     assert ('"ci":null' in user_agent) == (not expected_like_ci)
 
 
+def test_user_agent_override(monkeypatch):
+    monkeypatch.setenv("PIP_USER_AGENT_INSTALLER_OVERRIDE", "pipenv/1.0.0")
+    PipSession().headers["User-Agent"].startswith("pipenv/1.0.0")
+
+
 class FakeStream(object):
 
     def __init__(self, contents):


### PR DESCRIPTION
This will allow pipenv to report itself as the downloader, which in turn, will allow us to measure pipenv adoption. This is marked as "trivial" because it's an internal-only change and the only project we want to use this is pipenv.

Context: https://github.com/pypa/packaging-problems/issues/58#issuecomment-390070132