### PR TITLE
Remove an unneeded argument from populate_requirement_set()

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -183,14 +183,13 @@ class RequirementCommand(IndexGroupCommand):
             py_version_info=py_version_info
         )
 
-    @staticmethod
     def populate_requirement_set(
+        self,
         requirement_set,  # type: RequirementSet
         args,             # type: List[str]
         options,          # type: Values
         finder,           # type: PackageFinder
         session,          # type: PipSession
-        name,             # type: str
         wheel_cache,      # type: Optional[WheelCache]
     ):
         # type: (...) -> None
@@ -240,7 +239,7 @@ class RequirementCommand(IndexGroupCommand):
         requirement_set.require_hashes = options.require_hashes
 
         if not (args or options.editables or options.requirements):
-            opts = {'name': name}
+            opts = {'name': self.name}
             if options.find_links:
                 raise CommandError(
                     'You must give at least one requirement to %(name)s '

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -120,7 +120,6 @@ class DownloadCommand(RequirementCommand):
                     options,
                     finder,
                     session,
-                    self.name,
                     None
                 )
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -318,7 +318,7 @@ class InstallCommand(RequirementCommand):
                 try:
                     self.populate_requirement_set(
                         requirement_set, args, options, finder, session,
-                        self.name, wheel_cache
+                        wheel_cache
                     )
                     preparer = self.make_requirement_preparer(
                         temp_directory=directory,

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -124,7 +124,7 @@ class WheelCommand(RequirementCommand):
                 try:
                     self.populate_requirement_set(
                         requirement_set, args, options, finder, session,
-                        self.name, wheel_cache
+                        wheel_cache
                     )
 
                     preparer = self.make_requirement_preparer(

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -190,8 +190,7 @@ class TestRequirementSet(object):
         with requirements_file('--require-hashes', tmpdir) as reqs_file:
             options, args = command.parse_args(['-r', reqs_file])
             command.populate_requirement_set(
-                req_set, args, options, finder, session, command.name,
-                wheel_cache=None,
+                req_set, args, options, finder, session, wheel_cache=None,
             )
         assert req_set.require_hashes
 


### PR DESCRIPTION
This removes an unneeded argument from `RequirementCommand.populate_requirement_set()`.