### PR TITLE
Simplify FrozenRequirement._init_args_from_dist()

### DIFF
--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -188,15 +188,17 @@ class FrozenRequirement(object):
                     "falling back to uneditable format", exc
                 )
                 req = None
-            if req is None:
-                logger.warning(
-                    'Could not determine repository location of %s', location
-                )
-                comments.append(
-                    '## !! Could not determine repository location'
-                )
-                req = dist.as_requirement()
-                editable = False
+            if req is not None:
+                return (req, editable, comments)
+
+            logger.warning(
+                'Could not determine repository location of %s', location
+            )
+            comments.append(
+                '## !! Could not determine repository location'
+            )
+            req = dist.as_requirement()
+            editable = False
 
             return (req, editable, comments)
 

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -176,7 +176,6 @@ class FrozenRequirement(object):
         This method is for use in FrozenRequirement.from_dist().
         """
         location = os.path.normcase(os.path.abspath(dist.location))
-        comments = []
         from pip._internal.vcs import vcs, get_src_requirement
         if dist_is_editable(dist) and vcs.get_backend_name(location):
             try:
@@ -188,12 +187,12 @@ class FrozenRequirement(object):
                 )
             else:
                 if req is not None:
-                    return (req, True, comments)
+                    return (req, True, [])
 
             logger.warning(
                 'Could not determine repository location of %s', location
             )
-            comments.append('## !! Could not determine repository location')
+            comments = ['## !! Could not determine repository location']
             req = dist.as_requirement()
 
             return (req, False, comments)
@@ -207,17 +206,17 @@ class FrozenRequirement(object):
         ver_match = cls._rev_re.search(version)
         date_match = cls._date_re.search(version)
         if not (ver_match or date_match):
-            return (req, False, comments)
+            return (req, False, [])
 
         svn_backend = vcs.get_backend('svn')
         if svn_backend:
             svn_location = svn_backend().get_location(dist, dependency_links)
         if not svn_location:
             logger.warning('Warning: cannot find svn location for %s', req)
-            comments.append(
+            comments = [
                 '## FIXME: could not find svn URL in dependency_links '
                 'for this package:'
-            )
+            ]
             return (req, False, comments)
 
         deprecated(
@@ -227,9 +226,9 @@ class FrozenRequirement(object):
             gone_in="19.0",
             issue=4187,
         )
-        comments.append(
+        comments = [
             '# Installing as editable to satisfy requirement %s:' % req
-        )
+        ]
         if ver_match:
             rev = ver_match.group(1)
         else:

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -228,25 +228,26 @@ class FrozenRequirement(object):
                 '## FIXME: could not find svn URL in dependency_links '
                 'for this package:'
             )
+            return (req, editable, comments)
+
+        deprecated(
+            "SVN editable detection based on dependency links "
+            "will be dropped in the future.",
+            replacement=None,
+            gone_in="19.0",
+            issue=4187,
+        )
+        comments.append(
+            '# Installing as editable to satisfy requirement %s:' %
+            req
+        )
+        if ver_match:
+            rev = ver_match.group(1)
         else:
-            deprecated(
-                "SVN editable detection based on dependency links "
-                "will be dropped in the future.",
-                replacement=None,
-                gone_in="19.0",
-                issue=4187,
-            )
-            comments.append(
-                '# Installing as editable to satisfy requirement %s:' %
-                req
-            )
-            if ver_match:
-                rev = ver_match.group(1)
-            else:
-                rev = '{%s}' % date_match.group(1)
-            editable = True
-            egg_name = cls.egg_name(dist)
-            req = make_vcs_requirement_url(svn_location, rev, egg_name)
+            rev = '{%s}' % date_match.group(1)
+        editable = True
+        egg_name = cls.egg_name(dist)
+        req = make_vcs_requirement_url(svn_location, rev, egg_name)
 
         return (req, editable, comments)
 

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -193,9 +193,7 @@ class FrozenRequirement(object):
             logger.warning(
                 'Could not determine repository location of %s', location
             )
-            comments.append(
-                '## !! Could not determine repository location'
-            )
+            comments.append('## !! Could not determine repository location')
             req = dist.as_requirement()
 
             return (req, False, comments)
@@ -213,14 +211,9 @@ class FrozenRequirement(object):
 
         svn_backend = vcs.get_backend('svn')
         if svn_backend:
-            svn_location = svn_backend().get_location(
-                dist,
-                dependency_links,
-            )
+            svn_location = svn_backend().get_location(dist, dependency_links)
         if not svn_location:
-            logger.warning(
-                'Warning: cannot find svn location for %s', req,
-            )
+            logger.warning('Warning: cannot find svn location for %s', req)
             comments.append(
                 '## FIXME: could not find svn URL in dependency_links '
                 'for this package:'
@@ -235,8 +228,7 @@ class FrozenRequirement(object):
             issue=4187,
         )
         comments.append(
-            '# Installing as editable to satisfy requirement %s:' %
-            req
+            '# Installing as editable to satisfy requirement %s:' % req
         )
         if ver_match:
             rev = ver_match.group(1)

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -186,9 +186,9 @@ class FrozenRequirement(object):
                     "Error when trying to get requirement for VCS system %s, "
                     "falling back to uneditable format", exc
                 )
-                req = None
-            if req is not None:
-                return (req, True, comments)
+            else:
+                if req is not None:
+                    return (req, True, comments)
 
             logger.warning(
                 'Could not determine repository location of %s', location

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -209,40 +209,42 @@ class FrozenRequirement(object):
         version = specs[0][1]
         ver_match = cls._rev_re.search(version)
         date_match = cls._date_re.search(version)
-        if ver_match or date_match:
-            svn_backend = vcs.get_backend('svn')
-            if svn_backend:
-                svn_location = svn_backend().get_location(
-                    dist,
-                    dependency_links,
-                )
-            if not svn_location:
-                logger.warning(
-                    'Warning: cannot find svn location for %s', req,
-                )
-                comments.append(
-                    '## FIXME: could not find svn URL in dependency_links '
-                    'for this package:'
-                )
+        if not (ver_match or date_match):
+            return (req, editable, comments)
+
+        svn_backend = vcs.get_backend('svn')
+        if svn_backend:
+            svn_location = svn_backend().get_location(
+                dist,
+                dependency_links,
+            )
+        if not svn_location:
+            logger.warning(
+                'Warning: cannot find svn location for %s', req,
+            )
+            comments.append(
+                '## FIXME: could not find svn URL in dependency_links '
+                'for this package:'
+            )
+        else:
+            deprecated(
+                "SVN editable detection based on dependency links "
+                "will be dropped in the future.",
+                replacement=None,
+                gone_in="19.0",
+                issue=4187,
+            )
+            comments.append(
+                '# Installing as editable to satisfy requirement %s:' %
+                req
+            )
+            if ver_match:
+                rev = ver_match.group(1)
             else:
-                deprecated(
-                    "SVN editable detection based on dependency links "
-                    "will be dropped in the future.",
-                    replacement=None,
-                    gone_in="19.0",
-                    issue=4187,
-                )
-                comments.append(
-                    '# Installing as editable to satisfy requirement %s:' %
-                    req
-                )
-                if ver_match:
-                    rev = ver_match.group(1)
-                else:
-                    rev = '{%s}' % date_match.group(1)
-                editable = True
-                egg_name = cls.egg_name(dist)
-                req = make_vcs_requirement_url(svn_location, rev, egg_name)
+                rev = '{%s}' % date_match.group(1)
+            editable = True
+            egg_name = cls.egg_name(dist)
+            req = make_vcs_requirement_url(svn_location, rev, egg_name)
 
         return (req, editable, comments)
 


### PR DESCRIPTION
This PR simplifies `FrozenRequirement. _init_args_from_dist()` by using guard clauses when it makes sense, and eliminating temporary variables that aren't needed. This lets us significantly reduce the amount of indentation and if-else branching.

The PR is broken up into a number of commits, each one making a single, simple refactoring change.