### PR TITLE
fix un-vendored support; add missing entry for pep517

### DIFF
--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -74,6 +74,7 @@ if DEBUNDLED:
     vendored("packaging")
     vendored("packaging.version")
     vendored("packaging.specifiers")
+    vendored("pep517")
     vendored("pkg_resources")
     vendored("progress")
     vendored("pytoml")


### PR DESCRIPTION
News fragment not required as it's not officially supported.

Discovered when packaging pip for Arch Linux.

/cc @felixonmars