### PR TITLE
Exclude Python from Windows Defender scanning

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,8 +64,8 @@ test_script:
             subst T: $env:TEMP
             $env:TEMP = "T:\"
             $env:TMP = "T:\"
-            tox -e py -- -m unit
+            tox -e py -- -m unit -n auto
             if ($LastExitCode -eq 0 -and $env:RUN_INTEGRATION_TESTS -eq "True") {
-                tox -e py -- --use-venv -m integration -n2 --durations=20
+                tox -e py -- --use-venv -m integration -n auto --durations=20
             }
         }

--- a/.azure-pipelines/steps/run-tests-windows.yml
+++ b/.azure-pipelines/steps/run-tests-windows.yml
@@ -2,6 +2,9 @@ parameters:
   runIntegrationTests:
 
 steps:
+- powershell: Set-MpPreference -DisableRealtimeMonitoring $true
+  displayName: Disable Windows Defender Monitoring
+
 - task: UsePythonVersion@0
   displayName: Use Python $(python.version)
   inputs:


### PR DESCRIPTION
In a VM this results in a 2x speedup on some of our slowest tests, let's see how it looks in CI.

Edit: On Appveyor we're using the Visual Studio 2015 image which has Windows Server 2012 - no `*-MpPreference` commands available there, and I can't find info on whether antivirus is a factor.