### PR TITLE
Simplify FoundCandidates

### DIFF
--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -191,7 +191,12 @@ class TestCandidateEvaluator:
 
         assert found_candidates._candidates == candidates
         assert found_candidates._evaluator is evaluator
-        assert found_candidates._versions == {'1.10', '1.11'}
+        expected_applicable = candidates[:2]
+        assert [str(c.version) for c in expected_applicable] == [
+            '1.10',
+            '1.11',
+        ]
+        assert found_candidates._applicable_candidates == expected_applicable
 
     @pytest.mark.parametrize('yanked_reason, expected', [
         # Test a non-yanked file.


### PR DESCRIPTION
This PR simplifies the `FoundCandidates` class by moving the calculation logic in `FoundCandidates.iter_applicable()` into the `make_found_candidates()` function that creates a `FoundCandidates` object.

This makes it so `FoundCandidates` behaves more like a simple container. It also makes it so that the determination of applicable candidates happens just once when the `FoundCandidates` object is created, instead of each time one wants to iterate over the applicable candidates.

This PR also adds the first test of the `make_found_candidates()` method.

This PR will come in handy for some later PR's.