### PR TITLE
delete some dead code

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -50,7 +50,6 @@ logger = logging.getLogger(__name__)
 class Command(object):
     name = None  # type: Optional[str]
     usage = None  # type: Optional[str]
-    hidden = False  # type: bool
     ignore_require_venv = False  # type: bool
 
     def __init__(self, isolated=False):

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -35,13 +35,11 @@ from pip._internal.models.index import PyPI
 from pip._internal.utils.encoding import auto_decode
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.glibc import libc_ver
-from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
-    ARCHIVE_EXTENSIONS, ask_path_exists, backup_dir, call_subprocess, consume,
-    display_path, format_size, get_installed_version, rmtree,
-    split_auth_from_netloc, splitext, unpack_file,
+    ARCHIVE_EXTENSIONS, ask_path_exists, backup_dir, consume, display_path,
+    format_size, get_installed_version, rmtree, split_auth_from_netloc,
+    splitext, unpack_file,
 )
-from pip._internal.utils.setuptools_build import SETUPTOOLS_SHIM
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.ui import DownloadProgressProvider
@@ -765,42 +763,6 @@ def unpack_file_url(
     # a download dir is specified and not already downloaded
     if download_dir and not already_downloaded_path:
         _copy_file(from_path, download_dir, link)
-
-
-def _copy_dist_from_dir(link_path, location):
-    """Copy distribution files in `link_path` to `location`.
-
-    Invoked when user requests to install a local directory. E.g.:
-
-        pip install .
-        pip install ~/dev/git-repos/python-prompt-toolkit
-
-    """
-
-    # Note: This is currently VERY SLOW if you have a lot of data in the
-    # directory, because it copies everything with `shutil.copytree`.
-    # What it should really do is build an sdist and install that.
-    # See https://github.com/pypa/pip/issues/2195
-
-    if os.path.isdir(location):
-        rmtree(location)
-
-    # build an sdist
-    setup_py = 'setup.py'
-    sdist_args = [sys.executable]
-    sdist_args.append('-c')
-    sdist_args.append(SETUPTOOLS_SHIM % setup_py)
-    sdist_args.append('sdist')
-    sdist_args += ['--dist-dir', location]
-    logger.info('Running setup.py sdist for %s', link_path)
-
-    with indent_log():
-        call_subprocess(sdist_args, cwd=link_path)
-
-    # unpack sdist into `location`
-    sdist = os.path.join(location, os.listdir(location)[0])
-    logger.info('Unpacking sdist %s into %s', sdist, location)
-    unpack_file(sdist, location, content_type=None, link=None)
 
 
 class PipXmlrpcTransport(xmlrpc_client.Transport):

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -173,12 +173,6 @@ class RequirementSet(object):
             return True
         return False
 
-    @property
-    def has_requirements(self):
-        # type: () -> List[InstallRequirement]
-        return list(req for req in self.requirements.values() if not
-                    req.constraint) or self.unnamed_requirements
-
     def get_requirement(self, project_name):
         # type: (str) -> InstallRequirement
         for name in project_name, project_name.lower():

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import contextlib
 import errno
 import io
-import locale
 # we have a submodule named 'logging' which would shadow this if we used the
 # regular name:
 import logging as std_logging
@@ -772,32 +771,6 @@ def call_subprocess(
     if not show_stdout:
         return ''.join(all_output)
     return None
-
-
-def read_text_file(filename):
-    # type: (str) -> str
-    """Return the contents of *filename*.
-
-    Try to decode the file contents with utf-8, the preferred system encoding
-    (e.g., cp1252 on some Windows machines), and latin1, in that order.
-    Decoding a byte string with latin1 will never raise an error. In the worst
-    case, the returned string will contain some garbage characters.
-
-    """
-    with open(filename, 'rb') as fp:
-        data = fp.read()
-
-    encodings = ['utf-8', locale.getpreferredencoding(False), 'latin1']
-    for enc in encodings:
-        try:
-            # https://github.com/python/mypy/issues/1174
-            data = data.decode(enc)  # type: ignore
-        except UnicodeDecodeError:
-            continue
-        break
-
-    assert not isinstance(data, bytes)  # Latin1 should have worked.
-    return data
 
 
 def _make_build_dir(build_dir):

--- a/src/pip/_internal/utils/ui.py
+++ b/src/pip/_internal/utils/ui.py
@@ -8,10 +8,7 @@ import time
 from signal import SIGINT, default_int_handler, signal
 
 from pip._vendor import six
-from pip._vendor.progress.bar import (
-    Bar, ChargingBar, FillingCirclesBar, FillingSquaresBar, IncrementalBar,
-    ShadyBar,
-)
+from pip._vendor.progress.bar import Bar, FillingCirclesBar, IncrementalBar
 from pip._vendor.progress.helpers import HIDE_CURSOR, SHOW_CURSOR, WritelnMixin
 from pip._vendor.progress.spinner import Spinner
 
@@ -213,20 +210,6 @@ class DownloadSilentBar(BaseDownloadProgressBar, SilentBar):  # type: ignore
 
 class DownloadIncrementalBar(BaseDownloadProgressBar,  # type: ignore
                              IncrementalBar):
-    pass
-
-
-class DownloadChargingBar(BaseDownloadProgressBar,  # type: ignore
-                          ChargingBar):
-    pass
-
-
-class DownloadShadyBar(BaseDownloadProgressBar, ShadyBar):  # type: ignore
-    pass
-
-
-class DownloadFillingSquaresBar(BaseDownloadProgressBar,  # type: ignore
-                                FillingSquaresBar):
     pass
 
 

--- a/tests/functional/test_help.py
+++ b/tests/functional/test_help.py
@@ -81,9 +81,6 @@ def test_help_commands_equally_functional(in_memory_pip):
     assert all(len(o) > 0 for o in out)
 
     for name, cls in commands.items():
-        if cls.hidden:
-            continue
-
         assert (
             in_memory_pip.pip('help', name).stdout ==
             in_memory_pip.pip(name, '--help').stdout != ""

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 
 import pytest
-from mock import Mock, mock_open, patch
+from mock import patch
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
@@ -23,7 +23,6 @@ from pip._internal.req.constructors import (
 from pip._internal.req.req_file import process_line
 from pip._internal.req.req_tracker import RequirementTracker
 from pip._internal.resolve import Resolver
-from pip._internal.utils.misc import read_text_file
 from tests.lib import DATA_DIR, assert_raises_regexp, requirements_file
 
 
@@ -315,21 +314,6 @@ class TestRequirementSet(object):
             '3d0a6d4e8bfa6',
             lineno=2
         ))
-
-
-@pytest.mark.parametrize(('file_contents', 'expected'), [
-    (b'\xf6\x80', b'\xc3\xb6\xe2\x82\xac'),  # cp1252
-    (b'\xc3\xb6\xe2\x82\xac', b'\xc3\xb6\xe2\x82\xac'),  # utf-8
-    (b'\xc3\xb6\xe2', b'\xc3\x83\xc2\xb6\xc3\xa2'),  # Garbage
-])
-def test_egg_info_data(file_contents, expected):
-    om = mock_open(read_data=file_contents)
-    em = Mock()
-    em.return_value = 'cp1252'
-    with patch('pip._internal.utils.misc.open', om, create=True):
-        with patch('locale.getpreferredencoding', em):
-            ret = read_text_file('foo')
-    assert ret == expected.decode('utf-8')
 
 
 class TestInstallRequirement(object):


### PR DESCRIPTION
dead code detected via [dead](https://github.com/asottile/dead)

(noticed [this issue](https://github.com/asottile/dead/issues/5) while doing this -- worked around it with `grep`)

here's the summary of the removed things:

- **`hidden`**: last reference removed in 8447f39fe1be52e746df3bc9a6c4a157d68421dc
- **`_copy_dist_from_dir`**: introduced in 4c405a0ad3c308eae0dba9c1b72615d886df2bd1 but not referenced
- **`has_requirements`**: last reference removed in 893f0b002905550f9d54cb01601a4bd0d0275f28
- **`read_text_file`**: last reference removed in 52d87f2e3031ad91f1dd09bd264dc9d8ec0305c2
- ~**`remove_auth_from_url`**: last reference removed in 78371cc95079e3bba43e88bcb67e0b9f8f883a50~ planned to be used in a future PR
- **(several progress bar types)**: introduced in 0552ffeeda62759797cfdccaba8a3fa0cf816199 but never referenced

The eventual "clean" command I reached was:

```bash
dead --exclude '^docs/'  | grep -v '/_vendor/' | grep -Ev '^(news|InstalledCSVRow|unregister|pretty_eta|download_speed|MaxLevelFilter|BetterRotatingFileHandler|ColorizedStreamHandler|deprecated|ReqFileLines|RequirementInfo|CheckResult|PackageSet|CandidateSortingKey|SecureOrigin|Kind|format_option_strings|format_heading|format_usage|format_description|format_epilog) '
```

most of the exclusions are type aliases (asottile/dead#5 not recognizing PEP 484 type comments)