### PR TITLE
Fix #5624: installing a Git ref for installs other than the first

### DIFF
--- a/news/5624.bugfix
+++ b/news/5624.bugfix
@@ -1,1 +1,1 @@
-Fix installing a Git ref for installs after the first.
+Allow a Git ref to be installed over an existing installation.

--- a/news/5624.bugfix
+++ b/news/5624.bugfix
@@ -1,0 +1,1 @@
+Fix installing a Git ref for installs after the first.

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -295,7 +295,7 @@ class VersionControl(object):
         """
         raise NotImplementedError
 
-    def update(self, dest, rev_options):
+    def update(self, dest, url, rev_options):
         """
         Update an already-existing repo to the given ``rev_options``.
 
@@ -345,7 +345,7 @@ class VersionControl(object):
                         self.repo_name,
                         rev_display,
                     )
-                    self.update(dest, rev_options)
+                    self.update(dest, url, rev_options)
                 else:
                     logger.info('Skipping because already up-to-date.')
                 return

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -62,7 +62,7 @@ class Bazaar(VersionControl):
     def switch(self, dest, url, rev_options):
         self.run_command(['switch', url], cwd=dest)
 
-    def update(self, dest, rev_options):
+    def update(self, dest, url, rev_options):
         cmd_args = ['pull', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -59,7 +59,7 @@ class Mercurial(VersionControl):
             cmd_args = ['update', '-q'] + rev_options.to_args()
             self.run_command(cmd_args, cwd=dest)
 
-    def update(self, dest, rev_options):
+    def update(self, dest, url, rev_options):
         self.run_command(['pull', '-q'], cwd=dest)
         cmd_args = ['update', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -57,7 +57,7 @@ class Subversion(VersionControl):
         cmd_args = ['switch'] + rev_options.to_args() + [url, dest]
         self.run_command(cmd_args)
 
-    def update(self, dest, rev_options):
+    def update(self, dest, url, rev_options):
         cmd_args = ['update'] + rev_options.to_args() + [dest]
         self.run_command(cmd_args)
 

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -108,37 +108,40 @@ def test_git_get_src_requirements(git, dist):
 
 
 @patch('pip._internal.vcs.git.Git.get_revision_sha')
-def test_git_check_rev_options_ref_exists(get_sha_mock):
+def test_git_resolve_revision_rev_exists(get_sha_mock):
     get_sha_mock.return_value = '123456'
     git = Git()
     rev_options = git.make_rev_options('develop')
 
-    new_options = git.check_rev_options('.', rev_options)
+    url = 'git+https://git.example.com'
+    new_options = git.resolve_revision('.', url, rev_options)
     assert new_options.rev == '123456'
 
 
 @patch('pip._internal.vcs.git.Git.get_revision_sha')
-def test_git_check_rev_options_ref_not_found(get_sha_mock):
+def test_git_resolve_revision_rev_not_found(get_sha_mock):
     get_sha_mock.return_value = None
     git = Git()
     rev_options = git.make_rev_options('develop')
 
-    new_options = git.check_rev_options('.', rev_options)
+    url = 'git+https://git.example.com'
+    new_options = git.resolve_revision('.', url, rev_options)
     assert new_options.rev == 'develop'
 
 
 @patch('pip._internal.vcs.git.Git.get_revision_sha')
-def test_git_check_rev_options_not_found_warning(get_sha_mock, caplog):
+def test_git_resolve_revision_not_found_warning(get_sha_mock, caplog):
     get_sha_mock.return_value = None
     git = Git()
 
+    url = 'git+https://git.example.com'
     sha = 40 * 'a'
     rev_options = git.make_rev_options(sha)
-    new_options = git.check_rev_options('.', rev_options)
+    new_options = git.resolve_revision('.', url, rev_options)
     assert new_options.rev == sha
 
     rev_options = git.make_rev_options(sha[:6])
-    new_options = git.check_rev_options('.', rev_options)
+    new_options = git.resolve_revision('.', url, rev_options)
     assert new_options.rev == 'aaaaaa'
 
     # Check that a warning got logged only for the abbreviated hash.


### PR DESCRIPTION
This gets installing a Git "ref" working for pip installs other than the first.

This change also has some independent benefits. For example, it simplifies the implementation of `Git.fetch_new()` by pulling some of the code out into a new (renamed) method called `Git.resolve_revision()` -- responsible for resolving all types of revision names (branch, tags, and refs, etc). Because this method is also called in `Git.update()` (just like `Git.fetch_new()`), it fixes the issue.