### PR TITLE
Implement #5500: Allow pip to prefer local package over remote

### DIFF
--- a/news/5500.feature
+++ b/news/5500.feature
@@ -1,0 +1,2 @@
+Add options --prefer-local-compatible to make pip prefer local packages satisfying the
+package requirement. If local package found, no remote URLs will be checked

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -303,4 +303,5 @@ class RequirementCommand(Command):
             abi=abi,
             implementation=implementation,
             prefer_binary=options.prefer_binary,
+            prefer_local_compatible=options.prefer_local_compatible,
         )

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -529,6 +529,19 @@ def prefer_binary():
     )
 
 
+def prefer_local_compatible():
+    return Option(
+        '--prefer-local-compatible',
+        dest='prefer_local_compatible',
+        action="store_true",
+        default=False,
+        help=("Prefer local packages (e.g. through --find-links) that "
+              "satisfies the version specifier. This option delays checking "
+              "remote URLs for newer available packages until no local "
+              "compatible package is found."),
+    )
+
+
 cache_dir = partial(
     Option,
     "--cache-dir",

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -69,6 +69,7 @@ class DownloadCommand(RequirementCommand):
             help=("Download packages into <dir>."),
         )
 
+        cmd_opts.add_option(cmdoptions.prefer_local_compatible())
         cmd_opts.add_option(cmdoptions.platform())
         cmd_opts.add_option(cmdoptions.python_version())
         cmd_opts.add_option(cmdoptions.implementation())

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -191,6 +191,7 @@ class InstallCommand(RequirementCommand):
         cmd_opts.add_option(cmdoptions.no_binary())
         cmd_opts.add_option(cmdoptions.only_binary())
         cmd_opts.add_option(cmdoptions.prefer_binary())
+        cmd_opts.add_option(cmdoptions.prefer_local_compatible())
         cmd_opts.add_option(cmdoptions.no_clean())
         cmd_opts.add_option(cmdoptions.require_hashes())
         cmd_opts.add_option(cmdoptions.progress_bar())


### PR DESCRIPTION
Add option --prefer-local-compatible to download and install commands

With this option enabled, local directories specified with --find-links
are searched first. If package requirements are satisfied by packages
found locally, the local package will be preferred, and no remote URLs
will be checked.

See discussion at https://github.com/pypa/pip/issues/5500