### PR TITLE
improve handling of file URIs

### DIFF
--- a/news/5892.bugfix
+++ b/news/5892.bugfix
@@ -1,0 +1,1 @@
+Improve handling of file URIs: correctly handle `file://localhost/...` and don't try to use UNC paths on Unix.

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -473,18 +473,17 @@ def url_to_path(url):
 
     _, netloc, path, _, _ = urllib_parse.urlsplit(url)
 
-    if netloc:
-        if netloc == 'localhost':
-            # According to RFC 8089, same as empty authority.
-            netloc = ''
-        elif sys.platform == 'win32':
-            # If we have a UNC path, prepend UNC share notation.
-            netloc = '\\\\' + netloc
-        else:
-            raise ValueError(
-                'non-local file URIs are not supported on this platform: %r'
-                % url
-            )
+    if not netloc or netloc == 'localhost':
+        # According to RFC 8089, same as empty authority.
+        netloc = ''
+    elif sys.platform == 'win32':
+        # If we have a UNC path, prepend UNC share notation.
+        netloc = '\\\\' + netloc
+    else:
+        raise ValueError(
+            'non-local file URIs are not supported on this platform: %r'
+            % url
+        )
 
     path = urllib_request.url2pathname(netloc + path)
     return path

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -473,9 +473,18 @@ def url_to_path(url):
 
     _, netloc, path, _, _ = urllib_parse.urlsplit(url)
 
-    # if we have a UNC path, prepend UNC share notation
     if netloc:
-        netloc = '\\\\' + netloc
+        if netloc == 'localhost':
+            # According to RFC 8089, same as empty authority.
+            netloc = ''
+        elif sys.platform == 'win32':
+            # If we have a UNC path, prepend UNC share notation.
+            netloc = '\\\\' + netloc
+        else:
+            raise ValueError(
+                'non-local file URIs are not supported on this platform: %r'
+                % url
+            )
 
     path = urllib_request.url2pathname(netloc + path)
     return path

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -127,7 +127,12 @@ def test_path_to_url_unix():
 
 @pytest.mark.skipif("sys.platform == 'win32'")
 def test_url_to_path_unix():
+    assert url_to_path('file:tmp') == 'tmp'
     assert url_to_path('file:///tmp/file') == '/tmp/file'
+    assert url_to_path('file:/path/to/file') == '/path/to/file'
+    assert url_to_path('file://localhost/tmp/file') == '/tmp/file'
+    with pytest.raises(ValueError):
+        url_to_path('file://somehost/tmp/file')
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")
@@ -141,8 +146,11 @@ def test_path_to_url_win():
 
 @pytest.mark.skipif("sys.platform != 'win32'")
 def test_url_to_path_win():
-    assert url_to_path('file:///c:/tmp/file') == 'C:\\tmp\\file'
+    assert url_to_path('file:tmp') == 'tmp'
+    assert url_to_path('file:///c:/tmp/file') == r'C:\tmp\file'
     assert url_to_path('file://unc/as/path') == r'\\unc\as\path'
+    assert url_to_path('file:c:/path/to/file') == r'C:\path\to\file'
+    assert url_to_path('file://localhost/c:/tmp/file') == r'C:\tmp\file'
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")


### PR DESCRIPTION
* correctly handle `file://localhost/...` URIs, as per [RFC 8089](https://tools.ietf.org/html/rfc8089#section-2): `file://localhost/some/path` is equivalent to `file:///some/path`
* don't try to use UNC paths on Unix