### PR TITLE
Simplify InstallRequirement.prepare_metadata()

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -457,6 +457,17 @@ class InstallRequirement(object):
         # no more moves are needed.
         self._ideal_build_dir = None
 
+    def warn_on_mismatching_name(self):
+        metadata_name = canonicalize_name(self.metadata["Name"])
+        if canonicalize_name(self.req.name) != metadata_name:
+            logger.warning(
+                'Generating metadata for package %s '
+                'produced metadata for project name %s. Fix your '
+                '#egg=%s fragments.',
+                self.name, metadata_name, self.name
+            )
+            self.req = Requirement(metadata_name)
+
     def remove_temporary_source(self):
         # type: () -> None
         """Remove the source files from this requirement, if they are marked
@@ -607,15 +618,7 @@ class InstallRequirement(object):
         if not self.name:
             self.move_to_correct_build_directory()
         else:
-            metadata_name = canonicalize_name(self.metadata["Name"])
-            if canonicalize_name(self.req.name) != metadata_name:
-                logger.warning(
-                    'Generating metadata for package %s '
-                    'produced metadata for project name %s. Fix your '
-                    '#egg=%s fragments.',
-                    self.name, metadata_name, self.name
-                )
-                self.req = Requirement(metadata_name)
+            self.warn_on_mismatching_name()
 
     @property
     def metadata(self):

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -445,13 +445,12 @@ class InstallRequirement(object):
             path=new_location, kind="req-install",
         )
 
-        # Correct the metadata directory, if it exists
-        if self.metadata_directory:
-            old_meta = self.metadata_directory
-            rel = os.path.relpath(old_meta, start=old_location.path)
-            new_meta = os.path.join(new_location, rel)
-            new_meta = os.path.normpath(os.path.abspath(new_meta))
-            self.metadata_directory = new_meta
+        # Correct the metadata directory
+        old_meta = self.metadata_directory
+        rel = os.path.relpath(old_meta, start=old_location.path)
+        new_meta = os.path.join(new_location, rel)
+        new_meta = os.path.normpath(os.path.abspath(new_meta))
+        self.metadata_directory = new_meta
 
         # Done with any "move built files" work, since have moved files to the
         # "ideal" build location. Setting to None allows to clearly flag that

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -459,14 +459,18 @@ class InstallRequirement(object):
 
     def warn_on_mismatching_name(self):
         metadata_name = canonicalize_name(self.metadata["Name"])
-        if canonicalize_name(self.req.name) != metadata_name:
-            logger.warning(
-                'Generating metadata for package %s '
-                'produced metadata for project name %s. Fix your '
-                '#egg=%s fragments.',
-                self.name, metadata_name, self.name
-            )
-            self.req = Requirement(metadata_name)
+        if canonicalize_name(self.req.name) == metadata_name:
+            # Everything is fine.
+            return
+
+        # If we're here, there's a mismatch. Log a warning about it.
+        logger.warning(
+            'Generating metadata for package %s '
+            'produced metadata for project name %s. Fix your '
+            '#egg=%s fragments.',
+            self.name, metadata_name, self.name
+        )
+        self.req = Requirement(metadata_name)
 
     def remove_temporary_source(self):
         # type: () -> None


### PR DESCRIPTION
This refactor moves out logic from prepare_metadata, to make it an overall orchestration method -- only containing "broad" details of what has to be done to "prepare metadata".