### PR TITLE
Use ZipFile.open instead of ZipFile.read

### DIFF
--- a/news/5848.bugfix
+++ b/news/5848.bugfix
@@ -1,2 +1,1 @@
-Extract files from wheels in chunks, to avoid memory issues on smaller
-platforms when handling wheels containing large files.
+Greatly reduce memory usage when installing wheels containing large files.

--- a/news/5848.bugfix
+++ b/news/5848.bugfix
@@ -1,6 +1,2 @@
-Extract files from wheel archives in chunks, instead of decompressing the
-entire file content into memory before writing it to disk. For the vast
-majority of cases (PCs with ample RAM and/or small wheels) this makes no
-difference. But there are some circumstances (e.g. a Raspberry Pi with no swap,
-the default config, plus a wheel containing huge libraries like Tensorflow) in
-which this leads to a failure to unpack and a crash with a MemoryError.
+Extract files from wheels in chunks, to avoid memory issues on smaller
+platforms when handling wheels containing large files.

--- a/news/5848.bugfix
+++ b/news/5848.bugfix
@@ -1,0 +1,6 @@
+Extract files from wheel archives in chunks, instead of decompressing the
+entire file content into memory before writing it to disk. For the vast
+majority of cases (PCs with ample RAM and/or small wheels) this makes no
+difference. But there are some circumstances (e.g. a Raspberry Pi with no swap,
+the default config, plus a wheel containing huge libraries like Tensorflow) in
+which this leads to a failure to unpack and a crash with a MemoryError.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -478,6 +478,9 @@ def unzip_file(filename, location, flatten=True):
                 ensure_dir(fn)
             else:
                 ensure_dir(dir)
+                # Open the archive member as a file-like-object so we can
+                # copy it in chunks with copyfileobj; using read() instead
+                # potentially allocates an arbitrarily large amount of memory
                 fp = zip.open(name)
                 try:
                     with open(fn, 'wb') as destfp:

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -468,7 +468,6 @@ def unzip_file(filename, location, flatten=True):
         leading = has_leading_dir(zip.namelist()) and flatten
         for info in zip.infolist():
             name = info.filename
-            data = zip.read(name)
             fn = name
             if leading:
                 fn = split_leading_dir(name)[1]
@@ -479,9 +478,10 @@ def unzip_file(filename, location, flatten=True):
                 ensure_dir(fn)
             else:
                 ensure_dir(dir)
-                fp = open(fn, 'wb')
+                fp = zip.open(name)
                 try:
-                    fp.write(data)
+                    with open(fn, 'wb') as destfp:
+                        shutil.copyfileobj(fp, destfp)
                 finally:
                     fp.close()
                     mode = info.external_attr >> 16

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -478,9 +478,8 @@ def unzip_file(filename, location, flatten=True):
                 ensure_dir(fn)
             else:
                 ensure_dir(dir)
-                # Open the archive member as a file-like-object so we can
-                # copy it in chunks with copyfileobj; using read() instead
-                # potentially allocates an arbitrarily large amount of memory
+                # Don't use read() to avoid allocating an arbitrarily large
+                # chunk of memory for the file's content
                 fp = zip.open(name)
                 try:
                     with open(fn, 'wb') as destfp:


### PR DESCRIPTION
To avoid huge memory usage in unusual situations (e.g. the TensorFlow wheel on a Raspberry Pi), use `ZipFile.open` and `shutil.copyfileobj` instead of `ZipFile.read`, which loads all the decompressed data of the file (an arbitrarily large amount) into a byte-string. On the Pi, this can lead to out-of-memory situations when there's no swap (the default configuration of Raspbian), and the wheel contains huge files.