### PR TITLE
Remove unactionable FIXME in `InstallRequirement`

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -786,7 +786,6 @@ class InstallRequirement(object):
             no_user_config=self.isolated
         )
         with indent_log():
-            # FIXME: should we do --install-headers here too?
             with self.build_env:
                 call_subprocess(
                     base_cmd +


### PR DESCRIPTION
`setup.py develop` doesn't accept `--install-headers`, so there's no
need for this comment.

For those curious, this FIXME originates from the first git commit c2000d7d.