### PR TITLE
Remove extra `.` in docs

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -247,7 +247,7 @@ Some examples:
 
   SomeProject
   SomeProject == 1.3
-  SomeProject >=1.2,<.2.0
+  SomeProject >=1.2,<2.0
   SomeProject[foo, bar]
   SomeProject~=1.4.2
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
