### PR TITLE
Fix #6654: filter yanked files before calling get_best_candidate()

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -347,6 +347,7 @@ class RequirementCommand(Command):
 
         return PackageFinder.create(
             search_scope=search_scope,
+            allow_yanked=True,
             format_control=options.format_control,
             trusted_hosts=options.trusted_hosts,
             allow_all_prereleases=options.pre,

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -116,8 +116,10 @@ class ListCommand(Command):
         """
         search_scope = make_search_scope(options)
 
+        # Pass allow_yanked=False to ignore yanked versions.
         return PackageFinder.create(
             search_scope=search_scope,
+            allow_yanked=False,
             allow_all_prereleases=options.pre,
             trusted_hosts=options.trusted_hosts,
             session=session,
@@ -183,10 +185,7 @@ class ListCommand(Command):
                                       if not candidate.version.is_prerelease]
 
                 evaluator = finder.candidate_evaluator
-                # Pass allow_yanked=False to ignore yanked versions.
-                best_candidate = evaluator.get_best_candidate(
-                    all_candidates, allow_yanked=False,
-                )
+                best_candidate = evaluator.get_best_candidate(all_candidates)
                 if best_candidate is None:
                     continue
 

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -11,7 +11,7 @@ from pip._internal.utils.models import KeyBasedCompareMixin
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Tuple, Union
+    from typing import Optional, Text, Tuple, Union
     from pip._internal.index import HTMLPage
 
 
@@ -24,7 +24,7 @@ class Link(KeyBasedCompareMixin):
         url,                   # type: str
         comes_from=None,       # type: Optional[Union[str, HTMLPage]]
         requires_python=None,  # type: Optional[str]
-        yanked_reason=None,    # type: Optional[str]
+        yanked_reason=None,    # type: Optional[Text]
     ):
         # type: (...) -> None
         """

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -125,17 +125,16 @@ def pip_version_check(session, options):
             # Lets use PackageFinder to see what the latest pip version is
             search_scope = make_search_scope(options, suppress_no_index=True)
 
+            # Pass allow_yanked=False so we don't suggest upgrading to a
+            # yanked version.
             finder = PackageFinder.create(
                 search_scope=search_scope,
+                allow_yanked=False,
                 allow_all_prereleases=False,  # Explicitly set to False
                 trusted_hosts=options.trusted_hosts,
                 session=session,
             )
-            # Pass allow_yanked=False so we don't suggest upgrading to a
-            # yanked version.
-            candidate = finder.find_candidates("pip").get_best(
-                allow_yanked=False,
-            )
+            candidate = finder.find_candidates("pip").get_best()
             if candidate is None:
                 return
             pypi_version = str(candidate.version)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -104,6 +104,7 @@ def make_test_finder(
 
     return PackageFinder.create(
         search_scope=search_scope,
+        allow_yanked=True,
         allow_all_prereleases=allow_all_prereleases,
         trusted_hosts=trusted_hosts,
         session=session,

--- a/tests/unit/test_build_env.py
+++ b/tests/unit/test_build_env.py
@@ -27,7 +27,11 @@ def run_with_build_env(script, setup_script_contents,
             from pip._internal.models.search_scope import SearchScope
 
             search_scope = SearchScope.create([%r], [])
-            finder = PackageFinder.create(search_scope, session=PipSession())
+            finder = PackageFinder.create(
+                search_scope,
+                allow_yanked=True,
+                session=PipSession(),
+            )
             build_env = BuildEnvironment()
 
             try:

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -218,7 +218,10 @@ class TestWheel:
         ]
         target_python = TargetPython()
         target_python._valid_tags = valid_tags
-        evaluator = CandidateEvaluator(target_python=target_python)
+        evaluator = CandidateEvaluator(
+            allow_yanked=True,
+            target_python=target_python,
+        )
         sort_key = evaluator._sort_key
         results = sorted(links, key=sort_key, reverse=True)
         results2 = sorted(reversed(links), key=sort_key, reverse=True)
@@ -426,7 +429,7 @@ class TestCandidateEvaluator(object):
     def setup(self):
         self.search_name = 'pytest'
         self.canonical_name = 'pytest'
-        self.evaluator = CandidateEvaluator()
+        self.evaluator = CandidateEvaluator(allow_yanked=True)
 
     @pytest.mark.parametrize('url, expected_version', [
         ('http:/yo/pytest-1.0.tar.gz', '1.0'),

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -16,7 +16,7 @@ class MockFoundCandidates(object):
     def __init__(self, best):
         self._best = best
 
-    def get_best(self, allow_yanked):
+    def get_best(self):
         return self._best
 
 


### PR DESCRIPTION
Addresses #6654.

This PR also adds support for yanked reasons with non-ascii characters.