### PR TITLE
Explicit support and tests for `hg+file` scheme for `pip install`.

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -404,7 +404,7 @@ Mercurial
 ~~~~~~~~~
 
 The supported schemes are: ``hg+http``, ``hg+https``,
-``hg+static-http`` and ``hg+ssh``.
+``hg+static-http``, ``hg+ssh`` and ``hg+file``.
 
 Here are the supported forms::
 

--- a/news/4358.bugfix
+++ b/news/4358.bugfix
@@ -1,0 +1,2 @@
+Not a feature because the ``hg+file`` scheme was already functioning implicitly but inconsistently documented.
+This change is to make the scheme support explicit, including tests and docs.

--- a/news/4358.bugfix
+++ b/news/4358.bugfix
@@ -1,2 +1,1 @@
-Not a feature because the ``hg+file`` scheme was already functioning implicitly but inconsistently documented.
-This change is to make the scheme support explicit, including tests and docs.
+Correct inconsistency related to the `hg+file` scheme.

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -17,7 +17,9 @@ class Mercurial(VersionControl):
     name = 'hg'
     dirname = '.hg'
     repo_name = 'clone'
-    schemes = ('hg', 'hg+http', 'hg+https', 'hg+ssh', 'hg+static-http')
+    schemes = (
+        'hg', 'hg+http', 'hg+https', 'hg+ssh', 'hg+static-http', 'hg+file'
+    )
 
     def get_base_rev_args(self, rev):
         return [rev]

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -289,7 +289,6 @@ def test_basic_install_editable_from_hg(script, tmpdir):
     assert path_to_url(pkg_path).startswith("file://")
 
 
-
 @need_mercurial
 def test_vcs_url_final_slash_normalization(script, tmpdir):
     """

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -281,11 +281,13 @@ def test_install_editable_uninstalls_existing_from_path(script, data):
 
 @need_mercurial
 def test_basic_install_editable_from_hg(script, tmpdir):
-    """Test cloning from Mercurial."""
+    """Test cloning and hg+file install from Mercurial."""
     pkg_path = _create_test_package(script, name='testpackage', vcs='hg')
     args = ['install', '-e', 'hg+%s#egg=testpackage' % path_to_url(pkg_path)]
     result = script.pip(*args, **{"expect_error": True})
     result.assert_installed('testpackage', with_files=['.hg'])
+    assert path_to_url(pkg_path).startswith("file://")
+
 
 
 @need_mercurial


### PR DESCRIPTION
Reworking #5935 to be more complete for #4358

The ``hg+file`` scheme was already functioning implicitly (with test coverage) but inconsistently documented. This change is to make the scheme support explicit, including tests and docs.