### PR TITLE
Change CollectedLinks to store project page URLs

### DIFF
--- a/docs/html/development/architecture/package-finding.rst
+++ b/docs/html/development/architecture/package-finding.rst
@@ -15,17 +15,16 @@ Overview
 Here is a rough description of the process that pip uses to choose what
 file to download for a package, given a requirement:
 
-1. Access the various network and file system locations configured for pip
-   that contain package files. These locations can include, for example,
-   pip's :ref:`--index-url <--index-url>` (with default
-   https://pypi.org/simple/ ) and any configured
-   :ref:`--extra-index-url <--extra-index-url>` locations.
-   Each of these locations is a `PEP 503`_ "simple repository" page, which
-   is an HTML page of anchor links.
-2. Collect together all of the links (e.g. by parsing the anchor links
-   from the HTML pages) and create ``Link`` objects from each of these.
-   The :ref:`LinkCollector <link-collector-class>` class is responsible
-   for both this step and the previous.
+1. Collect together the various network and file system locations containing
+   project package files. These locations are derived, for example, from pip's
+   :ref:`--index-url <--index-url>` (with default https://pypi.org/simple/ )
+   setting and any configured :ref:`--extra-index-url <--extra-index-url>`
+   locations. Each of the project page URL's is an HTML page of anchor links,
+   as defined in `PEP 503`_, the "Simple Repository API."
+2. For each project page URL, fetch the HTML and parse out the anchor links,
+   creating a ``Link`` object from each one. The :ref:`LinkCollector
+   <link-collector-class>` class is responsible for both the previous step
+   and fetching the HTML over the network.
 3. Determine which of the links are minimally relevant, using the
    :ref:`LinkEvaluator <link-evaluator-class>` class.  Create an
    ``InstallationCandidate`` object (aka candidate for install) for each
@@ -111,6 +110,12 @@ One of ``PackageFinder``'s main top-level methods is
    class's ``compute_best_candidate()`` method on the return value of
    ``find_all_candidates()``. This corresponds to steps 4-5 of the Overview.
 
+``PackageFinder`` also has a ``process_project_url()`` method (called by
+``find_best_candidate()``) to process a `PEP 503`_ "simple repository"
+project page. This method fetches and parses the HTML from a PEP 503 project
+page URL, extracts the anchor elements and creates ``Link`` objects from
+them, and then evaluates those links.
+
 
 .. _link-collector-class:
 
@@ -119,12 +124,8 @@ The ``LinkCollector`` class
 
 The :ref:`LinkCollector <link-collector-class>` class is the class
 responsible for collecting the raw list of "links" to package files
-(represented as ``Link`` objects). An instance of the class accesses the
-various `PEP 503`_ HTML "simple repository" pages, parses their HTML,
-extracts the links from the anchor elements, and creates ``Link`` objects
-from that information. The ``LinkCollector`` class is "unintelligent" in that
-it doesn't do any evaluation of whether the links are relevant to the
-original requirement; it just collects them.
+(represented as ``Link`` objects) from file system locations, as well as the
+`PEP 503`_ project page URL's that ``PackageFinder`` should access.
 
 The ``LinkCollector`` class takes into account the user's :ref:`--find-links
 <--find-links>`, :ref:`--extra-index-url <--extra-index-url>`, and related
@@ -132,6 +133,10 @@ options when deciding which locations to collect links from. The class's main
 method is the ``collect_links()`` method. The :ref:`PackageFinder
 <package-finder-class>` class invokes this method as the first step of its
 ``find_all_candidates()`` method.
+
+``LinkCollector`` also has a ``fetch_page()`` method to fetch the HTML from a
+project page URL. This method is "unintelligent" in that it doesn't parse the
+HTML.
 
 The ``LinkCollector`` class is the only class in the ``index`` sub-package that
 makes network requests and is the only class in the sub-package that depends

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -483,6 +483,13 @@ class LinkCollector(object):
         # type: () -> List[str]
         return self.search_scope.find_links
 
+    def fetch_page(self, location):
+        # type: (Link) -> Optional[HTMLPage]
+        """
+        Fetch an HTML page containing package links.
+        """
+        return _get_html_page(location, session=self.session)
+
     def _get_pages(self, locations):
         # type: (Iterable[Link]) -> Iterable[HTMLPage]
         """
@@ -490,7 +497,7 @@ class LinkCollector(object):
         locations that have errors.
         """
         for location in locations:
-            page = _get_html_page(location, session=self.session)
+            page = self.fetch_page(location)
             if page is None:
                 continue
 

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -91,7 +91,7 @@ def test_command_line_append_flags(script, virtualenv, data):
         'test.pypi.org',
     )
     assert (
-        "Analyzing links from page https://test.pypi.org"
+        "Fetching project page and analyzing links: https://test.pypi.org"
         in result.stdout
     ), str(result)
     virtualenv.clear()
@@ -100,7 +100,7 @@ def test_command_line_append_flags(script, virtualenv, data):
         '--trusted-host', 'test.pypi.org',
     )
     assert (
-        "Analyzing links from page https://test.pypi.org"
+        "Fetching project page and analyzing links: https://test.pypi.org"
         in result.stdout
     )
     assert (
@@ -124,7 +124,7 @@ def test_command_line_appends_correctly(script, data):
     )
 
     assert (
-        "Analyzing links from page https://test.pypi.org"
+        "Fetching project page and analyzing links: https://test.pypi.org"
         in result.stdout
     ), result.stdout
     assert (

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -456,14 +456,8 @@ class TestLinkCollector(object):
             url, session=link_collector.session,
         )
 
-    @patch('pip._internal.index.collector._get_html_response')
-    def test_collect_links(self, mock_get_html_response, caplog, data):
+    def test_collect_links(self, caplog, data):
         caplog.set_level(logging.DEBUG)
-
-        expected_url = 'https://pypi.org/simple/twine/'
-
-        fake_response = make_fake_html_response(expected_url)
-        mock_get_html_response.return_value = fake_response
 
         link_collector = make_test_link_collector(
             find_links=[data.find_links],
@@ -473,10 +467,6 @@ class TestLinkCollector(object):
         )
         actual = link_collector.collect_links('twine')
 
-        mock_get_html_response.assert_called_once_with(
-            expected_url, session=link_collector.session,
-        )
-
         # Spot-check the CollectedLinks return value.
         assert len(actual.files) > 20
         check_links_include(actual.files, names=['simple-1.0.tar.gz'])
@@ -484,13 +474,7 @@ class TestLinkCollector(object):
         assert len(actual.find_links) == 1
         check_links_include(actual.find_links, names=['packages'])
 
-        actual_pages = actual.pages
-        assert list(actual_pages) == [expected_url]
-        actual_page_links = actual_pages[expected_url]
-        assert len(actual_page_links) == 1
-        assert actual_page_links[0].url == (
-            'https://pypi.org/abc-1.0.tar.gz#md5=000000000'
-        )
+        assert actual.project_urls == [Link('https://pypi.org/simple/twine/')]
 
         expected_message = dedent("""\
         1 location(s) to search for versions of twine:

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -436,13 +436,34 @@ def check_links_include(links, names):
 class TestLinkCollector(object):
 
     @patch('pip._internal.index.collector._get_html_response')
+    def test_fetch_page(self, mock_get_html_response):
+        url = 'https://pypi.org/simple/twine/'
+
+        fake_response = make_fake_html_response(url)
+        mock_get_html_response.return_value = fake_response
+
+        location = Link(url)
+        link_collector = make_test_link_collector()
+        actual = link_collector.fetch_page(location)
+
+        assert actual.content == fake_response.content
+        assert actual.encoding is None
+        assert actual.url == url
+
+        # Also check that the right session object was passed to
+        # _get_html_response().
+        mock_get_html_response.assert_called_once_with(
+            url, session=link_collector.session,
+        )
+
+    @patch('pip._internal.index.collector._get_html_response')
     def test_collect_links(self, mock_get_html_response, caplog, data):
         caplog.set_level(logging.DEBUG)
 
         expected_url = 'https://pypi.org/simple/twine/'
 
-        fake_page = make_fake_html_response(expected_url)
-        mock_get_html_response.return_value = fake_page
+        fake_response = make_fake_html_response(expected_url)
+        mock_get_html_response.return_value = fake_response
 
         link_collector = make_test_link_collector(
             find_links=[data.find_links],

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -473,6 +473,22 @@ class TestLinkEvaluator(object):
         assert actual == (False, expected_msg)
 
 
+def test_process_project_url(data):
+    project_name = 'simple'
+    index_url = data.index_url('simple')
+    project_url = Link('{}/{}'.format(index_url, project_name))
+    finder = make_test_finder(index_urls=[index_url])
+    link_evaluator = finder.make_link_evaluator(project_name)
+    actual = finder.process_project_url(
+        project_url, link_evaluator=link_evaluator,
+    )
+
+    assert len(actual) == 1
+    package_link = actual[0]
+    assert package_link.project == 'simple'
+    assert str(package_link.version) == '1.0'
+
+
 def test_find_all_candidates_nothing():
     """Find nothing without anything"""
     finder = make_test_finder()


### PR DESCRIPTION
This is a refactoring PR that changes `CollectedLinks` to store the project page URLs instead of the mapping of "project page URL" to "list of links". In particular, `LinkCollector.collect_links()` will no longer do any fetching of pages. Instead, the network / page-fetching code is moved to `LinkCollector.fetch_page()` (to be called by `PackageFinder`).

These changes are useful for two main reasons:

1. It decouples the HTML-parsing code from `LinkCollector`, so `LinkCollector` no longer has to know about HTML-parsing. Instead, it more encapsulates just the network aspects, combined with knowing about and processing the relevant CLI options like `--find-links`. This will help more generally in isolating out the network code from the package-finding logic.

2. It will make it easier for us to filter out (aka evaluate) links _while_ we're parsing the HTML, instead of storing the full list of links, only later to do another pass over them later to pick out which ones are meaningful. This approach is useful e.g. if the full list of links is gigantic, but only a small fraction of them correspond to project links.

This PR also simplifies `PackageFinder.find_all_candidates()` by refactoring out a `PackageFinder.process_project_url()` method, which is responsible for calling `LinkCollector.fetch_page()` and then doing the HTML-parsing and link evaluation.