### PR TITLE
Fix 3.8-dev: Consistent version wrangling

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1306,7 +1306,7 @@ def test_double_install_fail(script):
 def _get_expected_error_text():
     return (
         "Package 'pkga' requires a different Python: {} not in '<1.0'"
-    ).format(sys.version.split()[0])
+    ).format('.'.join(map(str, sys.version_info[:3])))
 
 
 def test_install_incompatible_python_requires(script):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->


Some tests fail on Python 3.8 because of a version mismatch, `3.8.0b2+` v. `3.8.0`:

```
E       AssertionError: Script result: python -m pip install /tmp/pytest-of-travis/pytest-0/popen-gw0/test_install_incompatible_pyth0/workspace/scratch/pkga
E           return code: 1
E         -- stderr: --------------------
E         ERROR: Package 'pkga' requires a different Python: 3.8.0 not in '<1.0'
E         
E         -- stdout: --------------------
E         Processing ./pkga
E         
E       assert "Package 'pkga' requires a different Python: 3.8.0b2+ not in '<1.0'" in "ERROR: Package 'pkga' requires a different Python: 3.8.0 not in '<1.0'\n"
E        +  where "Package 'pkga' requires a different Python: 3.8.0b2+ not in '<1.0'" = _get_expected_error_text()
E        +  and   "ERROR: Package 'pkga' requires a different Python: 3.8.0 not in '<1.0'\n" = <tests.lib.TestPipResult object at 0x7fa26e02d790>.stderr
```

* This is because the expected version comes from `sys.version.split()[0]` (`3.8.0b2+`)

* And the actual version comes from `'.'.join(map(str, version_info))` (`3.8.0`),
where `version_info = sys.version_info[:3]` (`(3, 8, 0)`)

Instead, calculate the expected version in the same way as the actual.

The `3.8-dev` build is allowed to fail, but it's better it's green 🍏