### PR TITLE
Pass the specifier to CandidateEvaluator via create() instead of get_applicable_candidates()

### DIFF
--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -3,6 +3,7 @@ import sys
 
 import pytest
 from mock import Mock, patch
+from pip._vendor.packaging.specifiers import SpecifierSet
 from pkg_resources import parse_version
 
 import pip._internal.pep425tags
@@ -216,7 +217,10 @@ class TestWheel:
             ('pyT', 'TEST', 'any'),
             ('pyT', 'none', 'any'),
         ]
-        evaluator = CandidateEvaluator('my-project', supported_tags=valid_tags)
+        specifier = SpecifierSet()
+        evaluator = CandidateEvaluator(
+            'my-project', supported_tags=valid_tags, specifier=specifier,
+        )
         sort_key = evaluator._sort_key
         results = sorted(links, key=sort_key, reverse=True)
         results2 = sorted(reversed(links), key=sort_key, reverse=True)


### PR DESCRIPTION
This PR makes `CandidateEvaluator`'s API a bit more consistent by passing the `specifier` to the `CandidateEvaluator.create()` creation method instead of `CandidateEvaluator. get_applicable_candidates()` after the `CandidateEvaluator` is already created. This is more consistent because `specifier` parallels `hashes` (they are both `InstallRequirement` attributes), and `hashes` is already being passed to `create()`.