### PR TITLE
Remove unused WheelBuilder.no_clean

### DIFF
--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -192,7 +192,6 @@ class WheelCommand(RequirementCommand):
                     preparer, wheel_cache,
                     build_options=options.build_options or [],
                     global_options=options.global_options or [],
-                    no_clean=options.no_clean,
                     path_to_wheelnames=options.path_to_wheelnames
                 )
                 build_failures = wb.build(

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -205,7 +205,6 @@ class WheelBuilder(object):
         build_options=None,  # type: Optional[List[str]]
         global_options=None,  # type: Optional[List[str]]
         check_binary_allowed=None,  # type: Optional[BinaryAllowedPredicate]
-        no_clean=False,  # type: bool
         path_to_wheelnames=None,  # type: Optional[Union[bytes, Text]]
     ):
         # type: (...) -> None
@@ -221,7 +220,6 @@ class WheelBuilder(object):
         self.build_options = build_options or []
         self.global_options = global_options or []
         self.check_binary_allowed = check_binary_allowed
-        self.no_clean = no_clean
         # path where to save built names of built wheels
         self.path_to_wheelnames = path_to_wheelnames
         # file names of built wheel names


### PR DESCRIPTION
WheelBuilder.no_clean is not used anywhere AFAICT, removing it.