### PR TITLE
Support including port part in trusted-host

### DIFF
--- a/news/6886.feature
+++ b/news/6886.feature
@@ -1,0 +1,1 @@
+Support including a port number in ``--trusted-host`` for both HTTP ans HTTPS.

--- a/news/6886.feature
+++ b/news/6886.feature
@@ -1,1 +1,1 @@
-Support including a port number in ``--trusted-host`` for both HTTP ans HTTPS.
+Support including a port number in ``--trusted-host`` for both HTTP and HTTPS.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -391,8 +391,8 @@ def trusted_host():
         action="append",
         metavar="HOSTNAME",
         default=[],
-        help="Mark this host as trusted, even though it does not have valid "
-             "or any HTTPS. A host:port pair is also acceptable.",
+        help="Mark this host or host:port pair as trusted, even though it "
+             "does not have valid or any HTTPS.",
     )
 
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -392,7 +392,7 @@ def trusted_host():
         metavar="HOSTNAME",
         default=[],
         help="Mark this host as trusted, even though it does not have valid "
-             "or any HTTPS.",
+             "or any HTTPS. A host:port pair is also acceptable.",
     )
 
 

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -77,7 +77,7 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.vcs.versioncontrol import AuthInfo, VersionControl
 
     Credentials = Tuple[str, str, str]
