### PR TITLE
Fix inconsistent behavior of trusted host

### DIFF
--- a/news/6705.bugfix
+++ b/news/6705.bugfix
@@ -1,1 +1,2 @@
-Fix --trusted-host processing under HTTPS to trust any port number used with the host.
+Fix ``--trusted-host`` processing under HTTPS to trust any port number used
+with the host.

--- a/news/6705.bugfix
+++ b/news/6705.bugfix
@@ -1,0 +1,1 @@
+Fix --trusted-host processing under HTTPS to trust any port number used with the host.

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -43,10 +43,12 @@ from pip._internal.utils.misc import (
     ask_password,
     ask_path_exists,
     backup_dir,
+    build_url_from_netloc,
     consume,
     display_path,
     format_size,
     get_installed_version,
+    netloc_has_port,
     path_to_url,
     remove_auth_from_url,
     rmtree,
@@ -608,7 +610,13 @@ class PipSession(requests.Session):
 
     def add_insecure_host(self, host):
         # type: (str) -> None
-        self.mount('https://{}/'.format(host), self._insecure_adapter)
+        self.mount(build_url_from_netloc(host) + '/', self._insecure_adapter)
+        if not netloc_has_port(host):
+            # Mount wildcard ports for the same host.
+            self.mount(
+                build_url_from_netloc(host) + ':',
+                self._insecure_adapter
+            )
 
     def request(self, method, url, *args, **kwargs):
         # Allow setting a default timeout on a session

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -1081,6 +1081,27 @@ def path_to_url(path):
     return url
 
 
+def build_url_from_netloc(netloc, scheme='https'):
+    # type: (str, str) -> str
+    """
+    Build a full URL from a netloc.
+    """
+    if netloc.count(':') >= 2 and '@' not in netloc and '[' not in netloc:
+        # It must be a bare IPv6 address, then wrap it with brackets.
+        netloc = '[{}]'.format(netloc)
+    return '{}://{}'.format(scheme, netloc)
+
+
+def netloc_has_port(netloc):
+    # type: (str) -> bool
+    """
+    Return whether the netloc has a port part.
+    """
+    url = build_url_from_netloc(netloc)
+    parsed = urllib_parse.urlparse(url)
+    return bool(parsed.port)
+
+
 def split_auth_from_netloc(netloc):
     """
     Parse out and remove the auth information from a netloc.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -1087,7 +1087,7 @@ def build_url_from_netloc(netloc, scheme='https'):
     Build a full URL from a netloc.
     """
     if netloc.count(':') >= 2 and '@' not in netloc and '[' not in netloc:
-        # It must be a bare IPv6 address, then wrap it with brackets.
+        # It must be a bare IPv6 address, so wrap it with brackets.
         netloc = '[{}]'.format(netloc)
     return '{}://{}'.format(scheme, netloc)
 

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -533,9 +533,11 @@ class TestPipSession:
             insecure_hosts=["example.com"],
         )
 
-        assert not hasattr(session.adapters["https://example.com/"], "cache")
         assert "https://example.com/" in session.adapters
+        # Check that the "port wildcard" is present.
         assert "https://example.com:" in session.adapters
+        # Check that the cache isn't enabled.
+        assert not hasattr(session.adapters["https://example.com/"], "cache")
 
 
 @pytest.mark.parametrize(["input_url", "url", "username", "password"], [

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -527,13 +527,15 @@ class TestPipSession:
 
         assert not hasattr(session.adapters["http://"], "cache")
 
-    def test_insecure_host_cache_is_not_enabled(self, tmpdir):
+    def test_insecure_host_adapter(self, tmpdir):
         session = PipSession(
             cache=tmpdir.joinpath("test-cache"),
             insecure_hosts=["example.com"],
         )
 
         assert not hasattr(session.adapters["https://example.com/"], "cache")
+        assert "https://example.com/" in session.adapters
+        assert "https://example.com:" in session.adapters
 
 
 @pytest.mark.parametrize(["input_url", "url", "username", "password"], [

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1225,7 +1225,7 @@ def test_path_to_url_win():
     assert path_to_url('file') == 'file:' + urllib_request.pathname2url(path)
 
 
-@pytest.mark.parametrize('netloc, url, has_port', [
+@pytest.mark.parametrize('netloc, expected_url, expected_has_port', [
     # Test domain name.
     ('example.com', 'https://example.com', False),
     ('example.com:5000', 'https://example.com:5000', True),
@@ -1243,9 +1243,11 @@ def test_path_to_url_win():
         True
     )
 ])
-def test_build_url_from_netloc_and_netloc_has_port(netloc, url, has_port):
-    assert build_url_from_netloc(netloc) == url
-    assert netloc_has_port(netloc) is has_port
+def test_build_url_from_netloc_and_netloc_has_port(
+    netloc, expected_url, expected_has_port,
+):
+    assert build_url_from_netloc(netloc) == expected_url
+    assert netloc_has_port(netloc) is expected_has_port
 
 
 @pytest.mark.parametrize('netloc, expected', [


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Closes #6705 

Propose for a hostname without port for the trusted-host option value and deprecate the other manner. Make sure all ports are recognized as insecure sources for the same host.

- [x] News entry
- [x] Test cases
- [x] Deprecation warning