### PR TITLE
Redact password from various log messages

### DIFF
--- a/news/4746.bugfix
+++ b/news/4746.bugfix
@@ -1,1 +1,1 @@
-Redact username/password from log messages when installing packages from Git
+Redact password from the URL in various log messages.

--- a/news/4746.bugfix
+++ b/news/4746.bugfix
@@ -1,1 +1,1 @@
-Remove username/password from log messages when installing packages from Git
+Redact username/password from log messages when installing packages from Git

--- a/news/4746.bugfix
+++ b/news/4746.bugfix
@@ -1,0 +1,1 @@
+Remove username/password from log messages when installing packages from Git

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -33,7 +33,7 @@ from pip._internal.utils.deprecation import RemovedInPip11Warning
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
     ARCHIVE_EXTENSIONS, SUPPORTED_EXTENSIONS, cached_property, normalize_path,
-    remove_auth_from_url, splitext,
+    redact_auth_from_url, splitext,
 )
 from pip._internal.utils.packaging import check_requires_python
 from pip._internal.wheel import Wheel, wheel_ext
@@ -198,7 +198,7 @@ class PackageFinder(object):
         if self.index_urls and self.index_urls != [PyPI.simple_url]:
             lines.append(
                 "Looking in indexes: {}".format(", ".join(
-                    remove_auth_from_url(url) for url in self.index_urls))
+                    redact_auth_from_url(url) for url in self.index_urls))
             )
         if self.find_links:
             lines.append(
@@ -938,10 +938,10 @@ class Link(object):
         else:
             rp = ''
         if self.comes_from:
-            return '%s (from %s)%s' % (remove_auth_from_url(self.url),
+            return '%s (from %s)%s' % (redact_auth_from_url(self.url),
                                        self.comes_from, rp)
         else:
-            return remove_auth_from_url(str(self.url))
+            return redact_auth_from_url(str(self.url))
 
     def __repr__(self):
         return '<Link %s>' % self

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -33,7 +33,7 @@ from pip._internal.utils.deprecation import RemovedInPip11Warning
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
     ARCHIVE_EXTENSIONS, SUPPORTED_EXTENSIONS, cached_property, normalize_path,
-    redact_auth_from_url, splitext,
+    redact_password_from_url, splitext,
 )
 from pip._internal.utils.packaging import check_requires_python
 from pip._internal.wheel import Wheel, wheel_ext
@@ -198,7 +198,7 @@ class PackageFinder(object):
         if self.index_urls and self.index_urls != [PyPI.simple_url]:
             lines.append(
                 "Looking in indexes: {}".format(", ".join(
-                    redact_auth_from_url(url) for url in self.index_urls))
+                    redact_password_from_url(url) for url in self.index_urls))
             )
         if self.find_links:
             lines.append(
@@ -938,10 +938,10 @@ class Link(object):
         else:
             rp = ''
         if self.comes_from:
-            return '%s (from %s)%s' % (redact_auth_from_url(self.url),
+            return '%s (from %s)%s' % (redact_password_from_url(self.url),
                                        self.comes_from, rp)
         else:
-            return redact_auth_from_url(str(self.url))
+            return redact_password_from_url(str(self.url))
 
     def __repr__(self):
         return '<Link %s>' % self

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -939,7 +939,7 @@ class Link(object):
             rp = ''
         if self.comes_from:
             return '%s (from %s)%s' % (remove_auth_from_url(self.url),
-                                      self.comes_from, rp)
+                                       self.comes_from, rp)
         else:
             return remove_auth_from_url(str(self.url))
 

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -938,9 +938,10 @@ class Link(object):
         else:
             rp = ''
         if self.comes_from:
-            return '%s (from %s)%s' % (self.url, self.comes_from, rp)
+            return '%s (from %s)%s' % (remove_auth_from_url(self.url),
+                                      self.comes_from, rp)
         else:
-            return str(self.url)
+            return remove_auth_from_url(str(self.url))
 
     def __repr__(self):
         return '<Link %s>' % self

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -42,7 +42,7 @@ from pip._internal.utils.misc import (
     _make_build_dir, ask_path_exists, backup_dir, call_subprocess,
     display_path, dist_in_site_packages, dist_in_usersite, ensure_dir,
     get_installed_version, is_installable_dir, read_text_file,
-    remove_auth_from_url, rmtree,
+    redact_auth_from_url, rmtree,
 )
 from pip._internal.utils.setuptools_build import SETUPTOOLS_SHIM
 from pip._internal.utils.temp_dir import TempDirectory
@@ -279,9 +279,9 @@ class InstallRequirement(object):
         if self.req:
             s = str(self.req)
             if self.link:
-                s += ' from %s' % remove_auth_from_url(self.link.url)
+                s += ' from %s' % redact_auth_from_url(self.link.url)
         else:
-            s = remove_auth_from_url(self.link.url) if self.link else None
+            s = redact_auth_from_url(self.link.url) if self.link else None
         if self.satisfied_by is not None:
             s += ' in %s' % display_path(self.satisfied_by.location)
         if self.comes_from:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -41,7 +41,8 @@ from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
     _make_build_dir, ask_path_exists, backup_dir, call_subprocess,
     display_path, dist_in_site_packages, dist_in_usersite, ensure_dir,
-    get_installed_version, is_installable_dir, read_text_file, rmtree,
+    get_installed_version, is_installable_dir, read_text_file,
+    remove_auth_from_url, rmtree,
 )
 from pip._internal.utils.setuptools_build import SETUPTOOLS_SHIM
 from pip._internal.utils.temp_dir import TempDirectory
