### PR TITLE
Simplify local_repos.py

### DIFF
--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -110,9 +110,7 @@ def test_multiple_requirements_files(script, tmpdir):
             -r %s-req.txt
         """) %
         (
-            local_checkout(
-                'svn+http://svn.colorstudy.com/INITools/trunk', tmpdir,
-            ),
+            local_checkout('svn+http://svn.colorstudy.com/INITools', tmpdir),
             other_lib_name
         ),
     )

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -51,9 +51,7 @@ class Tests_UserSite:
         result = script.pip(
             'install', '--user', '-e',
             '%s#egg=initools' %
-            local_checkout(
-                'svn+http://svn.colorstudy.com/INITools/trunk', tmpdir,
-            )
+            local_checkout('svn+http://svn.colorstudy.com/INITools', tmpdir)
         )
         result.assert_installed('INITools', use_user_site=True)
 

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -276,12 +276,13 @@ def test_git_with_tag_name_and_update(script, tmpdir):
     Test cloning a git repository and updating to a different version.
     """
     url_path = 'pypa/pip-test-package.git'
-    local_url = _github_checkout(url_path, tmpdir, egg='pip-test-package')
+    base_local_url = _github_checkout(url_path, tmpdir)
+
+    local_url = '{}#egg=pip-test-package'.format(base_local_url)
     result = script.pip('install', '-e', local_url)
     result.assert_installed('pip-test-package', with_files=['.git'])
 
-    new_local_url = _github_checkout(url_path, tmpdir)
-    new_local_url += '@0.1.2#egg=pip-test-package'
+    new_local_url = '{}@0.1.2#egg=pip-test-package'.format(base_local_url)
     result = script.pip(
         'install', '--global-option=--version', '-e', new_local_url,
     )

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -358,13 +358,16 @@ def test_uninstall_from_reqs_file(script, tmpdir):
     Test uninstall from a requirements file.
 
     """
+    local_svn_url = local_checkout(
+        'svn+http://svn.colorstudy.com/INITools/trunk',
+        tmpdir,
+    )
     script.scratch_path.joinpath("test-req.txt").write_text(
         textwrap.dedent("""
             -e %s#egg=initools
             # and something else to test out:
             PyLogo<0.4
