### PR TITLE
Add missed --trusted-host to supported options in pip install docs

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -153,6 +153,7 @@ The following options are supported:
   *  :ref:`--no-binary <install_--no-binary>`
   *  :ref:`--only-binary <install_--only-binary>`
   *  :ref:`--require-hashes <--require-hashes>`
+  *  :ref:`--trusted-host <--trusted-host>`
 
 For example, to specify :ref:`--no-index <--no-index>` and 2 :ref:`--find-links <--find-links>` locations:
 

--- a/news/6421.doc
+++ b/news/6421.doc
@@ -1,0 +1,1 @@
+Add missed `--trusted-host` to supported options in pip install docs.


### PR DESCRIPTION
Adds missed `--trusted-host` to the list of supported options [below the line](https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format):
> The following options are supported:
