### PR TITLE
Upgrade Sphinx version for Read the Docs

### DIFF
--- a/news/6471.doc
+++ b/news/6471.doc
@@ -1,2 +1,1 @@
-Upgrade Sphinx version for Read the Docs
-from 1.7.9 to 2.0.1
+Upgrade Sphinx version used to build documentation.

--- a/news/6471.doc
+++ b/news/6471.doc
@@ -1,0 +1,2 @@
+Upgrade Sphinx version for Read the Docs
+from 1.7.9 to 2.0.1

--- a/tools/docs-requirements.txt
+++ b/tools/docs-requirements.txt
@@ -1,4 +1,4 @@
-sphinx == 1.7.*
+sphinx == 2.0.1
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands = pytest --timeout 300 --cov=pip --cov-report=term-missing --cov-report
 [testenv:docs]
 # Don't skip install here since pip_sphinxext uses pip's internals.
 deps = -r{toxinidir}/tools/docs-requirements.txt
-basepython = python3.5
+basepython = python3.6
 commands =
     sphinx-build -W -d {envtmpdir}/doctrees/html -b html docs/html docs/build/html
     # Having the conf.py in the docs/html is weird but needed because we

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands = pytest --timeout 300 --cov=pip --cov-report=term-missing --cov-report
 [testenv:docs]
 # Don't skip install here since pip_sphinxext uses pip's internals.
 deps = -r{toxinidir}/tools/docs-requirements.txt
-basepython = python2.7
+basepython = python3.5
 commands =
     sphinx-build -W -d {envtmpdir}/doctrees/html -b html docs/html docs/build/html
     # Having the conf.py in the docs/html is weird but needed because we


### PR DESCRIPTION
Because sphinx 2.0.1 doesn't support, I changed basepython version of docs from 2.7 to 3.5 

fixed : #6471 
