### PR TITLE
Ignore errors copying socket files for source installs (in Python 3).

### DIFF
--- a/news/5306.bugfix
+++ b/news/5306.bugfix
@@ -1,0 +1,1 @@
+Ignore errors copying socket files for local source installs.

--- a/news/5306.bugfix
+++ b/news/5306.bugfix
@@ -1,1 +1,1 @@
-Ignore errors copying socket files for local source installs.
+Ignore errors copying socket files for local source installs (in Python 3).

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -88,7 +88,8 @@ if MYPY_CHECK_RUNNING:
         )
     else:
         CopytreeKwargs = TypedDict(
-            'CopytreeKwargs', {
+            'CopytreeKwargs',
+            {
                 'copy_function': Callable[[str, str], None],
                 'ignore': Callable[[str, List[str]], List[str]],
                 'ignore_dangling_symlinks': bool,

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import shutil
 import stat
 
 from pip._internal.utils.compat import get_path_uid
@@ -29,6 +30,35 @@ def check_path_owner(path):
         else:
             previous, path = path, os.path.dirname(path)
     return False  # assume we don't own the path
+
+
+def copytree(*args, **kwargs):
+    """Wrap shutil.copytree() to map errors copying socket file to
+    SpecialFileError.
+
+    See also https://bugs.python.org/issue37700.
+    """
+    def to_correct_error(src, dest, error):
+        for f in [src, dest]:
+            try:
+                if is_socket(f):
+                    new_error = shutil.SpecialFileError("`%s` is a socket" % f)
+                    return (src, dest, new_error)
+            except OSError:
+                # An error has already occurred. Another error here is not
+                # a problem and we can ignore it.
+                pass
+
+        return (src, dest, error)
+
+    try:
+        shutil.copytree(*args, **kwargs)
+    except shutil.Error as e:
+        errors = e.args[0]
+        new_errors = [
+            to_correct_error(src, dest, error) for src, dest, error in errors
+        ]
+        raise shutil.Error(new_errors)
 
 
 def is_socket(path):

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import stat
 
 from pip._internal.utils.compat import get_path_uid
 
@@ -28,3 +29,8 @@ def check_path_owner(path):
         else:
             previous, path = path, os.path.dirname(path)
     return False  # assume we don't own the path
+
+
+def is_socket(path):
+    # type: (str) -> bool
+    return stat.S_ISSOCK(os.lstat(path).st_mode)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -504,11 +504,13 @@ def test_install_from_local_directory_with_socket_file(script, data, tmpdir):
 
     shutil.copytree(to_copy, to_install)
     # Socket file, should be ignored.
-    make_socket_file(os.path.join(to_install, "example"))
+    socket_file_path = os.path.join(to_install, "example")
+    make_socket_file(socket_file_path)
 
-    result = script.pip("install", to_install, expect_error=False)
+    result = script.pip("install", "--verbose", to_install, expect_error=False)
     assert package_folder in result.files_created, str(result.stdout)
     assert egg_info_file in result.files_created, str(result)
+    assert str(socket_file_path) in result.stderr
 
 
 def test_install_from_local_directory_with_no_setup_py(script, data):

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2,7 +2,6 @@ import distutils
 import glob
 import os
 import shutil
-import socket
 import sys
 import textwrap
 from os.path import curdir, join, pardir
@@ -25,6 +24,7 @@ from tests.lib import (
     pyversion_tuple,
     requirements_file,
 )
+from tests.lib.filesystem import make_socket_file
 from tests.lib.local_repos import local_checkout
 from tests.lib.path import Path
 
@@ -496,16 +496,17 @@ def test_install_from_local_directory_with_socket_file(script, data, tmpdir):
     Test installing from a local directory containing a socket file.
     """
     egg_info_file = (
-        script.site_packages / 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
+        script.site_packages / "FSPkg-0.1.dev0-py%s.egg-info" % pyversion
     )
-    package_folder = script.site_packages / 'fspkg'
+    package_folder = script.site_packages / "fspkg"
     to_copy = data.packages.joinpath("FSPkg")
     to_install = tmpdir.joinpath("src")
-    shutil.copytree(to_copy, to_install)
-    sock = socket.socket(socket.AF_UNIX)
-    sock.bind(os.path.join(to_install, "example"))
-    result = script.pip("install", to_install, expect_error=False)
 
+    shutil.copytree(to_copy, to_install)
+    # Socket file, should be ignored.
+    make_socket_file(os.path.join(to_install, "example"))
+
+    result = script.pip("install", to_install, expect_error=False)
     assert package_folder in result.files_created, str(result.stdout)
     assert egg_info_file in result.files_created, str(result)
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -490,7 +490,7 @@ def test_install_from_local_directory_with_symlinks_to_directories(
     assert egg_info_folder in result.files_created, str(result)
 
 
-@pytest.mark.skipif("sys.platform == 'win32'")
+@pytest.mark.skipif("sys.platform == 'win32' or sys.version_info < (3,)")
 def test_install_from_local_directory_with_socket_file(script, data, tmpdir):
     """
     Test installing from a local directory containing a socket file.

--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -1,0 +1,47 @@
+"""Helpers for filesystem-dependent tests.
+"""
+import os
+import socket
+import subprocess
+import sys
+from functools import partial
+from itertools import chain
+
+from .path import Path
+
+
+def make_socket_file(path):
+    # Socket paths are limited to 108 characters (sometimes less) so we
+    # chdir before creating it and use a relative path name.
+    cwd = os.getcwd()
+    os.chdir(os.path.dirname(path))
+    try:
+        sock = socket.socket(socket.AF_UNIX)
+        sock.bind(os.path.basename(path))
+    finally:
+        os.chdir(cwd)
+
+
+def make_unreadable_file(path):
+    Path(path).touch()
+    os.chmod(path, 0o000)
+    if sys.platform == "win32":
+        username = os.environ["USERNAME"]
+        # Remove "Read Data/List Directory" permission for current user, but
+        # leave everything else.
+        args = ["icacls", path, "/deny", username + ":(RD)"]
+        subprocess.check_call(args)
+
+
+def get_filelist(base):
+    def join(dirpath, dirnames, filenames):
+        relative_dirpath = os.path.relpath(dirpath, base)
+        join_dirpath = partial(os.path.join, relative_dirpath)
+        return chain(
+            (join_dirpath(p) for p in dirnames),
+            (join_dirpath(p) for p in filenames),
+        )
+
+    return set(chain.from_iterable(
+        join(*dirinfo) for dirinfo in os.walk(base)
+    ))

--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -26,6 +26,7 @@ def make_unreadable_file(path):
     Path(path).touch()
     os.chmod(path, 0o000)
     if sys.platform == "win32":
+        # Once we drop PY2 we can use `os.getlogin()` instead.
         username = os.environ["USERNAME"]
         # Remove "Read Data/List Directory" permission for current user, but
         # leave everything else.

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -363,15 +363,22 @@ def test_copy_source_tree(clean_project, tmpdir):
 
 
 @pytest.mark.skipif("sys.platform == 'win32'")
-def test_copy_source_tree_with_socket(clean_project, tmpdir):
+def test_copy_source_tree_with_socket(clean_project, tmpdir, caplog):
     target = tmpdir.joinpath("target")
     expected_files = get_filelist(clean_project)
-    make_socket_file(clean_project.joinpath("aaa"))
+    socket_path = str(clean_project.joinpath("aaa"))
+    make_socket_file(socket_path)
 
     _copy_source_tree(clean_project, target)
 
     copied_files = get_filelist(target)
     assert expected_files == copied_files
+
+    # Warning should have been logged.
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == 'WARNING'
+    assert socket_path in record.message
 
 
 @pytest.mark.skipif("sys.platform == 'win32'")
@@ -392,7 +399,7 @@ def test_copy_source_tree_with_socket_fails_with_no_socket_error(
     assert unreadable_file in errored_files
 
     copied_files = get_filelist(target)
-    # Even with errors, all files should have been copied.
+    # All files without errors should have been copied.
     assert expected_files == copied_files
 
 
@@ -410,7 +417,7 @@ def test_copy_source_tree_with_unreadable_dir_fails(clean_project, tmpdir):
     assert unreadable_file in errored_files
 
     copied_files = get_filelist(target)
-    # Even with errors, all files should have been copied.
+    # All files without errors should have been copied.
     assert expected_files == copied_files
 
 

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -362,7 +362,7 @@ def test_copy_source_tree(clean_project, tmpdir):
     assert expected_files == copied_files
 
 
-@pytest.mark.skipif("sys.platform == 'win32'")
+@pytest.mark.skipif("sys.platform == 'win32' or sys.version_info < (3,)")
 def test_copy_source_tree_with_socket(clean_project, tmpdir, caplog):
     target = tmpdir.joinpath("target")
     expected_files = get_filelist(clean_project)
@@ -381,7 +381,7 @@ def test_copy_source_tree_with_socket(clean_project, tmpdir, caplog):
     assert socket_path in record.message
 
 
-@pytest.mark.skipif("sys.platform == 'win32'")
+@pytest.mark.skipif("sys.platform == 'win32' or sys.version_info < (3,)")
 def test_copy_source_tree_with_socket_fails_with_no_socket_error(
     clean_project, tmpdir
 ):

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -1,6 +1,7 @@
 import functools
 import hashlib
 import os
+import shutil
 import sys
 from io import BytesIO
 from shutil import copy, rmtree
@@ -15,6 +16,7 @@ from pip._internal.download import (
     MultiDomainBasicAuth,
     PipSession,
     SafeFileCache,
+    _copy_source_tree,
     _download_http_url,
     _get_url_scheme,
     parse_content_disposition,
@@ -28,6 +30,12 @@ from pip._internal.models.link import Link
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.misc import path_to_url
 from tests.lib import create_file
+from tests.lib.filesystem import (
+    get_filelist,
+    make_socket_file,
+    make_unreadable_file,
+)
+from tests.lib.path import Path
 
 
 @pytest.fixture(scope="function")
@@ -332,6 +340,78 @@ def test_url_to_path_path_to_url_symmetry_win():
 
     unc_path = r'\\unc\share\path'
     assert url_to_path(path_to_url(unc_path)) == unc_path
+
+
+@pytest.fixture
+def clean_project(tmpdir_factory, data):
+    tmpdir = Path(str(tmpdir_factory.mktemp("clean_project")))
+    new_project_dir = tmpdir.joinpath("FSPkg")
+    path = data.packages.joinpath("FSPkg")
+    shutil.copytree(path, new_project_dir)
+    return new_project_dir
+
+
+def test_copy_source_tree(clean_project, tmpdir):
+    target = tmpdir.joinpath("target")
+    expected_files = get_filelist(clean_project)
+    assert len(expected_files) == 3
+
+    _copy_source_tree(clean_project, target)
+
+    copied_files = get_filelist(target)
+    assert expected_files == copied_files
+
+
+@pytest.mark.skipif("sys.platform == 'win32'")
+def test_copy_source_tree_with_socket(clean_project, tmpdir):
+    target = tmpdir.joinpath("target")
+    expected_files = get_filelist(clean_project)
+    make_socket_file(clean_project.joinpath("aaa"))
+
+    _copy_source_tree(clean_project, target)
+
+    copied_files = get_filelist(target)
+    assert expected_files == copied_files
+
+
+@pytest.mark.skipif("sys.platform == 'win32'")
+def test_copy_source_tree_with_socket_fails_with_no_socket_error(
+    clean_project, tmpdir
+):
+    target = tmpdir.joinpath("target")
+    expected_files = get_filelist(clean_project)
+    make_socket_file(clean_project.joinpath("aaa"))
+    unreadable_file = clean_project.joinpath("bbb")
+    make_unreadable_file(unreadable_file)
+
+    with pytest.raises(shutil.Error) as e:
+        _copy_source_tree(clean_project, target)
+
+    errored_files = [err[0] for err in e.value.args[0]]
+    assert len(errored_files) == 1
+    assert unreadable_file in errored_files
+
+    copied_files = get_filelist(target)
+    # Even with errors, all files should have been copied.
+    assert expected_files == copied_files
+
+
+def test_copy_source_tree_with_unreadable_dir_fails(clean_project, tmpdir):
+    target = tmpdir.joinpath("target")
+    expected_files = get_filelist(clean_project)
+    unreadable_file = clean_project.joinpath("bbb")
+    make_unreadable_file(unreadable_file)
+
+    with pytest.raises(shutil.Error) as e:
+        _copy_source_tree(clean_project, target)
+
+    errored_files = [err[0] for err in e.value.args[0]]
+    assert len(errored_files) == 1
+    assert unreadable_file in errored_files
+
+    copied_files = get_filelist(target)
+    # Even with errors, all files should have been copied.
+    assert expected_files == copied_files
 
 
 class Test_unpack_file_url(object):

--- a/tests/unit/test_utils_filesystem.py
+++ b/tests/unit/test_utils_filesystem.py
@@ -4,9 +4,8 @@ import shutil
 import pytest
 
 from pip._internal.utils.filesystem import copy2_fixed, is_socket
-
-from ..lib.filesystem import make_socket_file, make_unreadable_file
-from ..lib.path import Path
+from tests.lib.filesystem import make_socket_file, make_unreadable_file
+from tests.lib.path import Path
 
 
 def make_file(path):

--- a/tests/unit/test_utils_filesystem.py
+++ b/tests/unit/test_utils_filesystem.py
@@ -1,0 +1,41 @@
+import os
+
+import pytest
+
+from pip._internal.utils.filesystem import is_socket
+
+from ..lib.filesystem import make_socket_file
+from ..lib.path import Path
+
+
+def make_file(path):
+    Path(path).touch()
+
+
+def make_valid_symlink(path):
+    target = path + "1"
+    make_file(target)
+    os.symlink(target, path)
+
+
+def make_broken_symlink(path):
+    os.symlink("foo", path)
+
+
+def make_dir(path):
+    os.mkdir(path)
+
+
+@pytest.mark.skipif("sys.platform == 'win32'")
+@pytest.mark.parametrize("create,result", [
+    (make_socket_file, True),
+    (make_file, False),
+    (make_valid_symlink, False),
+    (make_broken_symlink, False),
+    (make_dir, False),
+])
+def test_is_socket(create, result, tmpdir):
+    target = tmpdir.joinpath("target")
+    create(target)
+    assert os.path.lexists(target)
+    assert is_socket(target) == result

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
 pip = python {toxinidir}/tools/tox_pip.py
 
 [testenv]
+# Remove USERNAME once we drop PY2.
 passenv = CI GIT_SSL_CAINFO USERNAME
 setenv =
     # This is required in order to get UTF-8 output inside of the subprocesses

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
 pip = python {toxinidir}/tools/tox_pip.py
 
 [testenv]
-passenv = CI GIT_SSL_CAINFO
+passenv = CI GIT_SSL_CAINFO USERNAME
 setenv =
     # This is required in order to get UTF-8 output inside of the subprocesses
     # that our tests use.


### PR DESCRIPTION
Addresses the same as #6802, but only worries about Python 3 compatibility.

Fixes #5306.