### PR TITLE
Give an error when --wheel-dir isn't writable

### DIFF
--- a/news/5740.bugfix
+++ b/news/5740.bugfix
@@ -1,0 +1,1 @@
+Show an error message when the --wheel-dir directory is not writable.

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -654,7 +654,7 @@ class WheelBuilder(object):
                     logger.info('Stored in directory: %s', output_dir)
                     return wheel_path
                 except Exception:
-                    pass
+                    logger.exception('Error storing in directory: %s', output_dir)
             # Ignore return, we can't do anything else useful.
             self._clean_one(req)
             return None

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -654,7 +654,9 @@ class WheelBuilder(object):
                     logger.info('Stored in directory: %s', output_dir)
                     return wheel_path
                 except Exception:
-                    logger.exception('Error storing in directory: %s', output_dir)
+                    logger.exception(
+                        'Error storing in directory: %s', output_dir
+                    )
             # Ignore return, we can't do anything else useful.
             self._clean_one(req)
             return None


### PR DESCRIPTION
Give an error when --wheel-dir isn't writable.

Fixes #5740.