### PR TITLE
Add @pytest.mark.network to a test that did not have it

### DIFF
--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -226,6 +226,7 @@ def test_pip_wheel_with_pep518_build_reqs_no_isolation(script, data,
     assert "Installing build dependencies" not in result.stdout, result.stdout
 
 
+@pytest.mark.network
 def test_pip_wheel_with_user_set_in_config(script, data):
     script.pip('install', 'wheel')
     script.pip('download', 'setuptools', 'wheel', '-d', data.packages)


### PR DESCRIPTION
This being missing broke an AppVeyor build.

https://ci.appveyor.com/project/pypa/pip/build/1.0.2650/job/qv5uidwb1ya4dawi
