### PR TITLE
Include subdirectory URL fragments in cache keys

### DIFF
--- a/news/7333.bugfix
+++ b/news/7333.bugfix
@@ -1,0 +1,1 @@
+Include ``subdirectory`` URL fragments in cache keys.

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -77,19 +77,18 @@ class Cache(object):
 
         return parts
 
-    def _get_candidates(self, link, package_name):
+    def _get_candidates(self, link, canonical_package_name):
         # type: (Link, Optional[str]) -> List[Any]
         can_not_cache = (
             not self.cache_dir or
-            not package_name or
+            not canonical_package_name or
             not link
         )
         if can_not_cache:
             return []
 
-        canonical_name = canonicalize_name(package_name)
         formats = self.format_control.get_allowed_formats(
-            canonical_name
+            canonical_package_name
         )
         if not self.allowed_formats.intersection(formats):
             return []
@@ -176,12 +175,12 @@ class SimpleWheelCache(Cache):
             return link
 
         canonical_package_name = canonicalize_name(package_name)
-        for wheel_name in self._get_candidates(link, package_name):
+        for wheel_name in self._get_candidates(link, canonical_package_name):
             try:
                 wheel = Wheel(wheel_name)
             except InvalidWheelFilename:
                 continue
-            if wheel.name != canonical_package_name:
+            if canonicalize_name(wheel.name) != canonical_package_name:
                 continue
             if not wheel.supported(supported_tags):
                 # Built for a different python/arch/etc

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -181,6 +181,12 @@ class SimpleWheelCache(Cache):
             except InvalidWheelFilename:
                 continue
             if canonicalize_name(wheel.name) != canonical_package_name:
+                logger.debug(
+                    "Ignoring cached wheel {} for {} as it "
+                    "does not match the expected distribution name {}.".format(
+                        wheel_name, link, package_name
+                    )
+                )
                 continue
             if not wheel.supported(supported_tags):
                 # Built for a different python/arch/etc

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -172,15 +172,15 @@ class SimpleWheelCache(Cache):
         # type: (...) -> Link
         candidates = []
 
-        canonical_package_name = None
-        if package_name:
-            canonical_package_name = canonicalize_name(package_name)
+        if not package_name:
+            return link
+
+        canonical_package_name = canonicalize_name(package_name)
         for wheel_name in self._get_candidates(link, package_name):
             try:
                 wheel = Wheel(wheel_name)
             except InvalidWheelFilename:
                 continue
-            assert canonical_package_name
             if wheel.name != canonical_package_name:
                 continue
             if not wheel.supported(supported_tags):

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,13 +1,44 @@
+import os
+
 from pip._internal.cache import WheelCache
+from pip._internal.models.format_control import FormatControl
+from pip._internal.models.link import Link
 from pip._internal.utils.compat import expanduser
+from pip._internal.utils.misc import ensure_dir
 
 
-class TestWheelCache:
+def test_expands_path():
+    wc = WheelCache("~/.foo/", None)
+    assert wc.cache_dir == expanduser("~/.foo/")
 
-    def test_expands_path(self):
-        wc = WheelCache("~/.foo/", None)
-        assert wc.cache_dir == expanduser("~/.foo/")
 
-    def test_falsey_path_none(self):
-        wc = WheelCache(False, None)
-        assert wc.cache_dir is None
+def test_falsey_path_none():
+    wc = WheelCache(False, None)
+    assert wc.cache_dir is None
+
+
+def test_subdirectory_fragment():
+    """
+    Test the subdirectory URL fragment is part of the cache key.
+    """
+    wc = WheelCache("~/.foo/", None)
+    link1 = Link("git+https://g.c/o/r#subdirectory=d1")
+    link2 = Link("git+https://g.c/o/r#subdirectory=d2")
+    assert wc.get_path_for_link(link1) != wc.get_path_for_link(link2)
+
+
+def test_wheel_name_filter(tmpdir):
+    """
+    Test the wheel cache filters on wheel name when several wheels
+    for different package are stored under the same cache directory.
+    """
+    wc = WheelCache(tmpdir, FormatControl())
+    link = Link("https://g.c/package.tar.gz")
+    cache_path = wc.get_path_for_link(link)
+    ensure_dir(cache_path)
+    with open(os.path.join(cache_path, "package-1.0-py3-none-any.whl"), "w"):
+        pass
+    # package matches wheel name
+    assert wc.get(link, "package", [("py3", "none", "any")]) is not link
+    # package2 does not match wheel name
+    assert wc.get(link, "package2", [("py3", "none", "any")]) is link


### PR DESCRIPTION
- include subdirectory fragments as part of cache keys
- filter on wheel name in addition to tags when selecting wheels from cache, as a safety net in case wheels for different distributions end up in the same cache directory

Fixes #7333