### PR TITLE
Improve logging in LinkCollector.collect_links()

### DIFF
--- a/src/pip/_internal/collector.py
+++ b/src/pip/_internal/collector.py
@@ -25,7 +25,7 @@ from pip._internal.vcs import is_url, vcs
 if MYPY_CHECK_RUNNING:
     from typing import (
         Callable, Dict, Iterable, List, MutableMapping, Optional, Sequence,
-        Set, Tuple, Union,
+        Tuple, Union,
     )
     import xml.etree.ElementTree
 
@@ -482,12 +482,7 @@ class LinkCollector(object):
         Yields (page, page_url) from the given locations, skipping
         locations that have errors.
         """
-        seen = set()  # type: Set[Link]
         for location in locations:
-            if location in seen:
-                continue
-            seen.add(location)
-
             page = _get_html_page(location, session=self.session)
             if page is None:
                 continue
@@ -525,6 +520,7 @@ class LinkCollector(object):
             if self.session.is_secure_origin(link)
         ]
 
+        url_locations = _remove_duplicate_links(url_locations)
         logger.debug('%d location(s) to search for versions of %s:',
                      len(url_locations), project_name)
 

--- a/src/pip/_internal/collector.py
+++ b/src/pip/_internal/collector.py
@@ -521,11 +521,14 @@ class LinkCollector(object):
         ]
 
         url_locations = _remove_duplicate_links(url_locations)
-        logger.debug('%d location(s) to search for versions of %s:',
-                     len(url_locations), project_name)
-
-        for location in url_locations:
-            logger.debug('* %s', location)
+        lines = [
+            '{} location(s) to search for versions of {}:'.format(
+                len(url_locations), project_name,
+            ),
+        ]
+        for link in url_locations:
+            lines.append('* {}'.format(link))
+        logger.debug('\n'.join(lines))
 
         pages_links = {}
         for page in self._get_pages(url_locations):

--- a/src/pip/_internal/collector.py
+++ b/src/pip/_internal/collector.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import mimetypes
 import os
+from collections import OrderedDict
 
 from pip._vendor import html5lib, requests
 from pip._vendor.distlib.compat import unescape
@@ -354,6 +355,15 @@ def _get_html_page(link, session=None):
     else:
         return HTMLPage(resp.content, resp.url, resp.headers)
     return None
+
+
+def _remove_duplicate_links(links):
+    # type: (Iterable[Link]) -> List[Link]
+    """
+    Return a list of links, with duplicates removed and ordering preserved.
+    """
+    # We preserve the ordering when removing duplicates because we can.
+    return list(OrderedDict.fromkeys(links))
 
 
 def group_locations(locations, expand_dir=False):

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -449,7 +449,6 @@ class TestLinkCollector(object):
 
         actual = [record_tuple[1:] for record_tuple in caplog.record_tuples]
         assert actual == [
-            (logging.DEBUG, '2 location(s) to search for versions of twine:'),
-            (logging.DEBUG, '* https://pypi.org/simple/twine/'),
+            (logging.DEBUG, '1 location(s) to search for versions of twine:'),
             (logging.DEBUG, '* https://pypi.org/simple/twine/'),
         ]

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -447,8 +447,9 @@ class TestLinkCollector(object):
             'https://pypi.org/abc-1.0.tar.gz#md5=000000000'
         )
 
-        actual = [record_tuple[1:] for record_tuple in caplog.record_tuples]
-        assert actual == [
-            (logging.DEBUG, '1 location(s) to search for versions of twine:'),
-            (logging.DEBUG, '* https://pypi.org/simple/twine/'),
+        expected_message = dedent("""\
+        1 location(s) to search for versions of twine:
+        * https://pypi.org/simple/twine/""")
+        assert caplog.record_tuples == [
+            ('pip._internal.collector', logging.DEBUG, expected_message),
         ]

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -16,6 +16,7 @@ from pip._internal.collector import (
     _get_html_response,
     _NotHTML,
     _NotHTTP,
+    _remove_duplicate_links,
     group_locations,
 )
 from pip._internal.download import PipSession
@@ -341,6 +342,20 @@ def test_get_html_page_directory_append_index(tmpdir):
                 session=session,
             ),
         ]
+
+
+def test_remove_duplicate_links():
+    links = [
+        # We choose Links that will test that ordering is preserved.
+        Link('https://example.com/2'),
+        Link('https://example.com/1'),
+        Link('https://example.com/2'),
+    ]
+    actual = _remove_duplicate_links(links)
+    assert actual == [
+        Link('https://example.com/2'),
+        Link('https://example.com/1'),
+    ]
 
 
 def test_group_locations__file_expand_dir(data):


### PR DESCRIPTION
This PR does a few minor things, including the following:

* removes the duplicate links in `LinkCollector.collect_links()` _before_ logging them,
* as a result of the above, makes `LinkCollector. _get_pages()` simpler,
* uses one log message in all, instead of one for each link, plus the intro line, and
* adds the first tests of the logging in `LinkCollector.collect_links()`.

