### PR TITLE
Improve performance of the Bazaar VCS backend

### DIFF
--- a/news/5443.bugfix
+++ b/news/5443.bugfix
@@ -1,0 +1,1 @@
+Avoid creating an unnecessary local clone of a Bazaar branch when exporting.

--- a/news/5444.bugfix
+++ b/news/5444.bugfix
@@ -1,0 +1,1 @@
+Use the much faster 'bzr co --lightweight' to obtain a copy of a Bazaar tree.

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -42,13 +42,11 @@ class Bazaar(VersionControl):
         if os.path.exists(location):
             rmtree(location)
 
-        with TempDirectory(kind="export") as temp_dir:
-            self.unpack(temp_dir.path)
-
-            self.run_command(
-                ['export', location],
-                cwd=temp_dir.path, show_stdout=False,
-            )
+        url, rev_options = self.get_url_rev_options()
+        self.run_command(
+            ['export', location, url] + rev_options.to_args(),
+            show_stdout=False,
+        )
 
     def fetch_new(self, dest, url, rev_options):
         rev_display = rev_options.to_display()
@@ -58,14 +56,15 @@ class Bazaar(VersionControl):
             rev_display,
             display_path(dest),
         )
-        cmd_args = ['branch', '-q'] + rev_options.to_args() + [url, dest]
+        cmd_args = (['checkout', '--lightweight', '-q'] +
+                    rev_options.to_args() + [url, dest])
         self.run_command(cmd_args)
 
     def switch(self, dest, url, rev_options):
         self.run_command(['switch', url], cwd=dest)
 
-    def update(self, dest, url, rev_options):
-        cmd_args = ['pull', '-q'] + rev_options.to_args()
+    def update(self, dest, rev_options):
+        cmd_args = ['update', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 
     def get_url_rev_and_auth(self, url):

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -9,7 +9,6 @@ from pip._internal.download import path_to_url
 from pip._internal.utils.misc import (
     display_path, make_vcs_requirement_url, rmtree,
 )
-from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.vcs import VersionControl, vcs
 
 logger = logging.getLogger(__name__)

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -63,7 +63,7 @@ class Bazaar(VersionControl):
     def switch(self, dest, url, rev_options):
         self.run_command(['switch', url], cwd=dest)
 
-    def update(self, dest, rev_options):
+    def update(self, dest, url, rev_options):
         cmd_args = ['update', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 


### PR DESCRIPTION
Improve performance of the Bazaar VCS backend:

* Use lightweight checkouts rather than a full branch clone
* Export directly from the remote branch

This significantly improves performance for Bazaar branches. E.g. for installing bzr itself ("bzr+lp:bzr"):

Performance on my system for 'bzr co --lightweight lp:bzr':

     0.60s user 0.11s system 5% cpu 12.234 total

Performance on my system for 'bzr branch lp:bzr' (current behaviour):

     65.41s user 1.48s system 39% cpu 2:47.91 total

Fixes #5443 
Fixes #5444
