### PR TITLE
Do not log 'Already Installed' messages as raised in issue #5900

### DIFF
--- a/news/5900.feature
+++ b/news/5900.feature
@@ -1,0 +1,1 @@
+Adds the feature to prevent printing the information message "Already Installed" with the option `--no-info-already-installed` for the `pip install`command.

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -154,6 +154,7 @@ class DownloadCommand(RequirementCommand):
                     use_user_site=False,
                     upgrade_strategy="to-satisfy-only",
                     force_reinstall=False,
+                    no_info_already=False,
                     ignore_dependencies=options.ignore_dependencies,
                     ignore_requires_python=False,
                     ignore_installed=True,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -192,6 +192,14 @@ class InstallCommand(RequirementCommand):
             help="Do not warn about broken dependencies",
         )
 
+        cmd_opts.add_option(
+            "--no-info-already-installed",
+            dest="no_info_already",
+            action='store_true',
+            default=False,
+            help="Do not print message if nothing is done",
+        )
+
         cmd_opts.add_option(cmdoptions.no_binary())
         cmd_opts.add_option(cmdoptions.only_binary())
         cmd_opts.add_option(cmdoptions.prefer_binary())
@@ -310,6 +318,7 @@ class InstallCommand(RequirementCommand):
                         use_user_site=options.use_user_site,
                         upgrade_strategy=upgrade_strategy,
                         force_reinstall=options.force_reinstall,
+                        no_info_already=options.no_info_already,
                         ignore_dependencies=options.ignore_dependencies,
                         ignore_requires_python=options.ignore_requires_python,
                         ignore_installed=options.ignore_installed,

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -153,6 +153,7 @@ class WheelCommand(RequirementCommand):
                         use_user_site=False,
                         upgrade_strategy="to-satisfy-only",
                         force_reinstall=False,
+                        no_msg_for_doing_nothing=False,
                         ignore_dependencies=options.ignore_dependencies,
                         ignore_requires_python=options.ignore_requires_python,
                         ignore_installed=True,

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -330,7 +330,8 @@ class RequirementPreparer(object):
 
         return abstract_dist
 
-    def prepare_installed_requirement(self, req, require_hashes, skip_reason):
+    def prepare_installed_requirement(
+            self, req, require_hashes, skip_reason, no_info_already):
         """Prepare an already-installed requirement
         """
         assert req.satisfied_by, "req should have been satisfied but isn't"
@@ -338,10 +339,11 @@ class RequirementPreparer(object):
             "did not get skip reason skipped but req.satisfied_by "
             "is set to %r" % (req.satisfied_by,)
         )
-        logger.info(
-            'Requirement %s: %s (%s)',
-            skip_reason, req, req.satisfied_by.version
-        )
+        if skip_reason and not no_info_already:
+            logger.info(
+                'Requirement %s: %s (%s)',
+                skip_reason, req, req.satisfied_by.version
+            )
         with indent_log():
             if require_hashes:
                 logger.debug(

--- a/src/pip/_internal/resolve.py
+++ b/src/pip/_internal/resolve.py
@@ -35,7 +35,7 @@ class Resolver(object):
 
     def __init__(self, preparer, session, finder, wheel_cache, use_user_site,
                  ignore_dependencies, ignore_installed, ignore_requires_python,
-                 force_reinstall, isolated, upgrade_strategy):
+                 force_reinstall, isolated, upgrade_strategy, no_info_already):
         super(Resolver, self).__init__()
         assert upgrade_strategy in self._allowed_strategies
 
@@ -56,6 +56,7 @@ class Resolver(object):
         self.ignore_installed = ignore_installed
         self.ignore_requires_python = ignore_requires_python
         self.use_user_site = use_user_site
+        self.no_info_already = no_info_already
 
         self._discovered_dependencies = defaultdict(list)
 
@@ -200,7 +201,7 @@ class Resolver(object):
 
         if req.satisfied_by:
             return self.preparer.prepare_installed_requirement(
-                req, self.require_hashes, skip_reason
+                req, self.require_hashes, skip_reason, self.no_info_already
             )
 
         upgrade_allowed = self._is_upgrade_allowed(req)

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -58,7 +58,7 @@ class TestRequirementSet(object):
             use_user_site=False, upgrade_strategy="to-satisfy-only",
             ignore_dependencies=False, ignore_installed=False,
             ignore_requires_python=False, force_reinstall=False,
-            isolated=False,
+            isolated=False, no_info_already=False
         )
 
     def test_no_reuse_existing_build_dir(self, data):


### PR DESCRIPTION
Adds the feature to prevent printing the information message "Already Installed" with the option `--no-info-already-installed` for the `pip install`command.