### PR TITLE
add 'local' as highest precedence architecture for wheel

### DIFF
--- a/news/6523.feature
+++ b/news/6523.feature
@@ -1,0 +1,2 @@
+Add 'local' as highest precedence arch tag for Linux wheels, to override
+manylinux1 when needed.

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -342,7 +342,7 @@ def get_supported(
             # https://www.python.org/dev/peps/pep-0571/#backwards-compatibility-with-manylinux1-wheels
             arches = [arch, 'manylinux1' + arch_sep + arch_suffix]
         elif platform is None:
-            arches = []
+            arches = ['local']
             if is_manylinux2010_compatible():
                 arches.append('manylinux2010' + arch_sep + arch_suffix)
             if is_manylinux1_compatible():


### PR DESCRIPTION
Sometimes it is useful to be able to build a wheel on the local machine that has a higher precedence than a manylinux wheel. If a certain manylinux wheel is broken, you might compile a non-manylinux wheel on the local machine and place it in a directory on $PIP_FIND_LINKS. Then pip would automatically choose the new wheel without requiring an extra argument per package.

The theory of operation is that the contents of a wheel compiled on the "local" machine are more-specific, from the point of view of that machine, than any other wheel.

These tags are supported after this change, on my machine:

```python
[('cp27', 'cp27mu', 'local'),
 ('cp27', 'cp27mu', 'manylinux2010_x86_64'),
 ('cp27', 'cp27mu', 'manylinux1_x86_64'),
 ('cp27', 'cp27mu', 'linux_x86_64'),
 ('cp27', 'none', 'local'),
 ('cp27', 'none', 'manylinux2010_x86_64'),
 ('cp27', 'none', 'manylinux1_x86_64'),
 ('cp27', 'none', 'linux_x86_64'),
 ('py2', 'none', 'local'),
 ('py2', 'none', 'manylinux2010_x86_64'),
 ('py2', 'none', 'manylinux1_x86_64'),
 ('py2', 'none', 'linux_x86_64'),
 ('cp27', 'none', 'any'),
 ('cp2', 'none', 'any'),
 ('py27', 'none', 'any'),
 ('py2', 'none', 'any'),
 ('py26', 'none', 'any'),
 ('py25', 'none', 'any'),
 ('py24', 'none', 'any'),
 ('py23', 'none', 'any'),
 ('py22', 'none', 'any'),
 ('py21', 'none', 'any'),
 ('py20', 'none', 'any')]
```

References #6523 