### PR TITLE
Test call_subprocess more thoroughly; fix spinner edge cases

### DIFF
--- a/news/6312.bugfix
+++ b/news/6312.bugfix
@@ -1,0 +1,3 @@
+The spinner no longer displays a completion message after subprocess calls
+not needing a spinner. It also no longer incorrectly reports an error after
+certain subprocess calls to Git that succeeded.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -925,7 +925,7 @@ class TestCallSubprocess(object):
         # output is already being written to the console.
         self.check_result(
             capfd, caplog, log_level, spinner, result, expected,
-            expected_spinner=(0, 'done'),
+            expected_spinner=(0, None),
         )
 
     @pytest.mark.parametrize((
@@ -936,13 +936,13 @@ class TestCallSubprocess(object):
             # Test some cases that should result in show_spinner false.
             (0, False, None, logging.DEBUG, (None, 'done', 0)),
             # Test show_stdout=True.
-            (0, True, None, logging.DEBUG, (None, 'done', 0)),
-            (0, True, None, logging.INFO, (None, 'done', 0)),
-            (0, True, None, logging.WARNING, (None, 'done', 0)),
+            (0, True, None, logging.DEBUG, (None, None, 0)),
+            (0, True, None, logging.INFO, (None, None, 0)),
+            (0, True, None, logging.WARNING, (None, None, 0)),
             # Test a non-zero exit status.
             (3, False, None, logging.INFO, (InstallationError, 'error', 2)),
             # Test a non-zero exit status also in extra_ok_returncodes.
-            (3, False, (3, ), logging.INFO, (None, 'error', 2)),
+            (3, False, (3, ), logging.INFO, (None, 'done', 2)),
     ])
     def test_spinner_finish(
         self, exit_status, show_stdout, extra_ok_returncodes, log_level,


### PR DESCRIPTION
The main purpose of this PR is to test `call_subprocess()` more thoroughly for a subsequent PR.

However, in the process I noticed a couple edge cases with the spinner that this PR fixes. They are--

1. The spinner says `error` if the return code was non-zero but was one of the passed `extra_ok_returncodes` (and so should be acceptable). The spinner should instead say `done`.

2. The spinner reports a final `done` / `error` finishing message even if the spinner wasn't actually used (e.g. in the case that `show_stdout` was true).

Both of these fixes can be seen in the changes in the test expectation in the second commit of this PR.
