### PR TITLE
Prefer io.BytesIO over six; available on all supported Pythons

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,10 +11,10 @@ import sys
 import tempfile
 import time
 import warnings
+from io import BytesIO
 
 import pytest
 from mock import Mock, patch
-from pip._vendor.six import BytesIO
 
 from pip._internal.exceptions import (
     HashMismatch, HashMissing, InstallationError, UnsupportedPythonVersion,


### PR DESCRIPTION
On all supported Pythons, the `io.BytesIO` is always a stream implementation using an in-memory bytes buffer. Makes code slightly more forward compatible by reducing use of the six module.
