### PR TITLE
req: improve extras/markers/link handling

### DIFF
--- a/news/5788.bugfix
+++ b/news/5788.bugfix
@@ -1,0 +1,1 @@
+Make requirements' messages more consistent.

--- a/news/5889.bugfix
+++ b/news/5889.bugfix
@@ -1,0 +1,1 @@
+Fix exception when installing a package depending on an already installed dependency using a PEP 508 requirement.

--- a/news/5892.bugfix
+++ b/news/5892.bugfix
@@ -1,0 +1,1 @@
+Improve handling of file URIs: correctly handle `file://localhost/...` and don't try to use UNC paths on Unix.

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -470,9 +470,18 @@ def url_to_path(url):
 
     _, netloc, path, _, _ = urllib_parse.urlsplit(url)
 
-    # if we have a UNC path, prepend UNC share notation
     if netloc:
-        netloc = '\\\\' + netloc
+        if netloc == 'localhost':
+            # According to RFC 8089, same as empty authority.
+            netloc = ''
+        elif sys.platform == 'win32':
+            # If we have a UNC path, prepend UNC share notation.
+            netloc = '\\\\' + netloc
+        else:
+            raise ValueError(
+                'non-local file URIs are not supported on this platform: %r'
+                % url
+            )
 
     path = urllib_request.url2pathname(netloc + path)
     return path

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -223,6 +223,8 @@ def install_req_from_line(
                     name
                 )
             link = Link(path_to_url(p))
+        else:
+            extras = None
 
     # it's a local file, dir, or url
     if link:

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -285,7 +285,8 @@ def install_req_from_req(
         PyPI.file_storage_domain,
         TestPyPI.file_storage_domain,
     ]
-    if req.url and comes_from.link.netloc in domains_not_allowed:
+    if req.url and comes_from and comes_from.link \
+       and comes_from.link.netloc in domains_not_allowed:
         # Explicitly disallow pypi packages that depend on external urls
         raise InstallationError(
             "Packages installed from PyPI cannot depend on packages "

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -168,7 +168,7 @@ def install_req_from_editable(
         link=Link(url),
         constraint=constraint,
         isolated=isolated,
-        options=options if options else {},
+        options=options,
         wheel_cache=wheel_cache,
         extras=extras_override or (),
     )
@@ -196,14 +196,13 @@ def install_req_from_line(
         markers = None
     name = name.strip()
     req = None
-    path = os.path.normpath(os.path.abspath(name))
     link = None
     extras = None
 
     if is_url(name):
         link = Link(name)
     else:
-        p, extras = _strip_extras(path)
+        p, extras = _strip_extras(os.path.normpath(os.path.abspath(name)))
         looks_like_dir = os.path.isdir(p) and (
             os.path.sep in name or
             (os.path.altsep is not None and os.path.altsep in name) or
@@ -266,7 +265,7 @@ def install_req_from_line(
     return InstallRequirement(
         req, comes_from, link=link, markers=markers,
         isolated=isolated,
-        options=options if options else {},
+        options=options,
         wheel_cache=wheel_cache,
         constraint=constraint,
         extras=extras,

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -127,7 +127,12 @@ def test_path_to_url_unix():
 
 @pytest.mark.skipif("sys.platform == 'win32'")
 def test_url_to_path_unix():
+    assert url_to_path('file:tmp') == 'tmp'
     assert url_to_path('file:///tmp/file') == '/tmp/file'
+    assert url_to_path('file:/path/to/file') == '/path/to/file'
+    assert url_to_path('file://localhost/tmp/file') == '/tmp/file'
+    with pytest.raises(ValueError):
+        url_to_path('file://somehost/tmp/file')
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")
@@ -141,8 +146,11 @@ def test_path_to_url_win():
 
 @pytest.mark.skipif("sys.platform != 'win32'")
 def test_url_to_path_win():
-    assert url_to_path('file:///c:/tmp/file') == 'C:\\tmp\\file'
+    assert url_to_path('file:tmp') == 'tmp'
+    assert url_to_path('file:///c:/tmp/file') == r'C:\tmp\file'
     assert url_to_path('file://unc/as/path') == r'\\unc\as\path'
+    assert url_to_path('file:c:/path/to/file') == r'C:\path\to\file'
+    assert url_to_path('file://localhost/c:/tmp/file') == r'C:\tmp\file'
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")


### PR DESCRIPTION
- ensure this information is not duplicated at both the `InstallRequirement` and `InstallRequirement.req` levels
- make the output more consistent, and not dependent on whether an `InstallRequirement` was created with `install_req_from_line` or `install_req_from_req`

Before:
- `package@url` -> `Collecting package@ url from url (from ...)` / `Collecting ... (from package@ url->...)`
- `package[extra]>=1.0; marker` -> `Collecting package[extra]` / `Collecting .. (from package[extra])` (when used from the command line), but `Collecting package[extra]; marker` / `Collecting .. (from package[extra]; marker->...)` when coming from a package requirements
- `package-0.8-py2.py3-none-any.whl[test]; marker` -> `Processing package-0.8-py2.py3-none-any.whl` / `Collecting ... (from package==0.8)`

Basically the format will now consistently looks like: `Collecting package==2.0 from URL (from ...)` / `Collecting ... (from package[extra]==2.0)`.