### PR TITLE
Add some encoding return values to pip debug

### DIFF
--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import locale
 import logging
 import sys
 
@@ -100,6 +101,11 @@ class DebugCommand(Command):
         show_value('pip version', get_pip_version())
         show_value('sys.version', sys.version)
         show_value('sys.executable', sys.executable)
+        show_value('sys.getdefaultencoding', sys.getdefaultencoding())
+        show_value('sys.getfilesystemencoding', sys.getfilesystemencoding())
+        show_value(
+            'locale.getpreferredencoding', locale.getpreferredencoding(),
+        )
         show_value('sys.platform', sys.platform)
         show_sys_implementation()
 

--- a/tests/functional/test_debug.py
+++ b/tests/functional/test_debug.py
@@ -3,6 +3,25 @@ import pytest
 from pip._internal import pep425tags
 
 
+@pytest.mark.parametrize('expected_text', [
+    'sys.executable: ',
+    'sys.getdefaultencoding: ',
+    'sys.getfilesystemencoding: ',
+    'locale.getpreferredencoding: ',
+    'sys.platform: ',
+    'sys.implementation:',
+])
+def test_debug(script, expected_text):
+    """
+    Check that certain strings are present in the output.
+    """
+    args = ['debug']
+    result = script.pip(*args, allow_stderr_warning=True)
+    stdout = result.stdout
+
+    assert expected_text in stdout
+
+
 @pytest.mark.parametrize(
     'args',
     [
@@ -10,17 +29,13 @@ from pip._internal import pep425tags
         ['--verbose'],
     ]
 )
-def test_debug(script, args):
+def test_debug__tags(script, args):
     """
-    Check simple option cases.
+    Check the compatible tag output.
     """
     args = ['debug'] + args
     result = script.pip(*args, allow_stderr_warning=True)
     stdout = result.stdout
-
-    assert 'sys.executable: ' in stdout
-    assert 'sys.platform: ' in stdout
-    assert 'sys.implementation:' in stdout
 
     tags = pep425tags.get_supported()
     expected_tag_header = 'Compatible tags: {}'.format(len(tags))


### PR DESCRIPTION
I think this diagnostic info could be useful for us to have in the next release. The return values of--

* `sys.getdefaultencoding()`
* `sys.getfilesystemencoding()`
* `locale.getpreferredencoding()`

Sample output of the new lines:

```
...
sys.executable: ...
sys.getdefaultencoding: utf-8
sys.getfilesystemencoding: utf-8
locale.getpreferredencoding: UTF-8
sys.platform: darwin
...
```