### PR TITLE
Reduce dependency on ctypes when discovering glibc version.

### DIFF
--- a/news/6543.bugfix
+++ b/news/6543.bugfix
@@ -1,1 +1,1 @@
-The version info for glibc is now extracted from ``os`` instead of ``ctypes`` (which may be missing).
+If possible, the version info for glibc is extracted from ``os`` instead of ``ctypes`` (which may be missing).

--- a/news/6543.bugfix
+++ b/news/6543.bugfix
@@ -1,1 +1,1 @@
-If possible, the version info for glibc is extracted from ``os`` instead of ``ctypes`` (which may be missing).
+Prefer ``os.confstr`` to ``ctypes`` when extracting glibc version info.

--- a/news/6543.bugfix
+++ b/news/6543.bugfix
@@ -1,0 +1,1 @@
+The version info for glibc is now extracted from ``os`` instead of ``ctypes`` (which may be missing).

--- a/news/6675.bugfix
+++ b/news/6675.bugfix
@@ -1,1 +1,1 @@
-The version info for glibc is now extracted from ``os`` instead of ``ctypes`` (which may be missing).
+If possible, the version info for glibc is extracted from ``os`` instead of ``ctypes`` (which may be missing).

--- a/news/6675.bugfix
+++ b/news/6675.bugfix
@@ -1,1 +1,1 @@
-If possible, the version info for glibc is extracted from ``os`` instead of ``ctypes`` (which may be missing).
+Prefer ``os.confstr`` to ``ctypes`` when extracting glibc version info.

--- a/news/6675.bugfix
+++ b/news/6675.bugfix
@@ -1,0 +1,1 @@
+The version info for glibc is now extracted from ``os`` instead of ``ctypes`` (which may be missing).

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -10,17 +10,32 @@ if MYPY_CHECK_RUNNING:
     from typing import Optional, Tuple
 
 
-def glibc_version_string():
+def glibc_version_string_os():
     # type: () -> Optional[str]
-    "Returns glibc version string, or None if not using glibc."
+    """Returns glibc version string, or None if not using glibc.
 
-    try:  # https://github.com/pypa/pip/issues/6675#issue-463147612
-        glibc_version = os.confstr("CS_GNU_LIBC_VERSION").split()
+    This should be paired with glibc_version_string_ctypes as a fallback:
+    glibc_ver = glibc_version_string_os() or glibc_version_string_ctypes()
+    """
+
+    # os.confstr is quite a bit faster than ctypes.DLL.
+    # It's also less likely to be broken or missing.
+
+    # This strategy is used in the standard library platform module:
+    # https://github.com/python/cpython/blob/fcf1d003bf4f0100c9d0921ff3d70e1127ca1b71/Lib/platform.py#L175-L183
+
+    try:
+        # os.confstr("CS_GNU_LIBC_VERSION") returns a string like "glibc 2.17":
+        _, version = os.confstr("CS_GNU_LIBC_VERSION").split()
     except (AttributeError, OSError, ValueError):
-        pass  # os.confstr() or CS_GNU_LIBC_VERSION not available...
-    else:
-        if len(glibc_version) == 2:
-            return glibc_version[-1]
+        # os.confstr() or CS_GNU_LIBC_VERSION not available (or a bad value)...
+        return None
+    return version
+
+
+def glibc_version_string_ctypes():
+    # type: () -> Optional[str]
+    "Fallback ctypes implementation of glibc_version_string_os."
 
     try:
         import ctypes
@@ -69,7 +84,7 @@ def check_glibc_version(version_str, required_major, minimum_minor):
 
 def have_compatible_glibc(required_major, minimum_minor):
     # type: (int, int) -> bool
-    version_str = glibc_version_string()  # type: Optional[str]
+    version_str = glibc_version_string_os() or glibc_version_string_ctypes()
     if version_str is None:
         return False
     return check_glibc_version(version_str, required_major, minimum_minor)
