### PR TITLE
Replaces overly specific function definition with more general alternative

### DIFF
--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os.path
 import sys
+import packaging
 
 from pip._vendor import lockfile, pkg_resources
 from pip._vendor.packaging import version as packaging_version
@@ -76,15 +77,13 @@ class SelfCheckState(object):
                           separators=(",", ":"))
 
 
-def was_installed_by_pip(pkg):
-    # type: (str) -> bool
-    """Checks whether pkg was installed by pip
+def get_installer(dist):
+    # type: (Distribution) -> str
 
     This is used not to display the upgrade message when pip is in fact
     installed by system package manager, such as dnf on Fedora.
     """
     try:
-        dist = pkg_resources.get_distribution(pkg)
         return (dist.has_metadata('INSTALLER') and
                 'pip' in dist.get_metadata_lines('INSTALLER'))
     except pkg_resources.DistributionNotFound:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
[Fixes #6533](https://github.com/pypa/pip/issues/6533)
