### PR TITLE
Pin pytest-xdist to < 1.28.0

### DIFF
--- a/tools/tests-requirements.txt
+++ b/tools/tests-requirements.txt
@@ -6,7 +6,8 @@ pytest-cov
 # Prevent installing 7.0 which has install_requires "pytest >= 3.10".
 pytest-rerunfailures<7.0
 pytest-timeout
-pytest-xdist
+# Prevent installing 1.28.0 which has install_requires "pytest >= 4.4.0".
+pytest-xdist<1.28.0
 pyyaml
 setuptools>=39.2.0  # Needed for `setuptools.wheel.Wheel` support.
 scripttest


### PR DESCRIPTION
This is to unblock CI.

pytest-xdist just came out with a new release (1.28.0) that is causing CI to break.