### PR TITLE
Set --use-venv on Azure Pipelines

### DIFF
--- a/.azure-pipelines/steps/run-tests-windows.yml
+++ b/.azure-pipelines/steps/run-tests-windows.yml
@@ -43,7 +43,7 @@ steps:
       # https://bugs.python.org/issue18199
       $env:TEMP = "R:\Temp"
 
-      tox -e py -- -m integration -n auto --duration=5 --junit-xml=junit/integration-test.xml
+      tox -e py -- --use-venv -m integration -n auto --duration=5 --junit-xml=junit/integration-test.xml
     displayName: Tox run integration tests
 
 - task: PublishTestResults@2

--- a/.azure-pipelines/steps/run-tests.yml
+++ b/.azure-pipelines/steps/run-tests.yml
@@ -11,10 +11,10 @@ steps:
   displayName: Tox run unit tests
 
 # Run integration tests in two groups so we will fail faster if there is a failure in the first group
-- script: tox -e py -- -m integration -n auto --duration=5 -k "not test_install" --junit-xml=junit/integration-test-group0.xml
+- script: tox -e py -- --use-venv -m integration -n auto --duration=5 -k "not test_install" --junit-xml=junit/integration-test-group0.xml
   displayName: Tox run Group 0 integration tests
 
-- script: tox -e py -- -m integration -n auto --duration=5 -k "test_install" --junit-xml=junit/integration-test-group1.xml
+- script: tox -e py -- --use-venv -m integration -n auto --duration=5 -k "test_install" --junit-xml=junit/integration-test-group1.xml
   displayName: Tox run Group 1 integration tests
 
 - task: PublishTestResults@2


### PR DESCRIPTION
This is already passed on our other CI platforms, just seeing if it makes a speed difference.