### PR TITLE
Update pypy on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,13 @@ jobs:
     # PyPy
     - stage: secondary
       env: GROUP=1
-      python: pypy3.5-6.0
+      python: pypy3.5-7.0.0
     - env: GROUP=2
-      python: pypy3.5-6.0
+      python: pypy3.5-7.0.0
     - env: GROUP=1
-      python: pypy2.7-6.0
+      python: pypy2.7-7.1.1
     - env: GROUP=2
-      python: pypy2.7-6.0
+      python: pypy2.7-7.1.1
     # Other Supported CPython
     - env: GROUP=1
       python: 3.6


### PR DESCRIPTION
The versions we were testing were pretty old (about 1.5 years) - and were causing Travis to be the slowest of our checks. Updating to a more recent version gives us a little more incentive to dig into *why* the tests are slower, since any revelations may be more relevant upstream.

* pypy2.7-7.1.1
* pypy3.5-7.0.0 - pypy3.6 was beta until 7.2.0 which is not yet available on Travis (and a few of our tests [here](https://travis-ci.org/pypa/pip/jobs/604716994#L385) were failing because pypy doesn't return 120 on broken stdout until 7.2.0).