### PR TITLE
Add partial CA info to pip debug

### DIFF
--- a/news/7146.feature
+++ b/news/7146.feature
@@ -1,0 +1,1 @@
+This change adds CA information to ``pip debug``.

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -5,7 +5,10 @@ from __future__ import absolute_import
 
 import locale
 import logging
+import os
 import sys
+
+from pip._vendor.certifi import where
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
@@ -108,6 +111,15 @@ class DebugCommand(Command):
             'locale.getpreferredencoding', locale.getpreferredencoding(),
         )
         show_value('sys.platform', sys.platform)
+        show_value(
+            'os.environ.get(\'REQUESTS_CA_BUNDLE\')',
+            str(os.environ.get('REQUESTS_CA_BUNDLE'))
+        )
+        show_value(
+            'os.environ.get(\'CURL_CA_BUNDLE\')',
+            str(os.environ.get('CURL_CA_BUNDLE'))
+        )
+        show_value('pip._vendor.certifi.where()', where())
         show_sys_implementation()
 
         show_tags(options)

--- a/tests/functional/test_debug.py
+++ b/tests/functional/test_debug.py
@@ -10,6 +10,9 @@ from pip._internal import pep425tags
     'locale.getpreferredencoding: ',
     'sys.platform: ',
     'sys.implementation:',
+    'os.environ.get(\'REQUESTS_CA_BUNDLE\')',
+    'os.environ.get(\'CURL_CA_BUNDLE\')',
+    'pip._vendor.certifi.where()'
 ])
 def test_debug(script, expected_text):
     """


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

#7146 Still need to get the `highest-priority pip configuration file` along with its filepath. I am curious about the best way to do that and won't be sad if someone else wants to
