### PR TITLE
user_guide: Fix "Requirements Files" reference

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -49,8 +49,6 @@ For more information and examples, see the :ref:`pip install` reference.
 .. _PyPI: https://pypi.org/
 
 
-.. _`Requirements Files`:
-
 Using a Proxy Server
 ********************
 
@@ -64,6 +62,9 @@ pip can be configured to connect through a proxy server in various ways:
 * using ``proxy`` in a :ref:`config-file`
 * by setting the standard environment-variables ``http_proxy``, ``https_proxy``
   and ``no_proxy``.
+
+
+.. _`Requirements Files`:
 
 Requirements Files
 ******************

--- a/news/user_guide_fix_requirements_file_ref.doc
+++ b/news/user_guide_fix_requirements_file_ref.doc
@@ -1,0 +1,1 @@
+Fix "Requirements Files" reference in User Guide


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->