### PR TITLE
Add make_resolver() to RequirementCommand base class

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -31,6 +31,7 @@ from pip._internal.exceptions import (
     UninstallationError,
 )
 from pip._internal.index import PackageFinder
+from pip._internal.legacy_resolve import Resolver
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.operations.prepare import RequirementPreparer
@@ -280,6 +281,41 @@ class RequirementCommand(Command):
             progress_bar=options.progress_bar,
             build_isolation=options.build_isolation,
             req_tracker=req_tracker,
+        )
+
+    @staticmethod
+    def make_resolver(
+            preparer,                            # type: RequirementPreparer
+            session,                             # type: PipSession
+            finder,                              # type: PackageFinder
+            options,                             # type: Values
+            wheel_cache=None,                    # type: Optional[WheelCache]
+            use_user_site=False,                 # type: bool
+            ignore_installed=True,               # type: bool
+            ignore_requires_python=False,        # type: bool
+            force_reinstall=False,               # type: bool
+            upgrade_strategy="to-satisfy-only",  # type: str
+            use_pep517=None,                     # type: Optional[bool]
+            py_version_info=None            # type: Optional[Tuple[int, ...]]
+    ):
+        # type: (...) -> Resolver
+        """
+        Create a Resolver instance for the given parameters.
+        """
+        return Resolver(
+            preparer=preparer,
+            session=session,
+            finder=finder,
+            wheel_cache=wheel_cache,
+            use_user_site=use_user_site,
+            ignore_dependencies=options.ignore_dependencies,
+            ignore_installed=ignore_installed,
+            ignore_requires_python=ignore_requires_python,
+            force_reinstall=force_reinstall,
+            isolated=options.isolated_mode,
+            upgrade_strategy=upgrade_strategy,
+            use_pep517=use_pep517,
+            py_version_info=py_version_info
         )
 
     @staticmethod

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -133,8 +133,8 @@ class DownloadCommand(RequirementCommand):
 
                 resolver = self.make_resolver(
                     preparer=preparer,
-                    session=session,
                     finder=finder,
+                    session=session,
                     options=options,
                     py_version_info=options.python_version,
                 )

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -6,7 +6,6 @@ import os
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import RequirementCommand
 from pip._internal.cli.cmdoptions import make_target_python
-from pip._internal.legacy_resolve import Resolver
 from pip._internal.req import RequirementSet
 from pip._internal.req.req_tracker import RequirementTracker
 from pip._internal.utils.filesystem import check_path_owner
@@ -132,19 +131,12 @@ class DownloadCommand(RequirementCommand):
                     download_dir=options.download_dir,
                 )
 
-                resolver = Resolver(
+                resolver = self.make_resolver(
                     preparer=preparer,
-                    finder=finder,
                     session=session,
-                    wheel_cache=None,
-                    use_user_site=False,
-                    upgrade_strategy="to-satisfy-only",
-                    force_reinstall=False,
-                    ignore_dependencies=options.ignore_dependencies,
+                    finder=finder,
+                    options=options,
                     py_version_info=options.python_version,
-                    ignore_requires_python=False,
-                    ignore_installed=True,
-                    isolated=options.isolated_mode,
                 )
                 resolver.resolve(requirement_set)
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -327,8 +327,8 @@ class InstallCommand(RequirementCommand):
                     )
                     resolver = self.make_resolver(
                         preparer=preparer,
-                        session=session,
                         finder=finder,
+                        session=session,
                         options=options,
                         wheel_cache=wheel_cache,
                         use_user_site=options.use_user_site,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -19,7 +19,6 @@ from pip._internal.exceptions import (
     InstallationError,
     PreviousBuildDirError,
 )
-from pip._internal.legacy_resolve import Resolver
 from pip._internal.locations import distutils_scheme
 from pip._internal.operations.check import check_install_conflicts
 from pip._internal.req import RequirementSet, install_given_reqs
@@ -326,19 +325,18 @@ class InstallCommand(RequirementCommand):
                         options=options,
                         req_tracker=req_tracker,
                     )
-                    resolver = Resolver(
+                    resolver = self.make_resolver(
                         preparer=preparer,
-                        finder=finder,
                         session=session,
+                        finder=finder,
+                        options=options,
                         wheel_cache=wheel_cache,
                         use_user_site=options.use_user_site,
-                        upgrade_strategy=upgrade_strategy,
-                        force_reinstall=options.force_reinstall,
-                        ignore_dependencies=options.ignore_dependencies,
-                        ignore_requires_python=options.ignore_requires_python,
                         ignore_installed=options.ignore_installed,
-                        isolated=options.isolated_mode,
-                        use_pep517=options.use_pep517
+                        ignore_requires_python=options.ignore_requires_python,
+                        force_reinstall=options.force_reinstall,
+                        upgrade_strategy=upgrade_strategy,
+                        use_pep517=options.use_pep517,
                     )
                     resolver.resolve(requirement_set)
 

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -8,7 +8,6 @@ from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import RequirementCommand
 from pip._internal.exceptions import CommandError, PreviousBuildDirError
-from pip._internal.legacy_resolve import Resolver
 from pip._internal.req import RequirementSet
 from pip._internal.req.req_tracker import RequirementTracker
 from pip._internal.utils.temp_dir import TempDirectory
@@ -135,19 +134,14 @@ class WheelCommand(RequirementCommand):
                         wheel_download_dir=options.wheel_dir,
                     )
 
-                    resolver = Resolver(
+                    resolver = self.make_resolver(
                         preparer=preparer,
-                        finder=finder,
                         session=session,
+                        finder=finder,
+                        options=options,
                         wheel_cache=wheel_cache,
-                        use_user_site=False,
-                        upgrade_strategy="to-satisfy-only",
-                        force_reinstall=False,
-                        ignore_dependencies=options.ignore_dependencies,
                         ignore_requires_python=options.ignore_requires_python,
-                        ignore_installed=True,
-                        isolated=options.isolated_mode,
-                        use_pep517=options.use_pep517
+                        use_pep517=options.use_pep517,
                     )
                     resolver.resolve(requirement_set)
 

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -136,8 +136,8 @@ class WheelCommand(RequirementCommand):
 
                     resolver = self.make_resolver(
                         preparer=preparer,
-                        session=session,
                         finder=finder,
+                        session=session,
                         options=options,
                         wheel_cache=wheel_cache,
                         ignore_requires_python=options.ignore_requires_python,


### PR DESCRIPTION
@cjerdonek / @pradyunsg  there are not many `options` parameters that are shared by install, wheel and download modules other than `options.ignore_dependencies` and `isolated=options.isolated_mode`.

I ended up passing some of the **options** as a separate parameter. Please, advice if that can be optimized.