### PR TITLE
Fix rmtree_errorhandler to skip nonexistent dirs

### DIFF
--- a/news/4910.bugfix
+++ b/news/4910.bugfix
@@ -1,0 +1,1 @@
+Fix ``rmtree_errorhandler`` to skip non-existing directories.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -182,7 +182,7 @@ def rmtree_errorhandler(func, path, exc_info):
     remove them, an exception is thrown.  We catch that here, remove the
     read-only attribute, and hopefully continue without problems."""
     try:
-        is_readonly = os.stat(path).st_mode & stat.S_IREAD
+        is_readonly = not (os.stat(path).st_mode & stat.S_IWRITE)
     except (IOError, OSError):
         # The path already removed, nothing to do
         return

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -181,8 +181,14 @@ def rmtree_errorhandler(func, path, exc_info):
     """On Windows, the files in .svn are read-only, so when rmtree() tries to
     remove them, an exception is thrown.  We catch that here, remove the
     read-only attribute, and hopefully continue without problems."""
+    try:
+        is_readonly = os.stat(path).st_mode & stat.S_IREAD
+    except (IOError, OSError):
+        # The path already removed, nothing to do
+        return
+
     # if file type currently read only
-    if os.stat(path).st_mode & stat.S_IREAD:
+    if is_readonly:
         # convert to read/write
         os.chmod(path, stat.S_IWRITE)
         # use the original function to repeat the operation

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -182,13 +182,12 @@ def rmtree_errorhandler(func, path, exc_info):
     remove them, an exception is thrown.  We catch that here, remove the
     read-only attribute, and hopefully continue without problems."""
     try:
-        is_readonly = not (os.stat(path).st_mode & stat.S_IWRITE)
+        has_attr_readonly = not (os.stat(path).st_mode & stat.S_IWRITE)
     except (IOError, OSError):
-        # The path already removed, nothing to do
+        # it's equivalent to os.path.exists
         return
 
