### PR TITLE
Fix #5889 which occurs when `comes_from.link` is None

### DIFF
--- a/news/5889.bugfix
+++ b/news/5889.bugfix
@@ -1,0 +1,1 @@
+Fix exception when installing a package depending on an already installed dependency using a PEP 508 requirement.

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -325,7 +325,8 @@ def install_req_from_req_string(
         PyPI.file_storage_domain,
         TestPyPI.file_storage_domain,
     ]
-    if req.url and comes_from.link.netloc in domains_not_allowed:
+    if req.url and comes_from and comes_from.link \
+       and comes_from.link.netloc in domains_not_allowed:
         # Explicitly disallow pypi packages that depend on external urls
         raise InstallationError(
             "Packages installed from PyPI cannot depend on packages "


### PR DESCRIPTION
fixes issue #5889, which blocks a private-package use case of installing a package C, that requires package B via a direct URL requirement, which requires A via direct URL requirement (a la pep508).

@benoit-pierre said:
> * allow calling it with `comes_from=None` (easier for testing)
> * handle the case where `comes_from.link is None` (which can happen
  if a package using a PEP 508 URL requirement is already installed)

On benoit-pierre's PR #5893, @cjerdonek suggested that a slimmer PR might be better, so here it is.  This may be a total _faux pas_, but I've cherry-picked the commit he made, as it fixes issue #5889.

I see that on the PR #5893 @cjerdonek asked for a unit test, but I'm not familiar enough with pip internals to set up that unit test.  The test that benoit-pierre wrote should ensure that there isn't a regression that blocks this use-case again.
