### PR TITLE
Use mypy's default of strict_optional=True

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -107,9 +107,6 @@ strict_optional = False
 [mypy-pip/_internal/utils/ui]
 strict_optional = False
 
-[mypy-pip/_internal/vcs/subversion]
-strict_optional = False
-
 [mypy-pip/_internal/wheel]
 strict_optional = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,9 +59,6 @@ strict_optional = False
 [mypy-pip/_internal/models/link]
 strict_optional = False
 
-[mypy-pip/_internal/models/target_python]
-strict_optional = False
-
 [mypy-pip/_internal/operations/check]
 strict_optional = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,9 +98,6 @@ strict_optional = False
 [mypy-pip/_internal/utils/glibc]
 strict_optional = False
 
-[mypy-pip/_internal/utils/logging]
-strict_optional = False
-
 [mypy-pip/_internal/utils/misc]
 strict_optional = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,9 +53,6 @@ strict_optional = False
 [mypy-pip/_internal/models/format_control]
 strict_optional = False
 
-[mypy-pip/_internal/models/link]
-strict_optional = False
-
 [mypy-pip/_internal/operations/check]
 strict_optional = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,10 +25,96 @@ ignore = W504
 [mypy]
 follow_imports = silent
 ignore_missing_imports = True
+
+[mypy-pip/_internal/build_env]
+strict_optional = False
+
+[mypy-pip/_internal/cache]
+strict_optional = False
+
+[mypy-pip/_internal/cli/base_command]
+strict_optional = False
+
+[mypy-pip/_internal/cli/cmdoptions]
+strict_optional = False
+
+[mypy-pip/_internal/configuration]
+strict_optional = False
+
+[mypy-pip/_internal/download]
+strict_optional = False
+
+[mypy-pip/_internal/index]
+strict_optional = False
+
+[mypy-pip/_internal/legacy_resolve]
+strict_optional = False
+
+[mypy-pip/_internal/locations]
+strict_optional = False
+
+[mypy-pip/_internal/models/format_control]
+strict_optional = False
+
+[mypy-pip/_internal/models/link]
+strict_optional = False
+
+[mypy-pip/_internal/models/target_python]
+strict_optional = False
+
+[mypy-pip/_internal/operations/check]
+strict_optional = False
+
+[mypy-pip/_internal/operations/freeze]
+strict_optional = False
+
+[mypy-pip/_internal/operations/prepare]
+strict_optional = False
+
+[mypy-pip/_internal/pep425tags]
 strict_optional = False
 
 [mypy-pip/_internal/req/*]
 disallow_untyped_defs = True
+
+[mypy-pip/_internal/req]
+strict_optional = False
+
+[mypy-pip/_internal/req/constructors]
+strict_optional = False
+
+[mypy-pip/_internal/req/req_file]
+strict_optional = False
+
+[mypy-pip/_internal/req/req_install]
+strict_optional = False
+
+[mypy-pip/_internal/req/req_set]
+strict_optional = False
+
+[mypy-pip/_internal/req/req_tracker]
+strict_optional = False
+
+[mypy-pip/_internal/utils/encoding]
+strict_optional = False
+
+[mypy-pip/_internal/utils/glibc]
+strict_optional = False
+
+[mypy-pip/_internal/utils/logging]
+strict_optional = False
+
+[mypy-pip/_internal/utils/misc]
+strict_optional = False
+
+[mypy-pip/_internal/utils/ui]
+strict_optional = False
+
+[mypy-pip/_internal/vcs/subversion]
+strict_optional = False
+
+[mypy-pip/_internal/wheel]
+strict_optional = False
 
 [mypy-pip/_vendor/*]
 follow_imports = skip

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,6 @@ strict_optional = False
 [mypy-pip/_internal/configuration]
 strict_optional = False
 
-[mypy-pip/_internal/download]
-strict_optional = False
-
 [mypy-pip/_internal/index]
 strict_optional = False
 

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -55,6 +55,9 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.utils.hashes import Hashes
     from pip._internal.vcs.versioncontrol import AuthInfo, VersionControl
 
+    Credentials = Tuple[str, str, str]
+
+
 __all__ = ['get_file_content',
            'is_url', 'url_to_path', 'path_to_url',
            'is_archive_file', 'unpack_vcs_link',
@@ -224,7 +227,7 @@ class MultiDomainBasicAuth(AuthBase):
         # this value is set to the credentials they entered. After the
         # request authenticates, the caller should call
         # ``save_credentials`` to save these.
-        self._credentials_to_save = None   # type: Tuple[str, str, str]
+        self._credentials_to_save = None  # type: Optional[Credentials]
 
     def _get_index_url(self, url):
         """Return the original index URL matching the requested URL.
@@ -748,7 +751,7 @@ def _download_url(
     resp,  # type: Response
     link,  # type: Link
     content_file,  # type: IO
-    hashes,  # type: Hashes
+    hashes,  # type: Optional[Hashes]
     progress_bar  # type: str
 ):
     # type: (...) -> None
@@ -1002,8 +1005,8 @@ class PipXmlrpcTransport(xmlrpc_client.Transport):
 
 
 def unpack_url(
-    link,  # type: Optional[Link]
-    location,  # type: Optional[str]
+    link,  # type: Link
+    location,  # type: str
     download_dir=None,  # type: Optional[str]
     only_download=False,  # type: bool
     session=None,  # type: Optional[PipSession]
@@ -1077,7 +1080,7 @@ def _download_http_url(
     link,  # type: Link
     session,  # type: PipSession
     temp_dir,  # type: str
-    hashes,  # type: Hashes
+    hashes,  # type: Optional[Hashes]
     progress_bar  # type: str
 ):
     # type: (...) -> Tuple[str, str]
@@ -1121,7 +1124,7 @@ def _download_http_url(
     content_disposition = resp.headers.get('content-disposition')
     if content_disposition:
         filename = parse_content_disposition(content_disposition, filename)
-    ext = splitext(filename)[1]
+    ext = splitext(filename)[1]  # type: Optional[str]
     if not ext:
         ext = mimetypes.guess_extension(content_type)
         if ext:
@@ -1137,7 +1140,7 @@ def _download_http_url(
 
 
 def _check_download_dir(link, download_dir, hashes):
-    # type: (Link, str, Hashes) -> Optional[str]
+    # type: (Link, str, Optional[Hashes]) -> Optional[str]
     """ Check download_dir for previously downloaded file with correct hash
         If a correct file is found return its path else None
     """

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -206,5 +206,8 @@ class Link(KeyBasedCompareMixin):
         """
         if not self.has_hash:
             return False
+        # Assert non-None so mypy knows self.hash_name and self.hash are str.
+        assert self.hash_name is not None
+        assert self.hash is not None
 
         return hashes.is_hash_allowed(self.hash_name, hex_digest=self.hash)

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -83,10 +83,10 @@ class InstallRequirement(object):
         self.req = req
         self.comes_from = comes_from
         self.constraint = constraint
-        if source_dir is not None:
-            self.source_dir = os.path.normpath(os.path.abspath(source_dir))
+        if source_dir is None:
+            self.source_dir = None  # type: Optional[str]
         else:
-            self.source_dir = None
+            self.source_dir = os.path.normpath(os.path.abspath(source_dir))
         self.editable = editable
 
         self._wheel_cache = wheel_cache
@@ -169,7 +169,7 @@ class InstallRequirement(object):
             s += ' in %s' % display_path(self.satisfied_by.location)
         if self.comes_from:
             if isinstance(self.comes_from, six.string_types):
-                comes_from = self.comes_from
+                comes_from = self.comes_from  # type: Optional[str]
             else:
                 comes_from = self.comes_from.from_path()
             if comes_from:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -294,7 +294,7 @@ class InstallRequirement(object):
         return s
 
     def build_location(self, build_dir):
-        # type: (str) -> Optional[str]
+        # type: (str) -> str
         assert build_dir is not None
         if self._temp_build_dir.path is not None:
             return self._temp_build_dir.path

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -821,7 +821,7 @@ def call_subprocess(
     unset_environ=None,  # type: Optional[Iterable[str]]
     spinner=None  # type: Optional[SpinnerInterface]
 ):
-    # type: (...) -> Optional[Text]
+    # type: (...) -> Text
     """
     Args:
       show_stdout: if true, use INFO to log the subprocess's stderr and

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -118,7 +118,7 @@ def get_pip_version():
 
 
 def normalize_version_info(py_version_info):
-    # type: (Optional[Tuple[int, ...]]) -> Optional[Tuple[int, int, int]]
+    # type: (Tuple[int, ...]) -> Tuple[int, int, int]
     """
     Convert a tuple of ints representing a Python version to one of length
     three.
@@ -129,9 +129,6 @@ def normalize_version_info(py_version_info):
     :return: a tuple of length three if `py_version_info` is non-None.
         Otherwise, return `py_version_info` unchanged (i.e. None).
     """
-    if py_version_info is None:
-        return None
-
     if len(py_version_info) < 3:
         py_version_info += (3 - len(py_version_info)) * (0,)
     elif len(py_version_info) > 3:

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -550,7 +550,7 @@ class VersionControl(object):
         extra_environ=None,  # type: Optional[Mapping[str, Any]]
         spinner=None  # type: Optional[SpinnerInterface]
     ):
-        # type: (...) -> Optional[Text]
+        # type: (...) -> Text
         """
         Run a VCS subcommand
         This is simply a wrapper around call_subprocess that adds the VCS

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -739,7 +739,6 @@ class TestGlibc(object):
 
 
 @pytest.mark.parametrize('version_info, expected', [
-    (None, None),
     ((), (0, 0, 0)),
     ((3, ), (3, 0, 0)),
     ((3, 6), (3, 6, 0)),


### PR DESCRIPTION
This PR changes our `setup.cfg` to use mypy's default of `strict_optional=True`. Instead, the list of files exempted from this default are explicitly listed. This is nice for a few reasons: (1) files adhering to `strict_optional=True` now get checked, so it prevents regressions, (2) new files added automatically use `strict_optional=True` (because it's the default), and (3) it provides a list that we can see of which files still need to be converted, which gives us an actionable check-list of TODO's.

This PR also converts four files over to use `strict_optional` (one commit for each one).

Refs: #4748 (umbrella issue)