### PR TITLE
Warn if a path in PATH starts with tilde during install

### DIFF
--- a/news/6414.feature
+++ b/news/6414.feature
@@ -1,0 +1,1 @@
+Warn if a path in PATH starts with tilde during ``pip install``.

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -210,6 +210,17 @@ def message_about_scripts_not_on_PATH(scripts):
     else:
         msg_lines.append(last_line_fmt.format("these directories"))
 
+    # Add a note if any directory starts with ~
+    warn_for_tilde = any([
+        i[0] == "~" for i in os.environ.get("PATH", "").split(os.pathsep) if i
+    ])
+    if warn_for_tilde:
+        tilde_warning_msg = (
+            "NOTE: The current PATH contains path(s) starting with `~`, "
+            "which may not be expanded by all applications."
+        )
+        msg_lines.append(tilde_warning_msg)
+
     # Returns the formatted multiline message
     return "\n".join(msg_lines)
 

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -211,9 +211,9 @@ def message_about_scripts_not_on_PATH(scripts):
         msg_lines.append(last_line_fmt.format("these directories"))
 
     # Add a note if any directory starts with ~
-    warn_for_tilde = any([
+    warn_for_tilde = any(
         i[0] == "~" for i in os.environ.get("PATH", "").split(os.pathsep) if i
-    ])
+    )
     if warn_for_tilde:
         tilde_warning_msg = (
             "NOTE: The current PATH contains path(s) starting with `~`, "

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -651,40 +651,6 @@ class TestMessageAboutScriptsNotOnPATH(object):
         )
         assert retval is None
 
-    def test_single_script_tilde_at_start__single_dir_not_on_PATH(self):
-        retval = self._template(
-            paths=['~/e', '/c/d/bin'],
-            scripts=['/c/d/foo']
-        )
-        assert retval is not None
-        assert "--no-warn-script-location" in retval
-        assert "foo is installed in '/c/d'" in retval
-        assert self.tilde_warning_msg in retval
-
-    def test_two_script_tilde_at_start__single_dir_not_on_PATH(self):
-        retval = self._template(
-            paths=['~e/f', '/c/d/bin'],
-            scripts=['/c/d/foo', '/c/d/baz']
-        )
-        assert retval is not None
-        assert "--no-warn-script-location" in retval
-        assert "baz and foo are installed in '/c/d'" in retval
-        assert self.tilde_warning_msg in retval
-
-    def test_multi_script_tilde_at_start__multi_dir_not_on_PATH(self):
-        retval = self._template(
-            paths=['/a/b', '/c/d/bin', '~e/f'],
-            scripts=[
-                '/c/d/foo', '/c/d/bar', '/c/d/baz',
-                '/a/b/c/spam', '/e/f/tilde'
-            ]
-        )
-        assert retval is not None
-        assert "--no-warn-script-location" in retval
-        assert "bar, baz and foo are installed in '/c/d'" in retval
-        assert "spam is installed in '/a/b/c'" in retval
-        assert self.tilde_warning_msg in retval
-
     def test_multi_script_all_tilde__multi_dir_not_on_PATH(self):
         retval = self._template(
             paths=['/a/b', '/c/d/bin', '~e/f'],
@@ -697,66 +663,8 @@ class TestMessageAboutScriptsNotOnPATH(object):
         assert "--no-warn-script-location" in retval
         assert "bar, baz and foo are installed in '/c/d'" in retval
         assert "eggs and spam are installed in '/a/b/c'" in retval
+        assert "tilde is installed in '/e/f'" in retval
         assert self.tilde_warning_msg in retval
-
-    def test_two_script_tilde_at_start__single_dir_on_PATH(self):
-        retval = self._template(
-            paths=['/a/b', '/c/d/bin', '~/e'],
-            scripts=['/a/b/foo', '/a/b/baz']
-        )
-        assert retval is None
-
-    def test_multi_script_tilde_at_start__multi_dir_on_PATH(self):
-        retval = self._template(
-            paths=['/a/b', '/c/d/bin', '~e/f'],
-            scripts=['/a/b/foo', '/a/b/bar', '/a/b/baz', '/c/d/bin/spam']
-        )
-        assert retval is None
-
-    def test_multi_script_tilde_at_start__single_dir_on_PATH(self):
-        retval = self._template(
-            paths=['/a/b', '/c/d/bin', '~e/f'],
-            scripts=['/a/b/foo', '/a/b/bar', '/a/b/baz']
-        )
-        assert retval is None
-
-    def test_single_script_tilde_at_start__single_dir_on_PATH(self):
-        retval = self._template(
-            paths=['/a/b', '/c/d/bin', '~e/f'],
-            scripts=['/a/b/foo']
-        )
-        assert retval is None
-
-    def test_single_script_tilde_not_at_start__single_dir_not_on_PATH(self):
-        retval = self._template(
-            paths=['/e/f~f', '/c/d/bin'],
-            scripts=['/c/d/foo']
-        )
-        assert retval is not None
-        assert "--no-warn-script-location" in retval
-        assert "foo is installed in '/c/d'" in retval
-        assert self.tilde_warning_msg not in retval
-
-    def test_two_script_tilde_not_at_start__single_dir_not_on_PATH(self):
-        retval = self._template(
-            paths=['/e/f~f', '/c/d/bin'],
-            scripts=['/c/d/foo', '/c/d/baz']
-        )
-        assert retval is not None
-        assert "--no-warn-script-location" in retval
-        assert "baz and foo are installed in '/c/d'" in retval
-        assert self.tilde_warning_msg not in retval
-
-    def test_multi_script_tilde_not_at_start__multi_dir_not_on_PATH(self):
-        retval = self._template(
-            paths=['/e/f~f', '/c/d/bin'],
-            scripts=['/c/d/foo', '/c/d/bar', '/c/d/baz', '/e/f~f/c/spam']
-        )
-        assert retval is not None
-        assert "--no-warn-script-location" in retval
-        assert "bar, baz and foo are installed in '/c/d'" in retval
-        assert "spam is installed in '/e/f~f/c'" in retval
-        assert self.tilde_warning_msg not in retval
 
     def test_multi_script_all_tilde_not_at_start__multi_dir_not_on_PATH(self):
         retval = self._template(


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Warn if a path in PATH starts with tilde during install

The changes here are as documented at [comment for issue #6414 ](https://github.com/pypa/pip/issues/6414#issuecomment-524693393)

1. Update pip._internal.wheel.message_about_scripts_not_on_PATH here to check and trace a note as mentioned above if any path in PATH starts with a ~.
2. Add a test to tests.unit.test_wheel.TestMessageAboutScriptsNotOnPATH here to cover this case.