### PR TITLE
Remove unused project_name argument from LinkCollector._get_pages()

### DIFF
--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -363,8 +363,8 @@ class LinkCollector(object):
         # type: () -> List[str]
         return self.search_scope.find_links
 
-    def _get_pages(self, locations, project_name):
-        # type: (Iterable[Link], str) -> Iterable[HTMLPage]
+    def _get_pages(self, locations):
+        # type: (Iterable[Link]) -> Iterable[HTMLPage]
         """
         Yields (page, page_url) from the given locations, skipping
         locations that have errors.
@@ -419,7 +419,7 @@ class LinkCollector(object):
             logger.debug('* %s', location)
 
         pages_links = {}
-        for page in self._get_pages(url_locations, project_name):
+        for page in self._get_pages(url_locations):
             pages_links[page.url] = list(page.iter_links())
 
         return CollectedLinks(

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -37,7 +37,7 @@ def make_no_network_finder(
     )
     # Replace the PackageFinder._link_collector's _get_pages() with a no-op.
     link_collector = finder._link_collector
-    link_collector._get_pages = lambda locations, project_name: []
+    link_collector._get_pages = lambda locations: []
 
     return finder
 


### PR DESCRIPTION
This removes the unused `project_name` argument from `LinkCollector._get_pages()`.

This argument has been unused for at least four years. Here is what the function looked like four years ago:
https://github.com/pypa/pip/blob/a38da832c46c355113183a4eada70a398908ca23/pip/index.py#L578-L599
