### PR TITLE
Add double quotes to pip install from VCS

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -387,7 +387,7 @@ So if your repository layout is:
       - some_file
     - some_other_file
 
-You'll need to use ``pip install -e vcs+protocol://repo_url/#egg=pkg&subdirectory=pkg_dir``.
+You'll need to use ``pip install -e "vcs+protocol://repo_url/#egg=pkg&subdirectory=pkg_dir"``.
 
 
 Git


### PR DESCRIPTION
According to https://stackoverflow.com/a/19516714/2199657, the URL needs to be quoted to prevent `&` from being interpreted by shell or cmd. 