### PR TITLE
Fix #5874: Filter out candidates with hash mismatches.

### DIFF
--- a/news/5874.feature
+++ b/news/5874.feature
@@ -1,0 +1,1 @@
+Only select candidates in hash-checking mode that will pass hash checks.

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -407,24 +407,19 @@ class FoundCandidates(object):
             # a HashMissing error get raised later.
             # This is not a security check: after download the contents will
             # be hashed and compared to the known-good hashes.
-            def test_against_hashes(candidate):
-                link = candidate.location
-                if not link.hash:
-                    # We can only filter candidates with hashes in their URLs.
-                    return True
-                is_match = hashes.test_against_hash(link.hash_name, link.hash)
-                if not is_match:
-                    logger.warning(
-                        "candidate %s ignored: hash %s:%s not among provided "
-                        "hashes",
-                        link.filename, link.hash_name, link.hash,
-                    )
-                return is_match
-
             candidates = self._evaluator.get_best_candidates(iter_candidates)
             for c in candidates:
-                if test_against_hashes(c):
+                link = c.location
+                if not link.hash:
+                    # We can only filter candidates with hashes in their URLs.
                     return c
+                if hashes.test_against_hash(link.hash_name, link.hash):
+                    return c
+                logger.warning(
+                    "candidate %s ignored: hash %s:%s not among provided "
+                    "hashes",
+                    link.filename, link.hash_name, link.hash,
+                )
         else:
             candidates = list(iter_candidates)
             return self._evaluator.get_best_candidate(candidates)

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -51,7 +51,7 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.pep425tags import Pep425Tag
     from pip._internal.req import InstallRequirement
     from pip._internal.download import PipSession
-    from pip._internal.utils import Hashes
+    from pip._internal.utils.hashes import Hashes
 
     SecureOrigin = Tuple[str, str, Optional[str]]
     BuildTag = Tuple[Any, ...]  # either empty tuple or Tuple[int, str]

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -395,10 +395,16 @@ class FoundCandidates(object):
         candidates = list(self.iter_applicable())
         if hashes:
             # If we are in hash-checking mode, filter out candidates that will
-            # fail the hash check. This prevents HashMismatch errors when a new
-            # distribution is uploaded for an old release.
+            # fail the hash check per the hash provided in their Link URL.
+            # This prevents HashMismatch errors when a new distribution is
+            # uploaded for an old release.
+            # This is not a security check: after download the contents will
+            # be hashed and compared to the known-good hashes.
             def test_against_hashes(candidate):
                 link = candidate.location
+                if not link.hash:
+                    # We can only filter candidates with hashes in their URLs.
+                    return True
                 is_match = hashes.test_against_hash(link.hash_name, link.hash)
                 if not is_match:
                     logger.warning(

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -86,6 +86,11 @@ class Hashes(object):
         with open(path, 'rb') as file:
             return self.check_against_file(file)
 
+    def test_against_hash(self, hash_name, hash_value):
+        # type (str, str) -> bool
+        """Return whether a given hash is among the known-good hashes."""
+        return hash_value in self._allowed.get(hash_name, [])
+
     def __nonzero__(self):
         # type: () -> bool
         """Return whether I know any known-good hashes."""

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -115,7 +115,9 @@ class TestRequirementSet(object):
         ))
         # This flag activates --require-hashes mode:
         reqset.add_requirement(get_processed_req_from_line(
-            'tracefront==0.1 --hash=sha256:somehash', lineno=2,
+            'tracefront==0.1 --hash=sha256:d74cd6119a883bf15e2bae63ac0fea33b48'
+            '45e1a76b82aad586537d92a25bb51',
+            lineno=2,
         ))
         # This hash should be accepted because it came from the reqs file, not
         # from the internet:
@@ -145,7 +147,8 @@ class TestRequirementSet(object):
             r'    blessings==1.0 --hash=sha256:[0-9a-f]+\n'
             r'THESE PACKAGES DO NOT MATCH THE HASHES.*\n'
             r'    tracefront==0.1 .*:\n'
-            r'        Expected sha256 somehash\n'
+            r'        Expected sha256 d74cd6119a883bf15e2bae63ac0fea33b4845e1a'
+            r'76b82aad586537d92a25bb51\n'
             r'             Got        [0-9a-f]+$',
             resolver.resolve,
             reqset


### PR DESCRIPTION
Implements @di's proposed solution to #5874.

Changes the behavior of `pip install` in hash-checking mode to filter out any candidates whose hashes (obtained via URL) do not match the hashes provided. This prevents a HashMismatch error when a more preferred binary distribution is upload for a release after a user pins the hashes for that release. Instead a warning is logged when a distribution is skipped due to hash mismatches:
```
Collecting tox==3.9.0 (from -r requirements.txt (line 1))               
  WARNING: candidate tox-3.9.0-py2.py3-none-any.whl ignored: hash sha256:1b166b93d2ce66bb7b253ba944d2be89e0c9d432d49eeb9da2988b4902a4684e not among provided hashes
  WARNING: candidate tox-3.9.0.tar.gz ignored: hash sha256:665cbdd99f5c196dd80d1d8db8c8cf5d48b1ae1f778bccd1bdf14d5aaf4ca0fc not among provided hashes
```

Note that a second hash comparison is performed when the candidate is downloaded. This is important because the first check is not secure: it trusts that the hash in the URL is the same as the hash in the content, and it also does not error when the user is in hash-checking mode but has not provided a hash.

This still needs tests, but I would like to check that this is the right approach before adding them.