### PR TITLE
Add support for passing stdin to `call_subprocess()`.

### DIFF
--- a/news/5601.feature
+++ b/news/5601.feature
@@ -1,0 +1,2 @@
+Add support for passing stdin data to ``call_subprocess()`` and
+``VersionControl.run_command()``.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -603,7 +603,8 @@ def unpack_file(filename, location, content_type, link):
 def call_subprocess(cmd, show_stdout=True, cwd=None,
                     on_returncode='raise',
                     command_desc=None,
-                    extra_environ=None, unset_environ=None, spinner=None):
+                    extra_environ=None, unset_environ=None, spinner=None,
+                    stdin=None):
     """
     Args:
       unset_environ: an iterable of environment variable names to unset
@@ -654,6 +655,8 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
             cmd, stderr=subprocess.STDOUT, stdin=subprocess.PIPE,
             stdout=stdout, cwd=cwd, env=env,
         )
+        if stdin:
+            proc.stdin.write(stdin)
         proc.stdin.close()
     except Exception as exc:
         logger.critical(

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -435,7 +435,7 @@ class VersionControl(object):
     def run_command(self, cmd, show_stdout=True, cwd=None,
                     on_returncode='raise',
                     command_desc=None,
-                    extra_environ=None, spinner=None):
+                    extra_environ=None, spinner=None, stdin=None):
         """
         Run a VCS subcommand
         This is simply a wrapper around call_subprocess that adds the VCS
@@ -447,7 +447,7 @@ class VersionControl(object):
                                    on_returncode,
                                    command_desc, extra_environ,
                                    unset_environ=self.unset_environ,
-                                   spinner=spinner)
+                                   spinner=spinner, stdin=stdin)
         except OSError as e:
             # errno.ENOENT = no such file or directory
             # In other words, the VCS executable isn't available


### PR DESCRIPTION
This code was originally part of #4857.

Until a public VCS API is available I'm planning to write a hacky wrapper around `pip` that injects perforce support. I believe this change will still be useful even after the API is completed. Supplying a perforce client specification to `p4 client` sadly requires stdin to be supplied.