### PR TITLE
Factor out legacy wheel build function

### DIFF
--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -200,7 +200,7 @@ def _build_wheel_legacy(
     python_tag=None,  # type: Optional[str]
 ):
     # type: (...) -> Optional[str]
-    """Build one InstallRequirement using the "legacy" build process.
+    """Build one unpacked package using the "legacy" build process.
 
     Returns path to wheel if successfully built. Otherwise, returns None.
     """

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -163,7 +163,7 @@ def format_command_result(
 def get_legacy_build_wheel_path(
     names,  # type: List[str]
     temp_dir,  # type: str
-    req,  # type: InstallRequirement
+    name,  # type: str
     command_args,  # type: List[str]
     command_output,  # type: Text
 ):
@@ -174,7 +174,7 @@ def get_legacy_build_wheel_path(
     if not names:
         msg = (
             'Legacy build of wheel for {!r} created no files.\n'
-        ).format(req.name)
+        ).format(name)
         msg += format_command_result(command_args, command_output)
         logger.warning(msg)
         return None
@@ -183,7 +183,7 @@ def get_legacy_build_wheel_path(
         msg = (
             'Legacy build of wheel for {!r} created more than one file.\n'
             'Filenames (choosing first): {}\n'
-        ).format(req.name, names)
+        ).format(name, names)
         msg += format_command_result(command_args, command_output)
         logger.warning(msg)
 
@@ -359,7 +359,7 @@ class WheelBuilder(object):
             wheel_path = get_legacy_build_wheel_path(
                 names=names,
                 temp_dir=tempd,
-                req=req,
+                name=req.name,
                 command_args=wheel_args,
                 command_output=output,
             )

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -250,10 +250,14 @@ class WheelBuilder(object):
         # type: (...) -> Optional[str]
         with TempDirectory(kind="wheel") as temp_dir:
             if req.use_pep517:
-                builder = self._build_one_pep517
+                wheel_path = self._build_one_pep517(
+                    req, temp_dir.path, python_tag=python_tag
+                )
             else:
-                builder = self._build_one_legacy
-            wheel_path = builder(req, temp_dir.path, python_tag=python_tag)
+                wheel_path = self._build_one_legacy(
+                    req, temp_dir.path, python_tag=python_tag
+                )
+
             if wheel_path is not None:
                 wheel_name = os.path.basename(wheel_path)
                 dest_path = os.path.join(output_dir, wheel_name)

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -12,9 +12,7 @@ from pip._internal import pep425tags, wheel
 from pip._internal.commands.wheel import WheelCommand
 from pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
 from pip._internal.locations import get_scheme
-from pip._internal.models.link import Link
 from pip._internal.models.scheme import Scheme
-from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.misc import hash_file
 from pip._internal.utils.unpacking import unpack_file
@@ -24,36 +22,6 @@ from pip._internal.wheel import (
 )
 from pip._internal.wheel_builder import get_legacy_build_wheel_path
 from tests.lib import DATA_DIR, assert_paths_equal
-
-
-def make_test_install_req(base_name=None):
-    """
-    Return an InstallRequirement object for testing purposes.
-    """
-    if base_name is None:
-        base_name = 'pendulum-2.0.4'
-
-    req = Requirement('pendulum')
-    link_url = (
-        'https://files.pythonhosted.org/packages/aa/{base_name}.tar.gz'
-        '#sha256=cf535d36c063575d4752af36df928882b2e0e31541b4482c97d637527'
-        '85f9fcb'
-    ).format(base_name=base_name)
-    link = Link(
-        url=link_url,
-        comes_from='https://pypi.org/simple/pendulum/',
-        requires_python='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    )
-    req = InstallRequirement(
-        req=req,
-        comes_from=None,
-        constraint=False,
-        editable=False,
-        link=link,
-        source_dir='/tmp/pip-install-9py5m2z1/pendulum',
-    )
-
-    return req
 
 
 @pytest.mark.parametrize('file_tag, expected', [
@@ -66,11 +34,10 @@ def test_format_tag(file_tag, expected):
 
 
 def call_get_legacy_build_wheel_path(caplog, names):
-    req = make_test_install_req()
     wheel_path = get_legacy_build_wheel_path(
         names=names,
         temp_dir='/tmp/abcd',
-        req=req,
+        name='pendulum',
         command_args=['arg1', 'arg2'],
         command_output='output line 1\noutput line 2\n',
     )


### PR DESCRIPTION
This reduces the usage of `InstallRequirement` and starts the process of breaking up the wheel build responsibility into separate standalone functions.