### PR TITLE
Redirect verbose output to stderr for `pip freeze`.

### DIFF
--- a/news/6024.bugfix
+++ b/news/6024.bugfix
@@ -1,0 +1,1 @@
+Log verbose output to ``stderr`` for ``pip freeze``.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -38,7 +38,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, List, Tuple, Any
+    from typing import Any, IO, List, Optional, Tuple
     from optparse import Values
     from pip._internal.cache import WheelCache
     from pip._internal.req.req_set import RequirementSet
@@ -52,6 +52,7 @@ class Command(object):
     name = None  # type: Optional[str]
     usage = None  # type: Optional[str]
     ignore_require_venv = False  # type: bool
+    debug_stream = sys.stdout  # type: IO[str]
 
     def __init__(self, isolated=False):
         # type: (bool) -> None
@@ -149,6 +150,7 @@ class Command(object):
         level_number = setup_logging(
             verbosity=self.verbosity,
             no_color=options.no_color,
+            debug_stream=self.debug_stream,
             user_log_file=options.log,
         )
 

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -22,7 +22,7 @@ class FreezeCommand(Command):
     usage = """
       %prog [options]"""
     summary = 'Output installed packages in requirements format.'
-    log_streams = ("ext://sys.stderr", "ext://sys.stderr")
+    debug_stream = sys.stderr
 
     def __init__(self, *args, **kw):
         super(FreezeCommand, self).__init__(*args, **kw)


### PR DESCRIPTION
By default log messages go to `stdout`. Prior to 18.0 `pip freeze` had a
workaround in place to use `stderr` in place of `stdout`, however
refactoring changed this behavior.

The original behavior is now reinstated, so `pip freeze` output is not
mangled by debug logging.

Fixes #6024.