### PR TITLE
Make tags required in Wheel.support_index_min() and supported()

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -18,7 +18,7 @@ from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pep517.wrappers import Pep517HookCaller
 
-from pip._internal import wheel
+from pip._internal import pep425tags, wheel
 from pip._internal.build_env import NoOpBuildEnvironment
 from pip._internal.exceptions import InstallationError
 from pip._internal.models.link import Link
@@ -222,7 +222,12 @@ class InstallRequirement(object):
             self.link = finder.find_requirement(self, upgrade)
         if self._wheel_cache is not None and not require_hashes:
             old_link = self.link
-            self.link = self._wheel_cache.get(self.link, self.name)
+            supported_tags = pep425tags.get_supported()
+            self.link = self._wheel_cache.get(
+                link=self.link,
+                package_name=self.name,
+                supported_tags=supported_tags,
+            )
             if old_link != self.link:
                 logger.debug('Using cached wheel link: %s', self.link)
 

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import logging
 from collections import OrderedDict
 
+from pip._internal import pep425tags
 from pip._internal.exceptions import InstallationError
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -88,7 +89,8 @@ class RequirementSet(object):
         # single requirements file.
         if install_req.link and install_req.link.is_wheel:
             wheel = Wheel(install_req.link.filename)
-            if self.check_supported_wheels and not wheel.supported():
+            tags = pep425tags.get_supported()
+            if (self.check_supported_wheels and not wheel.supported(tags)):
                 raise InstallationError(
                     "%s is not a supported wheel on this platform." %
                     wheel.filename

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -736,8 +736,8 @@ class Wheel(object):
         """
         return sorted(format_tag(tag) for tag in self.file_tags)
 
-    def support_index_min(self, tags=None):
-        # type: (Optional[List[Pep425Tag]]) -> int
+    def support_index_min(self, tags):
+        # type: (List[Pep425Tag]) -> int
         """
         Return the lowest index that one of the wheel's file_tag combinations
         achieves in the given list of supported tags.
@@ -745,18 +745,21 @@ class Wheel(object):
         For example, if there are 8 supported tags and one of the file tags
         is first in the list, then return 0.
 
+        :param tags: the PEP 425 tags to check the wheel against, in order
+            with most preferred first.
+
         :raises ValueError: If none of the wheel's file tags match one of
             the supported tags.
         """
-        if tags is None:  # for mock
-            tags = pep425tags.get_supported()
         return min(tags.index(tag) for tag in self.file_tags if tag in tags)
 
-    def supported(self, tags=None):
-        # type: (Optional[List[Pep425Tag]]) -> bool
-        """Return whether this wheel is supported by one of the given tags."""
-        if tags is None:  # for mock
-            tags = pep425tags.get_supported()
+    def supported(self, tags):
+        # type: (List[Pep425Tag]) -> bool
+        """
+        Return whether the wheel is compatible with one of the given tags.
+
+        :param tags: the PEP 425 tags to check the wheel against.
+        """
         return not self.file_tags.isdisjoint(tags)
 
 


### PR DESCRIPTION
Currently, a couple of the `Wheel` class's methods have a "hidden" dependency on the list of supported tags. This PR surfaces that dependency by making the `tags` argument required, and then further surfaces it in the `SimpleWheelCache` classes.

I think it's possible there might be a bug lurking somewhere because of this, in cases where the list of supported tags can be changed due to passing any of the target-python options like `--python-version`, etc. `pip download` is one command that could be affected. This PR will help with knowing if anything is affected. We might later want to make sure that the `tags` being passed at the various call sites reflect the `TargetPython` passed on the command-line.
