### PR TITLE
tests: fix typos

### DIFF
--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -72,7 +72,7 @@ def test_cleanup_after_install_from_local_directory(script, data):
     script.assert_no_temp()
 
 
-def test_cleanup_req_satisifed_no_name(script, data):
+def test_cleanup_req_satisfied_no_name(script, data):
     """
     Test cleanup when req is already satisfied, and req has no 'name'
     """

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -76,7 +76,7 @@ class TestLocations:
         return result
 
 
-class TestDisutilsScheme:
+class TestDistutilsScheme:
 
     def test_root_modifies_appropriately(self, monkeypatch):
         # This deals with nt/posix path differences


### PR DESCRIPTION
Follow-up of #6807 ignoring `_vendor` changes.
