### PR TITLE
rehash hard-codes sha256, remove algo param

### DIFF
--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -51,9 +51,9 @@ VERSION_COMPATIBLE = (1, 0)
 logger = logging.getLogger(__name__)
 
 
-def rehash(path, algo='sha256', blocksize=1 << 20):
-    """Return (hash, length) for path using hashlib.new(algo)"""
-    h = hashlib.new(algo)
+def rehash(path, blocksize=1 << 20):
+    """Return (hash, length) for path using hashlib.sha256()"""
+    h = hashlib.sha256()
     length = 0
     with open(path, 'rb') as f:
         for block in read_chunks(f, size=blocksize):


### PR DESCRIPTION
A fancy noop -- I was reading some of the code and noticed this oddity.  prior to this change `rehash` took an `algo` parameter (`pip` never passed this in) but would always return a string that said `sha256=...`.