### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,8 +7,6 @@ environment:
       RUN_INTEGRATION_TESTS: "True"
     # Unit tests only.
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python34"
-    - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"

--- a/.azure-pipelines/jobs/test-windows.yml
+++ b/.azure-pipelines/jobs/test-windows.yml
@@ -32,9 +32,6 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      Python34-x64:
-        python.version: '3.4'
-        python.architecture: x64
       Python35-x64:
         python.version: '3.5'
         python.architecture: x64
@@ -44,9 +41,6 @@ jobs:
       # This is for Windows, so test x86 builds
       Python27-x86:
         python.version: '2.7'
-        python.architecture: x86
-      Python34-x86:
-        python.version: '3.4'
         python.architecture: x86
       Python35-x86:
         python.version: '3.5'

--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -29,9 +29,6 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   strategy:
     matrix:
-      Python34:
-        python.version: '3.4'
-        python.architecture: x64
       Python35:
         python.version: '3.5'
         python.architecture: x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,6 @@ jobs:
       python: 3.5
     - env: GROUP=2
       python: 3.5
-    - env: GROUP=1
-      python: 3.4
-    - env: GROUP=2
-      python: 3.4
 
     - env: GROUP=1
       python: 3.8-dev

--- a/docs/html/installing.rst
+++ b/docs/html/installing.rst
@@ -109,7 +109,7 @@ On Windows [4]_::
 Python and OS Compatibility
 ---------------------------
 
-pip works with CPython versions 2.7, 3.4, 3.5, 3.6, 3.7 and also pypy.
+pip works with CPython versions 2.7, 3.5, 3.6, 3.7 and also PyPy.
 
 This means pip works on the latest patch version of each of these minor
 versions. Previous patch versions are supported on a best effort approach.

--- a/news/6685.removal
+++ b/news/6685.removal
@@ -1,0 +1,1 @@
+Drop support for EOL Python 3.4.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -79,5 +78,5 @@ setup(
     },
 
     zip_safe=False,
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
 )

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -152,15 +152,7 @@ class Command(object):
             user_log_file=options.log,
         )
 
-        if sys.version_info[:2] == (3, 4):
-            deprecated(
-                "Python 3.4 support has been deprecated. pip 19.1 will be the "
-                "last one supporting it. Please upgrade your Python as Python "
-                "3.4 won't be maintained after March 2019 (cf PEP 429).",
-                replacement=None,
-                gone_in='19.2',
-            )
-        elif sys.version_info[:2] == (2, 7):
+        if sys.version_info[:2] == (2, 7):
             message = (
                 "A future version of pip will drop support for Python 2.7."
             )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.4.0
 envlist =
     docs, packaging, lint-py2, lint-py3, mypy,
-    py27, py34, py35, py36, py37, py38, pypy, pypy3
+    py27, py35, py36, py37, py38, pypy, pypy3
 
 [helpers]
 # Wrapper for calls to pip that make sure the version being used is the


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Python 3.4 was EOL on 2019-03-16 and deprecated in https://github.com/pypa/pip/pull/6123 and pip 19.0.

The deprecation warning reads:

> Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429).

pip 19.2 is coming soon (https://github.com/pypa/pip/issues/6630) so drop support for Python 3.4.
