### PR TITLE
Fix is_url from splitting the scheme incorrectly when using PEP 440's direct references

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -244,8 +244,7 @@ pip supports installing from a package index using a :term:`requirement
 specifier <pypug:Requirement Specifier>`. Generally speaking, a requirement
 specifier is composed of a project name followed by optional :term:`version
 specifiers <pypug:Version Specifier>`.  :pep:`508` contains a full specification
-of the format of a requirement (pip does not support the ``url_req`` form
-of specifier at this time).
+of the format of a requirement.
 
 Some examples:
 
@@ -264,6 +263,13 @@ Since version 6.0, pip also supports specifiers containing `environment markers
 
   SomeProject ==5.4 ; python_version < '2.7'
   SomeProject; sys_platform == 'win32'
+
+Since version 19.1, pip also supports `direct references
+<https://www.python.org/dev/peps/pep-0440/#direct-references>`__ like so:
+
+ ::
+
+  SomeProject @ file:///somewhere/...
 
 Environment markers are supported in the command line and in requirements files.
 
@@ -878,6 +884,14 @@ Examples
 
       $ pip install ./downloads/SomePackage-1.0.4.tar.gz
       $ pip install http://my.package.repo/SomePackage-1.0.4.zip
+
+
+#. Install a particular source archive file following :pep:`440` direct references.
+
+    ::
+
+      $ pip install SomeProject==1.0.4@http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl
+      $ pip install "SomeProject==1.0.4 @ http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl"
 
 
 #. Install from alternative package repositories.

--- a/news/6202.bugfix
+++ b/news/6202.bugfix
@@ -1,0 +1,2 @@
+Fix requirement line parser to correctly handle PEP 440 requirements with a URL
+pointing to an archive file.

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -21,6 +21,8 @@ from pip._internal.legacy_resolve import Resolver
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req import InstallRequirement, RequirementSet
 from pip._internal.req.constructors import (
+    _get_url_from_path,
+    _looks_like_path,
     install_req_from_editable,
     install_req_from_line,
     parse_editable,
@@ -653,3 +655,95 @@ def test_mismatched_versions(caplog, tmpdir):
         'Requested simplewheel==2.0, '
         'but installing version 1.0'
     )
+
+
+@pytest.mark.parametrize('args, expected', [
+    # Test UNIX-like paths
+    (('/path/to/installable'), True),
+    # Test relative paths
+    (('./path/to/installable'), True),
+    # Test current path
+    (('.'), True),
+    # Test url paths
+    (('https://whatever.com/test-0.4-py2.py3-bogus-any.whl'), True),
+    # Test pep440 paths
+    (('test @ https://whatever.com/test-0.4-py2.py3-bogus-any.whl'), True),
+    # Test wheel
+    (('simple-0.1-py2.py3-none-any.whl'), False),
+])
+def test_looks_like_path(args, expected):
+    assert _looks_like_path(args) == expected
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("win"),
+    reason='Test only available on Windows'
+)
+@pytest.mark.parametrize('args, expected', [
+    # Test relative paths
+    (('.\\path\\to\\installable'), True),
+    (('relative\\path'), True),
+    # Test absolute paths
+    (('C:\\absolute\\path'), True),
+])
+def test_looks_like_path_win(args, expected):
+    assert _looks_like_path(args) == expected
+
+
+@pytest.mark.parametrize('args, mock_returns, expected', [
+    # Test pep440 urls
+    (('/path/to/foo @ git+http://foo.com@ref#egg=foo',
+     'foo @ git+http://foo.com@ref#egg=foo'), (False, False), None),
+    # Test pep440 urls without spaces
+    (('/path/to/foo@git+http://foo.com@ref#egg=foo',
+     'foo @ git+http://foo.com@ref#egg=foo'), (False, False), None),
+    # Test pep440 wheel
+    (('/path/to/test @ https://whatever.com/test-0.4-py2.py3-bogus-any.whl',
+     'test @ https://whatever.com/test-0.4-py2.py3-bogus-any.whl'),
+     (False, False), None),
+    # Test name is not a file
+    (('/path/to/simple==0.1',
+     'simple==0.1'),
+     (False, False), None),
+])
+@patch('pip._internal.req.req_install.os.path.isdir')
+@patch('pip._internal.req.req_install.os.path.isfile')
+def test_get_url_from_path(
+    isdir_mock, isfile_mock, args, mock_returns, expected
+):
+    isdir_mock.return_value = mock_returns[0]
+    isfile_mock.return_value = mock_returns[1]
+    assert _get_url_from_path(*args) is expected
+
+
+@patch('pip._internal.req.req_install.os.path.isdir')
+@patch('pip._internal.req.req_install.os.path.isfile')
+def test_get_url_from_path__archive_file(isdir_mock, isfile_mock):
+    isdir_mock.return_value = False
+    isfile_mock.return_value = True
+    name = 'simple-0.1-py2.py3-none-any.whl'
+    path = os.path.join('/path/to/' + name)
+    url = path_to_url(path)
+    assert _get_url_from_path(path, name) == url
+
+
+@patch('pip._internal.req.req_install.os.path.isdir')
+@patch('pip._internal.req.req_install.os.path.isfile')
+def test_get_url_from_path__installable_dir(isdir_mock, isfile_mock):
+    isdir_mock.return_value = True
+    isfile_mock.return_value = True
+    name = 'some/setuptools/project'
+    path = os.path.join('/path/to/' + name)
+    url = path_to_url(path)
+    assert _get_url_from_path(path, name) == url
+
+
+@patch('pip._internal.req.req_install.os.path.isdir')
+def test_get_url_from_path__installable_error(isdir_mock):
+    isdir_mock.return_value = True
+    name = 'some/setuptools/project'
+    path = os.path.join('/path/to/' + name)
+    with pytest.raises(InstallationError) as e:
+        _get_url_from_path(path, name)
+    err_msg = e.value.args[0]
+    assert "Neither 'setup.py' nor 'pyproject.toml' found" in err_msg

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -335,6 +335,33 @@ class TestInstallRequirement(object):
         req = install_req_from_line(url + fragment)
         assert req.link.url == url + fragment, req.link
 
