### PR TITLE
Revert "Skip AppVeyor builds on non-code changes"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,14 +13,6 @@ environment:
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
 
-skip_commits:
-  files:
-    - .github/
-    - docs/
-    - news/
-    - tools/travis/
-    - '**/*.rst'
-
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"


### PR DESCRIPTION
Reverts pypa/pip#5478
Reopens #5185 

Reverted since AppVeyor is not reporting status for PRs when it's skipping builds.