### PR TITLE
CI: move Python35-x64 from Appveyor to Azure

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,8 +3,6 @@ environment:
     # Unit and integration tests.
     - PYTHON: "C:\\Python27-x64"
       RUN_INTEGRATION_TESTS: "True"
-    - PYTHON: "C:\\Python35-x64"
-      RUN_INTEGRATION_TESTS: "True"
     - PYTHON: "C:\\Python36-x64"
       RUN_INTEGRATION_TESTS: "True"
     # Unit tests only.

--- a/.azure-pipelines/jobs/test-windows.yml
+++ b/.azure-pipelines/jobs/test-windows.yml
@@ -12,10 +12,13 @@ jobs:
       Python27-x86:
         python.version: '2.7'
         python.architecture: x86
+      Python35-x64:
+        python.version: '3.5'
+        python.architecture: x64
       Python37-x64:
         python.version: '3.7'
         python.architecture: x64
-    maxParallel: 2
+    maxParallel: 3
 
   steps:
   - template: ../steps/run-tests-windows.yml


### PR DESCRIPTION
Since Appveyor provides less runner and is often the bottleneck

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
