### PR TITLE
Refactor SETUPTOOLS_SHIM with function make_setuptools_shim_args

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -33,7 +33,7 @@ from pip._internal.utils.misc import (
     get_installed_version, redact_password_from_url, rmtree,
 )
 from pip._internal.utils.packaging import get_metadata
-from pip._internal.utils.setuptools_build import SETUPTOOLS_SHIM
+from pip._internal.utils.setuptools_build import make_setuptools_shim_args
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.ui import open_spinner
@@ -595,7 +595,7 @@ class InstallRequirement(object):
                 'Running setup.py (path:%s) egg_info for package from %s',
                 self.setup_py_path, self.link,
             )
-        script = SETUPTOOLS_SHIM.format(self.setup_py_path)
+        script = make_setuptools_shim_args(self.setup_py_path)
         base_cmd = [sys.executable, '-c', script]
         if self.isolated:
             base_cmd += ["--no-user-cfg"]
@@ -757,7 +757,7 @@ class InstallRequirement(object):
                     [
                         sys.executable,
                         '-c',
-                        SETUPTOOLS_SHIM.format(self.setup_py_path)
+                        make_setuptools_shim_args(self.setup_py_path)
                     ] +
                     list(global_options) +
                     ['develop', '--no-deps'] +
@@ -1004,7 +1004,7 @@ class InstallRequirement(object):
         # type: (...) -> List[str]
         install_args = [sys.executable, "-u"]
         install_args.append('-c')
-        install_args.append(SETUPTOOLS_SHIM.format(self.setup_py_path))
+        install_args.append(make_setuptools_shim_args(self.setup_py_path))
         install_args += list(global_options) + \
             ['install', '--record', record_filename]
         install_args += ['--single-version-externally-managed']

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -595,8 +595,7 @@ class InstallRequirement(object):
                 'Running setup.py (path:%s) egg_info for package from %s',
                 self.setup_py_path, self.link,
             )
-        script = make_setuptools_shim_args(self.setup_py_path)
-        base_cmd = [sys.executable, '-c', script]
+        base_cmd = make_setuptools_shim_args(self.setup_py_path)
         if self.isolated:
             base_cmd += ["--no-user-cfg"]
         egg_info_cmd = base_cmd + ['egg_info']
@@ -754,11 +753,7 @@ class InstallRequirement(object):
             # FIXME: should we do --install-headers here too?
             with self.build_env:
                 call_subprocess(
-                    [
-                        sys.executable,
-                        '-c',
-                        make_setuptools_shim_args(self.setup_py_path)
-                    ] +
+                    make_setuptools_shim_args(self.setup_py_path) +
                     list(global_options) +
                     ['develop', '--no-deps'] +
                     list(install_options),
@@ -1002,9 +997,8 @@ class InstallRequirement(object):
         pycompile  # type: bool
     ):
         # type: (...) -> List[str]
-        install_args = [sys.executable, "-u"]
-        install_args.append('-c')
-        install_args.append(make_setuptools_shim_args(self.setup_py_path))
+        install_args = make_setuptools_shim_args(self.setup_py_path,
+                                                 unbuffered=True)
         install_args += list(global_options) + \
             ['install', '--record', record_filename]
         install_args += ['--single-version-externally-managed']

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -998,7 +998,7 @@ class InstallRequirement(object):
     ):
         # type: (...) -> List[str]
         install_args = make_setuptools_shim_args(self.setup_py_path,
-                                                 unbuffered=True)
+                                                 unbuffered_output=True)
         install_args += list(global_options) + \
             ['install', '--record', record_filename]
         install_args += ['--single-version-externally-managed']

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -3,7 +3,8 @@ import sys
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional
+    from typing import List
+
 # Shim to wrap setup.py invocation with setuptools
 #
 # We set sys.argv[0] to the path to the underlying setup.py file so
