### PR TITLE
Return InstallationResult from requirement installation

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -463,13 +463,13 @@ class InstallCommand(RequirementCommand):
                 )
                 working_set = pkg_resources.WorkingSet(lib_locations)
 
-                reqs = sorted(installed, key=operator.attrgetter('name'))
+                installed.sort(key=operator.attrgetter('name'))
                 items = []
-                for req in reqs:
-                    item = req.name
+                for result in installed:
+                    item = result.name
                     try:
                         installed_version = get_installed_version(
-                            req.name, working_set=working_set
+                            result.name, working_set=working_set
                         )
                         if installed_version:
                             item += '-' + installed_version

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -23,6 +23,16 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+class InstallationResult(object):
+    def __init__(self, name):
+        # type: (str) -> None
+        self.name = name
+
+    def __repr__(self):
+        # type: () -> str
+        return "InstallationResult(name={!r})".format(self.name)
+
+
 def install_given_reqs(
     to_install,  # type: List[InstallRequirement]
     install_options,  # type: List[str]
@@ -30,7 +40,7 @@ def install_given_reqs(
     *args,  # type: Any
     **kwargs  # type: Any
 ):
-    # type: (...) -> List[InstallRequirement]
+    # type: (...) -> List[InstallationResult]
     """
     Install everything in the given list.
 
@@ -42,6 +52,8 @@ def install_given_reqs(
             'Installing collected packages: %s',
             ', '.join([req.name for req in to_install]),
         )
+
+    installed = []
 
     with indent_log():
         for requirement in to_install:
@@ -79,4 +91,6 @@ def install_given_reqs(
                     uninstalled_pathset.commit()
             requirement.remove_temporary_source()
 
-    return to_install
+            installed.append(InstallationResult(requirement.name))
+
+    return installed


### PR DESCRIPTION
`InstallationResult` holds basic information needed for post-install checks. This will be used later to hold the list of installed files, which will enable:

1. moving checks for scripts being on PATH into `pip._internal.commands.install` from `pip._internal.wheel`
1. adding more checks on the installed files (#7228, #6863)

This also reduces the usages of `InstallRequirement`, making it easier to refactor.