### PR TITLE
Remove Resolver.session

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -173,7 +173,6 @@ class RequirementCommand(IndexGroupCommand):
     @staticmethod
     def make_resolver(
         preparer,                            # type: RequirementPreparer
-        session,                             # type: PipSession
         finder,                              # type: PackageFinder
         options,                             # type: Values
         wheel_cache=None,                    # type: Optional[WheelCache]
@@ -197,7 +196,6 @@ class RequirementCommand(IndexGroupCommand):
         )
         return Resolver(
             preparer=preparer,
-            session=session,
             finder=finder,
             make_install_req=make_install_req,
             use_user_site=use_user_site,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -149,6 +149,7 @@ class RequirementCommand(IndexGroupCommand):
         temp_build_dir,           # type: TempDirectory
         options,                  # type: Values
         req_tracker,              # type: RequirementTracker
+        session,                  # type: PipSession
         download_dir=None,        # type: str
         wheel_download_dir=None,  # type: str
     ):
@@ -166,6 +167,7 @@ class RequirementCommand(IndexGroupCommand):
             progress_bar=options.progress_bar,
             build_isolation=options.build_isolation,
             req_tracker=req_tracker,
+            session=session,
         )
 
     @staticmethod

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -129,6 +129,7 @@ class DownloadCommand(RequirementCommand):
                 temp_build_dir=directory,
                 options=options,
                 req_tracker=req_tracker,
+                session=session,
                 download_dir=options.download_dir,
             )
 

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -136,7 +136,6 @@ class DownloadCommand(RequirementCommand):
             resolver = self.make_resolver(
                 preparer=preparer,
                 finder=finder,
-                session=session,
                 options=options,
                 py_version_info=options.python_version,
             )

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -364,6 +364,7 @@ class InstallCommand(RequirementCommand):
                     temp_build_dir=directory,
                     options=options,
                     req_tracker=req_tracker,
+                    session=session,
                 )
                 resolver = self.make_resolver(
                     preparer=preparer,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -369,7 +369,6 @@ class InstallCommand(RequirementCommand):
                 resolver = self.make_resolver(
                     preparer=preparer,
                     finder=finder,
-                    session=session,
                     options=options,
                     wheel_cache=wheel_cache,
                     use_user_site=options.use_user_site,

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -180,7 +180,6 @@ class WheelCommand(RequirementCommand):
                 resolver = self.make_resolver(
                     preparer=preparer,
                     finder=finder,
-                    session=session,
                     options=options,
                     wheel_cache=wheel_cache,
                     ignore_requires_python=options.ignore_requires_python,

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -173,6 +173,7 @@ class WheelCommand(RequirementCommand):
                     temp_build_dir=directory,
                     options=options,
                     req_tracker=req_tracker,
+                    session=session,
                     wheel_download_dir=options.wheel_dir,
                 )
 

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -45,7 +45,6 @@ if MYPY_CHECK_RUNNING:
     from pip._vendor import pkg_resources
 
     from pip._internal.distributions import AbstractDistribution
-    from pip._internal.network.session import PipSession
     from pip._internal.index.package_finder import PackageFinder
     from pip._internal.operations.prepare import RequirementPreparer
     from pip._internal.req.req_install import InstallRequirement
@@ -116,7 +115,6 @@ class Resolver(object):
     def __init__(
         self,
         preparer,  # type: RequirementPreparer
-        session,  # type: PipSession
         finder,  # type: PackageFinder
         make_install_req,  # type: InstallRequirementProvider
         use_user_site,  # type: bool
@@ -141,7 +139,6 @@ class Resolver(object):
 
         self.preparer = preparer
         self.finder = finder
-        self.session = session
 
         self.require_hashes_option = require_hashes
 

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -307,7 +307,7 @@ class Resolver(object):
         # We eagerly populate the link, since that's our "legacy" behavior.
         req.populate_link(self.finder, upgrade_allowed, require_hashes)
         abstract_dist = self.preparer.prepare_linked_requirement(
-            req, self.session, self.finder, require_hashes
+            req, self.finder, require_hashes
         )
 
         # NOTE

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -544,7 +544,8 @@ class RequirementPreparer(object):
         wheel_download_dir,  # type: Optional[str]
         progress_bar,  # type: str
         build_isolation,  # type: bool
-        req_tracker  # type: RequirementTracker
+        req_tracker,  # type: RequirementTracker
+        session,  # type: PipSession
     ):
         # type: (...) -> None
         super(RequirementPreparer, self).__init__()
@@ -552,6 +553,7 @@ class RequirementPreparer(object):
         self.src_dir = src_dir
         self.build_dir = build_dir
         self.req_tracker = req_tracker
+        self.session = session
 
         # Where still-packed archives should be written to. If None, they are
         # not saved, and are deleted immediately after unpacking.
@@ -593,7 +595,6 @@ class RequirementPreparer(object):
     def prepare_linked_requirement(
         self,
         req,  # type: InstallRequirement
-        session,  # type: PipSession
         finder,  # type: PackageFinder
         require_hashes,  # type: bool
     ):
@@ -672,7 +673,7 @@ class RequirementPreparer(object):
             try:
                 unpack_url(
                     link, req.source_dir, download_dir,
-                    session=session, hashes=hashes,
+                    session=self.session, hashes=hashes,
                     progress_bar=self.progress_bar
                 )
             except requests.HTTPError as exc:

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -75,6 +75,7 @@ class TestRequirementSet(object):
             progress_bar="on",
             build_isolation=True,
             req_tracker=RequirementTracker(),
+            session=PipSession(),
         )
         make_install_req = partial(
             install_req_from_req_string,

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -86,7 +86,7 @@ class TestRequirementSet(object):
         return Resolver(
             preparer=preparer,
             make_install_req=make_install_req,
-            session=PipSession(), finder=finder,
+            finder=finder,
             use_user_site=False, upgrade_strategy="to-satisfy-only",
             ignore_dependencies=False, ignore_installed=False,
             ignore_requires_python=False, force_reinstall=False,


### PR DESCRIPTION
Previously the Resolver was just holding this object to pass it to RequirementPreparer. Now RequirementPreparer has its own session, which reduces the responsibilities of Resolver.