### PR TITLE
Make PipTestEnvironment stderr checks more assertive

### DIFF
--- a/news/6871.trivial
+++ b/news/6871.trivial
@@ -1,0 +1,1 @@
+Make ``PipTestEnvironment`` stderr checks more assertive.

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -65,7 +65,7 @@ def test_completion_alone(script):
     """
     Test getting completion for none shell, just pip completion
     """
-    result = script.pip('completion', allow_stderr_error=True)
+    result = script.pip('completion', expect_stderr_error=True)
     assert 'ERROR: You must pass --bash or --fish or --zsh' in result.stderr, \
            'completion alone failed -- ' + result.stderr
 

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -287,6 +287,7 @@ def test_completion_uses_same_executable_name(script, flag, deprecated_python):
     executable_name = 'pip{}'.format(sys.version_info[0])
     # Deprecated python versions produce an extra deprecation warning
     result = script.run(
-        executable_name, 'completion', flag, expect_stderr=deprecated_python,
+        executable_name, 'completion', flag,
+        expect_stderr_warning=deprecated_python,
     )
     assert executable_name in result.stdout

--- a/tests/functional/test_debug.py
+++ b/tests/functional/test_debug.py
@@ -16,7 +16,7 @@ def test_debug(script, expected_text):
     Check that certain strings are present in the output.
     """
     args = ['debug']
-    result = script.pip(*args, allow_stderr_warning=True)
+    result = script.pip(*args, expect_stderr_warning=True)
     stdout = result.stdout
 
     assert expected_text in stdout
@@ -34,7 +34,7 @@ def test_debug__tags(script, args):
     Check the compatible tag output.
     """
     args = ['debug'] + args
-    result = script.pip(*args, allow_stderr_warning=True)
+    result = script.pip(*args, expect_stderr_warning=True)
     stdout = result.stdout
 
     tags = pep425tags.get_supported()
@@ -58,7 +58,7 @@ def test_debug__target_options(script, args, expected):
     Check passing target-related options.
     """
     args = ['debug'] + args
-    result = script.pip(*args, allow_stderr_warning=True)
+    result = script.pip(*args, expect_stderr_warning=True)
     stdout = result.stdout
 
     assert 'Compatible tags: ' in stdout

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -63,7 +63,7 @@ def test_basic_freeze(script):
     script.pip_install_local(
         '-r', script.scratch_path / 'initools-req.txt',
     )
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent("""\
         ...simple==2.0
         simple2==3.0...
