### PR TITLE
Remove assertion from req_uninstall.py

### DIFF
--- a/news/5439.bugfix
+++ b/news/5439.bugfix
@@ -1,0 +1,1 @@
+Remove assertion in req_uninstall.py that would fail as part of the normal workflow

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -362,12 +362,6 @@ class UninstallPathSet(object):
 
         elif develop_egg_link:
             # develop egg
-            with open(develop_egg_link, 'r') as fh:
-                link_pointer = os.path.normcase(fh.readline().strip())
-            assert (link_pointer == dist.location), (
-                'Egg-link %s does not match installed location of %s '
-                '(at %s)' % (link_pointer, dist.project_name, dist.location)
-            )
             paths_to_remove.add(develop_egg_link)
             easy_install_pth = os.path.join(os.path.dirname(develop_egg_link),
                                             'easy-install.pth')


### PR DESCRIPTION
This is a newer version of https://github.com/pypa/pip/pull/5442. So instead of trying to make the assertion pass, I will just remove it.

Fixes https://github.com/pypa/pip/issues/5439.