### PR TITLE
Break HTMLPage apart, extract some of it into pip._internal.repositories

### DIFF
--- a/news/5822.trivial
+++ b/news/5822.trivial
@@ -1,0 +1,1 @@
+Refactor HTMLPage into a generator function and a few helper functions.

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -414,7 +414,15 @@ class PackageFinder(object):
         )
 
         page_versions = []
-        for page in self._get_pages(url_locations, project_name):
+
+        seen_locations = set()
+        for location in url_locations:
+            if location in seen_locations:
+                continue
+            seen_locations.add(location)
+            page = self._get_page(location)
+            if page is None:
+                continue
             logger.debug('Analyzing links from page %s', page.url)
             with indent_log():
                 page_versions.extend(
@@ -547,23 +555,6 @@ class PackageFinder(object):
             ', '.join(sorted(compatible_versions, key=parse_version))
         )
         return best_candidate.location
-
-    def _get_pages(self, locations, project_name):
-        """
-        Yields (page, page_url) from the given locations, skipping
-        locations that have errors.
-        """
-        seen = set()
-        for location in locations:
-            if location in seen:
-                continue
-            seen.add(location)
-
-            page = self._get_page(location)
-            if page is None:
-                continue
-
-            yield page
 
     _py_version_re = re.compile(r'-py([123]\.?[0-9]?)$')
 

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -714,7 +714,6 @@ class HTMLPage(object):
         self.encoding = encoding
         self.content = content
         self.url = url
-        self.headers = headers
 
     def __str__(self):
         return self.url

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -1,7 +1,6 @@
 """Routines related to PyPI, indexes"""
 from __future__ import absolute_import
 
-import cgi
 import itertools
 import logging
 import mimetypes
@@ -33,6 +32,7 @@ from pip._internal.pep425tags import get_supported
 from pip._internal.repositories.entries import (
     match_egg_info_version, parse_base_url,
 )
+from pip._internal.repositories.utils import get_content_type_encoding
 from pip._internal.utils.compat import ipaddress
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.logging import indent_log
@@ -703,15 +703,7 @@ class HTMLPage(object):
     """Represents one page, along with its URL"""
 
     def __init__(self, content, url, headers=None):
-        # Determine if we have any encoding information in our headers
-        encoding = None
-        if headers and "Content-Type" in headers:
-            content_type, params = cgi.parse_header(headers["Content-Type"])
-
-            if "charset" in params:
-                encoding = params['charset']
-
-        self.encoding = encoding
+        self.encoding = get_content_type_encoding(headers)
         self.content = content
         self.url = url
 

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -847,7 +847,7 @@ class HTMLPage(object):
                 url = _clean_link(urllib_parse.urljoin(base_url, href))
                 pyrequire = anchor.get('data-requires-python')
                 pyrequire = unescape(pyrequire) if pyrequire else None
-                yield Link(url, self, requires_python=pyrequire)
+                yield Link(url, self.url, requires_python=pyrequire)
 
 
 LINK_CLEAN_RE = re.compile(r'[^a-z0-9$&+,/:;=?@.#%_\\|-]', re.I)

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -711,12 +711,8 @@ class HTMLPage(object):
             if "charset" in params:
                 encoding = params['charset']
 
+        self.encoding = encoding
         self.content = content
-        self.parsed = html5lib.parse(
-            self.content,
-            transport_encoding=encoding,
-            namespaceHTMLElements=False,
-        )
         self.url = url
         self.headers = headers
 
@@ -845,8 +841,13 @@ class HTMLPage(object):
     @property
     def links(self):
         """Yields all links in the page"""
