### PR TITLE
Ignore pre-release versions when prompting for upgrade

### DIFF
--- a/news/5175.bugfix
+++ b/news/5175.bugfix
@@ -1,0 +1,1 @@
+No longer prompt for upgrade to pre-release versions of pip.

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -113,6 +113,13 @@ def pip_version_check(session, options):
             all_candidates = finder.find_all_candidates("pip")
             if not all_candidates:
                 return
+
+            all_candidates = [
+                candidate
+                for candidate in all_candidates
+                if candidate.version.pre is None
+            ]
+
             pypi_version = str(
                 max(all_candidates, key=lambda c: c.version).version
             )

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -18,8 +18,10 @@ class MockPackageFinder(object):
     BASE_URL = 'https://pypi.org/simple/pip-{0}.tar.gz'
     PIP_PROJECT_NAME = 'pip'
     INSTALLATION_CANDIDATES = [
-        InstallationCandidate(PIP_PROJECT_NAME, '6.9.0',
-                              BASE_URL.format('6.9.0')),
+        InstallationCandidate(PIP_PROJECT_NAME, '10.0.0b2',
+                              BASE_URL.format('10.0.0b2')),
+        InstallationCandidate(PIP_PROJECT_NAME, '9.0.3',
+                              BASE_URL.format('9.0.3')),
         InstallationCandidate(PIP_PROJECT_NAME, '3.3.1',
                               BASE_URL.format('3.3.1')),
         InstallationCandidate(PIP_PROJECT_NAME, '1.0',
@@ -69,11 +71,13 @@ def _options():
         # Test we return None when installed version is None
         ('1970-01-01T10:00:00Z', None, '1.0', 'pip', False, False),
         # Need an upgrade - upgrade warning should print
-        ('1970-01-01T10:00:00Z', '1.0', '6.9.0', 'pip', True, True),
+        ('1970-01-01T10:00:00Z', '1.0', '9.0.3', 'pip', True, True),
         # Upgrade available, pip installed via rpm - warning should not print
-        ('1970-01-01T10:00:00Z', '1.0', '6.9.0', 'rpm', True, False),
+        ('1970-01-01T10:00:00Z', '1.0', '9.0.3', 'rpm', True, False),
         # No upgrade - upgrade warning should not print
-        ('1970-01-9T10:00:00Z', '6.9.0', '6.9.0', 'pip', False, False),
+        ('1970-01-9T10:00:00Z', '9.0.3', '9.0.3', 'pip', False, False),
+        # Pre-release available - upgrade warning should not print
+        ('1970-01-9T10:00:00Z', '9.0.3', '10.0.0b2', 'pip', False, False),
     ]
 )
 def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,


### PR DESCRIPTION
This is a PR to solve #5175.

The possible candidates for updating are filtered to remove any versions that contain a pre-release.

I've also updated the unit test to properly reproduce and test for the error. The old values for the versions didn't trigger it but the new versions committed will.