### PR TITLE
Rename `tox lint-py3` to `tox lint`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ jobs:
     # Basic Checks
     - stage: primary
       env: TOXENV=docs
+    - env: TOXENV=lint
     - env: TOXENV=lint-py2
       python: 2.7
-    - env: TOXENV=lint-py3
     - env: TOXENV=mypy
     - env: TOXENV=packaging
     # Latest CPython

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -75,10 +75,10 @@ To use linters locally, run:
 
 .. code-block:: console
 
+    $ tox -e lint
     $ tox -e lint-py2
-    $ tox -e lint-py3
 
-The above commands run the linters on Python 2 followed by Python 3.
+The above commands run the linters on Python 3 followed by Python 2.
 
 .. note::
 

--- a/tools/travis/run.sh
+++ b/tools/travis/run.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Short circuit tests and linting jobs if there are no code changes involved.
-if [[ $TOXENV != docs ]] && [[ $TOXENV != lint-py2 ]] && [[ $TOXENV != lint-py3 ]]; then
-    # Keep lint-py2 & lint-py3 for docs/conf.py
+if [[ $TOXENV != docs ]] && [[ $TOXENV != lint-py2 ]] && [[ $TOXENV != lint ]]; then
+    # Keep lint and lint-py2, for docs/conf.py
     if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
     then
         echo "This is not a PR -- will do a complete build."

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.4.0
 envlist =
-    docs, packaging, lint-py2, lint-py3, mypy,
+    docs, packaging, mypy, lint, lint-py2,
     py27, py35, py36, py37, py38, pypy, pypy3
 
 [helpers]
@@ -63,7 +63,7 @@ commands =
     flake8 src tests
     isort --check-only --diff
 
-[testenv:lint-py3]
+[testenv:lint]
 skip_install = True
 basepython = python3
 deps = {[lint]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,15 @@ commands =
 [lint]
 deps = -r{toxinidir}/tools/requirements/lint.txt
 
+[testenv:lint]
+skip_install = True
+basepython = python3
+deps = {[lint]deps}
+commands_pre =
+commands =
+    flake8
+    isort --check-only --diff
+
 [testenv:lint-py2]
 skip_install = True
 basepython = python2
@@ -61,15 +70,6 @@ commands_pre =
 # No need to flake8 docs, tools & tasks in py2
 commands =
     flake8 src tests
-    isort --check-only --diff
-
-[testenv:lint]
-skip_install = True
-basepython = python3
-deps = {[lint]deps}
-commands_pre =
-commands =
-    flake8
     isort --check-only --diff
 
 [testenv:mypy]


### PR DESCRIPTION
Also update references to it, in Travis CI config and in documentation.
