### PR TITLE
Fix a freeze debug log message.

### DIFF
--- a/news/6383.bugfix
+++ b/news/6383.bugfix
@@ -1,0 +1,2 @@
+Fix a debug log message when freezing an editable, non-version controlled
+requirement.

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -178,7 +178,7 @@ def get_requirement_info(dist):
     if not vc_type:
         req = dist.as_requirement()
         logger.debug(
-            'No VCS found for editable requirement {!r} in: {!r}', req,
+            'No VCS found for editable requirement "%s" in: %r', req,
             location,
         )
         comments = [

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -126,7 +126,7 @@ def test_freeze_editable_not_vcs(script, tmpdir):
     # as a VCS directory.
     os.rename(os.path.join(pkg_path, '.git'), os.path.join(pkg_path, '.bak'))
     script.pip('install', '-e', pkg_path)
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze')
 
     # We need to apply os.path.normcase() to the path since that is what
     # the freeze code does.

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -184,9 +184,7 @@ def test_git_with_sha1_revisions(script):
         'git', 'rev-parse', 'HEAD~1',
         cwd=version_pkg_path,
     ).stdout.strip()
-    version = _install_version_pkg(
-        script, version_pkg_path, rev=sha1, expect_stderr=True,
-    )
+    version = _install_version_pkg(script, version_pkg_path, rev=sha1)
     assert '0.1' == version
 
 
@@ -200,9 +198,7 @@ def test_git_with_short_sha1_revisions(script):
         'git', 'rev-parse', 'HEAD~1',
         cwd=version_pkg_path,
     ).stdout.strip()[:7]
-    version = _install_version_pkg(
-        script, version_pkg_path, rev=sha1, expect_stderr=True,
-    )
+    version = _install_version_pkg(script, version_pkg_path, rev=sha1)
     assert '0.1' == version
 
 
@@ -212,11 +208,7 @@ def test_git_with_branch_name_as_revision(script):
     """
     version_pkg_path = _create_test_package(script)
     branch = 'test_branch'
-    script.run(
-        'git', 'checkout', '-b', branch,
-        expect_stderr=True,
-        cwd=version_pkg_path,
-    )
+    script.run('git', 'checkout', '-b', branch, cwd=version_pkg_path)
     _change_test_package_version(script, version_pkg_path)
     version = _install_version_pkg(script, version_pkg_path, rev=branch)
     assert 'some different version' == version
@@ -227,11 +219,7 @@ def test_git_with_tag_name_as_revision(script):
     Git backend should be able to install from tag names
     """
     version_pkg_path = _create_test_package(script)
-    script.run(
-        'git', 'tag', 'test_tag',
-        expect_stderr=True,
-        cwd=version_pkg_path,
-    )
+    script.run('git', 'tag', 'test_tag', cwd=version_pkg_path)
     _change_test_package_version(script, version_pkg_path)
     version = _install_version_pkg(script, version_pkg_path, rev='test_tag')
     assert '0.1' == version
@@ -241,7 +229,7 @@ def _add_ref(script, path, ref):
     """
     Add a new ref to a repository at the given path.
     """
-    script.run('git', 'update-ref', ref, 'HEAD', expect_stderr=True, cwd=path)
+    script.run('git', 'update-ref', ref, 'HEAD', cwd=path)
 
 
 def test_git_install_ref(script):
@@ -253,7 +241,7 @@ def test_git_install_ref(script):
     _change_test_package_version(script, version_pkg_path)
 
     version = _install_version_pkg(
-        script, version_pkg_path, rev='refs/foo/bar', expect_stderr=True,
+        script, version_pkg_path, rev='refs/foo/bar',
     )
     assert '0.1' == version
 
@@ -267,14 +255,12 @@ def test_git_install_then_install_ref(script):
     _add_ref(script, version_pkg_path, 'refs/foo/bar')
     _change_test_package_version(script, version_pkg_path)
 
-    version = _install_version_pkg(
-        script, version_pkg_path, expect_stderr=True,
-    )
+    version = _install_version_pkg(script, version_pkg_path)
     assert 'some different version' == version
 
     # Now install the ref.
     version = _install_version_pkg(
-        script, version_pkg_path, rev='refs/foo/bar', expect_stderr=True,
+        script, version_pkg_path, rev='refs/foo/bar',
     )
     assert '0.1' == version
 
@@ -388,13 +374,8 @@ def test_editable__branch_with_sha_same_as_default(script):
     """
     version_pkg_path = _create_test_package(script)
     # Create a second branch with the same SHA.
-    script.run(
-        'git', 'branch', 'develop', expect_stderr=True,
-        cwd=version_pkg_path,
-    )
-    _install_version_pkg_only(
-        script, version_pkg_path, rev='develop', expect_stderr=True
-    )
+    script.run('git', 'branch', 'develop', cwd=version_pkg_path)
+    _install_version_pkg_only(script, version_pkg_path, rev='develop')
 
     branch = _get_editable_branch(script, 'version-pkg')
     assert branch == 'develop'
@@ -410,16 +391,11 @@ def test_editable__branch_with_sha_different_from_default(script):
     """
     version_pkg_path = _create_test_package(script)
     # Create a second branch.
