### PR TITLE
I simplify the function was_installed_by_pip

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,6 +7,9 @@ As a reminder, all contributors are expected to follow our [Code of Conduct][coc
 
 [coc]: https://www.pypa.io/en/latest/code-of-conduct/
 
+## Development Documentation
+
+If you want to get involved look at our development documentation [Dev documentation](https://pip.pypa.io/en/latest/development/)
 
 ## Bot Commands
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ As a reminder, all contributors are expected to follow our [Code of Conduct][coc
 
 ## Development Documentation
 
-If you want to get involved look at our development documentation [Dev documentation](https://pip.pypa.io/en/latest/development/)
+Our [development documentation](https://pip.pypa.io/en/latest/development/) contains details on how to get started with contributing to pip, and details of our development processes.
 
 ## Bot Commands
 

--- a/news/6533.trivial
+++ b/news/6533.trivial
@@ -1,0 +1,1 @@
+Override the definition of the function was_installed_by_pip (src\pip\_internal\utils\outdated.py) too specific with a more general alternative

--- a/news/6579.trivial
+++ b/news/6579.trivial
@@ -1,0 +1,1 @@
+Link with developer documentation added in .github/CONTRIBUTING.md

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -14,6 +14,7 @@ from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.misc import ensure_dir, get_installed_version
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+from pip._internal.utils import get_installer
 
 if MYPY_CHECK_RUNNING:
     import optparse
@@ -85,8 +86,7 @@ def was_installed_by_pip(pkg):
     """
     try:
         dist = pkg_resources.get_distribution(pkg)
-        return (dist.has_metadata('INSTALLER') and
-                'pip' in dist.get_metadata_lines('INSTALLER'))
+        return "pip" == get_installer(dist)
     except pkg_resources.DistributionNotFound:
         return False
 

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -14,7 +14,7 @@ from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.misc import ensure_dir, get_installed_version
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.utils import get_installer
+from pip._internal.utils.packaging import get_installer
 
 if MYPY_CHECK_RUNNING:
     import optparse


### PR DESCRIPTION
Simplify the function **was_installed_by_pip** of the module (pip._internal.utils.outdated) by calling the function **get_installer** of the module (pip._internal.utils.packaging)

