### PR TITLE
Simplify requirement file parsing

### DIFF
--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -29,7 +29,7 @@ from pip._internal.req.constructors import (
     install_req_from_req_string,
     parse_editable,
 )
-from pip._internal.req.req_file import process_line
+from pip._internal.req.req_file import ParsedLine, get_line_parser, handle_line
 from pip._internal.req.req_tracker import RequirementTracker
 from pip._internal.utils.urls import path_to_url
 from tests.lib import (
@@ -41,7 +41,18 @@ from tests.lib import (
 
 
 def get_processed_req_from_line(line, fname='file', lineno=1):
-    req = list(process_line(line, fname, lineno))[0]
+    line_parser = get_line_parser(None)
+    args_str, opts = line_parser(line)
+    parsed_line = ParsedLine(
+        fname,
+        lineno,
+        fname,
+        args_str,
+        opts,
+        False,
+    )
+    req = handle_line(parsed_line)
+    assert req is not None
     req.is_direct = True
     return req
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -5,6 +5,7 @@ import textwrap
 
 import pytest
 from mock import Mock, patch
+from pip._vendor.six import PY2
 from pretend import stub
 
 import pip._internal.req.req_file  # this will be monkeypatched
@@ -169,98 +170,133 @@ class TestSkipRegex(object):
         assert [(1, line)] == list(preprocess(line, pattern))
 
 
+@pytest.fixture
+def line_processor(
+    monkeypatch,
+    tmpdir,
+):
+    def process_line(
+        line,
+        filename,
+        line_number,
+        finder=None,
+        options=None,
+        session=None,
+        constraint=False,
+    ):
+        if session is None:
+            session = PipSession()
+
+        prefix = '\n' * (line_number - 1)
+        path = tmpdir.joinpath(filename)
+        path.parent.mkdir(exist_ok=True)
+        path.write_text(prefix + line)
+        monkeypatch.chdir(str(tmpdir))
+        return list(parse_requirements(
+            filename,
+            finder=finder,
+            options=options,
+            session=session,
+            constraint=constraint,
+        ))
+
+    return process_line
+
+
 class TestProcessLine(object):
     """tests for `process_line`"""
 
-    def test_parser_error(self):
+    def test_parser_error(self, line_processor):
         with pytest.raises(RequirementsFileParseError):
-            list(process_line("--bogus", "file", 1))
+            line_processor("--bogus", "file", 1)
 
-    def test_parser_offending_line(self):
+    def test_parser_offending_line(self, line_processor):
         line = 'pkg==1.0.0 --hash=somehash'
         with pytest.raises(RequirementsFileParseError) as err:
-            list(process_line(line, 'file', 1))
+            line_processor(line, 'file', 1)
         assert line in str(err.value)
 
-    def test_parser_non_offending_line(self):
+    def test_parser_non_offending_line(self, line_processor):
         try:
-            list(process_line('pkg==1.0.0 --hash=sha256:somehash', 'file', 1))
+            line_processor('pkg==1.0.0 --hash=sha256:somehash', 'file', 1)
         except RequirementsFileParseError:
             pytest.fail('Reported offending line where it should not.')
 
-    def test_only_one_req_per_line(self):
+    def test_only_one_req_per_line(self, line_processor):
         # pkg_resources raises the ValueError
         with pytest.raises(InstallationError):
-            list(process_line("req1 req2", "file", 1))
+            line_processor("req1 req2", "file", 1)
 
-    def test_error_message(self):
+    def test_error_message(self, line_processor):
         """
         Test the error message if a parsing error occurs (all of path,
         line number, and hint).
         """
-        iterator = process_line(
-            'my-package=1.0',
-            filename='path/requirements.txt',
-            line_number=3
-        )
         with pytest.raises(InstallationError) as exc:
-            list(iterator)
+            line_processor(
+                'my-package=1.0',
+                filename='path/requirements.txt',
+                line_number=3
+            )
 
+        package_name = "u'my-package=1.0'" if PY2 else "'my-package=1.0'"
         expected = (
-            "Invalid requirement: 'my-package=1.0' "
+            "Invalid requirement: {} "
             '(from line 3 of path/requirements.txt)\n'
             'Hint: = is not a valid operator. Did you mean == ?'
-        )
+        ).format(package_name)
         assert str(exc.value) == expected
 
-    def test_yield_line_requirement(self):
+    def test_yield_line_requirement(self, line_processor):
         line = 'SomeProject'
         filename = 'filename'
         comes_from = '-r %s (line %s)' % (filename, 1)
         req = install_req_from_line(line, comes_from=comes_from)
-        assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
+        assert repr(line_processor(line, filename, 1)[0]) == repr(req)
 
-    def test_yield_pep440_line_requirement(self):
+    def test_yield_pep440_line_requirement(self, line_processor):
         line = 'SomeProject @ https://url/SomeProject-py2-py3-none-any.whl'
         filename = 'filename'
         comes_from = '-r %s (line %s)' % (filename, 1)
         req = install_req_from_line(line, comes_from=comes_from)
-        assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
+        assert repr(line_processor(line, filename, 1)[0]) == repr(req)
 
-    def test_yield_line_constraint(self):
+    def test_yield_line_constraint(self, line_processor):
         line = 'SomeProject'
         filename = 'filename'
         comes_from = '-c %s (line %s)' % (filename, 1)
         req = install_req_from_line(
             line, comes_from=comes_from, constraint=True)
-        found_req = list(process_line(line, filename, 1, constraint=True))[0]
+        found_req = line_processor(line, filename, 1, constraint=True)[0]
         assert repr(found_req) == repr(req)
         assert found_req.constraint is True
 
-    def test_yield_line_requirement_with_spaces_in_specifier(self):
+    def test_yield_line_requirement_with_spaces_in_specifier(
+        self, line_processor
+    ):
         line = 'SomeProject >= 2'
         filename = 'filename'
         comes_from = '-r %s (line %s)' % (filename, 1)
         req = install_req_from_line(line, comes_from=comes_from)
-        assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
+        assert repr(line_processor(line, filename, 1)[0]) == repr(req)
         assert str(req.req.specifier) == '>=2'
 
-    def test_yield_editable_requirement(self):
+    def test_yield_editable_requirement(self, line_processor):
         url = 'git+https://url#egg=SomeProject'
         line = '-e %s' % url
         filename = 'filename'
         comes_from = '-r %s (line %s)' % (filename, 1)
         req = install_req_from_editable(url, comes_from=comes_from)
-        assert repr(list(process_line(line, filename, 1))[0]) == repr(req)
+        assert repr(line_processor(line, filename, 1)[0]) == repr(req)
 
-    def test_yield_editable_constraint(self):
+    def test_yield_editable_constraint(self, line_processor):
         url = 'git+https://url#egg=SomeProject'
         line = '-e %s' % url
         filename = 'filename'
         comes_from = '-c %s (line %s)' % (filename, 1)
         req = install_req_from_editable(
             url, comes_from=comes_from, constraint=True)
-        found_req = list(process_line(line, filename, 1, constraint=True))[0]
+        found_req = line_processor(line, filename, 1, constraint=True)[0]
         assert repr(found_req) == repr(req)
         assert found_req.constraint is True
 
@@ -288,16 +324,16 @@ class TestProcessLine(object):
                             parse_requirements_stub.call)
         assert list(process_line(line, 'filename', 1)) == [(req, True)]
 
