### PR TITLE
Mark 6 tests as network tests

### DIFF
--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -721,6 +721,7 @@ def test_freeze_user(script, virtualenv, data):
     assert 'simple2' not in result.stdout
 
 
+@pytest.mark.network
 def test_freeze_path(tmpdir, script, data):
     """
     Test freeze with --path.
@@ -734,6 +735,7 @@ def test_freeze_path(tmpdir, script, data):
     _check_output(result.stdout, expected)
 
 
+@pytest.mark.network
 @pytest.mark.incompatible_with_test_venv
 def test_freeze_path_exclude_user(tmpdir, script, data):
     """
@@ -756,6 +758,7 @@ def test_freeze_path_exclude_user(tmpdir, script, data):
     _check_output(result.stdout, expected)
 
 
+@pytest.mark.network
 def test_freeze_path_multiple(tmpdir, script, data):
     """
     Test freeze with multiple --path arguments.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1325,6 +1325,7 @@ def test_install_no_binary_disables_building_wheels(script, data, with_wheel):
     assert "Running setup.py install for upper" in str(res), str(res)
 
 
+@pytest.mark.network
 def test_install_no_binary_builds_pep_517_wheel(script, data, with_wheel):
     to_install = data.packages.joinpath('pep517_setup_and_pyproject')
     res = script.pip(

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -133,6 +133,7 @@ def test_command_line_appends_correctly(script, data):
     ), 'stdout: {}'.format(result.stdout)
 
 
+@pytest.mark.network
 def test_config_file_override_stack(script, virtualenv):
     """
     Test config files (global, overriding a global config with a

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -8,6 +8,7 @@ from tests.lib import assert_all_changes, pyversion
 from tests.lib.local_repos import local_checkout
 
 
+@pytest.mark.network
 def test_no_upgrade_unless_requested(script):
     """
     No upgrade if not specifically requested.


### PR DESCRIPTION
Marking 6 tests as needing network access. The full failure logs can be seen [here](https://paste.fedoraproject.org/paste/99JGP4jUAEdRqzx8pVwNBg], and I've also put them in the commit message.

When I run the tests the exact same way but with internet access, they all pass:

    tests/functional/test_freeze.py::test_freeze_path PASSED                 [  4%]
    tests/functional/test_freeze.py::test_freeze_path_exclude_user PASSED    [  4%]
    tests/functional/test_freeze.py::test_freeze_path_multiple PASSED        [  4%]
    tests/functional/test_install.py::test_install_no_binary_builds_pep_517_wheel PASSED [ 10%]
    tests/functional/test_install_config.py::test_config_file_override_stack PASSED [ 12%]
    tests/functional/test_install_upgrade.py::test_no_upgrade_unless_requested PASSED [ 15%]
    ...
    = 1501 passed, 18 skipped, 131 deselected, 5 xfailed, 34 warnings in 492.43 seconds =