@@ -20,7 +21,14 @@ _SETUPTOOLS_SHIM = (
 
 
 def make_setuptools_shim_args(setup_py_path, unbuffered_output=False):
-    # type: (str, Optional[bool]) -> list
+    # type: (str, bool) -> List[str]
+    """
+    Get setuptools command arguments with shim wrapped setup file invocation.
+
+    :param setup_py_path: The path to setup.py to be wrapped.
+    :param unbuffered_output: If True, adds the unbuffered switch to the
+     argument list.
+    """
     args = [sys.executable]
     if unbuffered_output:
         args.append('-u')

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -10,19 +10,19 @@ if MYPY_CHECK_RUNNING:
 # setuptools / distutils don't take the path to the setup.py to be "-c" when
 # invoking via the shim.  This avoids e.g. the following manifest_maker
 # warning: "warning: manifest_maker: standard file '-c' not found".
+_SETUPTOOLS_SHIM = (
+    "import sys, setuptools, tokenize; sys.argv[0] = {0!r}; __file__={0!r};"
+    "f=getattr(tokenize, 'open', open)(__file__);"
+    "code=f.read().replace('\\r\\n', '\\n');"
+    "f.close();"
+    "exec(compile(code, __file__, 'exec'))"
+)
 
 
-def make_setuptools_shim_args(setup_py_path, unbuffered=False):
+def make_setuptools_shim_args(setup_py_path, unbuffered_output=False):
     # type: (str, Optional[bool]) -> list
-    setuptools_shim = (
-        "import sys, setuptools, tokenize;"
-        "sys.argv[0] = {0!r}; __file__={0!r};"
-        "f=getattr(tokenize, 'open', open)(__file__);"
-        "code=f.read().replace('\\r\\n', '\\n');"
-        "f.close();"
-        "exec(compile(code, __file__, 'exec'))"
-    )
-    shim_args = [sys.executable, '-c', setuptools_shim.format(setup_py_path)]
-    if unbuffered:
-        shim_args.insert(1, '-u')
-    return shim_args
+    args = [sys.executable]
+    if unbuffered_output:
+        args.append('-u')
+    args.extend(['-c', _SETUPTOOLS_SHIM.format(setup_py_path)])
+    return args

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -1,3 +1,5 @@
+import sys
+
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -11,13 +13,16 @@ if MYPY_CHECK_RUNNING:
 
 
 def make_setuptools_shim_args(setup_py_path, unbuffered=False):
-    # type: (str, Optional[bool]) -> str
-    buffering = 0 if unbuffered else -1
-    return (
+    # type: (str, Optional[bool]) -> list
+    setuptools_shim = (
         "import sys, setuptools, tokenize;"
         "sys.argv[0] = {0!r}; __file__={0!r};"
-        "f=getattr(tokenize, 'open', open)(__file__, buffering={1});"
+        "f=getattr(tokenize, 'open', open)(__file__);"
         "code=f.read().replace('\\r\\n', '\\n');"
         "f.close();"
         "exec(compile(code, __file__, 'exec'))"
-    ).format(setup_py_path, buffering)
+    )
+    shim_args = [sys.executable, '-c', setuptools_shim.format(setup_py_path)]
+    if unbuffered:
+        shim_args.insert(1, '-u')
+    return shim_args

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -1,13 +1,23 @@
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional
 # Shim to wrap setup.py invocation with setuptools
 #
 # We set sys.argv[0] to the path to the underlying setup.py file so
 # setuptools / distutils don't take the path to the setup.py to be "-c" when
 # invoking via the shim.  This avoids e.g. the following manifest_maker
 # warning: "warning: manifest_maker: standard file '-c' not found".
-SETUPTOOLS_SHIM = (
-    "import sys, setuptools, tokenize; sys.argv[0] = {0!r}; __file__={0!r};"
-    "f=getattr(tokenize, 'open', open)(__file__);"
-    "code=f.read().replace('\\r\\n', '\\n');"
-    "f.close();"
-    "exec(compile(code, __file__, 'exec'))"
-)
+
+
+def make_setuptools_shim_args(setup_py_path, unbuffered=False):
+    # type: (str, Optional[bool]) -> str
+    buffering = 0 if unbuffered else -1
+    return (
+        "import sys, setuptools, tokenize;"
+        "sys.argv[0] = {0!r}; __file__={0!r};"
+        "f=getattr(tokenize, 'open', open)(__file__, buffering={1});"
+        "code=f.read().replace('\\r\\n', '\\n');"
+        "f.close();"
+        "exec(compile(code, __file__, 'exec'))"
+    ).format(setup_py_path, buffering)

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -36,7 +36,7 @@ from pip._internal.utils.misc import (
     LOG_DIVIDER, call_subprocess, captured_stdout, ensure_dir,
     format_command_args, path_to_url, read_chunks,
 )
-from pip._internal.utils.setuptools_build import SETUPTOOLS_SHIM
+from pip._internal.utils.setuptools_build import make_setuptools_shim_args
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.ui import open_spinner
@@ -930,7 +930,7 @@ class WheelBuilder(object):
         # virtualenv.
         return [
             sys.executable, '-u', '-c',
-            SETUPTOOLS_SHIM.format(req.setup_py_path)
+            make_setuptools_shim_args(req.setup_py_path)
         ] + list(self.global_options)
 
     def _build_one_pep517(self, req, tempd, python_tag=None):

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -928,10 +928,8 @@ class WheelBuilder(object):
         # isolating. Currently, it breaks Python in virtualenvs, because it
         # relies on site.py to find parts of the standard library outside the
         # virtualenv.
-        return [
-            sys.executable, '-u', '-c',
-            make_setuptools_shim_args(req.setup_py_path)
-        ] + list(self.global_options)
+        return make_setuptools_shim_args(
+            req.setup_py_path, unbuffered=True) + list(self.global_options)
 
     def _build_one_pep517(self, req, tempd, python_tag=None):
         """Build one InstallRequirement using the PEP 517 build process.

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -928,8 +928,9 @@ class WheelBuilder(object):
         # isolating. Currently, it breaks Python in virtualenvs, because it
         # relies on site.py to find parts of the standard library outside the
         # virtualenv.
-        return make_setuptools_shim_args(
-            req.setup_py_path, unbuffered=True) + list(self.global_options)
+        base_cmd = make_setuptools_shim_args(req.setup_py_path,
+                                             unbuffered_output=True)
+        return base_cmd + list(self.global_options)
 
     def _build_one_pep517(self, req, tempd, python_tag=None):
         """Build one InstallRequirement using the PEP 517 build process.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1272,11 +1272,13 @@ def test_make_setuptools_shim_args(unbuffered):
     shim = (
         "import sys, setuptools, tokenize;"
         "sys.argv[0] = 'setup.py'; __file__='setup.py';"
-        "f=getattr(tokenize, 'open', open)(__file__, buffering=-1);"
+        "f=getattr(tokenize, 'open', open)(__file__);"
         "code=f.read().replace('\\r\\n', '\\n');"
         "f.close();"
         "exec(compile(code, __file__, 'exec'))"
     )
-    shim = shim if not unbuffered else shim.replace("buffering=-1",
-                                                    "buffering=0")
-    assert built_shim == shim
+    base_cmd = [sys.executable, "-c", shim]
+    if unbuffered:
+        base_cmd.insert(1, "-u")
+
+    assert built_shim == base_cmd

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1266,24 +1266,16 @@ def test_deprecated_message_reads_well():
     )
 
 
