### PR TITLE
Simplify requirement file parsing

### DIFF
--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -232,7 +232,6 @@ def process_line(
         elif not SCHEME_RE.search(req_path):
             # do a join so relative paths work
             req_path = os.path.join(os.path.dirname(filename), req_path)
-        # TODO: Why not use `comes_from='-r {} (line {})'` here as well?
         parsed_reqs = parse_requirements(
             req_path, finder, comes_from, options, session,
             constraint=nested_constraint, wheel_cache=wheel_cache

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -83,8 +83,8 @@ class TestPreprocess(object):
           ern
           line2
         """)
-        options.skip_requirements_regex = 'pattern'
-        result = preprocess(content, options)
+        skip_requirements_regex = 'pattern'
+        result = preprocess(content, skip_requirements_regex)
         assert list(result) == [(3, 'line2')]
 
     def test_skip_regex_after_joining_case2(self, options):
@@ -93,8 +93,8 @@ class TestPreprocess(object):
           line2
           line3
         """)
-        options.skip_requirements_regex = 'pattern'
-        result = preprocess(content, options)
+        skip_requirements_regex = 'pattern'
+        result = preprocess(content, skip_requirements_regex)
         assert list(result) == [(3, 'line3')]
 
 
@@ -154,24 +154,19 @@ class TestSkipRegex(object):
     """tests for `skip_reqex``"""
 
     def test_skip_regex_pattern_match(self):
-        options = stub(skip_requirements_regex='.*Bad.*')
+        pattern = '.*Bad.*'
         line = '--extra-index-url Bad'
-        assert [] == list(skip_regex(enumerate([line]), options))
+        assert [] == list(skip_regex(enumerate([line]), pattern))
 
     def test_skip_regex_pattern_not_match(self):
-        options = stub(skip_requirements_regex='.*Bad.*')
+        pattern = '.*Bad.*'
         line = '--extra-index-url Good'
-        assert [(0, line)] == list(skip_regex(enumerate([line]), options))
+        assert [(0, line)] == list(skip_regex(enumerate([line]), pattern))
 
     def test_skip_regex_no_options(self):
-        options = None
+        pattern = None
         line = '--extra-index-url Good'
-        assert [(0, line)] == list(skip_regex(enumerate([line]), options))
-
-    def test_skip_regex_no_skip_option(self):
-        options = stub(skip_requirements_regex=None)
-        line = '--extra-index-url Good'
-        assert [(0, line)] == list(skip_regex(enumerate([line]), options))
+        assert [(1, line)] == list(preprocess(line, pattern))
 
 
 class TestProcessLine(object):


### PR DESCRIPTION
This is the first part of a cleanup and refactoring of our requirement file parsing.

The general goal is to decouple the file/line parsing from the construction of the requirements objects. To that end, this PR reduces coupling between a few components and moves the parsing-specific logic to one place in `process_line` so that the extraction will be easier to review.

This PR does not go all the way to extract the parsing logic because many tests in `tests.unit.test_req_file` rely on the current interface. I'd rather bundle those into their own change.