### PR TITLE
sys.version fixes for python 3.10

### DIFF
--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -23,6 +23,15 @@ if MYPY_CHECK_RUNNING:
 USER_CACHE_DIR = appdirs.user_cache_dir("pip")
 
 
+def get_major_minor_version():
+    # type: () -> str
+    """
+    Return the major-minor version of the current Python as a string, e.g.
+    "3.7" or "3.10".
+    """
+    return '{}.{}'.format(*sys.version_info)
+
+
 def get_src_prefix():
     if running_under_virtualenv():
         src_prefix = os.path.join(sys.prefix, 'src')
@@ -127,7 +136,7 @@ def distutils_scheme(dist_name, user=False, home=None, root=None,
             sys.prefix,
             'include',
             'site',
-            'python{}.{}'.format(*sys.version_info),
+            'python{}'.format(get_major_minor_version()),
             dist_name,
         )
 

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -127,7 +127,7 @@ def distutils_scheme(dist_name, user=False, home=None, root=None,
             sys.prefix,
             'include',
             'site',
-            'python' + sys.version[:3],
+            'python{}.{}'.format(*sys.version_info),
             dist_name,
         )
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -118,7 +118,7 @@ def get_pip_version():
 
     return (
         'pip {} from {} (python {})'.format(
-            __version__, pip_pkg_dir, sys.version[:3],
+            __version__, pip_pkg_dir, '{}.{}'.format(*sys.version_info),
         )
     )
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -30,7 +30,11 @@ from pip._vendor.six.moves.urllib.parse import unquote as urllib_unquote
 
 from pip import __version__
 from pip._internal.exceptions import CommandError, InstallationError
-from pip._internal.locations import site_packages, user_site
+from pip._internal.locations import (
+    get_major_minor_version,
+    site_packages,
+    user_site,
+)
 from pip._internal.utils.compat import (
     WINDOWS,
     console_to_str,
@@ -118,7 +122,7 @@ def get_pip_version():
 
     return (
         'pip {} from {} (python {})'.format(
-            __version__, pip_pkg_dir, '{}.{}'.format(*sys.version_info),
+            __version__, pip_pkg_dir, get_major_minor_version(),
         )
     )
 

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -557,10 +557,10 @@ if __name__ == '__main__':
             generated.extend(maker.make(spec))
 
         if os.environ.get("ENSUREPIP_OPTIONS", "") != "altinstall":
-            spec = 'pip%s = %s' % (sys.version[:1], pip_script)
+            spec = 'pip%s = %s' % (sys.version_info[0], pip_script)
             generated.extend(maker.make(spec))
 
-        spec = 'pip%s = %s' % (sys.version[:3], pip_script)
+        spec = 'pip%s = %s' % ('{}.{}'.format(*sys.version_info), pip_script)
         generated.extend(maker.make(spec))
         # Delete any other versioned pip entry points
         pip_ep = [k for k in console if re.match(r'pip(\d(\.\d)?)?$', k)]
@@ -572,7 +572,9 @@ if __name__ == '__main__':
             spec = 'easy_install = ' + easy_install_script
             generated.extend(maker.make(spec))
 
-        spec = 'easy_install-%s = %s' % (sys.version[:3], easy_install_script)
+        spec = 'easy_install-%s = %s' % (
+            '{}.{}'.format(*sys.version_info), easy_install_script,
+        )
         generated.extend(maker.make(spec))
         # Delete any other versioned easy_install entry points
         easy_install_ep = [

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -29,7 +29,7 @@ from pip._internal.exceptions import (
     InvalidWheelFilename,
     UnsupportedWheel,
 )
-from pip._internal.locations import distutils_scheme
+from pip._internal.locations import distutils_scheme, get_major_minor_version
 from pip._internal.models.link import Link
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.marker_files import PIP_DELETE_MARKER_FILENAME
@@ -560,7 +560,7 @@ if __name__ == '__main__':
             spec = 'pip%s = %s' % (sys.version_info[0], pip_script)
             generated.extend(maker.make(spec))
 
-        spec = 'pip%s = %s' % ('{}.{}'.format(*sys.version_info), pip_script)
+        spec = 'pip%s = %s' % (get_major_minor_version(), pip_script)
         generated.extend(maker.make(spec))
         # Delete any other versioned pip entry points
         pip_ep = [k for k in console if re.match(r'pip(\d(\.\d)?)?$', k)]
@@ -573,7 +573,7 @@ if __name__ == '__main__':
             generated.extend(maker.make(spec))
 
         spec = 'easy_install-%s = %s' % (
-            '{}.{}'.format(*sys.version_info), easy_install_script,
+            get_major_minor_version(), easy_install_script,
         )
         generated.extend(maker.make(spec))
         # Delete any other versioned easy_install entry points

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -15,6 +15,7 @@ from scripttest import FoundDir, TestFileEnvironment
 
 from pip._internal.download import PipSession
 from pip._internal.index import PackageFinder
+from pip._internal.locations import get_major_minor_version
 from pip._internal.models.search_scope import SearchScope
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
@@ -29,7 +30,7 @@ if MYPY_CHECK_RUNNING:
 DATA_DIR = Path(__file__).parent.parent.joinpath("data").abspath
 SRC_DIR = Path(__file__).abspath.parent.parent.parent
 
-pyversion = '{}.{}'.format(*sys.version_info)
+pyversion = get_major_minor_version()
 pyversion_tuple = sys.version_info
 
 CURRENT_PY_VERSION_INFO = sys.version_info[:3]

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -29,7 +29,7 @@ if MYPY_CHECK_RUNNING:
 DATA_DIR = Path(__file__).parent.parent.joinpath("data").abspath
 SRC_DIR = Path(__file__).abspath.parent.parent.parent
 
-pyversion = sys.version[:3]
+pyversion = '{}.{}'.format(*sys.version_info)
 pyversion_tuple = sys.version_info
 
 CURRENT_PY_VERSION_INFO = sys.version_info[:3]

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -36,9 +36,7 @@ class TestTargetPython:
         """
         Test passing py_version_info=None.
         """
-        # Get the index of the second dot.
-        index = sys.version.find('.', 2)
-        current_major_minor = sys.version[:index]  # e.g. "3.6"
+        current_major_minor = '{}.{}'.format(*sys.version_info)
 
         target_python = TargetPython(py_version_info=None)
 

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -1,10 +1,8 @@
-import sys
-
 import pytest
 from mock import patch
 
 from pip._internal.models.target_python import TargetPython
-from tests.lib import CURRENT_PY_VERSION_INFO
+from tests.lib import CURRENT_PY_VERSION_INFO, pyversion
 
 
 class TestTargetPython:
@@ -36,14 +34,12 @@ class TestTargetPython:
         """
         Test passing py_version_info=None.
         """
-        current_major_minor = '{}.{}'.format(*sys.version_info)
-
         target_python = TargetPython(py_version_info=None)
 
         assert target_python._given_py_version_info is None
 
         assert target_python.py_version_info == CURRENT_PY_VERSION_INFO
-        assert target_python.py_version == current_major_minor
+        assert target_python.py_version == pyversion
 
     @pytest.mark.parametrize('kwargs, expected', [
         ({}, ''),


### PR DESCRIPTION
mostly just wanted to fix the output of this:

```console
$ pip --version
pip 19.0.3 from /home/asottile/workspace/virtualenv/pyvenv10/lib/python3.10/site-packages/pip (python 3.1)
```

there appear to be quite a few references to `sys.version[...]` in the `_vendor` directory so this doesn't fix all the cases just yet