### PR TITLE
#6858: Changes to report any missing packages in pip show

### DIFF
--- a/news/6858.feature
+++ b/news/6858.feature
@@ -1,0 +1,1 @@
+Make ``pip show`` warn about packages not found.

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -60,6 +60,11 @@ def search_packages_info(query):
         installed[canonicalize_name(p.project_name)] = p
 
     query_names = [canonicalize_name(name) for name in query]
+    missing = sorted(
+        [name for name, pkg in zip(query, query_names) if pkg not in installed]
+    )
+    if missing:
+        logger.warning('Package(s) not found: %s', ', '.join(missing))
 
     for dist in [installed[pkg] for pkg in query_names if pkg in installed]:
         package = {

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -79,6 +79,34 @@ def test_find_package_not_found():
     assert len(list(result)) == 0
 
 
+def test_report_single_not_found(script):
+    """
+    Test passing one name and that isn't found.
+    """
+    # We choose a non-canonicalized name to test that the non-canonical
+    # form is logged.
+    # Also, the following should report an error as there are no results
+    # to print. Consequently, there is no need to pass
+    # allow_stderr_warning=True since this is implied by expect_error=True.
+    result = script.pip('show', 'Abcd-3', expect_error=True)
+    assert 'WARNING: Package(s) not found: Abcd-3' in result.stderr
+    assert not result.stdout.splitlines()
+
+
+def test_report_mixed_not_found(script):
+    """
+    Test passing a mixture of found and not-found names.
+    """
+    # We test passing non-canonicalized names.
+    result = script.pip(
+        'show', 'Abcd3', 'A-B-C', 'pip', allow_stderr_warning=True
+    )
+    assert 'WARNING: Package(s) not found: A-B-C, Abcd3' in result.stderr
+    lines = result.stdout.splitlines()
+    assert len(lines) == 10
+    assert 'Name: pip' in lines
+
+
 def test_search_any_case():
     """
     Search for a package in any case.
@@ -86,7 +114,7 @@ def test_search_any_case():
     """
     result = list(search_packages_info(['PIP']))
     assert len(result) == 1
-    assert 'pip' == result[0]['name']
+    assert result[0]['name'] == 'pip'
 
 
 def test_more_than_one_package():


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Added reporting via logger.error of unfound packages to pip show command, also added test cases and news item.

Closes #6858