### PR TITLE
Change local_checkout() to accept tmpdir

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -299,8 +299,7 @@ def test_install_editable_uninstalls_existing(data, script, tmpdir):
         'install', '-e',
         '%s#egg=pip-test-package' %
         local_checkout(
-            'git+https://github.com/pypa/pip-test-package.git',
-            tmpdir.joinpath("cache"),
+            'git+https://github.com/pypa/pip-test-package.git', tmpdir,
         ),
     )
     result.assert_installed('pip-test-package', with_files=['.git'])
@@ -374,7 +373,7 @@ def test_vcs_url_urlquote_normalization(script, tmpdir):
         local_checkout(
             'bzr+http://bazaar.launchpad.net/%7Edjango-wikiapp/django-wikiapp'
             '/release-0.1',
-            tmpdir.joinpath("cache"),
+            tmpdir,
         ),
     )
 
@@ -652,7 +651,7 @@ def test_install_using_install_option_and_editable(script, tmpdir):
     url = 'git+git://github.com/pypa/pip-test-package'
     result = script.pip(
         'install', '-e', '%s#egg=pip-test-package' %
-        local_checkout(url, tmpdir.joinpath("cache")),
+        local_checkout(url, tmpdir),
         '--install-option=--script-dir=%s' % folder,
         expect_stderr=True)
     script_file = (
@@ -671,7 +670,7 @@ def test_install_global_option_using_editable(script, tmpdir):
     url = 'hg+http://bitbucket.org/runeh/anyjson'
     result = script.pip(
         'install', '--global-option=--version', '-e',
-        '%s@0.2.5#egg=anyjson' % local_checkout(url, tmpdir.joinpath("cache")),
+        '%s@0.2.5#egg=anyjson' % local_checkout(url, tmpdir),
         expect_stderr=True)
     assert 'Successfully installed anyjson' in result.stdout
 

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -47,10 +47,7 @@ def test_cleanup_after_install_editable_from_hg(script, tmpdir):
         'install',
         '-e',
         '%s#egg=ScriptTest' %
-        local_checkout(
-            'hg+https://bitbucket.org/ianb/scripttest',
-            tmpdir.joinpath("cache"),
-        ),
+        local_checkout('hg+https://bitbucket.org/ianb/scripttest', tmpdir),
     )
     build = script.venv_path / 'build'
     src = script.venv_path / 'src'

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -111,8 +111,7 @@ def test_multiple_requirements_files(script, tmpdir):
         """) %
         (
             local_checkout(
-                'svn+http://svn.colorstudy.com/INITools/trunk',
-                tmpdir.joinpath("cache"),
+                'svn+http://svn.colorstudy.com/INITools/trunk', tmpdir,
             ),
             other_lib_name
         ),

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -349,8 +349,7 @@ def test_install_with_ignoreinstalled_requested(script):
 def test_upgrade_vcs_req_with_no_dists_found(script, tmpdir):
     """It can upgrade a VCS requirement that has no distributions otherwise."""
     req = "%s#egg=pip-test-package" % local_checkout(
-        "git+https://github.com/pypa/pip-test-package.git",
-        tmpdir.joinpath("cache"),
+        "git+https://github.com/pypa/pip-test-package.git", tmpdir,
     )
     script.pip("install", req)
     result = script.pip("install", "-U", req)

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -52,8 +52,7 @@ class Tests_UserSite:
             'install', '--user', '-e',
             '%s#egg=initools' %
             local_checkout(
-                'svn+http://svn.colorstudy.com/INITools/trunk',
-                tmpdir.joinpath("cache"),
+                'svn+http://svn.colorstudy.com/INITools/trunk', tmpdir,
             )
         )
         result.assert_installed('INITools', use_user_site=True)

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -58,7 +58,7 @@ def _github_checkout(url_path, temp_dir, rev=None, egg=None, scheme=None):
     if scheme is None:
         scheme = 'https'
     url = 'git+{}://github.com/{}'.format(scheme, url_path)
-    local_url = local_checkout(url, temp_dir.joinpath('cache'))
+    local_url = local_checkout(url, temp_dir)
     if rev is not None:
         local_url += '@{}'.format(rev)
     if egg is not None:

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -296,8 +296,7 @@ def test_uninstall_editable_from_svn(script, tmpdir):
     result = script.pip(
         'install', '-e',
         '%s#egg=initools' % local_checkout(
-            'svn+http://svn.colorstudy.com/INITools/trunk',
-            tmpdir.joinpath("cache"),
+            'svn+http://svn.colorstudy.com/INITools/trunk', tmpdir,
         ),
     )
     result.assert_installed('INITools')
@@ -318,34 +317,29 @@ def test_uninstall_editable_from_svn(script, tmpdir):
 def test_uninstall_editable_with_source_outside_venv(script, tmpdir):
     """
     Test uninstalling editable install from existing source outside the venv.
