### PR TITLE
DRY up test_install_vcs_git.py with _checkout_into_temp()

### DIFF
--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -10,21 +10,24 @@ from tests.lib.git_submodule_helpers import (
 from tests.lib.local_repos import local_checkout
 
 
-def _checkout_into_temp(url, temp_dir, egg=None):
+def _checkout_into_temp(url_info, temp_dir, egg=None):
     """
-    Call local_checkout(), and return the resulting URL.
+    Call local_checkout() with a GitHub URL, and return the resulting URL.
 
     Args:
-      url: a package URL (e.g. a "git+https://" or "git+git://" URL).
+      url_info: a pair of strings (scheme, url_path) to create a package URL
+        by completing the format string "git+{}://github.com/{}".
       temp_dir: the pytest tmpdir value.
       egg: an optional project name to append to the URL as the egg fragment,
         prior to returning.
     """
-    package_url = local_checkout(url, temp_dir.join("cache"))
+    scheme, url_path = url_info
+    url = 'git+{}://github.com/{}'.format(scheme, url_path)
+    local_url = local_checkout(url, temp_dir.join('cache'))
     if egg is not None:
-        package_url += '#egg={}'.format(egg)
+        local_url += '#egg={}'.format(egg)
 
-    return package_url
+    return local_url
 
 
 def _make_version_pkg_url(path, rev=None):
@@ -97,8 +100,8 @@ def test_install_editable_from_git_with_https(script, tmpdir):
     """
     Test cloning from Git with https.
     """
-    url = 'git+https://github.com/pypa/pip-test-package.git'
-    local_url = _checkout_into_temp(url, tmpdir, egg='pip-test-package')
+    url_info = ('https', 'pypa/pip-test-package.git')
+    local_url = _checkout_into_temp(url_info, tmpdir, egg='pip-test-package')
     result = script.pip('install', '-e', local_url, expect_error=True)
     result.assert_installed('pip-test-package', with_files=['.git'])
 
@@ -241,12 +244,12 @@ def test_git_with_tag_name_and_update(script, tmpdir):
     """
     Test cloning a git repository and updating to a different version.
     """
-    url = 'git+https://github.com/pypa/pip-test-package.git'
-    local_url = _checkout_into_temp(url, tmpdir, egg='pip-test-package')
+    url_info = ('https', 'pypa/pip-test-package.git')
+    local_url = _checkout_into_temp(url_info, tmpdir, egg='pip-test-package')
     result = script.pip('install', '-e', local_url, expect_error=True)
     result.assert_installed('pip-test-package', with_files=['.git'])
 
-    new_local_url = _checkout_into_temp(url, tmpdir)
+    new_local_url = _checkout_into_temp(url_info, tmpdir)
     new_local_url += '@0.1.2#egg=pip-test-package'
     result = script.pip(
         'install', '--global-option=--version', '-e', new_local_url,
@@ -261,8 +264,8 @@ def test_git_branch_should_not_be_changed(script, tmpdir):
     Editable installations should not change branch
     related to issue #32 and #161
     """
-    url = 'git+https://github.com/pypa/pip-test-package.git'
-    local_url = _checkout_into_temp(url, tmpdir, egg='pip-test-package')
+    url_info = ('https', 'pypa/pip-test-package.git')
+    local_url = _checkout_into_temp(url_info, tmpdir, egg='pip-test-package')
     script.pip('install', '-e', local_url, expect_error=True)
     source_dir = script.venv_path / 'src' / 'pip-test-package'
     result = script.run('git', 'branch', cwd=source_dir)
@@ -274,11 +277,9 @@ def test_git_with_non_editable_unpacking(script, tmpdir):
     """
     Test cloning a git repository from a non-editable URL with a given tag.
     """
-    url = (
-        'git+https://github.com/pypa/pip-test-package.git@0.1.2'
-        '#egg=pip-test-package'
-    )
-    local_url = _checkout_into_temp(url, tmpdir)
+    url_path = 'pypa/pip-test-package.git@0.1.2#egg=pip-test-package'
+    url_info = ('https', url_path)
+    local_url = _checkout_into_temp(url_info, tmpdir)
     result = script.pip(
         'install', '--global-option=--version', local_url, expect_error=True,
     )
@@ -291,8 +292,8 @@ def test_git_with_editable_where_egg_contains_dev_string(script, tmpdir):
     Test cloning a git repository from an editable url which contains "dev"
     string
     """
-    url = 'git+git://github.com/dcramer/django-devserver.git'
-    local_url = _checkout_into_temp(url, tmpdir, egg='django-devserver')
+    url_info = ('git', 'dcramer/django-devserver.git')
+    local_url = _checkout_into_temp(url_info, tmpdir, egg='django-devserver')
     result = script.pip('install', '-e', local_url)
     result.assert_installed('django-devserver', with_files=['.git'])
 
@@ -303,8 +304,8 @@ def test_git_with_non_editable_where_egg_contains_dev_string(script, tmpdir):
     Test cloning a git repository from a non-editable url which contains "dev"
     string
     """
-    url = 'git+git://github.com/dcramer/django-devserver.git'
-    local_url = _checkout_into_temp(url, tmpdir, egg='django-devserver')
+    url_info = ('git', 'dcramer/django-devserver.git')
+    local_url = _checkout_into_temp(url_info, tmpdir, egg='django-devserver')
     result = script.pip('install', local_url)
     devserver_folder = script.site_packages / 'devserver'
     assert devserver_folder in result.files_created, str(result)


### PR DESCRIPTION
This is a follow-on to PR #5714 to DRY up the calls to `local_checkout()` and the construction of URLs inside `test_install_vcs_git.py`.

The patch adds a function called `_checkout_into_temp()` to reduce more of the copy-paste and make the tests a bit more compact, etc.

