### PR TITLE
Implement --deps-only install mode

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -780,6 +780,25 @@ No other build system commands are invoked by the ``pip install`` command.
 
 Installing a package from a wheel does not invoke the build system at all.
 
+Dependency-only installations
++++++++++++++++++++++++++++++
+
+In some situations it can be useful to only install the dependencies of a
+package and avoid installing the package itself. An example would be setting up
+a development environment with all development dependencies but not the
+package itself. This can be done with the `--no-deps` option:
+
+$ pip install --deps-only .[test]
+
+Note that there can be cases when not all dependencies will be installed when
+using this option. Consider an example where package A is a dependency of B
+and the following command is issued:
+
+$ pip install --deps-only A B
+
+Pip will skip the installation of A and B, but because B depends on A a
+dependency won't be satisfied.
+
 .. _PyPI: https://pypi.org/
 .. _setuptools extras: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
 

--- a/news/4783.feature
+++ b/news/4783.feature
@@ -1,0 +1,1 @@
+Add ``--deps-only`` option to ``pip install`` to install dependencies only.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1431,3 +1431,40 @@ def test_install_conflict_warning_can_be_suppressed(script, data):
         'install', '--no-index', pkgB_path, '--no-warn-conflicts'
     )
     assert "Successfully installed pkgB-2.0" in result2.stdout, str(result2)
+
+
+def test_install_deps_only(script):
+    result = script.pip_install_local(
+        'require_simple',
+        '--deps-only')
+
+    assert result.returncode == 0
+    assert "Successfully installed simple-3.0" in result.stdout
+    assert "require-simple" not in result.stdout
+
+
+def test_install_deps_only_no_packages_installed(script):
+    result = script.pip_install_local('simple', '--deps-only',
+                                      expect_error=True)
+    assert result.returncode == 1
+    assert "Nothing to install" in result.stderr
+
+
+def test_install_deps_only_editable(script, data):
+    to_install = data.packages.join("FSPkg")
+    result = script.pip('install', '--deps-only', '-e', to_install,
+                        expect_error=True)
+    assert result.returncode == 1
+    assert "Cannot use --deps-only with " \
+           "editable installations" in result.stderr
+
+
+def test_install_deps_only_requirments_file(script, tmpdir):
+    with requirements_file('simple2\n', tmpdir) as reqs_file:
+        result = script.pip_install_local('-r',
+                                          reqs_file.abspath,
+                                          '--deps-only',
+                                          expect_error=True)
+
+        assert result.returncode == 1
+        assert "Cannot use --deps-only with requirements file" in result.stderr


### PR DESCRIPTION
Specifying `--deps-only` will skip the top level targets and install dependencies only. This can be useful for setting up a development environment without installing the main package itself.

Resolves: #4783