### PR TITLE
Clean up PackageFinder._link_package_versions()

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -340,7 +340,6 @@ def _parse_package_version(link, search, valid_tags):
     signify parsing errors, or an unsupported environment. Te callee should
     catch the exception, and convert it to string for logging.
     """
-    version = None
     if link.egg_fragment:
         egg_info = link.egg_fragment
         ext = link.ext
@@ -353,16 +352,13 @@ def _parse_package_version(link, search, valid_tags):
         if "macosx10" in link.path and ext == '.zip':
             raise _MacOSXZip(link, search)
         if ext == wheel_ext:
-            version = _parse_binary_package_version(link, search, valid_tags)
+            return _parse_binary_package_version(link, search, valid_tags)
 
     # This should be up by the search.ok_binary check, but see issue 2700.
     if "source" not in search.formats and ext != wheel_ext:
         raise _SourceLinkNotPermitted(link, search)
 
-    if not version:
-        version = _parse_source_package_version(link, egg_info, search)
-
-    return version
+    return _parse_source_package_version(link, egg_info, search)
 
 
 class PackageFinder(object):

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -340,11 +340,9 @@ def _parse_package_version(link, search, valid_tags):
     signify parsing errors, or an unsupported environment. Te callee should
     catch the exception, and convert it to string for logging.
     """
-    if link.egg_fragment:
-        egg_info = link.egg_fragment
-        ext = link.ext
-    else:
-        egg_info, ext = link.splitext()
+    egg_info = link.egg_fragment or link.splitext()[0]
+    ext = link.ext
+    if not link.egg_fragment:
         if not ext:
             raise _LinkNotAFile(link, search)
         if ext not in SUPPORTED_EXTENSIONS:

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -815,7 +815,10 @@ class PackageFinder(object):
             return
 
         if not version:
-            version = _egg_info_matches(egg_info, search.canonical)
+            try:
+                version = _egg_info_matches(egg_info, search.canonical)
+            except ValueError:
+                version = None
         if not version:
             self._log_skipped_link(
                 link, 'Missing project version for %s' % search.supplied)
@@ -877,15 +880,15 @@ def _egg_info_matches(egg_info, canonical_name):
     :param egg_info: The string to parse. E.g. foo-2.1
     :param canonical_name: The canonicalized name of the package this
         belongs to.
+
+    Returns the version part as a string. The string is never empty. Raises
+    ValueError if parsing fails, or if the version part is empty.
     """
-    try:
-        version_start = _find_name_version_sep(egg_info, canonical_name) + 1
-    except ValueError:
-        return None
+    version_start = _find_name_version_sep(egg_info, canonical_name) + 1
     version = egg_info[version_start:]
-    if not version:
-        return None
-    return version
+    if version:
+        return version
+    raise ValueError("{} does not match {}".format(egg_info, canonical_name))
 
 
 def _determine_base_url(document, page_url):

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -303,7 +303,7 @@ def _parse_binary_package_version(link, search, valid_tags):
     return wheel.version
 
 
-def _parse_source_package_version(link, egg_info, search):
+def _parse_source_package_version(link, search):
     """Parse package version from a source link.
 
     This is a helper function for `_parse_package_version()`. The egg-info
@@ -311,6 +311,8 @@ def _parse_source_package_version(link, egg_info, search):
     and parsed with `_PYTHON_VERSION_RE` to ensure it is compatible with the
     current environment.
     """
+    egg_info = link.egg_fragment or link.splitext()[0]
+
     try:
         info = _egg_info_matches(egg_info, search.canonical)
     except ValueError:
@@ -340,7 +342,6 @@ def _parse_package_version(link, search, valid_tags):
     signify parsing errors, or an unsupported environment. Te callee should
     catch the exception, and convert it to string for logging.
     """
-    egg_info = link.egg_fragment or link.splitext()[0]
     ext = link.ext
     if not link.egg_fragment:
         if not ext:
