### PR TITLE
Fix the pip version check when using --no-cache-dir

### DIFF
--- a/news/5679.bugfix
+++ b/news/5679.bugfix
@@ -1,0 +1,1 @@
+The pip version check will now work correctly when using ``--no-cache-dir``.

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 
 class SelfCheckState(object):
     def __init__(self, cache_dir):
+        # cache_dir might be unset (e.g. False)
+        if not cache_dir:
+            self.statefile_path = None
+            self.state = {}
+            return
+
         self.statefile_path = os.path.join(cache_dir, "selfcheck.json")
 
         # Load the existing state
@@ -32,6 +38,9 @@ class SelfCheckState(object):
             self.state = {}
 
     def save(self, pypi_version, current_time):
+        if self.statefile_path is None:
+            return
+
         # Check to make sure that we own the directory
         if not check_path_owner(os.path.dirname(self.statefile_path)):
             return

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -169,3 +169,8 @@ def test_self_check_state(monkeypatch, tmpdir):
 
     # json.dumps will call this a number of times
     assert len(fake_file.write.calls)
+
+
+def test_self_check_state_no_cache_dir():
+    state = outdated.SelfCheckState(cache_dir=False)
+    assert state.state == {}


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#adding-a-news-entry
-->
The pip version check will now work correctly when using ``--no-cache-dir``.

Fixes #5679