### PR TITLE
Don't append "m" ABI flag in Python 3.8

### DIFF
--- a/news/6885.bugfix
+++ b/news/6885.bugfix
@@ -1,0 +1,1 @@
+Fix 'm' flag erroneously being appended to ABI tag in Python 3.8 on platforms that do not provide SOABI

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -117,7 +117,9 @@ def get_abi_tag():
             d = 'd'
         if get_flag('WITH_PYMALLOC',
                     lambda: impl == 'cp',
-                    warn=(impl == 'cp')):
+                    warn=(impl == 'cp' and
+                          sys.version_info < (3, 8))) \
+                and sys.version_info < (3, 8):
             m = 'm'
         if get_flag('Py_UNICODE_SIZE',
                     lambda: sys.maxunicode == 0x10ffff,

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -47,6 +47,10 @@ class TestPEP425Tags(object):
         base = pip._internal.pep425tags.get_abbr_impl() + \
             pip._internal.pep425tags.get_impl_ver()
 
+        if sys.version_info >= (3, 8):
+            # Python 3.8 removes the m flag, so don't look for it.
+            flags = flags.replace('m', '')
+
         if sys.version_info < (3, 3):
             config_vars.update({'Py_UNICODE_SIZE': 2})
             mock_gcf = self.mock_get_config_var(**config_vars)


### PR DESCRIPTION
In Python 3.8, the `m` flag is no longer appended to the SOABI, since the ABI is longer influenced by enabling pymalloc.  This PR should fix the ability to install Python 3.8 wheels on Windows.  In Python 3.8, `sys.abiflags` is an empty string.

https://docs.python.org/dev/whatsnew/3.8.html#build-and-c-api-changes
https://bugs.python.org/issue36707

See also pypa/wheel#303