### PR TITLE
Include package name in a freeze warning if package is not installed

### DIFF
--- a/news/13D1F422-0CB9-450F-B4DD-9486524712E5.feature
+++ b/news/13D1F422-0CB9-450F-B4DD-9486524712E5.feature
@@ -1,0 +1,1 @@
+Include the package name in a freeze warning if the package is not installed.

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -114,10 +114,10 @@ def freeze(
                         # but has been processed already
                         if not req_files[line_req.name]:
                             logger.warning(
-                                "Requirement file [%s] contains %s, but that "
-                                "package is not installed",
+                                "Requirement file [%s] contains %s, but "
+                                "package %r is not installed",
                                 req_file_path,
-                                COMMENT_RE.sub('', line).strip(),
+                                COMMENT_RE.sub('', line).strip(), line_req.name
                             )
                         else:
                             req_files[line_req.name].append(req_file_path)


### PR DESCRIPTION
This PR makes one warning message a little more informative.

Specifically, when freeze warns that a package listed in a requirements file isn't installed, the message is changed from this--

> Requirement file [hint.txt] contains NoExist==4.2, but that package is not installed

To this--

> Requirement file [hint.txt] contains NoExist==4.2, but package 'NoExist' is not installed

This is especially helpful if the requirement `NoExist==4.2` is replaced by a URL with egg fragment. Without this addition to the log message, it's not clear what package pip parsed from the URL and was looking for.
