### PR TITLE
Respect --global-option and --install-option for VCS installs.

### DIFF
--- a/news/5518.bugfix
+++ b/news/5518.bugfix
@@ -1,0 +1,2 @@
+Respect ``--global-option`` and ``--install-option`` when installing from
+a version control url (e.g. ``git``).

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -763,10 +763,6 @@ def should_use_ephemeral_cache(
     if req.editable or not req.source_dir:
         return None
 
-    if req.link and not req.link.is_artifact:
-        # VCS checkout. Build wheel just for this run.
-        return True
-
     if "binary" not in format_control.get_allowed_formats(
             canonicalize_name(req.name)):
         logger.info(
@@ -774,6 +770,10 @@ def should_use_ephemeral_cache(
             "being disabled for it.", req.name,
         )
         return None
+
+    if req.link and not req.link.is_artifact:
+        # VCS checkout. Build wheel just for this run.
+        return True
 
     link = req.link
     base, ext = link.splitext()


### PR DESCRIPTION
Fixes #5518 (and duplicates #5576 and #6379).