### PR TITLE
Consistently catch exceptions in index.py

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -16,7 +16,7 @@ from pip._vendor.distlib.compat import unescape
 from pip._vendor.packaging import specifiers
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import parse as parse_version
-from pip._vendor.requests.exceptions import RetryError, SSLError
+from pip._vendor.requests.exceptions import HTTPError, RetryError, SSLError
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib import request as urllib_request
 
@@ -237,7 +237,7 @@ def _get_html_page(link, session=None):
             'Skipping page %s because the %s request got Content-Type: %s',
             link, exc.request_desc, exc.content_type,
         )
-    except requests.HTTPError as exc:
+    except HTTPError as exc:
         _handle_get_page_fail(link, exc)
     except RetryError as exc:
         _handle_get_page_fail(link, exc)


### PR DESCRIPTION
This resolves issue #4195.

In index.py's index retrieval routine we were catching
requests.HTTPError to log and ignore 404s and other similar HTTP server
errors when pulling from (extra-)index-urls. Unfortunately, the actual
path to that exception is requests.exceptions.HTTPError and the alias we
were using does not work when pip is installed with unvendored libs as
with the debian packaged pip.

Thankfully the fix is simple. Import and use
requests.exceptions.HTTPError. This comes with the added bonus of
fitting in with the existing handling for RetryError and SSLError. With
this change in place upstream pip and downstream packaged pip should
both catch this exception properly.

Note: I've not added any tests cases as I'm unsure how to test the
distro packaging case within pip's testsuite. However, the existing test
suite should hopefully cover that this isn't a regression and I've
manually confirmed that this works with a hacked up debian package
install. Also this is how we handle RetryError and SSLError.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