@@ -278,9 +279,9 @@ class InstallRequirement(object):
         if self.req:
             s = str(self.req)
             if self.link:
-                s += ' from %s' % self.link.url
+                s += ' from %s' % remove_auth_from_url(self.link.url)
         else:
-            s = self.link.url if self.link else None
+            s = remove_auth_from_url(self.link.url) if self.link else None
         if self.satisfied_by is not None:
             s += ' in %s' % display_path(self.satisfied_by.location)
         if self.comes_from:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -42,7 +42,7 @@ from pip._internal.utils.misc import (
     _make_build_dir, ask_path_exists, backup_dir, call_subprocess,
     display_path, dist_in_site_packages, dist_in_usersite, ensure_dir,
     get_installed_version, is_installable_dir, read_text_file,
-    redact_auth_from_url, rmtree,
+    redact_password_from_url, rmtree,
 )
 from pip._internal.utils.setuptools_build import SETUPTOOLS_SHIM
 from pip._internal.utils.temp_dir import TempDirectory
@@ -279,9 +279,9 @@ class InstallRequirement(object):
         if self.req:
             s = str(self.req)
             if self.link:
-                s += ' from %s' % redact_auth_from_url(self.link.url)
+                s += ' from %s' % redact_password_from_url(self.link.url)
         else:
-            s = redact_auth_from_url(self.link.url) if self.link else None
+            s = redact_password_from_url(self.link.url) if self.link else None
         if self.satisfied_by is not None:
             s += ' in %s' % display_path(self.satisfied_by.location)
         if self.comes_from:

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -860,8 +860,8 @@ def redact_password_from_url(url):
     purl = urllib_parse.urlsplit(url)
 
     redacted_netloc = purl.netloc
-    if purl.password:
-        auth, netloc = redacted_netloc.split('@')
+    if purl.password is not None:
+        auth, netloc = redacted_netloc.rsplit('@', 1)
         auth = auth.split(':')[0] + ':****'
         redacted_netloc = auth + '@' + netloc
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -854,22 +854,17 @@ def enum(*sequential, **named):
 
 
 def redact_password_from_url(url):
-    # Return a copy of url by redacting the password with '****' in case it
-    # was present in the url.
-
-    # parsed url
+    """Return a copy of the url by redacting the password in case it was
+    present. The password will be replaced with '****'.
+    """
     purl = urllib_parse.urlsplit(url)
 
-    # redact the password
     redacted_netloc = purl.netloc
-    if '@' in redacted_netloc:
-        userpass, netloc = redacted_netloc.split('@')
-        if ':' in userpass:
-            userpass = userpass.split(':')[0] + ':****'
+    if purl.password:
+        auth, netloc = redacted_netloc.split('@')
+        auth = auth.split(':')[0] + ':****'
+        redacted_netloc = auth + '@' + netloc
 
