### PR TITLE
Add info about egg names in dependency links

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -354,8 +354,9 @@ the :ref:`--editable <install_--editable>` option) or not.
 The "project name" component of the url suffix "egg=<project name>-<version>"
 is used by pip in its dependency logic to identify the project prior
 to pip downloading and analyzing the metadata.  The optional "version"
-component of the egg name is not functionally important.  It merely
-provides a human-readable clue as to what version is in use. For projects
+component of the egg name provides a human-readable clue as to what
+version is in use. While usually not functionally important, it is
+mandatory when specifying a dependency link.  For projects
 where setup.py is not in the root of project, "subdirectory" component
 is used. Value of "subdirectory" component should be a path starting from root
 of the project to where setup.py is located.

--- a/news/5431.doc
+++ b/news/5431.doc
@@ -1,0 +1,1 @@
+Add info about egg names in dependency links


### PR DESCRIPTION
Dependency links will not be correctly followed if the version isn't specified
in the egg name. The debug info will read
`Could not parse version from link`

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
