### PR TITLE
Fix get_branch() to work if the current branch shares a name with a tag

### DIFF
--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -653,6 +653,7 @@ def call_subprocess(
     show_stdout=True,  # type: bool
     cwd=None,  # type: Optional[str]
     on_returncode='raise',  # type: str
+    returncodes=None,  # type: Optional[Iterable[int]]
     command_desc=None,  # type: Optional[str]
     extra_environ=None,  # type: Optional[Mapping[str, Any]]
     unset_environ=None,  # type: Optional[Iterable[str]]
@@ -661,9 +662,13 @@ def call_subprocess(
     # type: (...) -> Optional[Text]
     """
     Args:
+      returncodes: an iterable of integer return codes that are acceptable,
+        in addition to 0. Defaults to None, which means [].
       unset_environ: an iterable of environment variable names to unset
         prior to calling subprocess.Popen().
     """
+    if returncodes is None:
+        returncodes = []
     if unset_environ is None:
         unset_environ = []
     # This function's handling of subprocess output is confusing and I
@@ -740,7 +745,7 @@ def call_subprocess(
             spinner.finish("error")
         else:
             spinner.finish("done")
-    if proc.returncode:
+    if proc.returncode and proc.returncode not in returncodes:
         if on_returncode == 'raise':
             if (logger.getEffectiveLevel() > std_logging.DEBUG and
                     not show_stdout):

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -653,7 +653,7 @@ def call_subprocess(
     show_stdout=True,  # type: bool
     cwd=None,  # type: Optional[str]
     on_returncode='raise',  # type: str
-    returncodes=None,  # type: Optional[Iterable[int]]
+    extra_ok_returncodes=None,  # type: Optional[Iterable[int]]
     command_desc=None,  # type: Optional[str]
     extra_environ=None,  # type: Optional[Mapping[str, Any]]
     unset_environ=None,  # type: Optional[Iterable[str]]
@@ -662,13 +662,13 @@ def call_subprocess(
     # type: (...) -> Optional[Text]
     """
     Args:
-      returncodes: an iterable of integer return codes that are acceptable,
-        in addition to 0. Defaults to None, which means [].
+      extra_ok_returncodes: an iterable of integer return codes that are
+        acceptable, in addition to 0. Defaults to None, which means [].
       unset_environ: an iterable of environment variable names to unset
         prior to calling subprocess.Popen().
     """
-    if returncodes is None:
-        returncodes = []
+    if extra_ok_returncodes is None:
+        extra_ok_returncodes = []
     if unset_environ is None:
         unset_environ = []
     # This function's handling of subprocess output is confusing and I
@@ -745,7 +745,7 @@ def call_subprocess(
             spinner.finish("error")
         else:
             spinner.finish("done")
-    if proc.returncode and proc.returncode not in returncodes:
+    if proc.returncode and proc.returncode not in extra_ok_returncodes:
         if on_returncode == 'raise':
             if (logger.getEffectiveLevel() > std_logging.DEBUG and
                     not show_stdout):

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -467,7 +467,7 @@ class VersionControl(object):
         show_stdout=True,  # type: bool
         cwd=None,  # type: Optional[str]
         on_returncode='raise',  # type: str
-        returncodes=None,  # type: Optional[Iterable[int]]
+        extra_ok_returncodes=None,  # type: Optional[Iterable[int]]
         command_desc=None,  # type: Optional[str]
         extra_environ=None,  # type: Optional[Mapping[str, Any]]
         spinner=None  # type: Optional[SpinnerInterface]
@@ -482,7 +482,7 @@ class VersionControl(object):
         try:
             return call_subprocess(cmd, show_stdout, cwd,
                                    on_returncode=on_returncode,
-                                   returncodes=returncodes,
+                                   extra_ok_returncodes=extra_ok_returncodes,
                                    command_desc=command_desc,
                                    extra_environ=extra_environ,
                                    unset_environ=self.unset_environ,

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -17,7 +17,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     from typing import (  # noqa: F401
-        Dict, Optional, Tuple, List, Type, Any, Mapping, Text
+        Any, Dict, Iterable, List, Mapping, Optional, Text, Tuple, Type
     )
     from pip._internal.utils.ui import SpinnerInterface  # noqa: F401
 
@@ -467,6 +467,7 @@ class VersionControl(object):
         show_stdout=True,  # type: bool
         cwd=None,  # type: Optional[str]
         on_returncode='raise',  # type: str
+        returncodes=None,  # type: Optional[Iterable[int]]
         command_desc=None,  # type: Optional[str]
         extra_environ=None,  # type: Optional[Mapping[str, Any]]
         spinner=None  # type: Optional[SpinnerInterface]
@@ -480,8 +481,10 @@ class VersionControl(object):
         cmd = [self.name] + cmd
         try:
             return call_subprocess(cmd, show_stdout, cwd,
-                                   on_returncode,
-                                   command_desc, extra_environ,
+                                   on_returncode=on_returncode,
+                                   returncodes=returncodes,
+                                   command_desc=command_desc,
+                                   extra_environ=extra_environ,
                                    unset_environ=self.unset_environ,
                                    spinner=spinner)
         except OSError as e:

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -84,11 +84,13 @@ class Git(VersionControl):
         Return the current branch, or None if HEAD isn't at a branch
         (e.g. detached HEAD).
         """
-        # The -q causes the command to exit with status code 1 instead of
-        # 128 if "HEAD" is not a symbolic ref but a detached HEAD.
+        # git-symbolic-ref exits with empty stdout if "HEAD" is a detached
+        # HEAD rather than a symbolic ref.  In addition, the -q causes the
+        # command to exit with status code 1 instead of 128 in this case
+        # and to suppress the message to stderr.
         args = ['symbolic-ref', '-q', 'HEAD']
         output = self.run_command(
-            args, returncodes=(1, ), show_stdout=False, cwd=location,
+            args, extra_ok_returncodes=(1, ), show_stdout=False, cwd=location,
         )
         ref = output.strip()
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -79,7 +79,7 @@ class Git(VersionControl):
         version = '.'.join(version.split('.')[:3])
         return parse_version(version)
 
-    def get_branch(self, location):
+    def get_current_branch(self, location):
         """
         Return the current branch, or None if HEAD isn't at a branch
         (e.g. detached HEAD).
@@ -210,7 +210,7 @@ class Git(VersionControl):
                 if not self.is_commit_id_equal(dest, rev_options.rev):
                     cmd_args = ['checkout', '-q'] + rev_options.to_args()
                     self.run_command(cmd_args, cwd=dest)
-            elif self.get_branch(dest) != branch_name:
+            elif self.get_current_branch(dest) != branch_name:
                 # Then a specific branch was requested, and that branch
                 # is not yet checked out.
                 track_branch = 'origin/{}'.format(branch_name)

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -84,14 +84,18 @@ class Git(VersionControl):
         Return the current branch, or None if HEAD isn't at a branch
         (e.g. detached HEAD).
         """
-        args = ['rev-parse', '--abbrev-ref', 'HEAD']
-        output = self.run_command(args, show_stdout=False, cwd=location)
-        branch = output.strip()
+        # The -q causes the command to exit with status code 1 instead of
+        # 128 if "HEAD" is not a symbolic ref but a detached HEAD.
+        args = ['symbolic-ref', '-q', 'HEAD']
+        output = self.run_command(
+            args, returncodes=(1, ), show_stdout=False, cwd=location,
+        )
+        ref = output.strip()
 
-        if branch == 'HEAD':
-            return None
+        if ref.startswith('refs/heads/'):
+            return ref[len('refs/heads/'):]
 
-        return branch
+        return None
 
     def export(self, location):
         """Export the Git repository at the url to the destination location"""

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -83,14 +83,14 @@ def test_get_remote_url(script, tmpdir):
     assert remote_url == source_url
 
 
-def test_get_branch(script):
+def test_get_current_branch(script):
     repo_dir = str(script.scratch_path)
 
     script.run('git', 'init', cwd=repo_dir)
     sha = do_commit(script, repo_dir)
 
     git = Git()
-    assert git.get_branch(repo_dir) == 'master'
+    assert git.get_current_branch(repo_dir) == 'master'
 
     # Switch to a branch with the same SHA as "master" but whose name
     # is alphabetically after.
@@ -98,11 +98,11 @@ def test_get_branch(script):
         'git', 'checkout', '-b', 'release', cwd=repo_dir,
         expect_stderr=True,
     )
-    assert git.get_branch(repo_dir) == 'release'
+    assert git.get_current_branch(repo_dir) == 'release'
 
     # Also test the detached HEAD case.
     script.run('git', 'checkout', sha, cwd=repo_dir, expect_stderr=True)
-    assert git.get_branch(repo_dir) is None
+    assert git.get_current_branch(repo_dir) is None
 
 
 def test_get_revision_sha(script):


### PR DESCRIPTION
This PR tightens up a helper function to address an edge case revealed by issue #5867.

The helper function returns the name of the branch that `HEAD` is at, if `HEAD` is at a branch. However, this didn't work if `HEAD` is at a branch whose name also matches the name of a tag.

I found that the cleanest way to do this was to use a Git command that exits with status code 1 in the case of a detached `HEAD`, so I added a new argument to `call_subprocess()` that lets one indicate additional return codes that are okay (i.e. in addition to 0).

This new argument will also help on another issue that can benefit from a similar Git command that returns 0 or 1.
