### PR TITLE
Make no-response bot, wait for less time

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before issue is closed for lack of response
-daysUntilClose: 30
+daysUntilClose: 15
 # Label requiring a response
 responseRequiredLabel: "S: awaiting response"
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable


### PR DESCRIPTION
Given that we're all pretty active right now, I think making this window shorter would be helpful.