### PR TITLE
consolidate vcs link detection

### DIFF
--- a/news/6883.trivial
+++ b/news/6883.trivial
@@ -1,0 +1,1 @@
+replace is_vcs_url function by is_vcs Link property

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -76,7 +76,7 @@ if MYPY_CHECK_RUNNING:
 __all__ = ['get_file_content',
            'is_url', 'url_to_path', 'path_to_url',
            'is_archive_file', 'unpack_vcs_link',
-           'unpack_file_url', 'is_vcs_url', 'is_file_url',
+           'unpack_file_url', 'is_file_url',
            'unpack_http_url', 'unpack_url',
            'parse_content_disposition', 'sanitize_content_filename']
 
@@ -744,11 +744,6 @@ def _get_used_vcs_backend(link):
     return None
 
 
-def is_vcs_url(link):
-    # type: (Link) -> bool
-    return bool(_get_used_vcs_backend(link))
-
-
 def is_file_url(link):
     # type: (Link) -> bool
     return link.url.lower().startswith('file:')
@@ -1063,7 +1058,7 @@ def unpack_url(
         would ordinarily raise HashUnsupported) are allowed.
     """
     # non-editable vcs urls
-    if is_vcs_url(link):
+    if link.is_vcs:
         unpack_vcs_link(link, location)
 
     # file urls

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -180,18 +180,20 @@ class Link(KeyBasedCompareMixin):
         return self.ext == WHEEL_EXTENSION
 
     @property
+    def is_vcs(self):
+        # type: () -> bool
+        from pip._internal.vcs import vcs
+
+        return self.scheme in vcs.all_schemes
+
+    @property
     def is_artifact(self):
         # type: () -> bool
         """
         Determines if this points to an actual artifact (e.g. a tarball) or if
         it points to an "abstract" thing like a path or a VCS location.
         """
-        from pip._internal.vcs import vcs
-
-        if self.scheme in vcs.all_schemes:
-            return False
-
-        return True
+        return not self.is_vcs
 
     @property
     def is_yanked(self):

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -16,7 +16,6 @@ from pip._internal.distributions.installed import InstalledDistribution
 from pip._internal.download import (
     is_dir_url,
     is_file_url,
-    is_vcs_url,
     unpack_url,
     url_to_path,
 )
@@ -163,7 +162,7 @@ class RequirementPreparer(object):
                 # we would report less-useful error messages for
                 # unhashable requirements, complaining that there's no
                 # hash provided.
-                if is_vcs_url(link):
+                if link.is_vcs:
                     raise VcsHashUnsupported()
                 elif is_file_url(link) and is_dir_url(link):
                     raise DirectoryUrlHashUnsupported()

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -815,7 +815,7 @@ def should_use_ephemeral_cache(
         )
         return None
 
-    if req.link and not req.link.is_artifact:
+    if req.link and req.link.is_vcs:
         # VCS checkout. Build wheel just for this run.
         return True
 

--- a/tests/unit/test_link.py
+++ b/tests/unit/test_link.py
@@ -127,3 +127,13 @@ class TestLink:
         url = 'https://example.com/wheel.whl#sha512={}'.format(128 * 'a')
         link = Link(url)
         assert link.is_hash_allowed(hashes) == expected
+
+    @pytest.mark.parametrize('url, expected', [
+        ('git+https://github.com/org/repo', True),
+        ('bzr+http://bzr.myproject.org/MyProject/trunk/#egg=MyProject', True),
+        ('https://example.com/some.whl', False),
+        ('file://home/foo/some.whl', False),
+    ])
+    def test_is_vcs(self, url, expected):
+        link = Link(url)
+        assert link.is_vcs is expected

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -126,7 +126,6 @@ def test_should_use_ephemeral_cache__disallow_binaries_and_vcs_checkout(
     causes should_use_ephemeral_cache() to return None for VCS checkouts.
     """
     req = Requirement('pendulum')
-    # Passing a VCS url causes link.is_artifact to return False.
     link = Link(url='git+https://git.example.com/pendulum.git')
     req = InstallRequirement(
         req=req,
@@ -137,7 +136,7 @@ def test_should_use_ephemeral_cache__disallow_binaries_and_vcs_checkout(
         source_dir='/tmp/pip-install-9py5m2z1/pendulum',
     )
     assert not req.is_wheel
-    assert not req.link.is_artifact
+    assert req.link.is_vcs
 
     format_control = FormatControl()
     if disallow_binaries:


### PR DESCRIPTION
While working on #6853 and #6851, it was not immediately obvious to me why `not link.is_artifact` means it is a VCS link. 

So I thought I could make this little readability improvement, by replacing the global `is_vcs_url` function by a `is_vcs` property of `Link`.