### PR TITLE
Don't crash on invalid requirements in installed packages

### DIFF
--- a/news/5839.bugfix
+++ b/news/5839.bugfix
@@ -1,0 +1,1 @@
+Fix crashes from unparseable requirements when checking installed packages.

--- a/src/pip/_internal/commands/check.py
+++ b/src/pip/_internal/commands/check.py
@@ -16,7 +16,7 @@ class CheckCommand(Command):
     summary = 'Verify installed packages have compatible dependencies.'
 
     def run(self, options, args):
-        package_set = create_package_set_from_installed()
+        package_set, parsing_probs = create_package_set_from_installed()
         missing, conflicting = check_package_set(package_set)
 
         for project_name in missing:
@@ -35,7 +35,7 @@ class CheckCommand(Command):
                     project_name, version, req, dep_name, dep_version,
                 )
 
-        if missing or conflicting:
+        if missing or conflicting or parsing_probs:
             return 1
         else:
             logger.info("No broken requirements found.")

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -474,7 +474,7 @@ class InstallCommand(RequirementCommand):
     def _warn_about_conflicts(self, to_install):
         try:
             package_set, _dep_info = check_install_conflicts(to_install)
-        except Exception as e:
+        except Exception:
             logger.error("Error checking for conflicts.", exc_info=True)
             return
         missing, conflicting = _dep_info

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -472,7 +472,11 @@ class InstallCommand(RequirementCommand):
                     )
 
     def _warn_about_conflicts(self, to_install):
-        package_set, _dep_info = check_install_conflicts(to_install)
+        try:
+            package_set, _dep_info = check_install_conflicts(to_install)
+        except Exception as e:
+            logger.error("Error checking for conflicts.", exc_info=True)
+            return
         missing, conflicting = _dep_info
 
         # NOTE: There is some duplication here from pip check

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -4,6 +4,7 @@
 from collections import namedtuple
 
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.pkg_resources import RequirementParseError
 
 from pip._internal.operations.prepare import make_abstract_dist
 from pip._internal.utils.misc import get_installed_distributions
@@ -38,7 +39,11 @@ def create_package_set_from_installed(**kwargs):
     package_set = {}
     for dist in get_installed_distributions(**kwargs):
         name = canonicalize_name(dist.project_name)
-        package_set[name] = PackageDetails(dist.version, dist.requires())
+        try:
+            package_set[name] = PackageDetails(dist.version, dist.requires())
+        except RequirementParseError:
+            # Don't crash on broken metadata
+            pass  # TODO: log a warning?
     return package_set
 
 

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -1,8 +1,8 @@
 """Validation of dependencies of packages
 """
 
-from collections import namedtuple
 import logging
+from collections import namedtuple
 
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.pkg_resources import RequirementParseError

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -2,6 +2,7 @@
 """
 
 from collections import namedtuple
+import logging
 
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.pkg_resources import RequirementParseError
@@ -9,6 +10,8 @@ from pip._vendor.pkg_resources import RequirementParseError
 from pip._internal.operations.prepare import make_abstract_dist
 from pip._internal.utils.misc import get_installed_distributions
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+logger = logging.getLogger(__name__)
 
 if MYPY_CHECK_RUNNING:
     from pip._internal.req.req_install import InstallRequirement  # noqa: F401
@@ -41,9 +44,9 @@ def create_package_set_from_installed(**kwargs):
         name = canonicalize_name(dist.project_name)
         try:
             package_set[name] = PackageDetails(dist.version, dist.requires())
-        except RequirementParseError:
+        except RequirementParseError as e:
             # Don't crash on broken metadata
-            pass  # TODO: log a warning?
+            logging.warning("Error parsing requirements for %s: %s", name, e)
     return package_set
 
 

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -32,7 +32,7 @@ PackageDetails = namedtuple('PackageDetails', ['version', 'requires'])
 
 
 def create_package_set_from_installed(**kwargs):
-    # type: (**Any) -> PackageSet
+    # type: (**Any) -> Tuple[PackageSet, bool]
     """Converts a list of distributions into a PackageSet.
     """
     # Default to using all packages installed on the system
@@ -40,6 +40,7 @@ def create_package_set_from_installed(**kwargs):
         kwargs = {"local_only": False, "skip": ()}
 
     package_set = {}
+    problems = False
     for dist in get_installed_distributions(**kwargs):
         name = canonicalize_name(dist.project_name)
         try:
@@ -47,7 +48,8 @@ def create_package_set_from_installed(**kwargs):
         except RequirementParseError as e:
             # Don't crash on broken metadata
             logging.warning("Error parsing requirements for %s: %s", name, e)
-    return package_set
+            problems = True
+    return package_set, problems
 
 
 def check_package_set(package_set, should_ignore=None):
@@ -103,7 +105,7 @@ def check_install_conflicts(to_install):
     installing given requirements
     """
     # Start from the current state
-    package_set = create_package_set_from_installed()
+    package_set, _ = create_package_set_from_installed()
     # Install packages
     would_be_installed = _simulate_installation_of(to_install, package_set)
 

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -232,7 +232,7 @@ def test_basic_check_broken_metadata(script):
         f.write('Metadata-Version: 2.1\n'
                 'Name: pkga\n'
                 'Version: 1.0\n'
-                'Requires-Dist: pip; python_version == "3.4"; extra == "test"\n'
+                'Requires-Dist: pip; python_version == "3.4";extra == "test"\n'
                 )
 
     result = script.pip('check', expect_error=True)

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -223,6 +223,7 @@ def test_check_development_versions_are_also_considered(script):
     assert matches_expected_lines(result.stdout, expected_lines)
     assert result.returncode == 0
 
+
 def test_basic_check_broken_metadata(script):
     # Create some corrupt metadata
     dist_info_dir = script.site_packages_path / 'pkga-1.0.dist-info'
@@ -231,8 +232,8 @@ def test_basic_check_broken_metadata(script):
         f.write('Metadata-Version: 2.1\n'
                 'Name: pkga\n'
                 'Version: 1.0\n'
-                'Requires-Dist: requests; python_version == "3.4"; extra == "test"\n'
-               )
+                'Requires-Dist: pip; python_version == "3.4"; extra == "test"\n'
+                )
 
     result = script.pip('check', expect_error=True)
 

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -222,3 +222,19 @@ def test_check_development_versions_are_also_considered(script):
     )
     assert matches_expected_lines(result.stdout, expected_lines)
     assert result.returncode == 0
+
+def test_basic_check_broken_metadata(script):
+    # Create some corrupt metadata
+    dist_info_dir = script.site_packages_path / 'pkga-1.0.dist-info'
+    dist_info_dir.mkdir()
+    with open(dist_info_dir / 'METADATA', 'w') as f:
+        f.write('Metadata-Version: 2.1\n'
+                'Name: pkga\n'
+                'Version: 1.0\n'
+                'Requires-Dist: requests; python_version == "3.4"; extra == "test"\n'
+               )
+
+    result = script.pip('check', expect_error=True)
+
+    assert 'Error parsing requirements' in result.stderr
+    assert result.returncode == 1


### PR DESCRIPTION
See #5839. This adds exception handling in two places:

1. Inside the checking code, so that an error message can be logged which describes the package name - the tracebacks at the moment don't make it clear which package has the problem.
2. Where the `pip install` machinery calls into the check machinery, because I believe that an uncaught error in checking shouldn't be able to crash the install process.

