### PR TITLE
Reduce context/options passed to Resolver

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -180,15 +180,12 @@ class RequirementCommand(IndexGroupCommand):
             session=session,
             finder=finder,
             make_install_req=make_install_req,
-            wheel_cache=wheel_cache,
             use_user_site=use_user_site,
             ignore_dependencies=options.ignore_dependencies,
             ignore_installed=ignore_installed,
             ignore_requires_python=ignore_requires_python,
             force_reinstall=force_reinstall,
-            isolated=options.isolated_mode,
             upgrade_strategy=upgrade_strategy,
-            use_pep517=use_pep517,
             py_version_info=py_version_info
         )
 

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -6,6 +6,7 @@ PackageFinder machinery and all its vendored dependencies, etc.
 """
 
 import os
+from functools import partial
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.cmdoptions import make_search_scope
@@ -18,6 +19,7 @@ from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req.constructors import (
     install_req_from_editable,
     install_req_from_line,
+    install_req_from_req_string,
 )
 from pip._internal.req.req_file import parse_requirements
 from pip._internal.utils.misc import normalize_path
@@ -167,10 +169,17 @@ class RequirementCommand(IndexGroupCommand):
         """
         Create a Resolver instance for the given parameters.
         """
+        make_install_req = partial(
+            install_req_from_req_string,
+            isolated=options.isolated_mode,
+            wheel_cache=wheel_cache,
+            use_pep517=use_pep517,
+        )
         return Resolver(
             preparer=preparer,
             session=session,
             finder=finder,
+            make_install_req=make_install_req,
             wheel_cache=wheel_cache,
             use_user_site=use_user_site,
             ignore_dependencies=options.ignore_dependencies,

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -156,6 +156,7 @@ class Resolver(object):
         self.ignore_requires_python = ignore_requires_python
         self.use_user_site = use_user_site
         self.use_pep517 = use_pep517
+        self._make_install_req = install_req_from_req_string
 
         self._discovered_dependencies = \
             defaultdict(list)  # type: DefaultDict[str, List]
@@ -381,7 +382,7 @@ class Resolver(object):
         more_reqs = []  # type: List[InstallRequirement]
 
         def add_req(subreq, extras_requested):
-            sub_install_req = install_req_from_req_string(
+            sub_install_req = self._make_install_req(
                 str(subreq),
                 req_to_install,
                 isolated=self.isolated,

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -16,6 +16,7 @@ for sub-dependencies
 import logging
 import sys
 from collections import defaultdict
+from functools import partial
 from itertools import chain
 
 from pip._vendor.packaging import specifiers
@@ -156,7 +157,12 @@ class Resolver(object):
         self.ignore_requires_python = ignore_requires_python
         self.use_user_site = use_user_site
         self.use_pep517 = use_pep517
-        self._make_install_req = install_req_from_req_string
+        self._make_install_req = partial(
+            install_req_from_req_string,
+            isolated=self.isolated,
+            wheel_cache=self.wheel_cache,
+            use_pep517=self.use_pep517,
+        )
 
         self._discovered_dependencies = \
             defaultdict(list)  # type: DefaultDict[str, List]
@@ -385,9 +391,6 @@ class Resolver(object):
             sub_install_req = self._make_install_req(
                 str(subreq),
                 req_to_install,
-                isolated=self.isolated,
-                wheel_cache=self.wheel_cache,
-                use_pep517=self.use_pep517
             )
             parent_req_name = req_to_install.name
             to_scan_again, add_to_parent = requirement_set.add_requirement(

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -16,7 +16,6 @@ for sub-dependencies
 import logging
 import sys
 from collections import defaultdict
-from functools import partial
 from itertools import chain
 
 from pip._vendor.packaging import specifiers
@@ -28,7 +27,6 @@ from pip._internal.exceptions import (
     HashErrors,
     UnsupportedPythonVersion,
 )
-from pip._internal.req.constructors import install_req_from_req_string
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
     dist_in_usersite,
@@ -45,7 +43,6 @@ if MYPY_CHECK_RUNNING:
     from typing import Callable, DefaultDict, List, Optional, Set, Tuple
     from pip._vendor import pkg_resources
 
-    from pip._internal.cache import WheelCache
     from pip._internal.distributions import AbstractDistribution
     from pip._internal.download import PipSession
     from pip._internal.index import PackageFinder
@@ -121,15 +118,12 @@ class Resolver(object):
         session,  # type: PipSession
         finder,  # type: PackageFinder
         make_install_req,  # type: InstallRequirementProvider
-        wheel_cache,  # type: Optional[WheelCache]
         use_user_site,  # type: bool
         ignore_dependencies,  # type: bool
         ignore_installed,  # type: bool
         ignore_requires_python,  # type: bool
         force_reinstall,  # type: bool
-        isolated,  # type: bool
         upgrade_strategy,  # type: str
-        use_pep517=None,  # type: Optional[bool]
         py_version_info=None,  # type: Optional[Tuple[int, ...]]
     ):
         # type: (...) -> None
@@ -147,21 +141,15 @@ class Resolver(object):
         self.finder = finder
         self.session = session
 
-        # NOTE: This would eventually be replaced with a cache that can give
-        #       information about both sdist and wheels transparently.
-        self.wheel_cache = wheel_cache
-
         # This is set in resolve
         self.require_hashes = None  # type: Optional[bool]
 
         self.upgrade_strategy = upgrade_strategy
         self.force_reinstall = force_reinstall
-        self.isolated = isolated
         self.ignore_dependencies = ignore_dependencies
         self.ignore_installed = ignore_installed
         self.ignore_requires_python = ignore_requires_python
         self.use_user_site = use_user_site
-        self.use_pep517 = use_pep517
         self._make_install_req = make_install_req
 
         self._discovered_dependencies = \

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -42,7 +42,7 @@ from pip._internal.utils.packaging import (
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import DefaultDict, List, Optional, Set, Tuple
+    from typing import Callable, DefaultDict, List, Optional, Set, Tuple
     from pip._vendor import pkg_resources
 
     from pip._internal.cache import WheelCache
@@ -52,6 +52,10 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.operations.prepare import RequirementPreparer
     from pip._internal.req.req_install import InstallRequirement
     from pip._internal.req.req_set import RequirementSet
+
+    InstallRequirementProvider = Callable[
+        [str, InstallRequirement], InstallRequirement
+    ]
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +120,7 @@ class Resolver(object):
         preparer,  # type: RequirementPreparer
         session,  # type: PipSession
         finder,  # type: PackageFinder
+        make_install_req,  # type: InstallRequirementProvider
         wheel_cache,  # type: Optional[WheelCache]
         use_user_site,  # type: bool
         ignore_dependencies,  # type: bool
@@ -157,12 +162,7 @@ class Resolver(object):
         self.ignore_requires_python = ignore_requires_python
         self.use_user_site = use_user_site
         self.use_pep517 = use_pep517
-        self._make_install_req = partial(
-            install_req_from_req_string,
-            isolated=self.isolated,
-            wheel_cache=self.wheel_cache,
-            use_pep517=self.use_pep517,
-        )
+        self._make_install_req = make_install_req
 
         self._discovered_dependencies = \
             defaultdict(list)  # type: DefaultDict[str, List]

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 import tempfile
+from functools import partial
 
 import pytest
 from mock import patch
@@ -23,6 +24,7 @@ from pip._internal.req import InstallRequirement, RequirementSet
 from pip._internal.req.constructors import (
     install_req_from_editable,
     install_req_from_line,
+    install_req_from_req_string,
     parse_editable,
 )
 from pip._internal.req.req_file import process_line
@@ -61,8 +63,15 @@ class TestRequirementSet(object):
             build_isolation=True,
             req_tracker=RequirementTracker(),
         )
+        make_install_req = partial(
+            install_req_from_req_string,
+            isolated=False,
+            wheel_cache=None,
+            use_pep517=None,
+        )
         return Resolver(
             preparer=preparer, wheel_cache=None,
+            make_install_req=make_install_req,
             session=PipSession(), finder=finder,
             use_user_site=False, upgrade_strategy="to-satisfy-only",
             ignore_dependencies=False, ignore_installed=False,

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -70,13 +70,12 @@ class TestRequirementSet(object):
             use_pep517=None,
         )
         return Resolver(
-            preparer=preparer, wheel_cache=None,
+            preparer=preparer,
             make_install_req=make_install_req,
             session=PipSession(), finder=finder,
             use_user_site=False, upgrade_strategy="to-satisfy-only",
             ignore_dependencies=False, ignore_installed=False,
             ignore_requires_python=False, force_reinstall=False,
-            isolated=False,
         )
 
     def test_no_reuse_existing_build_dir(self, data):


### PR DESCRIPTION
Instead of passing data and having `Resolver` construct `InstallRequirement`s, we pass a function that does it.