### PR TITLE
Refactor _get_used_vcs_backend

### DIFF
--- a/news/7281.trivial
+++ b/news/7281.trivial
@@ -1,0 +1,1 @@
+refactor _get_used_vcs_backend

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -66,7 +66,6 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.req.req_install import InstallRequirement
     from pip._internal.req.req_tracker import RequirementTracker
     from pip._internal.utils.hashes import Hashes
-    from pip._internal.vcs.versioncontrol import VersionControl
 
     if PY2:
         CopytreeKwargs = TypedDict(
@@ -103,20 +102,9 @@ def _get_prepared_distribution(req, req_tracker, finder, build_isolation):
 
 def unpack_vcs_link(link, location):
     # type: (Link, str) -> None
-    vcs_backend = _get_used_vcs_backend(link)
+    vcs_backend = vcs.get_backend_for_scheme(link.scheme)
     assert vcs_backend is not None
     vcs_backend.unpack(location, url=hide_url(link.url))
-
-
-def _get_used_vcs_backend(link):
-    # type: (Link) -> Optional[VersionControl]
-    """
-    Return a VersionControl object or None.
-    """
-    for vcs_backend in vcs.backends:
-        if link.scheme in vcs_backend.schemes:
-            return vcs_backend
-    return None
 
 
 def _progress_indicator(iterable, *args, **kwargs):

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -237,6 +237,16 @@ class VcsSupport(object):
                 return vcs_backend
         return None
 
+    def get_backend_for_scheme(self, scheme):
+        # type: (str) -> Optional[VersionControl]
+        """
+        Return a VersionControl object or None.
+        """
+        for vcs_backend in self._registry.values():
+            if scheme in vcs_backend.schemes:
+                return vcs_backend
+        return None
+
     def get_backend(self, name):
         # type: (str) -> Optional[VersionControl]
         """

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -6,8 +6,13 @@ import os
 
 import pytest
 
+from pip._internal.vcs import vcs
 from pip._internal.vcs.git import Git, RemoteNotFoundError
 from tests.lib import _create_test_package, _git_commit, _test_path_to_file_url
+
+
+def test_get_backend_for_scheme():
+    assert vcs.get_backend_for_scheme("git+https") is vcs.get_backend("Git")
 
 
 def get_head_sha(script, dest):


### PR DESCRIPTION
Move `_get_used_vcs_backend` to the `vcs` package and refactor it so it does not need to know what a `Link` is. Rename it `get_backend_for_scheme` and put it close to it's siblings `get_backend` and `get_backend_for_dir`.

Towards #6851 