### PR TITLE
tweak AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ environment:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"
+  - "python -m pip install --upgrade --disable-pip-version-check pip setuptools wheel"
   - "pip install --upgrade certifi tox tox-venv"
   - "pip freeze --all"
   # Fix git SSL errors.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,9 @@ environment:
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
 
+matrix:
+    fast_finish: true
+
 clone_depth: 50
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,8 @@ environment:
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
 
+clone_depth: 50
+
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,6 @@ environment:
   matrix:
     # Unit and integration tests.
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python36-x64"
-    - PYTHON: "C:\\Python27"
       RUN_INTEGRATION_TESTS: "True"
     - PYTHON: "C:\\Python36-x64"
       RUN_INTEGRATION_TESTS: "True"
@@ -35,6 +33,8 @@ cache:
 
 test_script:
     - ps: |
+        $ErrorActionPreference = "Stop"
+
         function should_run_tests {
             if ("$env:APPVEYOR_PULL_REQUEST_NUMBER" -eq "") {
                 Write-Host "Not a pull request - running tests"
@@ -64,10 +64,8 @@ test_script:
             subst T: $env:TEMP
             $env:TEMP = "T:\"
             $env:TMP = "T:\"
-            if ($env:RUN_INTEGRATION_TESTS -eq "True") {
-                tox -e py -- --use-venv -m integration -n 3 --duration=5
-            }
-            else {
-                tox -e py -- -m unit -n 3
+            tox -e py -- -m unit
+            if ($LastExitCode -eq 0 -and $env:RUN_INTEGRATION_TESTS -eq "True") {
+                tox -e py -- --use-venv -m integration -n2 --durations=20
             }
         }


### PR DESCRIPTION
* update/install pip, setuptools and wheel: so wheels can be built for requirements that are installed from source
* only clone the first 50 commits (same as for Travis)
* merge back unit/integration runs (a little bit faster)
* immediately finish build once one of the jobs fails

Rational for the last change: if the 2 first jobs don't complete successfully, the chances that the others do are very slim (to say the least). The only failures have seen are usually transient network errors, and there's no way to restart a job (unlike Travis), so the whole build will have to be run again anyway. Add to that the time it takes to run a full build and the fact that the queue is shared with other pypa projects (setuptools), and I think failing early is much nicer for everybody.