### PR TITLE
Issue #6163: Postpone using PEP 517 by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ nosetests.xml
 coverage.xml
 *.cover
 tests/data/common_wheels/
+pip-wheel-metadata
 
 # Misc
 *~

--- a/news/6163.bugfix
+++ b/news/6163.bugfix
@@ -1,4 +1,4 @@
 Pending compatibility improvements for setup.py files that expect their
 directory to be on sys.path, revert to using the legacy direct `setup.py`
-invocation approach to install packages that don't have a `build-system`
-section in their `pyproject.toml` file.
+invocation approach to install packages that don't have
+`build-system.build-backend` explicitly set in their `pyproject.toml` file.

--- a/news/6163.bugfix
+++ b/news/6163.bugfix
@@ -1,3 +1,4 @@
 Pending compatibility improvements for setup.py files that expect their
-directory to be on sys.path, revert to installing packages that don't
-specify a build backend with the legacy `setup.py` path.
+directory to be on sys.path, revert to using the legacy direct `setup.py`
+invocation approach to install packages that don't have a `build-system`
+section in their `pyproject.toml` file.

--- a/news/6163.bugfix
+++ b/news/6163.bugfix
@@ -1,0 +1,3 @@
+Pending compatibility improvements for setup.py files that expect their
+directory to be on sys.path, revert to installing packages that don't
+specify a build backend with the legacy `setup.py` path.

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -97,9 +97,10 @@ def load_pyproject_toml(
     # we do so if the project has a pyproject.toml file.
     elif use_pep517 is None:
         # use_pep517 = has_pyproject
-        # Issue #6163 workaround: override this logic for now, and use
-        # the legacy setup.py code path even if pyproject.toml exists
-        use_pep517 = False
+        # Issue #6163 workaround: override this logic for now, and also use
+        # the legacy setup.py code path for pyproject.toml files that don't
+        # have a build-system section
+        use_pep517 = bool(build_system)
         # End issue #6163 workaround
 
     # At this point, we know whether we're going to use PEP 517.

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -96,7 +96,11 @@ def load_pyproject_toml(
     # and the user hasn't explicitly stated a preference,
     # we do so if the project has a pyproject.toml file.
     elif use_pep517 is None:
-        use_pep517 = has_pyproject
+        # use_pep517 = has_pyproject
+        # Issue #6163 workaround: override this logic for now, and use
+        # the legacy setup.py code path even if pyproject.toml exists
+        use_pep517 = False
+        # End issue #6163 workaround
 
     # At this point, we know whether we're going to use PEP 517.
     assert use_pep517 is not None
@@ -113,6 +117,7 @@ def load_pyproject_toml(
         # In the absence of any explicit backend specification, we
         # assume the setuptools backend, and require wheel and a version
         # of setuptools that supports that backend.
+
         build_system = {
             "requires": ["setuptools>=40.2.0", "wheel"],
             "build-backend": "setuptools.build_meta",
@@ -154,7 +159,7 @@ def load_pyproject_toml(
         # If the user didn't specify a backend, we assume they want to use
         # the setuptools backend. But we can't be sure they have included
         # a version of setuptools which supplies the backend, or wheel
-        # (which is neede by the backend) in their requirements. So we
+        # (which is needed by the backend) in their requirements. So we
         # make a note to check that those requirements are present once
         # we have set up the environment.
         # This is quite a lot of work to check for a very specific case. But

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -98,9 +98,9 @@ def load_pyproject_toml(
     elif use_pep517 is None:
         # use_pep517 = has_pyproject
         # Issue #6163 workaround: override this logic for now, and also use
-        # the legacy setup.py code path for pyproject.toml files that don't
-        # have a build-system section
-        use_pep517 = build_system is not None
+        # the legacy setup.py non-isolated build code path for all
+        # pyproject.toml files that don't have build-system.build-backend set
+        use_pep517 = False
         # End issue #6163 workaround
 
     # At this point, we know whether we're going to use PEP 517.

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -100,7 +100,7 @@ def load_pyproject_toml(
         # Issue #6163 workaround: override this logic for now, and also use
         # the legacy setup.py code path for pyproject.toml files that don't
         # have a build-system section
-        use_pep517 = bool(build_system)
+        use_pep517 = build_system is not None
         # End issue #6163 workaround
 
     # At this point, we know whether we're going to use PEP 517.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -86,6 +86,8 @@ def test_pep518_refuses_invalid_build_system(script, data, common_wheels):
     assert "does not comply with PEP 518" in result.stderr
 
 
+# Issue #6163 workaround means this next case doesn't actually use PEP 518
+@pytest.mark.xfail(strict=True)
 def test_pep518_allows_missing_requires(script, data, common_wheels):
     result = script.pip(
         'install', '-f', common_wheels,

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -66,6 +66,8 @@ def test_pep518_refuses_conflicting_requires(script, data):
     ), str(result)
 
 
+# Issue #6163 workaround means this next case doesn't use isolated builds
+@pytest.mark.xfail(strict=True)
 def test_pep518_refuses_invalid_requires(script, data, common_wheels):
     result = script.pip(
         'install', '-f', common_wheels,
@@ -76,6 +78,8 @@ def test_pep518_refuses_invalid_requires(script, data, common_wheels):
     assert "does not comply with PEP 518" in result.stderr
 
 
+# Issue #6163 workaround means this next case doesn't use isolated builds
+@pytest.mark.xfail(strict=True)
 def test_pep518_refuses_invalid_build_system(script, data, common_wheels):
     result = script.pip(
         'install', '-f', common_wheels,
@@ -86,7 +90,7 @@ def test_pep518_refuses_invalid_build_system(script, data, common_wheels):
     assert "does not comply with PEP 518" in result.stderr
 
 
-# Issue #6163 workaround means this next case doesn't actually use PEP 518
+# Issue #6163 workaround means this next case doesn't use isolated builds
 @pytest.mark.xfail(strict=True)
 def test_pep518_allows_missing_requires(script, data, common_wheels):
     result = script.pip(

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -130,17 +130,17 @@ def make_pyproject_with_setup(tmpdir, build_system=True, set_backend=True):
     setup_script = (
         'from setuptools import setup\n'
     )
-    expect_script_dir_on_path = True
     if build_system:
         buildsys = {
             'requires': ['setuptools', 'wheel'],
         }
         if set_backend:
             buildsys['build-backend'] = 'setuptools.build_meta'
-            expect_script_dir_on_path = False
         project_data = pytoml.dumps({'build-system': buildsys})
+        expect_script_dir_on_path = False
     else:
         project_data = ''
+        expect_script_dir_on_path = True
 
     if expect_script_dir_on_path:
         setup_script += (

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -123,3 +123,78 @@ def test_pep517_install_with_no_cache_dir(script, tmpdir, data):
         project_dir,
     )
     result.assert_installed('project', editable=False)
+
+
+def make_pyproject_with_setup(tmpdir, build_system=True, set_backend=True):
+    project_dir = (tmpdir / 'project').mkdir()
+    setup_script = (
+        'from setuptools import setup\n'
+    )
+    expect_script_dir_on_path = True
+    if build_system:
+        buildsys = {
+            'requires': ['setuptools', 'wheel'],
+        }
+        if set_backend:
+            buildsys['build-backend'] = 'setuptools.build_meta'
+            expect_script_dir_on_path = False
+        project_data = pytoml.dumps({'build-system': buildsys})
+    else:
+        project_data = ''
+
+    if expect_script_dir_on_path:
+        setup_script += (
+            'from pep517_test import __version__\n'
+        )
+    else:
+        setup_script += (
+            'try:\n'
+            '    import pep517_test\n'
+            'except ImportError:\n'
+            '    pass\n'
+            'else:\n'
+            '    raise RuntimeError("Source dir incorrectly on sys.path")\n'
+        )
+
+    setup_script += (
+        'setup(name="pep517_test", version="0.1", packages=["pep517_test"])'
+    )
+
+    project_dir.join('pyproject.toml').write(project_data)
+    project_dir.join('setup.py').write(setup_script)
+    package_dir = (project_dir / "pep517_test").mkdir()
+    package_dir.join('__init__.py').write('__version__ = "0.1"')
+    return project_dir, "pep517_test"
+
+
+def test_no_build_system_section(script, tmpdir, data, common_wheels):
+    """Check builds with setup.py, pyproject.toml, but no build-system section.
+    """
+    project_dir, name = make_pyproject_with_setup(tmpdir, build_system=False)
+    result = script.pip(
+        'install', '--no-cache-dir', '--no-index', '-f', common_wheels,
+        project_dir,
+    )
+    result.assert_installed(name, editable=False)
+
+
+def test_no_build_backend_entry(script, tmpdir, data, common_wheels):
+    """Check builds with setup.py, pyproject.toml, but no build-backend-entry.
+    """
+    project_dir, name = make_pyproject_with_setup(tmpdir, set_backend=False)
+    result = script.pip(
+        'install', '--no-cache-dir', '--no-index', '-f', common_wheels,
+        project_dir,
+    )
+    result.assert_installed(name, editable=False)
+
+
+def test_explicit_setuptools_backend(script, tmpdir, data, common_wheels):
+    """Check builds with setup.py, pyproject.toml, and a build-system entry.
+    """
+    project_dir, name = make_pyproject_with_setup(tmpdir)
+    result = script.pip(
+        'install', '--no-cache-dir', '--no-index', '-f', common_wheels,
+        project_dir,
+    )
+    result.assert_installed(name, editable=False)

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -130,17 +130,17 @@ def make_pyproject_with_setup(tmpdir, build_system=True, set_backend=True):
     setup_script = (
         'from setuptools import setup\n'
     )
+    expect_script_dir_on_path = True
     if build_system:
         buildsys = {
             'requires': ['setuptools', 'wheel'],
         }
         if set_backend:
             buildsys['build-backend'] = 'setuptools.build_meta'
+            expect_script_dir_on_path = False
         project_data = pytoml.dumps({'build-system': buildsys})
-        expect_script_dir_on_path = False
     else:
         project_data = ''
-        expect_script_dir_on_path = True
 
     if expect_script_dir_on_path:
         setup_script += (


### PR DESCRIPTION
* Temporarily changes the mode selection logic to
  only implicitly use PEP 517 if the pyproject.toml
  build-system table is present

* Adds sys.path test cases for 3 pyproject.toml scenarios:
  - no build-system section
  - build-system section without build-backend
  - build-system section with build-backend
