### PR TITLE
Remove old comment in Resolver.

### DIFF
--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -227,7 +227,6 @@ class Resolver(object):
             req.conflicts_with = req.satisfied_by
         req.satisfied_by = None
 
-    # XXX: Stop passing requirement_set for options
     def _check_skip_installed(self, req_to_install):
         # type: (InstallRequirement) -> Optional[str]
         """Check if req_to_install should be skipped.


### PR DESCRIPTION
`Resolver._check_skip_installed` took a `requirement_set` in #4526 ([here](https://github.com/pypa/pip/pull/4526/files#diff-8420b2c8c652bf6dad67313a5997a27cR186-R187)) but it was removed in #4577 ([here](https://github.com/pypa/pip/pull/4577/files#diff-8420b2c8c652bf6dad67313a5997a27cR112-R113)), so this comment is no longer needed.
