### PR TITLE
Rewrite egg_info_matches with canonicalize_name

### DIFF
--- a/news/5870.bugfix
+++ b/news/5870.bugfix
@@ -1,0 +1,1 @@
+Canonicalize sdist file names so they can be matched to a canonicalized package name passed to ``pip install``.

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -816,7 +816,7 @@ class PackageFinder(object):
 
         if not version:
             version = _egg_info_matches(egg_info, search.canonical)
-        if version is None:
+        if not version:
             self._log_skipped_link(
                 link, 'Missing project version for %s' % search.supplied)
             return
@@ -882,7 +882,10 @@ def _egg_info_matches(egg_info, canonical_name):
         version_start = _find_name_version_sep(egg_info, canonical_name) + 1
     except ValueError:
         return None
-    return egg_info[version_start:]
+    version = egg_info[version_start:]
+    if not version:
+        return None
+    return version
 
 
 def _determine_base_url(document, page_url):

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -815,7 +815,7 @@ class PackageFinder(object):
             return
 
         if not version:
-            version = egg_info_matches(egg_info, search.supplied, link)
+            version = _egg_info_matches(egg_info, search.canonical, link)
         if version is None:
             self._log_skipped_link(
                 link, 'Missing project version for %s' % search.supplied)
@@ -846,33 +846,20 @@ class PackageFinder(object):
         return InstallationCandidate(search.supplied, version, link)
 
 
-def egg_info_matches(
-        egg_info, search_name, link,
-        _egg_info_re=re.compile(r'([a-z0-9_.]+)-([a-z0-9_.!+-]+)', re.I)):
+def _egg_info_matches(egg_info, canonical_name, link):
     """Pull the version part out of a string.
 
     :param egg_info: The string to parse. E.g. foo-2.1
-    :param search_name: The name of the package this belongs to. None to
-        infer the name. Note that this cannot unambiguously parse strings
-        like foo-2-2 which might be foo, 2-2 or foo-2, 2.
+    :param canonical_name: The canonicalized name of the package this
+        belongs to.
     :param link: The link the string came from, for logging on failure.
     """
-    match = _egg_info_re.search(egg_info)
-    if not match:
-        logger.debug('Could not parse version from link: %s', link)
+    if not canonicalize_name(egg_info).startswith(canonical_name):
         return None
-    if search_name is None:
-        full_match = match.group(0)
-        return full_match.split('-', 1)[-1]
-    name = match.group(0).lower()
-    # To match the "safe" name that pkg_resources creates:
-    name = name.replace('_', '-')
-    # project name and version must be separated by a dash
-    look_for = search_name.lower() + "-"
-    if name.startswith(look_for):
-        return match.group(0)[len(look_for):]
-    else:
+    # Project name and version must be separated by a dash.
+    if egg_info[len(canonical_name)] != "-":
         return None
+    return egg_info[(len(canonical_name) + 1):]
 
 
 def _determine_base_url(document, page_url):

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -620,6 +620,15 @@ class Wheel(object):
         return bool(set(tags).intersection(self.file_tags))
 
 
+def _contains_egg_info(
+        s, _egg_info_re=re.compile(r'([a-z0-9_.]+)-([a-z0-9_.!+-]+)', re.I)):
+    """Determine whether the string looks like an egg_info.
+
+    :param s: The string to parse. E.g. foo-2.1
+    """
+    return bool(_egg_info_re.search(s))
+
+
 class WheelBuilder(object):
     """Build wheels from a RequirementSet."""
 
@@ -712,7 +721,6 @@ class WheelBuilder(object):
             newly built wheel, in preparation for installation.
         :return: True if all the wheels built correctly.
         """
-        from pip._internal import index
         from pip._internal.models.link import Link
 
         building_is_possible = self._wheel_dir or (
@@ -742,7 +750,7 @@ class WheelBuilder(object):
                 if autobuilding:
                     link = req.link
                     base, ext = link.splitext()
-                    if index.egg_info_matches(base, None, link) is None:
+                    if not _contains_egg_info(base):
                         # E.g. local directory. Build wheel just for this run.
                         ephem_cache = True
                     if "binary" not in format_control.get_allowed_formats(

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -185,6 +185,10 @@ def test_get_formatted_locations_basic_auth():
         # Should be able to detect collapsed characters in the egg info.
         ("foo--bar-1.0", "foo-bar", 8),
         ("foo-_bar-1.0", "foo-bar", 8),
+
+        # The package name must not ends with a dash (PEP 508), so the first
+        # dash would be the separator, not the second.
+        ("zope.interface--4.5.0", "zope-interface", 14),
     ],
 )
 def test_find_name_version_sep(egg_info, canonical_name, expected):
@@ -215,6 +219,7 @@ def test_find_name_version_sep(egg_info, canonical_name, expected):
 
         # Invalid.
         ("the-package-name-8.19", "does-not-match", None),
+        ("zope.interface.-4.5.0", "zope.interface", None),
     ],
 )
 def test_egg_info_matches(egg_info, canonical_name, expected):

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -13,6 +13,26 @@ from pip._internal.utils.misc import unpack_file
 from tests.lib import DATA_DIR
 
 
+@pytest.mark.parametrize(
+    "s, expected",
+    [
+        # Trivial.
+        ("pip-18.0", True),
+
+        # Ambiguous.
+        ("foo-2-2", True),
+        ("im-valid", True),
+
+        # Invalid.
+        ("invalid", False),
+        ("im_invalid", False),
+    ],
+)
+def test_contains_egg_info(s, expected):
+    result = wheel._contains_egg_info(s)
+    assert result == expected
+
+
 @pytest.mark.parametrize("console_scripts",
                          ["pip = pip._internal.main:pip",
                           "pip:pip = pip._internal.main:pip"])


### PR DESCRIPTION
Fix #5870. I also took the chance to clean up repeated calls to `match.group(0)` in the function.