-    script.run(
-        'git', 'branch', 'develop', expect_stderr=True,
-        cwd=version_pkg_path,
-    )
+    script.run('git', 'branch', 'develop', cwd=version_pkg_path)
     # Add another commit to the master branch to give it a different sha.
     _change_test_package_version(script, version_pkg_path)
 
-    version = _install_version_pkg(
-        script, version_pkg_path, rev='develop', expect_stderr=True
-    )
+    version = _install_version_pkg(script, version_pkg_path, rev='develop')
     assert version == '0.1'
 
     branch = _get_editable_branch(script, 'version-pkg')
@@ -437,10 +413,7 @@ def test_editable__non_master_default_branch(script):
     version_pkg_path = _create_test_package(script)
     # Change the default branch of the remote repo to a name that is
     # alphabetically after "master".
-    script.run(
-        'git', 'checkout', '-b', 'release', expect_stderr=True,
-        cwd=version_pkg_path,
-    )
+    script.run('git', 'checkout', '-b', 'release', cwd=version_pkg_path)
     _install_version_pkg_only(script, version_pkg_path)
 
     branch = _get_editable_branch(script, 'version-pkg')

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -19,12 +19,12 @@ def get_head_sha(script, dest):
 
 
 def checkout_ref(script, repo_dir, ref):
-    script.run('git', 'checkout', ref, cwd=repo_dir, expect_stderr=True)
+    script.run('git', 'checkout', ref, cwd=repo_dir)
 
 
 def checkout_new_branch(script, repo_dir, branch):
     script.run(
-        'git', 'checkout', '-b', branch, cwd=repo_dir, expect_stderr=True,
+        'git', 'checkout', '-b', branch, cwd=repo_dir,
     )
 
 
@@ -87,7 +87,7 @@ def test_get_remote_url(script, tmpdir):
     do_commit(script, source_dir)
 
     repo_dir = str(tmpdir / 'repo')
-    script.run('git', 'clone', source_url, repo_dir, expect_stderr=True)
+    script.run('git', 'clone', source_url, repo_dir)
 
     remote_url = Git.get_remote_url(repo_dir)
     assert remote_url == source_url

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from contextlib import contextmanager
+from textwrap import dedent
 import os
 import sys
 import re
@@ -263,6 +264,17 @@ class TestPipResult(object):
                 )
 
 
+def make_check_stderr_message(stderr, line, reason):
+    """
+    Create an exception message to use inside check_stderr().
+    """
+    return dedent("""\
+    {reason}:
+     Caused by line: {line!r}
+     Complete stderr: {stderr}
+    """).format(stderr=stderr, line=line, reason=reason)
+
+
 def check_stderr(
     stderr, allow_stderr_warning=None, allow_stderr_error=None,
 ):
@@ -293,22 +305,34 @@ def check_stderr(
 
     lines = stderr.splitlines()
     for line in lines:
+        # First check for logging errors which are sent directly to stderr
+        # and so bypass any configured log formatter.  The
+        # "--- Logging error ---" string is used in Python 3.4+, and
+        # "Logged from file " is used in Python 2.
+        if (line.startswith('--- Logging error ---') or
+                line.startswith('Logged from file ')):
+            reason = 'stderr has a logging error, which is never allowed'
+            msg = make_check_stderr_message(stderr, line=line, reason=reason)
+            raise RuntimeError(msg)
+
         if line.startswith('ERROR: '):
-            raise RuntimeError(
+            reason = (
                 'stderr has an unexpected error '
-                '(pass allow_stderr_error=True to permit this): {}'
-                .format(line)
+                '(pass allow_stderr_error=True to permit this)'
             )
+            msg = make_check_stderr_message(stderr, line=line, reason=reason)
+            raise RuntimeError(msg)
         if allow_stderr_warning:
             continue
 
         if (line.startswith('WARNING: ') or
                 line.startswith(DEPRECATION_MSG_PREFIX)):
-            raise RuntimeError(
+            reason = (
                 'stderr has an unexpected warning '
-                '(pass allow_stderr_warning=True to permit this): {}'
-                .format(line)
+                '(pass allow_stderr_warning=True to permit this)'
             )
+            msg = make_check_stderr_message(stderr, line=line, reason=reason)
+            raise RuntimeError(msg)
 
 
 class PipTestEnvironment(TestFileEnvironment):


### PR DESCRIPTION
The main purpose of this PR is to fix a non-fatal logging error in a debug log message in `freeze.py` (first commit out of the four in this PR).

It also does the following related things:

1. (second commit) Update `PipTestEnvironment` to also check for logging errors when `allow_stderr_error` is false, and also add a test to check that this works. This will help to catch and prevent similar errors in the future.
2. (third commit) Remove a bunch of unneeded `expect_stderr=True` arguments in VCS tests. (If (1) and (2) had been done before, the logging error would have been detected by the test suite.)
3. (fourth and final commit of the PR) Also remove some unneeded `expect_error=True` in some VCS tests. This unveiled a broken test (`test_git_with_non_editable_unpacking`), which is also fixed in the fourth commit.

Possible future change / improvement: also check for logging errors when our tests are running even if `allow_stderr_error` is true.
