### PR TITLE
Travis CI - Stages, Cleanup and magic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,48 +3,53 @@ sudo: false
 cache: pip
 dist: trusty
 
-matrix:
-  fast_finish: true
+jobs:
   include:
+    # Basic Checks
     - env: TOXENV=docs
     - env: TOXENV=lint-py2
     - env: TOXENV=lint-py3
+      python: 3.6
     - env: TOXENV=mypy
     - env: TOXENV=packaging
-    # PyPy jobs start first -- they are the slowest
-    - env: TOXENV=pypy3-functional-install
-      python: pypy3
-    - env: TOXENV=pypy3-others
-      python: pypy3
-    - env: TOXENV=pypy-functional-install
-      python: pypy
-    - env: TOXENV=pypy-others
-      python: pypy
-    # Latest Stable CPython jobs
-    - env: TOXENV=py27-functional-install
+    # Latest CPython
+    - env: GROUP=1
       python: 2.7
-    - env: TOXENV=py27-others
+    - env: GROUP=2
       python: 2.7
-    - env: TOXENV=py36-functional-install
+    - env: GROUP=1
       python: 3.6
-    - env: TOXENV=py36-others
+    - env: GROUP=2
       python: 3.6
-    # All the other Py3 versions
-    - env: TOXENV=py35-functional-install
+
+    # PyPy
+    - env: GROUP=1
+      python: pypy3
+    - env: GROUP=2
+      python: pypy3
+    - env: GROUP=1
+      python: pypy
+    - env: GROUP=2
+      python: pypy
+    # Older Supported CPython
+    - env: GROUP=1
       python: 3.5
-    - env: TOXENV=py35-others
+    - env: GROUP=2
       python: 3.5
-    - env: TOXENV=py34-functional-install
+    - env: GROUP=1
       python: 3.4
-    - env: TOXENV=py34-others
+    - env: GROUP=2
       python: 3.4
-    # Nightly Python goes last
-    - env: TOXENV=py37-functional-install
-      python: nightly
-    - env: TOXENV=py37-others
-      python: nightly
+
+    - env: GROUP=1
+      python: 3.7-dev
+    - env: GROUP=2
+      python: 3.7-dev
+
+  # It's okay to fail on the in-development CPython version.
+  fast_finish: true
   allow_failures:
-    - python: nightly
+    - python: 3.7-dev
 
 before_install: .travis/setup.sh
 install: travis_retry .travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,15 @@ sudo: false
 cache: pip
 dist: trusty
 
+stages:
+- primary
+- secondary
+
 jobs:
   include:
     # Basic Checks
-    - env: TOXENV=docs
+    - stage: primary
+      env: TOXENV=docs
     - env: TOXENV=lint-py2
     - env: TOXENV=lint-py3
       python: 3.6
@@ -22,8 +27,10 @@ jobs:
     - env: GROUP=2
       python: 3.6
 
+    # Complete checking for ensuring compatibility
     # PyPy
-    - env: GROUP=1
+    - stage: secondary
+      env: GROUP=1
       python: pypy3
     - env: GROUP=2
       python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ matrix:
   allow_failures:
     - python: nightly
 
+before_install: .travis/setup.sh
 install: travis_retry .travis/install.sh
 script: .travis/run.sh
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -2,8 +2,5 @@
 set -e
 set -x
 
-git config --global user.email "pypa-dev@googlegroups.com"
-git config --global user.name "pip"
-
 pip install --upgrade setuptools
 pip install --upgrade tox

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+echo "Setting Git Credentials..."
+git config --global user.email "pypa-dev@googlegroups.com"
+git config --global user.name "pip"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     docs, packaging, lint-py2, lint-py3, mypy,
-    py{27,34,35,36,37,py,py3}-{functional-install,others}
+    py27, py34, py35, py67, py37, pypy, pypy3
 
 [testenv]
 passenv = CI GIT_SSL_CAINFO


### PR DESCRIPTION
Changes:

- move non-install commands out of the `travis_retry` call
- renamed "RUN_INSTALL_TESTS" to "GROUP"
- removal of tox factors
- auto-detection of tox's env from Travis's environment variables
- addition of build stages (closes #5095)
