### PR TITLE
Clean up wheel.move_wheel_files

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -484,9 +484,9 @@ class InstallRequirement(object):
         # type: (...) -> None
         wheel.install_unpacked_wheel(
             self.name,
-            str(self.req),
             wheeldir,
             scheme=scheme,
+            req_description=str(self.req),
             pycompile=pycompile,
             warn_script_location=warn_script_location,
         )

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -484,7 +484,7 @@ class InstallRequirement(object):
         pycompile=True  # type: bool
     ):
         # type: (...) -> None
-        wheel.move_wheel_files(
+        wheel.install_unpacked_wheel(
             self.name, self.req, wheeldir,
             user=use_user_site,
             home=home,

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -23,6 +23,7 @@ from pip._vendor.pep517.wrappers import Pep517HookCaller
 from pip._internal import pep425tags, wheel
 from pip._internal.build_env import NoOpBuildEnvironment
 from pip._internal.exceptions import InstallationError
+from pip._internal.locations import distutils_scheme
 from pip._internal.models.link import Link
 from pip._internal.operations.generate_metadata import get_metadata_generator
 from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
@@ -60,7 +61,7 @@ from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Any, Dict, Iterable, List, Optional, Sequence, Union,
+        Any, Dict, Iterable, List, Mapping, Optional, Sequence, Union,
     )
     from pip._internal.build_env import BuildEnvironment
     from pip._internal.cache import WheelCache
@@ -476,22 +477,17 @@ class InstallRequirement(object):
     def move_wheel_files(
         self,
         wheeldir,  # type: str
-        root=None,  # type: Optional[str]
-        home=None,  # type: Optional[str]
-        prefix=None,  # type: Optional[str]
+        scheme,  # type: Mapping[str, str]
         warn_script_location=True,  # type: bool
-        use_user_site=False,  # type: bool
         pycompile=True  # type: bool
     ):
         # type: (...) -> None
         wheel.install_unpacked_wheel(
-            self.name, self.req, wheeldir,
-            user=use_user_site,
-            home=home,
-            root=root,
-            prefix=prefix,
+            self.name,
+            self.req,
+            wheeldir,
+            scheme=scheme,
             pycompile=pycompile,
-            isolated=self.isolated,
             warn_script_location=warn_script_location,
         )
 
@@ -859,10 +855,15 @@ class InstallRequirement(object):
             version = wheel.wheel_version(self.source_dir)
             wheel.check_compatibility(version, self.name)
 
+            scheme = distutils_scheme(
+                self.name, user=use_user_site, home=home, root=root,
+                isolated=self.isolated, prefix=prefix,
+            )
             self.move_wheel_files(
-                self.source_dir, root=root, prefix=prefix, home=home,
+                self.source_dir,
+                scheme=scheme,
                 warn_script_location=warn_script_location,
-                use_user_site=use_user_site, pycompile=pycompile,
+                pycompile=pycompile,
             )
             self.install_succeeded = True
             return

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -484,7 +484,7 @@ class InstallRequirement(object):
         # type: (...) -> None
         wheel.install_unpacked_wheel(
             self.name,
-            self.req,
+            str(self.req),
             wheeldir,
             scheme=scheme,
             pycompile=pycompile,

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -332,7 +332,7 @@ class PipScriptMaker(ScriptMaker):
 
 def install_unpacked_wheel(
     name,  # type: str
-    req,  # type: Requirement
+    req,  # type: str
     wheeldir,  # type: str
     scheme,  # type: Mapping[str, str]
     pycompile=True,  # type: bool
@@ -393,7 +393,7 @@ def install_unpacked_wheel(
                 elif (is_base and
                         s.endswith('.dist-info') and
                         canonicalize_name(s).startswith(
-                            canonicalize_name(req.name))):
+                            canonicalize_name(name))):
                     assert not info_dir, ('Multiple .dist-info directories: ' +
                                           destsubdir + ', ' +
                                           ', '.join(info_dir))

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -330,7 +330,7 @@ class PipScriptMaker(ScriptMaker):
         return super(PipScriptMaker, self).make(specification, options)
 
 
-def move_wheel_files(
+def install_unpacked_wheel(
     name,  # type: str
     req,  # type: Requirement
     wheeldir,  # type: str

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -34,7 +34,7 @@ from pip._internal.exceptions import (
     InvalidWheelFilename,
     UnsupportedWheel,
 )
-from pip._internal.locations import distutils_scheme, get_major_minor_version
+from pip._internal.locations import get_major_minor_version
 from pip._internal.models.link import Link
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.marker_files import has_delete_marker_file
@@ -334,13 +334,8 @@ def install_unpacked_wheel(
     name,  # type: str
     req,  # type: Requirement
     wheeldir,  # type: str
-    user=False,  # type: bool
-    home=None,  # type: Optional[str]
-    root=None,  # type: Optional[str]
+    scheme,  # type: Mapping[str, str]
     pycompile=True,  # type: bool
-    scheme=None,  # type: Optional[Mapping[str, str]]
-    isolated=False,  # type: bool
-    prefix=None,  # type: Optional[str]
     warn_script_location=True  # type: bool
 ):
     # type: (...) -> None
@@ -348,12 +343,6 @@ def install_unpacked_wheel(
     # TODO: Investigate and break this up.
     # TODO: Look into moving this into a dedicated class for representing an
     #       installation.
-
-    if not scheme:
-        scheme = distutils_scheme(
-            name, user=user, home=home, root=root, isolated=isolated,
-            prefix=prefix,
-        )
 
     if root_is_purelib(name, wheeldir):
         lib_dir = scheme['purelib']

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -661,7 +661,7 @@ class TestInstallUnpackedWheel(object):
     def test_std_install(self, data, tmpdir):
         self.prep(data, tmpdir)
         wheel.install_unpacked_wheel(
-            self.name, self.req, self.src, scheme=self.scheme)
+            self.name, str(self.req), self.src, scheme=self.scheme)
         self.assert_installed()
 
     def test_install_prefix(self, data, tmpdir):
@@ -677,7 +677,7 @@ class TestInstallUnpackedWheel(object):
         )
         wheel.install_unpacked_wheel(
             self.name,
-            self.req,
+            str(self.req),
             self.src,
             scheme=scheme,
         )
@@ -697,7 +697,7 @@ class TestInstallUnpackedWheel(object):
         os.makedirs(src_empty_dir)
         assert os.path.isdir(src_empty_dir)
         wheel.install_unpacked_wheel(
-            self.name, self.req, self.src, scheme=self.scheme)
+            self.name, str(self.req), self.src, scheme=self.scheme)
         self.assert_installed()
         assert not os.path.isdir(
             os.path.join(self.dest_dist_info, 'empty_dir'))

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -619,7 +619,7 @@ class TestWheelFile(object):
         assert w.version == '0.1-1'
 
 
-class TestMoveWheelFiles(object):
+class TestInstallUnpackedWheel(object):
     """
     Tests for moving files from wheel src to scheme paths
     """
@@ -659,14 +659,14 @@ class TestMoveWheelFiles(object):
 
     def test_std_install(self, data, tmpdir):
         self.prep(data, tmpdir)
-        wheel.move_wheel_files(
+        wheel.install_unpacked_wheel(
             self.name, self.req, self.src, scheme=self.scheme)
         self.assert_installed()
 
     def test_install_prefix(self, data, tmpdir):
         prefix = os.path.join(os.path.sep, 'some', 'path')
         self.prep(data, tmpdir)
-        wheel.move_wheel_files(
+        wheel.install_unpacked_wheel(
             self.name,
             self.req,
             self.src,
@@ -688,7 +688,7 @@ class TestMoveWheelFiles(object):
             self.src_dist_info, 'empty_dir', 'empty_dir')
         os.makedirs(src_empty_dir)
         assert os.path.isdir(src_empty_dir)
-        wheel.move_wheel_files(
+        wheel.install_unpacked_wheel(
             self.name, self.req, self.src, scheme=self.scheme)
         self.assert_installed()
         assert not os.path.isdir(

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -661,7 +661,11 @@ class TestInstallUnpackedWheel(object):
     def test_std_install(self, data, tmpdir):
         self.prep(data, tmpdir)
         wheel.install_unpacked_wheel(
-            self.name, str(self.req), self.src, scheme=self.scheme)
+            self.name,
+            self.src,
+            scheme=self.scheme,
+            req_description=str(self.req),
+        )
         self.assert_installed()
 
     def test_install_prefix(self, data, tmpdir):
@@ -677,9 +681,9 @@ class TestInstallUnpackedWheel(object):
         )
         wheel.install_unpacked_wheel(
             self.name,
-            str(self.req),
             self.src,
             scheme=scheme,
+            req_description=str(self.req),
         )
 
         bin_dir = 'Scripts' if WINDOWS else 'bin'
@@ -697,7 +701,11 @@ class TestInstallUnpackedWheel(object):
         os.makedirs(src_empty_dir)
         assert os.path.isdir(src_empty_dir)
         wheel.install_unpacked_wheel(
-            self.name, str(self.req), self.src, scheme=self.scheme)
+            self.name,
+            self.src,
+            scheme=self.scheme,
+            req_description=str(self.req),
+        )
         self.assert_installed()
         assert not os.path.isdir(
             os.path.join(self.dest_dist_info, 'empty_dir'))

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -10,6 +10,7 @@ from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal import pep425tags, wheel
 from pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
+from pip._internal.locations import distutils_scheme
 from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.compat import WINDOWS
@@ -666,12 +667,19 @@ class TestInstallUnpackedWheel(object):
     def test_install_prefix(self, data, tmpdir):
         prefix = os.path.join(os.path.sep, 'some', 'path')
         self.prep(data, tmpdir)
+        scheme = distutils_scheme(
+            self.name,
+            user=False,
+            home=None,
+            root=tmpdir,
+            isolated=False,
+            prefix=prefix,
+        )
         wheel.install_unpacked_wheel(
             self.name,
             self.req,
             self.src,
-            root=tmpdir,
-            prefix=prefix,
+            scheme=scheme,
         )
 
         bin_dir = 'Scripts' if WINDOWS else 'bin'


### PR DESCRIPTION
This simplifies the interface in preparation for moving the function to an install-related module.