### PR TITLE
Use link.is_artifact property instead of scheme checking

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -19,7 +19,6 @@ from pip._internal.utils.hashes import MissingHashes
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import display_path, normalize_path
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
     from typing import Any, Optional
@@ -349,7 +348,7 @@ class RequirementPreparer(object):
                 abstract_dist.prep_for_dist(finder, self.build_isolation)
             if self._download_should_save:
                 # Make a .zip of the source_dir we already created.
-                if req.link.scheme in vcs.all_schemes:
+                if not req.link.is_artifact:
                     req.archive(self.download_dir)
         return abstract_dist
 


### PR DESCRIPTION
Just a trivial clean up.