### PR TITLE
Default to --user install in certain conditions

### DIFF
--- a/news/1668.feature
+++ b/news/1668.feature
@@ -1,0 +1,2 @@
+Default to doing a user install (as if ``--user`` was passed) when the main
+site-packages directory is not writeable and user site-packages are enabled.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -29,7 +29,7 @@ from pip._internal.exceptions import (
     InstallationError,
     PreviousBuildDirError,
 )
-from pip._internal.locations import distutils_scheme, site_packages
+from pip._internal.locations import distutils_scheme
 from pip._internal.operations.check import check_install_conflicts
 from pip._internal.req import RequirementSet, install_given_reqs
 from pip._internal.req.req_tracker import RequirementTracker

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -643,7 +643,7 @@ def decide_user_install(
     if not site.ENABLE_USER_SITE:
         return False
 
-    # If we don't have permissions for a non-user install, choose a user install
+    # If we don't have permission for a non-user install, choose a user install
     return not site_packages_writable(
         root=root_path, isolated=isolated_mode,
     )

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -316,6 +316,8 @@ class InstallCommand(RequirementCommand):
                 options.use_user_site = False
             elif site.ENABLE_USER_SITE:
                 options.use_user_site = True
+                install_options.append('--user')
+                install_options.append('--prefix=')
 
         target_temp_dir = None  # type: Optional[TempDirectory]
         target_temp_dir_path = None  # type: Optional[str]

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -596,7 +596,7 @@ def get_lib_location_guesses(*args, **kwargs):
 
 def site_packages_writable(**kwargs):
     return all(
-        test_writable_dir(d) for d in get_lib_location_guesses(**kwargs)
+        test_writable_dir(d) for d in set(get_lib_location_guesses(**kwargs))
     )
 
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -647,7 +647,8 @@ def decide_user_install(
         logger.debug("Non-user install because user site-packages disabled")
         return False
 
-    # If we don't have permission for a non-user install, choose a user install
+    # If we have permission for a non-user install, do that,
+    # otherwise do a user install.
     if site_packages_writable(root=root_path, isolated=isolated_mode):
         logger.debug("Non-user install because site-packages writeable")
         return False

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -602,10 +602,10 @@ def site_packages_writable(**kwargs):
 
 def decide_user_install(
     use_user_site,  # type: Optional[bool]
-    prefix_path,  # type: Optional[str]
-    target_dir,  # type: Optional[str]
-    root_path,  # type: Optional[str]
-    isolated_mode,  # type: bool
+    prefix_path=None,  # type: Optional[str]
+    target_dir=None,  # type: Optional[str]
+    root_path=None,  # type: Optional[str]
+    isolated_mode=False,  # type: bool
 ):
     # type: (...) -> bool
     """Determine whether to do a user install based on the input options.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -13,6 +13,7 @@ import logging
 import operator
 import os
 import shutil
+import site
 from optparse import SUPPRESS_HELP
 
 from pip._vendor import pkg_resources
@@ -28,11 +29,11 @@ from pip._internal.exceptions import (
     InstallationError,
     PreviousBuildDirError,
 )
-from pip._internal.locations import distutils_scheme
+from pip._internal.locations import distutils_scheme, site_packages
 from pip._internal.operations.check import check_install_conflicts
 from pip._internal.req import RequirementSet, install_given_reqs
 from pip._internal.req.req_tracker import RequirementTracker
-from pip._internal.utils.filesystem import check_path_owner
+from pip._internal.utils.filesystem import check_path_owner, test_writable_dir
 from pip._internal.utils.misc import (
     ensure_dir,
     get_installed_version,
@@ -304,6 +305,17 @@ class InstallCommand(RequirementCommand):
                 )
             install_options.append('--user')
             install_options.append('--prefix=')
+
+        elif options.use_user_site is None:
+            if options.prefix_path or options.target_dir:
+                options.use_user_site = False
+            elif site_packages_writable(
+                    root=options.root_path,
+                    isolated=options.isolated_mode
+            ):
+                options.use_user_site = False
+            elif site.ENABLE_USER_SITE:
+                options.use_user_site = True
 
         target_temp_dir = None  # type: Optional[TempDirectory]
         target_temp_dir_path = None  # type: Optional[str]
@@ -592,6 +604,10 @@ class InstallCommand(RequirementCommand):
 def get_lib_location_guesses(*args, **kwargs):
     scheme = distutils_scheme('', *args, **kwargs)
     return [scheme['purelib'], scheme['platlib']]
+
+
+def site_packages_writable(**kwargs):
+    return all(test_writable_dir(d) for d in get_lib_location_guesses(**kwargs))
 
 
 def create_env_error_message(error, show_traceback, using_user_site):

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -607,7 +607,9 @@ def get_lib_location_guesses(*args, **kwargs):
 
 
 def site_packages_writable(**kwargs):
-    return all(test_writable_dir(d) for d in get_lib_location_guesses(**kwargs))
+    return all(
+        test_writable_dir(d) for d in get_lib_location_guesses(**kwargs)
+    )
 
 
 def create_env_error_message(error, show_traceback, using_user_site):

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -617,6 +617,7 @@ def decide_user_install(
     which is provided by the other arguments.
     """
     if use_user_site is False:
+        logger.debug("Non-user install by explicit request")
         return False
 
     if use_user_site is True:
@@ -630,6 +631,7 @@ def decide_user_install(
                 "Can not perform a '--user' install. User site-packages "
                 "are not visible in this virtualenv."
             )
+        logger.debug("User install by explicit request")
         return True
 
     # If we are here, user installs have not been explicitly requested/avoided
@@ -637,16 +639,22 @@ def decide_user_install(
 
     # user install incompatible with --prefix/--target
     if prefix_path or target_dir:
+        logger.debug("Non-user install due to --prefix or --target option")
         return False
 
     # If user installs are not enabled, choose a non-user install
     if not site.ENABLE_USER_SITE:
+        logger.debug("Non-user install because user site-packages disabled")
         return False
 
     # If we don't have permission for a non-user install, choose a user install
-    return not site_packages_writable(
-        root=root_path, isolated=isolated_mode,
-    )
+    if site_packages_writable(root=root_path, isolated=isolated_mode):
+        logger.debug("Non-user install because site-packages writeable")
+        return False
+
+    logger.info("Defaulting to user installation because normal site-packages "
+                "is not writeable")
+    return True
 
 
 def create_env_error_message(error, show_traceback, using_user_site):

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -141,8 +141,7 @@ def _test_writable_dir_win(path):
         name = basename + ''.join(random.choice(alphabet) for _ in range(6))
         file = os.path.join(path, name)
         try:
-            with open(file, mode='xb'):
-                pass
+            fd = os.open(file, os.O_RDWR | os.O_CREAT | os.O_EXCL)
         except OSError as e:
             if e.errno == errno.EEXIST:
                 continue
@@ -153,6 +152,7 @@ def _test_writable_dir_win(path):
                 return False
             raise
         else:
+            os.close(fd)
             os.unlink(file)
             return True
 

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -119,6 +119,7 @@ else:
 # test_writable_dir and _test_writable_dir_win are copied from Flit,
 # with the author's agreement to also place them under pip's license.
 def test_writable_dir(path):
+    # type: (str) -> bool
     """Check if a directory is writable.
 
     Uses os.access() on POSIX, tries creating files on Windows.
@@ -130,6 +131,7 @@ def test_writable_dir(path):
 
 
 def _test_writable_dir_win(path):
+    # type: (str) -> bool
     # os.access doesn't work on Windows: http://bugs.python.org/issue2528
     # and we can't use tempfile: http://bugs.python.org/issue22107
     basename = 'accesstest_deleteme_fishfingers_custard_'

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -157,4 +157,6 @@ def _test_writable_dir_win(path):
             return True
 
     # This should never be reached
-    raise EnvironmentError('Unexpected condition testing for writable directory')
+    raise EnvironmentError(
+        'Unexpected condition testing for writable directory'
+    )

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import os.path
 import random
@@ -142,13 +143,15 @@ def _test_writable_dir_win(path):
         try:
             with open(file, mode='xb'):
                 pass
-        except FileExistsError:
-            continue
-        except PermissionError:
-            # This could be because there's a directory with the same name.
-            # But it's highly unlikely there's a directory called that,
-            # so we'll assume it's because the parent directory is not writable.
-            return False
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                continue
+            if e.errno == errno.EPERM:
+                # This could be because there's a directory with the same name.
+                # But it's highly unlikely there's a directory called that,
+                # so we'll assume it's because the parent dir is not writable.
+                return False
+            raise
         else:
             os.unlink(file)
             return True

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -125,6 +125,13 @@ def test_writable_dir(path):
 
     Uses os.access() on POSIX, tries creating files on Windows.
     """
+    # If the directory doesn't exist, find the closest parent that does.
+    while not os.path.isdir(path):
+        parent = os.path.dirname(path)
+        if parent == path:
+            break  # Should never get here, but infinite loops are bad
+        path = parent
+
     if os.name == 'posix':
         return os.access(path, os.W_OK)
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -248,7 +248,6 @@ def test_basic_editable_install(script):
         in result.stderr
     )
     assert not result.files_created
-    assert not result.files_updated
 
 
 @pytest.mark.svn

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -245,7 +245,9 @@ def test_upgrade_to_same_version_from_url(script):
         'https://files.pythonhosted.org/packages/source/I/INITools/INITools-'
         '0.3.tar.gz',
     )
-    assert not result2.files_updated, 'INITools 0.3 reinstalled same version'
+    assert script.site_packages / 'initools' not in result2.files_updated, (
+        'INITools 0.3 reinstalled same version'
+    )
     result3 = script.pip('uninstall', 'initools', '-y')
     assert_all_changes(result, result3, [script.venv / 'build', 'cache'])
 

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -1,6 +1,6 @@
 from mock import Mock, call, patch
 
-from pip._internal.commands.install import build_wheels
+from pip._internal.commands.install import build_wheels, decide_user_install
 
 
 class TestWheelCache:
@@ -61,3 +61,37 @@ class TestWheelCache:
         ]
 
         assert build_failures == ['a']
