### PR TITLE
Address #5874: Prefer candidates with allowed hashes

### DIFF
--- a/news/5874.feature
+++ b/news/5874.feature
@@ -1,0 +1,2 @@
+When choosing candidates to install, prefer candidates with a hash matching
+one of the user-provided hashes.

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -13,6 +13,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 if MYPY_CHECK_RUNNING:
     from typing import Optional, Text, Tuple, Union
     from pip._internal.index import HTMLPage
+    from pip._internal.utils.hashes import Hashes
 
 
 class Link(KeyBasedCompareMixin):
@@ -193,3 +194,17 @@ class Link(KeyBasedCompareMixin):
     def is_yanked(self):
         # type: () -> bool
         return self.yanked_reason is not None
+
+    @property
+    def has_hash(self):
+        return self.hash_name is not None
+
+    def is_hash_allowed(self, hashes):
+        # type: (Hashes) -> bool
+        """
+        Return True if the link has a hash and it is allowed.
+        """
+        if not self.has_hash:
+            return False
+
+        return hashes.is_hash_allowed(self.hash_name, hex_digest=self.hash)

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -44,6 +44,14 @@ class Hashes(object):
         """
         self._allowed = {} if hashes is None else hashes
 
+    def is_hash_allowed(
+        self,
+        hash_name,   # type: str
+        hex_digest,  # type: str
+    ):
+        """Return whether the given hex digest is allowed."""
+        return hex_digest in self._allowed.get(hash_name, [])
+
     def check_against_chunks(self, chunks):
         # type: (Iterator[bytes]) -> None
         """Check good hashes against ones built from iterable of chunks of

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -11,14 +11,27 @@ from pip._internal.index import (
     CandidateEvaluator, CandidatePreferences, FormatControl, HTMLPage, Link,
     LinkEvaluator, PackageFinder, _check_link_requires_python, _clean_link,
     _determine_base_url, _extract_version_from_fragment,
-    _find_name_version_sep, _get_html_page,
+    _find_name_version_sep, _get_html_page, filter_unallowed_hashes,
 )
 from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.models.search_scope import SearchScope
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.pep425tags import get_supported
+from pip._internal.utils.hashes import Hashes
 from tests.lib import CURRENT_PY_VERSION_INFO, make_test_finder
