### PR TITLE
Remove an extraneous closing bracket in a help option

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -596,7 +596,7 @@ no_clean = partial(
     '--no-clean',
     action='store_true',
     default=False,
-    help="Don't clean up build directories)."
+    help="Don't clean up build directories."
 )  # type: Any
 
 pre = partial(


### PR DESCRIPTION
Spotted while running locally.