### PR TITLE
Document enabling --no-warn-script-location

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -396,8 +396,8 @@ set like this:
     ignore-installed = true
     no-dependencies = yes
 
-To enable the boolean options ``--no-compile`` and ``--no-cache-dir``, falsy
-values have to be used:
+To enable the boolean options ``--no-compile``, ``--no-warn-script-location``
+and ``--no-cache-dir``, falsy values have to be used:
 
 .. code-block:: ini
 
@@ -406,6 +406,7 @@ values have to be used:
 
     [install]
     no-compile = no
+    no-warn-script-location = false
 
 Appending options like ``--find-links`` can be written on multiple lines:
 


### PR DESCRIPTION
Closes https://github.com/pypa/pip/issues/6209

Minor change letting users know about `--no-warn-script-location` requiring falsy values to be enabled

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
