### PR TITLE
WIP: Remove exhaustive file checks

### DIFF
--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -24,7 +24,7 @@ def test_download_if_requested(script):
         'download', '-d', 'pip_downloads', 'INITools==0.1'
     )
     assert Path('scratch') / 'pip_downloads' / 'INITools-0.1.tar.gz' \
-        in result.files_created
+        in result.files_created2
     assert script.site_packages / 'initools' not in result.files_created
 
 
@@ -33,11 +33,11 @@ def test_basic_download_setuptools(script):
     """
     It should download (in the scratch path) and not install if requested.
     """
-    result = script.pip('download', 'setuptools')
-    setuptools_prefix = str(Path('scratch') / 'setuptools')
-    assert any(
-        path.startswith(setuptools_prefix) for path in result.files_created
-    )
+    result = script.pip('download', 'setuptools')  # noqa
+    setuptools_prefix = str(Path('scratch') / 'setuptools')  # noqa
+    # assert any(
+    #     path.startswith(setuptools_prefix) for path in result.files_created
+    # )
 
 
 def test_download_wheel(script, data):
@@ -52,7 +52,7 @@ def test_download_wheel(script, data):
     )
     assert (
         Path('scratch') / 'meta-1.0-py2.py3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
     assert script.site_packages / 'piptestpackage' not in result.files_created
 
@@ -69,7 +69,7 @@ def test_single_download_from_requirements_file(script):
     result = script.pip(
         'download', '-r', script.scratch_path / 'test-req.txt', '-d', '.',
     )
-    assert Path('scratch') / 'INITools-0.1.tar.gz' in result.files_created
+    assert Path('scratch') / 'INITools-0.1.tar.gz' in result.files_created2
     assert script.site_packages / 'initools' not in result.files_created
 
 
@@ -81,11 +81,12 @@ def test_basic_download_should_download_dependencies(script):
     result = script.pip(
         'download', 'Paste[openid]==1.7.5.1', '-d', '.'
     )
-    assert Path('scratch') / 'Paste-1.7.5.1.tar.gz' in result.files_created
-    openid_tarball_prefix = str(Path('scratch') / 'python-openid-')
-    assert any(
-        path.startswith(openid_tarball_prefix) for path in result.files_created
-    )
+    assert Path('scratch') / 'Paste-1.7.5.1.tar.gz' in result.files_created2
+    openid_tarball_prefix = str(Path('scratch') / 'python-openid-')  # noqa
+    # assert any(
+    #     path.startswith(openid_tarball_prefix) for path in
+    #     result.files_created
+    # )
     assert script.site_packages / 'openid' not in result.files_created
 
 
@@ -99,7 +100,7 @@ def test_download_wheel_archive(script, data):
         'download', wheel_path,
         '-d', '.', '--no-deps'
     )
-    assert Path('scratch') / wheel_filename in result.files_created
+    assert Path('scratch') / wheel_filename in result.files_created2
 
 
 def test_download_should_download_wheel_deps(script, data):
@@ -113,8 +114,8 @@ def test_download_should_download_wheel_deps(script, data):
         'download', wheel_path,
         '-d', '.', '--find-links', data.find_links, '--no-index'
     )
-    assert Path('scratch') / wheel_filename in result.files_created
-    assert Path('scratch') / dep_filename in result.files_created
+    assert Path('scratch') / wheel_filename in result.files_created2
+    assert Path('scratch') / dep_filename in result.files_created2
 
 
 @pytest.mark.network
@@ -129,7 +130,7 @@ def test_download_should_skip_existing_files(script):
     result = script.pip(
         'download', '-r', script.scratch_path / 'test-req.txt', '-d', '.',
     )
-    assert Path('scratch') / 'INITools-0.1.tar.gz' in result.files_created
+    assert Path('scratch') / 'INITools-0.1.tar.gz' in result.files_created2
     assert script.site_packages / 'initools' not in result.files_created
 
     # adding second package to test-req.txt
@@ -142,10 +143,11 @@ def test_download_should_skip_existing_files(script):
     result = script.pip(
         'download', '-r', script.scratch_path / 'test-req.txt', '-d', '.',
     )
-    openid_tarball_prefix = str(Path('scratch') / 'python-openid-')
-    assert any(
-        path.startswith(openid_tarball_prefix) for path in result.files_created
-    )
+    openid_tarball_prefix = str(Path('scratch') / 'python-openid-')  # noqa
+    # assert any(
+    #     path.startswith(openid_tarball_prefix) for path in
+    #     result.files_created
+    # )
     assert Path('scratch') / 'INITools-0.1.tar.gz' not in result.files_created
     assert script.site_packages / 'initools' not in result.files_created
     assert script.site_packages / 'openid' not in result.files_created
@@ -161,7 +163,7 @@ def test_download_vcs_link(script):
     )
     assert (
         Path('scratch') / 'pip-test-package-0.1.1.zip'
-        in result.files_created
+        in result.files_created2
     )
     assert script.site_packages / 'piptestpackage' not in result.files_created
 
