### PR TITLE
Remove svn handling in unpacking.unpack_file

### DIFF
--- a/news/7037.removal
+++ b/news/7037.removal
@@ -1,0 +1,2 @@
+Remove undocumented support for http:// requirements pointing to SVN
+repositories.

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -1024,7 +1024,7 @@ def unpack_http_url(
 
         # unpack the archive to the build dir location. even when only
         # downloading archives, they have to be unpacked to parse dependencies
-        unpack_file(from_path, location, content_type, link)
+        unpack_file(from_path, location, content_type)
 
         # a download dir is specified; let's copy the archive there
         if download_dir and not already_downloaded_path:
@@ -1120,7 +1120,7 @@ def unpack_file_url(
 
     # unpack the archive to the build dir location. even when only downloading
     # archives, they have to be unpacked to parse dependencies
-    unpack_file(from_path, location, content_type, link)
+    unpack_file(from_path, location, content_type)
 
     # a download dir is specified and not already downloaded
     if download_dir and not already_downloaded_path:

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 
 import logging
 import os
-import re
 import shutil
 import stat
 import tarfile
@@ -25,7 +24,7 @@ from pip._internal.utils.misc import ensure_dir
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Iterable, List, Optional, Match, Text, Union
+    from typing import Iterable, List, Optional, Text, Union
 
 
 logger = logging.getLogger(__name__)
@@ -52,23 +51,6 @@ def current_umask():
     mask = os.umask(0)
     os.umask(mask)
     return mask
-
-
-def file_contents(filename):
-    # type: (str) -> Text
-    with open(filename, 'rb') as fp:
-        return fp.read().decode('utf-8')
-
-
-def is_svn_page(html):
-    # type: (Union[str, Text]) -> Optional[Match[Union[str, Text]]]
-    """
-    Returns true if the page appears to be the index page of an svn repository
-    """
-    return (
-        re.search(r'<title>[^<]*Revision \d+:', html) and
-        re.search(r'Powered by (?:<a[^>]*?>)?Subversion', html, re.I)
-    )
 
 
 def split_leading_dir(path):

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -27,8 +27,6 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 if MYPY_CHECK_RUNNING:
     from typing import Iterable, List, Optional, Match, Text, Union
 
-    from pip._internal.models.link import Link
-
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +229,6 @@ def unpack_file(
         filename,  # type: str
         location,  # type: str
         content_type,  # type: Optional[str]
-        link  # type: Optional[Link]
 ):
     # type: (...) -> None
     filename = os.path.realpath(filename)

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -21,7 +21,7 @@ from pip._internal.utils.filetypes import (
     XZ_EXTENSIONS,
     ZIP_EXTENSIONS,
 )
-from pip._internal.utils.misc import ensure_dir, hide_url
+from pip._internal.utils.misc import ensure_dir
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -253,14 +253,6 @@ def unpack_file(
         )
     ):
         untar_file(filename, location)
-    elif (
-        content_type and content_type.startswith('text/html') and
-        is_svn_page(file_contents(filename))
-    ):
-        # We don't really care about this
-        from pip._internal.vcs.subversion import Subversion
-        hidden_url = hide_url('svn+' + link.url)
-        Subversion().unpack(location, url=hidden_url)
     else:
         # FIXME: handle?
         # FIXME: magic signatures?

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -370,9 +370,9 @@ def test_wheel_version(tmpdir, data):
     future_version = (1, 9)
 
     unpack_file(data.packages.joinpath(future_wheel),
-                tmpdir + 'future', None, None)
+                tmpdir + 'future', None)
     unpack_file(data.packages.joinpath(broken_wheel),
-                tmpdir + 'broken', None, None)
+                tmpdir + 'broken', None)
 
     assert wheel.wheel_version(tmpdir + 'future') == future_version
     assert not wheel.wheel_version(tmpdir + 'broken')
@@ -593,7 +593,7 @@ class TestWheelFile(object):
     def test_unpack_wheel_no_flatten(self, tmpdir):
         filepath = os.path.join(DATA_DIR, 'packages',
                                 'meta-1.0-py2.py3-none-any.whl')
-        unpack_file(filepath, tmpdir, 'application/zip', None)
+        unpack_file(filepath, tmpdir, 'application/zip')
         assert os.path.isdir(os.path.join(tmpdir, 'meta-1.0.dist-info'))
 
     def test_purelib_platlib(self, data):
@@ -633,7 +633,7 @@ class TestMoveWheelFiles(object):
         self.req = Requirement('sample')
         self.src = os.path.join(tmpdir, 'src')
         self.dest = os.path.join(tmpdir, 'dest')
-        unpack_file(self.wheelpath, self.src, None, None)
+        unpack_file(self.wheelpath, self.src, None)
         self.scheme = {
             'scripts': os.path.join(self.dest, 'bin'),
             'purelib': os.path.join(self.dest, 'lib'),


### PR DESCRIPTION
There are two code paths that lead to `unpacking.unpack_file`:

1. `download.unpack_url` -> {`download.unpack_http_url`, `download.unpack_file_url`} -> `unpacking.unpack_file`
2. `wheel.build` -> `download.unpack_file_url` -> `unpacking.unpack_file`

In 1, we first check whether the provided link in a VCS URL and if so we call `vcs_backend.unpack` directly.

In 2, we only pass in the wheel file itself - no chance the removed code is called.