### PR TITLE
Drop support for EOL Python 3.4 (2)

### DIFF
--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 HAS_TLS = (ssl is not None) or IS_PYOPENSSL
 
-if sys.version_info >= (3, 4):
+if sys.version_info >= (3,):
     uses_pycache = True
     from importlib.util import cache_from_source
 else:
@@ -62,7 +62,7 @@ else:
     uses_pycache = cache_from_source is not None
 
 
-if sys.version_info >= (3, 5):
+if sys.version_info >= (3,):
     backslashreplace_decode = "backslashreplace"
 else:
     # In version 3.4 and older, backslashreplace exists
@@ -202,7 +202,7 @@ def get_path_uid(path):
     return file_uid
 
 
-if sys.version_info >= (3, 4):
+if sys.version_info >= (3,):
     from importlib.machinery import EXTENSION_SUFFIXES
 
     def get_extension_suffixes():

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -63,7 +63,7 @@ else:
 
 
 if PY2:
-    # In version 3.4 and older, backslashreplace exists
+    # In Python 2.7, backslashreplace exists
     # but does not support use for decoding.
     # We implement our own replace handler for this
     # situation, so that we can consistently use

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -9,7 +9,7 @@ import os
 import shutil
 import sys
 
-from pip._vendor.six import PY2, PY3, text_type
+from pip._vendor.six import PY3, text_type
 from pip._vendor.urllib3.util import IS_PYOPENSSL
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -72,9 +72,8 @@ else:
     # backslash replacement for all versions.
     def backslashreplace_decode_fn(err):
         raw_bytes = (err.object[i] for i in range(err.start, err.end))
