### PR TITLE
Repurpose the pip._internal.models namespace

### DIFF
--- a/src/pip/_internal/cmdoptions.py
+++ b/src/pip/_internal/cmdoptions.py
@@ -17,7 +17,7 @@ from pip._internal.index import (
     FormatControl, fmt_ctl_handle_mutual_exclude, fmt_ctl_no_binary,
 )
 from pip._internal.locations import USER_CACHE_DIR, src_prefix
-from pip._internal.models import PyPI
+from pip._internal.models.index import PyPI
 from pip._internal.utils.hashes import STRONG_HASHES
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.ui import BAR_TYPES

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -15,7 +15,7 @@ from pip._internal.basecommand import SUCCESS, Command
 from pip._internal.compat import get_terminal_size
 from pip._internal.download import PipXmlrpcTransport
 from pip._internal.exceptions import CommandError
-from pip._internal.models import PyPI
+from pip._internal.models.index import PyPI
 from pip._internal.status_codes import NO_MATCHES_FOUND
 from pip._internal.utils.logging import indent_log
 

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -33,7 +33,7 @@ import pip
 from pip._internal.compat import WINDOWS
 from pip._internal.exceptions import HashMismatch, InstallationError
 from pip._internal.locations import write_delete_marker_file
-from pip._internal.models import PyPI
+from pip._internal.models.index import PyPI
 from pip._internal.utils.encoding import auto_decode
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.glibc import libc_ver

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -27,7 +27,7 @@ from pip._internal.exceptions import (
     BestVersionAlreadyInstalled, DistributionNotFound, InvalidWheelFilename,
     UnsupportedWheel,
 )
-from pip._internal.models import PyPI
+from pip._internal.models.index import PyPI
 from pip._internal.pep425tags import get_supported
 from pip._internal.utils.deprecation import RemovedInPip11Warning
 from pip._internal.utils.logging import indent_log

--- a/src/pip/_internal/models/__init__.py
+++ b/src/pip/_internal/models/__init__.py
@@ -1,4 +1,2 @@
-from pip._internal.models.index import Index, PyPI
-
-
-__all__ = ["Index", "PyPI"]
+"""A package that contains models that represent entities.
+"""


### PR DESCRIPTION
Sorta in preparation for #5051.

Regardless, this is probably easier to follow today.