### PR TITLE
Be stricter in identiying git commit hashes

### DIFF
--- a/news/git_looks_like_hash.trivial
+++ b/news/git_looks_like_hash.trivial
@@ -1,0 +1,1 @@
+Be stricter in identifying git commit hashes.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -21,7 +21,7 @@ urlunsplit = urllib_parse.urlunsplit
 logger = logging.getLogger(__name__)
 
 
-HASH_REGEX = re.compile('[a-fA-F0-9]{40}')
+HASH_REGEX = re.compile('^[a-fA-F0-9]{40}$')
 
 
 def looks_like_hash(sha):

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -105,6 +105,7 @@ def test_looks_like_hash():
     assert looks_like_hash(18 * 'a' + '0123456789abcdefABCDEF')
     assert not looks_like_hash(40 * 'g')
     assert not looks_like_hash(39 * 'a')
+    assert not looks_like_hash(41 * 'a')
 
 
 @pytest.mark.parametrize('vcs_cls, remote_url, expected', [


### PR DESCRIPTION
A trivial PR with a more precise regexp to identify git commit hashes.

The only use for this regexp at the moment is to mask a warning.