### PR TITLE
Add --target-scripts to provide path for binaries

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -370,7 +370,7 @@ class InstallRequirement(object):
 
     def move_wheel_files(self, wheeldir, root=None, home=None, prefix=None,
                          warn_script_location=True, use_user_site=False,
-                         pycompile=True):
+                         pycompile=True, scripts_target_dir=None):
         move_wheel_files(
             self.name, self.req, wheeldir,
             user=use_user_site,
@@ -380,6 +380,7 @@ class InstallRequirement(object):
             pycompile=pycompile,
             isolated=self.isolated,
             warn_script_location=warn_script_location,
+            scripts_target_dir=scripts_target_dir
         )
 
     # Things valid for sdists
@@ -743,7 +744,7 @@ class InstallRequirement(object):
 
     def install(self, install_options, global_options=None, root=None,
                 home=None, prefix=None, warn_script_location=True,
-                use_user_site=False, pycompile=True):
+                use_user_site=False, pycompile=True, scripts_target_dir=None):
         global_options = global_options if global_options is not None else []
         if self.editable:
             self.install_editable(
@@ -753,11 +754,11 @@ class InstallRequirement(object):
         if self.is_wheel:
             version = wheel.wheel_version(self.source_dir)
             wheel.check_compatibility(version, self.name)
-
             self.move_wheel_files(
                 self.source_dir, root=root, prefix=prefix, home=home,
                 warn_script_location=warn_script_location,
                 use_user_site=use_user_site, pycompile=pycompile,
+                scripts_target_dir=scripts_target_dir
             )
             self.install_succeeded = True
             return

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -226,7 +226,7 @@ def sorted_outrows(outrows):
 
 def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
                      pycompile=True, scheme=None, isolated=False, prefix=None,
-                     warn_script_location=True):
+                     warn_script_location=True, scripts_target_dir=None):
     """Install a wheel"""
 
     if not scheme:
@@ -234,6 +234,9 @@ def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
             name, user=user, home=home, root=root, isolated=isolated,
             prefix=prefix,
         )
+
+    if scripts_target_dir is not None:
+        scheme['scripts'] = scripts_target_dir
 
     if root_is_purelib(name, wheeldir):
         lib_dir = scheme['purelib']


### PR DESCRIPTION
For `pip install`, this introduces a new option, `--scripts-target`, only to be used with `--target`, so that users can now specify a different path for scripts/binaries instead of the default `$target_dir/bin`.

For wheel installations, the given path is injected to `scheme` in `move_wheel_files()`.
For non-wheels, it is used as `--install-scripts`.

This should close #3934.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
