### PR TITLE
Add split_auth_from_netloc() to misc.py

### DIFF
--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -145,10 +145,6 @@ def test_git__get_netloc_and_auth(netloc, expected):
     ('user@example.com', ('example.com', ('user', None))),
     # Test with username and password.
     ('user:pass@example.com', ('example.com', ('user', 'pass'))),
-    # Test the password containing an @ symbol.
-    ('user:pass@word@example.com', ('example.com', ('user', 'pass@word'))),
-    # Test the password containing a : symbol.
-    ('user:pass:word@example.com', ('example.com', ('user', 'pass:word'))),
 ])
 def test_subversion__get_netloc_and_auth(netloc, expected):
     """


### PR DESCRIPTION
This PR moves the implementation of `Subversion.get_netloc_and_auth()` to `misc.py`. A couple of benefits of this are--

1. It lets us ensure that `remove_auth_from_url()` and `Subversion.get_netloc_and_auth()` both use the same logic for splitting the auth information from the netloc (in particular splitting along the rightmost "@"), and it lets us centralize the tests.

2. This also sets up PR #5590 to be implemented with less code duplication, since some of the needed logic is already implemented by `Subversion.get_netloc_and_auth()`.
