### PR TITLE
Mark 3 tests as network tests

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -542,6 +542,7 @@ def test_install_argparse_shadowed(script):
     assert "Not uninstalling argparse" in result.stdout
 
 
+@pytest.mark.network
 @pytest.mark.skipif("sys.version_info < (3,4)")
 def test_upgrade_argparse_shadowed(script):
     # If argparse is installed - even if shadowed for imported - we support

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -297,6 +297,7 @@ def test_constraints_local_editable_install_causes_error(script, data):
     assert 'Could not satisfy constraints for' in result.stderr
 
 
+@pytest.mark.network
 def test_constraints_local_editable_install_pep518(script, data):
     to_install = data.src.join("pep518-3.0")
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -219,6 +219,7 @@ def test_pip_wheel_with_user_set_in_config(script, data, common_wheels):
     assert "Successfully built withpyproject" in result.stdout, result.stdout
 
 
+@pytest.mark.network
 def test_pep517_wheels_are_not_confused_with_other_files(script, tmpdir, data):
     """Check correct wheels are copied. (#6196)
     """


### PR DESCRIPTION
    ________________ test_constraints_local_editable_install_pep518 ________________
    ...
    ----------------------------- Captured stdout call -----------------------------
    Script result: python -m pip download setuptools wheel -d /tmp/pytest-of-mockbuild/pytest-0/test_constraints_local_editabl0/data/packages
      return code: 1
    -- stderr: --------------------
      Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fba7fdeb160>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
      Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fba7fdeb0b8>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
      Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fba7fdeb4e0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
      Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fba7fdeb6d8>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
      Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fba7fdeb860>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
      Could not find a version that satisfies the requirement setuptools (from versions: )
    No matching distribution found for setuptools

    _____________ test_pep517_wheels_are_not_confused_with_other_files _____________
    ...
    -- stdout: --------------------
    Processing /tmp/pytest-of-mockbuild/pytest-0/test_pep517_wheels_are_not_con0/data/src/withpyproject
      Installing build dependencies: started
      Installing build dependencies: finished with status 'error'
      Complete output from command /tmp/pytest-of-mockbuild/pytest-0/test_pep517_wheels_are_not_con0/workspace/venv/bin/python /builddir/build/BUILDROOT/python-pip-19.0.2-1.fc30.x86_64/usr/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pytest-of-mockbuild/pytest-0/test_pep517_wheels_are_not_con0/workspace/tmp/pip-build-env-3un7dqu3/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools wheel:
      Collecting setuptools
        Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fb7cf5a8898>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
        Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fb7cf5b9588>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
        Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fb7cf5b9470>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
        Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fb7cf5b9278>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
        Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7fb7cf5b9208>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/setuptools/
        Could not find a version that satisfies the requirement setuptools (from versions: )
      No matching distribution found for setuptools

    ________________________ test_upgrade_argparse_shadowed ________________________
    ...
    ----------------------------- Captured stdout call -----------------------------
    Script result: python -m pip install argparse==1.3
      return code: 1
    -- stderr: --------------------
      Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7ff07d6db240>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/argparse/
      Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7ff07d6db358>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/argparse/
      Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7ff07d6db400>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/argparse/
      Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7ff07d6db518>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/argparse/
      Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.VerifiedHTTPSConnection object at 0x7ff07d6c7710>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/argparse/
      Could not find a version that satisfies the requirement argparse==1.3 (from versions: )
    No matching distribution found for argparse==1.3

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
