### PR TITLE
Share script fixtures across tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,7 +345,7 @@ def common_wheels():
 
 @pytest.fixture(scope="session")
 def shared_data(tmpdir_factory):
-    return TestData.copy(Path(tmpdir_factory.mktemp("data")))
+    return TestData.copy(Path(str(tmpdir_factory.mktemp("data"))))
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -343,6 +343,11 @@ def common_wheels():
     return DATA_DIR.joinpath('common_wheels')
 
 
+@pytest.fixture(scope="session")
+def shared_data(tmpdir_factory):
+    return TestData.copy(Path(tmpdir_factory.mktemp("data")))
+
+
 @pytest.fixture
 def data(tmpdir):
     return TestData.copy(tmpdir.joinpath("data"))

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -37,20 +37,31 @@ compctl -K _pip_completion pip"""),
 )
 
 
+@pytest.fixture(scope="session")
+def script_with_launchers(
+    tmpdir_factory, script_factory, common_wheels, pip_src
+):
+    tmpdir = Path(str(tmpdir_factory.mktemp("script_with_launchers")))
+    script = script_factory(tmpdir.joinpath("workspace"))
+    # Re-install pip so we get the launchers.
+    script.pip_install_local('-f', common_wheels, pip_src)
+    return script
+
+
 @pytest.mark.parametrize(
     'shell, completion',
     COMPLETION_FOR_SUPPORTED_SHELLS_TESTS,
     ids=[t[0] for t in COMPLETION_FOR_SUPPORTED_SHELLS_TESTS],
 )
-def test_completion_for_supported_shells(script, pip_src, common_wheels,
-                                         shell, completion):
+def test_completion_for_supported_shells(
+    script_with_launchers, shell, completion
+):
     """
     Test getting completion for bash shell
     """
-    # Re-install pip so we get the launchers.
-    script.pip_install_local('-f', common_wheels, pip_src)
-
-    result = script.pip('completion', '--' + shell, use_module=False)
+    result = script_with_launchers.pip(
+        'completion', '--' + shell, use_module=False
+    )
     assert completion in result.stdout, str(result.stdout)
 
 

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -3,30 +3,35 @@ import os
 
 import pytest
 
+from tests.lib.path import Path
 
-def test_basic_list(script, data):
+
+@pytest.fixture(scope="session")
+def simple_script(tmpdir_factory, script_factory, shared_data):
+    tmpdir = Path(str(tmpdir_factory.mktemp("pip_test_package")))
+    script = script_factory(tmpdir.joinpath("workspace"))
+    script.pip(
+        'install', '-f', shared_data.find_links, '--no-index', 'simple==1.0',
+        'simple2==3.0',
+    )
+    return script
+
+
+def test_basic_list(simple_script):
     """
     Test default behavior of list command without format specifier.
 
     """
-    script.pip(
-        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
-        'simple2==3.0',
-    )
-    result = script.pip('list')
+    result = simple_script.pip('list')
     assert 'simple     1.0' in result.stdout, str(result)
     assert 'simple2    3.0' in result.stdout, str(result)
 
 
-def test_verbose_flag(script, data):
+def test_verbose_flag(simple_script):
     """
     Test the list command with the '-v' option
     """
-    script.pip(
-        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
-        'simple2==3.0',
-    )
-    result = script.pip('list', '-v', '--format=columns')
+    result = simple_script.pip('list', '-v', '--format=columns')
     assert 'Package' in result.stdout, str(result)
     assert 'Version' in result.stdout, str(result)
     assert 'Location' in result.stdout, str(result)
@@ -35,15 +40,11 @@ def test_verbose_flag(script, data):
     assert 'simple2    3.0' in result.stdout, str(result)
 
 
-def test_columns_flag(script, data):
+def test_columns_flag(simple_script):
     """
     Test the list command with the '--format=columns' option
     """
-    script.pip(
-        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
-        'simple2==3.0',
-    )
-    result = script.pip('list', '--format=columns')
+    result = simple_script.pip('list', '--format=columns')
     assert 'Package' in result.stdout, str(result)
     assert 'Version' in result.stdout, str(result)
     assert 'simple (1.0)' not in result.stdout, str(result)
@@ -51,22 +52,18 @@ def test_columns_flag(script, data):
     assert 'simple2    3.0' in result.stdout, str(result)
 
 
-def test_format_priority(script, data):
+def test_format_priority(simple_script):
     """
     Test that latest format has priority over previous ones.
     """
-    script.pip(
-        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
-        'simple2==3.0',
-    )
-    result = script.pip('list', '--format=columns', '--format=freeze',
-                        expect_stderr=True)
+    result = simple_script.pip('list', '--format=columns', '--format=freeze',
+                               expect_stderr=True)
     assert 'simple==1.0' in result.stdout, str(result)
     assert 'simple2==3.0' in result.stdout, str(result)
     assert 'simple     1.0' not in result.stdout, str(result)
     assert 'simple2    3.0' not in result.stdout, str(result)
 
-    result = script.pip('list', '--format=freeze', '--format=columns')
+    result = simple_script.pip('list', '--format=freeze', '--format=columns')
     assert 'Package' in result.stdout, str(result)
     assert 'Version' in result.stdout, str(result)
     assert 'simple==1.0' not in result.stdout, str(result)
@@ -75,23 +72,21 @@ def test_format_priority(script, data):
     assert 'simple2    3.0' in result.stdout, str(result)
 
 
-def test_local_flag(script, data):
+def test_local_flag(simple_script):
     """
     Test the behavior of --local flag in the list command
 
     """
-    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
-    result = script.pip('list', '--local', '--format=json')
+    result = simple_script.pip('list', '--local', '--format=json')
     assert {"name": "simple", "version": "1.0"} in json.loads(result.stdout)
 
 
-def test_local_columns_flag(script, data):
+def test_local_columns_flag(simple_script):
     """
     Test the behavior of --local --format=columns flags in the list command
 
     """
-    script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
-    result = script.pip('list', '--local', '--format=columns')
+    result = simple_script.pip('list', '--local', '--format=columns')
     assert 'Package' in result.stdout
     assert 'Version' in result.stdout
     assert 'simple (1.0)' not in result.stdout
@@ -479,30 +474,22 @@ def test_not_required_flag(script, data):
     assert 'TopoRequires3 ' not in result.stdout
 
 
-def test_list_freeze(script, data):
+def test_list_freeze(simple_script):
     """
     Test freeze formatting of list command
 
     """
-    script.pip(
-        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
-        'simple2==3.0',
-    )
-    result = script.pip('list', '--format=freeze')
+    result = simple_script.pip('list', '--format=freeze')
     assert 'simple==1.0' in result.stdout, str(result)
     assert 'simple2==3.0' in result.stdout, str(result)
 
 
-def test_list_json(script, data):
+def test_list_json(simple_script):
     """
     Test json formatting of list command
 
     """
-    script.pip(
-        'install', '-f', data.find_links, '--no-index', 'simple==1.0',
-        'simple2==3.0',
-    )
-    result = script.pip('list', '--format=json')
+    result = simple_script.pip('list', '--format=json')
     data = json.loads(result.stdout)
     assert {'name': 'simple', 'version': '1.0'} in data
     assert {'name': 'simple2', 'version': '3.0'} in data


### PR DESCRIPTION
We now have a `script_factory` pytest fixture that we can use to create reusable script objects. These can be used across multiple tests.

This helps because each usage of the plain `script` fixture requires:

1. copying the whole template virtual environment
2. (usually) copying test data (`tests.lib.TestData` via the `data` fixture)
3. some setup/installation that is usually common across multiple tests

I just picked two example functional test files to start - I think there are a lot more opportunities to improve our test speed here.

Makes progress on #4497.