### PR TITLE
Add type annotations to most of the files in pip/_internal

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -32,7 +32,7 @@ from pip._internal.utils.outdated import pip_version_check
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, List, Union, Tuple, Any  # noqa: F401
+    from typing import Optional, List, Tuple, Any  # noqa: F401
     from optparse import Values  # noqa: F401
     from pip._internal.cache import WheelCache  # noqa: F401
     from pip._internal.req.req_set import RequirementSet  # noqa: F401

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -114,7 +114,7 @@ help_ = partial(
     dest='help',
     action='help',
     help='Show help.',
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 isolated_mode = partial(
     Option,
@@ -126,7 +126,7 @@ isolated_mode = partial(
         "Run pip in an isolated mode, ignoring environment variables and user "
         "configuration."
     ),
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 require_virtualenv = partial(
     Option,
@@ -136,7 +136,7 @@ require_virtualenv = partial(
     action='store_true',
     default=False,
     help=SUPPRESS_HELP
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 verbose = partial(
     Option,
@@ -145,7 +145,7 @@ verbose = partial(
     action='count',
     default=0,
     help='Give more output. Option is additive, and can be used up to 3 times.'
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 no_color = partial(
     Option,
@@ -154,7 +154,7 @@ no_color = partial(
     action='store_true',
     default=False,
     help="Suppress colored output",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 version = partial(
     Option,
@@ -162,7 +162,7 @@ version = partial(
     dest='version',
     action='store_true',
     help='Show version and exit.',
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 quiet = partial(
     Option,
@@ -175,7 +175,7 @@ quiet = partial(
         ' times (corresponding to WARNING, ERROR, and CRITICAL logging'
         ' levels).'
     ),
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 progress_bar = partial(
     Option,
@@ -188,7 +188,7 @@ progress_bar = partial(
         'Specify type of progress to be displayed [' +
         '|'.join(BAR_TYPES.keys()) + '] (default: %default)'
     ),
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 log = partial(
     Option,
@@ -196,7 +196,7 @@ log = partial(
     dest="log",
     metavar="path",
     help="Path to a verbose appending log."
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 no_input = partial(
     Option,
@@ -206,7 +206,7 @@ no_input = partial(
     action='store_true',
     default=False,
     help=SUPPRESS_HELP
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 proxy = partial(
     Option,
@@ -215,7 +215,7 @@ proxy = partial(
     type='str',
     default='',
     help="Specify a proxy in the form [user:passwd@]proxy.server:port."
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 retries = partial(
     Option,
@@ -225,7 +225,7 @@ retries = partial(
     default=5,
     help="Maximum number of retries each connection should attempt "
          "(default %default times).",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 timeout = partial(
     Option,
@@ -235,7 +235,7 @@ timeout = partial(
     type='float',
     default=15,
     help='Set the socket timeout (default %default seconds).',
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 skip_requirements_regex = partial(
     Option,
@@ -245,7 +245,7 @@ skip_requirements_regex = partial(
     type='str',
     default='',
     help=SUPPRESS_HELP,
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 def exists_action():
@@ -271,7 +271,7 @@ cert = partial(
     type='str',
     metavar='path',
     help="Path to alternate CA bundle.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 client_cert = partial(
     Option,
@@ -282,7 +282,7 @@ client_cert = partial(
     metavar='path',
     help="Path to SSL client certificate, a single file containing the "
          "private key and the certificate in PEM format.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 index_url = partial(
     Option,
@@ -294,7 +294,7 @@ index_url = partial(
          "This should point to a repository compliant with PEP 503 "
          "(the simple repository API) or a local directory laid out "
          "in the same format.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 def extra_index_url():
@@ -317,7 +317,7 @@ no_index = partial(
     action='store_true',
     default=False,
     help='Ignore package index (only looking at --find-links URLs instead).',
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 def find_links():
@@ -355,7 +355,7 @@ process_dependency_links = partial(
     action="store_true",
     default=False,
     help="Enable the processing of dependency links.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 def constraints():
@@ -406,7 +406,7 @@ src = partial(
     help='Directory to check out editable projects into. '
     'The default in a virtualenv is "<venv path>/src". '
     'The default for global installs is "<current dir>/src".'
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 def _get_format_control(values, option):
@@ -432,7 +432,7 @@ def _handle_only_binary(option, opt_str, value, parser):
 
 
 def no_binary():
-    # type: () -> Option
+    # type: (...) -> Option
     format_control = FormatControl(set(), set())
     return Option(
         "--no-binary", dest="format_control", action="callback",
@@ -448,7 +448,7 @@ def no_binary():
 
 
 def only_binary():
-    # type: () -> Option
+    # type: (...) -> Option
     format_control = FormatControl(set(), set())
     return Option(
         "--only-binary", dest="format_control", action="callback",
@@ -471,7 +471,7 @@ platform = partial(
     default=None,
     help=("Only use wheels compatible with <platform>. "
           "Defaults to the platform of the running system."),
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 python_version = partial(
@@ -486,7 +486,7 @@ python_version = partial(
           "version (e.g. '2') can be specified to match all "
           "minor revs of that major version.  A minor version "
           "(e.g. '34') can also be specified."),
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 implementation = partial(
@@ -500,7 +500,7 @@ implementation = partial(
           " or 'ip'. If not specified, then the current "
           "interpreter implementation is used.  Use 'py' to force "
           "implementation-agnostic wheels."),
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 abi = partial(
@@ -515,7 +515,7 @@ abi = partial(
           "you will need to specify --implementation, "
           "--platform, and --python-version when using "
           "this option."),
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 def prefer_binary():
@@ -536,7 +536,7 @@ cache_dir = partial(
     default=USER_CACHE_DIR,
     metavar="dir",
     help="Store the cache data in <dir>."
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 def no_cache_dir_callback(option, opt, value, parser):
@@ -570,7 +570,7 @@ no_cache = partial(
     action="callback",
     callback=no_cache_dir_callback,
     help="Disable the cache.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 no_deps = partial(
     Option,
@@ -579,7 +579,7 @@ no_deps = partial(
     action='store_true',
     default=False,
     help="Don't install package dependencies.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 build_dir = partial(
     Option,
@@ -591,7 +591,7 @@ build_dir = partial(
          'The location of temporary directories can be controlled by setting '
          'the TMPDIR environment variable (TEMP on Windows) appropriately. '
          'When passed, build directories are not cleaned in case of failures.'
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 ignore_requires_python = partial(
     Option,
@@ -599,7 +599,7 @@ ignore_requires_python = partial(
     dest='ignore_requires_python',
     action='store_true',
     help='Ignore the Requires-Python information.'
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 no_build_isolation = partial(
     Option,
@@ -610,7 +610,7 @@ no_build_isolation = partial(
     help='Disable isolation when building a modern source distribution. '
          'Build dependencies specified by PEP 518 must be already installed '
          'if this option is used.'
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 use_pep517 = partial(
     Option,
@@ -642,7 +642,7 @@ install_options = partial(
          "bin\"). Use multiple --install-option options to pass multiple "
          "options to setup.py install. If you are using an option with a "
          "directory path, be sure to use absolute path.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 global_options = partial(
     Option,
@@ -652,7 +652,7 @@ global_options = partial(
     metavar='options',
     help="Extra global options to be supplied to the setup.py "
          "call before the install command.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 no_clean = partial(
     Option,
@@ -660,7 +660,7 @@ no_clean = partial(
     action='store_true',
     default=False,
     help="Don't clean up build directories."
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 pre = partial(
     Option,
@@ -669,7 +669,7 @@ pre = partial(
     default=False,
     help="Include pre-release and development versions. By default, "
          "pip only finds stable versions.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 disable_pip_version_check = partial(
     Option,
@@ -679,7 +679,7 @@ disable_pip_version_check = partial(
     default=False,
     help="Don't periodically check PyPI to determine whether a new version "
          "of pip is available for download. Implied with --no-index.",
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 # Deprecated, Remove later
@@ -689,7 +689,7 @@ always_unzip = partial(
     dest='always_unzip',
     action='store_true',
     help=SUPPRESS_HELP,
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 def _merge_hash(option, opt_str, value, parser):
@@ -697,7 +697,7 @@ def _merge_hash(option, opt_str, value, parser):
     """Given a value spelled "algo:digest", append the digest to a list
     pointed to in a dict by the algo name."""
     if not parser.values.hashes:
-        parser.values.hashes = {}
+        parser.values.hashes = {}  # type: ignore
     try:
         algo, digest = value.split(':', 1)
     except ValueError:
@@ -721,7 +721,7 @@ hash = partial(
     type='string',
     help="Verify that the package's archive matches this "
          'hash before installing. Example: --hash=sha256:abcdef...',
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 require_hashes = partial(
@@ -733,7 +733,7 @@ require_hashes = partial(
     help='Require a hash to check each requirement against, for '
          'repeatable installs. This option is implied when any package in a '
          'requirements file has a --hash option.',
-)  # type: partial[Option]
+)  # type: Callable[..., Option]
 
 
 ##########

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -432,7 +432,7 @@ def _handle_only_binary(option, opt_str, value, parser):
 
 
 def no_binary():
-    # type: (...) -> Option
+    # type: () -> Option
     format_control = FormatControl(set(), set())
     return Option(
         "--no-binary", dest="format_control", action="callback",
@@ -448,7 +448,7 @@ def no_binary():
 
 
 def only_binary():
-    # type: (...) -> Option
+    # type: () -> Option
     format_control = FormatControl(set(), set())
     return Option(
         "--only-binary", dest="format_control", action="callback",

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -28,7 +28,12 @@ from pip._internal.utils.misc import (
     protect_pip_from_modification_on_windows,
 )
 from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.wheel import WheelBuilder
+
+if MYPY_CHECK_RUNNING:
+    from typing import List  # noqa: F401
+    from pip._internal.req import InstallRequirement  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -499,6 +504,7 @@ class InstallCommand(RequirementCommand):
                     )
 
     def _warn_about_conflicts(self, to_install):
+        # type: (List[InstallRequirement]) -> None
         try:
             package_set, _dep_info = check_install_conflicts(to_install)
         except Exception:

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -48,7 +48,7 @@ from pip._internal.utils.ui import DownloadProgressProvider
 from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Tuple, Dict, IO  # noqa: F401
+    from typing import Optional, Tuple, Dict, IO, Text  # noqa: F401
     from pip._internal.models.link import Link  # noqa: F401
     from pip._internal.utils.hashes import Hashes  # noqa: F401
 
@@ -401,7 +401,7 @@ class PipSession(requests.Session):
 
 
 def get_file_content(url, comes_from=None, session=None):
-    # type: (str, Optional[str], Optional[PipSession]) -> Tuple[str, str]
+    # type: (str, Optional[str], Optional[PipSession]) -> Tuple[str, Text]
     """Gets the content of a file; it may be a filename, file: URL, or
     http: URL.  Returns (location, content).  Content is unicode.
 

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -543,6 +543,7 @@ def _download_url(
         hashes,  # type: Hashes
         progress_bar  # type: str
 ):
+    # type: (...) -> None
     try:
         total_length = int(resp.headers['content-length'])
     except (ValueError, KeyError, TypeError):

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -48,7 +48,7 @@ from pip._internal.utils.ui import DownloadProgressProvider
 from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Tuple, Dict  # noqa: F401
+    from typing import Optional, Tuple, Dict, IO  # noqa: F401
     from pip._internal.models.link import Link  # noqa: F401
     from pip._internal.utils.hashes import Hashes  # noqa: F401
 
@@ -537,11 +537,11 @@ def _progress_indicator(iterable, *args, **kwargs):
 
 
 def _download_url(
-        resp,
-        link,
-        content_file,
-        hashes,
-        progress_bar
+        resp,  # type: Response
+        link,  # type: Link
+        content_file,  # type: IO
+        hashes,  # type: Hashes
+        progress_bar  # type: str
 ):
     try:
         total_length = int(resp.headers['content-length'])

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -48,7 +48,7 @@ from pip._internal.utils.ui import DownloadProgressProvider
 from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Tuple, Dict, IO, Text  # noqa: F401
+    from typing import Optional, Tuple, Dict, IO, Text, Union  # noqa: F401
     from pip._internal.models.link import Link  # noqa: F401
     from pip._internal.utils.hashes import Hashes  # noqa: F401
 
@@ -452,7 +452,7 @@ _url_slash_drive_re = re.compile(r'/*([a-z])\|', re.I)
 
 
 def is_url(name):
-    # type: (str) -> bool
+    # type: (Union[str, Text]) -> bool
     """Returns true if the name looks like a URL"""
     if ':' not in name:
         return False
@@ -479,7 +479,7 @@ def url_to_path(url):
 
 
 def path_to_url(path):
-    # type: (str) -> str
+    # type: (Union[str, Text]) -> str
     """
     Convert a path to a file: URL.  The path will be made absolute and have
     quoted path parts.

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -5,6 +5,12 @@ from itertools import chain, groupby, repeat
 
 from pip._vendor.six import iteritems
 
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional  # noqa: F401
+    from pip._internal.req.req_install import InstallRequirement  # noqa: F401
+
 
 class PipError(Exception):
     """Base pip exception"""
@@ -96,7 +102,7 @@ class HashError(InstallationError):
         typically available earlier.
 
     """
-    req = None
+    req = None  # type: Optional[InstallRequirement]
     head = ''
 
     def body(self):

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -38,7 +38,22 @@ from pip._internal.utils.misc import (
     redact_password_from_url,
 )
 from pip._internal.utils.packaging import check_requires_python
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.wheel import Wheel, wheel_ext
+
+if MYPY_CHECK_RUNNING:
+    from logging import Logger  # noqa: F401
+    from typing import (Tuple, Optional, Any, List,  # noqa: F401
+                        Union, Callable, Set, Sequence, Iterable,
+                        MutableMapping)
+    from pip._vendor.packaging.version import _BaseVersion  # noqa: F401
+    from pip._vendor.requests import Response  # noqa: F401
+    from pip._internal.req import InstallRequirement  # noqa: F401
+    from pip._internal.download import PipSession  # noqa: F401
+
+    _SecureOrigin = Tuple[str, str, Optional[str]]
+    _BuildTag = Tuple[Any, ...]  # possibly empty Tuple[int, str]
+    _CandidateSortingKey = Tuple[int, _BaseVersion, _BuildTag, Optional[int]]
 
 __all__ = ['FormatControl', 'PackageFinder']
 
@@ -53,13 +68,14 @@ SECURE_ORIGINS = [
     ("file", "*", None),
     # ssh is always secure.
     ("ssh", "*", "*"),
-]
+]  # type: List[_SecureOrigin]
 
 
 logger = logging.getLogger(__name__)
 
 
 def _match_vcs_scheme(url):
+    # type: (str) -> Optional[str]
     """Look for VCS schemes in the URL.
 
     Returns the matched VCS scheme, or None if there's no match.
@@ -72,6 +88,7 @@ def _match_vcs_scheme(url):
 
 
 def _is_url_like_archive(url):
+    # type: (str) -> bool
     """Return whether the URL looks like an archive.
     """
     filename = Link(url).filename
@@ -83,12 +100,14 @@ def _is_url_like_archive(url):
 
 class _NotHTML(Exception):
     def __init__(self, content_type, request_desc):
+        # type: (str, str) -> None
         super(_NotHTML, self).__init__(content_type, request_desc)
         self.content_type = content_type
         self.request_desc = request_desc
 
 
 def _ensure_html_header(response):
+    # type: (Response) -> None
     """Check the Content-Type header to ensure the response contains HTML.
 
     Raises `_NotHTML` if the content type is not text/html.
@@ -103,6 +122,7 @@ class _NotHTTP(Exception):
 
 
 def _ensure_html_response(url, session):
+    # type: (str, PipSession) -> None
     """Send a HEAD request to the URL, and ensure the response contains HTML.
 
     Raises `_NotHTTP` if the URL is not available for a HEAD request, or
@@ -119,6 +139,7 @@ def _ensure_html_response(url, session):
 
 
 def _get_html_response(url, session):
+    # type: (str, PipSession) -> Response
     """Access an HTML page with GET, and return the response.
 
     This consists of three parts:
@@ -168,13 +189,19 @@ def _get_html_response(url, session):
     return resp
 
 
-def _handle_get_page_fail(link, reason, url, meth=None):
+def _handle_get_page_fail(
+        link,  # type: Link
+        reason,  # type: Union[str, Exception]
+        meth=None  # type: Optional[Callable[..., None]]
+):
+    # type: (...) -> None
     if meth is None:
         meth = logger.debug
     meth("Could not fetch URL %s: %s - skipping", link, reason)
 
 
 def _get_html_page(link, session=None):
+    # type: (Link, Optional[PipSession]) -> Optional[HTMLPage]
     if session is None:
         raise TypeError(
             "_get_html_page() missing 1 required keyword argument: 'session'"
@@ -211,19 +238,20 @@ def _get_html_page(link, session=None):
             link, exc.request_desc, exc.content_type,
         )
     except requests.HTTPError as exc:
-        _handle_get_page_fail(link, exc, url)
+        _handle_get_page_fail(link, exc)
     except RetryError as exc:
-        _handle_get_page_fail(link, exc, url)
+        _handle_get_page_fail(link, exc)
     except SSLError as exc:
         reason = "There was a problem confirming the ssl certificate: "
         reason += str(exc)
-        _handle_get_page_fail(link, reason, url, meth=logger.info)
+        _handle_get_page_fail(link, reason, meth=logger.info)
     except requests.ConnectionError as exc:
-        _handle_get_page_fail(link, "connection error: %s" % exc, url)
+        _handle_get_page_fail(link, "connection error: %s" % exc)
     except requests.Timeout:
-        _handle_get_page_fail(link, "timed out", url)
+        _handle_get_page_fail(link, "timed out")
     else:
         return HTMLPage(resp.content, resp.url, resp.headers)
+    return None
 
 
 class PackageFinder(object):
@@ -233,11 +261,22 @@ class PackageFinder(object):
     packages, by reading pages and looking for appropriate links.
     """
 
-    def __init__(self, find_links, index_urls, allow_all_prereleases=False,
-                 trusted_hosts=None, process_dependency_links=False,
-                 session=None, format_control=None, platform=None,
-                 versions=None, abi=None, implementation=None,
-                 prefer_binary=False):
+    def __init__(
+            self,
+            find_links,  # type: List[str]
+            index_urls,  # type: List[str]
+            allow_all_prereleases=False,  # type: bool
+            trusted_hosts=None,  # type: Optional[Iterable[str]]
+            process_dependency_links=False,  # type: bool
+            session=None,  # type: Optional[PipSession]
+            format_control=None,  # type: Optional[FormatControl]
+            platform=None,  # type: Optional[str]
+            versions=None,  # type: Optional[Iterable[str]]
+            abi=None,  # type: Optional[str]
+            implementation=None,  # type: Optional[str]
+            prefer_binary=False  # type: bool
+    ):
+        # type: (...) -> None
         """Create a PackageFinder.
 
         :param format_control: A FormatControl object or None. Used to control
@@ -266,7 +305,7 @@ class PackageFinder(object):
         # it and if it exists, use the normalized version.
         # This is deliberately conservative - it might be fine just to
         # blindly normalize anything starting with a ~...
-        self.find_links = []
+        self.find_links = []  # type: List[str]
         for link in find_links:
             if link.startswith('~'):
                 new_link = normalize_path(link)
@@ -275,10 +314,10 @@ class PackageFinder(object):
             self.find_links.append(link)
 
         self.index_urls = index_urls
-        self.dependency_links = []
+        self.dependency_links = []  # type: List[str]
 
         # These are boring links that have already been logged somehow:
-        self.logged_links = set()
+        self.logged_links = set()  # type: Set[Link]
 
         self.format_control = format_control or FormatControl(set(), set())
 
@@ -286,7 +325,7 @@ class PackageFinder(object):
         self.secure_origins = [
             ("*", host, "*")
             for host in (trusted_hosts if trusted_hosts else [])
-        ]
+        ]  # type: List[_SecureOrigin]
 
         # Do we want to allow _all_ pre-releases?
         self.allow_all_prereleases = allow_all_prereleases
@@ -322,6 +361,7 @@ class PackageFinder(object):
                     break
 
     def get_formatted_locations(self):
+        # type: () -> str
         lines = []
         if self.index_urls and self.index_urls != [PyPI.simple_url]:
             lines.append(
@@ -335,6 +375,7 @@ class PackageFinder(object):
         return "\n".join(lines)
 
     def add_dependency_links(self, links):
+        # type: (Iterable[str]) -> None
         # FIXME: this shouldn't be global list this, it should only
         # apply to requirements of the package that specifies the
         # dependency_links value
@@ -351,6 +392,7 @@ class PackageFinder(object):
 
     @staticmethod
     def _sort_locations(locations, expand_dir=False):
+        # type: (Sequence[str], bool) -> Tuple[List[str], List[str]]
         """
         Sort locations into "files" (archives) and "urls", and return
         a pair of lists (files,urls)
@@ -407,6 +449,7 @@ class PackageFinder(object):
         return files, urls
 
     def _candidate_sort_key(self, candidate):
+        # type: (InstallationCandidate) -> _CandidateSortingKey
         """
         Function used to generate link sort key for link tuples.
         The greater the return value, the more preferred it is.
@@ -421,7 +464,7 @@ class PackageFinder(object):
               with the same version, would have to be considered equal
         """
         support_num = len(self.valid_tags)
-        build_tag = tuple()
+        build_tag = tuple()  # type: _BuildTag
         binary_preference = 0
         if candidate.location.is_wheel:
             # can raise InvalidWheelFilename
@@ -443,6 +486,7 @@ class PackageFinder(object):
         return (binary_preference, candidate.version, build_tag, pri)
 
     def _validate_secure_origin(self, logger, location):
+        # type: (Logger, Link) -> bool
         # Determine if this url used a secure transport mechanism
         parsed = urllib_parse.urlparse(str(location))
         origin = (parsed.scheme, parsed.hostname, parsed.port)
@@ -474,7 +518,7 @@ class PackageFinder(object):
                 network = ipaddress.ip_network(
                     secure_origin[1]
                     if isinstance(secure_origin[1], six.text_type)
-                    else secure_origin[1].decode("utf8")
+                    else secure_origin[1].decode("utf8")  # type: ignore
                 )
             except ValueError:
                 # We don't have both a valid address or a valid network, so
@@ -514,6 +558,7 @@ class PackageFinder(object):
         return False
 
     def _get_index_urls_locations(self, project_name):
+        # type: (str) -> List[str]
         """Returns the locations found via self.index_urls
 
         Checks the url_name on the main (first in the list) index and
@@ -536,6 +581,7 @@ class PackageFinder(object):
         return [mkurl_pypi_url(url) for url in self.index_urls]
 
     def find_all_candidates(self, project_name):
+        # type: (str) -> List[Optional[InstallationCandidate]]
         """Find all available InstallationCandidate for project_name
 
         This checks index_urls, find_links and dependency_links.
@@ -619,6 +665,7 @@ class PackageFinder(object):
         )
 
     def find_requirement(self, req, upgrade):
+        # type: (InstallRequirement, bool) -> Optional[Link]
         """Try to find a Link matching req
 
         Expects req, an InstallRequirement and upgrade, a boolean
@@ -656,7 +703,8 @@ class PackageFinder(object):
             best_candidate = None
 
         if req.satisfied_by is not None:
-            installed_version = parse_version(req.satisfied_by.version)
+            # type error fixed in mypy==0.641, remove after update
+            installed_version = parse_version(req.satisfied_by.version)  # type: ignore  # noqa: E501
         else:
             installed_version = None
 
@@ -718,11 +766,12 @@ class PackageFinder(object):
         return best_candidate.location
 
     def _get_pages(self, locations, project_name):
+        # type: (Iterable[Link], str) -> Iterable[HTMLPage]
         """
         Yields (page, page_url) from the given locations, skipping
         locations that have errors.
         """
-        seen = set()
+        seen = set()  # type: Set[Link]
         for location in locations:
             if location in seen:
                 continue
@@ -737,12 +786,13 @@ class PackageFinder(object):
     _py_version_re = re.compile(r'-py([123]\.?[0-9]?)$')
 
     def _sort_links(self, links):
+        # type: (Iterable[Link]) -> List[Link]
         """
         Returns elements of links in order, non-egg links first, egg links
         second, while eliminating duplicates
         """
         eggs, no_eggs = [], []
-        seen = set()
+        seen = set()  # type: Set[Link]
         for link in links:
             if link not in seen:
                 seen.add(link)
@@ -752,7 +802,12 @@ class PackageFinder(object):
                     no_eggs.append(link)
         return no_eggs + eggs
 
-    def _package_versions(self, links, search):
+    def _package_versions(
+            self,
+            links,  # type: Iterable[Link]
+            search  # type: Search
+    ):
+        # type: (...) -> List[Optional[InstallationCandidate]]
         result = []
         for link in self._sort_links(links):
             v = self._link_package_versions(link, search)
@@ -761,11 +816,13 @@ class PackageFinder(object):
         return result
 
     def _log_skipped_link(self, link, reason):
+        # type: (Link, str) -> None
         if link not in self.logged_links:
             logger.debug('Skipping link %s; %s', link, reason)
             self.logged_links.add(link)
 
     def _link_package_versions(self, link, search):
+        # type: (Link, Search) -> Optional[InstallationCandidate]
         """Return an InstallationCandidate or None"""
         version = None
         if link.egg_fragment:
@@ -775,35 +832,35 @@ class PackageFinder(object):
             egg_info, ext = link.splitext()
             if not ext:
                 self._log_skipped_link(link, 'not a file')
-                return
+                return None
             if ext not in SUPPORTED_EXTENSIONS:
                 self._log_skipped_link(
                     link, 'unsupported archive format: %s' % ext,
                 )
-                return
+                return None
             if "binary" not in search.formats and ext == wheel_ext:
                 self._log_skipped_link(
                     link, 'No binaries permitted for %s' % search.supplied,
                 )
-                return
+                return None
             if "macosx10" in link.path and ext == '.zip':
                 self._log_skipped_link(link, 'macosx10 one')
-                return
+                return None
             if ext == wheel_ext:
                 try:
                     wheel = Wheel(link.filename)
                 except InvalidWheelFilename:
                     self._log_skipped_link(link, 'invalid wheel filename')
-                    return
+                    return None
                 if canonicalize_name(wheel.name) != search.canonical:
                     self._log_skipped_link(
                         link, 'wrong project name (not %s)' % search.supplied)
-                    return
+                    return None
 
                 if not wheel.supported(self.valid_tags):
                     self._log_skipped_link(
                         link, 'it is not compatible with this Python')
-                    return
+                    return None
 
                 version = wheel.version
 
@@ -812,14 +869,14 @@ class PackageFinder(object):
             self._log_skipped_link(
                 link, 'No sources permitted for %s' % search.supplied,
             )
-            return
+            return None
 
         if not version:
             version = _egg_info_matches(egg_info, search.canonical)
         if not version:
             self._log_skipped_link(
                 link, 'Missing project version for %s' % search.supplied)
-            return
+            return None
 
         match = self._py_version_re.search(version)
         if match:
@@ -828,7 +885,7 @@ class PackageFinder(object):
             if py_version != sys.version[:3]:
                 self._log_skipped_link(
                     link, 'Python version is incorrect')
-                return
+                return None
         try:
             support_this_python = check_requires_python(link.requires_python)
         except specifiers.InvalidSpecifier:
@@ -840,13 +897,14 @@ class PackageFinder(object):
             logger.debug("The package %s is incompatible with the python "
                          "version in use. Acceptable python versions are: %s",
                          link, link.requires_python)
-            return
+            return None
         logger.debug('Found link %s, version: %s', link, version)
 
         return InstallationCandidate(search.supplied, version, link)
 
 
 def _find_name_version_sep(egg_info, canonical_name):
+    # type: (str, str) -> int
     """Find the separator's index based on the package's canonical name.
 
     `egg_info` must be an egg info string for the given package, and
@@ -872,6 +930,7 @@ def _find_name_version_sep(egg_info, canonical_name):
 
 
 def _egg_info_matches(egg_info, canonical_name):
+    # type: (str, str) -> Optional[str]
     """Pull the version part out of a string.
 
     :param egg_info: The string to parse. E.g. foo-2.1
@@ -921,16 +980,19 @@ _CLEAN_LINK_RE = re.compile(r'[^a-z0-9$&+,/:;=?@.#%_\\|-]', re.I)
 
 
 def _clean_link(url):
+    # type: (str) -> str
     """Makes sure a link is fully encoded.  That is, if a ' ' shows up in
     the link, it will be rewritten to %20 (while not over-quoting
     % or other characters)."""
-    return _CLEAN_LINK_RE.sub(lambda match: '%%%2x' % ord(match.group(0)), url)
+    # type error fixed in mypy==0.641, remove after update
+    return _CLEAN_LINK_RE.sub(lambda match: '%%%2x' % ord(match.group(0)), url)  # type: ignore  # noqa: E501
 
 
 class HTMLPage(object):
     """Represents one page, along with its URL"""
 
     def __init__(self, content, url, headers=None):
+        # type: (bytes, str, MutableMapping[str, str]) -> None
         self.content = content
         self.url = url
         self.headers = headers
@@ -939,6 +1001,7 @@ class HTMLPage(object):
         return redact_password_from_url(self.url)
 
     def iter_links(self):
+        # type: () -> Iterable[Link]
         """Yields all links in the page"""
         document = html5lib.parse(
             self.content,

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -51,9 +51,9 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.req import InstallRequirement  # noqa: F401
     from pip._internal.download import PipSession  # noqa: F401
 
-    _SecureOrigin = Tuple[str, str, Optional[str]]
-    _BuildTag = Tuple[Any, ...]  # possibly empty Tuple[int, str]
-    _CandidateSortingKey = Tuple[int, _BaseVersion, _BuildTag, Optional[int]]
+    SecureOrigin = Tuple[str, str, Optional[str]]
+    BuildTag = Tuple[Any, ...]  # possibly empty Tuple[int, str]
+    CandidateSortingKey = Tuple[int, _BaseVersion, BuildTag, Optional[int]]
 
 __all__ = ['FormatControl', 'PackageFinder']
 
@@ -68,7 +68,7 @@ SECURE_ORIGINS = [
     ("file", "*", None),
     # ssh is always secure.
     ("ssh", "*", "*"),
-]  # type: List[_SecureOrigin]
+]  # type: List[SecureOrigin]
 
 
 logger = logging.getLogger(__name__)
@@ -325,7 +325,7 @@ class PackageFinder(object):
         self.secure_origins = [
             ("*", host, "*")
             for host in (trusted_hosts if trusted_hosts else [])
-        ]  # type: List[_SecureOrigin]
+        ]  # type: List[SecureOrigin]
 
         # Do we want to allow _all_ pre-releases?
         self.allow_all_prereleases = allow_all_prereleases
@@ -449,7 +449,7 @@ class PackageFinder(object):
         return files, urls
 
     def _candidate_sort_key(self, candidate):
-        # type: (InstallationCandidate) -> _CandidateSortingKey
+        # type: (InstallationCandidate) -> CandidateSortingKey
         """
         Function used to generate link sort key for link tuples.
         The greater the return value, the more preferred it is.
@@ -464,7 +464,7 @@ class PackageFinder(object):
               with the same version, would have to be considered equal
         """
         support_num = len(self.valid_tags)
-        build_tag = tuple()  # type: _BuildTag
+        build_tag = tuple()  # type: BuildTag
         binary_preference = 0
         if candidate.location.is_wheel:
             # can raise InvalidWheelFilename

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -271,7 +271,7 @@ class PackageFinder(object):
             session=None,  # type: Optional[PipSession]
             format_control=None,  # type: Optional[FormatControl]
             platform=None,  # type: Optional[str]
-            versions=None,  # type: Optional[Iterable[str]]
+            versions=None,  # type: Optional[List[str]]
             abi=None,  # type: Optional[str]
             implementation=None,  # type: Optional[str]
             prefer_binary=False  # type: bool

--- a/src/pip/_internal/models/candidate.py
+++ b/src/pip/_internal/models/candidate.py
@@ -1,6 +1,12 @@
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.utils.models import KeyBasedCompareMixin
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from pip._vendor.packaging.version import _BaseVersion  # noqa: F401
+    from pip._internal.models.link import Link  # noqa: F401
+    from typing import Any, Union  # noqa: F401
 
 
 class InstallationCandidate(KeyBasedCompareMixin):
@@ -8,8 +14,9 @@ class InstallationCandidate(KeyBasedCompareMixin):
     """
 
     def __init__(self, project, version, location):
+        # type: (Any, str, Link) -> None
         self.project = project
-        self.version = parse_version(version)
+        self.version = parse_version(version)  # type: _BaseVersion
         self.location = location
 
         super(InstallationCandidate, self).__init__(
@@ -18,6 +25,7 @@ class InstallationCandidate(KeyBasedCompareMixin):
         )
 
     def __repr__(self):
+        # type: () -> str
         return "<InstallationCandidate({!r}, {!r}, {!r})>".format(
             self.project, self.version, self.location,
         )

--- a/src/pip/_internal/models/index.py
+++ b/src/pip/_internal/models/index.py
@@ -6,6 +6,7 @@ class PackageIndex(object):
     """
 
     def __init__(self, url, file_storage_domain):
+        # type: (str, str) -> None
         super(PackageIndex, self).__init__()
         self.url = url
         self.netloc = urllib_parse.urlsplit(url).netloc
@@ -18,6 +19,7 @@ class PackageIndex(object):
         self.file_storage_domain = file_storage_domain
 
     def _url_for_path(self, path):
+        # type: (str) -> str
         return urllib_parse.urljoin(self.url, path)
 
 

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -6,7 +6,11 @@ from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._internal.download import path_to_url
 from pip._internal.utils.misc import redact_password_from_url, splitext
 from pip._internal.utils.models import KeyBasedCompareMixin
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.wheel import wheel_ext
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional, Tuple  # noqa: F401
 
 
 class Link(KeyBasedCompareMixin):
@@ -54,6 +58,7 @@ class Link(KeyBasedCompareMixin):
 
     @property
     def filename(self):
+        # type: () -> str
         _, netloc, path, _, _ = urllib_parse.urlsplit(self.url)
         name = posixpath.basename(path.rstrip('/')) or netloc
         name = urllib_parse.unquote(name)
@@ -62,25 +67,31 @@ class Link(KeyBasedCompareMixin):
 
     @property
     def scheme(self):
+        # type: () -> str
         return urllib_parse.urlsplit(self.url)[0]
 
     @property
     def netloc(self):
+        # type: () -> str
         return urllib_parse.urlsplit(self.url)[1]
 
     @property
     def path(self):
+        # type: () -> str
         return urllib_parse.unquote(urllib_parse.urlsplit(self.url)[2])
 
     def splitext(self):
+        # type: () -> Tuple[str, str]
         return splitext(posixpath.basename(self.path.rstrip('/')))
 
     @property
     def ext(self):
+        # type: () -> str
         return self.splitext()[1]
 
     @property
     def url_without_fragment(self):
+        # type: () -> str
         scheme, netloc, path, query, fragment = urllib_parse.urlsplit(self.url)
         return urllib_parse.urlunsplit((scheme, netloc, path, query, None))
 
@@ -88,6 +99,7 @@ class Link(KeyBasedCompareMixin):
 
     @property
     def egg_fragment(self):
+        # type: () -> Optional[str]
         match = self._egg_fragment_re.search(self.url)
         if not match:
             return None
@@ -97,6 +109,7 @@ class Link(KeyBasedCompareMixin):
 
     @property
     def subdirectory_fragment(self):
+        # type: () -> Optional[str]
         match = self._subdirectory_fragment_re.search(self.url)
         if not match:
             return None
@@ -108,6 +121,7 @@ class Link(KeyBasedCompareMixin):
 
     @property
     def hash(self):
+        # type: () -> Optional[str]
         match = self._hash_re.search(self.url)
         if match:
             return match.group(2)
@@ -115,6 +129,7 @@ class Link(KeyBasedCompareMixin):
 
     @property
     def hash_name(self):
+        # type: () -> Optional[str]
         match = self._hash_re.search(self.url)
         if match:
             return match.group(1)
@@ -122,14 +137,17 @@ class Link(KeyBasedCompareMixin):
 
     @property
     def show_url(self):
+        # type: () -> Optional[str]
         return posixpath.basename(self.url.split('#', 1)[0].split('?', 1)[0])
 
     @property
     def is_wheel(self):
+        # type: () -> bool
         return self.ext == wheel_ext
 
     @property
     def is_artifact(self):
+        # type: () -> bool
         """
         Determines if this points to an actual artifact (e.g. a tarball) or if
         it points to an "abstract" thing like a path or a VCS location.

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -10,7 +10,8 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.wheel import wheel_ext
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Tuple  # noqa: F401
+    from typing import Optional, Tuple, Union  # noqa: F401
+    from pip._internal.index import HTMLPage  # noqa: F401
 
 
 class Link(KeyBasedCompareMixin):
@@ -18,6 +19,7 @@ class Link(KeyBasedCompareMixin):
     """
 
     def __init__(self, url, comes_from=None, requires_python=None):
+        # type: (str, Optional[Union[str, HTMLPage]], Optional[str]) -> None
         """
         url:
             url of the resource pointed to (href of the link)

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -10,7 +10,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.wheel import wheel_ext
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Tuple, Union  # noqa: F401
+    from typing import Optional, Tuple, Union, Text  # noqa: F401
     from pip._internal.index import HTMLPage  # noqa: F401
 
 

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -17,17 +17,31 @@ from pip._internal.req.req_file import COMMENT_RE
 from pip._internal.utils.misc import (
     dist_is_editable, get_installed_distributions,
 )
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import (Iterator, Optional, List,  # noqa: F401
+                        Container, Set, Dict, Tuple, Iterable, Union)
+    from pip._internal.cache import WheelCache  # noqa: F401
+    from pip._vendor.pkg_resources import (Distribution,  # noqa: F401
+                                           Requirement)
+
 
 logger = logging.getLogger(__name__)
 
 
 def freeze(
-        requirement=None,
-        find_links=None, local_only=None, user_only=None, skip_regex=None,
-        isolated=False,
-        wheel_cache=None,
-        exclude_editable=False,
-        skip=()):
+        requirement=None,  # type: Optional[List[str]]
+        find_links=None,  # type: Optional[List[str]]
+        local_only=None,  # type: Optional[bool]
+        user_only=None,  # type: Optional[bool]
+        skip_regex=None,  # type: Optional[str]
+        isolated=False,  # type: bool
+        wheel_cache=None,  # type: Optional[WheelCache]
+        exclude_editable=False,  # type: bool
+        skip=()  # type: Container[str]
+):
+    # type: (...) -> Iterator[str]
     find_links = find_links or []
     skip_match = None
 
@@ -36,7 +50,7 @@ def freeze(
 
     for link in find_links:
         yield '-f %s' % link
-    installations = {}
+    installations = {}  # type: Dict[str, FrozenRequirement]
     for dist in get_installed_distributions(local_only=local_only,
                                             skip=(),
                                             user_only=user_only):
@@ -57,10 +71,10 @@ def freeze(
         # should only be emitted once, even if the same option is in multiple
         # requirements files, so we need to keep track of what has been emitted
         # so that we don't emit it again if it's seen again
-        emitted_options = set()
+        emitted_options = set()  # type: Set[str]
         # keep track of which files a requirement is in so that we can
         # give an accurate warning if a requirement appears multiple times.
-        req_files = collections.defaultdict(list)
+        req_files = collections.defaultdict(list)  # type: Dict[str, List[str]]
         for req_file_path in requirement:
             with open(req_file_path) as req_file:
                 for line in req_file:
@@ -144,6 +158,7 @@ def freeze(
 
 
 def get_requirement_info(dist):
+    # type: (Distribution) -> Tuple[Optional[Union[str, Requirement]], bool, List[str]]  # noqa: E501
     """
     Compute and return values (req, editable, comments) for use in
     FrozenRequirement.from_dist().
@@ -197,6 +212,7 @@ def get_requirement_info(dist):
 
 class FrozenRequirement(object):
     def __init__(self, name, req, editable, comments=()):
+        # type: (str, Union[str, Requirement], bool, Iterable[str]) -> None
         self.name = name
         self.req = req
         self.editable = editable
@@ -204,6 +220,7 @@ class FrozenRequirement(object):
 
     @classmethod
     def from_dist(cls, dist):
+        # type: (Distribution) -> FrozenRequirement
         req, editable, comments = get_requirement_info(dist)
         if req is None:
             req = dist.as_requirement()

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -6,16 +6,27 @@ import os
 from pip._vendor import pytoml, six
 
 from pip._internal.exceptions import InstallationError
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Any, Tuple, Optional, List  # noqa: F401
 
 
 def _is_list_of_str(obj):
+    # type: (Any) -> bool
     return (
         isinstance(obj, list) and
         all(isinstance(item, six.string_types) for item in obj)
     )
 
 
-def load_pyproject_toml(use_pep517, pyproject_toml, setup_py, req_name):
+def load_pyproject_toml(
+        use_pep517,  # type: Optional[bool]
+        pyproject_toml,  # type: str
+        setup_py,  # type: str
+        req_name  # type: str
+):
+    # type: (...) -> Optional[Tuple[List[str], str, List[str]]]
     """Load the pyproject.toml file.
 
     Parameters:
@@ -123,7 +134,7 @@ def load_pyproject_toml(use_pep517, pyproject_toml, setup_py, req_name):
         ))
 
     backend = build_system.get("build-backend")
-    check = []
+    check = []  # type: List[str]
     if backend is None:
         # If the user didn't specify a backend, we assume they want to use
         # the setuptools backend. But we can't be sure they have included

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -6,7 +6,10 @@ from .req_install import InstallRequirement
 from .req_set import RequirementSet
 from .req_file import parse_requirements
 from pip._internal.utils.logging import indent_log
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
+if MYPY_CHECK_RUNNING:
+    from typing import List, Iterable, Sequence  # noqa: F401
 
 __all__ = [
     "RequirementSet", "InstallRequirement",
@@ -16,8 +19,13 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-def install_given_reqs(to_install, install_options, global_options=(),
-                       *args, **kwargs):
+def install_given_reqs(
+        to_install,  # type: List[InstallRequirement]
+        install_options,  # type: List[str]
+        global_options=(),  # type: Sequence[str]
+        *args, **kwargs
+):
+    # type: (...) -> List[InstallRequirement]
     """
     Install everything in the given list.
 

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -25,8 +25,15 @@ from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.misc import is_installable_dir
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs import vcs
 from pip._internal.wheel import Wheel
+
+if MYPY_CHECK_RUNNING:
+    from typing import (Optional, Tuple, Set, Any,  # noqa: F401
+                        Mapping, Union, Text)
+    from pip._internal.cache import WheelCache  # noqa: F401
+
 
 __all__ = [
     "install_req_from_editable", "install_req_from_line",
@@ -38,6 +45,7 @@ operators = Specifier._operators.keys()
 
 
 def _strip_extras(path):
+    # type: (str) -> Tuple[str, Optional[str]]
     m = re.match(r'^(.+)(\[[^\]]+\])$', path)
     extras = None
     if m:
@@ -50,6 +58,7 @@ def _strip_extras(path):
 
 
 def parse_editable(editable_req):
+    # type: (str) -> Tuple[Optional[str], str, Optional[Set[str]]]
     """Parses an editable requirement into:
         - a requirement name
         - an URL
@@ -115,6 +124,7 @@ def parse_editable(editable_req):
 
 
 def deduce_helpful_msg(req):
+    # type: (str) -> str
     """Returns helpful msg in case requirements file does not exist,
     or cannot be parsed.
 
@@ -135,7 +145,7 @@ def deduce_helpful_msg(req):
                     " the packages specified within it."
         except RequirementParseError:
             logger.debug("Cannot parse '%s' as requirements \
-            file" % (req), exc_info=1)
+            file" % (req), exc_info=True)
     else:
         msg += " File '%s' does not exist." % (req)
     return msg
@@ -145,9 +155,15 @@ def deduce_helpful_msg(req):
 
 
 def install_req_from_editable(
-    editable_req, comes_from=None, use_pep517=None, isolated=False,
-    options=None, wheel_cache=None, constraint=False
+        editable_req,  # type: str
+        comes_from=None,  # type: Optional[str]
+        use_pep517=None,  # type: Optional[bool]
+        isolated=False,  # type: bool
+        options=None,  # type: Optional[Mapping[Text, Any]]
+        wheel_cache=None,  # type: Optional[WheelCache]
+        constraint=False  # type: bool
 ):
+    # type: (...) -> InstallRequirement
     name, url, extras_override = parse_editable(editable_req)
     if url.startswith('file:'):
         source_dir = url_to_path(url)
@@ -175,9 +191,15 @@ def install_req_from_editable(
 
 
 def install_req_from_line(
-    name, comes_from=None, use_pep517=None, isolated=False, options=None,
-    wheel_cache=None, constraint=False
+        name,  # type: str
+        comes_from=None,  # type: Optional[Union[str, InstallRequirement]]
+        use_pep517=None,  # type: Optional[bool]
+        isolated=False,  # type: bool
+        options=None,  # type: Optional[Mapping[Text, Any]]
+        wheel_cache=None,  # type: Optional[WheelCache]
+        constraint=False  # type: bool
 ):
+    # type: (...) -> InstallRequirement
     """Creates an InstallRequirement from a name, which might be a
     requirement, directory containing 'setup.py', filename, or URL.
     """
@@ -186,24 +208,24 @@ def install_req_from_line(
     else:
         marker_sep = ';'
     if marker_sep in name:
-        name, markers = name.split(marker_sep, 1)
-        markers = markers.strip()
-        if not markers:
+        name, markers_as_string = name.split(marker_sep, 1)
+        markers_as_string = markers_as_string.strip()
+        if not markers_as_string:
             markers = None
         else:
-            markers = Marker(markers)
+            markers = Marker(markers_as_string)
     else:
         markers = None
     name = name.strip()
-    req = None
+    req_as_string = None
     path = os.path.normpath(os.path.abspath(name))
     link = None
-    extras = None
+    extras_as_string = None
 
     if is_url(name):
         link = Link(name)
     else:
-        p, extras = _strip_extras(path)
+        p, extras_as_string = _strip_extras(path)
         looks_like_dir = os.path.isdir(p) and (
             os.path.sep in name or
             (os.path.altsep is not None and os.path.altsep in name) or
@@ -234,34 +256,37 @@ def install_req_from_line(
         # wheel file
         if link.is_wheel:
             wheel = Wheel(link.filename)  # can raise InvalidWheelFilename
-            req = "%s==%s" % (wheel.name, wheel.version)
+            req_as_string = "%s==%s" % (wheel.name, wheel.version)
         else:
             # set the req to the egg fragment.  when it's not there, this
             # will become an 'unnamed' requirement
-            req = link.egg_fragment
+            req_as_string = link.egg_fragment
 
     # a requirement specifier
     else:
-        req = name
+        req_as_string = name
 
-    if extras:
-        extras = Requirement("placeholder" + extras.lower()).extras
+    if extras_as_string:
+        extras = Requirement("placeholder" + extras_as_string.lower()).extras
     else:
         extras = ()
-    if req is not None:
+    if req_as_string is not None:
         try:
-            req = Requirement(req)
+            req = Requirement(req_as_string)
         except InvalidRequirement:
-            if os.path.sep in req:
+            if os.path.sep in req_as_string:
                 add_msg = "It looks like a path."
-                add_msg += deduce_helpful_msg(req)
-            elif '=' in req and not any(op in req for op in operators):
+                add_msg += deduce_helpful_msg(req_as_string)
+            elif ('=' in req_as_string and
+                  not any(op in req_as_string for op in operators)):
                 add_msg = "= is not a valid operator. Did you mean == ?"
             else:
                 add_msg = ""
             raise InstallationError(
-                "Invalid requirement: '%s'\n%s" % (req, add_msg)
+                "Invalid requirement: '%s'\n%s" % (req_as_string, add_msg)
             )
+    else:
+        req = None
 
     return InstallRequirement(
         req, comes_from, link=link, markers=markers,
@@ -273,12 +298,16 @@ def install_req_from_line(
     )
 
 
-def install_req_from_req(
-    req, comes_from=None, isolated=False, wheel_cache=None,
-    use_pep517=None
+def install_req_from_req_string(
+        req_string,  # type: str
+        comes_from=None,  # type: Optional[InstallRequirement]
+        isolated=False,  # type: bool
+        wheel_cache=None,  # type: Optional[WheelCache]
+        use_pep517=None  # type: Optional[bool]
 ):
+    # type: (...) -> InstallRequirement
     try:
-        req = Requirement(req)
+        req = Requirement(req_string)
     except InvalidRequirement:
         raise InstallationError("Invalid requirement: '%s'" % req)
 

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -22,7 +22,8 @@ from pip._internal.req.constructors import (
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Iterator, Tuple, Optional, List, Callable, Text  # noqa: F401
+    from typing import (Iterator, Tuple, Optional,  # noqa: F401
+                        List, Callable, Text)
     from pip._internal.req import InstallRequirement  # noqa: F401
     from pip._internal.cache import WheelCache  # noqa: F401
     from pip._internal.index import PackageFinder  # noqa: F401
@@ -305,8 +306,9 @@ def join_lines(lines_enum):
     primary_line_number = None
     new_line = []  # type: List[Text]
     for line_number, line in lines_enum:
-        if not line.endswith('\\') or COMMENT_RE.match(line):
-            if COMMENT_RE.match(line):
+        # fixed in mypy==0.641
+        if not line.endswith('\\') or COMMENT_RE.match(line):  # type: ignore
+            if COMMENT_RE.match(line):  # type: ignore
                 # this ensures comments are always matched later
                 line = ' ' + line
             if new_line:
@@ -333,7 +335,8 @@ def ignore_comments(lines_enum):
     Strips comments and filter empty lines.
     """
     for line_number, line in lines_enum:
-        line = COMMENT_RE.sub('', line)
+        # fixed in mypy==0.641
+        line = COMMENT_RE.sub('', line)  # type: ignore
         line = line.strip()
         if line:
             yield line_number, line
@@ -372,9 +375,10 @@ def expand_env_variables(lines_enum):
     Valid characters in variable names follow the `POSIX standard
     <http://pubs.opengroup.org/onlinepubs/9699919799/>`_ and are limited
     to uppercase letter, digits and the `_` (underscore).
-    """
+        """
     for line_number, line in lines_enum:
-        for env_var, var_name in ENV_VAR_RE.findall(line):
+        # fixed in mypy==0.641
+        for env_var, var_name in ENV_VAR_RE.findall(line):  # type: ignore
             value = os.getenv(var_name)
             if not value:
                 continue

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -22,7 +22,7 @@ from pip._internal.req.constructors import (
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Iterator, Tuple, Optional, List, Callable  # noqa: F401
+    from typing import Iterator, Tuple, Optional, List, Callable, Text  # noqa: F401
     from pip._internal.req import InstallRequirement  # noqa: F401
     from pip._internal.cache import WheelCache  # noqa: F401
     from pip._internal.index import PackageFinder  # noqa: F401
@@ -111,12 +111,13 @@ def parse_requirements(
 
 
 def preprocess(content, options):
+    # type: (Text, Optional[optparse.Values]) -> Iterator[Tuple[int, Text]]
     """Split, filter, and join lines, and return a line iterator
 
     :param content: the content of the requirements file
     :param options: cli options
     """
-    lines_enum = enumerate(content.splitlines(), start=1)
+    lines_enum = enumerate(content.splitlines(), start=1)  # type: Iterator[Tuple[int, Text]]  # noqa: E501
     lines_enum = join_lines(lines_enum)
     lines_enum = ignore_comments(lines_enum)
     lines_enum = skip_regex(lines_enum, options)
@@ -125,7 +126,7 @@ def preprocess(content, options):
 
 
 def process_line(
-        line,  # type: str
+        line,  # type: Text
         filename,  # type: str
         line_number,  # type: int
         finder=None,  # type: Optional[PackageFinder]
@@ -165,7 +166,8 @@ def process_line(
         # Prior to 2.7.3, shlex cannot deal with unicode entries
         # https://github.com/python/mypy/issues/1174
         options_str = options_str.encode('utf8')  # type: ignore
-    opts, _ = parser.parse_args(shlex.split(options_str), defaults)
+    # https://github.com/python/mypy/issues/1174
+    opts, _ = parser.parse_args(shlex.split(options_str), defaults)  # type: ignore  # noqa: E501
 
     # preserve for the nested code path
     line_comes_from = '%s %s (line %s)' % (
@@ -253,7 +255,7 @@ def process_line(
 
 
 def break_args_options(line):
-    # type: (str) -> Tuple[str, str]
+    # type: (Text) -> Tuple[str, Text]
     """Break up the line into an args and options string.  We only want to shlex
     (and then optparse) the options, not the args.  args can contain markers
     which are corrupted by shlex.
@@ -267,11 +269,11 @@ def break_args_options(line):
         else:
             args.append(token)
             options.pop(0)
-    return ' '.join(args), ' '.join(options)
+    return ' '.join(args), ' '.join(options)  # type: ignore
 
 
 def build_parser(line):
-    # type: (str) -> optparse.OptionParser
+    # type: (Text) -> optparse.OptionParser
     """
     Return a parser for parsing requirement lines
     """
@@ -296,12 +298,12 @@ def build_parser(line):
 
 
 def join_lines(lines_enum):
-    # type: (Iterator[Tuple[int, str]]) -> Iterator[Tuple[int, str]]
+    # type: (Iterator[Tuple[int, Text]]) -> Iterator[Tuple[int, Text]]
     """Joins a line ending in '\' with the previous line (except when following
     comments).  The joined line takes on the index of the first line.
     """
     primary_line_number = None
-    new_line = []  # type: List[str]
+    new_line = []  # type: List[Text]
     for line_number, line in lines_enum:
         if not line.endswith('\\') or COMMENT_RE.match(line):
             if COMMENT_RE.match(line):
@@ -326,7 +328,7 @@ def join_lines(lines_enum):
 
 
 def ignore_comments(lines_enum):
-    # type: (Iterator[Tuple[int, str]]) -> Iterator[Tuple[int, str]]
+    # type: (Iterator[Tuple[int, Text]]) -> Iterator[Tuple[int, Text]]
     """
     Strips comments and filter empty lines.
     """
@@ -338,10 +340,10 @@ def ignore_comments(lines_enum):
 
 
 def skip_regex(
-        lines_enum,  # type: Iterator[Tuple[int, str]]
+        lines_enum,  # type: Iterator[Tuple[int, Text]]
         options  # type: Optional[optparse.Values]
 ):
-    # type: (...) -> Iterator[Tuple[int, str]]
+    # type: (...) -> Iterator[Tuple[int, Text]]
     """
     Skip lines that match '--skip-requirements-regex' pattern
 
@@ -355,7 +357,7 @@ def skip_regex(
 
 
 def expand_env_variables(lines_enum):
-    # type: (Iterator[Tuple[int, str]]) -> Iterator[Tuple[int, str]]
+    # type: (Iterator[Tuple[int, Text]]) -> Iterator[Tuple[int, Text]]
     """Replace all environment variables that can be retrieved via `os.getenv`.
 
     The only allowed format for environment variables defined in the

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -5,7 +5,13 @@ from collections import OrderedDict
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.utils.logging import indent_log
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.wheel import Wheel
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional, List, Tuple, Dict, Iterable  # noqa: F401
+    from pip._internal.req.req_install import InstallRequirement  # noqa: F401
+
 
 logger = logging.getLogger(__name__)
 
@@ -13,18 +19,19 @@ logger = logging.getLogger(__name__)
 class RequirementSet(object):
 
     def __init__(self, require_hashes=False, check_supported_wheels=True):
+        # type: (bool, bool) -> None
         """Create a RequirementSet.
         """
 
-        self.requirements = OrderedDict()
+        self.requirements = OrderedDict()  # type: Dict[str, InstallRequirement]  # noqa: E501
         self.require_hashes = require_hashes
         self.check_supported_wheels = check_supported_wheels
 
         # Mapping of alias: real_name
-        self.requirement_aliases = {}
-        self.unnamed_requirements = []
-        self.successfully_downloaded = []
-        self.reqs_to_cleanup = []
+        self.requirement_aliases = {}  # type: Dict[str, str]
+        self.unnamed_requirements = []  # type: List[InstallRequirement]
+        self.successfully_downloaded = []  # type: List[InstallRequirement]
+        self.reqs_to_cleanup = []  # type: List[InstallRequirement]
 
     def __str__(self):
         reqs = [req for req in self.requirements.values()
@@ -39,8 +46,13 @@ class RequirementSet(object):
         return ('<%s object; %d requirement(s): %s>'
                 % (self.__class__.__name__, len(reqs), reqs_str))
 
-    def add_requirement(self, install_req, parent_req_name=None,
-                        extras_requested=None):
+    def add_requirement(
+            self,
+            install_req,  # type: InstallRequirement
+            parent_req_name=None,  # type: Optional[str]
+            extras_requested=None  # type: Optional[Iterable[str]]
+    ):
+        # type: (...) -> Tuple[List[InstallRequirement], Optional[InstallRequirement]]  # noqa: E501
         """Add install_req as a requirement to install.
 
         :param parent_req_name: The name of the requirement that needed this
@@ -152,6 +164,7 @@ class RequirementSet(object):
         return [existing_req], existing_req
 
     def has_requirement(self, project_name):
+        # type: (str) -> bool
         name = project_name.lower()
         if (name in self.requirements and
            not self.requirements[name].constraint or
@@ -162,10 +175,12 @@ class RequirementSet(object):
 
     @property
     def has_requirements(self):
+        # type: () -> List[InstallRequirement]
         return list(req for req in self.requirements.values() if not
                     req.constraint) or self.unnamed_requirements
 
     def get_requirement(self, project_name):
+        # type: (str) -> InstallRequirement
         for name in project_name, project_name.lower():
             if name in self.requirements:
                 return self.requirements[name]
@@ -174,6 +189,7 @@ class RequirementSet(object):
         raise KeyError("No project with the name %r" % project_name)
 
     def cleanup_files(self):
+        # type: () -> None
         """Clean up files, remove builds."""
         logger.debug('Cleaning up...')
         with indent_log():

--- a/src/pip/_internal/req/req_tracker.py
+++ b/src/pip/_internal/req/req_tracker.py
@@ -7,6 +7,12 @@ import logging
 import os
 
 from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Set, Iterator  # noqa: F401
+    from pip._internal.req.req_install import InstallRequirement  # noqa: F401
+    from pip._internal.models.link import Link  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +20,7 @@ logger = logging.getLogger(__name__)
 class RequirementTracker(object):
 
     def __init__(self):
+        # type: () -> None
         self._root = os.environ.get('PIP_REQ_TRACKER')
         if self._root is None:
             self._temp_dir = TempDirectory(delete=False, kind='req-tracker')
@@ -23,7 +30,7 @@ class RequirementTracker(object):
         else:
             self._temp_dir = None
             logger.debug('Re-using requirements tracker %r', self._root)
-        self._entries = set()
+        self._entries = set()  # type: Set[InstallRequirement]
 
     def __enter__(self):
         return self
@@ -32,10 +39,12 @@ class RequirementTracker(object):
         self.cleanup()
 
     def _entry_path(self, link):
+        # type: (Link) -> str
         hashed = hashlib.sha224(link.url_without_fragment.encode()).hexdigest()
         return os.path.join(self._root, hashed)
 
     def add(self, req):
+        # type: (InstallRequirement) -> None
         link = req.link
         info = str(req)
         entry_path = self._entry_path(link)
@@ -54,12 +63,14 @@ class RequirementTracker(object):
             logger.debug('Added %s to build tracker %r', req, self._root)
 
     def remove(self, req):
+        # type: (InstallRequirement) -> None
         link = req.link
         self._entries.remove(req)
         os.unlink(self._entry_path(link))
         logger.debug('Removed %s from build tracker %r', req, self._root)
 
     def cleanup(self):
+        # type: () -> None
         for req in set(self._entries):
             self.remove(req)
         remove = self._temp_dir is not None
@@ -71,6 +82,7 @@ class RequirementTracker(object):
 
     @contextlib.contextmanager
     def track(self, req):
+        # type: (InstallRequirement) -> Iterator[None]
         self.add(req)
         yield
         self.remove(req)

--- a/src/pip/_internal/resolve.py
+++ b/src/pip/_internal/resolve.py
@@ -18,10 +18,21 @@ from pip._internal.exceptions import (
     BestVersionAlreadyInstalled, DistributionNotFound, HashError, HashErrors,
     UnsupportedPythonVersion,
 )
-from pip._internal.req.constructors import install_req_from_req
+from pip._internal.req.constructors import install_req_from_req_string
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import dist_in_usersite, ensure_dir
 from pip._internal.utils.packaging import check_dist_requires_python
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional, DefaultDict, List, Set  # noqa: F401
+    from pip._internal.download import PipSession  # noqa: F401
+    from pip._internal.req.req_install import InstallRequirement  # noqa: F401
+    from pip._internal.index import PackageFinder  # noqa: F401
+    from pip._internal.req.req_set import RequirementSet  # noqa: F401
+    from pip._internal.operations.prepare import (DistAbstraction,  # noqa: F401, E501
+                                                  RequirementPreparer)
+    from pip._internal.cache import WheelCache  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +44,22 @@ class Resolver(object):
 
     _allowed_strategies = {"eager", "only-if-needed", "to-satisfy-only"}
 
-    def __init__(self, preparer, session, finder, wheel_cache, use_user_site,
-                 ignore_dependencies, ignore_installed, ignore_requires_python,
-                 force_reinstall, isolated, upgrade_strategy, use_pep517=None):
+    def __init__(
+            self,
+            preparer,  # type: RequirementPreparer
+            session,  # type: PipSession
+            finder,  # type: PackageFinder
+            wheel_cache,  # type: Optional[WheelCache]
+            use_user_site,  # type: bool
+            ignore_dependencies,  # type: bool
+            ignore_installed,  # type: bool
+            ignore_requires_python,  # type: bool
+            force_reinstall,  # type: bool
+            isolated,  # type: bool
+            upgrade_strategy,  # type: str
+            use_pep517=None  # type: Optional[bool]
+    ):
+        # type: (...) -> None
         super(Resolver, self).__init__()
         assert upgrade_strategy in self._allowed_strategies
 
@@ -47,7 +71,8 @@ class Resolver(object):
         #       information about both sdist and wheels transparently.
         self.wheel_cache = wheel_cache
 
-        self.require_hashes = None  # This is set in resolve
+        # This is set in resolve
+        self.require_hashes = None  # type: Optional[bool]
 
         self.upgrade_strategy = upgrade_strategy
         self.force_reinstall = force_reinstall
@@ -58,9 +83,10 @@ class Resolver(object):
         self.use_user_site = use_user_site
         self.use_pep517 = use_pep517
 
-        self._discovered_dependencies = defaultdict(list)
+        self._discovered_dependencies = defaultdict(list)  # type: DefaultDict[str, List]  # noqa: E501
 
     def resolve(self, requirement_set):
+        # type: (RequirementSet) -> None
         """Resolve what operations need to be done
 
         As a side-effect of this method, the packages (and their dependencies)
@@ -95,7 +121,7 @@ class Resolver(object):
         # exceptions cannot be checked ahead of time, because
         # req.populate_link() needs to be called before we can make decisions
         # based on link type.
-        discovered_reqs = []
+        discovered_reqs = []  # type: List[InstallRequirement]
         hash_errors = HashErrors()
         for req in chain(root_reqs, discovered_reqs):
             try:
@@ -110,6 +136,7 @@ class Resolver(object):
             raise hash_errors
 
     def _is_upgrade_allowed(self, req):
+        # type: (InstallRequirement) -> bool
         if self.upgrade_strategy == "to-satisfy-only":
             return False
         elif self.upgrade_strategy == "eager":
@@ -119,6 +146,7 @@ class Resolver(object):
             return req.is_direct
 
     def _set_req_to_reinstall(self, req):
+        # type: (InstallRequirement) -> None
         """
         Set a requirement to be installed.
         """
@@ -130,6 +158,7 @@ class Resolver(object):
 
     # XXX: Stop passing requirement_set for options
     def _check_skip_installed(self, req_to_install):
+        # type: (InstallRequirement) -> Optional[str]
         """Check if req_to_install should be skipped.
 
         This will check if the req is installed, and whether we should upgrade
@@ -182,6 +211,7 @@ class Resolver(object):
         return None
 
     def _get_abstract_dist_for(self, req):
+        # type: (InstallRequirement) -> DistAbstraction
         """Takes a InstallRequirement and returns a single AbstractDist \
         representing a prepared variant of the same.
         """
@@ -239,6 +269,7 @@ class Resolver(object):
         return abstract_dist
 
     def _resolve_one(self, requirement_set, req_to_install):
+        # type: (RequirementSet, InstallRequirement) -> List[InstallRequirement]  # noqa: E501
         """Prepare a single requirements file.
 
         :return: A list of additional InstallRequirements to also install.
@@ -266,10 +297,10 @@ class Resolver(object):
             else:
                 raise
 
-        more_reqs = []
+        more_reqs = []  # type: List[InstallRequirement]
 
         def add_req(subreq, extras_requested):
-            sub_install_req = install_req_from_req(
+            sub_install_req = install_req_from_req_string(
                 str(subreq),
                 req_to_install,
                 isolated=self.isolated,
@@ -328,6 +359,7 @@ class Resolver(object):
         return more_reqs
 
     def get_installation_order(self, req_set):
+        # type: (RequirementSet) -> List[InstallRequirement]
         """Create the installation order.
 
         The installation order is topological - requirements are installed
@@ -338,7 +370,7 @@ class Resolver(object):
         # installs the user specified things in the order given, except when
         # dependencies must come earlier to achieve topological order.
         order = []
-        ordered_reqs = set()
+        ordered_reqs = set()  # type: Set[InstallRequirement]
 
         def schedule(req):
             if req.satisfied_by or req in ordered_reqs:

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -23,8 +23,8 @@ except ImportError:
         from pip._vendor import ipaddress  # type: ignore
     except ImportError:
         import ipaddr as ipaddress  # type: ignore
-        ipaddress.ip_address = ipaddress.IPAddress
-        ipaddress.ip_network = ipaddress.IPNetwork
+        ipaddress.ip_address = ipaddress.IPAddress  # type: ignore
+        ipaddress.ip_network = ipaddress.IPNetwork  # type: ignore
 
 
 __all__ = [

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -56,10 +56,10 @@ def deprecated(reason, replacement, gone_in, issue=None):
     """Helper to deprecate existing functionality.
 
     reason:
-        Textual reason shown to the user about why this functionality has
+        strual reason shown to the user about why this functionality has
         been deprecated.
     replacement:
-        Textual suggestion shown to the user about what alternative
+        strual suggestion shown to the user about what alternative
         functionality they can use.
     gone_in:
         The version of pip does this functionality should get removed in.

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -56,10 +56,10 @@ def deprecated(reason, replacement, gone_in, issue=None):
     """Helper to deprecate existing functionality.
 
     reason:
-        strual reason shown to the user about why this functionality has
+        Textual reason shown to the user about why this functionality has
         been deprecated.
     replacement:
-        strual suggestion shown to the user about what alternative
+        Textual suggestion shown to the user about what alternative
         functionality they can use.
     gone_in:
         The version of pip does this functionality should get removed in.

--- a/src/pip/_internal/utils/encoding.py
+++ b/src/pip/_internal/utils/encoding.py
@@ -6,7 +6,7 @@ import sys
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Text, List, Tuple  # noqa: F401
+    from typing import List, Tuple, Text  # noqa: F401
 
 BOMS = [
     (codecs.BOM_UTF8, 'utf8'),

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -44,7 +44,7 @@ else:
 
 if MYPY_CHECK_RUNNING:
     from typing import (Optional, Tuple, Iterable, List,  # noqa: F401
-                        Match, Union, Set, Any, Mapping, Text, AnyStr)
+                        Match, Union, Any, Mapping, Text, AnyStr, Container)
     from pip._vendor.pkg_resources import Distribution  # noqa: F401
     from pip._internal.models.link import Link  # noqa: F401
     from pip._internal.utils.ui import SpinnerInterface  # noqa: F401
@@ -368,7 +368,7 @@ def get_installed_distributions(local_only=True,
                                 include_editables=True,
                                 editables_only=False,
                                 user_only=False):
-    # type: (bool, Set[str], bool, bool, bool) -> List[Distribution]
+    # type: (bool, Container[str], bool, bool, bool) -> List[Distribution]
     """
     Return a list of installed Distribution objects.
 
@@ -605,8 +605,8 @@ def untar_file(filename, location):
 def unpack_file(
         filename,  # type: str
         location,  # type: str
-        content_type,  # type: str
-        link  # type: Link
+        content_type,  # type: Optional[str]
+        link  # type: Optional[Link]
 ):
     # type: (...) -> None
     filename = os.path.realpath(filename)

--- a/src/pip/_internal/utils/ui.py
+++ b/src/pip/_internal/utils/ui.py
@@ -21,7 +21,7 @@ from pip._internal.utils.misc import format_size
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any  # noqa: F401
+    from typing import Any, Iterator, IO  # noqa: F401
 
 try:
     from pip._vendor import colorama
@@ -292,6 +292,7 @@ def DownloadProgressProvider(progress_bar, max=None):
 
 @contextlib.contextmanager
 def hidden_cursor(file):
+    # type: (IO) -> Iterator[None]
     # The Windows terminal does not support the hide/show cursor ANSI codes,
     # even via colorama. So don't even try.
     if WINDOWS:
@@ -311,19 +312,32 @@ def hidden_cursor(file):
 
 class RateLimiter(object):
     def __init__(self, min_update_interval_seconds):
+        # type: (float) -> None
         self._min_update_interval_seconds = min_update_interval_seconds
-        self._last_update = 0
+        self._last_update = 0  # type: float
 
     def ready(self):
+        # type: () -> bool
         now = time.time()
         delta = now - self._last_update
         return delta >= self._min_update_interval_seconds
 
     def reset(self):
+        # type: () -> None
         self._last_update = time.time()
 
 
-class InteractiveSpinner(object):
+class SpinnerInterface(object):
+    def spin(self):
+        # type: () -> None
+        raise NotImplementedError()
+
+    def finish(self, final_status):
+        # type: (str) -> None
+        raise NotImplementedError()
+
+
+class InteractiveSpinner(SpinnerInterface):
     def __init__(self, message, file=None, spin_chars="-\\|/",
                  # Empirically, 8 updates/second looks nice
                  min_update_interval_seconds=0.125):
@@ -352,6 +366,7 @@ class InteractiveSpinner(object):
         self._rate_limiter.reset()
 
     def spin(self):
+        # type: () -> None
         if self._finished:
             return
         if not self._rate_limiter.ready():
@@ -359,6 +374,7 @@ class InteractiveSpinner(object):
         self._write(next(self._spin_cycle))
 
     def finish(self, final_status):
+        # type: (str) -> None
         if self._finished:
             return
         self._write(final_status)
@@ -371,8 +387,9 @@ class InteractiveSpinner(object):
 # We still print updates occasionally (once every 60 seconds by default) to
 # act as a keep-alive for systems like Travis-CI that take lack-of-output as
 # an indication that a task has frozen.
-class NonInteractiveSpinner(object):
+class NonInteractiveSpinner(SpinnerInterface):
     def __init__(self, message, min_update_interval_seconds=60):
+        # type: (str, float) -> None
         self._message = message
         self._finished = False
         self._rate_limiter = RateLimiter(min_update_interval_seconds)
@@ -384,6 +401,7 @@ class NonInteractiveSpinner(object):
         logger.info("%s: %s", self._message, status)
 
     def spin(self):
+        # type: () -> None
         if self._finished:
             return
         if not self._rate_limiter.ready():
@@ -391,6 +409,7 @@ class NonInteractiveSpinner(object):
         self._update("still running...")
 
     def finish(self, final_status):
+        # type: (str) -> None
         if self._finished:
             return
         self._update("finished with status '%s'" % (final_status,))
@@ -399,6 +418,7 @@ class NonInteractiveSpinner(object):
 
 @contextlib.contextmanager
 def open_spinner(message):
+    # type: (str) -> Iterator[SpinnerInterface]
     # Interactive spinner goes directly to sys.stdout rather than being routed
     # through the logging system, but it acts like it has level INFO,
     # i.e. it's only displayed if we're at level INFO or better.
@@ -407,7 +427,8 @@ def open_spinner(message):
     if sys.stdout.isatty() and logger.getEffectiveLevel() <= logging.INFO:
         spinner = InteractiveSpinner(message)
     else:
-        spinner = NonInteractiveSpinner(message)
+        # https://github.com/python/mypy/issues/1174
+        spinner = NonInteractiveSpinner(message)  # type: ignore
     try:
         with hidden_cursor(sys.stdout):
             yield spinner

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -40,7 +40,9 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.ui import open_spinner
 
 if MYPY_CHECK_RUNNING:
-    from typing import Dict, List, Optional  # noqa: F401
+    from typing import Dict, List, Optional, Sequence, Mapping  # noqa: F401
+    from pip._vendor.packaging.requirements import Requirement  # noqa: F401
+
 
 wheel_ext = '.whl'
 
@@ -152,7 +154,7 @@ def get_entrypoints(filename):
 
 
 def message_about_scripts_not_on_PATH(scripts):
-    # type: (List[str]) -> Optional[str]
+    # type: (Sequence[str]) -> Optional[str]
     """Determine if any scripts are not on PATH and format a warning.
 
     Returns a warning message if one or more scripts are not on PATH,
@@ -232,9 +234,20 @@ def sorted_outrows(outrows):
     return sorted(outrows, key=lambda row: tuple(str(x) for x in row))
 
 
-def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
-                     pycompile=True, scheme=None, isolated=False, prefix=None,
-                     warn_script_location=True):
+def move_wheel_files(
+        name,  # type: str
+        req,  # type: Requirement
+        wheeldir,  # type: str
+        user=False,  # type: bool
+        home=None,  # type: Optional[str]
+        root=None,  # type: Optional[str]
+        pycompile=True,  # type: bool
+        scheme=None,  # type: Optional[Mapping[str, str]]
+        isolated=False,  # type: bool
+        prefix=None,  # type: Optional[str]
+        warn_script_location=True  # type: bool
+):
+    # type: (...) -> None
     """Install a wheel"""
 
     if not scheme:
@@ -248,7 +261,7 @@ def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
     else:
         lib_dir = scheme['platlib']
 
-    info_dir = []
+    info_dir = []  # type: List[str]
     data_dirs = []
     source = wheeldir.rstrip(os.path.sep) + os.path.sep
 
@@ -258,7 +271,7 @@ def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
     #   generated = files newly generated during the install (script wrappers)
     installed = {}
     changed = set()
-    generated = []
+    generated = []  # type: List[str]
 
     # Compile all of the pyc files that we're going to be installing
     if pycompile:
@@ -416,8 +429,9 @@ def move_wheel_files(name, req, wheeldir, user=False, home=None, root=None,
             "import_name": entry.suffix.split(".")[0],
             "func": entry.suffix,
         }
-
-    maker._get_script_text = _get_script_text
+    # ignore type, because mypy disallows assigning to a method,
+    # see https://github.com/python/mypy/issues/2427
+    maker._get_script_text = _get_script_text  # type: ignore
     maker.script_template = r"""# -*- coding: utf-8 -*-
 import re
 import sys

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -1,7 +1,6 @@
 import sys
 
 import pytest
-
 from mock import patch
 
 from pip._internal import pep425tags


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/4748.

Half of all `# type: ignore` in the codebase could be removed after mypy updated to latest version, will do it in the separate PR, or if this one will stay unmerged till 0.650 is out. 