### PR TITLE
Handle non-ascii commands in Python 2 in make_subprocess_output_error()

### DIFF
--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -15,7 +15,7 @@ from pip._vendor.urllib3.util import IS_PYOPENSSL
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Tuple, Text
+    from typing import Optional, Text, Tuple, Union
 
 try:
     import _ssl  # noqa
@@ -83,18 +83,29 @@ else:
     backslashreplace_decode = "backslashreplace_decode"
 
 
-def console_to_str(data):
-    # type: (bytes) -> Text
-    """Return a string, safe for output, of subprocess output.
-
-    We assume the data is in the locale preferred encoding.
-    If it won't decode properly, we warn the user but decode as
-    best we can.
-
-    We also ensure that the output can be safely written to
-    standard output without encoding errors.
+def str_to_display(data, desc=None):
+    # type: (Union[bytes, Text], Optional[str]) -> Text
     """
+    For display or logging purposes, convert a bytes object (or text) to
+    text (e.g. unicode in Python 2) safe for output.
 
+    :param desc: An optional phrase describing the input data, for use in
+        the log message if a warning is logged. Defaults to "Bytes object".
+
+    This function should never error out and so can take a best effort
+    approach. It is okay to be lossy if needed since the return value is
+    just for display.
+
+    We assume the data is in the locale preferred encoding. If it won't
+    decode properly, we warn the user but decode as best we can.
+
+    We also ensure that the output can be safely written to standard output
+    without encoding errors.
+    """
+    if isinstance(data, text_type):
+        return data
+
+    # Otherwise, data is a bytes object (str in Python 2).
     # First, get the encoding we assume. This is the preferred
     # encoding for the locale, unless that is not found, or
     # it is ASCII, in which case assume UTF-8
@@ -107,10 +118,10 @@ def console_to_str(data):
     try:
         decoded_data = data.decode(encoding)
     except UnicodeDecodeError:
-        logger.warning(
-            "Subprocess output does not appear to be encoded as %s",
-            encoding,
-        )
+        if desc is None:
+            desc = 'Bytes object'
+        msg_format = '{} does not appear to be encoded as %s'.format(desc)
+        logger.warning(msg_format, encoding)
         decoded_data = data.decode(encoding, errors=backslashreplace_decode)
 
     # Make sure we can print the output, by encoding it to the output
@@ -136,6 +147,13 @@ def console_to_str(data):
         decoded_data = output_encoded.decode(output_encoding)
 
     return decoded_data
+
+
+def console_to_str(data):
+    # type: (bytes) -> Text
+    """Return a string, safe for output, of subprocess output.
+    """
+    return str_to_display(data, desc='Subprocess output')
 
 
 if sys.version_info >= (3,):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import locale
 import os
 
@@ -5,7 +7,7 @@ import pytest
 
 import pip._internal.utils.compat as pip_compat
 from pip._internal.utils.compat import (
-    console_to_str, expanduser, get_path_uid, native_str,
+    console_to_str, expanduser, get_path_uid, native_str, str_to_display,
 )
 
 
@@ -43,6 +45,58 @@ def test_get_path_uid_symlink_without_NOFOLLOW(tmpdir, monkeypatch):
     os.symlink(f, fs)
     with pytest.raises(OSError):
         get_path_uid(fs)
+
+
+@pytest.mark.parametrize('data, expected', [
+    ('abc', u'abc'),
+    # Test text (unicode in Python 2) input.
+    (u'abc', u'abc'),
+    # Test text input with non-ascii characters.
+    (u'déf', u'déf'),
+])
+def test_str_to_display(data, expected):
+    actual = str_to_display(data)
+    assert actual == expected, (
+        # Show the encoding for easier troubleshooting.
+        'encoding: {!r}'.format(locale.getpreferredencoding())
+    )
+
+
+@pytest.mark.parametrize('data, encoding, expected', [
+    # Test str input with non-ascii characters.
+    ('déf', 'utf-8', u'déf'),
+    # Test bytes input with non-ascii characters:
+    (u'déf'.encode('utf-8'), 'utf-8', u'déf'),
+    # Test a Windows encoding.
+    (u'déf'.encode('cp1252'), 'cp1252', u'déf'),
+    # Test a Windows encoding with incompatibly encoded text.
+    (u'déf'.encode('utf-8'), 'cp1252', u'dÃ©f'),
+])
+def test_str_to_display__encoding(monkeypatch, data, encoding, expected):
+    monkeypatch.setattr(locale, 'getpreferredencoding', lambda: encoding)
+    actual = str_to_display(data)
+    assert actual == expected, (
+        # Show the encoding for easier troubleshooting.
+        'encoding: {!r}'.format(locale.getpreferredencoding())
+    )
+
+
+def test_str_to_display__decode_error(monkeypatch, caplog):
+    monkeypatch.setattr(locale, 'getpreferredencoding', lambda: 'utf-8')
+    # Encode with an incompatible encoding.
+    data = u'ab'.encode('utf-16')
+    actual = str_to_display(data)
+
+    assert actual == u'\\xff\\xfea\x00b\x00', (
+        # Show the encoding for easier troubleshooting.
+        'encoding: {!r}'.format(locale.getpreferredencoding())
+    )
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == 'WARNING'
+    assert record.message == (
+        'Bytes object does not appear to be encoded as utf-8'
+    )
 
 
 def test_console_to_str(monkeypatch):


### PR DESCRIPTION
This is a follow-up to PR #6655 to fix a potential Python 2 `str` issue if the formatted command contains non-ascii characters. We want to be sure we don't trigger an error in `make_subprocess_output_error()` when calling `str.format()` if the command `str` contains non-ascii characters.

The PR does this by exposing a slightly more general variant of the `console_to_str()` function we  call `str_to_display()`. It can be used to convert any byte string to text for logging purposes and not just bytes coming from a subprocess stdout (which is what `console_to_str()` was previously added for).
