### PR TITLE
Don't install development tree for non-test tox jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ basepython = python3
 commands = pytest --timeout 300 --cov=pip --cov-report=term-missing --cov-report=xml --cov-report=html tests/unit {posargs}
 
 [testenv:docs]
+# Don't skip install here since docs.pipext uses pip's internals.
 deps = -r{toxinidir}/tools/docs-requirements.txt
 basepython = python2.7
 commands =
@@ -26,6 +27,7 @@ commands =
     sphinx-build -W -d {envtmpdir}/doctrees -b man  docs docs/build/man
 
 [testenv:packaging]
+skip_install = True
 deps =
     check-manifest
     readme_renderer
@@ -40,16 +42,19 @@ commands =
     isort --check-only --diff
 
 [testenv:lint-py2]
+skip_install = True
 basepython = python2
 deps = {[lint]deps}
 commands = {[lint]commands}
 
 [testenv:lint-py3]
+skip_install = True
 basepython = python3
 deps = {[lint]deps}
 commands = {[lint]commands}
 
 [testenv:mypy]
+skip_install = True
 basepython = python3
 deps = mypy
 commands =


### PR DESCRIPTION
This allows for linting jobs to directly proceed to installation of lint
tools and ensures that the pip version installed in those environments
isn't broken even when the local tree might be broken.
