### PR TITLE
Fix documentation links for index options

### DIFF
--- a/docs/html/development/architecture/package-finding.rst
+++ b/docs/html/development/architecture/package-finding.rst
@@ -17,10 +17,11 @@ file to download for a package, given a requirement:
 
 1. Collect together the various network and file system locations containing
    project package files. These locations are derived, for example, from pip's
-   :ref:`--index-url <--index-url>` (with default https://pypi.org/simple/ )
-   setting and any configured :ref:`--extra-index-url <--extra-index-url>`
-   locations. Each of the project page URL's is an HTML page of anchor links,
-   as defined in `PEP 503`_, the "Simple Repository API."
+   :ref:`--index-url <install_--index-url>` (with default
+   https://pypi.org/simple/ ) setting and any configured
+   :ref:`--extra-index-url <install_--extra-index-url>` locations. Each of the
+   project page URL's is an HTML page of anchor links, as defined in
+   `PEP 503`_, the "Simple Repository API."
 2. For each project page URL, fetch the HTML and parse out the anchor links,
    creating a ``Link`` object from each one. The :ref:`LinkCollector
    <link-collector-class>` class is responsible for both the previous step
@@ -128,9 +129,9 @@ responsible for collecting the raw list of "links" to package files
 `PEP 503`_ project page URL's that ``PackageFinder`` should access.
 
 The ``LinkCollector`` class takes into account the user's :ref:`--find-links
-<--find-links>`, :ref:`--extra-index-url <--extra-index-url>`, and related
-options when deciding which locations to collect links from. The class's main
-method is the ``collect_links()`` method. The :ref:`PackageFinder
+<install_--find-links>`, :ref:`--extra-index-url <install_--extra-index-url>`,
+and related options when deciding which locations to collect links from. The
+class's main method is the ``collect_links()`` method. The :ref:`PackageFinder
 <package-finder-class>` class invokes this method as the first step of its
 ``find_all_candidates()`` method.
 

--- a/docs/html/reference/pip_download.rst
+++ b/docs/html/reference/pip_download.rst
@@ -47,7 +47,7 @@ Options
 
 .. pip-command-options:: download
 
-.. pip-index-options::
+.. pip-index-options:: download
 
 
 Examples

--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -153,17 +153,17 @@ To interpret the requirements file in UTF-8 format add a comment
 
 The following options are supported:
 
-  *  :ref:`-i, --index-url <--index-url>`
-  *  :ref:`--extra-index-url <--extra-index-url>`
-  *  :ref:`--no-index <--no-index>`
-  *  :ref:`-f, --find-links <--find-links>`
+  *  :ref:`-i, --index-url <install_--index-url>`
+  *  :ref:`--extra-index-url <install_--extra-index-url>`
+  *  :ref:`--no-index <install_--no-index>`
+  *  :ref:`-f, --find-links <install_--find-links>`
   *  :ref:`--no-binary <install_--no-binary>`
   *  :ref:`--only-binary <install_--only-binary>`
-  *  :ref:`--require-hashes <--require-hashes>`
+  *  :ref:`--require-hashes <install_--require-hashes>`
   *  :ref:`--trusted-host <--trusted-host>`
 
-For example, to specify :ref:`--no-index <--no-index>` and two
-:ref:`--find-links <--find-links>` locations:
+For example, to specify :ref:`--no-index <install_--no-index>` and two
+:ref:`--find-links <install_--find-links>` locations:
 
 ::
 
@@ -824,7 +824,7 @@ Options
 
 .. pip-command-options:: install
 
-.. pip-index-options::
+.. pip-index-options:: install
 
 
 .. _`pip install Examples`:

--- a/docs/html/reference/pip_list.rst
+++ b/docs/html/reference/pip_list.rst
@@ -20,7 +20,7 @@ Options
 
 .. pip-command-options:: list
 
-.. pip-index-options::
+.. pip-index-options:: list
 
 
 Examples

--- a/docs/html/reference/pip_wheel.rst
+++ b/docs/html/reference/pip_wheel.rst
@@ -59,7 +59,7 @@ Options
 
 .. pip-command-options:: wheel
 
-.. pip-index-options::
+.. pip-index-options:: wheel
 
 
 Examples

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -515,7 +515,7 @@ $ pip wheel --wheel-dir DIR -r requirements.txt
 
 
 Then, to install from local only, you'll be using :ref:`--find-links
-<--find-links>` and :ref:`--no-index <--no-index>` like so::
+<install_--find-links>` and :ref:`--no-index <install_--no-index>` like so::
 
 $ pip install --no-index --find-links=DIR -r requirements.txt
 

--- a/docs/pip_sphinxext.py
+++ b/docs/pip_sphinxext.py
@@ -86,9 +86,13 @@ class PipGeneralOptions(PipOptions):
 
 
 class PipIndexOptions(PipOptions):
+    required_arguments = 1
+
     def process_options(self):
+        cmd_name = self.arguments[0]
         self._format_options(
-            [o() for o in cmdoptions.index_group['options']]
+            [o() for o in cmdoptions.index_group['options']],
+            cmd_name=cmd_name,
         )
 
 

--- a/news/7347.doc
+++ b/news/7347.doc
@@ -1,0 +1,1 @@
+Fix documentation links for index options


### PR DESCRIPTION
In the documentation the links for the pip commands index options
are mixed up.

The index options are common to multiple commands, but in the
documentation they should be specific to a command for the links to
point to the right chapter.

Fixes #7347