### PR TITLE
Store PackageFinder.trusted_hosts instead of secure_origins

### DIFF
--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -185,7 +185,7 @@ class BuildEnvironment(object):
             args.append('--no-index')
         for link in finder.find_links:
             args.extend(['--find-links', link])
-        for _, host, _ in finder.secure_origins:
+        for host in finder.trusted_hosts:
             args.extend(['--trusted-host', host])
         if finder.allow_all_prereleases:
             args.append('--pre')

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -251,8 +251,7 @@ def process_line(
         if opts.pre:
             finder.set_allow_all_prereleases()
         if opts.trusted_hosts:
-            finder.secure_origins.extend(
-                ("*", host, "*") for host in opts.trusted_hosts)
+            finder.extend_trusted_hosts(opts.trusted_hosts)
 
 
 def break_args_options(line):

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -316,7 +316,7 @@ class TestProcessLine(object):
 
     def test_set_finder_trusted_host(self, finder):
         list(process_line("--trusted-host=url", "file", 1, finder=finder))
-        assert finder.secure_origins == [('*', 'url', '*')]
+        assert finder.trusted_hosts == ['url']
 
     def test_noop_always_unzip(self, finder):
         # noop, but confirm it can be set


### PR DESCRIPTION
This PR simplifies the `PackageFinder` class by storing the original `trusted_hosts` instead of `secure_origins`. As you can see from the PR, a couple interactions with the `PackageFinder` class become simplified when this happens. It also simplifies the `create()` method and makes the computation of the `secure_origins` separately testable (which this PR does).