### PR TITLE
Hide security-sensitive strings in VCS command log messages

### DIFF
--- a/news/6890.bugfix
+++ b/news/6890.bugfix
@@ -1,0 +1,2 @@
+Hide security-sensitive strings like passwords in log messages related to
+version control system (aka VCS) command invocations.

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -48,6 +48,7 @@ from pip._internal.utils.misc import (
     display_path,
     format_size,
     get_installed_version,
+    hide_url,
     netloc_has_port,
     path_to_url,
     remove_auth_from_url,
@@ -729,8 +730,10 @@ def is_archive_file(name):
 
 
 def unpack_vcs_link(link, location):
+    # type: (Link, str) -> None
     vcs_backend = _get_used_vcs_backend(link)
-    vcs_backend.unpack(location, url=link.url)
+    assert vcs_backend is not None
+    vcs_backend.unpack(location, url=hide_url(link.url))
 
 
 def _get_used_vcs_backend(link):

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -38,6 +38,7 @@ from pip._internal.utils.misc import (
     dist_in_usersite,
     ensure_dir,
     get_installed_version,
+    hide_url,
     redact_password_from_url,
     rmtree,
 )
@@ -813,11 +814,11 @@ class InstallRequirement(object):
         vc_type, url = self.link.url.split('+', 1)
         vcs_backend = vcs.get_backend(vc_type)
         if vcs_backend:
-            url = self.link.url
+            hidden_url = hide_url(self.link.url)
             if obtain:
-                vcs_backend.obtain(self.source_dir, url=url)
+                vcs_backend.obtain(self.source_dir, url=hidden_url)
             else:
-                vcs_backend.export(self.source_dir, url=url)
+                vcs_backend.export(self.source_dir, url=hidden_url)
         else:
             assert 0, (
                 'Unexpected version control type (in %s): %s'

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -766,9 +766,19 @@ def unpack_file(
 
 
 def make_command(*args):
-    # type: (Union[str, HiddenText]) -> CommandArgs
+    # type: (Union[str, HiddenText, CommandArgs]) -> CommandArgs
+    """
+    Create a CommandArgs object.
+    """
     command_args = []  # type: CommandArgs
-    command_args.extend(args)
+    for arg in args:
+        # Check for list instead of CommandArgs since CommandArgs is
+        # only known during type-checking.
+        if isinstance(arg, list):
+            command_args.extend(arg)
+        else:
+            # Otherwise, arg is str or HiddenText.
+            command_args.append(arg)
 
     return command_args
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -1241,24 +1241,24 @@ def redact_password_from_url(url):
 class HiddenText(object):
     def __init__(
         self,
-        secret,         # type: str
-        redacted=None,  # type: Optional[str]
+        secret,    # type: str
+        redacted,  # type: str
     ):
         # type: (...) -> None
-        if redacted is None:
-            redacted = '****'
-
         self.secret = secret
         self.redacted = redacted
 
     def __repr__(self):
+        # type: (...) -> str
         return '<HiddenText {!r}>'.format(str(self))
 
     def __str__(self):
+        # type: (...) -> str
         return self.redacted
 
     # This is useful for testing.
     def __eq__(self, other):
+        # type: (Any) -> bool
         if type(self) != type(other):
             return False
 
@@ -1266,10 +1266,16 @@ class HiddenText(object):
         # just the raw, original string.
         return (self.secret == other.secret)
 
+    # We need to provide an explicit __ne__ implementation for Python 2.
+    # TODO: remove this when we drop PY2 support.
+    def __ne__(self, other):
+        # type: (Any) -> bool
+        return not self == other
+
 
 def hide_value(value):
     # type: (str) -> HiddenText
-    return HiddenText(value)
+    return HiddenText(value, redacted='****')
 
 
 def hide_url(url):

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -5,12 +5,18 @@ import os
 
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
-from pip._internal.utils.misc import display_path, path_to_url, rmtree
+from pip._internal.utils.misc import (
+    display_path,
+    make_command,
+    path_to_url,
+    rmtree,
+)
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs.versioncontrol import VersionControl, vcs
 
 if MYPY_CHECK_RUNNING:
     from typing import Optional, Tuple
+    from pip._internal.utils.misc import HiddenText
     from pip._internal.vcs.versioncontrol import AuthInfo, RevOptions
 
 
@@ -38,7 +44,7 @@ class Bazaar(VersionControl):
         return ['-r', rev]
 
     def export(self, location, url):
-        # type: (str, str) -> None
+        # type: (str, HiddenText) -> None
         """
         Export the Bazaar repository at the url to the destination location
         """
@@ -48,12 +54,12 @@ class Bazaar(VersionControl):
 
         url, rev_options = self.get_url_rev_options(url)
         self.run_command(
-            ['export', location, url] + rev_options.to_args(),
+            make_command('export', location, url) + rev_options.to_args(),
             show_stdout=False,
         )
 
     def fetch_new(self, dest, url, rev_options):
-        # type: (str, str, RevOptions) -> None
+        # type: (str, HiddenText, RevOptions) -> None
         rev_display = rev_options.to_display()
         logger.info(
             'Checking out %s%s to %s',
@@ -61,16 +67,18 @@ class Bazaar(VersionControl):
             rev_display,
             display_path(dest),
         )
-        cmd_args = ['branch', '-q'] + rev_options.to_args() + [url, dest]
+        cmd_args = (
+            make_command('branch', '-q') + rev_options.to_args() + [url, dest]
+        )
         self.run_command(cmd_args)
 
     def switch(self, dest, url, rev_options):
-        # type: (str, str, RevOptions) -> None
-        self.run_command(['switch', url], cwd=dest)
+        # type: (str, HiddenText, RevOptions) -> None
+        self.run_command(make_command('switch', url), cwd=dest)
 
     def update(self, dest, url, rev_options):
-        # type: (str, str, RevOptions) -> None
-        cmd_args = ['pull', '-q'] + rev_options.to_args()
+        # type: (str, HiddenText, RevOptions) -> None
+        cmd_args = make_command('pull', '-q') + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 
     @classmethod

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -54,7 +54,7 @@ class Bazaar(VersionControl):
 
         url, rev_options = self.get_url_rev_options(url)
         self.run_command(
-            make_command('export', location, url) + rev_options.to_args(),
+            make_command('export', location, url, rev_options.to_args()),
             show_stdout=False,
         )
 
@@ -68,7 +68,7 @@ class Bazaar(VersionControl):
             display_path(dest),
         )
         cmd_args = (
-            make_command('branch', '-q') + rev_options.to_args() + [url, dest]
+            make_command('branch', '-q', rev_options.to_args(), url, dest)
         )
         self.run_command(cmd_args)
 
@@ -78,7 +78,7 @@ class Bazaar(VersionControl):
 
     def update(self, dest, url, rev_options):
         # type: (str, HiddenText, RevOptions) -> None
-        cmd_args = make_command('pull', '-q') + rev_options.to_args()
+        cmd_args = make_command('pull', '-q', rev_options.to_args())
         self.run_command(cmd_args, cwd=dest)
 
     @classmethod

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -173,7 +173,7 @@ class Git(VersionControl):
 
         # If it looks like a ref, we have to fetch it explicitly.
         cls.run_command(
-            make_command('fetch', '-q', url) + rev_options.to_args(),
+            make_command('fetch', '-q', url, rev_options.to_args()),
             cwd=dest,
         )
         # Change the revision to the SHA of the ref we fetched
@@ -211,8 +211,8 @@ class Git(VersionControl):
                 # Only do a checkout if the current commit id doesn't match
                 # the requested revision.
                 if not self.is_commit_id_equal(dest, rev_options.rev):
-                    cmd_args = (
-                        make_command('checkout', '-q') + rev_options.to_args()
+                    cmd_args = make_command(
+                        'checkout', '-q', rev_options.to_args(),
                     )
                     self.run_command(cmd_args, cwd=dest)
             elif self.get_current_branch(dest) != branch_name:
@@ -233,7 +233,7 @@ class Git(VersionControl):
             make_command('config', 'remote.origin.url', url),
             cwd=dest,
         )
-        cmd_args = make_command('checkout', '-q') + rev_options.to_args()
+        cmd_args = make_command('checkout', '-q', rev_options.to_args())
         self.run_command(cmd_args, cwd=dest)
 
         self.update_submodules(dest)
@@ -248,9 +248,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q'], cwd=dest)
         # Then reset to wanted revision (maybe even origin/master)
         rev_options = self.resolve_revision(dest, url, rev_options)
-        cmd_args = (
-            make_command('reset', '--hard', '-q') + rev_options.to_args()
-        )
+        cmd_args = make_command('reset', '--hard', '-q', rev_options.to_args())
         self.run_command(cmd_args, cwd=dest)
         #: update submodules
         self.update_submodules(dest)

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -200,10 +200,7 @@ class Git(VersionControl):
     def fetch_new(self, dest, url, rev_options):
         # type: (str, HiddenText, RevOptions) -> None
         rev_display = rev_options.to_display()
-        logger.info(
-            'Cloning %s%s to %s', url,
-            rev_display, display_path(dest),
-        )
+        logger.info('Cloning %s%s to %s', url, rev_display, display_path(dest))
         self.run_command(make_command('clone', '-q', url, dest))
 
         if rev_options.rev:

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -5,12 +5,13 @@ import os
 
 from pip._vendor.six.moves import configparser
 
-from pip._internal.utils.misc import display_path, path_to_url
+from pip._internal.utils.misc import display_path, make_command, path_to_url
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs.versioncontrol import VersionControl, vcs
 
 if MYPY_CHECK_RUNNING:
+    from pip._internal.utils.misc import HiddenText
     from pip._internal.vcs.versioncontrol import RevOptions
 
 
@@ -28,7 +29,7 @@ class Mercurial(VersionControl):
         return [rev]
 
     def export(self, location, url):
-        # type: (str, str) -> None
+        # type: (str, HiddenText) -> None
         """Export the Hg repository at the url to the destination location"""
         with TempDirectory(kind="export") as temp_dir:
             self.unpack(temp_dir.path, url=url)
@@ -38,7 +39,7 @@ class Mercurial(VersionControl):
             )
 
     def fetch_new(self, dest, url, rev_options):
-        # type: (str, str, RevOptions) -> None
+        # type: (str, HiddenText, RevOptions) -> None
         rev_display = rev_options.to_display()
         logger.info(
             'Cloning hg %s%s to %s',
@@ -46,17 +47,19 @@ class Mercurial(VersionControl):
             rev_display,
             display_path(dest),
         )
-        self.run_command(['clone', '--noupdate', '-q', url, dest])
-        cmd_args = ['update', '-q'] + rev_options.to_args()
-        self.run_command(cmd_args, cwd=dest)
+        self.run_command(make_command('clone', '--noupdate', '-q', url, dest))
+        self.run_command(
+            make_command('update', '-q') + rev_options.to_args(),
+            cwd=dest,
+        )
 
     def switch(self, dest, url, rev_options):
-        # type: (str, str, RevOptions) -> None
+        # type: (str, HiddenText, RevOptions) -> None
         repo_config = os.path.join(dest, self.dirname, 'hgrc')
         config = configparser.RawConfigParser()
         try:
             config.read(repo_config)
-            config.set('paths', 'default', url)
+            config.set('paths', 'default', url.secret)
             with open(repo_config, 'w') as config_file:
                 config.write(config_file)
         except (OSError, configparser.NoSectionError) as exc:
@@ -64,13 +67,13 @@ class Mercurial(VersionControl):
                 'Could not switch Mercurial repository to %s: %s', url, exc,
             )
         else:
