### PR TITLE
Let Conda work with PIP_REQUIRE_VIRTUALENV flag

### DIFF
--- a/news/conda.feature
+++ b/news/conda.feature
@@ -1,0 +1,1 @@
+Let Conda work with PIP_REQUIRE_VIRTUALENV flag

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -52,6 +52,8 @@ def running_under_virtualenv():
         return True
     elif sys.prefix != getattr(sys, "base_prefix", sys.prefix):
         return True
+    elif os.path.dirname(sys.prefix) == os.environ.get("CONDA_ENVS"):
+        return True
 
     return False
 


### PR DESCRIPTION
- Context:
After several tried with `pip.conf`, I still not manage to make `pip install` work with conda while I put `PIP_REQUIRE_VIRTUALENV` in my `.bash_profile`. Thus I open this PR for using a dummy way to check is it virtual environment if it's handled by conda.

- Approach:
In the `.bashxx` file, we put a environment varible which is called `CONDA_ENVS` which indicate the path to your conda venv parents folder, e.g. `export CONDA_ENVS=/Users/$USER/conda/envs`. In the `locations.py`, I add another logic to check if the dirname of `sys.prefix` is same as `CONDA_ENVS`.

- Impact:
Nothing to Report. But looking for reviews and suggestions. Thanks 🙏 