### PR TITLE
Reenable flake8 checks for unused imports and cleanup existing ones

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,6 @@ default_section = THIRDPARTY
 include_trailing_comma = true
 
 [flake8]
-# Ignoring unused imports since mypy would warn of that.
-ignore = F401
 exclude = .tox,.idea,*.egg,build,_vendor,data
 select = E,W,F
 

--- a/src/pip/_internal/basecommand.py
+++ b/src/pip/_internal/basecommand.py
@@ -30,7 +30,7 @@ from pip._internal.utils.outdated import pip_version_check
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional
+    from typing import Optional  # noqa: F401
 
 __all__ = ['Command']
 

--- a/src/pip/_internal/cmdoptions.py
+++ b/src/pip/_internal/cmdoptions.py
@@ -23,7 +23,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.ui import BAR_TYPES
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any
+    from typing import Any  # noqa: F401
 
 
 def make_option_group(group, parser):

--- a/src/pip/_internal/commands/__init__.py
+++ b/src/pip/_internal/commands/__init__.py
@@ -20,8 +20,8 @@ from pip._internal.commands.wheel import WheelCommand
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import List, Type
-    from pip._internal.basecommand import Command
+    from typing import List, Type  # noqa: F401
+    from pip._internal.basecommand import Command  # noqa: F401
 
 commands_order = [
     InstallCommand,

--- a/src/pip/_internal/commands/check.py
+++ b/src/pip/_internal/commands/check.py
@@ -4,7 +4,6 @@ from pip._internal.basecommand import Command
 from pip._internal.operations.check import (
     check_package_set, create_package_set_from_installed,
 )
-from pip._internal.utils.misc import get_installed_distributions
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -27,7 +27,9 @@ from pip._internal.utils.misc import ensure_dir, enum
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any, Dict, Iterable, List, NewType, Optional, Tuple
+    from typing import (  # noqa: F401
+        Any, Dict, Iterable, List, NewType, Optional, Tuple
+    )
 
     RawConfigParser = configparser.RawConfigParser  # Shorthand
     Kind = NewType("Kind", str)

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -30,7 +30,6 @@ from pip._vendor.six.moves.urllib.parse import unquote as urllib_unquote
 from pip._vendor.urllib3.util import IS_PYOPENSSL
 
 import pip
-from pip._internal.compat import WINDOWS
 from pip._internal.exceptions import HashMismatch, InstallationError
 from pip._internal.locations import write_delete_marker_file
 from pip._internal.models.index import PyPI

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -8,7 +8,7 @@ import site
 import sys
 import sysconfig
 from distutils import sysconfig as distutils_sysconfig
-from distutils.command.install import SCHEME_KEYS, install  # type: ignore
+from distutils.command.install import SCHEME_KEYS
 
 from pip._internal.compat import WINDOWS, expanduser
 from pip._internal.utils import appdirs

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -8,7 +8,7 @@ import site
 import sys
 import sysconfig
 from distutils import sysconfig as distutils_sysconfig
-from distutils.command.install import SCHEME_KEYS
+from distutils.command.install import SCHEME_KEYS  # type: ignore
 
 from pip._internal.compat import WINDOWS, expanduser
 from pip._internal.utils import appdirs

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -11,8 +11,8 @@ from pip._internal.utils.misc import get_installed_distributions
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from pip._internal.req.req_install import InstallRequirement
-    from typing import Any, Dict, Iterator, Set, Tuple, List
+    from pip._internal.req.req_install import InstallRequirement  # noqa: F401
+    from typing import Any, Dict, Iterator, Set, Tuple, List  # noqa: F401
 
     # Shorthands
     PackageSet = Dict[str, 'PackageDetails']

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -28,7 +28,7 @@ from pip._internal.compat import native_str
 from pip._internal.download import (
     is_archive_file, is_url, path_to_url, url_to_path,
 )
-from pip._internal.exceptions import InstallationError, UninstallationError
+from pip._internal.exceptions import InstallationError
 from pip._internal.locations import (
     PIP_DELETE_MARKER_FILENAME, running_under_virtualenv,
 )

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -9,7 +9,7 @@ import warnings
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any
+    from typing import Any  # noqa: F401
 
 
 class PipDeprecationWarning(Warning):

--- a/src/pip/_internal/utils/typing.py
+++ b/src/pip/_internal/utils/typing.py
@@ -18,10 +18,10 @@ curious maintainer can reach here to read this.
 
 In pip, all static-typing related imports should be guarded as follows:
 
-    from pip.utils.typing import MYPY_CHECK_RUNNING
+    from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
     if MYPY_CHECK_RUNNING:
-        from typing import ...
+        from typing import ...  # noqa: F401
 
 Ref: https://github.com/python/mypy/issues/3216
 """

--- a/src/pip/_internal/utils/ui.py
+++ b/src/pip/_internal/utils/ui.py
@@ -21,7 +21,7 @@ from pip._internal.utils.misc import format_size
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any
+    from typing import Any  # noqa: F401
 
 try:
     from pip._vendor import colorama

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -17,8 +17,8 @@ from pip._internal.utils.misc import (
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Dict, Optional, Tuple
-    from pip._internal.basecommand import Command
+    from typing import Dict, Optional, Tuple  # noqa: F401
+    from pip._internal.basecommand import Command  # noqa: F401
 
 __all__ = ['vcs', 'get_src_requirement']
 

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -1,7 +1,6 @@
 """Handles all VCS (version control) support"""
 from __future__ import absolute_import
 
-import copy
 import errno
 import logging
 import os

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import collections
 import compileall
-import copy
 import csv
 import hashlib
 import logging

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -41,7 +41,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.ui import open_spinner
 
 if MYPY_CHECK_RUNNING:
-    from typing import Dict, List, Optional
+    from typing import Dict, List, Optional  # noqa: F401
 
 wheel_ext = '.whl'
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1,4 +1,3 @@
-import os
 import textwrap
 
 import pytest

--- a/tests/functional/test_install_force_reinstall.py
+++ b/tests/functional/test_install_force_reinstall.py
@@ -1,4 +1,3 @@
-import pytest
 
 from tests.lib import assert_all_changes
 

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -1,7 +1,6 @@
 import distutils
 import glob
 import os
-import sys
 
 import pytest
 

--- a/tests/functional/test_no_color.py
+++ b/tests/functional/test_no_color.py
@@ -2,9 +2,7 @@
 Test specific for the --no-color option
 """
 import os
-import platform
 import subprocess
-import sys
 
 import pytest
 


### PR DESCRIPTION
As it turns out, I might have been living in a dreamy world where mypy checks for unused imports -- it doesn't.

This PR is rectifying that and cleaning up the mess the incorrect assumption resulted in.