### PR TITLE
Simplify build loop in WheelBuilder.build

### DIFF
--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -1076,11 +1076,6 @@ class WheelBuilder(object):
         if not buildset:
             return []
 
-        # Is any wheel build not using the ephemeral cache?
-        if any(not ephem_cache for _, ephem_cache in buildset):
-            if should_unpack:
-                assert self.wheel_cache.cache_dir
-
         # TODO by @pradyunsg
         # Should break up this method into 2 separate methods.
 

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -1095,15 +1095,17 @@ class WheelBuilder(object):
                         output_dir = _cache.get_ephem_path_for_link(req.link)
                     else:
                         output_dir = _cache.get_path_for_link(req.link)
-                    try:
-                        ensure_dir(output_dir)
-                    except OSError as e:
-                        logger.warning("Building wheel for %s failed: %s",
-                                       req.name, e)
-                        build_failure.append(req)
-                        continue
                 else:
                     output_dir = self._wheel_dir
+
+                try:
+                    ensure_dir(output_dir)
+                except OSError as e:
+                    logger.warning("Building wheel for %s failed: %s",
+                                   req.name, e)
+                    build_failure.append(req)
+                    continue
+
                 wheel_file = self._build_one(
                     req, output_dir,
                     python_tag=python_tag,

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -1089,15 +1089,14 @@ class WheelBuilder(object):
         if should_unpack:
             python_tag = pep425tags.implementation_tag
 
-        _cache = self.wheel_cache  # shorter name
         with indent_log():
             build_success, build_failure = [], []
             for req, ephem in buildset:
                 if should_unpack:
                     if ephem:
-                        output_dir = _cache.get_ephem_path_for_link(req.link)
+                        output_dir = self.wheel_cache.get_ephem_path_for_link(req.link)
                     else:
-                        output_dir = _cache.get_path_for_link(req.link)
+                        output_dir = self.wheel_cache.get_path_for_link(req.link)
                 else:
                     output_dir = self._wheel_dir
 

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -1073,7 +1073,9 @@ class WheelBuilder(object):
 
             if should_unpack:
                 if ephem_cache:
-                    output_dir = self.wheel_cache.get_ephem_path_for_link(req.link)
+                    output_dir = self.wheel_cache.get_ephem_path_for_link(
+                        req.link
+                    )
                 else:
                     output_dir = self.wheel_cache.get_path_for_link(req.link)
             else:

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -1078,10 +1078,8 @@ class WheelBuilder(object):
 
         # Is any wheel build not using the ephemeral cache?
         if any(not ephem_cache for _, ephem_cache in buildset):
-            have_directory_for_build = self._wheel_dir or (
-                should_unpack and self.wheel_cache.cache_dir
-            )
-            assert have_directory_for_build
+            if should_unpack:
+                assert self.wheel_cache.cache_dir
 
         # TODO by @pradyunsg
         # Should break up this method into 2 separate methods.

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -1084,13 +1084,16 @@ class WheelBuilder(object):
             'Building wheels for collected packages: %s',
             ', '.join([req.name for (req, _) in buildset]),
         )
+
+        python_tag = None
+        if should_unpack:
+            python_tag = pep425tags.implementation_tag
+
         _cache = self.wheel_cache  # shorter name
         with indent_log():
             build_success, build_failure = [], []
             for req, ephem in buildset:
-                python_tag = None
                 if should_unpack:
-                    python_tag = pep425tags.implementation_tag
                     if ephem:
                         output_dir = _cache.get_ephem_path_for_link(req.link)
                     else:

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -1071,7 +1071,15 @@ class WheelBuilder(object):
             if ephem_cache is None:
                 continue
 
-            buildset.append((req, ephem_cache))
+            if should_unpack:
+                if ephem_cache:
+                    output_dir = self.wheel_cache.get_ephem_path_for_link(req.link)
+                else:
+                    output_dir = self.wheel_cache.get_path_for_link(req.link)
+            else:
+                output_dir = self._wheel_dir
+
+            buildset.append((req, output_dir))
 
         if not buildset:
             return []
@@ -1091,15 +1099,7 @@ class WheelBuilder(object):
 
         with indent_log():
             build_success, build_failure = [], []
-            for req, ephem in buildset:
-                if should_unpack:
-                    if ephem:
-                        output_dir = self.wheel_cache.get_ephem_path_for_link(req.link)
-                    else:
-                        output_dir = self.wheel_cache.get_path_for_link(req.link)
-                else:
-                    output_dir = self._wheel_dir
-
+            for req, output_dir in buildset:
                 try:
                     ensure_dir(output_dir)
                 except OSError as e:

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -1071,6 +1071,7 @@ class WheelBuilder(object):
             if ephem_cache is None:
                 continue
 
+            # Determine where the wheel should go.
             if should_unpack:
                 if ephem_cache:
                     output_dir = self.wheel_cache.get_ephem_path_for_link(
@@ -1105,8 +1106,10 @@ class WheelBuilder(object):
                 try:
                     ensure_dir(output_dir)
                 except OSError as e:
-                    logger.warning("Building wheel for %s failed: %s",
-                                   req.name, e)
+                    logger.warning(
+                        "Building wheel for %s failed: %s",
+                        req.name, e,
+                    )
                     build_failure.append(req)
                     continue
 


### PR DESCRIPTION
Benefits:

1. it is easier to understand `(requirement, output_directory)` input into a loop that builds wheels vs `(requirement, ephem)` input into a loop that calculates the output directory (using `should_unpack` and several member variables) and *then* builds wheels
1. as the main build loop is simpler, a future PR can attempt to extract `InstallRequirement`-specific stuff out of the second half of the loop with much less noise
1. simplifies the usage of `should_unpack` (i.e. "called from `commands/install.py`"), so we may be able to remove it entirely soon in favor of separate functions or parametrizing any caller-specific logic