### PR TITLE
Refactor _get_html_page() to use exceptions for flow control

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -707,7 +707,7 @@ class PackageFinder(object):
                 continue
             seen.add(location)
 
-            page = self._get_page(location)
+            page = _get_html_page(location, session=self.session)
             if page is None:
                 continue
 
@@ -823,9 +823,6 @@ class PackageFinder(object):
         logger.debug('Found link %s, version: %s', link, version)
 
         return InstallationCandidate(search.supplied, version, link)
-
-    def _get_page(self, link):
-        return _get_html_page(link, session=self.session)
 
 
 def egg_info_matches(


### PR DESCRIPTION
#5800 part 1b-2 (part of #5822). Flow control of HTTP requests is now done with exceptions. I’m going to keep pumping out patches for a while, so feel free to call cut at any point to make a release.