### PR TITLE
Improve documentation in misc.py

### DIFF
--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -322,7 +322,9 @@ def dist_in_site_packages(dist):
 
 
 def dist_is_editable(dist):
-    """Is distribution an editable install?"""
+    """
+    Return True if given Distribution is an editable install.
+    """
     for path_item in sys.path:
         egg_link = os.path.join(path_item, dist.project_name + '.egg-link')
         if os.path.isfile(egg_link):


### PR DESCRIPTION
Improve the documentation of the `dist_is_editable()` function, by making it consistent with other similar functions in `misc.py`.

This PR is minor, and does not require a news file fragment.

