### PR TITLE
Add a link to pip's dev documentation from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,10 @@ If you find bugs, need help, or want to talk to the developers please use our ma
 * `Discourse channel`_
 * `User IRC`_
 
-If you want to get involved head over to GitHub to get the source code and feel free to jump on the developer mailing lists and chat rooms:
+If you want to get involved head over to GitHub to get the source code, look at our development documentation and feel free to jump on the developer mailing lists and chat rooms:
 
 * `GitHub page`_
+* `Dev documentation`_
 * `Dev mailing list`_
 * `Dev IRC`_
 
@@ -39,6 +40,7 @@ rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
 .. _Usage: https://pip.pypa.io/en/stable/
 .. _Release notes: https://pip.pypa.io/en/stable/news.html
 .. _GitHub page: https://github.com/pypa/pip
+.. _Dev documentation: https://pip.pypa.io/en/latest/development
 .. _Issue tracking: https://github.com/pypa/pip/issues
 .. _Discourse channel: https://discuss.python.org/c/packaging
 .. _Dev mailing list: https://groups.google.com/forum/#!forum/pypa-dev


### PR DESCRIPTION
Add a link to pip's development documentation from README (#6553)