### PR TITLE
Redact URL to hide password

### DIFF
--- a/news/6295.bugfix
+++ b/news/6295.bugfix
@@ -1,1 +1,1 @@
-Redacts the URL of the extra index when `pip -v` to hide the user's password
+Redact the password from the extra index URL when using ``pip -v``.

--- a/news/6295.bugfix
+++ b/news/6295.bugfix
@@ -1,0 +1,1 @@
+Redacts the URL of the extra index when `pip -v` to hide the user's password

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -74,6 +74,17 @@ SECURE_ORIGINS = [
 logger = logging.getLogger(__name__)
 
 
+def _redacted_url(url):
+    """Redact the URL to remove the basic auth password
+    """
+    parsed = urllib_parse.urlparse(url)
+
+    replaced = parsed._replace(netloc="{}:{}@{}".format(parsed.username, "<pwd>", parsed.hostname))
+    replaced_url = replaced.geturl()
+
+    return replaced_url
+
+
 def _match_vcs_scheme(url):
     # type: (str) -> Optional[str]
     """Look for VCS schemes in the URL.
@@ -155,7 +166,7 @@ def _get_html_response(url, session):
     if _is_url_like_archive(url):
         _ensure_html_response(url, session=session)
 
-    logger.debug('Getting page %s', url)
+    logger.debug('Getting page %s', _redacted_url(url))
 
     resp = session.get(
         url,

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -74,17 +74,6 @@ SECURE_ORIGINS = [
 logger = logging.getLogger(__name__)
 
 
-def _redacted_url(url):
-    """Redact the URL to remove the basic auth password
-    """
-    parsed = urllib_parse.urlparse(url)
-
-    replaced = parsed._replace(netloc="{}:{}@{}".format(parsed.username, "<pwd>", parsed.hostname))
-    replaced_url = replaced.geturl()
-
-    return replaced_url
-
-
 def _match_vcs_scheme(url):
     # type: (str) -> Optional[str]
     """Look for VCS schemes in the URL.
@@ -166,7 +155,7 @@ def _get_html_response(url, session):
     if _is_url_like_archive(url):
         _ensure_html_response(url, session=session)
 
-    logger.debug('Getting page %s', _redacted_url(url))
+    logger.debug('Getting page %s', redact_password_from_url(url))
 
     resp = session.get(
         url,

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -40,27 +40,6 @@ def test_command_line_options_override_env_vars(script, virtualenv):
     assert "Getting page https://download.zope.org/ppix" in result.stdout
 
 
-def test_no_password_in_debug_message(script, virtualenv):
-    """
-    Test that password in the URL is not logged
-    """
-    password = "my_password"
-
-    result = script.pip(
-        'install',
-        '-vvv',
-        '--index-url', 'https://user:{}@example.com/simple/'.format(password)
-        'INITools',
-        expect_error=True
-    )
-
-    assert password not in result.stdout
-    assert (
-        "Getting page https://user:***@example.com/simple/initools"
-        in result.stdout
-    )
-
-
 @pytest.mark.network
 def test_env_vars_override_config_file(script, virtualenv):
     """

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -40,6 +40,19 @@ def test_command_line_options_override_env_vars(script, virtualenv):
     assert "Getting page https://download.zope.org/ppix" in result.stdout
 
 
+def test_no_password_in_debug_message(script, virtualenv):
+    """
+    Test that password in the URL is not logged
+    """
+    script.environ['PIP_INDEX_URL'] = 'https://user:my_password@example.com/simple/'
+    result = script.pip('install', '-vvv', 'INITools', expect_error=True)
+    assert (
+        "Getting page https://user:<pwd>@example.com/simple/initools"
+        in result.stdout
+    )
+    virtualenv.clear()
+
+
 @pytest.mark.network
 def test_env_vars_override_config_file(script, virtualenv):
     """

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -46,10 +46,13 @@ def test_no_password_in_debug_message(script, virtualenv):
     """
     password = "my_password"
 
-    script.environ['PIP_INDEX_URL'] = (
-        'https://user:{}@example.com/simple/'.format(password)
+    result = script.pip(
+        'install',
+        '-vvv',
+        '--index-url', 'https://user:{}@example.com/simple/'.format(password)
+        'INITools',
+        expect_error=True
     )
-    result = script.pip('install', '-vvv', 'INITools', expect_error=True)
 
     assert password not in result.stdout
     assert (

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -44,13 +44,18 @@ def test_no_password_in_debug_message(script, virtualenv):
     """
     Test that password in the URL is not logged
     """
-    script.environ['PIP_INDEX_URL'] = 'https://user:my_password@example.com/simple/'
+    password = "my_password"
+
+    script.environ['PIP_INDEX_URL'] = (
+        'https://user:{}@example.com/simple/'.format(password)
+    )
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
+
+    assert password not in result.stdout
     assert (
-        "Getting page https://user:<pwd>@example.com/simple/initools"
+        "Getting page https://user:***@example.com/simple/initools"
         in result.stdout
     )
-    virtualenv.clear()
 
 
 @pytest.mark.network

--- a/tests/unit/test_index_html_page.py
+++ b/tests/unit/test_index_html_page.py
@@ -120,8 +120,8 @@ def test_get_html_response_no_head(url):
 
 def test_get_html_response_dont_log_clear_text_password(caplog):
     """
-    `_get_html_response()` shouldn't log the full index's URL includoing the
-    user's password in clear text on DEBUG channel but only the redacted URL
+    `_get_html_response()` should redact the password from the index URL
+    in its DEBUG log message.
     """
     session = mock.Mock(PipSession)
 

--- a/tests/unit/test_index_html_page.py
+++ b/tests/unit/test_index_html_page.py
@@ -118,8 +118,7 @@ def test_get_html_response_no_head(url):
     ]
 
 
-@mock.patch("pip._internal.index.logger")
-def test_get_html_response_dont_log_clear_text_password(m_logger):
+def test_get_html_response_dont_log_clear_text_password(caplog):
     """
     `_get_html_response()` shouldn't send a HEAD request if the URL does not
     look like an archive, only the GET request that retrieves data.
@@ -133,11 +132,17 @@ def test_get_html_response_dont_log_clear_text_password(m_logger):
         "get.return_value": "text/html",
     }))
 