-        base_url = parse_base_url(self.parsed, self.url)
-        for anchor in self.parsed.findall(".//a"):
+        document = html5lib.parse(
+            self.content,
+            transport_encoding=self.encoding,
+            namespaceHTMLElements=False,
+        )
+        base_url = parse_base_url(document, self.url)
+        for anchor in document.findall(".//a"):
             if anchor.get("href"):
                 href = anchor.get("href")
                 url = self.clean_link(

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -37,7 +37,7 @@ from pip._internal.utils.compat import ipaddress
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
-    ARCHIVE_EXTENSIONS, SUPPORTED_EXTENSIONS, cached_property, normalize_path,
+    ARCHIVE_EXTENSIONS, SUPPORTED_EXTENSIONS, normalize_path,
     remove_auth_from_url,
 )
 from pip._internal.utils.packaging import check_requires_python
@@ -842,18 +842,15 @@ class HTMLPage(object):
 
         return resp.headers.get("Content-Type", "")
 
-    @cached_property
-    def base_url(self):
-        return parse_base_url(self.parsed, self.url)
-
     @property
     def links(self):
         """Yields all links in the page"""
+        base_url = parse_base_url(self.parsed, self.url)
         for anchor in self.parsed.findall(".//a"):
             if anchor.get("href"):
                 href = anchor.get("href")
                 url = self.clean_link(
-                    urllib_parse.urljoin(self.base_url, href)
+                    urllib_parse.urljoin(base_url, href)
                 )
                 pyrequire = anchor.get('data-requires-python')
                 pyrequire = unescape(pyrequire) if pyrequire else None

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -30,7 +30,9 @@ from pip._internal.models.format_control import FormatControl
 from pip._internal.models.index import PyPI
 from pip._internal.models.link import Link
 from pip._internal.pep425tags import get_supported
-from pip._internal.repositories.entries import match_egg_info_version
+from pip._internal.repositories.entries import (
+    match_egg_info_version, parse_base_url,
+)
 from pip._internal.utils.compat import ipaddress
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.logging import indent_log
@@ -842,14 +844,7 @@ class HTMLPage(object):
 
     @cached_property
     def base_url(self):
-        bases = [
-            x for x in self.parsed.findall(".//base")
-            if x.get("href") is not None
-        ]
-        if bases and bases[0].get("href"):
-            return bases[0].get("href")
-        else:
-            return self.url
+        return parse_base_url(self.parsed, self.url)
 
     @property
     def links(self):

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -421,8 +421,6 @@ class PackageFinder(object):
                 continue
             seen_locations.add(location)
             links = self._iter_links(location)
