### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ pip
 `User list <http://groups.google.com/group/python-virtualenv>`_ |
 `Dev list <http://groups.google.com/group/pypa-dev>`_ |
 `GitHub <https://github.com/pypa/pip>`_ |
-`PyPI <https://pypi.python.org/pypi/pip/>`_ |
+`PyPI <https://pypi.org/project/pip/>`_ |
 User IRC: #pypa |
 Dev IRC: #pypa-dev
 


### PR DESCRIPTION
Was mistakenly reverted in commit
508517f0d7898618d656310ddd797200944b0136.