### PR TITLE
Sort RECORD rows only by path and hash, not size

### DIFF
--- a/news/5868.bugfix
+++ b/news/5868.bugfix
@@ -1,0 +1,1 @@
+Fix sorting `TypeError` in `move_wheel_files()` when installing packages containing record entries conflicting with generated files.

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -8,6 +8,7 @@ import compileall
 import csv
 import hashlib
 import logging
+import operator
 import os.path
 import re
 import shutil
@@ -511,7 +512,7 @@ if __name__ == '__main__':
                 outrows.append((normpath(f, lib_dir), digest, length))
             for f in installed:
                 outrows.append((installed[f], '', ''))
-            for row in sorted(outrows):
+            for row in sorted(outrows, key=operator.itemgetter(0, 1)):
                 writer.writerow(row)
     shutil.move(temp_record, record)
 


### PR DESCRIPTION
This prevents pip from crashing because of #5868. Note that this does not really address duplicate rows or other RECORD problems mentioned in the thread, simply prevents pip from crashing because of them.