-            if not links:
-                continue
             with indent_log():
                 page_versions.extend(
                     self._package_versions(links, search)
@@ -668,7 +666,7 @@ class PackageFinder(object):
 
     # For mocking in unit tests.
     def _iter_links(self, link):
-        return collect_links(link, session=self.session)
+        return _iter_links(link, session=self.session)
 
 
 def egg_info_matches(egg_info, search_name, link, _egg_info_re=None):
@@ -690,163 +688,141 @@ def egg_info_matches(egg_info, search_name, link, _egg_info_re=None):
     return None
 
 
-def collect_links(location, session):
-    page = HTMLPage.get_page(location, session=session)
-    if page is None:
-        return None
-    logger.debug('Analyzing links from page %s', page.url)
-    return page.links
+def _handle_collect_links_fail(link, reason, url, meth=None):
+    if meth is None:
+        meth = logger.debug
+    meth("Could not fetch URL %s: %s - skipping", link, reason)
 
 
-class HTMLPage(object):
-    """Represents one page, along with its URL"""
+def _iter_links(link, session):
+    url = link.url
+    url = url.split('#', 1)[0]
 
-    def __init__(self, content, url, headers=None):
-        self.encoding = get_content_type_encoding(headers)
-        self.content = content
-        self.url = url
+    # Check for VCS schemes that do not support lookup as web pages.
+    from pip._internal.vcs import VcsSupport
+    for scheme in VcsSupport.schemes:
+        if url.lower().startswith(scheme) and url[len(scheme)] in '+:':
+            logger.debug('Cannot look at %s URL %s', scheme, link)
+            return
 
-    def __str__(self):
-        return self.url
+    def _get_content_type(url, session):
+        """Get the Content-Type of the given url, using a HEAD request"""
+        scheme, netloc, path, query, fragment = urllib_parse.urlsplit(url)
+        if scheme not in {'http', 'https'}:
+            # FIXME: some warning or something?
+            # assertion error?
+            return ''
 
-    @classmethod
-    def get_page(cls, link, session=None):
-        if session is None:
-            raise TypeError(
-                "get_page() missing 1 required keyword argument: 'session'"
-            )
+        resp = session.head(url, allow_redirects=True)
+        resp.raise_for_status()
 
-        url = link.url
-        url = url.split('#', 1)[0]
+        return resp.headers.get("Content-Type", "")
 
-        # Check for VCS schemes that do not support lookup as web pages.
-        from pip._internal.vcs import VcsSupport
-        for scheme in VcsSupport.schemes:
-            if url.lower().startswith(scheme) and url[len(scheme)] in '+:':
-                logger.debug('Cannot look at %s URL %s', scheme, link)
-                return None
+    args = None
+    try:
+        filename = link.filename
+        for bad_ext in ARCHIVE_EXTENSIONS:
+            if filename.endswith(bad_ext):
+                content_type = _get_content_type(url, session=session)
+                if content_type.lower().startswith('text/html'):
+                    break
+                else:
+                    logger.debug(
+                        'Skipping page %s because of Content-Type: %s',
+                        link,
+                        content_type,
+                    )
+                    return
 
-        def _handle_fail(link, reason, url, meth=None):
-            if meth is None:
-                meth = logger.debug
-            meth("Could not fetch URL %s: %s - skipping", link, reason)
+        logger.debug('Getting page %s', url)
 
-        def _get_content_type(url, session):
-            """Get the Content-Type of the given url, using a HEAD request"""
-            scheme, netloc, path, query, fragment = urllib_parse.urlsplit(url)
-            if scheme not in {'http', 'https'}:
-                # FIXME: some warning or something?
-                # assertion error?
-                return ''
+        # Tack index.html onto file:// URLs that point to directories
+        (scheme, netloc, path, params, query, fragment) = \
+            urllib_parse.urlparse(url)
+        if (scheme == 'file' and
+                os.path.isdir(urllib_request.url2pathname(path))):
+            # add trailing slash if not present so urljoin doesn't trim
+            # final segment
+            if not url.endswith('/'):
+                url += '/'
+            url = urllib_parse.urljoin(url, 'index.html')
+            logger.debug(' file: URL is directory, getting %s', url)
 
-            resp = session.head(url, allow_redirects=True)
-            resp.raise_for_status()
-
-            return resp.headers.get("Content-Type", "")
-
-        try:
-            filename = link.filename
-            for bad_ext in ARCHIVE_EXTENSIONS:
-                if filename.endswith(bad_ext):
-                    content_type = _get_content_type(url, session=session)
-                    if content_type.lower().startswith('text/html'):
-                        break
-                    else:
-                        logger.debug(
-                            'Skipping page %s because of Content-Type: %s',
-                            link,
-                            content_type,
-                        )
-                        return
-
-            logger.debug('Getting page %s', url)
-
-            # Tack index.html onto file:// URLs that point to directories
-            (scheme, netloc, path, params, query, fragment) = \
-                urllib_parse.urlparse(url)
-            if (scheme == 'file' and
-                    os.path.isdir(urllib_request.url2pathname(path))):
-                # add trailing slash if not present so urljoin doesn't trim
-                # final segment
-                if not url.endswith('/'):
-                    url += '/'
-                url = urllib_parse.urljoin(url, 'index.html')
-                logger.debug(' file: URL is directory, getting %s', url)
-
-            resp = session.get(
-                url,
-                headers={
-                    "Accept": "text/html",
-                    # We don't want to blindly returned cached data for
-                    # /simple/, because authors generally expecting that
-                    # twine upload && pip install will function, but if
-                    # they've done a pip install in the last ~10 minutes
-                    # it won't. Thus by setting this to zero we will not
-                    # blindly use any cached data, however the benefit of
-                    # using max-age=0 instead of no-cache, is that we will
-                    # still support conditional requests, so we will still
-                    # minimize traffic sent in cases where the page hasn't
-                    # changed at all, we will just always incur the round
-                    # trip for the conditional GET now instead of only
-                    # once per 10 minutes.
-                    # For more information, please see pypa/pip#5670.
-                    "Cache-Control": "max-age=0",
-                },
-            )
-            resp.raise_for_status()
-
-            # The check for archives above only works if the url ends with
-            # something that looks like an archive. However that is not a
-            # requirement of an url. Unless we issue a HEAD request on every
-            # url we cannot know ahead of time for sure if something is HTML
-            # or not. However we can check after we've downloaded it.
-            content_type = resp.headers.get('Content-Type', 'unknown')
-            if not content_type.lower().startswith("text/html"):
-                logger.debug(
-                    'Skipping page %s because of Content-Type: %s',
-                    link,
-                    content_type,
-                )
-                return
-
-            inst = cls(resp.content, resp.url, resp.headers)
-        except requests.HTTPError as exc:
-            _handle_fail(link, exc, url)
-        except SSLError as exc:
-            reason = "There was a problem confirming the ssl certificate: "
-            reason += str(exc)
-            _handle_fail(link, reason, url, meth=logger.info)
-        except requests.ConnectionError as exc:
-            _handle_fail(link, "connection error: %s" % exc, url)
-        except requests.Timeout:
-            _handle_fail(link, "timed out", url)
-        else:
-            return inst
-
-    @property
-    def links(self):
-        """Yields all links in the page"""
-        document = html5lib.parse(
-            self.content,
-            transport_encoding=self.encoding,
-            namespaceHTMLElements=False,
+        resp = session.get(
+            url,
+            headers={
+                "Accept": "text/html",
+                # We don't want to blindly returned cached data for
+                # /simple/, because authors generally expecting that
+                # twine upload && pip install will function, but if
+                # they've done a pip install in the last ~10 minutes
+                # it won't. Thus by setting this to zero we will not
+                # blindly use any cached data, however the benefit of
+                # using max-age=0 instead of no-cache, is that we will
+                # still support conditional requests, so we will still
+                # minimize traffic sent in cases where the page hasn't
+                # changed at all, we will just always incur the round
+                # trip for the conditional GET now instead of only
+                # once per 10 minutes.
+                # For more information, please see pypa/pip#5670.
+                "Cache-Control": "max-age=0",
+            },
         )
-        base_url = parse_base_url(document, self.url)
+        resp.raise_for_status()
 
-        def _clean_link(url):
-            """Makes sure a link is fully encoded.  That is, if a ' ' shows up
-            in the link, it will be rewritten to %20 (while not over-quoting
-            % or other characters)."""
-            return LINK_CLEAN_RE.sub(
-                lambda match: '%%%2x' % ord(match.group(0)), url)
+        # The check for archives above only works if the url ends with
+        # something that looks like an archive. However that is not a
+        # requirement of an url. Unless we issue a HEAD request on every
+        # url we cannot know ahead of time for sure if something is HTML
+        # or not. However we can check after we've downloaded it.
+        content_type = resp.headers.get('Content-Type', 'unknown')
+        if not content_type.lower().startswith("text/html"):
+            logger.debug(
+                'Skipping page %s because of Content-Type: %s',
+                link,
+                content_type,
+            )
+            return
 
-        for anchor in document.findall(".//a"):
-            if anchor.get("href"):
-                href = anchor.get("href")
-                url = _clean_link(urllib_parse.urljoin(base_url, href))
-                pyrequire = anchor.get('data-requires-python')
-                pyrequire = unescape(pyrequire) if pyrequire else None
-                yield Link(url, self.url, requires_python=pyrequire)
+        args = (resp.content, resp.url, resp.headers)
+    except requests.HTTPError as exc:
+        _handle_collect_links_fail(link, exc, url)
+    except SSLError as exc:
+        reason = "There was a problem confirming the ssl certificate: "
+        reason += str(exc)
+        _handle_collect_links_fail(link, reason, url, meth=logger.info)
+    except requests.ConnectionError as exc:
+        _handle_collect_links_fail(link, "connection error: %s" % exc, url)
+    except requests.Timeout:
+        _handle_collect_links_fail(link, "timed out", url)
+
+    if args is None:
+        return
+
+    logger.debug('Analyzing links from page %s', resp.url)
+
+    content, url, headers = args
+    encoding = get_content_type_encoding(headers)
+    document = html5lib.parse(
+        content, transport_encoding=encoding, namespaceHTMLElements=False,
+    )
+    base_url = parse_base_url(document, url)
+
+    for anchor in document.findall(".//a"):
+        href = anchor.get("href")
+        if not href:
+            continue
+        url = _clean_link(urllib_parse.urljoin(base_url, href))
+        pyrequire = anchor.get('data-requires-python')
+        pyrequire = unescape(pyrequire) if pyrequire else None
+        yield Link(url, url, requires_python=pyrequire)
+
+
+def _clean_link(url):
+    """Makes sure a link is fully encoded.  That is, if a ' ' shows up
+    in the link, it will be rewritten to %20 (while not over-quoting
+    % or other characters)."""
+    return LINK_CLEAN_RE.sub(lambda match: '%%%2x' % ord(match.group(0)), url)
 
 
 LINK_CLEAN_RE = re.compile(r'[^a-z0-9$&+,/:;=?@.#%_\\|-]', re.I)

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -18,7 +18,7 @@ class Link(KeyBasedCompareMixin):
         url:
             url of the resource pointed to (href of the link)
         comes_from:
-            instance of HTMLPage where the link was found, or string.
+            a string to indicate where/how the link was found.
         requires_python:
             String containing the `Requires-Python` metadata field, specified
             in PEP 345. This may be specified by a data-requires-python

--- a/src/pip/_internal/repositories/entries.py
+++ b/src/pip/_internal/repositories/entries.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import re
+
+EGG_INFO_RE = re.compile(r"([a-z0-9_.]+)-([a-z0-9_.!+-]+)", re.IGNORECASE)
+
+
+def match_egg_info_version(egg_info, package_name, _egg_info_re=EGG_INFO_RE):
+    """Pull the version part out of a string.
+
+    :param egg_info: The string to parse. E.g. foo-2.1
+    :param package_name: The name of the package this belongs to. None to
+        infer the name. Note that this cannot unambiguously parse strings
+        like foo-2-2 which might be foo, 2-2 or foo-2, 2.
+    """
+    match = _egg_info_re.search(egg_info)
+    if not match:
+        raise ValueError(egg_info)
+    if package_name is None:
+        return match.group(0).split("-", 1)[-1]
+    name = match.group(0).lower()
+    # To match the "safe" name that pkg_resources creates:
+    name = name.replace('_', '-')
+    # project name and version must be separated by a dash
+    look_for = package_name.lower() + "-"
+    if name.startswith(look_for):
+        return match.group(0)[len(look_for):]
+    return None

--- a/src/pip/_internal/repositories/entries.py
+++ b/src/pip/_internal/repositories/entries.py
@@ -27,3 +27,27 @@ def match_egg_info_version(egg_info, package_name, _egg_info_re=EGG_INFO_RE):
     if name.startswith(look_for):
         return match.group(0)[len(look_for):]
     return None
+
+
+def parse_base_url(document, page_url):
+    """Get the base URL of this document.
+
+    This looks for a ``<base>`` tag in the HTML document. If present, its href
+    attribute denotes the base URL of anchor tags in the document. If there is
+    no such tag (or if it does not have a valid href attribute), the HTML
+    file's URL is used as the base URL.
+
+    :param document: An HTML document representation. The current
+        implementation expects the result of ``html5lib.parse()``.
+    :param page_url: The URL of the HTML document.
+    """
+    bases = [
+        x for x in document.findall(".//base")
+        if x.get("href") is not None
+    ]
+    if not bases:
+        return page_url
+    parsed_url = bases[0].get("href")
+    if parsed_url:
+        return parsed_url
+    return page_url

--- a/src/pip/_internal/repositories/utils.py
+++ b/src/pip/_internal/repositories/utils.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import cgi
+
+
+def get_content_type_encoding(headers):
+    """Parse the encoding information from HTTP headers.
+
+    The charset part of the `Content-Type` header is returned, or None of
+    there is none present.
+
+    :param headers: A dict-like mapping, or None.
+    """
+    if headers and "Content-Type" in headers:
+        content_type, params = cgi.parse_header(headers["Content-Type"])
+        if "charset" in params:
+            return params['charset']
+    return None

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -349,7 +349,7 @@ def test_finder_priority_nonegg_over_eggfragments():
 
     finder = PackageFinder(links, [], session=PipSession())
 
-    with patch.object(finder, "_get_pages", lambda x, y: []):
+    with patch.object(finder, "_iter_links", lambda x: []):
         all_versions = finder.find_all_candidates(req.name)
         assert all_versions[0].location.url.endswith('tar.gz')
         assert all_versions[1].location.url.endswith('#egg=bar-1.0')
@@ -361,7 +361,7 @@ def test_finder_priority_nonegg_over_eggfragments():
     links.reverse()
     finder = PackageFinder(links, [], session=PipSession())
 
-    with patch.object(finder, "_get_pages", lambda x, y: []):
+    with patch.object(finder, "_iter_links", lambda x: []):
         all_versions = finder.find_all_candidates(req.name)
         assert all_versions[0].location.url.endswith('tar.gz')
         assert all_versions[1].location.url.endswith('#egg=bar-1.0')
@@ -386,14 +386,14 @@ def test_finder_only_installs_stable_releases(data):
     links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
     finder = PackageFinder(links, [], session=PipSession())
 
-    with patch.object(finder, "_get_pages", lambda x, y: []):
+    with patch.object(finder, "_iter_links", lambda x: []):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-1.0.tar.gz"
 
     links.reverse()
     finder = PackageFinder(links, [], session=PipSession())
 
-    with patch.object(finder, "_get_pages", lambda x, y: []):
+    with patch.object(finder, "_iter_links", lambda x: []):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-1.0.tar.gz"
 
@@ -448,7 +448,7 @@ def test_finder_installs_pre_releases(data):
         session=PipSession(),
     )
 
-    with patch.object(finder, "_get_pages", lambda x, y: []):
+    with patch.object(finder, "_iter_links", lambda x: []):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
@@ -459,7 +459,7 @@ def test_finder_installs_pre_releases(data):
         session=PipSession(),
     )
 
