### PR TITLE
Link to issue tracker from NEWS file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ package_dir = "src"
 filename = "NEWS.rst"
 directory = "news/"
 title_format = "{version} ({project_date})"
+issue_format = "`#{issue} <https://github.com/pypa/pip/issues/{issue}>`_"
 template = "news/_template.rst"
 
   [[tool.towncrier.type]]


### PR DESCRIPTION
Uses the newer `issue_format` key from towncrier to enable using links in the NEWS.rst file. For an example of how this looks, you can see [towncrier's own NEWS][1] file.

[1]: https://github.com/hawkowl/towncrier/blob/master/NEWS.rst#towncrier-1860-2018-07-05