### PR TITLE
Fix uninstall of editable on py27 in debian virtualenv

### DIFF
--- a/news/5193.bugfix
+++ b/news/5193.bugfix
@@ -1,0 +1,3 @@
+Allow uninstalling editable installs on python 2.7 under debian.
+Workaround for how sysconfig reports "purelib" path in a virtualenv
+under debian.

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -56,13 +56,19 @@ def get_src_prefix():
 
 # FIXME doesn't account for venv linked to global site-packages
 
-site_packages = sysconfig.get_path("purelib")  # type: Optional[str]
-
-# This is because of a bug in PyPy's sysconfig module, see
+# This is needed as Debian-patched virtualenv and PyPy
+# have a bug in sysconfig module.
+# https://github.com/pypa/pip/issues/5193
 # https://bitbucket.org/pypy/pypy/issues/2506/sysconfig-returns-incorrect-paths
-# for more information.
-if platform.python_implementation().lower() == "pypy":
-    site_packages = distutils_sysconfig.get_python_lib()
+can_not_depend_on_purelib = (
+    sys.version_info[:2] == (2, 7) or
+    platform.python_implementation().lower() == "pypy"
+)
+if can_not_depend_on_purelib:
+    site_packages = distutils_sysconfig.get_python_lib()  # type: Optional[str]
+else:
+    site_packages = sysconfig.get_path("purelib")  # type: Optional[str]
+
 try:
     # Use getusersitepackages if this is present, as it ensures that the
     # value is initialised properly.

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -64,10 +64,11 @@ can_not_depend_on_purelib = (
     sys.version_info[:2] == (2, 7) or
     platform.python_implementation().lower() == "pypy"
 )
+site_packages = None  # type: Optional[str]
 if can_not_depend_on_purelib:
-    site_packages = distutils_sysconfig.get_python_lib()  # type: Optional[str]
+    site_packages = distutils_sysconfig.get_python_lib()
 else:
-    site_packages = sysconfig.get_path("purelib")  # type: Optional[str]
+    site_packages = sysconfig.get_path("purelib")
 
 try:
     # Use getusersitepackages if this is present, as it ensures that the

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -470,11 +470,7 @@ def dist_is_editable(dist):
     """
     Return True if given Distribution is an editable install.
     """
-    for path_item in sys.path:
-        egg_link = os.path.join(path_item, dist.project_name + '.egg-link')
-        if os.path.isfile(egg_link):
-            return True
-    return False
+    return bool(egg_link_path(dist))
 
 
 def get_installed_distributions(


### PR DESCRIPTION
Fixes #5193

- The first commit is a workaround for what appears to be a virtualenv/debian bug with python 2.7
- With that workaround in place, the second commit simplifies detection of editable installs by reusing the egg-link detection method