### PR TITLE
Fix option name for smart quotes in sphinxdoc conf

### DIFF
--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -173,9 +173,21 @@ html_static_path = []
 # using the given strftime format.
 html_last_updated_fmt = '%b %d, %Y'
 
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-smart_quotes = False
+# If true, the Docutils Smart Quotes transform (originally based on
+# SmartyPants) will be used to convert characters like quotes and dashes
+# to typographically correct entities.  The default is True.
+smartquotes = True
+
+# This string, for use with Docutils 0.14 or later, customizes the
+# SmartQuotes transform. The default of "qDe" converts normal quote
+# characters ('"' and "'"), en and em dashes ("--" and "---"), and
+# ellipses "...".
+#    For now, we disable the conversion of dashes so that long options
+# like "--find-links" won't render as "-find-links" if included in the
+# text in places where monospaced type can't be used. For example, backticks
+# can't be used inside roles like :ref:`--no-index <--no-index>` because
+# of nesting.
+smartquotes_action = "qe"
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {

--- a/news/6422.doc
+++ b/news/6422.doc
@@ -1,0 +1,2 @@
+Make dashes render correctly when displaying long options like
+``--find-links`` in the text.


### PR DESCRIPTION
Fixes transform double dashes to a long dash. For the instance you can see this issue in [this section](https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format).

Correct option name described here: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-smartquotes

---

### Before 
<img width="525" alt="Снимок экрана 2019-04-19 в 11 10 24" src="https://user-images.githubusercontent.com/7377671/56404940-d123a700-6293-11e9-848a-d75884c2d87c.png">

---

### After
<img width="522" alt="Снимок экрана 2019-04-19 в 11 18 37" src="https://user-images.githubusercontent.com/7377671/56405117-e77e3280-6294-11e9-9f5b-706b92335bf5.png">

