### PR TITLE
Change PackageFinder to accept py_version_info instead of python_versions

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -324,7 +324,7 @@ class RequirementCommand(Command):
         options,               # type: Values
         session,               # type: PipSession
         platform=None,         # type: Optional[str]
-        python_versions=None,  # type: Optional[List[str]]
+        py_version_info=None,  # type: Optional[Tuple[int, ...]]
         abi=None,              # type: Optional[str]
         implementation=None,   # type: Optional[str]
         ignore_requires_python=None,  # type: Optional[bool]
@@ -352,7 +352,7 @@ class RequirementCommand(Command):
             allow_all_prereleases=options.pre,
             session=session,
             platform=platform,
-            versions=python_versions,
+            py_version_info=py_version_info,
             abi=abi,
             implementation=implementation,
             prefer_binary=options.prefer_binary,

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -543,7 +543,8 @@ cache_dir = partial(
 )  # type: Callable[..., Option]
 
 
-def no_cache_dir_callback(option, opt, value, parser):
+def _handle_no_cache_dir(option, opt, value, parser):
+    # type: (Option, str, str, OptionParser) -> None
     """
     Process a value provided for the --no-cache-dir option.
 
@@ -575,7 +576,7 @@ no_cache = partial(
     "--no-cache-dir",
     dest="cache_dir",
     action="callback",
-    callback=no_cache_dir_callback,
+    callback=_handle_no_cache_dir,
     help="Disable the cache.",
 )  # type: Callable[..., Option]
 
@@ -620,7 +621,8 @@ no_build_isolation = partial(
 )  # type: Callable[..., Option]
 
 
-def no_use_pep517_callback(option, opt, value, parser):
+def _handle_no_use_pep517(option, opt, value, parser):
+    # type: (Option, str, str, OptionParser) -> None
     """
     Process a value provided for the --no-use-pep517 option.
 
@@ -658,7 +660,7 @@ no_use_pep517 = partial(
     '--no-use-pep517',
     dest='use_pep517',
     action='callback',
-    callback=no_use_pep517_callback,
+    callback=_handle_no_use_pep517,
     default=None,
     help=SUPPRESS_HELP
 )  # type: Any
@@ -724,7 +726,7 @@ always_unzip = partial(
 )  # type: Callable[..., Option]
 
 
-def _merge_hash(option, opt_str, value, parser):
+def _handle_merge_hash(option, opt_str, value, parser):
     # type: (Option, str, str, OptionParser) -> None
     """Given a value spelled "algo:digest", append the digest to a list
     pointed to in a dict by the algo name."""
