### PR TITLE
Skip AppVeyor builds on non-code changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,14 @@ environment:
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
 
+skip_commits:
+  files:
+    - .github/
+    - docs/
+    - news/
+    - tools/travis/
+    - '**/*.rst'
+
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"


### PR DESCRIPTION
Closes #5185 

As per https://www.appveyor.com/docs/how-to/filtering-commits/#skip-commits-2, we can use `skip_commits.files` on AppVeyor to skip CI builds when there are no code changes.

Based on some related reading, it seems AppVeyor gives a green signal when this happens, which is cool since we only run tests on AppVeyor and not documentation checks etc.