### PR TITLE
Prefix user_log (--log) entries with timestamp

### DIFF
--- a/news/6141.feature
+++ b/news/6141.feature
@@ -1,1 +1,1 @@
-Prefix user_log lines with their timestamp.
+Prefix pip's --log file lines with their timestamp.

--- a/news/6141.feature
+++ b/news/6141.feature
@@ -1,0 +1,1 @@
+Prefix user_log lines with their timestamp.

--- a/news/6141.feature
+++ b/news/6141.feature
@@ -1,1 +1,1 @@
-Prefix pip's --log file lines with their timestamp.
+Prefix pip's ``--log`` file lines with their timestamp.

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -56,8 +56,8 @@ class IndentingFormatter(logging.Formatter):
         formatted = logging.Formatter.format(self, record)
         prefix = ''
         if self.timestamp:
-          prefix = logging.Formatter.formatTime(
-              self, record, "%Y-%m-%dT%H:%M:%S ")
+            prefix = logging.Formatter.formatTime(
+                self, record, "%Y-%m-%dT%H:%M:%S ")
         prefix += " " * get_indentation()
         formatted = "".join([
             prefix + line

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -62,8 +62,7 @@ class IndentingFormatter(logging.Formatter):
         formatted = super(IndentingFormatter, self).format(record)
         prefix = ''
         if self.add_timestamp:
-            prefix = super(IndentingFormatter, self).formatTime(
-                record, "%Y-%m-%dT%H:%M:%S ")
+            prefix = self.formatTime(record, "%Y-%m-%dT%H:%M:%S ")
         prefix += " " * get_indentation()
         formatted = "".join([
             prefix + line

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -59,7 +59,8 @@ class IndentingFormatter(logging.Formatter):
         by our current indentation level.
         """
         formatted = logging.Formatter.format(self, record)
-        timestamp_prefix = self.timestamper.format(record) if self.timestamper else ''
+        timestamp_prefix = (self.timestamper.format(record) if self.timestamper
+                            else '')
         formatted = "".join([
             timestamp_prefix + (" " * get_indentation()) + line
             for line in formatted.splitlines(True)

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -45,7 +45,13 @@ def get_indentation():
 
 class IndentingFormatter(logging.Formatter):
     def __init__(self, *args, **kwargs):
-        self.timestamp = kwargs.pop("timestamp", False)
+        """
+        A logging.Formatter obeying containing indent_log contexts.
+
+        :param add_timestamp: A bool indicating output lines should be prefixed
+            with their record's timestamp.
+        """
+        self.add_timestamp = kwargs.pop("add_timestamp", False)
         super(IndentingFormatter, self).__init__(*args, **kwargs)
 
     def format(self, record):
@@ -53,11 +59,11 @@ class IndentingFormatter(logging.Formatter):
         Calls the standard formatter, but will indent all of the log messages
         by our current indentation level.
         """
-        formatted = logging.Formatter.format(self, record)
+        formatted = super(IndentingFormatter, self).format(record)
         prefix = ''
-        if self.timestamp:
-            prefix = logging.Formatter.formatTime(
-                self, record, "%Y-%m-%dT%H:%M:%S ")
+        if self.add_timestamp:
+            prefix = super(IndentingFormatter, self).formatTime(
+                record, "%Y-%m-%dT%H:%M:%S ")
         prefix += " " * get_indentation()
         formatted = "".join([
             prefix + line
@@ -197,7 +203,7 @@ def setup_logging(verbosity, no_color, user_log_file):
             "indent_with_timestamp": {
                 "()": IndentingFormatter,
                 "format": "%(message)s",
-                "timestamp": True,
+                "add_timestamp": True,
             },
         },
         "handlers": {

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -45,12 +45,7 @@ def get_indentation():
 
 class IndentingFormatter(logging.Formatter):
     def __init__(self, *args, **kwargs):
-        if kwargs.pop("timestamp", False):
-            self.timestamper = logging.Formatter(
-                fmt="%(asctime)s ",
-                datefmt=kwargs.get("datefmt", "%Y-%m-%dT%H:%M:%S"))
-        else:
-            self.timestamper = None
+        self.timestamp = kwargs.pop("timestamp", False)
         super(IndentingFormatter, self).__init__(*args, **kwargs)
 
     def format(self, record):
@@ -59,10 +54,13 @@ class IndentingFormatter(logging.Formatter):
         by our current indentation level.
         """
         formatted = logging.Formatter.format(self, record)
-        timestamp_prefix = (self.timestamper.format(record) if self.timestamper
-                            else '')
+        prefix = ''
+        if self.timestamp:
+          prefix = logging.Formatter.formatTime(
+              self, record, "%Y-%m-%dT%H:%M:%S ")
+        prefix += " " * get_indentation()
         formatted = "".join([
-            timestamp_prefix + (" " * get_indentation()) + line
+            prefix + line
             for line in formatted.splitlines(True)
         ])
         return formatted
@@ -196,7 +194,7 @@ def setup_logging(verbosity, no_color, user_log_file):
                 "()": IndentingFormatter,
                 "format": "%(message)s",
             },
-            "indent_and_timestamp": {
+            "indent_with_timestamp": {
                 "()": IndentingFormatter,
                 "format": "%(message)s",
                 "timestamp": True,
@@ -223,7 +221,7 @@ def setup_logging(verbosity, no_color, user_log_file):
                 "class": handler_classes["file"],
                 "filename": additional_log_file,
                 "delay": True,
-                "formatter": "indent_and_timestamp",
+                "formatter": "indent_with_timestamp",
             },
         },
         "root": {

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 
 from pip._internal.cli.base_command import Command
 
@@ -39,9 +40,12 @@ class Test_base_command_logging(object):
     options
     """
 
-    def _remove_timestamp(self, l):
-        timestamp_prefix_length = len('2019-01-16T22:00:37 ')
-        return l[timestamp_prefix_length:]
+    def setup(self):
+        self.old_time = time.time
+        time.time = lambda: 1547704837.4
+
+    def teardown(self):
+        time.time = self.old_time
 
     def test_log_command_success(self, tmpdir):
         """
@@ -51,7 +55,7 @@ class Test_base_command_logging(object):
         log_path = tmpdir.join('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
-            assert 'fake' == self._remove_timestamp(f.read().strip())[:4]
+            assert f.read().startswith('2019-01-16T22:00:37 fake')
 
     def test_log_command_error(self, tmpdir):
         """
@@ -61,7 +65,7 @@ class Test_base_command_logging(object):
         log_path = tmpdir.join('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
-            assert 'fake' == self._remove_timestamp(f.read().strip())[:4]
+            assert f.read().startswith('2019-01-16T22:00:37 fake')
 
     def test_log_file_command_error(self, tmpdir):
         """
@@ -71,18 +75,7 @@ class Test_base_command_logging(object):
         log_file_path = tmpdir.join('log_file')
         cmd.main(['fake', '--log-file', log_file_path])
         with open(log_file_path) as f:
-            assert 'fake' == self._remove_timestamp(f.read().strip())[:4]
-
-    def test_log_command_is_timestamped(self, tmpdir):
-        """
-        Test the --log option logs a timestamp
-        """
-        cmd = FakeCommand()
-        log_path = tmpdir.join('log')
-        cmd.main(['fake', '--log', log_path])
-        with open(log_path) as f:
-            assert re.match('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} ',
-                            f.read().strip())
+            assert f.read().startswith('2019-01-16T22:00:37 fake')
 
     def test_unicode_messages(self, tmpdir):
         """

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -46,14 +46,16 @@ class Test_base_command_logging(object):
         time.time = lambda: 1547704837.4
         self.old_tz = getattr(os.environ, 'TZ', None)
         os.environ['TZ'] = 'UTC'
-        time.tzset()
+        if 'tzset' in dir(time):
+          time.tzset()
 
     def teardown(self):
         if self.old_tz:
             os.environ['TZ'] = self.old_tz
         else:
             del os.environ['TZ']
-        time.tzset()
+        if 'tzset' in dir(time):
+          time.tzset()
         time.time = self.old_time
 
     def test_log_command_success(self, tmpdir):

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from pip._internal.cli.base_command import Command
 
@@ -38,6 +39,10 @@ class Test_base_command_logging(object):
     options
     """
 
+    def _remove_timestamp(self, l):
+        timestamp_prefix_length = len('2019-01-16T22:00:37 ')
+        return l[timestamp_prefix_length:]
+
     def test_log_command_success(self, tmpdir):
         """
         Test the --log option logs when command succeeds
@@ -46,7 +51,7 @@ class Test_base_command_logging(object):
         log_path = tmpdir.join('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
-            assert 'fake' == f.read().strip()[:4]
+            assert 'fake' == self._remove_timestamp(f.read().strip())[:4]
 
     def test_log_command_error(self, tmpdir):
         """
@@ -56,7 +61,7 @@ class Test_base_command_logging(object):
         log_path = tmpdir.join('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
-            assert 'fake' == f.read().strip()[:4]
+            assert 'fake' == self._remove_timestamp(f.read().strip())[:4]
 
     def test_log_file_command_error(self, tmpdir):
         """
@@ -66,7 +71,18 @@ class Test_base_command_logging(object):
         log_file_path = tmpdir.join('log_file')
         cmd.main(['fake', '--log-file', log_file_path])
         with open(log_file_path) as f:
-            assert 'fake' == f.read().strip()[:4]
+            assert 'fake' == self._remove_timestamp(f.read().strip())[:4]
+
+    def test_log_command_is_timestamped(self, tmpdir):
+        """
+        Test the --log option logs a timestamp
+        """
+        cmd = FakeCommand()
+        log_path = tmpdir.join('log')
+        cmd.main(['fake', '--log', log_path])
+        with open(log_path) as f:
+            assert re.match('^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2} ',
+                            f.read().strip())
 
     def test_unicode_messages(self, tmpdir):
         """

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import os
 import time
 
@@ -47,7 +46,7 @@ class Test_base_command_logging(object):
         self.old_tz = getattr(os.environ, 'TZ', None)
         os.environ['TZ'] = 'UTC'
         if 'tzset' in dir(time):
-          time.tzset()
+            time.tzset()
 
     def teardown(self):
         if self.old_tz:
@@ -55,7 +54,7 @@ class Test_base_command_logging(object):
         else:
             del os.environ['TZ']
         if 'tzset' in dir(time):
-          time.tzset()
+            time.tzset()
         time.time = self.old_time
 
     def test_log_command_success(self, tmpdir):

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import os
 import time
 
 from pip._internal.cli.base_command import Command
@@ -43,8 +44,16 @@ class Test_base_command_logging(object):
     def setup(self):
         self.old_time = time.time
         time.time = lambda: 1547704837.4
+        self.old_tz = getattr(os.environ, 'TZ', None)
+        os.environ['TZ'] = 'UTC'
+        time.tzset()
 
     def teardown(self):
+        if self.old_tz:
+            os.environ['TZ'] = self.old_tz
+        else:
+            del os.environ['TZ']
+        time.tzset()
         time.time = self.old_time
 
     def test_log_command_success(self, tmpdir):
@@ -55,7 +64,7 @@ class Test_base_command_logging(object):
         log_path = tmpdir.join('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
-            assert f.read().startswith('2019-01-16T22:00:37 fake')
+            assert f.read().startswith('2019-01-17T06:00:37 fake')
 
     def test_log_command_error(self, tmpdir):
         """
@@ -65,7 +74,7 @@ class Test_base_command_logging(object):
         log_path = tmpdir.join('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
-            assert f.read().startswith('2019-01-16T22:00:37 fake')
+            assert f.read().startswith('2019-01-17T06:00:37 fake')
 
     def test_log_file_command_error(self, tmpdir):
         """
@@ -75,7 +84,7 @@ class Test_base_command_logging(object):
         log_file_path = tmpdir.join('log_file')
         cmd.main(['fake', '--log-file', log_file_path])
         with open(log_file_path) as f:
-            assert f.read().startswith('2019-01-16T22:00:37 fake')
+            assert f.read().startswith('2019-01-17T06:00:37 fake')
 
     def test_unicode_messages(self, tmpdir):
         """

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -43,9 +43,12 @@ class Test_base_command_logging(object):
     def setup(self):
         self.old_time = time.time
         time.time = lambda: 1547704837.4
+        # Robustify the tests below to the ambient timezone by setting it
+        # explicitly here.
         self.old_tz = getattr(os.environ, 'TZ', None)
         os.environ['TZ'] = 'UTC'
-        if 'tzset' in dir(time):
+        # time.tzset() is not implemented on some platforms (notably, Windows).
+        if hasattr(time, 'tzset'):
             time.tzset()
 
     def teardown(self):
@@ -65,7 +68,7 @@ class Test_base_command_logging(object):
         log_path = tmpdir.join('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
-            assert f.read().startswith('2019-01-17T06:00:37 fake')
+            assert f.read().rstrip() == '2019-01-17T06:00:37 fake'
 
     def test_log_command_error(self, tmpdir):
         """

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -27,6 +27,14 @@ class TestIndentingFormatter(object):
         if 'tzset' in dir(time):
             time.tzset()
 
+    def test_format(self, tmpdir):
+        record = logging.makeLogRecord(dict(
+            created=1547704837.4,
+            msg='hello\nworld',
+        ))
+        f = IndentingFormatter(fmt="%(message)s")
+        assert f.format(record) == 'hello\nworld'
+
     def test_format_with_timestamp(self, tmpdir):
         record = logging.makeLogRecord(dict(
             created=1547704837.4,
@@ -35,11 +43,3 @@ class TestIndentingFormatter(object):
         f = IndentingFormatter(fmt="%(message)s", add_timestamp=True)
         expected = '2019-01-17T06:00:37 hello\n2019-01-17T06:00:37 world'
         assert f.format(record) == expected
-
-    def test_format(self, tmpdir):
-        record = logging.makeLogRecord(dict(
-            created=1547704837.4,
-            msg='hello\nworld',
-        ))
-        f = IndentingFormatter(fmt="%(message)s", add_timestamp=False)
-        assert f.format(record) == 'hello\nworld'

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,26 @@
+import logging
+import re
+import time
+
+from pip._internal.utils.logging import IndentingFormatter
+
+class Test_IndentingFormatter(object):
+    """
+    Test `pip._internal.utils.logging.IndentingFormatter`
+    """
+
+    def test_formatter_with_timestamp(self, tmpdir):
+        record = logging.makeLogRecord(dict(
+            created=1547704837.4,
+            msg='hello\nworld',
+        ))
+        f = IndentingFormatter(fmt="%(message)s", timestamp=True)
+        assert f.format(record) == '2019-01-16T22:00:37 hello\n2019-01-16T22:00:37 world'
+
+    def test_formatter_without_timestamp(self, tmpdir):
+        record = logging.makeLogRecord(dict(
+            created=1547704837.4,
+            msg='hello\nworld',
+        ))
+        f = IndentingFormatter(fmt="%(message)s", timestamp=False)
+        assert f.format(record) == 'hello\nworld'

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -4,6 +4,7 @@ import time
 
 from pip._internal.utils.logging import IndentingFormatter
 
+
 class Test_IndentingFormatter(object):
     """
     Test `pip._internal.utils.logging.IndentingFormatter`
@@ -13,7 +14,7 @@ class Test_IndentingFormatter(object):
         self.old_tz = getattr(os.environ, 'TZ', None)
         os.environ['TZ'] = 'UTC'
         if 'tzset' in dir(time):
-          time.tzset()
+            time.tzset()
 
     def teardown(self):
         if self.old_tz:
@@ -21,7 +22,7 @@ class Test_IndentingFormatter(object):
         else:
             del os.environ['TZ']
         if 'tzset' in dir(time):
-          time.tzset()
+            time.tzset()
 
     def test_formatter_with_timestamp(self, tmpdir):
         record = logging.makeLogRecord(dict(
@@ -29,7 +30,8 @@ class Test_IndentingFormatter(object):
             msg='hello\nworld',
         ))
         f = IndentingFormatter(fmt="%(message)s", timestamp=True)
-        assert f.format(record) == '2019-01-17T06:00:37 hello\n2019-01-17T06:00:37 world'
+        assert (f.format(record) ==
+                '2019-01-17T06:00:37 hello\n2019-01-17T06:00:37 world')
 
     def test_formatter_without_timestamp(self, tmpdir):
         record = logging.makeLogRecord(dict(

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -11,9 +11,12 @@ class Test_IndentingFormatter(object):
     """
 
     def setup(self):
+        # Robustify the tests below to the ambient timezone by setting it
+        # explicitly here.
         self.old_tz = getattr(os.environ, 'TZ', None)
         os.environ['TZ'] = 'UTC'
-        if 'tzset' in dir(time):
+        # time.tzset() is not implemented on some platforms (notably, Windows).
+        if hasattr(time, 'tzset'):
             time.tzset()
 
     def teardown(self):
@@ -24,19 +27,19 @@ class Test_IndentingFormatter(object):
         if 'tzset' in dir(time):
             time.tzset()
 
-    def test_formatter_with_timestamp(self, tmpdir):
+    def test_format_with_timestamp(self, tmpdir):
         record = logging.makeLogRecord(dict(
             created=1547704837.4,
             msg='hello\nworld',
         ))
-        f = IndentingFormatter(fmt="%(message)s", timestamp=True)
-        assert (f.format(record) ==
-                '2019-01-17T06:00:37 hello\n2019-01-17T06:00:37 world')
+        f = IndentingFormatter(fmt="%(message)s", add_timestamp=True)
+        expected = '2019-01-17T06:00:37 hello\n2019-01-17T06:00:37 world'
+        assert f.format(record) == expected
 
-    def test_formatter_without_timestamp(self, tmpdir):
+    def test_format(self, tmpdir):
         record = logging.makeLogRecord(dict(
             created=1547704837.4,
             msg='hello\nworld',
         ))
-        f = IndentingFormatter(fmt="%(message)s", timestamp=False)
+        f = IndentingFormatter(fmt="%(message)s", add_timestamp=False)
         assert f.format(record) == 'hello\nworld'

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,5 +1,5 @@
 import logging
-import re
+import os
 import time
 
 from pip._internal.utils.logging import IndentingFormatter
@@ -9,13 +9,25 @@ class Test_IndentingFormatter(object):
     Test `pip._internal.utils.logging.IndentingFormatter`
     """
 
+    def setup(self):
+        self.old_tz = getattr(os.environ, 'TZ', None)
+        os.environ['TZ'] = 'UTC'
+        time.tzset()
+
+    def teardown(self):
+        if self.old_tz:
+            os.environ['TZ'] = self.old_tz
+        else:
+            del os.environ['TZ']
+        time.tzset()
+
     def test_formatter_with_timestamp(self, tmpdir):
         record = logging.makeLogRecord(dict(
             created=1547704837.4,
             msg='hello\nworld',
         ))
         f = IndentingFormatter(fmt="%(message)s", timestamp=True)
-        assert f.format(record) == '2019-01-16T22:00:37 hello\n2019-01-16T22:00:37 world'
+        assert f.format(record) == '2019-01-17T06:00:37 hello\n2019-01-17T06:00:37 world'
 
     def test_formatter_without_timestamp(self, tmpdir):
         record = logging.makeLogRecord(dict(

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -5,9 +5,9 @@ import time
 from pip._internal.utils.logging import IndentingFormatter
 
 
-class Test_IndentingFormatter(object):
+class TestIndentingFormatter(object):
     """
-    Test `pip._internal.utils.logging.IndentingFormatter`
+    Test `pip._internal.utils.logging.IndentingFormatter`.
     """
 
     def setup(self):

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -12,14 +12,16 @@ class Test_IndentingFormatter(object):
     def setup(self):
         self.old_tz = getattr(os.environ, 'TZ', None)
         os.environ['TZ'] = 'UTC'
-        time.tzset()
+        if 'tzset' in dir(time):
+          time.tzset()
 
     def teardown(self):
         if self.old_tz:
             os.environ['TZ'] = self.old_tz
         else:
             del os.environ['TZ']
-        time.tzset()
+        if 'tzset' in dir(time):
+          time.tzset()
 
     def test_formatter_with_timestamp(self, tmpdir):
         record = logging.makeLogRecord(dict(


### PR DESCRIPTION
Why? Eases post-facto analysis of time spent in different phases of pip operation.

Historical note:
https://github.com/pypa/pip/commit/767d11e49cb916e2d4637421d524efcb8d02ae8d#diff-b670e3b192038c9ffe810c1a12c0c51fL219
made it so that pip invocations emit zero timestamp information to the log
file. Prior to that each pip invocation's start time was written out (search
that commit's diff for [strftime]).

Result: https://gist.github.com/fischman/f570886219de5c64a3b695300195c70a

Resolves https://github.com/pypa/pip/issues/6141
