### PR TITLE
Fix #5500: Make pip download prefer local package over remote

### DIFF
--- a/news/5500.bugfix
+++ b/news/5500.bugfix
@@ -1,0 +1,1 @@
+Fix Pip download prefers newer package version even when local package exists

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -513,12 +513,19 @@ class PackageFinder(object):
             # Again, converting to str to deal with debundling.
             c for c in all_candidates if str(c.version) in compatible_versions
         ]
+        best_candidate = None
 
-        if applicable_candidates:
+        # See if there are any candidates found locally provided by find_links
+        if self.find_links:
+            file_candidates = [cand for cand in applicable_candidates
+                               if cand.location.scheme == "file"]
+            if file_candidates:
+                best_candidate = max(file_candidates,
+                                     key=self._candidate_sort_key)
+
+        if applicable_candidates and best_candidate is None:
             best_candidate = max(applicable_candidates,
                                  key=self._candidate_sort_key)
-        else:
-            best_candidate = None
 
         if req.satisfied_by is not None:
             installed_version = parse_version(req.satisfied_by.version)

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -296,8 +296,26 @@ def test_finder_priority_file_over_page(data):
     assert all(version.location.scheme == 'https'
                for version in all_versions[1:]), all_versions
 
+
+def test_finder_priority_older_file_over_newer_page(data):
+    """
+    Test PackageFinder prefers an older local package file over newer page link
+    """
+    links = [data.find_links,  'https://foo/gmpy-1.16.tar.gz']
+    finder = PackageFinder(
+        links,
+        ["http://pypi.org/simple/"],
+        session=PipSession(),
+    )
+    req = InstallRequirement.from_line('gmpy', None)
+    all_versions = finder.find_all_candidates(req.name)
+
+    assert all_versions[0].location.scheme == 'file'
+    assert all_versions[1].location.scheme == 'https'
+
     link = finder.find_requirement(req, False)
     assert link.url.startswith("file://")
+    assert link.filename == "gmpy-1.15.tar.gz"
 
 
 def test_finder_deplink():


### PR DESCRIPTION
If a package already exists in a directory specified with --find-links,
PackageFinder still prefers a newer version of the package found
at the remote package index.

Fix by preferring local package file when found.

