### PR TITLE
Remove interpreter-specific major version tag

### DIFF
--- a/news/7355.removal
+++ b/news/7355.removal
@@ -1,0 +1,4 @@
+Remove interpreter-specific major version tag e.g. ``cp3-none-any``
+from consideration. This behavior was not documented strictly, and this
+tag in particular is `not useful <https://snarky.ca/the-challenges-in-designing-a-library-for-pep-425/>`_.
+Anyone with a use case can create an issue with pypa/packaging.

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -433,9 +433,6 @@ def get_supported(
 
     # No abi / arch, but requires our implementation:
     supported.append(('%s%s' % (impl, versions[0]), 'none', 'any'))
-    # Tagged specifically as being cross-version compatible
-    # (with just the major version specified)
-    supported.append(('%s%s' % (impl, versions[0][0]), 'none', 'any'))
 
     # No abi / arch, generic Python
     for i, version in enumerate(versions):

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -621,20 +621,6 @@ def test_download_specify_implementation(script, data):
     )
 
     data.reset()
-    fake_wheel(data, 'fake-1.0-fk2.fk3-none-any.whl')
-    result = script.pip(
-        'download', '--no-index', '--find-links', data.find_links,
-        '--only-binary=:all:',
-        '--dest', '.',
-        '--implementation', 'fk',
-        'fake'
-    )
-    assert (
-        Path('scratch') / 'fake-1.0-fk2.fk3-none-any.whl'
-        in result.files_created
-    )
-
-    data.reset()
     fake_wheel(data, 'fake-1.0-fk3-none-any.whl')
     result = script.pip(
         'download', '--no-index', '--find-links', data.find_links,


### PR DESCRIPTION
As mentioned in https://snarky.ca/the-challenges-in-designing-a-library-for-pep-425/
this tag doesn't make much sense + it impedes our usage of
packaging.tags.

In terms of backwards-compatibility, we attest to try to match
compatible wheels as best as possible, and this tag doesn't represent
that.

See also [pypa/packaging#187 (comment)](https://github.com/pypa/packaging/issues/187#issuecomment-552156753).

Progresses #6908.