### PR TITLE
Document that "coding: utf-8" is supported in requirements.txt

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -148,6 +148,9 @@ and the newline following it is effectively ignored.
 
 Comments are stripped *before* line continuations are processed.
 
+To interpret the requirements file in UTF-8 format add a comment
+``# -*- coding: utf-8 -*-`` to the first or second line of the file.
+
 The following options are supported:
 
   *  :ref:`-i, --index-url <--index-url>`

--- a/news/7182.doc
+++ b/news/7182.doc
@@ -1,0 +1,1 @@
+Document that "coding: utf-8" is supported in requirements.txt

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -509,6 +509,7 @@ def get_file_content(url, comes_from=None, session=None):
     # type: (str, Optional[str], Optional[PipSession]) -> Tuple[str, Text]
     """Gets the content of a file; it may be a filename, file: URL, or
     http: URL.  Returns (location, content).  Content is unicode.
+    Respects # -*- coding: declarations on the retrieved files.
 
     :param url:         File path or url.
     :param comes_from:  Origin description of requirements.


### PR DESCRIPTION
Fixes #7182

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
