### PR TITLE
Add make_test_finder() helper function

### DIFF
--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -1,10 +1,8 @@
 from pip._vendor import pytoml
 
 from pip._internal.build_env import BuildEnvironment
-from pip._internal.download import PipSession
-from pip._internal.index import PackageFinder
 from pip._internal.req import InstallRequirement
-from tests.lib import path_to_url
+from tests.lib import make_test_finder, path_to_url
 
 
 def make_project(tmpdir, requires=[], backend=None):
@@ -23,7 +21,7 @@ def test_backend(tmpdir, data):
     req = InstallRequirement(None, None, source_dir=project_dir)
     req.load_pyproject_toml()
     env = BuildEnvironment()
-    finder = PackageFinder.create([data.backends], [], session=PipSession())
+    finder = make_test_finder(find_links=[data.backends])
     env.install_requirements(finder, ["dummy_backend"], 'normal', "Installing")
     conflicting, missing = env.check_requirements(["dummy_backend"])
     assert not conflicting and not missing

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -14,7 +14,15 @@ import pytest
 from scripttest import FoundDir, TestFileEnvironment
 
 from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
+from pip._internal.download import PipSession
+from pip._internal.index import PackageFinder
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from tests.lib.path import Path, curdir
+
+if MYPY_CHECK_RUNNING:
+    from typing import Iterable, List, Optional
+    from pip._internal.models.target_python import TargetPython
+
 
 DATA_DIR = Path(__file__).folder.folder.join("data").abspath
 SRC_DIR = Path(__file__).abspath.folder.folder.folder
@@ -67,6 +75,35 @@ def create_file(path, contents=None):
             f.write(contents)
         else:
             f.write("\n")
+
+
+def make_test_finder(
+    find_links=None,  # type: Optional[List[str]]
+    index_urls=None,  # type: Optional[List[str]]
+    allow_all_prereleases=False,  # type: bool
+    trusted_hosts=None,           # type: Optional[Iterable[str]]
+    session=None,                 # type: Optional[PipSession]
+    target_python=None,           # type: Optional[TargetPython]
+):
+    # type: (...) -> PackageFinder
+    """
+    Create a PackageFinder for testing purposes.
+    """
+    if find_links is None:
+        find_links = []
+    if index_urls is None:
+        index_urls = []
+    if session is None:
+        session = PipSession()
+
+    return PackageFinder.create(
+        find_links,
+        index_urls,
+        allow_all_prereleases=allow_all_prereleases,
+        trusted_hosts=trusted_hosts,
+        session=session,
+        target_python=target_python,
+    )
 
 
 class TestData(object):

--- a/tests/unit/test_build_env.py
+++ b/tests/unit/test_build_env.py
@@ -3,9 +3,7 @@ from textwrap import dedent
 import pytest
 
 from pip._internal.build_env import BuildEnvironment
-from pip._internal.download import PipSession
-from pip._internal.index import PackageFinder
-from tests.lib import create_basic_wheel_for_package
+from tests.lib import create_basic_wheel_for_package, make_test_finder
 
 
 def indent(text, prefix):
@@ -59,9 +57,7 @@ def test_build_env_allow_empty_requirements_install():
 def test_build_env_allow_only_one_install(script):
     create_basic_wheel_for_package(script, 'foo', '1.0')
     create_basic_wheel_for_package(script, 'bar', '1.0')
-    finder = PackageFinder.create(
-        [script.scratch_path], [], session=PipSession(),
-    )
+    finder = make_test_finder(find_links=[script.scratch_path])
     build_env = BuildEnvironment()
     for prefix in ('normal', 'overlay'):
         build_env.install_requirements(finder, ['foo'], prefix,

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -11,7 +11,6 @@ from pip._internal.download import PipSession
 from pip._internal.exceptions import (
     InstallationError, RequirementsFileParseError,
 )
-from pip._internal.index import PackageFinder
 from pip._internal.models.format_control import FormatControl
 from pip._internal.req.constructors import (
     install_req_from_editable, install_req_from_line,
@@ -20,7 +19,7 @@ from pip._internal.req.req_file import (
     break_args_options, ignore_comments, join_lines, parse_requirements,
     preprocess, process_line, skip_regex,
 )
-from tests.lib import requirements_file
+from tests.lib import make_test_finder, requirements_file
 
 
 @pytest.fixture
@@ -30,7 +29,7 @@ def session():
 
 @pytest.fixture
 def finder(session):
-    return PackageFinder.create([], [], session=session)
+    return make_test_finder(session=session)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds a `make_test_finder()` helper function. A few benefits of this are that--

1. we don't have to pass a dummy session everywhere (`session=PipSession()`),
2. we don't have to pass both positional arguments (`find_links` and `index_urls`) when one or both aren't needed, and
3. it decouples our test code from the signature of `PackageFinder.create()` (approx. 50 calls), which will free us up to modify `PackageFinder.create()`'s signature.
