### PR TITLE
Fix utils.encoding.auto_decode() LookupError  with invalid encodings

### DIFF
--- a/news/6054.bugfix
+++ b/news/6054.bugfix
@@ -1,0 +1,4 @@
+Fix ``utils.encoding.auto_decode()`` ``LookupError`` with invalid encodings.
+``utils.encoding.auto_decode()`` was broken when decoding Big Endian BOM
+byte-strings on Little Endian or vice versa.
+

--- a/src/pip/_internal/utils/encoding.py
+++ b/src/pip/_internal/utils/encoding.py
@@ -9,13 +9,13 @@ if MYPY_CHECK_RUNNING:
     from typing import List, Tuple, Text
 
 BOMS = [
-    (codecs.BOM_UTF8, 'utf8'),
-    (codecs.BOM_UTF16, 'utf16'),
-    (codecs.BOM_UTF16_BE, 'utf16-be'),
-    (codecs.BOM_UTF16_LE, 'utf16-le'),
-    (codecs.BOM_UTF32, 'utf32'),
-    (codecs.BOM_UTF32_BE, 'utf32-be'),
-    (codecs.BOM_UTF32_LE, 'utf32-le'),
+    (codecs.BOM_UTF8, 'utf-8'),
+    (codecs.BOM_UTF16, 'utf-16'),
+    (codecs.BOM_UTF16_BE, 'utf-16-be'),
+    (codecs.BOM_UTF16_LE, 'utf-16-le'),
+    (codecs.BOM_UTF32, 'utf-32'),
+    (codecs.BOM_UTF32_BE, 'utf-32-be'),
+    (codecs.BOM_UTF32_LE, 'utf-32-le'),
 ]  # type: List[Tuple[bytes, Text]]
 
 ENCODING_RE = re.compile(br'coding[:=]\s*([-\w.]+)')


### PR DESCRIPTION
`utils.encoding.auto_decode()` was broken when decoding Big Endian BOM byte-strings on Little Endian or vice versa.

The `TestEncoding.test_auto_decode_utf16_le` test was failing on Big Endian systems, such as Fedora's s390x builders. A similar test, but with BE BOM `test_auto_decode_utf16_be` was added in order to reproduce this on a Little Endian system (which is much easier to come by).

A regression test was added to check that all listed encodings in `utils.encoding.BOMS` are valid.

Fixes https://github.com/pypa/pip/issues/6054