### PR TITLE
Change VersionControl.get_src_requirement() to accept the project name

### DIFF
--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -168,7 +168,7 @@ def get_requirement_info(dist):
         return (location, True, comments)
 
     try:
-        req = vc_type().get_src_requirement(dist, location)
+        req = vc_type().get_src_requirement(location, dist.project_name)
     except BadCommand:
         logger.warning(
             'cannot determine version of editable source in %s '

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -850,13 +850,15 @@ def enum(*sequential, **named):
     return type('Enum', (), enums)
 
 
-def make_vcs_requirement_url(repo_url, rev, egg_project_name, subdir=None):
+def make_vcs_requirement_url(repo_url, rev, project_name, subdir=None):
     """
     Return the URL for a VCS requirement.
 
     Args:
       repo_url: the remote VCS url, with any needed VCS prefix (e.g. "git+").
+      project_name: the (unescaped) project name.
     """
+    egg_project_name = pkg_resources.to_filename(project_name)
     req = '{}@{}#egg={}'.format(repo_url, rev, egg_project_name)
     if subdir:
         req += '&subdirectory={}'.format(subdir)

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -411,7 +411,7 @@ class VersionControl(object):
             rmtree(location)
         self.obtain(location)
 
-    def get_src_requirement(self, dist, location):
+    def get_src_requirement(self, location, project_name):
         """
         Return a string representing the requirement needed to
         redownload the files currently present in location, something

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -94,15 +94,14 @@ class Bazaar(VersionControl):
         )
         return revision.splitlines()[-1]
 
-    def get_src_requirement(self, dist, location):
+    def get_src_requirement(self, location, project_name):
         repo = self.get_url(location)
         if not repo:
             return None
         if not repo.lower().startswith('bzr:'):
             repo = 'bzr+' + repo
         current_rev = self.get_revision(location)
-        egg_project_name = dist.egg_name().split('-', 1)[0]
-        return make_vcs_requirement_url(repo, current_rev, egg_project_name)
+        return make_vcs_requirement_url(repo, current_rev, project_name)
 
     def is_commit_id_equal(self, dest, name):
         """Always assume the versions don't match"""

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -293,14 +293,13 @@ class Git(VersionControl):
             return None
         return os.path.relpath(location, root_dir)
 
-    def get_src_requirement(self, dist, location):
+    def get_src_requirement(self, location, project_name):
         repo = self.get_url(location)
         if not repo.lower().startswith('git:'):
             repo = 'git+' + repo
         current_rev = self.get_revision(location)
-        egg_project_name = dist.egg_name().split('-', 1)[0]
         subdir = self._get_subdirectory(location)
-        req = make_vcs_requirement_url(repo, current_rev, egg_project_name,
+        req = make_vcs_requirement_url(repo, current_rev, project_name,
                                        subdir=subdir)
 
         return req

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -84,14 +84,12 @@ class Mercurial(VersionControl):
             show_stdout=False, cwd=location).strip()
         return current_rev_hash
 
-    def get_src_requirement(self, dist, location):
+    def get_src_requirement(self, location, project_name):
         repo = self.get_url(location)
         if not repo.lower().startswith('hg:'):
             repo = 'hg+' + repo
         current_rev_hash = self.get_revision_hash(location)
-        egg_project_name = dist.egg_name().split('-', 1)[0]
-        return make_vcs_requirement_url(repo, current_rev_hash,
-                                        egg_project_name)
+        return make_vcs_requirement_url(repo, current_rev_hash, project_name)
 
     def is_commit_id_equal(self, dest, name):
         """Always assume the versions don't match"""

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -195,15 +195,13 @@ class Subversion(VersionControl):
 
         return url, rev
 
-    def get_src_requirement(self, dist, location):
+    def get_src_requirement(self, location, project_name):
         repo = self.get_url(location)
         if repo is None:
             return None
         repo = 'svn+' + repo
         rev = self.get_revision(location)
-        # FIXME: why not project name?
-        egg_project_name = dist.egg_name().split('-', 1)[0]
-        return make_vcs_requirement_url(repo, rev, egg_project_name)
+        return make_vcs_requirement_url(repo, rev, project_name)
 
     def is_commit_id_equal(self, dest, name):
         """Always assume the versions don't match"""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -646,6 +646,9 @@ def test_call_subprocess_closes_stdin():
     # Test with None subdir.
     (('git+https://example.com/pkg', 'dev', 'myproj', None),
      'git+https://example.com/pkg@dev#egg=myproj'),
+    # Test an unescaped project name.
+    (('git+https://example.com/pkg', 'dev', 'zope-interface'),
+     'git+https://example.com/pkg@dev#egg=zope_interface'),
 ])
 def test_make_vcs_requirement_url(args, expected):
     actual = make_vcs_requirement_url(*args)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -80,13 +80,6 @@ def git():
     return git
 
 
-@pytest.fixture
-def dist():
-    dist = Mock()
-    dist.egg_name = Mock(return_value='pip_test_package')
-    return dist
-
-
 def test_looks_like_hash():
     assert looks_like_hash(40 * 'a')
     assert looks_like_hash(40 * 'A')
@@ -97,14 +90,13 @@ def test_looks_like_hash():
 
 
 @pytest.mark.network
-def test_git_get_src_requirements(git, dist):
-    ret = git.get_src_requirement(dist, location='.')
+def test_git_get_src_requirements(git):
+    ret = git.get_src_requirement('.', 'pip-test-package')
 
-    assert ret == ''.join([
-        'git+https://github.com/pypa/pip-test-package',
-        '@5547fa909e83df8bd743d3978d6667497983a4b7',
-        '#egg=pip_test_package'
-    ])
+    assert ret == (
+        'git+https://github.com/pypa/pip-test-package'
+        '@5547fa909e83df8bd743d3978d6667497983a4b7#egg=pip_test_package'
+    )
 
 
 @patch('pip._internal.vcs.git.Git.get_revision_sha')


### PR DESCRIPTION
This simplifies `VersionControl.get_src_requirement()` by changing it to accept the unescaped project name instead of a `Distribution` object.

The implementation of `Distribution.egg_name()` explains part of the simplification:
https://github.com/pypa/pip/blob/b0f06c8d1513c20ef1a362e7126ad579d725d86a/src/pip/_vendor/pkg_resources/__init__.py#L2649-L2658