### PR TITLE
Fix the "+" check in VersionControl.get_url_rev_and_auth()

### DIFF
--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -228,14 +228,15 @@ class VersionControl(object):
 
         Returns: (url, rev, (username, password)).
         """
-        error_message = (
-            "Sorry, '%s' is a malformed VCS url. "
-            "The format is <vcs>+<protocol>://<url>, "
-            "e.g. svn+http://myrepo/svn/MyApp#egg=MyApp"
-        )
-        assert '+' in url, error_message % url
-        url = url.split('+', 1)[1]
         scheme, netloc, path, query, frag = urllib_parse.urlsplit(url)
+        if '+' not in scheme:
+            raise AssertionError(
+                "Sorry, '{}' is a malformed VCS url. "
+                "The format is <vcs>+<protocol>://<url>, "
+                "e.g. svn+http://myrepo/svn/MyApp#egg=MyApp".format(url)
+            )
+        # Remove the vcs prefix.
+        scheme = scheme.split('+', 1)[1]
         netloc, user_pass = self.get_netloc_and_auth(netloc)
         rev = None
         if '@' in path:

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -231,7 +231,7 @@ class VersionControl(object):
         scheme, netloc, path, query, frag = urllib_parse.urlsplit(url)
         if '+' not in scheme:
             raise ValueError(
-                "Sorry, '{}' is a malformed VCS url. "
+                "Sorry, {!r} is a malformed VCS url. "
                 "The format is <vcs>+<protocol>://<url>, "
                 "e.g. svn+http://myrepo/svn/MyApp#egg=MyApp".format(url)
             )

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -230,7 +230,7 @@ class VersionControl(object):
         """
         scheme, netloc, path, query, frag = urllib_parse.urlsplit(url)
         if '+' not in scheme:
-            raise AssertionError(
+            raise ValueError(
                 "Sorry, '{}' is a malformed VCS url. "
                 "The format is <vcs>+<protocol>://<url>, "
                 "e.g. svn+http://myrepo/svn/MyApp#egg=MyApp".format(url)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -200,7 +200,7 @@ def test_version_control__get_url_rev_and_auth__missing_plus(url):
     Test passing a URL to VersionControl.get_url_rev_and_auth() with a "+"
     missing from the scheme.
     """
-    with pytest.raises(AssertionError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         VersionControl().get_url_rev_and_auth(url)
 
     assert 'malformed VCS url' in str(excinfo.value)


### PR DESCRIPTION
I noticed that the check for a "+" symbol inside `VersionControl.get_url_rev_and_auth()` is being done improperly:
https://github.com/pypa/pip/blob/dc71dc5fbe552328316f8444ce7d82c65bc2191d/src/pip/_internal/vcs/__init__.py#L231-L238

It should be checking for the symbol in the scheme, but it's checking for the symbol anywhere in the URL. This can result in false negatives (e.g. URL's missing a plus symbol in the scheme but containing one in the path).

I added tests, including a failing test for the test case I just described.