### PR TITLE
Make _check_dist_requires_python() parallel _check_link_requires_python(), and add more complete tests

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -272,7 +272,7 @@ def _check_link_requires_python(
         value if the given Python version isn't compatible.
     """
     try:
-        support_this_python = check_requires_python(
+        is_compatible = check_requires_python(
             link.requires_python, version_info=version_info,
         )
     except specifiers.InvalidSpecifier:
@@ -281,7 +281,7 @@ def _check_link_requires_python(
             link.requires_python, link,
         )
     else:
-        if not support_this_python:
+        if not is_compatible:
             version = '.'.join(map(str, version_info))
             if not ignore_requires_python:
                 logger.debug(

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -6,7 +6,6 @@ from email.parser import FeedParser
 from pip._vendor import pkg_resources
 from pip._vendor.packaging import specifiers, version
 
-from pip._internal import exceptions
 from pip._internal.utils.misc import display_path
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -56,31 +55,6 @@ def get_metadata(dist):
     feed_parser = FeedParser()
     feed_parser.feed(metadata)
     return feed_parser.close()
-
-
-def check_dist_requires_python(dist, version_info):
-    """
-    :param version_info: A 3-tuple of ints representing the Python
-        major-minor-micro version to check (e.g. `sys.version_info[:3]`).
-    """
-    pkg_info_dict = get_metadata(dist)
-    requires_python = pkg_info_dict.get('Requires-Python')
-    try:
-        if not check_requires_python(
-            requires_python, version_info=version_info,
-        ):
-            raise exceptions.UnsupportedPythonVersion(
-                "%s requires Python '%s' but the running Python is %s" % (
-                    dist.project_name,
-                    requires_python,
-                    '.'.join(map(str, version_info)),)
-            )
-    except specifiers.InvalidSpecifier as e:
-        logger.warning(
-            "Package %s has an invalid Requires-Python entry %s - %s",
-            dist.project_name, requires_python, e,
-        )
-        return
 
 
 def get_installer(dist):

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -57,6 +57,23 @@ def get_metadata(dist):
     return feed_parser.close()
 
 
+def get_requires_python(dist):
+    # type: (pkg_resources.Distribution) -> Optional[str]
+    """
+    Return the "Requires-Python" metadata for a distribution, or None
+    if not present.
+    """
+    pkg_info_dict = get_metadata(dist)
+    requires_python = pkg_info_dict.get('Requires-Python')
+
+    if requires_python is not None:
+        # Convert to a str to satisfy the type checker, since requires_python
+        # can be a Header object.
+        requires_python = str(requires_python)
+
+    return requires_python
+
+
 def get_installer(dist):
     # type: (Distribution) -> str
     if dist.has_metadata('INSTALLER'):

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1305,6 +1305,12 @@ def test_double_install_fail(script):
     assert msg in result.stderr
 
 
+def _get_expected_error_text():
+    return (
+        "Package 'pkga' requires a different Python: {} not in '<1.0'"
+    ).format(sys.version.split()[0])
+
+
 def test_install_incompatible_python_requires(script):
     script.scratch_path.join("pkga").mkdir()
     pkga_path = script.scratch_path / 'pkga'
@@ -1315,8 +1321,7 @@ def test_install_incompatible_python_requires(script):
               version='0.1')
     """))
     result = script.pip('install', pkga_path, expect_error=True)
-    assert ("pkga requires Python '<1.0' "
-            "but the running Python is ") in result.stderr, str(result)
+    assert _get_expected_error_text() in result.stderr, str(result)
 
 
 def test_install_incompatible_python_requires_editable(script):