@@ -99,7 +114,7 @@ def libc_ver():
     Returns a tuple of strings (lib, version) which default to empty strings
     in case the lookup fails.
     """
-    glibc_version = glibc_version_string()
+    glibc_version = glibc_version_string_os() or glibc_version_string_ctypes()
     if glibc_version is None:
         return ("", "")
     else:

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -15,11 +15,35 @@ def glibc_version_string():
     "Returns glibc version string, or None if not using glibc."
 
     try:  # https://github.com/pypa/pip/issues/6675#issue-463147612
-        glibc_version = os.confstr('CS_GNU_LIBC_VERSION').split()
+        glibc_version = os.confstr("CS_GNU_LIBC_VERSION").split()
     except (AttributeError, OSError, ValueError):
-        return None  # os.confstr() or CS_GNU_LIBC_VERSION not available...
+        pass  # os.confstr() or CS_GNU_LIBC_VERSION not available...
+    else:
+        return glibc_version[-1] if len(glibc_version) == 2 else None
 
-    return glibc_version[-1] if len(glibc_version) == 2 else None
+    try:
+        import ctypes
+    except ImportError:
+        return None
+
+    # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
+    # manpage says, "If filename is NULL, then the returned handle is for the
+    # main program". This way we can let the linker do the work to figure out
+    # which libc our process is actually using.
+    process_namespace = ctypes.CDLL(None)
+    try:
+        gnu_get_libc_version = process_namespace.gnu_get_libc_version
+    except AttributeError:
+        # Symbol doesn't exist -> therefore, we are not linked to
+        # glibc.
+        return None
+    # Call gnu_get_libc_version, which returns a string like "2.5"
+    gnu_get_libc_version.restype = ctypes.c_char_p
+    version_str = gnu_get_libc_version()
+    # py2 / py3 compatibility:
+    if not isinstance(version_str, str):
+        version_str = version_str.decode("ascii")
+    return version_str
 
 
 # Separated out from have_compatible_glibc for easier unit testing

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -19,7 +19,8 @@ def glibc_version_string():
     except (AttributeError, OSError, ValueError):
         pass  # os.confstr() or CS_GNU_LIBC_VERSION not available...
     else:
-        return glibc_version[-1] if len(glibc_version) == 2 else None
+        if len(glibc_version) == 2:
+            return glibc_version[-1]
 
     try:
         import ctypes

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -10,20 +10,19 @@ if MYPY_CHECK_RUNNING:
     from typing import Optional, Tuple
 
 
-def glibc_version_string_os():
+def glibc_version_string():
     # type: () -> Optional[str]
-    """Returns glibc version string, or None if not using glibc.
+    "Returns glibc version string, or None if not using glibc."
+    return glibc_version_string_confstr() or glibc_version_string_ctypes()
 
-    This should be paired with glibc_version_string_ctypes as a fallback:
-    glibc_ver = glibc_version_string_os() or glibc_version_string_ctypes()
-    """
 
-    # os.confstr is quite a bit faster than ctypes.DLL.
-    # It's also less likely to be broken or missing.
-
-    # This strategy is used in the standard library platform module:
+def glibc_version_string_confstr():
+    # type: () -> Optional[str]
+    "Primary implementation of glibc_version_string using os.confstr."
+    # os.confstr is quite a bit faster than ctypes.DLL. It's also less likely
+    # to be broken or missing. This strategy is used in the standard library
+    # platform module:
     # https://github.com/python/cpython/blob/fcf1d003bf4f0100c9d0921ff3d70e1127ca1b71/Lib/platform.py#L175-L183
-
     try:
         # os.confstr("CS_GNU_LIBC_VERSION") returns a string like "glibc 2.17":
         _, version = os.confstr("CS_GNU_LIBC_VERSION").split()
@@ -35,7 +34,7 @@ def glibc_version_string_os():
 
 def glibc_version_string_ctypes():
     # type: () -> Optional[str]
-    "Fallback ctypes implementation of glibc_version_string_os."
+    "Fallback implementation of glibc_version_string using ctypes."
 
     try:
         import ctypes
@@ -84,7 +83,7 @@ def check_glibc_version(version_str, required_major, minimum_minor):
 
 def have_compatible_glibc(required_major, minimum_minor):
     # type: (int, int) -> bool
-    version_str = glibc_version_string_os() or glibc_version_string_ctypes()
+    version_str = glibc_version_string()
     if version_str is None:
         return False
     return check_glibc_version(version_str, required_major, minimum_minor)
@@ -114,7 +113,7 @@ def libc_ver():
     Returns a tuple of strings (lib, version) which default to empty strings
     in case the lookup fails.
     """
