### PR TITLE
Try to fix cache dir thing

### DIFF
--- a/news/6158.bugfix
+++ b/news/6158.bugfix
@@ -1,0 +1,1 @@
+Allow install to proceed even if there is no cache dir available.

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -840,13 +840,6 @@ class WheelBuilder(object):
             newly built wheel, in preparation for installation.
         :return: True if all the wheels built correctly.
         """
-        # TODO: This check fails if --no-cache-dir is set. And yet we
-        #       might be able to build into the ephemeral cache, surely?
-        building_is_possible = self._wheel_dir or (
-            autobuilding and self.wheel_cache.cache_dir
-        )
-        assert building_is_possible
-
         buildset = []
         format_control = self.finder.format_control
         for req in requirements:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -365,6 +365,21 @@ def test_vcs_url_urlquote_normalization(script, tmpdir):
     )
 
 
+def test_basic_install_from_local_directory_with_no_cache_dir(script, data):
+    """
+    Test installing with --no-cache-dir, so wheels can't be built there.
+    """
+    to_install = data.packages.join("FSPkg")
+    result = script.pip(
+        'install', to_install, '--no-cache-dir',  expect_error=False)
+    fspkg_folder = script.site_packages / 'fspkg'
+    egg_info_folder = (
+        script.site_packages / 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
+    )
+    assert fspkg_folder in result.files_created, str(result.stdout)
+    assert egg_info_folder in result.files_created, str(result)
+
+
 def test_basic_install_from_local_directory(script, data):
     """
     Test installing from a local directory.


### PR DESCRIPTION
Here's a possible fix for #6158.  It only removes the assert.  When the assert would have failed, in my manual tests, pip now uses setup.py install instead of building a wheel and then installing from the wheel.  This may not be the end state that PyPA wants?  I saw comments about using the ephemeral cache instead, but I don't think that's what it's doing now.  So anyway, if this is not what's wanted, that's fine with me and my feelings won't be hurt, but I thought I would get us started with a possible fix.