### PR TITLE
Decorate tests using SVN with pytest.mark.svn

### DIFF
--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -95,6 +95,7 @@ def test_relative_requirements_file(script, data):
 
 
 @pytest.mark.network
+@pytest.mark.svn
 def test_multiple_requirements_files(script, tmpdir):
     """
     Test installing from multiple nested requirements files.

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -41,6 +41,7 @@ class Tests_UserSite:
         assert 'INITools' == project_name, project_name
 
     @pytest.mark.network
+    @pytest.mark.svn
     def test_install_subversion_usersite_editable_with_distribute(
             self, script, tmpdir):
         """

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -357,6 +357,7 @@ def _test_uninstall_editable_with_source_outside_venv(
 
 
 @pytest.mark.network
+@pytest.mark.svn
 def test_uninstall_from_reqs_file(script, tmpdir):
     """
     Test uninstall from a requirements file.


### PR DESCRIPTION
Some tests were missing the marker and were therefore run with

    tox -e py36 -- -k "not svn"

and failed since `svnadmin` was not found.