### PR TITLE
Non zero exit code when canceling uninstall

### DIFF
--- a/news/3363.feature
+++ b/news/3363.feature
@@ -1,0 +1,1 @@
+Cancelling an uninstall with "n" answer will cause pip to exit with code 1.

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -44,6 +44,7 @@ class UninstallCommand(Command):
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
+        exit_code = 0  # Assume successful outcome
         with self._build_session(options) as session:
             reqs_to_uninstall = {}
             for name in args:
@@ -70,8 +71,11 @@ class UninstallCommand(Command):
             )
 
             for req in reqs_to_uninstall.values():
-                uninstall_pathset = req.uninstall(
+                uninstall_exit_code, uninstall_pathset = req.uninstall(
                     auto_confirm=options.yes, verbose=self.verbosity > 0,
                 )
                 if uninstall_pathset:
                     uninstall_pathset.commit()
+                if uninstall_exit_code != 0:
+                    exit_code = uninstall_exit_code
+            return exit_code

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -868,8 +868,8 @@ class InstallRequirement(object):
         dist = self.satisfied_by or self.conflicts_with
 
         uninstalled_pathset = UninstallPathSet.from_dist(dist)
-        uninstalled_pathset.remove(auto_confirm, verbose)
-        return uninstalled_pathset
+        exit_code = uninstalled_pathset.remove(auto_confirm, verbose)
+        return exit_code, uninstalled_pathset
 
     def _clean_zip_name(self, name, prefix):  # only used by archive.
         assert name.startswith(prefix + os.path.sep), (

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -224,8 +224,7 @@ class UninstallPathSet(object):
 
                 logger.info('Successfully uninstalled %s', dist_name_version)
                 return 0
-            else:
-                return 1
+            return 1
 
     def _allowed_to_proceed(self, verbose):
         """Display which files would be deleted and prompt for confirmation

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -223,6 +223,9 @@ class UninstallPathSet(object):
                     pth.remove()
 
                 logger.info('Successfully uninstalled %s', dist_name_version)
+                return 0
+            else:
+                return 1
 
     def _allowed_to_proceed(self, verbose):
         """Display which files would be deleted and prompt for confirmation

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -532,7 +532,7 @@ def test_uninstall_ignores_missing_packages_and_uninstalls_rest(script, data):
 def test_uninstall_cancel_exit_code(script):
     script.pip_install_local('simple')
     with pytest.raises(AssertionError, match="Script returned code: 1"):
-        result = script.pip(
+        script.pip(
             'uninstall', 'simple',
             stdin=b'n', quiet=True
         )

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -527,3 +527,12 @@ def test_uninstall_ignores_missing_packages_and_uninstalls_rest(script, data):
     assert "Skipping non-existent-pkg as it is not installed." in result.stderr
     assert "Successfully uninstalled simple" in result.stdout
     assert result.returncode == 0, "Expected clean exit"
+
+
+def test_uninstall_cancel_exit_code(script):
+    script.pip_install_local('simple')
+    with pytest.raises(AssertionError, match="Script returned code: 1"):
+        result = script.pip(
+            'uninstall', 'simple',
+            stdin=b'n', quiet=True
+        )


### PR DESCRIPTION
When cancelling an uninstall pip will exit with exit code 1.

Example Output:
```
<$> pip uninstall six
Uninstalling six-1.11.0:
  Would remove:
    /Users/mark/projects/pip/pip_venv/lib/python3.6/site-packages/six-1.11.0.dist-info/*
    /Users/mark/projects/pip/pip_venv/lib/python3.6/site-packages/six.py
Proceed (y/n)? n
<$> echo $?
1
```

Closes #3363 