-        redacted_netloc = userpass + '@' + netloc
-
-    # redacted url
     url_pieces = (
         purl.scheme, redacted_netloc, purl.path, purl.query, purl.fragment
     )
@@ -878,16 +873,14 @@ def redact_password_from_url(url):
 
 
 def remove_auth_from_url(url):
-    # Return a copy of url with 'username:password@' removed.
-    # username/pass params are passed to subversion through flags
-    # and are not recognized in the url.
-
-    # parsed url
+    """Return a copy of url with 'username:password@' removed.
+    Username/pass params are passed to subversion through flags
+    and are not recognized in the url.
+    """
     purl = urllib_parse.urlsplit(url)
     stripped_netloc = \
         purl.netloc.split('@')[-1]
 
-    # stripped url
     url_pieces = (
         purl.scheme, stripped_netloc, purl.path, purl.query, purl.fragment
     )

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -51,7 +51,7 @@ __all__ = ['rmtree', 'display_path', 'backup_dir',
            'captured_stdout', 'ensure_dir',
            'ARCHIVE_EXTENSIONS', 'SUPPORTED_EXTENSIONS',
            'get_installed_version',
-           'redact_auth_from_url', 'remove_auth_from_url']
+           'redact_password_from_url', 'remove_auth_from_url']
 
 
 logger = std_logging.getLogger(__name__)
@@ -853,18 +853,21 @@ def enum(*sequential, **named):
     return type('Enum', (), enums)
 
 
-def redact_auth_from_url(url):
-    # Return a copy of url with 'username:password@' redacted by
-    # substituting the credentials with '<redacted>' in case they
-    # were present in the url.
+def redact_password_from_url(url):
+    # Return a copy of url by redacting the password with '****' in case it
+    # was present in the url.
 
     # parsed url
     purl = urllib_parse.urlsplit(url)
 
-    # redact credentials
+    # redact the password
     redacted_netloc = purl.netloc
     if '@' in redacted_netloc:
-        redacted_netloc = '<redacted>@' + redacted_netloc.split('@')[-1]
+        userpass, netloc = redacted_netloc.split('@')
+        if ':' in userpass:
+            userpass = userpass.split(':')[0] + ':****'
+
+        redacted_netloc = userpass + '@' + netloc
 
     # redacted url
     url_pieces = (

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -50,7 +50,8 @@ __all__ = ['rmtree', 'display_path', 'backup_dir',
            'unzip_file', 'untar_file', 'unpack_file', 'call_subprocess',
            'captured_stdout', 'ensure_dir',
            'ARCHIVE_EXTENSIONS', 'SUPPORTED_EXTENSIONS',
-           'get_installed_version', 'remove_auth_from_url']
+           'get_installed_version',
+           'redact_auth_from_url', 'remove_auth_from_url']
 
 
 logger = std_logging.getLogger(__name__)
@@ -850,6 +851,27 @@ def enum(*sequential, **named):
     reverse = {value: key for key, value in enums.items()}
     enums['reverse_mapping'] = reverse
     return type('Enum', (), enums)
+
+
+def redact_auth_from_url(url):
+    # Return a copy of url with 'username:password@' redacted by
+    # substituting the credentials with '<redacted>' in case they
+    # were present in the url.
+
+    # parsed url
+    purl = urllib_parse.urlsplit(url)
+
+    # redact credentials
+    redacted_netloc = purl.netloc
+    if '@' in redacted_netloc:
+        redacted_netloc = '<redacted>@' + redacted_netloc.split('@')[-1]
+
+    # redacted url
+    url_pieces = (
+        purl.scheme, redacted_netloc, purl.path, purl.query, purl.fragment
+    )
+    surl = urllib_parse.urlunsplit(url_pieces)
+    return surl
 
 
 def remove_auth_from_url(url):

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -10,7 +10,7 @@ from pip._vendor.six.moves.urllib import request as urllib_request
 
 from pip._internal.compat import samefile
 from pip._internal.exceptions import BadCommand
-from pip._internal.utils.misc import display_path
+from pip._internal.utils.misc import display_path, remove_auth_from_url
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.vcs import VersionControl, vcs
 
