### PR TITLE
Make versions argument singular for pep425tags.get_supported()

### DIFF
--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -91,12 +91,12 @@ class TargetPython(object):
             # versions=None uses special default logic.
             py_version_info = self._given_py_version_info
             if py_version_info is None:
-                versions = None
+                version = None
             else:
-                versions = [version_info_to_nodot(py_version_info)]
+                version = version_info_to_nodot(py_version_info)
 
             tags = get_supported(
-                versions=versions,
+                version=version,
                 platform=self.platform,
                 abi=self.abi,
                 impl=self.implementation,

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -326,7 +326,7 @@ def get_all_minor_versions_as_strings(version_info):
 
 
 def get_supported(
-    versions=None,  # type: Optional[List[str]]
+    version=None,  # type: Optional[str]
     platform=None,  # type: Optional[str]
     impl=None,  # type: Optional[str]
     abi=None  # type: Optional[str]
@@ -335,8 +335,8 @@ def get_supported(
     """Return a list of supported tags for each version specified in
     `versions`.
 
-    :param versions: a list of string versions, of the form ["33", "32"],
-        or None. The first version will be assumed to support our ABI.
+    :param version: a string version, of the form "33" or "32",
+        or None. The version will be assumed to support our ABI.
     :param platform: specify the exact platform you want valid
         tags for, or None. If None, use the local system platform.
     :param impl: specify the exact implementation you want valid
@@ -347,9 +347,11 @@ def get_supported(
     supported = []
 
     # Versions must be given with respect to the preference
-    if versions is None:
+    if version is None:
         version_info = get_impl_version_info()
         versions = get_all_minor_versions_as_strings(version_info)
+    else:
+        versions = [version]
 
     impl = impl or get_abbr_impl()
 

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -64,20 +64,20 @@ class TestTargetPython:
         actual = target_python.format_given()
         assert actual == expected
 
-    @pytest.mark.parametrize('py_version_info, expected_versions', [
-        ((), ['']),
-        ((2, ), ['2']),
-        ((3, ), ['3']),
-        ((3, 7), ['37']),
-        ((3, 7, 3), ['37']),
+    @pytest.mark.parametrize('py_version_info, expected_version', [
+        ((), ''),
+        ((2, ), '2'),
+        ((3, ), '3'),
+        ((3, 7), '37'),
+        ((3, 7, 3), '37'),
         # Check a minor version with two digits.
-        ((3, 10, 1), ['310']),
+        ((3, 10, 1), '310'),
         # Check that versions=None is passed to get_tags().
         (None, None),
     ])
     @patch('pip._internal.models.target_python.get_supported')
     def test_get_tags(
-        self, mock_get_supported, py_version_info, expected_versions,
+        self, mock_get_supported, py_version_info, expected_version,
     ):
         mock_get_supported.return_value = ['tag-1', 'tag-2']
 
@@ -85,8 +85,8 @@ class TestTargetPython:
         actual = target_python.get_tags()
         assert actual == ['tag-1', 'tag-2']
 
-        actual = mock_get_supported.call_args[1]['versions']
-        assert actual == expected_versions
+        actual = mock_get_supported.call_args[1]['version']
+        assert actual == expected_version
 
         # Check that the value was cached.
         assert target_python._valid_tags == ['tag-1', 'tag-2']

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -303,7 +303,7 @@ class TestWheelFile(object):
         Wheels built for macOS 10.6 are supported on 10.9
         """
         tags = pep425tags.get_supported(
-            ['27'], platform='macosx_10_9_intel', impl='cp'
+            '27', platform='macosx_10_9_intel', impl='cp'
         )
         w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_6_intel.whl')
         assert w.supported(tags=tags)
@@ -315,7 +315,7 @@ class TestWheelFile(object):
         Wheels built for macOS 10.9 are not supported on 10.6
         """
         tags = pep425tags.get_supported(
-            ['27'], platform='macosx_10_6_intel', impl='cp'
+            '27', platform='macosx_10_6_intel', impl='cp'
         )
         w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
         assert not w.supported(tags=tags)
@@ -325,22 +325,22 @@ class TestWheelFile(object):
         Multi-arch wheels (intel) are supported on components (i386, x86_64)
         """
         universal = pep425tags.get_supported(
-            ['27'], platform='macosx_10_5_universal', impl='cp'
+            '27', platform='macosx_10_5_universal', impl='cp'
         )
         intel = pep425tags.get_supported(
-            ['27'], platform='macosx_10_5_intel', impl='cp'
+            '27', platform='macosx_10_5_intel', impl='cp'
         )
         x64 = pep425tags.get_supported(
-            ['27'], platform='macosx_10_5_x86_64', impl='cp'
+            '27', platform='macosx_10_5_x86_64', impl='cp'
         )
         i386 = pep425tags.get_supported(
-            ['27'], platform='macosx_10_5_i386', impl='cp'
+            '27', platform='macosx_10_5_i386', impl='cp'
         )
         ppc = pep425tags.get_supported(
-            ['27'], platform='macosx_10_5_ppc', impl='cp'
+            '27', platform='macosx_10_5_ppc', impl='cp'
         )
         ppc64 = pep425tags.get_supported(
-            ['27'], platform='macosx_10_5_ppc64', impl='cp'
+            '27', platform='macosx_10_5_ppc64', impl='cp'
         )
 
         w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_5_intel.whl')
@@ -363,10 +363,10 @@ class TestWheelFile(object):
         Single-arch wheels (x86_64) are not supported on multi-arch (intel)
         """
         universal = pep425tags.get_supported(
-            ['27'], platform='macosx_10_5_universal', impl='cp'
+            '27', platform='macosx_10_5_universal', impl='cp'
         )
         intel = pep425tags.get_supported(
-            ['27'], platform='macosx_10_5_intel', impl='cp'
+            '27', platform='macosx_10_5_intel', impl='cp'
         )
 
         w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_5_i386.whl')


### PR DESCRIPTION
This simplifies the interface of this function in preparation for
switching to packaging.tags.

Progresses #6908.