### PR TITLE
Test on Python 3.8 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ jobs:
     - env: GROUP=2
       python: 2.7
     - env: GROUP=1
+      python: 3.8
     - env: GROUP=2
+      python: 3.8
 
     # Complete checking for ensuring compatibility
     # PyPy
@@ -39,6 +41,8 @@ jobs:
       python: pypy2.7-6.0
     # Other Supported CPython
     - env: GROUP=1
+    - env: GROUP=2
+    - env: GROUP=1
       python: 3.6
     - env: GROUP=2
       python: 3.6
@@ -46,16 +50,8 @@ jobs:
       python: 3.5
     - env: GROUP=2
       python: 3.5
-
-    - env: GROUP=1
-      python: 3.8-dev
-    - env: GROUP=2
-      python: 3.8-dev
 
   fast_finish: true
-  # It's okay to fail on the in-development CPython version.
-  allow_failures:
-    - python: 3.8-dev
 
 before_install: tools/travis/setup.sh
 install: travis_retry tools/travis/install.sh


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Python 3.8.0 final is now available on Travis CI as `3.8`.

Follows on from https://github.com/pypa/pip/pull/7219.

Like PR #7221, but does not change the base Python to 3.8, because the vendoring job fails, likely due to https://github.com/pypa/pip/issues/6222.

Whilst the PR to fix that (https://github.com/pypa/pip/pull/6606) is awaiting review, keep using 3.7 as the base version for docs/lint/vendoring.