### PR TITLE
Fixes #3055 Uninstall causes paths to exceed MAX_PATH limit

### DIFF
--- a/news/3055.bugfix
+++ b/news/3055.bugfix
@@ -1,0 +1,1 @@
+Avoids creating excessively long temporary paths when uninstalling packages.

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -17,7 +17,7 @@ from pip._internal.utils.misc import (
     FakeFile, ask, dist_in_usersite, dist_is_local, egg_link_path, is_local,
     normalize_path, renames,
 )
-from pip._internal.utils.temp_dir import TempDirectory, AdjacentTempDirectory
+from pip._internal.utils.temp_dir import AdjacentTempDirectory
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def compress_for_rename(paths):
     remaining = set(paths)
     unchecked = sorted(set(os.path.split(p)[0] for p in remaining), key=len)
     wildcards = set()
-    
+
     def norm_join(*a):
         return os.path.normcase(os.path.join(*a))
 

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -102,7 +102,7 @@ def compress_for_rename(paths):
     This set may include directories when the original sequence of paths
     included every file on disk.
     """
-    case_map =  dict((os.path.normcase(p), p) for p in paths)
+    case_map = dict((os.path.normcase(p), p) for p in paths)
     remaining = set(case_map)
     unchecked = sorted(set(os.path.split(p)[0]
                            for p in case_map.values()), key=len)

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -17,7 +17,7 @@ from pip._internal.utils.misc import (
     FakeFile, ask, dist_in_usersite, dist_is_local, egg_link_path, is_local,
     normalize_path, renames,
 )
-from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.utils.temp_dir import TempDirectory, AdjacentTempDirectory
 
 logger = logging.getLogger(__name__)
 
@@ -86,14 +86,47 @@ def compact(paths):
     sep = os.path.sep
     short_paths = set()
     for path in sorted(paths, key=len):
-        should_add = any(
+        should_skip = any(
             path.startswith(shortpath.rstrip("*")) and
             path[len(shortpath.rstrip("*").rstrip(sep))] == sep
             for shortpath in short_paths
         )
-        if not should_add:
+        if not should_skip:
             short_paths.add(path)
     return short_paths
+
+
+def compress_for_rename(paths):
+    """Returns a set containing the paths that need to be renamed.
+
+    This set may include directories when the original sequence of paths
+    included every file on disk.
+    """
+    remaining = set(paths)
+    unchecked = sorted(set(os.path.split(p)[0] for p in remaining), key=len)
+    wildcards = set()
+    
+    def norm_join(*a):
+        return os.path.normcase(os.path.join(*a))
+
+    for root in unchecked:
+        if any(root.startswith(w) for w in wildcards):
+            # This directory has already been handled.
+            continue
+
+        all_files = set()
+        all_subdirs = set()
+        for dirname, subdirs, files in os.walk(root):
+            all_subdirs.update(norm_join(root, dirname, d) for d in subdirs)
+            all_files.update(norm_join(root, dirname, f) for f in files)
+        # If all the files we found are in our remaining set of files to
+        # remove, then remove them from the latter set and add a wildcard
+        # for the directory.
+        if len(all_files - remaining) == 0:
+            remaining.difference_update(all_files)
+            wildcards.add(root + os.sep)
+
+    return remaining | wildcards
 
 
 def compress_for_output_listing(paths):
@@ -153,7 +186,7 @@ class UninstallPathSet(object):
         self._refuse = set()
         self.pth = {}
         self.dist = dist
-        self.save_dir = TempDirectory(kind="uninstall")
+        self._save_dirs = []
         self._moved_paths = []
 
     def _permitted(self, path):
@@ -193,9 +226,17 @@ class UninstallPathSet(object):
             self._refuse.add(pth_file)
 
     def _stash(self, path):
-        return os.path.join(
-            self.save_dir.path, os.path.splitdrive(path)[1].lstrip(os.path.sep)
-        )
+        best = None
+        for save_dir in self._save_dirs:
+            if not path.startswith(save_dir.original + os.sep):
+                continue
+            if not best or len(save_dir.original) > len(best.original):
+                best = save_dir
+        if best is None:
+            best = AdjacentTempDirectory(os.path.dirname(path))
+            best.create()
+            self._save_dirs.append(best)
+        return os.path.join(best.path, os.path.relpath(path, best.original))
 
     def remove(self, auto_confirm=False, verbose=False):
         """Remove paths in ``self.paths`` with confirmation (unless
@@ -215,12 +256,10 @@ class UninstallPathSet(object):
 
         with indent_log():
             if auto_confirm or self._allowed_to_proceed(verbose):
-                self.save_dir.create()
-
-                for path in sorted(compact(self.paths)):
+                for path in sorted(compact(compress_for_rename(self.paths))):
                     new_path = self._stash(path)
                     logger.debug('Removing file or directory %s', path)
-                    self._moved_paths.append(path)
+                    self._moved_paths.append((path, new_path))
                     renames(path, new_path)
                 for pth in self.pth.values():
                     pth.remove()
@@ -251,20 +290,21 @@ class UninstallPathSet(object):
         _display('Would remove:', will_remove)
         _display('Would not remove (might be manually added):', will_skip)
         _display('Would not remove (outside of prefix):', self._refuse)
+        if verbose:
+            _display('Will actually move:', compress_for_rename(self.paths))
 
         return ask('Proceed (y/n)? ', ('y', 'n')) == 'y'
 
     def rollback(self):
         """Rollback the changes previously made by remove()."""
-        if self.save_dir.path is None:
+        if not self._save_dirs:
             logger.error(
                 "Can't roll back %s; was not uninstalled",
                 self.dist.project_name,
             )
             return False
         logger.info('Rolling back uninstall of %s', self.dist.project_name)
-        for path in self._moved_paths:
-            tmp_path = self._stash(path)
+        for path, tmp_path in self._moved_paths:
             logger.debug('Replacing %s', path)
             renames(tmp_path, path)
         for pth in self.pth.values():
@@ -272,7 +312,8 @@ class UninstallPathSet(object):
 
     def commit(self):
         """Remove temporary save dir: rollback will no longer be possible."""
-        self.save_dir.cleanup()
+        for save_dir in self._save_dirs:
+            save_dir.cleanup()
         self._moved_paths = []
 
     @classmethod

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import itertools
 import logging
 import os.path
-import shutil
 import tempfile
 
 from pip._internal.utils.misc import rmtree
@@ -115,8 +114,12 @@ class AdjacentTempDirectory(TempDirectory):
         package).
         """
         for i in range(1, len(name)):
-            for candidate in itertools.permutations(cls.LEADING_CHARS, i):
-                yield ''.join(candidate) + name[i:]
+            if name[i] in cls.LEADING_CHARS:
+                continue
+            for candidate in itertools.combinations_with_replacement(cls.LEADING_CHARS, i):
+                new_name = ''.join(candidate) + name[i:]
+                if new_name != name:
+                    yield new_name
 
     def create(self):
         root, name = os.path.split(self.original)
@@ -136,4 +139,3 @@ class AdjacentTempDirectory(TempDirectory):
                 tempfile.mkdtemp(prefix="pip-{}-".format(self.kind))
             )
         logger.debug("Created temporary directory: {}".format(self.path))
-

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -116,7 +116,8 @@ class AdjacentTempDirectory(TempDirectory):
         for i in range(1, len(name)):
             if name[i] in cls.LEADING_CHARS:
                 continue
-            for candidate in itertools.combinations_with_replacement(cls.LEADING_CHARS, i):
+            for candidate in itertools.combinations_with_replacement(
+                    cls.LEADING_CHARS, i):
                 new_name = ''.join(candidate) + name[i:]
                 if new_name != name:
                     yield new_name

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -120,7 +120,6 @@ class AdjacentTempDirectory(TempDirectory):
 
     def create(self):
         root, name = os.path.split(self.original)
-        os.makedirs(root, exist_ok=True)
         for candidate in self._generate_names(name):
             path = os.path.join(root, candidate)
             try:

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -6,7 +6,7 @@ from mock import Mock
 import pip._internal.req.req_uninstall
 from pip._internal.req.req_uninstall import (
     UninstallPathSet, compact, compress_for_output_listing,
-    uninstallation_paths,
+    compress_for_rename, uninstallation_paths,
 )
 from tests.lib import create_file
 
@@ -90,9 +90,24 @@ def test_compressed_listing(tmpdir):
         "lib/mypkg/support/would_be_skipped.skip.py",
     ])
 
+    expected_rename = in_tmpdir([
+        "bin/",
+        "lib/mypkg.dist-info/",
+        "lib/mypkg/would_be_removed.txt",
+        "lib/mypkg/__init__.py",
+        "lib/mypkg/my_awesome_code.py",
+        "lib/mypkg/__pycache__/",
+        "lib/mypkg/support/support_file.py",
+        "lib/mypkg/support/more_support.py",
+        "lib/mypkg/support/__pycache__/",
+        "lib/random_other_place/",
+    ])
+
     will_remove, will_skip = compress_for_output_listing(sample)
+    will_rename = compress_for_rename(sample)
     assert sorted(expected_skip) == sorted(compact(will_skip))
     assert sorted(expected_remove) == sorted(compact(will_remove))
+    assert sorted(expected_rename) == sorted(compact(will_rename))
 
 
 class TestUninstallPathSet(object):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -30,7 +30,7 @@ from pip._internal.utils.misc import (
     split_auth_from_netloc, untar_file, unzip_file,
 )
 from pip._internal.utils.packaging import check_dist_requires_python
-from pip._internal.utils.temp_dir import TempDirectory, AdjacentTempDirectory
+from pip._internal.utils.temp_dir import AdjacentTempDirectory, TempDirectory
 
 
 class Tests_EgglinkPath:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -548,15 +548,16 @@ class TestTempDirectory(object):
         assert tmp_dir.path is None
         assert not os.path.exists(created_path)
 
-    @pytest.mark.parametrize("name",
-        [
-            "ABC",
-            "ABC.dist-info",
-            "_+-",
-            "_package",
-        ])
+    @pytest.mark.parametrize("name", [
+        "ABC",
+        "ABC.dist-info",
+        "_+-",
+        "_package",
+    ])
     def test_adjacent_directory_names(self, name):
-        names = lambda: AdjacentTempDirectory._generate_names(name)
+        def names():
+            return AdjacentTempDirectory._generate_names(name)
+
         chars = AdjacentTempDirectory.LEADING_CHARS
 
         # Ensure many names are unique
@@ -572,7 +573,8 @@ class TestTempDirectory(object):
         assert not any(n == name for n in names())
 
         # Check the first group are correct
-        assert all(x == y for x, y in zip(some_names, [c + name[1:] for c in chars]))
+        assert all(x == y for x, y in
+                   zip(some_names, [c + name[1:] for c in chars]))
 
 
 class TestGlibc(object):


### PR DESCRIPTION
Fixes #3055 Uninstall causes paths to exceed MAX_PATH limit
Moves files to adjacent directory to avoid creating a deeper path when uninstalling.