@@ -105,7 +105,7 @@ def test_freeze_with_invalid_names(script):
     )
     for pkgname in valid_pkgnames + invalid_pkgnames:
         fake_install(pkgname, script.site_packages_path)
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     for pkgname in valid_pkgnames:
         _check_output(
             result.stdout,
@@ -178,9 +178,9 @@ def test_freeze_svn(script, tmpdir):
     # Install with develop
     script.run(
         'python', 'setup.py', 'develop',
-        cwd=checkout_path, expect_stderr=True
+        cwd=checkout_path, expect_stderr_warning=True
     )
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent("""\
         ...-e svn+...#egg=version_pkg
         ...""")
@@ -198,15 +198,18 @@ def test_freeze_exclude_editable(script, tmpdir):
 
     result = script.run(
         'git', 'clone', pkg_version, 'pip-test-package',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     repo_dir = script.scratch_path / 'pip-test-package'
     result = script.run(
         'python', 'setup.py', 'develop',
         cwd=repo_dir,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
-    result = script.pip('freeze', '--exclude-editable', expect_stderr=True)
+    result = script.pip(
+        'freeze', '--exclude-editable',
+        expect_stderr_warning=True,
+    )
     expected = textwrap.dedent(
         """
             ...-e git+...#egg=version_pkg
@@ -226,15 +229,15 @@ def test_freeze_git_clone(script, tmpdir):
 
     result = script.run(
         'git', 'clone', pkg_version, 'pip-test-package',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     repo_dir = script.scratch_path / 'pip-test-package'
     result = script.run(
         'python', 'setup.py', 'develop',
         cwd=repo_dir,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent(
         """
             ...-e git+...#egg=version_pkg
@@ -245,7 +248,7 @@ def test_freeze_git_clone(script, tmpdir):
 
     result = script.pip(
         'freeze', '-f', '%s#egg=pip_test_package' % repo_dir,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     expected = textwrap.dedent(
         """
@@ -261,7 +264,7 @@ def test_freeze_git_clone(script, tmpdir):
     script.run(
         'git', 'checkout', '-b', 'branch/name/with/slash',
         cwd=repo_dir,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     # Create a new commit to ensure that the commit has only one branch
     # or tag name associated to it (to avoid the non-determinism reported
@@ -269,7 +272,7 @@ def test_freeze_git_clone(script, tmpdir):
     script.run('touch', 'newfile', cwd=repo_dir)
     script.run('git', 'add', 'newfile', cwd=repo_dir)
     _git_commit(script, repo_dir, message='...')
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent(
         """
             ...-e ...@...#egg=version_pkg
@@ -291,15 +294,15 @@ def test_freeze_git_clone_srcdir(script, tmpdir):
 
     result = script.run(
         'git', 'clone', pkg_version, 'pip-test-package',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     repo_dir = script.scratch_path / 'pip-test-package'
     result = script.run(
         'python', 'setup.py', 'develop',
         cwd=repo_dir / 'subdir',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent(
         """
             ...-e git+...#egg=version_pkg&subdirectory=subdir
@@ -310,7 +313,7 @@ def test_freeze_git_clone_srcdir(script, tmpdir):
 
     result = script.pip(
         'freeze', '-f', '%s#egg=pip_test_package' % repo_dir,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     expected = textwrap.dedent(
         """
@@ -332,18 +335,18 @@ def test_freeze_git_remote(script, tmpdir):
 
     result = script.run(
         'git', 'clone', pkg_version, 'pip-test-package',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     repo_dir = script.scratch_path / 'pip-test-package'
     result = script.run(
         'python', 'setup.py', 'develop',
         cwd=repo_dir,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     origin_remote = pkg_version
     other_remote = pkg_version + '-other'
     # check frozen remote after clone
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent(
         """
             ...-e git+{remote}@...#egg=version_pkg
@@ -354,7 +357,7 @@ def test_freeze_git_remote(script, tmpdir):
     # check frozen remote when there is no remote named origin
     script.run('git', 'remote', 'remove', 'origin', cwd=repo_dir)
     script.run('git', 'remote', 'add', 'other', other_remote, cwd=repo_dir)
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent(
         """
             ...-e git+{remote}@...#egg=version_pkg
@@ -365,7 +368,7 @@ def test_freeze_git_remote(script, tmpdir):
     # when there are more than one origin, priority is given to the
     # remote named origin
     script.run('git', 'remote', 'add', 'origin', origin_remote, cwd=repo_dir)
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent(
         """
             ...-e git+{remote}@...#egg=version_pkg
@@ -386,15 +389,15 @@ def test_freeze_mercurial_clone(script, tmpdir):
 
     result = script.run(
         'hg', 'clone', pkg_version, 'pip-test-package',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     repo_dir = script.scratch_path / 'pip-test-package'
     result = script.run(
         'python', 'setup.py', 'develop',
         cwd=repo_dir,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent(
         """
             ...-e hg+...#egg=version_pkg
@@ -405,7 +408,7 @@ def test_freeze_mercurial_clone(script, tmpdir):
 
     result = script.pip(
         'freeze', '-f', '%s#egg=pip_test_package' % repo_dir,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     expected = textwrap.dedent(
         """
@@ -434,9 +437,9 @@ def test_freeze_bazaar_clone(script, tmpdir):
     result = script.run(
         'python', 'setup.py', 'develop',
         cwd=script.scratch_path / 'bzr-package',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
-    result = script.pip('freeze', expect_stderr=True)
+    result = script.pip('freeze', expect_stderr_warning=True)
     expected = textwrap.dedent("""\
         ...-e bzr+file://...@1#egg=version_pkg
         ...""")
@@ -445,7 +448,7 @@ def test_freeze_bazaar_clone(script, tmpdir):
     result = script.pip(
         'freeze', '-f',
         '%s/#egg=django-wikiapp' % checkout_path,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     expected = textwrap.dedent("""\
         -f %(repo)s/#egg=django-wikiapp
@@ -484,7 +487,8 @@ def test_freeze_with_requirement_option_file_url_egg_not_installed(
     requirements_path.write_text(url + '\n')
 
     result = script.pip(
-        'freeze', '--requirement', 'requirements.txt', expect_stderr=True,
+        'freeze', '--requirement', 'requirements.txt',
+        expect_stderr_warning=True,
     )
     expected_err = (
         'WARNING: Requirement file [requirements.txt] contains {}, '
@@ -511,7 +515,7 @@ def test_freeze_with_requirement_option(script):
     result = script.pip_install_local('simple')
     result = script.pip(
         'freeze', '--requirement', 'hint.txt',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     expected = textwrap.dedent("""\
         INITools==0.2
@@ -547,7 +551,7 @@ def test_freeze_with_requirement_option_multiple(script):
     result = script.pip_install_local('meta')
     result = script.pip(
         'freeze', '--requirement', 'hint1.txt', '--requirement', 'hint2.txt',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     expected = textwrap.dedent("""\
         INITools==0.2
@@ -589,7 +593,7 @@ def test_freeze_with_requirement_option_package_repeated_one_file(script):
     result = script.pip_install_local('meta')
     result = script.pip(
         'freeze', '--requirement', 'hint1.txt',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     expected_out = textwrap.dedent("""\
         simple2==1.0
@@ -625,7 +629,7 @@ def test_freeze_with_requirement_option_package_repeated_multi_file(script):
     result = script.pip(
         'freeze', '--requirement', 'hint1.txt',
         '--requirement', 'hint2.txt',
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     expected_out = textwrap.dedent("""\
         simple==1.0
@@ -657,7 +661,7 @@ def test_freeze_user(script, virtualenv, data):
                              '--user', 'simple==2.0')
     script.pip_install_local('--find-links', data.find_links,
                              'simple2==3.0')
-    result = script.pip('freeze', '--user', expect_stderr=True)
+    result = script.pip('freeze', '--user', expect_stderr_warning=True)
     expected = textwrap.dedent("""\
         simple==2.0
         <BLANKLINE>""")

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1512,7 +1512,7 @@ def test_install_conflict_results_in_warning(script, data):
 
     # Then install an incorrect version of the dependency
     result2 = script.pip(
-        'install', '--no-index', pkgB_path, allow_stderr_error=True,
+        'install', '--no-index', pkgB_path, expect_stderr_error=True,
     )
     assert "pkga 1.0 has requirement pkgb==1.0" in result2.stderr, str(result2)
     assert "Successfully installed pkgB-2.0" in result2.stdout, str(result2)

--- a/tests/functional/test_install_check.py
+++ b/tests/functional/test_install_check.py
@@ -35,7 +35,7 @@ def test_check_install_canonicalization(script, deprecated_python):
         '--no-index',
         normal_path,
         '--quiet',
-        allow_stderr_error=True,
+        expect_stderr_error=True,
     )
     expected_lines = [
         "ERROR: pkga 1.0 requires SPECIAL.missing, which is not installed.",
@@ -91,7 +91,7 @@ def test_check_install_does_not_warn_for_out_of_graph_issues(
 
     # Install conflict package
     result = script.pip(
-        'install', '--no-index', pkg_conflict_path, allow_stderr_error=True,
+        'install', '--no-index', pkg_conflict_path, expect_stderr_error=True,
     )
     assert matches_expected_lines(result.stderr, [
         "ERROR: broken 1.0 requires missing, which is not installed.",

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -213,7 +213,7 @@ def test_install_no_binary_via_config_disables_cached_wheels(
         config_file.close()
         res = script.pip(
             'install', '--no-index', '-f', data.find_links,
-            'upper', expect_stderr=True)
+            'upper', expect_stderr_warning=True)
     finally:
         os.unlink(config_file.name)
     assert "Successfully installed upper-2.0" in str(res), str(res)

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -10,7 +10,7 @@ def test_simple_extras_install_from_pypi(script):
     Test installing a package from PyPI using extras dependency Paste[openid].
     """
     result = script.pip(
-        'install', 'Paste[openid]==1.7.5.1', expect_stderr=True,
+        'install', 'Paste[openid]==1.7.5.1', expect_stderr_warning=True,
     )
     initools_folder = script.site_packages / 'openid'
     assert initools_folder in result.files_created, result.files_created
@@ -24,13 +24,13 @@ def test_extras_after_wheel(script, data):
 
     no_extra = script.pip(
         'install', '--no-index', '-f', data.find_links,
-        'requires_simple_extra', expect_stderr=True,
+        'requires_simple_extra', expect_stderr_warning=True,
     )
     assert simple not in no_extra.files_created, no_extra.files_created
 
     extra = script.pip(
         'install', '--no-index', '-f', data.find_links,
-        'requires_simple_extra[extra]', expect_stderr=True,
+        'requires_simple_extra[extra]', expect_stderr_warning=True,
     )
     assert simple in extra.files_created, extra.files_created
 
@@ -41,7 +41,7 @@ def test_no_extras_uninstall(script):
     No extras dependency gets uninstalled when the root package is uninstalled
     """
     result = script.pip(
-        'install', 'Paste[openid]==1.7.5.1', expect_stderr=True,
+        'install', 'Paste[openid]==1.7.5.1', expect_stderr_warning=True,
     )
     assert join(script.site_packages, 'paste') in result.files_created, (
         sorted(result.files_created.keys())
@@ -65,7 +65,7 @@ def test_nonexistent_extra_warns_user_no_wheel(script, data):
     result = script.pip(
         'install', '--no-binary=:all:', '--no-index',
         '--find-links=' + data.find_links,
-        'simple[nonexistent]', expect_stderr=True,
+        'simple[nonexistent]', expect_stderr_warning=True,
     )
     assert (
         "simple 3.0 does not provide the extra 'nonexistent'"
@@ -83,7 +83,7 @@ def test_nonexistent_extra_warns_user_with_wheel(script, data):
     result = script.pip(
         'install', '--no-index',
         '--find-links=' + data.find_links,
-        'simplewheel[nonexistent]', expect_stderr=True,
+        'simplewheel[nonexistent]', expect_stderr_warning=True,
     )
     assert (
         "simplewheel 2.0 does not provide the extra 'nonexistent'"
@@ -98,7 +98,7 @@ def test_nonexistent_options_listed_in_order(script, data):
     result = script.pip(
         'install', '--no-index',
         '--find-links=' + data.find_links,
-        'simplewheel[nonexistent, nope]', expect_stderr=True,
+        'simplewheel[nonexistent, nope]', expect_stderr_warning=True,
     )
     msg = (
         "  WARNING: simplewheel 2.0 does not provide the extra 'nonexistent'\n"

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -177,7 +177,7 @@ def test_install_local_editable_with_extras(script, data):
     res = script.pip_install_local(
         '-e', to_install + '[bar]',
         expect_error=False,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     assert script.site_packages / 'easy-install.pth' in res.files_updated, (
         str(res)
@@ -262,7 +262,7 @@ def test_install_option_in_requirements_file(script, data, virtualenv):
         'install', '--no-index', '-f', data.find_links, '-r',
         script.scratch_path / 'reqs.txt',
         '--install-option=--home=%s' % script.scratch_path.joinpath("home2"),
-        expect_stderr=True)
+        expect_stderr_warning=True)
 
     package_dir = script.scratch / 'home1' / 'lib' / 'python' / 'simple'
     assert package_dir in result.files_created
@@ -503,7 +503,7 @@ def test_install_unsupported_wheel_file(script, data):
     result = script.pip(
         'install', '-r', script.scratch_path / 'wheel-file.txt',
         expect_error=True,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     assert ("simple.dist-0.1-py1-none-invalid.whl is not a supported " +
             "wheel on this platform" in result.stderr)

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -368,8 +368,8 @@ def test_upgrade_vcs_req_with_dist_found(script):
             "743aad47656b27"
         )
     )
-    script.pip("install", req, expect_stderr=True)
-    result = script.pip("install", "-U", req, expect_stderr=True)
+    script.pip("install", req, expect_stderr_warning=True)
+    result = script.pip("install", "-U", req, expect_stderr_warning=True)
     assert "pypi.org" not in result.stdout, result.stdout
 
 
@@ -415,5 +415,5 @@ class TestUpgradeDistributeToSetuptools(object):
         self.script.run(
             self.ve_bin / 'python', 'setup.py', 'install',
             cwd=pip_src,
-            expect_stderr=True,
+            expect_stderr_warning=True,
         )

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -83,7 +83,8 @@ def _make_version_pkg_url(path, rev=None):
     return url
 
 
-def _install_version_pkg_only(script, path, rev=None, expect_stderr=False):
+def _install_version_pkg_only(script, path, rev=None,
+                              expect_stderr_warning=False):
     """
     Install the version_pkg package in editable mode (without returning
     the version).
@@ -94,10 +95,13 @@ def _install_version_pkg_only(script, path, rev=None, expect_stderr=False):
       rev: an optional revision to install like a branch name or tag.
     """
     version_pkg_url = _make_version_pkg_url(path, rev=rev)
-    script.pip('install', '-e', version_pkg_url, expect_stderr=expect_stderr)
+    script.pip(
+        'install', '-e', version_pkg_url,
+        expect_stderr_warning=expect_stderr_warning,
+    )
 
 
-def _install_version_pkg(script, path, rev=None, expect_stderr=False):
+def _install_version_pkg(script, path, rev=None, expect_stderr_warning=False):
     """
     Install the version_pkg package in editable mode, and return the version
     installed.
@@ -108,7 +112,7 @@ def _install_version_pkg(script, path, rev=None, expect_stderr=False):
       rev: an optional revision to install like a branch name or tag.
     """
     _install_version_pkg_only(
-        script, path, rev=rev, expect_stderr=expect_stderr,
+        script, path, rev=rev, expect_stderr_warning=expect_stderr_warning,
     )
     result = script.run('version_pkg')
     version = result.stdout.strip()

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -22,7 +22,7 @@ def test_install_from_future_wheel_version(script, data):
     package = data.packages.joinpath("futurewheel-1.9-py2.py3-none-any.whl")
     result = script.pip(
         'install', package, '--no-index', expect_error=False,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     result.assert_installed('futurewheel', without_egg_link=True,
                             editable=False)

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -60,7 +60,7 @@ def test_format_priority(script, data):
         'simple2==3.0',
     )
     result = script.pip('list', '--format=columns', '--format=freeze',
-                        expect_stderr=True)
+                        expect_stderr_warning=True)
     assert 'simple==1.0' in result.stdout, str(result)
     assert 'simple2==3.0' in result.stdout, str(result)
     assert 'simple     1.0' not in result.stdout, str(result)
@@ -472,7 +472,7 @@ def test_not_required_flag(script, data):
     script.pip(
         'install', '-f', data.find_links, '--no-index', 'TopoRequires4'
     )
-    result = script.pip('list', '--not-required', expect_stderr=True)
+    result = script.pip('list', '--not-required', expect_stderr_warning=True)
     assert 'TopoRequires4 ' in result.stdout, str(result)
     assert 'TopoRequires ' not in result.stdout
     assert 'TopoRequires2 ' not in result.stdout

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -87,7 +87,7 @@ def test_report_single_not_found(script):
     # form is logged.
     # Also, the following should report an error as there are no results
     # to print. Consequently, there is no need to pass
-    # allow_stderr_warning=True since this is implied by expect_error=True.
+    # expect_stderr_warning=True since this is implied by expect_error=True.
     result = script.pip('show', 'Abcd-3', expect_error=True)
     assert 'WARNING: Package(s) not found: Abcd-3' in result.stderr
     assert not result.stdout.splitlines()
@@ -99,7 +99,7 @@ def test_report_mixed_not_found(script):
     """
     # We test passing non-canonicalized names.
     result = script.pip(
-        'show', 'Abcd3', 'A-B-C', 'pip', allow_stderr_warning=True
+        'show', 'Abcd3', 'A-B-C', 'pip', expect_stderr_warning=True
     )
     assert 'WARNING: Package(s) not found: A-B-C, Abcd3' in result.stderr
     lines = result.stdout.splitlines()

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -53,7 +53,7 @@ def test_basic_uninstall_distutils(script):
     assert {"name": "distutils-install", "version": "0.1"} \
         in json.loads(result.stdout)
     result = script.pip('uninstall', 'distutils_install', '-y',
-                        expect_stderr=True, expect_error=True)
+                        expect_stderr_warning=True, expect_error=True)
     assert (
         "Cannot uninstall 'distutils-install'. It is a distutils installed "
         "project and thus we cannot accurately determine which files belong "
@@ -67,7 +67,7 @@ def test_basic_uninstall_with_scripts(script):
     Uninstall an easy_installed package with scripts.
 
     """
-    result = script.easy_install('PyLogo', expect_stderr=True)
+    result = script.easy_install('PyLogo', expect_stderr_warning=True)
     easy_install_pth = script.site_packages / 'easy-install.pth'
     pylogo = sys.platform == 'win32' and 'pylogo' or 'PyLogo'
     assert(pylogo in result.files_updated[easy_install_pth].bytes)
@@ -86,7 +86,7 @@ def test_uninstall_easy_install_after_import(script):
 
     """
     result = script.easy_install('--always-unzip', 'INITools==0.2',
-                                 expect_stderr=True)
+                                 expect_stderr_warning=True)
     # the import forces the generation of __pycache__ if the version of python
     # supports it
     script.run('python', '-c', "import initools")
@@ -109,8 +109,8 @@ def test_uninstall_trailing_newline(script):
     lacks a trailing newline
 
     """
-    script.easy_install('INITools==0.2', expect_stderr=True)
-    script.easy_install('PyLogo', expect_stderr=True)
+    script.easy_install('INITools==0.2', expect_stderr_warning=True)
+    script.easy_install('PyLogo', expect_stderr_warning=True)
     easy_install_pth = script.site_packages_path / 'easy-install.pth'
 
     # trim trailing newline from easy-install.pth
@@ -337,7 +337,7 @@ def _test_uninstall_editable_with_source_outside_venv(
         'git', 'clone',
         local_repo('git+git://github.com/pypa/pip-test-package', tmpdir),
         temp_pkg_dir,
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
     result2 = script.pip('install', '-e', temp_pkg_dir)
     assert join(
@@ -473,9 +473,9 @@ def test_uninstall_setuptools_develop_install(script, data):
     """Try uninstall after setup.py develop followed of setup.py install"""
     pkg_path = data.packages.joinpath("FSPkg")
     script.run('python', 'setup.py', 'develop',
-               expect_stderr=True, cwd=pkg_path)
+               expect_stderr_warning=True, cwd=pkg_path)
     script.run('python', 'setup.py', 'install',
-               expect_stderr=True, cwd=pkg_path)
+               expect_stderr_warning=True, cwd=pkg_path)
     list_result = script.pip('list', '--format=json')
     assert {"name": os.path.normcase("FSPkg"), "version": "0.1.dev0"} \
         in json.loads(list_result.stdout), str(list_result)
@@ -500,10 +500,10 @@ def test_uninstall_editable_and_pip_install(script, data):
 
     pkg_path = data.packages.joinpath("FSPkg")
     script.pip('install', '-e', '.',
-               expect_stderr=True, cwd=pkg_path)
+               expect_stderr_warning=True, cwd=pkg_path)
     # ensure both are installed with --ignore-installed:
     script.pip('install', '--ignore-installed', '.',
-               expect_stderr=True, cwd=pkg_path)
+               expect_stderr_warning=True, cwd=pkg_path)
     list_result = script.pip('list', '--format=json')
     assert {"name": "FSPkg", "version": "0.1.dev0"} \
         in json.loads(list_result.stdout)
@@ -523,7 +523,7 @@ def test_uninstall_ignores_missing_packages(script, data):
     """Uninstall of a non existent package prints a warning and exits cleanly
     """
     result = script.pip(
-        'uninstall', '-y', 'non-existent-pkg', expect_stderr=True,
+        'uninstall', '-y', 'non-existent-pkg', expect_stderr_warning=True,
     )
 
     assert "Skipping non-existent-pkg as it is not installed." in result.stderr
@@ -533,7 +533,8 @@ def test_uninstall_ignores_missing_packages(script, data):
 def test_uninstall_ignores_missing_packages_and_uninstalls_rest(script, data):
     script.pip_install_local('simple')
     result = script.pip(
-        'uninstall', '-y', 'non-existent-pkg', 'simple', expect_stderr=True,
+        'uninstall', '-y', 'non-existent-pkg', 'simple',
+        expect_stderr_warning=True,
     )
 
     assert "Skipping non-existent-pkg as it is not installed." in result.stderr

--- a/tests/functional/test_warning.py
+++ b/tests/functional/test_warning.py
@@ -13,7 +13,7 @@ def test_environ(script, tmpdir):
         deprecation.deprecated("deprecated!", replacement=None, gone_in=None)
     '''))
 
-    result = script.run('python', demo, expect_stderr=True)
+    result = script.run('python', demo, expect_stderr_warning=True)
     expected = 'WARNING:pip._internal.deprecations:DEPRECATION: deprecated!\n'
     assert result.stderr == expected
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -522,10 +522,6 @@ class PipTestEnvironment(TestFileEnvironment):
             exits with 0.  Otherwise, asserts that the command exits with a
             non-zero exit code.  Passing True also implies expect_stderr_error
             and expect_stderr_warning.
-        :param expect_stderr: whether to allow warnings in stderr (equivalent
-            to `expect_stderr_warning`).  This argument is an abbreviated
-            version of `expect_stderr_warning` and is also kept for backwards
-            compatibility.
         """
         if self.verbose:
             print('>> running %s %s' % (args, kw))
@@ -553,15 +549,6 @@ class PipTestEnvironment(TestFileEnvironment):
                     'expect_error=True'
                 )
             expect_stderr_error = True
-
-        elif kw.get('expect_stderr'):
-            # Then default to allowing logged warnings.
-            if expect_stderr_warning is not None and not expect_stderr_warning:
-                raise RuntimeError(
-                    'cannot pass expect_stderr_warning=False with '
-                    'expect_stderr=True'
-                )
-            expect_stderr_warning = True
 
         if expect_stderr_error:
             if expect_stderr_warning is not None and not expect_stderr_warning:
@@ -712,7 +699,7 @@ def _create_main_file(dir_path, name=None, output=None):
 
 
 def _git_commit(env_or_script, repo_dir, message=None, args=None,
-                expect_stderr=False):
+                expect_stderr_warning=False):
     """
     Run git-commit.
 
@@ -732,7 +719,10 @@ def _git_commit(env_or_script, repo_dir, message=None, args=None,
     ]
     new_args.extend(args)
     new_args.extend(['-m', message])
-    env_or_script.run(*new_args, cwd=repo_dir, expect_stderr=expect_stderr)
+    env_or_script.run(
+        *new_args, cwd=repo_dir,
+        expect_stderr_warning=expect_stderr_warning
+    )
 
 
 def _vcs_add(script, version_pkg_path, vcs='git'):
@@ -872,7 +862,7 @@ def _change_test_package_version(script, version_pkg_path):
     # Pass -a to stage the change to the main file.
     _git_commit(
         script, version_pkg_path, message='messed version', args=['-a'],
-        expect_stderr=True,
+        expect_stderr_warning=True,
     )
 
 

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -182,20 +182,6 @@ class TestPipTestEnvironment:
         with assert_error_startswith(RuntimeError, expected_start):
             script.run('python', expect_stderr_error=False, expect_error=True)
 
-    def test_run__expect_stderr_warning_false_error_with_expect_stderr(
-        self, script,
-    ):
-        """
-        Test passing expect_stderr_warning=False with expect_stderr=True.
-        """
-        expected_start = (
-            'cannot pass expect_stderr_warning=False with expect_stderr=True'
-        )
-        with assert_error_startswith(RuntimeError, expected_start):
-            script.run(
-                'python', expect_stderr_warning=False, expect_stderr=True,
-            )
-
     @pytest.mark.parametrize('arg_name', (
         'expect_error',
         'expect_stderr_error',

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -113,20 +113,20 @@ class TestPipTestEnvironment:
         # Check that no error happens.
         self.run_stderr_with_prefix(script, prefix)
 
-    def test_run__allow_stderr_warning(self, script):
+    def test_run__expect_stderr_warning(self, script):
         """
-        Test passing allow_stderr_warning=True.
+        Test passing expect_stderr_warning=True.
         """
         # Check that no error happens.
         self.run_stderr_with_prefix(
-            script, 'WARNING', allow_stderr_warning=True,
+            script, 'WARNING', expect_stderr_warning=True,
         )
 
         # Check that an error still happens with ERROR.
         expected_start = 'stderr has an unexpected error'
         with assert_error_startswith(RuntimeError, expected_start):
             self.run_stderr_with_prefix(
-                script, 'ERROR', allow_stderr_warning=True,
+                script, 'ERROR', expect_stderr_warning=True,
             )
 
     @pytest.mark.parametrize('prefix', (
@@ -182,31 +182,31 @@ class TestPipTestEnvironment:
         with assert_error_startswith(RuntimeError, expected_start):
             script.run('python', allow_stderr_error=False, expect_error=True)
 
-    def test_run__allow_stderr_warning_false_error_with_expect_stderr(
+    def test_run__expect_stderr_warning_false_error_with_expect_stderr(
         self, script,
     ):
         """
-        Test passing allow_stderr_warning=False with expect_stderr=True.
+        Test passing expect_stderr_warning=False with expect_stderr=True.
         """
         expected_start = (
-            'cannot pass allow_stderr_warning=False with expect_stderr=True'
+            'cannot pass expect_stderr_warning=False with expect_stderr=True'
         )
         with assert_error_startswith(RuntimeError, expected_start):
             script.run(
-                'python', allow_stderr_warning=False, expect_stderr=True,
+                'python', expect_stderr_warning=False, expect_stderr=True,
             )
 
     @pytest.mark.parametrize('arg_name', (
         'expect_error',
         'allow_stderr_error',
     ))
-    def test_run__allow_stderr_warning_false_error(self, script, arg_name):
+    def test_run__expect_stderr_warning_false_error(self, script, arg_name):
         """
-        Test passing allow_stderr_warning=False when it is not allowed.
+        Test passing expect_stderr_warning=False when it is not allowed.
         """
-        kwargs = {'allow_stderr_warning': False, arg_name: True}
+        kwargs = {'expect_stderr_warning': False, arg_name: True}
         expected_start = (
-            'cannot pass allow_stderr_warning=False with '
+            'cannot pass expect_stderr_warning=False with '
             'allow_stderr_error=True'
         )
         with assert_error_startswith(RuntimeError, expected_start):

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -134,12 +134,12 @@ class TestPipTestEnvironment:
         'WARNING',
         'ERROR',
     ))
-    def test_run__allow_stderr_error(self, script, prefix):
+    def test_run__expect_stderr_error(self, script, prefix):
         """
-        Test passing allow_stderr_error=True.
+        Test passing expect_stderr_error=True.
         """
         # Check that no error happens.
-        self.run_stderr_with_prefix(script, prefix, allow_stderr_error=True)
+        self.run_stderr_with_prefix(script, prefix, expect_stderr_error=True)
 
     @pytest.mark.parametrize('prefix, expected_start', (
         ('DEPRECATION', 'stderr has an unexpected warning'),
@@ -163,24 +163,24 @@ class TestPipTestEnvironment:
         expected_start = 'stderr has a logging error, which is never allowed'
         with assert_error_startswith(RuntimeError, expected_start):
             # Pass a bad substitution string.  Also, pass
-            # allow_stderr_error=True to check that the RuntimeError occurs
+            # expect_stderr_error=True to check that the RuntimeError occurs
             # even under the stricter test condition of when we are allowing
             # other types of errors.
             self.run_with_log_command(
-                script, sub_string='{!r}', allow_stderr_error=True,
+                script, sub_string='{!r}', expect_stderr_error=True,
             )
 
-    def test_run__allow_stderr_error_false_error_with_expect_error(
+    def test_run__expect_stderr_error_false_error_with_expect_error(
         self, script,
     ):
         """
-        Test passing allow_stderr_error=False with expect_error=True.
+        Test passing expect_stderr_error=False with expect_error=True.
         """
         expected_start = (
-            'cannot pass allow_stderr_error=False with expect_error=True'
+            'cannot pass expect_stderr_error=False with expect_error=True'
         )
         with assert_error_startswith(RuntimeError, expected_start):
-            script.run('python', allow_stderr_error=False, expect_error=True)
+            script.run('python', expect_stderr_error=False, expect_error=True)
 
     def test_run__expect_stderr_warning_false_error_with_expect_stderr(
         self, script,
@@ -198,7 +198,7 @@ class TestPipTestEnvironment:
 
     @pytest.mark.parametrize('arg_name', (
         'expect_error',
-        'allow_stderr_error',
+        'expect_stderr_error',
     ))
     def test_run__expect_stderr_warning_false_error(self, script, arg_name):
         """
@@ -207,7 +207,7 @@ class TestPipTestEnvironment:
         kwargs = {'expect_stderr_warning': False, arg_name: True}
         expected_start = (
             'cannot pass expect_stderr_warning=False with '
-            'allow_stderr_error=True'
+            'expect_stderr_error=True'
         )
         with assert_error_startswith(RuntimeError, expected_start):
             script.run('python', **kwargs)


### PR DESCRIPTION
Closes #6871.

TODO

- [X] 1. Rename `allow_stderr_warning` to `expect_stderr_warning`.
- [X] 2. Rename `allow_stderr_error` to `expect_stderr_error`.
- [X] 3. Rename `expect_stderr` to `expect_stderr_warning`.
- [ ] 4. Respect `expect_stderr_warning` and `expect_stderr_error`. Fail If the argument is passed and a warning or an error isn't present.