### PR TITLE
Fix editable-mode logic when pyproject.toml present

### DIFF
--- a/news/6370.bugfix
+++ b/news/6370.bugfix
@@ -1,0 +1,3 @@
+Fix the handling of editable mode during installs when ``pyproject.toml`` is
+present but PEP 517 doesn't require the source tree to be treated as
+``pyproject.toml``-style.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -99,6 +99,36 @@ class IsSDist(DistAbstraction):
     def dist(self):
         return self.req.get_dist()
 
+    def _raise_conflicts(self, conflicting_with, conflicting_reqs):
+        conflict_messages = [
+            '%s is incompatible with %s' % (installed, wanted)
+            for installed, wanted in sorted(conflicting_reqs)
+        ]
+        raise InstallationError(
+            "Some build dependencies for %s conflict with %s: %s." % (
+                self.req, conflicting_with, ', '.join(conflict_messages))
+        )
+
+    def install_backend_dependencies(self, finder):
+        # type: (PackageFinder) -> None
+        """
+        Install any extra build dependencies that the backend requests.
+
+        :param finder: a PackageFinder object.
+        """
+        req = self.req
+        with req.build_env:
+            # We need to have the env active when calling the hook.
+            req.spin_message = "Getting requirements to build wheel"
+            reqs = req.pep517_backend.get_requires_for_build_wheel()
+        conflicting, missing = req.build_env.check_requirements(reqs)
+        if conflicting:
+            self._raise_conflicts("the backend dependencies", conflicting)
+        req.build_env.install_requirements(
+            finder, missing, 'normal',
+            "Installing backend dependencies"
+        )
+
     def prep_for_dist(self, finder, build_isolation):
         # type: (PackageFinder, bool) -> None
         # Prepare for building. We need to:
@@ -107,13 +137,6 @@ class IsSDist(DistAbstraction):
 
         self.req.load_pyproject_toml()
         should_isolate = self.req.use_pep517 and build_isolation
-
-        def _raise_conflicts(conflicting_with, conflicting_reqs):
-            raise InstallationError(
-                "Some build dependencies for %s conflict with %s: %s." % (
-                    self.req, conflicting_with, ', '.join(
-                        '%s is incompatible with %s' % (installed, wanted)
-                        for installed, wanted in sorted(conflicting))))
 
         if should_isolate:
             # Isolate in a BuildEnvironment and install the build-time
@@ -127,8 +150,8 @@ class IsSDist(DistAbstraction):
                 self.req.requirements_to_check
             )
             if conflicting:
-                _raise_conflicts("PEP 517/518 supported requirements",
-                                 conflicting)
+                self._raise_conflicts("PEP 517/518 supported requirements",
+                                      conflicting)
             if missing:
                 logger.warning(
                     "Missing build requirements in pyproject.toml for %s.",
@@ -139,20 +162,11 @@ class IsSDist(DistAbstraction):
                     "pip cannot fall back to setuptools without %s.",
                     " and ".join(map(repr, sorted(missing)))
                 )
+
             # Install any extra build dependencies that the backend requests.
             # This must be done in a second pass, as the pyproject.toml
             # dependencies must be installed before we can call the backend.
-            with self.req.build_env:
-                # We need to have the env active when calling the hook.
-                self.req.spin_message = "Getting requirements to build wheel"
-                reqs = self.req.pep517_backend.get_requires_for_build_wheel()
-            conflicting, missing = self.req.build_env.check_requirements(reqs)
-            if conflicting:
-                _raise_conflicts("the backend dependencies", conflicting)
-            self.req.build_env.install_requirements(
-                finder, missing, 'normal',
-                "Installing backend dependencies"
-            )
+            self.install_backend_dependencies(finder=finder)
 
         self.req.prepare_metadata()
         self.req.assert_source_matches_version()

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -136,7 +136,11 @@ class IsSDist(DistAbstraction):
         #   2. Set up the build environment
 
         self.req.load_pyproject_toml()
-        should_isolate = self.req.use_pep517 and build_isolation
+
+        should_isolate = (
+            (self.req.use_pep517 or self.req.pyproject_requires) and
+            build_isolation
+        )
 
         if should_isolate:
             # Isolate in a BuildEnvironment and install the build-time
@@ -163,10 +167,12 @@ class IsSDist(DistAbstraction):
                     " and ".join(map(repr, sorted(missing)))
                 )
 
