### PR TITLE
Get CI working again: pin pytest-rerunfailures to < 7.0

### DIFF
--- a/tools/tests-requirements.txt
+++ b/tools/tests-requirements.txt
@@ -3,7 +3,8 @@ mock
 pretend
 pytest==3.8.2
 pytest-cov
-pytest-rerunfailures
+# Prevent installing 7.0 which has install_requires "pytest >= 3.10".
+pytest-rerunfailures<7.0
 pytest-timeout
 pytest-xdist
 pyyaml


### PR DESCRIPTION
This is an attempt to unblock CI.