### PR TITLE
Show shorter details of the URL when downloading from PyPI

### DIFF
--- a/news/7225.feature
+++ b/news/7225.feature
@@ -1,0 +1,1 @@
+Show only the filename (instead of full URL), when downloading from PyPI.

--- a/src/pip/_internal/download.py
+++ b/src/pip/_internal/download.py
@@ -224,7 +224,7 @@ def _download_url(
 
     progress_indicator = _progress_indicator
 
-    if link.netloc == PyPI.netloc:
+    if link.netloc == PyPI.file_storage_domain:
         url = link.show_url
     else:
         url = link.url_without_fragment

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -226,7 +226,7 @@ def test_basic_install_from_pypi(script):
     """
     Test installing a package from PyPI.
     """
-    result = script.pip('install', '-vvv', 'INITools==0.2')
+    result = script.pip('install', 'INITools==0.2')
     egg_info_folder = (
         script.site_packages / 'INITools-0.2-py%s.egg-info' % pyversion
     )
@@ -237,6 +237,13 @@ def test_basic_install_from_pypi(script):
     # Should not display where it's looking for files
     assert "Looking in indexes: " not in result.stdout
     assert "Looking in links: " not in result.stdout
+
+    # Ensure that we don't print the full URL.
+    #    The URL should be trimmed to only the last part of the path in it,
+    #    when installing from PyPI. The assertion here only checks for
+    #    `https://` since that's likely to show up if we're not trimming in
+    #    the correct circumstances.
+    assert "https://" not in result.stdout
 
 
 def test_basic_editable_install(script):


### PR DESCRIPTION
This was something I noticed while working w/ folks at PyCon India.

We had, in the past, shown shorter link names in our output, when downloading from PyPI. This PR restores that ability as well as updating a test so that we don't accidentally start printing it again.

ref: 383de6d30e7bf70e61222d62d58652f67b3d39b2