@@ -182,7 +184,7 @@ def test_only_binary_set_then_download_specific_platform(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
 
@@ -202,7 +204,7 @@ def test_no_deps_set_then_download_specific_platform(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
 
@@ -260,7 +262,7 @@ def test_download_specify_platform(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
     result = script.pip(
@@ -285,7 +287,7 @@ def test_download_specify_platform(script, data):
     assert (
         Path('scratch') /
         'fake-1.0-py2.py3-none-macosx_10_9_x86_64.whl'
-        in result.files_created
+        in result.files_created2
     )
 
     # OSX platform wheels are not backward-compatible.
@@ -317,7 +319,7 @@ def test_download_specify_platform(script, data):
     )
     assert (
         Path('scratch') / 'fake-2.0-py2.py3-none-linux_x86_64.whl'
-        in result.files_created
+        in result.files_created2
     )
 
 
@@ -346,7 +348,7 @@ class TestDownloadPlatformManylinuxes(object):
         )
         assert (
             Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
-            in result.files_created
+            in result.files_created2
         )
 
     @pytest.mark.parametrize("wheel_abi,platform", [
@@ -369,7 +371,7 @@ class TestDownloadPlatformManylinuxes(object):
             '--platform', platform,
             'fake',
         )
-        assert Path('scratch') / wheel in result.files_created
+        assert Path('scratch') / wheel in result.files_created2
 
     def test_explicit_platform_only(self, data, script):
         """
@@ -402,7 +404,7 @@ def test_download__python_version(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
     result = script.pip(
@@ -452,7 +454,7 @@ def test_download__python_version(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-py2-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
     result = script.pip(
@@ -472,7 +474,7 @@ def test_download__python_version(script, data):
     )
     assert (
         Path('scratch') / 'fake-2.0-py3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
 
@@ -549,7 +551,7 @@ def test_download_specify_abi(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
     result = script.pip(
@@ -583,7 +585,7 @@ def test_download_specify_abi(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-fk2-fakeabi-fake_platform.whl'
-        in result.files_created
+        in result.files_created2
     )
 
     result = script.pip(
@@ -613,7 +615,7 @@ def test_download_specify_implementation(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-py2.py3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
     data.reset()
@@ -627,7 +629,7 @@ def test_download_specify_implementation(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-fk2.fk3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
     data.reset()
@@ -642,7 +644,7 @@ def test_download_specify_implementation(script, data):
     )
     assert (
         Path('scratch') / 'fake-1.0-fk3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
 
     result = script.pip(
@@ -686,7 +688,7 @@ def test_download_prefer_binary_when_tarball_higher_than_wheel(script, data):
     )
     assert (
         Path('scratch') / 'source-0.8-py2.py3-none-any.whl'
-        in result.files_created
+        in result.files_created2
     )
     assert (
         Path('scratch') / 'source-1.0.tar.gz'
@@ -710,7 +712,7 @@ def test_download_prefer_binary_when_wheel_doesnt_satisfy_req(script, data):
     )
     assert (
         Path('scratch') / 'source-1.0.tar.gz'
-        in result.files_created
+        in result.files_created2
     )
     assert (
         Path('scratch') / 'source-0.8-py2.py3-none-any.whl'
@@ -728,5 +730,5 @@ def test_download_prefer_binary_when_only_tarball_exists(script, data):
     )
     assert (
         Path('scratch') / 'source-1.0.tar.gz'
-        in result.files_created
+        in result.files_created2
     )

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -113,7 +113,7 @@ def test_pep518_allows_missing_requires(script, data, common_wheels):
     assert "Installing build dependencies" in result.stdout, result.stdout
 
     assert result.returncode == 0
-    assert result.files_created
+    assert result.files_created2
 
 
 def test_pep518_with_user_pip(script, pip_src, data, common_wheels):
@@ -199,8 +199,8 @@ def test_pip_second_command_line_interface_works(
         script.site_packages / 'INITools-0.2-py%s.egg-info' % pyversion
     )
     initools_folder = script.site_packages / 'initools'
-    assert egg_info_folder in result.files_created, str(result)
-    assert initools_folder in result.files_created, str(result)
+    assert egg_info_folder in result.files_created2, str(result)
+    assert initools_folder in result.files_created2, str(result)
 
 
 def test_install_exit_status_code_when_no_requirements(script):
@@ -230,8 +230,8 @@ def test_basic_install_from_pypi(script):
         script.site_packages / 'INITools-0.2-py%s.egg-info' % pyversion
     )
     initools_folder = script.site_packages / 'initools'
-    assert egg_info_folder in result.files_created, str(result)
-    assert initools_folder in result.files_created, str(result)
+    assert egg_info_folder in result.files_created2, str(result)
+    assert initools_folder in result.files_created2, str(result)
 
     # Should not display where it's looking for files
     assert "Looking in indexes: " not in result.stdout
@@ -318,18 +318,18 @@ def test_install_editable_uninstalls_existing_from_path(script, data):
     assert 'Successfully installed simplewheel' in result.stdout
     simple_folder = script.site_packages / 'simplewheel'
     result.assert_installed('simplewheel', editable=False)
-    assert simple_folder in result.files_created, str(result.stdout)
+    assert simple_folder in result.files_created2, str(result.stdout)
 
     result = script.pip(
         'install', '-e',
         to_install,
     )
     install_path = script.site_packages / 'simplewheel.egg-link'
-    assert install_path in result.files_created, str(result)
+    assert install_path in result.files_created2, str(result)
     assert 'Found existing installation: simplewheel 1.0' in result.stdout
     assert 'Uninstalling simplewheel-' in result.stdout
     assert 'Successfully uninstalled simplewheel' in result.stdout
-    assert simple_folder in result.files_deleted, str(result.stdout)
+    assert simple_folder in result.files_deleted2, str(result.stdout)
 
 
 @need_mercurial
@@ -388,8 +388,8 @@ def test_basic_install_from_local_directory(script, data):
     egg_info_folder = (
         script.site_packages / 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
     )
-    assert fspkg_folder in result.files_created, str(result.stdout)
-    assert egg_info_folder in result.files_created, str(result)
+    assert fspkg_folder in result.files_created2, str(result.stdout)
+    assert egg_info_folder in result.files_created2, str(result)
 
 
 def test_basic_install_relative_directory(script, data):
@@ -417,14 +417,14 @@ def test_basic_install_relative_directory(script, data):
         # Regular install.
         result = script.pip('install', req_path,
                             cwd=script.scratch_path)
-        assert egg_info_file in result.files_created, str(result)
-        assert package_folder in result.files_created, str(result)
+        assert egg_info_file in result.files_created2, str(result)
+        assert package_folder in result.files_created2, str(result)
         script.pip('uninstall', '-y', 'fspkg')
 
         # Editable install.
         result = script.pip('install', '-e' + req_path,
                             cwd=script.scratch_path)
-        assert egg_link_file in result.files_created, str(result)
+        assert egg_link_file in result.files_created2, str(result)
         script.pip('uninstall', '-y', 'fspkg')
 
 
@@ -490,8 +490,8 @@ def test_install_from_local_directory_with_symlinks_to_directories(
     egg_info_folder = (
         script.site_packages / 'symlinks-0.1.dev0-py%s.egg-info' % pyversion
     )
-    assert pkg_folder in result.files_created, str(result.stdout)
-    assert egg_info_folder in result.files_created, str(result)
+    assert pkg_folder in result.files_created2, str(result.stdout)
+    assert egg_info_folder in result.files_created2, str(result)
 
 
 @pytest.mark.skipif("sys.platform == 'win32' or sys.version_info < (3,)")
@@ -512,8 +512,8 @@ def test_install_from_local_directory_with_socket_file(script, data, tmpdir):
     make_socket_file(socket_file_path)
 
     result = script.pip("install", "--verbose", to_install, expect_error=False)
-    assert package_folder in result.files_created, str(result.stdout)
-    assert egg_info_file in result.files_created, str(result)
+    assert package_folder in result.files_created2, str(result.stdout)
+    assert egg_info_file in result.files_created2, str(result)
     assert str(socket_file_path) in result.stderr
 
 
@@ -602,8 +602,8 @@ def test_install_curdir(script, data):
     egg_info_folder = (
         script.site_packages / 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
     )
-    assert fspkg_folder in result.files_created, str(result.stdout)
-    assert egg_info_folder in result.files_created, str(result)
+    assert fspkg_folder in result.files_created2, str(result.stdout)
+    assert egg_info_folder in result.files_created2, str(result)
 
 
 def test_install_pardir(script, data):
@@ -616,8 +616,8 @@ def test_install_pardir(script, data):
     egg_info_folder = (
         script.site_packages / 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
     )
-    assert fspkg_folder in result.files_created, str(result.stdout)
-    assert egg_info_folder in result.files_created, str(result)
+    assert fspkg_folder in result.files_created2, str(result.stdout)
+    assert egg_info_folder in result.files_created2, str(result)
 
 
 @pytest.mark.network
@@ -658,7 +658,7 @@ def test_install_using_install_option_and_editable(script, tmpdir):
         script.venv / 'src' / 'pip-test-package' /
         folder / 'pip-test-package' + script.exe
     )
-    assert script_file in result.files_created
+    assert script_file in result.files_created2
 
 
 @pytest.mark.network
@@ -683,7 +683,7 @@ def test_install_package_with_same_name_in_curdir(script):
     script.scratch_path.joinpath("mock==0.6").mkdir()
     result = script.pip('install', 'mock==0.6')
     egg_folder = script.site_packages / 'mock-0.6.0-py%s.egg-info' % pyversion
-    assert egg_folder in result.files_created, str(result)
+    assert egg_folder in result.files_created2, str(result)
 
 
 mock100_setup_py = textwrap.dedent('''\
@@ -701,7 +701,7 @@ def test_install_folder_using_dot_slash(script):
     pkg_path.joinpath("setup.py").write_text(mock100_setup_py)
     result = script.pip('install', './mock')
     egg_folder = script.site_packages / 'mock-100.1-py%s.egg-info' % pyversion
-    assert egg_folder in result.files_created, str(result)
+    assert egg_folder in result.files_created2, str(result)
 
 
 def test_install_folder_using_slash_in_the_end(script):
@@ -713,7 +713,7 @@ def test_install_folder_using_slash_in_the_end(script):
     pkg_path.joinpath("setup.py").write_text(mock100_setup_py)
     result = script.pip('install', 'mock' + os.path.sep)
     egg_folder = script.site_packages / 'mock-100.1-py%s.egg-info' % pyversion
-    assert egg_folder in result.files_created, str(result)
+    assert egg_folder in result.files_created2, str(result)
 
 
 def test_install_folder_using_relative_path(script):
@@ -726,7 +726,7 @@ def test_install_folder_using_relative_path(script):
     pkg_path.joinpath("setup.py").write_text(mock100_setup_py)
     result = script.pip('install', Path('initools') / 'mock')
     egg_folder = script.site_packages / 'mock-100.1-py%s.egg-info' % pyversion
-    assert egg_folder in result.files_created, str(result)
+    assert egg_folder in result.files_created2, str(result)
 
 
 @pytest.mark.network
@@ -740,8 +740,8 @@ def test_install_package_which_contains_dev_in_name(script):
         script.site_packages / 'django_devserver-0.0.4-py%s.egg-info' %
         pyversion
     )
-    assert devserver_folder in result.files_created, str(result.stdout)
-    assert egg_info_folder in result.files_created, str(result)
+    assert devserver_folder in result.files_created2, str(result.stdout)
+    assert egg_info_folder in result.files_created2, str(result)
 
 
 def test_install_package_with_target(script):
@@ -750,7 +750,7 @@ def test_install_package_with_target(script):
     """
     target_dir = script.scratch_path / 'target'
     result = script.pip_install_local('-t', target_dir, "simple==1.0")
-    assert Path('scratch') / 'target' / 'simple' in result.files_created, (
+    assert Path('scratch') / 'target' / 'simple' in result.files_created2, (
         str(result)
     )
 
@@ -758,28 +758,28 @@ def test_install_package_with_target(script):
     result = script.pip_install_local(
         '-t', target_dir, "simple==1.0", expect_stderr=True,
     )
-    assert not Path('scratch') / 'target' / 'simple' in result.files_updated
+    assert Path('scratch') / 'target' / 'simple' not in result.files_updated
 
     # Test upgrade call, check that new version is installed
     result = script.pip_install_local('--upgrade', '-t',
                                       target_dir, "simple==2.0")
-    assert Path('scratch') / 'target' / 'simple' in result.files_updated, (
+    assert Path('scratch') / 'target' / 'simple' in result.files_updated2, (
         str(result)
     )
     egg_folder = (
         Path('scratch') / 'target' / 'simple-2.0-py%s.egg-info' % pyversion)
-    assert egg_folder in result.files_created, (
+    assert egg_folder in result.files_created2, (
         str(result)
     )
 
     # Test install and upgrade of single-module package
     result = script.pip_install_local('-t', target_dir, 'singlemodule==0.0.0')
     singlemodule_py = Path('scratch') / 'target' / 'singlemodule.py'
-    assert singlemodule_py in result.files_created, str(result)
+    assert singlemodule_py in result.files_created2, str(result)
 
     result = script.pip_install_local('-t', target_dir, 'singlemodule==0.0.1',
                                       '--upgrade')
-    assert singlemodule_py in result.files_updated, str(result)
+    assert singlemodule_py in result.files_updated2, str(result)
 
 
 def test_install_nonlocal_compatible_wheel(script, data):
@@ -799,7 +799,7 @@ def test_install_nonlocal_compatible_wheel(script, data):
     assert result.returncode == SUCCESS
 
     distinfo = Path('scratch') / 'target' / 'simplewheel-2.0-1.dist-info'
-    assert distinfo in result.files_created
+    assert distinfo in result.files_created2
 
     # Test install without --target
     result = script.pip(
@@ -829,7 +829,7 @@ def test_install_nonlocal_compatible_wheel_path(script, data):
     assert result.returncode == SUCCESS
 
     distinfo = Path('scratch') / 'target' / 'simplewheel-2.0.dist-info'
-    assert distinfo in result.files_created
+    assert distinfo in result.files_created2
 
     # Test a full path requirement (without --target)
     result = script.pip(
@@ -889,7 +889,7 @@ def test_install_package_with_root(script, data):
         os.path.join(script.scratch, 'root'),
         normal_install_path
     )
-    assert root_path in result.files_created, str(result)
+    assert root_path in result.files_created2, str(result)
 
     # Should show find-links location in output
     assert "Looking in indexes: " not in result.stdout
@@ -911,7 +911,7 @@ def test_install_package_with_prefix(script, data):
         distutils.sysconfig.get_python_lib(prefix=rel_prefix_path) /
         'simple-1.0-py{}.egg-info'.format(pyversion)
     )
-    assert install_path in result.files_created, str(result)
+    assert install_path in result.files_created2, str(result)
 
 
 def test_install_editable_with_prefix(script):
@@ -942,7 +942,7 @@ def test_install_editable_with_prefix(script):
 
     # assert pkga is installed at correct location
     install_path = script.scratch / site_packages / 'pkga.egg-link'
-    assert install_path in result.files_created, str(result)
+    assert install_path in result.files_created2, str(result)
 
 
 def test_install_package_conflict_prefix_and_user(script, data):
@@ -1005,7 +1005,7 @@ def test_url_req_case_mismatch_no_index(script, data):
 
     # only Upper-1.0.tar.gz should get installed.
     egg_folder = script.site_packages / 'Upper-1.0-py%s.egg-info' % pyversion
-    assert egg_folder in result.files_created, str(result)
+    assert egg_folder in result.files_created2, str(result)
     egg_folder = script.site_packages / 'Upper-2.0-py%s.egg-info' % pyversion
     assert egg_folder not in result.files_created, str(result)
 
@@ -1032,7 +1032,7 @@ def test_url_req_case_mismatch_file_index(script, data):
 
     # only Upper-1.0.tar.gz should get installed.
     egg_folder = script.site_packages / 'Dinner-1.0-py%s.egg-info' % pyversion
-    assert egg_folder in result.files_created, str(result)
+    assert egg_folder in result.files_created2, str(result)
     egg_folder = script.site_packages / 'Dinner-2.0-py%s.egg-info' % pyversion
     assert egg_folder not in result.files_created, str(result)
 
@@ -1051,7 +1051,7 @@ def test_url_incorrect_case_no_index(script, data):
     egg_folder = script.site_packages / 'Upper-1.0-py%s.egg-info' % pyversion
     assert egg_folder not in result.files_created, str(result)
     egg_folder = script.site_packages / 'Upper-2.0-py%s.egg-info' % pyversion
-    assert egg_folder in result.files_created, str(result)
+    assert egg_folder in result.files_created2, str(result)
 
 
 def test_url_incorrect_case_file_index(script, data):
@@ -1069,7 +1069,7 @@ def test_url_incorrect_case_file_index(script, data):
     egg_folder = script.site_packages / 'Dinner-1.0-py%s.egg-info' % pyversion
     assert egg_folder not in result.files_created, str(result)
     egg_folder = script.site_packages / 'Dinner-2.0-py%s.egg-info' % pyversion
-    assert egg_folder in result.files_created, str(result)
+    assert egg_folder in result.files_created2, str(result)
 
     # Should show index-url location in output
     assert "Looking in indexes: " in result.stdout
@@ -1486,14 +1486,14 @@ def test_installed_files_recorded_in_deterministic_order(script, data):
     installed_files_path = (
         script.site_packages / egg_info / 'installed-files.txt'
     )
-    assert fspkg_folder in result.files_created, str(result.stdout)
-    assert installed_files_path in result.files_created, str(result)
+    assert fspkg_folder in result.files_created2, str(result.stdout)
+    assert installed_files_path in result.files_created2, str(result)
 
-    installed_files_path = result.files_created[installed_files_path].full
-    installed_files_lines = [
-        p for p in Path(installed_files_path).read_text().split('\n') if p
-    ]
-    assert installed_files_lines == sorted(installed_files_lines)
+    # installed_files_path = result.files_created[installed_files_path].full
+    # installed_files_lines = [
+    #     p for p in Path(installed_files_path).read_text().split('\n') if p
+    # ]
+    # assert installed_files_lines == sorted(installed_files_lines)
 
 
 def test_install_conflict_results_in_warning(script, data):
@@ -1553,7 +1553,7 @@ def test_target_install_ignores_distutils_config_install_prefix(script):
     result = script.pip_install_local('simplewheel', '-t', target)
     assert (
         "Successfully installed simplewheel" in result.stdout and
-        (target - script.base_path) in result.files_created and
+        (target - script.base_path) in result.files_created2 and
         (prefix - script.base_path) not in result.files_created
     ), str(result)
 

--- a/tests/functional/test_install_compat.py
+++ b/tests/functional/test_install_compat.py
@@ -30,7 +30,7 @@ def test_debian_egg_name_workaround(script):
     # so even if this test runs on a Debian/Ubuntu system with broken
     # setuptools, since our test runs inside a venv we'll still have the normal
     # .egg-info
-    assert egg_info in result.files_created, "Couldn't find %s" % egg_info
+    assert egg_info in result.files_created2, "Couldn't find %s" % egg_info
 
     # The Debian no-pyversion version of the .egg-info
     mangled = os.path.join(script.site_packages, "INITools-0.2.egg-info")

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -13,7 +13,7 @@ def test_simple_extras_install_from_pypi(script):
         'install', 'Paste[openid]==1.7.5.1', expect_stderr=True,
     )
     initools_folder = script.site_packages / 'openid'
-    assert initools_folder in result.files_created, result.files_created
+    assert initools_folder in result.files_created2, result.files_created
 
 
 def test_extras_after_wheel(script, data):
@@ -32,7 +32,7 @@ def test_extras_after_wheel(script, data):
         'install', '--no-index', '-f', data.find_links,
         'requires_simple_extra[extra]', expect_stderr=True,
     )
-    assert simple in extra.files_created, extra.files_created
+    assert simple in extra.files_created2, extra.files_created
 
 
 @pytest.mark.network
@@ -43,10 +43,10 @@ def test_no_extras_uninstall(script):
     result = script.pip(
         'install', 'Paste[openid]==1.7.5.1', expect_stderr=True,
     )
-    assert join(script.site_packages, 'paste') in result.files_created, (
+    assert join(script.site_packages, 'paste') in result.files_created2, (
         sorted(result.files_created.keys())
     )
-    assert join(script.site_packages, 'openid') in result.files_created, (
+    assert join(script.site_packages, 'openid') in result.files_created2, (
         sorted(result.files_created.keys())
     )
     result2 = script.pip('uninstall', 'Paste', '-y')

--- a/tests/functional/test_install_force_reinstall.py
+++ b/tests/functional/test_install_force_reinstall.py
@@ -23,7 +23,7 @@ def check_force_reinstall(script, specifier, expected):
     check_installed_version(script, 'simplewheel', '1.0')
 
     result2 = script.pip_install_local('--force-reinstall', specifier)
-    assert result2.files_updated, 'force-reinstall failed'
+    assert result2.files_updated2, 'force-reinstall failed'
     check_installed_version(script, 'simplewheel', expected)
 
     result3 = script.pip('uninstall', 'simplewheel', '-y')

--- a/tests/functional/test_install_index.py
+++ b/tests/functional/test_install_index.py
@@ -20,8 +20,8 @@ def test_find_links_relative_path(script, data):
         script.site_packages / 'parent-0.1-py%s.egg-info' % pyversion
     )
     initools_folder = script.site_packages / 'parent'
-    assert egg_info_folder in result.files_created, str(result)
-    assert initools_folder in result.files_created, str(result)
+    assert egg_info_folder in result.files_created2, str(result)
+    assert initools_folder in result.files_created2, str(result)
 
 
 def test_find_links_requirements_file_relative_path(script, data):
@@ -41,8 +41,8 @@ def test_find_links_requirements_file_relative_path(script, data):
         script.site_packages / 'parent-0.1-py%s.egg-info' % pyversion
     )
     initools_folder = script.site_packages / 'parent'
-    assert egg_info_folder in result.files_created, str(result)
-    assert initools_folder in result.files_created, str(result)
+    assert egg_info_folder in result.files_created2, str(result)
+    assert initools_folder in result.files_created2, str(result)
 
 
 def test_install_from_file_index_hash_link(script, data):
@@ -54,7 +54,7 @@ def test_install_from_file_index_hash_link(script, data):
     egg_info_folder = (
         script.site_packages / 'simple-1.0-py%s.egg-info' % pyversion
     )
-    assert egg_info_folder in result.files_created, str(result)
+    assert egg_info_folder in result.files_created2, str(result)
 
 
 def test_file_index_url_quoting(script, data):
@@ -66,9 +66,9 @@ def test_file_index_url_quoting(script, data):
         'install', '-vvv', '--index-url', index_url, 'simple',
         expect_error=False,
     )
-    assert (script.site_packages / 'simple') in result.files_created, (
+    assert (script.site_packages / 'simple') in result.files_created2, (
         str(result.stdout)
     )
     assert (
         script.site_packages / 'simple-1.0-py%s.egg-info' % pyversion
-    ) in result.files_created, str(result)
+    ) in result.files_created2, str(result)

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -29,12 +29,12 @@ def test_requirements_file(script):
     )
     assert (
         script.site_packages / 'INITools-0.2-py%s.egg-info' %
-        pyversion in result.files_created
+        pyversion in result.files_created2
     )
-    assert script.site_packages / 'initools' in result.files_created
-    assert result.files_created[script.site_packages / other_lib_name].dir
+    assert script.site_packages / 'initools' in result.files_created2
+    assert result.files_created2[script.site_packages / other_lib_name].dir
     fn = '%s-%s-py%s.egg-info' % (other_lib_name, other_lib_version, pyversion)
-    assert result.files_created[script.site_packages / fn].dir
+    assert result.files_created2[script.site_packages / fn].dir
 
 
 def test_schema_check_in_requirements_file(script):
@@ -83,8 +83,8 @@ def test_relative_requirements_file(script, data):
                                script.scratch_path) as reqs_file:
             result = script.pip('install', '-vvv', '-r', reqs_file.name,
                                 cwd=script.scratch_path)
-            assert egg_info_file in result.files_created, str(result)
-            assert package_folder in result.files_created, str(result)
+            assert egg_info_file in result.files_created2, str(result)
+            assert package_folder in result.files_created2, str(result)
             script.pip('uninstall', '-y', 'fspkg')
 
         # Editable install.
@@ -92,7 +92,7 @@ def test_relative_requirements_file(script, data):
                                script.scratch_path) as reqs_file:
             result = script.pip('install', '-vvv', '-r', reqs_file.name,
                                 cwd=script.scratch_path)
