### PR TITLE
Adjust the deprecation policy to be time based

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -195,19 +195,19 @@ reworked and resubmitted for the next release.
 Deprecation Policy
 ==================
 
-Any change to pip that removes or significantly alters user-visible behaviour
+Any change to pip that removes or significantly alters user-visible behavior
 that is described in the pip documentation will be deprecated for a minimum of
-one released version before the change occurs. Deprecation will take the form of
-a warning being issued by pip when the feature is used. Longer deprecation
-periods, or deprecation warnings for behaviour changes that would not normally
-be covered by this policy, are also possible depending on circumstances, but
-this is at the discretion of the pip developers.
+6 months before the change occurs. Deprecation will take the form of a warning
+being issued by pip when the feature is used. Longer deprecation periods, or
+deprecation warnings for behavior changes that would not normally be covered by
+this policy, are also possible depending on circumstances, but this is at the
+discretion of the pip developers.
 
 Note that the documentation is the sole reference for what counts as agreed
-behaviour. If something isn't explicitly mentioned in the documentation, it can
+behavior. If something isn't explicitly mentioned in the documentation, it can
 be changed without warning, or any deprecation period, in a pip release.
 However, we are aware that the documentation isn't always complete - PRs that
-document existing behaviour with the intention of covering that behaviour with
+document existing behavior with the intention of covering that behavior with
 the above deprecation process are always acceptable, and will be considered on
 their merits.
 

--- a/news/deprecation.process
+++ b/news/deprecation.process
@@ -1,1 +1,2 @@
-Formally document our deprecation process
+Formally document our deprecation process as a minimum of 6 months of deprecation
+warnings.


### PR DESCRIPTION
@pypa/pip-committers 

This came up in https://github.com/pypa/pip/pull/5542, but basically, the current policy is based upon the number of releases, but we don't know exactly how many releases we're going to have, because we may skip releases, etc. Instead this adjusts the policy so that it is time based.

This doesn't *really* affect the policy much, but it makes it more obvious for end users who aren't familiar with our particular release cadence how long they have to no longer rely on deprecated behavior. It also fits in well with our general assumption that people should be staying on the latest version wherever possible.