### PR TITLE
Warn when dropping index URL value to directory

### DIFF
--- a/news/5827.feature
+++ b/news/5827.feature
@@ -1,0 +1,1 @@
+A warning message is emitted when dropping an ``--[extra-]index-url`` value that points to an existing local directory.

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -216,6 +216,11 @@ class PackageFinder(object):
                             sort_path(os.path.join(path, item))
                     elif is_file_url:
                         urls.append(url)
+                    else:
+                        logger.warning(
+                            "Path '{0}' is ignored: "
+                            "it is a directory.".format(path),
+                        )
                 elif os.path.isfile(path):
                     sort_path(path)
                 else:


### PR DESCRIPTION
Close #5827. I opt to only add the warning for now instead of refactoring the whole thing. `expand_dir` adds a lot of complexity to this function, and I want to eliminate it first. I think it would be easier to get the function to work “properly” before changing how its invoked.