### PR TITLE
Tighten up the test suite's stderr checks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,7 +303,7 @@ def script(tmpdir, virtualenv, deprecated_python):
         assert_no_temp=True,
 
         # Deprecated python versions produce an extra deprecation warning
-        pip_expect_stderr=deprecated_python,
+        pip_expect_warning=deprecated_python,
     )
 
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1474,8 +1474,7 @@ def test_install_conflict_results_in_warning(script, data):
 
     # Then install an incorrect version of the dependency
     result2 = script.pip(
-        'install', '--no-index', pkgB_path,
-        expect_stderr=True,
+        'install', '--no-index', pkgB_path, allow_stderr_error=True,
     )
     assert "pkga 1.0 has requirement pkgb==1.0" in result2.stderr, str(result2)
     assert "Successfully installed pkgB-2.0" in result2.stdout, str(result2)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -462,12 +462,6 @@ class PipTestEnvironment(TestFileEnvironment):
     def pip(self, *args, **kwargs):
         if self.pip_expect_warning:
             kwargs['allow_stderr_warning'] = True
-        # On old versions of Python, urllib3/requests will raise a warning
-        # about the lack of an SSLContext. Expect it when running commands
-        # that will touch the outside world.
-        if (pyversion_tuple < (2, 7, 9) and
-                args and args[0] in ('search', 'install', 'download')):
-            kwargs['expect_stderr'] = True
         if kwargs.pop('use_module', True):
             exe = 'python'
             args = ('-m', 'pip') + args

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -445,9 +445,19 @@ class PipTestEnvironment(TestFileEnvironment):
 
         if kw.get('expect_error'):
             # Then default to allowing logged errors.
+            if allow_stderr_error is not None and not allow_stderr_error:
+                raise RuntimeError(
+                    'cannot pass allow_stderr_error=False with '
+                    'expect_error=True'
+                )
             allow_stderr_error = True
         elif kw.get('expect_stderr'):
             # Then default to allowing logged warnings.
+            if allow_stderr_warning is not None and not allow_stderr_warning:
+                raise RuntimeError(
+                    'cannot pass allow_stderr_warning=False with '
+                    'expect_stderr=True'
+                )
             allow_stderr_warning = True
 
         # Pass expect_stderr=True to allow any stderr.  We do this because

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -423,9 +423,9 @@ class PipTestEnvironment(TestFileEnvironment):
         :param allow_stderr_error: whether a logged error is allowed in
             stderr.  Passing True for this argument implies
             `allow_stderr_warning` since warnings are weaker than errors.
-        :param expect_stderr: allow any stderr (equivalent to passing
-            `allow_stderr_error`).  This argument is an abbreviated version
-            of `allow_stderr_error` and is also kept for backwards
+        :param expect_stderr: whether to allow warnings in stderr (equivalent
+            to `allow_stderr_warning`).  This argument is an abbreviated
+            version of `allow_stderr_warning` and is also kept for backwards
             compatibility.
         """
         if self.verbose:
@@ -443,9 +443,12 @@ class PipTestEnvironment(TestFileEnvironment):
         allow_stderr_error = kw.pop('allow_stderr_error', None)
         allow_stderr_warning = kw.pop('allow_stderr_warning', None)
 
-        if kw.get('expect_error') or kw.get('expect_stderr'):
+        if kw.get('expect_error'):
             # Then default to allowing logged errors.
             allow_stderr_error = True
+        elif kw.get('expect_stderr'):
+            # Then default to allowing logged warnings.
+            allow_stderr_warning = True
 
         # Pass expect_stderr=True to allow any stderr.  We do this because
         # we do our checking of stderr further on in check_stderr().

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -378,7 +378,7 @@ class PipTestEnvironment(TestFileEnvironment):
 
         # Whether all pip invocations should expect stderr
         # (useful for Python version deprecation)
-        self.pip_expect_stderr = kwargs.pop('pip_expect_stderr', None)
+        self.pip_expect_warning = kwargs.pop('pip_expect_warning', None)
 
         # Call the TestFileEnvironment __init__
         super(PipTestEnvironment, self).__init__(base_path, *args, **kwargs)
@@ -460,8 +460,8 @@ class PipTestEnvironment(TestFileEnvironment):
         return TestPipResult(result, verbose=self.verbose)
 
     def pip(self, *args, **kwargs):
-        if self.pip_expect_stderr:
-            kwargs['expect_stderr'] = True
+        if self.pip_expect_warning:
+            kwargs['allow_stderr_warning'] = True
         # On old versions of Python, urllib3/requests will raise a warning
         # about the lack of an SSLContext. Expect it when running commands
         # that will touch the outside world.

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -140,7 +140,6 @@ class TestPipTestEnvironment:
             self.run_stderr_with_prefix(script, prefix)
 
     @pytest.mark.parametrize('arg_name', (
-        'expect_stderr',
         'expect_error',
         'allow_stderr_error',
     ))

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -139,6 +139,32 @@ class TestPipTestEnvironment:
         with assert_error_startswith(RuntimeError, expected_start):
             self.run_stderr_with_prefix(script, prefix)
 
+    def test_run__allow_stderr_error_false_error_with_expect_error(
+        self, script,
+    ):
+        """
+        Test passing allow_stderr_error=False with expect_error=True.
+        """
+        expected_start = (
+            'cannot pass allow_stderr_error=False with expect_error=True'
+        )
+        with assert_error_startswith(RuntimeError, expected_start):
+            script.run('python', allow_stderr_error=False, expect_error=True)
+
+    def test_run__allow_stderr_warning_false_error_with_expect_stderr(
+        self, script,
+    ):
+        """
+        Test passing allow_stderr_warning=False with expect_stderr=True.
+        """
+        expected_start = (
+            'cannot pass allow_stderr_warning=False with expect_stderr=True'
+        )
+        with assert_error_startswith(RuntimeError, expected_start):
+            script.run(
+                'python', allow_stderr_warning=False, expect_stderr=True,
+            )
+
     @pytest.mark.parametrize('arg_name', (
         'expect_error',
         'allow_stderr_error',


### PR DESCRIPTION
This is a relatively simple PR that does the following four things (each in a separate commit):

1. Makes deprecated_python pass `allow_stderr_warning=True` instead of `expect_stderr=True`. This narrows / tightens up the test expectation.
2. Removes the logic for an old check for an `SSLContext` warning, since that is now subsumed by the deprecated Python check.
3. Makes `expect_stderr=True` mean the weaker `allow_stderr_warning=True`. Similar to (1), this makes the test expectation more specific.
4. Checks for a couple more incompatible argument combinations, which is similar to the suggestion @xavfernandez made to me on PR #6342.
