### PR TITLE
Remove dependence on PackageFinder in WheelBuilder.build

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -393,7 +393,7 @@ class InstallCommand(RequirementCommand):
                             legacy_requirements.append(req)
 
                     wheel_builder = WheelBuilder(
-                        finder, preparer, wheel_cache,
+                        preparer, wheel_cache,
                         build_options=[], global_options=[],
                         check_binary_allowed=check_binary_allowed,
                     )

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -15,6 +15,7 @@ import shutil
 from optparse import SUPPRESS_HELP
 
 from pip._vendor import pkg_resources
+from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
@@ -46,7 +47,9 @@ if MYPY_CHECK_RUNNING:
     from optparse import Values
     from typing import Any, List
 
+    from pip._internal.models.format_control import FormatControl
     from pip._internal.req.req_install import InstallRequirement
+    from pip._internal.wheel import BinaryAllowedPredicate
 
 
 logger = logging.getLogger(__name__)
@@ -92,6 +95,17 @@ def build_wheels(
         )
 
     return build_failures
+
+
+def get_check_binary_allowed(format_control):
+    # type: (FormatControl) -> BinaryAllowedPredicate
+    def check_binary_allowed(req):
+        # type: (InstallRequirement) -> bool
+        canonical_name = canonicalize_name(req.name)
+        allowed_formats = format_control.get_allowed_formats(canonical_name)
+        return "binary" in allowed_formats
+
+    return check_binary_allowed
 
 
 class InstallCommand(RequirementCommand):
@@ -366,6 +380,9 @@ class InstallCommand(RequirementCommand):
                         modifying_pip=requirement_set.has_requirement("pip")
                     )
 
+                    check_binary_allowed = get_check_binary_allowed(
+                        finder.format_control
+                    )
                     # Consider legacy and PEP517-using requirements separately
                     legacy_requirements = []
                     pep517_requirements = []
@@ -378,6 +395,7 @@ class InstallCommand(RequirementCommand):
                     wheel_builder = WheelBuilder(
                         finder, preparer, wheel_cache,
                         build_options=[], global_options=[],
+                        check_binary_allowed=check_binary_allowed,
                     )
 
                     build_failures = build_wheels(

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -154,7 +154,7 @@ class WheelCommand(RequirementCommand):
 
                     # build wheels
                     wb = WheelBuilder(
-                        finder, preparer, wheel_cache,
+                        preparer, wheel_cache,
                         build_options=options.build_options or [],
                         global_options=options.global_options or [],
                         no_clean=options.no_clean,

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -58,7 +58,6 @@ if MYPY_CHECK_RUNNING:
     )
     from pip._vendor.packaging.requirements import Requirement
     from pip._internal.req.req_install import InstallRequirement
-    from pip._internal.index import FormatControl, PackageFinder
     from pip._internal.operations.prepare import (
         RequirementPreparer
     )
@@ -778,7 +777,6 @@ def _contains_egg_info(
 
 def should_use_ephemeral_cache(
     req,  # type: InstallRequirement
-    format_control,  # type: FormatControl
     should_unpack,  # type: bool
     cache_available,  # type: bool
     check_binary_allowed,  # type: BinaryAllowedPredicate
@@ -899,7 +897,6 @@ class WheelBuilder(object):
 
     def __init__(
         self,
-        finder,  # type: PackageFinder
         preparer,  # type: RequirementPreparer
         wheel_cache,  # type: WheelCache
         build_options=None,  # type: Optional[List[str]]
@@ -908,7 +905,6 @@ class WheelBuilder(object):
         no_clean=False  # type: bool
     ):
         # type: (...) -> None
-        self.finder = finder
         if check_binary_allowed is None:
             # Binaries allowed by default.
             check_binary_allowed = _always_true
@@ -1071,13 +1067,11 @@ class WheelBuilder(object):
         )
 
         buildset = []
-        format_control = self.finder.format_control
         cache_available = bool(self.wheel_cache.cache_dir)
 
         for req in requirements:
             ephem_cache = should_use_ephemeral_cache(
                 req,
-                format_control=format_control,
                 should_unpack=should_unpack,
                 cache_available=cache_available,
                 check_binary_allowed=self.check_binary_allowed,

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -812,7 +812,7 @@ def should_use_ephemeral_cache(
     if "binary" not in format_control.get_allowed_formats(
             canonicalize_name(req.name)):
         logger.info(
-            "Skipping bdist_wheel for %s, due to binaries "
+            "Skipping wheel build for %s, due to binaries "
             "being disabled for it.", req.name,
         )
         return None

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -101,9 +101,12 @@ def test_should_use_ephemeral_cache__issue_6197(
     assert req.link.is_artifact
 
     format_control = FormatControl()
+
+    always_true = Mock(return_value=True)
+
     ephem_cache = wheel.should_use_ephemeral_cache(
         req, format_control=format_control, should_unpack=should_unpack,
-        cache_available=cache_available,
+        cache_available=cache_available, check_binary_allowed=always_true,
     )
     assert ephem_cache is expected
 
@@ -142,10 +145,12 @@ def test_should_use_ephemeral_cache__disallow_binaries_and_vcs_checkout(
     if disallow_binaries:
         format_control.disallow_binaries()
 
+    check_binary_allowed = Mock(return_value=not disallow_binaries)
+
     # The cache_available value doesn't matter for this test.
     ephem_cache = wheel.should_use_ephemeral_cache(
         req, format_control=format_control, should_unpack=True,
-        cache_available=True,
+        cache_available=True, check_binary_allowed=check_binary_allowed,
     )
     assert ephem_cache is expected
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -10,7 +10,6 @@ from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal import pep425tags, wheel
 from pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
-from pip._internal.index import FormatControl
 from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.compat import WINDOWS
@@ -100,12 +99,10 @@ def test_should_use_ephemeral_cache__issue_6197(
     assert not req.is_wheel
     assert req.link.is_artifact
 
-    format_control = FormatControl()
-
     always_true = Mock(return_value=True)
 
     ephem_cache = wheel.should_use_ephemeral_cache(
-        req, format_control=format_control, should_unpack=should_unpack,
+        req, should_unpack=should_unpack,
         cache_available=cache_available, check_binary_allowed=always_true,
     )
     assert ephem_cache is expected
@@ -141,15 +138,11 @@ def test_should_use_ephemeral_cache__disallow_binaries_and_vcs_checkout(
     assert not req.is_wheel
     assert req.link.is_vcs
 
-    format_control = FormatControl()
-    if disallow_binaries:
-        format_control.disallow_binaries()
-
     check_binary_allowed = Mock(return_value=not disallow_binaries)
 
     # The cache_available value doesn't matter for this test.
     ephem_cache = wheel.should_use_ephemeral_cache(
-        req, format_control=format_control, should_unpack=True,
+        req, should_unpack=True,
         cache_available=True, check_binary_allowed=check_binary_allowed,
     )
     assert ephem_cache is expected
@@ -701,7 +694,6 @@ class TestWheelBuilder(object):
                 as mock_build_one:
             wheel_req = Mock(is_wheel=True, editable=False, constraint=False)
             wb = wheel.WheelBuilder(
-                finder=Mock(),
                 preparer=Mock(),
                 wheel_cache=Mock(cache_dir=None),
             )


### PR DESCRIPTION
Previously, `WheelBuilder` and `should_use_ephemeral_cache` had to know about `PackageFinder`s and `FormatControl`s. Now they don't!