### PR TITLE
Refactor out a new VersionControl.fetch_new() method.

### DIFF
--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -260,6 +260,17 @@ class VersionControl(object):
         """
         raise NotImplementedError
 
+    def fetch_new(self, dest, url, rev_options):
+        """
+        Fetch a revision from a repository, in the case that this is the
+        first fetch from the repository.
+
+        Args:
+          dest: the directory to fetch the repository to.
+          rev_options: a RevOptions object.
+        """
+        raise NotImplementedError
+
     def switch(self, dest, url, rev_options):
         """
         Switch the repo at ``dest`` to point to ``URL``.

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -48,6 +48,17 @@ class Bazaar(VersionControl):
                 cwd=temp_dir.path, show_stdout=False,
             )
 
+    def fetch_new(self, dest, url, rev_options):
+        rev_display = rev_options.to_display()
+        logger.info(
+            'Checking out %s%s to %s',
+            url,
+            rev_display,
+            display_path(dest),
+        )
+        cmd_args = ['branch', '-q'] + rev_options.to_args() + [url, dest]
+        self.run_command(cmd_args)
+
     def switch(self, dest, url, rev_options):
         self.run_command(['switch', url], cwd=dest)
 
@@ -59,15 +70,7 @@ class Bazaar(VersionControl):
         url, rev = self.get_url_rev()
         rev_options = self.make_rev_options(rev)
         if self.check_destination(dest, url, rev_options):
-            rev_display = rev_options.to_display()
-            logger.info(
-                'Checking out %s%s to %s',
-                url,
-                rev_display,
-                display_path(dest),
-            )
-            cmd_args = ['branch', '-q'] + rev_options.to_args() + [url, dest]
-            self.run_command(cmd_args)
+            self.fetch_new(dest, url, rev_options)
 
     def get_url_rev(self):
         # hotfix the URL scheme after removing bzr+ from bzr+ssh:// readd it

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -31,6 +31,18 @@ class Mercurial(VersionControl):
                 ['archive', location], show_stdout=False, cwd=temp_dir.path
             )
 
+    def fetch_new(self, dest, url, rev_options):
+        rev_display = rev_options.to_display()
+        logger.info(
+            'Cloning hg %s%s to %s',
+            url,
+            rev_display,
+            display_path(dest),
+        )
+        self.run_command(['clone', '--noupdate', '-q', url, dest])
+        cmd_args = ['update', '-q'] + rev_options.to_args()
+        self.run_command(cmd_args, cwd=dest)
+
     def switch(self, dest, url, rev_options):
         repo_config = os.path.join(dest, self.dirname, 'hgrc')
         config = configparser.SafeConfigParser()
@@ -56,16 +68,7 @@ class Mercurial(VersionControl):
         url, rev = self.get_url_rev()
         rev_options = self.make_rev_options(rev)
         if self.check_destination(dest, url, rev_options):
-            rev_display = rev_options.to_display()
-            logger.info(
-                'Cloning hg %s%s to %s',
-                url,
-                rev_display,
-                display_path(dest),
-            )
-            self.run_command(['clone', '--noupdate', '-q', url, dest])
-            cmd_args = ['update', '-q'] + rev_options.to_args()
-            self.run_command(cmd_args, cwd=dest)
+            self.fetch_new(dest, url, rev_options)
 
     def get_url(self, location):
         url = self.run_command(

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -73,6 +73,17 @@ class Subversion(VersionControl):
             cmd_args = ['export'] + rev_options.to_args() + [url, location]
             self.run_command(cmd_args, show_stdout=False)
 
+    def fetch_new(self, dest, url, rev_options):
+        rev_display = rev_options.to_display()
+        logger.info(
+            'Checking out %s%s to %s',
+            url,
+            rev_display,
+            display_path(dest),
+        )
+        cmd_args = ['checkout', '-q'] + rev_options.to_args() + [url, dest]
+        self.run_command(cmd_args)
+
     def switch(self, dest, url, rev_options):
         cmd_args = ['switch'] + rev_options.to_args() + [url, dest]
         self.run_command(cmd_args)
@@ -86,15 +97,7 @@ class Subversion(VersionControl):
         rev_options = get_rev_options(self, url, rev)
         url = remove_auth_from_url(url)
         if self.check_destination(dest, url, rev_options):
-            rev_display = rev_options.to_display()
-            logger.info(
-                'Checking out %s%s to %s',
-                url,
-                rev_display,
-                display_path(dest),
-            )
-            cmd_args = ['checkout', '-q'] + rev_options.to_args() + [url, dest]
-            self.run_command(cmd_args)
+            self.fetch_new(dest, url, rev_options)
 
     def get_location(self, dist, dependency_links):
         for url in dependency_links:


### PR DESCRIPTION
This refactors out a new method of the `VersionControl` class called `fetch_new()`, to parallel `switch()` and `update()`.

With this update, the `obtain()` method is (nearly) identical in every `VersionControl` subclass. This will let us move `obtain()` to the base class in a future commit and combine it with `check_destination()`.

This will make it easier to add new VCS implementations since `fetch_new()` has a clearer and simpler responsibility (corresponding to `clone` for systems like `git` and `hg`) than the current `obtain()`.
