### PR TITLE
Simplify linter use and make configuration consistent

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,10 +11,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import glob
 import os
 import re
 import sys
-import glob
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,9 @@
 [isort]
 skip =
-    _vendor
-    __main__.py
+    .tox,
+    .scratch,
+    _vendor,
+    data
 multi_line_output = 5
 known_third_party =
     pip._vendor
@@ -12,7 +14,11 @@ default_section = THIRDPARTY
 include_trailing_comma = true
 
 [flake8]
-exclude = .tox,.idea,.scratch,*.egg,build,_vendor,data
+exclude =
+    .tox,
+    .scratch,
+    _vendor,
+    data
 select = E,W,F
 
 [mypy]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/src/pip/__main__.py
+++ b/src/pip/__main__.py
@@ -13,7 +13,7 @@ if __package__ == '':
     path = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(0, path)
 
-from pip._internal import main as _main  # noqa
+from pip._internal import main as _main  # isort:skip # noqa
 
 if __name__ == '__main__':
     sys.exit(_main())

--- a/tox.ini
+++ b/tox.ini
@@ -36,8 +36,8 @@ commands =
 [lint]
 deps = -r{toxinidir}/tools/lint-requirements.txt
 commands =
-    flake8 .
-    isort --recursive --check-only --diff src/pip tests
+    flake8
+    isort --check-only --diff
 
 [testenv:lint-py2]
 basepython = python2


### PR DESCRIPTION
- Moves ignoring logic to configuration, expanding the scope to cover files not previously covered.
- Makes running flake8 and isort as simple as running `flake8` and `isort` locally, if the dev environment is setup correctly.
- Config files look slightly cleaner. ✨ 