### PR TITLE
Simplify PackageFinder best candidate API some more

### DIFF
--- a/docs/html/development/architecture/index.rst
+++ b/docs/html/development/architecture/index.rst
@@ -15,6 +15,7 @@ Architecture of pip's internals
 .. toctree::
     :maxdepth: 2
 
+    package-finding
 
 
 .. _`tracking issue`: https://github.com/pypa/pip/issues/6831

--- a/docs/html/development/architecture/package-finding.rst
+++ b/docs/html/development/architecture/package-finding.rst
@@ -1,0 +1,202 @@
+Finding and choosing files (``index.py`` and ``PackageFinder``)
+---------------------------------------------------------------
+
+The ``index.py`` module is a top-level module in pip responsible for deciding
+what file to download and from where, given a requirement for a project. The
+module's functionality is largely exposed through and coordinated by the
+module's ``PackageFinder`` class.
+
+
+.. _index-py-overview:
+
+Overview
+********
+
+Here is a rough description of the process that pip uses to choose what
+file to download for a package, given a requirement:
+
+1. Access the various network and file system locations configured for pip
+   that contain package files. These locations can include, for example,
+   pip's :ref:`--index-url <--index-url>` (with default
+   https://pypi.org/simple/ ) and any configured
+   :ref:`--extra-index-url <--extra-index-url>` locations.
+   Each of these locations is a `PEP 503`_ "simple repository" page, which
+   is an HTML page of anchor links.
+2. Collect together all of the links (e.g. by parsing the anchor links
+   from the HTML pages) and create ``Link`` objects from each of these.
+3. Determine which of the links are minimally relevant, using the
+   :ref:`LinkEvaluator <link-evaluator-class>` class.  Create an
+   ``InstallationCandidate`` object (aka candidate for install) for each
+   of these relevant links.
+4. Further filter the collection of ``InstallationCandidate`` objects (using
+   the :ref:`CandidateEvaluator <candidate-evaluator-class>` class) to a
+   collection of "applicable" candidates.
+5. If there are applicable candidates, choose the best candidate by sorting
+   them (again using the :ref:`CandidateEvaluator
+   <candidate-evaluator-class>` class).
+
+The remainder of this section is organized by documenting some of the
+classes inside ``index.py``, in the following order:
+
+* the main :ref:`PackageFinder <package-finder-class>` class,
+* the :ref:`LinkEvaluator <link-evaluator-class>` class,
+* the :ref:`CandidateEvaluator <candidate-evaluator-class>` class,
+* the :ref:`CandidatePreferences <candidate-preferences-class>` class, and
+* the :ref:`BestCandidateResult <best-candidate-result-class>` class.
+
+
+.. _package-finder-class:
+
+The ``PackageFinder`` class
+***************************
+
+The ``PackageFinder`` class is the primary way through which code in pip
+interacts with ``index.py``. It is an umbrella class that encapsulates and
+groups together various package-finding functionality.
+
+The ``PackageFinder`` class is responsible for searching the network and file
+system for what versions of a package pip can install, and also for deciding
+which version is most preferred, given the user's preferences, target Python
+environment, etc.
+
+The pip commands that use the ``PackageFinder`` class are:
+
+* :ref:`pip download`
+* :ref:`pip install`
+* :ref:`pip list`
+* :ref:`pip wheel`
+
+The pip commands requiring use of the ``PackageFinder`` class generally
+instantiate ``PackageFinder`` only once for the whole pip invocation. In
+fact, pip creates this ``PackageFinder`` instance when command options
+are first parsed.
+
+With the excepton of :ref:`pip list`, each of the above commands is
+implemented as a ``Command`` class inheriting from ``RequirementCommand``
+(for example :ref:`pip download` is implemented by ``DownloadCommand``), and
+the ``PackageFinder`` instance is created by calling the
+``RequirementCommand`` class's ``_build_package_finder()`` method. ``pip
+list``, on the other hand, constructs its ``PackageFinder`` instance by
+calling the ``ListCommand`` class's ``_build_package_finder()``. (This
+difference may simply be historical and may not actually be necessary.)
+
+Each of these commands also uses the ``PackageFinder`` class for pip's
+"self-check," (i.e. to check whether a pip upgrade is available). In this
+case, the ``PackageFinder`` instance is created by the ``outdated.py``
+module's ``pip_version_check()`` function.
+
+The ``PackageFinder`` class is responsible for doing all of the things listed
+in the :ref:`Overview <index-py-overview>` section like fetching and parsing
+`PEP 503`_ simple repository HTML pages, evaluating which links in the simple
+repository pages are relevant for each requirement, and further filtering and
+sorting by preference the candidates for install coming from the relevant
+links.
+
+One of ``PackageFinder``'s main top-level methods is
+``find_best_candidate()``. This method does the following two things:
+
+1. Calls its ``find_all_candidates()`` method, which reads and parses all the
+   index URL's provided by the user, constructs a :ref:`LinkEvaluator
+   <link-evaluator-class>` object to filter out some of those links, and then
+   returns a list of ``InstallationCandidates`` (aka candidates for install).
+   This corresponds to steps 1-3 of the :ref:`Overview <index-py-overview>`
+   above.
+2. Constructs a ``CandidateEvaluator`` object and uses that to determine
+   the best candidate. It does this by calling the ``CandidateEvaluator``
+   class's ``compute_best_candidate()`` method on the return value of
+   ``find_all_candidates()``. This corresponds to steps 4-5 of the Overview.
+
+
+.. _link-evaluator-class:
+
+The ``LinkEvaluator`` class
+***************************
+
+The ``LinkEvaluator`` class contains the business logic for determining
+whether a link (e.g. in a simple repository page) satisfies minimal
+conditions to be a candidate for install (resulting in an
+``InstallationCandidate`` object). When making this determination, the
+``LinkEvaluator`` instance uses information like the target Python
+interpreter as well as user preferences like whether binary files are
+allowed or preferred, etc.
+
+Specifically, the ``LinkEvaluator`` class has an ``evaluate_link()`` method
+that returns whether a link is a candidate for install.
+
+Instances of this class are created by the ``PackageFinder`` class's
+``make_link_evaluator()`` on a per-requirement basis.
+
+
+.. _candidate-evaluator-class:
+
+The ``CandidateEvaluator`` class
+********************************
+
+The ``CandidateEvaluator`` class contains the business logic for evaluating
+which ``InstallationCandidate`` objects should be preferred. This can be
+viewed as a determination that is finer-grained than that performed by the
+``LinkEvaluator`` class.
+
+In particular, the ``CandidateEvaluator`` class uses the whole set of
+``InstallationCandidate`` objects when making its determinations, as opposed
+to evaluating each candidate in isolation, as ``LinkEvaluator`` does. For
+example, whether a pre-release is eligible for selection or whether a file
+whose hash doesn't match is eligible depends on properties of the collection
+as a whole.
+
+The ``CandidateEvaluator`` class uses information like the list of `PEP 425`_
+tags compatible with the target Python interpreter, hashes provided by the
+user, and other user preferences, etc.
+
+Specifically, the class has a ``get_applicable_candidates()`` method.
+This accepts the ``InstallationCandidate`` objects resulting from the links
+accepted by the ``LinkEvaluator`` class's ``evaluate_link()`` method, and
+it further filters them to a list of "applicable" candidates.
+
+The ``CandidateEvaluator`` class also has a ``sort_best_candidate()`` method
+that orders the applicable candidates by preference, and then returns the
+best (i.e. most preferred).
+
+Finally, the class has a ``compute_best_candidate()`` method that calls
+``get_applicable_candidates()`` followed by ``sort_best_candidate()``, and
+then returning a :ref:`BestCandidateResult <best-candidate-result-class>`
+object encapsulating both the intermediate and final results of the decision.
+
+Instances of ``CandidateEvaluator`` are created by the ``PackageFinder``
+class's ``make_candidate_evaluator()`` method on a per-requirement basis.
+
+
+.. _candidate-preferences-class:
+
+The ``CandidatePreferences`` class
+**********************************
+
+The ``CandidatePreferences`` class is a simple container class that groups
+together some of the user preferences that ``PackageFinder`` uses to
+construct ``CandidateEvaluator`` objects (via the ``PackageFinder`` class's
+``make_candidate_evaluator()`` method).
+
+A ``PackageFinder`` instance has a ``_candidate_prefs`` attribute whose value
+is a ``CandidatePreferences`` instance. Since ``PackageFinder`` has a number
+of responsibilities and options that control its behavior, grouping the
+preferences specific to ``CandidateEvaluator`` helps maintainers know which
+attributes are needed only for ``CandidateEvaluator``.
+
+
+.. _best-candidate-result-class:
+
+The ``BestCandidateResult`` class
+*********************************
+
+The ``BestCandidateResult`` class is a convenience "container" class that
+encapsulates the result of finding the best candidate for a requirement.
+(By "container" we mean an object that simply contains data and has no
+business logic or state-changing methods of its own.)
+
+The class is the return type of both the ``CandidateEvaluator`` class's
+``compute_best_candidate()`` method and the ``PackageFinder`` class's
+``find_best_candidate()`` method.
+
+
+.. _`PEP 425`: https://www.python.org/dev/peps/pep-0425/
+.. _`PEP 503`: https://www.python.org/dev/peps/pep-0503/

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -192,7 +192,7 @@ class ListCommand(IndexGroupCommand):
                 evaluator = finder.make_candidate_evaluator(
                     project_name=dist.project_name,
                 )
-                best_candidate = evaluator.get_best_candidate(all_candidates)
+                best_candidate = evaluator.sort_best_candidate(all_candidates)
                 if best_candidate is None:
                     continue
 

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -565,6 +565,13 @@ class BestCandidateResult(object):
         :param best_candidate: The most preferred candidate found, or None
             if no applicable candidates were found.
         """
+        assert set(applicable_candidates) <= set(candidates)
+
+        if best_candidate is None:
+            assert not applicable_candidates
+        else:
+            assert best_candidate in applicable_candidates
+
         self._applicable_candidates = applicable_candidates
         self._candidates = candidates
 

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -646,24 +646,6 @@ class CandidateEvaluator(object):
             project_name=self._project_name,
         )
 
-    def compute_best_candidate(
-        self,
-        candidates,      # type: List[InstallationCandidate]
-    ):
-        # type: (...) -> BestCandidateResult
-        """
-        Compute and return a `BestCandidateResult` instance.
-        """
-        applicable_candidates = self.get_applicable_candidates(candidates)
-
-        best_candidate = self.sort_best_candidate(applicable_candidates)
-
-        return BestCandidateResult(
-            candidates,
-            applicable_candidates=applicable_candidates,
-            best_candidate=best_candidate,
-        )
-
     def _sort_key(self, candidate):
         # type: (InstallationCandidate) -> CandidateSortingKey
         """
@@ -753,6 +735,24 @@ class CandidateEvaluator(object):
             logger.warning(msg)
 
         return best_candidate
+
+    def compute_best_candidate(
+        self,
+        candidates,      # type: List[InstallationCandidate]
+    ):
+        # type: (...) -> BestCandidateResult
+        """
+        Compute and return a `BestCandidateResult` instance.
+        """
+        applicable_candidates = self.get_applicable_candidates(candidates)
+
+        best_candidate = self.sort_best_candidate(applicable_candidates)
+
+        return BestCandidateResult(
+            candidates,
+            applicable_candidates=applicable_candidates,
+            best_candidate=best_candidate,
+        )
 
 
 class BestCandidateResult(object):

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -545,6 +545,44 @@ class CandidatePreferences(object):
         self.prefer_binary = prefer_binary
 
 
+class BestCandidateResult(object):
+    """A collection of candidates, returned by `PackageFinder.find_best_candidate`.
+
+    This class is only intended to be instantiated by CandidateEvaluator's
+    `compute_best_candidate()` method.
+    """
+
+    def __init__(
+        self,
+        candidates,             # type: List[InstallationCandidate]
+        applicable_candidates,  # type: List[InstallationCandidate]
+        best_candidate,         # type: Optional[InstallationCandidate]
+    ):
+        # type: (...) -> None
+        """
+        :param candidates: A sequence of all available candidates found.
+        :param applicable_candidates: The applicable candidates.
+        :param best_candidate: The most preferred candidate found, or None
+            if no applicable candidates were found.
+        """
+        self._applicable_candidates = applicable_candidates
+        self._candidates = candidates
+
+        self.best_candidate = best_candidate
+
+    def iter_all(self):
+        # type: () -> Iterable[InstallationCandidate]
+        """Iterate through all candidates.
+        """
+        return iter(self._candidates)
+
+    def iter_applicable(self):
+        # type: () -> Iterable[InstallationCandidate]
+        """Iterate through the applicable candidates.
+        """
+        return iter(self._applicable_candidates)
+
+
 class CandidateEvaluator(object):
 
     """
@@ -753,44 +791,6 @@ class CandidateEvaluator(object):
             applicable_candidates=applicable_candidates,
             best_candidate=best_candidate,
         )
-
-
-class BestCandidateResult(object):
-    """A collection of candidates, returned by `PackageFinder.find_best_candidate`.
-
-    This class is only intended to be instantiated by CandidateEvaluator's
-    `compute_best_candidate()` method.
-    """
-
-    def __init__(
-        self,
-        candidates,             # type: List[InstallationCandidate]
-        applicable_candidates,  # type: List[InstallationCandidate]
-        best_candidate,         # type: Optional[InstallationCandidate]
-    ):
-        # type: (...) -> None
-        """
-        :param candidates: A sequence of all available candidates found.
-        :param applicable_candidates: The applicable candidates.
-        :param best_candidate: The most preferred candidate found, or None
-            if no applicable candidates were found.
-        """
-        self._applicable_candidates = applicable_candidates
-        self._candidates = candidates
-
-        self.best_candidate = best_candidate
-
-    def iter_all(self):
-        # type: () -> Iterable[InstallationCandidate]
-        """Iterate through all candidates.
-        """
-        return iter(self._candidates)
-
-    def iter_applicable(self):
-        # type: () -> Iterable[InstallationCandidate]
-        """Iterate through the applicable candidates.
-        """
-        return iter(self._applicable_candidates)
 
 
 class PackageFinder(object):

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -139,7 +139,7 @@ def pip_version_check(session, options):
                 trusted_hosts=options.trusted_hosts,
                 session=session,
             )
-            best_candidate = finder.find_best_candidate("pip").get_best()
+            best_candidate = finder.find_best_candidate("pip").best_candidate
             if best_candidate is None:
                 return
             pypi_version = str(best_candidate.version)

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -139,10 +139,10 @@ def pip_version_check(session, options):
                 trusted_hosts=options.trusted_hosts,
                 session=session,
             )
-            candidate = finder.find_candidates("pip").get_best()
-            if candidate is None:
+            best_candidate = finder.find_best_candidate("pip").get_best()
+            if best_candidate is None:
                 return
-            pypi_version = str(candidate.version)
+            pypi_version = str(best_candidate.version)
 
             # save that we've performed a check
             state.save(pypi_version, current_time)

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -400,13 +400,14 @@ class TestCandidateEvaluator:
         result = evaluator.compute_best_candidate(candidates)
 
         assert result._candidates == candidates
-        assert result._evaluator is evaluator
         expected_applicable = candidates[:2]
         assert [str(c.version) for c in expected_applicable] == [
             '1.10',
             '1.11',
         ]
         assert result._applicable_candidates == expected_applicable
+
+        assert result.best_candidate is expected_applicable[1]
 
     @pytest.mark.parametrize('hex_digest, expected', [
         # Test a link with no hash.

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -409,6 +409,25 @@ class TestCandidateEvaluator:
 
         assert result.best_candidate is expected_applicable[1]
 
+    def test_compute_best_candidate__none_best(self):
+        """
+        Test returning a None best candidate.
+        """
+        specifier = SpecifierSet('<= 1.10')
+        versions = ['1.11', '1.12']
+        candidates = [
+            make_mock_candidate(version) for version in versions
+        ]
+        evaluator = CandidateEvaluator.create(
+            'my-project',
+            specifier=specifier,
+        )
+        result = evaluator.compute_best_candidate(candidates)
+
+        assert result._candidates == candidates
+        assert result._applicable_candidates == []
+        assert result.best_candidate is None
+
     @pytest.mark.parametrize('hex_digest, expected', [
         # Test a link with no hash.
         (None, 0),

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -12,7 +12,7 @@ from pip._internal.index import InstallationCandidate
 from pip._internal.utils import outdated
 
 
-class MockFoundCandidates(object):
+class MockBestCandidateResult(object):
     def __init__(self, best):
         self._best = best
 
@@ -37,8 +37,8 @@ class MockPackageFinder(object):
     def create(cls, *args, **kwargs):
         return cls()
 
-    def find_candidates(self, project_name):
-        return MockFoundCandidates(self.INSTALLATION_CANDIDATES[0])
+    def find_best_candidate(self, project_name):
+        return MockBestCandidateResult(self.INSTALLATION_CANDIDATES[0])
 
 
 class MockDistribution(object):

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -14,10 +14,7 @@ from pip._internal.utils import outdated
 
 class MockBestCandidateResult(object):
     def __init__(self, best):
-        self._best = best
-
-    def get_best(self):
-        return self._best
+        self.best_candidate = best
 
 
 class MockPackageFinder(object):


### PR DESCRIPTION
This PR makes a few minor changes to `PackageFinder`'s "best candidate" API to simplify things and improve the readability / make it easier to understand. Specifically, the PR does the following--

* Rename `PackageFinder.find_candidates()` to `PackageFinder.find_best_candidate()` because that is what the method is used for. There is also already a `PackageFinder.find_all_candidates()` method, so the rename makes things less confusing since there are now no longer two methods `find_all_candidates()` and `find_candidates()` with similar-sounding names.

* Change the type of the return value of `PackageFinder.find_best_candidate()` from `FoundCandidates` to `BestCandidateResult` (by renaming `FoundCandidates` to `BestCandidateResult`), since the purpose of this class is to expose the best candidate.

* Compute the `best_candidate` and pass it to the `BestCandidateResult` constructor instead of computing the best candidate lazily. The best candidate is now exposed as a `best_candidate` attribute of the `BestCandidateResult` object instead of via `FoundCandidates.get_best()`. This is better for a couple reasons: (1) the applicable candidates and best candidate are now both handled the same way (namely by passing them in when instantiating instead of computing lazily), and (2) we no longer need to pass the whole `CandidateEvaluator` object into the `FoundCandidates` object, eliminating a bit of circularity that was of concern before. This completes the process of converting `FoundCandidates` to a simple data container class, so that it doesn't actually compute anything on its own.

* Rename the current `CandidateEvaluator.get_best_candidate()` to `CandidateEvaluator.sort_best_candidate()` because this is the method that gets the best candidate by sorting, and add a new `CandidateEvaluator.compute_best_candidate()` method responsible for filtering applicable candidates, calling `sort_best_candidate()`, and constructing the `BestCandidateResult` object.

* Adds to the `BestCandidateResult` constructor the assertion that @xavfernandez requested here: https://github.com/pypa/pip/pull/6684#discussion_r301100506
