### PR TITLE
Breakout constructors from InstallRequirement

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -22,9 +22,10 @@ from pip._internal.exceptions import (
 )
 from pip._internal.index import PackageFinder
 from pip._internal.locations import running_under_virtualenv
-from pip._internal.req.constructors import install_req_from_editable
+from pip._internal.req.constructors import (
+    install_req_from_editable, install_req_from_line,
+)
 from pip._internal.req.req_file import parse_requirements
-from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.logging import setup_logging
 from pip._internal.utils.misc import get_prog, normalize_path
 from pip._internal.utils.outdated import pip_version_check
@@ -209,7 +210,7 @@ class RequirementCommand(Command):
                 requirement_set.add_requirement(req_to_add)
 
         for req in args:
-            req_to_add = InstallRequirement.from_line(
+            req_to_add = install_req_from_line(
                 req, None, isolated=options.isolated_mode,
                 wheel_cache=wheel_cache
             )

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -22,6 +22,7 @@ from pip._internal.exceptions import (
 )
 from pip._internal.index import PackageFinder
 from pip._internal.locations import running_under_virtualenv
+from pip._internal.req.constructors import install_req_from_editable
 from pip._internal.req.req_file import parse_requirements
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.logging import setup_logging
@@ -216,7 +217,7 @@ class RequirementCommand(Command):
             requirement_set.add_requirement(req_to_add)
 
         for req in options.editables:
-            req_to_add = InstallRequirement.from_editable(
+            req_to_add = install_req_from_editable(
                 req,
                 isolated=options.isolated_mode,
                 wheel_cache=wheel_cache

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -4,7 +4,8 @@ from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.cli.base_command import Command
 from pip._internal.exceptions import InstallationError
-from pip._internal.req import InstallRequirement, parse_requirements
+from pip._internal.req import parse_requirements
+from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import protect_pip_from_modification_on_windows
 
 
@@ -47,7 +48,7 @@ class UninstallCommand(Command):
         with self._build_session(options) as session:
             reqs_to_uninstall = {}
             for name in args:
-                req = InstallRequirement.from_line(
+                req = install_req_from_line(
                     name, isolated=options.isolated_mode,
                 )
                 if req.name:

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -10,8 +10,9 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.pkg_resources import RequirementParseError
 
 from pip._internal.exceptions import InstallationError
-from pip._internal.req import InstallRequirement
-from pip._internal.req.constructors import install_req_from_editable
+from pip._internal.req.constructors import (
+    install_req_from_editable, install_req_from_line,
+)
 from pip._internal.req.req_file import COMMENT_RE
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.misc import (
@@ -106,7 +107,7 @@ def freeze(
                             wheel_cache=wheel_cache,
                         )
                     else:
-                        line_req = InstallRequirement.from_line(
+                        line_req = install_req_from_line(
                             COMMENT_RE.sub('', line).strip(),
                             isolated=isolated,
                             wheel_cache=wheel_cache,

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -11,6 +11,7 @@ from pip._vendor.pkg_resources import RequirementParseError
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.req import InstallRequirement
+from pip._internal.req.constructors import install_req_from_editable
 from pip._internal.req.req_file import COMMENT_RE
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.misc import (
@@ -99,7 +100,7 @@ def freeze(
                             line = line[2:].strip()
                         else:
                             line = line[len('--editable'):].strip().lstrip('=')
-                        line_req = InstallRequirement.from_editable(
+                        line_req = install_req_from_editable(
                             line,
                             isolated=isolated,
                             wheel_cache=wheel_cache,

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -8,18 +8,45 @@ These are meant to be used elsewhere within pip to create instances of
 InstallRequirement.
 """
 
+import logging
 import os
+import re
+import traceback
 
+from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+from pip._vendor.packaging.specifiers import Specifier
+from pip._vendor.pkg_resources import RequirementParseError, parse_requirements
 
-# XXX: Temporarily importing _strip_extras
-from pip._internal.download import path_to_url, url_to_path
+from pip._internal.download import (
+    is_archive_file, is_url, path_to_url, url_to_path,
+)
 from pip._internal.exceptions import InstallationError
 from pip._internal.models.link import Link
-from pip._internal.req.req_install import InstallRequirement, _strip_extras
+from pip._internal.req.req_install import InstallRequirement
+from pip._internal.utils.misc import is_installable_dir
 from pip._internal.vcs import vcs
+from pip._internal.wheel import Wheel
 
-__all__ = ["install_req_from_editable", "parse_editable"]
+__all__ = [
+    "install_req_from_editable", "install_req_from_line",
+    "parse_editable"
+]
+
+logger = logging.getLogger(__name__)
+operators = Specifier._operators.keys()
+
+
+def _strip_extras(path):
+    m = re.match(r'^(.+)(\[[^\]]+\])$', path)
+    extras = None
+    if m:
+        path_no_extras = m.group(1)
+        extras = m.group(2)
+    else:
+        path_no_extras = path
+
+    return path_no_extras, extras
 
 
 def parse_editable(editable_req):
@@ -87,6 +114,36 @@ def parse_editable(editable_req):
     return package_name, url, None
 
 
+def deduce_helpful_msg(req):
+    """Returns helpful msg in case requirements file does not exist,
+    or cannot be parsed.
+
+    :params req: Requirements file path
+    """
+    msg = ""
+    if os.path.exists(req):
+        msg = " It does exist."
+        # Try to parse and check if it is a requirements file.
+        try:
+            with open(req, 'r') as fp:
+                # parse first line only
+                next(parse_requirements(fp.read()))
+                msg += " The argument you provided " + \
+                    "(%s) appears to be a" % (req) + \
+                    " requirements file. If that is the" + \
+                    " case, use the '-r' flag to install" + \
+                    " the packages specified within it."
+        except RequirementParseError:
+            logger.debug("Cannot parse '%s' as requirements \
+            file" % (req), exc_info=1)
+    else:
+        msg += " File '%s' does not exist." % (req)
+    return msg
+
+
+# ---- The actual constructors follow ----
+
+
 def install_req_from_editable(
     editable_req, comes_from=None, isolated=False, options=None,
     wheel_cache=None, constraint=False
@@ -113,4 +170,103 @@ def install_req_from_editable(
         options=options if options else {},
         wheel_cache=wheel_cache,
         extras=extras_override or (),
+    )
+
+
+def install_req_from_line(
+    name, comes_from=None, isolated=False, options=None, wheel_cache=None,
+    constraint=False
+):
+    """Creates an InstallRequirement from a name, which might be a
+    requirement, directory containing 'setup.py', filename, or URL.
+    """
+    if is_url(name):
+        marker_sep = '; '
+    else:
+        marker_sep = ';'
+    if marker_sep in name:
+        name, markers = name.split(marker_sep, 1)
+        markers = markers.strip()
+        if not markers:
+            markers = None
+        else:
+            markers = Marker(markers)
+    else:
+        markers = None
+    name = name.strip()
+    req = None
+    path = os.path.normpath(os.path.abspath(name))
+    link = None
+    extras = None
+
+    if is_url(name):
+        link = Link(name)
+    else:
+        p, extras = _strip_extras(path)
+        looks_like_dir = os.path.isdir(p) and (
+            os.path.sep in name or
+            (os.path.altsep is not None and os.path.altsep in name) or
+            name.startswith('.')
+        )
+        if looks_like_dir:
+            if not is_installable_dir(p):
+                raise InstallationError(
+                    "Directory %r is not installable. Neither 'setup.py' "
+                    "nor 'pyproject.toml' found." % name
+                )
+            link = Link(path_to_url(p))
+        elif is_archive_file(p):
+            if not os.path.isfile(p):
+                logger.warning(
+                    'Requirement %r looks like a filename, but the '
+                    'file does not exist',
+                    name
+                )
+            link = Link(path_to_url(p))
+
+    # it's a local file, dir, or url
+    if link:
+        # Handle relative file URLs
+        if link.scheme == 'file' and re.search(r'\.\./', link.url):
+            link = Link(
+                path_to_url(os.path.normpath(os.path.abspath(link.path))))
+        # wheel file
+        if link.is_wheel:
+            wheel = Wheel(link.filename)  # can raise InvalidWheelFilename
+            req = "%s==%s" % (wheel.name, wheel.version)
+        else:
+            # set the req to the egg fragment.  when it's not there, this
+            # will become an 'unnamed' requirement
+            req = link.egg_fragment
+
+    # a requirement specifier
+    else:
+        req = name
+
+    if extras:
+        extras = Requirement("placeholder" + extras.lower()).extras
+    else:
+        extras = ()
+    if req is not None:
+        try:
+            req = Requirement(req)
+        except InvalidRequirement:
+            if os.path.sep in req:
+                add_msg = "It looks like a path."
+                add_msg += deduce_helpful_msg(req)
+            elif '=' in req and not any(op in req for op in operators):
+                add_msg = "= is not a valid operator. Did you mean == ?"
+            else:
+                add_msg = traceback.format_exc()
+            raise InstallationError(
+                "Invalid requirement: '%s'\n%s" % (req, add_msg)
+            )
+
+    return InstallRequirement(
+        req, comes_from, link=link, markers=markers,
+        isolated=isolated,
+        options=options if options else {},
+        wheel_cache=wheel_cache,
+        constraint=constraint,
+        extras=extras,
     )

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -22,6 +22,7 @@ from pip._internal.download import (
     is_archive_file, is_url, path_to_url, url_to_path,
 )
 from pip._internal.exceptions import InstallationError
+from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.misc import is_installable_dir
@@ -269,4 +270,29 @@ def install_req_from_line(
         wheel_cache=wheel_cache,
         constraint=constraint,
         extras=extras,
+    )
+
+
+def install_req_from_req(
+    req, comes_from=None, isolated=False, wheel_cache=None
+):
+    try:
+        req = Requirement(req)
+    except InvalidRequirement:
+        raise InstallationError("Invalid requirement: '%s'" % req)
+
+    domains_not_allowed = [
+        PyPI.file_storage_domain,
+        TestPyPI.file_storage_domain,
+    ]
+    if req.url and comes_from.link.netloc in domains_not_allowed:
+        # Explicitly disallow pypi packages that depend on external urls
+        raise InstallationError(
+            "Packages installed from PyPI cannot depend on packages "
+            "which are not also hosted on PyPI.\n"
+            "%s depends on %s " % (comes_from.name, req)
+        )
+
+    return InstallRequirement(
+        req, comes_from, isolated=isolated, wheel_cache=wheel_cache
     )

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -1,0 +1,116 @@
+"""Backing implementation for InstallRequirement's various constructors
+
+The idea here is that these formed a major chunk of InstallRequirement's size
+so, moving them and support code dedicated to them outside of that class
+helps creates for better understandability for the rest of the code.
+
+These are meant to be used elsewhere within pip to create instances of
+InstallRequirement.
+"""
+
+import os
+
+from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+
+# XXX: Temporarily importing _strip_extras
+from pip._internal.download import path_to_url, url_to_path
+from pip._internal.exceptions import InstallationError
+from pip._internal.models.link import Link
+from pip._internal.req.req_install import InstallRequirement, _strip_extras
+from pip._internal.vcs import vcs
+
+__all__ = ["install_req_from_editable", "parse_editable"]
+
+
+def parse_editable(editable_req):
+    """Parses an editable requirement into:
+        - a requirement name
+        - an URL
+        - extras
+        - editable options
+    Accepted requirements:
+        svn+http://blahblah@rev#egg=Foobar[baz]&subdirectory=version_subdir
+        .[some_extra]
+    """
+
+    url = editable_req
+
+    # If a file path is specified with extras, strip off the extras.
+    url_no_extras, extras = _strip_extras(url)
+
+    if os.path.isdir(url_no_extras):
+        if not os.path.exists(os.path.join(url_no_extras, 'setup.py')):
+            raise InstallationError(
+                "Directory %r is not installable. File 'setup.py' not found." %
+                url_no_extras
+            )
+        # Treating it as code that has already been checked out
+        url_no_extras = path_to_url(url_no_extras)
+
+    if url_no_extras.lower().startswith('file:'):
+        package_name = Link(url_no_extras).egg_fragment
+        if extras:
+            return (
+                package_name,
+                url_no_extras,
+                Requirement("placeholder" + extras.lower()).extras,
+            )
+        else:
+            return package_name, url_no_extras, None
+
+    for version_control in vcs:
+        if url.lower().startswith('%s:' % version_control):
+            url = '%s+%s' % (version_control, url)
+            break
+
+    if '+' not in url:
+        raise InstallationError(
+            '%s should either be a path to a local project or a VCS url '
+            'beginning with svn+, git+, hg+, or bzr+' %
+            editable_req
+        )
+
+    vc_type = url.split('+', 1)[0].lower()
+
+    if not vcs.get_backend(vc_type):
+        error_message = 'For --editable=%s only ' % editable_req + \
+            ', '.join([backend.name + '+URL' for backend in vcs.backends]) + \
+            ' is currently supported'
+        raise InstallationError(error_message)
+
+    package_name = Link(url).egg_fragment
+    if not package_name:
+        raise InstallationError(
+            "Could not detect requirement name for '%s', please specify one "
+            "with #egg=your_package_name" % editable_req
+        )
+    return package_name, url, None
+
+
+def install_req_from_editable(
+    editable_req, comes_from=None, isolated=False, options=None,
+    wheel_cache=None, constraint=False
+):
+    name, url, extras_override = parse_editable(editable_req)
+    if url.startswith('file:'):
+        source_dir = url_to_path(url)
+    else:
+        source_dir = None
+
+    if name is not None:
+        try:
+            req = Requirement(name)
+        except InvalidRequirement:
+            raise InstallationError("Invalid requirement: '%s'" % name)
+    else:
+        req = None
+    return InstallRequirement(
+        req, comes_from, source_dir=source_dir,
+        editable=True,
+        link=Link(url),
+        constraint=constraint,
+        isolated=isolated,
+        options=options if options else {},
+        wheel_cache=wheel_cache,
+        extras=extras_override or (),
+    )

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -16,8 +16,9 @@ from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._internal.cli import cmdoptions
 from pip._internal.download import get_file_content
 from pip._internal.exceptions import RequirementsFileParseError
-from pip._internal.req.constructors import install_req_from_editable
-from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.constructors import (
+    install_req_from_editable, install_req_from_line,
+)
 
 __all__ = ['parse_requirements']
 
@@ -152,7 +153,7 @@ def process_line(line, filename, line_number, finder=None, comes_from=None,
         for dest in SUPPORTED_OPTIONS_REQ_DEST:
             if dest in opts.__dict__ and opts.__dict__[dest]:
                 req_options[dest] = opts.__dict__[dest]
-        yield InstallRequirement.from_line(
+        yield install_req_from_line(
             args_str, line_comes_from, constraint=constraint,
             isolated=isolated, options=req_options, wheel_cache=wheel_cache
         )

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -16,6 +16,7 @@ from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._internal.cli import cmdoptions
 from pip._internal.download import get_file_content
 from pip._internal.exceptions import RequirementsFileParseError
+from pip._internal.req.constructors import install_req_from_editable
 from pip._internal.req.req_install import InstallRequirement
 
 __all__ = ['parse_requirements']
@@ -159,7 +160,7 @@ def process_line(line, filename, line_number, finder=None, comes_from=None,
     # yield an editable requirement
     elif opts.editables:
         isolated = options.isolated_mode if options else False
-        yield InstallRequirement.from_editable(
+        yield install_req_from_editable(
             opts.editables[0], comes_from=line_comes_from,
             constraint=constraint, isolated=isolated, wheel_cache=wheel_cache
         )

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -22,9 +22,7 @@ from pip._vendor.pkg_resources import RequirementParseError, parse_requirements
 
 from pip._internal import wheel
 from pip._internal.build_env import NoOpBuildEnvironment
-from pip._internal.download import (
-    is_archive_file, is_url, path_to_url, url_to_path,
-)
+from pip._internal.download import is_archive_file, is_url, path_to_url
 from pip._internal.exceptions import InstallationError
 from pip._internal.locations import (
     PIP_DELETE_MARKER_FILENAME, running_under_virtualenv,
@@ -149,33 +147,6 @@ class InstallRequirement(object):
 
     # Constructors
     #   TODO: Move these out of this class into custom methods.
-    @classmethod
-    def from_editable(cls, editable_req, comes_from=None, isolated=False,
-                      options=None, wheel_cache=None, constraint=False):
-        name, url, extras_override = parse_editable(editable_req)
-        if url.startswith('file:'):
-            source_dir = url_to_path(url)
-        else:
-            source_dir = None
-
-        if name is not None:
-            try:
-                req = Requirement(name)
-            except InvalidRequirement:
-                raise InstallationError("Invalid requirement: '%s'" % name)
-        else:
-            req = None
-        return cls(
-            req, comes_from, source_dir=source_dir,
-            editable=True,
-            link=Link(url),
-            constraint=constraint,
-            isolated=isolated,
-            options=options if options else {},
-            wheel_cache=wheel_cache,
-            extras=extras_override or (),
-        )
-
     @classmethod
     def from_req(cls, req, comes_from=None, isolated=False, wheel_cache=None):
         try:
@@ -1027,71 +998,6 @@ class InstallRequirement(object):
                                           py_ver_str, self.name)]
 
         return install_args
-
-
-def parse_editable(editable_req):
-    """Parses an editable requirement into:
-        - a requirement name
-        - an URL
-        - extras
-        - editable options
-    Accepted requirements:
-        svn+http://blahblah@rev#egg=Foobar[baz]&subdirectory=version_subdir
-        .[some_extra]
-    """
-
-    url = editable_req
-
-    # If a file path is specified with extras, strip off the extras.
-    url_no_extras, extras = _strip_extras(url)
-
-    if os.path.isdir(url_no_extras):
-        if not os.path.exists(os.path.join(url_no_extras, 'setup.py')):
-            raise InstallationError(
-                "Directory %r is not installable. File 'setup.py' not found." %
-                url_no_extras
-            )
-        # Treating it as code that has already been checked out
-        url_no_extras = path_to_url(url_no_extras)
-
-    if url_no_extras.lower().startswith('file:'):
-        package_name = Link(url_no_extras).egg_fragment
-        if extras:
-            return (
-                package_name,
-                url_no_extras,
-                Requirement("placeholder" + extras.lower()).extras,
-            )
-        else:
-            return package_name, url_no_extras, None
-
-    for version_control in vcs:
-        if url.lower().startswith('%s:' % version_control):
-            url = '%s+%s' % (version_control, url)
-            break
-
-    if '+' not in url:
-        raise InstallationError(
-            '%s should either be a path to a local project or a VCS url '
-            'beginning with svn+, git+, hg+, or bzr+' %
-            editable_req
-        )
-
-    vc_type = url.split('+', 1)[0].lower()
-
-    if not vcs.get_backend(vc_type):
-        error_message = 'For --editable=%s only ' % editable_req + \
-            ', '.join([backend.name + '+URL' for backend in vcs.backends]) + \
-            ' is currently supported'
-        raise InstallationError(error_message)
-
-    package_name = Link(url).egg_fragment
-    if not package_name:
-        raise InstallationError(
-            "Could not detect requirement name for '%s', please specify one "
-            "with #egg=your_package_name" % editable_req
-        )
-    return package_name, url, None
 
 
 def deduce_helpful_msg(req):

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -9,7 +9,7 @@ import zipfile
 from distutils.util import change_root
 
 from pip._vendor import pkg_resources, six
-from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
@@ -21,7 +21,6 @@ from pip._internal.exceptions import InstallationError
 from pip._internal.locations import (
     PIP_DELETE_MARKER_FILENAME, running_under_virtualenv,
 )
-from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.models.link import Link
 from pip._internal.pyproject import load_pyproject_toml
 from pip._internal.req.req_uninstall import UninstallPathSet
@@ -124,29 +123,6 @@ class InstallRequirement(object):
         # Setting an explicit value before loading pyproject.toml is supported,
         # but after loading this flag should be treated as read only.
         self.use_pep517 = None
-
-    # Constructors
-    #   TODO: Move these out of this class into custom methods.
-    @classmethod
-    def from_req(cls, req, comes_from=None, isolated=False, wheel_cache=None):
-        try:
-            req = Requirement(req)
-        except InvalidRequirement:
-            raise InstallationError("Invalid requirement: '%s'" % req)
-
-        domains_not_allowed = [
-            PyPI.file_storage_domain,
-            TestPyPI.file_storage_domain,
-        ]
-        if req.url and comes_from.link.netloc in domains_not_allowed:
-            # Explicitly disallow pypi packages that depend on external urls
-            raise InstallationError(
-                "Packages installed from PyPI cannot depend on packages "
-                "which are not also hosted on PyPI.\n"
-                "%s depends on %s " % (comes_from.name, req)
-            )
-
-        return cls(req, comes_from, isolated=isolated, wheel_cache=wheel_cache)
 
     def __str__(self):
         if self.req:

--- a/src/pip/_internal/resolve.py
+++ b/src/pip/_internal/resolve.py
@@ -18,7 +18,7 @@ from pip._internal.exceptions import (
     BestVersionAlreadyInstalled, DistributionNotFound, HashError, HashErrors,
     UnsupportedPythonVersion,
 )
-from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.constructors import install_req_from_req
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import dist_in_usersite, ensure_dir
 from pip._internal.utils.packaging import check_dist_requires_python
@@ -268,7 +268,7 @@ class Resolver(object):
         more_reqs = []
 
         def add_req(subreq, extras_requested):
-            sub_install_req = InstallRequirement.from_req(
+            sub_install_req = install_req_from_req(
                 str(subreq),
                 req_to_install,
                 isolated=self.isolated,

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -11,7 +11,7 @@ from tempfile import mkdtemp
 import pretend
 import pytest
 
-from pip._internal.req import InstallRequirement
+from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import rmtree
 from tests.lib import assert_all_changes, create_test_package_with_setup
 from tests.lib.local_repos import local_checkout, local_repo
@@ -439,7 +439,7 @@ def test_uninstall_non_local_distutils(caplog, monkeypatch, tmpdir):
     get_dist = pretend.call_recorder(lambda x: dist)
     monkeypatch.setattr("pip._vendor.pkg_resources.get_distribution", get_dist)
 
-    req = InstallRequirement.from_line("thing")
+    req = install_req_from_line("thing")
     req.uninstall()
 
     assert os.path.exists(einfo)

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -17,8 +17,10 @@ from pip._internal.exceptions import (
 from pip._internal.index import PackageFinder
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req import InstallRequirement, RequirementSet
+from pip._internal.req.constructors import (
+    install_req_from_editable, parse_editable,
+)
 from pip._internal.req.req_file import process_line
-from pip._internal.req.req_install import parse_editable
 from pip._internal.req.req_tracker import RequirementTracker
 from pip._internal.resolve import Resolver
 from pip._internal.utils.misc import read_text_file
@@ -85,7 +87,7 @@ class TestRequirementSet(object):
         non-wheel installs.
         """
         reqset = RequirementSet()
-        req = InstallRequirement.from_editable(
+        req = install_req_from_editable(
             data.packages.join("LocalEnvironMarker")
         )
         req.is_direct = True
@@ -398,7 +400,7 @@ class TestInstallRequirement(object):
     def test_url_preserved_editable_req(self):
         """Confirm the url is preserved in a editable requirement"""
         url = 'git+http://foo.com@ref#egg=foo'
-        req = InstallRequirement.from_editable(url)
+        req = install_req_from_editable(url)
         assert req.link.url == url
 
     @pytest.mark.parametrize('path', (
@@ -512,7 +514,7 @@ class TestInstallRequirement(object):
         url = '.[ex1,ex2]'
         filename = 'filename'
         comes_from = '-r %s (line %s)' % (filename, 1)
-        req = InstallRequirement.from_editable(url, comes_from=comes_from)
+        req = install_req_from_editable(url, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}
 
@@ -520,7 +522,7 @@ class TestInstallRequirement(object):
         url = 'git+https://url#egg=SomeProject[ex1,ex2]'
         filename = 'filename'
         comes_from = '-r %s (line %s)' % (filename, 1)
-        req = InstallRequirement.from_editable(url, comes_from=comes_from)
+        req = install_req_from_editable(url, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -12,12 +12,13 @@ from pip._internal.exceptions import (
     InstallationError, RequirementsFileParseError,
 )
 from pip._internal.index import PackageFinder
-from pip._internal.req.constructors import install_req_from_editable
+from pip._internal.req.constructors import (
+    install_req_from_editable, install_req_from_line,
+)
 from pip._internal.req.req_file import (
     break_args_options, ignore_comments, join_lines, parse_requirements,
     preprocess, process_line, skip_regex,
 )
-from pip._internal.req.req_install import InstallRequirement
 from tests.lib import requirements_file
 
 
@@ -193,14 +194,14 @@ class TestProcessLine(object):
         line = 'SomeProject'
         filename = 'filename'
         comes_from = '-r %s (line %s)' % (filename, 1)
-        req = InstallRequirement.from_line(line, comes_from=comes_from)
+        req = install_req_from_line(line, comes_from=comes_from)
         assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
 
     def test_yield_line_constraint(self):
         line = 'SomeProject'
         filename = 'filename'
         comes_from = '-c %s (line %s)' % (filename, 1)
-        req = InstallRequirement.from_line(
+        req = install_req_from_line(
             line, comes_from=comes_from, constraint=True)
         found_req = list(process_line(line, filename, 1, constraint=True))[0]
         assert repr(found_req) == repr(req)
@@ -210,7 +211,7 @@ class TestProcessLine(object):
         line = 'SomeProject >= 2'
         filename = 'filename'
         comes_from = '-r %s (line %s)' % (filename, 1)
-        req = InstallRequirement.from_line(line, comes_from=comes_from)
+        req = install_req_from_line(line, comes_from=comes_from)
         assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
         assert str(req.req.specifier) == '>=2'
 
@@ -235,7 +236,7 @@ class TestProcessLine(object):
 
     def test_nested_requirements_file(self, monkeypatch):
         line = '-r another_file'
-        req = InstallRequirement.from_line('SomeProject')
+        req = install_req_from_line('SomeProject')
         import pip._internal.req.req_file
 
         def stub_parse_requirements(req_url, finder, comes_from, options,
@@ -248,7 +249,7 @@ class TestProcessLine(object):
 
     def test_nested_constraints_file(self, monkeypatch):
         line = '-c another_file'
-        req = InstallRequirement.from_line('SomeProject')
+        req = install_req_from_line('SomeProject')
         import pip._internal.req.req_file
 
         def stub_parse_requirements(req_url, finder, comes_from, options,

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -12,6 +12,7 @@ from pip._internal.exceptions import (
     InstallationError, RequirementsFileParseError,
 )
 from pip._internal.index import PackageFinder
+from pip._internal.req.constructors import install_req_from_editable
 from pip._internal.req.req_file import (
     break_args_options, ignore_comments, join_lines, parse_requirements,
     preprocess, process_line, skip_regex,
@@ -218,7 +219,7 @@ class TestProcessLine(object):
         line = '-e %s' % url
         filename = 'filename'
         comes_from = '-r %s (line %s)' % (filename, 1)
-        req = InstallRequirement.from_editable(url, comes_from=comes_from)
+        req = install_req_from_editable(url, comes_from=comes_from)
         assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
 
     def test_yield_editable_constraint(self):
@@ -226,7 +227,7 @@ class TestProcessLine(object):
         line = '-e %s' % url
         filename = 'filename'
         comes_from = '-c %s (line %s)' % (filename, 1)
-        req = InstallRequirement.from_editable(
+        req = install_req_from_editable(
             url, comes_from=comes_from, constraint=True)
         found_req = list(process_line(line, filename, 1, constraint=True))[0]
         assert repr(found_req) == repr(req)

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -3,6 +3,7 @@ import tempfile
 
 import pytest
 
+from pip._internal.req.constructors import install_req_from_line
 from pip._internal.req.req_install import InstallRequirement
 
 
@@ -36,7 +37,7 @@ class TestInstallRequirementBuildDirectory(object):
         with open(setup_py_path, 'w') as f:
             f.write('')
 
-        requirement = InstallRequirement.from_line(
+        requirement = install_req_from_line(
             str(install_dir).replace(os.sep, os.altsep or os.sep)
         )
 


### PR DESCRIPTION
Built on top of #5452.

The idea here is that the constructors compose of about ~200 LOC and moving them out of the class would make it clear what support functions (defined at the top-level of the module) are used by them; allowing for cleanup and making it easier to focus on the other methods.