### PR TITLE
req: fix possible exception in `install_req_from_req`

### DIFF
--- a/news/5889.bugfix
+++ b/news/5889.bugfix
@@ -1,0 +1,1 @@
+Fix exception when installing a package depending on an already installed dependency using a PEP 508 requirement.

--- a/news/5892.bugfix
+++ b/news/5892.bugfix
@@ -1,0 +1,1 @@
+Improve handling of file URIs: correctly handle `file://localhost/...` and don't try to use UNC paths on Unix.

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -470,9 +470,18 @@ def url_to_path(url):
 
     _, netloc, path, _, _ = urllib_parse.urlsplit(url)
 
-    # if we have a UNC path, prepend UNC share notation
     if netloc:
-        netloc = '\\\\' + netloc
+        if netloc == 'localhost':
+            # According to RFC 8089, same as empty authority.
+            netloc = ''
+        elif sys.platform == 'win32':
+            # If we have a UNC path, prepend UNC share notation.
+            netloc = '\\\\' + netloc
+        else:
+            raise ValueError(
+                'non-local file URIs are not supported on this platform: %r'
+                % url
+            )
 
     path = urllib_request.url2pathname(netloc + path)
     return path

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -285,7 +285,8 @@ def install_req_from_req(
         PyPI.file_storage_domain,
         TestPyPI.file_storage_domain,
     ]
-    if req.url and comes_from.link.netloc in domains_not_allowed:
+    if req.url and comes_from and comes_from.link \
+       and comes_from.link.netloc in domains_not_allowed:
         # Explicitly disallow pypi packages that depend on external urls
         raise InstallationError(
             "Packages installed from PyPI cannot depend on packages "

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -127,7 +127,12 @@ def test_path_to_url_unix():
 
 @pytest.mark.skipif("sys.platform == 'win32'")
 def test_url_to_path_unix():
+    assert url_to_path('file:tmp') == 'tmp'
     assert url_to_path('file:///tmp/file') == '/tmp/file'
+    assert url_to_path('file:/path/to/file') == '/path/to/file'
+    assert url_to_path('file://localhost/tmp/file') == '/tmp/file'
+    with pytest.raises(ValueError):
+        url_to_path('file://somehost/tmp/file')
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")
@@ -141,8 +146,11 @@ def test_path_to_url_win():
 
 @pytest.mark.skipif("sys.platform != 'win32'")
 def test_url_to_path_win():
-    assert url_to_path('file:///c:/tmp/file') == 'C:\\tmp\\file'
+    assert url_to_path('file:tmp') == 'tmp'
+    assert url_to_path('file:///c:/tmp/file') == r'C:\tmp\file'
     assert url_to_path('file://unc/as/path') == r'\\unc\as\path'
+    assert url_to_path('file:c:/path/to/file') == r'C:\path\to\file'
+    assert url_to_path('file://localhost/c:/tmp/file') == r'C:\tmp\file'
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")


### PR DESCRIPTION
* allow calling it with `comes_from=None` (easier for testing)
* handle the case where `comes_from.link is None` (which can happen if a package using a PEP 508 URL requirement is already installed)

Fix #5889.

Note: this depends on #5892 for the test.