### PR TITLE
Fix PackageFinder to respect allow_all_prereleases

### DIFF
--- a/news/5175.bugfix
+++ b/news/5175.bugfix
@@ -1,0 +1,1 @@
+Fix `PackageFinder.find_all_candidates` to enforce `allow_all_prereleases` option 

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -613,10 +613,17 @@ class PackageFinder(object):
             )
 
         # This is an intentional priority ordering
-        all_candidates = file_versions + find_links_versions + page_versions + dependency_versions
+        all_candidates = (
+            file_versions 
+            + find_links_versions 
+            + page_versions 
+            + dependency_versions
+        )
         if (not self.allow_all_prereleases):
-            all_candidates = [candidate for candidate in all_candidates
-                              if not candidate.version.is_prerelease]
+            all_candidates = [candidate 
+                for candidate in all_candidates
+                if not candidate.version.is_prerelease
+            ]
         return (all_candidates)
 
     def find_requirement(self, req, upgrade):

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -626,8 +626,10 @@ class PackageFinder(object):
         Returns a Link if found,
         Raises DistributionNotFound or BestVersionAlreadyInstalled otherwise
         """
-        all_candidates = self.find_all_candidates(req.name)
-
+        all_candidates = self.find_all_candidates(
+            req.name, 
+            allow_all_prereleases=req.specifier.prereleases
+        )
         # Filter out anything which doesn't match our specifier
         compatible_versions = set(
             req.specifier.filter(

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -463,7 +463,7 @@ def test_finder_installs_pre_releases(data):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
-def test_finder_does_not_return_pre_release_candidates(data):
+def test_finder_does_not_candidate_pre_releases(data):
     """
     Test PackageFinder finds pre-releases if asked to.
     """
@@ -483,7 +483,7 @@ def test_finder_does_not_return_pre_release_candidates(data):
     links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
     finder = PackageFinder(
         links, [],
-        allow_all_prereleases=False,
+        allow_all_prereleases=True,
         session=PipSession(),
     )
 
@@ -530,14 +530,14 @@ def test_finder_installs_pre_releases_with_version_spec():
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
         link = finder.find_requirement(req, False)
-        assert link.url == "https://foo/bar-1.0.tar.gz"
+        assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
     links.reverse()
     finder = PackageFinder(links, [], session=PipSession())
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
         link = finder.find_requirement(req, False)
-        assert link.url == "https://foo/bar-1.0.tar.gz"
+        assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
 
 class test_link_package_versions(object):

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -463,6 +463,44 @@ def test_finder_installs_pre_releases(data):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
+def test_finder_does_not_candidate_pre_releases(data):
+    """
+    Test PackageFinder finds pre-releases if asked to.
+    """
+
+    req = install_req_from_line("bar", None)
+
+    # using a local index (that has pre & dev releases)
+    finder = PackageFinder(
+        [], [data.index_url("pre")],
+        allow_all_prereleases=False,
+        session=PipSession(),
+    )
+    for link in finder.find_all_candidates("bar"):
+        assert not link.version.is_prerelease
+
+    # using find-links
+    links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
+    finder = PackageFinder(
+        links, [],
+        allow_all_prereleases=True,
+        session=PipSession(),
+    )
+
+    with patch.object(finder, "_get_pages", lambda x, y: []):
+        for link in finder.find_all_candidates("bar"):
+            assert not link.version.is_prerelease
+
+    links.reverse()
+    finder = PackageFinder(
+        links, [],
+        allow_all_prereleases=True,
+        session=PipSession(),
+    )
+
+    with patch.object(finder, "_get_pages", lambda x, y: []):
+        for link in finder.find_all_candidates("bar"):
+            assert not link.version.is_prerelease
 
 def test_finder_installs_dev_releases(data):
     """

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -476,8 +476,8 @@ def test_finder_does_not_candidate_pre_releases(data):
         allow_all_prereleases=False,
         session=PipSession(),
     )
-    for link in finder.find_all_candidates("bar"):
-        assert not link.version.is_prerelease
+    for candidate in finder.find_all_candidates("bar"):
+        assert not candidate.version.is_prerelease
 
     # using find-links
     links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
@@ -488,8 +488,8 @@ def test_finder_does_not_candidate_pre_releases(data):
     )
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
-        for link in finder.find_all_candidates("bar"):
-            assert not link.version.is_prerelease
+        for candidate in finder.find_all_candidates("bar"):
+            assert not candidate.version.is_prerelease
 
     links.reverse()
     finder = PackageFinder(
@@ -499,8 +499,8 @@ def test_finder_does_not_candidate_pre_releases(data):
     )
 
     with patch.object(finder, "_get_pages", lambda x, y: []):
-        for link in finder.find_all_candidates("bar"):
-            assert not link.version.is_prerelease
+        for candidate in finder.find_all_candidates("bar"):
+            assert not candidate.version.is_prerelease
 
 def test_finder_installs_dev_releases(data):
     """

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -463,6 +463,7 @@ def test_finder_installs_pre_releases(data):
         link = finder.find_requirement(req, False)
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
+
 def test_finder_does_not_candidate_pre_releases(data):
     """
     Test PackageFinder finds pre-releases if asked to.
@@ -476,7 +477,7 @@ def test_finder_does_not_candidate_pre_releases(data):
         allow_all_prereleases=False,
         session=PipSession(),
     )
-    for candidate in finder.find_all_candidates("bar"):
+    for candidate in finder.find_all_candidates(req):
         assert not candidate.version.is_prerelease
 
     # using find-links
@@ -501,6 +502,7 @@ def test_finder_does_not_candidate_pre_releases(data):
     with patch.object(finder, "_get_pages", lambda x, y: []):
         for candidate in finder.find_all_candidates("bar"):
             assert not candidate.version.is_prerelease
+
 
 def test_finder_installs_dev_releases(data):
     """

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -483,7 +483,7 @@ def test_finder_does_not_candidate_pre_releases(data):
     links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
     finder = PackageFinder(
         links, [],
-        allow_all_prereleases=True,
+        allow_all_prereleases=False,
         session=PipSession(),
     )
 


### PR DESCRIPTION
Fix 'PackageFinder.find_all_candidates' to respect 'allow_all_prereleases'

Closes #5175

This is another PR following #5927 to address comments raised by @benoit-pierre to ensure that if there is a pre-release in the requirements then prerelease packages are allowed to be installed.
