### PR TITLE
Eliminate base_command.py's dependence on PipSession

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -1,8 +1,5 @@
 """Base Command class, and related routines"""
 
-# The following comment should be removed at some point in the future.
-# mypy: strict-optional=False
-
 from __future__ import absolute_import, print_function
 
 import logging
@@ -39,7 +36,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, List, Tuple, Any
+    from typing import List, Tuple, Any
     from optparse import Values
 
 __all__ = ['Command']
@@ -48,15 +45,14 @@ logger = logging.getLogger(__name__)
 
 
 class Command(object):
-    name = None  # type: Optional[str]
-    usage = None  # type: Optional[str]
+    usage = None  # type: str
     ignore_require_venv = False  # type: bool
 
     def __init__(self, name, summary, isolated=False):
         # type: (str, str, bool) -> None
         parser_kw = {
             'usage': self.usage,
-            'prog': '%s %s' % (get_prog(), self.name),
+            'prog': '%s %s' % (get_prog(), name),
             'formatter': UpdatingDefaultsHelpFormatter(),
             'add_help_option': False,
             'name': name,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -128,11 +128,11 @@ class RequirementCommand(IndexGroupCommand):
 
     @staticmethod
     def make_requirement_preparer(
-            temp_directory,           # type: TempDirectory
-            options,                  # type: Values
-            req_tracker,              # type: RequirementTracker
-            download_dir=None,        # type: str
-            wheel_download_dir=None,  # type: str
+        temp_directory,           # type: TempDirectory
+        options,                  # type: Values
+        req_tracker,              # type: RequirementTracker
+        download_dir=None,        # type: str
+        wheel_download_dir=None,  # type: str
     ):
         # type: (...) -> RequirementPreparer
         """
@@ -150,18 +150,18 @@ class RequirementCommand(IndexGroupCommand):
 
     @staticmethod
     def make_resolver(
-            preparer,                            # type: RequirementPreparer
-            session,                             # type: PipSession
-            finder,                              # type: PackageFinder
-            options,                             # type: Values
-            wheel_cache=None,                    # type: Optional[WheelCache]
-            use_user_site=False,                 # type: bool
-            ignore_installed=True,               # type: bool
-            ignore_requires_python=False,        # type: bool
-            force_reinstall=False,               # type: bool
-            upgrade_strategy="to-satisfy-only",  # type: str
-            use_pep517=None,                     # type: Optional[bool]
-            py_version_info=None            # type: Optional[Tuple[int, ...]]
+        preparer,                            # type: RequirementPreparer
+        session,                             # type: PipSession
+        finder,                              # type: PackageFinder
+        options,                             # type: Values
+        wheel_cache=None,                    # type: Optional[WheelCache]
+        use_user_site=False,                 # type: bool
+        ignore_installed=True,               # type: bool
+        ignore_requires_python=False,        # type: bool
+        force_reinstall=False,               # type: bool
+        upgrade_strategy="to-satisfy-only",  # type: str
+        use_pep517=None,                     # type: Optional[bool]
+        py_version_info=None            # type: Optional[Tuple[int, ...]]
     ):
         # type: (...) -> Resolver
         """
@@ -184,14 +184,15 @@ class RequirementCommand(IndexGroupCommand):
         )
 
     @staticmethod
-    def populate_requirement_set(requirement_set,  # type: RequirementSet
-                                 args,             # type: List[str]
-                                 options,          # type: Values
-                                 finder,           # type: PackageFinder
-                                 session,          # type: PipSession
-                                 name,             # type: str
-                                 wheel_cache       # type: Optional[WheelCache]
-                                 ):
+    def populate_requirement_set(
+        requirement_set,  # type: RequirementSet
+        args,             # type: List[str]
+        options,          # type: Values
+        finder,           # type: PackageFinder
+        session,          # type: PipSession
+        name,             # type: str
+        wheel_cache,      # type: Optional[WheelCache]
+    ):
         # type: (...) -> None
         """
         Marshal cmd line args into a requirement set.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -7,8 +7,8 @@ from pip._vendor import six
 from pip._vendor.six.moves import zip_longest
 
 from pip._internal.cli import cmdoptions
-from pip._internal.cli.base_command import Command
 from pip._internal.cli.cmdoptions import make_search_scope
+from pip._internal.cli.req_command import IndexGroupCommand
 from pip._internal.exceptions import CommandError
 from pip._internal.index import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
@@ -21,7 +21,7 @@ from pip._internal.utils.packaging import get_installer
 logger = logging.getLogger(__name__)
 
 
-class ListCommand(Command):
+class ListCommand(IndexGroupCommand):
     """
     List installed packages, including editables.
 

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -12,6 +12,7 @@ from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.six.moves import xmlrpc_client  # type: ignore
 
 from pip._internal.cli.base_command import Command
+from pip._internal.cli.req_command import SessionCommandMixin
 from pip._internal.cli.status_codes import NO_MATCHES_FOUND, SUCCESS
 from pip._internal.download import PipXmlrpcTransport
 from pip._internal.exceptions import CommandError
@@ -22,7 +23,7 @@ from pip._internal.utils.logging import indent_log
 logger = logging.getLogger(__name__)
 
 
-class SearchCommand(Command):
+class SearchCommand(SessionCommandMixin, Command):
     """Search for PyPI packages whose name or summary contains <query>."""
 
     usage = """

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -3,13 +3,14 @@ from __future__ import absolute_import
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.cli.base_command import Command
+from pip._internal.cli.req_command import SessionCommandMixin
 from pip._internal.exceptions import InstallationError
 from pip._internal.req import parse_requirements
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import protect_pip_from_modification_on_windows
 
 
-class UninstallCommand(Command):
+class UninstallCommand(SessionCommandMixin, Command):
     """
     Uninstall packages.
 

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -2,6 +2,8 @@ import logging
 import os
 import time
 
