### PR TITLE
Display CA information in pip debug

### DIFF
--- a/news/7146.feature
+++ b/news/7146.feature
@@ -1,0 +1,1 @@
+Display CA information in ``pip debug``.

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -133,10 +133,10 @@ class DebugCommand(Command):
         show_value('sys.platform', sys.platform)
         show_sys_implementation()
 
+        show_value("'cert' config value", ca_bundle_info(self.parser.config))
         show_value("REQUESTS_CA_BUNDLE", os.environ.get('REQUESTS_CA_BUNDLE'))
         show_value("CURL_CA_BUNDLE", os.environ.get('CURL_CA_BUNDLE'))
         show_value("pip._vendor.certifi.where()", where())
-        show_value("'cert' config value", ca_bundle_info(self.parser.config))
 
         show_tags(options)
 

--- a/tests/functional/test_debug.py
+++ b/tests/functional/test_debug.py
@@ -10,10 +10,11 @@ from pip._internal import pep425tags
     'locale.getpreferredencoding: ',
     'sys.platform: ',
     'sys.implementation:',
+    '\'cert\' config value: ',
     'REQUESTS_CA_BUNDLE: ',
     'CURL_CA_BUNDLE: ',
     'pip._vendor.certifi.where(): ',
-    '\'cert\' config value: ',
+
 ])
 def test_debug(script, expected_text):
     """

--- a/tests/functional/test_debug.py
+++ b/tests/functional/test_debug.py
@@ -10,6 +10,10 @@ from pip._internal import pep425tags
     'locale.getpreferredencoding: ',
     'sys.platform: ',
     'sys.implementation:',
+    'REQUESTS_CA_BUNDLE: ',
+    'CURL_CA_BUNDLE: ',
+    'pip._vendor.certifi.where(): ',
+    '\'cert\' config value: ',
 ])
 def test_debug(script, expected_text):
     """


### PR DESCRIPTION
Add CA information to pip debug and add corresponding changes to test_debug.py
Fixes #7146 