### PR TITLE
Use nox to further automate our release mechanisms

### DIFF
--- a/.azure-pipelines/jobs/package.yml
+++ b/.azure-pipelines/jobs/package.yml
@@ -15,20 +15,19 @@ jobs:
     inputs:
       versionSpec: '3'
 
-  - bash: pip install twine nox setuptools wheel
+  - bash: |
+      git config --global user.email "pypa-dev@googlegroups.com"
+      git config --global user.name "pip"
+    displayName: Setup Git credentials
+
+  - bash: pip install nox
     displayName: Install dependencies
 
-  - bash: nox -s generate_authors
-    displayName: Generate AUTHORS.txt
+  - bash: nox -s prepare-release -- 99.9
+    displayName: Prepare dummy release
 
-  - bash: nox -s generate_news -- --yes
-    displayName: Generate NEWS.rst
-
-  - bash: python setup.py sdist bdist_wheel
-    displayName: Create sdist and wheel
-
-  - bash: twine check dist/*
-    displayName: Check distributions with twine
+  - bash: nox -s build-release -- 99.9
+    displayName: Generate distributions for the dummy release
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: dist'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     args: []
   - id: mypy
     name: mypy, for Py2
-    exclude: noxfile.py|docs|tests
+    exclude: noxfile.py|tools/automation/release|docs|tests
     args: ["-2"]
 
 - repo: https://github.com/pre-commit/pygrep-hooks

--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -80,31 +80,19 @@ Creating a new release
 ----------------------
 
 #. Checkout the current pip ``master`` branch.
-#. Ensure you have the latest ``wheel``, ``setuptools``, ``twine`` and ``nox`` packages installed.
-#. Generate a new ``AUTHORS.txt`` (``nox -s generate_authors``) and commit the
-   results.
-#. Bump the version in ``pip/__init__.py`` to the release version and commit
-   the results. Usually this involves dropping just the ``.devN`` suffix on the
-   version.
-#. Generate a new ``NEWS.rst`` (``nox -s generate_news``) and commit the
-   results.
-#. Create a tag at the current commit, of the form ``YY.N``
-   (``git tag YY.N``).
-#. Checkout the tag (``git checkout YY.N``).
-#. Create the distribution files (``python setup.py sdist bdist_wheel``).
-#. Upload the distribution files to PyPI using twine
-   (``twine upload dist/*``).
+#. Ensure you have the latest ``nox`` and ``twine`` installed.
+#. Prepare for release using ``nox -s prepare-release -- YY.N``.
+   This will update the relevant files and tag the correct commit.
+#. Build the release artifacts using ``nox -s build-release -- YY.N``.
+   This will checkout the tag, generate the distribution files to be
+   uploaded and checkout the master branch again.
+#. Upload the distribution files to PyPI using ``twine upload dist/*``.
 #. Push all of the changes including the tag.
 #. Regenerate the ``get-pip.py`` script in the `get-pip repository`_ (as
    documented there) and commit the results.
 #. Submit a Pull Request to `CPython`_ adding the new version of pip (and upgrading
    setuptools) to ``Lib/ensurepip/_bundled``, removing the existing version, and
    adjusting the versions listed in ``Lib/ensurepip/__init__.py``.
-
-
-.. note::
-
-  Steps 3 to 6 are automated in ``nox -s release -- YY.N`` command.
 
 
 .. note::
@@ -117,6 +105,7 @@ Creating a new release
 
 
 .. note::
+
   If the ``get-pip.py`` script needs to be updated due to changes in pip internals
   and if the last ``M.m/get-pip.py`` published still uses the default template, make
   sure to first duplicate ``templates/default.py`` as ``templates/pre-YY.N.py``
@@ -135,7 +124,7 @@ order to create one of these the changes should already be merged into the
    command ``git checkout -b release/YY.N.Z+1 YY.N``.
 #. Cherry pick the fixed commits off of the ``master`` branch, fixing any
    conflicts.
-#. Follow the steps 3 to 6 from above (or call ``nox -s release -- YY.N.Z+1``)
+#. Run ``nox -s prepare-release -- YY.N.Z+1``.
 #. Merge master into your release branch and drop the news files that have been
    included in your release (otherwise they would also appear in the ``YY.N+1``
    changelog)

--- a/tools/automation/release/__init__.py
+++ b/tools/automation/release/__init__.py
@@ -4,6 +4,7 @@ These are written according to the order they are called in.
 """
 
 import io
+import os
 import subprocess
 
 
@@ -102,3 +103,9 @@ def get_next_development_version(version):
         minor += 1
 
     return f"{major}.{minor}.dev0"
+
+
+def have_files_in_folder(folder_name):
+    if not os.path.exists(folder_name):
+        return False
+    return bool(os.listdir(folder_name))

--- a/tools/automation/release/__init__.py
+++ b/tools/automation/release/__init__.py
@@ -1,0 +1,104 @@
+"""Helpers for release automation.
+
+These are written according to the order they are called in.
+"""
+
+import io
+import subprocess
+
+
+def get_version_from_arguments(arguments):
+    """Checks the arguments passed to `nox -s release`.
+
+    If there is only 1 argument that looks like a pip version, returns that.
+    Otherwise, returns None.
+    """
+    if len(arguments) != 1:
+        return None
+
+    version = arguments[0]
+
+    parts = version.split('.')
+    if not 2 <= len(parts) <= 3:
+        # Not of the form: YY.N or YY.N.P
+        return None
+
+    if not all(part.isdigit() for part in parts):
+        # Not all segments are integers.
+        return None
+
+    # All is good.
+    return version
+
+
+def modified_files_in_git(*args):
+    return subprocess.run(
+        ["git", "diff", "--no-patch", "--exit-code", *args],
+        capture_output=True,
+    ).returncode
+
+
+def get_author_list():
+    """Get the list of authors from Git commits.
+    """
+    # subprocess because session.run doesn't give us stdout
+    result = subprocess.run(
+        ["git", "log", "--use-mailmap", "--format=%aN <%aE>"],
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+    # Create a unique list.
+    authors = []
+    seen_authors = set()
+    for author in result.stdout.splitlines():
+        author = author.strip()
+        if author.lower() not in seen_authors:
+            seen_authors.add(author.lower())
+            authors.append(author)
+
+    # Sort our list of Authors by their case insensitive name
+    return sorted(authors, key=lambda x: x.lower())
+
+
+def generate_authors(filename: str) -> None:
+    # Get our list of authors
+    authors = get_author_list()
+
+    # Write our authors to the AUTHORS file
+    with io.open(filename, "w", encoding="utf-8") as fp:
+        fp.write(u"\n".join(authors))
+        fp.write(u"\n")
+
+
+def commit_file(session, filename, *, message):
+    session.run("git", "add", filename, external=True, silent=True)
+    session.run("git", "commit", "-m", message, external=True, silent=True)
+
+
+def generate_news(session, version):
+    session.install("towncrier")
+    session.run("towncrier", "--yes", "--version", version, silent=True)
+
+
+def update_version_file(new_version, filepath):
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write('__version__ = "{}"\n'.format(new_version))
+
+
+def create_git_tag(session, tag_name, *, message):
+    session.run("git", "tag", "-m", message, tag_name, external=True, silent=True)
+
+
+def get_next_development_version(version):
+    major, minor, *_ = map(int, version.split("."))
+
+    # We have at most 4 releases, starting with 0. Once we reach 3, we'd want
+    # to roll-over to the next year's release numbers.
+    if minor == 3:
+        major += 1
+        minor = 0
+    else:
+        minor += 1
+
+    return f"{major}.{minor}.dev0"


### PR DESCRIPTION
Not sure why I kept working on this past 2am. But hey, now we have our release process reduced significantly.

- Get rid of `generate_*` nox commands, since, well, there's no point in invoking them directly if everything is automated.
- Create a new `tools/automation/release/__init__.py` file, that contains helpers for release process automation.
- Add a new build-release command, to go from tagged release -> distributions in dist/.
- Nicer version bumping scheme that's in-compliance with our current release cadence.

Other than that, the fact that 7150861 needed commits to be made to the branch, meant that I was completely confused while working on it and lost my work once. Anyway, I think this works, since I managed to get to a distribution using this two commands on my machine. :P