### PR TITLE
Fix error when autocompleting after flag 

### DIFF
--- a/news/5751.bugfix
+++ b/news/5751.bugfix
@@ -1,0 +1,1 @@
+Avoid traceback printing on autocomplete after flags in the CLI.

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -116,7 +116,8 @@ def get_path_completion_type(cwords, cword, opts):
             continue
         for o in str(opt).split('/'):
             if cwords[cword - 2].split('=')[0] == o:
-                if any(x in ('path', 'file', 'dir')
+                if not opt.metavar or any(
+                        x in ('path', 'file', 'dir')
                         for x in opt.metavar.split('/')):
                     return opt.metavar
 

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -204,6 +204,30 @@ def test_completion_not_files_after_option(script, data):
     )
 
 
+@pytest.mark.parametrize("cl_opts", ["-U", "--user", "-h"])
+def test_completion_not_files_after_nonexpecting_option(script, data, cl_opts):
+    """
+    Test not getting completion files after options which not applicable
+    (e.g. ``pip install``)
+    """
+    res, env = setup_completion(
+        script=script,
+        words=('pip install %s r' % cl_opts),
+        cword='2',
+        cwd=data.completion_paths,
+    )
+    assert not any(out in res.stdout for out in
+                   ('requirements.txt', 'readme.txt',)), (
+        "autocomplete function completed <file> when "
+        "it should not complete"
+    )
+    assert not any(os.path.join(out, '') in res.stdout
+                   for out in ('replay', 'resources')), (
+        "autocomplete function completed <dir> when "
+        "it should not complete"
+    )
+
+
 def test_completion_directories_after_option(script, data):
     """
     Test getting completion <dir> after options in command


### PR DESCRIPTION
When running autocomplete after any command-line option with unspecified 'metavar' attribute, a traceback for an 'AttributeError' would be displayed. This is fixed for first checking if 'metavar' was defined. Fixes #5751 