### PR TITLE
Add warning about multiple .egg-info/ #6048

### DIFF
--- a/news/6048.feature
+++ b/news/6048.feature
@@ -1,0 +1,1 @@
+A warning message is emitted when multiple '.egg-info/' directories are found on `pip install -e .`.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -606,6 +606,18 @@ class InstallRequirement(object):
                     key=lambda x: x.count(os.path.sep) +
                     (os.path.altsep and x.count(os.path.altsep) or 0)
                 )
+                logger.warning(
+                    (
+                        'Multiple "*.egg-info/" in "%(base)s" found: %(filenames)s. '  # noqa: E501
+                        'In most cases, You should delete them except one which corresponding to the package. '  # noqa: E501
+                        'pip is going to refer %(chosen)s to install the package.'  # noqa: E501
+                    ),
+                    {
+                        "filenames": filenames,
+                        "chosen": filenames[0],
+                        "base": base
+                    }
+                )
             self._egg_info_path = os.path.join(base, filenames[0])
         return self._egg_info_path
 


### PR DESCRIPTION
Logs warning when multiple`.egg-info/` found on `pip install -e .`.

Solve https://github.com/pypa/pip/issues/6048.

This is a solution I just came up with. Please reject If there are more better solution.
