### PR TITLE
Add development commands to nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -31,9 +31,9 @@ def get_author_list():
 
 
 # -----------------------------------------------------------------------------
-# Commands used during the release process
+# Release Commands
 # -----------------------------------------------------------------------------
-@nox.session
+@nox.session(python=False)
 def generate_authors(session):
     # Get our list of authors
     session.log("Collecting author names")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,4 @@
-"""Release time helpers, executed using nox.
+"""Automation using nox.
 """
 
 import io

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,8 +84,11 @@ def test(session):
     session.run(*protected_pip("install", "."))
     session.run(*protected_pip("install", "-r", REQUIREMENTS["tests"]))
 
+    # Parallelize tests as much as possible, by default.
+    arguments = session.posargs or ["-n", "auto"]
+
     # Run the tests
-    session.run("pytest", *session.posargs, env={"LC_CTYPE": "en_US.UTF-8"})
+    session.run("pytest", *arguments, env={"LC_CTYPE": "en_US.UTF-8"})
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,6 +73,9 @@ def should_update_common_wheels():
 
 # -----------------------------------------------------------------------------
 # Development Commands
+#   These are currently prototypes to evaluate whether we want to switch over
+#   completely to nox for all our automation. Contributors should prefer using
+#   `tox -e ...` until this note is removed.
 # -----------------------------------------------------------------------------
 @nox.session(python=["2.7", "3.5", "3.6", "3.7", "pypy"])
 def test(session):


### PR DESCRIPTION
Toward #6721 

Spent a couple of hours after filing #7087, to look into porting our quirky tox setup to nox. I think this should seem less mysterious to someone who's not familiar with the automation tool being used.

I'm not proposing we switch over anything (CI/docs etc) to using nox for our development processes, just yet -- I want to test out this setup, and make sure that it does work well for local development work before exploring that.
