### PR TITLE
Begin splitting handling of legacy and modern source distributions

### DIFF
--- a/src/pip/_internal/distributions/__init__.py
+++ b/src/pip/_internal/distributions/__init__.py
@@ -1,4 +1,5 @@
-from pip._internal.distributions.source.legacy import SourceDistribution
+from pip._internal.distributions.source.legacy import LegacySourceDistribution
+from pip._internal.distributions.source.modern import ModernSourceDistribution
 from pip._internal.distributions.wheel import WheelDistribution
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -15,11 +16,18 @@ def make_distribution_for_install_requirement(install_req):
     # Editable requirements will always be source distributions. They use the
     # legacy logic until we create a modern standard for them.
     if install_req.editable:
-        return SourceDistribution(install_req)
+        return LegacySourceDistribution(install_req)
 
     # If it's a wheel, it's a WheelDistribution
     if install_req.is_wheel:
         return WheelDistribution(install_req)
 
-    # Otherwise, a SourceDistribution
-    return SourceDistribution(install_req)
+    # Since legacy and standard-backed (PEP 517) build logic differs, we
+    # construct the appropriate kind of Distribution for them, after checking
+    # the pyproject.toml file in the distribution.
+    install_req.load_pyproject_toml()
+
+    if not install_req.use_pep517:
+        return LegacySourceDistribution(install_req)
+
+    return ModernSourceDistribution(install_req)

--- a/src/pip/_internal/distributions/source/legacy.py
+++ b/src/pip/_internal/distributions/source/legacy.py
@@ -6,15 +6,10 @@ logger = logging.getLogger(__name__)
 
 
 class LegacySourceDistribution(AbstractDistribution):
-    """Represents a source distribution.
+    """Represents a legacy source distribution.
 