+
+
+class TestDecideUserInstall:
+    @patch('site.ENABLE_USER_SITE', True)
+    @patch('pip._internal.commands.install.site_packages_writable')
+    def test_prefix_and_target(self, sp_writable):
+        sp_writable.return_value = False
+
+        assert decide_user_install(
+            use_user_site=None, prefix_path='foo'
+        ) is False
+
+        assert decide_user_install(
+            use_user_site=None, target_dir='bar'
+        ) is False
+
+    @patch('pip._internal.commands.install.site_packages_writable')
+    def test_user_site_enabled(self, sp_writable):
+        sp_writable.return_value = False
+
+        with patch('site.ENABLE_USER_SITE', True):
+            assert decide_user_install(use_user_site=None) is True
+
+        with patch('site.ENABLE_USER_SITE', False):
+            assert decide_user_install(use_user_site=None) is False
+
+    @patch('site.ENABLE_USER_SITE', True)
+    @patch('pip._internal.commands.install.site_packages_writable')
+    def test_site_packages_access(self, sp_writable):
+        sp_writable.return_value = True
+        assert decide_user_install(use_user_site=None) is False
+
+        sp_writable.return_value = False
+        assert decide_user_install(use_user_site=None) is True

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -1,3 +1,4 @@
+import pytest
 from mock import Mock, call, patch
 
 from pip._internal.commands.install import build_wheels, decide_user_install
