### PR TITLE
Revert "Ignore new warnings traced on tox invocation."

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,9 +65,6 @@ test_script:
             subst T: $env:TEMP
             $env:TEMP = "T:\"
             $env:TMP = "T:\"
-            # Workaround warnings traced in packaging.requirements with pyparsing 2.4.1.
-            # See pypa/packaging#170 and tox-dev/tox#1375.
-            $env:PYTHONWARNINGS = "ignore:warn_ungrouped_named_tokens_in_collection"
             tox -e py -- -m unit
             if ($LastExitCode -eq 0 -and $env:RUN_INTEGRATION_TESTS -eq "True") {
                 tox -e py -- --use-venv -m integration -n2 --durations=20


### PR DESCRIPTION
Reverts pypa/pip#6769

There has been a new pyparsing release that disables that warning by default.