+
+
+def make_mock_candidate(version, yanked_reason=None, hex_digest=None):
+    url = 'https://example.com/pkg-{}.tar.gz'.format(version)
+    if hex_digest is not None:
+        assert len(hex_digest) == 64
+        url += '#sha256={}'.format(hex_digest)
+
+    link = Link(url, yanked_reason=yanked_reason)
+    candidate = InstallationCandidate('mypackage', version, link)
+
+    return candidate
 
 
 @pytest.mark.parametrize('requires_python, expected', [
@@ -170,6 +183,30 @@ class TestLinkEvaluator:
         assert actual == expected
 
 
+@pytest.mark.parametrize('hex_digest, expected_versions', [
+    (None, ['1.0', '1.1', '1.2']),
+    (64 * 'a', ['1.0', '1.1']),
+    (64 * 'b', ['1.0', '1.2']),
+    (64 * 'c', ['1.0', '1.1', '1.2']),
+])
+def test_filter_unallowed_hashes(hex_digest, expected_versions):
+    candidates = [
+        make_mock_candidate('1.0'),
+        make_mock_candidate('1.1', hex_digest=(64 * 'a')),
+        make_mock_candidate('1.2', hex_digest=(64 * 'b')),
+    ]
+    hashes_data = {
+        'sha256': [hex_digest],
+    }
+    hashes = Hashes(hashes_data)
+    actual = filter_unallowed_hashes(candidates, hashes=hashes)
+
+    actual_versions = [str(candidate.version) for candidate in actual]
+    assert actual_versions == expected_versions
+    # Check that the return value is always different from the given value.
+    assert actual is not candidates
+
+
 class TestCandidateEvaluator:
 
     @pytest.mark.parametrize('allow_all_prereleases, prefer_binary', [
@@ -198,18 +235,11 @@ class TestCandidateEvaluator:
         expected_tags = get_supported()
         assert evaluator._supported_tags == expected_tags
 
-    def make_mock_candidate(self, version, yanked_reason=None):
-        url = 'https://example.com/pkg-{}.tar.gz'.format(version)
-        link = Link(url, yanked_reason=yanked_reason)
-        candidate = InstallationCandidate('mypackage', version, link)
-
-        return candidate
-
     def test_get_applicable_candidates(self):
         specifier = SpecifierSet('<= 1.11')
         versions = ['1.10', '1.11', '1.12']
         candidates = [
-            self.make_mock_candidate(version) for version in versions
+            make_mock_candidate(version) for version in versions
         ]
         evaluator = CandidateEvaluator.create()
         actual = evaluator.get_applicable_candidates(
@@ -226,7 +256,7 @@ class TestCandidateEvaluator:
         specifier = SpecifierSet('<= 1.11')
         versions = ['1.10', '1.11', '1.12']
         candidates = [
-            self.make_mock_candidate(version) for version in versions
+            make_mock_candidate(version) for version in versions
         ]
         evaluator = CandidateEvaluator.create()
         found_candidates = evaluator.make_found_candidates(
@@ -275,10 +305,10 @@ class TestCandidateEvaluator:
         Test all candidates yanked.
         """
         candidates = [
-            self.make_mock_candidate('1.0', yanked_reason='bad metadata #1'),
+            make_mock_candidate('1.0', yanked_reason='bad metadata #1'),
             # Put the best candidate in the middle, to test sorting.
-            self.make_mock_candidate('3.0', yanked_reason='bad metadata #3'),
-            self.make_mock_candidate('2.0', yanked_reason='bad metadata #2'),
+            make_mock_candidate('3.0', yanked_reason='bad metadata #3'),
+            make_mock_candidate('2.0', yanked_reason='bad metadata #2'),
         ]
         expected_best = candidates[1]
         evaluator = CandidateEvaluator.create()
@@ -310,7 +340,7 @@ class TestCandidateEvaluator:
         Test the log message with various reason strings.
         """
         candidates = [
-            self.make_mock_candidate('1.0', yanked_reason=yanked_reason),
+            make_mock_candidate('1.0', yanked_reason=yanked_reason),
         ]
         evaluator = CandidateEvaluator.create()
         actual = evaluator.get_best_candidate(candidates)
@@ -332,11 +362,11 @@ class TestCandidateEvaluator:
         Test the best candidates being yanked, but not all.
         """
         candidates = [
-            self.make_mock_candidate('4.0', yanked_reason='bad metadata #4'),
+            make_mock_candidate('4.0', yanked_reason='bad metadata #4'),
             # Put the best candidate in the middle, to test sorting.
-            self.make_mock_candidate('2.0'),
-            self.make_mock_candidate('3.0', yanked_reason='bad metadata #3'),
-            self.make_mock_candidate('1.0'),
+            make_mock_candidate('2.0'),
+            make_mock_candidate('3.0', yanked_reason='bad metadata #3'),
+            make_mock_candidate('1.0'),
         ]
         expected_best = candidates[1]
         evaluator = CandidateEvaluator.create()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -442,6 +442,22 @@ class Test_normalize_path(object):
 class TestHashes(object):
     """Tests for pip._internal.utils.hashes"""
 
+    @pytest.mark.parametrize('hash_name, hex_digest, expected', [
+        # Test a value that matches but with the wrong hash_name.
+        ('sha384', 128 * 'a', False),
+        # Test matching values, including values other than the first.
+        ('sha512', 128 * 'a', True),
+        ('sha512', 128 * 'b', True),
+        # Test a matching hash_name with a value that doesn't match.
+        ('sha512', 128 * 'c', False),
+    ])
+    def test_is_hash_allowed(self, hash_name, hex_digest, expected):
+        hashes_data = {
+            'sha512': [128 * 'a', 128 * 'b'],
+        }
+        hashes = Hashes(hashes_data)
+        assert hashes.is_hash_allowed(hash_name, hex_digest) == expected
+
     def test_success(self, tmpdir):
         """Make sure no error is raised when at least one hash matches.
 


### PR DESCRIPTION
This is a follow-on to PR #6687 that addresses issue #5874. PR #6687 makes this PR possible because it added support for creating a new `CandidateEvaluator` for each `Requirement` (since the allowed hashes can vary per requirement).

This PR uses an approach different from PR #6464. Instead of filtering the candidates post hoc inside `get_best_candidate()` and _after_ sorting by preference, the approach in this PR uses `index.py`'s concept of "applicable" candidates combined with using the sort preference itself to do the choosing. First, it uses the allowed hashes to determine which candidates are applicable: if at least one link has a matching hash, then links with non-matching hashes are considered not applicable and filtered out of consideration (and links with matching hashes or no hash _are_ applicable and so are kept). Otherwise, if no link has a matching hash, the list of applicable links is kept the same and no links are filtered out for hash reasons. Then, in the phase of sorting applicable candidates, links with matching hashes are preferred over links whose hash doesn't match (or that don't have a hash).

In a follow-on PR, I can implement @dstufft's suggestion of logging a warning if a link is more preferred but has no hash listed: https://github.com/pypa/pip/issues/5874#issuecomment-428721237