-            assert egg_link_file in result.files_created, str(result)
+            assert egg_link_file in result.files_created2, str(result)
             script.pip('uninstall', '-y', 'fspkg')
 
 
@@ -120,10 +120,10 @@ def test_multiple_requirements_files(script, tmpdir):
     result = script.pip(
         'install', '-r', script.scratch_path / 'initools-req.txt'
     )
-    assert result.files_created[script.site_packages / other_lib_name].dir
+    assert result.files_created2[script.site_packages / other_lib_name].dir
     fn = '%s-%s-py%s.egg-info' % (other_lib_name, other_lib_version, pyversion)
-    assert result.files_created[script.site_packages / fn].dir
-    assert script.venv / 'src' / 'initools' in result.files_created
+    assert result.files_created2[script.site_packages / fn].dir
+    assert script.venv / 'src' / 'initools' in result.files_created2
 
 
 def test_package_in_constraints_and_dependencies(script, data):
@@ -179,13 +179,13 @@ def test_install_local_editable_with_extras(script, data):
         expect_error=False,
         expect_stderr=True,
     )
-    assert script.site_packages / 'easy-install.pth' in res.files_updated, (
+    assert script.site_packages / 'easy-install.pth' in res.files_updated2, (
         str(res)
     )
     assert (
-        script.site_packages / 'LocalExtras.egg-link' in res.files_created
+        script.site_packages / 'LocalExtras.egg-link' in res.files_created2
     ), str(res)
-    assert script.site_packages / 'simple' in res.files_created, str(res)
+    assert script.site_packages / 'simple' in res.files_created2, str(res)
 
 
 def test_install_collected_dependencies_first(script):
@@ -265,7 +265,7 @@ def test_install_option_in_requirements_file(script, data, virtualenv):
         expect_stderr=True)
 
     package_dir = script.scratch / 'home1' / 'lib' / 'python' / 'simple'
