### PR TITLE
Write separate statefiles per prefix.

### DIFF
--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -78,15 +78,13 @@ class SelfCheckState(object):
 
         # Attempt to write out our version check file
         with lockfile.LockFile(self.statefile_path):
-            if os.path.exists(self.statefile_path):
-                with open(self.statefile_path) as statefile:
-                    state = json.load(statefile)
-            else:
-                state = {}
-
-            state[self.key] = {
-                "last_check": current_time.strftime(SELFCHECK_DATE_FMT),
-                "pypi_version": pypi_version,
+            # Since we have a prefix-specific state file, we can just
+            # overwrite whatever is there, no need to check.
+            state = {
+                self.key: {
+                    "last_check": current_time.strftime(SELFCHECK_DATE_FMT),
+                    "pypi_version": pypi_version,
+                },
             }
 
             with open(self.statefile_path, "w") as statefile:

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -76,21 +76,22 @@ class SelfCheckState(object):
         # ahead and make sure that all our directories are created.
         ensure_dir(os.path.dirname(self.statefile_path))
 
+        state = {
+            # Include the key so it's easy to tell which pip wrote the
+            # file.
+            "key": self.key,
+            "last_check": current_time.strftime(SELFCHECK_DATE_FMT),
+            "pypi_version": pypi_version,
+        }
+
+        text = json.dumps(state, sort_keys=True, separators=(",", ":"))
+
         # Attempt to write out our version check file
         with lockfile.LockFile(self.statefile_path):
             # Since we have a prefix-specific state file, we can just
             # overwrite whatever is there, no need to check.
-            state = {
-                # Include the key so it's easy to tell which pip wrote the
-                # file.
-                "key": self.key,
-                "last_check": current_time.strftime(SELFCHECK_DATE_FMT),
-                "pypi_version": pypi_version,
-            }
-
             with open(self.statefile_path, "w") as statefile:
-                json.dump(state, statefile, sort_keys=True,
-                          separators=(",", ":"))
+                statefile.write(text)
 
 
 def was_installed_by_pip(pkg):

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -52,7 +52,7 @@ class SelfCheckState(object):
             )
             try:
                 with open(self.statefile_path) as statefile:
-                    self.state = json.load(statefile)[self.key]
+                    self.state = json.load(statefile)
             except (IOError, ValueError, KeyError):
                 # Explicitly suppressing exceptions, since we don't want to
                 # error out if the cache file is invalid.
@@ -81,10 +81,11 @@ class SelfCheckState(object):
             # Since we have a prefix-specific state file, we can just
             # overwrite whatever is there, no need to check.
             state = {
-                self.key: {
-                    "last_check": current_time.strftime(SELFCHECK_DATE_FMT),
-                    "pypi_version": pypi_version,
-                },
+                # Include the key so it's easy to tell which pip wrote the
+                # file.
+                "key": self.key,
+                "last_check": current_time.strftime(SELFCHECK_DATE_FMT),
+                "pypi_version": pypi_version,
             }
 
             with open(self.statefile_path, "w") as statefile:

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -41,11 +41,15 @@ class SelfCheckState(object):
             self.statefile_path = os.path.join(cache_dir, "selfcheck.json")
             try:
                 with open(self.statefile_path) as statefile:
-                    self.state = json.load(statefile)[sys.prefix]
+                    self.state = json.load(statefile)[self.key]
             except (IOError, ValueError, KeyError):
                 # Explicitly suppressing exceptions, since we don't want to
                 # error out if the cache file is invalid.
                 pass
+
+    @property
+    def key(self):
+        return sys.prefix
 
     def save(self, pypi_version, current_time):
         # type: (str, datetime.datetime) -> None
@@ -69,7 +73,7 @@ class SelfCheckState(object):
             else:
                 state = {}
 
