### PR TITLE
Improved error message for invalid editable requirement.

### DIFF
--- a/news/6648.bugfix
+++ b/news/6648.bugfix
@@ -1,0 +1,1 @@
+Improve error message printed when an invalid editable requirement is provided.

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -109,9 +109,9 @@ def parse_editable(editable_req):
 
     if '+' not in url:
         raise InstallationError(
-            '%s should either be a path to a local project or a VCS url '
-            'beginning with svn+, git+, hg+, or bzr+' %
-            editable_req
+            '{} is not a valid editable requirement. '
+            'It should either be a path to a local project or a VCS URL '
+            '(beginning with svn+, git+, hg+, or bzr+).'.format(editable_req)
         )
 
     vc_type = url.split('+', 1)[0].lower()

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -230,7 +230,7 @@ def test_basic_editable_install(script):
     """
     result = script.pip('install', '-e', 'INITools==0.2', expect_error=True)
     assert (
-        "INITools==0.2 should either be a path to a local project or a VCS url"
+        "INITools==0.2 is not a valid editable requirement"
         in result.stderr
     )
     assert not result.files_created


### PR DESCRIPTION
Add a more generic and less misleading error message when both ```--Ue``` and ```--upgrade-strategy``` is passed as args.

Closes: #6648 