### PR TITLE
Revert "Limit progress updates to avoid swamping the TTY"

### DIFF
--- a/news/5124.trivial
+++ b/news/5124.trivial
@@ -1,1 +1,0 @@
-Limit progress bar update interval to 200 ms.

--- a/src/pip/_internal/utils/ui.py
+++ b/src/pip/_internal/utils/ui.py
@@ -137,7 +137,6 @@ class DownloadProgressMixin(object):
     def __init__(self, *args, **kwargs):
         super(DownloadProgressMixin, self).__init__(*args, **kwargs)
         self.message = (" " * (get_indentation() + 2)) + self.message
-        self.last_update = 0.0
 
     @property
     def downloaded(self):
@@ -161,15 +160,6 @@ class DownloadProgressMixin(object):
             yield x
             self.next(n)
         self.finish()
-
-    def update(self):
-        # limit updates to avoid swamping the TTY
-        now = time.time()
-        if now < self.last_update + 0.2:
-            return
-        self.last_update = now
-
-        super(DownloadProgressMixin, self).update()
 
 
 class WindowsMixin(object):


### PR DESCRIPTION
Reverts pypa/pip#5124

The PR caused issues with the progressbar not reaching 100%. I missed this in the testing because trying out on large packages isn't a good idea.

<img width="455" alt="screen shot 2018-09-19 at 9 18 54 am" src="https://user-images.githubusercontent.com/3275593/45730015-15ab6f00-bbed-11e8-8595-2aa667d2fb66.png">