-    assert package_dir in result.files_created
+    assert package_dir in result.files_created2
 
 
 def test_constraints_not_installed_by_default(script, data):
@@ -389,7 +389,7 @@ def test_install_with_extras_from_constraints(script, data):
     )
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', 'LocalExtras')
-    assert script.site_packages / 'simple' in result.files_created
+    assert script.site_packages / 'simple' in result.files_created2
 
 
 def test_install_with_extras_from_install(script, data):
@@ -399,7 +399,7 @@ def test_install_with_extras_from_install(script, data):
     )
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', 'LocalExtras[baz]')
-    assert script.site_packages / 'singlemodule.py'in result.files_created
+    assert script.site_packages / 'singlemodule.py'in result.files_created2
 
 
 def test_install_with_extras_joined(script, data):
@@ -410,8 +410,8 @@ def test_install_with_extras_joined(script, data):
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', 'LocalExtras[baz]'
     )
-    assert script.site_packages / 'simple' in result.files_created
-    assert script.site_packages / 'singlemodule.py'in result.files_created
+    assert script.site_packages / 'simple' in result.files_created2
+    assert script.site_packages / 'singlemodule.py'in result.files_created2
 
 
 def test_install_with_extras_editable_joined(script, data):
@@ -421,8 +421,8 @@ def test_install_with_extras_editable_joined(script, data):
     )
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', 'LocalExtras[baz]')
-    assert script.site_packages / 'simple' in result.files_created
-    assert script.site_packages / 'singlemodule.py'in result.files_created
+    assert script.site_packages / 'simple' in result.files_created2
+    assert script.site_packages / 'singlemodule.py'in result.files_created2
 
 
 def test_install_distribution_full_union(script, data):
@@ -430,8 +430,8 @@ def test_install_distribution_full_union(script, data):
     result = script.pip_install_local(
         to_install, to_install + "[bar]", to_install + "[baz]")
     assert 'Running setup.py install for LocalExtras' in result.stdout
-    assert script.site_packages / 'simple' in result.files_created
-    assert script.site_packages / 'singlemodule.py' in result.files_created
+    assert script.site_packages / 'simple' in result.files_created2
+    assert script.site_packages / 'singlemodule.py' in result.files_created2
 
 
 def test_install_distribution_duplicate_extras(script, data):
@@ -449,7 +449,7 @@ def test_install_distribution_union_with_constraints(script, data):
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', to_install + '[baz]')
     assert 'Running setup.py install for LocalExtras' in result.stdout
-    assert script.site_packages / 'singlemodule.py' in result.files_created
+    assert script.site_packages / 'singlemodule.py' in result.files_created2
 
 
 def test_install_distribution_union_with_versions(script, data):
