### PR TITLE
Store VersionControl objects instead of classes in the VCS registry

### DIFF
--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -51,7 +51,7 @@ if MYPY_CHECK_RUNNING:
     )
     from pip._internal.models.link import Link
     from pip._internal.utils.hashes import Hashes
-    from pip._internal.vcs import AuthInfo
+    from pip._internal.vcs import AuthInfo, VersionControl
 
 try:
     import ssl  # noqa
@@ -551,13 +551,14 @@ def unpack_vcs_link(link, location):
 
 
 def _get_used_vcs_backend(link):
+    # type: (Link) -> Optional[VersionControl]
     """
     Return a VersionControl object or None.
     """
-    for backend in vcs.backends:
-        if link.scheme in backend.schemes:
-            vcs_backend = backend()
+    for vcs_backend in vcs.backends:
+        if link.scheme in vcs_backend.schemes:
             return vcs_backend
+    return None
 
 
 def is_vcs_url(link):

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -173,9 +173,9 @@ def get_requirement_info(dist):
     location = os.path.normcase(os.path.abspath(dist.location))
 
     from pip._internal.vcs import vcs, RemoteNotFoundError
-    vc_type = vcs.get_backend_type(location)
+    vcs_backend = vcs.get_backend_for_dir(location)
 
-    if not vc_type:
+    if vcs_backend is None:
         req = dist.as_requirement()
         logger.debug(
             'No VCS found for editable requirement "%s" in: %r', req,
@@ -187,12 +187,12 @@ def get_requirement_info(dist):
         return (location, True, comments)
 
     try:
-        req = vc_type.get_src_requirement(location, dist.project_name)
+        req = vcs_backend.get_src_requirement(location, dist.project_name)
     except RemoteNotFoundError:
         req = dist.as_requirement()
         comments = [
             '# Editable {} install with no remote ({})'.format(
-                vc_type.__name__, req,
+                type(vcs_backend).__name__, req,
             )
         ]
         return (location, True, comments)
@@ -202,7 +202,7 @@ def get_requirement_info(dist):
             'cannot determine version of editable source in %s '
             '(%s command not found in path)',
             location,
-            vc_type.name,
+            vcs_backend.name,
         )
         return (None, True, [])
 

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -165,14 +165,10 @@ class VcsSupport(object):
             self._registry[cls.name] = cls
             logger.debug('Registered VCS backend: %s', cls.name)
 
-    def unregister(self, cls=None, name=None):
-        # type: (Optional[Type[VersionControl]], Optional[str]) -> None
+    def unregister(self, name):
+        # type: (str) -> None
         if name in self._registry:
             del self._registry[name]
-        elif cls in self._registry.values():
-            del self._registry[cls.name]
-        else:
-            logger.warning('Cannot unregister because no class or name given')
 
     def get_backend_type(self, location):
         # type: (str) -> Optional[Type[VersionControl]]

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -122,7 +122,7 @@ class RevOptions(object):
 
 
 class VcsSupport(object):
-    _registry = {}  # type: Dict[str, Type[VersionControl]]
+    _registry = {}  # type: Dict[str, VersionControl]
     schemes = ['ssh', 'git', 'hg', 'bzr', 'sftp', 'svn']
 
     def __init__(self):
@@ -140,7 +140,7 @@ class VcsSupport(object):
 
     @property
     def backends(self):
-        # type: () -> List[Type[VersionControl]]
+        # type: () -> List[VersionControl]
         return list(self._registry.values())
 
     @property
@@ -162,7 +162,7 @@ class VcsSupport(object):
             logger.warning('Cannot register VCS %s', cls.__name__)
             return
         if cls.name not in self._registry:
-            self._registry[cls.name] = cls
+            self._registry[cls.name] = cls()
             logger.debug('Registered VCS backend: %s', cls.name)
 
     def unregister(self, name):
@@ -170,17 +170,17 @@ class VcsSupport(object):
         if name in self._registry:
             del self._registry[name]
 
-    def get_backend_type(self, location):
-        # type: (str) -> Optional[Type[VersionControl]]
+    def get_backend_for_dir(self, location):
+        # type: (str) -> Optional[VersionControl]
         """
-        Return the type of the version control backend if found at given
-        location, e.g. vcs.get_backend_type('/path/to/vcs/checkout')
+        Return a VersionControl object if a repository of that type is found
+        at the given directory.
         """
-        for vc_type in self._registry.values():
-            if vc_type.controls_location(location):
+        for vcs_backend in self._registry.values():
+            if vcs_backend.controls_location(location):
                 logger.debug('Determine that %s uses VCS: %s',
-                             location, vc_type.name)
-                return vc_type
+                             location, vcs_backend.name)
+                return vcs_backend
         return None
 
     def get_backend(self, name):
@@ -189,10 +189,7 @@ class VcsSupport(object):
         Return a VersionControl object or None.
         """
         name = name.lower()
-        if name in self._registry:
-            vc_type = self._registry[name]
-            return vc_type()
-        return None
+        return self._registry.get(name)
 
 
 vcs = VcsSupport()


### PR DESCRIPTION
This is a relatively simple change made possible by PR #6408. It changes the VCS registry to store `VersionControl` objects instead of `VersionControl` classes.

This change is useful because it lets us do things like lazily obtain and cache the version of each installed VCS command (once and globally), if needed (e.g. for issue #6386).

It also simplifies the API somewhat because callers will now no longer need to instantiate a `VersionControl` object after getting the class from the registry. They can just use the object directly from the registry.