-            cmd_args = ['update', '-q'] + rev_options.to_args()
+            cmd_args = make_command('update', '-q') + rev_options.to_args()
             self.run_command(cmd_args, cwd=dest)
 
     def update(self, dest, url, rev_options):
-        # type: (str, str, RevOptions) -> None
+        # type: (str, HiddenText, RevOptions) -> None
         self.run_command(['pull', '-q'], cwd=dest)
-        cmd_args = ['update', '-q'] + rev_options.to_args()
+        cmd_args = make_command('update', '-q') + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)
 
     @classmethod

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -49,7 +49,7 @@ class Mercurial(VersionControl):
         )
         self.run_command(make_command('clone', '--noupdate', '-q', url, dest))
         self.run_command(
-            make_command('update', '-q') + rev_options.to_args(),
+            make_command('update', '-q', rev_options.to_args()),
             cwd=dest,
         )
 
@@ -67,13 +67,13 @@ class Mercurial(VersionControl):
                 'Could not switch Mercurial repository to %s: %s', url, exc,
             )
         else:
-            cmd_args = make_command('update', '-q') + rev_options.to_args()
+            cmd_args = make_command('update', '-q', rev_options.to_args())
             self.run_command(cmd_args, cwd=dest)
 
     def update(self, dest, url, rev_options):
         # type: (str, HiddenText, RevOptions) -> None
         self.run_command(['pull', '-q'], cwd=dest)
