### PR TITLE
Add misc.make_vcs_requirement_url()

### DIFF
--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -16,7 +16,7 @@ from pip._internal.req.constructors import (
 from pip._internal.req.req_file import COMMENT_RE
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.misc import (
-    dist_is_editable, get_installed_distributions,
+    dist_is_editable, get_installed_distributions, make_vcs_requirement_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -233,11 +233,8 @@ class FrozenRequirement(object):
                     else:
                         rev = '{%s}' % date_match.group(1)
                     editable = True
-                    req = '%s@%s#egg=%s' % (
-                        svn_location,
-                        rev,
-                        cls.egg_name(dist)
-                    )
+                    egg_name = cls.egg_name(dist)
+                    req = make_vcs_requirement_url(svn_location, rev, egg_name)
         return cls(dist.project_name, req, editable, comments)
 
     @staticmethod

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -856,6 +856,20 @@ def enum(*sequential, **named):
     return type('Enum', (), enums)
 
 
+def make_vcs_requirement_url(repo_url, rev, egg_project_name, subdir=None):
+    """
+    Return the URL for a VCS requirement.
+
+    Args:
+      repo_url: the remote VCS url, with any needed VCS prefix (e.g. "git+").
+    """
+    req = '{}@{}#egg={}'.format(repo_url, rev, egg_project_name)
+    if subdir:
+        req += '&subdirectory={}'.format(subdir)
+
+    return req
+
+
 def split_auth_from_netloc(netloc):
     """
     Parse out and remove the auth information from a netloc.

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -6,7 +6,9 @@ import os
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
 from pip._internal.download import path_to_url
-from pip._internal.utils.misc import display_path, rmtree
+from pip._internal.utils.misc import (
+    display_path, make_vcs_requirement_url, rmtree,
+)
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.vcs import VersionControl, vcs
 
@@ -98,9 +100,9 @@ class Bazaar(VersionControl):
             return None
         if not repo.lower().startswith('bzr:'):
             repo = 'bzr+' + repo
-        egg_project_name = dist.egg_name().split('-', 1)[0]
         current_rev = self.get_revision(location)
-        return '%s@%s#egg=%s' % (repo, current_rev, egg_project_name)
+        egg_project_name = dist.egg_name().split('-', 1)[0]
+        return make_vcs_requirement_url(repo, current_rev, egg_project_name)
 
     def is_commit_id_equal(self, dest, name):
         """Always assume the versions don't match"""

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -10,7 +10,7 @@ from pip._vendor.six.moves.urllib import request as urllib_request
 
 from pip._internal.exceptions import BadCommand
 from pip._internal.utils.compat import samefile
-from pip._internal.utils.misc import display_path
+from pip._internal.utils.misc import display_path, make_vcs_requirement_url
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.vcs import VersionControl, vcs
 
@@ -294,12 +294,12 @@ class Git(VersionControl):
         repo = self.get_url(location)
         if not repo.lower().startswith('git:'):
             repo = 'git+' + repo
-        egg_project_name = dist.egg_name().split('-', 1)[0]
         current_rev = self.get_revision(location)
-        req = '%s@%s#egg=%s' % (repo, current_rev, egg_project_name)
-        subdirectory = self._get_subdirectory(location)
-        if subdirectory:
-            req += '&subdirectory=' + subdirectory
+        egg_project_name = dist.egg_name().split('-', 1)[0]
+        subdir = self._get_subdirectory(location)
+        req = make_vcs_requirement_url(repo, current_rev, egg_project_name,
+                                       subdir=subdir)
+
         return req
 
     def get_url_rev_and_auth(self, url):

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -6,7 +6,7 @@ import os
 from pip._vendor.six.moves import configparser
 
 from pip._internal.download import path_to_url
-from pip._internal.utils.misc import display_path
+from pip._internal.utils.misc import display_path, make_vcs_requirement_url
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.vcs import VersionControl, vcs
 
@@ -88,9 +88,10 @@ class Mercurial(VersionControl):
         repo = self.get_url(location)
         if not repo.lower().startswith('hg:'):
             repo = 'hg+' + repo
-        egg_project_name = dist.egg_name().split('-', 1)[0]
         current_rev_hash = self.get_revision_hash(location)
-        return '%s@%s#egg=%s' % (repo, current_rev_hash, egg_project_name)
+        egg_project_name = dist.egg_name().split('-', 1)[0]
+        return make_vcs_requirement_url(repo, current_rev_hash,
+                                        egg_project_name)
 
     def is_commit_id_equal(self, dest, name):
         """Always assume the versions don't match"""

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -7,7 +7,7 @@ import re
 from pip._internal.models.link import Link
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
-    display_path, rmtree, split_auth_from_netloc,
+    display_path, make_vcs_requirement_url, rmtree, split_auth_from_netloc,
 )
 from pip._internal.vcs import VersionControl, vcs
 
@@ -199,10 +199,11 @@ class Subversion(VersionControl):
         repo = self.get_url(location)
         if repo is None:
             return None
+        repo = 'svn+' + repo
+        rev = self.get_revision(location)
         # FIXME: why not project name?
         egg_project_name = dist.egg_name().split('-', 1)[0]
-        rev = self.get_revision(location)
-        return 'svn+%s@%s#egg=%s' % (repo, rev, egg_project_name)
+        return make_vcs_requirement_url(repo, rev, egg_project_name)
 
     def is_commit_id_equal(self, dest, name):
         """Always assume the versions don't match"""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -639,13 +639,7 @@ def test_call_subprocess_closes_stdin():
      'git+https://example.com/pkg@dev#egg=myproj'),
 ])
 def test_make_vcs_requirement_url(args, expected):
-    if len(args) == 3:
-        url, rev, egg_name = args
-        actual = make_vcs_requirement_url(url, rev, egg_name)
-    else:
-        url, rev, egg_name, subdir = args
-        actual = make_vcs_requirement_url(url, rev, egg_name, subdir=subdir)
-
+    actual = make_vcs_requirement_url(*args)
     assert actual == expected
 
 


### PR DESCRIPTION
This adds a `make_src_requirement()` (edited: `make_vcs_requirement_url()`) function to centralize / DRY up the format string used to construct the URL inside `get_src_requirement()`.