### PR TITLE
Change the return type of Wheel.support_index_min() from Optional[int] to int

### DIFF
--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -737,17 +737,20 @@ class Wheel(object):
         return sorted(format_tag(tag) for tag in self.file_tags)
 
     def support_index_min(self, tags=None):
-        # type: (Optional[List[Pep425Tag]]) -> Optional[int]
+        # type: (Optional[List[Pep425Tag]]) -> int
         """
         Return the lowest index that one of the wheel's file_tag combinations
-        achieves in the supported_tags list e.g. if there are 8 supported tags,
-        and one of the file tags is first in the list, then return 0.  Returns
-        None is the wheel is not supported.
+        achieves in the given list of supported tags.
+
+        For example, if there are 8 supported tags and one of the file tags
+        is first in the list, then return 0.
+
+        :raises ValueError: If none of the wheel's file tags match one of
+            the supported tags.
         """
         if tags is None:  # for mock
             tags = pep425tags.get_supported()
-        indexes = [tags.index(c) for c in self.file_tags if c in tags]
-        return min(indexes) if indexes else None
+        return min(tags.index(tag) for tag in self.file_tags if tag in tags)
 
     def supported(self, tags=None):
         # type: (Optional[List[Pep425Tag]]) -> bool

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -751,10 +751,10 @@ class Wheel(object):
 
     def supported(self, tags=None):
         # type: (Optional[List[Pep425Tag]]) -> bool
-        """Is this wheel supported on this system?"""
+        """Return whether this wheel is supported by one of the given tags."""
         if tags is None:  # for mock
             tags = pep425tags.get_supported()
-        return bool(set(tags).intersection(self.file_tags))
+        return not self.file_tags.isdisjoint(tags)
 
 
 def _contains_egg_info(

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -566,12 +566,13 @@ class TestWheelFile(object):
         w = wheel.Wheel('simple-0.1-py2-none-TEST.whl')
         assert w.support_index_min(tags=tags) == 0
 
-    def test_support_index_min_none(self):
+    def test_support_index_min__none_supported(self):
         """
-        Test `support_index_min` returns None, when wheel not supported
+        Test a wheel not supported by the given tags.
         """
         w = wheel.Wheel('simple-0.1-py2-none-any.whl')
-        assert w.support_index_min(tags=[]) is None
+        with pytest.raises(ValueError):
+            w.support_index_min(tags=[])
 
     def test_unpack_wheel_no_flatten(self):
         from pip._internal.utils import misc as utils


### PR DESCRIPTION
This changes the return type of `Wheel.support_index_min()` from `Optional[int]` to `int`. This addresses one of the strict-optional mypy warnings in `index.py` -- specifically the one resulting from this line: https://github.com/pypa/pip/blob/76e1f1b5e6172f3a603f42fd9f15a3ef980c094d/src/pip/_internal/index.py#L712