### PR TITLE
Address #4759: change freeze to support editable Git repos with no remote

### DIFF
--- a/news/4759.bugfix
+++ b/news/4759.bugfix
@@ -1,0 +1,1 @@
+Editable Git installs without a remote now freeze as editable.

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -172,7 +172,7 @@ def get_requirement_info(dist):
 
     location = os.path.normcase(os.path.abspath(dist.location))
 
-    from pip._internal.vcs import vcs
+    from pip._internal.vcs import vcs, RemoteNotFoundError
     vc_type = vcs.get_backend_type(location)
 
     if not vc_type:
@@ -188,6 +188,15 @@ def get_requirement_info(dist):
 
     try:
         req = vc_type().get_src_requirement(location, dist.project_name)
+    except RemoteNotFoundError:
+        req = dist.as_requirement()
+        comments = [
+            '# Editable {} install with no remote ({})'.format(
+                vc_type.__name__, req,
+            )
+        ]
+        return (location, True, comments)
+
     except BadCommand:
         logger.warning(
             'cannot determine version of editable source in %s '

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -456,6 +456,9 @@ class VersionControl(object):
     def get_remote_url(self, location):
         """
         Return the url used at location
+
+        Raises RemoteNotFoundError if the repository does not have a remote
+        url configured.
         """
         raise NotImplementedError
 

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -29,6 +29,10 @@ __all__ = ['vcs']
 logger = logging.getLogger(__name__)
 
 
+class RemoteNotFoundError(Exception):
+    pass
+
+
 class RevOptions(object):
 
     """

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -146,6 +146,8 @@ def test_freeze_editable_git_with_no_remote(script, tmpdir):
     script.pip('install', '-e', pkg_path)
     result = script.pip('freeze')
 
+    assert result.stderr == ''
+
     # We need to apply os.path.normcase() to the path since that is what
     # the freeze code does.
     expected = textwrap.dedent("""\

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -137,6 +137,24 @@ def test_freeze_editable_not_vcs(script, tmpdir):
     _check_output(result.stdout, expected)
 
 
+@pytest.mark.git
+def test_freeze_editable_git_with_no_remote(script, tmpdir):
+    """
+    Test an editable install that is not version controlled.
+    """
+    pkg_path = _create_test_package(script)
+    script.pip('install', '-e', pkg_path)
+    result = script.pip('freeze')
+
+    # We need to apply os.path.normcase() to the path since that is what
+    # the freeze code does.
+    expected = textwrap.dedent("""\
+    ...# Editable, version-controlled with no remote (version-pkg==0.1)
+    -e {}
+    ...""".format(os.path.normcase(pkg_path)))
+    _check_output(result.stdout, expected)
+
+
 @pytest.mark.svn
 def test_freeze_svn(script, tmpdir):
     """Test freezing a svn checkout"""

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -140,7 +140,7 @@ def test_freeze_editable_not_vcs(script, tmpdir):
 @pytest.mark.git
 def test_freeze_editable_git_with_no_remote(script, tmpdir):
     """
-    Test an editable install that is not version controlled.
+    Test an editable Git install with no remote url.
     """
     pkg_path = _create_test_package(script)
     script.pip('install', '-e', pkg_path)
@@ -149,7 +149,7 @@ def test_freeze_editable_git_with_no_remote(script, tmpdir):
     # We need to apply os.path.normcase() to the path since that is what
     # the freeze code does.
     expected = textwrap.dedent("""\
-    ...# Editable, version-controlled with no remote (version-pkg==0.1)
+    ...# Editable Git install with no remote (version-pkg==0.1)
     -e {}
     ...""".format(os.path.normcase(pkg_path)))
     _check_output(result.stdout, expected)

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -367,20 +367,6 @@ def test_git_with_ambiguous_revs(script):
     result.assert_installed('version-pkg', with_files=['.git'])
 
 
-def test_git_works_with_editable_non_origin_repo(script):
-    # set up, create a git repo and install it as editable from a local
-    # directory path
-    version_pkg_path = _create_test_package(script)
-    script.pip('install', '-e', version_pkg_path.abspath)
-
-    # 'freeze'ing this should not fall over, but should result in stderr output
-    # warning
-    result = script.pip('freeze', expect_stderr=True)
-    assert "Error when trying to get requirement" in result.stderr
-    assert "Could not determine repository location" in result.stdout
-    assert "version-pkg==0.1" in result.stdout
-
-
 def test_editable__no_revision(script):
     """
     Test a basic install in editable mode specifying no revision.

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -4,7 +4,9 @@ Contains functional tests of the Git class.
 
 import os
 
-from pip._internal.vcs.git import Git
+import pytest
+
+from pip._internal.vcs.git import Git, RemoteNotFoundError
 from tests.lib import _create_test_package, _git_commit, _test_path_to_file_url
 
 
@@ -91,6 +93,20 @@ def test_get_remote_url(script, tmpdir):
 
     remote_url = Git().get_remote_url(repo_dir)
     assert remote_url == source_url
+
+
+def test_get_remote_url__no_remote(script, tmpdir):
+    """
+    Test a repo with no remote.
+    """
+    repo_dir = tmpdir / 'temp-repo'
+    repo_dir.mkdir()
+    repo_dir = str(repo_dir)
+
+    script.run('git', 'init', cwd=repo_dir)
+
+    with pytest.raises(RemoteNotFoundError):
+        Git().get_remote_url(repo_dir)
 
 
 def test_get_current_branch(script):


### PR DESCRIPTION
This fixes #4759. This PR also addresses review comments I made on PR #4760, which was another proposed fix for #4759. 