### PR TITLE
Rename {setup_py_dir -> unpacked_source_directory}

### DIFF
--- a/src/pip/_internal/operations/generate_metadata.py
+++ b/src/pip/_internal/operations/generate_metadata.py
@@ -41,7 +41,9 @@ def _generate_metadata_legacy(install_req):
     # egg.
     egg_base_option = []  # type: List[str]
     if not install_req.editable:
-        egg_info_dir = os.path.join(install_req.setup_py_dir, 'pip-egg-info')
+        egg_info_dir = os.path.join(
+            install_req.unpacked_source_directory, 'pip-egg-info',
+        )
         egg_base_option = ['--egg-base', egg_info_dir]
 
         # setuptools complains if the target directory does not exist.
@@ -50,7 +52,7 @@ def _generate_metadata_legacy(install_req):
     with install_req.build_env:
         call_subprocess(
             base_cmd + ["egg_info"] + egg_base_option,
-            cwd=install_req.setup_py_dir,
+            cwd=install_req.unpacked_source_directory,
             command_desc='python setup.py egg_info',
         )
 

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -21,9 +21,9 @@ def _is_list_of_str(obj):
     )
 
 
-def make_pyproject_path(setup_py_dir):
+def make_pyproject_path(unpacked_source_directory):
     # type: (str) -> str
-    path = os.path.join(setup_py_dir, 'pyproject.toml')
+    path = os.path.join(unpacked_source_directory, 'pyproject.toml')
 
     # Python2 __file__ should not be unicode
     if six.PY2 and isinstance(path, six.text_type):

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -1019,12 +1019,16 @@ class WheelBuilder(object):
                 wheel_args += ["--python-tag", python_tag]
 
             try:
-                output = call_subprocess(wheel_args, cwd=req.setup_py_dir,
-                                         spinner=spinner)
+                output = call_subprocess(
+                    wheel_args,
+                    cwd=req.unpacked_source_directory,
+                    spinner=spinner,
+                )
             except Exception:
                 spinner.finish("error")
                 logger.error('Failed building wheel for %s', req.name)
                 return None
+
             names = os.listdir(tempd)
             wheel_path = get_legacy_build_wheel_path(
                 names=names,


### PR DESCRIPTION
Why: Because PEP 517 means you won't necessarily have a `setup.py` in your unpacked sources.
