### PR TITLE
Override PIP_USER if running_under_virtualenv

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -301,7 +301,7 @@ class InstallCommand(RequirementCommand):
                     "Ignoring '--user', since user site-packages are not "
                     "visible in this virtualenv."
                 )
-            options.use_user_site = False
+                options.use_user_site = False
             install_options.append('--user')
             install_options.append('--prefix=')
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -297,10 +297,11 @@ class InstallCommand(RequirementCommand):
                     "different installation locations"
                 )
             if virtualenv_no_global():
-                raise InstallationError(
-                    "Can not perform a '--user' install. User site-packages "
-                    "are not visible in this virtualenv."
+                logger.info(
+                    "Ignoring '--user', since user site-packages are not "
+                    "visible in this virtualenv."
                 )
+            options.use_user_site = False
             install_options.append('--user')
             install_options.append('--prefix=')
 

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -361,7 +361,7 @@ class Configuration(object):
     def _get_environ_vars(self):
         # type: () -> Iterable[Tuple[str, str]]
         """Returns a generator with all environmental vars with prefix PIP_"""
-        if running_under_virtualenv:
+        if running_under_virtualenv():
             os.environ['PIP_USER'] = 'no'
         for key, val in os.environ.items():
             should_be_yielded = (

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -360,6 +360,8 @@ class Configuration(object):
     def _get_environ_vars(self):
         # type: () -> Iterable[Tuple[str, str]]
         """Returns a generator with all environmental vars with prefix PIP_"""
+        if 'VIRTUAL_ENV' in os.environ:
+            os.environ['PIP_USER'] = 'no'
         for key, val in os.environ.items():
             should_be_yielded = (
                 key.startswith("PIP_") and

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -29,6 +29,7 @@ from pip._internal.utils import appdirs
 from pip._internal.utils.compat import WINDOWS, expanduser
 from pip._internal.utils.misc import ensure_dir, enum
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+from pip._internal.utils.virtualenv import running_under_virtualenv
 
 if MYPY_CHECK_RUNNING:
     from typing import (
@@ -360,7 +361,7 @@ class Configuration(object):
     def _get_environ_vars(self):
         # type: () -> Iterable[Tuple[str, str]]
         """Returns a generator with all environmental vars with prefix PIP_"""
-        if 'VIRTUAL_ENV' in os.environ:
+        if running_under_virtualenv:
             os.environ['PIP_USER'] = 'no'
         for key, val in os.environ.items():
             should_be_yielded = (

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -29,7 +29,6 @@ from pip._internal.utils import appdirs
 from pip._internal.utils.compat import WINDOWS, expanduser
 from pip._internal.utils.misc import ensure_dir, enum
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.utils.virtualenv import running_under_virtualenv
 
 if MYPY_CHECK_RUNNING:
     from typing import (
@@ -361,8 +360,6 @@ class Configuration(object):
     def _get_environ_vars(self):
         # type: () -> Iterable[Tuple[str, str]]
         """Returns a generator with all environmental vars with prefix PIP_"""
-        if running_under_virtualenv():
-            os.environ['PIP_USER'] = 'no'
         for key, val in os.environ.items():
             should_be_yielded = (
                 key.startswith("PIP_") and


### PR DESCRIPTION
This PR sets an environment variable to override any `PIP_USER` setting when being used within a virtual environment which sets a `VIRTUAL_ENV` environment variable.

This works around issues such as https://github.com/pypa/pip/issues/2081, https://github.com/pypa/pip/issues/4141 and https://github.com/pypa/pip/issues/5702 .

It's a pretty naive solution, and I've tested only under Linux so this may be an incomplete solution for macOS/Windows.