-    # if file type currently read only
-    if is_readonly:
+    if has_attr_readonly:
         # convert to read/write
         os.chmod(path, stat.S_IWRITE)
         # use the original function to repeat the operation

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -59,6 +59,7 @@ from pip._internal.utils.misc import (
     redact_netloc,
     remove_auth_from_url,
     rmtree,
+    rmtree_errorhandler,
     split_auth_from_netloc,
     split_auth_netloc_from_url,
     untar_file,
@@ -384,6 +385,65 @@ class TestUnpackArchives(object):
         test_file = data.packages.joinpath("test_zip.zip")
         unzip_file(test_file, self.tempdir)
         self.confirm_files()
+
+
+def test_rmtree_errorhandler_not_existing_directory(tmpdir):
+    """
+    Test rmtree_errorhandler ignores the given non-existing directory.
+    """
+    not_existing_path = str(tmpdir / 'foo')
+    mock_func = Mock()
+    rmtree_errorhandler(mock_func, not_existing_path, None)
+    mock_func.assert_not_called()
+
+
+def test_rmtree_errorhandler_readonly_directory(tmpdir):
+    """
+    Test rmtree_errorhandler makes the given read-only directory writable.
+    """
+    # Create read only directory
+    path = str((tmpdir / 'subdir').mkdir())
+    os.chmod(path, stat.S_IREAD)
+
+    # Make sure mock_func is called with the given path
+    mock_func = Mock()
+    rmtree_errorhandler(mock_func, path, None)
+    mock_func.assert_called_with(path)
+
+    # Make sure the path is become writable
+    assert os.stat(path).st_mode & stat.S_IWRITE
+
+
+def test_rmtree_errorhandler_reraises_error(tmpdir):
+    """
+    Test rmtree_errorhandler reraises an exception
+    by the given non-readonly directory.
+    """
+    # Create directory without read permission
+    path = str((tmpdir / 'subdir').mkdir())
+    os.chmod(path, ~stat.S_IREAD)
+
+    mock_func = Mock()
+    try:
+        # Make sure the handler reraises an exception.
+        # Note that the raise statement without expression and
+        # active exception in the current scope throws
+        # the RuntimeError on Python3 and the TypeError on Python2.
+        with pytest.raises((RuntimeError, TypeError)):
+            rmtree_errorhandler(mock_func, path, None)
+    finally:
+        # Restore the read permission to let the pytest to clean up temp dirs
+        os.chmod(path, stat.S_IREAD)
+
+    mock_func.assert_not_called()
+
+
+def test_rmtree_skips_not_existing_directory():
+    """
+    Test wrapped rmtree doesn't raise an error
+    by the given non-existing directory.
+    """
+    rmtree.__wrapped__('non-existing-subdir')
 
 
 class Failer:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -421,19 +421,15 @@ def test_rmtree_errorhandler_reraises_error(tmpdir):
     """
     # Create directory without read permission
     path = str((tmpdir / 'subdir').mkdir())
-    os.chmod(path, ~stat.S_IREAD)
+    os.chmod(path, stat.S_IWRITE)
 
     mock_func = Mock()
-    try:
-        # Make sure the handler reraises an exception.
-        # Note that the raise statement without expression and
-        # active exception in the current scope throws
-        # the RuntimeError on Python3 and the TypeError on Python2.
-        with pytest.raises((RuntimeError, TypeError)):
-            rmtree_errorhandler(mock_func, path, None)
-    finally:
-        # Restore the read permission to let the pytest to clean up temp dirs
-        os.chmod(path, stat.S_IREAD)
+    # Make sure the handler reraises an exception.
+    # Note that the raise statement without expression and
+    # active exception in the current scope throws
+    # the RuntimeError on Python3 and the TypeError on Python2.
+    with pytest.raises((RuntimeError, TypeError)):
+        rmtree_errorhandler(mock_func, path, None)
 
     mock_func.assert_not_called()
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -387,13 +387,13 @@ class TestUnpackArchives(object):
         self.confirm_files()
 
 
-def test_rmtree_errorhandler_not_existing_directory(tmpdir):
+def test_rmtree_errorhandler_nonexistent_directory(tmpdir):
     """
     Test rmtree_errorhandler ignores the given non-existing directory.
     """
-    not_existing_path = str(tmpdir / 'foo')
+    nonexistent_path = str(tmpdir / 'foo')
     mock_func = Mock()
-    rmtree_errorhandler(mock_func, not_existing_path, None)
+    rmtree_errorhandler(mock_func, nonexistent_path, None)
     mock_func.assert_not_called()
 
 
@@ -410,36 +410,37 @@ def test_rmtree_errorhandler_readonly_directory(tmpdir):
     rmtree_errorhandler(mock_func, path, None)
     mock_func.assert_called_with(path)
 
-    # Make sure the path is become writable
+    # Make sure the path is now writable
     assert os.stat(path).st_mode & stat.S_IWRITE
 
 
 def test_rmtree_errorhandler_reraises_error(tmpdir):
     """
     Test rmtree_errorhandler reraises an exception
-    by the given non-readonly directory.
+    by the given unreadable directory.
     """
     # Create directory without read permission
     path = str((tmpdir / 'subdir').mkdir())
     os.chmod(path, stat.S_IWRITE)
 
     mock_func = Mock()
-    # Make sure the handler reraises an exception.
-    # Note that the raise statement without expression and
-    # active exception in the current scope throws
-    # the RuntimeError on Python3 and the TypeError on Python2.
-    with pytest.raises((RuntimeError, TypeError)):
-        rmtree_errorhandler(mock_func, path, None)
+
+    try:
+        raise RuntimeError('test message')
+    except RuntimeError:
+        # Make sure the handler reraises an exception
+        with pytest.raises(RuntimeError, match='test message'):
+            rmtree_errorhandler(mock_func, path, None)
 
     mock_func.assert_not_called()
 
 
-def test_rmtree_skips_not_existing_directory():
+def test_rmtree_skips_nonexistent_directory():
     """
     Test wrapped rmtree doesn't raise an error
-    by the given non-existing directory.
+    by the given nonexistent directory.
     """
-    rmtree.__wrapped__('non-existing-subdir')
+    rmtree.__wrapped__('nonexistent-subdir')
 
 
 class Failer:


### PR DESCRIPTION
Fixes #4910.

> If on error the provided path does not exist then we should just return and not re-raise the exception. The check should be before os.stat in that function.

I decided to wrap os.stat to try/except instead, since `os.path.exists` [does](https://github.com/python/cpython/blob/a49f203e052c6fb1244d4e55c3fccc439dda0e2e/Lib/genericpath.py#L16-L22) the same thing.