### PR TITLE
Fix pip download VCS scp-like URLs

### DIFF
--- a/news/6296.bugfix
+++ b/news/6296.bugfix
@@ -1,0 +1,1 @@
+Fix ``pip download`` scp-like VCS URLs. For example, ``pip download git+git@github.com:pypa/pip``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [isort]
 skip =
     .tox,
+    .venv,
     .scratch,
     _vendor,
     data
@@ -16,6 +17,7 @@ include_trailing_comma = true
 [flake8]
 exclude =
     .tox,
+    .venv,
     .scratch,
     _vendor,
     data

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -49,7 +49,7 @@ from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Optional, Tuple, Dict, IO, Text, Union, Type
+        Optional, Tuple, Dict, IO, Text, Union
     )
     from pip._internal.models.link import Link
     from pip._internal.utils.hashes import Hashes
@@ -513,15 +513,16 @@ def unpack_vcs_link(link, location):
 
 
 def _get_used_vcs_backend(url):
-    # type: (str) -> Optional[Type[VersionControl]]
+    # type: (Text) -> Optional[VersionControl]
     for backend in vcs.backends:
         if backend.is_valid_url(url):
             vcs_backend = backend(url)
             return vcs_backend
+    return None
 
 
 def is_vcs_url(url):
-    # type: (str) -> bool
+    # type: (Text) -> bool
     return bool(vcs.get_backend_by_url(url))
 
 

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -156,8 +156,4 @@ class Link(KeyBasedCompareMixin):
         it points to an "abstract" thing like a path or a VCS location.
         """
         from pip._internal.vcs import vcs
-
-        if self.scheme in vcs.all_schemes:
-            return False
-
-        return True
+        return not bool(vcs.get_backend_by_url(self.url))

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -19,7 +19,6 @@ from pip._internal.utils.hashes import MissingHashes
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import display_path, normalize_path
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
     from typing import Any, Optional
@@ -288,7 +287,7 @@ class RequirementPreparer(object):
                 # we would report less-useful error messages for
                 # unhashable requirements, complaining that there's no
                 # hash provided.
-                if is_vcs_url(link):
+                if is_vcs_url(link.url):
                     raise VcsHashUnsupported()
                 elif is_file_url(link) and is_dir_url(link):
                     raise DirectoryUrlHashUnsupported()
@@ -349,7 +348,7 @@ class RequirementPreparer(object):
                 abstract_dist.prep_for_dist(finder, self.build_isolation)
             if self._download_should_save:
                 # Make a .zip of the source_dir we already created.
-                if req.link.scheme in vcs.all_schemes:
+                if not req.link.is_artifact:
                     req.archive(self.download_dir)
         return abstract_dist
 

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -173,7 +173,7 @@ class VcsSupport(object):
         return None
 
     def get_backend_by_url(self, url):
-        # type: (str) -> Optional[Type[VersionControl]]
+        # type: (Text) -> Optional[Type[VersionControl]]
         """
         Return the backend class of the version control if found by given
         URL, e.g. vcs.get_backend_by_url('git+https://github.com/pypa/pip.git')
@@ -547,7 +547,7 @@ class VersionControl(object):
 
     @classmethod
     def is_valid_url(cls, url):
-        # type: (str) -> bool
+        # type: (Text) -> bool
         """
         Return whether an URL has a supported scheme for this Version Control.
         """

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -172,6 +172,18 @@ class VcsSupport(object):
             return self._registry[name]
         return None
 
+    def get_backend_by_url(self, url):
+        # type: (str) -> Optional[Type[VersionControl]]
+        """
+        Return the backend class of the version control if found by given
+        URL, e.g. vcs.get_backend_by_url('git+https://github.com/pypa/pip.git')
+        """
+
+        for backend in self.backends:
+            if backend.is_valid_url(url):
+                return backend
+        return None
+
 
 vcs = VcsSupport()
 
@@ -532,3 +544,14 @@ class VersionControl(object):
         the Git override checks that Git is actually available.
         """
         return cls.is_repository_directory(location)
+
+    @classmethod
+    def is_valid_url(cls, url):
+        # type: (str) -> bool
+        """
+        Return whether an URL has a supported scheme for this Version Control.
+        """
+        scheme = urllib_parse.urlsplit(url)[0]
+        if scheme in cls.schemes:
+            return True
+        return False

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -14,7 +14,11 @@ from pip._internal.utils.misc import (
     display_path, make_vcs_requirement_url, redact_password_from_url,
 )
 from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs import RemoteNotFoundError, VersionControl, vcs
+
+if MYPY_CHECK_RUNNING:
+    from typing import Text
 
 urlsplit = urllib_parse.urlsplit
 urlunsplit = urllib_parse.urlunsplit
@@ -367,6 +371,7 @@ class Git(VersionControl):
 
     @classmethod
     def is_valid_url(cls, url):
+        # type: (Text) -> bool
         """
         Return whether an URL has a supported scheme for this Version Control.
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -365,5 +365,19 @@ class Git(VersionControl):
                          "because git is not available", location)
             return False
 
+    @classmethod
+    def is_valid_url(cls, url):
+        """
+        Return whether an URL has a supported scheme for this Version Control.
+
+        This overrided method handles scp-like URLs,
+        e.g. 'user@hostname:user/repo.git'.
+        """
+
+        scheme, _, path, _, _ = urlsplit(url)
+        if not scheme and path.startswith('git+'):
+            return True
+        return super(Git, cls).is_valid_url(url)
+
 
 vcs.register(Git)

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -166,6 +166,22 @@ def test_download_vcs_link(script):
     assert script.site_packages / 'piptestpackage' not in result.files_created
 
 
+@pytest.mark.network
+def test_download_vcs_scp_like_url(script):
+    """
+    It should download a vcs scp-like URL, for example:
+    git+user@hostname:user/repo.git. Test for the issue #6293.
+    """
+    result = script.pip(
+        'download', '-d', '.', 'git+git@github.com:pypa/pip-test-package.git'
+    )
+    assert (
+        Path('scratch') / 'pip-test-package-0.1.1.zip'
+        in result.files_created
+    )
+    assert script.site_packages / 'piptestpackage' not in result.files_created
+
+
 def test_only_binary_set_then_download_specific_platform(script, data):
     """
     Confirm that specifying an interpreter/platform constraint


### PR DESCRIPTION
For example: git+user@hostname:user/repo.git
Fixes #6293.