### PR TITLE
Fix #4733 by deleting the failing example

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -845,8 +845,8 @@ Examples
 
       $ pip install SomePackage[PDF]
       $ pip install git+https://git.repo/some_pkg.git#egg=SomePackage[PDF]
+      $ pip install .[PDF]  # project in current directory
       $ pip install SomePackage[PDF]==3.0
-      $ pip install -e .[PDF]==3.0  # editable project in current directory
       $ pip install SomePackage[PDF,EPUB]  # multiple extras
 
 

--- a/news/4733.doc
+++ b/news/4733.doc
@@ -1,0 +1,1 @@
+Replace a failing example of pip installs with extras with a working one.


### PR DESCRIPTION
This example did not make sense unless it was possible to install specify a
version of a package one installs referencing by the path (here: `.`) .

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
No news file, because it is a trivial fix.