@@ -158,7 +158,8 @@ class Git(VersionControl):
     def fetch_new(self, dest, url, rev_options):
         rev_display = rev_options.to_display()
         logger.info(
-            'Cloning %s%s to %s', url, rev_display, display_path(dest),
+            'Cloning %s%s to %s', remove_auth_from_url(url), rev_display,
+            display_path(dest),
         )
         self.run_command(['clone', '-q', url, dest])
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -10,7 +10,7 @@ from pip._vendor.six.moves.urllib import request as urllib_request
 
 from pip._internal.compat import samefile
 from pip._internal.exceptions import BadCommand
-from pip._internal.utils.misc import display_path, redact_auth_from_url
+from pip._internal.utils.misc import display_path, redact_password_from_url
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.vcs import VersionControl, vcs
 
@@ -158,7 +158,7 @@ class Git(VersionControl):
     def fetch_new(self, dest, url, rev_options):
         rev_display = rev_options.to_display()
         logger.info(
-            'Cloning %s%s to %s', redact_auth_from_url(url), rev_display,
+            'Cloning %s%s to %s', redact_password_from_url(url), rev_display,
             display_path(dest),
         )
         self.run_command(['clone', '-q', url, dest])

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -10,7 +10,7 @@ from pip._vendor.six.moves.urllib import request as urllib_request
 
 from pip._internal.compat import samefile
 from pip._internal.exceptions import BadCommand
-from pip._internal.utils.misc import display_path, remove_auth_from_url
+from pip._internal.utils.misc import display_path, redact_auth_from_url
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.vcs import VersionControl, vcs
 
