### PR TITLE
Fix NameError when handling InvalidRequirement in install_req_from_req_string

### DIFF
--- a/news/6419.bugfix
+++ b/news/6419.bugfix
@@ -1,0 +1,1 @@
+Fix NameError when handling InvalidRequirement in install_req_from_req_string.

--- a/news/6419.bugfix
+++ b/news/6419.bugfix
@@ -1,1 +1,1 @@
-Fix NameError when handling InvalidRequirement in install_req_from_req_string.
+Fix ``NameError`` when handling an invalid requirement.

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -319,7 +319,7 @@ def install_req_from_req_string(
     try:
         req = Requirement(req_string)
     except InvalidRequirement:
-        raise InstallationError("Invalid requirement: '%s'" % req)
+        raise InstallationError("Invalid requirement: '%s'" % req_string)
 
     domains_not_allowed = [
         PyPI.file_storage_domain,

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -4,6 +4,7 @@ import tempfile
 import pytest
 from pip._vendor.packaging.requirements import Requirement
 
+from pip._internal.exceptions import InstallationError
 from pip._internal.req.constructors import (
     install_req_from_line, install_req_from_req_string,
 )
@@ -48,6 +49,14 @@ class TestInstallRequirementBuildDirectory(object):
 
 
 class TestInstallRequirementFrom(object):
+
+    def test_install_req_from_string_invalid_requirement(self):
+        """
+        Requirement strings that cannot be parsed by
+        packaging.requirements.Requirement raise an InstallationError.
+        """
+        with pytest.raises(InstallationError):
+            install_req_from_req_string("http:/this/is/invalid")
 
     def test_install_req_from_string_without_comes_from(self):
         """

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -55,8 +55,12 @@ class TestInstallRequirementFrom(object):
         Requirement strings that cannot be parsed by
         packaging.requirements.Requirement raise an InstallationError.
         """
-        with pytest.raises(InstallationError):
+        with pytest.raises(InstallationError) as excinfo:
             install_req_from_req_string("http:/this/is/invalid")
+
+        assert str(excinfo.value) == (
+            "Invalid requirement: 'http:/this/is/invalid'"
+        )
 
     def test_install_req_from_string_without_comes_from(self):
         """


### PR DESCRIPTION
Previously, an InvalidRequirement would raise a NameError while trying to raise an InstallationError because `req` was not defined.

Discovered while working on #6402.