### PR TITLE
Better workaround for cache poisoning (#3025, #7319)

### DIFF
--- a/news/7296.bugfix
+++ b/news/7296.bugfix
@@ -1,0 +1,5 @@
+Make sure ``pip wheel`` never outputs pure python wheels with a
+python implementation tag. Better fix/workaround for
+`#3025 <https://github.com/pypa/pip/issues/3025>`_ by
+using a per-implementation wheel cache instead of caching pure python
+wheels with an implementation tag in their name.

--- a/news/7296.removal
+++ b/news/7296.removal
@@ -1,3 +1,3 @@
 The pip>=20 wheel cache is not retro-compatible with previous versions. Until
-version 21, pip will still be able to take advantage of existing legacy cache
+pip 21.0, pip will continue to take advantage of existing legacy cache
 entries.

--- a/news/7296.removal
+++ b/news/7296.removal
@@ -1,0 +1,3 @@
+The pip>=20 wheel cache is not retro-compatible with previous versions. Until
+version 21, pip will still be able to take advantage of existing legacy cache
+entries.

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -8,15 +8,14 @@ import hashlib
 import json
 import logging
 import os
-import sys
 
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import InvalidWheelFilename
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
+from pip._internal.pep425tags import interpreter_name, interpreter_version
 from pip._internal.utils.compat import expanduser
-from pip._internal.utils.misc import interpreter_name
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import path_to_url
@@ -104,11 +103,8 @@ class Cache(object):
         # depending on the python version their setup.py is being run on,
         # and don't encode the difference in compatibility tags.
         # https://github.com/pypa/pip/issues/7296
-        key_parts["interpreter"] = "{}-{}.{}".format(
-            interpreter_name(),
-            sys.version_info[0],
-            sys.version_info[1],
-        )
+        key_parts["interpreter_name"] = interpreter_name()
+        key_parts["interpreter_version"] = interpreter_version()
 
         # Encode our key url with sha224, we'll use this because it has similar
         # security properties to sha256, but with a shorter total output (and

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -5,6 +5,7 @@
 # mypy: strict-optional=False
 
 import hashlib
+import json
 import logging
 import os
 import sys
@@ -30,14 +31,9 @@ logger = logging.getLogger(__name__)
 
 def _hash_dict(d):
     # type: (Dict[str, str]) -> str
-    """Return a sha224 of a dictionary where keys and values are strings."""
-    h = hashlib.new('sha224')
-    for k in sorted(d.keys()):
-        h.update(k.encode())
-        h.update("=".encode())
-        h.update(d[k].encode())
-        h.update(b"\0")
-    return h.hexdigest()
+    """Return a stable sha224 of a dictionary."""
+    s = json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha224(s.encode("ascii")).hexdigest()
 
 
 class Cache(object):

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -54,6 +54,9 @@ def get_abbr_impl():
     return pyimpl
 
 
+interpreter_name = get_abbr_impl
+
+
 def version_info_to_nodot(version_info):
     # type: (Tuple[int, ...]) -> str
     # Only use up to the first two numbers.
@@ -67,6 +70,9 @@ def get_impl_ver():
     if not impl_ver or get_abbr_impl() == 'pp':
         impl_ver = ''.join(map(str, get_impl_version_info()))
     return impl_ver
+
+
+interpreter_version = get_impl_ver
 
 
 def get_impl_version_info():

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -83,14 +83,6 @@ def get_impl_version_info():
         return sys.version_info[0], sys.version_info[1]
 
 
-def get_impl_tag():
-    # type: () -> str
-    """
-    Returns the Tag for this specific implementation.
-    """
-    return "{}{}".format(get_abbr_impl(), get_impl_ver())
-
-
 def get_flag(var, fallback, expected=True, warn=True):
     # type: (str, Callable[..., bool], Union[bool, int], bool) -> bool
     """Use a fallback method for determining SOABI flags if the needed config
@@ -459,6 +451,3 @@ def get_supported(
         supported.append(('py%s' % (version,), 'none', 'any'))
 
     return supported
-
-
-implementation_tag = get_impl_tag()

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -11,6 +11,7 @@ import hashlib
 import io
 import logging
 import os
+import platform
 import posixpath
 import shutil
 import stat
@@ -879,3 +880,13 @@ def hash_file(path, blocksize=1 << 20):
             length += len(block)
             h.update(block)
     return (h, length)  # type: ignore
+
+
+def interpreter_name():
+    # type: () -> str
+    try:
+        name = sys.implementation.name  # type: ignore
+    except AttributeError:  # pragma: no cover
+        # Python 2.7 compatibility.
+        name = platform.python_implementation().lower()
+    return name

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -11,7 +11,6 @@ import hashlib
 import io
 import logging
 import os
-import platform
 import posixpath
 import shutil
 import stat
@@ -880,13 +879,3 @@ def hash_file(path, blocksize=1 << 20):
             length += len(block)
             h.update(block)
     return (h, length)  # type: ignore
-
-
-def interpreter_name():
-    # type: () -> str
-    try:
-        name = sys.implementation.name  # type: ignore
-    except AttributeError:  # pragma: no cover
-        # Python 2.7 compatibility.
-        name = platform.python_implementation().lower()
-    return name

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -52,7 +52,6 @@ def make_setuptools_bdist_wheel_args(
     global_options,  # type: Sequence[str]
     build_options,  # type: Sequence[str]
     destination_dir,  # type: str
-    python_tag,  # type: Optional[str]
 ):
     # type: (...) -> List[str]
     # NOTE: Eventually, we'd want to also -S to the flags here, when we're
@@ -66,8 +65,6 @@ def make_setuptools_bdist_wheel_args(
     )
     args += ["bdist_wheel", "-d", destination_dir]
     args += build_options
-    if python_tag is not None:
-        args += ["--python-tag", python_tag]
     return args
 
 

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -9,7 +9,6 @@ import os.path
 import re
 import shutil
 
-from pip._internal import pep425tags
 from pip._internal.models.link import Link
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.marker_files import has_delete_marker_file
@@ -447,10 +446,6 @@ class WheelBuilder(object):
             ', '.join([req.name for (req, _) in buildset]),
         )
 
-        python_tag = None
-        if should_unpack:
-            python_tag = pep425tags.implementation_tag
-
         with indent_log():
             build_success, build_failure = [], []
             for req, output_dir in buildset:
@@ -464,10 +459,7 @@ class WheelBuilder(object):
                     build_failure.append(req)
                     continue
 
-                wheel_file = self._build_one(
-                    req, output_dir,
-                    python_tag=python_tag,
-                )
+                wheel_file = self._build_one(req, output_dir)
                 if wheel_file:
                     if should_unpack:
                         # XXX: This is mildly duplicative with prepare_files,

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -12,7 +12,6 @@ import pytest
 from pip._vendor.six import PY2
 
 from pip import __version__ as pip_current_version
-from pip._internal import pep425tags
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.utils.misc import rmtree
@@ -1297,9 +1296,9 @@ def test_install_builds_wheels(script, data, with_wheel):
     assert "Running setup.py install for requir" not in str(res), str(res)
     # wheelbroken has to run install
     assert "Running setup.py install for wheelb" in str(res), str(res)
-    # We want to make sure we used the correct implementation tag
+    # We want to make sure pure python wheels do not have an implementation tag
     assert wheels == [
-        "Upper-2.0-{}-none-any.whl".format(pep425tags.implementation_tag),
+        "Upper-2.0-py{}-none-any.whl".format(sys.version_info[0]),
     ]
 
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -49,3 +49,23 @@ def test_cache_hash():
     assert h == "c7d60d08b1079254d236e983501fa26c016d58d16010725b27ed0af2"
     h = _hash_dict({"url": "https://g.c/o/r", "subdirectory": "sd"})
     assert h == "9cba35d4ccf04b7cde751b44db347fd0f21fa47d1276e32f9d47864c"
+
+
+def test_get_path_for_link_legacy(tmpdir):
+    """
+    Test that an existing cache entry that was created with the legacy hashing
+    mechanism is used.
+    """
+    wc = WheelCache(tmpdir, FormatControl())
+    link = Link("https://g.c/o/r")
+    path = wc.get_path_for_link(link)
+    legacy_path = wc.get_path_for_link_legacy(link)
+    assert path != legacy_path
+    ensure_dir(path)
+    with open(os.path.join(path, "test-pyz-none-any.whl"), "w"):
+        pass
+    ensure_dir(legacy_path)
+    with open(os.path.join(legacy_path, "test-pyx-none-any.whl"), "w"):
+        pass
+    expected_candidates = {"test-pyx-none-any.whl", "test-pyz-none-any.whl"}
+    assert set(wc._get_candidates(link, "test")) == expected_candidates

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,6 +1,6 @@
 import os
 
-from pip._internal.cache import WheelCache
+from pip._internal.cache import WheelCache, _hash_dict
 from pip._internal.models.format_control import FormatControl
 from pip._internal.models.link import Link
 from pip._internal.utils.compat import expanduser
@@ -42,3 +42,10 @@ def test_wheel_name_filter(tmpdir):
     assert wc.get(link, "package", [("py3", "none", "any")]) is not link
     # package2 does not match wheel name
     assert wc.get(link, "package2", [("py3", "none", "any")]) is link
+
+
+def test_cache_hash():
+    h = _hash_dict({"url": "https://g.c/o/r"})
+    assert h == "c7d60d08b1079254d236e983501fa26c016d58d16010725b27ed0af2"
+    h = _hash_dict({"url": "https://g.c/o/r", "subdirectory": "sd"})
+    assert h == "9cba35d4ccf04b7cde751b44db347fd0f21fa47d1276e32f9d47864c"

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -46,9 +46,11 @@ def test_wheel_name_filter(tmpdir):
 
 def test_cache_hash():
     h = _hash_dict({"url": "https://g.c/o/r"})
-    assert h == "c7d60d08b1079254d236e983501fa26c016d58d16010725b27ed0af2"
+    assert h == "72aa79d3315c181d2cc23239d7109a782de663b6f89982624d8c1e86"
     h = _hash_dict({"url": "https://g.c/o/r", "subdirectory": "sd"})
-    assert h == "9cba35d4ccf04b7cde751b44db347fd0f21fa47d1276e32f9d47864c"
+    assert h == "8b13391b6791bf7f3edeabb41ea4698d21bcbdbba7f9c7dc9339750d"
+    h = _hash_dict({"subdirectory": u"/\xe9e"})
+    assert h == "f83b32dfa27a426dec08c21bf006065dd003d0aac78e7fc493d9014d"
 
 
 def test_get_path_for_link_legacy(tmpdir):

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -182,22 +182,6 @@ def test_format_command_result__empty_output(caplog, log_level):
     ]
 
 
-def test_python_tag():
-    wheelnames = [
-        'simplewheel-1.0-py2.py3-none-any.whl',
-        'simplewheel-1.0-py27-none-any.whl',
-        'simplewheel-2.0-1-py2.py3-none-any.whl',
-    ]
-    newnames = [
-        'simplewheel-1.0-py37-none-any.whl',
-        'simplewheel-1.0-py37-none-any.whl',
-        'simplewheel-2.0-1-py37-none-any.whl',
-    ]
-    for name, expected in zip(wheelnames, newnames):
-        result = wheel_builder.replace_python_tag(name, 'py37')
-        assert result == expected
-
-
 class TestWheelBuilder(object):
 
     def test_skip_building_wheels(self, caplog):


### PR DESCRIPTION
Make sure ``pip wheel`` never outputs pure python wheels with a
python implementation tag. Better fix/workaround for #3025 by
using a per-implementation wheel cache instead of caching pure python
wheels with an implementation tag in their name.

Fixes #7296