@@ -158,7 +158,7 @@ class Git(VersionControl):
     def fetch_new(self, dest, url, rev_options):
         rev_display = rev_options.to_display()
         logger.info(
-            'Cloning %s%s to %s', remove_auth_from_url(url), rev_display,
+            'Cloning %s%s to %s', redact_auth_from_url(url), rev_display,
             display_path(dest),
         )
         self.run_command(['clone', '-q', url, dest])

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -143,8 +143,7 @@ def test_secure_origin(location, trusted, expected):
 
 def test_get_formatted_locations_basic_auth():
     """
-    Test that basic authentication credentials defined in URL
-    is not included in formatted output.
+    Test that the password defined in URL is not included in formatted output.
     """
     index_urls = [
         'https://pypi.org/simple',
@@ -153,4 +152,4 @@ def test_get_formatted_locations_basic_auth():
     finder = PackageFinder([], index_urls, session=[])
 
     result = finder.get_formatted_locations()
-    assert 'user' not in result and 'pass' not in result
+    assert 'user' in result and 'pass' not in result

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -649,6 +649,8 @@ def test_remove_auth_from_url(auth_url, expected_url):
 
 
 @pytest.mark.parametrize('auth_url, expected_url', [
+    ('http://domain.tld:8080/',
+     'http://domain.tld:8080/',),
     ('http://user@domain.tld:8080/',
      'http://user@domain.tld:8080/',),
     ('https://domain.tld/project/tags/v0.2',
@@ -665,6 +667,10 @@ def test_remove_auth_from_url(auth_url, expected_url):
      'https://user:****@domain.tld/',),
     ('https://us%3Aer:pass@domain.tld/',
      'https://us%3Aer:****@domain.tld/',),
+    ('https://user:pass@word@domain.tld/',
+     'https://user:****@domain.tld/',),
+    ('https://user:@domain.tld/',
+     'https://user:****@domain.tld/',),
     ('git+https://pypi.org/something',
      'git+https://pypi.org/something'),
     ('git+ssh://git@pypi.org/something',

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -628,20 +628,20 @@ def test_call_subprocess_closes_stdin():
 
 
 @pytest.mark.parametrize('auth_url, expected_url', [
-    ('https://user:pass@domain.tld/project/tags/v0.2',
-     'https://domain.tld/project/tags/v0.2'),
     ('https://domain.tld/project/tags/v0.2',
      'https://domain.tld/project/tags/v0.2',),
-    ('https://user:pass@domain.tld/svn/project/trunk@8181',
-     'https://domain.tld/svn/project/trunk@8181'),
     ('https://domain.tld/project/trunk@8181',
      'https://domain.tld/project/trunk@8181',),
+    ('https://user:pass@domain.tld/project/tags/v0.2',
+     'https://domain.tld/project/tags/v0.2'),
+    ('https://user:pass@domain.tld/svn/project/trunk@8181',
+     'https://domain.tld/svn/project/trunk@8181'),
     ('git+https://pypi.org/something',
-     'git+https://pypi.org/something'),
-    ('git+https://user:pass@pypi.org/something',
      'git+https://pypi.org/something'),
     ('git+ssh://git@pypi.org/something',
      'git+ssh://pypi.org/something'),
+    ('git+https://user:pass@pypi.org/something',
+     'git+https://pypi.org/something'),
 ])
 def test_remove_auth_from_url(auth_url, expected_url):
     url = remove_auth_from_url(auth_url)
@@ -649,22 +649,28 @@ def test_remove_auth_from_url(auth_url, expected_url):
 
 
 @pytest.mark.parametrize('auth_url, expected_url', [
-    ('https://user:pass@domain.tld/project/tags/v0.2',
-     'https://user:****@domain.tld/project/tags/v0.2'),
-    ('https://domain.tld/project/tags/v0.2',
-     'https://domain.tld/project/tags/v0.2',),
-    ('https://user:pass@domain.tld/svn/project/trunk@8181',
-     'https://user:****@domain.tld/svn/project/trunk@8181'),
-    ('https://domain.tld/project/trunk@8181',
-     'https://domain.tld/project/trunk@8181',),
     ('http://user@domain.tld:8080/',
      'http://user@domain.tld:8080/',),
+    ('https://domain.tld/project/tags/v0.2',
+     'https://domain.tld/project/tags/v0.2',),
+    ('https://domain.tld/project/trunk@8181',
+     'https://domain.tld/project/trunk@8181',),
+    ('https://user:pass@domain.tld/project/tags/v0.2',
+     'https://user:****@domain.tld/project/tags/v0.2'),
+    ('https://user:pass@domain.tld/svn/project/trunk@8181',
+     'https://user:****@domain.tld/svn/project/trunk@8181'),
+    ('https://user:pass:word@domain.tld/',
+     'https://user:****@domain.tld/',),
+    ('https://user:pass%3Aword@domain.tld/',
+     'https://user:****@domain.tld/',),
+    ('https://us%3Aer:pass@domain.tld/',
+     'https://us%3Aer:****@domain.tld/',),
     ('git+https://pypi.org/something',
      'git+https://pypi.org/something'),
-    ('git+https://user:pass@pypi.org/something',
-     'git+https://user:****@pypi.org/something'),
     ('git+ssh://git@pypi.org/something',
      'git+ssh://git@pypi.org/something'),
+    ('git+https://user:pass@pypi.org/something',
+     'git+https://user:****@pypi.org/something'),
 ])
 def test_redact_password_from_url(auth_url, expected_url):
     url = redact_password_from_url(auth_url)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -657,7 +657,7 @@ def test_remove_auth_from_url(auth_url, expected_url):
      'https://user:****@domain.tld/svn/project/trunk@8181'),
     ('https://domain.tld/project/trunk@8181',
      'https://domain.tld/project/trunk@8181',),
-     ('http://user@domain.tld:8080/',
+    ('http://user@domain.tld:8080/',
      'http://user@domain.tld:8080/',),
     ('git+https://pypi.org/something',
      'git+https://pypi.org/something'),

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -24,8 +24,8 @@ from pip._internal.utils.glibc import check_glibc_version
 from pip._internal.utils.hashes import Hashes, MissingHashes
 from pip._internal.utils.misc import (
     call_subprocess, egg_link_path, ensure_dir, get_installed_distributions,
-    get_prog, normalize_path, remove_auth_from_url, rmtree, untar_file,
-    unzip_file,
+    get_prog, normalize_path, redact_auth_from_url, remove_auth_from_url,
+    rmtree, untar_file, unzip_file,
 )
 from pip._internal.utils.packaging import check_dist_requires_python
 from pip._internal.utils.temp_dir import TempDirectory
@@ -645,4 +645,25 @@ def test_call_subprocess_closes_stdin():
 ])
 def test_remove_auth_from_url(auth_url, expected_url):
     url = remove_auth_from_url(auth_url)
+    assert url == expected_url
+
+
+@pytest.mark.parametrize('auth_url, expected_url', [
+    ('https://user:pass@domain.tld/project/tags/v0.2',
+     'https://<redacted>@domain.tld/project/tags/v0.2'),
+    ('https://domain.tld/project/tags/v0.2',
+     'https://domain.tld/project/tags/v0.2',),
+    ('https://user:pass@domain.tld/svn/project/trunk@8181',
+     'https://<redacted>@domain.tld/svn/project/trunk@8181'),
+    ('https://domain.tld/project/trunk@8181',
+     'https://domain.tld/project/trunk@8181',),
+    ('git+https://pypi.org/something',
+     'git+https://pypi.org/something'),
+    ('git+https://user:pass@pypi.org/something',
+     'git+https://<redacted>@pypi.org/something'),
+    ('git+ssh://git@pypi.org/something',
+     'git+ssh://<redacted>@pypi.org/something'),
+])
+def test_redact_auth_from_url(auth_url, expected_url):
+    url = redact_auth_from_url(auth_url)
     assert url == expected_url

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -24,7 +24,7 @@ from pip._internal.utils.glibc import check_glibc_version
 from pip._internal.utils.hashes import Hashes, MissingHashes
 from pip._internal.utils.misc import (
     call_subprocess, egg_link_path, ensure_dir, get_installed_distributions,
-    get_prog, normalize_path, redact_auth_from_url, remove_auth_from_url,
+    get_prog, normalize_path, redact_password_from_url, remove_auth_from_url,
     rmtree, untar_file, unzip_file,
 )
 from pip._internal.utils.packaging import check_dist_requires_python
@@ -650,20 +650,22 @@ def test_remove_auth_from_url(auth_url, expected_url):
 
 @pytest.mark.parametrize('auth_url, expected_url', [
     ('https://user:pass@domain.tld/project/tags/v0.2',
-     'https://<redacted>@domain.tld/project/tags/v0.2'),
+     'https://user:****@domain.tld/project/tags/v0.2'),
     ('https://domain.tld/project/tags/v0.2',
      'https://domain.tld/project/tags/v0.2',),
     ('https://user:pass@domain.tld/svn/project/trunk@8181',
-     'https://<redacted>@domain.tld/svn/project/trunk@8181'),
+     'https://user:****@domain.tld/svn/project/trunk@8181'),
     ('https://domain.tld/project/trunk@8181',
      'https://domain.tld/project/trunk@8181',),
+     ('http://user@domain.tld:8080/',
+     'http://user@domain.tld:8080/',),
     ('git+https://pypi.org/something',
      'git+https://pypi.org/something'),
     ('git+https://user:pass@pypi.org/something',
-     'git+https://<redacted>@pypi.org/something'),
+     'git+https://user:****@pypi.org/something'),
     ('git+ssh://git@pypi.org/something',
-     'git+ssh://<redacted>@pypi.org/something'),
+     'git+ssh://git@pypi.org/something'),
 ])
-def test_redact_auth_from_url(auth_url, expected_url):
-    url = redact_auth_from_url(auth_url)
+def test_redact_password_from_url(auth_url, expected_url):
+    url = redact_password_from_url(auth_url)
     assert url == expected_url


### PR DESCRIPTION
Redact all authentication information when logging urls of Git-based requirements.

Current behavior:
```
Collecting git+https://username:password@gitlab.com/user/project
  Cloning https://username:password@gitlab.com/user/project to /private/var/folders/rp/7lwtlxfs11g5v1k_9vxph_md2rygl_/T/pip-req-build-04B4B0
Requirement already satisfied (use --upgrade to upgrade): project==0.1.0 from git+https://username:password@gitlab.com/user/project in /usr/local/lib/python2.7/site-packages
```

New behavior:
```
Collecting git+https://username:***@gitlab.com/user/project
  Cloning https://username:***@gitlab.com/user/project to /private/var/folders/rp/7lwtlxfs11g5v1k_9vxph_md2rygl_/T/pip-req-build-04B4B0
Requirement already satisfied (use --upgrade to upgrade): project==0.1.0 from git+https://username:***@gitlab.com/user/project in /usr/local/lib/python2.7/site-packages
```

Fixes #4746 