### PR TITLE
tox: fix environment setup

### DIFF
--- a/tools/tox_pip.py
+++ b/tools/tox_pip.py
@@ -1,0 +1,28 @@
+import os
+import shutil
+import subprocess
+import sys
+from glob import glob
+
+VIRTUAL_ENV = os.environ['VIRTUAL_ENV']
+TOX_PIP_DIR = os.path.join(VIRTUAL_ENV, 'pip')
+
+
+def pip(args):
+    # First things first, get a recent (stable) version of pip.
+    if not os.path.exists(TOX_PIP_DIR):
+        subprocess.check_call([sys.executable, '-m', 'pip',
+                               '--disable-pip-version-check',
+                               'install', '-t', TOX_PIP_DIR,
+                               'pip'])
+        shutil.rmtree(glob(os.path.join(TOX_PIP_DIR, 'pip-*.dist-info'))[0])
+    # And use that version.
+    pypath = os.environ.get('PYTHONPATH')
+    pypath = pypath.split(os.pathsep) if pypath is not None else []
+    pypath.insert(0, TOX_PIP_DIR)
+    os.environ['PYTHONPATH'] = os.pathsep.join(pypath)
+    subprocess.check_call([sys.executable, '-m', 'pip'] + args)
+
+
+if __name__ == '__main__':
+    pip(sys.argv[1:])

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,11 @@ envlist =
     docs, packaging, lint-py2, lint-py3, mypy,
     py27, py34, py35, py36, py37, py38, pypy, pypy3
 
+[helpers]
+# Wrapper for calls to pip that make sure the version being used is the
+# original virtualenv (stable) version, and not the code being tested.
+pip = python {toxinidir}/tools/tox_pip.py
+
 [testenv]
 passenv = CI GIT_SSL_CAINFO
 setenv =
@@ -11,7 +16,8 @@ setenv =
     LC_CTYPE = en_US.UTF-8
 deps = -r{toxinidir}/tools/tests-requirements.txt
 commands = pytest --timeout 300 []
-install_command = python -m pip install {opts} {packages}
+install_command = {[helpers]pip} install {opts} {packages}
+list_dependencies_command = {[helpers]pip} freeze --all
 usedevelop = True
 
 [testenv:coverage-py3]


### PR DESCRIPTION
Use the virtualenv's pip for installing dependencies, not the code that is about to be tested. Another stab at #4657 and a simpler (IMHO) alternative to and closes #5770.