### PR TITLE
Consolidate `--path` parsing into `cmdoptions.py`

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -822,6 +822,24 @@ require_hashes = partial(
 )  # type: Callable[..., Option]
 
 
+list_path = partial(
+    Option,
+    '--path',
+    dest='path',
+    action='append',
+    help='Restrict to the specified installation path for listing '
+         'packages (can be used multiple times).'
+)  # type: Callable[..., Option]
+
+
+def check_list_path_option(options):
+    # type: (Values) -> None
+    if options.path and (options.user or options.local):
+        raise CommandError(
+            "Cannot combine '--path' with '--user' or '--local'"
+        )
+
+
 ##########
 # groups #
 ##########

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 import sys
 
 from pip._internal.cache import WheelCache
+from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
-from pip._internal.exceptions import CommandError
 from pip._internal.models.format_control import FormatControl
 from pip._internal.operations.freeze import freeze
 from pip._internal.utils.compat import stdlib_pkgs
@@ -57,12 +57,7 @@ class FreezeCommand(Command):
             action='store_true',
             default=False,
             help='Only output packages installed in user-site.')
-        self.cmd_opts.add_option(
-            '--path',
-            dest='path',
-            action='append',
-            help='Restrict to the specified installation path for listing '
-                 'packages (can be used multiple times).')
+        self.cmd_opts.add_option(cmdoptions.list_path())
         self.cmd_opts.add_option(
             '--all',
             dest='freeze_all',
@@ -84,10 +79,7 @@ class FreezeCommand(Command):
         if not options.freeze_all:
             skip.update(DEV_PKGS)
 
-        if options.path and (options.user or options.local):
-            raise CommandError(
-                "Cannot combine '--path' with '--user' or '--local'"
-            )
+        cmdoptions.check_list_path_option(options)
 
         freeze_kwargs = dict(
             requirement=options.requirements,

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -62,12 +62,7 @@ class ListCommand(Command):
             action='store_true',
             default=False,
             help='Only output packages installed in user-site.')
-        self.cmd_opts.add_option(
-            '--path',
-            dest='path',
-            action='append',
-            help='Restrict to the specified installation path for listing '
-                 'packages (can be used multiple times).')
+        cmd_opts.add_option(cmdoptions.list_path())
         cmd_opts.add_option(
             '--pre',
             action='store_true',
@@ -131,10 +126,7 @@ class ListCommand(Command):
             raise CommandError(
                 "Options --outdated and --uptodate cannot be combined.")
 
-        if options.path and (options.user or options.local):
-            raise CommandError(
-                "Cannot combine '--path' with '--user' or '--local'"
-            )
+        cmdoptions.check_list_path_option(options)
 
         packages = get_installed_distributions(
             local_only=options.local,


### PR DESCRIPTION
This option is used both in the `freeze` and `list` commands. The code to parse the option and validate that it's not used with incompatible arguments should be done in one place.

This addresses [@cjerdonek's comment](https://github.com/pypa/pip/pull/6580#issuecomment-501399668) in #6580.
