### PR TITLE
Make more VersionControl methods class methods

### DIFF
--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -337,7 +337,8 @@ class VersionControl(object):
         url = urllib_parse.urlunsplit((scheme, netloc, path, query, ''))
         return url, rev, user_pass
 
-    def make_rev_args(self, username, password):
+    @classmethod
+    def make_rev_args(cls, username, password):
         """
         Return the RevOptions "extra arguments" to use in obtain().
         """

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -293,7 +293,8 @@ class VersionControl(object):
         """
         raise NotImplementedError
 
-    def get_netloc_and_auth(self, netloc, scheme):
+    @classmethod
+    def get_netloc_and_auth(cls, netloc, scheme):
         """
         Parse the repository URL's netloc, and return the new netloc to use
         along with auth information.

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -261,8 +261,8 @@ class VersionControl(object):
         self.url = url
         super(VersionControl, self).__init__(*args, **kwargs)
 
-    @classmethod
-    def get_base_rev_args(cls, rev):
+    @staticmethod
+    def get_base_rev_args(rev):
         """
         Return the base revision arguments for a vcs command.
 
@@ -344,8 +344,8 @@ class VersionControl(object):
         url = urllib_parse.urlunsplit((scheme, netloc, path, query, ''))
         return url, rev, user_pass
 
-    @classmethod
-    def make_rev_args(cls, username, password):
+    @staticmethod
+    def make_rev_args(username, password):
         """
         Return the RevOptions "extra arguments" to use in obtain().
         """

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -59,11 +59,16 @@ class RevOptions(object):
     Instances of this class should be treated as if immutable.
     """
 
-    def __init__(self, vcs, rev=None, extra_args=None):
-        # type: (VersionControl, Optional[str], Optional[List[str]]) -> None
+    def __init__(
+        self,
+        vc_class,  # type: Type[VersionControl]
+        rev=None,  # type: Optional[str]
+        extra_args=None,  # type: Optional[List[str]]
+    ):
+        # type: (...) -> None
         """
         Args:
-          vcs: a VersionControl object.
+          vc_class: a VersionControl subclass.
           rev: the name of the revision to install.
           extra_args: a list of extra options.
         """
@@ -72,16 +77,16 @@ class RevOptions(object):
 
         self.extra_args = extra_args
         self.rev = rev
-        self.vcs = vcs
+        self.vc_class = vc_class
 
     def __repr__(self):
-        return '<RevOptions {}: rev={!r}>'.format(self.vcs.name, self.rev)
+        return '<RevOptions {}: rev={!r}>'.format(self.vc_class.name, self.rev)
 
     @property
     def arg_rev(self):
         # type: () -> Optional[str]
         if self.rev is None:
-            return self.vcs.default_arg_rev
+            return self.vc_class.default_arg_rev
 
         return self.rev
 
@@ -93,7 +98,7 @@ class RevOptions(object):
         args = []  # type: List[str]
         rev = self.arg_rev
         if rev is not None:
-            args += self.vcs.get_base_rev_args(rev)
+            args += self.vc_class.get_base_rev_args(rev)
         args += self.extra_args
 
         return args
@@ -113,7 +118,7 @@ class RevOptions(object):
         Args:
           rev: the name of the revision for the new object.
         """
-        return self.vcs.make_rev_options(rev, extra_args=self.extra_args)
+        return self.vc_class.make_rev_options(rev, extra_args=self.extra_args)
 
 
 class VcsSupport(object):
@@ -266,7 +271,8 @@ class VersionControl(object):
         """
         raise NotImplementedError
 
-    def make_rev_options(self, rev=None, extra_args=None):
+    @classmethod
+    def make_rev_options(cls, rev=None, extra_args=None):
         # type: (Optional[str], Optional[List[str]]) -> RevOptions
         """
         Return a RevOptions object.
@@ -275,7 +281,7 @@ class VersionControl(object):
           rev: the name of a revision to install.
           extra_args: a list of extra options.
         """
-        return RevOptions(self, rev, extra_args=extra_args)
+        return RevOptions(cls, rev, extra_args=extra_args)
 
     @classmethod
     def _is_local_repository(cls, repo):

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -312,7 +312,8 @@ class VersionControl(object):
         """
         return netloc, (None, None)
 
-    def get_url_rev_and_auth(self, url):
+    @classmethod
+    def get_url_rev_and_auth(cls, url):
         # type: (str) -> Tuple[str, Optional[str], AuthInfo]
         """
         Parse the repository URL to use, and return the URL, revision,
@@ -329,7 +330,7 @@ class VersionControl(object):
             )
         # Remove the vcs prefix.
         scheme = scheme.split('+', 1)[1]
-        netloc, user_pass = self.get_netloc_and_auth(netloc, scheme)
+        netloc, user_pass = cls.get_netloc_and_auth(netloc, scheme)
         rev = None
         if '@' in path:
             path, rev = path.rsplit('@', 1)

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -256,7 +256,8 @@ class VersionControl(object):
         self.url = url
         super(VersionControl, self).__init__(*args, **kwargs)
 