-    with patch.object(finder, "_get_pages", lambda x, y: []):
+    with patch.object(finder, "_iter_links", lambda x: []):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
@@ -490,14 +490,14 @@ def test_finder_installs_pre_releases_with_version_spec():
 
     finder = PackageFinder(links, [], session=PipSession())
 
-    with patch.object(finder, "_get_pages", lambda x, y: []):
+    with patch.object(finder, "_iter_links", lambda x: []):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
     links.reverse()
     finder = PackageFinder(links, [], session=PipSession())
 
-    with patch.object(finder, "_get_pages", lambda x, y: []):
+    with patch.object(finder, "_iter_links", lambda x: []):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -3,7 +3,7 @@ import os.path
 import pytest
 
 from pip._internal.download import PipSession
-from pip._internal.index import HTMLPage, Link, PackageFinder
+from pip._internal.index import Link, PackageFinder
 
 
 def test_sort_locations_file_expand_dir(data):
@@ -85,30 +85,6 @@ class TestLink(object):
         url = 'git+https://example.com/package#subdirectory=subdir&egg=eggname'
         assert 'eggname' == Link(url).egg_fragment
         assert 'subdir' == Link(url).subdirectory_fragment
-
-
-@pytest.mark.parametrize(
-    ("html", "url", "expected"),
-    [
-        (b"<html></html>", "https://example.com/", "https://example.com/"),
-        (
-            b"<html><head>"
-            b"<base href=\"https://foo.example.com/\">"
-            b"</head></html>",
-            "https://example.com/",
-            "https://foo.example.com/",
-        ),
-        (
-            b"<html><head>"
-            b"<base><base href=\"https://foo.example.com/\">"
-            b"</head></html>",
-            "https://example.com/",
-            "https://foo.example.com/",
-        ),
-    ],
-)
-def test_base_url(html, url, expected):
-    assert HTMLPage(html, url).base_url == expected
 
 
 class MockLogger(object):

