### PR TITLE
Issue5963

### DIFF
--- a/news/5963.bugfix
+++ b/news/5963.bugfix
@@ -1,0 +1,1 @@
+update error message when setting config variables.

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -372,10 +372,14 @@ class Configuration(object):
         parsers = self._parsers[self.load_only]
         
         if not parsers:
-            errorMsg = "Fatal Internal error [id=2]. Please report as a bug."
             if (self.load_only == kinds.VENV and not running_under_virtualenv()):
-                errorMsg = "Please use --venv option under virtual env."
-            # This should not happen if everything works correctly.
+                errorMsg = "Please use --venv option under virtual environment."
+            elif (self.load_only == kinds.USER and self.isolated):
+                errorMsg = "User configuration can not be changed in isolated mode."
+            else:
+                # This should not happen if everything works correctly.
+                errorMsg = "Fatal Internal error [id=2]. Please report as a bug."
+                
             raise ConfigurationError(
                 errorMsg
             )

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -370,10 +370,14 @@ class Configuration(object):
         # type: () -> Tuple[str, RawConfigParser]
         # Determine which parser to modify
         parsers = self._parsers[self.load_only]
+        
         if not parsers:
+            errorMsg = "Fatal Internal error [id=2]. Please report as a bug."
+            if (self.load_only == kinds.VENV and not running_under_virtualenv()):
+                errorMsg = "Please use --venv option under virtual env."
             # This should not happen if everything works correctly.
             raise ConfigurationError(
-                "Fatal Internal error [id=2]. Please report as a bug."
+                errorMsg
             )
 
         # Use the highest priority parser.

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -378,7 +378,6 @@ class Configuration(object):
             else:
                 # This should not happen if everything works correctly.
                 errorMsg = "Fatal Internal error [id=2]. Please report as a bug."
-                
             raise ConfigurationError(
                 errorMsg
             )

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -370,7 +370,6 @@ class Configuration(object):
         # type: () -> Tuple[str, RawConfigParser]
         # Determine which parser to modify
         parsers = self._parsers[self.load_only]
-        
         if not parsers:
             if (self.load_only == kinds.VENV and not running_under_virtualenv()):
                 errorMsg = "Please use --venv option under virtual environment."

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -371,13 +371,16 @@ class Configuration(object):
         # Determine which parser to modify
         parsers = self._parsers[self.load_only]
         if not parsers:
-            if (self.load_only == kinds.VENV and not running_under_virtualenv()):
-                errorMsg = "Please use --venv option under virtual environment."
-            elif (self.load_only == kinds.USER and self.isolated):
-                errorMsg = "User configuration can not be changed in isolated mode."
+            if self.load_only == kinds.VENV and not running_under_virtualenv():
+                errorMsg = "Please use --venv option " \
+                           "under virtual environment."
+            elif self.load_only == kinds.USER and self.isolated:
+                errorMsg = "User configuration " \
+                           "can not be set in isolated mode."
             else:
                 # This should not happen if everything works correctly.
-                errorMsg = "Fatal Internal error [id=2]. Please report as a bug."
+                errorMsg = "Fatal Internal error [id=2]. " \
+                           "Please report as a bug."
             raise ConfigurationError(
                 errorMsg
             )


### PR DESCRIPTION
This pr fixes problem in ISSUE #5963 
The reason that the internal error happens is: clients are trying to set a virtual env config variable but it is not under virtual environment. Add better error message to help clients find what they need to do when the error happens.
Also the same problem will happen when clients are trying to set a user config variable but enable the isolated mode at the same time. Also add better error message for it.