### PR TITLE
Centralize setuptools args construction

### DIFF
--- a/src/pip/_internal/operations/generate_metadata.py
+++ b/src/pip/_internal/operations/generate_metadata.py
@@ -12,7 +12,8 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
-    from typing import Callable, List
+    from typing import Callable, List, Optional
+
     from pip._internal.req.req_install import InstallRequirement
 
 logger = logging.getLogger(__name__)
@@ -104,22 +105,26 @@ def _generate_metadata_legacy(install_req):
     if install_req.isolated:
         base_cmd += ["--no-user-cfg"]
 
+    base_cmd += ["egg_info"]
+
+    egg_info_dir = None  # type: Optional[str]
     # For non-editable installs, don't put the .egg-info files at the root,
     # to avoid confusion due to the source code being considered an installed
     # egg.
-    egg_base_option = []  # type: List[str]
     if not install_req.editable:
         egg_info_dir = os.path.join(
             install_req.unpacked_source_directory, 'pip-egg-info',
         )
-        egg_base_option = ['--egg-base', egg_info_dir]
 
         # setuptools complains if the target directory does not exist.
         ensure_dir(egg_info_dir)
 
+    if egg_info_dir:
+        base_cmd += ['--egg-base', egg_info_dir]
+
     with install_req.build_env:
         call_subprocess(
-            base_cmd + ["egg_info"] + egg_base_option,
+            base_cmd,
             cwd=install_req.unpacked_source_directory,
             command_desc='python setup.py egg_info',
         )

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -687,20 +687,23 @@ class InstallRequirement(object):
         # type: (...) -> None
         logger.info('Running setup.py develop for %s', self.name)
 
