### PR TITLE
Move _clean_zip_name into a nested function

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -749,19 +749,20 @@ class InstallRequirement(object):
         uninstalled_pathset.remove(auto_confirm, verbose)
         return uninstalled_pathset
 
-    def _clean_zip_name(self, name, prefix):  # only used by archive.
-        # type: (str, str) -> str
-        assert name.startswith(prefix + os.path.sep), (
-            "name %r doesn't start with prefix %r" % (name, prefix)
-        )
-        name = name[len(prefix) + 1:]
-        name = name.replace(os.path.sep, '/')
-        return name
-
     def _get_archive_name(self, path, parentdir, rootdir):
         # type: (str, str, str) -> str
+
+        def _clean_zip_name(name, prefix):
+            # type: (str, str) -> str
+            assert name.startswith(prefix + os.path.sep), (
+                "name %r doesn't start with prefix %r" % (name, prefix)
+            )
+            name = name[len(prefix) + 1:]
+            name = name.replace(os.path.sep, '/')
+            return name
+
         path = os.path.join(parentdir, path)
-        name = self._clean_zip_name(path, rootdir)
+        name = _clean_zip_name(path, rootdir)
         return self.name + '/' + name
 
     def archive(self, build_dir):


### PR DESCRIPTION
Why: Better models how it's used

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