-            # Install any extra build dependencies that the backend requests.
-            # This must be done in a second pass, as the pyproject.toml
-            # dependencies must be installed before we can call the backend.
-            self.install_backend_dependencies(finder=finder)
+            if self.req.use_pep517:
+                # If we're using PEP 517, then install any extra build
+                # dependencies that the backend requested.  This must be
+                # done in a second pass, as the pyproject.toml dependencies
+                # must be installed before we can call the backend.
+                self.install_backend_dependencies(finder=finder)
 
         self.req.prepare_metadata()
         self.req.assert_source_matches_version()

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -485,7 +485,7 @@ class InstallRequirement(object):
         use_pep517 attribute can be used to determine whether we should
         follow the PEP 517 or legacy (setup.py) code path.
         """
-        pep517_data = load_pyproject_toml(
+        requires, pep517_data = load_pyproject_toml(
             self.use_pep517,
             self.editable,
             self.pyproject_toml,
@@ -493,13 +493,14 @@ class InstallRequirement(object):
             str(self)
         )
 
-        if pep517_data is None:
-            self.use_pep517 = False
-        else:
-            self.use_pep517 = True
-            requires, backend, check = pep517_data
+        use_pep517 = bool(pep517_data)
+
+        self.use_pep517 = use_pep517
+        self.pyproject_requires = requires
+
+        if use_pep517:
+            backend, check = pep517_data
             self.requirements_to_check = check
-            self.pyproject_requires = requires
             self.pep517_backend = Pep517HookCaller(self.setup_py_dir, backend)
 
             # Use a custom function to call subprocesses

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -302,8 +302,12 @@ def test_constraints_local_editable_install_pep518(script, data):
     to_install = data.src.join("pep518-3.0")
 
     script.pip('download', 'setuptools', 'wheel', '-d', data.packages)
+    # --no-use-pep517 has to be passed since a pyproject.toml file is
+    # present but PEP 517 doesn't support editable mode.
     script.pip(
-        'install', '--no-index', '-f', data.find_links, '-e', to_install)
+        'install', '--no-use-pep517', '--no-index', '-f', data.find_links,
+        '-e', to_install,
+    )
 
 
 def test_constraints_local_install_causes_error(script, data):

--- a/tests/unit/test_pep517.py
+++ b/tests/unit/test_pep517.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import pytest
 
 from pip._internal.exceptions import InstallationError
@@ -5,8 +7,19 @@ from pip._internal.pyproject import resolve_pyproject_toml
 from pip._internal.req import InstallRequirement
 
 
-@pytest.mark.parametrize('editable', [False, True])
-def test_resolve_pyproject_toml__pep_517_optional(editable):
+@contextmanager
+def assert_error_startswith(exc_type, expected_start, expected_substr):
+    with pytest.raises(InstallationError) as excinfo:
+        yield
+
+    err_args = excinfo.value.args
+    assert len(err_args) == 1
+    msg = err_args[0]
+    assert msg.startswith(expected_start), 'full message: {}'.format(msg)
+    assert expected_substr in msg, 'full message: {}'.format(msg)
+
+
+def test_resolve_pyproject_toml__pep_517_optional():
     """
     Test resolve_pyproject_toml() when has_pyproject=True but the source
     tree isn't pyproject.toml-style per PEP 517.
@@ -16,15 +29,55 @@ def test_resolve_pyproject_toml__pep_517_optional(editable):
         has_pyproject=True,
         has_setup=True,
         use_pep517=None,
-        editable=editable,
+        editable=False,
         req_name='my-package',
     )
     expected = (
         ['setuptools>=40.8.0', 'wheel'],
-        'setuptools.build_meta:__legacy__',
-        [],
+        ('setuptools.build_meta:__legacy__', []),
     )
     assert actual == expected
