### PR TITLE
Fix handling of requests exceptions when dependencies are debundled

### DIFF
--- a/news/6111.bugfix
+++ b/news/6111.bugfix
@@ -1,0 +1,1 @@
+Fix handling of requests exceptions when dependencies are debundled.

--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -80,6 +80,7 @@ if DEBUNDLED:
     vendored("pytoml")
     vendored("retrying")
     vendored("requests")
+    vendored("requests.exceptions")
     vendored("requests.packages")
     vendored("requests.packages.urllib3")
     vendored("requests.packages.urllib3._collections")


### PR DESCRIPTION
Apparently Python thinks `pip._vendor.requests.exceptions.HTTPError` and `requests.HTTPError` are different classes, causing the following error when querying out-dated packages:
```
$ PYTHONPATH=./src python -c 'from pip._internal import main; main()' list -o
Exception:
Traceback (most recent call last):
  File "/home/yen/Projects/pip/src/pip/_internal/cli/base_command.py", line 154, in main
    status = self.run(options, args)
  File "/home/yen/Projects/pip/src/pip/_internal/commands/list.py", line 138, in run
    packages = self.get_outdated(packages, options)
  File "/home/yen/Projects/pip/src/pip/_internal/commands/list.py", line 149, in get_outdated
    dist for dist in self.iter_packages_latest_infos(packages, options)
  File "/home/yen/Projects/pip/src/pip/_internal/commands/list.py", line 149, in <listcomp>
    dist for dist in self.iter_packages_latest_infos(packages, options)
  File "/home/yen/Projects/pip/src/pip/_internal/commands/list.py", line 184, in iter_packages_latest_infos
    all_candidates = finder.find_all_candidates(dist.key)
  File "/home/yen/Projects/pip/src/pip/_internal/index.py", line 635, in find_all_candidates
    for page in self._get_pages(url_locations, project_name):
  File "/home/yen/Projects/pip/src/pip/_internal/index.py", line 782, in _get_pages
    page = _get_html_page(location, session=self.session)
  File "/home/yen/Projects/pip/src/pip/_internal/index.py", line 230, in _get_html_page
    resp = _get_html_response(url, session=session)
  File "/home/yen/Projects/pip/src/pip/_internal/index.py", line 181, in _get_html_response
    resp.raise_for_status()
  File "/usr/lib/python3.7/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
pip._vendor.requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://pypi.org/simple/ufw/
```
Steps to reproduce this issue:
1. [Patch setuptools](https://github.com/pypa/pip/issues/5429#issuecomment-390705580) due to another debundling issue
2. Install a Python package not hosted on PyPI (e.g., [ufw](https://launchpad.net/ufw))
3. Enable debundling in pip. I do it by modifying vendor:
```Diff
diff --git a/src/pip/_vendor/__init__.py b/src/pip/_vendor/__init__.py
index b919b540..76ec847d 100644
--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -14,7 +14,7 @@ import sys
 # Downstream redistributors which have debundled our dependencies should also
 # patch this value to be true. This will trigger the additional patching
 # to cause things like "six" to be available as pip.
-DEBUNDLED = False
+DEBUNDLED = True

 # By default, look in this directory for a bunch of .whl files which we will
 # add to the beginning of sys.path before attempting to import anything. This
@@ -30,6 +30,7 @@ def vendored(modulename):
     vendored_name = "{0}.{1}".format(__name__, modulename)

     try:
+        raise ImportError
         __import__(vendored_name, globals(), locals(), level=0)
     except ImportError:
         try:
```