### PR TITLE
Make setuptools args explicit

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -302,10 +302,6 @@ class InstallCommand(RequirementCommand):
             isolated_mode=options.isolated_mode,
         )
 
-        if options.use_user_site:
-            install_options.append('--user')
-            install_options.append('--prefix=')
-
         target_temp_dir = None  # type: Optional[TempDirectory]
         target_temp_dir_path = None  # type: Optional[str]
         if options.target_dir:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -317,7 +317,6 @@ class InstallCommand(RequirementCommand):
             # Create a target directory for using with the target option
             target_temp_dir = TempDirectory(kind="target")
             target_temp_dir_path = target_temp_dir.path
-            install_options.append('--home=' + target_temp_dir_path)
 
         global_options = options.global_options or []
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -675,6 +675,7 @@ class InstallRequirement(object):
         install_options,  # type: List[str]
         global_options,  # type: Sequence[str]
         prefix,  # type: Optional[str]
+        home,  # type: Optional[str]
         use_user_site,  # type: bool
     ):
         # type: (...) -> None
@@ -686,6 +687,7 @@ class InstallRequirement(object):
             install_options=install_options,
             no_user_config=self.isolated,
             prefix=prefix,
+            home=home,
             use_user_site=use_user_site,
         )
 
@@ -848,6 +850,7 @@ class InstallRequirement(object):
                 install_options,
                 global_options,
                 prefix=prefix,
+                home=home,
                 use_user_site=use_user_site,
             )
             return
@@ -895,6 +898,7 @@ class InstallRequirement(object):
                 root=root,
                 prefix=prefix,
                 header_dir=header_dir,
+                home=home,
                 use_user_site=use_user_site,
                 no_user_config=self.isolated,
                 pycompile=pycompile,

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -675,6 +675,7 @@ class InstallRequirement(object):
         install_options,  # type: List[str]
         global_options,  # type: Sequence[str]
         prefix,  # type: Optional[str]
+        use_user_site,  # type: bool
     ):
         # type: (...) -> None
         logger.info('Running setup.py develop for %s', self.name)
@@ -685,6 +686,7 @@ class InstallRequirement(object):
             install_options=install_options,
             no_user_config=self.isolated,
             prefix=prefix,
+            use_user_site=use_user_site,
         )
 
         with indent_log():
@@ -843,7 +845,10 @@ class InstallRequirement(object):
         global_options = global_options if global_options is not None else []
         if self.editable:
             self.install_editable(
-                install_options, global_options, prefix=prefix,
+                install_options,
+                global_options,
+                prefix=prefix,
+                use_user_site=use_user_site,
             )
             return
         if self.is_wheel:
@@ -890,6 +895,7 @@ class InstallRequirement(object):
                 root=root,
                 prefix=prefix,
                 header_dir=header_dir,
+                use_user_site=use_user_site,
                 no_user_config=self.isolated,
                 pycompile=pycompile,
             )

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -673,8 +673,8 @@ class InstallRequirement(object):
     def install_editable(
         self,
         install_options,  # type: List[str]
-        global_options=(),  # type: Sequence[str]
-        prefix=None  # type: Optional[str]
+        global_options,  # type: Sequence[str]
+        prefix,  # type: Optional[str]
     ):
         # type: (...) -> None
         logger.info('Running setup.py develop for %s', self.name)

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -91,6 +91,7 @@ def make_setuptools_develop_args(
     install_options,  # type: Sequence[str]
     no_user_config,  # type: bool
     prefix,  # type: Optional[str]
+    home,  # type: Optional[str]
     use_user_site,  # type: bool
 ):
     # type: (...) -> List[str]
@@ -108,6 +109,8 @@ def make_setuptools_develop_args(
 
     if prefix:
         args += ["--prefix", prefix]
+    if home is not None:
+        args += ["--home", home]
 
     if use_user_site:
         args += ["--user", "--prefix="]
@@ -141,6 +144,7 @@ def make_setuptools_install_args(
     root,  # type: Optional[str]
     prefix,  # type: Optional[str]
     header_dir,  # type: Optional[str]
+    home,  # type: Optional[str]
     use_user_site,  # type: bool
     no_user_config,  # type: bool
     pycompile  # type: bool
@@ -162,6 +166,8 @@ def make_setuptools_install_args(
         args += ["--root", root]
     if prefix is not None:
         args += ["--prefix", prefix]
+    if home is not None:
+        args += ["--home", home]
     if use_user_site:
         args += ["--user", "--prefix="]
 

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -91,8 +91,11 @@ def make_setuptools_develop_args(
     install_options,  # type: Sequence[str]
     no_user_config,  # type: bool
     prefix,  # type: Optional[str]
+    use_user_site,  # type: bool
 ):
     # type: (...) -> List[str]
+    assert not (use_user_site and prefix)
+
     args = make_setuptools_shim_args(
         setup_py_path,
         global_options=global_options,
@@ -105,6 +108,9 @@ def make_setuptools_develop_args(
 
     if prefix:
         args += ["--prefix", prefix]
+
+    if use_user_site:
+        args += ["--user", "--prefix="]
 
     return args
 
@@ -135,10 +141,14 @@ def make_setuptools_install_args(
     root,  # type: Optional[str]
     prefix,  # type: Optional[str]
     header_dir,  # type: Optional[str]
+    use_user_site,  # type: bool
     no_user_config,  # type: bool
     pycompile  # type: bool
 ):
     # type: (...) -> List[str]
+    assert not (use_user_site and prefix)
+    assert not (use_user_site and root)
+
     args = make_setuptools_shim_args(
         setup_py_path,
         global_options=global_options,
@@ -152,6 +162,8 @@ def make_setuptools_install_args(
         args += ["--root", root]
     if prefix is not None:
         args += ["--prefix", prefix]
+    if use_user_site:
+        args += ["--user", "--prefix="]
 
     if pycompile:
         args += ["--compile"]


### PR DESCRIPTION
Previously we were adding options for `--user` and `--target` to `install_options`. Now we pass these through to `InstallRequirement.install` explicitly. This reduces the scope of code that needs to know about setuptools and removes the last 2 cases where we were editing `install_options` outside of the setuptools args builder functions.