### PR TITLE
req_tracker: add protection from Windows' SilentCleanup...

### DIFF
--- a/news/5807.bugfix
+++ b/news/5807.bugfix
@@ -1,0 +1,1 @@
+Fix possible failures due to Window' SilentCleanup task deleting an empty temporary directory in use by pip.

--- a/src/pip/_internal/req/req_tracker.py
+++ b/src/pip/_internal/req/req_tracker.py
@@ -20,6 +20,10 @@ class RequirementTracker(object):
             self._temp_dir.create()
             self._root = os.environ['PIP_REQ_TRACKER'] = self._temp_dir.path
             logger.debug('Created requirements tracker %r', self._root)
+            # Ensure the directory is not left empty, so it does not get
+            # deleted behind our backs by Windows' SilentCleanup task
+            # (while pip is busy with a big download).
+            open(os.path.join(self._root, 'not_empty'), 'w').close()
         else:
             self._temp_dir = None
             logger.debug('Re-using requirements tracker %r', self._root)


### PR DESCRIPTION
Ensure the directory is not left empty, so it does not get deleted behind our backs by Windows' SilentCleanup task (while pip is busy with a big download).

Fix #5790.