### PR TITLE
Move markers related constant & function in their own module

### DIFF
--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -28,13 +28,13 @@ from pip._vendor.six.moves.urllib import request as urllib_request
 
 import pip
 from pip._internal.exceptions import HashMismatch, InstallationError
-from pip._internal.locations import write_delete_marker_file
 from pip._internal.models.index import PyPI
 # Import ssl from compat so the initial import occurs in only one place.
 from pip._internal.utils.compat import HAS_TLS, ssl
 from pip._internal.utils.encoding import auto_decode
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.glibc import libc_ver
+from pip._internal.utils.marker_files import write_delete_marker_file
 from pip._internal.utils.misc import (
     ARCHIVE_EXTENSIONS, ask, ask_input, ask_password, ask_path_exists,
     backup_dir, consume, display_path, format_size, get_installed_version,

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -22,26 +22,6 @@ if MYPY_CHECK_RUNNING:
 USER_CACHE_DIR = appdirs.user_cache_dir("pip")
 
 
-DELETE_MARKER_MESSAGE = '''\
-This file is placed here by pip to indicate the source was put
-here by pip.
-
-Once this package is successfully installed this source code will be
-deleted (unless you remove this file).
-'''
-PIP_DELETE_MARKER_FILENAME = 'pip-delete-this-directory.txt'
-
-
-def write_delete_marker_file(directory):
-    # type: (str) -> None
-    """
-    Write the pip delete marker file into this directory.
-    """
-    filepath = os.path.join(directory, PIP_DELETE_MARKER_FILENAME)
-    with open(filepath, 'w') as marker_fp:
-        marker_fp.write(DELETE_MARKER_MESSAGE)
-
-
 def running_under_virtualenv():
     # type: () -> bool
     """

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -18,15 +18,14 @@ from pip._vendor.pep517.wrappers import Pep517HookCaller
 from pip._internal import wheel
 from pip._internal.build_env import NoOpBuildEnvironment
 from pip._internal.exceptions import InstallationError
-from pip._internal.locations import (
-    PIP_DELETE_MARKER_FILENAME, running_under_virtualenv,
-)
+from pip._internal.locations import running_under_virtualenv
 from pip._internal.models.link import Link
 from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
 from pip._internal.req.req_uninstall import UninstallPathSet
 from pip._internal.utils.compat import native_str
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.logging import indent_log
+from pip._internal.utils.marker_files import PIP_DELETE_MARKER_FILENAME
 from pip._internal.utils.misc import (
     _make_build_dir, ask_path_exists, backup_dir, call_subprocess,
     display_path, dist_in_site_packages, dist_in_usersite, ensure_dir,

--- a/src/pip/_internal/utils/marker_files.py
+++ b/src/pip/_internal/utils/marker_files.py
@@ -1,0 +1,20 @@
+import os.path
+
+DELETE_MARKER_MESSAGE = '''\
+This file is placed here by pip to indicate the source was put
+here by pip.
+
+Once this package is successfully installed this source code will be
+deleted (unless you remove this file).
+'''
+PIP_DELETE_MARKER_FILENAME = 'pip-delete-this-directory.txt'
+
+
+def write_delete_marker_file(directory):
+    # type: (str) -> None
+    """
+    Write the pip delete marker file into this directory.
+    """
+    filepath = os.path.join(directory, PIP_DELETE_MARKER_FILENAME)
+    with open(filepath, 'w') as marker_fp:
+        marker_fp.write(DELETE_MARKER_MESSAGE)

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -32,11 +32,11 @@ from pip import __version__
 from pip._internal.exceptions import CommandError, InstallationError
 from pip._internal.locations import (
     running_under_virtualenv, site_packages, user_site, virtualenv_no_global,
-    write_delete_marker_file,
 )
 from pip._internal.utils.compat import (
     WINDOWS, console_to_str, expanduser, stdlib_pkgs, str_to_display,
 )
+from pip._internal.utils.marker_files import write_delete_marker_file
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if PY2:

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -27,11 +27,10 @@ from pip._internal.download import unpack_url
 from pip._internal.exceptions import (
     InstallationError, InvalidWheelFilename, UnsupportedWheel,
 )
-from pip._internal.locations import (
-    PIP_DELETE_MARKER_FILENAME, distutils_scheme,
-)
+from pip._internal.locations import distutils_scheme
 from pip._internal.models.link import Link
 from pip._internal.utils.logging import indent_log
+from pip._internal.utils.marker_files import PIP_DELETE_MARKER_FILENAME
 from pip._internal.utils.misc import (
     LOG_DIVIDER, call_subprocess, captured_stdout, ensure_dir,
     format_command_args, path_to_url, read_chunks,

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -4,7 +4,7 @@ from os.path import exists
 import pytest
 
 from pip._internal.cli.status_codes import PREVIOUS_BUILD_DIR_ERROR
-from pip._internal.locations import write_delete_marker_file
+from pip._internal.utils.marker_files import write_delete_marker_file
 from tests.lib import need_mercurial
 from tests.lib.local_repos import local_checkout
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -6,7 +6,7 @@ from os.path import exists
 import pytest
 
 from pip._internal.cli.status_codes import ERROR, PREVIOUS_BUILD_DIR_ERROR
-from pip._internal.locations import write_delete_marker_file
+from pip._internal.utils.marker_files import write_delete_marker_file
 from tests.lib import pyversion
 
 


### PR DESCRIPTION
It didn't seem related with the rest of the locations module

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
