### PR TITLE
HTMLPage cleanup and egg_info_matches fix

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -731,7 +731,7 @@ class HTMLPage(object):
         return self.url
 
     @classmethod
-    def get_page(cls, link, skip_archives=True, session=None):
+    def get_page(cls, link, session=None):
         if session is None:
             raise TypeError(
                 "get_page() missing 1 required keyword argument: 'session'"
@@ -748,22 +748,21 @@ class HTMLPage(object):
                 return None
 
         try:
-            if skip_archives:
-                filename = link.filename
-                for bad_ext in ARCHIVE_EXTENSIONS:
-                    if filename.endswith(bad_ext):
-                        content_type = cls._get_content_type(
-                            url, session=session,
+            filename = link.filename
+            for bad_ext in ARCHIVE_EXTENSIONS:
+                if filename.endswith(bad_ext):
+                    content_type = cls._get_content_type(
+                        url, session=session,
+                    )
+                    if content_type.lower().startswith('text/html'):
+                        break
+                    else:
+                        logger.debug(
+                            'Skipping page %s because of Content-Type: %s',
+                            link,
+                            content_type,
                         )
-                        if content_type.lower().startswith('text/html'):
-                            break
-                        else:
-                            logger.debug(
-                                'Skipping page %s because of Content-Type: %s',
-                                link,
-                                content_type,
-                            )
-                            return
+                        return
 
             logger.debug('Getting page %s', url)
 

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -694,7 +694,7 @@ def egg_info_matches(
         return None
     if search_name is None:
         full_match = match.group(0)
-        return full_match[full_match.index('-'):]
+        return full_match.split('-', 1)[-1]
     name = match.group(0).lower()
     # To match the "safe" name that pkg_resources creates:
     name = name.replace('_', '-')


### PR DESCRIPTION
My first baby steps toward #5800.

It seems the `skip_archives` argument is never specified from any call sites (only one, actually, in `PackageFinder._get_page()`), so the block is always run. I simply removed the check.

`egg_info_matches` was discussed in https://github.com/pypa/pip/issues/5800#issuecomment-424774495. This function is used in two places, `PackageFinder._link_package_versions()` and `wheel.WheelBuilder.build()`. The former always passes a real `search_name`, so the branch is only reachable by the latter. `WheelBuilder` does not actually use the return value, however, only checks whether it is None, so the bug does not affect anything in pip currently.