### PR TITLE
Do not use user setting when inside of a venv

### DIFF
--- a/news/7148.bugfix
+++ b/news/7148.bugfix
@@ -1,0 +1,1 @@
+Ignore ``user`` setting when running inside of a virtual environment.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -94,7 +94,14 @@ class Command(CommandContextMixIn):
     def parse_args(self, args):
         # type: (List[str]) -> Tuple
         # factored out for testability
-        return self.parser.parse_args(args)
+        option, args = self.parser.parse_args(args)
+        if running_under_virtualenv() and option.use_user_site:
+            logger.warning(
+                "`user` option is set to true "
+                "inside of a virtual environment, ignoring."
+            )
+            option.use_user_site = False
+        return option, args
 
     def main(self, args):
         # type: (List[str]) -> int


### PR DESCRIPTION
- Fixes #7148

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