-    def test_options_on_a_requirement_line(self):
+    def test_options_on_a_requirement_line(self, line_processor):
         line = 'SomeProject --install-option=yo1 --install-option yo2 '\
                '--global-option="yo3" --global-option "yo4"'
         filename = 'filename'
-        req = list(process_line(line, filename, 1))[0]
+        req = line_processor(line, filename, 1)[0]
         assert req.options == {
             'global_options': ['yo3', 'yo4'],
             'install_options': ['yo1', 'yo2']}
 
-    def test_hash_options(self):
+    def test_hash_options(self, line_processor):
         """Test the --hash option: mostly its value storage.
 
         Make sure it reads and preserve multiple hashes.
@@ -310,7 +346,7 @@ class TestProcessLine(object):
                 '--hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8'
                 'e5a6c65260e9cb8a7')
         filename = 'filename'
-        req = list(process_line(line, filename, 1))[0]
+        req = line_processor(line, filename, 1)[0]
         assert req.options == {'hashes': {
             'sha256': ['2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e730433'
                        '62938b9824',
@@ -319,35 +355,37 @@ class TestProcessLine(object):
             'sha384': ['59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcd'
                        'b9c666fa90125a3c79f90397bdf5f6a13de828684f']}}
 
-    def test_set_isolated(self, options):
+    def test_set_isolated(self, line_processor, options):
         line = 'SomeProject'
         filename = 'filename'
         options.isolated_mode = True
-        result = process_line(line, filename, 1, options=options)
-        assert list(result)[0].isolated
+        result = line_processor(line, filename, 1, options=options)
+        assert result[0].isolated
 
-    def test_set_finder_no_index(self, finder):
-        list(process_line("--no-index", "file", 1, finder=finder))
+    def test_set_finder_no_index(self, line_processor, finder):
+        line_processor("--no-index", "file", 1, finder=finder)
         assert finder.index_urls == []
 
-    def test_set_finder_index_url(self, finder):
-        list(process_line("--index-url=url", "file", 1, finder=finder))
+    def test_set_finder_index_url(self, line_processor, finder):
+        line_processor("--index-url=url", "file", 1, finder=finder)
         assert finder.index_urls == ['url']
 
-    def test_set_finder_find_links(self, finder):
-        list(process_line("--find-links=url", "file", 1, finder=finder))
+    def test_set_finder_find_links(self, line_processor, finder):
+        line_processor("--find-links=url", "file", 1, finder=finder)
         assert finder.find_links == ['url']
 
-    def test_set_finder_extra_index_urls(self, finder):
-        list(process_line("--extra-index-url=url", "file", 1, finder=finder))
+    def test_set_finder_extra_index_urls(self, line_processor, finder):
+        line_processor("--extra-index-url=url", "file", 1, finder=finder)
         assert finder.index_urls == ['url']
 
-    def test_set_finder_trusted_host(self, caplog, session, finder):
+    def test_set_finder_trusted_host(
+        self, line_processor, caplog, session, finder
+    ):
         with caplog.at_level(logging.INFO):
-            list(process_line(
+            line_processor(
                 "--trusted-host=host1 --trusted-host=host2:8080",
                 "file.txt", 1, finder=finder, session=session,
-            ))
+            )
         assert list(finder.trusted_hosts) == ['host1', 'host2:8080']
         session = finder._link_collector.session
         assert session.adapters['https://host1/'] is session._insecure_adapter
@@ -363,23 +401,30 @@ class TestProcessLine(object):
         )
         assert expected in actual
 
-    def test_noop_always_unzip(self, finder):
+    def test_noop_always_unzip(self, line_processor, finder):
         # noop, but confirm it can be set
-        list(process_line("--always-unzip", "file", 1, finder=finder))
+        line_processor("--always-unzip", "file", 1, finder=finder)
 
-    def test_set_finder_allow_all_prereleases(self, finder):
-        list(process_line("--pre", "file", 1, finder=finder))
+    def test_set_finder_allow_all_prereleases(self, line_processor, finder):
+        line_processor("--pre", "file", 1, finder=finder)
         assert finder.allow_all_prereleases
 
-    def test_relative_local_find_links(self, finder, monkeypatch):
+    def test_relative_local_find_links(
+        self, line_processor, finder, monkeypatch, tmpdir
+    ):
         """
         Test a relative find_links path is joined with the req file directory
         """
+        base_path = tmpdir / 'path'
+
+        def normalize(path):
+            return os.path.normcase(
+                os.path.abspath(os.path.normpath(str(path)))
+            )
+
         # Make sure the test also passes on windows
-        req_file = os.path.normcase(os.path.abspath(
-            os.path.normpath('/path/req_file.txt')))
-        nested_link = os.path.normcase(os.path.abspath(
-            os.path.normpath('/path/rel_path')))
+        req_file = normalize(base_path / 'req_file.txt')
+        nested_link = normalize(base_path / 'rel_path')
         exists_ = os.path.exists
 
         def exists(path):
@@ -387,9 +432,9 @@ class TestProcessLine(object):
                 return True
             else:
                 exists_(path)
+
         monkeypatch.setattr(os.path, 'exists', exists)
-        list(process_line("--find-links=rel_path", req_file, 1,
-                          finder=finder))
+        line_processor("--find-links=rel_path", req_file, 1, finder=finder)
         assert finder.find_links == [nested_link]
 
     def test_relative_http_nested_req_files(self, finder, monkeypatch):


### PR DESCRIPTION
Followup to #7245.

The motivation for this change is to parameterize `InstallRequirement` construction.

When processing requirements files, there was a single function (`req.req_file.process_line`) responsible for all line handling, to include

- parsing the line
- recursing through nested requirements files
- updating global options
- creating requirements.

Now, we have split the responsibility into two. `req.req_file.handle_line` is responsible for updating global options and creating requirements. `req.req_file.RequirementsFileParser` is responsible for parsing lines and recursing through nested requirements files.

In a later PR, `handle_line` will be provided to `parse_requirements` instead of the various options that it currently takes and passes-through.