### PR TITLE
Use a helper to ensure tox always runs a known-good pip version

### DIFF
--- a/tools/tox_pip.py
+++ b/tools/tox_pip.py
@@ -1,0 +1,91 @@
+"""A simple wrapper to ensure tox always uses a known-good pip.
+"""
+
+import distutils.sysconfig
+import itertools
+import os
+import shutil
+import subprocess
+import sys
+from glob import glob
+from os.path import basename, exists, join
+
+VIRTUAL_ENV = os.environ["VIRTUAL_ENV"]
+SITE_PACKAGES = distutils.sysconfig.get_python_lib()
+
+TOX_PIP_DIR = join(VIRTUAL_ENV, "pip-backup")
+EXECUTABLE_BACKUP = join(TOX_PIP_DIR, "bin")
+PACKAGE_BACKUP = join(TOX_PIP_DIR, "package")
+
+
+# Logic for finding the right files
+def get_installed_files(where):
+    sources = join(where, "pip")
+    dist_infos = glob(join(where, "pip-*.dist-info"))
+    egg_stuff = glob(join(where, "pip*.egg-*"))
+
+    return filter(exists, itertools.chain([sources], dist_infos, egg_stuff))
+
+
+def get_binaries(where):
+    return glob(join(where, "bin", "pip*"))
+
+
+# Logic for moving the files around.
+def backup_as_known_good():
+    # Make the backup directory
+    os.mkdir(TOX_PIP_DIR)
+
+    # Copy executable/launchers.
+    os.mkdir(EXECUTABLE_BACKUP)
+    for entry in get_binaries(VIRTUAL_ENV):
+        shutil.copy2(entry, join(EXECUTABLE_BACKUP, basename(entry)))
+
+    # Copy package and distribution info.
+    os.mkdir(PACKAGE_BACKUP)
+    for path in get_installed_files(SITE_PACKAGES):
+        shutil.copytree(path, join(PACKAGE_BACKUP, basename(path)))
+
+
+def remove_existing_installation():
+    # Remove executables/launchers.
+    for entry in get_binaries(VIRTUAL_ENV):
+        os.unlink(entry)
+
+    # Remove package and distribution info.
+    for path in get_installed_files(SITE_PACKAGES):
+        if os.path.isfile(path):
+            os.unlink(path)
+        else:
+            shutil.rmtree(path)
+
+
+def install_known_good_pip():
+    # Copy executables/launchers.
+    for entry in get_binaries(TOX_PIP_DIR):
+        shutil.copy2(entry, join(VIRTUAL_ENV, "bin", basename(entry)))
+
+    # Move package and distribution info.
+    for path in get_installed_files(PACKAGE_BACKUP):
+        shutil.copytree(path, join(SITE_PACKAGES, basename(path)))
+
+
+def run(args):
+    # First things first, safeguard the environment original pip so it can be
+    # used for all calls.
+    if not exists(TOX_PIP_DIR):
+        backup_as_known_good()
+
+    remove_existing_installation()
+    install_known_good_pip()
+
+    # Run the command.
+    #   We just do a python -m pip here because this is a known good pip, which
+    #   is expected to work properly.
+    cmd = [sys.executable, "-m", "pip"]
+    cmd.extend(args)
+    subprocess.check_call(cmd)
+
+
+if __name__ == "__main__":
+    run(sys.argv[1:])

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,46 @@
 [tox]
+skipsdist = True
 envlist =
     docs, packaging, lint-py2, lint-py3, mypy,
     py27, py34, py35, py36, py37, py38, pypy, pypy3
 
+[shorthands]
+pip = python {toxinidir}/tools/tox_pip.py
+
 [testenv]
+skip_install = True
+# Environment variables
 passenv = CI GIT_SSL_CAINFO
 setenv =
-    # This is required in order to get UTF-8 output inside of the subprocesses
-    # that our tests use.
+    # Required to get UTF-8 output inside of the subprocesses in tests.
     LC_CTYPE = en_US.UTF-8
+# Use tox_pip.py for when tox runs pip.
+install_command = {[shorthands]pip} install {opts} {packages}
+list_dependencies_command = {[shorthands]pip} freeze
+# The regular stuff
 deps = -r{toxinidir}/tools/tests-requirements.txt
-commands = pytest --timeout 300 []
-install_command = python -m pip install {opts} {packages}
-usedevelop = True
+commands =
+    {[shorthands]pip} install -e {toxinidir}
+    pytest --timeout 300 []
 
 [testenv:coverage-py3]
 basepython = python3
 commands = pytest --timeout 300 --cov=pip --cov-report=term-missing --cov-report=xml --cov-report=html tests/unit {posargs}
 
 [testenv:docs]
-# Don't skip install here since pip_sphinxext uses pip's internals.
 deps = -r{toxinidir}/tools/docs-requirements.txt
 basepython = python2.7
 commands =
+    # Our sphinx extension generates command information, using the installed version
+    {[shorthands]pip} install -e {toxinidir}
+
     sphinx-build -W -d {envtmpdir}/doctrees/html -b html docs/html docs/build/html
     # Having the conf.py in the docs/html is weird but needed because we
     # can not use a different configuration directory vs source directory on RTD
     # currently -- https://github.com/rtfd/readthedocs.org/issues/1543.
-    # That is why we have a "-c docs/html" in the next line.
     sphinx-build -W -d {envtmpdir}/doctrees/man -b man docs/man docs/build/man -c docs/html
 
 [testenv:packaging]
-skip_install = True
 deps =
     check-manifest
     readme_renderer
@@ -46,19 +55,16 @@ commands =
     isort --check-only --diff
 
 [testenv:lint-py2]
-skip_install = True
 basepython = python2
 deps = {[lint]deps}
 commands = {[lint]commands}
 
 [testenv:lint-py3]
-skip_install = True
 basepython = python3
 deps = {[lint]deps}
 commands = {[lint]commands}
 
 [testenv:mypy]
-skip_install = True
 basepython = python3
 deps = mypy
 commands =


### PR DESCRIPTION
Similar to #4657 

Adds a helper that backs up a known good pip on the first invocation in a tox venv and replaces the installed version with that on every subsequent run. Arguably there's scope for improvement here by not replacing unless it might be broken but I'd consider that an optimization.

This change as it stands, means breaking pip horribly does not result in tox environments not being functional, which is an improvement.