### PR TITLE
Move format_size to pip._internal.utils.ui

### DIFF
--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -26,7 +26,6 @@ from pip._internal.utils.misc import (
     backup_dir,
     consume,
     display_path,
-    format_size,
     hide_url,
     path_to_display,
     rmtree,
@@ -34,7 +33,7 @@ from pip._internal.utils.misc import (
 )
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.utils.ui import DownloadProgressProvider
+from pip._internal.utils.ui import DownloadProgressProvider, format_size
 from pip._internal.utils.unpacking import unpack_file
 from pip._internal.utils.urls import get_url_scheme
 from pip._internal.vcs import vcs

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -70,7 +70,7 @@ else:
 
 __all__ = ['rmtree', 'display_path', 'backup_dir',
            'ask', 'splitext',
-           'format_size', 'is_installable_dir',
+           'is_installable_dir',
            'normalize_path',
            'renames', 'get_prog',
            'call_subprocess',
@@ -272,18 +272,6 @@ def ask_password(message):
     """Ask for a password interactively."""
     _check_no_input(message)
     return getpass.getpass(message)
-
-
-def format_size(bytes):
-    # type: (float) -> str
-    if bytes > 1000 * 1000:
-        return '%.1fMB' % (bytes / 1000.0 / 1000)
-    elif bytes > 10 * 1000:
-        return '%ikB' % (bytes / 1000)
-    elif bytes > 1000:
-        return '%.1fkB' % (bytes / 1000.0)
-    else:
-        return '%ibytes' % bytes
 
 
 def is_installable_dir(path):

--- a/src/pip/_internal/utils/ui.py
+++ b/src/pip/_internal/utils/ui.py
@@ -17,7 +17,6 @@ from pip._vendor.progress.spinner import Spinner
 
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.logging import get_indentation
-from pip._internal.utils.misc import format_size
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -31,6 +30,18 @@ except Exception:
     colorama = None
 
 logger = logging.getLogger(__name__)
+
+
+def format_size(bytes):
+    # type: (float) -> str
+    if bytes > 1000 * 1000:
+        return '%.1fMB' % (bytes / 1000.0 / 1000)
+    elif bytes > 10 * 1000:
+        return '%ikB' % (bytes / 1000)
+    elif bytes > 1000:
+        return '%.1fkB' % (bytes / 1000.0)
+    else:
+        return '%ibytes' % bytes
 
 
 def _select_progress_class(preferred, fallback):


### PR DESCRIPTION
Why: This removes the only direct dependency of utils.ui on utils.misc

Decoupling these will enable me to write a helper, for cleaner spinner handling for PEP 517 hooks (and other builds we do) in our build processes.