### PR TITLE
Fixes for the cases that raise Tracebacks in outdated pip version check

### DIFF
--- a/news/5433.bugfix
+++ b/news/5433.bugfix
@@ -1,0 +1,2 @@
+Run self-version-check only on commands that may access the index, instead of
+trying on every run and failing to do so due to missing options.

--- a/news/5679.bugfix
+++ b/news/5679.bugfix
@@ -1,0 +1,1 @@
+Avoid caching self-version-check information when cache is disabled.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -170,12 +170,14 @@ class Command(object):
 
             return UNKNOWN_ERROR
         finally:
-            # Check if we're using the latest version of pip available
-            skip_version_check = (
-                options.disable_pip_version_check or
-                getattr(options, "no_index", False)
+            allow_version_check = (
+                # Does this command have the index_group options?
+                hasattr(options, "no_index") and
+                # Is this command allowed to perform this check?
+                not (options.disable_pip_version_check or options.no_index)
             )
-            if not skip_version_check:
+            # Check if we're using the latest version of pip available
+            if allow_version_check:
                 session = self._build_session(
                     options,
                     retries=0,

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -22,16 +22,25 @@ logger = logging.getLogger(__name__)
 
 class SelfCheckState(object):
     def __init__(self, cache_dir):
-        self.statefile_path = os.path.join(cache_dir, "selfcheck.json")
+        self.state = {}
+        self.statefile_path = None
 
-        # Load the existing state
-        try:
-            with open(self.statefile_path) as statefile:
-                self.state = json.load(statefile)[sys.prefix]
-        except (IOError, ValueError, KeyError):
-            self.state = {}
+        # Try to load the existing state
+        if cache_dir:
+            self.statefile_path = os.path.join(cache_dir, "selfcheck.json")
+            try:
+                with open(self.statefile_path) as statefile:
+                    self.state = json.load(statefile)[sys.prefix]
+            except (IOError, ValueError, KeyError):
+                # Explicitly suppressing exceptions, since we don't want to
+                # error out if the cache file is invalid.
+                pass
 
     def save(self, pypi_version, current_time):
+        # If we do not have a path to cache in, don't bother saving.
+        if not self.statefile_path:
+            return
+
         # Check to make sure that we own the directory
         if not check_path_owner(os.path.dirname(self.statefile_path)):
             return

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -169,3 +169,9 @@ def test_self_check_state(monkeypatch, tmpdir):
 
     # json.dumps will call this a number of times
     assert len(fake_file.write.calls)
+
+
+def test_self_check_state_no_cache_dir():
+    state = outdated.SelfCheckState(cache_dir=False)
+    assert state.state == {}
+    assert state.statefile_path is None


### PR DESCRIPTION
Fixes #5679. The `selfcheck.json` file is stored in the cache. If the cache is disabled, this file can not be accessed and so pip shouldn't cache the version in that case.

Fixes #5433 (and closes #5680). Instead of performing the version check for every command, only perform the check with commands have the required (index) options.