### PR TITLE
Add a note in Vendoring Policies to remind of `vendored()` entries

### DIFF
--- a/src/pip/_vendor/README.rst
+++ b/src/pip/_vendor/README.rst
@@ -20,6 +20,8 @@ Vendoring Policy
   ``pip/_vendor/README.rst`` and their corresponding patches **MUST** be
   included ``tasks/vendoring/patches``.
 
+* Vendored libraries should have corresponding ``vendored()`` entries in
+  ``pip/_vendor/__init__.py``.
 
 Rationale
 ---------


### PR DESCRIPTION
To avoid future breakages like #4660, #5418 or #6056