### PR TITLE
Remove WheelBuilder's dependence on PipSession

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -1,3 +1,10 @@
+
+# The following comment should be removed at some point in the future.
+# It's included for now because without it InstallCommand.run() has a
+# couple errors where we have to know req.name is str rather than
+# Optional[str] for the InstallRequirement req.
+# mypy: strict-optional=False
+
 from __future__ import absolute_import
 
 import errno
@@ -13,7 +20,7 @@ from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.req_command import RequirementCommand
-from pip._internal.cli.status_codes import ERROR
+from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.exceptions import (
     CommandError,
     InstallationError,
@@ -30,8 +37,16 @@ from pip._internal.utils.misc import (
     protect_pip_from_modification_on_windows,
 )
 from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.virtualenv import virtualenv_no_global
 from pip._internal.wheel import WheelBuilder
+
+if MYPY_CHECK_RUNNING:
+    from optparse import Values
+    from typing import Any, List
+
+    from pip._internal.req.req_install import InstallRequirement
+
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +257,7 @@ class InstallCommand(RequirementCommand):
         self.parser.insert_option_group(0, cmd_opts)
 
     def run(self, options, args):
+        # type: (Values, List[Any]) -> int
         cmdoptions.check_install_build_global(options)
         upgrade_strategy = "to-satisfy-only"
         if options.upgrade:
@@ -425,9 +441,11 @@ class InstallCommand(RequirementCommand):
                         except Exception:
                             pass
                         items.append(item)
-                    installed = ' '.join(items)
-                    if installed:
-                        logger.info('Successfully installed %s', installed)
+                    installed_desc = ' '.join(items)
+                    if installed_desc:
+                        logger.info(
+                            'Successfully installed %s', installed_desc,
+                        )
                 except EnvironmentError as error:
                     show_traceback = (self.verbosity >= 1)
 
@@ -450,7 +468,8 @@ class InstallCommand(RequirementCommand):
             self._handle_target_dir(
                 options.target_dir, target_temp_dir, options.upgrade
             )
-        return requirement_set
+
+        return SUCCESS
 
     def _handle_target_dir(self, target_dir, target_temp_dir, upgrade):
         ensure_dir(target_dir)

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -63,7 +63,12 @@ def is_wheel_installed():
     return True
 
 
-def build_wheels(builder, pep517_requirements, legacy_requirements, session):
+def build_wheels(
+    builder,              # type: WheelBuilder
+    pep517_requirements,  # type: List[InstallRequirement]
+    legacy_requirements,  # type: List[InstallRequirement]
+):
+    # type: (...) -> List[InstallRequirement]
     """
     Build wheels for requirements, depending on whether wheel is installed.
     """
@@ -73,7 +78,7 @@ def build_wheels(builder, pep517_requirements, legacy_requirements, session):
     # Always build PEP 517 requirements
     build_failures = builder.build(
         pep517_requirements,
-        session=session, autobuilding=True
+        autobuilding=True,
     )
 
     if should_build_legacy:
@@ -82,7 +87,7 @@ def build_wheels(builder, pep517_requirements, legacy_requirements, session):
         # install for those.
         builder.build(
             legacy_requirements,
-            session=session, autobuilding=True
+            autobuilding=True,
         )
 
     return build_failures
@@ -378,7 +383,6 @@ class InstallCommand(RequirementCommand):
                         builder=wheel_builder,
                         pep517_requirements=pep517_requirements,
                         legacy_requirements=legacy_requirements,
-                        session=session,
                     )
 
                     # If we're using PEP 517, we cannot do a direct install

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -160,7 +160,7 @@ class WheelCommand(RequirementCommand):
                         no_clean=options.no_clean,
                     )
                     build_failures = wb.build(
-                        requirement_set.requirements.values(), session=session,
+                        requirement_set.requirements.values(),
                     )
                     if len(build_failures) != 0:
                         raise CommandError(

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -11,7 +11,13 @@ from pip._internal.exceptions import CommandError, PreviousBuildDirError
 from pip._internal.req import RequirementSet
 from pip._internal.req.req_tracker import RequirementTracker
 from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.wheel import WheelBuilder
+
+if MYPY_CHECK_RUNNING:
+    from optparse import Values
+    from typing import Any, List
+
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +107,7 @@ class WheelCommand(RequirementCommand):
         self.parser.insert_option_group(0, cmd_opts)
 
     def run(self, options, args):
+        # type: (Values, List[Any]) -> None
         cmdoptions.check_install_build_global(options)
 
         if options.build_dir:

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -27,7 +27,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.six import StringIO
 
 from pip._internal import pep425tags
-from pip._internal.download import unpack_url
+from pip._internal.download import unpack_file_url
 from pip._internal.exceptions import (
     InstallationError,
     InvalidWheelFilename,
@@ -57,7 +57,6 @@ if MYPY_CHECK_RUNNING:
     )
     from pip._vendor.packaging.requirements import Requirement
     from pip._internal.req.req_install import InstallRequirement
-    from pip._internal.download import PipSession
     from pip._internal.index import FormatControl, PackageFinder
     from pip._internal.operations.prepare import (
         RequirementPreparer
@@ -1032,7 +1031,6 @@ class WheelBuilder(object):
     def build(
         self,
         requirements,  # type: Iterable[InstallRequirement]
-        session,  # type: PipSession
         autobuilding=False  # type: bool
     ):
         # type: (...) -> List[InstallRequirement]
@@ -1122,10 +1120,7 @@ class WheelBuilder(object):
                         req.link = Link(path_to_url(wheel_file))
                         assert req.link.is_wheel
                         # extract the wheel into the dir
-                        unpack_url(
-                            req.link, req.source_dir, None, False,
-                            session=session,
-                        )
+                        unpack_file_url(link=req.link, location=req.source_dir)
                 else:
                     build_failure.append(req)
 

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -9,7 +9,6 @@ class TestWheelCache:
         self,
         pep517_requirements,
         legacy_requirements,
-        session,
     ):
         """
         Return: (mock_calls, return_value).
@@ -25,8 +24,6 @@ class TestWheelCache:
             builder=builder,
             pep517_requirements=pep517_requirements,
             legacy_requirements=legacy_requirements,
-            # A session value isn't needed.
-            session='<session>',
         )
 
         return (builder.build.mock_calls, build_failures)
@@ -38,13 +35,12 @@ class TestWheelCache:
         mock_calls, build_failures = self.check_build_wheels(
             pep517_requirements=['a', 'b'],
             legacy_requirements=['c', 'd'],
-            session='<session>',
         )
 
         # Legacy requirements were built.
         assert mock_calls == [
-            call(['a', 'b'], autobuilding=True, session='<session>'),
-            call(['c', 'd'], autobuilding=True, session='<session>'),
+            call(['a', 'b'], autobuilding=True),
+            call(['c', 'd'], autobuilding=True),
         ]
 
         # Legacy build failures are not included in the return value.
@@ -57,12 +53,11 @@ class TestWheelCache:
         mock_calls, build_failures = self.check_build_wheels(
             pep517_requirements=['a', 'b'],
             legacy_requirements=['c', 'd'],
-            session='<session>',
         )
 
         # Legacy requirements were not built.
         assert mock_calls == [
-            call(['a', 'b'], autobuilding=True, session='<session>'),
+            call(['a', 'b'], autobuilding=True),
         ]
 
         assert build_failures == ['a']

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -700,7 +700,7 @@ class TestWheelBuilder(object):
                 finder=Mock(), preparer=Mock(), wheel_cache=None,
             )
             with caplog.at_level(logging.INFO):
-                wb.build([wheel_req], session=Mock())
+                wb.build([wheel_req])
             assert "due to already being wheel" in caplog.text
             assert mock_build_one.mock_calls == []
 


### PR DESCRIPTION
This removes the `WheelBuilder` class's dependence on `PipSession`. It turns out `WheelBuilder` doesn't actually need to call the full `unpack_url()` -- only `unpack_file_url()`, which doesn't require network access. This simplifies some things.

I also added some minimal type-checking to the `install` and `wheel` command modules so I could have the benefit of mypy type-checking the calls to `WheelBuilder.build()`, which is what this PR changes.