### PR TITLE
Use a temp dir for pip-wheel-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ nosetests.xml
 coverage.xml
 *.cover
 tests/data/common_wheels/
-pip-wheel-metadata
 
 # Misc
 *~

--- a/news/6213.bugfix
+++ b/news/6213.bugfix
@@ -1,0 +1,1 @@
+The ``pip-wheel-metadata`` directory does not need to persist between invocations of pip, use a temporary directory instead of the current ``setup.py`` directory.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -562,6 +562,7 @@ class InstallRequirement(object):
         # type: () -> None
         assert self.pep517_backend is not None
 
+        # NOTE: This needs to be refactored to stop using atexit
         self._temp_dir = TempDirectory(delete=False, kind="req-install")
         self._temp_dir.create()
         metadata_dir = os.path.join(

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -556,23 +556,24 @@ class InstallRequirement(object):
         # type: () -> None
         assert self.pep517_backend is not None
 
-        metadata_dir = os.path.join(
-            self.setup_py_dir,
-            'pip-wheel-metadata'
-        )
-        ensure_dir(metadata_dir)
-
-        with self.build_env:
-            # Note that Pep517HookCaller implements a fallback for
-            # prepare_metadata_for_build_wheel, so we don't have to
-            # consider the possibility that this hook doesn't exist.
-            backend = self.pep517_backend
-            self.spin_message = "Preparing wheel metadata"
-            distinfo_dir = backend.prepare_metadata_for_build_wheel(
-                metadata_dir
+        with TempDirectory(delete=False) as temp_dir:
+            metadata_dir = os.path.join(
+                temp_dir.path,
+                'pip-wheel-metadata',
             )
+            ensure_dir(metadata_dir)
 
-        self.metadata_directory = os.path.join(metadata_dir, distinfo_dir)
+            with self.build_env:
+                # Note that Pep517HookCaller implements a fallback for
+                # prepare_metadata_for_build_wheel, so we don't have to
+                # consider the possibility that this hook doesn't exist.
+                backend = self.pep517_backend
+                self.spin_message = "Preparing wheel metadata"
+                distinfo_dir = backend.prepare_metadata_for_build_wheel(
+                    metadata_dir
+                )
+
+            self.metadata_directory = os.path.join(metadata_dir, distinfo_dir)
 
     def run_egg_info(self):
         # type: () -> None


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fixes https://github.com/pypa/pip/issues/6213.

The `pip-wheel-metadata` directory does not need to persist between invocations of pip, use a temporary directory instead of the current `setup.py` directory.

This wraps the code dealing with `pip-wheel-metadata` in `with TempDirectory(delete=False) as temp_dir:` and replaces `self.setup_py_dir` with `temp_dir`.

Tests fail because they're configured to not allow temp files after the tests end (`AssertionError: temp files not expected`). I'm not sure best how to fix this, suggestions welcome!
