### PR TITLE
Permit --no-use-pep517 with editable mode in more cases.

### DIFF
--- a/news/6434.feature
+++ b/news/6434.feature
@@ -1,0 +1,7 @@
+Allow ``--no-use-pep517`` to be used as a work-around when installing a
+project in editable mode, even when `PEP 517
+<https://www.python.org/dev/peps/pep-0517/>`_ mandates
+``pyproject.toml``-style processing (i.e. when the project has a
+``pyproject.toml`` file as well as a ``"build-backend"`` key for the
+``"build_system"`` value). Since this option conflicts with the PEP 517 spec,
+this mode of operation is officially unsupported.


### PR DESCRIPTION
Fixes #6434.

The two new messages this PR introduces are as follows:

1. "build-backend" present and use_pep517=None raises `InstallationError`:

> Error installing 'my-package': editable mode is not supported for pyproject.toml-style projects. This project is pyproject.toml-style because it has a pyproject.toml file and a "build-backend" key for the "build_system" value, but editable mode is undefined for pyproject.toml-style projects. Since the project has a setup.py, you may pass --no-use-pep517 to opt out of pyproject.toml-style processing. However, this is an unsupported combination. See PEP 517 for details on pyproject.toml-style projects.

2. "build-backend" present and use_pep517=False logs warning:

> WARNING: Installing 'my-package' in editable mode, which is not supported for pyproject.toml-style projects: this project is pyproject.toml-style because it has a pyproject.toml file and a "build-backend" key for the "build_system" value, but editable mode is undefined for pyproject.toml-style projects. See PEP 517 for details on pyproject.toml-style projects.

And for comparison, I'm including one of the messages that already exists from before and remains the same.

3. "build-backend" not present and use_pep517=None raises `InstallationError`:

> Error installing 'my-package': editable mode is not supported for pyproject.toml-style projects. pip is processing this project as pyproject.toml-style because it has a pyproject.toml file. Since the project has a setup.py and the pyproject.toml has no "build-backend" key for the "build_system" value, you may pass --no-use-pep517 to opt out of pyproject.toml-style processing. See PEP 517 for details on pyproject.toml-style projects.