### PR TITLE
fix support for invoking pip using `python src/pip ...`

### DIFF
--- a/news/5841.bugfix
+++ b/news/5841.bugfix
@@ -1,0 +1,1 @@
+Fix support for invoking pip using `python src/pip ...`.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -9,6 +9,7 @@ from sysconfig import get_paths
 
 from pip._vendor.pkg_resources import Requirement, VersionConflict, WorkingSet
 
+from pip import __file__ as pip_location
 from pip._internal.utils.misc import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.ui import open_spinner
@@ -93,8 +94,9 @@ class BuildEnvironment(object):
 
     def install_requirements(self, finder, requirements, message):
         args = [
-            sys.executable, '-m', 'pip', 'install', '--ignore-installed',
-            '--no-user', '--prefix', self.path, '--no-warn-script-location',
+            sys.executable, os.path.dirname(pip_location), 'install',
+            '--ignore-installed', '--no-user', '--prefix', self.path,
+            '--no-warn-script-location',
         ]
         if logger.getEffectiveLevel() <= logging.DEBUG:
             args.append('-v')

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -38,6 +38,19 @@ def test_pep518_uses_build_env(script, data, common_wheels, command, variant):
     )
 
 
+def test_pep518_build_env_uses_same_pip(script, data, pip_src, common_wheels):
+    """Ensure the subprocess call to pip for installing the
+    build dependencies is using the same version of pip.
+    """
+    with open(script.scratch_path / 'pip.py', 'w') as fp:
+        fp.write('raise ImportError')
+    script.run(
+        'python', pip_src / 'src/pip', 'install', '--no-index',
+        '-f', common_wheels, '-f', data.packages,
+        data.src.join("pep518-3.0"),
+    )
+
+
 def test_pep518_refuses_invalid_requires(script, data, common_wheels):
     result = script.pip(
         'install', '-f', common_wheels,


### PR DESCRIPTION
Ensure the subprocess call to pip for installing the PEP 518 build dependencies is using the same version of pip.