-
     """
-    cache_dir = tmpdir.joinpath("cache")
-
     try:
         temp = mkdtemp()
-        tmpdir = join(temp, 'pip-test-package')
+        temp_pkg_dir = join(temp, 'pip-test-package')
         _test_uninstall_editable_with_source_outside_venv(
             script,
             tmpdir,
-            cache_dir,
+            temp_pkg_dir,
         )
     finally:
         rmtree(temp)
 
 
 def _test_uninstall_editable_with_source_outside_venv(
-        script, tmpdir, cache_dir):
+    script, tmpdir, temp_pkg_dir,
+):
     result = script.run(
         'git', 'clone',
-        local_repo(
-            'git+git://github.com/pypa/pip-test-package',
-            cache_dir,
-        ),
-        tmpdir,
+        local_repo('git+git://github.com/pypa/pip-test-package', tmpdir),
+        temp_pkg_dir,
         expect_stderr=True,
     )
-    result2 = script.pip('install', '-e', tmpdir)
+    result2 = script.pip('install', '-e', temp_pkg_dir)
     assert join(
         script.site_packages, 'pip-test-package.egg-link'
     ) in result2.files_created, list(result2.files_created.keys())
@@ -370,10 +364,7 @@ def test_uninstall_from_reqs_file(script, tmpdir):
             # and something else to test out:
             PyLogo<0.4
         """) %
-        local_checkout(
-            'svn+http://svn.colorstudy.com/INITools/trunk',
-            tmpdir.joinpath("cache")
-        )
+        local_checkout('svn+http://svn.colorstudy.com/INITools/trunk', tmpdir)
     )
     result = script.pip('install', '-r', 'test-req.txt')
     script.scratch_path.joinpath("test-req.txt").write_text(
@@ -387,10 +378,7 @@ def test_uninstall_from_reqs_file(script, tmpdir):
             # and something else to test out:
             PyLogo<0.4
         """) %
-        local_checkout(
-            'svn+http://svn.colorstudy.com/INITools/trunk',
-            tmpdir.joinpath("cache")
-        )
+        local_checkout('svn+http://svn.colorstudy.com/INITools/trunk', tmpdir)
     )
     result2 = script.pip('uninstall', '-r', 'test-req.txt', '-y')
     assert_all_changes(

--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -6,8 +6,12 @@ import subprocess
 from pip._vendor.six.moves.urllib import request as urllib_request
 
 from pip._internal.utils.misc import hide_url
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs import bazaar, git, mercurial, subversion
 from tests.lib import path_to_url
+
+if MYPY_CHECK_RUNNING:
+    from tests.lib.path import Path
 
 
 def _create_initools_repository(directory):
@@ -68,7 +72,17 @@ def _get_vcs_and_checkout_url(remote_repository, directory):
     )
 
 
-def local_checkout(remote_repo, directory):
+def local_checkout(
+    remote_repo,  # type: str
+    temp_path,    # type: Path
+):
+    # type: (...) -> str
+    """
+    :param temp_path: the return value of the tmpdir fixture, which is a
+        temp directory Path object unique to each test function invocation,
+        created as a sub directory of the base temp directory.
+    """
+    directory = temp_path.joinpath('cache')
     if not os.path.exists(directory):
         os.mkdir(directory)
         # os.makedirs(directory)
@@ -78,5 +92,5 @@ def local_checkout(remote_repo, directory):
     return _get_vcs_and_checkout_url(remote_repo, directory)
 
 
-def local_repo(remote_repo, directory):
-    return local_checkout(remote_repo, directory).split('+', 1)[1]
+def local_repo(remote_repo, temp_path):
+    return local_checkout(remote_repo, temp_path).split('+', 1)[1]


### PR DESCRIPTION
This changes the `local_checkout()` test function to accept the return value of the `tmpdir` fixture instead of the cache directory. This simplifies pip's test code because instead of calling `temp_path.joinpath('cache')` at each of the 13 call sites, we can just call it once inside `local_checkout()`.