### PR TITLE
Allow dotted version strings for --python-version.

### DIFF
--- a/news/6585.feature
+++ b/news/6585.feature
@@ -1,0 +1,2 @@
+Allow ``--python-version`` to be passed as a dotted version string (e.g.
+``3.7`` or ``3.7.3``).

--- a/tests/unit/test_cmdoptions.py
+++ b/tests/unit/test_cmdoptions.py
@@ -4,12 +4,21 @@ from pip._internal.cli.cmdoptions import _convert_python_version
 
 
 @pytest.mark.parametrize('value, expected', [
-    ('2', (2,)),
-    ('3', (3,)),
-    ('34', (3, 4)),
+    ('', (None, None)),
+    ('2', ((2,), None)),
+    ('3', ((3,), None)),
+    ('3.7', ((3, 7), None)),
+    ('3.7.3', ((3, 7, 3), None)),
+    # Test strings without dots of length bigger than 1.
+    ('34', ((3, 4), None)),
     # Test a 2-digit minor version.
-    ('310', (3, 10)),
+    ('310', ((3, 10), None)),
+    # Test some values that fail to parse.
+    ('ab', ((), 'each version part must be an integer')),
+    ('3a', ((), 'each version part must be an integer')),
+    ('3.7.a', ((), 'each version part must be an integer')),
+    ('3.7.3.1', ((), 'at most three version parts are allowed')),
 ])
 def test_convert_python_version(value, expected):
     actual = _convert_python_version(value)
-    assert actual == expected
+    assert actual == expected, 'actual: {!r}'.format(actual)


### PR DESCRIPTION
As suggested in this comment by @xavfernandez, this PR adds support for passing dotted version strings to `--python-version`: https://github.com/pypa/pip/issues/6371#issuecomment-494971519

Currently, only major or major-minor version strings like `3` or `37` are supported (with no dot).