### PR TITLE
Unpin pytest from test-requirements.txt

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,7 @@ def tmpdir_factory(request, tmpdir_factory):
     """
     yield tmpdir_factory
     if not request.config.getoption("--keep-tmpdir"):
+        print("Removing:", tmpdir_factory.getbasetemp())
         tmpdir_factory.getbasetemp().remove(ignore_errors=True)
 
 

--- a/tools/tests-requirements.txt
+++ b/tools/tests-requirements.txt
@@ -1,7 +1,7 @@
 freezegun
 mock
 pretend
-pytest==3.8.2
+pytest
 pytest-cov
 # Prevent installing 7.0 which has install_requires "pytest >= 3.10".
 pytest-rerunfailures<7.0

--- a/tools/tests-requirements.txt
+++ b/tools/tests-requirements.txt
@@ -1,7 +1,7 @@
 freezegun
 mock
 pretend
-pytest
+pytest==3.9.3
 pytest-cov
 # Prevent installing 7.0 which has install_requires "pytest >= 3.10".
 pytest-rerunfailures<7.0


### PR DESCRIPTION
Hopefully, 3953fe6 is not needed anymore

Alternative to #6365