### PR TITLE
Rename compatible functions in tests.lib.path.Path.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def pip_src(tmpdir_factory):
             ignored.extend(fnmatch.filter(names, pattern))
         return set(ignored)
 
-    pip_src = Path(str(tmpdir_factory.mktemp('pip_src'))).join('pip_src')
+    pip_src = Path(str(tmpdir_factory.mktemp('pip_src'))).joinpath('pip_src')
     # Copy over our source tree so that each use is self contained
     shutil.copytree(
         SRC_DIR,
@@ -232,7 +232,9 @@ def virtualenv_template(request, tmpdir_factory, pip_src,
 
     # Create the virtual environment
     tmpdir = Path(str(tmpdir_factory.mktemp('virtualenv')))
-    venv = VirtualEnvironment(tmpdir.join("venv_orig"), venv_type=venv_type)
+    venv = VirtualEnvironment(
+        tmpdir.joinpath("venv_orig"), venv_type=venv_type
+    )
 
     # Install setuptools and pip.
     install_egg_link(venv, 'setuptools', setuptools_install)
@@ -248,7 +250,7 @@ def virtualenv_template(request, tmpdir_factory, pip_src,
             exe.startswith('python') or
             exe.startswith('libpy')  # Don't remove libpypy-c.so...
         ):
-            (venv.bin / exe).remove()
+            (venv.bin / exe).unlink()
 
     # Enable user site packages.
     venv.user_site_packages = True
@@ -268,7 +270,7 @@ def virtualenv(virtualenv_template, tmpdir, isolate):
     temporary directory. The returned object is a
     ``tests.lib.venv.VirtualEnvironment`` object.
     """
-    venv_location = tmpdir.join("workspace", "venv")
+    venv_location = tmpdir.joinpath("workspace", "venv")
     yield VirtualEnvironment(venv_location, virtualenv_template)
 
 
@@ -287,7 +289,7 @@ def script(tmpdir, virtualenv, deprecated_python):
     """
     return PipTestEnvironment(
         # The base location for our test environment
-        tmpdir.join("workspace"),
+        tmpdir.joinpath("workspace"),
 
         # Tell the Test Environment where our virtualenv is located
         virtualenv=virtualenv,
@@ -311,12 +313,12 @@ def script(tmpdir, virtualenv, deprecated_python):
 @pytest.fixture(scope="session")
 def common_wheels():
     """Provide a directory with latest setuptools and wheel wheels"""
-    return DATA_DIR.join('common_wheels')
+    return DATA_DIR.joinpath('common_wheels')
 
 
 @pytest.fixture
 def data(tmpdir):
-    return TestData.copy(tmpdir.join("data"))
+    return TestData.copy(tmpdir.joinpath("data"))
 
 
 class InMemoryPipResult(object):

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -8,9 +8,9 @@ from tests.lib.path import Path
 
 
 def fake_wheel(data, wheel_path):
-    data.packages.join(
+    data.packages.joinpath(
         'simple.dist-0.1-py2.py3-none-any.whl'
-    ).copy(data.packages.join(wheel_path))
+    ).copy(data.packages.joinpath(wheel_path))
 
 
 @pytest.mark.network
@@ -61,7 +61,7 @@ def test_single_download_from_requirements_file(script):
     It should support download (in the scratch path) from PyPI from a
     requirements file
     """
-    script.scratch_path.join("test-req.txt").write(textwrap.dedent("""
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
         INITools==0.1
         """))
     result = script.pip(
@@ -121,7 +121,7 @@ def test_download_should_skip_existing_files(script):
     """
     It should not download files already existing in the scratch dir
     """
-    script.scratch_path.join("test-req.txt").write(textwrap.dedent("""
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
         INITools==0.1
         """))
 
@@ -133,7 +133,7 @@ def test_download_should_skip_existing_files(script):
     assert script.site_packages / 'initools' not in result.files_created
 
     # adding second package to test-req.txt
-    script.scratch_path.join("test-req.txt").write(textwrap.dedent("""
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
         INITools==0.1
         python-openid==2.2.5
         """))
@@ -493,7 +493,7 @@ def make_wheel_with_python_requires(script, package_name, python_requires):
           python_requires='{}',
           version='1.0')
     """).format(package_name, python_requires)
-    package_dir.join('setup.py').write(text)
+    package_dir.joinpath('setup.py').write_text(text)
     script.run(
         'python', 'setup.py', 'bdist_wheel', '--universal', cwd=package_dir,
     )
@@ -674,7 +674,7 @@ def test_download_exit_status_code_when_blank_requirements_file(script):
     """
     Test download exit status code when blank requirements file specified
     """
-    script.scratch_path.join("blank.txt").write("\n")
+    script.scratch_path.joinpath("blank.txt").write_text("\n")
     script.pip('download', '-r', 'blank.txt')
 
 
@@ -699,7 +699,7 @@ def test_download_prefer_binary_when_tarball_higher_than_wheel(script, data):
 
 def test_download_prefer_binary_when_wheel_doesnt_satisfy_req(script, data):
     fake_wheel(data, 'source-0.8-py2.py3-none-any.whl')
-    script.scratch_path.join("test-req.txt").write(textwrap.dedent("""
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
         source>0.9
         """))
 

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -51,7 +51,7 @@ def test_basic_freeze(script):
     currently it is not).
 
     """
-    script.scratch_path.join("initools-req.txt").write(textwrap.dedent("""\
+    script.scratch_path.joinpath("initools-req.txt").write_text(textwrap.dedent("""\
         simple==2.0
         # and something else to test out:
         simple2<=3.0
@@ -476,8 +476,8 @@ def test_freeze_with_requirement_option_file_url_egg_not_installed(
     """
 
     url = path_to_url('my-package.tar.gz') + '#egg=Does.Not-Exist'
-    requirements_path = script.scratch_path.join('requirements.txt')
-    requirements_path.write(url + '\n')
+    requirements_path = script.scratch_path.joinpath('requirements.txt')
+    requirements_path.write_text(url + '\n')
 
     result = script.pip(
         'freeze', '--requirement', 'requirements.txt', expect_stderr=True,
@@ -498,7 +498,7 @@ def test_freeze_with_requirement_option(script):
 
     """
 
-    script.scratch_path.join("hint.txt").write(textwrap.dedent("""\
+    script.scratch_path.joinpath("hint.txt").write_text(textwrap.dedent("""\
         INITools==0.1
         NoExist==4.2  # A comment that ensures end of line comments work.
         simple==3.0; python_version > '1.0'
@@ -528,12 +528,12 @@ def test_freeze_with_requirement_option_multiple(script):
     --requirement hints
 
     """
-    script.scratch_path.join('hint1.txt').write(textwrap.dedent("""\
+    script.scratch_path.joinpath('hint1.txt').write_text(textwrap.dedent("""\
         INITools==0.1
         NoExist==4.2
         simple==3.0; python_version > '1.0'
     """) + _freeze_req_opts)
-    script.scratch_path.join('hint2.txt').write(textwrap.dedent("""\
+    script.scratch_path.joinpath('hint2.txt').write_text(textwrap.dedent("""\
         NoExist2==2.0
         simple2==1.0
     """) + _freeze_req_opts)
@@ -576,7 +576,7 @@ def test_freeze_with_requirement_option_package_repeated_one_file(script):
     Test freezing with single requirements file that contains a package
     multiple times
     """
-    script.scratch_path.join('hint1.txt').write(textwrap.dedent("""\
+    script.scratch_path.joinpath('hint1.txt').write_text(textwrap.dedent("""\
         simple2
         simple2
         NoExist
@@ -609,10 +609,10 @@ def test_freeze_with_requirement_option_package_repeated_multi_file(script):
     """
     Test freezing with multiple requirements file that contain a package
     """
-    script.scratch_path.join('hint1.txt').write(textwrap.dedent("""\
+    script.scratch_path.joinpath('hint1.txt').write_text(textwrap.dedent("""\
         simple
     """) + _freeze_req_opts)
-    script.scratch_path.join('hint2.txt').write(textwrap.dedent("""\
+    script.scratch_path.joinpath('hint2.txt').write_text(textwrap.dedent("""\
         simple
         NoExist
     """) + _freeze_req_opts)

--- a/tests/functional/test_hash.py
+++ b/tests/functional/test_hash.py
@@ -28,5 +28,5 @@ def test_bad_algo_option(script, tmpdir):
 def _hello_file(tmpdir):
     """Return a temp file to hash containing "hello"."""
     file = tmpdir / 'hashable'
-    file.write('hello')
+    file.write_text('hello')
     return file

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -26,14 +26,14 @@ def test_pep518_uses_build_env(script, data, common_wheels, command, variant):
     if variant == 'missing_setuptools':
         script.pip("uninstall", "-y", "setuptools")
     elif variant == 'bad_setuptools':
-        setuptools_mod = script.site_packages_path.join("setuptools.py")
+        setuptools_mod = script.site_packages_path.joinpath("setuptools.py")
         with open(setuptools_mod, 'a') as f:
             f.write('\nraise ImportError("toto")')
     else:
         raise ValueError(variant)
     script.pip(
         command, '--no-index', '-f', common_wheels, '-f', data.packages,
-        data.src.join("pep518-3.0"),
+        data.src.joinpath("pep518-3.0"),
     )
 
 
@@ -47,7 +47,7 @@ def test_pep518_build_env_uses_same_pip(
     script.run(
         'python', pip_src / 'src/pip', 'install', '--no-index',
         '-f', common_wheels, '-f', data.packages,
-        data.src.join("pep518-3.0"),
+        data.src.joinpath("pep518-3.0"),
         expect_stderr=deprecated_python,
     )
 
@@ -55,7 +55,7 @@ def test_pep518_build_env_uses_same_pip(
 def test_pep518_refuses_conflicting_requires(script, data):
     create_basic_wheel_for_package(script, 'setuptools', '1.0')
     create_basic_wheel_for_package(script, 'wheel', '1.0')
-    project_dir = data.src.join("pep518_conflicting_requires")
+    project_dir = data.src.joinpath("pep518_conflicting_requires")
     result = script.pip_install_local('-f', script.scratch_path,
                                       project_dir, expect_error=True)
     assert (
@@ -69,7 +69,7 @@ def test_pep518_refuses_conflicting_requires(script, data):
 def test_pep518_refuses_invalid_requires(script, data, common_wheels):
     result = script.pip(
         'install', '-f', common_wheels,
-        data.src.join("pep518_invalid_requires"),
+        data.src.joinpath("pep518_invalid_requires"),
         expect_error=True
     )
     assert result.returncode == 1
@@ -79,7 +79,7 @@ def test_pep518_refuses_invalid_requires(script, data, common_wheels):
 def test_pep518_refuses_invalid_build_system(script, data, common_wheels):
     result = script.pip(
         'install', '-f', common_wheels,
-        data.src.join("pep518_invalid_build_system"),
+        data.src.joinpath("pep518_invalid_build_system"),
         expect_error=True
     )
     assert result.returncode == 1
@@ -89,7 +89,7 @@ def test_pep518_refuses_invalid_build_system(script, data, common_wheels):
 def test_pep518_allows_missing_requires(script, data, common_wheels):
     result = script.pip(
         'install', '-f', common_wheels,
-        data.src.join("pep518_missing_requires"),
+        data.src.joinpath("pep518_missing_requires"),
         expect_stderr=True
     )
     # Make sure we don't warn when this occurs.
@@ -121,7 +121,7 @@ def test_pep518_with_user_pip(script, pip_src, data, common_wheels):
         fp.write('raise ImportError\n')
     script.pip(
         'wheel', '--no-index', '-f', common_wheels, '-f', data.packages,
-        data.src.join("pep518-3.0"),
+        data.src.joinpath("pep518-3.0"),
     )
 
 
@@ -130,7 +130,7 @@ def test_pep518_with_extra_and_markers(script, data, common_wheels):
         'wheel', '--no-index',
         '-f', common_wheels,
         '-f', data.find_links,
-        data.src.join("pep518_with_extra_and_markers-1.0"),
+        data.src.joinpath("pep518_with_extra_and_markers-1.0"),
     )
 
 
@@ -139,7 +139,7 @@ def test_pep518_with_namespace_package(script, data, common_wheels):
         'wheel', '--no-index',
         '-f', common_wheels,
         '-f', data.find_links,
-        data.src.join("pep518_with_namespace_package-1.0"),
+        data.src.joinpath("pep518_with_namespace_package-1.0"),
         use_module=True,
     )
 
@@ -202,7 +202,7 @@ def test_install_exit_status_code_when_blank_requirements_file(script):
     """
     Test install exit status code when blank requirements file specified
     """
-    script.scratch_path.join("blank.txt").write("\n")
+    script.scratch_path.joinpath("blank.txt").write_text("\n")
     script.pip('install', '-r', 'blank.txt')
 
 
@@ -276,7 +276,7 @@ def test_install_editable_uninstalls_existing(data, script, tmpdir):
     https://github.com/pypa/pip/issues/1548
     https://github.com/pypa/pip/pull/1552
     """
-    to_install = data.packages.join("pip-test-package-0.1.tar.gz")
+    to_install = data.packages.joinpath("pip-test-package-0.1.tar.gz")
     result = script.pip_install_local(to_install)
     assert 'Successfully installed pip-test-package' in result.stdout
     result.assert_installed('piptestpackage', editable=False)
@@ -286,7 +286,7 @@ def test_install_editable_uninstalls_existing(data, script, tmpdir):
         '%s#egg=pip-test-package' %
         local_checkout(
             'git+https://github.com/pypa/pip-test-package.git',
-            tmpdir.join("cache"),
+            tmpdir.joinpath("cache"),
         ),
     )
     result.assert_installed('pip-test-package', with_files=['.git'])
@@ -300,7 +300,7 @@ def test_install_editable_uninstalls_existing_from_path(script, data):
     Test that installing an editable uninstalls a previously installed
     non-editable version from path
     """
-    to_install = data.src.join('simplewheel-1.0')
+    to_install = data.src.joinpath('simplewheel-1.0')
     result = script.pip_install_local(to_install)
     assert 'Successfully installed simplewheel' in result.stdout
     simple_folder = script.site_packages / 'simplewheel'
@@ -360,7 +360,7 @@ def test_vcs_url_urlquote_normalization(script, tmpdir):
         local_checkout(
             'bzr+http://bazaar.launchpad.net/%7Edjango-wikiapp/django-wikiapp'
             '/release-0.1',
-            tmpdir.join("cache"),
+            tmpdir.joinpath("cache"),
         ),
     )
 
@@ -369,7 +369,7 @@ def test_basic_install_from_local_directory(script, data):
     """
     Test installing from a local directory.
     """
-    to_install = data.packages.join("FSPkg")
+    to_install = data.packages.joinpath("FSPkg")
     result = script.pip('install', to_install, expect_error=False)
     fspkg_folder = script.site_packages / 'fspkg'
     egg_info_folder = (
@@ -392,11 +392,11 @@ def test_basic_install_relative_directory(script, data):
     package_folder = script.site_packages / 'fspkg'
 
     # Compute relative install path to FSPkg from scratch path.
-    full_rel_path = data.packages.join('FSPkg') - script.scratch_path
+    full_rel_path = data.packages.joinpath('FSPkg') - script.scratch_path
     full_rel_url = (
         'file:' + full_rel_path.replace(os.path.sep, '/') + '#egg=FSPkg'
     )
-    embedded_rel_path = script.scratch_path.join(full_rel_path)
+    embedded_rel_path = script.scratch_path.joinpath(full_rel_path)
 
     # For each relative path, install as either editable or not using either
     # URLs with egg links or not.
@@ -423,7 +423,7 @@ def test_install_quiet(script, data):
     # everything. See:
     #   https://github.com/pypa/pip/issues/3418
     #   https://github.com/docker-library/python/issues/83
-    to_install = data.packages.join("FSPkg")
+    to_install = data.packages.joinpath("FSPkg")
     result = script.pip('install', '-qqq', to_install, expect_error=False)
     assert result.stdout == ""
     assert result.stderr == ""
@@ -471,7 +471,7 @@ def test_install_from_local_directory_with_symlinks_to_directories(
     """
     Test installing from a local directory containing symlinks to directories.
     """
-    to_install = data.packages.join("symlinks")
+    to_install = data.packages.joinpath("symlinks")
     result = script.pip('install', to_install, expect_error=False)
     pkg_folder = script.site_packages / 'symlinks'
     egg_info_folder = (
@@ -513,9 +513,9 @@ def test_editable_install__local_dir_no_setup_py_with_pyproject(
     Test installing in editable mode from a local directory with no setup.py
     but that does have pyproject.toml.
     """
-    local_dir = script.scratch_path.join('temp').mkdir()
-    pyproject_path = local_dir.join('pyproject.toml')
-    pyproject_path.write('')
+    local_dir = script.scratch_path.joinpath('temp').mkdir()
+    pyproject_path = local_dir.joinpath('pyproject.toml')
+    pyproject_path.write_text('')
 
     result = script.pip('install', '-e', local_dir, expect_error=True)
     assert not result.files_created
@@ -556,7 +556,7 @@ def test_install_curdir(script, data):
     """
     Test installing current directory ('.').
     """
-    run_from = data.packages.join("FSPkg")
+    run_from = data.packages.joinpath("FSPkg")
     # Python 2.4 Windows balks if this exists already
     egg_info = join(run_from, "FSPkg.egg-info")
     if os.path.isdir(egg_info):
@@ -574,7 +574,7 @@ def test_install_pardir(script, data):
     """
     Test installing parent directory ('..').
     """
-    run_from = data.packages.join("FSPkg", "fspkg")
+    run_from = data.packages.joinpath("FSPkg", "fspkg")
     result = script.pip('install', pardir, cwd=run_from, expect_error=False)
     fspkg_folder = script.site_packages / 'fspkg'
     egg_info_folder = (
@@ -600,7 +600,7 @@ def test_install_with_hacked_egg_info(script, data):
     """
     test installing a package which defines its own egg_info class
     """
-    run_from = data.packages.join("HackedEggInfo")
+    run_from = data.packages.joinpath("HackedEggInfo")
     result = script.pip('install', '.', cwd=run_from)
     assert 'Successfully installed hackedegginfo-0.0.0\n' in result.stdout
 
@@ -611,11 +611,11 @@ def test_install_using_install_option_and_editable(script, tmpdir):
     Test installing a tool using -e and --install-option
     """
     folder = 'script_folder'
-    script.scratch_path.join(folder).mkdir()
+    script.scratch_path.joinpath(folder).mkdir()
     url = 'git+git://github.com/pypa/pip-test-package'
     result = script.pip(
         'install', '-e', '%s#egg=pip-test-package' %
-        local_checkout(url, tmpdir.join("cache")),
+        local_checkout(url, tmpdir.joinpath("cache")),
         '--install-option=--script-dir=%s' % folder,
         expect_stderr=True)
     script_file = (
@@ -634,7 +634,7 @@ def test_install_global_option_using_editable(script, tmpdir):
     url = 'hg+http://bitbucket.org/runeh/anyjson'
     result = script.pip(
         'install', '--global-option=--version', '-e',
-        '%s@0.2.5#egg=anyjson' % local_checkout(url, tmpdir.join("cache")),
+        '%s@0.2.5#egg=anyjson' % local_checkout(url, tmpdir.joinpath("cache")),
         expect_stderr=True)
     assert 'Successfully installed anyjson' in result.stdout
 
@@ -644,7 +644,7 @@ def test_install_package_with_same_name_in_curdir(script):
     """
     Test installing a package with the same name of a local folder
     """
-    script.scratch_path.join("mock==0.6").mkdir()
+    script.scratch_path.joinpath("mock==0.6").mkdir()
     result = script.pip('install', 'mock==0.6')
     egg_folder = script.site_packages / 'mock-0.6.0-py%s.egg-info' % pyversion
     assert egg_folder in result.files_created, str(result)
@@ -660,9 +660,9 @@ def test_install_folder_using_dot_slash(script):
     """
     Test installing a folder using pip install ./foldername
     """
-    script.scratch_path.join("mock").mkdir()
+    script.scratch_path.joinpath("mock").mkdir()
     pkg_path = script.scratch_path / 'mock'
-    pkg_path.join("setup.py").write(mock100_setup_py)
+    pkg_path.joinpath("setup.py").write_text(mock100_setup_py)
     result = script.pip('install', './mock')
     egg_folder = script.site_packages / 'mock-100.1-py%s.egg-info' % pyversion
     assert egg_folder in result.files_created, str(result)
@@ -672,9 +672,9 @@ def test_install_folder_using_slash_in_the_end(script):
     r"""
     Test installing a folder using pip install foldername/ or foldername\
     """
-    script.scratch_path.join("mock").mkdir()
+    script.scratch_path.joinpath("mock").mkdir()
     pkg_path = script.scratch_path / 'mock'
-    pkg_path.join("setup.py").write(mock100_setup_py)
+    pkg_path.joinpath("setup.py").write_text(mock100_setup_py)
     result = script.pip('install', 'mock' + os.path.sep)
     egg_folder = script.site_packages / 'mock-100.1-py%s.egg-info' % pyversion
     assert egg_folder in result.files_created, str(result)
@@ -684,10 +684,10 @@ def test_install_folder_using_relative_path(script):
     """
     Test installing a folder using pip install folder1/folder2
     """
-    script.scratch_path.join("initools").mkdir()
-    script.scratch_path.join("initools", "mock").mkdir()
+    script.scratch_path.joinpath("initools").mkdir()
+    script.scratch_path.joinpath("initools", "mock").mkdir()
     pkg_path = script.scratch_path / 'initools' / 'mock'
-    pkg_path.join("setup.py").write(mock100_setup_py)
+    pkg_path.joinpath("setup.py").write_text(mock100_setup_py)
     result = script.pip('install', Path('initools') / 'mock')
     egg_folder = script.site_packages / 'mock-100.1-py%s.egg-info' % pyversion
     assert egg_folder in result.files_created, str(result)
@@ -814,7 +814,7 @@ def test_install_with_target_and_scripts_no_warning(script, with_wheel):
     target_dir = script.scratch_path / 'target'
     pkga_path = script.scratch_path / 'pkga'
     pkga_path.mkdir()
-    pkga_path.join("setup.py").write(textwrap.dedent("""
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1',
@@ -824,7 +824,7 @@ def test_install_with_target_and_scripts_no_warning(script, with_wheel):
               }
         )
     """))
-    pkga_path.join("pkga.py").write(textwrap.dedent("""
+    pkga_path.joinpath("pkga.py").write_text(textwrap.dedent("""
         def main(): pass
     """))
     result = script.pip('install', '--target', target_dir, pkga_path)
@@ -882,7 +882,7 @@ def test_install_editable_with_prefix(script):
     # make a dummy project
     pkga_path = script.scratch_path / 'pkga'
     pkga_path.mkdir()
-    pkga_path.join("setup.py").write(textwrap.dedent("""
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1')
@@ -930,7 +930,7 @@ def test_install_package_that_emits_unicode(script, data):
 
     Refs https://github.com/pypa/pip/issues/326
     """
-    to_install = data.packages.join("BrokenEmitsUTF8")
+    to_install = data.packages.joinpath("BrokenEmitsUTF8")
     result = script.pip(
         'install', to_install, expect_error=True, expect_temp=True, quiet=True,
     )
@@ -943,13 +943,13 @@ def test_install_package_that_emits_unicode(script, data):
 
 def test_install_package_with_utf8_setup(script, data):
     """Install a package with a setup.py that declares a utf-8 encoding."""
-    to_install = data.packages.join("SetupPyUTF8")
+    to_install = data.packages.joinpath("SetupPyUTF8")
     script.pip('install', to_install)
 
 
 def test_install_package_with_latin1_setup(script, data):
     """Install a package with a setup.py that declares a latin-1 encoding."""
-    to_install = data.packages.join("SetupPyLatin1")
+    to_install = data.packages.joinpath("SetupPyLatin1")
     script.pip('install', to_install)
 
 
@@ -1083,9 +1083,9 @@ def test_no_compiles_pyc(script):
 
 
 def test_install_upgrade_editable_depending_on_other_editable(script):
-    script.scratch_path.join("pkga").mkdir()
+    script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / 'pkga'
-    pkga_path.join("setup.py").write(textwrap.dedent("""
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1')
@@ -1094,9 +1094,9 @@ def test_install_upgrade_editable_depending_on_other_editable(script):
     result = script.pip('list', '--format=freeze')
     assert "pkga==0.1" in result.stdout
 
-    script.scratch_path.join("pkgb").mkdir()
+    script.scratch_path.joinpath("pkgb").mkdir()
     pkgb_path = script.scratch_path / 'pkgb'
-    pkgb_path.join("setup.py").write(textwrap.dedent("""
+    pkgb_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkgb',
               version='0.1',
@@ -1108,7 +1108,7 @@ def test_install_upgrade_editable_depending_on_other_editable(script):
 
 
 def test_install_subprocess_output_handling(script, data):
-    args = ['install', data.src.join('chattymodule')]
+    args = ['install', data.src.joinpath('chattymodule')]
 
     # Regular install should not show output from the chatty setup.py
     result = script.pip(*args)
@@ -1135,9 +1135,9 @@ def test_install_subprocess_output_handling(script, data):
 
 def test_install_log(script, data, tmpdir):
     # test that verbose logs go to "--log" file
-    f = tmpdir.join("log.txt")
+    f = tmpdir.joinpath("log.txt")
     args = ['--log=%s' % f,
-            'install', data.src.join('chattymodule')]
+            'install', data.src.joinpath('chattymodule')]
     result = script.pip(*args)
     assert 0 == result.stdout.count("HELLO FROM CHATTYMODULE")
     with open(f, 'r') as fp:
@@ -1162,7 +1162,7 @@ def test_cleanup_after_failed_wheel(script, with_wheel):
     res = script.pip_install_local('wheelbrokenafter', expect_stderr=True)
     # One of the effects of not cleaning up is broken scripts:
     script_py = script.bin_path / "script.py"
-    assert script_py.exists, script_py
+    assert script_py.exists(), script_py
     shebang = open(script_py, 'r').readline().strip()
     assert shebang != '#!python', shebang
     # OK, assert that we *said* we were cleaning up:
@@ -1179,7 +1179,7 @@ def test_install_builds_wheels(script, data, with_wheel):
     # NB This incidentally tests a local tree + tarball inputs
     # see test_install_editable_from_git_autobuild_wheel for editable
     # vcs coverage.
-    to_install = data.packages.join('requires_wheelbroken_upper')
+    to_install = data.packages.joinpath('requires_wheelbroken_upper')
     res = script.pip(
         'install', '--no-index', '-f', data.find_links,
         to_install, expect_stderr=True)
@@ -1211,7 +1211,7 @@ def test_install_builds_wheels(script, data, with_wheel):
 
 
 def test_install_no_binary_disables_building_wheels(script, data, with_wheel):
-    to_install = data.packages.join('requires_wheelbroken_upper')
+    to_install = data.packages.joinpath('requires_wheelbroken_upper')
     res = script.pip(
         'install', '--no-index', '--no-binary=upper', '-f', data.find_links,
         to_install, expect_stderr=True)
@@ -1249,9 +1249,9 @@ def test_install_no_binary_disables_cached_wheels(script, data, with_wheel):
 
 
 def test_install_editable_with_wrong_egg_name(script):
-    script.scratch_path.join("pkga").mkdir()
+    script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / 'pkga'
-    pkga_path.join("setup.py").write(textwrap.dedent("""
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1')
@@ -1310,9 +1310,9 @@ def _get_expected_error_text():
 
 
 def test_install_incompatible_python_requires(script):
-    script.scratch_path.join("pkga").mkdir()
+    script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / 'pkga'
-    pkga_path.join("setup.py").write(textwrap.dedent("""
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='<1.0',
@@ -1323,9 +1323,9 @@ def test_install_incompatible_python_requires(script):
 
 
 def test_install_incompatible_python_requires_editable(script):
-    script.scratch_path.join("pkga").mkdir()
+    script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / 'pkga'
-    pkga_path.join("setup.py").write(textwrap.dedent("""
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='<1.0',
@@ -1337,9 +1337,9 @@ def test_install_incompatible_python_requires_editable(script):
 
 
 def test_install_incompatible_python_requires_wheel(script, with_wheel):
-    script.scratch_path.join("pkga").mkdir()
+    script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / 'pkga'
-    pkga_path.join("setup.py").write(textwrap.dedent("""
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='<1.0',
@@ -1353,9 +1353,9 @@ def test_install_incompatible_python_requires_wheel(script, with_wheel):
 
 
 def test_install_compatible_python_requires(script):
-    script.scratch_path.join("pkga").mkdir()
+    script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / 'pkga'
-    pkga_path.join("setup.py").write(textwrap.dedent("""
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='>1.0',
@@ -1443,7 +1443,7 @@ def test_installed_files_recorded_in_deterministic_order(script, data):
     Ensure that we record the files installed by a package in a deterministic
     order, to make installs reproducible.
     """
-    to_install = data.packages.join("FSPkg")
+    to_install = data.packages.joinpath("FSPkg")
     result = script.pip('install', to_install, expect_error=False)
     fspkg_folder = script.site_packages / 'fspkg'
     egg_info = 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
@@ -1508,7 +1508,7 @@ def test_target_install_ignores_distutils_config_install_prefix(script):
     distutils_config = Path(os.path.expanduser('~'),
                             'pydistutils.cfg' if sys.platform == 'win32'
                             else '.pydistutils.cfg')
-    distutils_config.write(textwrap.dedent(
+    distutils_config.write_text(textwrap.dedent(
         '''
         [install]
         prefix=%s

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -49,7 +49,7 @@ def test_cleanup_after_install_editable_from_hg(script, tmpdir):
         '%s#egg=ScriptTest' %
         local_checkout(
             'hg+https://bitbucket.org/ianb/scripttest',
-            tmpdir.join("cache"),
+            tmpdir.joinpath("cache"),
         ),
         expect_error=True,
     )
@@ -64,7 +64,7 @@ def test_cleanup_after_install_from_local_directory(script, data):
     """
     Test clean up after installing from a local directory.
     """
-    to_install = data.packages.join("FSPkg")
+    to_install = data.packages.joinpath("FSPkg")
     script.pip('install', to_install, expect_error=False)
     build = script.venv_path / 'build'
     src = script.venv_path / 'src'
@@ -83,7 +83,7 @@ def test_cleanup_req_satisifed_no_name(script, data):
     # 2 examples of reqs that would do this
     # 1) https://bitbucket.org/ianb/initools/get/tip.zip
     # 2) parent-0.1.tar.gz
-    dist = data.packages.join("parent-0.1.tar.gz")
+    dist = data.packages.joinpath("parent-0.1.tar.gz")
 
     script.pip('install', dist)
     script.pip('install', dist)
@@ -130,7 +130,7 @@ def test_cleanup_prevented_upon_build_dir_exception(script, data):
     build_simple = build / 'simple'
     os.makedirs(build_simple)
     write_delete_marker_file(build_simple)
-    build_simple.join("setup.py").write("#")
+    build_simple.joinpath("setup.py").write_text("#")
     result = script.pip(
         'install', '-f', data.find_links, '--no-index', 'simple',
         '--build', build,

--- a/tests/functional/test_install_compat.py
+++ b/tests/functional/test_install_compat.py
@@ -54,5 +54,5 @@ def test_setup_py_with_dos_line_endings(script, data):
 
     Refs https://github.com/pypa/pip/issues/237
     """
-    to_install = data.packages.join("LineEndings")
+    to_install = data.packages.joinpath("LineEndings")
     script.pip('install', to_install, expect_error=False)

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -63,7 +63,7 @@ def _test_env_vars_override_config_file(script, virtualenv, config_file):
     # because there is/was a bug which only shows up in cases in which
     # 'config-item' and 'config_item' hash to the same value modulo the size
     # of the config dictionary.
-    (script.scratch_path / config_file).write(textwrap.dedent("""\
+    (script.scratch_path / config_file).write_text(textwrap.dedent("""\
         [global]
         no-index = 1
         """))
@@ -155,7 +155,7 @@ def test_config_file_override_stack(script, virtualenv):
 def _test_config_file_override_stack(script, virtualenv, config_file):
     # set this to make pip load it
     script.environ['PIP_CONFIG_FILE'] = config_file
-    (script.scratch_path / config_file).write(textwrap.dedent("""\
+    (script.scratch_path / config_file).write_text(textwrap.dedent("""\
         [global]
         index-url = https://download.zope.org/ppix
         """))
@@ -164,7 +164,7 @@ def _test_config_file_override_stack(script, virtualenv, config_file):
         "Getting page https://download.zope.org/ppix/initools" in result.stdout
     )
     virtualenv.clear()
-    (script.scratch_path / config_file).write(textwrap.dedent("""\
+    (script.scratch_path / config_file).write_text(textwrap.dedent("""\
         [global]
         index-url = https://download.zope.org/ppix
         [install]

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -112,7 +112,7 @@ def test_install_special_extra(script):
     # make a dummy project
     pkga_path = script.scratch_path / 'pkga'
     pkga_path.mkdir()
-    pkga_path.join("setup.py").write(textwrap.dedent("""
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1',

--- a/tests/functional/test_install_index.py
+++ b/tests/functional/test_install_index.py
@@ -26,7 +26,7 @@ def test_find_links_relative_path(script, data):
 
 def test_find_links_requirements_file_relative_path(script, data):
     """Test find-links as a relative path to a reqs file."""
-    script.scratch_path.join("test-req.txt").write(textwrap.dedent("""
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
         --no-index
         --find-links=%s
         parent==0.1

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -17,7 +17,7 @@ def test_requirements_file(script):
 
     """
     other_lib_name, other_lib_version = 'anyjson', '0.3'
-    script.scratch_path.join("initools-req.txt").write(textwrap.dedent("""\
+    script.scratch_path.joinpath("initools-req.txt").write_text(textwrap.dedent("""\
         INITools==0.2
         # and something else to test out:
         %s<=%s
@@ -40,7 +40,7 @@ def test_schema_check_in_requirements_file(script):
     Test installing from a requirements file with an invalid vcs schema..
 
     """
-    script.scratch_path.join("file-egg-req.txt").write(
+    script.scratch_path.joinpath("file-egg-req.txt").write_text(
         "\n%s\n" % (
             "git://github.com/alex/django-fixture-generator.git"
             "#egg=fixture_generator"
@@ -68,9 +68,9 @@ def test_relative_requirements_file(script, data):
     package_folder = script.site_packages / 'fspkg'
 
     # Compute relative install path to FSPkg from scratch path.
-    full_rel_path = data.packages.join('FSPkg') - script.scratch_path
+    full_rel_path = data.packages.joinpath('FSPkg') - script.scratch_path
     full_rel_url = 'file:' + full_rel_path + '#egg=FSPkg'
-    embedded_rel_path = script.scratch_path.join(full_rel_path)
+    embedded_rel_path = script.scratch_path.joinpath(full_rel_path)
 
     # For each relative path, install as either editable or not using either
     # URLs with egg links or not.
@@ -102,7 +102,7 @@ def test_multiple_requirements_files(script, tmpdir):
 
     """
     other_lib_name, other_lib_version = 'anyjson', '0.3'
-    script.scratch_path.join("initools-req.txt").write(
+    script.scratch_path.joinpath("initools-req.txt").write_text(
         textwrap.dedent("""
             -e %s@10#egg=INITools
             -r %s-req.txt
@@ -110,12 +110,12 @@ def test_multiple_requirements_files(script, tmpdir):
         (
             local_checkout(
                 'svn+http://svn.colorstudy.com/INITools/trunk',
-                tmpdir.join("cache"),
+                tmpdir.joinpath("cache"),
             ),
             other_lib_name
         ),
     )
-    script.scratch_path.join("%s-req.txt" % other_lib_name).write(
+    script.scratch_path.joinpath("%s-req.txt" % other_lib_name).write_text(
         "%s<=%s" % (other_lib_name, other_lib_version)
     )
     result = script.pip(
@@ -128,7 +128,7 @@ def test_multiple_requirements_files(script, tmpdir):
 
 
 def test_package_in_constraints_and_dependencies(script, data):
-    script.scratch_path.join("constraints.txt").write(
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "TopoRequires2==0.0.1\nTopoRequires==0.0.1"
     )
     result = script.pip('install', '--no-index', '-f',
@@ -138,8 +138,8 @@ def test_package_in_constraints_and_dependencies(script, data):
 
 
 def test_multiple_constraints_files(script, data):
-    script.scratch_path.join("outer.txt").write("-c inner.txt")
-    script.scratch_path.join("inner.txt").write(
+    script.scratch_path.joinpath("outer.txt").write_text("-c inner.txt")
+    script.scratch_path.joinpath("inner.txt").write_text(
         "Upper==1.0")
     result = script.pip(
         'install', '--no-index', '-f', data.find_links, '-c',
@@ -148,7 +148,7 @@ def test_multiple_constraints_files(script, data):
 
 
 def test_respect_order_in_requirements_file(script, data):
-    script.scratch_path.join("frameworks-req.txt").write(textwrap.dedent("""\
+    script.scratch_path.joinpath("frameworks-req.txt").write_text(textwrap.dedent("""\
         parent
         child
         simple
@@ -174,7 +174,7 @@ def test_respect_order_in_requirements_file(script, data):
 
 
 def test_install_local_editable_with_extras(script, data):
-    to_install = data.packages.join("LocalExtras")
+    to_install = data.packages.joinpath("LocalExtras")
     res = script.pip_install_local(
         '-e', to_install + '[bar]',
         expect_error=False,
@@ -231,7 +231,7 @@ def test_wheel_user_with_prefix_in_pydistutils_cfg(
     else:
         user_filename = "pydistutils.cfg"
     user_cfg = os.path.join(os.path.expanduser('~'), user_filename)
-    script.scratch_path.join("bin").mkdir()
+    script.scratch_path.joinpath("bin").mkdir()
     with open(user_cfg, "w") as cfg:
         cfg.write(textwrap.dedent("""
             [install]
@@ -251,18 +251,18 @@ def test_install_option_in_requirements_file(script, data, virtualenv):
     Test --install-option in requirements file overrides same option in cli
     """
 
-    script.scratch_path.join("home1").mkdir()
-    script.scratch_path.join("home2").mkdir()
+    script.scratch_path.joinpath("home1").mkdir()
+    script.scratch_path.joinpath("home2").mkdir()
 
-    script.scratch_path.join("reqs.txt").write(
+    script.scratch_path.joinpath("reqs.txt").write_text(
         textwrap.dedent(
             """simple --install-option='--home=%s'"""
-            % script.scratch_path.join("home1")))
+            % script.scratch_path.joinpath("home1")))
 
     result = script.pip(
         'install', '--no-index', '-f', data.find_links, '-r',
         script.scratch_path / 'reqs.txt',
-        '--install-option=--home=%s' % script.scratch_path.join("home2"),
+        '--install-option=--home=%s' % script.scratch_path.joinpath("home2"),
         expect_stderr=True)
 
     package_dir = script.scratch / 'home1' / 'lib' / 'python' / 'simple'
@@ -270,7 +270,7 @@ def test_install_option_in_requirements_file(script, data, virtualenv):
 
 
 def test_constraints_not_installed_by_default(script, data):
-    script.scratch_path.join("c.txt").write("requiresupper")
+    script.scratch_path.joinpath("c.txt").write_text("requiresupper")
     result = script.pip(
         'install', '--no-index', '-f', data.find_links, '-c',
         script.scratch_path / 'c.txt', 'Upper')
@@ -278,7 +278,7 @@ def test_constraints_not_installed_by_default(script, data):
 
 
 def test_constraints_only_causes_error(script, data):
-    script.scratch_path.join("c.txt").write("requiresupper")
+    script.scratch_path.joinpath("c.txt").write_text("requiresupper")
     result = script.pip(
         'install', '--no-index', '-f', data.find_links, '-c',
         script.scratch_path / 'c.txt', expect_error=True)
@@ -286,10 +286,10 @@ def test_constraints_only_causes_error(script, data):
 
 
 def test_constraints_local_editable_install_causes_error(script, data):
-    script.scratch_path.join("constraints.txt").write(
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "singlemodule==0.0.0"
     )
-    to_install = data.src.join("singlemodule")
+    to_install = data.src.joinpath("singlemodule")
     result = script.pip(
         'install', '--no-index', '-f', data.find_links, '-c',
         script.scratch_path / 'constraints.txt', '-e',
@@ -299,7 +299,7 @@ def test_constraints_local_editable_install_causes_error(script, data):
 
 @pytest.mark.network
 def test_constraints_local_editable_install_pep518(script, data):
-    to_install = data.src.join("pep518-3.0")
+    to_install = data.src.joinpath("pep518-3.0")
 
     script.pip('download', 'setuptools', 'wheel', '-d', data.packages)
     script.pip(
@@ -307,10 +307,10 @@ def test_constraints_local_editable_install_pep518(script, data):
 
 
 def test_constraints_local_install_causes_error(script, data):
-    script.scratch_path.join("constraints.txt").write(
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "singlemodule==0.0.0"
     )
-    to_install = data.src.join("singlemodule")
+    to_install = data.src.joinpath("singlemodule")
     result = script.pip(
         'install', '--no-index', '-f', data.find_links, '-c',
         script.scratch_path / 'constraints.txt',
@@ -319,8 +319,8 @@ def test_constraints_local_install_causes_error(script, data):
 
 
 def test_constraints_constrain_to_local_editable(script, data):
-    to_install = data.src.join("singlemodule")
-    script.scratch_path.join("constraints.txt").write(
+    to_install = data.src.joinpath("singlemodule")
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "-e %s#egg=singlemodule" % path_to_url(to_install)
     )
     result = script.pip(
@@ -330,8 +330,8 @@ def test_constraints_constrain_to_local_editable(script, data):
 
 
 def test_constraints_constrain_to_local(script, data):
-    to_install = data.src.join("singlemodule")
-    script.scratch_path.join("constraints.txt").write(
+    to_install = data.src.joinpath("singlemodule")
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "%s#egg=singlemodule" % path_to_url(to_install)
     )
     result = script.pip(
@@ -341,9 +341,9 @@ def test_constraints_constrain_to_local(script, data):
 
 
 def test_constrained_to_url_install_same_url(script, data):
-    to_install = data.src.join("singlemodule")
+    to_install = data.src.joinpath("singlemodule")
     constraints = path_to_url(to_install) + "#egg=singlemodule"
-    script.scratch_path.join("constraints.txt").write(constraints)
+    script.scratch_path.joinpath("constraints.txt").write_text(constraints)
     result = script.pip(
         'install', '--no-index', '-f', data.find_links, '-c',
         script.scratch_path / 'constraints.txt', to_install)
@@ -384,8 +384,8 @@ def test_double_install_spurious_hash_mismatch(
 
 
 def test_install_with_extras_from_constraints(script, data):
-    to_install = data.packages.join("LocalExtras")
-    script.scratch_path.join("constraints.txt").write(
+    to_install = data.packages.joinpath("LocalExtras")
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "%s#egg=LocalExtras[bar]" % path_to_url(to_install)
     )
     result = script.pip_install_local(
@@ -394,8 +394,8 @@ def test_install_with_extras_from_constraints(script, data):
 
 
 def test_install_with_extras_from_install(script, data):
-    to_install = data.packages.join("LocalExtras")
-    script.scratch_path.join("constraints.txt").write(
+    to_install = data.packages.joinpath("LocalExtras")
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "%s#egg=LocalExtras" % path_to_url(to_install)
     )
     result = script.pip_install_local(
@@ -404,8 +404,8 @@ def test_install_with_extras_from_install(script, data):
 
 
 def test_install_with_extras_joined(script, data):
-    to_install = data.packages.join("LocalExtras")
-    script.scratch_path.join("constraints.txt").write(
+    to_install = data.packages.joinpath("LocalExtras")
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "%s#egg=LocalExtras[bar]" % path_to_url(to_install)
     )
     result = script.pip_install_local(
@@ -416,8 +416,8 @@ def test_install_with_extras_joined(script, data):
 
 
 def test_install_with_extras_editable_joined(script, data):
-    to_install = data.packages.join("LocalExtras")
-    script.scratch_path.join("constraints.txt").write(
+    to_install = data.packages.joinpath("LocalExtras")
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "-e %s#egg=LocalExtras[bar]" % path_to_url(to_install)
     )
     result = script.pip_install_local(
@@ -427,7 +427,7 @@ def test_install_with_extras_editable_joined(script, data):
 
 
 def test_install_distribution_full_union(script, data):
-    to_install = data.packages.join("LocalExtras")
+    to_install = data.packages.joinpath("LocalExtras")
     result = script.pip_install_local(
         to_install, to_install + "[bar]", to_install + "[baz]")
     assert 'Running setup.py install for LocalExtras' in result.stdout
@@ -436,7 +436,7 @@ def test_install_distribution_full_union(script, data):
 
 
 def test_install_distribution_duplicate_extras(script, data):
-    to_install = data.packages.join("LocalExtras")
+    to_install = data.packages.joinpath("LocalExtras")
     package_name = to_install + "[bar]"
     with pytest.raises(AssertionError):
         result = script.pip_install_local(package_name, package_name)
@@ -444,8 +444,8 @@ def test_install_distribution_duplicate_extras(script, data):
 
 
 def test_install_distribution_union_with_constraints(script, data):
-    to_install = data.packages.join("LocalExtras")
-    script.scratch_path.join("constraints.txt").write(
+    to_install = data.packages.joinpath("LocalExtras")
+    script.scratch_path.joinpath("constraints.txt").write_text(
         "%s[bar]" % to_install)
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', to_install + '[baz]')
@@ -454,8 +454,8 @@ def test_install_distribution_union_with_constraints(script, data):
 
 
 def test_install_distribution_union_with_versions(script, data):
-    to_install_001 = data.packages.join("LocalExtras")
-    to_install_002 = data.packages.join("LocalExtras-0.0.2")
+    to_install_001 = data.packages.joinpath("LocalExtras")
+    to_install_002 = data.packages.joinpath("LocalExtras-0.0.2")
     result = script.pip_install_local(
         to_install_001 + "[bar]", to_install_002 + "[baz]")
     assert ("Successfully installed LocalExtras-0.0.1 simple-3.0 " +
@@ -468,7 +468,7 @@ def test_install_distribution_union_conflicting_extras(script, data):
     # without a resolver, pip does not detect the conflict between simple==1.0
     # and simple==2.0. Once a resolver is added, this conflict should be
     # detected.
-    to_install = data.packages.join("LocalExtras-0.0.2")
+    to_install = data.packages.joinpath("LocalExtras-0.0.2")
     result = script.pip_install_local(to_install, to_install + "[bar]",
                                       expect_error=True)
     assert 'installed' not in result.stdout
@@ -476,7 +476,7 @@ def test_install_distribution_union_conflicting_extras(script, data):
 
 
 def test_install_unsupported_wheel_link_with_marker(script):
-    script.scratch_path.join("with-marker.txt").write(
+    script.scratch_path.joinpath("with-marker.txt").write_text(
         textwrap.dedent("""\
             %s; %s
         """) %
@@ -498,9 +498,9 @@ def test_install_unsupported_wheel_link_with_marker(script):
 def test_install_unsupported_wheel_file(script, data):
     # Trying to install a local wheel with an incompatible version/type
     # should fail.
-    script.scratch_path.join("wheel-file.txt").write(textwrap.dedent("""\
+    script.scratch_path.joinpath("wheel-file.txt").write_text(textwrap.dedent("""\
         %s
-        """ % data.packages.join("simple.dist-0.1-py1-none-invalid.whl")))
+        """ % data.packages.joinpath("simple.dist-0.1-py1-none-invalid.whl")))
     result = script.pip(
         'install', '-r', script.scratch_path / 'wheel-file.txt',
         expect_error=True,
@@ -519,11 +519,11 @@ def test_install_options_local_to_package(script, data):
     packages.  This needs to be a functional test because the bug was around
     cross-contamination at install time.
     """
-    home_simple = script.scratch_path.join("for-simple")
-    test_simple = script.scratch.join("for-simple")
+    home_simple = script.scratch_path.joinpath("for-simple")
+    test_simple = script.scratch.joinpath("for-simple")
     home_simple.mkdir()
-    reqs_file = script.scratch_path.join("reqs.txt")
-    reqs_file.write(
+    reqs_file = script.scratch_path.joinpath("reqs.txt")
+    reqs_file.write_text(
         textwrap.dedent("""
             simple --install-option='--home=%s'
             INITools

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -262,7 +262,7 @@ def test_upgrade_from_reqs_file(script):
     Upgrade from a requirements file.
 
     """
-    script.scratch_path.join("test-req.txt").write(textwrap.dedent("""\
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""\
         PyLogo<0.4
         # and something else to test out:
         INITools==0.3
@@ -270,7 +270,7 @@ def test_upgrade_from_reqs_file(script):
     install_result = script.pip(
         'install', '-r', script.scratch_path / 'test-req.txt'
     )
-    script.scratch_path.join("test-req.txt").write(textwrap.dedent("""\
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""\
         PyLogo
         # and something else to test out:
         INITools
@@ -356,7 +356,7 @@ def test_upgrade_vcs_req_with_no_dists_found(script, tmpdir):
     """It can upgrade a VCS requirement that has no distributions otherwise."""
     req = "%s#egg=pip-test-package" % local_checkout(
         "git+https://github.com/pypa/pip-test-package.git",
-        tmpdir.join("cache"),
+        tmpdir.joinpath("cache"),
     )
     script.pip("install", req)
     result = script.pip("install", "-U", req)

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -53,7 +53,7 @@ class Tests_UserSite:
             '%s#egg=initools' %
             local_checkout(
                 'svn+http://svn.colorstudy.com/INITools/trunk',
-                tmpdir.join("cache"),
+                tmpdir.joinpath("cache"),
             )
         )
         result.assert_installed('INITools', use_user_site=True)
@@ -63,7 +63,7 @@ class Tests_UserSite:
         """
         Test installing current directory ('.') into usersite
         """
-        run_from = data.packages.join("FSPkg")
+        run_from = data.packages.joinpath("FSPkg")
         result = script.pip(
             'install', '-vvv', '--user', curdir,
             cwd=run_from,
@@ -87,7 +87,7 @@ class Tests_UserSite:
         # We can't use PYTHONNOUSERSITE, as it's not
         # honoured by virtualenv's custom site.py.
         virtualenv.user_site_packages = False
-        run_from = data.packages.join("FSPkg")
+        run_from = data.packages.joinpath("FSPkg")
         result = script.pip(
             'install', '--user', curdir,
             cwd=run_from,

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -55,7 +55,7 @@ def _github_checkout(url_path, temp_dir, rev=None, egg=None, scheme=None):
     if scheme is None:
         scheme = 'https'
     url = 'git+{}://github.com/{}'.format(scheme, url_path)
-    local_url = local_checkout(url, temp_dir.join('cache'))
+    local_url = local_checkout(url, temp_dir.joinpath('cache'))
     if rev is not None:
         local_url += '@{}'.format(rev)
     if egg is not None:

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -13,13 +13,13 @@ def test_install_from_future_wheel_version(script, data):
     """
     from tests.lib import TestFailure
 
-    package = data.packages.join("futurewheel-3.0-py2.py3-none-any.whl")
+    package = data.packages.joinpath("futurewheel-3.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=True)
     with pytest.raises(TestFailure):
         result.assert_installed('futurewheel', without_egg_link=True,
                                 editable=False)
 
-    package = data.packages.join("futurewheel-1.9-py2.py3-none-any.whl")
+    package = data.packages.joinpath("futurewheel-1.9-py2.py3-none-any.whl")
     result = script.pip(
         'install', package, '--no-index', expect_error=False,
         expect_stderr=True,
@@ -33,7 +33,7 @@ def test_install_from_broken_wheel(script, data):
     Test that installing a broken wheel fails properly
     """
     from tests.lib import TestFailure
-    package = data.packages.join("brokenwheel-1.0-py2.py3-none-any.whl")
+    package = data.packages.joinpath("brokenwheel-1.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=True)
     with pytest.raises(TestFailure):
         result.assert_installed('futurewheel', without_egg_link=True,
@@ -80,7 +80,7 @@ def test_basic_install_from_wheel_file(script, data):
     """
     Test installing directly from a wheel file.
     """
-    package = data.packages.join("simple.dist-0.1-py2.py3-none-any.whl")
+    package = data.packages.joinpath("simple.dist-0.1-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=False)
     dist_info_folder = script.site_packages / 'simple.dist-0.1.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
@@ -106,7 +106,7 @@ def test_install_from_wheel_with_headers(script, data):
     """
     Test installing from a wheel file with headers
     """
-    package = data.packages.join("headers.dist-0.1-py2.py3-none-any.whl")
+    package = data.packages.joinpath("headers.dist-0.1-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=False)
     dist_info_folder = script.site_packages / 'headers.dist-0.1.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
@@ -148,7 +148,9 @@ def test_install_wheel_with_target_and_data_files(script, data, with_wheel):
         )
     """
     target_dir = script.scratch_path / 'prjwithdatafile'
-    package = data.packages.join("prjwithdatafile-1.0-py2.py3-none-any.whl")
+    package = data.packages.joinpath(
+        "prjwithdatafile-1.0-py2.py3-none-any.whl"
+    )
     result = script.pip('install', package,
                         '-t', target_dir,
                         '--no-index',
@@ -192,7 +194,9 @@ def test_install_from_wheel_installs_deps(script, data):
     Test can install dependencies of wheels
     """
     # 'requires_source' depends on the 'source' project
-    package = data.packages.join("requires_source-1.0-py2.py3-none-any.whl")
+    package = data.packages.joinpath(
+        "requires_source-1.0-py2.py3-none-any.whl"
+    )
     result = script.pip(
         'install', '--no-index', '--find-links', data.find_links, package,
     )
@@ -204,7 +208,9 @@ def test_install_from_wheel_no_deps(script, data):
     Test --no-deps works with wheel installs
     """
     # 'requires_source' depends on the 'source' project
-    package = data.packages.join("requires_source-1.0-py2.py3-none-any.whl")
+    package = data.packages.joinpath(
+        "requires_source-1.0-py2.py3-none-any.whl"
+    )
     result = script.pip(
         'install', '--no-index', '--find-links', data.find_links, '--no-deps',
         package,
@@ -214,7 +220,7 @@ def test_install_from_wheel_no_deps(script, data):
 
 
 def test_wheel_record_lines_in_deterministic_order(script, data):
-    to_install = data.packages.join("simplewheel-1.0-py2.py3-none-any.whl")
+    to_install = data.packages.joinpath("simplewheel-1.0-py2.py3-none-any.whl")
     result = script.pip('install', to_install)
 
     dist_info_folder = script.site_packages / 'simplewheel-1.0.dist-info'
@@ -405,9 +411,9 @@ def test_wheel_no_compiles_pyc(script, data):
 
 def test_install_from_wheel_uninstalls_old_version(script, data):
     # regression test for https://github.com/pypa/pip/issues/1825
-    package = data.packages.join("simplewheel-1.0-py2.py3-none-any.whl")
+    package = data.packages.joinpath("simplewheel-1.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=True)
-    package = data.packages.join("simplewheel-2.0-py2.py3-none-any.whl")
+    package = data.packages.joinpath("simplewheel-2.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=False)
     dist_info_folder = script.site_packages / 'simplewheel-2.0.dist-info'
     assert dist_info_folder in result.files_created
@@ -416,7 +422,7 @@ def test_install_from_wheel_uninstalls_old_version(script, data):
 
 
 def test_wheel_compile_syntax_error(script, data):
-    package = data.packages.join("compilewheel-1.0-py2.py3-none-any.whl")
+    package = data.packages.joinpath("compilewheel-1.0-py2.py3-none-any.whl")
     result = script.pip('install', '--compile', package, '--no-index')
     assert 'yield from' not in result.stdout
     assert 'SyntaxError: ' not in result.stdout
@@ -425,6 +431,6 @@ def test_wheel_compile_syntax_error(script, data):
 def test_wheel_install_with_no_cache_dir(script, tmpdir, data):
     """Check wheel installations work, even with no cache.
     """
-    package = data.packages.join("simple.dist-0.1-py2.py3-none-any.whl")
+    package = data.packages.joinpath("simple.dist-0.1-py2.py3-none-any.whl")
     result = script.pip('install', '--no-cache-dir', '--no-index', package)
     result.assert_installed('simpledist', editable=False)

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -403,10 +403,12 @@ def test_outdated_pre(script, data):
     script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
 
     # Let's build a fake wheelhouse
-    script.scratch_path.join("wheelhouse").mkdir()
+    script.scratch_path.joinpath("wheelhouse").mkdir()
     wheelhouse_path = script.scratch_path / 'wheelhouse'
-    wheelhouse_path.join('simple-1.1-py2.py3-none-any.whl').write('')
-    wheelhouse_path.join('simple-2.0.dev0-py2.py3-none-any.whl').write('')
+    wheelhouse_path.joinpath('simple-1.1-py2.py3-none-any.whl').write_text('')
+    wheelhouse_path.joinpath(
+        'simple-2.0.dev0-py2.py3-none-any.whl'
+    ).write_text('')
     result = script.pip(
         'list', '--no-index', '--find-links', wheelhouse_path,
         '--format=json',
@@ -432,9 +434,9 @@ def test_outdated_formats(script, data):
     script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
 
     # Let's build a fake wheelhouse
-    script.scratch_path.join("wheelhouse").mkdir()
+    script.scratch_path.joinpath("wheelhouse").mkdir()
     wheelhouse_path = script.scratch_path / 'wheelhouse'
-    wheelhouse_path.join('simple-1.1-py2.py3-none-any.whl').write('')
+    wheelhouse_path.joinpath('simple-1.1-py2.py3-none-any.whl').write_text('')
     result = script.pip(
         'list', '--no-index', '--find-links', wheelhouse_path,
         '--format=freeze',

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -11,7 +11,7 @@ def make_project(tmpdir, requires=[], backend=None):
     if backend:
         buildsys['build-backend'] = backend
     data = pytoml.dumps({'build-system': buildsys})
-    project_dir.join('pyproject.toml').write(data)
+    project_dir.joinpath('pyproject.toml').write_text(data)
     return project_dir
 
 
@@ -48,7 +48,7 @@ def test_pep517_install_with_reqs(script, tmpdir, data):
         tmpdir, requires=['test_backend'],
         backend="test_backend"
     )
-    project_dir.join("backend_reqs.txt").write("simplewheel")
+    project_dir.joinpath("backend_reqs.txt").write_text("simplewheel")
     result = script.pip(
         'install', '--no-index',
         '-f', data.backends,
@@ -78,7 +78,7 @@ def test_conflicting_pep517_backend_requirements(script, tmpdir, data):
         tmpdir, requires=['test_backend', 'simplewheel==1.0'],
         backend="test_backend"
     )
-    project_dir.join("backend_reqs.txt").write("simplewheel==2.0")
+    project_dir.joinpath("backend_reqs.txt").write_text("simplewheel==2.0")
     result = script.pip(
         'install', '--no-index',
         '-f', data.backends,
@@ -99,7 +99,7 @@ def test_pep517_backend_requirements_already_satisfied(script, tmpdir, data):
         tmpdir, requires=['test_backend', 'simplewheel==1.0'],
         backend="test_backend"
     )
-    project_dir.join("backend_reqs.txt").write("simplewheel")
+    project_dir.joinpath("backend_reqs.txt").write_text("simplewheel")
     result = script.pip(
         'install', '--no-index',
         '-f', data.backends,
@@ -158,10 +158,10 @@ def make_pyproject_with_setup(tmpdir, build_system=True, set_backend=True):
         'setup(name="pep517_test", version="0.1", packages=["pep517_test"])'
     )
 
-    project_dir.join('pyproject.toml').write(project_data)
-    project_dir.join('setup.py').write(setup_script)
+    project_dir.joinpath('pyproject.toml').write_text(project_data)
+    project_dir.joinpath('setup.py').write_text(setup_script)
     package_dir = (project_dir / "pep517_test").mkdir()
-    package_dir.join('__init__.py').write('__version__ = "0.1"')
+    package_dir.joinpath('__init__.py').write_text('__version__ = "0.1"')
     return project_dir, "pep517_test"
 
 

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -25,7 +25,7 @@ def test_show_with_files_not_found(script, data):
     Test for show command with installed files listing enabled and
     installed-files.txt not found.
     """
-    editable = data.packages.join('SetupPyUTF8')
+    editable = data.packages.joinpath('SetupPyUTF8')
     script.pip('install', '-e', editable)
     result = script.pip('show', '-f', 'SetupPyUTF8')
     lines = result.stdout.splitlines()
@@ -42,7 +42,7 @@ def test_show_with_files_from_wheel(script, data):
     """
     Test that a wheel's files can be listed
     """
-    wheel_file = data.packages.join('simple.dist-0.1-py2.py3-none-any.whl')
+    wheel_file = data.packages.joinpath('simple.dist-0.1-py2.py3-none-any.whl')
     script.pip('install', '--no-index', wheel_file)
     result = script.pip('show', '-f', 'simple.dist')
     lines = result.stdout.splitlines()
@@ -113,7 +113,7 @@ def test_show_verbose_installer(script, data):
     """
     Test that the installer is shown (this currently needs a wheel install)
     """
-    wheel_file = data.packages.join('simple.dist-0.1-py2.py3-none-any.whl')
+    wheel_file = data.packages.joinpath('simple.dist-0.1-py2.py3-none-any.whl')
     script.pip('install', '--no-index', wheel_file)
     result = script.pip('show', '--verbose', 'simple.dist')
     lines = result.stdout.splitlines()

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -39,9 +39,9 @@ def test_basic_uninstall_distutils(script):
     Test basic install and uninstall.
 
     """
-    script.scratch_path.join("distutils_install").mkdir()
+    script.scratch_path.joinpath("distutils_install").mkdir()
     pkg_path = script.scratch_path / 'distutils_install'
-    pkg_path.join("setup.py").write(textwrap.dedent("""
+    pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from distutils.core import setup
         setup(
             name='distutils-install',
@@ -163,8 +163,8 @@ def test_uninstall_overlapping_package(script, data):
 
     See: GitHub issue #355 (pip uninstall removes things it didn't install)
     """
-    parent_pkg = data.packages.join("parent-0.1.tar.gz")
-    child_pkg = data.packages.join("child-0.1.tar.gz")
+    parent_pkg = data.packages.joinpath("parent-0.1.tar.gz")
+    child_pkg = data.packages.joinpath("child-0.1.tar.gz")
 
     result1 = script.pip('install', parent_pkg, expect_error=False)
     assert join(script.site_packages, 'parent') in result1.files_created, (
@@ -214,16 +214,18 @@ def test_uninstall_entry_point(script, console_scripts):
                        "ep:name2 = distutils_install"]
                       }
     )
-    script_name = script.bin_path.join(console_scripts.split('=')[0].strip())
+    script_name = script.bin_path.joinpath(
+        console_scripts.split('=')[0].strip()
+    )
     if sys.platform == 'win32':
         script_name += '.exe'
     result = script.pip('install', pkg_path)
-    assert script_name.exists
+    assert script_name.exists()
     result = script.pip('list', '--format=json')
     assert {"name": "ep-install", "version": "0.1"} \
         in json.loads(result.stdout)
     script.pip('uninstall', 'ep_install', '-y')
-    assert not script_name.exists
+    assert not script_name.exists()
     result2 = script.pip('list', '--format=json')
     assert {"name": "ep-install", "version": "0.1"} \
         not in json.loads(result2.stdout)
@@ -240,13 +242,13 @@ def test_uninstall_gui_scripts(script):
         version='0.1',
         entry_points={"gui_scripts": ["test_ = distutils_install", ], }
     )
-    script_name = script.bin_path.join('test_')
+    script_name = script.bin_path.joinpath('test_')
     if sys.platform == 'win32':
         script_name += '.exe'
     script.pip('install', pkg_path)
-    assert script_name.exists
+    assert script_name.exists()
     script.pip('uninstall', pkg_name, '-y')
-    assert not script_name.exists
+    assert not script_name.exists()
 
 
 @pytest.mark.network
@@ -295,7 +297,7 @@ def test_uninstall_editable_from_svn(script, tmpdir):
         'install', '-e',
         '%s#egg=initools' % local_checkout(
             'svn+http://svn.colorstudy.com/INITools/trunk',
-            tmpdir.join("cache"),
+            tmpdir.joinpath("cache"),
         ),
     )
     result.assert_installed('INITools')
@@ -318,7 +320,7 @@ def test_uninstall_editable_with_source_outside_venv(script, tmpdir):
     Test uninstalling editable install from existing source outside the venv.
 
     """
-    cache_dir = tmpdir.join("cache")
+    cache_dir = tmpdir.joinpath("cache")
 
     try:
         temp = mkdtemp()
@@ -363,7 +365,7 @@ def test_uninstall_from_reqs_file(script, tmpdir):
     Test uninstall from a requirements file.
 
     """
-    script.scratch_path.join("test-req.txt").write(
+    script.scratch_path.joinpath("test-req.txt").write_text(
         textwrap.dedent("""
             -e %s#egg=initools
             # and something else to test out:
@@ -371,11 +373,11 @@ def test_uninstall_from_reqs_file(script, tmpdir):
         """) %
         local_checkout(
             'svn+http://svn.colorstudy.com/INITools/trunk',
-            tmpdir.join("cache")
+            tmpdir.joinpath("cache")
         )
     )
     result = script.pip('install', '-r', 'test-req.txt')
-    script.scratch_path.join("test-req.txt").write(
+    script.scratch_path.joinpath("test-req.txt").write_text(
         textwrap.dedent("""
             # -f, -i, and --extra-index-url should all be ignored by uninstall
             -f http://www.example.com
@@ -388,7 +390,7 @@ def test_uninstall_from_reqs_file(script, tmpdir):
         """) %
         local_checkout(
             'svn+http://svn.colorstudy.com/INITools/trunk',
-            tmpdir.join("cache")
+            tmpdir.joinpath("cache")
         )
     )
     result2 = script.pip('uninstall', '-r', 'test-req.txt', '-y')
@@ -425,7 +427,7 @@ def test_uninstallpathset_no_paths(caplog):
 
 
 def test_uninstall_non_local_distutils(caplog, monkeypatch, tmpdir):
-    einfo = tmpdir.join("thing-1.0.egg-info")
+    einfo = tmpdir.joinpath("thing-1.0.egg-info")
     with open(einfo, "wb"):
         pass
 
@@ -449,7 +451,7 @@ def test_uninstall_wheel(script, data):
     """
     Test uninstalling a wheel
     """
-    package = data.packages.join("simple.dist-0.1-py2.py3-none-any.whl")
+    package = data.packages.joinpath("simple.dist-0.1-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index')
     dist_info_folder = script.site_packages / 'simple.dist-0.1.dist-info'
     assert dist_info_folder in result.files_created
@@ -459,7 +461,7 @@ def test_uninstall_wheel(script, data):
 
 def test_uninstall_setuptools_develop_install(script, data):
     """Try uninstall after setup.py develop followed of setup.py install"""
-    pkg_path = data.packages.join("FSPkg")
+    pkg_path = data.packages.joinpath("FSPkg")
     script.run('python', 'setup.py', 'develop',
                expect_stderr=True, cwd=pkg_path)
     script.run('python', 'setup.py', 'install',
@@ -486,7 +488,7 @@ def test_uninstall_editable_and_pip_install(script, data):
     # This becomes the default behavior in setuptools 25.
     script.environ['SETUPTOOLS_SYS_PATH_TECHNIQUE'] = 'raw'
 
-    pkg_path = data.packages.join("FSPkg")
+    pkg_path = data.packages.joinpath("FSPkg")
     script.pip('install', '-e', '.',
                expect_stderr=True, cwd=pkg_path)
     # ensure both are installed with --ignore-installed:

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -54,7 +54,7 @@ class Tests_UninstallUserSite:
         script.user_site_path.makedirs()
 
         # install
-        to_install = data.packages.join("FSPkg")
+        to_install = data.packages.joinpath("FSPkg")
         result1 = script.pip(
             'install', '--user', '-e', to_install, expect_error=False,
         )

--- a/tests/functional/test_warning.py
+++ b/tests/functional/test_warning.py
@@ -3,8 +3,8 @@ import textwrap
 
 def test_environ(script, tmpdir):
     """$PYTHONWARNINGS was added in python2.7"""
-    demo = tmpdir.join('warnings_demo.py')
-    demo.write(textwrap.dedent('''
+    demo = tmpdir.joinpath('warnings_demo.py')
+    demo.write_text(textwrap.dedent('''
         from logging import basicConfig
         from pip._internal.utils import deprecation
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -17,9 +17,11 @@ def auto_with_wheel(with_wheel):
 
 def add_files_to_dist_directory(folder):
     (folder / 'dist').makedirs()
-    (folder / 'dist' / 'a_name-0.0.1.tar.gz').write("hello")
+    (folder / 'dist' / 'a_name-0.0.1.tar.gz').write_text("hello")
     # Not adding a wheel file since that confuses setuptools' backend.
-    # (folder / 'dist' / 'a_name-0.0.1-py2.py3-none-any.whl').write("hello")
+    # (folder / 'dist' / 'a_name-0.0.1-py2.py3-none-any.whl').write_text(
+    #     "hello"
+    # )
 
 
 def test_wheel_exit_status_code_when_no_requirements(script):
@@ -35,7 +37,7 @@ def test_wheel_exit_status_code_when_blank_requirements_file(script):
     """
     Test wheel exit status code when blank requirements file specified
     """
-    script.scratch_path.join("blank.txt").write("\n")
+    script.scratch_path.joinpath("blank.txt").write_text("\n")
     script.pip('wheel', '-r', 'blank.txt')
 
 
@@ -73,7 +75,7 @@ def test_basic_pip_wheel_downloads_wheels(script, data):
 
 
 def test_pip_wheel_builds_when_no_binary_set(script, data):
-    data.packages.join('simple-3.0-py2.py3-none-any.whl').touch()
+    data.packages.joinpath('simple-3.0-py2.py3-none-any.whl').touch()
     # Check that the wheel package is ignored
     res = script.pip(
         'wheel', '--no-index', '--no-binary', ':all:',
@@ -171,7 +173,7 @@ def test_pip_wheel_fail_cause_of_previous_build_dir(script, data):
     build = script.venv_path / 'build' / 'simple'
     os.makedirs(build)
     write_delete_marker_file(script.venv_path / 'build' / 'simple')
-    build.join('setup.py').write('#')
+    build.joinpath('setup.py').write_text('#')
 
     # When I call pip trying to install things again
     result = script.pip(
@@ -187,7 +189,7 @@ def test_pip_wheel_fail_cause_of_previous_build_dir(script, data):
 def test_wheel_package_with_latin1_setup(script, data):
     """Create a wheel from a package with latin-1 encoded setup.py."""
 
-    pkg_to_wheel = data.packages.join("SetupPyLatin1")
+    pkg_to_wheel = data.packages.joinpath("SetupPyLatin1")
     result = script.pip('wheel', pkg_to_wheel)
     assert 'Successfully built SetupPyUTF8' in result.stdout
 
@@ -218,7 +220,7 @@ def test_pip_wheel_with_pep518_build_reqs_no_isolation(script, data):
 def test_pip_wheel_with_user_set_in_config(script, data, common_wheels):
     config_file = script.scratch_path / 'pip.conf'
     script.environ['PIP_CONFIG_FILE'] = str(config_file)
-    config_file.write("[install]\nuser = true")
+    config_file.write_text("[install]\nuser = true")
     result = script.pip(
         'wheel', data.src / 'withpyproject',
         '--no-index', '-f', common_wheels

--- a/tests/functional/test_yaml.py
+++ b/tests/functional/test_yaml.py
@@ -99,7 +99,7 @@ def handle_install_request(script, requirement):
 
 @pytest.mark.yaml
 @pytest.mark.parametrize(
-    "case", generate_yaml_tests(DATA_DIR.folder / "yaml"), ids=id_func
+    "case", generate_yaml_tests(DATA_DIR.parent / "yaml"), ids=id_func
 )
 def test_yaml_based(script, case):
     available = case.get("available", [])

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -26,8 +26,8 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.models.target_python import TargetPython
 
 
-DATA_DIR = Path(__file__).folder.folder.join("data").abspath
-SRC_DIR = Path(__file__).abspath.folder.folder.folder
+DATA_DIR = Path(__file__).parent.parent.joinpath("data").abspath
+SRC_DIR = Path(__file__).abspath.parent.parent.parent
 
 pyversion = sys.version[:3]
 pyversion_tuple = sys.version_info
@@ -144,31 +144,31 @@ class TestData(object):
 
     @property
     def packages(self):
-        return self.root.join("packages")
+        return self.root.joinpath("packages")
 
     @property
     def packages2(self):
-        return self.root.join("packages2")
+        return self.root.joinpath("packages2")
 
     @property
     def packages3(self):
-        return self.root.join("packages3")
+        return self.root.joinpath("packages3")
 
     @property
     def src(self):
-        return self.root.join("src")
+        return self.root.joinpath("src")
 
     @property
     def indexes(self):
-        return self.root.join("indexes")
+        return self.root.joinpath("indexes")
 
     @property
     def reqfiles(self):
-        return self.root.join("reqfiles")
+        return self.root.joinpath("reqfiles")
 
     @property
     def completion_paths(self):
-        return self.root.join("completion_paths")
+        return self.root.joinpath("completion_paths")
 
     @property
     def find_links(self):
@@ -184,10 +184,10 @@ class TestData(object):
 
     @property
     def backends(self):
-        return path_to_url(self.root.join("backends"))
+        return path_to_url(self.root.joinpath("backends"))
 
     def index_url(self, index="simple"):
-        return path_to_url(self.root.join("indexes", index))
+        return path_to_url(self.root.joinpath("indexes", index))
 
 
 class TestFailure(AssertionError):
@@ -414,24 +414,24 @@ class PipTestEnvironment(TestFileEnvironment):
         self.site_packages_path = venv.site
         self.bin_path = venv.bin
 
-        self.user_base_path = self.venv_path.join("user")
-        self.user_site_path = self.venv_path.join(
+        self.user_base_path = self.venv_path.joinpath("user")
+        self.user_site_path = self.venv_path.joinpath(
             "user",
             site.USER_SITE[len(site.USER_BASE) + 1:],
         )
         if sys.platform == 'win32':
             if sys.version_info >= (3, 5):
-                scripts_base = self.user_site_path.join('..').normpath
+                scripts_base = self.user_site_path.joinpath('..').normpath
             else:
                 scripts_base = self.user_base_path
-            self.user_bin_path = scripts_base.join('Scripts')
+            self.user_bin_path = scripts_base.joinpath('Scripts')
         else:
-            self.user_bin_path = self.user_base_path.join(
+            self.user_bin_path = self.user_base_path.joinpath(
                 self.bin_path - self.venv_path
             )
 
         # Create a Directory to use as a scratch pad
-        self.scratch_path = base_path.join("scratch").mkdir()
+        self.scratch_path = base_path.joinpath("scratch").mkdir()
 
         # Set our default working directory
         kwargs.setdefault("cwd", self.scratch_path)
@@ -472,7 +472,7 @@ class PipTestEnvironment(TestFileEnvironment):
         # create easy-install.pth in user_site, so we always have it updated
         #   instead of created
         self.user_site_path.makedirs()
-        self.user_site_path.join("easy-install.pth").touch()
+        self.user_site_path.joinpath("easy-install.pth").touch()
 
     def _ignore_file(self, fn):
         if fn.endswith('__pycache__') or fn.endswith(".pyc"):
@@ -661,7 +661,7 @@ def _create_main_file(dir_path, name=None, output=None):
         print({!r})
     """.format(output))
     filename = '{}.py'.format(name)
-    dir_path.join(filename).write(text)
+    dir_path.joinpath(filename).write_text(text)
 
 
 def _git_commit(env_or_script, repo_dir, message=None, args=None,
@@ -730,10 +730,10 @@ def _vcs_add(script, version_pkg_path, vcs='git'):
 
 
 def _create_test_package_with_subdirectory(script, subdirectory):
-    script.scratch_path.join("version_pkg").mkdir()
+    script.scratch_path.joinpath("version_pkg").mkdir()
     version_pkg_path = script.scratch_path / 'version_pkg'
     _create_main_file(version_pkg_path, name="version_pkg", output="0.1")
-    version_pkg_path.join("setup.py").write(
+    version_pkg_path.joinpath("setup.py").write_text(
         textwrap.dedent("""
     from setuptools import setup, find_packages
     setup(name='version_pkg',
@@ -743,11 +743,11 @@ def _create_test_package_with_subdirectory(script, subdirectory):
           entry_points=dict(console_scripts=['version_pkg=version_pkg:main']))
         """))
 
-    subdirectory_path = version_pkg_path.join(subdirectory)
+    subdirectory_path = version_pkg_path.joinpath(subdirectory)
     subdirectory_path.mkdir()
     _create_main_file(subdirectory_path, name="version_subpkg", output="0.1")
 
-    subdirectory_path.join('setup.py').write(
+    subdirectory_path.joinpath('setup.py').write_text(
         textwrap.dedent("""
 from setuptools import setup, find_packages
 setup(name='version_subpkg',
@@ -765,16 +765,16 @@ setup(name='version_subpkg',
 
 
 def _create_test_package_with_srcdir(script, name='version_pkg', vcs='git'):
-    script.scratch_path.join(name).mkdir()
+    script.scratch_path.joinpath(name).mkdir()
     version_pkg_path = script.scratch_path / name
-    subdir_path = version_pkg_path.join('subdir')
+    subdir_path = version_pkg_path.joinpath('subdir')
     subdir_path.mkdir()
-    src_path = subdir_path.join('src')
+    src_path = subdir_path.joinpath('src')
     src_path.mkdir()
-    pkg_path = src_path.join('pkg')
+    pkg_path = src_path.joinpath('pkg')
     pkg_path.mkdir()
-    pkg_path.join('__init__.py').write('')
-    subdir_path.join("setup.py").write(textwrap.dedent("""
+    pkg_path.joinpath('__init__.py').write_text('')
+    subdir_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup, find_packages
         setup(
             name='{name}',
@@ -787,10 +787,10 @@ def _create_test_package_with_srcdir(script, name='version_pkg', vcs='git'):
 
 
 def _create_test_package(script, name='version_pkg', vcs='git'):
-    script.scratch_path.join(name).mkdir()
+    script.scratch_path.joinpath(name).mkdir()
     version_pkg_path = script.scratch_path / name
     _create_main_file(version_pkg_path, name=name, output='0.1')
-    version_pkg_path.join("setup.py").write(textwrap.dedent("""
+    version_pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup, find_packages
         setup(
             name='{name}',
@@ -852,16 +852,16 @@ def requirements_file(contents, tmpdir):
 
     """
     path = tmpdir / 'reqs.txt'
-    path.write(contents)
+    path.write_text(contents)
     yield path
-    path.remove()
+    path.unlink()
 
 
 def create_test_package_with_setup(script, **setup_kwargs):
     assert 'name' in setup_kwargs, setup_kwargs
     pkg_path = script.scratch_path / setup_kwargs['name']
     pkg_path.mkdir()
-    pkg_path.join("setup.py").write(textwrap.dedent("""
+    pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         kwargs = %r
         setup(**kwargs)
@@ -941,8 +941,8 @@ def create_basic_wheel_for_package(script, name, version,
 
     for fname in files:
         path = script.temp_path / fname
-        path.folder.mkdir()
-        path.write(files[fname])
+        path.parent.mkdir()
+        path.write_text(files[fname])
 
     retval = script.scratch_path / archive_name
     generated = shutil.make_archive(retval, 'zip', script.temp_path)

--- a/tests/lib/git_submodule_helpers.py
+++ b/tests/lib/git_submodule_helpers.py
@@ -6,7 +6,7 @@ from tests.lib import _create_main_file, _git_commit
 
 
 def _create_test_package_submodule(env):
-    env.scratch_path.join("version_pkg_submodule").mkdir()
+    env.scratch_path.joinpath("version_pkg_submodule").mkdir()
     submodule_path = env.scratch_path / 'version_pkg_submodule'
     env.run('touch', 'testfile', cwd=submodule_path)
     env.run('git', 'init', cwd=submodule_path)
@@ -17,8 +17,8 @@ def _create_test_package_submodule(env):
 
 
 def _change_test_package_submodule(env, submodule_path):
-    submodule_path.join("testfile").write("this is a changed file")
-    submodule_path.join("testfile2").write("this is an added file")
+    submodule_path.joinpath("testfile").write_text("this is a changed file")
+    submodule_path.joinpath("testfile2").write_text("this is an added file")
     env.run('git', 'add', '.', cwd=submodule_path)
     _git_commit(env, submodule_path, message='submodule change')
 
@@ -39,14 +39,14 @@ def _create_test_package_with_submodule(env, rel_path):
     Args:
       rel_path: the location of the submodule relative to the superproject.
     """
-    env.scratch_path.join("version_pkg").mkdir()
+    env.scratch_path.joinpath("version_pkg").mkdir()
     version_pkg_path = env.scratch_path / 'version_pkg'
-    version_pkg_path.join("testpkg").mkdir()
+    version_pkg_path.joinpath("testpkg").mkdir()
     pkg_path = version_pkg_path / 'testpkg'
 
-    pkg_path.join("__init__.py").write("# hello there")
+    pkg_path.joinpath("__init__.py").write_text("# hello there")
     _create_main_file(pkg_path, name="version_pkg", output="0.1")
-    version_pkg_path.join("setup.py").write(textwrap.dedent('''\
+    version_pkg_path.joinpath("setup.py").write_text(textwrap.dedent('''\
                         from setuptools import setup, find_packages
                         setup(name='version_pkg',
                               version='0.1',

--- a/tests/lib/path.py
+++ b/tests/lib/path.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import glob
 import os
 import shutil
-import sys
 
 from pip._vendor import six
 
@@ -112,14 +111,14 @@ class Path(_base):
         return os.path.basename(self)
 
     @property
-    def namebase(self):
+    def stem(self):
         """
         '/home/a/bc.d' -> 'bc'
         """
         return Path(os.path.splitext(self)[0]).name
 
     @property
-    def ext(self):
+    def suffix(self):
         """
         '/home/a/bc.d' -> '.d'
         """
@@ -132,8 +131,7 @@ class Path(_base):
         """
         return Path(os.path.abspath(self))
 
-    @property
-    def realpath(self):
+    def resolve(self):
         """
         Resolves symbolic links.
         """
@@ -147,9 +145,9 @@ class Path(_base):
         return Path(os.path.normpath(self))
 
     @property
-    def folder(self):
+    def parent(self):
         """
-        Returns the folder of this path.
+        Returns the parent directory of this path.
 
         '/home/a/bc.d' -> '/home/a'
         '/home/a/' -> '/home/a'
@@ -157,7 +155,6 @@ class Path(_base):
         """
         return Path(os.path.dirname(self))
 
-    @property
     def exists(self):
         """
         Returns True if the path exists.
@@ -168,7 +165,7 @@ class Path(_base):
         """
         Creates a directory, if it doesn't exist already.
         """
-        if not self.exists:
+        if not self.exists():
             os.mkdir(self, mode)
         return self
 
@@ -176,17 +173,15 @@ class Path(_base):
         """
         Like mkdir(), but also creates parent directories.
         """
-        if not self.exists:
+        if not self.exists():
             os.makedirs(self, mode)
         return self
 
-    def remove(self):
+    def unlink(self):
         """
         Removes a file.
         """
         return os.remove(self)
-
-    rm = remove  # Alias.
 
     def rmdir(self):
         """
@@ -222,16 +217,20 @@ class Path(_base):
         return os.rename(self, to)
 
     def glob(self, pattern):
-        return (Path(i) for i in glob.iglob(self.join(pattern)))
+        return (Path(i) for i in glob.iglob(self.joinpath(pattern)))
 
-    def join(self, *parts):
+    def joinpath(self, *parts):
         return Path(self, *parts)
+
+    # TODO: Remove after removing inheritance from str.
+    def join(self, *parts):
+        raise RuntimeError('Path.join is invalid, use joinpath instead.')
 
     def read_text(self):
         with open(self, "r") as fp:
             return fp.read()
 
-    def write(self, content):
+    def write_text(self, content):
         with open(self, "w") as fp:
             fp.write(content)
 

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -51,7 +51,7 @@ class VirtualEnvironment(object):
         if self._template:
             # On Windows, calling `_virtualenv.path_locations(target)`
             # will have created the `target` directory...
-            if sys.platform == 'win32' and self.location.exists:
+            if sys.platform == 'win32' and self.location.exists():
                 self.location.rmdir()
             # Clone virtual environment from template.
             self._template.location.copytree(self.location)
@@ -145,7 +145,7 @@ class VirtualEnvironment(object):
         if self._sitecustomize is not None:
             contents += '\n' + self._sitecustomize
         sitecustomize = self.site / "sitecustomize.py"
-        sitecustomize.write(contents)
+        sitecustomize.write_text(contents)
         # Make sure bytecode is up-to-date too.
         assert compileall.compile_file(str(sitecustomize), quiet=1, force=True)
 
@@ -176,7 +176,7 @@ class VirtualEnvironment(object):
         if self._venv_type == 'virtualenv':
             marker = self.lib / "no-global-site-packages.txt"
             if self._user_site_packages:
-                marker.rm()
+                marker.unlink()
             else:
                 marker.touch()
         elif self._venv_type == 'venv':

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -102,7 +102,7 @@ class Test_base_command_logging(object):
         Test the --log option logs when command succeeds
         """
         cmd = FakeCommand()
-        log_path = tmpdir.join('log')
+        log_path = tmpdir.joinpath('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
             assert f.read().rstrip() == '2019-01-17T06:00:37,040 fake'
@@ -112,7 +112,7 @@ class Test_base_command_logging(object):
         Test the --log option logs when command fails
         """
         cmd = FakeCommand(error=True)
-        log_path = tmpdir.join('log')
+        log_path = tmpdir.joinpath('log')
         cmd.main(['fake', '--log', log_path])
         with open(log_path) as f:
             assert f.read().startswith('2019-01-17T06:00:37,040 fake')
@@ -122,7 +122,7 @@ class Test_base_command_logging(object):
         Test the --log-file option logs (when there's an error).
         """
         cmd = FakeCommand(error=True)
-        log_file_path = tmpdir.join('log_file')
+        log_file_path = tmpdir.joinpath('log_file')
         cmd.main(['fake', '--log-file', log_file_path])
         with open(log_file_path) as f:
             assert f.read().startswith('2019-01-17T06:00:37,040 fake')
@@ -132,5 +132,5 @@ class Test_base_command_logging(object):
         Tests that logging bytestrings and unicode objects don't break logging
         """
         cmd = FakeCommandWithUnicode()
-        log_path = tmpdir.join('log')
+        log_path = tmpdir.joinpath('log')
         cmd.main(['fake_unicode', '--log', log_path])

--- a/tests/unit/test_build_env.py
+++ b/tests/unit/test_build_env.py
@@ -14,7 +14,7 @@ def indent(text, prefix):
 def run_with_build_env(script, setup_script_contents,
                        test_script_contents=None):
     build_env_script = script.scratch_path / 'build_env.py'
-    build_env_script.write(
+    build_env_script.write_text(
         dedent(
             '''
             from __future__ import print_function
@@ -55,7 +55,7 @@ def run_with_build_env(script, setup_script_contents,
     args = ['python', build_env_script]
     if test_script_contents is not None:
         test_script = script.scratch_path / 'test.py'
-        test_script.write(dedent(test_script_contents))
+        test_script.write_text(dedent(test_script_contents))
         args.append(test_script)
     return script.run(*args)
 
@@ -173,7 +173,7 @@ def test_build_env_isolation(script):
     # And to another directory available through a .pth file.
     target = script.scratch_path / 'pth_install'
     script.pip_install_local('-t', target, pkg_whl)
-    (script.site_packages_path / 'build_requires.pth').write(
+    (script.site_packages_path / 'build_requires.pth').write_text(
         str(target) + '\n'
     )
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -25,8 +25,8 @@ def test_get_path_uid_without_NOFOLLOW(monkeypatch):
 @pytest.mark.skipif("sys.platform == 'win32'")
 @pytest.mark.skipif("not hasattr(os, 'symlink')")
 def test_get_path_uid_symlink(tmpdir):
-    f = tmpdir.mkdir("symlink").join("somefile")
-    f.write("content")
+    f = tmpdir.mkdir("symlink").joinpath("somefile")
+    f.write_text("content")
     fs = f + '_link'
     os.symlink(f, fs)
     with pytest.raises(OSError):
@@ -37,8 +37,8 @@ def test_get_path_uid_symlink(tmpdir):
 @pytest.mark.skipif("not hasattr(os, 'symlink')")
 def test_get_path_uid_symlink_without_NOFOLLOW(tmpdir, monkeypatch):
     monkeypatch.delattr("os.O_NOFOLLOW")
-    f = tmpdir.mkdir("symlink").join("somefile")
-    f.write("content")
+    f = tmpdir.mkdir("symlink").joinpath("somefile")
+    f.write_text("content")
     fs = f + '_link'
     os.symlink(f, fs)
     with pytest.raises(OSError):

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -24,7 +24,7 @@ from tests.lib import create_file
 
 @pytest.fixture(scope="function")
 def cache_tmpdir(tmpdir):
-    cache_dir = tmpdir.join("cache")
+    cache_dir = tmpdir.joinpath("cache")
     cache_dir.makedirs()
     yield cache_dir
 
@@ -43,7 +43,7 @@ def test_unpack_http_url_with_urllib_response_without_content_type(data):
     session = Mock()
     session.get = _fake_session_get
 
-    uri = path_to_url(data.packages.join("simple-1.0.tar.gz"))
+    uri = path_to_url(data.packages.joinpath("simple-1.0.tar.gz"))
     link = Link(uri)
     temp_dir = mkdtemp()
     try:
@@ -270,7 +270,7 @@ def test_download_http_url__no_directory_traversal(tmpdir):
     }
     session.get.return_value = resp
 
-    download_dir = tmpdir.join('download')
+    download_dir = tmpdir.joinpath('download')
     os.mkdir(download_dir)
     file_path, content_type = _download_http_url(
         link,
@@ -319,14 +319,14 @@ def test_url_to_path_path_to_url_symmetry_win():
 class Test_unpack_file_url(object):
 
     def prep(self, tmpdir, data):
-        self.build_dir = tmpdir.join('build')
-        self.download_dir = tmpdir.join('download')
+        self.build_dir = tmpdir.joinpath('build')
+        self.download_dir = tmpdir.joinpath('download')
         os.mkdir(self.build_dir)
         os.mkdir(self.download_dir)
         self.dist_file = "simple-1.0.tar.gz"
         self.dist_file2 = "simple-2.0.tar.gz"
-        self.dist_path = data.packages.join(self.dist_file)
-        self.dist_path2 = data.packages.join(self.dist_file2)
+        self.dist_path = data.packages.joinpath(self.dist_file)
+        self.dist_path2 = data.packages.joinpath(self.dist_file2)
         self.dist_url = Link(path_to_url(self.dist_path))
         self.dist_url2 = Link(path_to_url(self.dist_path2))
 
@@ -406,7 +406,7 @@ class Test_unpack_file_url(object):
 
     def test_unpack_file_url_thats_a_dir(self, tmpdir, data):
         self.prep(tmpdir, data)
-        dist_path = data.packages.join("FSPkg")
+        dist_path = data.packages.joinpath("FSPkg")
         dist_url = Link(path_to_url(dist_path))
         unpack_file_url(dist_url, self.build_dir,
                         download_dir=self.download_dir)
@@ -462,21 +462,21 @@ class TestPipSession:
         assert not hasattr(session.adapters["https://"], "cache")
 
     def test_cache_is_enabled(self, tmpdir):
-        session = PipSession(cache=tmpdir.join("test-cache"))
+        session = PipSession(cache=tmpdir.joinpath("test-cache"))
 
         assert hasattr(session.adapters["https://"], "cache")
 
         assert (session.adapters["https://"].cache.directory ==
-                tmpdir.join("test-cache"))
+                tmpdir.joinpath("test-cache"))
 
     def test_http_cache_is_not_enabled(self, tmpdir):
-        session = PipSession(cache=tmpdir.join("test-cache"))
+        session = PipSession(cache=tmpdir.joinpath("test-cache"))
 
         assert not hasattr(session.adapters["http://"], "cache")
 
     def test_insecure_host_cache_is_not_enabled(self, tmpdir):
         session = PipSession(
-            cache=tmpdir.join("test-cache"),
+            cache=tmpdir.joinpath("test-cache"),
             insecure_hosts=["example.com"],
         )
 

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -96,8 +96,8 @@ class TestDisutilsScheme:
         # This deals with nt/posix path differences
         install_scripts = os.path.normcase(os.path.abspath(
             os.path.join(os.path.sep, 'somewhere', 'else')))
-        f = tmpdir.mkdir("config").join("setup.cfg")
-        f.write("[install]\ninstall-scripts=" + install_scripts)
+        f = tmpdir.mkdir("config").joinpath("setup.cfg")
+        f.write_text("[install]\ninstall-scripts=" + install_scripts)
         from distutils.dist import Distribution
         # patch the function that returns what config files are present
         monkeypatch.setattr(
@@ -116,8 +116,8 @@ class TestDisutilsScheme:
         # This deals with nt/posix path differences
         install_lib = os.path.normcase(os.path.abspath(
             os.path.join(os.path.sep, 'somewhere', 'else')))
-        f = tmpdir.mkdir("config").join("setup.cfg")
-        f.write("[install]\ninstall-lib=" + install_lib)
+        f = tmpdir.mkdir("config").joinpath("setup.cfg")
+        f.write_text("[install]\ninstall-lib=" + install_lib)
         from distutils.dist import Distribution
         # patch the function that returns what config files are present
         monkeypatch.setattr(

--- a/tests/unit/test_pep517.py
+++ b/tests/unit/test_pep517.py
@@ -13,7 +13,7 @@ def test_use_pep517(data, source, expected):
     """
     Test that we choose correctly between PEP 517 and legacy code paths
     """
-    src = data.src.join(source)
+    src = data.src.joinpath(source)
     req = InstallRequirement(None, None, source_dir=src)
     req.load_pyproject_toml()
     assert req.use_pep517 is expected
@@ -27,7 +27,7 @@ def test_disabling_pep517_invalid(data, source, msg):
     """
     Test that we fail if we try to disable PEP 517 when it's not acceptable
     """
-    src = data.src.join(source)
+    src = data.src.joinpath(source)
     req = InstallRequirement(None, None, source_dir=src)
 
     # Simulate --no-use-pep517

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -91,7 +91,7 @@ class TestRequirementSet(object):
         """
         reqset = RequirementSet()
         req = install_req_from_editable(
-            data.packages.join("LocalEnvironMarker")
+            data.packages.joinpath("LocalEnvironMarker")
         )
         req.is_direct = True
         reqset.add_requirement(req)
@@ -200,7 +200,7 @@ class TestRequirementSet(object):
             'git+git://github.com/pypa/pip-test-package --hash=sha256:123',
             lineno=1,
         ))
-        dir_path = data.packages.join('FSPkg')
+        dir_path = data.packages.joinpath('FSPkg')
         reqset.add_requirement(get_processed_req_from_line(
             'file://%s' % (dir_path,),
             lineno=2,
@@ -343,7 +343,7 @@ class TestInstallRequirement(object):
     def test_unsupported_wheel_local_file_requirement_raises(self, data):
         reqset = RequirementSet()
         req = install_req_from_line(
-            data.packages.join('simple.dist-0.1-py1-none-invalid.whl'),
+            data.packages.joinpath('simple.dist-0.1-py1-none-invalid.whl'),
         )
         assert req.link is not None
         assert req.link.is_wheel

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -505,22 +505,22 @@ class TestParseRequirements(object):
             pass
 
     def test_multiple_appending_options(self, tmpdir, finder, options):
-        with open(tmpdir.join("req1.txt"), "w") as fp:
+        with open(tmpdir.joinpath("req1.txt"), "w") as fp:
             fp.write("--extra-index-url url1 \n")
             fp.write("--extra-index-url url2 ")
 
-        list(parse_requirements(tmpdir.join("req1.txt"), finder=finder,
+        list(parse_requirements(tmpdir.joinpath("req1.txt"), finder=finder,
                                 session=PipSession(), options=options))
 
         assert finder.index_urls == ['url1', 'url2']
 
     def test_skip_regex(self, tmpdir, finder, options):
         options.skip_requirements_regex = '.*Bad.*'
-        with open(tmpdir.join("req1.txt"), "w") as fp:
+        with open(tmpdir.joinpath("req1.txt"), "w") as fp:
             fp.write("--extra-index-url Bad \n")
             fp.write("--extra-index-url Good ")
 
-        list(parse_requirements(tmpdir.join("req1.txt"), finder=finder,
+        list(parse_requirements(tmpdir.joinpath("req1.txt"), finder=finder,
                                 options=options, session=PipSession()))
 
         assert finder.index_urls == ['Good']
@@ -535,14 +535,14 @@ class TestParseRequirements(object):
             ('DO_12_FACTOR', 'awwyeah'),
         )
 
-        with open(tmpdir.join('req1.txt'), 'w') as fp:
+        with open(tmpdir.joinpath('req1.txt'), 'w') as fp:
             fp.write(template % tuple(['${%s}' % k for k, _ in env_vars]))
 
         with patch('pip._internal.req.req_file.os.getenv') as getenv:
             getenv.side_effect = lambda n: dict(env_vars)[n]
 
             reqs = list(parse_requirements(
-                tmpdir.join('req1.txt'),
+                tmpdir.joinpath('req1.txt'),
                 finder=finder,
                 session=PipSession()
             ))
@@ -560,14 +560,14 @@ class TestParseRequirements(object):
             '%WINDOWS_FORMAT%github.com/user/repo/archive/master.zip'
         )
 
-        with open(tmpdir.join('req1.txt'), 'w') as fp:
+        with open(tmpdir.joinpath('req1.txt'), 'w') as fp:
             fp.write(req_url)
 
         with patch('pip._internal.req.req_file.os.getenv') as getenv:
             getenv.return_value = ''
 
             reqs = list(parse_requirements(
-                tmpdir.join('req1.txt'),
+                tmpdir.joinpath('req1.txt'),
                 finder=finder,
                 session=PipSession()
             ))
@@ -578,17 +578,17 @@ class TestParseRequirements(object):
                 'ignoring invalid env variable in req file failed'
 
     def test_join_lines(self, tmpdir, finder):
-        with open(tmpdir.join("req1.txt"), "w") as fp:
+        with open(tmpdir.joinpath("req1.txt"), "w") as fp:
             fp.write("--extra-index-url url1 \\\n--extra-index-url url2")
 
-        list(parse_requirements(tmpdir.join("req1.txt"), finder=finder,
+        list(parse_requirements(tmpdir.joinpath("req1.txt"), finder=finder,
                                 session=PipSession()))
 
         assert finder.index_urls == ['url1', 'url2']
 
     def test_req_file_parse_no_only_binary(self, data, finder):
         list(parse_requirements(
-            data.reqfiles.join("supported_options2.txt"), finder,
+            data.reqfiles.joinpath("supported_options2.txt"), finder,
             session=PipSession()))
         expected = FormatControl({'fred'}, {'wilma'})
         assert finder.format_control == expected
@@ -597,10 +597,10 @@ class TestParseRequirements(object):
         """
         Test parsing comments in a requirements file
         """
-        with open(tmpdir.join("req1.txt"), "w") as fp:
+        with open(tmpdir.joinpath("req1.txt"), "w") as fp:
             fp.write("# Comment ")
 
-        reqs = list(parse_requirements(tmpdir.join("req1.txt"), finder,
+        reqs = list(parse_requirements(tmpdir.joinpath("req1.txt"), finder,
                     session=PipSession()))
 
         assert not reqs
@@ -609,10 +609,10 @@ class TestParseRequirements(object):
         """
         Test parsing comments in a requirements file
         """
-        with open(tmpdir.join("req1.txt"), "w") as fp:
+        with open(tmpdir.joinpath("req1.txt"), "w") as fp:
             fp.write("https://example.com/foo.tar.gz # Comment ")
 
-        reqs = list(parse_requirements(tmpdir.join("req1.txt"), finder,
+        reqs = list(parse_requirements(tmpdir.joinpath("req1.txt"), finder,
                     session=PipSession()))
 
         assert len(reqs) == 1
@@ -622,10 +622,10 @@ class TestParseRequirements(object):
         """
         Test parsing comments in a requirements file
         """
-        with open(tmpdir.join("req1.txt"), "w") as fp:
+        with open(tmpdir.joinpath("req1.txt"), "w") as fp:
             fp.write("https://example.com/foo.tar.gz#egg=wat")
 
-        reqs = list(parse_requirements(tmpdir.join("req1.txt"), finder,
+        reqs = list(parse_requirements(tmpdir.joinpath("req1.txt"), finder,
                     session=PipSession()))
 
         assert len(reqs) == 1
@@ -635,7 +635,7 @@ class TestParseRequirements(object):
         """
         Test parsing a requirements file without a finder
         """
-        with open(tmpdir.join("req.txt"), "w") as fp:
+        with open(tmpdir.joinpath("req.txt"), "w") as fp:
             fp.write("""
     --find-links https://example.com/
     --index-url https://example.com/
@@ -644,7 +644,7 @@ class TestParseRequirements(object):
     --no-index
             """)
 
-        parse_requirements(tmpdir.join("req.txt"), session=PipSession())
+        parse_requirements(tmpdir.joinpath("req.txt"), session=PipSession())
 
     def test_install_requirements_with_options(self, tmpdir, finder, session,
                                                options):

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -163,13 +163,13 @@ class TestUninstallPathSet(object):
         # construct 2 paths:
         #  tmpdir/dir/file
         #  tmpdir/dirlink/file (where dirlink is a link to dir)
-        d = tmpdir.join('dir')
+        d = tmpdir.joinpath('dir')
         d.mkdir()
-        dlink = tmpdir.join('dirlink')
+        dlink = tmpdir.joinpath('dirlink')
         os.symlink(d, dlink)
-        d.join('file').touch()
-        path1 = str(d.join('file'))
-        path2 = str(dlink.join('file'))
+        d.joinpath('file').touch()
+        path1 = str(d.joinpath('file'))
+        path2 = str(dlink.joinpath('file'))
 
         ups = UninstallPathSet(dist=Mock())
         ups.add(path1)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -339,7 +339,7 @@ class TestUnpackArchives(object):
         """
         Test unpacking a *.tgz, and setting execute permissions
         """
-        test_file = data.packages.join("test_tar.tgz")
+        test_file = data.packages.joinpath("test_tar.tgz")
         untar_file(test_file, self.tempdir)
         self.confirm_files()
         # Check the timestamp of an extracted file
@@ -351,7 +351,7 @@ class TestUnpackArchives(object):
         """
         Test unpacking a *.zip, and setting execute permissions
         """
-        test_file = data.packages.join("test_zip.zip")
+        test_file = data.packages.joinpath("test_zip.zip")
         unzip_file(test_file, self.tempdir)
         self.confirm_files()
 
@@ -430,7 +430,7 @@ class TestHashes(object):
 
         """
         file = tmpdir / 'to_hash'
-        file.write('hello')
+        file.write_text('hello')
         hashes = Hashes({
             'sha256': ['2cf24dba5fb0a30e26e83b2ac5b9e29e'
                        '1b161e5c1fa7425e73043362938b9824'],

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -250,7 +250,7 @@ def test_get_legacy_build_wheel_path__multiple_names(caplog):
                          ["pip = pip._internal.main:pip",
                           "pip:pip = pip._internal.main:pip"])
 def test_get_entrypoints(tmpdir, console_scripts):
-    entry_points = tmpdir.join("entry_points.txt")
+    entry_points = tmpdir.joinpath("entry_points.txt")
     with open(str(entry_points), "w") as fp:
         fp.write("""
             [console_scripts]
@@ -290,8 +290,8 @@ def test_sorted_outrows(outrows, expected):
 
 
 def call_get_csv_rows_for_installed(tmpdir, text):
-    path = tmpdir.join('temp.txt')
-    path.write(text)
+    path = tmpdir.joinpath('temp.txt')
+    path.write_text(text)
 
     # Test that an installed file appearing in RECORD has its filename
     # updated in the new RECORD file.
@@ -353,9 +353,9 @@ def test_wheel_version(tmpdir, data):
     broken_wheel = 'brokenwheel-1.0-py2.py3-none-any.whl'
     future_version = (1, 9)
 
-    unpack_file(data.packages.join(future_wheel),
+    unpack_file(data.packages.joinpath(future_wheel),
                 tmpdir + 'future', None, None)
-    unpack_file(data.packages.join(broken_wheel),
+    unpack_file(data.packages.joinpath(broken_wheel),
                 tmpdir + 'broken', None, None)
 
     assert wheel.wheel_version(tmpdir + 'future') == future_version
@@ -593,11 +593,11 @@ class TestWheelFile(object):
         Test the "wheel is purelib/platlib" code.
         """
         packages = [
-            ("pure_wheel", data.packages.join("pure_wheel-1.7"), True),
-            ("plat_wheel", data.packages.join("plat_wheel-1.7"), False),
-            ("pure_wheel", data.packages.join(
+            ("pure_wheel", data.packages.joinpath("pure_wheel-1.7"), True),
+            ("plat_wheel", data.packages.joinpath("plat_wheel-1.7"), False),
+            ("pure_wheel", data.packages.joinpath(
                 "pure_wheel-_invalidversion_"), True),
-            ("plat_wheel", data.packages.join(
+            ("plat_wheel", data.packages.joinpath(
                 "plat_wheel-_invalidversion_"), False),
         ]
 
@@ -620,7 +620,7 @@ class TestMoveWheelFiles(object):
 
     def prep(self, data, tmpdir):
         self.name = 'sample'
-        self.wheelpath = data.packages.join(
+        self.wheelpath = data.packages.joinpath(
             'sample-1.2.0-py2.py3-none-any.whl')
         self.req = Requirement('sample')
         self.src = os.path.join(tmpdir, 'src')
@@ -820,7 +820,7 @@ class TestMessageAboutScriptsNotOnPATH(object):
 class TestWheelHashCalculators(object):
 
     def prep(self, tmpdir):
-        self.test_file = tmpdir.join("hash.file")
+        self.test_file = tmpdir.joinpath("hash.file")
         # Want this big enough to trigger the internal read loops.
         self.test_file_len = 2 * 1024 * 1024
         with open(str(self.test_file), "w") as fp:


### PR DESCRIPTION
Continuing the work for #6050. Several methods in our `tests.lib.path.Path` class have direct counterparts in `pathlib.Path`. In preparation for substituting `pathlib.Path`, this renames the methods/properties according to the following:

1. `namebase` -> `stem`
1. `ext` -> `suffix`
1. `folder` -> `parent`
1. `exists` -> `exists()`
1. `remove()` -> `unlink()`
1. `rm()` -> `unlink()`
1. `join()` -> `joinpath()`
1. `write()` -> `write_text()`

To remove any possibility of accidental usage of `str.join()`, a method has been added to `Path` that raises an exception. This can be removed after removing the inheritance from `str`.