### PR TITLE
Use packaging.tags for doing compatible wheel tag calculation

### DIFF
--- a/news/6908.removal
+++ b/news/6908.removal
@@ -1,0 +1,2 @@
+Remove wheel tag calculation from pip and use ``packaging.tags``. This
+should provide more tags ordered better than in prior releases.

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -23,7 +23,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Callable, Iterator, List, Optional, Set, Tuple, Union
+        Callable, List, Optional, Tuple, Union
     )
 
     from pip._vendor.packaging.tags import PythonVersion
@@ -315,15 +315,6 @@ def _get_custom_interpreter(implementation=None, version=None):
     return "{}{}".format(implementation, version)
 
 
-def _stable_unique_tags(tags):
-    # type: (List[Tag]) -> Iterator[Tag]
-    observed = set()  # type: Set[Tag]
-    for tag in tags:
-        if tag not in observed:
-            observed.add(tag)
-            yield tag
-
-
 def get_supported(
     version=None,  # type: Optional[str]
     platform=None,  # type: Optional[str]
@@ -343,7 +334,7 @@ def get_supported(
     :param abi: specify the exact abi you want valid
         tags for, or None. If None, use the local interpreter abi.
     """
-    supported = []  # type: List[Union[Tag, Tuple[str, str, str]]]
+    supported = []  # type: List[Tag]
 
     python_version = None  # type: Optional[PythonVersion]
     if version is not None:
@@ -384,8 +375,4 @@ def get_supported(
         )
     )
 
-    tags = [
-        parts if isinstance(parts, Tag) else Tag(*parts)
-        for parts in supported
-    ]
-    return list(_stable_unique_tags(tags))
+    return supported

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -315,30 +315,6 @@ def _get_custom_interpreter(implementation=None, version=None):
     return "{}{}".format(implementation, version)
 
 
-def _generic_tags(
-    version=None,  # type: Optional[str]
-    platform=None,  # type: Optional[str]
-    impl=None,  # type: Optional[str]
-    abi=None,  # type: Optional[str]
-):
-    # type: (...) -> Iterator[Tag]
-    interpreter = _get_custom_interpreter(impl, version)
-
-    abis = None  # type: Optional[List[str]]
-    if abi:
-        abis = [abi]
-
-    platforms = None  # type: Optional[List[str]]
-    if platform is not None:
-        platforms = _get_custom_platforms(platform, platform)
-
-    return generic_tags(
-        interpreter=interpreter,
-        abis=abis,
-        platforms=platforms,
-    )
-
-
 def _stable_unique_tags(tags):
     # type: (List[Tag]) -> Iterator[Tag]
     observed = set()  # type: Set[Tag]
@@ -393,7 +369,13 @@ def get_supported(
             )
         )
     else:
-        supported.extend(_generic_tags(version, platform, impl, abi))
+        supported.extend(
+            generic_tags(
+                interpreter=interpreter,
+                abis=abis,
+                platforms=platforms,
+            )
+        )
     supported.extend(
         compatible_tags(
             python_version=python_version,

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -25,6 +25,8 @@ if MYPY_CHECK_RUNNING:
         Callable, Iterator, List, Optional, Set, Tuple, Union
     )
 
+    from pip._vendor.packaging.tags import PythonVersion
+
 logger = logging.getLogger(__name__)
 
 _osx_arch_pat = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
@@ -295,6 +297,14 @@ def _get_custom_platforms(arch, platform):
     return arches
 
 
+def _get_python_version(version):
+    # type: (str) -> PythonVersion
+    if len(version) > 1:
+        return int(version[0]), int(version[1:])
+    else:
+        return (int(version[0]),)
+
+
 def _cpython_tags(
     version=None,  # type: Optional[str]
     platform=None,  # type: Optional[str]
@@ -405,8 +415,12 @@ def _compatible_tags(
     impl=None,  # type: Optional[str]
 ):
     # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
-    if version is None and platform is None and impl is None:
-        return compatible_tags()
+    python_version = None  # type: Optional[PythonVersion]
+    if version is not None:
+        python_version = _get_python_version(version)
+
+    if platform is None and impl is None:
+        return compatible_tags(python_version=python_version)
 
     supported = []  # type: List[Tuple[str, str, str]]
 

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -324,8 +324,12 @@ def _generic_tags(
     # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
     interpreter = _get_custom_interpreter(impl, version)
 
-    if platform is None and abi is None:
-        return generic_tags(interpreter=interpreter)
+    abis = None  # type: Optional[List[str]]
+    if abi:
+        abis = [abi]
+
+    if platform is None:
+        return generic_tags(interpreter=interpreter, abis=abis)
 
     supported = []  # type: List[Tuple[str, str, str]]
 
@@ -339,7 +343,7 @@ def _generic_tags(
 
     impl = impl or interpreter_name()
 
-    abis = []  # type: List[str]
+    abis = []  # type: ignore  # we will be removing this soon
 
     abi = abi or get_abi_tag()
     if abi:

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -315,31 +315,6 @@ def _get_custom_interpreter(implementation=None, version=None):
     return "{}{}".format(implementation, version)
 
 
-def _cpython_tags(
-    version=None,  # type: Optional[str]
-    platform=None,  # type: Optional[str]
-    abi=None,  # type: Optional[str]
-):
-    # type: (...) -> Iterator[Tag]
-    python_version = None  # type: Optional[PythonVersion]
-    if version is not None:
-        python_version = _get_python_version(version)
-
-    abis = None  # type: Optional[List[str]]
-    if abi is not None:
-        abis = [abi]
-
-    platforms = None  # type: Optional[List[str]]
-    if platform is not None:
-        platforms = _get_custom_platforms(platform, platform)
-
-    return cpython_tags(
-        python_version=python_version,
-        abis=abis,
-        platforms=platforms,
-    )
-
-
 def _generic_tags(
     version=None,  # type: Optional[str]
     platform=None,  # type: Optional[str]
@@ -428,13 +403,23 @@ def get_supported(
 
     interpreter = _get_custom_interpreter(impl, version)
 
+    abis = None  # type: Optional[List[str]]
+    if abi is not None:
+        abis = [abi]
+
     platforms = None  # type: Optional[List[str]]
     if platform is not None:
         platforms = _get_custom_platforms(platform, platform)
 
     is_cpython = (impl or interpreter_name()) == "cp"
     if is_cpython:
-        supported.extend(_cpython_tags(version, platform, abi))
+        supported.extend(
+            cpython_tags(
+                python_version=python_version,
+                abis=abis,
+                platforms=platforms,
+            )
+        )
     else:
         supported.extend(_generic_tags(version, platform, impl, abi))
     supported.extend(

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -328,8 +328,16 @@ def _generic_tags(
     if abi:
         abis = [abi]
 
-    if platform is None:
-        return generic_tags(interpreter=interpreter, abis=abis)
+    platforms = None  # type: Optional[List[str]]
+    if platform is not None:
+        platforms = _get_custom_platforms(platform, platform)
+
+    if True:
+        return generic_tags(
+            interpreter=interpreter,
+            abis=abis,
+            platforms=platforms,
+        )
 
     supported = []  # type: List[Tuple[str, str, str]]
 

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -329,8 +329,16 @@ def _cpython_tags(
     if abi is not None:
         abis = [abi]
 
-    if platform is None:
-        return cpython_tags(python_version=python_version, abis=abis)
+    platforms = None  # type: Optional[List[str]]
+    if platform is not None:
+        platforms = _get_custom_platforms(platform, platform)
+
+    if True:
+        return cpython_tags(
+            python_version=python_version,
+            abis=abis,
+            platforms=platforms,
+        )
 
     supported = []  # type: List[Tuple[str, str, str]]
 

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -321,7 +321,7 @@ def _generic_tags(
     impl=None,  # type: Optional[str]
     abi=None,  # type: Optional[str]
 ):
-    # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
+    # type: (...) -> Iterator[Tag]
     interpreter = _get_custom_interpreter(impl, version)
 
     abis = None  # type: Optional[List[str]]
@@ -332,41 +332,11 @@ def _generic_tags(
     if platform is not None:
         platforms = _get_custom_platforms(platform, platform)
 
-    if True:
-        return generic_tags(
-            interpreter=interpreter,
-            abis=abis,
-            platforms=platforms,
-        )
-
-    supported = []  # type: List[Tuple[str, str, str]]
-
-    # Versions must be given with respect to the preference
-    if version is None:
-        version_info = get_impl_version_info()
-        versions = get_all_minor_versions_as_strings(version_info)
-    else:
-        versions = [version]
-    current_version = versions[0]
-
-    impl = impl or interpreter_name()
-
-    abis = []  # type: ignore  # we will be removing this soon
-
-    abi = abi or get_abi_tag()
-    if abi:
-        abis[0:0] = [abi]
-
-    abis.append('none')
-
-    arches = _get_custom_platforms(platform or get_platform(), platform)
-
-    # Current version, current API (built specifically for our Python):
-    for abi in abis:
-        for arch in arches:
-            supported.append(('%s%s' % (impl, current_version), abi, arch))
-
-    return supported
+    return generic_tags(
+        interpreter=interpreter,
+        abis=abis,
+        platforms=platforms,
+    )
 
 
 def _stable_unique_tags(tags):

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -430,10 +430,15 @@ def _compatible_tags(
 
     interpreter = _get_custom_interpreter(impl, version)
 
-    if platform is None:
+    platforms = None  # type: Optional[List[str]]
+    if platform is not None:
+        platforms = _get_custom_platforms(platform, platform)
+
+    if True:
         return compatible_tags(
             python_version=python_version,
             interpreter=interpreter,
+            platforms=platforms,
         )
 
     supported = []  # type: List[Tuple[str, str, str]]

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -10,6 +10,7 @@ import sysconfig
 
 from pip._vendor.packaging.tags import (
     Tag,
+    compatible_tags,
     interpreter_name,
     interpreter_version,
     mac_platforms,
@@ -403,7 +404,10 @@ def _compatible_tags(
     platform=None,  # type: Optional[str]
     impl=None,  # type: Optional[str]
 ):
-    # type: (...) -> List[Tuple[str, str, str]]
+    # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
+    if version is None and platform is None and impl is None:
+        return compatible_tags()
+
     supported = []  # type: List[Tuple[str, str, str]]
 
     # Versions must be given with respect to the preference

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -343,19 +343,6 @@ def _cpython_tags(
             for arch in arches:
                 supported.append(("%s%s" % (impl, version), "abi3", arch))
 
-    # Has binaries, does not use the Python API:
-    for arch in arches:
-        supported.append(('py%s' % (current_version[0]), 'none', arch))
-
-    # No abi / arch, but requires our implementation:
-    supported.append(('%s%s' % (impl, current_version), 'none', 'any'))
-
-    # No abi / arch, generic Python
-    supported.append(('py%s' % (current_version,), 'none', 'any'))
-    supported.append(('py%s' % (current_version[0]), 'none', 'any'))
-    for version in other_versions:
-        supported.append(('py%s' % (version,), 'none', 'any'))
-
     return supported
 
 
@@ -408,19 +395,6 @@ def _generic_tags(
             for arch in arches:
                 supported.append(("%s%s" % (impl, version), "abi3", arch))
 
-    # Has binaries, does not use the Python API:
-    for arch in arches:
-        supported.append(('py%s' % (current_version[0]), 'none', arch))
-
-    # No abi / arch, but requires our implementation:
-    supported.append(('%s%s' % (impl, current_version), 'none', 'any'))
-
-    # No abi / arch, generic Python
-    supported.append(('py%s' % (current_version,), 'none', 'any'))
-    supported.append(('py%s' % (current_version[0]), 'none', 'any'))
-    for version in other_versions:
-        supported.append(('py%s' % (version,), 'none', 'any'))
-
     return supported
 
 
@@ -444,34 +418,7 @@ def _compatible_tags(
 
     impl = impl or interpreter_name()
 
-    abis = []  # type: List[str]
-
-    abi = abi or get_abi_tag()
-    if abi:
-        abis[0:0] = [abi]
-
-    supports_abi3 = not PY2 and impl == "cp"
-
-    if supports_abi3:
-        abis.append("abi3")
-
-    abis.append('none')
-
     arches = _get_custom_platforms(platform or get_platform(), platform)
-
-    # Current version, current API (built specifically for our Python):
-    for abi in abis:
-        for arch in arches:
-            supported.append(('%s%s' % (impl, current_version), abi, arch))
-
-    # abi3 modules compatible with older version of Python
-    if supports_abi3:
-        for version in other_versions:
-            # abi3 was introduced in Python 3.2
-            if version in {'31', '30'}:
-                break
-            for arch in arches:
-                supported.append(("%s%s" % (impl, version), "abi3", arch))
 
     # Has binaries, does not use the Python API:
     for arch in arches:

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -11,6 +11,7 @@ import sysconfig
 from pip._vendor.packaging.tags import (
     Tag,
     compatible_tags,
+    cpython_tags,
     interpreter_name,
     interpreter_version,
     mac_platforms,
@@ -319,7 +320,10 @@ def _cpython_tags(
     platform=None,  # type: Optional[str]
     abi=None,  # type: Optional[str]
 ):
-    # type: (...) -> List[Tuple[str, str, str]]
+    # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
+    if version is None and platform is None and abi is None:
+        return cpython_tags()
+
     supported = []  # type: List[Tuple[str, str, str]]
 
     # Versions must be given with respect to the preference

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -277,22 +277,13 @@ def _custom_manylinux_platforms(arch):
     return arches
 
 
-def _get_custom_platforms(arch, platform):
-    # type: (str, Optional[str]) -> List[str]
+def _get_custom_platforms(arch):
+    # type: (str) -> List[str]
     arch_prefix, arch_sep, arch_suffix = arch.partition('_')
     if arch.startswith('macosx'):
         arches = _mac_platforms(arch)
     elif arch_prefix in ['manylinux2014', 'manylinux2010']:
         arches = _custom_manylinux_platforms(arch)
-    elif platform is None:
-        arches = []
-        if is_manylinux2014_compatible():
-            arches.append('manylinux2014' + arch_sep + arch_suffix)
-        if is_manylinux2010_compatible():
-            arches.append('manylinux2010' + arch_sep + arch_suffix)
-        if is_manylinux1_compatible():
-            arches.append('manylinux1' + arch_sep + arch_suffix)
-        arches.append(arch)
     else:
         arches = [arch]
     return arches
@@ -348,7 +339,7 @@ def get_supported(
 
     platforms = None  # type: Optional[List[str]]
     if platform is not None:
-        platforms = _get_custom_platforms(platform, platform)
+        platforms = _get_custom_platforms(platform)
 
     is_cpython = (impl or interpreter_name()) == "cp"
     if is_cpython:

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -313,7 +313,7 @@ def get_supported(
     :param abi: specify the exact abi you want valid
         tags for, or None. If None, use the local interpreter abi.
     """
-    supported = []
+    supported = []  # type: List[Union[Tag, Tuple[str, str, str]]]
 
     # Versions must be given with respect to the preference
     if version is None:
@@ -368,4 +368,7 @@ def get_supported(
     for version in other_versions:
         supported.append(('py%s' % (version,), 'none', 'any'))
 
-    return [Tag(*parts) for parts in supported]
+    return [
+        parts if isinstance(parts, Tag) else Tag(*parts)
+        for parts in supported
+    ]

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -1,9 +1,7 @@
 """Generate and work with PEP 425 Compatibility Tags."""
 from __future__ import absolute_import
 
-import distutils.util
 import logging
-import platform
 import re
 import sys
 
@@ -47,38 +45,6 @@ def get_impl_version_info():
                 sys.pypy_version_info.minor)  # type: ignore
     else:
         return sys.version_info[0], sys.version_info[1]
-
-
-def _is_running_32bit():
-    # type: () -> bool
-    return sys.maxsize == 2147483647
-
-
-def get_platform():
-    # type: () -> str
-    """Return our platform name 'win32', 'linux_x86_64'"""
-    if sys.platform == 'darwin':
-        # distutils.util.get_platform() returns the release based on the value
-        # of MACOSX_DEPLOYMENT_TARGET on which Python was built, which may
-        # be significantly older than the user's current machine.
-        release, _, machine = platform.mac_ver()
-        split_ver = release.split('.')
-
-        if machine == "x86_64" and _is_running_32bit():
-            machine = "i386"
-        elif machine == "ppc64" and _is_running_32bit():
-            machine = "ppc"
-
-        return 'macosx_{}_{}_{}'.format(split_ver[0], split_ver[1], machine)
-
-    # XXX remove distutils dependency
-    result = distutils.util.get_platform().replace('.', '_').replace('-', '_')
-    if result == "linux_x86_64" and _is_running_32bit():
-        # 32 bit Python program (running on a 64 bit Linux): pip should only
-        # install and run 32 bit compiled extensions in that case.
-        result = "linux_i686"
-
-    return result
 
 
 def get_all_minor_versions_as_strings(version_info):

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -294,6 +294,201 @@ def _get_custom_platforms(arch, platform):
     return arches
 
 
+def _cpython_tags(
+    version=None,  # type: Optional[str]
+    platform=None,  # type: Optional[str]
+    impl=None,  # type: Optional[str]
+    abi=None,  # type: Optional[str]
+):
+    # type: (...) -> List[Tuple[str, str, str]]
+    supported = []  # type: List[Tuple[str, str, str]]
+
+    # Versions must be given with respect to the preference
+    if version is None:
+        version_info = get_impl_version_info()
+        versions = get_all_minor_versions_as_strings(version_info)
+    else:
+        versions = [version]
+    current_version = versions[0]
+    other_versions = versions[1:]
+
+    impl = impl or interpreter_name()
+
+    abis = []  # type: List[str]
+
+    abi = abi or get_abi_tag()
+    if abi:
+        abis[0:0] = [abi]
+
+    supports_abi3 = not PY2 and impl == "cp"
+
+    if supports_abi3:
+        abis.append("abi3")
+
+    abis.append('none')
+
+    arches = _get_custom_platforms(platform or get_platform(), platform)
+
+    # Current version, current API (built specifically for our Python):
+    for abi in abis:
+        for arch in arches:
+            supported.append(('%s%s' % (impl, current_version), abi, arch))
+
+    # abi3 modules compatible with older version of Python
+    if supports_abi3:
+        for version in other_versions:
+            # abi3 was introduced in Python 3.2
+            if version in {'31', '30'}:
+                break
+            for arch in arches:
+                supported.append(("%s%s" % (impl, version), "abi3", arch))
+
+    # Has binaries, does not use the Python API:
+    for arch in arches:
+        supported.append(('py%s' % (current_version[0]), 'none', arch))
+
+    # No abi / arch, but requires our implementation:
+    supported.append(('%s%s' % (impl, current_version), 'none', 'any'))
+
+    # No abi / arch, generic Python
+    supported.append(('py%s' % (current_version,), 'none', 'any'))
+    supported.append(('py%s' % (current_version[0]), 'none', 'any'))
+    for version in other_versions:
+        supported.append(('py%s' % (version,), 'none', 'any'))
+
+    return supported
+
+
+def _generic_tags(
+    version=None,  # type: Optional[str]
+    platform=None,  # type: Optional[str]
+    impl=None,  # type: Optional[str]
+    abi=None,  # type: Optional[str]
+):
+    # type: (...) -> List[Tuple[str, str, str]]
+    supported = []  # type: List[Tuple[str, str, str]]
+
+    # Versions must be given with respect to the preference
+    if version is None:
+        version_info = get_impl_version_info()
+        versions = get_all_minor_versions_as_strings(version_info)
+    else:
+        versions = [version]
+    current_version = versions[0]
+    other_versions = versions[1:]
+
+    impl = impl or interpreter_name()
+
+    abis = []  # type: List[str]
+
+    abi = abi or get_abi_tag()
+    if abi:
+        abis[0:0] = [abi]
+
+    supports_abi3 = not PY2 and impl == "cp"
+
+    if supports_abi3:
+        abis.append("abi3")
+
+    abis.append('none')
+
+    arches = _get_custom_platforms(platform or get_platform(), platform)
+
+    # Current version, current API (built specifically for our Python):
+    for abi in abis:
+        for arch in arches:
+            supported.append(('%s%s' % (impl, current_version), abi, arch))
+
+    # abi3 modules compatible with older version of Python
+    if supports_abi3:
+        for version in other_versions:
+            # abi3 was introduced in Python 3.2
+            if version in {'31', '30'}:
+                break
+            for arch in arches:
+                supported.append(("%s%s" % (impl, version), "abi3", arch))
+
+    # Has binaries, does not use the Python API:
+    for arch in arches:
+        supported.append(('py%s' % (current_version[0]), 'none', arch))
+
+    # No abi / arch, but requires our implementation:
+    supported.append(('%s%s' % (impl, current_version), 'none', 'any'))
+
+    # No abi / arch, generic Python
+    supported.append(('py%s' % (current_version,), 'none', 'any'))
+    supported.append(('py%s' % (current_version[0]), 'none', 'any'))
+    for version in other_versions:
+        supported.append(('py%s' % (version,), 'none', 'any'))
+
+    return supported
+
+
+def _compatible_tags(
+    version=None,  # type: Optional[str]
+    platform=None,  # type: Optional[str]
+    impl=None,  # type: Optional[str]
+    abi=None,  # type: Optional[str]
+):
+    # type: (...) -> List[Tuple[str, str, str]]
+    supported = []  # type: List[Tuple[str, str, str]]
+
+    # Versions must be given with respect to the preference
+    if version is None:
+        version_info = get_impl_version_info()
+        versions = get_all_minor_versions_as_strings(version_info)
+    else:
+        versions = [version]
+    current_version = versions[0]
+    other_versions = versions[1:]
+
+    impl = impl or interpreter_name()
+
+    abis = []  # type: List[str]
+
+    abi = abi or get_abi_tag()
+    if abi:
+        abis[0:0] = [abi]
+
+    supports_abi3 = not PY2 and impl == "cp"
+
+    if supports_abi3:
+        abis.append("abi3")
+
+    abis.append('none')
+
+    arches = _get_custom_platforms(platform or get_platform(), platform)
+
+    # Current version, current API (built specifically for our Python):
+    for abi in abis:
+        for arch in arches:
+            supported.append(('%s%s' % (impl, current_version), abi, arch))
+
+    # abi3 modules compatible with older version of Python
+    if supports_abi3:
+        for version in other_versions:
+            # abi3 was introduced in Python 3.2
+            if version in {'31', '30'}:
+                break
+            for arch in arches:
+                supported.append(("%s%s" % (impl, version), "abi3", arch))
+
+    # Has binaries, does not use the Python API:
+    for arch in arches:
+        supported.append(('py%s' % (current_version[0]), 'none', arch))
+
+    # No abi / arch, but requires our implementation:
+    supported.append(('%s%s' % (impl, current_version), 'none', 'any'))
+
+    # No abi / arch, generic Python
+    supported.append(('py%s' % (current_version,), 'none', 'any'))
+    supported.append(('py%s' % (current_version[0]), 'none', 'any'))
+    for version in other_versions:
+        supported.append(('py%s' % (version,), 'none', 'any'))
+
+    return supported
+
+
 def get_supported(
     version=None,  # type: Optional[str]
     platform=None,  # type: Optional[str]

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -18,7 +18,6 @@ from pip._vendor.packaging.tags import (
     mac_platforms,
 )
 
-import pip._internal.utils.glibc
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -134,94 +133,6 @@ def get_platform():
         result = "linux_i686"
 
     return result
-
-
-def is_linux_armhf():
-    # type: () -> bool
-    if get_platform() != "linux_armv7l":
-        return False
-    # hard-float ABI can be detected from the ELF header of the running
-    # process
-    try:
-        with open(sys.executable, 'rb') as f:
-            elf_header_raw = f.read(40)  # read 40 first bytes of ELF header
-    except (IOError, OSError, TypeError):
-        return False
-    if elf_header_raw is None or len(elf_header_raw) < 40:
-        return False
-    if isinstance(elf_header_raw, str):
-        elf_header = [ord(c) for c in elf_header_raw]
-    else:
-        elf_header = [b for b in elf_header_raw]
-    result = elf_header[0:4] == [0x7f, 0x45, 0x4c, 0x46]  # ELF magic number
-    result &= elf_header[4:5] == [1]  # 32-bit ELF
-    result &= elf_header[5:6] == [1]  # little-endian
-    result &= elf_header[18:20] == [0x28, 0]  # ARM machine
-    result &= elf_header[39:40] == [5]  # ARM EABIv5
-    result &= (elf_header[37:38][0] & 4) == 4  # EF_ARM_ABI_FLOAT_HARD
-    return result
-
-
-def is_manylinux1_compatible():
-    # type: () -> bool
-    # Only Linux, and only x86-64 / i686
-    if get_platform() not in {"linux_x86_64", "linux_i686"}:
-        return False
-
-    # Check for presence of _manylinux module
-    try:
-        import _manylinux
-        return bool(_manylinux.manylinux1_compatible)
-    except (ImportError, AttributeError):
-        # Fall through to heuristic check below
-        pass
-
-    # Check glibc version. CentOS 5 uses glibc 2.5.
-    return pip._internal.utils.glibc.have_compatible_glibc(2, 5)
-
-
-def is_manylinux2010_compatible():
-    # type: () -> bool
-    # Only Linux, and only x86-64 / i686
-    if get_platform() not in {"linux_x86_64", "linux_i686"}:
-        return False
-
-    # Check for presence of _manylinux module
-    try:
-        import _manylinux
-        return bool(_manylinux.manylinux2010_compatible)
-    except (ImportError, AttributeError):
-        # Fall through to heuristic check below
-        pass
-
-    # Check glibc version. CentOS 6 uses glibc 2.12.
-    return pip._internal.utils.glibc.have_compatible_glibc(2, 12)
-
-
-def is_manylinux2014_compatible():
-    # type: () -> bool
-    # Only Linux, and only supported architectures
-    platform = get_platform()
-    if platform not in {"linux_x86_64", "linux_i686", "linux_aarch64",
-                        "linux_armv7l", "linux_ppc64", "linux_ppc64le",
-                        "linux_s390x"}:
-        return False
-
-    # check for hard-float ABI in case we're running linux_armv7l not to
-    # install hard-float ABI wheel in a soft-float ABI environment
-    if platform == "linux_armv7l" and not is_linux_armhf():
-        return False
-
-    # Check for presence of _manylinux module
-    try:
-        import _manylinux
-        return bool(_manylinux.manylinux2014_compatible)
-    except (ImportError, AttributeError):
-        # Fall through to heuristic check below
-        pass
-
-    # Check glibc version. CentOS 7 uses glibc 2.17.
-    return pip._internal.utils.glibc.have_compatible_glibc(2, 17)
 
 
 def get_all_minor_versions_as_strings(version_info):

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -305,6 +305,15 @@ def _get_python_version(version):
         return (int(version[0]),)
 
 
+def _get_custom_interpreter(implementation=None, version=None):
+    # type: (Optional[str], Optional[str]) -> str
+    if implementation is None:
+        implementation = interpreter_name()
+    if version is None:
+        version = interpreter_version()
+    return "{}{}".format(implementation, version)
+
+
 def _cpython_tags(
     version=None,  # type: Optional[str]
     platform=None,  # type: Optional[str]
@@ -419,8 +428,13 @@ def _compatible_tags(
     if version is not None:
         python_version = _get_python_version(version)
 
-    if platform is None and impl is None:
-        return compatible_tags(python_version=python_version)
+    interpreter = _get_custom_interpreter(impl, version)
+
+    if platform is None:
+        return compatible_tags(
+            python_version=python_version,
+            interpreter=interpreter,
+        )
 
     supported = []  # type: List[Tuple[str, str, str]]
 

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -12,6 +12,7 @@ from pip._vendor.packaging.tags import (
     Tag,
     compatible_tags,
     cpython_tags,
+    generic_tags,
     interpreter_name,
     interpreter_version,
     mac_platforms,
@@ -320,7 +321,10 @@ def _generic_tags(
     impl=None,  # type: Optional[str]
     abi=None,  # type: Optional[str]
 ):
-    # type: (...) -> List[Tuple[str, str, str]]
+    # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
+    if version is None and platform is None and impl is None and abi is None:
+        return generic_tags()
+
     supported = []  # type: List[Tuple[str, str, str]]
 
     # Versions must be given with respect to the preference

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -321,8 +321,12 @@ def _cpython_tags(
     abi=None,  # type: Optional[str]
 ):
     # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
-    if version is None and platform is None and abi is None:
-        return cpython_tags()
+    python_version = None  # type: Optional[PythonVersion]
+    if version is not None:
+        python_version = _get_python_version(version)
+
+    if platform is None and abi is None:
+        return cpython_tags(python_version=python_version)
 
     supported = []  # type: List[Tuple[str, str, str]]
 

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 import logging
 import re
-import sys
 
 from pip._vendor.packaging.tags import (
     Tag,
@@ -31,30 +30,6 @@ def version_info_to_nodot(version_info):
     # type: (Tuple[int, ...]) -> str
     # Only use up to the first two numbers.
     return ''.join(map(str, version_info[:2]))
-
-
-def get_impl_version_info():
-    # type: () -> Tuple[int, ...]
-    """Return sys.version_info-like tuple for use in decrementing the minor
-    version."""
-    if interpreter_name() == 'pp':
-        # as per https://github.com/pypa/pip/issues/2882
-        # attrs exist only on pypy
-        return (sys.version_info[0],
-                sys.pypy_version_info.major,  # type: ignore
-                sys.pypy_version_info.minor)  # type: ignore
-    else:
-        return sys.version_info[0], sys.version_info[1]
-
-
-def get_all_minor_versions_as_strings(version_info):
-    # type: (Tuple[int, ...]) -> List[str]
-    versions = []
-    major = version_info[:-1]
-    # Support all previous minor Python versions.
-    for minor in range(version_info[-1], -1, -1):
-        versions.append(''.join(map(str, major + (minor,))))
-    return versions
 
 
 def _mac_platforms(arch):

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -325,8 +325,12 @@ def _cpython_tags(
     if version is not None:
         python_version = _get_python_version(version)
 
-    if platform is None and abi is None:
-        return cpython_tags(python_version=python_version)
+    abis = None  # type: Optional[List[str]]
+    if abi is not None:
+        abis = [abi]
+
+    if platform is None:
+        return cpython_tags(python_version=python_version, abis=abis)
 
     supported = []  # type: List[Tuple[str, str, str]]
 
@@ -339,7 +343,7 @@ def _cpython_tags(
     current_version = versions[0]
     other_versions = versions[1:]
 
-    abis = []  # type: List[str]
+    abis = []  # type: ignore  # we will be removing this soon
 
     abi = abi or get_abi_tag()
     if abi:

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -418,29 +418,6 @@ def _generic_tags(
     return supported
 
 
-def _compatible_tags(
-    version=None,  # type: Optional[str]
-    platform=None,  # type: Optional[str]
-    impl=None,  # type: Optional[str]
-):
-    # type: (...) -> Iterator[Tag]
-    python_version = None  # type: Optional[PythonVersion]
-    if version is not None:
-        python_version = _get_python_version(version)
-
-    interpreter = _get_custom_interpreter(impl, version)
-
-    platforms = None  # type: Optional[List[str]]
-    if platform is not None:
-        platforms = _get_custom_platforms(platform, platform)
-
-    return compatible_tags(
-        python_version=python_version,
-        interpreter=interpreter,
-        platforms=platforms,
-    )
-
-
 def _stable_unique_tags(tags):
     # type: (List[Tag]) -> Iterator[Tag]
     observed = set()  # type: Set[Tag]
@@ -471,9 +448,25 @@ def get_supported(
     """
     supported = []  # type: List[Union[Tag, Tuple[str, str, str]]]
 
+    python_version = None  # type: Optional[PythonVersion]
+    if version is not None:
+        python_version = _get_python_version(version)
+
+    interpreter = _get_custom_interpreter(impl, version)
+
+    platforms = None  # type: Optional[List[str]]
+    if platform is not None:
+        platforms = _get_custom_platforms(platform, platform)
+
     supported.extend(_cpython_tags(version, platform, impl, abi))
     supported.extend(_generic_tags(version, platform, impl, abi))
-    supported.extend(_compatible_tags(version, platform, impl))
+    supported.extend(
+        compatible_tags(
+            python_version=python_version,
+            interpreter=interpreter,
+            platforms=platforms,
+        )
+    )
 
     tags = [
         parts if isinstance(parts, Tag) else Tag(*parts)

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -320,7 +320,7 @@ def _cpython_tags(
     platform=None,  # type: Optional[str]
     abi=None,  # type: Optional[str]
 ):
-    # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
+    # type: (...) -> Iterator[Tag]
     python_version = None  # type: Optional[PythonVersion]
     if version is not None:
         python_version = _get_python_version(version)
@@ -333,54 +333,11 @@ def _cpython_tags(
     if platform is not None:
         platforms = _get_custom_platforms(platform, platform)
 
-    if True:
-        return cpython_tags(
-            python_version=python_version,
-            abis=abis,
-            platforms=platforms,
-        )
-
-    supported = []  # type: List[Tuple[str, str, str]]
-
-    # Versions must be given with respect to the preference
-    if version is None:
-        version_info = get_impl_version_info()
-        versions = get_all_minor_versions_as_strings(version_info)
-    else:
-        versions = [version]
-    current_version = versions[0]
-    other_versions = versions[1:]
-
-    abis = []  # type: ignore  # we will be removing this soon
-
-    abi = abi or get_abi_tag()
-    if abi:
-        abis[0:0] = [abi]
-
-    supports_abi3 = not PY2
-
-    if supports_abi3:
-        abis.append("abi3")
-
-    abis.append('none')
-
-    arches = _get_custom_platforms(platform or get_platform(), platform)
-
-    # Current version, current API (built specifically for our Python):
-    for abi in abis:
-        for arch in arches:
-            supported.append(('cp%s' % current_version, abi, arch))
-
-    # abi3 modules compatible with older version of Python
-    if supports_abi3:
-        for version in other_versions:
-            # abi3 was introduced in Python 3.2
-            if version in {'31', '30'}:
-                break
-            for arch in arches:
-                supported.append(("cp%s" % version, "abi3", arch))
-
-    return supported
+    return cpython_tags(
+        python_version=python_version,
+        abis=abis,
+        platforms=platforms,
+    )
 
 
 def _generic_tags(

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -423,7 +423,7 @@ def _compatible_tags(
     platform=None,  # type: Optional[str]
     impl=None,  # type: Optional[str]
 ):
-    # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
+    # type: (...) -> Iterator[Tag]
     python_version = None  # type: Optional[PythonVersion]
     if version is not None:
         python_version = _get_python_version(version)
@@ -434,42 +434,11 @@ def _compatible_tags(
     if platform is not None:
         platforms = _get_custom_platforms(platform, platform)
 
-    if True:
-        return compatible_tags(
-            python_version=python_version,
-            interpreter=interpreter,
-            platforms=platforms,
-        )
-
-    supported = []  # type: List[Tuple[str, str, str]]
-
-    # Versions must be given with respect to the preference
-    if version is None:
-        version_info = get_impl_version_info()
-        versions = get_all_minor_versions_as_strings(version_info)
-    else:
-        versions = [version]
-    current_version = versions[0]
-    other_versions = versions[1:]
-
-    impl = impl or interpreter_name()
-
-    arches = _get_custom_platforms(platform or get_platform(), platform)
-
-    # Has binaries, does not use the Python API:
-    for arch in arches:
-        supported.append(('py%s' % (current_version[0]), 'none', arch))
-
-    # No abi / arch, but requires our implementation:
-    supported.append(('%s%s' % (impl, current_version), 'none', 'any'))
-
-    # No abi / arch, generic Python
-    supported.append(('py%s' % (current_version,), 'none', 'any'))
-    supported.append(('py%s' % (current_version[0]), 'none', 'any'))
-    for version in other_versions:
-        supported.append(('py%s' % (version,), 'none', 'any'))
-
-    return supported
+    return compatible_tags(
+        python_version=python_version,
+        interpreter=interpreter,
+        platforms=platforms,
+    )
 
 
 def _stable_unique_tags(tags):

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -402,7 +402,6 @@ def _compatible_tags(
     version=None,  # type: Optional[str]
     platform=None,  # type: Optional[str]
     impl=None,  # type: Optional[str]
-    abi=None,  # type: Optional[str]
 ):
     # type: (...) -> List[Tuple[str, str, str]]
     supported = []  # type: List[Tuple[str, str, str]]
@@ -468,7 +467,7 @@ def get_supported(
 
     supported.extend(_cpython_tags(version, platform, impl, abi))
     supported.extend(_generic_tags(version, platform, impl, abi))
-    supported.extend(_compatible_tags(version, platform, impl, abi))
+    supported.extend(_compatible_tags(version, platform, impl))
 
     tags = [
         parts if isinstance(parts, Tag) else Tag(*parts)

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -317,7 +317,6 @@ def _get_custom_interpreter(implementation=None, version=None):
 def _cpython_tags(
     version=None,  # type: Optional[str]
     platform=None,  # type: Optional[str]
-    impl=None,  # type: Optional[str]
     abi=None,  # type: Optional[str]
 ):
     # type: (...) -> List[Tuple[str, str, str]]
@@ -332,15 +331,13 @@ def _cpython_tags(
     current_version = versions[0]
     other_versions = versions[1:]
 
-    impl = impl or interpreter_name()
-
     abis = []  # type: List[str]
 
     abi = abi or get_abi_tag()
     if abi:
         abis[0:0] = [abi]
 
-    supports_abi3 = not PY2 and impl == "cp"
+    supports_abi3 = not PY2
 
     if supports_abi3:
         abis.append("abi3")
@@ -352,7 +349,7 @@ def _cpython_tags(
     # Current version, current API (built specifically for our Python):
     for abi in abis:
         for arch in arches:
-            supported.append(('%s%s' % (impl, current_version), abi, arch))
+            supported.append(('cp%s' % current_version, abi, arch))
 
     # abi3 modules compatible with older version of Python
     if supports_abi3:
@@ -361,7 +358,7 @@ def _cpython_tags(
             if version in {'31', '30'}:
                 break
             for arch in arches:
-                supported.append(("%s%s" % (impl, version), "abi3", arch))
+                supported.append(("cp%s" % version, "abi3", arch))
 
     return supported
 
@@ -460,7 +457,7 @@ def get_supported(
 
     is_cpython = (impl or interpreter_name()) == "cp"
     if is_cpython:
-        supported.extend(_cpython_tags(version, platform, impl, abi))
+        supported.extend(_cpython_tags(version, platform, abi))
     else:
         supported.extend(_generic_tags(version, platform, impl, abi))
     supported.extend(

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -322,8 +322,10 @@ def _generic_tags(
     abi=None,  # type: Optional[str]
 ):
     # type: (...) -> Union[Iterator[Tag], List[Tuple[str, str, str]]]
-    if version is None and platform is None and impl is None and abi is None:
-        return generic_tags()
+    interpreter = _get_custom_interpreter(impl, version)
+
+    if platform is None and abi is None:
+        return generic_tags(interpreter=interpreter)
 
     supported = []  # type: List[Tuple[str, str, str]]
 

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -16,7 +16,6 @@ from pip._vendor.packaging.tags import (
     interpreter_version,
     mac_platforms,
 )
-from pip._vendor.six import PY2
 
 import pip._internal.utils.glibc
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -331,7 +330,6 @@ def _generic_tags(
     else:
         versions = [version]
     current_version = versions[0]
-    other_versions = versions[1:]
 
     impl = impl or interpreter_name()
 
@@ -341,11 +339,6 @@ def _generic_tags(
     if abi:
         abis[0:0] = [abi]
 
-    supports_abi3 = not PY2 and impl == "cp"
-
-    if supports_abi3:
-        abis.append("abi3")
-
     abis.append('none')
 
     arches = _get_custom_platforms(platform or get_platform(), platform)
@@ -354,15 +347,6 @@ def _generic_tags(
     for abi in abis:
         for arch in arches:
             supported.append(('%s%s' % (impl, current_version), abi, arch))
-
-    # abi3 modules compatible with older version of Python
-    if supports_abi3:
-        for version in other_versions:
-            # abi3 was introduced in Python 3.2
-            if version in {'31', '30'}:
-                break
-            for arch in arches:
-                supported.append(("%s%s" % (impl, version), "abi3", arch))
 
     return supported
 

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -458,8 +458,11 @@ def get_supported(
     if platform is not None:
         platforms = _get_custom_platforms(platform, platform)
 
-    supported.extend(_cpython_tags(version, platform, impl, abi))
-    supported.extend(_generic_tags(version, platform, impl, abi))
+    is_cpython = (impl or interpreter_name()) == "cp"
+    if is_cpython:
+        supported.extend(_cpython_tags(version, platform, impl, abi))
+    else:
+        supported.extend(_generic_tags(version, platform, impl, abi))
     supported.extend(
         compatible_tags(
             python_version=python_version,

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -4,9 +4,7 @@
 from __future__ import absolute_import
 
 import os
-import re
 import sys
-import warnings
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -67,32 +65,6 @@ def glibc_version_string_ctypes():
         version_str = version_str.decode("ascii")
 
     return version_str
-
-
-# Separated out from have_compatible_glibc for easier unit testing
-def check_glibc_version(version_str, required_major, minimum_minor):
-    # type: (str, int, int) -> bool
-    # Parse string and check against requested version.
-    #
-    # We use a regexp instead of str.split because we want to discard any
-    # random junk that might come after the minor version -- this might happen
-    # in patched/forked versions of glibc (e.g. Linaro's version of glibc
-    # uses version strings like "2.20-2014.11"). See gh-3588.
-    m = re.match(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)", version_str)
-    if not m:
-        warnings.warn("Expected glibc version with 2 components major.minor,"
-                      " got: %s" % version_str, RuntimeWarning)
-        return False
-    return (int(m.group("major")) == required_major and
-            int(m.group("minor")) >= minimum_minor)
-
-
-def have_compatible_glibc(required_major, minimum_minor):
-    # type: (int, int) -> bool
-    version_str = glibc_version_string()
-    if version_str is None:
-        return False
-    return check_glibc_version(version_str, required_major, minimum_minor)
 
 
 # platform.libc_ver regularly returns completely nonsensical glibc

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -170,6 +170,7 @@ class TestManylinuxTags(object):
 
 class TestManylinux1Tags(object):
 
+    @pytest.mark.xfail
     @patch('pip._internal.pep425tags.is_manylinux2010_compatible',
            lambda: False)
     @patch('pip._internal.pep425tags.is_manylinux2014_compatible',
@@ -200,6 +201,7 @@ class TestManylinux1Tags(object):
 
 class TestManylinux2010Tags(object):
 
+    @pytest.mark.xfail
     @patch('pip._internal.pep425tags.is_manylinux2014_compatible',
            lambda: False)
     @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
@@ -253,6 +255,7 @@ class TestManylinux2010Tags(object):
 
 class TestManylinux2014Tags(object):
 
+    @pytest.mark.xfail
     @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
     @patch('pip._internal.utils.glibc.have_compatible_glibc',
            lambda major, minor: True)

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -168,69 +168,7 @@ class TestManylinuxTags(object):
         assert not is_manylinux_compatible()
 
 
-class TestManylinux1Tags(object):
-
-    @pytest.mark.xfail
-    @patch('pip._internal.pep425tags.is_manylinux2010_compatible',
-           lambda: False)
-    @patch('pip._internal.pep425tags.is_manylinux2014_compatible',
-           lambda: False)
-    @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
-    @patch('pip._internal.utils.glibc.have_compatible_glibc',
-           lambda major, minor: True)
-    @patch('sys.platform', 'linux2')
-    def test_manylinux1_tag_is_first(self):
-        """
-        Test that the more specific tag manylinux1 comes first.
-        """
-        groups = {}
-        for tag in pep425tags.get_supported():
-            groups.setdefault(
-                (tag.interpreter, tag.abi), []
-            ).append(tag.platform)
-
-        for arches in groups.values():
-            if arches == ['any']:
-                continue
-            # Expect the most specific arch first:
-            if len(arches) == 3:
-                assert arches == ['manylinux1_x86_64', 'linux_x86_64', 'any']
-            else:
-                assert arches == ['manylinux1_x86_64', 'linux_x86_64']
-
-
 class TestManylinux2010Tags(object):
-
-    @pytest.mark.xfail
-    @patch('pip._internal.pep425tags.is_manylinux2014_compatible',
-           lambda: False)
-    @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
-    @patch('pip._internal.utils.glibc.have_compatible_glibc',
-           lambda major, minor: True)
-    @patch('sys.platform', 'linux2')
-    def test_manylinux2010_tag_is_first(self):
-        """
-        Test that the more specific tag manylinux2010 comes first.
-        """
-        groups = {}
-        for tag in pep425tags.get_supported():
-            groups.setdefault(
-                (tag.interpreter, tag.abi), []
-            ).append(tag.platform)
-
-        for arches in groups.values():
-            if arches == ['any']:
-                continue
-            # Expect the most specific arch first:
-            if len(arches) == 4:
-                assert arches == ['manylinux2010_x86_64',
-                                  'manylinux1_x86_64',
-                                  'linux_x86_64',
-                                  'any']
-            else:
-                assert arches == ['manylinux2010_x86_64',
-                                  'manylinux1_x86_64',
-                                  'linux_x86_64']
 
     @pytest.mark.parametrize("manylinux2010,manylinux1", [
         ("manylinux2010_x86_64", "manylinux1_x86_64"),
@@ -254,37 +192,6 @@ class TestManylinux2010Tags(object):
 
 
 class TestManylinux2014Tags(object):
-
-    @pytest.mark.xfail
-    @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
-    @patch('pip._internal.utils.glibc.have_compatible_glibc',
-           lambda major, minor: True)
-    @patch('sys.platform', 'linux2')
-    def test_manylinux2014_tag_is_first(self):
-        """
-        Test that the more specific tag manylinux2014 comes first.
-        """
-        groups = {}
-        for tag in pep425tags.get_supported():
-            groups.setdefault(
-                (tag.interpreter, tag.abi), []
-            ).append(tag.platform)
-
-        for arches in groups.values():
-            if arches == ['any']:
-                continue
-            # Expect the most specific arch first:
-            if len(arches) == 5:
-                assert arches == ['manylinux2014_x86_64',
-                                  'manylinux2010_x86_64',
-                                  'manylinux1_x86_64',
-                                  'linux_x86_64',
-                                  'any']
-            else:
-                assert arches == ['manylinux2014_x86_64',
-                                  'manylinux2010_x86_64',
-                                  'manylinux1_x86_64',
-                                  'linux_x86_64']
 
     @pytest.mark.parametrize("manylinuxA,manylinuxB", [
         ("manylinux2014_x86_64", ["manylinux2010_x86_64",

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -119,55 +119,6 @@ class TestPEP425Tags(object):
         self.abi_tag_unicode('dm', {'Py_DEBUG': True, 'WITH_PYMALLOC': True})
 
 
-@pytest.mark.parametrize('is_manylinux_compatible', [
-    pep425tags.is_manylinux1_compatible,
-    pep425tags.is_manylinux2010_compatible,
-    pep425tags.is_manylinux2014_compatible,
-])
-class TestManylinuxTags(object):
-    """
-    Tests common to all manylinux tags (e.g. manylinux1, manylinux2010,
-    ...)
-    """
-    @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
-    @patch('pip._internal.utils.glibc.have_compatible_glibc',
-           lambda major, minor: True)
-    def test_manylinux_compatible_on_linux_x86_64(self,
-                                                  is_manylinux_compatible):
-        """
-        Test that manylinuxes are enabled on linux_x86_64
-        """
-        assert is_manylinux_compatible()
-
-    @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_i686')
-    @patch('pip._internal.utils.glibc.have_compatible_glibc',
-           lambda major, minor: True)
-    def test_manylinux_compatible_on_linux_i686(self,
-                                                is_manylinux_compatible):
-        """
-        Test that manylinuxes are enabled on linux_i686
-        """
-        assert is_manylinux_compatible()
-
-    @patch('pip._internal.pep425tags.get_platform', lambda: 'linux_x86_64')
-    @patch('pip._internal.utils.glibc.have_compatible_glibc',
-           lambda major, minor: False)
-    def test_manylinux_2(self, is_manylinux_compatible):
-        """
-        Test that manylinuxes are disabled with incompatible glibc
-        """
-        assert not is_manylinux_compatible()
-
-    @patch('pip._internal.pep425tags.get_platform', lambda: 'arm6vl')
-    @patch('pip._internal.utils.glibc.have_compatible_glibc',
-           lambda major, minor: True)
-    def test_manylinux_3(self, is_manylinux_compatible):
-        """
-        Test that manylinuxes are disabled on arm6vl
-        """
-        assert not is_manylinux_compatible()
-
-
 class TestManylinux2010Tags(object):
 
     @pytest.mark.parametrize("manylinux2010,manylinux1", [

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,7 +10,6 @@ import shutil
 import stat
 import sys
 import time
-import warnings
 from io import BytesIO
 
 import pytest
@@ -24,7 +23,6 @@ from pip._internal.exceptions import (
 from pip._internal.utils.deprecation import PipDeprecationWarning, deprecated
 from pip._internal.utils.encoding import BOMS, auto_decode
 from pip._internal.utils.glibc import (
-    check_glibc_version,
     glibc_version_string,
     glibc_version_string_confstr,
     glibc_version_string_ctypes,
@@ -538,38 +536,6 @@ def raises(error):
 
 
 class TestGlibc(object):
-    def test_manylinux_check_glibc_version(self):
-        """
-        Test that the check_glibc_version function is robust against weird
-        glibc version strings.
-        """
-        for two_twenty in ["2.20",
-                           # used by "linaro glibc", see gh-3588
-                           "2.20-2014.11",
-                           # weird possibilities that I just made up
-                           "2.20+dev",
-                           "2.20-custom",
-                           "2.20.1",
-                           ]:
-            assert check_glibc_version(two_twenty, 2, 15)
-            assert check_glibc_version(two_twenty, 2, 20)
-            assert not check_glibc_version(two_twenty, 2, 21)
-            assert not check_glibc_version(two_twenty, 3, 15)
-            assert not check_glibc_version(two_twenty, 1, 15)
-
-        # For strings that we just can't parse at all, we should warn and
-        # return false
-        for bad_string in ["asdf", "", "foo.bar"]:
-            with warnings.catch_warnings(record=True) as ws:
-                warnings.filterwarnings("always")
-                assert not check_glibc_version(bad_string, 2, 5)
-                for w in ws:
-                    if "Expected glibc version with" in str(w.message):
-                        break
-                else:
-                    # Didn't find the warning we were expecting
-                    assert False
-
     @pytest.mark.skipif("sys.platform == 'win32'")
     def test_glibc_version_string(self, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
# Introduction

`packaging.tags` provides a simple [`sys_tags`](https://packaging.pypa.io/en/latest/tags/#packaging.tags.sys_tags) function for getting applicable tags for the running interpreter, but it does not allow customization of arguments. Since pip allows users to provide explicit interpreter (e.g. "pp"), platform (e.g. "linux_x86_64"), abi (e.g. "abi3"), and version (e.g. "35"), we have to use a different interface.

packaging.tags provides three functions for users that need to customize tag generation:

1. [`cpython_tags`](https://packaging.pypa.io/en/latest/tags/#packaging.tags.cpython_tags) - for tags applicable to CPython only
2. [`generic_tags`](https://packaging.pypa.io/en/latest/tags/#packaging.tags.generic_tags) - for tags applicable to any non-CPython Python implementation
3. [`compatible_tags`](https://packaging.pypa.io/en/latest/tags/#packaging.tags.compatible_tags) - for tags that are not specific to an interpreter
   implementation

`cpython_tags` and `generic_tags` are mutually exclusive, and return tags that are the highest priority. These tags are the most specific.

`compatible_tags` are always applicable, and a lower priority since they may just be compatible with e.g. the Python language version, but lack optimizations available in compiled code available for a specific interpreter/ABI/platform.

In this PR we remove most of our custom logic in `pip._internal.pep425tags`, instead relying on these three functions from `packaging.tags`.

# Approach

It's a given that we want to switch to `packaging.tags` for calculating compatible wheel tags, but while doing that we have a few other goals:

1. minimize bugs merged by making changes easy to review
2. if possible, compare the implementation in `packaging.tags` with what is currently in pip so we can understand possible issues that may be raised later

To satisfy 1, the PR is broken into small commits that should each be easy to recognize the literal changes of and confirm as equivalent or understand the scope of change. Each commit should pass lint checks and tests, which should reduce the number of trivial things that need to be worried about and ensure that all changes are self-contained.

To satisfy 2, we take an approach that transforms `pep425tags` into something that looks closer to `packaging.tags` before actually using the functions.

For each of the 3 custom tags functions, we make a copy of `get_supported`, then:

1. Refactor it locally, taking into account its new, more limited, responsibilities
2. Introduce the packaging.tags function for the case where there are no custom arguments provided
3. Customize arguments one-by-one and delegate to the packaging.tags function
4. When there is no pip-specific logic left, remove the intermediate function and use the packaging.tags function directly in `get_supported`

Following that, we remove unused utility methods, then in the end we're left with an implementation that relies solely on the tag generation in packaging.tags.

----

Fixes #6908.