@@ -1330,8 +1335,7 @@ def test_install_incompatible_python_requires_editable(script):
     """))
     result = script.pip(
         'install', '--editable=%s' % pkga_path, expect_error=True)
-    assert ("pkga requires Python '<1.0' "
-            "but the running Python is ") in result.stderr, str(result)
+    assert _get_expected_error_text() in result.stderr, str(result)
 
 
 def test_install_incompatible_python_requires_wheel(script, with_wheel):
@@ -1347,8 +1351,7 @@ def test_install_incompatible_python_requires_wheel(script, with_wheel):
         'python', 'setup.py', 'bdist_wheel', '--universal', cwd=pkga_path)
     result = script.pip('install', './pkga/dist/pkga-0.1-py2.py3-none-any.whl',
                         expect_error=True)
-    assert ("pkga requires Python '<1.0' "
-            "but the running Python is ") in result.stderr
+    assert _get_expected_error_text() in result.stderr, str(result)
 
 
 def test_install_compatible_python_requires(script):

--- a/tests/unit/test_resolve.py
+++ b/tests/unit/test_resolve.py
@@ -1,32 +1,83 @@
-import sys
+import logging
 
 import pytest
-from mock import Mock
+from mock import patch
 
 from pip._internal.exceptions import UnsupportedPythonVersion
-from pip._internal.resolve import check_dist_requires_python
+from pip._internal.resolve import _check_dist_requires_python
 
 
-class TestCheckRequiresPython(object):
+class FakeDist(object):
 
-    @pytest.mark.parametrize(
-        ("metadata", "should_raise"),
-        [
-            ("Name: test\n", False),
-            ("Name: test\nRequires-Python:", False),
-            ("Name: test\nRequires-Python: invalid_spec", False),
-            ("Name: test\nRequires-Python: <=1", True),
-        ],
-    )
-    def test_check_requires(self, metadata, should_raise):
-        fake_dist = Mock(
-            has_metadata=lambda _: True,
-            get_metadata=lambda _: metadata)
-        version_info = sys.version_info[:3]
-        if should_raise:
-            with pytest.raises(UnsupportedPythonVersion):
-                check_dist_requires_python(
-                    fake_dist, version_info=version_info,
-                )
-        else:
-            check_dist_requires_python(fake_dist, version_info=version_info)
+    def __init__(self, project_name):
+        self.project_name = project_name
+
+
+@pytest.fixture
+def dist():
+    return FakeDist('my-project')
+
+
+@patch('pip._internal.resolve.get_requires_python')
+class TestCheckDistRequiresPython(object):
+
+    """
+    Test _check_dist_requires_python().
+    """
+
+    def test_compatible(self, mock_get_requires, caplog, dist):
+        caplog.set_level(logging.DEBUG)
+        mock_get_requires.return_value = '== 3.6.5'
+        _check_dist_requires_python(
+            dist,
+            version_info=(3, 6, 5),
+            ignore_requires_python=False,
+        )
+        assert not len(caplog.records)
+
+    def test_invalid_specifier(self, mock_get_requires, caplog, dist):
+        caplog.set_level(logging.DEBUG)
+        mock_get_requires.return_value = 'invalid'
+        _check_dist_requires_python(
+            dist,
+            version_info=(3, 6, 5),
+            ignore_requires_python=False,
+        )
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == 'WARNING'
+        assert record.message == (
+            "Package 'my-project' has an invalid Requires-Python: "
+            "Invalid specifier: 'invalid'"
+        )
+
+    def test_incompatible(self, mock_get_requires, dist):
+        mock_get_requires.return_value = '== 3.6.4'
+        with pytest.raises(UnsupportedPythonVersion) as exc:
+            _check_dist_requires_python(
+                dist,
+                version_info=(3, 6, 5),
+                ignore_requires_python=False,
+            )
+        assert str(exc.value) == (
+            "Package 'my-project' requires a different Python: "
+            "3.6.5 not in '== 3.6.4'"
+        )
+
+    def test_incompatible_with_ignore_requires(
+        self, mock_get_requires, caplog, dist,
+    ):
+        caplog.set_level(logging.DEBUG)
+        mock_get_requires.return_value = '== 3.6.4'
+        _check_dist_requires_python(
+            dist,
+            version_info=(3, 6, 5),
+            ignore_requires_python=True,
+        )
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == 'DEBUG'
+        assert record.message == (
+            "Ignoring failed Requires-Python check for package 'my-project': "
+            "3.6.5 not in '== 3.6.4'"
+        )

--- a/tests/unit/test_resolve.py
+++ b/tests/unit/test_resolve.py
@@ -1,0 +1,32 @@
+import sys
+
+import pytest
+from mock import Mock
+
+from pip._internal.exceptions import UnsupportedPythonVersion
+from pip._internal.resolve import check_dist_requires_python
+
+
+class TestCheckRequiresPython(object):
+
+    @pytest.mark.parametrize(
+        ("metadata", "should_raise"),
+        [
+            ("Name: test\n", False),
+            ("Name: test\nRequires-Python:", False),
+            ("Name: test\nRequires-Python: invalid_spec", False),
+            ("Name: test\nRequires-Python: <=1", True),
+        ],
+    )
+    def test_check_requires(self, metadata, should_raise):
+        fake_dist = Mock(
+            has_metadata=lambda _: True,
+            get_metadata=lambda _: metadata)
+        version_info = sys.version_info[:3]
+        if should_raise:
+            with pytest.raises(UnsupportedPythonVersion):
+                check_dist_requires_python(
+                    fake_dist, version_info=version_info,
+                )
+        else:
+            check_dist_requires_python(fake_dist, version_info=version_info)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,7 +20,7 @@ import pytest
 from mock import Mock, patch
 
 from pip._internal.exceptions import (
-    HashMismatch, HashMissing, InstallationError, UnsupportedPythonVersion,
+    HashMismatch, HashMissing, InstallationError,
 )
 from pip._internal.utils.encoding import BOMS, auto_decode
 from pip._internal.utils.glibc import check_glibc_version
@@ -31,7 +31,6 @@ from pip._internal.utils.misc import (
     redact_password_from_url, remove_auth_from_url, rmtree,
     split_auth_from_netloc, split_auth_netloc_from_url, untar_file, unzip_file,
 )
-from pip._internal.utils.packaging import check_dist_requires_python
 from pip._internal.utils.temp_dir import AdjacentTempDirectory, TempDirectory
 from pip._internal.utils.ui import SpinnerInterface
 
@@ -697,31 +696,6 @@ class TestGlibc(object):
                 else:
                     # Didn't find the warning we were expecting
                     assert False
-
-
-class TestCheckRequiresPython(object):
-
-    @pytest.mark.parametrize(
-        ("metadata", "should_raise"),
-        [
-            ("Name: test\n", False),
-            ("Name: test\nRequires-Python:", False),
-            ("Name: test\nRequires-Python: invalid_spec", False),
-            ("Name: test\nRequires-Python: <=1", True),
-        ],
-    )
-    def test_check_requires(self, metadata, should_raise):
-        fake_dist = Mock(
-            has_metadata=lambda _: True,
-            get_metadata=lambda _: metadata)
-        version_info = sys.version_info[:3]
-        if should_raise:
-            with pytest.raises(UnsupportedPythonVersion):
-                check_dist_requires_python(
-                    fake_dist, version_info=version_info,
-                )
-        else:
-            check_dist_requires_python(fake_dist, version_info=version_info)
 
 
 class TestGetProg(object):


### PR DESCRIPTION
This PR (1) moves `check_dist_requires_python()` to `resolve.py` where it used, (2) makes its implementation closely parallel `index.py`'s `_check_link_requires_python()`, (3) adds an `ignore_requires_python` argument (like`_check_link_requires_python()`), and (4) tests it quite fully (including log messages, exception messages, and all branch logic). It also sets us up for passing `py_version_info` to the `Resolver` class, which will help with other issues.

This is a refactor in preparation for addressing issue #5369 ("`pip download --python-version` fails when downloaded package doesn't support the Python version running pip") and related issues.