### PR TITLE
Ignore "require_virtualenv" in `pip config`

### DIFF
--- a/news/6991.bugfix
+++ b/news/6991.bugfix
@@ -1,0 +1,1 @@
+ Ignore "require_virtualenv" in `pip config`

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -34,6 +34,7 @@ class ConfigurationCommand(Command):
         default.
     """
 
+    ignore_require_venv = True
     usage = """
         %prog [<file-option>] list
         %prog [<file-option>] [--editor <editor-path>] edit


### PR DESCRIPTION
We'd want it to work even after someone (eg. me) does `pip config set global.require-virtualenv true`. :)