### PR TITLE
Add milliseconds to --log entry timestamps.

### DIFF
--- a/news/6587.feature
+++ b/news/6587.feature
@@ -1,0 +1,1 @@
+Update timestamps in pip's ``--log`` file to include milliseconds.

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -6,7 +6,6 @@ import logging
 import logging.handlers
 import os
 import sys
-import time
 from logging import Filter
 
 from pip._vendor.six import PY2
@@ -94,8 +93,6 @@ def get_indentation():
 
 class IndentingFormatter(logging.Formatter):
 
-    default_time_format = '%Y-%m-%dT%H:%M:%S'
-
     def __init__(self, *args, **kwargs):
         """
         A logging.Formatter that obeys the indent_log() context manager.
@@ -122,20 +119,6 @@ class IndentingFormatter(logging.Formatter):
 
         return 'ERROR: '
 
-    if PY2:
-        # Compatibility with default_time_format and default_msec_format from
-        # Python >= 3.3.
-        default_msec_format = '%s,%03d'
-
-        def formatTime(self, record, datefmt=None):
-            ct = self.converter(record.created)
-            if datefmt:
-                s = time.strftime(datefmt, ct)
-            else:
-                t = time.strftime(self.default_time_format, ct)
-                s = self.default_msec_format % (t, record.msecs)
-            return s
-
     def format(self, record):
         """
         Calls the standard formatter, but will indent all of the log message
@@ -147,7 +130,8 @@ class IndentingFormatter(logging.Formatter):
 
         prefix = ''
         if self.add_timestamp:
-            prefix = self.formatTime(record) + " "
+            t = self.formatTime(record, "%Y-%m-%dT%H:%M:%S")
+            prefix = '%s,%03d ' % (t, record.msecs)
         prefix += " " * get_indentation()
         formatted = "".join([
             prefix + line

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -130,6 +130,7 @@ class IndentingFormatter(logging.Formatter):
 
         prefix = ''
         if self.add_timestamp:
+            # TODO: Use Formatter.default_time_format after dropping PY2.
             t = self.formatTime(record, "%Y-%m-%dT%H:%M:%S")
             prefix = '%s,%03d ' % (t, record.msecs)
         prefix += " " * get_indentation()

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -81,7 +81,7 @@ class Test_base_command_logging(object):
 
     def setup(self):
         self.old_time = time.time
-        time.time = lambda: 1547704837.4
+        time.time = lambda: 1547704837.040001
         self.old_tz = os.environ.get('TZ')
         os.environ['TZ'] = 'UTC'
         # time.tzset() is not implemented on some platforms (notably, Windows).
@@ -105,7 +105,7 @@ class Test_base_command_logging(object):
         log_path = tmpdir.join('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
-            assert f.read().rstrip() == '2019-01-17T06:00:37 fake'
+            assert f.read().rstrip() == '2019-01-17T06:00:37,040 fake'
 
     def test_log_command_error(self, tmpdir):
         """
@@ -115,7 +115,7 @@ class Test_base_command_logging(object):
         log_path = tmpdir.join('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
-            assert f.read().startswith('2019-01-17T06:00:37 fake')
+            assert f.read().startswith('2019-01-17T06:00:37,040 fake')
 
     def test_log_file_command_error(self, tmpdir):
         """
@@ -125,7 +125,7 @@ class Test_base_command_logging(object):
         log_file_path = tmpdir.join('log_file')
         cmd.main(['fake', '--log-file', log_file_path])
         with open(log_file_path) as f:
-            assert f.read().startswith('2019-01-17T06:00:37 fake')
+            assert f.read().startswith('2019-01-17T06:00:37,040 fake')
 
     def test_unicode_messages(self, tmpdir):
         """

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -51,7 +51,10 @@ class TestIndentingFormatter(object):
     def make_record(self, msg, level_name):
         level_number = getattr(logging, level_name)
         attrs = dict(
-            msg=msg, created=1547704837.4, levelname=level_name,
+            msg=msg,
+            created=1547704837.040001,
+            msecs=40,
+            levelname=level_name,
             levelno=level_number,
         )
         record = logging.makeLogRecord(attrs)
@@ -75,9 +78,12 @@ class TestIndentingFormatter(object):
         assert f.format(record) == expected
 
     @pytest.mark.parametrize('level_name, expected', [
-        ('INFO', '2019-01-17T06:00:37 hello\n2019-01-17T06:00:37 world'),
+        ('INFO',
+         '2019-01-17T06:00:37,040 hello\n'
+         '2019-01-17T06:00:37,040 world'),
         ('WARNING',
-         '2019-01-17T06:00:37 WARNING: hello\n2019-01-17T06:00:37 world'),
+         '2019-01-17T06:00:37,040 WARNING: hello\n'
+         '2019-01-17T06:00:37,040 world'),
     ])
     def test_format_with_timestamp(self, level_name, expected):
         record = self.make_record('hello\nworld', level_name=level_name)


### PR DESCRIPTION
Resolves #6587.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
