### PR TITLE
Add FrozenRequirement._init_args_from_dist() helper method

### DIFF
--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -168,7 +168,13 @@ class FrozenRequirement(object):
     _date_re = re.compile(r'-(20\d\d\d\d\d\d)$')
 
     @classmethod
-    def from_dist(cls, dist, dependency_links):
+    def _init_args_from_dist(cls, dist, dependency_links):
+        """
+        Compute and return arguments (req, editable, comments) to pass to
+        FrozenRequirement.__init__().
+
+        This method is for use in FrozenRequirement.from_dist().
+        """
         location = os.path.normcase(os.path.abspath(dist.location))
         comments = []
         from pip._internal.vcs import vcs, get_src_requirement
@@ -235,7 +241,13 @@ class FrozenRequirement(object):
                     editable = True
                     egg_name = cls.egg_name(dist)
                     req = make_vcs_requirement_url(svn_location, rev, egg_name)
-        return cls(dist.project_name, req, editable, comments)
+
+        return (req, editable, comments)
+
+    @classmethod
+    def from_dist(cls, dist, dependency_links):
+        args = cls._init_args_from_dist(dist, dependency_links)
+        return cls(dist.project_name, *args)
 
     @staticmethod
     def egg_name(dist):


### PR DESCRIPTION
This refactors from `FrozenRequirement.from_dist()` a helper class method I'm calling `FrozenRequirement._init_args_from_dist()`.

This will be useful for issue #5031 (and independently of that issue) because it will let us use guard clauses to reduce indentation, cut down on the number of if-elses, and possibly remove some of the boolean "flag" variables. (Issue #5031 will likely require adding another if clause, which is what sparked this PR.)


