### PR TITLE
 Fix PackageFinder to respect allow_all_prereleases

### DIFF
--- a/news/5175.bugfix
+++ b/news/5175.bugfix
@@ -1,1 +1,1 @@
-Fix `PackageFinder.find_all_candidates` to enforce `allow_all_prereleases` option 
+Fix `PackageFinder.find_all_candidates` to respect the `allow_all_prereleases` parameter

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -613,10 +613,11 @@ class PackageFinder(object):
             )
 
         # This is an intentional priority ordering
-        return (
-            file_versions + find_links_versions + page_versions +
-            dependency_versions
-        )
+        all_candidates = file_versions + find_links_versions + page_versions + dependency_versions
+        if (not self.allow_all_prereleases):
+            all_candidates = [candidate for candidate in all_candidates
+                              if not candidate.version.is_prerelease]
+        return (all_candidates)
 
     def find_requirement(self, req, upgrade):
         """Try to find a Link matching req

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -463,7 +463,7 @@ def test_finder_installs_pre_releases(data):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
-def test_finder_does_not_candidate_pre_releases(data):
+def test_finder_does_not_return_pre_release_candidates(data):
     """
     Test PackageFinder finds pre-releases if asked to.
     """
@@ -483,7 +483,7 @@ def test_finder_does_not_candidate_pre_releases(data):
     links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
     finder = PackageFinder(
         links, [],
-        allow_all_prereleases=True,
+        allow_all_prereleases=False,
         session=PipSession(),
     )
 
@@ -530,14 +530,14 @@ def test_finder_installs_pre_releases_with_version_spec():
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
         link = finder.find_requirement(req, False)
-        assert link.url == "https://foo/bar-2.0b1.tar.gz"
+        assert link.url == "https://foo/bar-1.0.tar.gz"
 
     links.reverse()
     finder = PackageFinder(links, [], session=PipSession())
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
         link = finder.find_requirement(req, False)
-        assert link.url == "https://foo/bar-2.0b1.tar.gz"
+        assert link.url == "https://foo/bar-1.0.tar.gz"
 
 
 class test_link_package_versions(object):


### PR DESCRIPTION
Fix 'PackageFinder.find_all_candidates' to respect 'allow_all_prereleases'
Closes #5175