### PR TITLE
Mask passwds in downloads.py output

### DIFF
--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -47,6 +47,7 @@ from pip._internal.utils.misc import (
     format_size,
     get_installed_version,
     path_to_url,
+    redact_password_from_url,
     remove_auth_from_url,
     rmtree,
     split_auth_netloc_from_url,
@@ -839,13 +840,13 @@ def _download_url(
         progress_indicator = DownloadProgressProvider(progress_bar,
                                                       max=total_length)
         if total_length:
-            logger.info("Downloading %s (%s)", url, format_size(total_length))
+            logger.info("Downloading %s (%s)", redact_password_from_url(url), format_size(total_length))
         else:
-            logger.info("Downloading %s", url)
+            logger.info("Downloading %s", redact_password_from_url(url))
     elif cached_resp:
-        logger.info("Using cached %s", url)
+        logger.info("Using cached %s", redact_password_from_url(url))
     else:
-        logger.info("Downloading %s", url)
+        logger.info("Downloading %s", redact_password_from_url(url))
 
     logger.debug('Downloading from URL %s', link)
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

I found that the URL variable in download.py was just just being printed to stout so I took the function redact_password_from_url used else where (such as collector.py), imported it and used it to mask the passwords:
``python pip install https://test:test@github.com/test
Collecting https://test:****@github.com/test
Downloading https://test:****@github.com/test``