### PR TITLE
Fix some tests

### DIFF
--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -129,7 +129,7 @@ def test_cleanup_prevented_upon_build_dir_exception(script, data):
     build = script.venv_path / 'build'
     build_simple = build / 'simple'
     os.makedirs(build_simple)
-    write_delete_marker_file(build)
+    write_delete_marker_file(build_simple)
     build_simple.join("setup.py").write("#")
     result = script.pip(
         'install', '-f', data.find_links, '--no-index', 'simple',
@@ -137,6 +137,6 @@ def test_cleanup_prevented_upon_build_dir_exception(script, data):
         expect_error=True, expect_temp=True,
     )
 
-    assert result.returncode == PREVIOUS_BUILD_DIR_ERROR
-    assert "pip can't proceed" in result.stderr
-    assert exists(build_simple)
+    assert result.returncode == PREVIOUS_BUILD_DIR_ERROR, str(result)
+    assert "pip can't proceed" in result.stderr, str(result)
+    assert exists(build_simple), str(result)

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -175,7 +175,7 @@ def test_pip_wheel_fail_cause_of_previous_build_dir(
     # Given that I have a previous build dir of the `simple` package
     build = script.venv_path / 'build' / 'simple'
     os.makedirs(build)
-    write_delete_marker_file(script.venv_path / 'build')
+    write_delete_marker_file(script.venv_path / 'build' / 'simple')
     build.join('setup.py').write('#')
 
     # When I call pip trying to install things again


### PR DESCRIPTION
I noticed the `test_cleanup_prevented_upon_build_dir_exception` and `test_pip_wheel_fail_cause_of_previous_build_dir` tests were not creating the pip build marker file in the correct directory.