### PR TITLE
Cache wheels built from immutable VCS requirements

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -573,6 +573,9 @@ and use any packages found there. This is disabled via the same
 of that is not part of the pip API. As of 7.0, pip makes a subdirectory for
 each sdist that wheels are built from and places the resulting wheels inside.
 
+As of version 20.0, pip also caches wheels when building from an immutable Git
+reference (i.e. a commit hash).
+
 Pip attempts to choose the best wheels from those built in preference to
 building a new wheel. Note that this means when a package has both optional
 C extensions and builds ``py`` tagged wheels when the C extension can't be built

--- a/news/6640.feature
+++ b/news/6640.feature
@@ -1,0 +1,2 @@
+Cache wheels built from Git requirements that are considered immutable,
+because they point to a commit hash.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -64,7 +64,17 @@ class Git(VersionControl):
         _, rev_options = self.get_url_rev_options(hide_url(url))
         if not rev_options.rev:
             return False
-        return self.is_commit_id_equal(dest, rev_options.rev)
+        if not self.is_commit_id_equal(dest, rev_options.rev):
+            # the current commit is different from rev,
+            # which means rev was something else than a commit hash
+            return False
+        # return False in the rare case rev is both a commit hash
+        # and a tag or a branch; we don't want to cache in that case
+        # because that branch/tag could point to something else in the future
+        is_tag_or_branch = bool(
+            self.get_revision_sha(dest, rev_options.rev)[0]
+        )
+        return not is_tag_or_branch
 
     def get_git_version(self):
         VERSION_PFX = 'git version '

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -12,7 +12,7 @@ from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib import request as urllib_request
 
 from pip._internal.exceptions import BadCommand
-from pip._internal.utils.misc import display_path
+from pip._internal.utils.misc import display_path, hide_url
 from pip._internal.utils.subprocess import make_command
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -58,6 +58,13 @@ class Git(VersionControl):
     @staticmethod
     def get_base_rev_args(rev):
         return [rev]
+
+    def is_immutable_rev_checkout(self, url, dest):
+        # type: (str, str) -> bool
+        _, rev_options = self.get_url_rev_options(hide_url(url))
+        if not rev_options.rev:
+            return False
+        return self.is_commit_id_equal(dest, rev_options.rev)
 
     def get_git_version(self):
         VERSION_PFX = 'git version '

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -329,6 +329,20 @@ class VersionControl(object):
         """
         raise NotImplementedError
 
+    def is_immutable_rev_checkout(self, url, dest):
+        # type: (str, str) -> bool
+        """
+        Return true if the commit hash checked out at dest matches
+        the revision in url.
+
+        Always return False, if the VCS does not support immutable commit
+        hashes.
+
+        This method does not check if there are local uncommitted changes
+        in dest after checkout, as pip currently has no use case for that.
+        """
+        return False
+
     @classmethod
     def make_rev_options(cls, rev=None, extra_args=None):
         # type: (Optional[str], Optional[CommandArgs]) -> RevOptions

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -221,3 +221,20 @@ def test_is_commit_id_equal(script):
     assert not Git.is_commit_id_equal(version_pkg_path, 'abc123')
     # Also check passing a None value.
     assert not Git.is_commit_id_equal(version_pkg_path, None)
+
+
+def test_is_immutable_rev_checkout(script):
+    version_pkg_path = _create_test_package(script)
+    commit = script.run(
+        'git', 'rev-parse', 'HEAD',
+        cwd=version_pkg_path
+    ).stdout.strip()
+    assert Git().is_immutable_rev_checkout(
+        "git+https://g.c/o/r@" + commit, version_pkg_path
+    )
+    assert not Git().is_immutable_rev_checkout(
+        "git+https://g.c/o/r", version_pkg_path
+    )
+    assert not Git().is_immutable_rev_checkout(
+        "git+https://g.c/o/r@master", version_pkg_path
+    )


### PR DESCRIPTION
Cache wheels built from VCS requirements referring to an immutable revision (such as a git sha).

Closes #6640

TODO
- [x] wait on ~~#6853~~  #7262
- [x] use vcs.get_backend_for_scheme (from #7281)
- [x] integration test
- [x] update doc
- ~~support other VCS than Git~~ can be left for future PRs