### PR TITLE
Fix #6804: Fix "~" expansion in --find-links paths

### DIFF
--- a/news/6804.bugfix
+++ b/news/6804.bugfix
@@ -1,0 +1,2 @@
+Fix a regression that caused ``~`` expansion not to occur in ``--find-links``
+paths.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -370,9 +370,11 @@ def make_search_scope(options, suppress_no_index=False):
         )
         index_urls = []
 
-    search_scope = SearchScope(
-        find_links=options.find_links,
-        index_urls=index_urls,
+    # Make sure find_links is a list before passing to create().
+    find_links = options.find_links or []
+
+    search_scope = SearchScope.create(
+        find_links=find_links, index_urls=index_urls,
     )
 
     return search_scope

--- a/tests/unit/test_cmdoptions.py
+++ b/tests/unit/test_cmdoptions.py
@@ -1,5 +1,8 @@
+import os
+
 import pretend
 import pytest
+from mock import patch
 
 from pip._internal.cli.cmdoptions import (
     _convert_python_version,
@@ -8,20 +11,24 @@ from pip._internal.cli.cmdoptions import (
 
 
 @pytest.mark.parametrize(
-    'no_index, suppress_no_index, expected_index_urls', [
-        (False, False, ['default_url', 'url1', 'url2']),
-        (False, True, ['default_url', 'url1', 'url2']),
-        (True, False, []),
+    'find_links, no_index, suppress_no_index, expected', [
+        (['link1'], False, False,
+         (['link1'], ['default_url', 'url1', 'url2'])),
+        (['link1'], False, True, (['link1'], ['default_url', 'url1', 'url2'])),
+        (['link1'], True, False, (['link1'], [])),
         # Passing suppress_no_index=True suppresses no_index=True.
-        (True, True, ['default_url', 'url1', 'url2']),
+        (['link1'], True, True, (['link1'], ['default_url', 'url1', 'url2'])),
+        # Test options.find_links=False.
+        (False, False, False, ([], ['default_url', 'url1', 'url2'])),
     ],
 )
-def test_make_search_scope(no_index, suppress_no_index, expected_index_urls):
+def test_make_search_scope(find_links, no_index, suppress_no_index, expected):
     """
-    :param expected: the expected index_urls value.
+    :param expected: the expected (find_links, index_urls) values.
     """
+    expected_find_links, expected_index_urls = expected
     options = pretend.stub(
-        find_links=['link1'],
+        find_links=find_links,
         index_url='default_url',
         extra_index_urls=['url1', 'url2'],
         no_index=no_index,
@@ -29,8 +36,40 @@ def test_make_search_scope(no_index, suppress_no_index, expected_index_urls):
     search_scope = make_search_scope(
         options, suppress_no_index=suppress_no_index,
     )
-    assert search_scope.find_links == ['link1']
+    assert search_scope.find_links == expected_find_links
     assert search_scope.index_urls == expected_index_urls
+
+
+@patch('pip._internal.utils.misc.expanduser')
+def test_make_search_scope__find_links_expansion(mock_expanduser, tmpdir):
+    """
+    Test "~" expansion in --find-links paths.
+    """
+    # This is a mock version of expanduser() that expands "~" to the tmpdir.
+    def expand_path(path):
+        if path.startswith('~/'):
+            path = os.path.join(tmpdir, path[2:])
+        return path
+
+    mock_expanduser.side_effect = expand_path
+
+    options = pretend.stub(
+        find_links=['~/temp1', '~/temp2'],
+        index_url='default_url',
+        extra_index_urls=[],
+        no_index=False,
+    )
+    # Only create temp2 and not temp1 to test that "~" expansion only occurs
+    # when the directory exists.
+    temp2_dir = os.path.join(tmpdir, 'temp2')
+    os.mkdir(temp2_dir)
+
+    search_scope = make_search_scope(options)
+
+    # Only ~/temp2 gets expanded. Also, the path is normalized when expanded.
+    expected_temp2_dir = os.path.normcase(temp2_dir)
+    assert search_scope.find_links == ['~/temp1', expected_temp2_dir]
+    assert search_scope.index_urls == ['default_url']
 
 
 @pytest.mark.parametrize('value, expected', [

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -58,7 +58,7 @@ class MockDistribution(object):
 def _options():
     ''' Some default options that we pass to outdated.pip_version_check '''
     return pretend.stub(
-        find_links=False, index_url='default_url', extra_index_urls=[],
+        find_links=[], index_url='default_url', extra_index_urls=[],
         no_index=False, pre=False, trusted_hosts=False, cache_dir='',
     )
 


### PR DESCRIPTION
Fixes #6804.