### PR TITLE
Hide global options for subcommands unless --verbose

### DIFF
--- a/news/4433.feature
+++ b/news/4433.feature
@@ -1,0 +1,2 @@
+Global options are not shown for subcommands unless explicitly requested with
+`--verbose`.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -63,11 +63,11 @@ class Command(object):
         self.cmd_opts = optparse.OptionGroup(self.parser, optgroup_name)
 
         # Add the general options
-        gen_opts = cmdoptions.make_option_group(
+        self.gen_opts = cmdoptions.make_option_group(
             cmdoptions.general_group,
             self.parser,
         )
-        self.parser.add_option_group(gen_opts)
+        self.parser.add_option_group(self.gen_opts)
 
     def _build_session(self, options, retries=None, timeout=None):
         session = PipSession(
@@ -127,6 +127,15 @@ class Command(object):
         )
 
         if options.help:
+            if not options.verbose:
+                # hide General Options
+                self.parser.epilog = "\nAdd '-v' flag to show general "\
+                                     "options.\n"
+                self.parser.option_groups.remove(self.gen_opts)
+
+                # 'pip --help' is handled by pip.__init__.parseopt(),
+                # so it is not affected by absence of --verbose
+
             self.print_help()
             sys.exit(0)
 

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -109,6 +109,11 @@ class Command(object):
         # factored out for testability
         return self.parser.parse_args(args)
 
+    def print_help(self):
+        # factored out for uniform handling
+        # of 'help <command>' and '<command> --help' cases
+        self.parser.print_help()
+
     def main(self, args):
         options, args = self.parse_args(args)
 
@@ -120,6 +125,10 @@ class Command(object):
             no_color=options.no_color,
             user_log_file=options.log,
         )
+
+        if options.help:
+            self.print_help()
+            sys.exit(0)
 
         # TODO: Try to get these passing down from the command?
         #       without resorting to os.environ to hold these.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -122,7 +122,11 @@ class Command(object):
             # remove General Options group and restore after print
             saveepy = self.parser.epilog
             saveogr = self.parser.option_groups  # it is a list
-            self.parser.epilog = "\nAdd '-v' flag to show general "\
+            self.parser.epilog = ""
+            if len(saveogr) > 1:
+                # need newline for commands with own options
+                self.parser.epilog = "\n"
+            self.parser.epilog += "Add '-v' flag to show general "\
                                  "options.\n"
             self.parser.option_groups.remove(self.gen_opts)
             self.parser.print_help()

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -106,7 +106,7 @@ help_ = partial(
     Option,
     '-h', '--help',
     dest='help',
-    action='help',
+    action='store_true',
     help='Show help.',
 )  # type: Any
 

--- a/src/pip/_internal/commands/help.py
+++ b/src/pip/_internal/commands/help.py
@@ -32,6 +32,6 @@ class HelpCommand(Command):
             raise CommandError(' - '.join(msg))
 
         command = commands_dict[cmd_name]()
-        command.print_help()
+        command.print_help(options.verbose)
 
         return SUCCESS

--- a/src/pip/_internal/commands/help.py
+++ b/src/pip/_internal/commands/help.py
@@ -32,6 +32,6 @@ class HelpCommand(Command):
             raise CommandError(' - '.join(msg))
 
         command = commands_dict[cmd_name]()
-        command.parser.print_help()
+        command.print_help()
 
         return SUCCESS


### PR DESCRIPTION
Rebased #4433, which got bitrotten again.

I just rebased it. Need more time to see how can I run `pip` from checkout to test that nothing is broken during rebase. https://pip.pypa.io/en/stable/development/ is pretty silent about that.