### PR TITLE
Add instructions on disabling keyring

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -796,7 +796,7 @@ of ability. Some examples that you could consider include:
 .. _`Disable Keyring`:
 
 Disable Keyring
-***************************
+***************
 
 Keyring in certain cases can prevent the installing of certain packages and modules
 due to authentication errors. In such cases disabling the keyring is recommended.
@@ -807,9 +807,9 @@ There are various ways to disable the keyring. They are:
 
 - Set the password as null to preferred keyring for the relevant URL and username.
 
-- If the keyring version is 15.1.0 keyring can be disabled via command line using::
+- keyring >= 15.1.0 can be disabled via command line using::
 
-keyring --disable
+    keyring --disable
 
 - Set environment variable ``PYTHON_KEYRING_BACKEND`` to ``keyring.backends.null.Keyring``
 in a configuration file.

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -795,12 +795,12 @@ of ability. Some examples that you could consider include:
 
 .. _`Disable Keyring`:
 
-(Optional) Disable Keyring
+Disable Keyring
 ***************************
 
 Keyring in certain cases can prevent the installing of certain packages and modules
 due to authentication errors. In such cases disabling the keyring is recommended.
-Keyring can be manually uninstalled but doing so may invalidate other packages that 
+Keyring can be manually uninstalled but doing so may invalidate other packages that
 depends on Keyring.
 
 There are various ways to disable the keyring. They are:
@@ -812,4 +812,4 @@ There are various ways to disable the keyring. They are:
   keyring --disable
   
 - Set environment variable ``PYTHON_KEYRING_BACKEND`` to
-  ``keyring.backends.null.Keyring`` in a configuration file.
+``keyring.backends.null.Keyring`` in a configuration file.

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -791,3 +791,19 @@ of ability. Some examples that you could consider include:
 
 * ``distlib`` - Packaging and distribution utilities (including functions for
   interacting with PyPI).
+
+
+.. _`Disable Keyring`:
+
+(Optional) Disable Keyring
+***************************
+
+Keyring in certain cases can prevent the installing of certain packages and modules due to authentication errors. In such cases disabling the keyring is recommended.Keyring can be manually uninstalled but doing so may invalidate other packages that depends on Keyring.
+
+How to disable the keyring:
+- Set the password as null to preferred keyring for the relevant URL and username.
+- If the keyring version is 15.1.0 keyring can be disabled via command line using::
+
+  keyring --disable
+  
+- Set environment variable ``PYTHON_KEYRING_BACKEND`` to ``keyring.backends.null.Keyring`` in config file  

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -811,5 +811,5 @@ There are various ways to disable the keyring. They are:
 
     keyring --disable
 
-- Set environment variable ``PYTHON_KEYRING_BACKEND`` to ``keyring.backends.null.Keyring``
-in a configuration file.
+- Set environment variable ``PYTHON_KEYRING_BACKEND`` to
+``keyring.backends.null.Keyring`` in a configuration file.

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -811,5 +811,5 @@ There are various ways to disable the keyring. They are:
 
   keyring --disable
   
-- Set environment variable ``PYTHON_KEYRING_BACKEND`` to ``keyring.backends.null.Keyring``
-  in config file
+- Set environment variable ``PYTHON_KEYRING_BACKEND`` to
+  ``keyring.backends.null.Keyring`` in a configuration file.

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -809,7 +809,7 @@ There are various ways to disable the keyring. They are:
 
 - If the keyring version is 15.1.0 keyring can be disabled via command line using::
 
-  keyring --disable
-  
-- Set environment variable ``PYTHON_KEYRING_BACKEND`` to
-``keyring.backends.null.Keyring`` in a configuration file.
+keyring --disable
+
+- Set environment variable ``PYTHON_KEYRING_BACKEND`` to ``keyring.backends.null.Keyring``
+in a configuration file.

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -798,12 +798,18 @@ of ability. Some examples that you could consider include:
 (Optional) Disable Keyring
 ***************************
 
-Keyring in certain cases can prevent the installing of certain packages and modules due to authentication errors. In such cases disabling the keyring is recommended.Keyring can be manually uninstalled but doing so may invalidate other packages that depends on Keyring.
+Keyring in certain cases can prevent the installing of certain packages and modules
+due to authentication errors. In such cases disabling the keyring is recommended.
+Keyring can be manually uninstalled but doing so may invalidate other packages that 
+depends on Keyring.
 
-How to disable the keyring:
+There are various ways to disable the keyring. They are:
+
 - Set the password as null to preferred keyring for the relevant URL and username.
+
 - If the keyring version is 15.1.0 keyring can be disabled via command line using::
 
   keyring --disable
   
-- Set environment variable ``PYTHON_KEYRING_BACKEND`` to ``keyring.backends.null.Keyring`` in config file  
+- Set environment variable ``PYTHON_KEYRING_BACKEND`` to ``keyring.backends.null.Keyring``
+  in config file

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -812,4 +812,4 @@ There are various ways to disable the keyring. They are:
     keyring --disable
 
 - Set environment variable ``PYTHON_KEYRING_BACKEND`` to
-``keyring.backends.null.Keyring`` in a configuration file.
+  ``keyring.backends.null.Keyring`` in a configuration file.

--- a/news/6773.doc
+++ b/news/6773.doc
@@ -1,0 +1,1 @@
+Added documentation on how to disable keyring


### PR DESCRIPTION
Added documentation about how to disable keyring. Refered https://github.com/pypa/twine/issues/338 for it.

Fixes #6773.