### PR TITLE
Simplify CandidateEvaluator.evaluate_link()

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -273,7 +273,7 @@ class CandidateEvaluator(object):
         self._valid_tags = valid_tags
 
         # We compile the regex here instead of as a class attribute so as
-        # not to not impact pip start-up time.  This is also okay because
+        # not to impact pip start-up time.  This is also okay because
         # CandidateEvaluator is generally instantiated only once per pip
         # invocation (when PackageFinder is instantiated).
         self._py_version_re = re.compile(r'-py([123]\.?[0-9]?)$')

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -24,7 +24,7 @@ def check_requires_python(requires_python, version_info):
     """
     Check if the given Python version matches a `requires_python` specifier.
 
-    :param version_info: A tuple of ints representing the Python
+    :param version_info: A 3-tuple of ints representing the Python
         major-minor-micro version to check (e.g. `sys.version_info[:3]`).
 
     Returns `True` if the version of python in use matches the requirement.
@@ -38,8 +38,7 @@ def check_requires_python(requires_python, version_info):
         return True
     requires_python_specifier = specifiers.SpecifierSet(requires_python)
 
-    # We only use major.minor.micro
-    python_version = version.parse('.'.join(map(str, version_info[:3])))
+    python_version = version.parse('.'.join(map(str, version_info)))
     return python_version in requires_python_specifier
 
 
@@ -61,7 +60,7 @@ def get_metadata(dist):
 
 def check_dist_requires_python(dist, version_info):
     """
-    :param version_info: A tuple of ints representing the Python
+    :param version_info: A 3-tuple of ints representing the Python
         major-minor-micro version to check (e.g. `sys.version_info[:3]`).
     """
     pkg_info_dict = get_metadata(dist)
@@ -74,7 +73,7 @@ def check_dist_requires_python(dist, version_info):
                 "%s requires Python '%s' but the running Python is %s" % (
                     dist.project_name,
                     requires_python,
-                    '.'.join(map(str, version_info[:3])),)
+                    '.'.join(map(str, version_info)),)
             )
     except specifiers.InvalidSpecifier as e:
         logger.warning(

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -489,7 +489,7 @@ class TestCandidateEvaluator(object):
             canonical=self.canonical_name,
             formats=['source', 'binary'],
         )
-        result = self.evaluator.evaluate_link(link, search)
+        result = self.evaluator.get_install_candidate(link, search)
         expected = InstallationCandidate(self.search_name, self.version, link)
         assert result == expected, result
 
@@ -510,7 +510,7 @@ class TestCandidateEvaluator(object):
             canonical=self.canonical_name,
             formats=['source', 'binary'],
         )
-        result = self.evaluator.evaluate_link(link, search)
+        result = self.evaluator.get_install_candidate(link, search)
         assert result is None, result
 
 


### PR DESCRIPTION
This simplifies `CandidateEvaluator.evaluate_link()` by adding `CandidateEvaluator.get_install_candidate()`. This lets us (1) DRY up the ten calls to `_log_skipped_link()` with a single call, and (2) remove `evaluate_link()`'s dependence on both `_log_skipped_link()` and the `InstallationCandidate` class. This also makes `evaluate_link()` easier to test.

The PR also includes a couple tiny follow-up tweaks to PR #6478.