### PR TITLE
Update Python 2 docs URL to Python 3

### DIFF
--- a/docs/reference/pip_install.rst
+++ b/docs/reference/pip_install.rst
@@ -716,7 +716,7 @@ Package Index Options have an effect.
 
 The solution is to configure a "system" or "personal" `Distutils configuration
 file
-<http://docs.python.org/2/install/index.html#distutils-configuration-files>`_ to
+<https://docs.python.org/3/install/index.html#distutils-configuration-files>`_ to
 manage the fulfillment.
 
 For example, to have the dependency located at an alternate index, add this:


### PR DESCRIPTION
Python 3 docs are more actively maintained and are the future of the project.