### PR TITLE
Use python-version instead of deprecated version in GitHub Actions

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python ${{ matrix.env.PYTHON_VERSION || 3.7 }}
       uses: actions/setup-python@v1
       with:
-        version: ${{ matrix.env.PYTHON_VERSION || 3.7 }}
+        python-version: ${{ matrix.env.PYTHON_VERSION || 3.7 }}
     - name: Pre-configure global Git settings
       run: >-
         tools/travis/setup.sh

--- a/news/fix-deprecated-version-key.trivial
+++ b/news/fix-deprecated-version-key.trivial
@@ -1,0 +1,1 @@
+Use ``python-version`` instead of deprecated ``version``.


### PR DESCRIPTION
It's deprecated since https://github.com/actions/setup-python/commit/6f6fcee. See [deprecation warning](https://github.com/pypa/pip/runs/257378723#step:3:1):

<img width="492" alt="image" src="https://user-images.githubusercontent.com/7377671/66694712-c563eb00-ece0-11e9-83d7-b13cf0cd764a.png">