@@ -536,8 +536,8 @@ def test_install_options_local_to_package(script, data):
     simple = test_simple / 'lib' / 'python' / 'simple'
     bad = test_simple / 'lib' / 'python' / 'initools'
     good = script.site_packages / 'initools'
-    assert simple in result.files_created
-    assert result.files_created[simple].dir
+    assert simple in result.files_created2
+    assert result.files_created2[simple].dir
     assert bad not in result.files_created
-    assert good in result.files_created
-    assert result.files_created[good].dir
+    assert good in result.files_created2
+    assert result.files_created2[good].dir

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -74,11 +74,11 @@ def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(script):
     ), "should have installed require_simple==1.0"
     assert (
         script.site_packages / 'simple-3.0-py%s.egg-info' %
-        pyversion in result.files_created
+        pyversion in result.files_created2
     ), "should have installed simple==3.0"
     assert (
         script.site_packages / 'simple-1.0-py%s.egg-info' %
-        pyversion in result.files_deleted
+        pyversion in result.files_deleted2
     ), "should have uninstalled simple==1.0"
 
 
@@ -98,7 +98,7 @@ def test_eager_does_upgrade_dependecies_when_currently_satisfied(script):
     ), "should have installed require_simple==1.0"
     assert (
         (script.site_packages / 'simple-2.0-py%s.egg-info' % pyversion)
-        in result.files_deleted
+        in result.files_deleted2
     ), "should have uninstalled simple==2.0"
 
 
@@ -118,11 +118,11 @@ def test_eager_does_upgrade_dependecies_when_no_longer_satisfied(script):
     ), "should have installed require_simple==1.0"
     assert (
         script.site_packages / 'simple-3.0-py%s.egg-info' %
-        pyversion in result.files_created
+        pyversion in result.files_created2
     ), "should have installed simple==3.0"
     assert (
         script.site_packages / 'simple-1.0-py%s.egg-info' %
-        pyversion in result.files_deleted
+        pyversion in result.files_deleted2
     ), "should have uninstalled simple==1.0"
 
 
@@ -134,16 +134,16 @@ def test_upgrade_to_specific_version(script):
     """
     script.pip('install', 'INITools==0.1')
     result = script.pip('install', 'INITools==0.2')
-    assert result.files_created, (
+    assert result.files_created2, (
         'pip install with specific version did not upgrade'
     )
     assert (
         script.site_packages / 'INITools-0.1-py%s.egg-info' %
-        pyversion in result.files_deleted
+        pyversion in result.files_deleted2
     )
     assert (
         script.site_packages / 'INITools-0.2-py%s.egg-info' %
-        pyversion in result.files_created
+        pyversion in result.files_created2
     )
 
 
@@ -155,7 +155,7 @@ def test_upgrade_if_requested(script):
     """
     script.pip('install', 'INITools==0.1')
     result = script.pip('install', '--upgrade', 'INITools')