-        cmd_args = make_command('update', '-q') + rev_options.to_args()
+        cmd_args = make_command('update', '-q', rev_options.to_args())
         self.run_command(cmd_args, cwd=dest)
 
     @classmethod

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -8,7 +8,6 @@ import sys
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
     display_path,
-    hide_value,
     make_command,
     rmtree,
     split_auth_from_netloc,
@@ -97,12 +96,12 @@ class Subversion(VersionControl):
 
     @staticmethod
     def make_rev_args(username, password):
-        # type: (Optional[str], Optional[str]) -> CommandArgs
+        # type: (Optional[str], Optional[HiddenText]) -> CommandArgs
         extra_args = []  # type: CommandArgs
         if username:
             extra_args += ['--username', username]
         if password:
-            extra_args += ['--password', hide_value(password)]
+            extra_args += ['--password', password]
 
         return extra_args
 

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -288,9 +288,9 @@ class Subversion(VersionControl):
                 # Subversion doesn't like to check out over an existing
                 # directory --force fixes this, but was only added in svn 1.5
                 rmtree(location)
-            cmd_args = (
-                make_command('export') + self.get_remote_call_options() +
-                rev_options.to_args() + [url, location]
+            cmd_args = make_command(
+                'export', self.get_remote_call_options(),
+                rev_options.to_args(), url, location,
             )
             self.run_command(cmd_args, show_stdout=False)
 
@@ -303,25 +303,25 @@ class Subversion(VersionControl):
             rev_display,
             display_path(dest),
         )
