### PR TITLE
Reduce Resolver dependence on PackageFinder

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -8,6 +8,7 @@ PackageFinder machinery and all its vendored dependencies, etc.
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
+import logging
 import os
 from functools import partial
 
@@ -40,6 +41,8 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.req.req_set import RequirementSet
     from pip._internal.req.req_tracker import RequirementTracker
     from pip._internal.utils.temp_dir import TempDirectory
+
+logger = logging.getLogger(__name__)
 
 
 class SessionCommandMixin(CommandContextMixIn):
@@ -271,6 +274,18 @@ class RequirementCommand(IndexGroupCommand):
                 raise CommandError(
                     'You must give at least one requirement to %(name)s '
                     '(see "pip help %(name)s")' % opts)
+
+    @staticmethod
+    def trace_basic_info(finder):
+        # type: (PackageFinder) -> None
+        """
+        Trace basic information about the provided objects.
+        """
+        # Display where finder is looking for packages
+        search_scope = finder.search_scope
+        locations = search_scope.get_formatted_locations()
+        if locations:
+            logger.info(locations)
 
     def _build_package_finder(
         self,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -153,6 +153,7 @@ class RequirementCommand(IndexGroupCommand):
         options,                  # type: Values
         req_tracker,              # type: RequirementTracker
         session,                  # type: PipSession
+        finder,                   # type: PackageFinder
         download_dir=None,        # type: str
         wheel_download_dir=None,  # type: str
     ):
@@ -171,6 +172,7 @@ class RequirementCommand(IndexGroupCommand):
             build_isolation=options.build_isolation,
             req_tracker=req_tracker,
             session=session,
+            finder=finder,
         )
 
     @staticmethod

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -139,6 +139,9 @@ class DownloadCommand(RequirementCommand):
                 options=options,
                 py_version_info=options.python_version,
             )
+
+            self.trace_basic_info(finder)
+
             resolver.resolve(requirement_set)
 
             downloaded = ' '.join([

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -130,6 +130,7 @@ class DownloadCommand(RequirementCommand):
                 options=options,
                 req_tracker=req_tracker,
                 session=session,
+                finder=finder,
                 download_dir=options.download_dir,
             )
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -373,6 +373,9 @@ class InstallCommand(RequirementCommand):
                     upgrade_strategy=upgrade_strategy,
                     use_pep517=options.use_pep517,
                 )
+
+                self.trace_basic_info(finder)
+
                 resolver.resolve(requirement_set)
 
                 try:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -360,6 +360,7 @@ class InstallCommand(RequirementCommand):
                     options=options,
                     req_tracker=req_tracker,
                     session=session,
+                    finder=finder,
                 )
                 resolver = self.make_resolver(
                     preparer=preparer,

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -174,6 +174,7 @@ class WheelCommand(RequirementCommand):
                     options=options,
                     req_tracker=req_tracker,
                     session=session,
+                    finder=finder,
                     wheel_download_dir=options.wheel_dir,
                 )
 

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -185,6 +185,9 @@ class WheelCommand(RequirementCommand):
                     ignore_requires_python=options.ignore_requires_python,
                     use_pep517=options.use_pep517,
                 )
+
+                self.trace_basic_info(finder)
+
                 resolver.resolve(requirement_set)
 
                 # build wheels

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -181,12 +181,6 @@ class Resolver(object):
             any(req.has_hash_options for req in root_reqs)
         )
 
-        # Display where finder is looking for packages
-        search_scope = self.finder.search_scope
-        locations = search_scope.get_formatted_locations()
-        if locations:
-            logger.info(locations)
-
         # Actually prepare the files, and collect any exceptions. Most hash
         # exceptions cannot be checked ahead of time, because
         # req.populate_link() needs to be called before we can make decisions

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -280,7 +280,7 @@ class Resolver(object):
         """
         if req.editable:
             return self.preparer.prepare_editable_requirement(
-                req, require_hashes, self.use_user_site, self.finder,
+                req, require_hashes, self.use_user_site,
             )
 
         # satisfied_by is only evaluated by calling _check_skip_installed,
@@ -298,7 +298,7 @@ class Resolver(object):
         # We eagerly populate the link, since that's our "legacy" behavior.
         req.populate_link(self.finder, upgrade_allowed, require_hashes)
         abstract_dist = self.preparer.prepare_linked_requirement(
-            req, self.finder, require_hashes
+            req, require_hashes
         )
 
         # NOTE

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -509,6 +509,7 @@ class RequirementPreparer(object):
         build_isolation,  # type: bool
         req_tracker,  # type: RequirementTracker
         session,  # type: PipSession
+        finder,  # type: PackageFinder
     ):
         # type: (...) -> None
         super(RequirementPreparer, self).__init__()
@@ -517,6 +518,7 @@ class RequirementPreparer(object):
         self.build_dir = build_dir
         self.req_tracker = req_tracker
         self.session = session
+        self.finder = finder
 
         # Where still-packed archives should be written to. If None, they are
         # not saved, and are deleted immediately after unpacking.
@@ -558,7 +560,6 @@ class RequirementPreparer(object):
     def prepare_linked_requirement(
         self,
         req,  # type: InstallRequirement
-        finder,  # type: PackageFinder
         require_hashes,  # type: bool
     ):
         # type: (...) -> AbstractDistribution
@@ -666,7 +667,7 @@ class RequirementPreparer(object):
                 write_delete_marker_file(req.source_dir)
 
             abstract_dist = _get_prepared_distribution(
-                req, self.req_tracker, finder, self.build_isolation,
+                req, self.req_tracker, self.finder, self.build_isolation,
             )
 
             if self._download_should_save:
@@ -680,7 +681,6 @@ class RequirementPreparer(object):
         req,  # type: InstallRequirement
         require_hashes,  # type: bool
         use_user_site,  # type: bool
-        finder  # type: PackageFinder
     ):
         # type: (...) -> AbstractDistribution
         """Prepare an editable requirement
@@ -700,7 +700,7 @@ class RequirementPreparer(object):
             req.update_editable(not self._download_should_save)
 
             abstract_dist = _get_prepared_distribution(
-                req, self.req_tracker, finder, self.build_isolation,
+                req, self.req_tracker, self.finder, self.build_isolation,
             )
 
             if self._download_should_save:

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -76,6 +76,7 @@ class TestRequirementSet(object):
             build_isolation=True,
             req_tracker=RequirementTracker(),
             session=PipSession(),
+            finder=finder,
         )
         make_install_req = partial(
             install_req_from_req_string,


### PR DESCRIPTION
This helps make `Preparer` self-sufficient and reduces (almost completely) the need to pass `PackageFinder` to `Resolver`.