### PR TITLE
Remove HTMLPage.iter_links()

### DIFF
--- a/src/pip/_internal/collector.py
+++ b/src/pip/_internal/collector.py
@@ -155,7 +155,7 @@ def _get_html_response(url, session):
 
 
 def _get_encoding_from_headers(headers):
-    # type: (Optional[ResponseHeaders]) -> Optional[str]
+    # type: (ResponseHeaders) -> Optional[str]
     """Determine if we have any encoding information in our headers.
     """
     if headers and "Content-Type" in headers:

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -324,6 +324,18 @@ def test_get_html_page_invalid_scheme(caplog, url, vcs_scheme):
     ]
 
 
+def make_fake_html_page(url):
+    html = dedent(u"""\
+    <html><head><meta name="api-version" value="2" /></head>
+    <body>
+    <a href="/abc-1.0.tar.gz#md5=000000000">abc-1.0.tar.gz</a>
+    </body></html>
+    """)
+    content = html.encode('utf-8')
+    headers = {}
+    return HTMLPage(content, url=url, headers=headers)
+
+
 def test_get_html_page_directory_append_index(tmpdir):
     """`_get_html_page()` should append "index.html" to a directory URL.
     """
@@ -369,18 +381,6 @@ def test_group_locations__non_existing_path():
     """
     files, urls = group_locations([os.path.join('this', 'doesnt', 'exist')])
     assert not urls and not files, "nothing should have been found"
-
-
-def make_fake_html_page(url):
-    html = dedent(u"""\
-    <html><head><meta name="api-version" value="2" /></head>
-    <body>
-    <a href="/abc-1.0.tar.gz#md5=000000000">abc-1.0.tar.gz</a>
-    </body></html>
-    """)
-    content = html.encode('utf-8')
-    headers = {}
-    return HTMLPage(content, url=url, headers=headers)
 
 
 def check_links_include(links, names):


### PR DESCRIPTION
This PR simplifies the `HTMLPage` class by removing its `iter_links()` method, and the info of the response headers. This makes `HTMLPage` a simple container / data class. And the `parse_links()` function is kept simple because it doesn't have to know about response headers -- just the encoding.