### PR TITLE
Remove undocumented --skip-requirements-regex

### DIFF
--- a/news/skip_requirements_regex.removal
+++ b/news/skip_requirements_regex.removal
@@ -1,0 +1,1 @@
+Remove the undocumented ``--skip-requirements-regex`` argument.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -261,16 +261,6 @@ timeout = partial(
     help='Set the socket timeout (default %default seconds).',
 )  # type: Callable[..., Option]
 
-skip_requirements_regex = partial(
-    Option,
-    # A regex to be used to skip requirements
-    '--skip-requirements-regex',
-    dest='skip_requirements_regex',
-    type='str',
-    default='',
-    help=SUPPRESS_HELP,
-)  # type: Callable[..., Option]
-
 
 def exists_action():
     # type: () -> Option
@@ -886,7 +876,6 @@ general_group = {
         proxy,
         retries,
         timeout,
-        skip_requirements_regex,
         exists_action,
         trusted_host,
         cert,

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -89,7 +89,6 @@ class FreezeCommand(Command):
             local_only=options.local,
             user_only=options.user,
             paths=options.path,
-            skip_regex=options.skip_requirements_regex,
             isolated=options.isolated_mode,
             wheel_cache=wheel_cache,
             skip=skip,

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -107,7 +107,7 @@ def parse_requirements(
         filename, comes_from=comes_from, session=session
     )
 
-    lines_enum = preprocess(content, options)
+    lines_enum = preprocess(content)
 
     for line_number, line in lines_enum:
         req_iter = process_line(line, filename, line_number, finder,
@@ -117,7 +117,7 @@ def parse_requirements(
             yield req
 
 
-def preprocess(content, options):
+def preprocess(content):
     # type: (Text, Optional[optparse.Values]) -> ReqFileLines
     """Split, filter, and join lines, and return a line iterator
 

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -13,7 +13,6 @@ import re
 import shlex
 import sys
 
-from pip._vendor.six.moves import filterfalse
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
 from pip._internal.cli import cmdoptions
@@ -128,7 +127,6 @@ def preprocess(content, options):
     lines_enum = enumerate(content.splitlines(), start=1)  # type: ReqFileLines
     lines_enum = join_lines(lines_enum)
     lines_enum = ignore_comments(lines_enum)
-    lines_enum = skip_regex(lines_enum, options)
     lines_enum = expand_env_variables(lines_enum)
     return lines_enum
 
@@ -359,20 +357,6 @@ def ignore_comments(lines_enum):
         line = line.strip()
         if line:
             yield line_number, line
-
-
-def skip_regex(lines_enum, options):
-    # type: (ReqFileLines, Optional[optparse.Values]) -> ReqFileLines
-    """
-    Skip lines that match '--skip-requirements-regex' pattern
-
-    Note: the regex pattern is only built once
-    """
-    skip_regex = options.skip_requirements_regex if options else None
-    if skip_regex:
-        pattern = re.compile(skip_regex)
-        lines_enum = filterfalse(lambda e: pattern.search(e[1]), lines_enum)
-    return lines_enum
 
 
 def expand_env_variables(lines_enum):

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -359,12 +359,6 @@ class TestGeneralOptions(AddFakeCommandMixin):
         options2, args2 = main(['fake', '--timeout', '-1'])
         assert options1.timeout == options2.timeout == -1
 
-    def test_skip_requirements_regex(self):
-        options1, args1 = main(['--skip-requirements-regex', 'path', 'fake'])
-        options2, args2 = main(['fake', '--skip-requirements-regex', 'path'])
-        assert options1.skip_requirements_regex == 'path'
-        assert options2.skip_requirements_regex == 'path'
-
     def test_exists_action(self):
         options1, args1 = main(['--exists-action', 'w', 'fake'])
         options2, args2 = main(['fake', '--exists-action', 'w'])


### PR DESCRIPTION
Progresses #6221.

This reduces the number of configuration/CLI parameters by one and removes one source of dependence of requirements file parsing on incoming options.

I think that no deprecation period is acceptable given:

1. This option has not been documented publicly
1. No mentions of this option online except dependabot/feedback#252 or copies of the pip source code
1. In general we're moving away from these kind of workarounds - if this were suggested today I do not think it would be given much consideration