### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1207,7 +1207,7 @@ Improved Documentation
 
 - **Dropped support for Python 2.4** The minimum supported Python version is
   now Python 2.5.
-- Fixed pypi mirror support being broken on some DNS responses. Thanks
+- Fixed PyPI mirror support being broken on some DNS responses. Thanks
   philwhin. (#605)
 - Fixed pip uninstall removing files it didn't install. Thanks pjdelport.
   (#355)

--- a/tests/data/packages3/dinner/index.html
+++ b/tests/data/packages3/dinner/index.html
@@ -1,6 +1,6 @@
-<html><head><title>PyPi Mirror</title></head>
+<html><head><title>PyPI Mirror</title></head>
 <body>
-  <h1>PyPi Mirror</h1>
+  <h1>PyPI Mirror</h1>
   <h2>For testing --index-url with a file:// url for the index</h2>
   <a href='Dinner-1.0.tar.gz'>Dinner-1.0.tar.gz</a><br />
   <a href='Dinner-2.0.tar.gz'>Dinner-2.0.tar.gz</a><br />

--- a/tests/data/packages3/index.html
+++ b/tests/data/packages3/index.html
@@ -1,6 +1,6 @@
-<html><head><title>PyPi Mirror</title></head>
+<html><head><title>PyPI Mirror</title></head>
 <body>
-  <h1>PyPi Mirror</h1>
+  <h1>PyPI Mirror</h1>
   <h2>For testing --index-url with a file:// url for the index</h2>
   <a href='requiredinner'>requiredinner</a><br />
   <a href='Dinner'>Dinner</a><br />

--- a/tests/data/packages3/requiredinner/index.html
+++ b/tests/data/packages3/requiredinner/index.html
@@ -1,6 +1,6 @@
-<html><head><title>PyPi Mirror</title></head>
+<html><head><title>PyPI Mirror</title></head>
 <body>
-  <h1>PyPi Mirror</h1>
+  <h1>PyPI Mirror</h1>
   <h2>For testing --index-url with a file:// url for the index</h2>
   <a href='requiredinner-1.0.tar.gz'>requiredinner=1.0.tar.gz</a><br />
 </body>

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -57,7 +57,7 @@ def test_download_wheel(script, data):
 @pytest.mark.network
 def test_single_download_from_requirements_file(script):
     """
-    It should support download (in the scratch path) from PyPi from a
+    It should support download (in the scratch path) from PyPI from a
     requirements file
     """
     script.scratch_path.join("test-req.txt").write(textwrap.dedent("""

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -629,7 +629,7 @@ def test_install_folder_using_relative_path(script):
 @pytest.mark.network
 def test_install_package_which_contains_dev_in_name(script):
     """
-    Test installing package from pypi which contains 'dev' in name
+    Test installing package from PyPI which contains 'dev' in name
     """
     result = script.pip('install', 'django-devserver==0.0.4')
     devserver_folder = script.site_packages / 'devserver'

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -25,7 +25,7 @@ def test_version_compare():
 
 def test_pypi_xml_transformation():
     """
-    Test transformation of data structures (pypi xmlrpc to custom list).
+    Test transformation of data structures (PyPI xmlrpc to custom list).
 
     """
     pypi_hits = [

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -95,7 +95,7 @@ def test_finder_detects_latest_already_satisfied_find_links(data):
 def test_finder_detects_latest_already_satisfied_pypi_links():
     """Test PackageFinder detects latest already satisfied using pypi links"""
     req = install_req_from_line('initools', None)
-    # the latest initools on pypi is 0.3.1
+    # the latest initools on PyPI is 0.3.1
     latest_version = "0.3.1"
     satisfied_by = Mock(
         location="/path",


### PR DESCRIPTION
As spelled on https://pypi.org/.