### PR TITLE
Allow for use_user_site being set to an integer

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -617,12 +617,12 @@ def decide_user_install(
     which is provided by the other arguments.
     """
     # In some cases (config from tox), use_user_site can be set to an integer
-    # rather than a bool. Comparing == True/False instead of 'is' allows this.
-    if use_user_site == False:  # noqa: E712
+    # rather than a bool, which 'use_user_site is False' wouldn't catch.
+    if (use_user_site is not None) and (not use_user_site):
         logger.debug("Non-user install by explicit request")
         return False
 
-    if use_user_site == True:  # noqa: E712
+    if use_user_site:
         if prefix_path:
             raise CommandError(
                 "Can not combine '--user' and '--prefix' as they imply "

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -616,11 +616,13 @@ def decide_user_install(
     If use_user_site is None, the default behaviour depends on the environment,
     which is provided by the other arguments.
     """
-    if use_user_site is False:
+    # In some cases (config from tox), use_user_site can be set to an integer
+    # rather than a bool. Comparing == True/False instead of 'is' allows this.
+    if use_user_site == False:  # noqa: E712
         logger.debug("Non-user install by explicit request")
         return False
 
-    if use_user_site is True:
+    if use_user_site == True:  # noqa: E712
         if prefix_path:
             raise CommandError(
                 "Can not combine '--user' and '--prefix' as they imply "

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1586,6 +1586,20 @@ def test_target_install_ignores_distutils_config_install_prefix(script):
     assert relative_script_base not in result.files_created
 
 
+def test_user_config_accepted(script):
+    # user set in the config file is parsed as 0/1 instead of True/False.
+    # Check that this doesn't cause a problem.
+    config_file = script.scratch_path / 'pip.conf'
+    script.environ['PIP_CONFIG_FILE'] = str(config_file)
+    config_file.write_text("[install]\nuser = true")
+    result = script.pip_install_local('simplewheel')
+
+    assert "Successfully installed simplewheel" in result.stdout
+
+    relative_user = os.path.relpath(script.user_site_path, script.base_path)
+    assert join(relative_user, 'simplewheel') in result.files_created
+
+
 @pytest.mark.network
 @pytest.mark.skipif("sys.platform != 'win32'")
 @pytest.mark.parametrize('pip_name', [


### PR DESCRIPTION
This can come from tox config, as described in a comment:
https://github.com/pypa/pip/pull/7002#issuecomment-545108292

This PR implements @pradyunsg's suggested fix. The alternatives are to delve into how options & config are handled to fix it there, or to get it fixed in tox and hope no-one else hits it.

The `# noqa: E712` markers are required to stop flake8 from complaining that the comparisons should use `is`, as normally they should.