-    def get_base_rev_args(self, rev):
+    @classmethod
+    def get_base_rev_args(cls, rev):
         """
         Return the base revision arguments for a vcs command.
 

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -28,7 +28,8 @@ class Bazaar(VersionControl):
         if getattr(urllib_parse, 'uses_fragment', None):
             urllib_parse.uses_fragment.extend(['lp'])
 
-    def get_base_rev_args(self, rev):
+    @classmethod
+    def get_base_rev_args(cls, rev):
         return ['-r', rev]
 
     def export(self, location):

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -28,8 +28,8 @@ class Bazaar(VersionControl):
         if getattr(urllib_parse, 'uses_fragment', None):
             urllib_parse.uses_fragment.extend(['lp'])
 
-    @classmethod
-    def get_base_rev_args(cls, rev):
+    @staticmethod
+    def get_base_rev_args(rev):
         return ['-r', rev]
 
     def export(self, location):

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -63,9 +63,10 @@ class Bazaar(VersionControl):
         cmd_args = ['pull', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 
-    def get_url_rev_and_auth(self, url):
+    @classmethod
+    def get_url_rev_and_auth(cls, url):
         # hotfix the URL scheme after removing bzr+ from bzr+ssh:// readd it
-        url, rev, user_pass = super(Bazaar, self).get_url_rev_and_auth(url)
+        url, rev, user_pass = super(Bazaar, cls).get_url_rev_and_auth(url)
         if url.startswith('ssh://'):
             url = 'bzr+' + url
         return url, rev, user_pass

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -310,7 +310,8 @@ class Git(VersionControl):
             return None
         return os.path.relpath(location, root_dir)
 
-    def get_url_rev_and_auth(self, url):
+    @classmethod
+    def get_url_rev_and_auth(cls, url):
         """
         Prefixes stub URLs like 'user@hostname:user/repo.git' with 'ssh://'.
         That's required because although they use SSH they sometimes don't
@@ -320,10 +321,10 @@ class Git(VersionControl):
         if '://' not in url:
             assert 'file:' not in url
             url = url.replace('git+', 'git+ssh://')
-            url, rev, user_pass = super(Git, self).get_url_rev_and_auth(url)
+            url, rev, user_pass = super(Git, cls).get_url_rev_and_auth(url)
             url = url.replace('ssh://', '')
         else:
-            url, rev, user_pass = super(Git, self).get_url_rev_and_auth(url)
+            url, rev, user_pass = super(Git, cls).get_url_rev_and_auth(url)
 
         return url, rev, user_pass
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -61,7 +61,8 @@ class Git(VersionControl):
 
         super(Git, self).__init__(url, *args, **kwargs)
 
-    def get_base_rev_args(self, rev):
+    @classmethod
+    def get_base_rev_args(cls, rev):
         return [rev]
 
     def get_git_version(self):

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -61,8 +61,8 @@ class Git(VersionControl):
 
         super(Git, self).__init__(url, *args, **kwargs)
 
-    @classmethod
-    def get_base_rev_args(cls, rev):
+    @staticmethod
+    def get_base_rev_args(rev):
         return [rev]
 
     def get_git_version(self):

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -19,8 +19,8 @@ class Mercurial(VersionControl):
     repo_name = 'clone'
     schemes = ('hg', 'hg+http', 'hg+https', 'hg+ssh', 'hg+static-http')
 
-    @classmethod
-    def get_base_rev_args(cls, rev):
+    @staticmethod
+    def get_base_rev_args(rev):
         return [rev]
 
     def export(self, location):

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -19,7 +19,8 @@ class Mercurial(VersionControl):
     repo_name = 'clone'
     schemes = ('hg', 'hg+http', 'hg+https', 'hg+ssh', 'hg+static-http')
 
-    def get_base_rev_args(self, rev):
+    @classmethod
+    def get_base_rev_args(cls, rev):
         return [rev]
 
     def export(self, location):

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -29,7 +29,8 @@ class Subversion(VersionControl):
     def should_add_vcs_url_prefix(cls, remote_url):
         return True
 
-    def get_base_rev_args(self, rev):
+    @classmethod
+    def get_base_rev_args(cls, rev):
         return ['-r', rev]
 
     def export(self, location):

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -92,7 +92,8 @@ class Subversion(VersionControl):
             revision = max(revision, localrev)
         return revision
 
