### PR TITLE
(Fix Tests): Change method from shutil.remove to shutil.rmtree

### DIFF
--- a/news/7191.bugfix
+++ b/news/7191.bugfix
@@ -1,0 +1,1 @@
+Change method from shutil.remove to shutil.rmtree in noxfile.py.

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,7 +73,7 @@ def should_update_common_wheels():
 
     # Clear the stale cache.
     if need_to_repopulate:
-        shutil.remove(LOCATIONS["common-wheels"], ignore_errors=True)
+        shutil.rmtree(LOCATIONS["common-wheels"], ignore_errors=True)
 
     return need_to_repopulate
 


### PR DESCRIPTION
- `remove` was not a member of shutil and tests were failing because of
it. To fix it, `shutil.rmtree` is used.

Signed-off-by: Akash Srivastava <akashsrivastava4927@gmail.com>

fixes: https://github.com/pypa/pip/issues/7190
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
