### PR TITLE
Use --find-links before using indexes

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -504,8 +504,8 @@ class PackageFinder(object):
         # We want to filter out any thing which does not have a secure origin.
         url_locations = [
             link for link in itertools.chain(
-                (Link(url) for url in index_url_loc),
                 (Link(url) for url in fl_url_loc),
+                (Link(url) for url in index_url_loc),
                 (Link(url) for url in dep_url_loc),
             )
             if self._validate_secure_origin(logger, link)


### PR DESCRIPTION
--find-links often points to a local file system path which results in much
faster installations. When giving --find-links pip should lookup the path
*before* looking up the index which is usually much slower.

I am not adding anything to news since I consider this change as trivial. ;)

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
