### PR TITLE
install: First non-portable stab at fixing #5317

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -236,8 +236,9 @@ class InstallCommand(RequirementCommand):
                     "Can not perform a '--user' install. User site-packages "
                     "are not visible in this virtualenv."
                 )
-            install_options.append('--user')
-            install_options.append('--prefix=')
+            install_options.append('--install-dir=%s' \
+                                   % (os.path.join(os.path.expanduser('~'), '.local', 'lib',
+                                                   'python3.6', 'site-packages')))
 
         target_temp_dir = TempDirectory(kind="target")
         if options.target_dir:


### PR DESCRIPTION
This is a start at fixing issue #5317

**I'm aware this isn't portable / contains a very specific path**

But `--user` is broken for me and others, see issue #5317.

Help making it work again would be appreciated, I'm assuming maintainers will know at a glance how to make this portable.

Thanks