### PR TITLE
Move code out of pip._internal.__init__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,9 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "pip=pip._internal:main",
-            "pip%s=pip._internal:main" % sys.version_info[:1],
-            "pip%s.%s=pip._internal:main" % sys.version_info[:2],
+            "pip=pip._internal.main:main",
+            "pip%s=pip._internal.main:main" % sys.version_info[:1],
+            "pip%s.%s=pip._internal.main:main" % sys.version_info[:2],
         ],
     },
 

--- a/src/pip/__main__.py
+++ b/src/pip/__main__.py
@@ -13,7 +13,7 @@ if __package__ == '':
     path = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(0, path)
 
-from pip._internal import main as _main  # isort:skip # noqa
+from pip._internal.main import main as _main  # isort:skip # noqa
 
 if __name__ == '__main__':
     sys.exit(_main())

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
 
-import locale
-import logging
-import os
-import sys
 import warnings
 
 # We ignore certain warnings from urllib3, since they are not relevant to pip's
@@ -16,10 +12,6 @@ from pip._vendor.urllib3.exceptions import (
 
 import pip._internal.utils.inject_securetransport  # noqa
 from pip._internal.cli.autocompletion import autocomplete
-from pip._internal.cli.main_parser import parse_command
-from pip._internal.commands import create_command
-from pip._internal.exceptions import PipError
-from pip._internal.utils import deprecation
 
 # Raised when using --trusted-host.
 warnings.filterwarnings("ignore", category=InsecureRequestWarning)
@@ -27,33 +19,3 @@ warnings.filterwarnings("ignore", category=InsecureRequestWarning)
 #   Barry Warsaw noted (on 2016-06-17) that this should be done before
 #   importing pip.vcs, which has since moved to pip._internal.vcs.
 warnings.filterwarnings("ignore", category=DependencyWarning)
-
-logger = logging.getLogger(__name__)
-
-
-def main(args=None):
-    if args is None:
-        args = sys.argv[1:]
-
-    # Configure our deprecation warnings to be sent through loggers
-    deprecation.install_warning_logger()
-
-    autocomplete()
-
-    try:
-        cmd_name, cmd_args = parse_command(args)
-    except PipError as exc:
-        sys.stderr.write("ERROR: %s" % exc)
-        sys.stderr.write(os.linesep)
-        sys.exit(1)
-
-    # Needed for locale.getpreferredencoding(False) to work
-    # in pip._internal.utils.encoding.auto_decode
-    try:
-        locale.setlocale(locale.LC_ALL, '')
-    except locale.Error as e:
-        # setlocale can apparently crash if locale are uninitialized
-        logger.debug("Ignoring error %s when setting locale", e)
-    command = create_command(cmd_name, isolated=("--isolated" in cmd_args))
-
-    return command.main(cmd_args)

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -11,7 +11,6 @@ from pip._vendor.urllib3.exceptions import (
 )
 
 import pip._internal.utils.inject_securetransport  # noqa
-from pip._internal.cli.autocompletion import autocomplete
 
 # Raised when using --trusted-host.
 warnings.filterwarnings("ignore", category=InsecureRequestWarning)

--- a/src/pip/_internal/main.py
+++ b/src/pip/_internal/main.py
@@ -1,0 +1,44 @@
+"""Primary application entrypoint.
+"""
+from __future__ import absolute_import
+
+import locale
+import logging
+import os
+import sys
+
+from pip._internal.cli.autocompletion import autocomplete
+from pip._internal.cli.main_parser import parse_command
+from pip._internal.commands import create_command
+from pip._internal.exceptions import PipError
+from pip._internal.utils import deprecation
+
+logger = logging.getLogger(__name__)
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+
+    # Configure our deprecation warnings to be sent through loggers
+    deprecation.install_warning_logger()
+
+    autocomplete()
+
+    try:
+        cmd_name, cmd_args = parse_command(args)
+    except PipError as exc:
+        sys.stderr.write("ERROR: %s" % exc)
+        sys.stderr.write(os.linesep)
+        sys.exit(1)
+
+    # Needed for locale.getpreferredencoding(False) to work
+    # in pip._internal.utils.encoding.auto_decode
+    try:
+        locale.setlocale(locale.LC_ALL, '')
+    except locale.Error as e:
+        # setlocale can apparently crash if locale are uninitialized
+        logger.debug("Ignoring error %s when setting locale", e)
+    command = create_command(cmd_name, isolated=("--isolated" in cmd_args))
+
+    return command.main(cmd_args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 import six
 from setuptools.wheel import Wheel
 
-import pip._internal
+import pip._internal.main
 from tests.lib import DATA_DIR, SRC_DIR, TestData
 from tests.lib.path import Path
 from tests.lib.scripttest import PipTestEnvironment
@@ -342,7 +342,7 @@ class InMemoryPip(object):
             stdout = io.BytesIO()
         sys.stdout = stdout
         try:
-            returncode = pip._internal.main(list(args))
+            returncode = pip._internal.main.main(list(args))
         except SystemExit as e:
             returncode = e.code or 0
         finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 import six
 from setuptools.wheel import Wheel
 
-import pip._internal.main
+from pip._internal.main import main as pip_entry_point
 from tests.lib import DATA_DIR, SRC_DIR, TestData
 from tests.lib.path import Path
 from tests.lib.scripttest import PipTestEnvironment
@@ -342,7 +342,7 @@ class InMemoryPip(object):
             stdout = io.BytesIO()
         sys.stdout = stdout
         try:
-            returncode = pip._internal.main.main(list(args))
+            returncode = pip_entry_point(list(args))
         except SystemExit as e:
             returncode = e.code or 0
         finally:

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -78,7 +78,9 @@ def setup_completion(script, words, cword, cwd=None):
 
     # expect_error is True because autocomplete exists with 1 status code
     result = script.run(
-        'python', '-c', 'import pip._internal;pip._internal.autocomplete()',
+        'python', '-c',
+        'from pip._internal.cli.autocompletion import autocomplete;'
+        'autocomplete()',
         expect_error=True,
         cwd=cwd,
     )

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -4,9 +4,9 @@ from contextlib import contextmanager
 import pytest
 
 import pip._internal.configuration
-from pip._internal import main
 from pip._internal.commands import create_command
 from pip._internal.exceptions import PipError
+from pip._internal.main import main
 from tests.lib.options_helpers import AddFakeCommandMixin
 
 


### PR DESCRIPTION
Related to #4497.

Previously our main function and its associated imports were in `pip._internal.__init__` - this makes them unconditional for any access of pip internals. Now `main` is in `pip._internal.main`.

This is relevant to:

1. Improving test execution time - some of our longest tests are in `tests.unit.test_build_env`, which starts subprocesses and import internals which may not require everything that was in `__init__`.
2. Checking module import time - when we import so much in `__init__` it is difficult to use `-X importtime` to isolate slow-loading modules or modules that cause a lot of other transitive imports

A test on my machine shows that import of `pip._internal` previously took around 120ms before this change, and is now around 60ms.