### PR TITLE
Put Temp on RAM Disk for Azure Pipelines tests

### DIFF
--- a/.azure-pipelines/scripts/New-RAMDisk.ps1
+++ b/.azure-pipelines/scripts/New-RAMDisk.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true,
+    HelpMessage="Drive letter to use for the RAMDisk")]
+    [String]$drive,
+    [Parameter(HelpMessage="Size to allocate to the RAMDisk")]
+    [UInt64]$size=1GB
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+Write-Output "Installing FS-iSCSITarget-Server"
+Install-WindowsFeature -Name FS-iSCSITarget-Server
+
+Write-Output "Starting MSiSCSI"
+Start-Service MSiSCSI
+$retry = 10
+do {
+    $service = Get-Service MSiSCSI
+    if ($service.Status -eq "Running") {
+        break;
+    }
+    $retry--
+    Start-Sleep -Milliseconds 500
+} until ($retry -eq 0)
+
+$service = Get-Service MSiSCSI
+if ($service.Status -ne "Running") {
+    throw "MSiSCSI is not running"
+}
+
+Write-Output "Configuring Firewall"
+Get-NetFirewallServiceFilter -Service MSiSCSI | Enable-NetFirewallRule
+
+Write-Output "Configuring RAMDisk"
+# Must use external-facing IP address, otherwise New-IscsiTargetPortal is
+# unable to connect.
+$ip = (
+    Get-NetIPAddress -AddressFamily IPv4 |
+    Where-Object {$_.IPAddress -ne "127.0.0.1"}
+)[0].IPAddress
+if (
+    -not (Get-IscsiServerTarget -ComputerName localhost | Where-Object {$_.TargetName -eq "ramdisks"})
+) {
+    New-IscsiServerTarget `
+        -ComputerName localhost `
+        -TargetName ramdisks `
+        -InitiatorId IPAddress:$ip
+}
+
+$newVirtualDisk = New-IscsiVirtualDisk `
+    -ComputerName localhost `
+    -Path ramdisk:local$drive.vhdx `
+    -Size $size
+Add-IscsiVirtualDiskTargetMapping `
+    -ComputerName localhost `
+    -TargetName ramdisks `
+    -Path ramdisk:local$drive.vhdx
+
+Write-Output "Connecting to iSCSI"
+New-IscsiTargetPortal -TargetPortalAddress $ip
+Get-IscsiTarget | Where-Object {!$_.IsConnected} | Connect-IscsiTarget
+
+Write-Output "Configuring disk"
+$newDisk = Get-IscsiConnection |
+    Get-Disk |
+    Where-Object {$_.SerialNumber -eq $newVirtualDisk.SerialNumber}
+
+Set-Disk -InputObject $newDisk -IsOffline $false
+Initialize-Disk -InputObject $newDisk -PartitionStyle MBR
+New-Partition -InputObject $newDisk -UseMaximumSize -DriveLetter $drive
+
+Format-Volume -DriveLetter $drive -NewFileSystemLabel Temp -FileSystem NTFS

--- a/.azure-pipelines/steps/run-tests-windows.yml
+++ b/.azure-pipelines/steps/run-tests-windows.yml
@@ -8,10 +8,28 @@ steps:
     versionSpec: '$(python.version)'
     architecture: '$(python.architecture)'
 
+- task: PowerShell@2
+  inputs:
+    filePath: .azure-pipelines/scripts/New-RAMDisk.ps1
+    arguments: "-Drive R -Size 1GB"
+  displayName: Setup RAMDisk
+
+- powershell: |
+    mkdir R:\Temp
+    $acl = Get-Acl "R:\Temp"
+    $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        "Everyone", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow"
+    )
+    $acl.AddAccessRule($rule)
+    Set-Acl "R:\Temp" $acl
+  displayName: Set RAMDisk Permissions
+
 - bash: pip install --upgrade setuptools tox
   displayName: Install Tox
 
 - script: tox -e py -- -m unit -n 3 --junit-xml=junit/unit-test.xml
+  env:
+    TEMP: "R:\\Temp"
   displayName: Tox run unit tests
 
 - ${{ if eq(parameters.runIntegrationTests, 'true') }}:
@@ -23,9 +41,7 @@ steps:
 
       # Shorten paths to get under MAX_PATH or else integration tests will fail
       # https://bugs.python.org/issue18199
-      subst T: $env:TEMP
-      $env:TEMP = "T:\"
-      $env:TMP = "T:\"
+      $env:TEMP = "R:\Temp"
 
       tox -e py -- -m integration -n 3 --duration=5 --junit-xml=junit/integration-test.xml
     displayName: Tox run integration tests


### PR DESCRIPTION
Profiling on Azure Pipelines indicates that the majority of our time is
spent waiting for filesystem operations to complete. As a quick way to
improve our test speed in this area, we can do operations on a RAM disk
instead of the default SSDs.

Related to #4497, #6791.