### PR TITLE
Make RequirementTracker a better context manager

### DIFF
--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -755,3 +755,27 @@ def test_get_url_from_path__installable_error(isdir_mock):
         _get_url_from_path(path, name)
     err_msg = e.value.args[0]
     assert "Neither 'setup.py' nor 'pyproject.toml' found" in err_msg
+
+
+class TestRequirementTracker(object):
+    @pytest.fixture(autouse=True)
+    def blank_env(self):
+        with patch.dict(os.environ, clear=True):
+            yield
+
+    def test_no_side_effects_on_init(self):
+        RequirementTracker()
+        assert 'PIP_REQ_TRACKER' not in os.environ
+
+    def test_keeps_original_environ(self, tmpdir):
+        os.environ['PIP_REQ_TRACKER'] = str(tmpdir)
+        with RequirementTracker():
+            assert os.environ['PIP_REQ_TRACKER'] == str(tmpdir)
+        assert os.environ['PIP_REQ_TRACKER'] == str(tmpdir)
+
+    def test_setting_environ(self):
+        with RequirementTracker():
+            assert 'PIP_REQ_TRACKER' in os.environ
+
+        # Ensure that the cleanup is proper
+        assert 'PIP_REQ_TRACKER' not in os.environ

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -163,8 +163,8 @@ class TestRequirementSet(object):
                 HashErrors,
                 r'Hashes are required in --require-hashes mode, but they are '
                 r'missing .*\n'
-                r'    https://files\.pythonhosted\.org/packages/source/p/peep/peep'
-                r'-3\.1\.1\.tar\.gz --hash=sha256:[0-9a-f]+\n'
+                r'    https://files\.pythonhosted\.org/packages/source/p/peep/'
+                r'peep-3\.1\.1\.tar\.gz --hash=sha256:[0-9a-f]+\n'
                 r'    blessings==1.0 --hash=sha256:[0-9a-f]+\n'
                 r'THESE PACKAGES DO NOT MATCH THE HASHES.*\n'
                 r'    tracefront==0.1 .*:\n'
@@ -190,8 +190,8 @@ class TestRequirementSet(object):
                 HashErrors,
                 r'Hashes are required in --require-hashes mode, but they are '
                 r'missing .*\n'
-                r'    simple==1.0 --hash=sha256:393043e672415891885c9a2a0929b1af95'
-                r'fb866d6ca016b42d2e6ce53619b653$',
+                r'    simple==1.0 --hash=sha256:393043e672415891885c9a2a0929b1'
+                r'af95fb866d6ca016b42d2e6ce53619b653$',
                 resolver.resolve,
                 reqset
             )
@@ -240,10 +240,10 @@ class TestRequirementSet(object):
                 HashErrors,
                 r"Can't verify hashes for these requirements because we don't "
                 r"have a way to hash version control repositories:\n"
-                r"    git\+git://github\.com/pypa/pip-test-package \(from -r file "
-                r"\(line 1\)\)\n"
-                r"Can't verify hashes for these file:// requirements because they "
-                r"point to directories:\n"
+                r"    git\+git://github\.com/pypa/pip-test-package \(from -r "
+                r"file \(line 1\)\)\n"
+                r"Can't verify hashes for these file:// requirements because "
+                r"they point to directories:\n"
                 r"    file://.*{sep}data{sep}packages{sep}FSPkg "
                 r"\(from -r file \(line 2\)\)".format(sep=sep),
                 resolver.resolve,
@@ -293,8 +293,8 @@ class TestRequirementSet(object):
                 r'THESE PACKAGES DO NOT MATCH THE HASHES.*\n'
                 r'    file:///.*/data/packages/simple-1\.0\.tar\.gz .*:\n'
                 r'        Expected sha256 badbad\n'
-                r'             Got        393043e672415891885c9a2a0929b1af95fb866d'
-                r'6ca016b42d2e6ce53619b653$',
+                r'             Got        393043e672415891885c9a2a0929b1af95fb'
+                r'866d6ca016b42d2e6ce53619b653$',
                 resolver.resolve,
                 reqset,
             )

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -75,12 +75,16 @@ class TestRequirementSet(object):
                 req_tracker=tracker,
             )
             yield Resolver(
-                preparer=preparer,
+                finder=finder,
                 make_install_req=make_install_req,
-                session=PipSession(), finder=finder,
-                use_user_site=False, upgrade_strategy="to-satisfy-only",
-                ignore_dependencies=False, ignore_installed=False,
-                ignore_requires_python=False, force_reinstall=False,
+                preparer=preparer,
+                session=PipSession(),
+                upgrade_strategy="to-satisfy-only",
+                force_reinstall=False,
+                ignore_dependencies=False,
+                ignore_installed=False,
+                ignore_requires_python=False,
+                use_user_site=False,
             )
 
     def test_no_reuse_existing_build_dir(self, data):


### PR DESCRIPTION
Inspired by and closes #5882 

Initialize all the "build tracking" stuff on `__enter__` and remove the environment variable on `__exit__`.

Shoutout to @asottile for actually spotting the issue with RequirementTracker's context management. :)