@@ -77,21 +78,19 @@ class TestDecideUserInstall:
             use_user_site=None, target_dir='bar'
         ) is False
 
-    @patch('pip._internal.commands.install.site_packages_writable')
-    def test_user_site_enabled(self, sp_writable):
-        sp_writable.return_value = False
-
-        with patch('site.ENABLE_USER_SITE', True):
-            assert decide_user_install(use_user_site=None) is True
-
-        with patch('site.ENABLE_USER_SITE', False):
-            assert decide_user_install(use_user_site=None) is False
-
-    @patch('site.ENABLE_USER_SITE', True)
-    @patch('pip._internal.commands.install.site_packages_writable')
-    def test_site_packages_access(self, sp_writable):
-        sp_writable.return_value = True
-        assert decide_user_install(use_user_site=None) is False
-
-        sp_writable.return_value = False
-        assert decide_user_install(use_user_site=None) is True
+    @pytest.mark.parametrize(
+        "enable_user_site,site_packages_writable,result", [
+            (True, True, False),
+            (True, False, True),
+            (False, True, False),
+            (False, False, False),
+        ])
+    def test_most_cases(
+        self, enable_user_site, site_packages_writable, result, monkeypatch,
+    ):
+        monkeypatch.setattr('site.ENABLE_USER_SITE', enable_user_site)
+        monkeypatch.setattr(
+            'pip._internal.commands.install.site_packages_writable',
+            lambda **kw: site_packages_writable
+        )
+        assert decide_user_install(use_user_site=None) is result


### PR DESCRIPTION
A possible solution to #1668. ~I'm opening this for discussion, not as something ready to merge - I don't want to spend too much time on the details if the basic idea is no good.~

### Background

With Python installed systemwide on Linux, `pip install` typically fails because it tries to install packages somewhere where the user doesn't have write access. Some distros try to make `--user` installs the default to ease this - e.g. Debian has done so in the past, and Manjaro is experimenting with it. This can conflict with use cases which the distro maintainers weren't aware of, leading to confusion, and to issues which upstream developers reject as caused by distros (e.g. #3826, #4222, https://github.com/pypa/virtualenv/issues/1416).

This was mitigated by an improved error message in #5239, but there's still a desire to change behaviour.

The challenge with changing the default is that there are many scenarios where you *don't* want a user install. Installing in virtualenvs is the most obvious one people run into, but there are other environment tools such as conda and pyenv (pip's `running_under_virtualenv` function does not detect these). Then there are cases like installing packages as root in a docker container - you don't want to get a user install as root!

### Proposal

This PR aims to enable `--user` by default under very specific conditions:

1. The user has not explicitly specified otherwise in the command line, environment variable, or a config file.
2. The `--prefix` and `--target` options are not in use.
3. The global `site-packages` dir is not writeable, so doing a non-user install would fail.
4. User site-packages are enabled - to avoid surprises in isolated environments.

Crucially, it doesn't need to decide if it's in an environment - I don't think that question makes sense.

Checking if a directory is writeable on Windows is a bit tricky, because of some Python limitations. I've copied code I use for the same purpose in Flit, but it has had orders of magnitude less use than pip, so I wouldn't be surprised if it fails in some edge cases.

### Drawbacks

More complex behaviour would be more to understand.

E.g. if on a shared system I create a conda environment, and someone with read-only access tries to add to it using pip, they would get a user install - so it would appear to work, but break isolation and not modify the environment for collaborators. Whereas with the status quo they would get a PermissionError showing that something is wrong.

Arguably tools for conveniently creating Python environments should disable user site packages by default. But there are scenarios where it's very convenient (e.g. an institution provides a common conda environment, users can add a few packages without needing to learn about creating environments themselves).  