### PR TITLE
Fix handling of requests exceptions when dependencies are debundled

### DIFF
--- a/news/4195.bugfix
+++ b/news/4195.bugfix
@@ -1,0 +1,1 @@
+Fix handling of requests exceptions when dependencies are debundled.

--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -77,6 +77,7 @@ if DEBUNDLED:
     vendored("pytoml")
     vendored("retrying")
     vendored("requests")
+    vendored("requests.exceptions")
     vendored("requests.packages")
     vendored("requests.packages.urllib3")
     vendored("requests.packages.urllib3._collections")


### PR DESCRIPTION
Fix two issues with `DEBUNDLED = True`:

* `--extra-index-url` not working well (NEED TESTING) (#4195)
* `pip list -o --no-cache-dir` is broken if there are packages not hosted on PyPI. Tested on Arch Linux. (supersedes #6111)

Relevant PR:  #6367

Notes for distro packagers: this patch works only if 8ef3283fcf7c7c5537f305a374355edc96f40d3d is applied first.