### PR TITLE
Document issue tracker triage as a contribution area

### DIFF
--- a/docs/html/development/contributing.rst
+++ b/docs/html/development/contributing.rst
@@ -226,8 +226,13 @@ Becoming a maintainer
 
 If you want to become an official maintainer, start by helping out.
 
+As a first step, we welcome you to triage issues on pip's issue tracker. pip
+maintainers provide triage abilities to contributors once they have been around
+for some time and contributed positively to the project. This is optional and highly
+recommended for becoming a pip maintainer.
+
 Later, when you think you're ready, get in touch with one of the maintainers
-and they will initiate a vote.
+and they will initiate a vote among the existing maintainers.
 
 .. note::
 
@@ -239,8 +244,6 @@ and they will initiate a vote.
     - PyPI Publishing Access
     - CI Administration capabilities
     - ReadTheDocs Administration capabilities
-    
-    On getting commit access to pip, a contributor has the ability to manage bugs in pip's issue tracker.
 
 .. _`Studies have shown`: https://smartbear.com/smartbear/media/pdfs/wp-cc-11-best-practices-of-peer-code-review.pdf
 .. _`resolve merge conflicts`: https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/

--- a/docs/html/development/contributing.rst
+++ b/docs/html/development/contributing.rst
@@ -239,6 +239,8 @@ and they will initiate a vote.
     - PyPI Publishing Access
     - CI Administration capabilities
     - ReadTheDocs Administration capabilities
+    
+    On getting commit access to pip, a contributor has the ability to manage bugs in pip's issue tracker.
 
 .. _`Studies have shown`: https://smartbear.com/smartbear/media/pdfs/wp-cc-11-best-practices-of-peer-code-review.pdf
 .. _`resolve merge conflicts`: https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/


### PR DESCRIPTION
Documented triage permissions and the fact that contributors can help by triaging the issue tracker.

For #6524 and #6525.
