### PR TITLE
Mention package manager.

### DIFF
--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -135,7 +135,7 @@ def pip_version_check(session, options):
             logger.warning(
                 "You are using pip version %s, however version %s is "
                 "available.\nYou should consider upgrading via the "
-                "'%s install --upgrade pip' command.",
+                "'%s install --upgrade pip' command or your package manager.",
                 pip_version, pypi_version, pip_cmd
             )
     except Exception:


### PR DESCRIPTION
When an external package manager exists, the current recommendation can be confusing and may even be broken.
This PR mentions the package manager in the recommended action, in the hope of providing some hint when things go bad.

No need for news.