### PR TITLE
Remove utils/packaging.py's dependence on the current environment

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -360,7 +360,9 @@ class CandidateEvaluator(object):
                     link, 'Python version is incorrect')
                 return None
         try:
-            support_this_python = check_requires_python(link.requires_python)
+            support_this_python = check_requires_python(
+                link.requires_python, version_info=sys.version_info[:3],
+            )
         except specifiers.InvalidSpecifier:
             logger.debug("Package %s has an invalid Requires-Python entry: %s",
                          link.filename, link.requires_python)

--- a/src/pip/_internal/resolve.py
+++ b/src/pip/_internal/resolve.py
@@ -11,6 +11,7 @@ for sub-dependencies
 """
 
 import logging
+import sys
 from collections import defaultdict
 from itertools import chain
 
@@ -296,7 +297,7 @@ class Resolver(object):
         # Parse and return dependencies
         dist = abstract_dist.dist()
         try:
-            check_dist_requires_python(dist)
+            check_dist_requires_python(dist, version_info=sys.version_info[:3])
         except UnsupportedPythonVersion as err:
             if self.ignore_requires_python:
                 logger.warning(err.args[0])

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import logging
-import sys
 from email.parser import FeedParser
 
 from pip._vendor import pkg_resources
@@ -12,7 +11,7 @@ from pip._internal.utils.misc import display_path
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional
+    from typing import Optional, Tuple
     from email.message import Message
     from pip._vendor.pkg_resources import Distribution
 
@@ -20,10 +19,13 @@ if MYPY_CHECK_RUNNING:
 logger = logging.getLogger(__name__)
 
 
-def check_requires_python(requires_python):
-    # type: (Optional[str]) -> bool
+def check_requires_python(requires_python, version_info):
+    # type: (Optional[str], Tuple[int, ...]) -> bool
     """
-    Check if the python version in use match the `requires_python` specifier.
+    Check if the given Python version matches a `requires_python` specifier.
+
+    :param version_info: A tuple of ints representing the Python
+        major-minor-micro version to check (e.g. `sys.version_info[:3]`).
 
     Returns `True` if the version of python in use matches the requirement.
     Returns `False` if the version of python in use does not matches the
@@ -37,7 +39,7 @@ def check_requires_python(requires_python):
     requires_python_specifier = specifiers.SpecifierSet(requires_python)
 
     # We only use major.minor.micro
-    python_version = version.parse('.'.join(map(str, sys.version_info[:3])))
+    python_version = version.parse('.'.join(map(str, version_info[:3])))
     return python_version in requires_python_specifier
 
 
@@ -57,16 +59,22 @@ def get_metadata(dist):
     return feed_parser.close()
 
 
-def check_dist_requires_python(dist):
+def check_dist_requires_python(dist, version_info):
+    """
+    :param version_info: A tuple of ints representing the Python
+        major-minor-micro version to check (e.g. `sys.version_info[:3]`).
+    """
     pkg_info_dict = get_metadata(dist)
     requires_python = pkg_info_dict.get('Requires-Python')
     try:
-        if not check_requires_python(requires_python):
+        if not check_requires_python(
+            requires_python, version_info=version_info,
+        ):
             raise exceptions.UnsupportedPythonVersion(
                 "%s requires Python '%s' but the running Python is %s" % (
                     dist.project_name,
                     requires_python,
-                    '.'.join(map(str, sys.version_info[:3])),)
+                    '.'.join(map(str, version_info[:3])),)
             )
     except specifiers.InvalidSpecifier as e:
         logger.warning(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -714,11 +714,14 @@ class TestCheckRequiresPython(object):
         fake_dist = Mock(
             has_metadata=lambda _: True,
             get_metadata=lambda _: metadata)
+        version_info = sys.version_info[:3]
         if should_raise:
             with pytest.raises(UnsupportedPythonVersion):
-                check_dist_requires_python(fake_dist)
+                check_dist_requires_python(
+                    fake_dist, version_info=version_info,
+                )
         else:
-            check_dist_requires_python(fake_dist)
+            check_dist_requires_python(fake_dist, version_info=version_info)
 
 
 class TestGetProg(object):


### PR DESCRIPTION
This is a simple PR to remove `utils/packaging.py`'s dependence on the current environment (specifically, on `sys.version_info`). (You can see the removal of the dependence since the PR removes the `import sys` line from the module.)

Doing the above will help with testing because the dependency becomes explicit through the function arguments.