### PR TITLE
Add LinkEvaluator class

### DIFF
--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -82,7 +82,9 @@ class TargetPython(object):
     def get_tags(self):
         # type: () -> List[Pep425Tag]
         """
-        Return the supported tags to check wheel candidates against.
+        Return the supported PEP 425 tags to check wheel candidates against.
+
+        The tags are returned in order of preference (most preferred first).
         """
         if self._valid_tags is None:
             # Pass versions=None if no py_version_info was given since


### PR DESCRIPTION
Currently, the `CandidateEvaluator` class is responsible for both (1) evaluating whether links should become `InstallationCandidate`'s, and (2) determining which `InstallationCandidate`'s are "applicable," and knowing how to sort the applicable ones by preference. This PR splits off a `LinkEvaluator` class to handle (1). In this way, `LinkEvaluator` evaluates links (`Link` objects) and `CandidateEvaluator` evaluates candidates (`InstallationCandidate` objects). :)

One benefit of this additional encapsulation is that the new `CandidateEvaluator` class now has fewer dependencies. You can see that the sorting / filtering of candidates now only depends on three things: `supported_tags`, `prefer_binary`, and `allow_all_prereleases`, and not also on `allow_yanked`, `ignore_requires_python`, and the full `target_python`, all of which it depended on with the prior code.

This change also makes `PackageFinder`'s code a bit more intuitive IMO because it creates a `LinkEvaluator` object when it needs to instead of a `Search` object. (The `LinkEvaluator` class is essentially the `Search` class with some functionality attached to it, namely the `evaluate_link()` method.)