### PR TITLE
Only show Python 2.7 EOL date on CPython.

### DIFF
--- a/news/6207.bugfix
+++ b/news/6207.bugfix
@@ -1,0 +1,2 @@
+The Python 2 end of life warning now only shows on CPython, which is the
+implementation that has announced end of life plans.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -5,6 +5,7 @@ import logging
 import logging.config
 import optparse
 import os
+import platform
 import sys
 import traceback
 
@@ -145,14 +146,16 @@ class Command(object):
                 gone_in='19.2',
             )
         elif sys.version_info[:2] == (2, 7):
-            deprecated(
-                "Python 2.7 will reach the end of its life on January 1st, "
-                "2020. Please upgrade your Python as Python 2.7 won't be "
-                "maintained after that date. A future version of pip will "
-                "drop support for Python 2.7.",
-                replacement=None,
-                gone_in=None,
+            message = (
+                "A future version of pip will drop support for Python 2.7."
             )
+            if platform.python_implementation() == "CPython":
+                message = (
+                    "Python 2.7 will reach the end of its life on January "
+                    "1st, 2020. Please upgrade your Python as Python 2.7 "
+                    "won't be maintained after that date. "
+                ) + message
+            deprecated(message, replacement=None, gone_in=None)
 
         # TODO: Try to get these passing down from the command?
         #       without resorting to os.environ to hold these.


### PR DESCRIPTION
Other Python implementations, notably PyPy, are not EOL'ing on January
1, 2020.

I've left the core of the warning intact, and have just found https://discuss.python.org/t/packaging-and-python-2/662/73 about pip's own plans (obviously my hope would be that pip does continue to support py2, but will follow that along).

Closes: #6207