### PR TITLE
Clarify behavior of `--no-cache-dir` with respect to bdist_wheel

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -576,7 +576,8 @@ no_cache = partial(
     dest="cache_dir",
     action="callback",
     callback=no_cache_dir_callback,
-    help="Disable the cache.",
+    help='Disable the cache. Warning: also disables the wheel '
+         'build step (see pip issue #5749).',
 )  # type: Callable[..., Option]
 
 no_deps = partial(


### PR DESCRIPTION
Adds warning about the issue in #5749 (full wheel build is not run when `--no-cache-dir` is specified, leading to potentially broken install).

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
