### PR TITLE
Add regression test for check_requires_python with no package metadata

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -603,6 +603,13 @@ class TestCheckRequiresPython(object):
         else:
             check_dist_requires_python(fake_dist)
 
+    def test_no_metadata(self):
+        fake_dist = Mock(
+            has_metadata=lambda _: False,
+            location="foo"
+        )
+        check_dist_requires_python(fake_dist)
+
 
 class TestGetProg(object):
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Add a regression test for check_requires_python for the case where a package has no metadata (see issue https://github.com/pypa/pip/issues/5082).