+    caplog.set_level(logging.DEBUG)
+
     resp = _get_html_response(url_template.format(password), session=session)
 
     assert resp is not None
-    assert m_logger.debug.mock_calls == [
-        mock.call("Getting page %s", url_template.format("****"))
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == 'DEBUG'
+    assert record.message.splitlines() == [
+        "Getting page {}".format(url_template.format("****")),
     ]
 
 

--- a/tests/unit/test_index_html_page.py
+++ b/tests/unit/test_index_html_page.py
@@ -118,6 +118,29 @@ def test_get_html_response_no_head(url):
     ]
 
 
+@mock.patch("pip._internal.index.logger")
+def test_get_html_response_dont_log_clear_text_password(m_logger):
+    """
+    `_get_html_response()` shouldn't send a HEAD request if the URL does not
+    look like an archive, only the GET request that retrieves data.
+    """
+    password = "my_password"
+    url_template = "https://user:{}@example.com/simple/"
+    session = mock.Mock(PipSession)
+
+    # Mock the headers dict to ensure it is accessed.
+    session.get.return_value = mock.Mock(headers=mock.Mock(**{
+        "get.return_value": "text/html",
+    }))
+
+    resp = _get_html_response(url_template.format(password), session=session)
+
+    assert resp is not None
+    assert m_logger.debug.mock_calls == [
+        mock.call("Getting page %s", url_template.format("****"))
+    ]
+
+
 @pytest.mark.parametrize(
     "url, vcs_scheme",
     [

--- a/tests/unit/test_index_html_page.py
+++ b/tests/unit/test_index_html_page.py
@@ -120,11 +120,9 @@ def test_get_html_response_no_head(url):
 
 def test_get_html_response_dont_log_clear_text_password(caplog):
     """
-    `_get_html_response()` shouldn't send a HEAD request if the URL does not
-    look like an archive, only the GET request that retrieves data.
+    `_get_html_response()` shouldn't log the full index's URL includoing the
+    user's password in clear text on DEBUG channel but only the redacted URL
     """
-    password = "my_password"
-    url_template = "https://user:{}@example.com/simple/"
     session = mock.Mock(PipSession)
 
     # Mock the headers dict to ensure it is accessed.
@@ -134,7 +132,9 @@ def test_get_html_response_dont_log_clear_text_password(caplog):
 
     caplog.set_level(logging.DEBUG)
 
-    resp = _get_html_response(url_template.format(password), session=session)
+    resp = _get_html_response(
+        "https://user:my_password@example.com/simple/", session=session
+    )
 
     assert resp is not None
 
@@ -142,7 +142,7 @@ def test_get_html_response_dont_log_clear_text_password(caplog):
     record = caplog.records[0]
     assert record.levelname == 'DEBUG'
     assert record.message.splitlines() == [
-        "Getting page {}".format(url_template.format("****")),
+        "Getting page https://user:****@example.com/simple/",
     ]
 
 


### PR DESCRIPTION
When the verbose flag is used in `pip install` and in `~/.pip/pip.conf` you setup the access to you private registry with basic auth, i.e. `extra-index-url = https://username:pwd!@pypi.example.com/simple/`, when using `pip install -v` the password is printed in clear to stdout.

This PR redact the URL to hide original password.