### PR TITLE
Fix a typo in tests/lib/configuration_helpers.py

### DIFF
--- a/tests/lib/configuration_helpers.py
+++ b/tests/lib/configuration_helpers.py
@@ -34,13 +34,13 @@ class ConfigurationMixin(object):
         old = self.configuration._load_config_files
 
         @functools.wraps(old)
-        def overidden():
+        def overridden():
             # Manual Overload
             self.configuration._config[variant].update(di)
             self.configuration._parsers[variant].append((None, None))
             return old()
 
-        self.configuration._load_config_files = overidden
+        self.configuration._load_config_files = overridden
 
     @contextlib.contextmanager
     def tmpfile(self, contents):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
