### PR TITLE
Cache wheels that pip wheel built locally

### DIFF
--- a/news/6852.bugfix
+++ b/news/6852.bugfix
@@ -1,0 +1,2 @@
+Cache wheels that ``pip wheel`` built locally after downloading
+them as sdist. This matches what ``pip install`` does.

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -775,30 +775,30 @@ def _contains_egg_info(
 
 def should_build(
     req,  # type: InstallRequirement
-    should_unpack,  # type: bool
+    need_wheel,  # type: bool
     format_control,  # type: FormatControl
 ):
     """
     Return whether a wheel should be built based on the requirement
-    characteristics, and if it should be ultimately unpacked or not.
+    characteristics, and if a wheel is ultimately needed or not.
     """
     if req.constraint:
         # never build requirements that are merely constraints
         return False
 
     if req.is_wheel:
-        if not should_unpack:
+        if need_wheel:
             logger.info(
                 'Skipping %s, due to already being wheel.', req.name,
             )
         # never build a requirement that is already a wheel
         return False
 
-    if not should_unpack:
+    if need_wheel:
         return True
 
     if req.editable:
-        # don't build an editable if it should ultimately be unpacked
+        # don't build an editable if no wheel is needed
         return False
 
     if not req.source_dir:
@@ -1096,7 +1096,7 @@ class WheelBuilder(object):
         for req in requirements:
             if not should_build(
                 req,
-                should_unpack=should_unpack,
+                need_wheel=not should_unpack,
                 format_control=format_control,
             ):
                 continue

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -794,15 +794,18 @@ def should_build(
         # never build a requirement that is already a wheel
         return False
 
+    if not should_unpack:
+        return True
+
     if req.editable:
-        # don't build an editable if it should be unpacked
-        return not should_unpack
+        # don't build an editable if it should ultimately be unpacked
+        return False
 
     if not req.source_dir:
         # TODO explain what no source_dir means
-        return not should_unpack
+        return False
 
-    if should_unpack and "binary" not in format_control.get_allowed_formats(
+    if "binary" not in format_control.get_allowed_formats(
             canonicalize_name(req.name)):
         logger.info(
             "Skipping bdist_wheel for %s, due to binaries "

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -819,18 +819,11 @@ def should_build(
 def should_cache(
     req,  # type: InstallRequirement
     format_control,  # type: FormatControl
-    cache_available,  # type: bool
 ):
     # type: (...) -> Optional[bool]
     """
     Return whether to build an InstallRequirement object using the
-    wheel cache.
-
-    :param cache_available: whether a cache directory is available for the
-        should_unpack=True case.
-
-    :return: True to use the persistent cache,
-        False to use the ephemeral cache.
+    wheel cache, assuming the wheel cache is available.
     """
     if req.editable:
         # don't cache editable requirements because they can
@@ -855,12 +848,11 @@ def should_cache(
 
     link = req.link
     base, ext = link.splitext()
-    if cache_available and _contains_egg_info(base):
+    if _contains_egg_info(base):
         return True
 
     # Otherwise, build the wheel just for this run using the ephemeral
-    # cache since we are either in the case of e.g. a local directory, or
-    # no cache directory is available to use.
+    # cache since we are either in the case of e.g. a local directory.
     return False
 
 
@@ -1100,10 +1092,9 @@ class WheelBuilder(object):
                 format_control=format_control,
             ):
                 continue
-            use_ephemeral_cache = not should_cache(
-                req,
-                format_control=format_control,
-                cache_available=cache_available,
+            use_ephemeral_cache = (
+                not cache_available or
+                not should_cache(req, format_control=format_control)
             )
             buildset.append((req, use_ephemeral_cache))
 

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -844,7 +844,10 @@ def should_use_ephemeral_cache(
         return True
 
     if req.link and req.link.is_vcs:
-        # VCS checkout. Build wheel just for this run.
+        # VCS checkout. Build wheel just for this run
+        # unless it points to an immutable commit hash in which
+        # case it can be cached.
+        # TODO if req.link.is_vcs_immutable: return False
         return True
 
     link = req.link

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -61,6 +61,30 @@ def test_pip_wheel_success(script, data):
     assert "Successfully built simple" in result.stdout, result.stdout
 
 
+def test_pip_wheel_build_cache(script, data):
+    """
+    Test 'pip wheel' builds and caches.
+    """
+    result = script.pip(
+        'wheel', '--no-index', '-f', data.find_links,
+        'simple==3.0',
+    )
+    wheel_file_name = 'simple-3.0-py%s-none-any.whl' % pyversion[0]
+    wheel_file_path = script.scratch / wheel_file_name
+    assert wheel_file_path in result.files_created, result.stdout
+    assert "Successfully built simple" in result.stdout, result.stdout
+    # remove target file
+    (script.scratch_path / wheel_file_name).unlink()
+    # pip wheel again and test that no build occurs since
+    # we get the wheel from cache
+    result = script.pip(
+        'wheel', '--no-index', '-f', data.find_links,
+        'simple==3.0',
+    )
+    assert wheel_file_path in result.files_created, result.stdout
+    assert "Successfully built simple" not in result.stdout, result.stdout
+
+
 def test_basic_pip_wheel_downloads_wheels(script, data):
     """
     Test 'pip wheel' downloads wheels

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -153,7 +153,7 @@ def test_should_use_ephemeral_cache(
     format_control = FormatControl()
     if disallow_binaries:
         format_control.disallow_binaries()
-    should_use_ephemeral_cache = wheel.should_use_ephemeral_cache(
+    should_use_ephemeral_cache = not wheel.should_cache(
         req, format_control=format_control, cache_available=cache_available
     )
     assert should_use_ephemeral_cache is expected

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -133,28 +133,23 @@ def test_should_build(req, need_wheel, disallow_binaries, expected):
 
 
 @pytest.mark.parametrize(
-    "req, disallow_binaries, cache_available, expected",
+    "req, disallow_binaries, expected",
     [
-        (ReqMock(editable=True), False, True, False),
-        (ReqMock(editable=True), False, False, False),
-        (ReqMock(source_dir=None), False, True, False),
-        (ReqMock(source_dir=None), False, False, False),
-        (ReqMock(link=Link("git+https://g.c/org/repo")), False, True, False),
-        (ReqMock(link=Link("git+https://g.c/org/repo")), False, False, False),
-        (ReqMock(link=Link("https://g.c/dist.tgz")), False, True, False),
-        (ReqMock(link=Link("https://g.c/dist.tgz")), False, False, False),
-        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), False, True, True),
-        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), False, False, False),
+        (ReqMock(editable=True), False, False),
+        (ReqMock(source_dir=None), False, False),
+        (ReqMock(link=Link("git+https://g.c/org/repo")), False, False),
+        (ReqMock(link=Link("https://g.c/dist.tgz")), False, False),
+        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), False, True),
     ],
 )
 def test_should_cache(
-    req, disallow_binaries, cache_available, expected
+    req, disallow_binaries, expected
 ):
     format_control = FormatControl()
     if disallow_binaries:
         format_control.disallow_binaries()
     should_cache = wheel.should_cache(
-        req, format_control=format_control, cache_available=cache_available
+        req, format_control=format_control,
     )
     assert should_cache is expected
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -80,7 +80,7 @@ def test_format_tag(file_tag, expected):
 @pytest.mark.parametrize(
     "base_name, should_unpack, cache_available, expected",
     [
-        ('pendulum-2.0.4', False, False, False),
+        ('pendulum-2.0.4', False, False, True),
         # The following cases test should_unpack=True.
         # Test _contains_egg_info() returning True.
         ('pendulum-2.0.4', True, True, False),

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -135,28 +135,28 @@ def test_should_build(req, need_wheel, disallow_binaries, expected):
 @pytest.mark.parametrize(
     "req, disallow_binaries, cache_available, expected",
     [
-        (ReqMock(editable=True), False, True, True),
-        (ReqMock(editable=True), False, False, True),
-        (ReqMock(source_dir=None), False, True, True),
-        (ReqMock(source_dir=None), False, False, True),
-        (ReqMock(link=Link("git+https://g.c/org/repo")), False, True, True),
-        (ReqMock(link=Link("git+https://g.c/org/repo")), False, False, True),
-        (ReqMock(link=Link("https://g.c/dist.tgz")), False, True, True),
-        (ReqMock(link=Link("https://g.c/dist.tgz")), False, False, True),
-        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), False, True, False),
-        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), False, False, True),
+        (ReqMock(editable=True), False, True, False),
+        (ReqMock(editable=True), False, False, False),
+        (ReqMock(source_dir=None), False, True, False),
+        (ReqMock(source_dir=None), False, False, False),
+        (ReqMock(link=Link("git+https://g.c/org/repo")), False, True, False),
+        (ReqMock(link=Link("git+https://g.c/org/repo")), False, False, False),
+        (ReqMock(link=Link("https://g.c/dist.tgz")), False, True, False),
+        (ReqMock(link=Link("https://g.c/dist.tgz")), False, False, False),
+        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), False, True, True),
+        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), False, False, False),
     ],
 )
-def test_should_use_ephemeral_cache(
+def test_should_cache(
     req, disallow_binaries, cache_available, expected
 ):
     format_control = FormatControl()
     if disallow_binaries:
         format_control.disallow_binaries()
-    should_use_ephemeral_cache = not wheel.should_cache(
+    should_cache = wheel.should_cache(
         req, format_control=format_control, cache_available=cache_available
     )
-    assert should_use_ephemeral_cache is expected
+    assert should_cache is expected
 
 
 def test_format_command_result__INFO(caplog):

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -97,37 +97,37 @@ def test_format_tag(file_tag, expected):
 
 
 @pytest.mark.parametrize(
-    "req, should_unpack, disallow_binaries, expected",
+    "req, need_wheel, disallow_binaries, expected",
     [
-        # pip wheel (should_unpack=False)
-        (ReqMock(), False, False, True),
-        (ReqMock(), False, True, True),
-        (ReqMock(constraint=True), False, False, False),
-        (ReqMock(is_wheel=True), False, False, False),
-        (ReqMock(editable=True), False, False, True),
-        (ReqMock(source_dir=None), False, False, True),
-        (ReqMock(link=Link("git+https://g.c/org/repo")), False, False, True),
-        (ReqMock(link=Link("git+https://g.c/org/repo")), False, True, True),
-        # pip install (should_unpack=True)
+        # pip wheel (need_wheel=True)
         (ReqMock(), True, False, True),
-        (ReqMock(), True, True, False),
+        (ReqMock(), True, True, True),
         (ReqMock(constraint=True), True, False, False),
         (ReqMock(is_wheel=True), True, False, False),
-        (ReqMock(editable=True), True, False, False),
-        (ReqMock(source_dir=None), True, False, False),
+        (ReqMock(editable=True), True, False, True),
+        (ReqMock(source_dir=None), True, False, True),
+        (ReqMock(link=Link("git+https://g.c/org/repo")), True, False, True),
+        (ReqMock(link=Link("git+https://g.c/org/repo")), True, True, True),
+        # pip install (need_wheel=False)
+        (ReqMock(), False, False, True),
+        (ReqMock(), False, True, False),
+        (ReqMock(constraint=True), False, False, False),
+        (ReqMock(is_wheel=True), False, False, False),
+        (ReqMock(editable=True), False, False, False),
+        (ReqMock(source_dir=None), False, False, False),
         # By default (i.e. when binaries are allowed), VCS requirements
         # should be built in install mode.
-        (ReqMock(link=Link("git+https://g.c/org/repo")), True, False, True),
+        (ReqMock(link=Link("git+https://g.c/org/repo")), False, False, True),
         # Disallowing binaries, however, should cause them not to be built.
-        (ReqMock(link=Link("git+https://g.c/org/repo")), True, True, False),
+        (ReqMock(link=Link("git+https://g.c/org/repo")), False, True, False),
     ],
 )
-def test_should_build(req, should_unpack, disallow_binaries, expected):
+def test_should_build(req, need_wheel, disallow_binaries, expected):
     format_control = FormatControl()
     if disallow_binaries:
         format_control.disallow_binaries()
     should_build = wheel.should_build(
-        req, should_unpack=should_unpack, format_control=format_control
+        req, need_wheel=need_wheel, format_control=format_control
     )
     assert should_build is expected
 


### PR DESCRIPTION
Instead of building to the target wheel directory, build to cache and then copy the result to the target directory. This more closely matches what pip install does and makes the cache more effective.

Closes #6852 