### PR TITLE
Simplify handling of PEP 517 metadata temp dir

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -594,23 +594,18 @@ class InstallRequirement(object):
                 )
                 self.req = Requirement(metadata_name)
 
-    def cleanup(self):
-        # type: () -> None
-        if self._temp_dir is not None:
-            self._temp_dir.cleanup()
-
     def prepare_pep517_metadata(self):
         # type: () -> None
         assert self.pep517_backend is not None
 
         # NOTE: This needs to be refactored to stop using atexit
-        self._temp_dir = TempDirectory(delete=False, kind="req-install")
+        temp_dir = TempDirectory(kind="modern-metadata")
+        atexit.register(temp_dir.cleanup)
+
         metadata_dir = os.path.join(
-            self._temp_dir.path,
+            temp_dir.path,
             'pip-wheel-metadata',
         )
-        atexit.register(self.cleanup)
-
         ensure_dir(metadata_dir)
 
         with self.build_env:


### PR DESCRIPTION
I think the diff is fairly self-explanatory?

- Not using `temp_dir` as a context manager here, so, the `delete` argument to `__init__` has no effect and has been dropped.
- Use a better, more descriptive name for temporary directory
- Drop an unnecessary (and incorrect<sup>1</sup>) `InstallRequirement.cleanup`

<sup>1</sup> `self._temp_dir` is not set anywhere except `prepare_pep517_metadata`, so it'll fail with an `AttributeError` for everything else.
