### PR TITLE
Handle ImportError and OSError when importing ctypes (#6543)

### DIFF
--- a/news/6543.bugfix
+++ b/news/6543.bugfix
@@ -1,0 +1,1 @@
+Work around failure to import ctypes when resolving glibc version string.

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -1,10 +1,15 @@
 from __future__ import absolute_import
 
-import ctypes
 import re
 import warnings
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+# Work around https://bugs.python.org/issue37060.
+try:
+    import ctypes
+except (ImportError, OSError):
+    ctypes = None
 
 if MYPY_CHECK_RUNNING:
     from typing import Optional, Tuple
@@ -13,6 +18,9 @@ if MYPY_CHECK_RUNNING:
 def glibc_version_string():
     # type: () -> Optional[str]
     "Returns glibc version string, or None if not using glibc."
+
+    if not ctypes:
+        return None
 
     # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
     # manpage says, "If filename is NULL, then the returned handle is for the


### PR DESCRIPTION
Non-dynamic executables can raise OSError when importing ctypes
because dlopen(NULL) is called on module import and dlopen()
won't work on non-dynamic executables.

This commit teaches the glibc version sniffing module to
handle a missing or not working ctypes module.

With this change applied, `pip install` works on non-dynamic / fully statically linked Python executables on Linux.