-    The preparation step for these needs metadata for the packages to be
-    generated, either using PEP 517 or using the legacy `setup.py egg_info`.
-
-    NOTE from @pradyunsg (14 June 2019)
-    I expect SourceDistribution class will need to be split into
-    `legacy_source` (setup.py based) and `source` (PEP 517 based) when we start
-    bringing logic for preparation out of InstallRequirement into this class.
+    These distributions are based on a de-facto standard between pip and
+    setuptools, built upon the command line interface of 'setup.py'.
     """
 
     def get_pkg_resources_distribution(self):

--- a/src/pip/_internal/distributions/source/legacy.py
+++ b/src/pip/_internal/distributions/source/legacy.py
@@ -1,8 +1,6 @@
 import logging
 
-from pip._internal.build_env import BuildEnvironment
 from pip._internal.distributions.base import AbstractDistribution
-from pip._internal.exceptions import InstallationError
 
 logger = logging.getLogger(__name__)
 
@@ -23,53 +21,5 @@ class LegacySourceDistribution(AbstractDistribution):
         return self.req.get_dist()
 
     def prepare_distribution_metadata(self, finder, build_isolation):
-        should_isolate = self.req.use_pep517 and build_isolation
-
-        def _raise_conflicts(conflicting_with, conflicting_reqs):
-            raise InstallationError(
-                "Some build dependencies for %s conflict with %s: %s." % (
-                    self.req, conflicting_with, ', '.join(
-                        '%s is incompatible with %s' % (installed, wanted)
-                        for installed, wanted in sorted(conflicting))))
-
-        if should_isolate:
-            # Isolate in a BuildEnvironment and install the build-time
-            # requirements.
-            self.req.build_env = BuildEnvironment()
-            self.req.build_env.install_requirements(
-                finder, self.req.pyproject_requires, 'overlay',
-                "Installing build dependencies"
-            )
-            conflicting, missing = self.req.build_env.check_requirements(
-                self.req.requirements_to_check
-            )
-            if conflicting:
-                _raise_conflicts("PEP 517/518 supported requirements",
-                                 conflicting)
-            if missing:
-                logger.warning(
-                    "Missing build requirements in pyproject.toml for %s.",
-                    self.req,
-                )
-                logger.warning(
-                    "The project does not specify a build backend, and "
-                    "pip cannot fall back to setuptools without %s.",
-                    " and ".join(map(repr, sorted(missing)))
-                )
-            # Install any extra build dependencies that the backend requests.
-            # This must be done in a second pass, as the pyproject.toml
-            # dependencies must be installed before we can call the backend.
-            with self.req.build_env:
-                # We need to have the env active when calling the hook.
-                self.req.spin_message = "Getting requirements to build wheel"
-                reqs = self.req.pep517_backend.get_requires_for_build_wheel()
-            conflicting, missing = self.req.build_env.check_requirements(reqs)
-            if conflicting:
-                _raise_conflicts("the backend dependencies", conflicting)
-            self.req.build_env.install_requirements(
-                finder, missing, 'normal',
-                "Installing backend dependencies"
-            )
-
         self.req.prepare_metadata()
         self.req.assert_source_matches_version()

--- a/src/pip/_internal/distributions/source/legacy.py
+++ b/src/pip/_internal/distributions/source/legacy.py
@@ -23,11 +23,6 @@ class LegacySourceDistribution(AbstractDistribution):
         return self.req.get_dist()
 
     def prepare_distribution_metadata(self, finder, build_isolation):
-        # Prepare for building. We need to:
-        #   1. Load pyproject.toml (if it exists)
-        #   2. Set up the build environment
-
-        self.req.load_pyproject_toml()
         should_isolate = self.req.use_pep517 and build_isolation
 
         def _raise_conflicts(conflicting_with, conflicting_reqs):

--- a/src/pip/_internal/distributions/source/modern.py
+++ b/src/pip/_internal/distributions/source/modern.py
@@ -22,9 +22,7 @@ class ModernSourceDistribution(AbstractDistribution):
     def get_pkg_resources_distribution(self):
         return self.req.get_dist()
 
-    def prepare_distribution_metadata(self, finder, build_isolation):
-        should_isolate = self.req.use_pep517 and build_isolation
-
+    def _setup_isolation(self, finder):
         def _raise_conflicts(conflicting_with, conflicting_reqs):
             raise InstallationError(
                 "Some build dependencies for %s conflict with %s: %s." % (
@@ -32,44 +30,53 @@ class ModernSourceDistribution(AbstractDistribution):
                         '%s is incompatible with %s' % (installed, wanted)
                         for installed, wanted in sorted(conflicting))))
 
+        # Isolate in a BuildEnvironment and install the build-time
+        # requirements.
+        self.req.build_env = BuildEnvironment()
+        self.req.build_env.install_requirements(
+            finder, self.req.pyproject_requires, 'overlay',
+            "Installing build dependencies"
+        )
+        conflicting, missing = self.req.build_env.check_requirements(
+            self.req.requirements_to_check
+        )
+        if conflicting:
+            _raise_conflicts(
+                "PEP 517/518 supported requirements",
+                conflicting,
+            )
+        if missing:
+            logger.warning(
+                "Missing build requirements in pyproject.toml for %s.",
+                self.req,
+            )
+            logger.warning(
+                "The project does not specify a build backend, and "
+                "pip cannot fall back to setuptools without %s.",
+                " and ".join(map(repr, sorted(missing)))
+            )
+
+        # Install any extra build dependencies that the backend requests.
+        # This must be done in a second pass, as the pyproject.toml
+        # dependencies must be installed before we can call the backend.
+        with self.req.build_env:
+            # We need to have the env active when calling the hook.
+            self.req.spin_message = "Getting requirements to build wheel"
+            reqs = self.req.pep517_backend.get_requires_for_build_wheel()
+
+        conflicting, missing = self.req.build_env.check_requirements(reqs)
+        if conflicting:
+            _raise_conflicts("the backend dependencies", conflicting)
+
+        self.req.build_env.install_requirements(
+            finder, missing, 'normal',
+            "Installing backend dependencies"
+        )
+
+    def prepare_distribution_metadata(self, finder, build_isolation):
+        should_isolate = self.req.use_pep517 and build_isolation
         if should_isolate:
-            # Isolate in a BuildEnvironment and install the build-time
-            # requirements.
-            self.req.build_env = BuildEnvironment()
-            self.req.build_env.install_requirements(
-                finder, self.req.pyproject_requires, 'overlay',
-                "Installing build dependencies"
-            )
-            conflicting, missing = self.req.build_env.check_requirements(
-                self.req.requirements_to_check
-            )
-            if conflicting:
-                _raise_conflicts("PEP 517/518 supported requirements",
-                                 conflicting)
-            if missing:
-                logger.warning(
-                    "Missing build requirements in pyproject.toml for %s.",
-                    self.req,
-                )
-                logger.warning(
-                    "The project does not specify a build backend, and "
-                    "pip cannot fall back to setuptools without %s.",
-                    " and ".join(map(repr, sorted(missing)))
-                )
-            # Install any extra build dependencies that the backend requests.
-            # This must be done in a second pass, as the pyproject.toml
-            # dependencies must be installed before we can call the backend.
-            with self.req.build_env:
-                # We need to have the env active when calling the hook.
-                self.req.spin_message = "Getting requirements to build wheel"
-                reqs = self.req.pep517_backend.get_requires_for_build_wheel()
-            conflicting, missing = self.req.build_env.check_requirements(reqs)
-            if conflicting:
-                _raise_conflicts("the backend dependencies", conflicting)
-            self.req.build_env.install_requirements(
-                finder, missing, 'normal',
-                "Installing backend dependencies"
-            )
+            self._setup_isolation(finder)
 
         self.req.prepare_metadata()
         self.req.assert_source_matches_version()

--- a/src/pip/_internal/distributions/source/modern.py
+++ b/src/pip/_internal/distributions/source/modern.py
@@ -74,7 +74,7 @@ class ModernSourceDistribution(AbstractDistribution):
 
         self.req.build_env.install_requirements(
             finder, missing, 'normal',
-            "Installing backend dependencies"
+            "Installing backend dependencies",
         )
 
     def prepare_distribution_metadata(self, finder, build_isolation):

--- a/src/pip/_internal/distributions/source/modern.py
+++ b/src/pip/_internal/distributions/source/modern.py
@@ -24,11 +24,15 @@ class ModernSourceDistribution(AbstractDistribution):
 
     def _setup_isolation(self, finder):
         def _raise_conflicts(conflicting_with, conflicting_reqs):
+            incompatibility_message = ', '.join(
+                '%s is incompatible with %s' % (installed, wanted)
+                for installed, wanted in sorted(conflicting)
+            )
             raise InstallationError(
                 "Some build dependencies for %s conflict with %s: %s." % (
-                    self.req, conflicting_with, ', '.join(
-                        '%s is incompatible with %s' % (installed, wanted)
-                        for installed, wanted in sorted(conflicting))))
+                    self.req, conflicting_with, incompatibility_message,
+                )
+            )
 
         # Isolate in a BuildEnvironment and install the build-time
         # requirements.

--- a/src/pip/_internal/distributions/source/modern.py
+++ b/src/pip/_internal/distributions/source/modern.py
@@ -23,11 +23,6 @@ class ModernSourceDistribution(AbstractDistribution):
         return self.req.get_dist()
 
     def prepare_distribution_metadata(self, finder, build_isolation):
-        # Prepare for building. We need to:
-        #   1. Load pyproject.toml (if it exists)
-        #   2. Set up the build environment
-
-        self.req.load_pyproject_toml()
         should_isolate = self.req.use_pep517 and build_isolation
 
         def _raise_conflicts(conflicting_with, conflicting_reqs):

--- a/src/pip/_internal/distributions/source/modern.py
+++ b/src/pip/_internal/distributions/source/modern.py
@@ -7,7 +7,7 @@ from pip._internal.exceptions import InstallationError
 logger = logging.getLogger(__name__)
 
 
-class LegacySourceDistribution(AbstractDistribution):
+class ModernSourceDistribution(AbstractDistribution):
     """Represents a source distribution.
 
     The preparation step for these needs metadata for the packages to be


### PR DESCRIPTION
This PR initiates the work for separating code paths for handling legacy and source distributions. I'm gonna start by duplicating code between them and then changing which methods they call on InstallRequirement as we go ahead. This will be what follow-up PRs to this, will tackle. :)

This also moves code for build isolation into a dedicated method, that only exists on the `ModernSourceDistribution`.
