### PR TITLE
Make VersionControl.fetch_new() an instance method

### DIFF
--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -376,8 +376,7 @@ class VersionControl(object):
         """
         return (cls.normalize_url(url1) == cls.normalize_url(url2))
 
-    @classmethod
-    def fetch_new(cls, dest, url, rev_options):
+    def fetch_new(self, dest, url, rev_options):
         """
         Fetch a revision from a repository, in the case that this is the
         first fetch from the repository.

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -46,8 +46,7 @@ class Bazaar(VersionControl):
             show_stdout=False,
         )
 
-    @classmethod
-    def fetch_new(cls, dest, url, rev_options):
+    def fetch_new(self, dest, url, rev_options):
         rev_display = rev_options.to_display()
         logger.info(
             'Checking out %s%s to %s',
@@ -56,7 +55,7 @@ class Bazaar(VersionControl):
             display_path(dest),
         )
         cmd_args = ['branch', '-q'] + rev_options.to_args() + [url, dest]
-        cls.run_command(cmd_args)
+        self.run_command(cmd_args)
 
     def switch(self, dest, url, rev_options):
         self.run_command(['switch', url], cwd=dest)

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -180,36 +180,35 @@ class Git(VersionControl):
 
         return cls.get_revision(dest) == name
 
-    @classmethod
-    def fetch_new(cls, dest, url, rev_options):
+    def fetch_new(self, dest, url, rev_options):
         rev_display = rev_options.to_display()
         logger.info(
             'Cloning %s%s to %s', redact_password_from_url(url),
             rev_display, display_path(dest),
         )
-        cls.run_command(['clone', '-q', url, dest])
+        self.run_command(['clone', '-q', url, dest])
 
         if rev_options.rev:
             # Then a specific revision was requested.
-            rev_options = cls.resolve_revision(dest, url, rev_options)
+            rev_options = self.resolve_revision(dest, url, rev_options)
             branch_name = getattr(rev_options, 'branch_name', None)
             if branch_name is None:
                 # Only do a checkout if the current commit id doesn't match
                 # the requested revision.
-                if not cls.is_commit_id_equal(dest, rev_options.rev):
+                if not self.is_commit_id_equal(dest, rev_options.rev):
                     cmd_args = ['checkout', '-q'] + rev_options.to_args()
-                    cls.run_command(cmd_args, cwd=dest)
-            elif cls.get_current_branch(dest) != branch_name:
+                    self.run_command(cmd_args, cwd=dest)
+            elif self.get_current_branch(dest) != branch_name:
                 # Then a specific branch was requested, and that branch
                 # is not yet checked out.
                 track_branch = 'origin/{}'.format(branch_name)
                 cmd_args = [
                     'checkout', '-b', branch_name, '--track', track_branch,
                 ]
-                cls.run_command(cmd_args, cwd=dest)
+                self.run_command(cmd_args, cwd=dest)
 
         #: repo may contain submodules
-        cls.update_submodules(dest)
+        self.update_submodules(dest)
 
     def switch(self, dest, url, rev_options):
         self.run_command(['config', 'remote.origin.url', url], cwd=dest)

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -32,8 +32,7 @@ class Mercurial(VersionControl):
                 ['archive', location], show_stdout=False, cwd=temp_dir.path
             )
 
-    @classmethod
-    def fetch_new(cls, dest, url, rev_options):
+    def fetch_new(self, dest, url, rev_options):
         rev_display = rev_options.to_display()
         logger.info(
             'Cloning hg %s%s to %s',
@@ -41,9 +40,9 @@ class Mercurial(VersionControl):
             rev_display,
             display_path(dest),
         )
-        cls.run_command(['clone', '--noupdate', '-q', url, dest])
+        self.run_command(['clone', '--noupdate', '-q', url, dest])
         cmd_args = ['update', '-q'] + rev_options.to_args()
-        cls.run_command(cmd_args, cwd=dest)
+        self.run_command(cmd_args, cwd=dest)
 
     def switch(self, dest, url, rev_options):
         repo_config = os.path.join(dest, self.dirname, 'hgrc')

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -51,8 +51,7 @@ class Subversion(VersionControl):
             cmd_args = ['export'] + rev_options.to_args() + [url, location]
             self.run_command(cmd_args, show_stdout=False)
 
-    @classmethod
-    def fetch_new(cls, dest, url, rev_options):
+    def fetch_new(self, dest, url, rev_options):
         rev_display = rev_options.to_display()
         logger.info(
             'Checking out %s%s to %s',
@@ -61,7 +60,7 @@ class Subversion(VersionControl):
             display_path(dest),
         )
         cmd_args = ['checkout', '-q'] + rev_options.to_args() + [url, dest]
-        cls.run_command(cmd_args)
+        self.run_command(cmd_args)
 
     def switch(self, dest, url, rev_options):
         cmd_args = ['switch'] + rev_options.to_args() + [url, dest]


### PR DESCRIPTION
This PR is to allow https://github.com/pypa/pip/pull/6515 to proceed ("Properly support interactive Subversion client").

The PR changes `VersionControl.fetch_new()` back to an instance method to support a new use case (originally requested in https://github.com/pypa/pip/issues/6386). Before issue #6386, there wasn't a reason to store global state in `VersionControl` instances. And with PR #6492, we can now do so.