### PR TITLE
Display install instructions for pre-releases

### DIFF
--- a/news/5169.feature
+++ b/news/5169.feature
@@ -1,0 +1,1 @@
+Display hint on installing with --pre when search results include pre-release versions.

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -126,7 +126,11 @@ def print_results(hits, name_column_width=None, terminal_width=None):
                         logger.info('INSTALLED: %s (latest)', dist.version)
                     else:
                         logger.info('INSTALLED: %s', dist.version)
-                        logger.info('LATEST:    %s', latest)
+                        if parse_version(latest).pre:
+                            logger.info('LATEST:    %s (pre-release; install'
+                                        ' with "pip install --pre")', latest)
+                        else:
+                            logger.info('LATEST:    %s', latest)
         except UnicodeEncodeError:
             pass
 


### PR DESCRIPTION
Add a message to the output of `search` on installing pre-release versions to avoid confusion when attempting to install without `--pre`.

This is based on #5408 by @demophoon and completes the test case.

Closes #5408
Resolves #5169