### PR TITLE
Add debug logging to filter_unallowed_hashes()

### DIFF
--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -189,7 +189,9 @@ class ListCommand(Command):
                     all_candidates = [candidate for candidate in all_candidates
                                       if not candidate.version.is_prerelease]
 
-                evaluator = finder.make_candidate_evaluator()
+                evaluator = finder.make_candidate_evaluator(
+                    project_name=dist.project_name,
+                )
                 best_candidate = evaluator.get_best_candidate(all_candidates)
                 if best_candidate is None:
                     continue

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -510,6 +510,7 @@ class CandidateEvaluator(object):
     @classmethod
     def create(
         cls,
+        project_name,         # type: str
         target_python=None,   # type: Optional[TargetPython]
         prefer_binary=False,  # type: bool
         allow_all_prereleases=False,  # type: bool
@@ -529,6 +530,7 @@ class CandidateEvaluator(object):
         supported_tags = target_python.get_tags()
 
         return cls(
+            project_name=project_name,
             supported_tags=supported_tags,
             prefer_binary=prefer_binary,
             allow_all_prereleases=allow_all_prereleases,
@@ -537,6 +539,7 @@ class CandidateEvaluator(object):
 
     def __init__(
         self,
+        project_name,         # type: str
         supported_tags,       # type: List[Pep425Tag]
         prefer_binary=False,  # type: bool
         allow_all_prereleases=False,  # type: bool
@@ -550,6 +553,7 @@ class CandidateEvaluator(object):
         self._allow_all_prereleases = allow_all_prereleases
         self._hashes = hashes
         self._prefer_binary = prefer_binary
+        self._project_name = project_name
         self._supported_tags = supported_tags
 
     def get_applicable_candidates(
@@ -1105,12 +1109,17 @@ class PackageFinder(object):
         # This is an intentional priority ordering
         return file_versions + find_links_versions + page_versions
 
-    def make_candidate_evaluator(self, hashes=None):
-        # type: (Optional[Hashes]) -> CandidateEvaluator
+    def make_candidate_evaluator(
+        self,
+        project_name,  # type: str
+        hashes=None,   # type: Optional[Hashes]
+    ):
+        # type: (...) -> CandidateEvaluator
         """Create a CandidateEvaluator object to use.
         """
         candidate_prefs = self._candidate_prefs
         return CandidateEvaluator.create(
+            project_name=project_name,
             target_python=self._target_python,
             prefer_binary=candidate_prefs.prefer_binary,
             allow_all_prereleases=candidate_prefs.allow_all_prereleases,
@@ -1133,7 +1142,10 @@ class PackageFinder(object):
         :return: A `FoundCandidates` instance.
         """
         candidates = self.find_all_candidates(project_name)
-        candidate_evaluator = self.make_candidate_evaluator(hashes=hashes)
+        candidate_evaluator = self.make_candidate_evaluator(
+            project_name=project_name,
+            hashes=hashes,
+        )
         return candidate_evaluator.make_found_candidates(
             candidates, specifier=specifier,
         )

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -442,8 +442,9 @@ class LinkEvaluator(object):
 
 
 def filter_unallowed_hashes(
-    candidates,  # type: List[InstallationCandidate]
-    hashes,      # type: Hashes
+    candidates,    # type: List[InstallationCandidate]
+    hashes,        # type: Hashes
+    project_name,  # type: str
 ):
     # type: (...) -> List[InstallationCandidate]
     """
@@ -461,23 +462,58 @@ def filter_unallowed_hashes(
     have been installed (e.g. permitting the user to more easily update
     their requirements file with the desired hash).
     """
-    applicable = []
-    found_allowed_hash = False
+    if not hashes:
+        logger.debug(
+            'Given no hashes to check %s links for project %r: '
+            'discarding no candidates',
+            len(candidates),
+            project_name,
+        )
+        # Make sure we're not returning back the given value.
+        return list(candidates)
+
+    matches_or_no_digest = []
+    # Collect the non-matches for logging purposes.
+    non_matches = []
+    match_count = 0
     for candidate in candidates:
         link = candidate.location
         if not link.has_hash:
-            applicable.append(candidate)
+            pass
+        elif link.is_hash_allowed(hashes=hashes):
+            match_count += 1
+        else:
+            non_matches.append(candidate)
             continue
 
-        if link.is_hash_allowed(hashes=hashes):
-            found_allowed_hash = True
-            applicable.append(candidate)
+        matches_or_no_digest.append(candidate)
 
-    if found_allowed_hash:
-        return applicable
+    if match_count:
+        filtered = matches_or_no_digest
+    else:
+        # Make sure we're not returning back the given value.
+        filtered = list(candidates)
 
-    # Make sure we're not returning back the given value.
-    return list(candidates)
+    if len(filtered) == len(candidates):
+        discard_message = 'discarding no candidates'
+    else:
+        discard_message = 'discarding {} non-matches:\n  {}'.format(
+            len(non_matches),
+            '\n  '.join(str(candidate.location) for candidate in non_matches)
+        )
+
+    logger.debug(
+        'Checked %s links for project %r against %s hashes '
+        '(%s matches, %s no digest): %s',
+        len(candidates),
+        project_name,
+        hashes.digest_count,
+        match_count,
+        len(matches_or_no_digest) - match_count,
+        discard_message
+    )
+
+    return filtered
 
 
 class CandidatePreferences(object):
@@ -587,7 +623,9 @@ class CandidateEvaluator(object):
         ]
 
         return filter_unallowed_hashes(
-            candidates=applicable_candidates, hashes=self._hashes,
+            candidates=applicable_candidates,
+            hashes=self._hashes,
+            project_name=self._project_name,
         )
 
     def make_found_candidates(

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -44,6 +44,11 @@ class Hashes(object):
         """
         self._allowed = {} if hashes is None else hashes
 
+    @property
+    def digest_count(self):
+        # type: () -> int
+        return sum(len(digests) for digests in self._allowed.values())
+
     def is_hash_allowed(
         self,
         hash_name,   # type: str

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -216,7 +216,7 @@ class TestWheel:
             ('pyT', 'TEST', 'any'),
             ('pyT', 'none', 'any'),
         ]
-        evaluator = CandidateEvaluator(supported_tags=valid_tags)
+        evaluator = CandidateEvaluator('my-project', supported_tags=valid_tags)
         sort_key = evaluator._sort_key
         results = sorted(links, key=sort_key, reverse=True)
         results2 = sorted(reversed(links), key=sort_key, reverse=True)
@@ -242,7 +242,7 @@ class TestWheel:
                 Link("simplewheel-1.0-py2.py3-none-any.whl"),
             ),
         ]
-        candidate_evaluator = CandidateEvaluator.create()
+        candidate_evaluator = CandidateEvaluator.create('my-project')
         sort_key = candidate_evaluator._sort_key
         results = sorted(links, key=sort_key, reverse=True)
         results2 = sorted(reversed(links), key=sort_key, reverse=True)

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -219,6 +219,7 @@ class TestCandidateEvaluator:
         target_python = TargetPython()
         target_python._valid_tags = [('py36', 'none', 'any')]
         evaluator = CandidateEvaluator.create(
+            project_name='my-project',
             target_python=target_python,
             allow_all_prereleases=allow_all_prereleases,
             prefer_binary=prefer_binary,
@@ -231,7 +232,7 @@ class TestCandidateEvaluator:
         """
         Test passing target_python=None.
         """
-        evaluator = CandidateEvaluator.create()
+        evaluator = CandidateEvaluator.create('my-project')
         expected_tags = get_supported()
         assert evaluator._supported_tags == expected_tags
 
@@ -241,7 +242,7 @@ class TestCandidateEvaluator:
         candidates = [
             make_mock_candidate(version) for version in versions
         ]
-        evaluator = CandidateEvaluator.create()
+        evaluator = CandidateEvaluator.create('my-project')
         actual = evaluator.get_applicable_candidates(
             candidates, specifier=specifier,
         )
@@ -275,7 +276,7 @@ class TestCandidateEvaluator:
             'sha256': [64 * 'b'],
         }
         hashes = Hashes(hashes_data)
-        evaluator = CandidateEvaluator.create(hashes=hashes)
+        evaluator = CandidateEvaluator.create('my-project', hashes=hashes)
         actual = evaluator.get_applicable_candidates(
             candidates, specifier=specifier,
         )
@@ -288,7 +289,7 @@ class TestCandidateEvaluator:
         candidates = [
             make_mock_candidate(version) for version in versions
         ]
-        evaluator = CandidateEvaluator.create()
+        evaluator = CandidateEvaluator.create('my-project')
         found_candidates = evaluator.make_found_candidates(
             candidates, specifier=specifier,
         )
@@ -319,7 +320,7 @@ class TestCandidateEvaluator:
             'sha256': [64 * 'a'],
         }
         hashes = Hashes(hashes_data)
-        evaluator = CandidateEvaluator.create(hashes=hashes)
+        evaluator = CandidateEvaluator.create('my-project', hashes=hashes)
         sort_value = evaluator._sort_key(candidate)
         # The hash is reflected in the first element of the tuple.
         actual = sort_value[0]
@@ -336,7 +337,7 @@ class TestCandidateEvaluator:
         Test the effect of is_yanked on _sort_key()'s return value.
         """
         candidate = make_mock_candidate('1.0', yanked_reason=yanked_reason)
-        evaluator = CandidateEvaluator.create()
+        evaluator = CandidateEvaluator.create('my-project')
         sort_value = evaluator._sort_key(candidate)
         # Yanked / non-yanked is reflected in the second element of the tuple.
         actual = sort_value[1]
@@ -346,7 +347,7 @@ class TestCandidateEvaluator:
         """
         Test passing an empty list.
         """
-        evaluator = CandidateEvaluator.create()
+        evaluator = CandidateEvaluator.create('my-project')
         actual = evaluator.get_best_candidate([])
         assert actual is None
 
@@ -361,7 +362,7 @@ class TestCandidateEvaluator:
             make_mock_candidate('2.0', yanked_reason='bad metadata #2'),
         ]
         expected_best = candidates[1]
-        evaluator = CandidateEvaluator.create()
+        evaluator = CandidateEvaluator.create('my-project')
         actual = evaluator.get_best_candidate(candidates)
         assert actual is expected_best
         assert str(actual.version) == '3.0'
@@ -392,7 +393,7 @@ class TestCandidateEvaluator:
         candidates = [
             make_mock_candidate('1.0', yanked_reason=yanked_reason),
         ]
-        evaluator = CandidateEvaluator.create()
+        evaluator = CandidateEvaluator.create('my-project')
         actual = evaluator.get_best_candidate(candidates)
         assert str(actual.version) == '1.0'
 
@@ -419,7 +420,7 @@ class TestCandidateEvaluator:
             make_mock_candidate('1.0'),
         ]
         expected_best = candidates[1]
-        evaluator = CandidateEvaluator.create()
+        evaluator = CandidateEvaluator.create('my-project')
         actual = evaluator.get_best_candidate(candidates)
         assert actual is expected_best
         assert str(actual.version) == '2.0'
@@ -696,10 +697,13 @@ class TestPackageFinder:
 
         # Pass hashes to check that _hashes is set.
         hashes = Hashes({'sha256': [64 * 'a']})
-        evaluator = finder.make_candidate_evaluator(hashes=hashes)
+        evaluator = finder.make_candidate_evaluator(
+            'my-project', hashes=hashes,
+        )
         assert evaluator._allow_all_prereleases == allow_all_prereleases
         assert evaluator._hashes == hashes
         assert evaluator._prefer_binary == prefer_binary
+        assert evaluator._project_name == 'my-project'
         assert evaluator._supported_tags == [('py36', 'none', 'any')]
 
 


### PR DESCRIPTION
This is a follow-up to PR #6699 that adds debug logging to `filter_unallowed_hashes()` (a bit like the "skipped link" debug logging after each call to `LinkEvaluator.evaluate_link()`).