### PR TITLE
Added type hints to internals/utils

### DIFF
--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -5,6 +5,7 @@ from pip._internal.utils.compat import get_path_uid
 
 
 def check_path_owner(path):
+    # type: (str) -> bool
     # If we don't have a way to check the effective uid of this process, then
     # we'll just assume that we own the directory.
     if not hasattr(os, "geteuid"):
@@ -26,3 +27,4 @@ def check_path_owner(path):
                 return os.access(path, os.W_OK)
         else:
             previous, path = path, os.path.dirname(path)
+    return False  # assume we don't own the path

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -4,8 +4,14 @@ import ctypes
 import re
 import warnings
 
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional, Tuple  # noqa: F401
+
 
 def glibc_version_string():
+    # type: () -> Optional[str]
     "Returns glibc version string, or None if not using glibc."
 
     # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
@@ -32,6 +38,7 @@ def glibc_version_string():
 
 # Separated out from have_compatible_glibc for easier unit testing
 def check_glibc_version(version_str, required_major, minimum_minor):
+    # type: (str, int, int) -> bool
     # Parse string and check against requested version.
     #
     # We use a regexp instead of str.split because we want to discard any
@@ -48,6 +55,7 @@ def check_glibc_version(version_str, required_major, minimum_minor):
 
 
 def have_compatible_glibc(required_major, minimum_minor):
+    # type: (int, int) -> bool
     version_str = glibc_version_string()
     if version_str is None:
         return False
@@ -72,6 +80,7 @@ def have_compatible_glibc(required_major, minimum_minor):
 # misleading. Solution: instead of using platform, use our code that actually
 # works.
 def libc_ver():
+    # type: () -> Tuple[str, str]
     """Try to determine the glibc version
 
     Returns a tuple of strings (lib, version) which default to empty strings


### PR DESCRIPTION
Found a potential bug i.e. missing return statement in check_path_owner. If
while loop falls through without returning,
return a defensive False

related to #4748 