--- a/tests/unit/test_repositories.py
+++ b/tests/unit/test_repositories.py
@@ -1,7 +1,7 @@
 import pytest
 from pip._vendor import html5lib
 
-from pip._internal.repositories.entries import parse_base_url
+from pip._internal.repositories.entries import _parse_base_url
 
 
 @pytest.mark.parametrize(
@@ -28,4 +28,4 @@ def test_base_url(html, url, expected):
     document = html5lib.parse(
         html, transport_encoding=None, namespaceHTMLElements=False,
     )
-    assert parse_base_url(document, url) == expected
+    assert _parse_base_url(document, url) == expected

--- a/tests/unit/test_repositories.py
+++ b/tests/unit/test_repositories.py
@@ -1,0 +1,31 @@
+import pytest
+from pip._vendor import html5lib
+
+from pip._internal.repositories.entries import parse_base_url
+
+
+@pytest.mark.parametrize(
+    ("html", "url", "expected"),
+    [
+        (b"<html></html>", "https://example.com/", "https://example.com/"),
+        (
+            b"<html><head>"
+            b"<base href=\"https://foo.example.com/\">"
+            b"</head></html>",
+            "https://example.com/",
+            "https://foo.example.com/",
+        ),
+        (
+            b"<html><head>"
+            b"<base><base href=\"https://foo.example.com/\">"
+            b"</head></html>",
+            "https://example.com/",
+            "https://foo.example.com/",
+        ),
+    ],
+)
+def test_base_url(html, url, expected):
+    document = html5lib.parse(
+        html, transport_encoding=None, namespaceHTMLElements=False,
+    )
+    assert parse_base_url(document, url) == expected


### PR DESCRIPTION
What I really want to do for #5800, part 1 of many.

The end goal is to produce a `repositories` package that can be used on its own, maybe as part of `packaging`, or a standalone package. This involves taking parts of PackageFinder and HTMLPage and shuffle them.

I start with HTMLPage since it is completely internal to `index.py`. It is used strictly as a temporary object to generate links. An instance is created by making a request (or two), and parsing the content. The object is then iterated through almost immediately to generate link objects. So I made some refactoring, turn the class into a plain generator function, and was able to extract HTML-parsing parts into `repositories`. It might seem arbitrary what went into `repositories` and what didn’t, but I promise there is logic behind it, and it’ll show later (I hope).

There is a lot going on in this PR, but I feel I have documented my steps quite clearly in commit messages. It should be quite straightforward to make sense of each commit on its own (I move only one or two things around in each commit). These are also all tied together, so I can’t submit them in parallel. Please do tell me if you feel I should make a split at a certain point.