-        if PY2:
-            # Python 2 gave us characters - convert to numeric bytes
-            raw_bytes = (ord(b) for b in raw_bytes)
+        # Python 2 gave us characters - convert to numeric bytes
+        raw_bytes = (ord(b) for b in raw_bytes)
         return u"".join(u"\\x%x" % c for c in raw_bytes), err.end
     codecs.register_error(
         "backslashreplace_decode",

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -9,7 +9,7 @@ import os
 import shutil
 import sys
 
-from pip._vendor.six import text_type
+from pip._vendor.six import PY2, PY3, text_type
 from pip._vendor.urllib3.util import IS_PYOPENSSL
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 HAS_TLS = (ssl is not None) or IS_PYOPENSSL
 
-if sys.version_info >= (3,):
+if PY3:
     uses_pycache = True
     from importlib.util import cache_from_source
 else:
@@ -62,7 +62,7 @@ else:
     uses_pycache = cache_from_source is not None
 
 
-if sys.version_info >= (3,):
+if PY3:
     backslashreplace_decode = "backslashreplace"
 else:
     # In version 3.4 and older, backslashreplace exists
@@ -72,7 +72,7 @@ else:
     # backslash replacement for all versions.
     def backslashreplace_decode_fn(err):
         raw_bytes = (err.object[i] for i in range(err.start, err.end))
-        if sys.version_info[0] == 2:
+        if PY2:
             # Python 2 gave us characters - convert to numeric bytes
             raw_bytes = (ord(b) for b in raw_bytes)
         return u"".join(u"\\x%x" % c for c in raw_bytes), err.end
@@ -156,7 +156,7 @@ def console_to_str(data):
     return str_to_display(data, desc='Subprocess output')
 
 
-if sys.version_info >= (3,):
+if PY3:
     def native_str(s, replace=False):
         # type: (str, bool) -> str
         if isinstance(s, bytes):
@@ -202,7 +202,7 @@ def get_path_uid(path):
     return file_uid
 
 
-if sys.version_info >= (3,):
+if PY3:
     from importlib.machinery import EXTENSION_SUFFIXES
 
     def get_extension_suffixes():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,4 +352,4 @@ def in_memory_pip():
 @pytest.fixture
 def deprecated_python():
     """Used to indicate whether pip deprecated this python version"""
-    return sys.version_info[:2] in [(3, 4), (2, 7)]
+    return sys.version_info[:2] in [(2, 7)]

--- a/tests/data/packages/LocalEnvironMarker/setup.py
+++ b/tests/data/packages/LocalEnvironMarker/setup.py
@@ -22,6 +22,6 @@ setup(
     version='0.0.1',
     packages=find_packages(),
     extras_require={
-        ":python_version == '2.7' or python_version == '3.4'": ['simple'],
+        ":python_version == '2.7'": ['simple'],
     }
 )

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -20,8 +20,8 @@ from tests.lib import (
 from tests.lib.local_repos import local_checkout
 from tests.lib.path import Path
 
-python2_only = pytest.mark.skipif(not PY2, reason="Python 2 only")
-non_python2_only = pytest.mark.skipif(PY2, reason="Non-Python 2 only")
+skip_if_python2 = pytest.mark.skipif(PY2, reason="Non-Python 2 only")
+skip_if_not_python2 = pytest.mark.skipif(not PY2, reason="Python 2 only")
 
 
 @pytest.mark.parametrize('command', ('install', 'wheel'))
@@ -532,7 +532,7 @@ def test_editable_install__local_dir_no_setup_py_with_pyproject(
     assert 'A "pyproject.toml" file was found' in msg
 
 
-@python2_only
+@skip_if_not_python2
 @pytest.mark.xfail
 def test_install_argparse_shadowed(script):
     # When argparse is in the stdlib, we support installing it
@@ -547,7 +547,7 @@ def test_install_argparse_shadowed(script):
 
 
 @pytest.mark.network
-@non_python2_only
+@skip_if_python2
 def test_upgrade_argparse_shadowed(script):
     # If argparse is installed - even if shadowed for imported - we support
     # upgrading it and properly remove the older versions files.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -5,9 +5,8 @@ import sys
 import textwrap
 from os.path import curdir, join, pardir
 
-# Ignore because flake8 can't detect the use inside skipif().
-import pip._vendor.six  # noqa: F401
 import pytest
+from pip._vendor.six import PY2
 
 from pip._internal import pep425tags
 from pip._internal.cli.status_codes import ERROR, SUCCESS
@@ -20,6 +19,8 @@ from tests.lib import (
 )
 from tests.lib.local_repos import local_checkout
 from tests.lib.path import Path
+
+python2_only = pytest.mark.skipif(not PY2, reason="Python 2 only")
 
 
 @pytest.mark.parametrize('command', ('install', 'wheel'))
@@ -530,7 +531,7 @@ def test_editable_install__local_dir_no_setup_py_with_pyproject(
     assert 'A "pyproject.toml" file was found' in msg
 
 
-@pytest.mark.skipif("pip._vendor.six.PY3")
+@python2_only
 @pytest.mark.xfail
 def test_install_argparse_shadowed(script):
     # When argparse is in the stdlib, we support installing it

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -5,6 +5,7 @@ import sys
 import textwrap
 from os.path import curdir, join, pardir
 
+# Ignore because flake8 can't detect the use inside skipif().
 import pip._vendor.six  # noqa: F401
 import pytest
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -21,6 +21,7 @@ from tests.lib.local_repos import local_checkout
 from tests.lib.path import Path
 
 python2_only = pytest.mark.skipif(not PY2, reason="Python 2 only")
+non_python2_only = pytest.mark.skipif(PY2, reason="Non-Python 2 only")
 
 
 @pytest.mark.parametrize('command', ('install', 'wheel'))
@@ -546,7 +547,7 @@ def test_install_argparse_shadowed(script):
 
 
 @pytest.mark.network
-@pytest.mark.skipif("pip._vendor.six.PY2")
+@non_python2_only
 def test_upgrade_argparse_shadowed(script):
     # If argparse is installed - even if shadowed for imported - we support
     # upgrading it and properly remove the older versions files.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -528,7 +528,7 @@ def test_editable_install__local_dir_no_setup_py_with_pyproject(
     assert 'A "pyproject.toml" file was found' in msg
 
 
-@pytest.mark.skipif("sys.version_info >= (3,4)")
+@pytest.mark.skipif("sys.version_info >= (3,)")
 @pytest.mark.xfail
 def test_install_argparse_shadowed(script):
     # When argparse is in the stdlib, we support installing it
@@ -543,7 +543,7 @@ def test_install_argparse_shadowed(script):
 
 
 @pytest.mark.network
-@pytest.mark.skipif("sys.version_info < (3,4)")
+@pytest.mark.skipif("sys.version_info < (3,)")
 def test_upgrade_argparse_shadowed(script):
     # If argparse is installed - even if shadowed for imported - we support
     # upgrading it and properly remove the older versions files.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -5,6 +5,7 @@ import sys
 import textwrap
 from os.path import curdir, join, pardir
 
+import pip._vendor.six  # noqa: F401
 import pytest
 
 from pip._internal import pep425tags
@@ -528,7 +529,7 @@ def test_editable_install__local_dir_no_setup_py_with_pyproject(
     assert 'A "pyproject.toml" file was found' in msg
 
 
-@pytest.mark.skipif("sys.version_info >= (3,)")
+@pytest.mark.skipif("pip._vendor.six.PY3")
 @pytest.mark.xfail
 def test_install_argparse_shadowed(script):
     # When argparse is in the stdlib, we support installing it
@@ -543,7 +544,7 @@ def test_install_argparse_shadowed(script):
 
 
 @pytest.mark.network
-@pytest.mark.skipif("sys.version_info < (3,)")
+@pytest.mark.skipif("pip._vendor.six.PY2")
 def test_upgrade_argparse_shadowed(script):
     # If argparse is installed - even if shadowed for imported - we support
     # upgrading it and properly remove the older versions files.

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -83,7 +83,7 @@ class TestRequirementSet(object):
             reqset,
         )
 
-    # TODO: Update test when Python 2.7 or Python 3.4 is dropped.
+    # TODO: Update test when Python 2.7 is dropped.
     def test_environment_marker_extras(self, data):
         """
         Test that the environment marker extras are used with
@@ -99,7 +99,7 @@ class TestRequirementSet(object):
         resolver = self._basic_resolver(finder)
         resolver.resolve(reqset)
         # This is hacky but does test both case in py2 and py3
-        if sys.version_info[:2] in ((2, 7), (3, 4)):
+        if sys.version_info[:2] == (2, 7):
             assert reqset.has_requirement('simple')
         else:
             assert not reqset.has_requirement('simple')


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Continuation of PR https://github.com/pypa/pip/pull/6685.

As suggested in review, that PR was just for removing Python 3.4 from classifiers, CI, its deprecation warnings, and so on.

And here's a new PR for the other 3.4-related removals. 
