### PR TITLE
Internal refactoring for PEP 517

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -95,7 +95,7 @@ class IsSDist(DistAbstraction):
     def prep_for_dist(self, finder, build_isolation):
         # Before calling "setup.py egg_info", we need to set-up the build
         # environment.
-        build_requirements = self.req.get_pep_518_info()
+        build_requirements = self.req.pyproject_requires
         should_isolate = build_isolation and build_requirements is not None
 
         if should_isolate:

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -96,7 +96,7 @@ class IsSDist(DistAbstraction):
         # Before calling "setup.py egg_info", we need to set-up the build
         # environment.
         build_requirements = self.req.pyproject_requires
-        should_isolate = build_isolation and build_requirements is not None
+        should_isolate = self.req.use_pep517 and build_isolation
 
         if should_isolate:
             # Haven't implemented PEP 517 yet, so spew a warning about it if

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -605,11 +605,17 @@ class InstallRequirement(object):
         # means the user explicitly requested --no-use-pep517
         if (has_pyproject and not has_setup):
             if self.use_pep517 is False:
-                raise Exception("No setup.py")
+                raise InstallationError(
+                    "Disabling PEP 517 processing is invalid: "
+                    "project does not have a setup.py"
+                )
             self.use_pep517 = True
         if (build_system and "build-backend" in build_system):
             if self.use_pep517 is False:
-                raise Exception("Project specifies build backend")
+                raise InstallationError(
+                    "Disabling PEP 517 processing is invalid: "
+                    "project specifies a build-backend in pyproject.toml"
+                )
             self.use_pep517 = True
 
         # Choose whether to use PEP 517 if the user didn't say
@@ -619,7 +625,7 @@ class InstallRequirement(object):
             else:
                 self.use_pep517 = False
 
-        if not build_system:
+        if build_system is None:
             if self.use_pep517:
                 build_system = {
                     "requires": ["setuptools>=38.2.5", "wheel"],
@@ -656,7 +662,7 @@ class InstallRequirement(object):
                 reason="'build-system.requires' is not a list of strings.",
             ))
 
-        self._pyproject_requires = build_system["requires"]
+        self._pyproject_requires = requires
         self._pyproject_backend = build_system.get("build-backend")
 
     @property

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -220,8 +220,8 @@ class InstallRequirement(object):
             if looks_like_dir:
                 if not is_installable_dir(p):
                     raise InstallationError(
-                        "Directory %r is not installable. File 'setup.py' "
-                        "not found." % name
+                        "Directory %r is not installable. Neither 'setup.py' "
+                        "nor 'pyproject.toml' found." % name
                     )
                 link = Link(path_to_url(p))
             elif is_archive_file(p):

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -614,7 +614,10 @@ class InstallRequirement(object):
             if self.use_pep517 is False:
                 raise InstallationError(
                     "Disabling PEP 517 processing is invalid: "
-                    "project specifies a build-backend in pyproject.toml"
+                    "project specifies a build backend of {} "
+                    "in pyproject.toml".format(
+                        build_system["build-backend"]
+                    )
                 )
             self.use_pep517 = True
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -574,8 +574,8 @@ class InstallRequirement(object):
         """Load pyproject.toml.
 
         We cache the loaded data, so we only load and parse the file once.
-        Also, we extract the two values we care about (requires and build-backend)
-        and discard the rest.
+        Also, we extract the two values we care about (requires and
+        build-backend) and discard the rest.
         """
         if self._pyproject_toml_loaded:
             return

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -136,10 +136,10 @@ class InstallRequirement(object):
         self._pyproject_backend = None
 
         # Are we using PEP 517 for this requirement?
-        # This can be None until load_pyproject_toml has been called,
-        # after which it will have an explicit value.
-        # TODO: Maybe make this a property, but if we do we'll need
-        # to set the backing value based on the --use-pep517 flag.
+        # After pyproject.toml has been loaded, the only valid values are True
+        # and False. Before loading, None is valid (meaning "use the default").
+        # Setting an explicit value before loading pyproject.toml is supported,
+        # but after loading this flag should be treated as read only.
         self.use_pep517 = None
 
     # Constructors

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -187,11 +187,14 @@ def format_size(bytes):
 
 
 def is_installable_dir(path):
-    """Return True if `path` is a directory containing a setup.py file."""
+    """Return True if `path` is a directory containing a setup.py or pyproject.toml file."""
     if not os.path.isdir(path):
         return False
     setup_py = os.path.join(path, 'setup.py')
     if os.path.isfile(setup_py):
