### PR TITLE
Azure Pipelines: Test Linux and macOS on Python 3.8

### DIFF
--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -35,7 +35,10 @@ jobs:
       Python37:
         python.version: '3.7'
         python.architecture: x64
-    maxParallel: 3
+      Python38:
+        python.version: '3.8'
+        python.architecture: x64
+    maxParallel: 4
 
   steps:
   - template: ../steps/run-tests.yml


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
For #7229.

Python 3.8 is now available on Azure Pipelines: https://github.com/microsoft/azure-pipelines-image-generation/issues/1317#issuecomment-551965427.

I wasn't sure what the logic for calculating `maxParallel`, so I incremented it in the places where I added a new 3.8 job.

Please let me know if it should be adjusted.

This is for **Linux and macOS**. (See https://github.com/pypa/pip/pull/7320 for Windows, split from this as it's failing.)
