### PR TITLE
Simplify directory delete marker file check.

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -27,7 +27,10 @@ from pip._internal.req.req_uninstall import UninstallPathSet
 from pip._internal.utils.compat import native_str
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.logging import indent_log
-from pip._internal.utils.marker_files import PIP_DELETE_MARKER_FILENAME
+from pip._internal.utils.marker_files import (
+    PIP_DELETE_MARKER_FILENAME,
+    has_delete_marker_file,
+)
 from pip._internal.utils.misc import (
     _make_build_dir,
     ask_path_exists,
@@ -398,8 +401,7 @@ class InstallRequirement(object):
         # type: () -> None
         """Remove the source files from this requirement, if they are marked
         for deletion"""
-        if self.source_dir and os.path.exists(
-                os.path.join(self.source_dir, PIP_DELETE_MARKER_FILENAME)):
+        if self.source_dir and has_delete_marker_file(self.source_dir):
             logger.debug('Removing source in %s', self.source_dir)
             rmtree(self.source_dir)
         self.source_dir = None

--- a/src/pip/_internal/utils/marker_files.py
+++ b/src/pip/_internal/utils/marker_files.py
@@ -10,6 +10,10 @@ deleted (unless you remove this file).
 PIP_DELETE_MARKER_FILENAME = 'pip-delete-this-directory.txt'
 
 
+def has_delete_marker_file(directory):
+    return os.path.exists(os.path.join(directory, PIP_DELETE_MARKER_FILENAME))
+
+
 def write_delete_marker_file(directory):
     # type: (str) -> None
     """

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -36,7 +36,7 @@ from pip._internal.exceptions import (
 from pip._internal.locations import distutils_scheme, get_major_minor_version
 from pip._internal.models.link import Link
 from pip._internal.utils.logging import indent_log
-from pip._internal.utils.marker_files import PIP_DELETE_MARKER_FILENAME
+from pip._internal.utils.marker_files import has_delete_marker_file
 from pip._internal.utils.misc import (
     LOG_DIVIDER,
     call_subprocess,
@@ -1123,8 +1123,10 @@ class WheelBuilder(object):
                         # method.
                         # The code below assumes temporary source dirs -
                         # prevent it doing bad things.
-                        if req.source_dir and not os.path.exists(os.path.join(
-                                req.source_dir, PIP_DELETE_MARKER_FILENAME)):
+                        if (
+                            req.source_dir and
+                            not has_delete_marker_file(req.source_dir)
+                        ):
                             raise AssertionError(
                                 "bad source dir - missing marker")
                         # Delete the source we built the wheel from


### PR DESCRIPTION
Previously we were doing

```python
os.path.exists(os.path.join(obj.source_dir, PIP_DELETE_MARKER_FILENAME))
```

now we do

```python
has_delete_marker_file(obj.source_dir)
```

This is clearer, especially in `if` statements, and consolidates some of the code related to managing directories to be deleted.