### PR TITLE
Prevent the use of PIP_NO_USE_PEP517 to head off user confusion

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -555,7 +555,10 @@ def no_cache_dir_callback(option, opt, value, parser):
     # environment variable, like PIP_NO_CACHE_DIR=true.
     if value is not None:
         # Then parse the string value to get argument error-checking.
-        strtobool(value)
+        try:
+            strtobool(value)
+        except ValueError as exc:
+            raise_option_error(parser, option=option, msg=str(exc))
 
     # Originally, setting PIP_NO_CACHE_DIR to a value that strtobool()
     # converted to 0 (like "false" or "no") caused cache_dir to be disabled

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -27,17 +27,6 @@ def temp_environment_variable(name, value):
 
 
 @contextmanager
-def assert_raises_message(exc_class, expected):
-    """
-    Assert that an exception with the given type and message is raised.
-    """
-    with pytest.raises(exc_class) as excinfo:
-        yield
-
-    assert str(excinfo.value) == expected
-
-
-@contextmanager
 def assert_option_error(capsys, expected):
     """
     Assert that a SystemExit occurred because of a parsing error.
@@ -181,13 +170,16 @@ class TestOptionPrecedence(AddFakeCommandMixin):
         # value in this case).
         assert options.cache_dir is False
 
-    def test_cache_dir__PIP_NO_CACHE_DIR_invalid__with_no_cache_dir(self):
+    def test_cache_dir__PIP_NO_CACHE_DIR_invalid__with_no_cache_dir(
+            self, capsys,
+    ):
         """
         Test setting PIP_NO_CACHE_DIR to an invalid value while also passing
         --no-cache-dir.
         """
         os.environ['PIP_NO_CACHE_DIR'] = 'maybe'
-        with assert_raises_message(ValueError, "invalid truth value 'maybe'"):
+        expected_err = "--no-cache-dir error: invalid truth value 'maybe'"
+        with assert_option_error(capsys, expected=expected_err):
             main(['--no-cache-dir', 'fake'])
 
 

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -5,7 +5,25 @@ import pytest
 
 import pip._internal.configuration
 from pip._internal import main
+from pip._internal.commands import DownloadCommand
 from tests.lib.options_helpers import AddFakeCommandMixin
+
+
+@contextmanager
+def temp_environment_variable(name, value):
+    not_set = object()
+    original = os.environ[name] if name in os.environ else not_set
+    os.environ[name] = value
+
+    try:
+        yield
+    finally:
+        # Return the environment variable to its original state.
+        if original is not_set:
+            if name in os.environ:
+                del os.environ[name]
+        else:
+            os.environ[name] = original
 
 
 @contextmanager
@@ -17,6 +35,22 @@ def assert_raises_message(exc_class, expected):
         yield
 
     assert str(excinfo.value) == expected
+
+
+@contextmanager
+def assert_option_error(capsys, expected):
+    """
+    Assert that a SystemExit occurred because of a parsing error.
+
+    Args:
+      expected: an expected substring of stderr.
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        yield
+
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert expected in stderr
 
 
 def assert_is_default_cache_dir(value):
@@ -155,6 +189,89 @@ class TestOptionPrecedence(AddFakeCommandMixin):
         os.environ['PIP_NO_CACHE_DIR'] = 'maybe'
         with assert_raises_message(ValueError, "invalid truth value 'maybe'"):
             main(['--no-cache-dir', 'fake'])
+
+
+class TestUsePEP517Options(object):
+
+    """
+    Test options related to using --use-pep517.
+    """
+
+    def parse_args(self, args):
+        # We use DownloadCommand since that is one of the few Command
+        # classes with the use_pep517 options.
+        command = DownloadCommand()
+        options, args = command.parse_args(args)
+
+        return options
+
+    def test_no_option(self):
+        """
+        Test passing no option.
+        """
+        options = self.parse_args([])
+        assert options.use_pep517 is None
+
+    def test_use_pep517(self):
+        """
+        Test passing --use-pep517.
+        """
+        options = self.parse_args(['--use-pep517'])
+        assert options.use_pep517 is True
+
+    def test_no_use_pep517(self):
+        """
+        Test passing --no-use-pep517.
+        """
+        options = self.parse_args(['--no-use-pep517'])
+        assert options.use_pep517 is False
+
+    def test_PIP_USE_PEP517_true(self):
+        """
+        Test setting PIP_USE_PEP517 to "true".
+        """
+        with temp_environment_variable('PIP_USE_PEP517', 'true'):
+            options = self.parse_args([])
+        # This is an int rather than a boolean because strtobool() in pip's
+        # configuration code returns an int.
+        assert options.use_pep517 == 1
+
+    def test_PIP_USE_PEP517_false(self):
+        """
+        Test setting PIP_USE_PEP517 to "false".
+        """
+        with temp_environment_variable('PIP_USE_PEP517', 'false'):
+            options = self.parse_args([])
+        # This is an int rather than a boolean because strtobool() in pip's
+        # configuration code returns an int.
+        assert options.use_pep517 == 0
+
+    def test_use_pep517_and_PIP_USE_PEP517_false(self):
+        """
+        Test passing --use-pep517 and setting PIP_USE_PEP517 to "false".
+        """
+        with temp_environment_variable('PIP_USE_PEP517', 'false'):
+            options = self.parse_args(['--use-pep517'])
+        assert options.use_pep517 is True
+
+    def test_no_use_pep517_and_PIP_USE_PEP517_true(self):
+        """
+        Test passing --no-use-pep517 and setting PIP_USE_PEP517 to "true".
+        """
+        with temp_environment_variable('PIP_USE_PEP517', 'true'):
+            options = self.parse_args(['--no-use-pep517'])
+        assert options.use_pep517 is False
+
+    def test_PIP_NO_USE_PEP517(self, capsys):
+        """
+        Test setting PIP_NO_USE_PEP517, which isn't allowed.
+        """
+        expected_err = (
+            '--no-use-pep517 error: A value was passed for --no-use-pep517,\n'
+        )
+        with temp_environment_variable('PIP_NO_USE_PEP517', 'true'):
+            with assert_option_error(capsys, expected=expected_err):
+                self.parse_args([])
 
 
 class TestOptionsInterspersed(AddFakeCommandMixin):


### PR DESCRIPTION
This PR is a follow-up to PR #5743 (the PEP 517 PR). I'm hoping it can be merged in the same release that PEP 517 goes out since for backwards compatibility reasons we might not be able to merge it afterwards.

This PR addresses an issue I raised with that PR and discussed with @pfmoore in that issue. He and I agreed I would take care of it: https://github.com/pypa/pip/pull/5743#issuecomment-430542326

Basically, the change is to prevent from happening with the new `--no-use-pep517` option a confusion that happened in the past with certain other "no" options (like `--no-cache-dir`): https://github.com/pypa/pip/issues/5735
Namely, without this PR, someone can pass `PIP_NO_USE_PEP517=true`, and it will result in `options.use_pep517` being `True` instead of `False`, which is what one would logically expect.

This PR prevents this by not allowing the environment variable `PIP_NO_USE_PEP517` to be used. Instead, it instructs the user to use an appropriate value for `PIP_USE_PEP517`. Here is what the output looks like:

```
$ PIP_NO_USE_PEP517=true pip download xxx

Usage:   
  pip download [options] <requirement specifier> [package-index-options] ...
  pip download [options] -r <requirements file> [package-index-options] ...
  pip download [options] <vcs project url> ...
  pip download [options] <local project path> ...
  pip download [options] <archive url/path> ...

--no-use-pep517 error: A value was passed for --no-use-pep517,
probably using either the PIP_NO_USE_PEP517 environment variable or
the "no-use-pep517" config file option. Use an appropriate value of
the PIP_USE_PEP517 environment variable or the "use-pep517" config
file option instead.
```

The PR also improves handling of the corresponding `--no-cache-dir` scenario by raising a parser error instead of a `ValueError`, since I noticed that while implementing this PR. This results in a better error message display. Instead of a `ValueError` stack trace, the user will get this:

```
$ PIP_NO_CACHE_DIR=invalid pip list

Usage:   
  pip <command> [options]

--no-cache-dir error: invalid truth value 'invalid'
```

After this PR, it shouldn't be too hard also to address @pradyunsg's suggestions that he made here:
https://github.com/pypa/pip/pull/5743#issuecomment-435988502
since this PR sets up the option callback and tests, etc, needed for his suggestion.
