### PR TITLE
Support 32-bit Linux running on 64-bit ARM arch.

### DIFF
--- a/news/7352.bugfix
+++ b/news/7352.bugfix
@@ -1,0 +1,1 @@
+Support 32-bit Linux running on 64-bit ARM arch. A 32-bit Linux running on 64-bit ARM arch should have platform "linux_armv7l".

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -156,10 +156,13 @@ def get_platform():
 
     # XXX remove distutils dependency
     result = distutils.util.get_platform().replace('.', '_').replace('-', '_')
-    if result == "linux_x86_64" and _is_running_32bit():
+    if _is_running_32bit():
         # 32 bit Python program (running on a 64 bit Linux): pip should only
         # install and run 32 bit compiled extensions in that case.
-        result = "linux_i686"
+        if result == "linux_x86_64":
+            result = "linux_i686"
+        elif result == "linux_aarch64":
+            result = "linux_armv7l"
 
     return result
 


### PR DESCRIPTION
A 32-bit Linux running on 64-bit ARM arch should have platform "linux_armv7l".

Currently on a 32-bit OS that runs on a 64-bit ARM CPU (ARM-v8, aarch64), pip installing a armv7l wheel gives the following error message:

> foo_armv7l.wheel is not a supported wheel on this platform.

This is caused by a misjudgment of the platform in pip: pip judges the system to be armv8/aarch64, but the system is actually armv7l, which is 32-bit. This PR fixes this issue by following the solution similar to that of the x86_64/x86 pair.