### PR TITLE
Add type annotations to vcs files.

### DIFF
--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -6,7 +6,13 @@ import os
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
 from pip._internal.utils.misc import display_path, path_to_url, rmtree
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs.versioncontrol import VersionControl, vcs
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional, Tuple
+    from pip._internal.vcs.versioncontrol import AuthInfo, RevOptions
+
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +38,7 @@ class Bazaar(VersionControl):
         return ['-r', rev]
 
     def export(self, location, url):
+        # type: (str, str) -> None
         """
         Export the Bazaar repository at the url to the destination location
         """
@@ -46,6 +53,7 @@ class Bazaar(VersionControl):
         )
 
     def fetch_new(self, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> None
         rev_display = rev_options.to_display()
         logger.info(
             'Checking out %s%s to %s',
@@ -57,14 +65,17 @@ class Bazaar(VersionControl):
         self.run_command(cmd_args)
 
     def switch(self, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> None
         self.run_command(['switch', url], cwd=dest)
 
     def update(self, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> None
         cmd_args = ['pull', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 
     @classmethod
     def get_url_rev_and_auth(cls, url):
+        # type: (str) -> Tuple[str, Optional[str], AuthInfo]
         # hotfix the URL scheme after removing bzr+ from bzr+ssh:// readd it
         url, rev, user_pass = super(Bazaar, cls).get_url_rev_and_auth(url)
         if url.startswith('ssh://'):

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -163,6 +163,7 @@ class Git(VersionControl):
                 rev,
             )
 
+        assert rev is not None
         if not rev.startswith('refs/'):
             return rev_options
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -12,11 +12,17 @@ from pip._internal.exceptions import BadCommand
 from pip._internal.utils.compat import samefile
 from pip._internal.utils.misc import display_path, redact_password_from_url
 from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs.versioncontrol import (
     RemoteNotFoundError,
     VersionControl,
     vcs,
 )
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional, Tuple
+    from pip._internal.vcs.versioncontrol import AuthInfo, RevOptions
+
 
 urlsplit = urllib_parse.urlsplit
 urlunsplit = urllib_parse.urlunsplit
@@ -83,6 +89,7 @@ class Git(VersionControl):
         return None
 
     def export(self, location, url):
+        # type: (str, str) -> None
         """Export the Git repository at the url to the destination location"""
         if not location.endswith('/'):
             location = location + '/'
@@ -131,6 +138,7 @@ class Git(VersionControl):
 
     @classmethod
     def resolve_revision(cls, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> RevOptions
         """
         Resolve a revision to a new RevOptions object with the SHA1 of the
         branch, tag, or ref if found.
@@ -185,6 +193,7 @@ class Git(VersionControl):
         return cls.get_revision(dest) == name
 
     def fetch_new(self, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> None
         rev_display = rev_options.to_display()
         logger.info(
             'Cloning %s%s to %s', redact_password_from_url(url),
@@ -215,6 +224,7 @@ class Git(VersionControl):
         self.update_submodules(dest)
 
     def switch(self, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> None
         self.run_command(['config', 'remote.origin.url', url], cwd=dest)
         cmd_args = ['checkout', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
@@ -222,6 +232,7 @@ class Git(VersionControl):
         self.update_submodules(dest)
 
     def update(self, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> None
         # First fetch changes from the default remote
         if self.get_git_version() >= parse_version('1.9.0'):
             # fetch tags in addition to everything else
@@ -300,6 +311,7 @@ class Git(VersionControl):
 
     @classmethod
     def get_url_rev_and_auth(cls, url):
+        # type: (str) -> Tuple[str, Optional[str], AuthInfo]
         """
         Prefixes stub URLs like 'user@hostname:user/repo.git' with 'ssh://'.
         That's required because although they use SSH they sometimes don't

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -7,7 +7,12 @@ from pip._vendor.six.moves import configparser
 
 from pip._internal.utils.misc import display_path, path_to_url
 from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs.versioncontrol import VersionControl, vcs
+
+if MYPY_CHECK_RUNNING:
+    from pip._internal.vcs.versioncontrol import RevOptions
+
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +28,7 @@ class Mercurial(VersionControl):
         return [rev]
 
     def export(self, location, url):
+        # type: (str, str) -> None
         """Export the Hg repository at the url to the destination location"""
         with TempDirectory(kind="export") as temp_dir:
             self.unpack(temp_dir.path, url=url)
@@ -32,6 +38,7 @@ class Mercurial(VersionControl):
             )
 
     def fetch_new(self, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> None
         rev_display = rev_options.to_display()
         logger.info(
             'Cloning hg %s%s to %s',
@@ -44,6 +51,7 @@ class Mercurial(VersionControl):
         self.run_command(cmd_args, cwd=dest)
 
     def switch(self, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> None
         repo_config = os.path.join(dest, self.dirname, 'hgrc')
         config = configparser.RawConfigParser()
         try:
@@ -60,6 +68,7 @@ class Mercurial(VersionControl):
             self.run_command(cmd_args, cwd=dest)
 
     def update(self, dest, url, rev_options):
+        # type: (str, str, RevOptions) -> None
         self.run_command(['pull', '-q'], cwd=dest)
         cmd_args = ['update', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -24,6 +24,7 @@ if MYPY_CHECK_RUNNING:
     from typing import List, Optional, Tuple
     from pip._internal.vcs.versioncontrol import RevOptions
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -92,7 +93,8 @@ class Subversion(VersionControl):
 
     @staticmethod
     def make_rev_args(username, password):
-        extra_args = []
+        # type: (Optional[str], Optional[str]) -> List[str]
+        extra_args = []  # type: List[str]
         if username:
             extra_args += ['--username', username]
         if password:
@@ -273,6 +275,7 @@ class Subversion(VersionControl):
         return []
 
     def export(self, location, url):
+        # type: (str, str) -> None
         """Export the svn repository at the url to the destination location"""
         url, rev_options = self.get_url_rev_options(url)
 

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -82,6 +82,7 @@ class RevOptions(object):
         self.extra_args = extra_args
         self.rev = rev
         self.vc_class = vc_class
+        self.branch_name = None  # type: Optional[str]
 
     def __repr__(self):
         return '<RevOptions {}: rev={!r}>'.format(self.vc_class.name, self.rev)


### PR DESCRIPTION
This PR adds type annotations to all vcs files. This PR is done in preparation for fixing passwords provided in URLs that are leaking to stderr when the command is printed containing the raw URL.  The follow on PR is #6862

CC: @cjerdonek 