### PR TITLE
pip list --not-required --outdated should list only outdated packages…

### DIFF
--- a/news/5737.bugfix
+++ b/news/5737.bugfix
@@ -1,0 +1,1 @@
+`pip list --outdated --not-required` should list only outdated packages that are not dependencies of installed packages

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -134,6 +134,10 @@ class ListCommand(Command):
             include_editables=options.include_editable,
         )
 
+        # get_not_required must be called firstly in order to find and
+        # filter out all dependencies correctly. Otherwise a package
+        # can't be identified as requirement because some parent packages
+        # could be filtered out before.
         if options.not_required:
             packages = self.get_not_required(packages, options)
 

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -134,13 +134,13 @@ class ListCommand(Command):
             include_editables=options.include_editable,
         )
 
+        if options.not_required:
+            packages = self.get_not_required(packages, options)
+
         if options.outdated:
             packages = self.get_outdated(packages, options)
         elif options.uptodate:
             packages = self.get_uptodate(packages, options)
-
-        if options.not_required:
-            packages = self.get_not_required(packages, options)
 
         self.output_package_listing(packages, options)
 

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -384,6 +384,22 @@ def test_outdated_editables_columns_flag(script, data):
     )
 
 
+@pytest.mark.network
+def test_outdated_not_required_flag(script, data):
+    """
+    test the behavior of --outdated --not-required flag in the list command
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index',
+        'simple==2.0', 'require_simple==1.0'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index', '--outdated',
+        '--not-required', '--format=json',
+    )
+    assert [] == json.loads(result.stdout)
+
+
 def test_outdated_pre(script, data):
     script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
 

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -384,7 +384,6 @@ def test_outdated_editables_columns_flag(script, data):
     )
 
 
-@pytest.mark.network
 def test_outdated_not_required_flag(script, data):
     """
     test the behavior of --outdated --not-required flag in the list command


### PR DESCRIPTION

This PR solves #5737. Filtering out of not-required packages should be done before getting outdated here:

https://github.com/pypa/pip/blob/740b1acf9017b4c733fd0381c8c4c5c5f0831e43/src/pip/_internal/commands/list.py#L136-L144
Current behaviour, for example: Outdated package B is required by up-to-date package A. The list of outdated packages passed to `self.get_not_required` contains only package B. Therefore package B is not detected as the requirement of any other package in the list and therefore is not considered as dependency.

