### PR TITLE
Remove pytest version constraint for CI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 freezegun
 pretend
 pytest
-pytest-catchlog
 pytest-cov
 pytest-rerunfailures
 pytest-timeout

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,9 +6,9 @@ pytest-cov
 pytest-rerunfailures
 pytest-timeout
 pytest-xdist
-# Revert the following hack after a PyYAML is released supporting Py3.7
-pyyaml; python_version < "3.7"
-https://github.com/yaml/pyyaml/archive/master.zip#egg=pyyaml ; python_version >= "3.7"
 mock
 scripttest
 https://github.com/pypa/virtualenv/archive/master.zip#egg=virtualenv
+# Revert the following hack after a PyYAML is released supporting Py3.7
+pyyaml; python_version < "3.7"
+https://github.com/yaml/pyyaml/archive/master.zip#egg=pyyaml ; python_version >= "3.7"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,11 @@
 freezegun
+mock
 pretend
 pytest
 pytest-cov
 pytest-rerunfailures
 pytest-timeout
 pytest-xdist
-mock
 scripttest
 https://github.com/pypa/virtualenv/archive/master.zip#egg=virtualenv
 # Revert the following hack after a PyYAML is released supporting Py3.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 freezegun
 pretend
-pytest<=3.2.5
+pytest
 pytest-catchlog
 pytest-cov
 pytest-rerunfailures
@@ -10,5 +10,5 @@ pytest-xdist
 pyyaml; python_version < "3.7"
 https://github.com/yaml/pyyaml/archive/master.zip#egg=pyyaml ; python_version >= "3.7"
 mock
-scripttest>=1.3
+scripttest
 https://github.com/pypa/virtualenv/archive/master.zip#egg=virtualenv

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from pip._internal.commands.search import (
@@ -158,7 +160,10 @@ def test_search_print_results_should_contain_latest_versions(caplog):
             'versions': ['2.0.1', '2.0.3']
         }
     ]
-    print_results(hits)
+
+    with caplog.at_level(logging.INFO):
+        print_results(hits)
+
     log_messages = sorted([r.getMessage() for r in caplog.records])
     assert log_messages[0].startswith('testlib1 (1.0.5)')
     assert log_messages[1].startswith('testlib2 (2.0.3)')

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -1,6 +1,7 @@
 from __future__ import with_statement
 
 import json
+import logging
 import os
 import sys
 import textwrap
@@ -410,6 +411,9 @@ def test_uninstallpathset_no_paths(caplog):
     """
     from pip._internal.req.req_uninstall import UninstallPathSet
     from pkg_resources import get_distribution
+
+    caplog.set_level(logging.INFO)
+
     test_dist = get_distribution('pip')
     uninstall_set = UninstallPathSet(test_dist)
     uninstall_set.remove()  # with no files added to set


### PR DESCRIPTION
We were constrained to a really old version of pytest, for compatibility with Py3.3. Since we no longer support Py3.3, that can be dropped.

While I'm here, I'll clean up the file as well.