+    def test_pep440_wheel_link_requirement(self):
+        url = 'https://whatever.com/test-0.4-py2.py3-bogus-any.whl'
+        line = 'test @ https://whatever.com/test-0.4-py2.py3-bogus-any.whl'
+        req = install_req_from_line(line)
+        parts = str(req.req).split('@', 1)
+        assert len(parts) == 2
+        assert parts[0].strip() == 'test'
+        assert parts[1].strip() == url
+
+    def test_pep440_url_link_requirement(self):
+        url = 'git+http://foo.com@ref#egg=foo'
+        line = 'foo @ git+http://foo.com@ref#egg=foo'
+        req = install_req_from_line(line)
+        parts = str(req.req).split('@', 1)
+        assert len(parts) == 2
+        assert parts[0].strip() == 'foo'
+        assert parts[1].strip() == url
+
+    def test_url_with_authentication_link_requirement(self):
+        url = 'https://what@whatever.com/test-0.4-py2.py3-bogus-any.whl'
+        line = 'https://what@whatever.com/test-0.4-py2.py3-bogus-any.whl'
+        req = install_req_from_line(line)
+        assert req.link is not None
+        assert req.link.is_wheel
+        assert req.link.scheme == "https"
+        assert req.link.url == url
+
     def test_unsupported_wheel_link_requirement_raises(self):
         reqset = RequirementSet()
         req = install_req_from_line(

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -225,6 +225,13 @@ class TestProcessLine(object):
         req = install_req_from_line(line, comes_from=comes_from)
         assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
 
+    def test_yield_pep440_line_requirement(self):
+        line = 'SomeProject @ https://url/SomeProject-py2-py3-none-any.whl'
+        filename = 'filename'
+        comes_from = '-r %s (line %s)' % (filename, 1)
+        req = install_req_from_line(line, comes_from=comes_from)
+        assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
+
     def test_yield_line_constraint(self):
         line = 'SomeProject'
         filename = 'filename'


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Hello, 

This PR fixes #6202 and includes tests for this issue. 
When installing a .whl from a remote URL following this example,
`pip @ https:///somewhere/pip-1.3.1-py33-none-any.whl`

 `is_url` was splitting the scheme incorrectly and it wouldn't recognize the line as a URL. Pip would try (and fail) to reference a local .whl file instead. 