### PR TITLE
Fix #5889: AttributeError: 'NoneType' object has no attribute 'netloc'

### DIFF
--- a/news/5889.bugfix
+++ b/news/5889.bugfix
@@ -1,6 +1,2 @@
-Pip would like to ensure that requirements from pypi do not install dependencies from URLs.
-
-The check for "domains_not_allowed" in the "comes_from" requirement caused an exception if there was no comes from URL,
-or a default comes_from=None was set.  This bug has been removed.
-
-This appears to resolve Issue 5889.
+Fixed crash when installing a requirement from url that comes from a
+dependency without a URL.

--- a/news/5889.bugfix
+++ b/news/5889.bugfix
@@ -1,0 +1,6 @@
+Pip would like to ensure that requirements from pypi do not install dependencies from URLs.
+
+The check for "domains_not_allowed" in the "comes_from" requirement caused an exception if there was no comes from URL,
+or a default comes_from=None was set.  This bug has been removed.
+
+This appears to resolve Issue 5889.

--- a/news/5889.bugfix
+++ b/news/5889.bugfix
@@ -1,2 +1,1 @@
-Fixed crash when installing a requirement from url that comes from a
-dependency without a URL.
+Fixed crash when installing a requirement from url that comes from a dependency without a URL.

--- a/news/5889.bugfix
+++ b/news/5889.bugfix
@@ -1,1 +1,1 @@
-Fixed crash when installing a requirement from url that comes from a dependency without a URL.
+Fixed crash when installing a requirement from a URL that comes from a dependency without a URL.

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -325,7 +325,7 @@ def install_req_from_req_string(
         PyPI.file_storage_domain,
         TestPyPI.file_storage_domain,
     ]
