### PR TITLE
Fix the documentation build

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,7 @@
 sphinx == 1.7.*
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
+
+# `docs.pipext` uses pip's internals to generate documentation. So, we install
+# the current directory to make it work.
+.


### PR DESCRIPTION
It broke.

Turns out d633f0df1710c01b0ad2de649cf07355a3e44a78 was wrong -- though the comment has been updated to actually reflect the real situation.
