### PR TITLE
Under wine there is an environment variable with an empty string for …

### DIFF
--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -141,6 +141,9 @@ def call_subprocess(
         extra_ok_returncodes = []
     if unset_environ is None:
         unset_environ = []
+    if "" not in unset_environ:
+        # Empty string is illegal in Windows, in Wine this may be set in the host.
+        unset_environ.append("")
     # Most places in pip use show_stdout=False. What this means is--
     #
     # - We connect the child's output (combined stderr and stdout) to a


### PR DESCRIPTION
Under wine there is an environment variable with an empty string for a name, this causes pip to fail, if 'nt' is the OS then ignore this variable.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
