### PR TITLE
Simplify vcs.get_src_requirement().

### DIFF
--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -173,12 +173,18 @@ class FrozenRequirement(object):
         """
         location = os.path.normcase(os.path.abspath(dist.location))
         from pip._internal.vcs import vcs, get_src_requirement
-        if not dist_is_editable(dist) or not vcs.get_backend_name(location):
+        if not dist_is_editable(dist):
+            req = dist.as_requirement()
+            return (req, False, [])
+
+        vc_name = vcs.get_backend_name(location)
+
+        if not vc_name:
             req = dist.as_requirement()
             return (req, False, [])
 
         try:
-            req = get_src_requirement(dist, location)
+            req = get_src_requirement(vc_name, dist, location)
         except InstallationError as exc:
             logger.warning(
                 "Error when trying to get requirement for VCS system %s, "

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -177,14 +177,14 @@ class FrozenRequirement(object):
             req = dist.as_requirement()
             return (req, False, [])
 
-        vc_name = vcs.get_backend_name(location)
+        vc_type = vcs.get_backend_type(location)
 
-        if not vc_name:
+        if not vc_type:
             req = dist.as_requirement()
             return (req, False, [])
 
         try:
-            req = get_src_requirement(vc_name, dist, location)
+            req = get_src_requirement(vc_type, dist, location)
         except InstallationError as exc:
             logger.warning(
                 "Error when trying to get requirement for VCS system %s, "

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -150,12 +150,6 @@ class VcsSupport(object):
         if name in self._registry:
             return self._registry[name]
 
-    def get_backend_from_location(self, location):
-        vc_type = self.get_backend_name(location)
-        if vc_type:
-            return self.get_backend(vc_type)
-        return None
-
 
 vcs = VcsSupport()
 
@@ -487,8 +481,8 @@ class VersionControl(object):
         return cls.is_repository_directory(location)
 
 
-def get_src_requirement(dist, location):
-    version_control = vcs.get_backend_from_location(location)
+def get_src_requirement(vc_name, dist, location):
+    version_control = vcs.get_backend(vc_name)
     if version_control:
         try:
             return version_control().get_src_requirement(dist,

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -133,16 +133,16 @@ class VcsSupport(object):
         else:
             logger.warning('Cannot unregister because no class or name given')
 
-    def get_backend_name(self, location):
+    def get_backend_type(self, location):
         """
-        Return the name of the version control backend if found at given
-        location, e.g. vcs.get_backend_name('/path/to/vcs/checkout')
+        Return the type of the version control backend if found at given
+        location, e.g. vcs.get_backend_type('/path/to/vcs/checkout')
         """
         for vc_type in self._registry.values():
             if vc_type.controls_location(location):
                 logger.debug('Determine that %s uses VCS: %s',
                              location, vc_type.name)
-                return vc_type.name
+                return vc_type
         return None
 
     def get_backend(self, name):
@@ -481,23 +481,14 @@ class VersionControl(object):
         return cls.is_repository_directory(location)
 
 
-def get_src_requirement(vc_name, dist, location):
-    version_control = vcs.get_backend(vc_name)
-    if version_control:
-        try:
-            return version_control().get_src_requirement(dist,
-                                                         location)
-        except BadCommand:
-            logger.warning(
-                'cannot determine version of editable source in %s '
-                '(%s command not found in path)',
-                location,
-                version_control.name,
-            )
-            return dist.as_requirement()
-    logger.warning(
-        'cannot determine version of editable source in %s (is not SVN '
-        'checkout, Git clone, Mercurial clone or Bazaar branch)',
-        location,
-    )
-    return dist.as_requirement()
+def get_src_requirement(vc_type, dist, location):
+    try:
+        return vc_type().get_src_requirement(dist, location)
+    except BadCommand:
+        logger.warning(
+            'cannot determine version of editable source in %s '
+            '(%s command not found in path)',
+            location,
+            vc_type.name,
+        )
+        return dist.as_requirement()


### PR DESCRIPTION
This refactors away `VcsSupport.get_backend_from_location()` and simplifies `vcs.get_src_requirement()`.