### PR TITLE
WIP: Fix - Cannot access private repository using token

### DIFF
--- a/news/6795.bugfix
+++ b/news/6795.bugfix
@@ -1,0 +1,1 @@
+Allow access to an index using a URL embedded token

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -295,7 +295,7 @@ class MultiDomainBasicAuth(AuthBase):
                 logger.debug("Found credentials in keyring for %s", netloc)
                 return kr_auth
 
-        return None, None
+        return username, password
 
     def _get_url_and_credentials(self, original_url):
         """Return the credentials to use for the provided URL.
@@ -314,11 +314,11 @@ class MultiDomainBasicAuth(AuthBase):
 
         # If nothing cached, acquire new credentials without prompting
         # the user (e.g. from netrc, keyring, or similar).
-        if username is None or password is None:
+        if username is None and password is None:
             username, password = self._get_new_credentials(original_url)
 
-        if username is not None and password is not None:
-            # Store the username and password
+        if username is not None or password is not None:
+            # Store any acquired credentials
             self.passwords[netloc] = (username, password)
 
         return url, username, password
@@ -330,7 +330,7 @@ class MultiDomainBasicAuth(AuthBase):
         # Set the url of the request to the url without any credentials
         req.url = url
 
-        if username is not None and password is not None:
+        if username is not None or password is not None:
             # Send the basic auth with this request
             req = HTTPBasicAuth(username, password)(req)
 

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -332,7 +332,7 @@ class MultiDomainBasicAuth(AuthBase):
 
         if username is not None or password is not None:
             # Send the basic auth with this request
-            req = HTTPBasicAuth(username or "", password or "")(req) # Avoid passing Nonetype
+            req = HTTPBasicAuth(username or "", password or "")(req)
 
         # Attach a hook to handle 401 responses
         req.register_hook("response", self.handle_401)

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -332,7 +332,7 @@ class MultiDomainBasicAuth(AuthBase):
 
         if username is not None or password is not None:
             # Send the basic auth with this request
-            req = HTTPBasicAuth(username, password)(req)
+            req = HTTPBasicAuth(username or "", password or "")(req) # Avoid passing Nonetype
 
         # Attach a hook to handle 401 responses
         req.register_hook("response", self.handle_401)


### PR DESCRIPTION
This PR addresses a potential bug from 19.2 as discussed [here](https://github.com/pypa/pip/issues/6775#issuecomment-514278956). 

Embedding a token in an `index_url` is not working. 

For example:

`pip install SomeProject --index-url="https://TOKEN@some.where/somerepo/"`

throws an exception: `pip._internal.exceptions.DistributionNotFound` 
 
  _Any guidance/feedback would be appreciated!_