+
+
+def test_resolve_pyproject_toml__editable_with_build_system_requires():
+    """
+    Test a case of editable=True when build-system.requires are returned.
+    """
+    actual = resolve_pyproject_toml(
+        build_system={'requires': ['package-a', 'package=b']},
+        has_pyproject=True,
+        has_setup=True,
+        use_pep517=False,
+        editable=True,
+        req_name='my-package',
+    )
+    expected = (['package-a', 'package=b'], None)
+    assert actual == expected
+
+
+def test_resolve_pyproject_toml__editable_without_use_pep517_false():
+    """
+    Test passing editable=True when PEP 517 processing is optional, but
+    use_pep517=False hasn't been passed.
+    """
+    expected_start = (
+        "Error installing 'my-package': editable mode is not supported"
+    )
+    expected_substr = (
+        'you may pass --no-use-pep517 to opt out of pyproject.toml-style '
+        'processing'
+    )
+    with assert_error_startswith(
+        InstallationError, expected_start, expected_substr=expected_substr,
+    ):
+        resolve_pyproject_toml(
+            build_system=None,
+            has_pyproject=True,
+            has_setup=True,
+            use_pep517=None,
+            editable=True,
+            req_name='my-package',
+        )
 
 
 @pytest.mark.parametrize(
@@ -46,7 +99,12 @@ def test_resolve_pyproject_toml__editable_and_pep_517_required(
     Test that passing editable=True raises an error if PEP 517 processing
     is required.
     """
-    with pytest.raises(InstallationError) as excinfo:
+    expected_start = (
+        "Error installing 'my-package': editable mode is not supported"
+    )
+    with assert_error_startswith(
+        InstallationError, expected_start, expected_substr=expected_err,
+    ):
         resolve_pyproject_toml(
             build_system=build_system,
             has_pyproject=has_pyproject,
@@ -55,13 +113,50 @@ def test_resolve_pyproject_toml__editable_and_pep_517_required(
             editable=True,
             req_name='my-package',
         )
-    err_args = excinfo.value.args
-    assert len(err_args) == 1
-    msg = err_args[0]
-    assert msg.startswith(
-        "Error installing 'my-package': editable mode is not supported"
+
+
+@pytest.mark.parametrize(
+    'has_pyproject, has_setup, use_pep517, editable, build_system, '
+    'expected_err', [
+        # Test editable=False with no build-system.requires.
+        (True, False, None, False, {},
+         "it has a 'build-system' table but not 'build-system.requires'"),
+        # Test editable=True with no build-system.requires (we also
+        # need to pass use_pep517=False).
+        (True, True, False, True, {},
+         "it has a 'build-system' table but not 'build-system.requires'"),
+        # Test editable=False with a bad build-system.requires value.
+        (True, False, None, False, {'requires': 'foo'},
+         "'build-system.requires' is not a list of strings"),
+        # Test editable=True with a bad build-system.requires value (we also
+        # need to pass use_pep517=False).
+        (True, True, False, True, {'requires': 'foo'},
+         "'build-system.requires' is not a list of strings"),
+    ]
+)
+def test_resolve_pyproject_toml__bad_build_system_section(
+    has_pyproject, has_setup, use_pep517, editable, build_system,
+    expected_err,
+):
+    """
+    Test a pyproject.toml build-system section that doesn't conform to
+    PEP 518.
+    """
+    expected_start = (
+        'my-package has a pyproject.toml file that does not comply with '
+        'PEP 518:'
     )
-    assert expected_err in msg, 'full message: {}'.format(msg)
+    with assert_error_startswith(
+        InstallationError, expected_start, expected_substr=expected_err,
+    ):
+        resolve_pyproject_toml(
+            build_system=build_system,
+            has_pyproject=has_pyproject,
+            has_setup=has_setup,
+            use_pep517=use_pep517,
+            editable=editable,
+            req_name='my-package',
+        )
 
 
 @pytest.mark.parametrize(('source', 'expected'), [


### PR DESCRIPTION
This is the second of two PR's to address installing in editable mode when a `pyproject.toml` file is present. The first part was PR #6331, which has already been merged.

Whereas PR #6331 addressed the case when PEP 517 _requires_ handling the source tree as `pyproject.toml`-style, this PR addresses the case where it is _optional_ (i.e. PEP 517 doesn't mandate it).

Specifically, this PR does four things:

1. Raises an informative `InstallationError` if editable mode was requested, a `pyproject.toml` file is present but PEP 517 processing is optional, and  no other PEP 517-related options were passed. Among other things, the error message tells the user they can pass `--no-use-pep517` to bypass `pyproject.toml`-style processing and use editable mode. This behavior was discussed and agreed to on the comment thread for PR #6331. The error currently looks like this--

   > Error installing 'my-package': editable mode is not supported for pyproject.toml-style projects. pip is processing this project as pyproject.toml-style because it has a pyproject.toml file. Since the project has a setup.py and the pyproject.toml has no "build-backend" key for the "build_system" value, you may pass --no-use-pep517 to opt out of pyproject.toml-style processing. See PEP 517 for details on pyproject.toml-style projects.

2. Gets `pip install -e` working again for the PEP 517-is-optional case (provided `--no-use-pep517` was passed). Previously, this case was broken because when PEP 517 processing was turned on by default for pip, the `build-system.requires` section was ignored in the non-PEP 517 case (in the `IsSDist.prep_for_dist()` method).

3. Adds a lot more unit test coverage of `resolve_pyproject_toml()` (the pure function responsible for interpreting the various flags in relation to the contents of `pyproject.toml`). It also fixes `test_constraints_local_editable_install_pep518()` by passing `--no-use-pep517` to the `pip install -e` invocation in the test, which it should have been doing before.

4. Fixes some exception handling that occurs in `IsSDist.prep_for_dist()` when conflicts are found while processing build dependencies. The prior code constructed an exception message using a variable (`conflicting`) that hadn't been defined yet. So I don't think that code path was working before.
