### PR TITLE
Open pyproject.toml with UTF-8 encoding in all environments

### DIFF
--- a/news/5482.bugfix
+++ b/news/5482.bugfix
@@ -1,0 +1,1 @@
+Always read ``pyproject.toml`` as UTF-8. This fixes Unicode handling on Windows and Python 2.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import io
 import logging
 import os
 import re
@@ -444,7 +445,7 @@ class InstallRequirement(object):
         requirements, pip will default to installing setuptools and wheel.
         """
         if os.path.isfile(self.pyproject_toml):
-            with open(self.pyproject_toml) as f:
+            with io.open(self.pyproject_toml, encoding="utf-8") as f:
                 pp_toml = pytoml.load(f)
             build_sys = pp_toml.get('build-system', {})
             return (build_sys.get('requires', ['setuptools', 'wheel']), True)

--- a/tests/data/src/withpyproject/pyproject.toml
+++ b/tests/data/src/withpyproject/pyproject.toml
@@ -1,2 +1,4 @@
 [build-system]
 requires = ["setuptools", "wheel"]
+
+# Note: pyproject.toml is always UTF-8 🤡


### PR DESCRIPTION
Hello, Unicode police here.

TOML is always UTF-8. Without this change on Python 3 on Windows as well as on Python 2 everywhere, the pyproject.toml file was being open with the wrong encoding, crashing on my name and emojis.