### PR TITLE
Fix error trying to generate scripts warning when PATH not set

### DIFF
--- a/news/5558.bugfix
+++ b/news/5558.bugfix
@@ -1,0 +1,1 @@
+Fix error trying to generate scripts warning when PATH not set

--- a/news/5558.bugfix
+++ b/news/5558.bugfix
@@ -1,1 +1,1 @@
-Fix error trying to generate scripts warning when PATH not set
+Fix a crash that occurs when PATH not set, while generating script location warning.

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -163,7 +163,7 @@ def message_about_scripts_not_on_PATH(scripts):
     # We don't want to warn for directories that are on PATH.
     not_warn_dirs = [
         os.path.normcase(i).rstrip(os.sep) for i in
-        os.environ["PATH"].split(os.pathsep)
+        os.environ.get("PATH", "").split(os.pathsep)
     ]
     # If an executable sits with sys.executable, we don't warn for it.
     #     This covers the case of venv invocations without activating the venv.

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -470,3 +470,16 @@ class TestMessageAboutScriptsNotOnPATH(object):
             scripts=[os.path.join('a', 'b', 'c')]
         )
         assert retval is None
+
+    def test_missing_PATH_env_treated_as_empty_PATH_env(self):
+        scripts = ['a/b/foo']
+
+        env = os.environ.copy()
+        del env['PATH']
+        with patch.dict('os.environ', env, clear=True):
+            retval_missing = wheel.message_about_scripts_not_on_PATH(scripts)
+
+        with patch.dict('os.environ', {'PATH': ''}):
+            retval_empty = wheel.message_about_scripts_not_on_PATH(scripts)
+
+        assert retval_missing == retval_empty


### PR DESCRIPTION
fixes #5558

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
