### PR TITLE
Skip running svn tests when svn isn't installed

### DIFF
--- a/news/7193.bugfix
+++ b/news/7193.bugfix
@@ -1,0 +1,1 @@
+Skip running tests which require subversion, when svn isn't installed

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -12,6 +12,7 @@ from tests.lib import (
     _git_commit,
     need_bzr,
     need_mercurial,
+    need_svn,
     path_to_url,
 )
 
@@ -169,7 +170,7 @@ def test_freeze_editable_git_with_no_remote(script, tmpdir, deprecated_python):
     _check_output(result.stdout, expected)
 
 
-@pytest.mark.svn
+@need_svn
 def test_freeze_svn(script, tmpdir):
     """Test freezing a svn checkout"""
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -21,6 +21,7 @@ from tests.lib import (
     create_test_package_with_setup,
     need_bzr,
     need_mercurial,
+    need_svn,
     path_to_url,
     pyversion,
     pyversion_tuple,
@@ -251,7 +252,7 @@ def test_basic_editable_install(script):
     assert not result.files_updated
 
 
-@pytest.mark.svn
+@need_svn
 def test_basic_install_editable_from_svn(script):
     """
     Test checking out from svn.

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -5,6 +5,7 @@ import pytest
 
 from tests.lib import (
     _create_test_package_with_subdirectory,
+    need_svn,
     path_to_url,
     pyversion,
     requirements_file,
@@ -100,7 +101,7 @@ def test_relative_requirements_file(script, data):
 
 
 @pytest.mark.network
-@pytest.mark.svn
+@need_svn
 def test_multiple_requirements_files(script, tmpdir):
     """
     Test installing from multiple nested requirements files.

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -6,7 +6,7 @@ from os.path import curdir, isdir, isfile
 
 import pytest
 
-from tests.lib import pyversion
+from tests.lib import need_svn, pyversion
 from tests.lib.local_repos import local_checkout
 
 
@@ -41,7 +41,7 @@ class Tests_UserSite:
         assert 'INITools' == project_name, project_name
 
     @pytest.mark.network
-    @pytest.mark.svn
+    @need_svn
     def test_install_subversion_usersite_editable_with_distribute(
             self, script, tmpdir):
         """

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -13,7 +13,11 @@ import pytest
 
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import rmtree
-from tests.lib import assert_all_changes, create_test_package_with_setup
+from tests.lib import (
+    assert_all_changes,
+    create_test_package_with_setup,
+    need_svn,
+)
 from tests.lib.local_repos import local_checkout, local_repo
 
 
@@ -289,6 +293,7 @@ def test_uninstall_easy_installed_console_scripts(script):
 
 
 @pytest.mark.network
+@need_svn
 def test_uninstall_editable_from_svn(script, tmpdir):
     """
     Test uninstalling an editable installation from svn.
@@ -352,7 +357,7 @@ def _test_uninstall_editable_with_source_outside_venv(
 
 
 @pytest.mark.network
-@pytest.mark.svn
+@need_svn
 def test_uninstall_from_reqs_file(script, tmpdir):
     """
     Test uninstall from a requirements file.

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1037,6 +1037,12 @@ def need_bzr(fn):
     )(fn))
 
 
+def need_svn(fn):
+    return pytest.mark.svn(need_executable(
+        'Subversion', ('svn', '--version')
+    )(fn))
+
+
 def need_mercurial(fn):
     return pytest.mark.mercurial(need_executable(
         'Mercurial', ('hg', 'version')

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -13,7 +13,7 @@ from pip._internal.vcs.git import Git, looks_like_hash
 from pip._internal.vcs.mercurial import Mercurial
 from pip._internal.vcs.subversion import Subversion
 from pip._internal.vcs.versioncontrol import RevOptions, VersionControl
-from tests.lib import is_svn_installed, pyversion
+from tests.lib import is_svn_installed, need_svn, pyversion
 
 if pyversion >= '3':
     VERBOSE_FALSE = False
@@ -411,7 +411,7 @@ def test_subversion__init_use_interactive(
     assert svn.use_interactive == expected
 
 
-@pytest.mark.svn
+@need_svn
 def test_subversion__call_vcs_version():
     """
     Test Subversion.call_vcs_version() against local ``svn``.


### PR DESCRIPTION
Signed-off-by: Harsh Vardhan <harsh59v@gmail.com>

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

NOTE to maintainers:
1. I'll also be pushing a similar fix for skipping `svnadmin` (If it's okay to send it in the same PR, with a modified description)
[Update] Maybe it requires a separate discussion, not sure if `svn` client and `svnadmin` should be treated separately
~2. I'll push the NEWS changes soon~