### PR TITLE
Add --minor and --major flags to pip freeze based on semantically named packages

### DIFF
--- a/news/5582.feature
+++ b/news/5582.feature
@@ -1,0 +1,10 @@
+Addition of ``--minor`` and ``--major`` flags to the pip freeze command.
+
+For a given requirement, either will check if the version number of the package matches the PEP440 
+versioning specification, assuming semantic versioning is followed.
+
+- If `--minor` is applied, return the line `PACKAGE>=CURRENT,<MAJOR.MINOR+1.0`
+- If `--major` is applied, return the line `PACKAGE>=CURRENT,<MAJOR+1.0.0`
+- If a package that doesn't follow semver is found, the existing `==` syntax is used.
+
+Both flags are disabled by default.

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -67,6 +67,18 @@ class FreezeCommand(Command):
             dest='exclude_editable',
             action='store_true',
             help='Exclude editable package from output.')
+        self.cmd_opts.add_option(
+            '--major',
+            dest='semantic',
+            action='store_const',
+            const='major',
+            help='Freeze to major version.')
+        self.cmd_opts.add_option(
+            '--minor',
+            dest='semantic',
+            action='store_const',
+            const='minor',
+            help='Freeze to minor version.')
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -87,6 +99,7 @@ class FreezeCommand(Command):
             wheel_cache=wheel_cache,
             skip=skip,
             exclude_editable=options.exclude_editable,
+            semantic=options.semantic or None
         )
 
         try:

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -241,9 +241,6 @@ class FrozenRequirement(object):
                         cls.egg_name(dist)
                     )
             if sem_match and semantic:
-                # comments.append(
-                #         "# Using PEP404 semantic range for %s release" % semantic
-                #     )
                 req = cls.loose_semver(req.name, sem_match, semantic)
         return cls(dist.project_name, req, editable, comments)
 

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -27,7 +27,8 @@ def freeze(
         isolated=False,
         wheel_cache=None,
         exclude_editable=False,
-        skip=()):
+        skip=(),
+        semantic=False):
     find_links = find_links or []
     skip_match = None
 
@@ -53,7 +54,8 @@ def freeze(
         try:
             req = FrozenRequirement.from_dist(
                 dist,
-                dependency_links
+                dependency_links,
+                semantic
             )
         except RequirementParseError:
             logger.warning(
@@ -165,9 +167,10 @@ class FrozenRequirement(object):
 
     _rev_re = re.compile(r'-r(\d+)$')
     _date_re = re.compile(r'-(20\d\d\d\d\d\d)$')
+    _sem_re  = re.compile('^v?(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patchlevel>\\d+)~?(?P<special>[a-z]\\w+[\\d+])?$')
 
     @classmethod
-    def from_dist(cls, dist, dependency_links):
+    def from_dist(cls, dist, dependency_links, semantic):
         location = os.path.normcase(os.path.abspath(dist.location))
         comments = []
         from pip._internal.vcs import vcs, get_src_requirement
@@ -200,6 +203,8 @@ class FrozenRequirement(object):
             version = specs[0][1]
             ver_match = cls._rev_re.search(version)
             date_match = cls._date_re.search(version)
+            sem_match = cls._sem_re.match(version)
+
             if ver_match or date_match:
                 svn_backend = vcs.get_backend('svn')
                 if svn_backend:
@@ -235,7 +240,24 @@ class FrozenRequirement(object):
                         rev,
                         cls.egg_name(dist)
                     )
+            if sem_match and semantic:
+                # comments.append(
+                #         "# Using PEP404 semantic range for %s release" % semantic
+                #     )
+                req = cls.loose_semver(req.name, sem_match, semantic)
         return cls(dist.project_name, req, editable, comments)
+
+    @staticmethod
+    def loose_semver(spec, version, semantic):
+        if not semantic:
+            return version.string
+        this_version = version.string
+        parts = version.groupdict()
+        if semantic == 'major':
+            next_version = "%d.%d.%d" % (int(parts['major'])+1, 0, 0)
+        elif semantic == 'minor':
+            next_version = "%d.%d.%d" % (int(parts['major']), int(parts['minor'])+1, 0) 
+        return '%s>=%s,<%s' % (spec, this_version, next_version)
 
     @staticmethod
     def egg_name(dist):
@@ -249,4 +271,5 @@ class FrozenRequirement(object):
         req = self.req
         if self.editable:
             req = '-e %s' % req
+
         return '\n'.join(list(self.comments) + [str(req)]) + '\n'

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -587,3 +587,33 @@ def test_freeze_user(script, virtualenv, data):
         <BLANKLINE>""")
     _check_output(result.stdout, expected)
     assert 'simple2' not in result.stdout
+
+
+def test_freeze_minor(script):
+    """
+    Testing freeze with --minor, should ignore non-semver, x.x.x versioned packages
+    """
+    result = script.pip_install_local('singlemodule==0.0.1')
+    result = script.pip_install_local('simple2==2.0')
+
+    result = script.pip('freeze', '--minor', expect_stderr=True)
+    expected = textwrap.dedent("""\
+        simple2==2.0
+        singlemodule>=0.0.1,<0.1.0
+        <BLANKLINE>""")
+    _check_output(result.stdout, expected)
+
+
+def test_freeze_major(script):
+    """
+    Testing freeze with --major, should ignore non-semver, x.x.x versioned packages
+    """
+    result = script.pip_install_local('singlemodule==0.0.1')
+    result = script.pip_install_local('simple2==2.0')
+
+    result = script.pip('freeze', '--major', expect_stderr=True)
+    expected = textwrap.dedent("""\
+        simple2==2.0
+        singlemodule>=0.0.1,<1.0.0
+        <BLANKLINE>""")
+    _check_output(result.stdout, expected)


### PR DESCRIPTION
**Challenge**: `pip freeze > requirements.txt` is a very common way of pinning the dependencies installed within a development or test environment to ensure they are reproducible. 
A major challenge of this is that bugfix or security patches of dependent packages can be released and simply not upgraded because the `requirements.txt` of a library or application is so specific about the depending version.

This PR demonstrates 2 flags to the pip freeze command, `--minor` and `--major` that:
- For a given requirement, check if the version number matches the PEP440 versioning specification, assuming semantic versioning is followed.
- If `--minor` is applied, return the string `package>={current version},<{next version}` for example, if requests 2.19.1 is installed, it will give `requests>=2.19.1,<2.20.0`
- If `--major` is applied, then `requests>=2.19.1,<3.0.0` is given.
- If a package that doesn't follow semver is found, the existing `==` syntax is used.

Semantic Versioning states that a version number MAJOR.MINOR.PATCH, increment the:
- MAJOR version when you make incompatible API changes,
- MINOR version when you add functionality in a backwards-compatible manner, and
- PATCH version when you make backwards-compatible bug fixes.

Effectively, the existing behaviour is the very-conservative approach, `--minor` for environments where installation of bugfix and security updates is important and `--major` for fast-moving applications with strong test coverage.

This is my first contribution to pip, I've read the article on news and once I have the PR # I'll create the entry.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
