### PR TITLE
Import path_to_url() from utils/misc.py instead of download.py

### DIFF
--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -8,9 +8,9 @@ import os
 
 from pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.download import path_to_url
 from pip._internal.models.link import Link
 from pip._internal.utils.compat import expanduser
+from pip._internal.utils.misc import path_to_url
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.wheel import InvalidWheelFilename, Wheel

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -20,7 +20,7 @@ from pip._vendor.requests.exceptions import HTTPError, RetryError, SSLError
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib import request as urllib_request
 
-from pip._internal.download import HAS_TLS, is_url, path_to_url, url_to_path
+from pip._internal.download import HAS_TLS, is_url, url_to_path
 from pip._internal.exceptions import (
     BestVersionAlreadyInstalled, DistributionNotFound, InvalidWheelFilename,
     UnsupportedWheel,
@@ -34,7 +34,7 @@ from pip._internal.utils.compat import ipaddress
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
     ARCHIVE_EXTENSIONS, SUPPORTED_EXTENSIONS, WHEEL_EXTENSION, normalize_path,
-    redact_password_from_url,
+    path_to_url, redact_password_from_url,
 )
 from pip._internal.utils.packaging import check_requires_python
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -3,9 +3,8 @@ import re
 
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
-from pip._internal.download import path_to_url
 from pip._internal.utils.misc import (
-    WHEEL_EXTENSION, redact_password_from_url, splitext,
+    WHEEL_EXTENSION, path_to_url, redact_password_from_url, splitext,
 )
 from pip._internal.utils.models import KeyBasedCompareMixin
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -17,15 +17,13 @@ from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
 from pip._vendor.packaging.specifiers import Specifier
 from pip._vendor.pkg_resources import RequirementParseError, parse_requirements
 
-from pip._internal.download import (
-    is_archive_file, is_url, path_to_url, url_to_path,
-)
+from pip._internal.download import is_archive_file, is_url, url_to_path
 from pip._internal.exceptions import InstallationError
 from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.models.link import Link
 from pip._internal.pyproject import make_pyproject_path
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.misc import is_installable_dir
+from pip._internal.utils.misc import is_installable_dir, path_to_url
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs import vcs
 from pip._internal.wheel import Wheel

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -23,7 +23,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.six import StringIO
 
 from pip._internal import pep425tags
-from pip._internal.download import path_to_url, unpack_url
+from pip._internal.download import unpack_url
 from pip._internal.exceptions import (
     InstallationError, InvalidWheelFilename, UnsupportedWheel,
 )
@@ -34,7 +34,7 @@ from pip._internal.models.link import Link
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
     LOG_DIVIDER, call_subprocess, captured_stdout, ensure_dir,
-    format_command_args, read_chunks,
+    format_command_args, path_to_url, read_chunks,
 )
 from pip._internal.utils.setuptools_build import SETUPTOOLS_SHIM
 from pip._internal.utils.temp_dir import TempDirectory

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -12,11 +12,12 @@ from mock import Mock, patch
 import pip
 from pip._internal.download import (
     CI_ENVIRONMENT_VARIABLES, MultiDomainBasicAuth, PipSession, SafeFileCache,
-    path_to_url, unpack_file_url, unpack_http_url, url_to_path,
+    unpack_file_url, unpack_http_url, url_to_path,
 )
 from pip._internal.exceptions import HashMismatch
 from pip._internal.models.link import Link
 from pip._internal.utils.hashes import Hashes
+from pip._internal.utils.misc import path_to_url
 from tests.lib import create_file
 
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -10,7 +10,7 @@ from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.commands.install import InstallCommand
-from pip._internal.download import PipSession, path_to_url
+from pip._internal.download import PipSession
 from pip._internal.exceptions import (
     HashErrors, InstallationError, InvalidWheelFilename, PreviousBuildDirError,
 )
@@ -23,6 +23,7 @@ from pip._internal.req.constructors import (
 )
 from pip._internal.req.req_file import process_line
 from pip._internal.req.req_tracker import RequirementTracker
+from pip._internal.utils.misc import path_to_url
 from tests.lib import DATA_DIR, assert_raises_regexp, requirements_file
 
 


### PR DESCRIPTION
This is a follow-up to PR #6545 that changes our imports of `path_to_url()` to always import it from `utils/misc.py`. This eliminates some our dependencies on the top-level `download.py`. 