@@ -356,7 +357,7 @@ def _parse_package_version(link, search, valid_tags):
     if "source" not in search.formats and ext != wheel_ext:
         raise _SourceLinkNotPermitted(link, search)
 
-    return _parse_source_package_version(link, egg_info, search)
+    return _parse_source_package_version(link, search)
 
 
 class PackageFinder(object):

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -781,15 +781,15 @@ class PackageFinder(object):
                     link, 'unsupported archive format: %s' % ext,
                 )
                 return
-            if "binary" not in search.formats and ext == wheel_ext:
-                self._log_skipped_link(
-                    link, 'No binaries permitted for %s' % search.supplied,
-                )
-                return
             if "macosx10" in link.path and ext == '.zip':
                 self._log_skipped_link(link, 'macosx10 one')
                 return
             if ext == wheel_ext:
+                if "binary" not in search.formats:
+                    self._log_skipped_link(
+                        link, 'No binaries permitted for %s' % search.supplied,
+                    )
+                    return
                 try:
                     wheel = Wheel(link.filename)
                 except InvalidWheelFilename:

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -502,7 +502,7 @@ def test_finder_installs_pre_releases_with_version_spec():
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
 
-class test_link_package_versions(object):
+class TestLinkPackageVersions(object):
 
     # patch this for travis which has distribute in its base env for now
     @patch(

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -241,20 +241,30 @@ def test_find_name_version_sep_failure(egg_info, canonical_name):
         # Should be able to detect collapsed characters in the egg info.
         ("foo--bar-1.0", "foo-bar", "1.0"),
         ("foo-_bar-1.0", "foo-bar", "1.0"),
-
-        # Invalid.
-        ("the-package-name-8.19", "does-not-match", None),
-        ("zope.interface.-4.5.0", "zope.interface", None),
-        ("zope.interface-", "zope-interface", None),
-        ("zope.interface4.5.0", "zope-interface", None),
-        ("zope.interface.4.5.0", "zope-interface", None),
-        ("zope.interface.-4.5.0", "zope-interface", None),
-        ("zope.interface", "zope-interface", None),
     ],
 )
 def test_egg_info_matches(egg_info, canonical_name, expected):
     version = _egg_info_matches(egg_info, canonical_name)
     assert version == expected
+
+
+@pytest.mark.parametrize(
+    ("egg_info", "canonical_name"),
+    [
+        ("the-package-name-8.19", "does-not-match"),
+        ("zope.interface.-4.5.0", "zope.interface"),
+        ("zope.interface-", "zope-interface"),
+        ("zope.interface4.5.0", "zope-interface"),
+        ("zope.interface.4.5.0", "zope-interface"),
+        ("zope.interface.-4.5.0", "zope-interface"),
+        ("zope.interface", "zope-interface"),
+    ],
+)
+def test_egg_info_matches_fails(egg_info, canonical_name):
+    with pytest.raises(ValueError) as ctx:
+        _egg_info_matches(egg_info, canonical_name)
+    error = "{} does not match {}".format(egg_info, canonical_name)
+    assert str(ctx.value) == error
 
 
 def test_request_http_error(caplog):


### PR DESCRIPTION
This separates the internals of `_link_package_versions` into two parts. The inner part `_parse_package_version` deals with the logic flow, raising various exceptions along the way; the outer part catches them and log the appropriate message. The reason of this structure is that `_log_skipped_link` does some internal caching to prevent duplicate logging, and is extremely difficult to decouple from the logic otherwise. The logging part can probably be refactored out like the logic, but that’s for the future.

I think the behaviour of `PackageFinder._link_package_versions()` is already tested in `test_finders`, but please tell me if you think there’s any missing cases in existing tests.

https://github.com/pypa/pip/blob/35701ea3cd41eb62c2e9e13bf5ba16ce960bd8dc/tests/unit/test_finder.py#L505-L548