### PR TITLE
Remove the testenv:packaging sections from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,16 +40,6 @@ commands =
     # That is why we have a "-c docs/html" in the next line.
     sphinx-build -W -d {envtmpdir}/doctrees/man -b man docs/man docs/build/man -c docs/html
 
-[testenv:packaging]
-skip_install = True
-deps =
-    check-manifest
-    readme_renderer
-commands_pre =
-commands =
-    check-manifest
-    python setup.py check -m -r -s
-
 [testenv:lint]
 skip_install = True
 commands_pre =


### PR DESCRIPTION
Why: Because we no longer need it and it's covered in tox -e lint now.