-            state[sys.prefix] = {
+            state[self.key] = {
                 "last_check": current_time.strftime(SELFCHECK_DATE_FMT),
                 "pypi_version": pypi_version,
             }

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -35,8 +35,8 @@ logger = logging.getLogger(__name__)
 def _get_statefile_name(key):
     # type: (Union[str, Text]) -> str
     key_bytes = ensure_binary(key)
-    name = hashlib.sha256(key_bytes).hexdigest()
-    return "selfcheck-{}.json".format(name)
+    name = hashlib.sha224(key_bytes).hexdigest()
+    return name
 
 
 class SelfCheckState(object):
@@ -48,7 +48,7 @@ class SelfCheckState(object):
         # Try to load the existing state
         if cache_dir:
             self.statefile_path = os.path.join(
-                cache_dir, _get_statefile_name(self.key)
+                cache_dir, "selfcheck", _get_statefile_name(self.key)
             )
             try:
                 with open(self.statefile_path) as statefile:

--- a/src/pip/_internal/utils/outdated.py
+++ b/src/pip/_internal/utils/outdated.py
@@ -30,6 +30,9 @@ SELFCHECK_DATE_FMT = "%Y-%m-%dT%H:%M:%SZ"
 logger = logging.getLogger(__name__)
 
 
+_STATEFILE_NAME = "selfcheck.json"
+
+
 class SelfCheckState(object):
     def __init__(self, cache_dir):
         # type: (str) -> None
@@ -38,7 +41,7 @@ class SelfCheckState(object):
 
         # Try to load the existing state
         if cache_dir:
-            self.statefile_path = os.path.join(cache_dir, "selfcheck.json")
+            self.statefile_path = os.path.join(cache_dir, _STATEFILE_NAME)
             try:
                 with open(self.statefile_path) as statefile:
                     self.state = json.load(statefile)[self.key]

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -162,8 +162,8 @@ def _get_statefile_path(cache_dir, key):
 
 
 def test_self_check_state(monkeypatch, tmpdir):
-    CONTENT = '''{"pip_prefix": {"last_check": "1970-01-02T11:00:00Z",
-        "pypi_version": "1.0"}}'''
+    CONTENT = '''{"key": "pip_prefix", "last_check": "1970-01-02T11:00:00Z",
+        "pypi_version": "1.0"}'''
     fake_file = pretend.stub(
         read=pretend.call_recorder(lambda: CONTENT),
         write=pretend.call_recorder(lambda s: None),
@@ -229,10 +229,9 @@ def test_self_check_state_reads_expected_statefile(monkeypatch, tmpdir):
     last_check = "1970-01-02T11:00:00Z"
     pypi_version = "1.0"
     content = {
-        key: {
-            "last_check": last_check,
-            "pypi_version": pypi_version,
-        },
+        "key": key,
+        "last_check": last_check,
+        "pypi_version": pypi_version,
     }
 
     with open(statefile_path, "w") as f:
@@ -264,9 +263,8 @@ def test_self_check_state_writes_expected_statefile(monkeypatch, tmpdir):
         saved = json.load(f)
 
     expected = {
-        key: {
-            "last_check": last_check.strftime(outdated.SELFCHECK_DATE_FMT),
-            "pypi_version": pypi_version,
-        },
+        "key": key,
+        "last_check": last_check.strftime(outdated.SELFCHECK_DATE_FMT),
+        "pypi_version": pypi_version,
     }
     assert expected == saved

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -183,3 +183,12 @@ def test_self_check_state_no_cache_dir():
     state = outdated.SelfCheckState(cache_dir=False)
     assert state.state == {}
     assert state.statefile_path is None
+
+
+def test_self_check_state_key_uses_sys_prefix(monkeypatch):
+    key = "helloworld"
+
+    monkeypatch.setattr(sys, "prefix", key)
+    state = outdated.SelfCheckState("")
+
+    assert state.key == key

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -11,6 +11,7 @@ from pip._vendor import lockfile, pkg_resources
 
 from pip._internal.index import InstallationCandidate
 from pip._internal.utils import outdated
+from tests.lib.path import Path
 
 
 class MockFoundCandidates(object):
@@ -137,13 +138,11 @@ def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,
 
 
 statefile_name_case_1 = (
-    "selfcheck-"
-    "d0d922be2c876108df5bd95254ebf2b9228716063584a623cadcc72159364474.json"
+    "fcd2d5175dd33d5df759ee7b045264230205ef837bf9f582f7c3ada7"
 )
 
 statefile_name_case_2 = (
-    "selfcheck-"
-    "37d748d2f9a7d61c07aa598962da9a6a620b6b2203038952062471fbf22762ec.json"
+    "902cecc0745b8ecf2509ba473f3556f0ba222fedc6df433acda24aa5"
 )
 
 
@@ -157,7 +156,7 @@ def test_get_statefile_name_known_values(key, expected):
 
 def _get_statefile_path(cache_dir, key):
     return os.path.join(
-        cache_dir, outdated._get_statefile_name(key)
+        cache_dir, "selfcheck", outdated._get_statefile_name(key)
     )
 
 
@@ -184,7 +183,6 @@ def test_self_check_state(monkeypatch, tmpdir):
     monkeypatch.setattr(outdated, "check_path_owner", lambda p: True)
 
     monkeypatch.setattr(lockfile, 'LockFile', fake_lock)
-    monkeypatch.setattr(os.path, "exists", lambda p: True)
 
     cache_dir = tmpdir / 'cache_dir'
     key = 'pip_prefix'
@@ -233,6 +231,8 @@ def test_self_check_state_reads_expected_statefile(monkeypatch, tmpdir):
         "last_check": last_check,
         "pypi_version": pypi_version,
     }
+
+    Path(statefile_path).parent.mkdir()
 
     with open(statefile_path, "w") as f:
         json.dump(content, f)

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -136,6 +136,25 @@ def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,
         assert len(outdated.logger.warning.calls) == 0
 
 
+statefile_name_case_1 = (
+    "selfcheck-"
+    "d0d922be2c876108df5bd95254ebf2b9228716063584a623cadcc72159364474.json"
+)
+
+statefile_name_case_2 = (
+    "selfcheck-"
+    "37d748d2f9a7d61c07aa598962da9a6a620b6b2203038952062471fbf22762ec.json"
+)
+
+
+@pytest.mark.parametrize("key,expected", [
+    ("/hello/world/venv", statefile_name_case_1),
+    ("C:\\Users\\User\\Desktop\\venv", statefile_name_case_2),
+])
+def test_get_statefile_name_known_values(key, expected):
+    assert expected == outdated._get_statefile_name(key)
+
+
 def _get_statefile_path(cache_dir, key):
     return os.path.join(
         cache_dir, outdated._get_statefile_name(key)

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -136,8 +136,10 @@ def test_pip_version_check(monkeypatch, stored_time, installed_ver, new_ver,
         assert len(outdated.logger.warning.calls) == 0
 
 
-def _get_statefile_path(cache_dir):
-    return os.path.join(cache_dir, outdated._STATEFILE_NAME)
+def _get_statefile_path(cache_dir, key):
+    return os.path.join(
+        cache_dir, outdated._get_statefile_name(key)
+    )
 
 
 def test_self_check_state(monkeypatch, tmpdir):
@@ -166,12 +168,13 @@ def test_self_check_state(monkeypatch, tmpdir):
     monkeypatch.setattr(os.path, "exists", lambda p: True)
 
     cache_dir = tmpdir / 'cache_dir'
-    monkeypatch.setattr(sys, 'prefix', tmpdir / 'pip_prefix')
+    key = 'pip_prefix'
+    monkeypatch.setattr(sys, 'prefix', key)
 
     state = outdated.SelfCheckState(cache_dir=cache_dir)
     state.save('2.0', datetime.datetime.utcnow())
 
-    expected_path = _get_statefile_path(str(cache_dir))
+    expected_path = _get_statefile_path(str(cache_dir), key)
     assert fake_lock.calls == [pretend.call(expected_path)]
 
     assert fake_open.calls == [
@@ -203,7 +206,7 @@ def test_self_check_state_reads_expected_statefile(monkeypatch, tmpdir):
     cache_dir = tmpdir / "cache_dir"
     cache_dir.mkdir()
     key = "helloworld"
-    statefile_path = _get_statefile_path(str(cache_dir))
+    statefile_path = _get_statefile_path(str(cache_dir), key)
 
     last_check = "1970-01-02T11:00:00Z"
     pypi_version = "1.0"
@@ -228,7 +231,7 @@ def test_self_check_state_writes_expected_statefile(monkeypatch, tmpdir):
     cache_dir = tmpdir / "cache_dir"
     cache_dir.mkdir()
     key = "helloworld"
-    statefile_path = _get_statefile_path(str(cache_dir))
+    statefile_path = _get_statefile_path(str(cache_dir), key)
 
     last_check = datetime.datetime.strptime(
         "1970-01-02T11:00:00Z", outdated.SELFCHECK_DATE_FMT

--- a/tests/unit/test_unit_outdated.py
+++ b/tests/unit/test_unit_outdated.py
@@ -198,7 +198,6 @@ def test_self_check_state(monkeypatch, tmpdir):
 
     assert fake_open.calls == [
         pretend.call(expected_path),
-        pretend.call(expected_path),
         pretend.call(expected_path, 'w'),
     ]
 


### PR DESCRIPTION
Previously, we kept selfcheck info for all pip instances in the same file.

Now, we use a separate file per pip instance, simplifying the process of recording updated state.

Also added several tests that are a little less intrusive into the selfcheck implementation details.

Makes progress on #6954.