-    def get_netloc_and_auth(self, netloc, scheme):
+    @classmethod
+    def get_netloc_and_auth(cls, netloc, scheme):
         """
         This override allows the auth information to be passed to svn via the
         --username and --password options instead of via the URL.
@@ -100,8 +101,7 @@ class Subversion(VersionControl):
         if scheme == 'ssh':
             # The --username and --password options can't be used for
             # svn+ssh URLs, so keep the auth information in the URL.
-            return super(Subversion, self).get_netloc_and_auth(
-                netloc, scheme)
+            return super(Subversion, cls).get_netloc_and_auth(netloc, scheme)
 
         return split_auth_from_netloc(netloc)
 

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -113,7 +113,8 @@ class Subversion(VersionControl):
             url = 'svn+' + url
         return url, rev, user_pass
 
-    def make_rev_args(self, username, password):
+    @classmethod
+    def make_rev_args(cls, username, password):
         extra_args = []
         if username:
             extra_args += ['--username', username]

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -105,9 +105,10 @@ class Subversion(VersionControl):
 
         return split_auth_from_netloc(netloc)
 
-    def get_url_rev_and_auth(self, url):
+    @classmethod
+    def get_url_rev_and_auth(cls, url):
         # hotfix the URL scheme after removing svn+ from svn+ssh:// readd it
-        url, rev, user_pass = super(Subversion, self).get_url_rev_and_auth(url)
+        url, rev, user_pass = super(Subversion, cls).get_url_rev_and_auth(url)
         if url.startswith('ssh://'):
             url = 'svn+' + url
         return url, rev, user_pass

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -29,8 +29,8 @@ class Subversion(VersionControl):
     def should_add_vcs_url_prefix(cls, remote_url):
         return True
 
-    @classmethod
-    def get_base_rev_args(cls, rev):
+    @staticmethod
+    def get_base_rev_args(rev):
         return ['-r', rev]
 
     def export(self, location):
@@ -114,8 +114,8 @@ class Subversion(VersionControl):
             url = 'svn+' + url
         return url, rev, user_pass
 
-    @classmethod
-    def make_rev_args(cls, username, password):
+    @staticmethod
+    def make_rev_args(username, password):
         extra_args = []
         if username:
             extra_args += ['--username', username]

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -206,7 +206,7 @@ def test_git__get_netloc_and_auth(args, expected):
     Test VersionControl.get_netloc_and_auth().
     """
     netloc, scheme = args
-    actual = Git().get_netloc_and_auth(netloc, scheme)
+    actual = Git.get_netloc_and_auth(netloc, scheme)
     assert actual == expected
 
 
@@ -229,7 +229,7 @@ def test_subversion__get_netloc_and_auth(args, expected):
     Test Subversion.get_netloc_and_auth().
     """
     netloc, scheme = args
-    actual = Subversion().get_netloc_and_auth(netloc, scheme)
+    actual = Subversion.get_netloc_and_auth(netloc, scheme)
     assert actual == expected
 
 

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -241,10 +241,8 @@ def test_git__get_url_rev__idempotent():
     Also check that it doesn't change self.url.
     """
     url = 'git+git@git.example.com:MyProject#egg=MyProject'
-    vcs = Git(url)
-    result1 = vcs.get_url_rev_and_auth(url)
-    assert vcs.url == url
-    result2 = vcs.get_url_rev_and_auth(url)
+    result1 = Git.get_url_rev_and_auth(url)
+    result2 = Git.get_url_rev_and_auth(url)
     expected = ('git@git.example.com:MyProject', None, (None, None))
     assert result1 == expected
     assert result2 == expected
@@ -261,7 +259,7 @@ def test_version_control__get_url_rev_and_auth(url, expected):
     """
     Test the basic case of VersionControl.get_url_rev_and_auth().
     """
-    actual = VersionControl().get_url_rev_and_auth(url)
+    actual = VersionControl.get_url_rev_and_auth(url)
     assert actual == expected
 
 
@@ -276,7 +274,7 @@ def test_version_control__get_url_rev_and_auth__missing_plus(url):
     missing from the scheme.
     """
     with pytest.raises(ValueError) as excinfo:
-        VersionControl().get_url_rev_and_auth(url)
+        VersionControl.get_url_rev_and_auth(url)
 
     assert 'malformed VCS url' in str(excinfo.value)
 
@@ -305,8 +303,7 @@ def test_bazaar__get_url_rev_and_auth(url, expected):
     """
     Test Bazaar.get_url_rev_and_auth().
     """
-    bzr = Bazaar(url=url)
-    actual = bzr.get_url_rev_and_auth(url)
+    actual = Bazaar.get_url_rev_and_auth(url)
     assert actual == (expected, None, (None, None))
 
 
@@ -328,7 +325,7 @@ def test_subversion__get_url_rev_and_auth(url, expected):
     """
     Test Subversion.get_url_rev_and_auth().
     """
-    actual = Subversion().get_url_rev_and_auth(url)
+    actual = Subversion.get_url_rev_and_auth(url)
     assert actual == expected
 
 

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -340,7 +340,7 @@ def test_git__make_rev_args(username, password, expected):
     """
     Test VersionControl.make_rev_args().
     """
-    actual = Git().make_rev_args(username, password)
+    actual = Git.make_rev_args(username, password)
     assert actual == expected
 
 
@@ -353,7 +353,7 @@ def test_subversion__make_rev_args(username, password, expected):
     """
     Test Subversion.make_rev_args().
     """
-    actual = Subversion().make_rev_args(username, password)
+    actual = Subversion.make_rev_args(username, password)
     assert actual == expected
 
 


### PR DESCRIPTION
This turns more methods of the `VersionControl` class into class methods. This is part of a process of simplifying the VCS code.