### PR TITLE
Rephrase installation instructions

### DIFF
--- a/docs/html/installing.rst
+++ b/docs/html/installing.rst
@@ -18,12 +18,14 @@ Just make sure to :ref:`upgrade pip <Upgrading pip>`.
 Installing with get-pip.py
 --------------------------
 
-To install pip, securely download `get-pip.py
-<https://bootstrap.pypa.io/get-pip.py>`_. [1]_::
+To install pip, securely [1]_ download ``get-pip.py`` by following
+this link: `get-pip.py
+<https://bootstrap.pypa.io/get-pip.py>`_. Alternatively, use ``curl``::
 
  curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 
-Then run the following::
+Then run the following command in the folder where you
+have downloaded ``get-pip.py``::
 
  python get-pip.py
 

--- a/news/7222.doc
+++ b/news/7222.doc
@@ -1,0 +1,1 @@
+Add more clear installation instructions


### PR DESCRIPTION
Hi!

I was searching specifically for windows installation instructions and kept missing the link to the `get-pip.py`. It's because currently the instructions look a bit confusing and make it seem that running the `curl` command (`curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py`) is required to install `pip`. Python and pip are often used by beginner programmers that might get confused by this.

I made changes trying to make it a bit more clear that the goal is to just download the `get-pip.py` file and that the `curl` command is not required

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
