### PR TITLE
add documents for empty string environment variable 

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -192,6 +192,7 @@ runtime.
    There is no support for other variable expansion syntaxes such as
    ``$VARIABLE`` and ``%VARIABLE%``.
 
+
 .. _`Example Requirements File`:
 
 Example Requirements File

--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -192,6 +192,10 @@ runtime.
    There is no support for other variable expansion syntaxes such as
    ``$VARIABLE`` and ``%VARIABLE%``.
 
+.. note::
+   Environment variables set to be empty string will be ignored instead 
+   of being treated as false. Please use ``no``, ``false`` or ``0`` 
+   instead.
 
 .. _`Example Requirements File`:
 

--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -192,11 +192,6 @@ runtime.
    There is no support for other variable expansion syntaxes such as
    ``$VARIABLE`` and ``%VARIABLE%``.
 
-.. note::
-   Environment variables set to be empty string will be ignored instead 
-   of being treated as false. Please use ``no``, ``false`` or ``0`` 
-   instead.
-
 .. _`Example Requirements File`:
 
 Example Requirements File

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -448,6 +448,7 @@ is the same as calling::
    Environment variables set to be empty string will be ignored instead 
    of being treated as false. Please use ``no``, ``false`` or ``0`` instead.
 
+
 Config Precedence
 -----------------
 

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -443,6 +443,10 @@ is the same as calling::
 
     pip install --find-links=http://mirror1.example.com --find-links=http://mirror2.example.com
 
+.. note::
+
+   Environment variables set to be empty string will be ignored instead 
+   of being treated as false. Please use ``no``, ``false`` or ``0`` instead.
 
 Config Precedence
 -----------------

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -445,8 +445,8 @@ is the same as calling::
 
 .. note::
 
-   Environment variables set to be empty string will be ignored instead 
-   of being treated as false. Please use ``no``, ``false`` or ``0`` instead.
+   Environment variables set to be empty string will not be treated as false. Please use ``no``,
+   ``false`` or ``0`` instead.
 
 
 Config Precedence


### PR DESCRIPTION
Issue: #5528  
It is minor document change, so a news file fragment is not necessary.
This PR add documents to tell pip users do not use empty string environment variable if
they want this value to be false. 