-@pytest.mark.parametrize("setup_py_path", [
-    "setup.py",
-    "/dir/path/setup.py",
-    "../relative/path/setup.py",
-])
 @pytest.mark.parametrize("unbuffered_output", [False, True])
-def test_make_setuptools_shim_args(setup_py_path, unbuffered_output):
+def test_make_setuptools_shim_args(unbuffered_output):
     args = make_setuptools_shim_args(
-        setup_py_path,
+        "/dir/path/setup.py",
         unbuffered_output=unbuffered_output
     )
 
-    if unbuffered_output:
-        assert "-u" in args
-    else:
-        assert "-u" not in args
+    assert "-u" in args == unbuffered_output
 
     assert args[-2] == "-c"
 
-    assert "sys.argv[0] = '{}'".format(setup_py_path) in args[-1]
-    assert "__file__='{}'".format(setup_py_path) in args[-1]
+    assert "sys.argv[0] = '/dir/path/setup.py'" in args[-1]
+    assert "__file__='/dir/path/setup.py'" in args[-1]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1273,7 +1273,7 @@ def test_make_setuptools_shim_args(unbuffered_output):
         unbuffered_output=unbuffered_output
     )
 
-    assert "-u" in args == unbuffered_output
+    assert ("-u" in args) == unbuffered_output
 
     assert args[-2] == "-c"
 


### PR DESCRIPTION
I have replaced the `SETUPTOOLS_SHIM` with a function `make_setuptools_shim_args`.
I'm not quite sure how @cjerdonek wanted to use the `unbuffered` default arg, figured it should be passed to `open`.

Closes #6688 

Let me know if this change requires a news entry.