### PR TITLE
Provide better error message for editable installs attempted with pyproject.toml

### DIFF
--- a/news/6170.feature
+++ b/news/6170.feature
@@ -1,0 +1,2 @@
+Provide a better error message if attempting an editable install of a
+directory with a ``pyproject.toml`` but no ``setup.py``.

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import io
 import os
+import sys
 
 from pip._vendor import pytoml, six
 
@@ -18,6 +19,17 @@ def _is_list_of_str(obj):
         isinstance(obj, list) and
         all(isinstance(item, six.string_types) for item in obj)
     )
+
+
+def make_pyproject_path(setup_py_dir):
+    # type: (str) -> str
+    path = os.path.join(setup_py_dir, 'pyproject.toml')
+
+    # Python2 __file__ should not be unicode
+    if six.PY2 and isinstance(path, six.text_type):
+        path = path.encode(sys.getfilesystemencoding())
+
+    return path
 
 
 def load_pyproject_toml(

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -22,7 +22,7 @@ from pip._internal.locations import (
     PIP_DELETE_MARKER_FILENAME, running_under_virtualenv,
 )
 from pip._internal.models.link import Link
-from pip._internal.pyproject import load_pyproject_toml
+from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
 from pip._internal.req.req_uninstall import UninstallPathSet
 from pip._internal.utils.compat import native_str
 from pip._internal.utils.hashes import Hashes
@@ -471,13 +471,7 @@ class InstallRequirement(object):
         # type: () -> str
         assert self.source_dir, "No source dir for %s" % self
 
-        pp_toml = os.path.join(self.setup_py_dir, 'pyproject.toml')
-
-        # Python2 __file__ should not be unicode
-        if six.PY2 and isinstance(pp_toml, six.text_type):
-            pp_toml = pp_toml.encode(sys.getfilesystemencoding())
-
-        return pp_toml
+        return make_pyproject_path(self.setup_py_dir)
 
     def load_pyproject_toml(self):
         # type: () -> None

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -491,13 +491,41 @@ def test_install_from_local_directory_with_no_setup_py(script, data):
     assert "Neither 'setup.py' nor 'pyproject.toml' found." in result.stderr
 
 
-def test_editable_install_from_local_directory_with_no_setup_py(script, data):
+def test_editable_install__local_dir_no_setup_py(
+        script, data, deprecated_python):
     """
-    Test installing from a local directory with no 'setup.py'.
+    Test installing in editable mode from a local directory with no setup.py.
     """
     result = script.pip('install', '-e', data.root, expect_error=True)
     assert not result.files_created
-    assert "is not installable. File 'setup.py' not found." in result.stderr
+
+    msg = result.stderr
+    if deprecated_python:
+        assert 'File "setup.py" not found. ' in msg
+    else:
+        assert msg.startswith('File "setup.py" not found. ')
+    assert 'pyproject.toml' not in msg
+
+
+def test_editable_install__local_dir_no_setup_py_with_pyproject(
+        script, deprecated_python):
+    """
+    Test installing in editable mode from a local directory with no setup.py
+    but that does have pyproject.toml.
+    """
+    local_dir = script.scratch_path.join('temp').mkdir()
+    pyproject_path = local_dir.join('pyproject.toml')
+    pyproject_path.write('')
+
+    result = script.pip('install', '-e', local_dir, expect_error=True)
+    assert not result.files_created
+
+    msg = result.stderr
+    if deprecated_python:
+        assert 'File "setup.py" not found. ' in msg
+    else:
+        assert msg.startswith('File "setup.py" not found. ')
+    assert 'A "pyproject.toml" file was found' in msg
 
 
 @pytest.mark.skipif("sys.version_info >= (3,4)")


### PR DESCRIPTION
This addresses #6170.

The error message looks like this:

```
File "setup.py" not found. Directory cannot be installed in editable mode: <absolute-dir-path>
(A "pyproject.toml" file was found, but editable mode currently requires a setup.py based build.)
```
