### PR TITLE
FIX #6413 pip install <url> allow directory traversal

### DIFF
--- a/news/6413.bugfix
+++ b/news/6413.bugfix
@@ -1,0 +1,3 @@
+Prevent ``pip install <url>`` from permitting directory traversal if e.g.
+a malicious server sends a ``Content-Disposition`` header with a filename
+containing ``../`` or ``..\\``.


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/6413.