-        if prefix:
-            prefix_param = ['--prefix={}'.format(prefix)]
-            install_options = list(install_options) + prefix_param
-        base_cmd = make_setuptools_shim_args(
+        args = make_setuptools_shim_args(
             self.setup_py_path,
             global_options=global_options,
             no_user_config=self.isolated
         )
+
+        args.extend(["develop", "--no-deps"])
+
+        args.extend(install_options)
+
+        if prefix:
+            args.extend(["--prefix", prefix])
+
         with indent_log():
             with self.build_env:
                 call_subprocess(
-                    base_cmd +
-                    ['develop', '--no-deps'] +
-                    list(install_options),
+                    args,
                     cwd=self.unpacked_source_directory,
                 )
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -48,7 +48,10 @@ from pip._internal.utils.misc import (
     rmtree,
 )
 from pip._internal.utils.packaging import get_metadata
-from pip._internal.utils.setuptools_build import make_setuptools_shim_args
+from pip._internal.utils.setuptools_build import (
+    make_setuptools_develop_args,
+    make_setuptools_shim_args,
+)
 from pip._internal.utils.subprocess import (
     call_subprocess,
     runner_with_spinner_message,
@@ -687,18 +690,13 @@ class InstallRequirement(object):
         # type: (...) -> None
         logger.info('Running setup.py develop for %s', self.name)
 
-        args = make_setuptools_shim_args(
+        args = make_setuptools_develop_args(
             self.setup_py_path,
             global_options=global_options,
-            no_user_config=self.isolated
+            install_options=install_options,
+            no_user_config=self.isolated,
+            prefix=prefix,
         )
-
-        args.extend(["develop", "--no-deps"])
-
-        args.extend(install_options)
-
-        if prefix:
-            args.extend(["--prefix", prefix])
 
         with indent_log():
             with self.build_env:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -50,7 +50,7 @@ from pip._internal.utils.misc import (
 from pip._internal.utils.packaging import get_metadata
 from pip._internal.utils.setuptools_build import (
     make_setuptools_develop_args,
-    make_setuptools_shim_args,
+    make_setuptools_install_args,
 )
 from pip._internal.utils.subprocess import (
     call_subprocess,
@@ -887,7 +887,7 @@ class InstallRequirement(object):
 
         with TempDirectory(kind="record") as temp_dir:
             record_filename = os.path.join(temp_dir.path, 'install-record.txt')
-            install_args = self.get_install_args(
+            install_args = make_setuptools_install_args(
                 self.setup_py_path,
                 global_options=global_options,
                 install_options=install_options,
@@ -948,42 +948,3 @@ class InstallRequirement(object):
             inst_files_path = os.path.join(egg_info_dir, 'installed-files.txt')
             with open(inst_files_path, 'w') as f:
                 f.write('\n'.join(new_lines) + '\n')
-
-    def get_install_args(
-        self,
-        setup_py_path,  # type: str
-        global_options,  # type: Sequence[str]
-        install_options,  # type: Sequence[str]
-        record_filename,  # type: str
-        root,  # type: Optional[str]
-        prefix,  # type: Optional[str]
-        header_dir,  # type: Optional[str]
-        no_user_config,  # type: bool
-        pycompile  # type: bool
-    ):
-        # type: (...) -> List[str]
-        install_args = make_setuptools_shim_args(
-            setup_py_path,
-            global_options=global_options,
-            no_user_config=no_user_config,
-            unbuffered_output=True
-        )
-        install_args += ['install', '--record', record_filename]
-        install_args += ['--single-version-externally-managed']
-
-        if root is not None:
-            install_args += ['--root', root]
-        if prefix is not None:
-            install_args += ['--prefix', prefix]
-
-        if pycompile:
-            install_args += ["--compile"]
-        else:
-            install_args += ["--no-compile"]
-
-        if header_dir:
-            install_args += ['--install-headers', header_dir]
-
-        install_args += install_options
-
-        return install_args

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -881,7 +881,13 @@ class InstallRequirement(object):
         with TempDirectory(kind="record") as temp_dir:
             record_filename = os.path.join(temp_dir.path, 'install-record.txt')
             install_args = self.get_install_args(
-                global_options, record_filename, root, prefix, pycompile,
+                self.setup_py_path,
+                global_options=global_options,
+                record_filename=record_filename,
+                root=root,
+                prefix=prefix,
+                no_user_config=self.isolated,
+                pycompile=pycompile,
             )
 
             runner = runner_with_spinner_message(
@@ -936,17 +942,19 @@ class InstallRequirement(object):
 
     def get_install_args(
         self,
+        setup_py_path,  # type: str
         global_options,  # type: Sequence[str]
         record_filename,  # type: str
         root,  # type: Optional[str]
         prefix,  # type: Optional[str]
+        no_user_config,  # type: bool
         pycompile  # type: bool
     ):
         # type: (...) -> List[str]
         install_args = make_setuptools_shim_args(
-            self.setup_py_path,
+            setup_py_path,
             global_options=global_options,
-            no_user_config=self.isolated,
+            no_user_config=no_user_config,
             unbuffered_output=True
         )
         install_args += ['install', '--record', record_filename]

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -71,6 +71,24 @@ def make_setuptools_develop_args(
     return args
 
 
+def make_setuptools_egg_info_args(
+    setup_py_path,  # type: str
+    egg_info_dir,  # type: Optional[str]
+    no_user_config,  # type: bool
+):
+    # type: (...) -> List[str]
+    base_cmd = make_setuptools_shim_args(setup_py_path)
+    if no_user_config:
+        base_cmd += ["--no-user-cfg"]
+
+    base_cmd += ["egg_info"]
+
+    if egg_info_dir:
+        base_cmd += ['--egg-base', egg_info_dir]
+
+    return base_cmd
+
+
 def make_setuptools_install_args(
     setup_py_path,  # type: str
     global_options,  # type: Sequence[str]

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -47,6 +47,44 @@ def make_setuptools_shim_args(
     return args
 
 
+def make_setuptools_bdist_wheel_args(
+    setup_py_path,  # type: str
+    global_options,  # type: Sequence[str]
+    build_options,  # type: Sequence[str]
+    destination_dir,  # type: str
+    python_tag,  # type: Optional[str]
+):
+    # type: (...) -> List[str]
+    # NOTE: Eventually, we'd want to also -S to the flags here, when we're
+    # isolating. Currently, it breaks Python in virtualenvs, because it
+    # relies on site.py to find parts of the standard library outside the
+    # virtualenv.
+    args = make_setuptools_shim_args(
+        setup_py_path,
+        global_options=global_options,
+        unbuffered_output=True
+    )
+    args += ["bdist_wheel", "-d", destination_dir]
+    args += build_options
+    if python_tag is not None:
+        args += ["--python-tag", python_tag]
+    return args
+
+
+def make_setuptools_clean_args(
+    setup_py_path,  # type: str
+    global_options,  # type: Sequence[str]
+):
+    # type: (...) -> List[str]
+    args = make_setuptools_shim_args(
+        setup_py_path,
+        global_options=global_options,
+        unbuffered_output=True
+    )
+    args += ["clean", "--all"]
+    return args
+
+
 def make_setuptools_develop_args(
     setup_py_path,  # type: str
     global_options,  # type: Sequence[str]

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -3,7 +3,7 @@ import sys
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import List, Sequence
+    from typing import List, Optional, Sequence
 
 # Shim to wrap setup.py invocation with setuptools
 #
@@ -44,4 +44,28 @@ def make_setuptools_shim_args(
         args.extend(global_options)
     if no_user_config:
         args.append('--no-user-cfg')
+    return args
+
+
+def make_setuptools_develop_args(
+    setup_py_path,  # type: str
+    global_options,  # type: Sequence[str]
+    install_options,  # type: Sequence[str]
+    no_user_config,  # type: bool
+    prefix,  # type: Optional[str]
+):
+    # type: (...) -> List[str]
+    args = make_setuptools_shim_args(
+        setup_py_path,
+        global_options=global_options,
+        no_user_config=no_user_config,
+    )
+
+    args.extend(["develop", "--no-deps"])
+
+    args.extend(install_options)
+
+    if prefix:
+        args.extend(["--prefix", prefix])
+
     return args

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -21,10 +21,10 @@ _SETUPTOOLS_SHIM = (
 
 
 def make_setuptools_shim_args(
-        setup_py_path,  # type: str
-        global_options=None,  # type: Sequence[str]
-        no_user_config=False,  # type: bool
-        unbuffered_output=False  # type: bool
+    setup_py_path,  # type: str
+    global_options=None,  # type: Sequence[str]
+    no_user_config=False,  # type: bool
+    unbuffered_output=False  # type: bool
 ):
     # type: (...) -> List[str]
     """
@@ -38,12 +38,12 @@ def make_setuptools_shim_args(
     """
     args = [sys.executable]
     if unbuffered_output:
-        args.append('-u')
-    args.extend(['-c', _SETUPTOOLS_SHIM.format(setup_py_path)])
+        args += ["-u"]
+    args += ["-c", _SETUPTOOLS_SHIM.format(setup_py_path)]
     if global_options:
-        args.extend(global_options)
+        args += global_options
     if no_user_config:
-        args.append('--no-user-cfg')
+        args += ["--no-user-cfg"]
     return args
 
 
@@ -61,12 +61,12 @@ def make_setuptools_develop_args(
         no_user_config=no_user_config,
     )
 
-    args.extend(["develop", "--no-deps"])
+    args += ["develop", "--no-deps"]
 
-    args.extend(install_options)
+    args += install_options
 
     if prefix:
-        args.extend(["--prefix", prefix])
+        args += ["--prefix", prefix]
 
     return args
 
@@ -77,16 +77,16 @@ def make_setuptools_egg_info_args(
     no_user_config,  # type: bool
 ):
     # type: (...) -> List[str]
-    base_cmd = make_setuptools_shim_args(setup_py_path)
+    args = make_setuptools_shim_args(setup_py_path)
     if no_user_config:
-        base_cmd += ["--no-user-cfg"]
+        args += ["--no-user-cfg"]
 
-    base_cmd += ["egg_info"]
+    args += ["egg_info"]
 
     if egg_info_dir:
-        base_cmd += ['--egg-base', egg_info_dir]
+        args += ["--egg-base", egg_info_dir]
 
-    return base_cmd
+    return args
 
 
 def make_setuptools_install_args(
@@ -101,28 +101,28 @@ def make_setuptools_install_args(
     pycompile  # type: bool
 ):
     # type: (...) -> List[str]
-    install_args = make_setuptools_shim_args(
+    args = make_setuptools_shim_args(
         setup_py_path,
         global_options=global_options,
         no_user_config=no_user_config,
         unbuffered_output=True
     )
-    install_args += ['install', '--record', record_filename]
-    install_args += ['--single-version-externally-managed']
+    args += ["install", "--record", record_filename]
+    args += ["--single-version-externally-managed"]
 
     if root is not None:
-        install_args += ['--root', root]
+        args += ["--root", root]
     if prefix is not None:
-        install_args += ['--prefix', prefix]
+        args += ["--prefix", prefix]
 
     if pycompile:
-        install_args += ["--compile"]
+        args += ["--compile"]
     else:
-        install_args += ["--no-compile"]
+        args += ["--no-compile"]
 
     if header_dir:
-        install_args += ['--install-headers', header_dir]
+        args += ["--install-headers", header_dir]
 
-    install_args += install_options
+    args += install_options
 
-    return install_args
+    return args

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -69,3 +69,42 @@ def make_setuptools_develop_args(
         args.extend(["--prefix", prefix])
 
     return args
+
+
+def make_setuptools_install_args(
+    setup_py_path,  # type: str
+    global_options,  # type: Sequence[str]
+    install_options,  # type: Sequence[str]
+    record_filename,  # type: str
+    root,  # type: Optional[str]
+    prefix,  # type: Optional[str]
+    header_dir,  # type: Optional[str]
+    no_user_config,  # type: bool
+    pycompile  # type: bool
+):
+    # type: (...) -> List[str]
+    install_args = make_setuptools_shim_args(
+        setup_py_path,
+        global_options=global_options,
+        no_user_config=no_user_config,
+        unbuffered_output=True
+    )
+    install_args += ['install', '--record', record_filename]
+    install_args += ['--single-version-externally-managed']
+
+    if root is not None:
+        install_args += ['--root', root]
+    if prefix is not None:
+        install_args += ['--prefix', prefix]
+
+    if pycompile:
+        install_args += ["--compile"]
+    else:
+        install_args += ["--no-compile"]
+
+    if header_dir:
+        install_args += ['--install-headers', header_dir]
+
+    install_args += install_options
+
+    return install_args

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -957,23 +957,43 @@ class WheelBuilder(object):
             self._clean_one(req)
             return None
 
-    def _make_setuptools_bdist_wheel_args(self, req):
+    def _make_setuptools_bdist_wheel_args(
+        self,
+        setup_py_path,  # type: str
+        global_options,  # type: Sequence[str]
+        build_options,  # type: Sequence[str]
+        destination_dir,  # type: str
+        python_tag,  # type: Optional[str]
+    ):
+        # type: (...) -> List[str]
         # NOTE: Eventually, we'd want to also -S to the flags here, when we're
         # isolating. Currently, it breaks Python in virtualenvs, because it
         # relies on site.py to find parts of the standard library outside the
         # virtualenv.
-        return make_setuptools_shim_args(
-            req.setup_py_path,
-            global_options=self.global_options,
+        args = make_setuptools_shim_args(
+            setup_py_path,
+            global_options=global_options,
             unbuffered_output=True
         )
+        args += ["bdist_wheel", "-d", destination_dir]
+        args += build_options
+        if python_tag is not None:
+            args += ["--python-tag", python_tag]
+        return args
 
-    def _make_setuptools_clean_args(self, req):
-        return make_setuptools_shim_args(
-            req.setup_py_path,
-            global_options=self.global_options,
+    def _make_setuptools_clean_args(
+        self,
+        setup_py_path,  # type: str
+        global_options,  # type: Sequence[str]
+    ):
+        # type: (...) -> List[str]
+        args = make_setuptools_shim_args(
+            setup_py_path,
+            global_options=global_options,
             unbuffered_output=True
         )
+        args += ["clean", "--all"]
+        return args
 
     def _build_one_pep517(self, req, tempd, python_tag=None):
         """Build one InstallRequirement using the PEP 517 build process.
@@ -1019,11 +1039,13 @@ class WheelBuilder(object):
 
         Returns path to wheel if successfully built. Otherwise, returns None.
         """
-        wheel_args = self._make_setuptools_bdist_wheel_args(req)
-        wheel_args += ['bdist_wheel', '-d', tempd]
-        wheel_args += self.build_options
-        if python_tag is not None:
-            wheel_args += ["--python-tag", python_tag]
+        wheel_args = self._make_setuptools_bdist_wheel_args(
+            req.setup_py_path,
+            global_options=self.global_options,
+            build_options=self.build_options,
+            destination_dir=tempd,
+            python_tag=python_tag,
+        )
 
         spin_message = 'Building wheel for %s (setup.py)' % (req.name,)
         with open_spinner(spin_message) as spinner:
@@ -1051,8 +1073,10 @@ class WheelBuilder(object):
             return wheel_path
 
     def _clean_one(self, req):
-        clean_args = self._make_setuptools_clean_args(req)
-        clean_args += ['clean', '--all']
+        clean_args = self._make_setuptools_clean_args(
+            req.setup_py_path,
+            global_options=self.global_options,
+        )
 
         logger.info('Running setup.py clean for %s', req.name)
         try:

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -957,11 +957,18 @@ class WheelBuilder(object):
             self._clean_one(req)
             return None
 
-    def _base_setup_args(self, req):
+    def _make_setuptools_bdist_wheel_args(self, req):
         # NOTE: Eventually, we'd want to also -S to the flags here, when we're
         # isolating. Currently, it breaks Python in virtualenvs, because it
         # relies on site.py to find parts of the standard library outside the
         # virtualenv.
+        return make_setuptools_shim_args(
+            req.setup_py_path,
+            global_options=self.global_options,
+            unbuffered_output=True
+        )
+
+    def _make_setuptools_clean_args(self, req):
         return make_setuptools_shim_args(
             req.setup_py_path,
             global_options=self.global_options,
@@ -1012,16 +1019,15 @@ class WheelBuilder(object):
 
         Returns path to wheel if successfully built. Otherwise, returns None.
         """
-        base_args = self._base_setup_args(req)
+        wheel_args = self._make_setuptools_bdist_wheel_args(req)
+        wheel_args += ['bdist_wheel', '-d', tempd]
+        wheel_args += self.build_options
+        if python_tag is not None:
+            wheel_args += ["--python-tag", python_tag]
 
         spin_message = 'Building wheel for %s (setup.py)' % (req.name,)
         with open_spinner(spin_message) as spinner:
             logger.debug('Destination directory: %s', tempd)
-            wheel_args = base_args + ['bdist_wheel', '-d', tempd] \
-                + self.build_options
-
-            if python_tag is not None:
-                wheel_args += ["--python-tag", python_tag]
 
             try:
                 output = call_subprocess(
@@ -1045,10 +1051,10 @@ class WheelBuilder(object):
             return wheel_path
 
     def _clean_one(self, req):
-        base_args = self._base_setup_args(req)
+        clean_args = self._make_setuptools_clean_args(req)
+        clean_args += ['clean', '--all']
 
         logger.info('Running setup.py clean for %s', req.name)
-        clean_args = base_args + ['clean', '--all']
         try:
             call_subprocess(clean_args, cwd=req.source_dir)
             return True


### PR DESCRIPTION
By making the inputs to setuptools explicit, it will be easier to construct a higher-level object responsible for representing the legacy build interface.