### PR TITLE
Move _link_package_versions() to CandidateEvaluator

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -668,7 +668,7 @@ class PackageFinder(object):
         return [mkurl_pypi_url(url) for url in self.index_urls]
 
     def find_all_candidates(self, project_name):
-        # type: (str) -> List[Optional[InstallationCandidate]]
+        # type: (str) -> List[InstallationCandidate]
         """Find all available InstallationCandidate for project_name
 
         This checks index_urls and find_links.
@@ -873,7 +873,7 @@ class PackageFinder(object):
         links,  # type: Iterable[Link]
         search  # type: Search
     ):
-        # type: (...) -> List[Optional[InstallationCandidate]]
+        # type: (...) -> List[InstallationCandidate]
         result = []
         for link in self._sort_links(links):
             v = self._link_package_versions(link, search)

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -471,11 +471,8 @@ class TestLinkPackageVersions(object):
         self.version = '1.0'
         self.search_name = 'pytest'
         self.canonical_name = 'pytest'
-        self.finder = PackageFinder(
-            [],
-            [],
-            session=PipSession(),
-        )
+        valid_tags = pip._internal.pep425tags.get_supported()
+        self.evaluator = CandidateEvaluator(valid_tags=valid_tags)
 
     @pytest.mark.parametrize(
         'url',
@@ -492,7 +489,7 @@ class TestLinkPackageVersions(object):
             canonical=self.canonical_name,
             formats=['source', 'binary'],
         )
-        result = self.finder._link_package_versions(link, search)
+        result = self.evaluator._link_package_versions(link, search)
         expected = InstallationCandidate(self.search_name, self.version, link)
         assert result == expected, result
 
@@ -513,7 +510,7 @@ class TestLinkPackageVersions(object):
             canonical=self.canonical_name,
             formats=['source', 'binary'],
         )
-        result = self.finder._link_package_versions(link, search)
+        result = self.evaluator._link_package_versions(link, search)
         assert result is None, result
 
 

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -460,7 +460,7 @@ def test_finder_installs_pre_releases_with_version_spec():
         assert link.url == "https://foo/bar-2.0b1.tar.gz"
 
 
-class TestLinkPackageVersions(object):
+class TestCandidateEvaluator(object):
 
     # patch this for travis which has distribute in its base env for now
     @patch(
@@ -481,7 +481,7 @@ class TestLinkPackageVersions(object):
             'http:/yo/pytest-1.0-py2.py3-none-any.whl',
         ],
     )
-    def test_link_package_versions_match(self, url):
+    def test_evaluate_link__match(self, url):
         """Test that 'pytest' archives match for 'pytest'"""
         link = Link(url)
         search = Search(
@@ -489,7 +489,7 @@ class TestLinkPackageVersions(object):
             canonical=self.canonical_name,
             formats=['source', 'binary'],
         )
-        result = self.evaluator._link_package_versions(link, search)
+        result = self.evaluator.evaluate_link(link, search)
         expected = InstallationCandidate(self.search_name, self.version, link)
         assert result == expected, result
 
@@ -502,7 +502,7 @@ class TestLinkPackageVersions(object):
             'http:/yo/pytest_xdist-1.0-py2.py3-none-any.whl',
         ],
     )
-    def test_link_package_versions_substring_fails(self, url):
+    def test_evaluate_link__substring_fails(self, url):
         """Test that 'pytest<something> archives won't match for 'pytest'."""
         link = Link(url)
         search = Search(
@@ -510,7 +510,7 @@ class TestLinkPackageVersions(object):
             canonical=self.canonical_name,
             formats=['source', 'binary'],
         )
-        result = self.evaluator._link_package_versions(link, search)
+        result = self.evaluator.evaluate_link(link, search)
         assert result is None, result
 
 


### PR DESCRIPTION
This is a follow-on to PR #6424 and is also a refactor. It stems from the following comment: https://github.com/pypa/pip/pull/6424#issuecomment-485390109