### PR TITLE
Add command output logger

### DIFF
--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -12,7 +12,7 @@ from pip._vendor.six import PY2
 
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
-from pip._internal.utils.misc import ensure_dir, subprocess_logger
+from pip._internal.utils.misc import ensure_dir, subprocess_logger, command_logger
 
 try:
     import threading
@@ -333,6 +333,10 @@ def setup_logging(verbosity, no_color, user_log_file):
                 "()": "pip._internal.utils.logging.ExcludeLoggerFilter",
                 "name": subprocess_logger.name,
             },
+            "exclude_command": {
+                "()": "pip._internal.utils.logging.ExcludeLoggerFilter",
+                "name": command_logger.name,
+            },
         },
         "formatters": {
             "indent": {
@@ -351,7 +355,7 @@ def setup_logging(verbosity, no_color, user_log_file):
                 "class": handler_classes["stream"],
                 "no_color": no_color,
                 "stream": log_streams["stdout"],
-                "filters": ["exclude_subprocess", "exclude_warnings"],
+                "filters": ["exclude_subprocess", "exclude_warnings", "exclude_command"],
                 "formatter": "indent",
             },
             "console_errors": {
@@ -359,7 +363,7 @@ def setup_logging(verbosity, no_color, user_log_file):
                 "class": handler_classes["stream"],
                 "no_color": no_color,
                 "stream": log_streams["stderr"],
-                "filters": ["exclude_subprocess"],
+                "filters": ["exclude_subprocess", "exclude_command"],
                 "formatter": "indent",
             },
             # A handler responsible for logging to the console messages

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -89,6 +89,10 @@ __all__ = ['rmtree', 'display_path', 'backup_dir',
 logger = logging.getLogger(__name__)
 subprocess_logger = logging.getLogger('pip.subprocessor')
 
+command_logger = logging.getLogger('pip.command')
+log_command = command_logger.debug #TODO check if this should be defined here
+used_level = logging.DEBUG
+
 LOG_DIVIDER = '----------------------------------------'
 
 WHEEL_EXTENSION = '.whl'
@@ -993,7 +997,11 @@ def call_subprocess(
 
 def write_output(msg, *args):
     # type: (str, str) -> None
-    logger.info(msg, *args)
+    log_command(msg, *args)
+    if args == ():
+        print(msg)
+    else:
+        print(msg % args)
 
 
 def _make_build_dir(build_dir):

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -90,7 +90,7 @@ logger = logging.getLogger(__name__)
 subprocess_logger = logging.getLogger('pip.subprocessor')
 
 command_logger = logging.getLogger('pip.command')
-log_command = command_logger.debug #TODO check if this should be defined here
+log_command = command_logger.debug
 used_level = logging.DEBUG
 
 LOG_DIVIDER = '----------------------------------------'

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -90,8 +90,7 @@ logger = logging.getLogger(__name__)
 subprocess_logger = logging.getLogger('pip.subprocessor')
 
 command_logger = logging.getLogger('pip.command')
-log_command = command_logger.debug
-used_level = logging.DEBUG
+
 
 LOG_DIVIDER = '----------------------------------------'
 
@@ -997,7 +996,7 @@ def call_subprocess(
 
 def write_output(msg, *args):
     # type: (str, str) -> None
-    log_command(msg, *args)
+    command_logger.info(msg, *args)
     if args == ():
         print(msg)
     else:


### PR DESCRIPTION
Issue [6758](https://github.com/pypa/pip/issues/6758)

Print all messages to write_output

Created new logger called command_logger for commands that uses the default handler. All commands to write_output get sent to command_logger.