### PR TITLE
Don't use lockfile to protect updates to selfcheck file.

### DIFF
--- a/news/6954.bugfix
+++ b/news/6954.bugfix
@@ -1,0 +1,1 @@
+Don't use hardlinks for locking selfcheck state file.


### PR DESCRIPTION
Previously, we were using `lockfile.LockFile` to protect updates to `<cache dir>/selfcheck.json`.

This uses hard links to create file locks, which are not supported in several contexts (as raised in various issues).

Now, we securely create a temporary file next to the target file, write to it, and rename it to the target path (removing the target path first if it exists).

In general we are graceful to failure, retrying several times over the course of 1 second before giving up. The only expected failure here should be on Windows if another process has an open file handle, and since this file is not very large it is reasonable that another pip instance will be done reading within that time period - otherwise we silently pass.

Closes #6954.