### PR TITLE
Give specific error on connnection failure

### DIFF
--- a/news/5663.bugfix
+++ b/news/5663.bugfix
@@ -1,0 +1,1 @@
+Give a specific error message if pip cannot connect with the server.

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -394,7 +394,8 @@ class PipSession(requests.Session):
 
         # Dispatch the actual request
         try:
-            return super(PipSession, self).request(method, url, *args, **kwargs)
+            return super(PipSession, self).request(
+                method, url, *args, **kwargs)
         except requests.exceptions.ConnectionError:
             raise InstallationError(
                 'Could not connect to the server, '

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -393,7 +393,12 @@ class PipSession(requests.Session):
         kwargs.setdefault("timeout", self.timeout)
 
         # Dispatch the actual request
-        return super(PipSession, self).request(method, url, *args, **kwargs)
+        try:
+            return super(PipSession, self).request(method, url, *args, **kwargs)
+        except requests.exceptions.ConnectionError:
+            raise InstallationError(
+                'Could not connect to the server, '
+                'do you have a internet connection?')
 
 
 def get_file_content(url, comes_from=None, session=None):


### PR DESCRIPTION
Pip gives a generic error message at the moment, if it is unable to connect to the internet. This same error message is given if pip tries to download a package which does not exist. This commit gives a specific error message if pip is unable to connect to the server, to make clear what the error is.