### PR TITLE
Add InstallRequirement.format_debug() as a debugging helper

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -180,6 +180,21 @@ class InstallRequirement(object):
         return '<%s object: %s editable=%r>' % (
             self.__class__.__name__, str(self), self.editable)
 
+    def format_debug(self):
+        # type: () -> str
+        """An un-tested helper for getting state, for debugging.
+        """
+        attributes = vars(self)
+        names = sorted(attributes)
+
+        state = (
+            "{}={!r}".format(attr, attributes[attr]) for attr in sorted(names)
+        )
+        return '<{name} object: {{{state}}}>'.format(
+            name=self.__class__.__name__,
+            state=", ".join(state),
+        )
+
     def populate_link(self, finder, upgrade, require_hashes):
         # type: (PackageFinder, bool, bool) -> None
         """Ensure that if a link can be found for this, that it is found.


### PR DESCRIPTION
before:

```
<InstallRequirement object: six from https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl#sha256=3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c in <venv>/lib/python3.7/site-packages editable=False>
```

after:

```
<InstallRequirement object: _egg_info_path=None, _ideal_build_dir=None, _temp_build_dir=<TempDirectory None>, _wheel_cache=<pip._internal.cache.WheelCache object at 0x10465ab70>, build_env=<pip._internal.build_env.NoOpBuildEnvironment object at 0x10465a438>, comes_from=None, conflicts_with=six 1.12.0 (<venv>/lib/python3.7/site-packages), constraint=False, editable=False, extras=set(), install_succeeded=None, is_direct=True, isolated=False, link=<Link https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl#sha256=3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c (from https://pypi.org/simple/six/) (requires-python:>=2.6, !=3.0.*, !=3.1.*)>, markers=None, metadata_directory=None, options={}, original_link=None, pep517_backend=None, prepared=True, pyproject_requires=None, req=<Requirement('six')>, requirements_to_check=[], satisfied_by=six 1.12.0 (<venv>/lib/python3.7/site-packages), source_dir='/private/var/folders/4d/bt0_xfx56bjfmmt2bv3r5_qh0000gn/T/pip-install-cpe3_h8z/six', uninstalled_pathset=None, update=True, use_pep517=None>
```

---

Rationale: It is useful to know all the state held in InstallRequirement, especially when debugging.

AFAIK, this is not used anywhere in the user output, and the current representation isn't super useful for diagnosis anyway. I've been using this patch locally, when trying to understand how the flow works here -- I usually have this changeset in my working directory anyway so it'd be nice to actually put it into `master`.

Obviously, I'm open to alternative ideas that don't involve maintaining a separate (white/black)list of attributes and let me "expose" the state of the "surface" of an InstallRequirement object.
