### PR TITLE
travis: fix Python 3.8 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,12 @@ jobs:
 
     - env: GROUP=1
       python: 3.8-dev
+      dist: xenial
+      sudo: required
     - env: GROUP=2
       python: 3.8-dev
+      dist: xenial
+      sudo: required
 
   # It's okay to fail on the in-development CPython version.
   fast_finish: true


### PR DESCRIPTION
`dist: xenial` and `sudo: required` need to be used (as per the Python 3.7 jobs).