### PR TITLE
Add a TargetPython class

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -24,6 +24,7 @@ from pip._internal.exceptions import (
 )
 from pip._internal.index import PackageFinder
 from pip._internal.locations import running_under_virtualenv
+from pip._internal.models.target_python import TargetPython
 from pip._internal.req.constructors import (
     install_req_from_editable, install_req_from_line,
 )
@@ -344,6 +345,13 @@ class RequirementCommand(Command):
             )
             index_urls = []
 
+        target_python = TargetPython(
+            platform=platform,
+            py_version_info=py_version_info,
+            abi=abi,
+            implementation=implementation,
+        )
+
         return PackageFinder.create(
             find_links=options.find_links,
             format_control=options.format_control,
@@ -351,10 +359,7 @@ class RequirementCommand(Command):
             trusted_hosts=options.trusted_hosts,
             allow_all_prereleases=options.pre,
             session=session,
-            platform=platform,
-            py_version_info=py_version_info,
-            abi=abi,
-            implementation=implementation,
+            target_python=target_python,
             prefer_binary=options.prefer_binary,
             ignore_requires_python=ignore_requires_python,
         )

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -1,0 +1,80 @@
+import sys
+
+from pip._internal.pep425tags import get_supported, version_info_to_nodot
+from pip._internal.utils.misc import normalize_version_info
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional, Tuple
+
+
+class TargetPython(object):
+
+    """
+    Encapsulates the properties of a Python interpreter one is targeting
+    for a package install, download, etc.
+    """
+
+    def __init__(
+        self,
+        platform=None,  # type: Optional[str]
+        py_version_info=None,  # type: Optional[Tuple[int, ...]]
+        abi=None,  # type: Optional[str]
+        implementation=None,  # type: Optional[str]
+    ):
+        # type: (...) -> None
+        """
+        :param platform: A string or None. If None, searches for packages
+            that are supported by the current system. Otherwise, will find
+            packages that can be built on the platform passed in. These
+            packages will only be downloaded for distribution: they will
+            not be built locally.
+        :param py_version_info: An optional tuple of ints representing the
+            Python version information to use (e.g. `sys.version_info[:3]`).
+            This can have length 1, 2, or 3 when provided.
+        :param abi: A string or None. This is passed to pep425tags.py's
+            get_supported() function as is.
+        :param implementation: A string or None. This is passed to
+            pep425tags.py's get_supported() function as is.
+        """
+        # Store the given py_version_info for when we call get_supported().
+        self._given_py_version_info = py_version_info
+
+        if py_version_info is None:
+            py_version_info = sys.version_info[:3]
+        else:
+            py_version_info = normalize_version_info(py_version_info)
+
+        py_version = '.'.join(map(str, py_version_info[:2]))
+
+        self.abi = abi
+        self.implementation = implementation
+        self.platform = platform
+        self.py_version = py_version
+        self.py_version_info = py_version_info
+
+        # This is used to cache the return value of get_tags().
+        self._valid_tags = None
+
+    def get_tags(self):
+        """
+        Return the supported tags to check wheel candidates against.
+        """
+        if self._valid_tags is None:
+            # Pass versions=None if no py_version_info was given since
+            # versions=None uses special default logic.
+            py_version_info = self._given_py_version_info
+            if py_version_info is None:
+                versions = None
+            else:
+                versions = [version_info_to_nodot(py_version_info)]
+
+            tags = get_supported(
+                versions=versions,
+                platform=self.platform,
+                abi=self.abi,
+                impl=self.implementation,
+            )
+            self._valid_tags = tags
+
+        return self._valid_tags

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -22,6 +22,8 @@ SRC_DIR = Path(__file__).abspath.folder.folder.folder
 pyversion = sys.version[:3]
 pyversion_tuple = sys.version_info
 
+CURRENT_PY_VERSION_INFO = sys.version_info[:3]
+
 
 def assert_paths_equal(actual, expected):
     os.path.normpath(actual) == os.path.normpath(expected)

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -1,0 +1,84 @@
+import sys
+
+import pytest
+from mock import patch
+
+from pip._internal.models.target_python import TargetPython
+from tests.lib import CURRENT_PY_VERSION_INFO
+
+
+class TestTargetPython:
+
+    @pytest.mark.parametrize('py_version_info, expected', [
+        ((), ((0, 0, 0), '0.0')),
+        ((2, ), ((2, 0, 0), '2.0')),
+        ((3, ), ((3, 0, 0), '3.0')),
+        ((3, 7), ((3, 7, 0), '3.7')),
+        ((3, 7, 3), ((3, 7, 3), '3.7')),
+        # Check a minor version with two digits.
+        ((3, 10, 1), ((3, 10, 1), '3.10')),
+    ])
+    def test_init__py_version_info(self, py_version_info, expected):
+        """
+        Test passing the py_version_info argument.
+        """
+        expected_py_version_info, expected_py_version = expected
+
+        target_python = TargetPython(py_version_info=py_version_info)
+
+        # The _given_py_version_info attribute should be set as is.
+        assert target_python._given_py_version_info == py_version_info
+
+        assert target_python.py_version_info == expected_py_version_info
+        assert target_python.py_version == expected_py_version
+
+    def test_init__py_version_info_none(self):
+        """
+        Test passing py_version_info=None.
+        """
+        # Get the index of the second dot.
+        index = sys.version.find('.', 2)
+        current_major_minor = sys.version[:index]  # e.g. "3.6"
+
+        target_python = TargetPython(py_version_info=None)
+
+        assert target_python._given_py_version_info is None
+
+        assert target_python.py_version_info == CURRENT_PY_VERSION_INFO
+        assert target_python.py_version == current_major_minor
+
+    @pytest.mark.parametrize('py_version_info, expected_versions', [
+        ((), ['']),
+        ((2, ), ['2']),
+        ((3, ), ['3']),
+        ((3, 7), ['37']),
+        ((3, 7, 3), ['37']),
+        # Check a minor version with two digits.
+        ((3, 10, 1), ['310']),
+        # Check that versions=None is passed to get_tags().
+        (None, None),
+    ])
+    @patch('pip._internal.models.target_python.get_supported')
+    def test_get_tags(
+        self, mock_get_supported, py_version_info, expected_versions,
+    ):
+        mock_get_supported.return_value = ['tag-1', 'tag-2']
+
+        target_python = TargetPython(py_version_info=py_version_info)
+        actual = target_python.get_tags()
+        assert actual == ['tag-1', 'tag-2']
+
+        actual = mock_get_supported.call_args[1]['versions']
+        assert actual == expected_versions
+
+        # Check that the value was cached.
+        assert target_python._valid_tags == ['tag-1', 'tag-2']
+
+    def test_get_tags__uses_cached_value(self):
+        """
+        Test that get_tags() uses the cached value.
+        """
+        target_python = TargetPython(py_version_info=None)
+        target_python._valid_tags = ['tag-1', 'tag-2']
+        actual = target_python.get_tags()
+        assert actual == ['tag-1', 'tag-2']


### PR DESCRIPTION
This PR adds a `TargetPython` class to encapsulate the four option values of `platform`, `py_version_info`, `abi`, and `implementation`. This class also encapsulates (and computes) the list of valid tags. This refactoring is useful because e.g. it (1) cuts down on the complexity of `index.py`, (2) reduces the number of arguments that need to be passed around, and (3) isolates out more logic and lets us test it separately.
