### PR TITLE
Address #5031: freeze non-vcs editable installs as editable

### DIFF
--- a/news/5031.feature
+++ b/news/5031.feature
@@ -1,0 +1,1 @@
+Editable, non-VCS installs now freeze as editable.

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -158,8 +158,8 @@ def get_requirement_info(dist):
 
     if not vc_type:
         req = dist.as_requirement()
-        logger.info(
-            'Editable requirement {!r} not in VCS directory: {!r}', req,
+        logger.debug(
+            'No VCS found for editable requirement {!r} in: {!r}', req,
             location,
         )
         comments = [

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -157,7 +157,15 @@ def get_requirement_info(dist):
     vc_type = vcs.get_backend_type(location)
 
     if not vc_type:
-        return (None, False, [])
+        req = dist.as_requirement()
+        logger.info(
+            'Editable requirement {!r} not in VCS directory: {!r}', req,
+            location,
+        )
+        comments = [
+            '# Editable, no version control detected ({})'.format(req)
+        ]
+        return (location, True, comments)
 
     try:
         req = vc_type().get_src_requirement(dist, location)

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -116,6 +116,27 @@ def test_freeze_with_invalid_names(script):
         )
 
 
+@pytest.mark.git
+def test_freeze_editable_not_vcs(script, tmpdir):
+    """
+    Test an editable install that is not version controlled.
+    """
+    pkg_path = _create_test_package(script)
+    # Rename the .git directory so the directory is no longer recognized
+    # as a VCS directory.
+    os.rename(os.path.join(pkg_path, '.git'), os.path.join(pkg_path, '.bak'))
+    script.pip('install', '-e', pkg_path)
+    result = script.pip('freeze', expect_stderr=True)
+
+    # We need to apply os.path.normcase() to the path since that is what
+    # the freeze code does.
+    expected = textwrap.dedent("""\
+    ...# Editable, no version control detected (version-pkg==0.1)
+    -e {}
+    ...""".format(os.path.normcase(pkg_path)))
+    _check_output(result.stdout, expected)
+
+
 @pytest.mark.svn
 def test_freeze_svn(script, tmpdir):
     """Test freezing a svn checkout"""


### PR DESCRIPTION
This addresses #5031.

Note that if this PR is okay, I'd prefer to land PR #5881 first, which would require rebasing this one.