### PR TITLE
fix-5963: fail elegantly

### DIFF
--- a/news/5963.bugfix
+++ b/news/5963.bugfix
@@ -1,0 +1,1 @@
+This change will fail elegantly on a missing name or section in config

--- a/news/5963.bugfix
+++ b/news/5963.bugfix
@@ -1,1 +1,1 @@
-This change will fail elegantly on a missing name or section in config
+Fail elegantly when trying to set an incorrectly formatted key in config.

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -50,6 +50,12 @@ def _normalize_name(name):
 
 def _disassemble_key(name):
     # type: (str) -> List[str]
+    if "." not in name:
+        error_message = (
+            "Key does not contain dot separated section and key. "
+            "Perhaps you wanted to use 'global.{}' instead?"
+        ).format(name)
+        raise ConfigurationError(error_message)
     return name.split(".", 1)
 
 

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -59,4 +59,6 @@ class TestBasicLoading(ConfigurationMixin):
         assert lines == textwrap.dedent(expected).strip().splitlines()
 
     def test_forget_section(self, script):
-        script.pip("config", "set", "isolated", "true", expect_error=True)
+        result = script.pip("config", "set", "isolated", "true",
+                            expect_error=True)
+        assert "global.isolated" in result.stderr

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -57,3 +57,6 @@ class TestBasicLoading(ConfigurationMixin):
         """
 
         assert lines == textwrap.dedent(expected).strip().splitlines()
+
+    def test_forget_section(self, script):
+        script.pip("config", "set", "isolated", "true", expect_error=True)


### PR DESCRIPTION
Fail elegantly on on missing name or section in config set / unset
Fixes #5963 