@@ -749,7 +751,7 @@ hash = partial(
     # __dict__ copying in process_line().
     dest='hashes',
     action='callback',
-    callback=_merge_hash,
+    callback=_handle_merge_hash,
     type='string',
     help="Verify that the package's archive matches this "
          'hash before installing. Example: --hash=sha256:abcdef...',

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -24,7 +24,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.ui import BAR_TYPES
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any, Callable, Dict, Optional
+    from typing import Any, Callable, Dict, Optional, Tuple
     from optparse import OptionParser, Values
     from pip._internal.cli.parser import ConfigOptionParser
 
@@ -478,11 +478,36 @@ platform = partial(
 )  # type: Callable[..., Option]
 
 
+# This was made a separate function for unit-testing purposes.
+def _convert_python_version(value):
+    # type: (str) -> Tuple[int, ...]
+    """
+    Convert a string like "3" or "34" into a tuple of ints.
+    """
+    if len(value) == 1:
+        parts = [value]
+    else:
+        parts = [value[0], value[1:]]
+
+    return tuple(int(part) for part in parts)
+
+
+def _handle_python_version(option, opt_str, value, parser):
+    # type: (Option, str, str, OptionParser) -> None
+    """
+    Convert a string like "3" or "34" into a tuple of ints.
+    """
+    version_info = _convert_python_version(value)
+    parser.values.python_version = version_info
+
+
 python_version = partial(
     Option,
     '--python-version',
     dest='python_version',
     metavar='python_version',
+    action='callback',
+    callback=_handle_python_version, type='str',
     default=None,
     help=("Only use wheels compatible with Python "
           "interpreter version <version>. If not specified, then the "

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -88,11 +88,6 @@ class DownloadCommand(RequirementCommand):
         # of the RequirementSet code require that property.
         options.editables = []
 
-        if options.python_version:
-            python_versions = [options.python_version]
-        else:
-            python_versions = None
-
         cmdoptions.check_dist_restriction(options)
 
         options.src_dir = os.path.abspath(options.src_dir)
@@ -105,7 +100,7 @@ class DownloadCommand(RequirementCommand):
                 options=options,
                 session=session,
                 platform=options.platform,
-                python_versions=python_versions,
+                py_version_info=options.python_version,
                 abi=options.abi,
                 implementation=options.implementation,
             )

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -251,11 +251,6 @@ class InstallCommand(RequirementCommand):
 
         cmdoptions.check_dist_restriction(options, check_target=True)
 
-        if options.python_version:
-            python_versions = [options.python_version]
-        else:
-            python_versions = None
-
         options.src_dir = os.path.abspath(options.src_dir)
         install_options = options.install_options or []
         if options.use_user_site:
@@ -294,7 +289,7 @@ class InstallCommand(RequirementCommand):
                 options=options,
                 session=session,
                 platform=options.platform,
-                python_versions=python_versions,
+                py_version_info=options.python_version,
                 abi=options.abi,
                 implementation=options.implementation,
                 ignore_requires_python=options.ignore_requires_python,

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -29,7 +29,7 @@ from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.models.format_control import FormatControl
 from pip._internal.models.index import PyPI
 from pip._internal.models.link import Link
-from pip._internal.pep425tags import get_supported
+from pip._internal.pep425tags import get_supported, version_info_to_nodot
 from pip._internal.utils.compat import ipaddress
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
@@ -604,7 +604,7 @@ class PackageFinder(object):
         session=None,  # type: Optional[PipSession]
         format_control=None,  # type: Optional[FormatControl]
         platform=None,  # type: Optional[str]
-        versions=None,  # type: Optional[List[str]]
+        py_version_info=None,  # type: Optional[Tuple[int, ...]]
         abi=None,  # type: Optional[str]
         implementation=None,  # type: Optional[str]
         prefer_binary=False,  # type: bool
@@ -624,8 +624,10 @@ class PackageFinder(object):
             packages that can be built on the platform passed in. These
             packages will only be downloaded for distribution: they will
             not be built locally.
-        :param versions: A list of strings or None. This is passed directly
-            to pep425tags.py in the get_supported() method.
+        :param py_version_info: An optional tuple of ints representing the
+            Python version information to use (e.g. `sys.version_info[:3]`).
+            This can have length 1, 2, or 3. This is used to construct the
+            value passed to pep425tags.py's get_supported() function.
         :param abi: A string or None. This is passed directly
             to pep425tags.py in the get_supported() method.
         :param implementation: A string or None. This is passed directly
@@ -658,6 +660,11 @@ class PackageFinder(object):
             ("*", host, "*")
             for host in (trusted_hosts if trusted_hosts else [])
         ]  # type: List[SecureOrigin]
+
+        if py_version_info:
+            versions = [version_info_to_nodot(py_version_info)]
+        else:
+            versions = None
 
         # The valid tags to check potential found wheel candidates against
         valid_tags = get_supported(

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -49,6 +49,12 @@ def get_abbr_impl():
     return pyimpl
 
 
+def version_info_to_nodot(version_info):
+    # type: (Tuple[int, ...]) -> str
+    # Only use up to the first two numbers.
+    return ''.join(map(str, version_info[:2]))
+
+
 def get_impl_ver():
     # type: () -> str
     """Return implementation version."""

--- a/tests/unit/test_cmdoptions.py
+++ b/tests/unit/test_cmdoptions.py
@@ -1,0 +1,15 @@
+import pytest
+
+from pip._internal.cli.cmdoptions import _convert_python_version
+
+
+@pytest.mark.parametrize('value, expected', [
+    ('2', (2,)),
+    ('3', (3,)),
+    ('34', (3, 4)),
+    # Test a 2-digit minor version.
+    ('310', (3, 10)),
+])
+def test_convert_python_version(value, expected):
+    actual = _convert_python_version(value)
+    assert actual == expected

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -6,6 +6,21 @@ from mock import patch
 from pip._internal import pep425tags
 
 
+@pytest.mark.parametrize('version_info, expected', [
+    ((2,), '2'),
+    ((2, 8), '28'),
+    ((3,), '3'),
+    ((3, 6), '36'),
+    # Test a tuple of length 3.
+    ((3, 6, 5), '36'),
+    # Test a 2-digit minor version.
+    ((3, 10), '310'),
+])
+def test_version_info_to_nodot(version_info, expected):
+    actual = pep425tags.version_info_to_nodot(version_info)
+    assert actual == expected
+
+
 class TestPEP425Tags(object):
 
     def mock_get_config_var(self, **kwd):


### PR DESCRIPTION
This is a refactoring PR to change how `PackageFinder` accepts and stores the `--python-version` passed to it. The change is to pass a tuple of ints like `(3, 6)` rather than a list of strings `['36']` as it is currently doing. (For example, a list isn't actually needed since there is only ever at most one element.) This will be useful for issues like #5369 and #6117 (with PR #6357) and also makes the code easier to understand and work with.