### PR TITLE
utils: fix `has_leading_dir` corner case

### DIFF
--- a/news/5794.bugfix
+++ b/news/5794.bugfix
@@ -1,0 +1,1 @@
+Correctly handle archives with a single file.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -229,6 +229,11 @@ def split_leading_dir(path):
 def has_leading_dir(paths):
     """Returns true if all the paths have the same leading path name
     (i.e., everything is in one subdirectory in an archive)"""
+    if not paths:
+        return True
+    if len(paths) == 1:
+        prefix, rest = split_leading_dir(paths[0])
+        return bool(rest)
     common_prefix = None
     for path in paths:
         prefix, rest = split_leading_dir(path)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -24,8 +24,8 @@ from pip._internal.utils.glibc import check_glibc_version
 from pip._internal.utils.hashes import Hashes, MissingHashes
 from pip._internal.utils.misc import (
     call_subprocess, egg_link_path, ensure_dir, get_installed_distributions,
-    get_prog, make_vcs_requirement_url, normalize_path, redact_netloc,
-    redact_password_from_url, remove_auth_from_url, rmtree,
+    get_prog, has_leading_dir, make_vcs_requirement_url, normalize_path,
+    redact_netloc, redact_password_from_url, remove_auth_from_url, rmtree,
     split_auth_from_netloc, untar_file, unzip_file,
 )
 from pip._internal.utils.packaging import check_dist_requires_python
@@ -720,3 +720,40 @@ def test_remove_auth_from_url(auth_url, expected_url):
 def test_redact_password_from_url(auth_url, expected_url):
     url = redact_password_from_url(auth_url)
     assert url == expected_url
+
+
+HAS_LEADING_DIR_TESTS = (
+    ('', True),
+    ('setup.py', False),
+    ('dir/', False),
+    ('pkg-1.0/setup.py', True),
+    ('''
+     setup.py
+     module.py
+     ''', False),
+    ('''
+     pkg-1.0/setup.py
+     pkg-1.0/module.py
+     ''', True),
+    ('''
+     a/setup.py
+     b/module.py
+     ''', False),
+    ('''
+     pkg-1.0
+     pkg-1.0/
+     ''', True),
+    ('''
+     pkg-1.0/
+     pkg-1.0/
+     ''', True),
+    ('''
+     pkg-1.0/
+     pkg-1.0/setup.py
+     ''', True),
+)
+
+
+@pytest.mark.parametrize('tree, result', HAS_LEADING_DIR_TESTS)
+def test_has_leading_dir(tree, result):
+    assert has_leading_dir(tree.split()) == result


### PR DESCRIPTION
Handle archives with a single file (something that is used by setuptools' testsuite).