### PR TITLE
Tweak freeze comment for "no version control" case

### DIFF
--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -182,7 +182,7 @@ def get_requirement_info(dist):
             location,
         )
         comments = [
-            '# Editable, no version control detected ({})'.format(req)
+            '# Editable install with no version control ({})'.format(req)
         ]
         return (location, True, comments)
 

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -131,7 +131,7 @@ def test_freeze_editable_not_vcs(script, tmpdir):
     # We need to apply os.path.normcase() to the path since that is what
     # the freeze code does.
     expected = textwrap.dedent("""\
-    ...# Editable, no version control detected (version-pkg==0.1)
+    ...# Editable install with no version control (version-pkg==0.1)
     -e {}
     ...""".format(os.path.normcase(pkg_path)))
     _check_output(result.stdout, expected)


### PR DESCRIPTION
This PR slightly modifies the text for one of the comment strings in the freeze output. It makes the wording for the "no version control" case closely parallel the "Git with no remote" case.

So you can see the parallel language with the change, here is example text of the wording for both cases with the change in this PR:

```
# Editable install with no version control (version-pkg==0.1)

# Editable Git install with no remote (version-pkg==0.1)
```

The "no version control" case was introduced recently in PR #5905 and hasn't been released yet, so this is a follow-up to that.