-    glibc_version = glibc_version_string_os() or glibc_version_string_ctypes()
+    glibc_version = glibc_version_string()
     if glibc_version is None:
         return ("", "")
     else:

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import ctypes
+import os
 import re
 import warnings
 
@@ -14,26 +14,12 @@ def glibc_version_string():
     # type: () -> Optional[str]
     "Returns glibc version string, or None if not using glibc."
 
-    # ctypes.CDLL(None) internally calls dlopen(NULL), and as the dlopen
-    # manpage says, "If filename is NULL, then the returned handle is for the
-    # main program". This way we can let the linker do the work to figure out
-    # which libc our process is actually using.
-    process_namespace = ctypes.CDLL(None)
-    try:
-        gnu_get_libc_version = process_namespace.gnu_get_libc_version
-    except AttributeError:
-        # Symbol doesn't exist -> therefore, we are not linked to
-        # glibc.
-        return None
+    try:  # https://github.com/pypa/pip/issues/6675#issue-463147612
+        glibc_version = os.confstr('CS_GNU_LIBC_VERSION').split()
+    except (AttributeError, OSError, ValueError):
+        return None  # os.confstr() or CS_GNU_LIBC_VERSION not available...
 
-    # Call gnu_get_libc_version, which returns a string like "2.5"
-    gnu_get_libc_version.restype = ctypes.c_char_p
-    version_str = gnu_get_libc_version()
-    # py2 / py3 compatibility:
-    if not isinstance(version_str, str):
-        version_str = version_str.decode("ascii")
-
-    return version_str
+    return glibc_version[-1] if len(glibc_version) == 2 else None
 
 
 # Separated out from have_compatible_glibc for easier unit testing

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -37,12 +37,14 @@ def glibc_version_string():
         # Symbol doesn't exist -> therefore, we are not linked to
         # glibc.
         return None
+
     # Call gnu_get_libc_version, which returns a string like "2.5"
     gnu_get_libc_version.restype = ctypes.c_char_p
     version_str = gnu_get_libc_version()
     # py2 / py3 compatibility:
     if not isinstance(version_str, str):
         version_str = version_str.decode("ascii")
+
     return version_str
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -705,19 +705,22 @@ class TestGlibc(object):
 
     def test_glibc_version_string_os_fail(self, monkeypatch):
 
-        def raises(error):
-            raise error()
+        if hasattr(os, "confstr"):
 
-        monkeypatch.setattr(os, "confstr", lambda x: raises(ValueError))
-        assert glibc_version_string_os() is None
+            def raises(error):
+                raise error()
 
-        monkeypatch.setattr(os, "confstr", lambda x: raises(OSError))
-        assert glibc_version_string_os() is None
+            monkeypatch.setattr(os, "confstr", lambda x: raises(ValueError))
+            assert glibc_version_string_os() is None
 
-        monkeypatch.setattr(os, "confstr", lambda x: "XXX")
-        assert glibc_version_string_os() is None
+            monkeypatch.setattr(os, "confstr", lambda x: raises(OSError))
+            assert glibc_version_string_os() is None
 
-        monkeypatch.delattr(os, "confstr")
+            monkeypatch.setattr(os, "confstr", lambda x: "XXX")
+            assert glibc_version_string_os() is None
+
+            monkeypatch.delattr(os, "confstr")
+
         assert glibc_version_string_os() is None
 
     def test_glibc_version_string_ctypes_fail(self, monkeypatch):


### PR DESCRIPTION
Favor `os.confstr` when possible, falling back on the old `ctypes` implementation otherwise. Gracefully handle a missing `ctypes` module.

Closes #6543. Closes #6675. Supersedes and closes #6544.