### PR TITLE
Travis CI: preemptively switch to VM-based jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 cache: pip
 dist: trusty
 
@@ -41,11 +40,9 @@ jobs:
     - env: GROUP=1
       python: 3.7
       dist: xenial
-      sudo: required
     - env: GROUP=2
       python: 3.7
       dist: xenial
-      sudo: required
     - env: GROUP=1
       python: 3.5
     - env: GROUP=2
@@ -58,11 +55,9 @@ jobs:
     - env: GROUP=1
       python: 3.8-dev
       dist: xenial
-      sudo: required
     - env: GROUP=2
       python: 3.8-dev
       dist: xenial
-      sudo: required
 
   # It's okay to fail on the in-development CPython version.
   fast_finish: true


### PR DESCRIPTION
Rational: https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures.