### PR TITLE
Tweak the check of whether use_pep517 is false

### DIFF
--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -57,17 +57,20 @@ def load_pyproject_toml(
         build_system = None
 
     # The following cases must use PEP 517
-    # We check for use_pep517 equalling False because that
-    # means the user explicitly requested --no-use-pep517
+    # We check for use_pep517 being non-None and falsey because that means
+    # the user explicitly requested --no-use-pep517.  The value 0 as
+    # opposed to False can occur when the value is provided via an
+    # environment variable or config file option (due to the quirk of
+    # strtobool() returning an integer in pip's configuration code).
     if has_pyproject and not has_setup:
-        if use_pep517 is False:
+        if use_pep517 is not None and not use_pep517:
             raise InstallationError(
                 "Disabling PEP 517 processing is invalid: "
                 "project does not have a setup.py"
             )
         use_pep517 = True
     elif build_system and "build-backend" in build_system:
-        if use_pep517 is False:
+        if use_pep517 is not None and not use_pep517:
             raise InstallationError(
                 "Disabling PEP 517 processing is invalid: "
                 "project specifies a build backend of {} "


### PR DESCRIPTION
This PR addresses the issue I pointed out in this comment: https://github.com/pypa/pip/pull/6134#issuecomment-453960062

I'm keeping this separate from PR #6134 since it's a different issue, it's a much smaller change, and it can be reviewed independently of that issue.

I'm also marking this as a release blocker because it's related to the initial PEP 517 release.
