### PR TITLE
Break out VersionControl.is_repository_directory().

### DIFF
--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -200,14 +200,6 @@ class VersionControl(object):
         drive, tail = os.path.splitdrive(repo)
         return repo.startswith(os.path.sep) or drive
 
-    def is_repository_directory(self, path):
-        """
-        Return whether a directory path is a repository directory.
-        """
-        logger.debug('Checking in %s for %s (%s)...',
-                     path, self.dirname, self.name)
-        return os.path.exists(os.path.join(path, self.dirname))
-
     # See issue #1083 for why this method was introduced:
     # https://github.com/pypa/pip/issues/1083
     def translate_egg_surname(self, surname):
@@ -468,14 +460,25 @@ class VersionControl(object):
                 raise  # re-raise exception if a different error occurred
 
     @classmethod
+    def is_repository_directory(cls, path):
+        """
+        Return whether a directory path is a repository directory.
+        """
+        logger.debug('Checking in %s for %s (%s)...',
+                     path, cls.dirname, cls.name)
+        return os.path.exists(os.path.join(path, cls.dirname))
+
+    @classmethod
     def controls_location(cls, location):
         """
         Check if a location is controlled by the vcs.
         It is meant to be overridden to implement smarter detection
         mechanisms for specific vcs.
+
+        This can do more than is_repository_directory() alone.  For example,
+        the Git override checks that Git is actually available.
         """
-        vcs = cls()
-        return vcs.is_repository_directory(location)
+        return cls.is_repository_directory(location)
 
 
 def get_src_requirement(dist, location):

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -204,6 +204,8 @@ class VersionControl(object):
         """
         Return whether a directory path is a repository directory.
         """
+        logger.debug('Checking in %s for %s (%s)...',
+                     path, self.dirname, self.name)
         return os.path.exists(os.path.join(path, self.dirname))
 
     # See issue #1083 for why this method was introduced:
@@ -472,10 +474,8 @@ class VersionControl(object):
         It is meant to be overridden to implement smarter detection
         mechanisms for specific vcs.
         """
-        logger.debug('Checking in %s for %s (%s)...',
-                     location, cls.dirname, cls.name)
-        path = os.path.join(location, cls.dirname)
-        return os.path.exists(path)
+        vcs = cls()
+        return vcs.is_repository_directory(location)
 
 
 def get_src_requirement(dist, location):

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -200,6 +200,12 @@ class VersionControl(object):
         drive, tail = os.path.splitdrive(repo)
         return repo.startswith(os.path.sep) or drive
 
+    def is_repository_directory(self, path):
+        """
+        Return whether a directory path is a repository directory.
+        """
+        return os.path.exists(os.path.join(path, self.dirname))
+
     # See issue #1083 for why this method was introduced:
     # https://github.com/pypa/pip/issues/1083
     def translate_egg_surname(self, surname):
@@ -325,7 +331,7 @@ class VersionControl(object):
             return
 
         rev_display = rev_options.to_display()
-        if os.path.exists(os.path.join(dest, self.dirname)):
+        if self.is_repository_directory(dest):
             existing_url = self.get_url(dest)
             if self.compare_urls(existing_url, url):
                 logger.debug(


### PR DESCRIPTION
This PR turns one line of `VersionControl.obtain()` into its own method (and gives it a name) because it does something meaningful and self-contained.