-        cmd_args = (
-            make_command('checkout', '-q') + self.get_remote_call_options() +
-            rev_options.to_args() + [url, dest]
+        cmd_args = make_command(
+            'checkout', '-q', self.get_remote_call_options(),
+            rev_options.to_args(), url, dest,
         )
         self.run_command(cmd_args)
 
     def switch(self, dest, url, rev_options):
         # type: (str, HiddenText, RevOptions) -> None
-        cmd_args = (
-            make_command('switch') + self.get_remote_call_options() +
-            rev_options.to_args() + [url, dest]
+        cmd_args = make_command(
+            'switch', self.get_remote_call_options(), rev_options.to_args(),
+            url, dest,
         )
         self.run_command(cmd_args)
 
     def update(self, dest, url, rev_options):
         # type: (str, HiddenText, RevOptions) -> None
-        cmd_args = (
-            make_command('update') + self.get_remote_call_options() +
-            rev_options.to_args() + [dest]
+        cmd_args = make_command(
+            'update', self.get_remote_call_options(), rev_options.to_args(),
+            dest,
         )
         self.run_command(cmd_args)
 

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -17,6 +17,7 @@ from pip._internal.utils.misc import (
     call_subprocess,
     display_path,
     hide_url,
+    hide_value,
     make_command,
     rmtree,
 )
@@ -351,7 +352,7 @@ class VersionControl(object):
 
     @staticmethod
     def make_rev_args(username, password):
-        # type: (Optional[str], Optional[str]) -> CommandArgs
+        # type: (Optional[str], Optional[HiddenText]) -> CommandArgs
         """
         Return the RevOptions "extra arguments" to use in obtain().
         """
@@ -364,7 +365,10 @@ class VersionControl(object):
         some cases export(), as a tuple (url, rev_options).
         """
         secret_url, rev, user_pass = self.get_url_rev_and_auth(url.secret)
-        username, password = user_pass
+        username, secret_password = user_pass
+        password = None  # type: Optional[HiddenText]
+        if secret_password is not None:
+            password = hide_value(secret_password)
         extra_args = self.make_rev_args(username, password)
         rev_options = self.make_rev_options(rev, extra_args=extra_args)
 

--- a/tests/functional/test_vcs_bazaar.py
+++ b/tests/functional/test_vcs_bazaar.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 
+from pip._internal.utils.misc import hide_url
 from pip._internal.vcs.bazaar import Bazaar
 from tests.lib import (
     _test_path_to_file_url,
@@ -35,7 +36,7 @@ def test_export(script, tmpdir):
     _vcs_add(script, str(source_dir), vcs='bazaar')
 
     export_dir = str(tmpdir / 'export')
-    url = 'bzr+' + _test_path_to_file_url(source_dir)
+    url = hide_url('bzr+' + _test_path_to_file_url(source_dir))
     Bazaar().export(export_dir, url=url)
 
     assert os.listdir(export_dir) == ['test_file']
@@ -59,7 +60,7 @@ def test_export_rev(script, tmpdir):
     )
 
     export_dir = tmpdir / 'export'
-    url = 'bzr+' + _test_path_to_file_url(source_dir) + '@1'
+    url = hide_url('bzr+' + _test_path_to_file_url(source_dir) + '@1')
     Bazaar().export(str(export_dir), url=url)
 
     with open(export_dir / 'test_file', 'r') as f:

--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -5,6 +5,7 @@ import subprocess
 
 from pip._vendor.six.moves.urllib import request as urllib_request
 
+from pip._internal.utils.misc import hide_url
 from pip._internal.vcs import bazaar, git, mercurial, subversion
 from tests.lib import path_to_url
 
@@ -59,7 +60,8 @@ def _get_vcs_and_checkout_url(remote_repository, directory):
 
     destination_path = os.path.join(directory, repository_name)
     if not os.path.exists(destination_path):
-        vcs_class().obtain(destination_path, url=remote_repository)
+        url = hide_url(remote_repository)
+        vcs_class().obtain(destination_path, url=url)
     return '%s+%s' % (
         vcs,
         path_to_url('/'.join([directory, repository_name, branch])),

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1365,19 +1365,53 @@ def test_redact_password_from_url(auth_url, expected_url):
 
 class TestHiddenText:
 
-    def test_default_redacted(self):
-        hidden = HiddenText('my-secret')
-        assert repr(hidden) == "<HiddenText '****'>"
-        assert str(hidden) == '****'
-        assert hidden.redacted == '****'
-        assert hidden.secret == 'my-secret'
-
-    def test_custom_redacted(self):
+    def test_basic(self):
+        """
+        Test str(), repr(), and attribute access.
+        """
         hidden = HiddenText('my-secret', redacted='######')
         assert repr(hidden) == "<HiddenText '######'>"
         assert str(hidden) == '######'
         assert hidden.redacted == '######'
         assert hidden.secret == 'my-secret'
+
+    def test_equality_with_str(self):
+        """
+        Test equality (and inequality) with str objects.
+        """
+        hidden = HiddenText('secret', redacted='****')
+
+        # Test that the object doesn't compare equal to either its original
+        # or redacted forms.
+        assert hidden != hidden.secret
+        assert hidden.secret != hidden
+
+        assert hidden != hidden.redacted
+        assert hidden.redacted != hidden
+
+    def test_equality_same_secret(self):
+        """
+        Test equality with an object having the same secret.
+        """
+        # Choose different redactions for the two objects.
+        hidden1 = HiddenText('secret', redacted='****')
+        hidden2 = HiddenText('secret', redacted='####')
+
+        assert hidden1 == hidden2
+        # Also test __ne__.  This assertion fails in Python 2 without
+        # defining HiddenText.__ne__.
+        assert not hidden1 != hidden2
+
+    def test_equality_different_secret(self):
+        """
+        Test equality with an object having a different secret.
+        """
+        hidden1 = HiddenText('secret-1', redacted='****')
+        hidden2 = HiddenText('secret-2', redacted='****')
+
+        assert hidden1 != hidden2
+        # Also test __eq__.
+        assert not hidden1 == hidden2
 
 
 def test_hide_value():

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -6,7 +6,7 @@ from mock import patch
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import BadCommand
-from pip._internal.utils.misc import HiddenText, hide_url
+from pip._internal.utils.misc import HiddenText, hide_url, hide_value
 from pip._internal.vcs import make_vcs_requirement_url
 from pip._internal.vcs.bazaar import Bazaar
 from pip._internal.vcs.git import Git, looks_like_hash
@@ -343,7 +343,7 @@ def test_subversion__get_url_rev_and_auth(url, expected):
 @pytest.mark.parametrize('username, password, expected', [
     (None, None, []),
     ('user', None, []),
-    ('user', 'pass', []),
+    ('user', hide_value('pass'), []),
 ])
 def test_git__make_rev_args(username, password, expected):
     """
@@ -356,7 +356,8 @@ def test_git__make_rev_args(username, password, expected):
 @pytest.mark.parametrize('username, password, expected', [
     (None, None, []),
     ('user', None, ['--username', 'user']),
-    ('user', 'pass', ['--username', 'user', '--password', HiddenText('pass')]),
+    ('user', hide_value('pass'),
+     ['--username', 'user', '--password', HiddenText('pass')]),
 ])
 def test_subversion__make_rev_args(username, password, expected):
     """

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -6,6 +6,7 @@ from mock import patch
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import BadCommand
+from pip._internal.utils.misc import HiddenText, hide_url
 from pip._internal.vcs import make_vcs_requirement_url
 from pip._internal.vcs.bazaar import Bazaar
 from pip._internal.vcs.git import Git, looks_like_hash
@@ -355,7 +356,7 @@ def test_git__make_rev_args(username, password, expected):
 @pytest.mark.parametrize('username, password, expected', [
     (None, None, []),
     ('user', None, ['--username', 'user']),
-    ('user', 'pass', ['--username', 'user', '--password', 'pass']),
+    ('user', 'pass', ['--username', 'user', '--password', HiddenText('pass')]),
 ])
 def test_subversion__make_rev_args(username, password, expected):
     """
@@ -369,12 +370,15 @@ def test_subversion__get_url_rev_options():
     """
     Test Subversion.get_url_rev_options().
     """
-    url = 'svn+https://user:pass@svn.example.com/MyProject@v1.0#egg=MyProject'
-    url, rev_options = Subversion().get_url_rev_options(url)
-    assert url == 'https://svn.example.com/MyProject'
+    secret_url = (
+        'svn+https://user:pass@svn.example.com/MyProject@v1.0#egg=MyProject'
+    )
+    hidden_url = hide_url(secret_url)
+    url, rev_options = Subversion().get_url_rev_options(hidden_url)
+    assert url == HiddenText('https://svn.example.com/MyProject')
     assert rev_options.rev == 'v1.0'
     assert rev_options.extra_args == (
-        ['--username', 'user', '--password', 'pass']
+        ['--username', 'user', '--password', HiddenText('pass')]
     )
 
 
@@ -519,43 +523,48 @@ class TestSubversionArgs(TestCase):
         assert self.call_subprocess_mock.call_args[0][0] == args
 
     def test_obtain(self):
-        self.svn.obtain(self.dest, self.url)
-        self.assert_call_args(
-            ['svn', 'checkout', '-q', '--non-interactive', '--username',
-             'username', '--password', 'password',
-             'http://svn.example.com/', '/tmp/test'])
+        self.svn.obtain(self.dest, hide_url(self.url))
+        self.assert_call_args([
+            'svn', 'checkout', '-q', '--non-interactive', '--username',
+            'username', '--password', HiddenText('password'),
+            HiddenText('http://svn.example.com/'), '/tmp/test',
+        ])
 
     def test_export(self):
-        self.svn.export(self.dest, self.url)
-        self.assert_call_args(
-            ['svn', 'export', '--non-interactive', '--username', 'username',
-             '--password', 'password', 'http://svn.example.com/',
-             '/tmp/test'])
+        self.svn.export(self.dest, hide_url(self.url))
+        self.assert_call_args([
+            'svn', 'export', '--non-interactive', '--username', 'username',
+            '--password', HiddenText('password'),
+            HiddenText('http://svn.example.com/'), '/tmp/test',
+        ])
 
     def test_fetch_new(self):
-        self.svn.fetch_new(self.dest, self.url, self.rev_options)
-        self.assert_call_args(
-            ['svn', 'checkout', '-q', '--non-interactive',
-             'svn+http://username:password@svn.example.com/',
-             '/tmp/test'])
+        self.svn.fetch_new(self.dest, hide_url(self.url), self.rev_options)
+        self.assert_call_args([
+            'svn', 'checkout', '-q', '--non-interactive',
+            HiddenText('svn+http://username:password@svn.example.com/'),
+            '/tmp/test',
+        ])
 
     def test_fetch_new_revision(self):
         rev_options = RevOptions(Subversion, '123')
-        self.svn.fetch_new(self.dest, self.url, rev_options)
-        self.assert_call_args(
-            ['svn', 'checkout', '-q', '--non-interactive',
-             '-r', '123',
-             'svn+http://username:password@svn.example.com/',
-             '/tmp/test'])
+        self.svn.fetch_new(self.dest, hide_url(self.url), rev_options)
+        self.assert_call_args([
+            'svn', 'checkout', '-q', '--non-interactive', '-r', '123',
+            HiddenText('svn+http://username:password@svn.example.com/'),
+            '/tmp/test',
+        ])
 
     def test_switch(self):
-        self.svn.switch(self.dest, self.url, self.rev_options)
-        self.assert_call_args(
-            ['svn', 'switch', '--non-interactive',
-             'svn+http://username:password@svn.example.com/',
-             '/tmp/test'])
+        self.svn.switch(self.dest, hide_url(self.url), self.rev_options)
+        self.assert_call_args([
+            'svn', 'switch', '--non-interactive',
+            HiddenText('svn+http://username:password@svn.example.com/'),
+            '/tmp/test',
+        ])
 
     def test_update(self):
-        self.svn.update(self.dest, self.url, self.rev_options)
-        self.assert_call_args(
-            ['svn', 'update', '--non-interactive', '/tmp/test'])
+        self.svn.update(self.dest, hide_url(self.url), self.rev_options)
+        self.assert_call_args([
+            'svn', 'update', '--non-interactive', '/tmp/test',
+        ])

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -6,7 +6,7 @@ from mock import patch
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import BadCommand
-from pip._internal.utils.misc import HiddenText, hide_url, hide_value
+from pip._internal.utils.misc import hide_url, hide_value
 from pip._internal.vcs import make_vcs_requirement_url
 from pip._internal.vcs.bazaar import Bazaar
 from pip._internal.vcs.git import Git, looks_like_hash
@@ -357,7 +357,7 @@ def test_git__make_rev_args(username, password, expected):
     (None, None, []),
     ('user', None, ['--username', 'user']),
     ('user', hide_value('pass'),
-     ['--username', 'user', '--password', HiddenText('pass')]),
+     ['--username', 'user', '--password', hide_value('pass')]),
 ])
 def test_subversion__make_rev_args(username, password, expected):
     """
@@ -376,10 +376,10 @@ def test_subversion__get_url_rev_options():
     )
     hidden_url = hide_url(secret_url)
     url, rev_options = Subversion().get_url_rev_options(hidden_url)
-    assert url == HiddenText('https://svn.example.com/MyProject')
+    assert url == hide_url('https://svn.example.com/MyProject')
     assert rev_options.rev == 'v1.0'
     assert rev_options.extra_args == (
-        ['--username', 'user', '--password', HiddenText('pass')]
+        ['--username', 'user', '--password', hide_value('pass')]
     )
 
 
@@ -527,23 +527,23 @@ class TestSubversionArgs(TestCase):
         self.svn.obtain(self.dest, hide_url(self.url))
         self.assert_call_args([
             'svn', 'checkout', '-q', '--non-interactive', '--username',
-            'username', '--password', HiddenText('password'),
-            HiddenText('http://svn.example.com/'), '/tmp/test',
+            'username', '--password', hide_value('password'),
+            hide_url('http://svn.example.com/'), '/tmp/test',
         ])
 
     def test_export(self):
         self.svn.export(self.dest, hide_url(self.url))
         self.assert_call_args([
             'svn', 'export', '--non-interactive', '--username', 'username',
-            '--password', HiddenText('password'),
-            HiddenText('http://svn.example.com/'), '/tmp/test',
+            '--password', hide_value('password'),
+            hide_url('http://svn.example.com/'), '/tmp/test',
         ])
 
     def test_fetch_new(self):
         self.svn.fetch_new(self.dest, hide_url(self.url), self.rev_options)
         self.assert_call_args([
             'svn', 'checkout', '-q', '--non-interactive',
-            HiddenText('svn+http://username:password@svn.example.com/'),
+            hide_url('svn+http://username:password@svn.example.com/'),
             '/tmp/test',
         ])
 
@@ -552,7 +552,7 @@ class TestSubversionArgs(TestCase):
         self.svn.fetch_new(self.dest, hide_url(self.url), rev_options)
         self.assert_call_args([
             'svn', 'checkout', '-q', '--non-interactive', '-r', '123',
-            HiddenText('svn+http://username:password@svn.example.com/'),
+            hide_url('svn+http://username:password@svn.example.com/'),
             '/tmp/test',
         ])
 
@@ -560,7 +560,7 @@ class TestSubversionArgs(TestCase):
         self.svn.switch(self.dest, hide_url(self.url), self.rev_options)
         self.assert_call_args([
             'svn', 'switch', '--non-interactive',
-            HiddenText('svn+http://username:password@svn.example.com/'),
+            hide_url('svn+http://username:password@svn.example.com/'),
             '/tmp/test',
         ])
 

--- a/tests/unit/test_vcs_mercurial.py
+++ b/tests/unit/test_vcs_mercurial.py
@@ -6,6 +6,7 @@ import os
 
 from pip._vendor.six.moves import configparser
 
+from pip._internal.utils.misc import hide_url
 from pip._internal.vcs.mercurial import Mercurial
 from tests.lib import need_mercurial
 
@@ -24,7 +25,7 @@ def test_mercurial_switch_updates_config_file_when_found(tmpdir):
     hgrc_path = os.path.join(hg_dir, 'hgrc')
     with open(hgrc_path, 'w') as f:
         config.write(f)
-    hg.switch(tmpdir, 'new_url', options)
+    hg.switch(tmpdir, hide_url('new_url'), options)
 
     config.read(hgrc_path)
 


### PR DESCRIPTION
This PR adds a new `HiddenText` class to wrap sensitive strings and starts using them in the VCS modules to protect (1) URL's containing potential auth info, and (2) passwords that can be included in VCS command-line arguments. This finishes the work started in PR #6862.