### PR TITLE
Add a disclaimer to the "Installation Order" section

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -71,6 +71,10 @@ the chosen version is available, it is assumed that any source is acceptable
 Installation Order
 ++++++++++++++++++
 
+.. note:
+   This section only talks about installation order of runtime dependencies.
+   This does not apply to build dependencies (specified using PEP 518).
+
 As of v6.1.0, pip installs dependencies before their dependents, i.e. in
 "topological order."  This is the only commitment pip currently makes related
 to order.  While it may be coincidentally true that pip will install things in


### PR DESCRIPTION
This section has caused a lot of user confusion since PEP 517/518. It seems that users are referring to this section for advice about how to deal with build time issues, which contains statements that do not hold true for build requirements.
