### PR TITLE
Fix tests when running in git linked worktree.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,10 +169,16 @@ def isolate(tmpdir):
 @pytest.fixture(scope='session')
 def pip_src(tmpdir_factory):
     def not_code_files_and_folders(path, names):
-        # In the root directory, ignore all folders except "src"
+        # In the root directory...
         if path == SRC_DIR:
+            # ignore all folders except "src"
             folders = {name for name in names if os.path.isdir(path / name)}
-            return folders - {"src"}
+            to_ignore = folders - {"src"}
+            # and ignore ".git" if present (which may be a file if in a linked
+            # worktree).
+            if ".git" in names:
+                to_ignore.add(".git")
+            return to_ignore
 
         # Ignore all compiled files and egg-info.
         ignored = list()

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -123,15 +123,19 @@ def test_should_add_vcs_url_prefix(vcs_cls, remote_url, expected):
     assert actual == expected
 
 
-@patch('pip._internal.vcs.git.Git.get_revision')
 @patch('pip._internal.vcs.git.Git.get_remote_url')
+@patch('pip._internal.vcs.git.Git.get_revision')
+@patch('pip._internal.vcs.git.Git.get_subdirectory')
 @pytest.mark.network
-def test_git_get_src_requirements(mock_get_remote_url, mock_get_revision):
+def test_git_get_src_requirements(
+    mock_get_subdirectory, mock_get_revision, mock_get_remote_url
+):
     git_url = 'https://github.com/pypa/pip-test-package'
     sha = '5547fa909e83df8bd743d3978d6667497983a4b7'
 
     mock_get_remote_url.return_value = git_url
     mock_get_revision.return_value = sha
+    mock_get_subdirectory.return_value = None
 
     ret = Git.get_src_requirement('.', 'pip-test-package')
 


