### PR TITLE
Fix vendoring import rewriting, when imports are on first line

### DIFF
--- a/src/pip/_vendor/certifi/__main__.py
+++ b/src/pip/_vendor/certifi/__main__.py
@@ -1,2 +1,2 @@
-from certifi import where
+from pip._vendor.certifi import where
 print(where())

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -78,12 +78,12 @@ def rewrite_file_imports(item, vendored_libs):
     text = re.sub(r'pkg_resources.extern', r'pip._vendor', text)
     for lib in vendored_libs:
         text = re.sub(
-            r'(\n\s*)import %s(\n\s*)' % lib,
+            r'(\n\s*|^)import %s(\n\s*)' % lib,
             r'\1from pip._vendor import %s\2' % lib,
             text,
         )
         text = re.sub(
-            r'(\n\s*)from %s(\.|\s+)' % lib,
+            r'(\n\s*|^)from %s(\.|\s+)' % lib,
             r'\1from pip._vendor.%s\2' % lib,
             text,
         )


### PR DESCRIPTION
I'd noticed this while working on zazo integration and this affects a not-imported file in certifi; so I'm going to use that as the reason for making this PR.
