### PR TITLE
Clarify `--no-binary` when enumerating packages and add an example

### DIFF
--- a/docs/html/reference/pip_wheel.rst
+++ b/docs/html/reference/pip_wheel.rst
@@ -71,3 +71,9 @@ Examples
 
       $ pip wheel --wheel-dir=/tmp/wheelhouse SomePackage
       $ pip install --no-index --find-links=/tmp/wheelhouse SomePackage
+
+#. Build a wheel for a package from source
+
+    ::
+
+      $ pip wheel --no-binary SomePackage SomePackage

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -454,9 +454,9 @@ def no_binary():
         help="Do not use binary packages. Can be supplied multiple times, and "
              "each time adds to the existing value. Accepts either :all: to "
              "disable all binary packages, :none: to empty the set, or one or "
-             "more package names with commas between them. Note that some "
-             "packages are tricky to compile and may fail to install when "
-             "this option is used on them.",
+             "more package names with commas between them (no colons). Note "
+             "that some packages are tricky to compile and may fail to "
+             "install when this option is used on them.",
     )
 
 


### PR DESCRIPTION
Minor tweak to `--no-binary` documentation to specify that when
enumerating packages, the colons are not needed. Additionally,
add an example to demonstrate building a wheel from source.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
