### PR TITLE
Optimize upgrade of already-satisfied pinned requirement [re-push]

### DIFF
--- a/news/7133.feature
+++ b/news/7133.feature
@@ -1,0 +1,1 @@
+Optimize the upgrade of a pinned requirement that’s already satisfied to avoid hitting the package index.

--- a/src/pip/_internal/index.py
+++ b/src/pip/_internal/index.py
@@ -874,10 +874,15 @@ class PackageFinder(object):
         Returns a Link if found,
         Raises DistributionNotFound or BestVersionAlreadyInstalled otherwise
         """
-        hashes = req.hashes(trust_internet=False)
-        best_candidate_result = self.find_best_candidate(
-            req.name, specifier=req.specifier, hashes=hashes,
-        )
+        if req.is_pinned and req.satisfied_by is not None:
+            # Pinned version is already satisfied; no need to check
+            # the index for a better version.
+            best_candidate_result = BestCandidateResult([], [], None)
+        else:
+            hashes = req.hashes(trust_internet=False)
+            best_candidate_result = self.find_best_candidate(
+                req.name, specifier=req.specifier, hashes=hashes,
+            )
         best_candidate = best_candidate_result.best_candidate
 
         installed_version = None    # type: Optional[_BaseVersion]


### PR DESCRIPTION
(This is a re-push of 7132, which I’m scared to even link to because it gives a GitHub 500 error that doesn’t seem to be resolving itself. Feel free to close that one if you can figure out how.)

Example: after installing six 1.12.0, `pip install -Uv six==1.12.0` now returns immediately, instead of going to the index to check for a version that can’t possibly be considered better.

This optimization is most significant when upgrading via a requirements file with many pinned versions and some non-pinned versions.