### PR DESCRIPTION
[`git worktree`](https://git-scm.com/docs/git-worktree) is a mechanism to have multiple separate working trees related to the same repository.

When running the test suite, two tests were failing because of incorrect assumptions that were impacted by this feature.

1. In a linked worktree, `.git` is a plain file, not a directory. [Now](https://github.com/pypa/pip/compare/master...chrahunt:bugfix/fix-tests-in-linked-worktree?expand=1#diff-484462fced51d1a06b1d93b4a44dd535R170) we do not copy this file in the `pip_src` fixture.
2. The [`get_subdirectory`](https://github.com/pypa/pip/compare/master...chrahunt:bugfix/fix-tests-in-linked-worktree?expand=1#diff-5bbd286b91b615db20a038472b4cd672R128) method was not properly mocked out in one of the VCS tests, and this returns a different value when running the tests from a linked worktree vs not.

Even though personally I would love to prevent regressions on this in the future, I think the inconvenience of re-running all the tests in a linked worktree (via CI or some other way) is probably not worth it.

Test results:

<details>
<summary><strong>script.sh</strong></summary>

```
#!/bin/sh
cd $(mktemp -d)
python -m venv .venv
. .venv/bin/activate
pip install tox
git clone https://github.com/chrahunt/pip.git
cd pip
git worktree add -b new-master ../pip2
cd ../pip2
echo "#### FAILING TESTS ####"
tox -e py37 -- -n 16
git checkout bugfix/fix-tests-in-linked-worktree
echo "#### PASSING TESTS ####"
tox -e py37 -- -n 16
```

</details>

<details>
<summary><strong>output</strong></summary>

```
Collecting tox
  Using cached https://files.pythonhosted.org/packages/3f/21/66868fc9074e366d0dc6952c53c918230e772fd662e69b331bac7a67fcbe/tox-3.13.2-py2.py3-none-any.whl
Collecting packaging>=14 (from tox)
  Using cached https://files.pythonhosted.org/packages/ec/22/630ac83e8f8a9566c4f88038447ed9e16e6f10582767a01f31c769d9a71e/packaging-19.1-py2.py3-none-any.whl
Collecting importlib-metadata<1,>=0.12 (from tox)
  Using cached https://files.pythonhosted.org/packages/ad/aa/25fcbded2ab4ed4ff3071d1e000cd4f8f9c65653d2d7157dd105a8e81d42/importlib_metadata-0.19-py2.py3-none-any.whl
Collecting toml>=0.9.4 (from tox)
  Using cached https://files.pythonhosted.org/packages/a2/12/ced7105d2de62fa7c8fb5fce92cc4ce66b57c95fb875e9318dba7f8c5db0/toml-0.10.0-py2.py3-none-any.whl
Collecting pluggy<1,>=0.12.0 (from tox)
  Using cached https://files.pythonhosted.org/packages/06/ee/de89e0582276e3551df3110088bf20844de2b0e7df2748406876cc78e021/pluggy-0.12.0-py2.py3-none-any.whl
Collecting py<2,>=1.4.17 (from tox)
  Using cached https://files.pythonhosted.org/packages/76/bc/394ad449851729244a97857ee14d7cba61ddb268dce3db538ba2f2ba1f0f/py-1.8.0-py2.py3-none-any.whl
Collecting virtualenv>=14.0.0 (from tox)
  Using cached https://files.pythonhosted.org/packages/db/9e/df208b2baad146fe3fbe750eacadd6e49bcf2f2c3c1117b7192a7b28aec4/virtualenv-16.7.2-py2.py3-none-any.whl
Collecting six<2,>=1.0.0 (from tox)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting filelock<4,>=3.0.0 (from tox)
  Using cached https://files.pythonhosted.org/packages/93/83/71a2ee6158bb9f39a90c0dea1637f81d5eef866e188e1971a1b1ab01a35a/filelock-3.0.12-py3-none-any.whl
Collecting pyparsing>=2.0.2 (from packaging>=14->tox)
  Using cached https://files.pythonhosted.org/packages/11/fa/0160cd525c62d7abd076a070ff02b2b94de589f1a9789774f17d7c54058e/pyparsing-2.4.2-py2.py3-none-any.whl
Collecting attrs (from packaging>=14->tox)
  Using cached https://files.pythonhosted.org/packages/23/96/d828354fa2dbdf216eaa7b7de0db692f12c234f7ef888cc14980ef40d1d2/attrs-19.1.0-py2.py3-none-any.whl
Collecting zipp>=0.5 (from importlib-metadata<1,>=0.12->tox)
  Using cached https://files.pythonhosted.org/packages/da/bd/1a5fdf15aa44231fd09f63ecf175b60f057ae37ec65b343bb009364923f3/zipp-0.5.2-py2.py3-none-any.whl
Installing collected packages: six, pyparsing, attrs, packaging, zipp, importlib-metadata, toml, pluggy, py, virtualenv, filelock, tox
Successfully installed attrs-19.1.0 filelock-3.0.12 importlib-metadata-0.19 packaging-19.1 pluggy-0.12.0 py-1.8.0 pyparsing-2.4.2 six-1.12.0 toml-0.10.0 tox-3.13.2 virtualenv-16.7.2 zipp-0.5.2
You are using pip version 18.1, however version 19.2.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Cloning into 'pip'...
remote: Enumerating objects: 22, done.
remote: Counting objects: 100% (22/22), done.
remote: Compressing objects: 100% (20/20), done.
remote: Total 42957 (delta 4), reused 7 (delta 0), pack-reused 42935
Receiving objects: 100% (42957/42957), 50.05 MiB | 54.52 MiB/s, done.
Resolving deltas: 100% (29258/29258), done.
Preparing worktree (new branch 'new-master')
HEAD is now at 7c319ad7 Add a skeleton for architecture documentation (#6836)
#### FAILING TESTS ####
GLOB sdist-make: /tmp/user/1000/tmp.3EduFikNJC/pip2/setup.py
py37 create: /tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/py37
py37 installdeps: -r/tmp/user/1000/tmp.3EduFikNJC/pip2/tools/requirements/tests.txt
py37 inst: /tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/.tmp/package/1/pip-19.3.dev0.zip
py37 installed: apipkg==1.5,atomicwrites==1.3.0,attrs==19.1.0,coverage==4.5.4,execnet==1.6.1,freezegun==0.3.12,importlib-metadata==0.19,mock==3.0.5,more-itertools==7.2.0,pip==19.3.dev0,pluggy==0.12.0,pretend==1.0.9,py==1.8.0,pytest==3.8.2,pytest-cov==2.7.1,pytest-forked==1.0.2,pytest-rerunfailures==6.0,pytest-timeout==1.3.3,pytest-xdist==1.27.0,python-dateutil==2.8.0,PyYAML==5.1.2,scripttest==1.3,setuptools==41.0.1,six==1.12.0,virtualenv==16.7.2,wheel==0.33.4,zipp==0.5.2
py37 run-test-pre: PYTHONHASHSEED='2653805234'
py37 run-test-pre: commands[0] | python -c 'import shutil, sys; shutil.rmtree(sys.argv[1], ignore_errors=True)' /tmp/user/1000/tmp.3EduFikNJC/pip2/tests/data/common_wheels
py37 run-test-pre: commands[1] | python /tmp/user/1000/tmp.3EduFikNJC/pip2/tools/tox_pip.py wheel -w /tmp/user/1000/tmp.3EduFikNJC/pip2/tests/data/common_wheels -r /tmp/user/1000/tmp.3EduFikNJC/pip2/tools/requirements/tests-common_wheels.txt
Collecting setuptools>=40.8.0 (from -r tools/requirements/tests-common_wheels.txt (line 8))
  Using cached https://files.pythonhosted.org/packages/ec/51/f45cea425fd5cb0b0380f5b0f048ebc1da5b417e48d304838c02d6288a1e/setuptools-41.0.1-py2.py3-none-any.whl
  Saved ./tests/data/common_wheels/setuptools-41.0.1-py2.py3-none-any.whl
Collecting wheel (from -r tools/requirements/tests-common_wheels.txt (line 9))
  Using cached https://files.pythonhosted.org/packages/bb/10/44230dd6bf3563b8f227dbf344c908d412ad2ff48066476672f3a72e174e/wheel-0.33.4-py2.py3-none-any.whl
  Saved ./tests/data/common_wheels/wheel-0.33.4-py2.py3-none-any.whl
Skipping setuptools, due to already being wheel.
Skipping wheel, due to already being wheel.
py37 run-test: commands[0] | pytest --timeout 300 -n 16
========================================== test session starts ==========================================
platform linux -- Python 3.7.2, pytest-3.8.2, py-1.8.0, pluggy-0.12.0
rootdir: /tmp/user/1000/tmp.3EduFikNJC/pip2, inifile: setup.cfg
plugins: xdist-1.27.0, cov-2.7.1, rerunfailures-6.0, timeout-1.3.3, forked-1.0.2
timeout: 300.0s
timeout method: signal
timeout func_only: False
gw0 I / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 C gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 C gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 C gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 C gw0 ok / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 Cgw0 ok / gw1 ok / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 gw0 ok / gw1 ok / gw2 ok / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12gw0 ok / gw1 ok / gw2 ok / gw3 C / gw4 ok / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw1gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gwgw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / ggw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 C / gw9 C / gw10 C / gw11 C /gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 C / gw10 C / gw11 C gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 C / gw11 Cgw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 [1505] / gw7 ok / gw8 ok / gw9 ok / gw10 ok / ggw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 ok / gw8 ok / gw9 ok / gw10 okgw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 ok / gw8 ok / gw9 [1505] / gw1gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 ok / gw9 [1505] /gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 ok / gw9 [1505] /gw0 [1505] / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 ok / gw9 [150gw0 [1505] / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 [1505] / gw9 gw0 [1505] / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 [1505] / gw9 gw0 [1505] / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 [1505] / gw9 gw0 [1505] / gw1 ok / gw2 ok / gw3 [1505] / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 [1505] / gw0 [1505] / gw1 [1505] / gw2 ok / gw3 [1505] / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 [1505gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 [gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 ok / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 [gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 [1505] / ggw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 [1505] / gw9 [1505] / gw10 [1505] / gw11 [1505] / gw12 [1505] / gw13 [1505] / gw14 [1505] / gw15 [1505]
........s............................................................................F..x........ [  6%]
.........................................................................s....................... [ 12%]
..................x.............................................................................. [ 19%]
................................................................................................. [ 25%]
............................................s...............x.................................... [ 32%]
x................................................................................................ [ 38%]
.........................................................s....................................... [ 45%]
........................x........................................................................ [ 51%]
...................................................................................s............. [ 58%]
................................................................................................. [ 64%]
.................................................................................................. [ 70%]
.............................s.s...................................s............................. [ 77%]
..................s.................................................................F............ [ 83%]
................................................................................................. [ 90%]
................................................................................................. [ 96%]
................................s............s...                                                 [100%]sys:1: ResourceWarning: unclosed file <_io.TextIOWrapper name=0 mode='r' encoding='UTF-8'>
sys:1: ResourceWarning: unclosed file <_io.TextIOWrapper name=1 mode='w' encoding='UTF-8'>

=============================================== FAILURES ================================================
_________________________________________ test_freeze_with_pip __________________________________________
[gw15] linux -- Python 3.7.2 /tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/py37/bin/python

script = <tests.lib.PipTestEnvironment object at 0x7efbf069cd30>

    def test_freeze_with_pip(script):
        """Test pip shows itself"""
        result = script.pip('freeze', '--all')
>       assert 'pip==' in result.stdout
E       AssertionError: assert 'pip==' in '-e git+https://github.com/chrahunt/pip.git@7c319ad74a70e02f2d2cb105cf0cdc5372f8a92a#egg=pip&subdirectory=../../../../... no version control (setuptools==41.0.1)\n-e /tmp/user/1000/pytest-of-chris/pytest-25/popen-gw15/setuptools0/install\n'
E        +  where '-e git+https://github.com/chrahunt/pip.git@7c319ad74a70e02f2d2cb105cf0cdc5372f8a92a#egg=pip&subdirectory=../../../../... no version control (setuptools==41.0.1)\n-e /tmp/user/1000/pytest-of-chris/pytest-25/popen-gw15/setuptools0/install\n' = <tests.lib.TestPipResult object at 0x7efbf069cf28>.stdout

tests/functional/test_freeze.py:77: AssertionError
_____________________________________ test_git_get_src_requirements _____________________________________
[gw11] linux -- Python 3.7.2 /tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/py37/bin/python

mock_get_remote_url = <MagicMock name='get_remote_url' id='139620521408496'>
mock_get_revision = <MagicMock name='get_revision' id='139620521408440'>

    @patch('pip._internal.vcs.git.Git.get_revision')
    @patch('pip._internal.vcs.git.Git.get_remote_url')
    @pytest.mark.network
    def test_git_get_src_requirements(mock_get_remote_url, mock_get_revision):
        git_url = 'https://github.com/pypa/pip-test-package'
        sha = '5547fa909e83df8bd743d3978d6667497983a4b7'

        mock_get_remote_url.return_value = git_url
        mock_get_revision.return_value = sha

        ret = Git.get_src_requirement('.', 'pip-test-package')

>       assert ret == (
            'git+https://github.com/pypa/pip-test-package'
            '@5547fa909e83df8bd743d3978d6667497983a4b7#egg=pip_test_package'
        )
E       AssertionError: assert 'git+https://...../../../pip2' == 'git+https://g..._test_package'
E         Skipping 95 identical leading characters in diff, use -v to show
E         - est_package&subdirectory=../../../pip2
E         + est_package

tests/unit/test_vcs.py:138: AssertionError
======================================== short test summary info ========================================
FAIL tests/functional/test_freeze.py::test_freeze_with_pip
FAIL tests/unit/test_vcs.py::test_git_get_src_requirements
SKIP [1] tests/functional/test_configuration.py:19: Can't modify underlying file for any mode
SKIP [1] tests/functional/test_install.py:538: condition: sys.version_info >= (3,4)
SKIP [1] tests/unit/test_download.py:328: condition: sys.platform != 'win32'
SKIP [1] tests/unit/test_index.py:1059: condition: sys.platform != 'win32'
SKIP [1] tests/functional/test_search.py:81: Warehouse search behavior is different and no longer returns multiple results. See https://github.com/pypa/warehouse/issues/3717 for more information.
SKIP [2] tests/unit/test_utils.py:909: condition: sys.version_info >= (3,)
SKIP [1] tests/unit/test_utils.py:1217: condition: sys.platform != 'win32'
SKIP [1] tests/unit/test_vcs.py:23: Subversion is only required under Travis
SKIP [1] tests/functional/test_requests.py:4: <Skipped instance>
SKIP [1] tests/functional/test_vcs_bazaar.py:19: Bazaar is only required under Travis
XFAIL tests/functional/test_freeze.py::test_freeze_exclude_editable
XFAIL tests/functional/test_install_reqs.py::test_install_distribution_union_conflicting_extras
XFAIL tests/functional/test_yaml.py::test_yaml_based[install/conflicting_triangle]
XFAIL tests/functional/test_yaml.py::test_yaml_based[install/conflicting_diamond]
XFAIL tests/functional/test_yaml.py::test_yaml_based[install/extras-2]
=========================================== warnings summary ============================================
/tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/py37/lib/python3.7/site-packages/pip/_internal/pep425tags.py:34: RuntimeWarning: I have the wrong path!
  warnings.warn("{}".format(e), RuntimeWarning)

/tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/py37/lib/python3.7/site-packages/pip/_internal/req/req_file.py:189: UserWarning: Disabling all use of wheels due to the use of --build-options / --global-options / --install-options.
  cmdoptions.check_install_build_global(options, opts)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============== 2 failed, 1487 passed, 11 skipped, 5 xfailed, 2 warnings in 75.40 seconds ===============
ERROR: InvocationError for command /tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/py37/bin/pytest --timeout 300 -n 16 (exited with code 1)
________________________________________________ summary ________________________________________________
ERROR:   py37: commands failed
Branch 'bugfix/fix-tests-in-linked-worktree' set up to track remote branch 'bugfix/fix-tests-in-linked-worktree' from 'origin'.
Switched to a new branch 'bugfix/fix-tests-in-linked-worktree'
#### PASSING TESTS ####
GLOB sdist-make: /tmp/user/1000/tmp.3EduFikNJC/pip2/setup.py
py37 inst-nodeps: /tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/.tmp/package/1/pip-19.3.dev0.zip
py37 installed: apipkg==1.5,atomicwrites==1.3.0,attrs==19.1.0,coverage==4.5.4,execnet==1.6.1,freezegun==0.3.12,importlib-metadata==0.19,mock==3.0.5,more-itertools==7.2.0,pip==19.3.dev0,pluggy==0.12.0,pretend==1.0.9,py==1.8.0,pytest==3.8.2,pytest-cov==2.7.1,pytest-forked==1.0.2,pytest-rerunfailures==6.0,pytest-timeout==1.3.3,pytest-xdist==1.27.0,python-dateutil==2.8.0,PyYAML==5.1.2,scripttest==1.3,setuptools==41.0.1,six==1.12.0,virtualenv==16.7.2,wheel==0.33.4,zipp==0.5.2
py37 run-test-pre: PYTHONHASHSEED='460732193'
py37 run-test-pre: commands[0] | python -c 'import shutil, sys; shutil.rmtree(sys.argv[1], ignore_errors=True)' /tmp/user/1000/tmp.3EduFikNJC/pip2/tests/data/common_wheels
py37 run-test-pre: commands[1] | python /tmp/user/1000/tmp.3EduFikNJC/pip2/tools/tox_pip.py wheel -w /tmp/user/1000/tmp.3EduFikNJC/pip2/tests/data/common_wheels -r /tmp/user/1000/tmp.3EduFikNJC/pip2/tools/requirements/tests-common_wheels.txt
Collecting setuptools>=40.8.0 (from -r tools/requirements/tests-common_wheels.txt (line 8))
  Using cached https://files.pythonhosted.org/packages/ec/51/f45cea425fd5cb0b0380f5b0f048ebc1da5b417e48d304838c02d6288a1e/setuptools-41.0.1-py2.py3-none-any.whl
  Saved ./tests/data/common_wheels/setuptools-41.0.1-py2.py3-none-any.whl
Collecting wheel (from -r tools/requirements/tests-common_wheels.txt (line 9))
  Using cached https://files.pythonhosted.org/packages/bb/10/44230dd6bf3563b8f227dbf344c908d412ad2ff48066476672f3a72e174e/wheel-0.33.4-py2.py3-none-any.whl
  Saved ./tests/data/common_wheels/wheel-0.33.4-py2.py3-none-any.whl
Skipping setuptools, due to already being wheel.
Skipping wheel, due to already being wheel.
py37 run-test: commands[0] | pytest --timeout 300 -n 16
========================================== test session starts ==========================================
platform linux -- Python 3.7.2, pytest-3.8.2, py-1.8.0, pluggy-0.12.0
rootdir: /tmp/user/1000/tmp.3EduFikNJC/pip2, inifile: setup.cfg
plugins: xdist-1.27.0, cov-2.7.1, rerunfailures-6.0, timeout-1.3.3, forked-1.0.2
timeout: 300.0s
timeout method: signal
timeout func_only: False
gw0 I / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 I / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 I / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 I / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 I / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 I / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 I / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 I gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 C gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 C gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 C gw0 C / gw1 C / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 C gw0 C / gw1 ok / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 Cgw0 ok / gw1 ok / gw2 C / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12 gw0 ok / gw1 ok / gw2 ok / gw3 C / gw4 C / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw12gw0 ok / gw1 ok / gw2 ok / gw3 C / gw4 ok / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw1gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 C / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gwgw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 C / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / ggw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 C / gw8 C / gw9 C / gw10 C / gw11 C / gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 C / gw9 C / gw10 C / gw11 C /gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 C / gw10 C / gw11 C gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 C / gw11 Cgw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 ok / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / gw11 gw0 ok / gw1 [1505] / gw2 ok / gw3 ok / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 ok / ggw0 ok / gw1 [1505] / gw2 ok / gw3 [1505] / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw10 okgw0 [1505] / gw1 [1505] / gw2 ok / gw3 [1505] / gw4 ok / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok / gw1gw0 [1505] / gw1 [1505] / gw2 ok / gw3 [1505] / gw4 [1505] / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 ok /gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 ok / gw6 ok / gw7 ok / gw8 ok / gw9 gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 ok / gw7 ok / gw8 ok / gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 ok / gw8 ogw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 ok / gw8 [gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 ok / gw8 [gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 ok / gw8 [gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 ok / gw8 [gw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 [1505] / ggw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 [1505] / ggw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 [1505] / ggw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 [1505] / ggw0 [1505] / gw1 [1505] / gw2 [1505] / gw3 [1505] / gw4 [1505] / gw5 [1505] / gw6 [1505] / gw7 [1505] / gw8 [1505] / gw9 [1505] / gw10 [1505] / gw11 [1505] / gw12 [1505] / gw13 [1505] / gw14 [1505] / gw15 [1505]
.......s..................................................................................x...... [  6%]
.............................................................................s................... [ 12%]
...................x............................................................................. [ 19%]
................................................................................................. [ 25%]
..........................................................................................x...... [ 32%]
...........x..................................................................................... [ 38%]
.....................................................s........................................... [ 45%]
................................................................................................. [ 51%]
........x...s.................................................................................... [ 58%]
........s........................................................................................ [ 64%]
................................................................................................. [ 70%]
........................................................s....s.........s......................... [ 77%]
...........................................s...................................................... [ 83%]
.................................................................................................. [ 90%]
................................................................................................. [ 96%]
................................s...........s...                                                  [100%]
======================================== short test summary info ========================================
SKIP [1] tests/functional/test_configuration.py:19: Can't modify underlying file for any mode
SKIP [1] tests/functional/test_install.py:538: condition: sys.version_info >= (3,4)
SKIP [1] tests/unit/test_index.py:1059: condition: sys.platform != 'win32'
SKIP [1] tests/unit/test_download.py:328: condition: sys.platform != 'win32'
SKIP [1] tests/functional/test_search.py:81: Warehouse search behavior is different and no longer returns multiple results. See https://github.com/pypa/warehouse/issues/3717 for more information.
SKIP [2] tests/unit/test_utils.py:909: condition: sys.version_info >= (3,)
SKIP [1] tests/unit/test_utils.py:1217: condition: sys.platform != 'win32'
SKIP [1] tests/unit/test_vcs.py:23: Subversion is only required under Travis
SKIP [1] tests/functional/test_requests.py:4: <Skipped instance>
SKIP [1] tests/functional/test_vcs_bazaar.py:19: Bazaar is only required under Travis
XFAIL tests/functional/test_freeze.py::test_freeze_exclude_editable
XFAIL tests/functional/test_install_reqs.py::test_install_distribution_union_conflicting_extras
XFAIL tests/functional/test_yaml.py::test_yaml_based[install/conflicting_triangle]
XFAIL tests/functional/test_yaml.py::test_yaml_based[install/conflicting_diamond]
XFAIL tests/functional/test_yaml.py::test_yaml_based[install/extras-2]
=========================================== warnings summary ============================================
/tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/py37/lib/python3.7/site-packages/pip/_internal/pep425tags.py:34: RuntimeWarning: I have the wrong path!
  warnings.warn("{}".format(e), RuntimeWarning)

/tmp/user/1000/tmp.3EduFikNJC/pip2/.tox/py37/lib/python3.7/site-packages/pip/_internal/req/req_file.py:189: UserWarning: Disabling all use of wheels due to the use of --build-options / --global-options / --install-options.
  cmdoptions.check_install_build_global(options, opts)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
==================== 1489 passed, 11 skipped, 5 xfailed, 2 warnings in 73.48 seconds ====================
________________________________________________ summary ________________________________________________
  py37: commands succeeded
```

</details>


Fixes #6707.