### PR TITLE
Don't allow logging errors during tests even if allow_stderr_error=True

### DIFF
--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -80,6 +80,15 @@ def test_as_import(script):
 
 class TestPipTestEnvironment:
 
+    def run_stderr_with_prefix(self, script, prefix, **kwargs):
+        """
+        Call run() that prints stderr with the given prefix.
+        """
+        text = '{}: hello, world\\n'.format(prefix)
+        command = 'import sys; sys.stderr.write("{}")'.format(text)
+        args = [sys.executable, '-c', command]
+        script.run(*args, **kwargs)
+
     def run_with_log_command(self, script, sub_string, **kwargs):
         """
         Call run() on a command that logs a "%"-style format string using
@@ -89,15 +98,6 @@ class TestPipTestEnvironment:
             "import logging; logging.basicConfig(level='INFO'); "
             "logging.getLogger().info('sub: {}', 'foo')"
         ).format(sub_string)
-        args = [sys.executable, '-c', command]
-        script.run(*args, **kwargs)
-
-    def run_stderr_with_prefix(self, script, prefix, **kwargs):
-        """
-        Call run() that prints stderr with the given prefix.
-        """
-        text = '{}: hello, world\\n'.format(prefix)
-        command = 'import sys; sys.stderr.write("{}")'.format(text)
         args = [sys.executable, '-c', command]
         script.run(*args, **kwargs)
 

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -80,7 +80,7 @@ def test_as_import(script):
 
 class TestPipTestEnvironment:
 
-    def run_with_log_command(self, script, sub_string):
+    def run_with_log_command(self, script, sub_string, **kwargs):
         """
         Call run() on a command that logs a "%"-style format string using
         the given substring as the string's replacement field.
@@ -90,7 +90,7 @@ class TestPipTestEnvironment:
             "logging.getLogger().info('sub: {}', 'foo')"
         ).format(sub_string)
         args = [sys.executable, '-c', command]
-        script.run(*args)
+        script.run(*args, **kwargs)
 
     def run_stderr_with_prefix(self, script, prefix, **kwargs):
         """
@@ -162,8 +162,13 @@ class TestPipTestEnvironment:
 
         expected_start = 'stderr has a logging error, which is never allowed'
         with assert_error_startswith(RuntimeError, expected_start):
-            # Pass a bad substitution string.
-            self.run_with_log_command(script, sub_string='{!r}')
+            # Pass a bad substitution string.  Also, pass
+            # allow_stderr_error=True to check that the RuntimeError occurs
+            # even under the stricter test condition of when we are allowing
+            # other types of errors.
+            self.run_with_log_command(
+                script, sub_string='{!r}', allow_stderr_error=True,
+            )
 
     def test_run__allow_stderr_error_false_error_with_expect_error(
         self, script,


### PR DESCRIPTION
This is a follow-on to PR #6383 by addressing this follow-up task mentioned in the PR's [original comment](https://github.com/pypa/pip/pull/6383#issue-267392590):

> Possible future change / improvement: also check for logging errors when our tests are running even if `allow_stderr_error` is true.