### PR TITLE
make --python-version override python_version in requirement markers

### DIFF
--- a/news/6117.feature
+++ b/news/6117.feature
@@ -1,0 +1,3 @@
+The version of python used to evaluate `python_version` env markers in
+requirements files is now overridden by the `--python-version` command-line
+option, if specified.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -248,15 +248,15 @@ class RequirementCommand(Command):
             environment['python_version'] = version
         return environment
 
-    @classmethod
-    def populate_requirement_set(cls,
-                                 requirement_set,  # type: RequirementSet
+    @staticmethod
+    def populate_requirement_set(requirement_set,  # type: RequirementSet
                                  args,             # type: List[str]
                                  options,          # type: Values
                                  finder,           # type: PackageFinder
                                  session,          # type: PipSession
                                  name,             # type: str
-                                 wheel_cache       # type: Optional[WheelCache]
+                                 wheel_cache,      # type: Optional[WheelCache]
+                                 environment,      # type: Dict[str, Any]
                                  ):
         # type: (...) -> None
         """
@@ -264,8 +264,6 @@ class RequirementCommand(Command):
         """
         # NOTE: As a side-effect, options.require_hashes and
         #       requirement_set.require_hashes may be updated
-
-        environment = cls.get_environment(options)
 
         for filename in options.constraints:
             for req_to_add in parse_requirements(

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -240,24 +240,30 @@ class RequirementCommand(Command):
     @staticmethod
     def get_environment(options):
         # type: (Values) -> Dict[str, Any]
+        """
+        Get an environment dictionary compatible with
+        `packaging.markers.Marker`.
+        """
         environment = {}  # type: Dict[str, Any]
         version = getattr(options, 'python_version', None)
         if version:
             if len(version) >= 2:
+                # convert from xyz to x.yz
                 version = version[0] + '.' + version[1:]
             environment['python_version'] = version
         return environment
 
     @staticmethod
-    def populate_requirement_set(requirement_set,  # type: RequirementSet
-                                 args,             # type: List[str]
-                                 options,          # type: Values
-                                 finder,           # type: PackageFinder
-                                 session,          # type: PipSession
-                                 name,             # type: str
-                                 wheel_cache,      # type: Optional[WheelCache]
-                                 environment,      # type: Dict[str, Any]
-                                 ):
+    def populate_requirement_set(
+            requirement_set,   # type: RequirementSet
+            args,              # type: List[str]
+            options,           # type: Values
+            finder,            # type: PackageFinder
+            session,           # type: PipSession
+            name,              # type: str
+            wheel_cache,       # type: Optional[WheelCache]
+            environment=None,  # type: Optional[Dict[str, Any]]
+    ):
         # type: (...) -> None
         """
         Marshal cmd line args into a requirement set.

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -88,6 +88,8 @@ class DownloadCommand(RequirementCommand):
         # of the RequirementSet code require that property.
         options.editables = []
 
+        environment = self.get_environment(options)
+
         if options.python_version:
             python_versions = [options.python_version]
         else:
@@ -135,7 +137,8 @@ class DownloadCommand(RequirementCommand):
                     finder,
                     session,
                     self.name,
-                    None
+                    None,
+                    environment,
                 )
 
                 preparer = RequirementPreparer(
@@ -160,6 +163,7 @@ class DownloadCommand(RequirementCommand):
                     ignore_requires_python=False,
                     ignore_installed=True,
                     isolated=options.isolated_mode,
+                    environment=environment,
                 )
                 resolver.resolve(requirement_set)
 

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -172,7 +172,7 @@ def install_req_from_editable(
     options=None,  # type: Optional[Dict[str, Any]]
     wheel_cache=None,  # type: Optional[WheelCache]
     constraint=False,  # type: bool
-    environment=None  # type: Dict[str, Any]
+    environment=None  # type: Optional[Dict[str, Any]]
 ):
     # type: (...) -> InstallRequirement
     name, url, extras_override = parse_editable(editable_req)
@@ -210,7 +210,7 @@ def install_req_from_line(
     options=None,  # type: Optional[Dict[str, Any]]
     wheel_cache=None,  # type: Optional[WheelCache]
     constraint=False,  # type: bool
-    environment=None  # type: Dict[str, Any]
+    environment=None  # type: Optional[Dict[str, Any]]
 ):
     # type: (...) -> InstallRequirement
     """Creates an InstallRequirement from a name, which might be a
@@ -318,7 +318,7 @@ def install_req_from_req_string(
     isolated=False,  # type: bool
     wheel_cache=None,  # type: Optional[WheelCache]
     use_pep517=None,  # type: Optional[bool]
-    environment=None  # type: Dict[str, Any]
+    environment=None  # type: Optional[Dict[str, Any]]
 ):
     # type: (...) -> InstallRequirement
     try:

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -171,7 +171,8 @@ def install_req_from_editable(
     isolated=False,  # type: bool
     options=None,  # type: Optional[Dict[str, Any]]
     wheel_cache=None,  # type: Optional[WheelCache]
-    constraint=False  # type: bool
+    constraint=False,  # type: bool
+    environment=None  # type: Dict[str, Any]
 ):
     # type: (...) -> InstallRequirement
     name, url, extras_override = parse_editable(editable_req)
@@ -197,6 +198,7 @@ def install_req_from_editable(
         options=options if options else {},
         wheel_cache=wheel_cache,
         extras=extras_override or (),
+        environment=environment,
     )
 
 
@@ -207,7 +209,8 @@ def install_req_from_line(
     isolated=False,  # type: bool
     options=None,  # type: Optional[Dict[str, Any]]
     wheel_cache=None,  # type: Optional[WheelCache]
-    constraint=False  # type: bool
+    constraint=False,  # type: bool
+    environment=None  # type: Dict[str, Any]
 ):
     # type: (...) -> InstallRequirement
     """Creates an InstallRequirement from a name, which might be a
@@ -305,6 +308,7 @@ def install_req_from_line(
         wheel_cache=wheel_cache,
         constraint=constraint,
         extras=extras,
+        environment=environment,
     )
 
 
@@ -313,7 +317,8 @@ def install_req_from_req_string(
     comes_from=None,  # type: Optional[InstallRequirement]
     isolated=False,  # type: bool
     wheel_cache=None,  # type: Optional[WheelCache]
-    use_pep517=None  # type: Optional[bool]
+    use_pep517=None,  # type: Optional[bool]
+    environment=None  # type: Dict[str, Any]
 ):
     # type: (...) -> InstallRequirement
     try:
@@ -336,5 +341,5 @@ def install_req_from_req_string(
 
     return InstallRequirement(
         req, comes_from, isolated=isolated, wheel_cache=wheel_cache,
-        use_pep517=use_pep517
+        use_pep517=use_pep517, environment=environment
     )

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -23,7 +23,8 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Any, Callable, Iterator, List, NoReturn, Optional, Text, Tuple,
+        Any, Callable, Dict, Iterator, List, NoReturn, Optional, Text, 
+        Tuple,
     )
     from pip._internal.req import InstallRequirement
     from pip._internal.cache import WheelCache
@@ -78,7 +79,8 @@ def parse_requirements(
     session=None,  # type: Optional[PipSession]
     constraint=False,  # type: bool
     wheel_cache=None,  # type: Optional[WheelCache]
-    use_pep517=None  # type: Optional[bool]
+    use_pep517=None,  # type: Optional[bool]
+    environment=None  # type: Dict[str, Any]
 ):
     # type: (...) -> Iterator[InstallRequirement]
     """Parse a requirements file and yield InstallRequirement instances.
@@ -108,7 +110,8 @@ def parse_requirements(
     for line_number, line in lines_enum:
         req_iter = process_line(line, filename, line_number, finder,
                                 comes_from, options, session, wheel_cache,
-                                use_pep517=use_pep517, constraint=constraint)
+                                use_pep517=use_pep517, constraint=constraint,
+                                environment=environment)
         for req in req_iter:
             yield req
 
@@ -138,7 +141,8 @@ def process_line(
     session=None,  # type: Optional[PipSession]
     wheel_cache=None,  # type: Optional[WheelCache]
     use_pep517=None,  # type: Optional[bool]
-    constraint=False  # type: bool
+    constraint=False,  # type: bool
+    environment=None  # type: Dict[str, Any]
 ):
     # type: (...) -> Iterator[InstallRequirement]
     """Process a single requirements line; This can result in creating/yielding
@@ -190,7 +194,8 @@ def process_line(
         yield install_req_from_line(
             args_str, line_comes_from, constraint=constraint,
             use_pep517=use_pep517,
-            isolated=isolated, options=req_options, wheel_cache=wheel_cache
+            isolated=isolated, options=req_options, wheel_cache=wheel_cache,
+            environment=environment
         )
 
     # yield an editable requirement
@@ -199,7 +204,8 @@ def process_line(
         yield install_req_from_editable(
             opts.editables[0], comes_from=line_comes_from,
             use_pep517=use_pep517,
-            constraint=constraint, isolated=isolated, wheel_cache=wheel_cache
+            constraint=constraint, isolated=isolated, wheel_cache=wheel_cache,
+            environment=environment
         )
 
     # parse a nested requirements file
@@ -221,7 +227,8 @@ def process_line(
         # TODO: Why not use `comes_from='-r {} (line {})'` here as well?
         parsed_reqs = parse_requirements(
             req_path, finder, comes_from, options, session,
-            constraint=nested_constraint, wheel_cache=wheel_cache
+            constraint=nested_constraint, wheel_cache=wheel_cache,
+            environment=environment
         )
         for req in parsed_reqs:
             yield req

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -23,7 +23,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Any, Callable, Dict, Iterator, List, NoReturn, Optional, Text, 
+        Any, Callable, Dict, Iterator, List, NoReturn, Optional, Text,
         Tuple,
     )
     from pip._internal.req import InstallRequirement

--- a/src/pip/_internal/resolve.py
+++ b/src/pip/_internal/resolve.py
@@ -25,7 +25,7 @@ from pip._internal.utils.packaging import check_dist_requires_python
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, DefaultDict, List, Set
+    from typing import Any, DefaultDict, Dict, List, Optional, Set
     from pip._internal.download import PipSession
     from pip._internal.req.req_install import InstallRequirement
     from pip._internal.index import PackageFinder
@@ -58,7 +58,8 @@ class Resolver(object):
         force_reinstall,  # type: bool
         isolated,  # type: bool
         upgrade_strategy,  # type: str
-        use_pep517=None  # type: Optional[bool]
+        use_pep517=None,  # type: Optional[bool]
+        environment=None,  # type: Dict[str, Any]
     ):
         # type: (...) -> None
         super(Resolver, self).__init__()
@@ -83,6 +84,7 @@ class Resolver(object):
         self.ignore_requires_python = ignore_requires_python
         self.use_user_site = use_user_site
         self.use_pep517 = use_pep517
+        self.environment = environment if environment else {}
 
         self._discovered_dependencies = \
             defaultdict(list)  # type: DefaultDict[str, List]
@@ -311,7 +313,8 @@ class Resolver(object):
                 req_to_install,
                 isolated=self.isolated,
                 wheel_cache=self.wheel_cache,
-                use_pep517=self.use_pep517
+                use_pep517=self.use_pep517,
+                environment=self.environment,
             )
             parent_req_name = req_to_install.name
             to_scan_again, add_to_parent = requirement_set.add_requirement(

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -459,6 +459,29 @@ class TestInstallRequirement(object):
             assert str(req.markers) == str(Marker(markers))
             assert not req.match_markers()
 
+    def test_markers_match_from_line_with_env(self):
+        # match
+        for markers in (
+            'python_version >= "5.0"',
+            'sys_platform == %r' % sys.platform,
+        ):
+            line = 'name; ' + markers
+            req = install_req_from_line(line,
+                                        environment={'python_version': '5.5'})
+            assert str(req.markers) == str(Marker(markers))
+            assert req.match_markers()
+
+        # don't match
+        for markers in (
+            'python_version >= "2.0"',
+            'sys_platform != %r' % sys.platform,
+        ):
+            line = 'name; ' + markers
+            req = install_req_from_line(line,
+                                        environment={'python_version': '1.0'})
+            assert str(req.markers) == str(Marker(markers))
+            assert not req.match_markers()
+
     def test_markers_match(self):
         # match
         for markers in (

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -241,7 +241,8 @@ class TestProcessLine(object):
         import pip._internal.req.req_file
 
         def stub_parse_requirements(req_url, finder, comes_from, options,
-                                    session, wheel_cache, constraint):
+                                    session, wheel_cache, constraint,
+                                    environment):
             return [(req, constraint)]
         parse_requirements_stub = stub(call=stub_parse_requirements)
         monkeypatch.setattr(pip._internal.req.req_file, 'parse_requirements',
@@ -254,7 +255,8 @@ class TestProcessLine(object):
         import pip._internal.req.req_file
 
         def stub_parse_requirements(req_url, finder, comes_from, options,
-                                    session, wheel_cache, constraint):
+                                    session, wheel_cache, constraint,
+                                    environment):
             return [(req, constraint)]
         parse_requirements_stub = stub(call=stub_parse_requirements)
         monkeypatch.setattr(pip._internal.req.req_file, 'parse_requirements',


### PR DESCRIPTION
This PR resolves half of issue #6117.  

This PR ensures that if a user provides the `--python-version` cli option (e.g. to `pip download`), that `python_version` markers are evaluated as expected.   The other half of the issue -- doing the same for `--platform` -- seems a bit more difficult (e.g. how can I reliably break down a value passed to `--platform` into `sys.platform`, `platform.system()`, etc?).   This PR sets up the resolution of the platform issue by exposing an `environment` dictionary that can be used to override any part of the marker env.

