### PR TITLE
Optimize upgrade of already-satisfied pinned requirement

### DIFF
--- a/news/7132.feature
+++ b/news/7132.feature
@@ -1,0 +1,1 @@
+Skip reaching out to the package index, if a pinned version is already satisfied.

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -267,6 +267,10 @@ class Resolver(object):
         # requirements we have to pull the tree down and inspect to assess
         # the version #, so it's handled way down.
         if not req_to_install.link:
+            if req_to_install.is_pinned:
+                # No need to check the index for a better version.
+                return 'already satisfied'
+
             try:
                 self.finder.find_requirement(req_to_install, upgrade=True)
             except BestVersionAlreadyInstalled:


### PR DESCRIPTION
Example: after installing six 1.12.0, `pip install -Uv six==1.12.0` now returns immediately, instead of going to the index to check for a version that can’t possibly be considered better.

This optimization is most significant when upgrading via a requirements file with many pinned versions and some non-pinned versions.