### PR TITLE
Disable comment for lock-bot on auto-locking

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -5,7 +5,4 @@ exemptLabels: []
 # Label to add before locking, such as `outdated`. Set to `false` to disable
 lockLabel: "S: outdated"
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related bugs.
+lockComment: false


### PR DESCRIPTION
For users watching the repository it is really annoying with 1400 mails
already sent and 4400 more to come.
And the comment might be superfluous as the Github lock message:

    @lock lock bot locked as resolved and limited conversation to collaborators 6 days ago

provides a direct link to https://github.com/apps/lock explaining the
purpose of the bot.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
