### PR TITLE
Implement check for doc-only PRs on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,10 +28,37 @@ cache:
   - '%LOCALAPPDATA%\pip\Cache'
 
 test_script:
-  # Shorten paths, workaround https://bugs.python.org/issue18199
-  - "subst T: %TEMP%"
-  - "set TEMP=T:\\"
-  - "set TMP=T:\\"
-  - "tox -e py -- -m unit -n 3"
-  - "if \"%RUN_INTEGRATION_TESTS%\" == \"True\" (
-    tox -e py -- -m integration -n 3 --duration=5 )"
+    - ps: |
+        function should_run_tests {
+            if ("$env:APPVEYOR_PULL_REQUEST_NUMBER" -eq "") {
+                Write-Host "Not a pull request - running tests"
+                return $true
+            }
+            Write-Host "Pull request $env:APPVEYOR_PULL_REQUEST_NUMBER based on branch $env:APPVEYOR_REPO_BRANCH"
+            git fetch -q origin +refs/heads/$env:APPVEYOR_REPO_BRANCH
+            $changes = (git diff --name-only HEAD (git merge-base HEAD FETCH_HEAD))
+            Write-Host "Files changed:"
+            Write-Host $changes
+            $important = $changes | Where-Object { $_ -NotLike "*.rst" } |
+                                    Where-Object { $_ -NotLike "docs*" } |
+                                    Where-Object { $_ -NotLike "news*" } |
+                                    Where-Object { $_ -NotLike ".github*" }
+            if (!$important) {
+                Write-Host "Only documentation changes - skipping tests"
+                return $false
+            }
+
+            Write-Host "Pull request $env:APPVEYOR_PULL_REQUEST_NUMBER alters code - running tests"
+            return $true
+        }
+
+        if (should_run_tests) {
+            # Shorten paths, workaround https://bugs.python.org/issue18199
+            subst T: $env:TEMP
+            $env:TEMP = "T:\"
+            $env:TMP = "T:\"
+            tox -e py -- -m unit -n 3
+            if ($env:RUN_INTEGRATION_TESTS -eq "True") {
+                tox -e py -- -m integration -n 3 --duration=5
+            }
+        }


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/#adding-a-news-entry
-->
