### PR TITLE
Check path permissions earlier during install

### DIFF
--- a/news/6762.bugfix
+++ b/news/6762.bugfix
@@ -1,0 +1,1 @@
+Fail without collecting and downloading packages if user doesn't have write permissions.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -240,28 +240,28 @@ class InstallCommand(RequirementCommand):
         self.parser.insert_option_group(0, cmd_opts)
 
     def run(self, options, args):
-        if options.target_dir != None and not check_path_owner(options.target_dir):
+        if options.target_dir not None and not check_path_owner(options.target_dir):
             logger.error(
                 "The user that ran pip install doesn't have write access "
                 "to target directory '%s'",
                 options.target_dir,
             )
             return ERROR
-        if options.prefix_path != None and not check_path_owner(options.prefix_path):
+        if options.prefix_path not None and not check_path_owner(options.prefix_path):
             logger.error(
                 "The user that ran pip install doesn't have write access "
                 "to target prefix directory '%s'",
                 options.prefix_path,
             )
             return ERROR
-        if options.root_path != None and not check_path_owner(options.root_path):
+        if options.root_path not None and not check_path_owner(options.root_path):
             logger.error(
                 "The user that ran pip install doesn't have write access "
                 "to target root directory '%s'",
                 options.root_path,
             )
             return ERROR
-            
+
         cmdoptions.check_install_build_global(options)
         upgrade_strategy = "to-satisfy-only"
         if options.upgrade:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -240,6 +240,28 @@ class InstallCommand(RequirementCommand):
         self.parser.insert_option_group(0, cmd_opts)
 
     def run(self, options, args):
+        if options.target_dir != None and not check_path_owner(options.target_dir):
+            logger.error(
+                "The user that ran pip install doesn't have write access "
+                "to target directory '%s'",
+                options.target_dir,
+            )
+            return ERROR
+        if options.prefix_path != None and not check_path_owner(options.prefix_path):
+            logger.error(
+                "The user that ran pip install doesn't have write access "
+                "to target prefix directory '%s'",
+                options.prefix_path,
+            )
+            return ERROR
+        if options.root_path != None and not check_path_owner(options.root_path):
+            logger.error(
+                "The user that ran pip install doesn't have write access "
+                "to target root directory '%s'",
+                options.root_path,
+            )
+            return ERROR
+            
         cmdoptions.check_install_build_global(options)
         upgrade_strategy = "to-satisfy-only"
         if options.upgrade:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -240,21 +240,24 @@ class InstallCommand(RequirementCommand):
         self.parser.insert_option_group(0, cmd_opts)
 
     def run(self, options, args):
-        if options.target_dir not None and not check_path_owner(options.target_dir):
+        if (options.target_dir is not None and not
+                check_path_owner(options.target_dir)):
             logger.error(
                 "The user that ran pip install doesn't have write access "
                 "to target directory '%s'",
                 options.target_dir,
             )
             return ERROR
-        if options.prefix_path not None and not check_path_owner(options.prefix_path):
+        if (options.prefix_path is not None and not
+                check_path_owner(options.prefix_path)):
             logger.error(
                 "The user that ran pip install doesn't have write access "
                 "to target prefix directory '%s'",
                 options.prefix_path,
             )
             return ERROR
-        if options.root_path not None and not check_path_owner(options.root_path):
+        if (options.root_path is not None and not
+                check_path_owner(options.root_path)):
             logger.error(
                 "The user that ran pip install doesn't have write access "
                 "to target root directory '%s'",


### PR DESCRIPTION
# Enhancement proposal:
issue #6762

### Before

if a user runs `pip install` without write access to the target directory, it will collect and download packages before failing with permission denied.

![Before](https://user-images.githubusercontent.com/6099765/62008000-74514b80-b122-11e9-9658-d4f5bdd8348f.png)

### After

This PR uses the check_path_owner function from pip._internal.utils.filesystem to check write permissions and exits with an error message

![Screenshot from 2019-07-28 10-22-10](https://user-images.githubusercontent.com/6099765/62008016-8af7a280-b122-11e9-8081-c9d6b08627e5.png)

I'm still learning python. 
If it would be better to move the option checks to a function I'll close this and go ahead and do that.

Thank you for taking the time to review my PR. 