### PR TITLE
get-pip.py is mostly a giant base85'd blob and can't be reviewed

### DIFF
--- a/docs/html/installing.rst
+++ b/docs/html/installing.rst
@@ -23,8 +23,6 @@ To install pip, securely download `get-pip.py
 
  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 
-As when running any script downloaded from the web, ensure that you have
-reviewed the code and are happy that it works as you expect.
 Then run the following::
 
  python get-pip.py


### PR DESCRIPTION
It's basically not possible to meaningfully review a base85 blob, and generally people should be using ``ensurepip`` or virtualenv's built in support at this point-- although both of those just contain a zipped copy of pip just like this does, it's just an actual zip file instead of a zip file embedded as a binary blob.

