### PR TITLE
outdated.py: move SelfCheckState out of catch-all

### DIFF
--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -86,9 +86,8 @@ def pip_version_check(session, options):
     pip_version = packaging_version.parse(installed_version)
     pypi_version = None
 
+    state = SelfCheckState(cache_dir=options.cache_dir)
     try:
-        state = SelfCheckState(cache_dir=options.cache_dir)
-
         current_time = datetime.datetime.utcnow()
         # Determine if we need to refresh the state
         if "last_check" in state.state and "pypi_version" in state.state:


### PR DESCRIPTION
All exceptions are properly handled in SelfCheckState, no need for catch-all.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#adding-a-news-entry
-->

Are such code cleanups acceptable?