### PR TITLE
Allow -u for --user

### DIFF
--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -67,6 +67,7 @@ class ConfigurationCommand(Command):
         )
 
         self.cmd_opts.add_option(
+            '-u',
             '--user',
             dest='user_file',
             action='store_true',


### PR DESCRIPTION
Currently, pip install takes the `--user` option, which has no short version. Also, -u is available for pip install. Do you think such a change could make it through, given proper patch formatting ? Thanks in advance for your comments

Todo:

- [ ] [NEWS fragment](https://pip.pypa.io/en/latest/development/contributing/#news-entries)
- [ ] tests
- [ ] doc update