-    assert result.files_created, 'pip install --upgrade did not upgrade'
+    assert result.files_created2, 'pip install --upgrade did not upgrade'
     assert (
         script.site_packages / 'INITools-0.1-py%s.egg-info' %
         pyversion not in result.files_created
@@ -182,13 +182,13 @@ def test_upgrade_force_reinstall_newest(script):
     version if --force-reinstall is supplied.
     """
     result = script.pip('install', 'INITools')
-    assert script.site_packages / 'initools' in result.files_created, (
+    assert script.site_packages / 'initools' in result.files_created2, (
         sorted(result.files_created.keys())
     )
     result2 = script.pip(
         'install', '--upgrade', '--force-reinstall', 'INITools'
     )
-    assert result2.files_updated, 'upgrade to INITools 0.3 failed'
+    assert result2.files_updated2, 'upgrade to INITools 0.3 failed'
     result3 = script.pip('uninstall', 'initools', '-y')
     assert_all_changes(result, result3, [script.venv / 'build', 'cache'])
 
@@ -200,11 +200,11 @@ def test_uninstall_before_upgrade(script):
 
     """
     result = script.pip('install', 'INITools==0.2')
-    assert script.site_packages / 'initools' in result.files_created, (
+    assert script.site_packages / 'initools' in result.files_created2, (
         sorted(result.files_created.keys())
     )
     result2 = script.pip('install', 'INITools==0.3')
-    assert result2.files_created, 'upgrade to INITools 0.3 failed'
+    assert result2.files_created2, 'upgrade to INITools 0.3 failed'
     result3 = script.pip('uninstall', 'initools', '-y')
     assert_all_changes(result, result3, [script.venv / 'build', 'cache'])
 
@@ -216,7 +216,7 @@ def test_uninstall_before_upgrade_from_url(script):
 
     """
     result = script.pip('install', 'INITools==0.2')
-    assert script.site_packages / 'initools' in result.files_created, (
+    assert script.site_packages / 'initools' in result.files_created2, (
         sorted(result.files_created.keys())
     )
     result2 = script.pip(
@@ -224,7 +224,7 @@ def test_uninstall_before_upgrade_from_url(script):
         'https://files.pythonhosted.org/packages/source/I/INITools/INITools-'
         '0.3.tar.gz',
     )
-    assert result2.files_created, 'upgrade to INITools 0.3 failed'
+    assert result2.files_created2, 'upgrade to INITools 0.3 failed'
     result3 = script.pip('uninstall', 'initools', '-y')
     assert_all_changes(result, result3, [script.venv / 'build', 'cache'])
 
@@ -237,7 +237,7 @@ def test_upgrade_to_same_version_from_url(script):
 
     """
     result = script.pip('install', 'INITools==0.3')
-    assert script.site_packages / 'initools' in result.files_created, (
+    assert script.site_packages / 'initools' in result.files_created2, (
         sorted(result.files_created.keys())
     )
     result2 = script.pip(
@@ -291,7 +291,7 @@ def test_uninstall_rollback(script, data):
     result = script.pip(
         'install', '-f', data.find_links, '--no-index', 'broken==0.1'
     )
-    assert script.site_packages / 'broken.py' in result.files_created, list(
+    assert script.site_packages / 'broken.py' in result.files_created2, list(
         result.files_created.keys()
     )
     result2 = script.pip(
@@ -324,7 +324,7 @@ def test_should_not_install_always_from_cache(script):
     )
     assert (
         script.site_packages / 'INITools-0.1-py%s.egg-info' %
-        pyversion in result.files_created
+        pyversion in result.files_created2
     )
 
 
@@ -335,7 +335,7 @@ def test_install_with_ignoreinstalled_requested(script):
     """
     script.pip('install', 'INITools==0.1')
     result = script.pip('install', '-I', 'INITools==0.3')
-    assert result.files_created, 'pip install -I did not install'
+    assert result.files_created2, 'pip install -I did not install'
     # both the old and new metadata should be present.
     assert os.path.exists(
         script.site_packages_path / 'INITools-0.1-py%s.egg-info' % pyversion

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -68,12 +68,12 @@ class Tests_UserSite:
         )
 
         fspkg_folder = script.user_site / 'fspkg'
-        assert fspkg_folder in result.files_created, result.stdout
+        assert fspkg_folder in result.files_created2, result.stdout
 
         dist_info_folder = (
             script.user_site / 'FSPkg-0.1.dev0.dist-info'
         )
-        assert dist_info_folder in result.files_created
+        assert dist_info_folder in result.files_created2
 
     @pytest.mark.incompatible_with_test_venv
     def test_install_user_venv_nositepkgs_fails(self, virtualenv,
@@ -115,7 +115,7 @@ class Tests_UserSite:
             script.base_path / script.user_site / 'initools' /
             'configparser.py'
         )
-        assert egg_info_folder in result2.files_created, str(result2)
+        assert egg_info_folder in result2.files_created2, str(result2)
         assert not isfile(initools_v3_file), initools_v3_file
 
     @pytest.mark.network
@@ -136,8 +136,8 @@ class Tests_UserSite:
             script.user_site / 'INITools-0.1-py%s.egg-info' % pyversion
         )
         initools_folder = script.user_site / 'initools'
-        assert egg_info_folder in result2.files_created, str(result2)
-        assert initools_folder in result2.files_created, str(result2)
+        assert egg_info_folder in result2.files_created2, str(result2)
+        assert initools_folder in result2.files_created2, str(result2)
 
         # site still has 0.2 (can't look in result1; have to check)
         egg_info_folder = (
@@ -165,8 +165,8 @@ class Tests_UserSite:
             script.user_site / 'INITools-0.3.1-py%s.egg-info' % pyversion
         )
         initools_folder = script.user_site / 'initools'
-        assert egg_info_folder in result2.files_created, str(result2)
-        assert initools_folder in result2.files_created, str(result2)
+        assert egg_info_folder in result2.files_created2, str(result2)
+        assert initools_folder in result2.files_created2, str(result2)
 
         # site still has 0.2 (can't look in result1; have to check)
         egg_info_folder = (
@@ -201,7 +201,7 @@ class Tests_UserSite:
             script.base_path / script.user_site / 'initools' /
             'configparser.py'
         )
-        assert egg_info_folder in result3.files_created, str(result3)
+        assert egg_info_folder in result3.files_created2, str(result3)
         assert not isfile(initools_v3_file), initools_v3_file
 
         # site still has 0.2 (can't just look in result1; have to check)

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -176,7 +176,7 @@ def test_install_noneditable_git(script, tmpdir):
     result.assert_installed('piptestpackage',
                             without_egg_link=True,
                             editable=False)
-    assert egg_info_folder in result.files_created, str(result)
+    assert egg_info_folder in result.files_created2, str(result)
 
 
 def test_git_with_sha1_revisions(script):
@@ -341,7 +341,7 @@ def test_git_with_non_editable_where_egg_contains_dev_string(script, tmpdir):
     )
     result = script.pip('install', local_url)
     devserver_folder = script.site_packages / 'devserver'
-    assert devserver_folder in result.files_created, str(result)
+    assert devserver_folder in result.files_created2, str(result)
 
 
 def test_git_with_ambiguous_revs(script):
@@ -458,7 +458,7 @@ def test_check_submodule_addition(script):
     )
     assert (
         script.venv / 'src/version-pkg/testpkg/static/testfile'
-        in install_result.files_created
+        in install_result.files_created2
     )
 
     _change_test_package_submodule(script, submodule_path)
@@ -474,5 +474,5 @@ def test_check_submodule_addition(script):
 
     assert (
         script.venv / 'src/version-pkg/testpkg/static/testfile2'
-        in update_result.files_created
+        in update_result.files_created2
     )

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -16,6 +16,7 @@ def test_install_from_future_wheel_version(script, data):
     package = data.packages.joinpath("futurewheel-3.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=True)
     with pytest.raises(TestFailure):
+        raise TestFailure()
         result.assert_installed('futurewheel', without_egg_link=True,
                                 editable=False)
 
@@ -36,6 +37,7 @@ def test_install_from_broken_wheel(script, data):
     package = data.packages.joinpath("brokenwheel-1.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=True)
     with pytest.raises(TestFailure):
+        raise TestFailure()
         result.assert_installed('futurewheel', without_egg_link=True,
                                 editable=False)
 
@@ -50,11 +52,11 @@ def test_basic_install_from_wheel(script, data):
         expect_error=False,
     )
     dist_info_folder = script.site_packages / 'has.script-1.0.dist-info'
-    assert dist_info_folder in result.files_created, (dist_info_folder,
-                                                      result.files_created,
-                                                      result.stdout)
+    assert dist_info_folder in result.files_created2, (dist_info_folder,
+                                                       result.files_created,
+                                                       result.stdout)
     script_file = script.bin / 'script.py'
-    assert script_file in result.files_created
+    assert script_file in result.files_created2
 
 
 def test_basic_install_from_wheel_with_extras(script, data):
@@ -67,13 +69,13 @@ def test_basic_install_from_wheel_with_extras(script, data):
         expect_error=False,
     )
     dist_info_folder = script.site_packages / 'complex_dist-0.1.dist-info'
-    assert dist_info_folder in result.files_created, (dist_info_folder,
-                                                      result.files_created,
-                                                      result.stdout)
+    assert dist_info_folder in result.files_created2, (dist_info_folder,
+                                                       result.files_created,
+                                                       result.stdout)
     dist_info_folder = script.site_packages / 'simple.dist-0.1.dist-info'
-    assert dist_info_folder in result.files_created, (dist_info_folder,
-                                                      result.files_created,
-                                                      result.stdout)
+    assert dist_info_folder in result.files_created2, (dist_info_folder,
+                                                       result.files_created,
+                                                       result.stdout)
 
 
 def test_basic_install_from_wheel_file(script, data):
@@ -83,13 +85,13 @@ def test_basic_install_from_wheel_file(script, data):
     package = data.packages.joinpath("simple.dist-0.1-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=False)
     dist_info_folder = script.site_packages / 'simple.dist-0.1.dist-info'
-    assert dist_info_folder in result.files_created, (dist_info_folder,
-                                                      result.files_created,
-                                                      result.stdout)
+    assert dist_info_folder in result.files_created2, (dist_info_folder,
+                                                       result.files_created,
+                                                       result.stdout)
     installer = dist_info_folder / 'INSTALLER'
-    assert installer in result.files_created, (dist_info_folder,
-                                               result.files_created,
-                                               result.stdout)
+    assert installer in result.files_created2, (dist_info_folder,
+                                                result.files_created,
+                                                result.stdout)
     with open(script.base_path / installer, 'rb') as installer_file:
         installer_details = installer_file.read()
         assert installer_details == b'pip\n'
@@ -106,9 +108,9 @@ def test_install_from_wheel_with_headers(script, data):
     package = data.packages.joinpath("headers.dist-0.1-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=False)
     dist_info_folder = script.site_packages / 'headers.dist-0.1.dist-info'
-    assert dist_info_folder in result.files_created, (dist_info_folder,
-                                                      result.files_created,
-                                                      result.stdout)
+    assert dist_info_folder in result.files_created2, (dist_info_folder,
+                                                       result.files_created,
+                                                       result.stdout)
 
 
 def test_install_wheel_with_target(script, data, with_wheel):
@@ -120,9 +122,9 @@ def test_install_wheel_with_target(script, data, with_wheel):
         'install', 'simple.dist==0.1', '-t', target_dir,
         '--no-index', '--find-links=' + data.find_links,
     )
-    assert Path('scratch') / 'target' / 'simpledist' in result.files_created, (
-        str(result)
-    )
+    assert (
+        Path('scratch') / 'target' / 'simpledist' in result.files_created2
+    ), str(result)
 
 
 def test_install_wheel_with_target_and_data_files(script, data, with_wheel):
@@ -154,9 +156,9 @@ def test_install_wheel_with_target_and_data_files(script, data, with_wheel):
                         expect_error=False)
 
     assert (Path('scratch') / 'prjwithdatafile' / 'packages1' / 'README.txt'
-            in result.files_created), str(result)
+            in result.files_created2), str(result)
     assert (Path('scratch') / 'prjwithdatafile' / 'packages2' / 'README.txt'
-            in result.files_created), str(result)
+            in result.files_created2), str(result)
     assert (Path('scratch') / 'prjwithdatafile' / 'lib' / 'python'
             not in result.files_created), str(result)
 
@@ -170,7 +172,7 @@ def test_install_wheel_with_root(script, data):
         'install', 'simple.dist==0.1', '--root', root_dir,
         '--no-index', '--find-links=' + data.find_links,
     )
-    assert Path('scratch') / 'root' in result.files_created
+    assert Path('scratch') / 'root' in result.files_created2
 
 
 def test_install_wheel_with_prefix(script, data):
@@ -183,7 +185,7 @@ def test_install_wheel_with_prefix(script, data):
         '--no-index', '--find-links=' + data.find_links,
     )
     lib = distutils.sysconfig.get_python_lib(prefix=Path('scratch') / 'prefix')
-    assert lib in result.files_created, str(result)
+    assert lib in result.files_created2, str(result)
 
 
 def test_install_from_wheel_installs_deps(script, data):
@@ -223,14 +225,14 @@ def test_wheel_record_lines_in_deterministic_order(script, data):
     dist_info_folder = script.site_packages / 'simplewheel-1.0.dist-info'
     record_path = dist_info_folder / 'RECORD'
 
-    assert dist_info_folder in result.files_created, str(result)
-    assert record_path in result.files_created, str(result)
+    assert dist_info_folder in result.files_created2, str(result)
+    assert record_path in result.files_created2, str(result)
 
-    record_path = result.files_created[record_path].full
-    record_lines = [
-        p for p in Path(record_path).read_text().split('\n') if p
-    ]
-    assert record_lines == sorted(record_lines)
+    # record_path = result.files_created[record_path].full
+    # record_lines = [
+    #     p for p in Path(record_path).read_text().split('\n') if p
+    # ]
+    # assert record_lines == sorted(record_lines)
 
 
 def test_install_user_wheel(script, data, with_wheel):
@@ -242,9 +244,9 @@ def test_install_user_wheel(script, data, with_wheel):
         '--find-links=' + data.find_links,
     )
     egg_info_folder = script.user_site / 'has.script-1.0.dist-info'
-    assert egg_info_folder in result.files_created, str(result)
+    assert egg_info_folder in result.files_created2, str(result)
     script_file = script.user_bin / 'script.py'
-    assert script_file in result.files_created, str(result)
+    assert script_file in result.files_created2, str(result)
 
 
 def test_install_from_wheel_gen_entrypoint(script, data):
@@ -260,7 +262,7 @@ def test_install_from_wheel_gen_entrypoint(script, data):
         wrapper_file = script.bin / 't1.exe'
     else:
         wrapper_file = script.bin / 't1'
-    assert wrapper_file in result.files_created
+    assert wrapper_file in result.files_created2
 
     if os.name != "nt":
         assert bool(os.access(script.base_path / wrapper_file, os.X_OK))
@@ -280,7 +282,7 @@ def test_install_from_wheel_gen_uppercase_entrypoint(script, data):
         wrapper_file = script.bin / 'cmdName.exe'
     else:
         wrapper_file = script.bin / 'cmdName'
-    assert wrapper_file in result.files_created
+    assert wrapper_file in result.files_created2
 
     if os.name != "nt":
         assert bool(os.access(script.base_path / wrapper_file, os.X_OK))
@@ -299,8 +301,8 @@ def test_install_from_wheel_with_legacy(script, data):
     legacy_file1 = script.bin / 'testscript1.bat'
     legacy_file2 = script.bin / 'testscript2'
 
-    assert legacy_file1 in result.files_created
-    assert legacy_file2 in result.files_created
+    assert legacy_file1 in result.files_created2
+    assert legacy_file2 in result.files_created2
 
 
 def test_install_from_wheel_no_setuptools_entrypoint(script, data):
@@ -324,7 +326,7 @@ def test_install_from_wheel_no_setuptools_entrypoint(script, data):
     # is present and that the -script.py helper has been skipped. We can't
     # easily test that the wrapper from the wheel has been skipped /
     # overwritten without getting very platform-dependent, so omit that.
-    assert wrapper_file in result.files_created
+    assert wrapper_file in result.files_created2
     assert wrapper_helper not in result.files_created
 
 
@@ -343,8 +345,8 @@ def test_skipping_setuptools_doesnt_skip_legacy(script, data):
     legacy_file2 = script.bin / 'testscript2'
     wrapper_helper = script.bin / 't1-script.py'
 
-    assert legacy_file1 in result.files_created
-    assert legacy_file2 in result.files_created
+    assert legacy_file1 in result.files_created2
+    assert legacy_file2 in result.files_created2
     assert wrapper_helper not in result.files_created
 
 
@@ -361,7 +363,7 @@ def test_install_from_wheel_gui_entrypoint(script, data):
         wrapper_file = script.bin / 't1.exe'
     else:
         wrapper_file = script.bin / 't1'
-    assert wrapper_file in result.files_created
+    assert wrapper_file in result.files_created2
 
 
 def test_wheel_compiles_pyc(script, data):
@@ -413,7 +415,7 @@ def test_install_from_wheel_uninstalls_old_version(script, data):
     package = data.packages.joinpath("simplewheel-2.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index', expect_error=False)
     dist_info_folder = script.site_packages / 'simplewheel-2.0.dist-info'
-    assert dist_info_folder in result.files_created
+    assert dist_info_folder in result.files_created2
     dist_info_folder = script.site_packages / 'simplewheel-1.0.dist-info'
     assert dist_info_folder not in result.files_created
 

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -24,7 +24,7 @@ def test_basic_uninstall(script):
 
     """
     result = script.pip('install', 'INITools==0.2')
-    assert join(script.site_packages, 'initools') in result.files_created, (
+    assert join(script.site_packages, 'initools') in result.files_created2, (
         sorted(result.files_created.keys())
     )
     # the import forces the generation of __pycache__ if the version of python
@@ -69,8 +69,8 @@ def test_basic_uninstall_with_scripts(script):
     """
     result = script.easy_install('PyLogo', expect_stderr=True)
     easy_install_pth = script.site_packages / 'easy-install.pth'
-    pylogo = sys.platform == 'win32' and 'pylogo' or 'PyLogo'
-    assert(pylogo in result.files_updated[easy_install_pth].bytes)
+    pylogo = sys.platform == 'win32' and 'pylogo' or 'PyLogo'  # noqa
+    # assert(pylogo in result.files_updated2[easy_install_pth].bytes)
     result2 = script.pip('uninstall', 'pylogo', '-y')
     assert_all_changes(
         result,
@@ -143,16 +143,16 @@ def test_basic_uninstall_namespace_package(script):
 
     """
     result = script.pip('install', 'pd.requires==0.0.3')
-    assert join(script.site_packages, 'pd') in result.files_created, (
+    assert join(script.site_packages, 'pd') in result.files_created2, (
         sorted(result.files_created.keys())
     )
     result2 = script.pip('uninstall', 'pd.find', '-y')
     assert join(script.site_packages, 'pd') not in result2.files_deleted, (
         sorted(result2.files_deleted.keys())
     )
-    assert join(script.site_packages, 'pd', 'find') in result2.files_deleted, (
-        sorted(result2.files_deleted.keys())
-    )
+    assert (
+        join(script.site_packages, 'pd', 'find') in result2.files_deleted2
+    ), sorted(result2.files_deleted.keys())
 
 
 def test_uninstall_overlapping_package(script, data):
@@ -167,26 +167,26 @@ def test_uninstall_overlapping_package(script, data):
     child_pkg = data.packages.joinpath("child-0.1.tar.gz")
 
     result1 = script.pip('install', parent_pkg, expect_error=False)
-    assert join(script.site_packages, 'parent') in result1.files_created, (
+    assert join(script.site_packages, 'parent') in result1.files_created2, (
         sorted(result1.files_created.keys())
     )
     result2 = script.pip('install', child_pkg, expect_error=False)
-    assert join(script.site_packages, 'child') in result2.files_created, (
+    assert join(script.site_packages, 'child') in result2.files_created2, (
         sorted(result2.files_created.keys())
     )
     assert normpath(
         join(script.site_packages, 'parent/plugins/child_plugin.py')
-    ) in result2.files_created, sorted(result2.files_created.keys())
+    ) in result2.files_created2, sorted(result2.files_created.keys())
     # The import forces the generation of __pycache__ if the version of python
     #  supports it
     script.run('python', '-c', "import parent.plugins.child_plugin, child")
     result3 = script.pip('uninstall', '-y', 'child', expect_error=False)
-    assert join(script.site_packages, 'child') in result3.files_deleted, (
+    assert join(script.site_packages, 'child') in result3.files_deleted2, (
         sorted(result3.files_created.keys())
     )
     assert normpath(
         join(script.site_packages, 'parent/plugins/child_plugin.py')
-    ) in result3.files_deleted, sorted(result3.files_deleted.keys())
+    ) in result3.files_deleted2, sorted(result3.files_deleted.keys())
     assert join(script.site_packages, 'parent') not in result3.files_deleted, (
         sorted(result3.files_deleted.keys())
     )
@@ -260,7 +260,7 @@ def test_uninstall_console_scripts(script):
     args = ['install']
     args.append('discover')
     result = script.pip(*args)
-    assert script.bin / 'discover' + script.exe in result.files_created, (
+    assert script.bin / 'discover' + script.exe in result.files_created2, (
         sorted(result.files_created.keys())
     )
     result2 = script.pip('uninstall', 'discover', '-y')
@@ -273,7 +273,7 @@ def test_uninstall_easy_installed_console_scripts(script):
     Test uninstalling package with console_scripts that is easy_installed.
     """
     result = script.easy_install('discover')
-    assert script.bin / 'discover' + script.exe in result.files_created, (
+    assert script.bin / 'discover' + script.exe in result.files_created2, (
         sorted(result.files_created.keys())
     )
     result2 = script.pip('uninstall', 'discover', '-y')
@@ -301,7 +301,7 @@ def test_uninstall_editable_from_svn(script, tmpdir):
     )
     result.assert_installed('INITools')
     result2 = script.pip('uninstall', '-y', 'initools')
-    assert (script.venv / 'src' / 'initools' in result2.files_after)
+    assert (script.venv / 'src' / 'initools' in result2.files_after2)
     assert_all_changes(
         result,
         result2,
@@ -342,7 +342,7 @@ def _test_uninstall_editable_with_source_outside_venv(
     result2 = script.pip('install', '-e', temp_pkg_dir)
     assert join(
         script.site_packages, 'pip-test-package.egg-link'
-    ) in result2.files_created, list(result2.files_created.keys())
+    ) in result2.files_created2, list(result2.files_created.keys())
     result3 = script.pip('uninstall', '-y', 'pip-test-package')
     assert_all_changes(
         result,
@@ -442,7 +442,7 @@ def test_uninstall_wheel(script, data):
     package = data.packages.joinpath("simple.dist-0.1-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index')
     dist_info_folder = script.site_packages / 'simple.dist-0.1.dist-info'
-    assert dist_info_folder in result.files_created
+    assert dist_info_folder in result.files_created2
     result2 = script.pip('uninstall', 'simple.dist', '-y')
     assert_all_changes(result, result2, [])
 
@@ -465,7 +465,7 @@ def test_uninstall_with_symlink(script, data, tmpdir):
     with open(record_path, "a") as f:
         f.write("symlink,,\n")
     uninstall_result = script.pip('uninstall', 'simple.dist', '-y')
-    assert symlink_source in uninstall_result.files_deleted
+    assert symlink_source in uninstall_result.files_deleted2
     assert symlink_target.stat().st_mode == st_mode
 
 
@@ -480,13 +480,13 @@ def test_uninstall_setuptools_develop_install(script, data):
     assert {"name": os.path.normcase("FSPkg"), "version": "0.1.dev0"} \
         in json.loads(list_result.stdout), str(list_result)
     # Uninstall both develop and install
-    uninstall = script.pip('uninstall', 'FSPkg', '-y')
-    assert any(filename.endswith('.egg')
-               for filename in uninstall.files_deleted.keys())
-    uninstall2 = script.pip('uninstall', 'FSPkg', '-y')
-    assert join(
-        script.site_packages, 'FSPkg.egg-link'
-    ) in uninstall2.files_deleted, list(uninstall2.files_deleted.keys())
+    uninstall = script.pip('uninstall', 'FSPkg', '-y')  # noqa
+    # assert any(filename.endswith('.egg')
+    #            for filename in uninstall.files_deleted.keys())
+    uninstall2 = script.pip('uninstall', 'FSPkg', '-y')  # noqa
+    # assert join(
+    #     script.site_packages, 'FSPkg.egg-link'
+    # ) in uninstall2.files_deleted2, list(uninstall2.files_deleted.keys())
     list_result2 = script.pip('list', '--format=json')
     assert "FSPkg" not in {p["name"] for p in json.loads(list_result2.stdout)}
 
@@ -514,7 +514,7 @@ def test_uninstall_editable_and_pip_install(script, data):
     uninstall2 = script.pip('uninstall', 'FSPkg', '-y')
     assert join(
         script.site_packages, 'FSPkg.egg-link'
-    ) in uninstall2.files_deleted, list(uninstall2.files_deleted.keys())
+    ) in uninstall2.files_deleted2, list(uninstall2.files_deleted.keys())
     list_result2 = script.pip('list', '--format=json')
     assert "FSPkg" not in {p["name"] for p in json.loads(list_result2.stdout)}
 

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -59,7 +59,7 @@ class Tests_UninstallUserSite:
             'install', '--user', '-e', to_install, expect_error=False,
         )
         egg_link = script.user_site / 'FSPkg.egg-link'
-        assert egg_link in result1.files_created, str(result1.stdout)
+        assert egg_link in result1.files_created2, str(result1.stdout)
 
         # uninstall
         result2 = script.pip('uninstall', '-y', 'FSPkg')

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -57,7 +57,7 @@ def test_pip_wheel_success(script, data):
         % re.escape(wheel_file_name), result.stdout)
     assert re.search(
         r"^\s+Stored in directory: ", result.stdout, re.M)
-    assert wheel_file_path in result.files_created, result.stdout
+    assert wheel_file_path in result.files_created2, result.stdout
     assert "Successfully built simple" in result.stdout, result.stdout
 
 
@@ -70,7 +70,7 @@ def test_basic_pip_wheel_downloads_wheels(script, data):
     )
     wheel_file_name = 'simple.dist-0.1-py2.py3-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    assert wheel_file_path in result.files_created2, result.stdout
     assert "Saved" in result.stdout, result.stdout
 
 
@@ -95,7 +95,7 @@ def test_pip_wheel_builds_editable_deps(script, data):
     )
     wheel_file_name = 'simple-1.0-py%s-none-any.whl' % pyversion[0]
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    assert wheel_file_path in result.files_created2, result.stdout
 
 
 def test_pip_wheel_builds_editable(script, data):
@@ -109,7 +109,7 @@ def test_pip_wheel_builds_editable(script, data):
     )
     wheel_file_name = 'simplewheel-1.0-py%s-none-any.whl' % pyversion[0]
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    assert wheel_file_path in result.files_created2, result.stdout
 
 
 def test_pip_wheel_fail(script, data):
@@ -159,7 +159,7 @@ def test_pip_wheel_source_deps(script, data):
     )
     wheel_file_name = 'source-1.0-py%s-none-any.whl' % pyversion[0]
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    assert wheel_file_path in result.files_created2, result.stdout
     assert "Successfully built source" in result.stdout, result.stdout
 
 
@@ -199,7 +199,7 @@ def test_pip_wheel_with_pep518_build_reqs(script, data, common_wheels):
                         '-f', common_wheels, 'pep518==3.0',)
     wheel_file_name = 'pep518-3.0-py%s-none-any.whl' % pyversion[0]
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    assert wheel_file_path in result.files_created2, result.stdout
     assert "Successfully built pep518" in result.stdout, result.stdout
     assert "Installing build dependencies" in result.stdout, result.stdout
 
@@ -212,7 +212,7 @@ def test_pip_wheel_with_pep518_build_reqs_no_isolation(script, data):
     )
     wheel_file_name = 'pep518-3.0-py%s-none-any.whl' % pyversion[0]
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    assert wheel_file_path in result.files_created2, result.stdout
     assert "Successfully built pep518" in result.stdout, result.stdout
     assert "Installing build dependencies" not in result.stdout, result.stdout
 
@@ -240,7 +240,7 @@ def test_pep517_wheels_are_not_confused_with_other_files(script, tmpdir, data):
 
     wheel_file_name = 'withpyproject-0.0.1-py%s-none-any.whl' % pyversion[0]
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    assert wheel_file_path in result.files_created2, result.stdout
 
 
 def test_legacy_wheels_are_not_confused_with_other_files(script, tmpdir, data):
@@ -254,4 +254,4 @@ def test_legacy_wheels_are_not_confused_with_other_files(script, tmpdir, data):
 
     wheel_file_name = 'simplewheel-1.0-py%s-none-any.whl' % pyversion[0]
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    assert wheel_file_path in result.files_created2, result.stdout

--- a/tests/functional/test_yaml.py
+++ b/tests/functional/test_yaml.py
@@ -142,9 +142,9 @@ def test_yaml_based(script, case):
         )
 
         # Perform the requested action
-        effect = available_actions[action](script, request[action])
+        effect = available_actions[action](script, request[action])  # noqa
 
-        result = effect["_result_object"]
+        result = effect["_result_object"]  # noqa
         del effect["_result_object"]
 
-        assert effect == expected, str(result)
+        # assert effect == expected, str(result)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -7,6 +7,7 @@ import site
 import subprocess
 import sys
 import textwrap
+from collections import namedtuple
 from contextlib import contextmanager
 from textwrap import dedent
 
@@ -225,10 +226,28 @@ class TestFailure(AssertionError):
     pass
 
 
+FakeFile = namedtuple('File', ['dir'])
+
+
+class AlwaysContains(object):
+    def __contains__(self, item):
+        return True
+
+    def __bool__(self):
+        return True
+
+    def __getitem__(self, item):
+        return FakeFile(True)
+
+
 class TestPipResult(object):
 
     def __init__(self, impl, verbose=False):
         self._impl = impl
+        self.files_created2 = AlwaysContains()
+        self.files_updated2 = AlwaysContains()
+        self.files_deleted2 = AlwaysContains()
+        self.files_after2 = AlwaysContains()
 
         if verbose:
             print(self.stdout)
@@ -261,6 +280,7 @@ class TestPipResult(object):
     def assert_installed(self, pkg_name, editable=True, with_files=[],
                          without_files=[], without_egg_link=False,
                          use_user_site=False, sub_dir=False):
+        return
         e = self.test_env
 
         if editable:
@@ -493,6 +513,9 @@ class PipTestEnvironment(TestFileEnvironment):
         #   instead of created
         self.user_site_path.mkdir(parents=True)
         self.user_site_path.joinpath("easy-install.pth").touch()
+
+    def _find_files(self):
+        return {}
 
     def _ignore_file(self, fn):
         if fn.endswith('__pycache__') or fn.endswith(".pyc"):


### PR DESCRIPTION
Currently in scripttest all files contents in the script base directory before and after the script execution are iterated over and checksummed. This is a test to see what kind of gains we could get in test execution speed if we make these checks more specific.