### PR TITLE
Add a good-first-issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/~good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/~good-first-issue.md
@@ -1,0 +1,14 @@
+---
+name: (Maintainers Only) Good First Issue
+about: For maintainers, to create an issue that is good for new contributors
+
+---
+
+<!-- Write the issue below, provide clear instructions for resolution -->
+
+<!-- End of issue content. -->
+<!-- Leave the following intact -->
+
+---
+
+**Good First Issue**: This issue is a good starting point for first time contributors -- the process of fixing this should be a good introduction to pip's development workflow. If you've already contributed to pip, work on [another issue without this label](https://github.com/pypa/pip/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3A%22good+first+issue%22) instead. If there is not a corresponding pull request for this issue, it is up for grabs. For directions for getting set up, see our [Getting Started Guide](https://pip.pypa.io/en/latest/development/getting-started/). If you are working on this issue and have questions, feel free to ask them here, [`#pypa-dev` on Freenode](https://webchat.freenode.net/?channels=%23pypa-dev), or the [pypa-dev mailing list](https://groups.google.com/forum/#!forum/pypa-dev).

--- a/.github/ISSUE_TEMPLATE/~good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/~good-first-issue.md
@@ -1,6 +1,7 @@
 ---
 name: (Maintainers Only) Good First Issue
 about: For maintainers, to create an issue that is good for new contributors
+labels: ["good first issue"]
 
 ---
 


### PR DESCRIPTION
This is based on Warehouse's template, adapted to use language we
already use in our existing good-first-issues and with clearer
instructions for what's needed in these kinds of issues.
