### PR TITLE
(improve doc): add command to run test in parallel

### DIFF
--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -40,6 +40,12 @@ To run tests locally, run:
 
     $ tox -e py36
 
+Generally it takes long time to run tests. You can run tests in parallel, run:
+
+.. code-block:: console
+
+    $ tox -e py36 -- -n auto
+
 The example above runs tests against Python 3.6. You can also use other
 versions like ``py27`` and ``pypy3``.
 

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -40,7 +40,8 @@ To run tests locally, run:
 
     $ tox -e py36
 
-Generally it takes long time to run tests. You can run tests in parallel, run:
+Generally, it takes long time to run pip's test suite. To run tests in parallel,
+which is faster, run:
 
 .. code-block:: console
 

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -40,7 +40,7 @@ To run tests locally, run:
 
     $ tox -e py36
 
-Generally, it takes long time to run pip's test suite. To run tests in parallel,
+Generally, it can take a long time to run pip's test suite. To run tests in parallel,
 which is faster, run:
 
 .. code-block:: console


### PR DESCRIPTION
update doc to add command to run tests in parallel
Previously it was -
![Screenshot from 2019-10-14 12-52-02](https://user-images.githubusercontent.com/14263515/66734638-7e612b80-ee81-11e9-9a2c-8bea5e3beb74.png)

With this PR it will be-
![Screenshot from 2019-10-14 13-09-10](https://user-images.githubusercontent.com/14263515/66735421-eadd2a00-ee83-11e9-8221-bf9f5fafd2cd.png)


Fixes : https://github.com/pypa/pip/issues/7192
Signed-off-by: Shovan Maity <shovan.cse91@gmail.com>

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
