### PR TITLE
Fix backticks in a NEWS fragment

### DIFF
--- a/news/4358.bugfix
+++ b/news/4358.bugfix
@@ -1,1 +1,1 @@
-Correct inconsistency related to the `hg+file` scheme.
+Correct inconsistency related to the ``hg+file`` scheme.


### PR DESCRIPTION
CI is broken on master because of this.

/cc @chrahunt 