### PR TITLE
Fix pip download from an url in Windows

### DIFF
--- a/news/6436.bugfix
+++ b/news/6436.bugfix
@@ -1,0 +1,1 @@
+Fix "pip download" from an url in Windows

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -481,9 +481,14 @@ class InstallRequirement(object):
     @property
     def setup_py_dir(self):
         # type: () -> str
-        return os.path.join(
-            self.source_dir,
-            self.link and self.link.subdirectory_fragment or '')
+
+        if self.link and self.link.subdirectory_fragment:
+            return os.path.join(
+                self.source_dir,
+                self.link.subdirectory_fragment
+            )
+        else:
+            return self.source_dir
 
     @property
     def setup_py_path(self):
@@ -851,7 +856,8 @@ class InstallRequirement(object):
     def _clean_zip_name(self, name, prefix):  # only used by archive.
         # type: (str, str) -> str
         assert name.startswith(prefix + os.path.sep), (
-            "name %r doesn't start with prefix %r" % (name, prefix)
+            "name %r doesn't start with prefix %r" %
+            (name, prefix + os.path.sep)
         )
         name = name[len(prefix) + 1:]
         name = name.replace(os.path.sep, '/')

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -226,6 +226,17 @@ def test_install_local_with_subdirectory(script):
     result.assert_installed('version_subpkg.py', editable=False)
 
 
+@pytest.mark.network
+def test_download_local_with_subdirectory(script):
+    version_pkg_path = _create_test_package_with_subdirectory(script,
+                                                              'version_subdir')
+    script.pip(
+        'download',
+        '%s#egg=version_subpkg&subdirectory=version_subdir' %
+        ('git+' + path_to_url(version_pkg_path),)
+    )
+
+
 def test_wheel_user_with_prefix_in_pydistutils_cfg(
         script, data, with_wheel):
     if os.name == 'posix':


### PR DESCRIPTION
InstallRequirement relies on fact that setup_py_dir returns path without
directory separator at the end. In Linux this separator is stripped
by os.path.abspath, but in Windows it is not.

Also fix fix assertion message in _clean_zip_name to contain actual path
that was used in the condition.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