-        """) %
-        local_checkout('svn+http://svn.colorstudy.com/INITools/trunk', tmpdir)
+        """) % local_svn_url
     )
     result = script.pip('install', '-r', 'test-req.txt')
     script.scratch_path.joinpath("test-req.txt").write_text(
@@ -377,8 +380,7 @@ def test_uninstall_from_reqs_file(script, tmpdir):
             -e %s#egg=initools
             # and something else to test out:
             PyLogo<0.4
-        """) %
-        local_checkout('svn+http://svn.colorstudy.com/INITools/trunk', tmpdir)
+        """) % local_svn_url
     )
     result2 = script.pip('uninstall', '-r', 'test-req.txt', '-y')
     assert_all_changes(

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -295,8 +295,8 @@ def test_uninstall_editable_from_svn(script, tmpdir):
     """
     result = script.pip(
         'install', '-e',
-        '%s#egg=initools' % local_checkout(
-            'svn+http://svn.colorstudy.com/INITools/trunk', tmpdir,
+        '%s#egg=initools' % (
+            local_checkout('svn+http://svn.colorstudy.com/INITools', tmpdir)
         ),
     )
     result.assert_installed('INITools')
@@ -359,8 +359,7 @@ def test_uninstall_from_reqs_file(script, tmpdir):
 
     """
     local_svn_url = local_checkout(
-        'svn+http://svn.colorstudy.com/INITools/trunk',
-        tmpdir,
+        'svn+http://svn.colorstudy.com/INITools', tmpdir,
     )
     script.scratch_path.joinpath("test-req.txt").write_text(
         textwrap.dedent("""

--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -14,14 +14,12 @@ if MYPY_CHECK_RUNNING:
     from tests.lib.path import Path
 
 
-def _ensure_svn_initools_repo(directory):
+def _create_svn_initools_repo(directory):
     """
-    Create the SVN INITools repo if it doesn't already exist.
+    Create the SVN INITools repo.
     """
     initools_dir = os.path.join(directory, 'INITools')
-    repo_url_path = os.path.join(initools_dir, 'trunk')
-    if os.path.exists(initools_dir):
-        return repo_url_path
+    assert not os.path.exists(initools_dir)
 
     subprocess.check_call('svnadmin create INITools'.split(), cwd=directory)
 
@@ -40,7 +38,7 @@ def _ensure_svn_initools_repo(directory):
     devnull.close()
     os.remove(filename)
 
-    return repo_url_path
+    return os.path.join(initools_dir, 'trunk')
 
 
 def local_checkout(
@@ -62,7 +60,7 @@ def local_checkout(
 
     if vcs_name == 'svn':
         assert remote_repo.endswith('/INITools/trunk')
-        repo_url_path = _ensure_svn_initools_repo(directory)
+        repo_url_path = _create_svn_initools_repo(directory)
     else:
         repository_name = os.path.basename(remote_repo)
         repo_url_path = os.path.join(directory, repository_name)

--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -7,27 +7,32 @@ from pip._vendor.six.moves.urllib import request as urllib_request
 
 from pip._internal.utils.misc import hide_url
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.vcs import bazaar, git, mercurial, subversion
+from pip._internal.vcs import vcs
 from tests.lib import path_to_url
 
 if MYPY_CHECK_RUNNING:
     from tests.lib.path import Path
 
 
-def _create_initools_repository(directory):
+def _ensure_svn_initools_repo(directory):
+    """
+    Create the SVN INITools repo if it doesn't already exist.
+    """
+    initools_dir = os.path.join(directory, 'INITools')
+    repo_url_path = os.path.join(initools_dir, 'trunk')
+    if os.path.exists(initools_dir):
+        return repo_url_path
+
     subprocess.check_call('svnadmin create INITools'.split(), cwd=directory)
 
-
-def _dump_initools_repository(directory):
     filename, _ = urllib_request.urlretrieve(
         'http://bitbucket.org/hltbra/pip-initools-dump/raw/8b55c908a320/'
         'INITools_modified.dump'
     )
-    initools_folder = os.path.join(directory, 'INITools')
     devnull = open(os.devnull, 'w')
     dump = open(filename)
     subprocess.check_call(
-        ['svnadmin', 'load', initools_folder],
+        ['svnadmin', 'load', initools_dir],
         stdin=dump,
         stdout=devnull,
     )
@@ -35,41 +40,7 @@ def _dump_initools_repository(directory):
     devnull.close()
     os.remove(filename)
 
-
-def _create_svn_repository_for_initools(directory):
-    if not os.path.exists(os.path.join(directory, 'INITools')):
-        _create_initools_repository(directory)
-        _dump_initools_repository(directory)
-
-
-def _get_vcs_and_checkout_url(remote_repository, directory):
-    vcs_classes = {'svn': subversion.Subversion,
-                   'git': git.Git,
-                   'bzr': bazaar.Bazaar,
-                   'hg': mercurial.Mercurial}
-    default_vcs = 'svn'
-    if '+' not in remote_repository:
-        remote_repository = '%s+%s' % (default_vcs, remote_repository)
-    vcs, repository_path = remote_repository.split('+', 1)
-    vcs_class = vcs_classes[vcs]
-    branch = ''
-    if vcs == 'svn':
-        branch = os.path.basename(remote_repository)
-        # remove the slash
-        repository_name = os.path.basename(
-            remote_repository[:-len(branch) - 1]
-        )
-    else:
-        repository_name = os.path.basename(remote_repository)
-
-    destination_path = os.path.join(directory, repository_name)
-    if not os.path.exists(destination_path):
-        url = hide_url(remote_repository)
-        vcs_class().obtain(destination_path, url=url)
-    return '%s+%s' % (
-        vcs,
-        path_to_url('/'.join([directory, repository_name, branch])),
-    )
+    return repo_url_path
 
 
 def local_checkout(
@@ -82,14 +53,23 @@ def local_checkout(
         temp directory Path object unique to each test function invocation,
         created as a sub directory of the base temp directory.
     """
+    assert '+' in remote_repo
+    vcs_name, repository_path = remote_repo.split('+', 1)
+
     directory = temp_path.joinpath('cache')
     if not os.path.exists(directory):
         os.mkdir(directory)
-        # os.makedirs(directory)
 
-    if remote_repo.startswith('svn'):
-        _create_svn_repository_for_initools(directory)
-    return _get_vcs_and_checkout_url(remote_repo, directory)
+    if vcs_name == 'svn':
+        assert remote_repo.endswith('/INITools/trunk')
+        repo_url_path = _ensure_svn_initools_repo(directory)
+    else:
+        repository_name = os.path.basename(remote_repo)
+        repo_url_path = os.path.join(directory, repository_name)
+        vcs_backend = vcs.get_backend(vcs_name)
+        vcs_backend.obtain(repo_url_path, url=hide_url(remote_repo))
+
+    return '{}+{}'.format(vcs_name, path_to_url(repo_url_path))
 
 
 def local_repo(remote_repo, temp_path):

--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -66,6 +66,7 @@ def local_checkout(
     else:
         repository_name = os.path.basename(remote_repo)
         repo_url_path = os.path.join(directory, repository_name)
+        assert not os.path.exists(repo_url_path)
         vcs_backend = vcs.get_backend(vcs_name)
         vcs_backend.obtain(repo_url_path, url=hide_url(remote_repo))
 


### PR DESCRIPTION
This PR is a follow-on to PR #7012 that simplifies the code in the `local_repos.py` test module. For example, it:

* reduces the number of functions from 6 to 3,
* reduces the number of lines from 96 to ~75~ 73,
* eliminates some of the conditionals,
* adds some assertions so it's clearer how the main function is being used, and
* does some other simplifications like removing the need for the `vcs_classes` dict and the need to import every vcs submodule.

For example, for svn repos, the main function is only called with URL's ending in `"/INITools"` (because the function only works if the URL has such a format). Information like this isn't obvious otherwise because it requires looking at every one of the call sites.