### PR TITLE
Allow user to pass --prefix="" from command-line.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -113,6 +113,7 @@ Daniel Collins <accounts@dac.io>
 Daniel Hahler <git@thequod.de>
 Daniel Holth <dholth@fastmail.fm>
 Daniel Jost <torpedojost@gmail.com>
+Daniel Katz <katzdm@gmail.com>
 Daniel Shaulov <daniel.shaulov@gmail.com>
 Daniele Procida <daniele@vurt.org>
 Danny Hermes <daniel.j.hermes@gmail.com>

--- a/news/6396.bugfix
+++ b/news/6396.bugfix
@@ -1,0 +1,2 @@
+Allow user to pass --prefix="" from command-line to override global prefix settings with an empty
+prefix.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -459,11 +459,13 @@ class InstallCommand(RequirementCommand):
 
         if options.target_dir:
             self._handle_target_dir(
-                options.target_dir, target_temp_dir, options.upgrade
+                options.target_dir, target_temp_dir, options.upgrade,
+                options.prefix_path
             )
         return requirement_set
 
-    def _handle_target_dir(self, target_dir, target_temp_dir, upgrade):
+    def _handle_target_dir(
+            self, target_dir, target_temp_dir, upgrade, prefix_path):
         ensure_dir(target_dir)
 
         # Checking both purelib and platlib directories for installed
@@ -473,7 +475,8 @@ class InstallCommand(RequirementCommand):
         with target_temp_dir:
             # Checking both purelib and platlib directories for installed
             # packages to be moved to target directory
-            scheme = distutils_scheme('', home=target_temp_dir.path)
+            scheme = distutils_scheme(
+                '', home=target_temp_dir.path, prefix=prefix_path)
             purelib_dir = scheme['purelib']
             platlib_dir = scheme['platlib']
             data_dir = scheme['data']

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -174,7 +174,7 @@ def distutils_scheme(dist_name, user=False, home=None, root=None,
     i.user = user or i.user
     if user:
         i.prefix = ""
-    i.prefix = prefix or i.prefix
+    i.prefix = prefix if prefix is not None else i.prefix
     i.home = home or i.home
     i.root = root or i.root
     i.finalize_options()


### PR DESCRIPTION
In particular, this differentiates between `--prefix=""` and `--prefix=None`, and allows command-line nullifying of global prefix-settings.