### PR TITLE
Always merge extras from existing and incoming requirements

### DIFF
--- a/news/6239.bugfix
+++ b/news/6239.bugfix
@@ -1,0 +1,2 @@
+Always try to merge extras from same-named requirements to prevent ``package``
+from shadowing ``package[extra]``.

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -149,9 +149,7 @@ class RequirementSet(object):
         # If the existing requirement is NOT a constraint, we're done.
         # Otherwise the incoming one needs to be checked against it.
         if not existing_req.constraint:
-            if new_extras != cur_extras:
-                return [existing_req], existing_req
-            return [], existing_req
+            return [existing_req], existing_req
 
         does_not_satisfy_constraint = (
             install_req.link and

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -316,6 +316,21 @@ class TestRequirementSet(object):
             lineno=2
         ))
 
+    def test_add_requirement_extend_extra(self):
+        """Make sure adding a requirement with extra merges it with
+        an existing one with the same name (if exists).
+
+        See pypa/pip#6239.
+        """
+        reqset = RequirementSet()
+        reqset.add_requirement(get_processed_req_from_line(
+            'boxsdk', lineno=1,
+        ))
+        reqset.add_requirement(get_processed_req_from_line(
+            'boxsdk[jwt]', lineno=2,
+        ))
+        assert set(reqset.get_requirement('boxsdk').extras) == {'jwt'}
+
 
 @pytest.mark.parametrize(('file_contents', 'expected'), [
     (b'\xf6\x80', b'\xc3\xb6\xe2\x82\xac'),  # cp1252

--- a/tests/yaml/install/extras.yml
+++ b/tests/yaml/install/extras.yml
@@ -39,4 +39,3 @@ cases:
       - D 1.0.0
       - E 1.0.0
       - F 1.0.0
-  skip: true


### PR DESCRIPTION
Fix #6239. I added a unit test based on the issue to reflect the situation, so this can be caught if we fail to implement this in the new resolver.