-    if req.url and comes_from.link and comes_from.link.netloc in domains_not_allowed:
+    if req.url and comes_from and comes_from.link and comes_from.link.netloc in domains_not_allowed:
         # Explicitly disallow pypi packages that depend on external urls
         raise InstallationError(
             "Packages installed from PyPI cannot depend on packages "

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -325,8 +325,8 @@ def install_req_from_req_string(
         PyPI.file_storage_domain,
         TestPyPI.file_storage_domain,
     ]
-    if req.url and comes_from and comes_from.link and \
-            comes_from.link.netloc in domains_not_allowed:
+    if (req.url and comes_from and comes_from.link and
+            comes_from.link.netloc in domains_not_allowed):
         # Explicitly disallow pypi packages that depend on external urls
         raise InstallationError(
             "Packages installed from PyPI cannot depend on packages "

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -325,7 +325,8 @@ def install_req_from_req_string(
         PyPI.file_storage_domain,
         TestPyPI.file_storage_domain,
     ]
-    if req.url and comes_from and comes_from.link and comes_from.link.netloc in domains_not_allowed:
+    if req.url and comes_from and comes_from.link and \
+            comes_from.link.netloc in domains_not_allowed:
         # Explicitly disallow pypi packages that depend on external urls
         raise InstallationError(
             "Packages installed from PyPI cannot depend on packages "

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -325,7 +325,7 @@ def install_req_from_req_string(
         PyPI.file_storage_domain,
         TestPyPI.file_storage_domain,
     ]
-    if req.url and comes_from.link.netloc in domains_not_allowed:
+    if req.url and comes_from.link and comes_from.link.netloc in domains_not_allowed:
         # Explicitly disallow pypi packages that depend on external urls
         raise InstallationError(
             "Packages installed from PyPI cannot depend on packages "

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -2,12 +2,12 @@ import os
 import tempfile
 
 import pytest
+from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.req.constructors import (
-    install_req_from_line, install_req_from_req_string
+    install_req_from_line, install_req_from_req_string,
 )
 from pip._internal.req.req_install import InstallRequirement
-from pip._vendor.packaging.requirements import Requirement
 
 
 class TestInstallRequirementBuildDirectory(object):

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -54,10 +54,9 @@ class TestInstallRequirementFrom(object):
         Test to make sure that install_req_from_string succeeds
         when called with URL (PEP 508) but without comes_from.
         """
-
         # Test with a PEP 508 url install string:
-        wheel_url = "https://download.pytorch.org/whl/cu90/" \
-                    "torch-1.0.0-cp36-cp36m-win_amd64.whl"
+        wheel_url = ("https://download.pytorch.org/whl/cu90/" +
+                    "torch-1.0.0-cp36-cp36m-win_amd64.whl")
         install_str = "torch@ " + wheel_url
         install_req = install_req_from_req_string(install_str)
 
@@ -73,10 +72,9 @@ class TestInstallRequirementFrom(object):
         when called with URL (PEP 508) and comes_from
         does not have a link.
         """
-
         # Test with a PEP 508 url install string:
-        wheel_url = "https://download.pytorch.org/whl/cu90/" \
-                    "torch-1.0.0-cp36-cp36m-win_amd64.whl"
+        wheel_url = ("https://download.pytorch.org/whl/cu90/" +
+                    "torch-1.0.0-cp36-cp36m-win_amd64.whl")
         install_str = "torch@ " + wheel_url
 
         # Dummy numpy "comes_from" requirement without link:

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -3,8 +3,9 @@ import tempfile
 
 import pytest
 
-from pip._internal.req.constructors import install_req_from_line, \
-    install_req_from_req_string
+from pip._internal.req.constructors import (
+    install_req_from_line, install_req_from_req_string
+)
 from pip._internal.req.req_install import InstallRequirement
 from pip._vendor.packaging.requirements import Requirement
 

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -80,5 +80,4 @@ class TestInstallRequirementBuildDirectory(object):
         assert install_req.comes_from.link is None
         assert install_req.link.url == wheel_url
         assert install_req.req.url == wheel_url
-        assert install_req.comes_from is None
         assert install_req.is_wheel

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -55,8 +55,8 @@ class TestInstallRequirementFrom(object):
         when called with URL (PEP 508) but without comes_from.
         """
         # Test with a PEP 508 url install string:
-        wheel_url = ("https://download.pytorch.org/whl/cu90/" +
-                    "torch-1.0.0-cp36-cp36m-win_amd64.whl")
+        wheel_url = ("https://download.pytorch.org/whl/cu90/"
+                     "torch-1.0.0-cp36-cp36m-win_amd64.whl")
         install_str = "torch@ " + wheel_url
         install_req = install_req_from_req_string(install_str)
 
@@ -73,8 +73,8 @@ class TestInstallRequirementFrom(object):
         does not have a link.
         """
         # Test with a PEP 508 url install string:
-        wheel_url = ("https://download.pytorch.org/whl/cu90/" +
-                    "torch-1.0.0-cp36-cp36m-win_amd64.whl")
+        wheel_url = ("https://download.pytorch.org/whl/cu90/sds"
+                     "torch-1.0.0-cp36-cp36m-win_amd64.whl")
         install_str = "torch@ " + wheel_url
 
         # Dummy numpy "comes_from" requirement without link:

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -73,7 +73,7 @@ class TestInstallRequirementFrom(object):
         does not have a link.
         """
         # Test with a PEP 508 url install string:
-        wheel_url = ("https://download.pytorch.org/whl/cu90/sds"
+        wheel_url = ("https://download.pytorch.org/whl/cu90/"
                      "torch-1.0.0-cp36-cp36m-win_amd64.whl")
         install_str = "torch@ " + wheel_url
 

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -3,7 +3,8 @@ import tempfile
 
 import pytest
 
-from pip._internal.req.constructors import install_req_from_line, install_req_from_req_string, install_req_from_editable
+from pip._internal.req.constructors import install_req_from_line, \
+    install_req_from_req_string
 from pip._internal.req.req_install import InstallRequirement
 from pip._vendor.packaging.requirements import Requirement
 
@@ -46,12 +47,14 @@ class TestInstallRequirementBuildDirectory(object):
 
     def test_install_req_from_string_without_comes_from(self):
         """
-        Test to make sure that install_req_from_string succeeds when called with URL (PEP 508) but without comes_from.
+        Test to make sure that install_req_from_string succeeds
+        when called with URL (PEP 508) but without comes_from.
         """
 
         # Test with a PEP 508 url install string:
-        wheel_url = "https://download.pytorch.org/whl/cu90/torch-1.0.0-cp36-cp36m-win_amd64.whl"
-        install_str = "torch@ "+wheel_url
+        wheel_url = "https://download.pytorch.org/whl/cu90/" \
+                    "torch-1.0.0-cp36-cp36m-win_amd64.whl"
+        install_str = "torch@ " + wheel_url
         install_req = install_req_from_req_string(install_str)
 
         assert isinstance(install_req, InstallRequirement)
@@ -62,19 +65,25 @@ class TestInstallRequirementBuildDirectory(object):
 
     def test_install_req_from_string_with_comes_from_without_link(self):
         """
-        Test to make sure that install_req_from_string succeeds when called with URL (PEP 508) and comes_from
+        Test to make sure that install_req_from_string succeeds
+        when called with URL (PEP 508) and comes_from
         does not have a link.
         """
 
         # Test with a PEP 508 url install string:
-        wheel_url = "https://download.pytorch.org/whl/cu90/torch-1.0.0-cp36-cp36m-win_amd64.whl"
-        install_str = "torch@ "+wheel_url
+        wheel_url = "https://download.pytorch.org/whl/cu90/" \
+                    "torch-1.0.0-cp36-cp36m-win_amd64.whl"
+        install_str = "torch@ " + wheel_url
 
         # Dummy numpy "comes_from" requirement without link:
-        comes_from = InstallRequirement(Requirement("numpy>=1.15.0"), comes_from=None)
+        comes_from = InstallRequirement(
+            Requirement("numpy>=1.15.0"), comes_from=None
+        )
 
         # Attempt install from install string comes:
-        install_req = install_req_from_req_string(install_str, comes_from=comes_from)
+        install_req = install_req_from_req_string(
+            install_str, comes_from=comes_from
+        )
 
         assert isinstance(install_req, InstallRequirement)
         assert install_req.comes_from.link is None

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -3,8 +3,9 @@ import tempfile
 
 import pytest
 
-from pip._internal.req.constructors import install_req_from_line
+from pip._internal.req.constructors import install_req_from_line, install_req_from_req_string, install_req_from_editable
 from pip._internal.req.req_install import InstallRequirement
+from pip._vendor.packaging.requirements import Requirement
 
 
 class TestInstallRequirementBuildDirectory(object):
@@ -42,3 +43,42 @@ class TestInstallRequirementBuildDirectory(object):
         )
 
         assert requirement.link is not None
+
+    def test_install_req_from_string_without_comes_from(self):
+        """
+        Test to make sure that install_req_from_string succeeds when called with URL (PEP 508) but without comes_from.
+        """
+
+        # Test with a PEP 508 url install string:
+        wheel_url = "https://download.pytorch.org/whl/cu90/torch-1.0.0-cp36-cp36m-win_amd64.whl"
+        install_str = "torch@ "+wheel_url
+        install_req = install_req_from_req_string(install_str)
+
+        assert isinstance(install_req, InstallRequirement)
+        assert install_req.link.url == wheel_url
+        assert install_req.req.url == wheel_url
+        assert install_req.comes_from is None
+        assert install_req.is_wheel
+
+    def test_install_req_from_string_with_comes_from_without_link(self):
+        """
+        Test to make sure that install_req_from_string succeeds when called with URL (PEP 508) and comes_from
+        does not have a link.
+        """
+
+        # Test with a PEP 508 url install string:
+        wheel_url = "https://download.pytorch.org/whl/cu90/torch-1.0.0-cp36-cp36m-win_amd64.whl"
+        install_str = "torch@ "+wheel_url
+
+        # Dummy numpy "comes_from" requirement without link:
+        comes_from = InstallRequirement(Requirement("numpy>=1.15.0"), comes_from=None)
+
+        # Attempt install from install string comes:
+        install_req = install_req_from_req_string(install_str, comes_from=comes_from)
+
+        assert isinstance(install_req, InstallRequirement)
+        assert install_req.comes_from.link is None
+        assert install_req.link.url == wheel_url
+        assert install_req.req.url == wheel_url
+        assert install_req.comes_from is None
+        assert install_req.is_wheel

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -46,6 +46,9 @@ class TestInstallRequirementBuildDirectory(object):
 
         assert requirement.link is not None
 
+
+class TestInstallRequirementFrom(object):
+
     def test_install_req_from_string_without_comes_from(self):
         """
         Test to make sure that install_req_from_string succeeds


### PR DESCRIPTION
Hello, 

If accepted, this trivial change solves the issue I started to describe March 14 2019 in [issue 5889](https://github.com/pypa/pip/issues/5889).  To be self contained, I elaborate everything below:

- pip: 19.0.3
- OS: Windows 10 (using git bash)
- python: 3.6

I am installing a private package called `deep-nlp-embedding` (`pip install -e .`) that depends on another private package called `deep-nlp-core` that was previously installed with `pip install -e .`  

The package `deep-nlp-core` has install_requires:
```
install_requires = [
    "gensim>=3.4.0",
    "torch@ https://download.pytorch.org/whl/cu90/torch-1.0.0-cp36-cp36m-win_amd64.whl"
]
```

The package `deep-nlp-embeddings` has install_requires:
```
install_requires = [
    "deep-nlp-core"
]
```
**Finally** installing deep-nlp-embedding breaks pip:
```
$ pip install -e deep-nlp-embedding/
Obtaining file:///E:/Repos/flamingo-nlp/deep-nlp-embedding
Requirement already satisfied: deep-nlp-core in e:\repos\flamingo-nlp\deep-nlp-core (from deep-nlp-embedding==0.0.2) (0.0.2)
Exception:
Traceback (most recent call last):
  File "C:\Anaconda\envs\flamingo_nlp\lib\site-packages\pip\_internal\cli\base_command.py", line 179, in main
    status = self.run(options, args)
  File "C:\Anaconda\envs\flamingo_nlp\lib\site-packages\pip\_internal\commands\install.py", line 315, in run
    resolver.resolve(requirement_set)
  File "C:\Anaconda\envs\flamingo_nlp\lib\site-packages\pip\_internal\resolve.py", line 131, in resolve
    self._resolve_one(requirement_set, req)
  File "C:\Anaconda\envs\flamingo_nlp\lib\site-packages\pip\_internal\resolve.py", line 357, in _resolve_one
    add_req(subreq, extras_requested=available_requested)
  File "C:\Anaconda\envs\flamingo_nlp\lib\site-packages\pip\_internal\resolve.py", line 314, in add_req
    use_pep517=self.use_pep517
  File "C:\Anaconda\envs\flamingo_nlp\lib\site-packages\pip\_internal\req\constructors.py", line 328, in install_req_from_req_string
    if req.url and comes_from.link.netloc in domains_not_allowed:
AttributeError: 'NoneType' object has no attribute 'netloc'
```

Because this change is trivial, I assume it doesn't require a `NEWS.rst` entry.