### PR TITLE
Add an html5lib patch for Python 3.9 compatibility

### DIFF
--- a/news/6728.bugfix
+++ b/news/6728.bugfix
@@ -1,0 +1,1 @@
+Make vendored html5lib compatible with Python 3.9.

--- a/src/pip/_vendor/html5lib/_trie/_base.py
+++ b/src/pip/_vendor/html5lib/_trie/_base.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, unicode_literals
 
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python 2.7
+    from collections import Mapping
 
 
 class Trie(Mapping):

--- a/src/pip/_vendor/html5lib/treebuilders/dom.py
+++ b/src/pip/_vendor/html5lib/treebuilders/dom.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import, division, unicode_literals
 
 
-from collections import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:  # Python 2.7
+    from collections import MutableMapping
 from xml.dom import minidom, Node
 import weakref
 

--- a/tasks/vendoring/patches/html5lib.patch
+++ b/tasks/vendoring/patches/html5lib.patch
@@ -1,0 +1,31 @@
+diff --git a/src/pip/_vendor/html5lib/_trie/_base.py b/src/pip/_vendor/html5lib/_trie/_base.py
+index a1158bbb..6b71975f 100644
+--- a/src/pip/_vendor/html5lib/_trie/_base.py
++++ b/src/pip/_vendor/html5lib/_trie/_base.py
+@@ -1,6 +1,9 @@
+ from __future__ import absolute_import, division, unicode_literals
+ 
+-from collections import Mapping
++try:
++    from collections.abc import Mapping
++except ImportError:  # Python 2.7
++    from collections import Mapping
+ 
+ 
+ class Trie(Mapping):
+diff --git a/src/pip/_vendor/html5lib/treebuilders/dom.py b/src/pip/_vendor/html5lib/treebuilders/dom.py
+index dcfac220..d8b53004 100644
+--- a/src/pip/_vendor/html5lib/treebuilders/dom.py
++++ b/src/pip/_vendor/html5lib/treebuilders/dom.py
+@@ -1,7 +1,10 @@
+ from __future__ import absolute_import, division, unicode_literals
+ 
+ 
+-from collections import MutableMapping
++try:
++    from collections.abc import MutableMapping
++except ImportError:  # Python 2.7
++    from collections import MutableMapping
+ from xml.dom import minidom, Node
+ import weakref
+ 


### PR DESCRIPTION
The patch is adapted from https://github.com/html5lib/html5lib-python/commit/4f9235752cea29c5a31721440578b430823a1e69

Closes https://github.com/pypa/pip/issues/6407
Closes https://github.com/pypa/pip/issues/6237

---

Note that directly running `invoke vendoring.update` fails with: (excerpted logs)
```
    Running setup.py install for flit: started
      Running setup.py install for flit: finished with status 'error'
      Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-mfhm_92g/flit/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-jsux_uqt/install-record.txt --single-version-externally-managed --prefix /tmp/pip-build-env-_123g61o/overlay --compile:
      Traceback (most recent call last):
        File "<string>", line 1, in <module>
      ModuleNotFoundError: No module named 'setuptools'
```
I need to apply https://github.com/pypa/pip/pull/6606 to make vendoring work.

Also, `invoke vendoring.update` changes line endings from LF to CR/LF in `src/pip/_vendor/pytoml/LICENSE`. That seems irrevelant to html5lib, so I didn't commit that file.