-    SecureOrigin = Tuple[str, str, Union[None, int, str]]
+    SecureOrigin = Tuple[str, str, Optional[Union[int, str]]]
 
     if PY2:
         CopytreeKwargs = TypedDict(

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -38,6 +38,7 @@ from pip._internal.utils.misc import (
     ARCHIVE_EXTENSIONS,
     SUPPORTED_EXTENSIONS,
     WHEEL_EXTENSION,
+    build_netloc,
     path_to_url,
     redact_password_from_url,
 )
@@ -947,7 +948,8 @@ class PackageFinder(object):
     @property
     def trusted_hosts(self):
         # type: () -> Iterable[str]
-        return iter(self.session.pip_trusted_hosts)
+        for host_port in self.session.pip_trusted_origins:
+            yield build_netloc(*host_port)
 
     @property
     def allow_all_prereleases(self):

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -1129,6 +1129,19 @@ def path_to_url(path):
     return url
 
 
+def build_netloc(host, port):
+    # type: (str, Optional[int]) -> str
+    """
+    Build a netloc from a host-port pair
+    """
+    if port is None:
+        return host
+    if ':' in host:
+        # Only wrap host with square brackets when it is IPv6
+        host = '[{}]'.format(host)
+    return '{}:{}'.format(host, port)
+
+
 def build_url_from_netloc(netloc, scheme='https'):
     # type: (str, str) -> str
     """
@@ -1140,14 +1153,14 @@ def build_url_from_netloc(netloc, scheme='https'):
     return '{}://{}'.format(scheme, netloc)
 
 
-def netloc_has_port(netloc):
-    # type: (str) -> bool
+def parse_netloc(netloc):
+    # type: (str) -> Tuple[str, Optional[int]]
     """
-    Return whether the netloc has a port part.
+    Return the host-port pair from a netloc.
     """
     url = build_url_from_netloc(netloc)
     parsed = urllib_parse.urlparse(url)
-    return bool(parsed.port)
+    return parsed.hostname, parsed.port
 
 
 def split_auth_from_netloc(netloc):

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -359,8 +359,7 @@ class TestProcessLine(object):
         # Test the log message.
         actual = [(r.levelname, r.message) for r in caplog.records]
         expected = (
-            'INFO',
-            "adding trusted host: 'host1' (from line 1 of file.txt)"
+            'INFO', "adding trusted host: 'host1' (from line 1 of file.txt)"
         )
         assert expected in actual
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -345,19 +345,24 @@ class TestProcessLine(object):
     def test_set_finder_trusted_host(self, caplog, session, finder):
         with caplog.at_level(logging.INFO):
             list(process_line(
-                "--trusted-host=host", "file.txt", 1, finder=finder,
-                session=session,
+                "--trusted-host=host1 --trusted-host=host2:8080",
+                "file.txt", 1, finder=finder, session=session,
             ))
-        assert list(finder.trusted_hosts) == ['host']
+        assert list(finder.trusted_hosts) == ['host1', 'host2:8080']
         session = finder.session
-        assert session.adapters['https://host/'] is session._insecure_adapter
+        assert session.adapters['https://host1/'] is session._insecure_adapter
+        assert (
+            session.adapters['https://host2:8080/']
+            is session._insecure_adapter
+        )
 
         # Test the log message.
         actual = [(r.levelname, r.message) for r in caplog.records]
-        expected = [
-            ('INFO', "adding trusted host: 'host' (from line 1 of file.txt)"),
-        ]
-        assert actual == expected
+        expected = (
+            'INFO',
+            "adding trusted host: 'host1' (from line 1 of file.txt)"
+        )
+        assert expected in actual
 
     def test_noop_always_unzip(self, finder):
         # noop, but confirm it can be set

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -38,6 +38,7 @@ from pip._internal.utils.glibc import (
 from pip._internal.utils.hashes import Hashes, MissingHashes
 from pip._internal.utils.misc import (
     HiddenText,
+    build_netloc,
     build_url_from_netloc,
     call_subprocess,
     egg_link_path,
@@ -49,9 +50,9 @@ from pip._internal.utils.misc import (
     hide_value,
     make_command,
     make_subprocess_output_error,
-    netloc_has_port,
     normalize_path,
     normalize_version_info,
+    parse_netloc,
     path_to_display,
     path_to_url,
     redact_netloc,
@@ -1232,29 +1233,49 @@ def test_path_to_url_win():
     assert path_to_url('file') == 'file:' + urllib_request.pathname2url(path)
 
 
-@pytest.mark.parametrize('netloc, expected_url, expected_has_port', [
+@pytest.mark.parametrize('netloc, expected_url, expected_host_port', [
     # Test domain name.
-    ('example.com', 'https://example.com', False),
-    ('example.com:5000', 'https://example.com:5000', True),
+    ('example.com', 'https://example.com', ('example.com', None)),
+    ('example.com:5000', 'https://example.com:5000', ('example.com', 5000)),
     # Test IPv4 address.
-    ('127.0.0.1', 'https://127.0.0.1', False),
-    ('127.0.0.1:5000', 'https://127.0.0.1:5000', True),
+    ('127.0.0.1', 'https://127.0.0.1', ('127.0.0.1', None)),
+    ('127.0.0.1:5000', 'https://127.0.0.1:5000', ('127.0.0.1', 5000)),
     # Test bare IPv6 address.
-    ('2001:DB6::1', 'https://[2001:DB6::1]', False),
+    ('2001:db6::1', 'https://[2001:db6::1]', ('2001:db6::1', None)),
     # Test IPv6 with port.
-    ('[2001:DB6::1]:5000', 'https://[2001:DB6::1]:5000', True),
+    (
+        '[2001:db6::1]:5000',
+        'https://[2001:db6::1]:5000',
+        ('2001:db6::1', 5000)
+    ),
     # Test netloc with auth.
     (
         'user:password@localhost:5000',
         'https://user:password@localhost:5000',
-        True
+        ('localhost', 5000)
     )
 ])
-def test_build_url_from_netloc_and_netloc_has_port(
-    netloc, expected_url, expected_has_port,
+def test_build_url_from_netloc_and_parse_netloc(
+    netloc, expected_url, expected_host_port,
 ):
     assert build_url_from_netloc(netloc) == expected_url
-    assert netloc_has_port(netloc) is expected_has_port
+    assert parse_netloc(netloc) == expected_host_port
+
+
+@pytest.mark.parametrize('host_port, expected_netloc', [
+    # Test domain name.
+    (('example.com', None), 'example.com'),
+    (('example.com', 5000), 'example.com:5000'),
+    # Test IPv4 address.
+    (('127.0.0.1', None), '127.0.0.1'),
+    (('127.0.0.1', 5000), '127.0.0.1:5000'),
+    # Test bare IPv6 address.
+    (('2001:db6::1', None), '2001:db6::1'),
+    # Test IPv6 with port.
+    (('2001:db6::1', 5000), '[2001:db6::1]:5000'),
+])
+def test_build_netloc(host_port, expected_netloc):
+    assert build_netloc(*host_port) == expected_netloc
 
 
 @pytest.mark.parametrize('netloc, expected', [

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1233,6 +1233,22 @@ def test_path_to_url_win():
     assert path_to_url('file') == 'file:' + urllib_request.pathname2url(path)
 
 
+@pytest.mark.parametrize('host_port, expected_netloc', [
+    # Test domain name.
+    (('example.com', None), 'example.com'),
+    (('example.com', 5000), 'example.com:5000'),
+    # Test IPv4 address.
+    (('127.0.0.1', None), '127.0.0.1'),
+    (('127.0.0.1', 5000), '127.0.0.1:5000'),
+    # Test bare IPv6 address.
+    (('2001:db6::1', None), '2001:db6::1'),
+    # Test IPv6 with port.
+    (('2001:db6::1', 5000), '[2001:db6::1]:5000'),
+])
+def test_build_netloc(host_port, expected_netloc):
+    assert build_netloc(*host_port) == expected_netloc
+
+
 @pytest.mark.parametrize('netloc, expected_url, expected_host_port', [
     # Test domain name.
     ('example.com', 'https://example.com', ('example.com', None)),
@@ -1260,22 +1276,6 @@ def test_build_url_from_netloc_and_parse_netloc(
 ):
     assert build_url_from_netloc(netloc) == expected_url
     assert parse_netloc(netloc) == expected_host_port
-
-
-@pytest.mark.parametrize('host_port, expected_netloc', [
-    # Test domain name.
-    (('example.com', None), 'example.com'),
-    (('example.com', 5000), 'example.com:5000'),
-    # Test IPv4 address.
-    (('127.0.0.1', None), '127.0.0.1'),
-    (('127.0.0.1', 5000), '127.0.0.1:5000'),
-    # Test bare IPv6 address.
-    (('2001:db6::1', None), '2001:db6::1'),
-    # Test IPv6 with port.
-    (('2001:db6::1', 5000), '[2001:db6::1]:5000'),
-])
-def test_build_netloc(host_port, expected_netloc):
-    assert build_netloc(*host_port) == expected_netloc
 
 
 @pytest.mark.parametrize('netloc, expected', [


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Closes #6886
Closes #6710 

This PR proposes official support for including port part in trusted-host option, for both HTTP and HTTPS indexes. So:

`--trusted-host example.com` trusts all these indexes:

- `http://example.com`
- `http://example.com:8080`
- `https://example.com`
- `https://example.com:8080`

While `--trusted-host example.com:8080` only trusts the indexes with port 8080 exactly:

- `http://example.com:8080`
- `https://example.com:8080`