+        return True
+    pyproject_toml = os.path.join(path, 'pyproject.toml')
+    if os.path.isfile(pyproject_toml):
         return True
     return False
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -187,7 +187,8 @@ def format_size(bytes):
 
 
 def is_installable_dir(path):
-    """Return True if `path` is a directory containing a setup.py or pyproject.toml file."""
+    """Is path is a directory containing setup.py or pyproject.toml?
+    """
     if not os.path.isdir(path):
         return False
     setup_py = os.path.join(path, 'setup.py')

--- a/tests/data/src/pep517_pyproject_only/pyproject.toml
+++ b/tests/data/src/pep517_pyproject_only/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["foo"]
+build-backend = "foo"

--- a/tests/data/src/pep517_setup_and_pyproject/pyproject.toml
+++ b/tests/data/src/pep517_setup_and_pyproject/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["foo"]
+build-backend = "foo"

--- a/tests/data/src/pep517_setup_and_pyproject/setup.py
+++ b/tests/data/src/pep517_setup_and_pyproject/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup(name="dummy", version="0.1")

--- a/tests/data/src/pep517_setup_only/setup.py
+++ b/tests/data/src/pep517_setup_only/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup(name="dummy", version="0.1")

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -442,7 +442,8 @@ def test_install_from_local_directory_with_no_setup_py(script, data):
     """
     result = script.pip('install', data.root, expect_error=True)
     assert not result.files_created
-    assert "is not installable. File 'setup.py' not found." in result.stderr
+    assert "is not installable." in result.stderr
+    assert "Neither 'setup.py' nor 'pyproject.toml' found." in result.stderr
 
 
 def test_editable_install_from_local_directory_with_no_setup_py(script, data):

--- a/tests/unit/test_pep517.py
+++ b/tests/unit/test_pep517.py
@@ -1,0 +1,41 @@
+import pytest
+
+from pip._internal.exceptions import InstallationError
+from pip._internal.req import InstallRequirement
+
+
+@pytest.mark.parametrize(('source', 'expected'), [
+    ("pep517_setup_and_pyproject", True),
+    ("pep517_setup_only", False),
+    ("pep517_pyproject_only", True),
+])
+def test_use_pep517(data, source, expected):
+    """
+    Test that we choose correctly between PEP 517 and legacy code paths
+    """
+    src = data.src.join(source)
+    req = InstallRequirement(None, None, source_dir=src)
+    req.load_pyproject_toml()
+    assert req.use_pep517 is expected
+
+
+@pytest.mark.parametrize(('source', 'msg'), [
+    ("pep517_setup_and_pyproject", "specifies a build backend"),
+    ("pep517_pyproject_only", "does not have a setup.py"),
+])
+def test_disabling_pep517_invalid(data, source, msg):
+    """
+    Test that we fail if we try to disable PEP 517 when it's not acceptable
+    """
+    src = data.src.join(source)
+    req = InstallRequirement(None, None, source_dir=src)
+
+    # Simulate --no-use-pep517
+    req.use_pep517 = False
+
+    with pytest.raises(InstallationError) as e:
+        req.load_pyproject_toml()
+
+    err_msg = e.value.args[0]
+    assert "Disabling PEP 517 processing is invalid" in err_msg
+    assert msg in err_msg


### PR DESCRIPTION
This is the initial part of my work on PEP 517. It's basically an internal refactoring of the `pyproject.toml` handling in `InstallRequirement`. There's no user-visible change at this stage.

The main part of the change is to add a `use_pep517` flag to `InstallRequirement`. This captures our view on whether the requirement should use the "legacy" `setup.py` code path or the new PEP 517 code path. At the moment, all this flag is used for is to determine whether we intend to isolate the build by default (the `--no-build-isolation` flag can still override this).

Next phases of the work (in no particular order):

* Add a command line flag `--[no-]use-pep517` to allow the user to control the setting of the `use_pep517` attribute.
* Vendor the `pep517` wrapper library.
* Refactor to isolate the places where we currently assume we're using `setup.py`.
* Use PEP 517 hooks to add dynamic dependencies to the build environment.
* Actually call the PEP 517 backend to build wheels.

I want to get this first set of changes into master so they are out of the way. The test suite is passing on them, so I think that's a good point to bundle them up. I'd really rather not end up with a huge interlinked PR that's hard to review, so I plan on making things into smaller chunks as much as I can (even if that means that some of the PRs don't add much on their own).

I've marked this PR as trivial, as it's an internal refactoring, but I'm happy to add a news fragment if it's deemed necessary.

Reviews and comments are welcome - there's a lot of internal complexity in the `InstallRequirement` class, and I'm sure I'll have missed something (hopefully not in this PR, but definitely in future ones).