### PR TITLE
Fix error formatting

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -359,7 +359,7 @@ class InstallCommand(RequirementCommand):
                     # so we fail here.
                     if build_failures:
                         raise InstallationError(
-                            "Could not build wheels for {} which use" +
+                            "Could not build wheels for {} which use"
                             " PEP 517 and cannot be installed directly".format(
                                 ", ".join(r.name for r in build_failures)))
 


### PR DESCRIPTION
Minor bug fix. `+` has a lower precedence than the `.format`, so the formatting doesn't actually insert anything. Implicit string concatenation has higher (highest?) precedence.

```
Python 2.7.15 (default, Jan 21 2019, 10:44:40) 
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> "hello {}" + "!".format("world")
'hello {}!'
>>> ("hello {}" "!".format("world"))
'hello world!'

Python 3.7.2 (default, Jan 21 2019, 10:39:41) 
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> "hello {}" + "!".format("world")
'hello {}!'
>>> ("hello {}" "!".format("world"))
'hello world!'
```

(from the PR template...) Not worthy of a NEWS mention, imho...