### PR TITLE
Document that `--ignore-installed` is dangerous

### DIFF
--- a/news/6794.doc
+++ b/news/6794.doc
@@ -1,0 +1,1 @@
+Document that ``--ignore-installed`` is dangerous.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -191,7 +191,7 @@ class InstallCommand(RequirementCommand):
                  'This can break your system if the existing package '
                  'is of a different version or was installed '
                  'with a different package manager!'
-            )
+        )
 
         cmd_opts.add_option(cmdoptions.ignore_requires_python())
         cmd_opts.add_option(cmdoptions.no_build_isolation())

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -187,7 +187,11 @@ class InstallCommand(RequirementCommand):
             '-I', '--ignore-installed',
             dest='ignore_installed',
             action='store_true',
-            help='Ignore the installed packages (reinstalling instead).')
+            help='Ignore the installed packages, overwriting them. '
+                 'This can break your system if the existing package '
+                 'is of a different version or was installed '
+                 'with a different package manager!'
+            )
 
         cmd_opts.add_option(cmdoptions.ignore_requires_python())
         cmd_opts.add_option(cmdoptions.no_build_isolation())


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Subj, justification in https://stackoverflow.com/questions/53807511/pip-cannot-uninstall-package-it-is-a-distutils-installed-project/53807588#53807588