### PR TITLE
Make the ascii progress bar really be ascii, not Unicode

### DIFF
--- a/news/5671.bugfix
+++ b/news/5671.bugfix
@@ -1,0 +1,1 @@
+Make the "ascii" progress bar really be "ascii" and not Unicode.

--- a/src/pip/_internal/utils/ui.py
+++ b/src/pip/_internal/utils/ui.py
@@ -211,8 +211,8 @@ class DownloadSilentBar(BaseDownloadProgressBar, SilentBar):  # type: ignore
     pass
 
 
-class DownloadIncrementalBar(BaseDownloadProgressBar,  # type: ignore
-                             IncrementalBar):
+class DownloadBar(BaseDownloadProgressBar,  # type: ignore
+                  Bar):
     pass
 
 
@@ -269,7 +269,7 @@ class DownloadProgressSpinner(WindowsMixin, InterruptibleMixin,
 BAR_TYPES = {
     "off": (DownloadSilentBar, DownloadSilentBar),
     "on": (DefaultDownloadProgressBar, DownloadProgressSpinner),
-    "ascii": (DownloadIncrementalBar, DownloadProgressSpinner),
+    "ascii": (DownloadBar, DownloadProgressSpinner),
     "pretty": (DownloadFillingCirclesBar, DownloadProgressSpinner),
     "emoji": (DownloadBlueEmojiProgressBar, DownloadProgressSpinner)
 }


### PR DESCRIPTION
Found while debugging #5665 (*Not* a fix for that issue)

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#adding-a-news-entry
-->