+from mock import patch
+
 from pip._internal.cli.base_command import Command
 from pip._internal.utils.logging import BrokenStdoutLoggingError
 
@@ -70,6 +72,16 @@ class TestCommand(object):
 
         assert 'ERROR: Pipe to stdout was broken' in stderr
         assert 'Traceback (most recent call last):' in stderr
+
+
+@patch('pip._internal.cli.req_command.Command.handle_pip_version_check')
+def test_handle_pip_version_check_called(mock_handle_version_check):
+    """
+    Check that Command.handle_pip_version_check() is called.
+    """
+    cmd = FakeCommand()
+    cmd.main([])
+    mock_handle_version_check.assert_called_once()
 
 
 class Test_base_command_logging(object):

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,4 +1,5 @@
 import pytest
+from mock import patch
 
 from pip._internal.cli.req_command import (
     IndexGroupCommand,
@@ -6,6 +7,10 @@ from pip._internal.cli.req_command import (
     SessionCommandMixin,
 )
 from pip._internal.commands import commands_dict, create_command
+
+# These are the expected names of the commands whose classes inherit from
+# IndexGroupCommand.
+EXPECTED_INDEX_GROUP_COMMANDS = ['download', 'install', 'list', 'wheel']
 
 
 def check_commands(pred, expected):
@@ -51,19 +56,50 @@ def test_index_group_commands():
     """
     Test the commands inheriting from IndexGroupCommand.
     """
-    expected = ['download', 'install', 'list', 'wheel']
-
     def is_index_group_command(command):
         return isinstance(command, IndexGroupCommand)
 
-    check_commands(is_index_group_command, expected)
+    check_commands(is_index_group_command, EXPECTED_INDEX_GROUP_COMMANDS)
 
     # Also check that the commands inheriting from IndexGroupCommand are
     # exactly the commands with the --no-index option.
     def has_option_no_index(command):
         return command.parser.has_option('--no-index')
 
-    check_commands(has_option_no_index, expected)
+    check_commands(has_option_no_index, EXPECTED_INDEX_GROUP_COMMANDS)
+
+
+@pytest.mark.parametrize('command_name', EXPECTED_INDEX_GROUP_COMMANDS)
+@pytest.mark.parametrize(
+    'disable_pip_version_check, no_index, expected_called',
+    [
+        # pip_version_check() is only called when both
+        # disable_pip_version_check and no_index are False.
+        (False, False, True),
+        (False, True, False),
+        (True, False, False),
+        (True, True, False),
+    ],
+)
+@patch('pip._internal.cli.req_command.pip_version_check')
+def test_index_group_handle_pip_version_check(
+    mock_version_check, command_name, disable_pip_version_check, no_index,
+    expected_called,
+):
+    """
+    Test whether pip_version_check() is called when handle_pip_version_check()
+    is called, for each of the IndexGroupCommand classes.
+    """
+    command = create_command(command_name)
+    options = command.parser.get_default_values()
+    options.disable_pip_version_check = disable_pip_version_check
+    options.no_index = no_index
+
+    command.handle_pip_version_check(options)
+    if expected_called:
+        mock_version_check.assert_called_once()
+    else:
+        mock_version_check.assert_not_called()
 
 
 def test_requirement_commands():

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,6 +1,20 @@
 import pytest
 
+from pip._internal.cli.req_command import (
+    IndexGroupCommand,
+    RequirementCommand,
+    SessionCommandMixin,
+)
 from pip._internal.commands import commands_dict, create_command
+
+
+def check_commands(pred, expected):
+    """
+    Check the commands satisfying a predicate.
+    """
+    commands = [create_command(name) for name in sorted(commands_dict)]
+    actual = [command.name for command in commands if pred(command)]
+    assert actual == expected, 'actual: {}'.format(actual)
 
 
 def test_commands_dict__order():
@@ -20,3 +34,43 @@ def test_create_command(name):
     command = create_command(name)
     assert command.name == name
     assert command.summary == commands_dict[name].summary
+
+
+def test_session_commands():
+    """
+    Test which commands inherit from SessionCommandMixin.
+    """
+    def is_session_command(command):
+        return isinstance(command, SessionCommandMixin)
+
+    expected = ['download', 'install', 'list', 'search', 'uninstall', 'wheel']
+    check_commands(is_session_command, expected)
+
+
+def test_index_group_commands():
+    """
+    Test the commands inheriting from IndexGroupCommand.
+    """
+    expected = ['download', 'install', 'list', 'wheel']
+
+    def is_index_group_command(command):
+        return isinstance(command, IndexGroupCommand)
+
+    check_commands(is_index_group_command, expected)
+
+    # Also check that the commands inheriting from IndexGroupCommand are
+    # exactly the commands with the --no-index option.
+    def has_option_no_index(command):
+        return command.parser.has_option('--no-index')
+
+    check_commands(has_option_no_index, expected)
+
+
+def test_requirement_commands():
+    """
+    Test which commands inherit from RequirementCommand.
+    """
+    def is_requirement_command(command):
+        return isinstance(command, RequirementCommand)
+
+    check_commands(is_requirement_command, ['download', 'install', 'wheel'])


### PR DESCRIPTION
This is a follow-on to PR #6835 that finishes removing `base_command.py`'s dependency on `index.py` / `PackageFinder`, `PipSession`, and `pip_version_check`, etc.

This is again related to #4768 ("Speedup startup time").