### PR TITLE
Update link to peer review PDF

### DIFF
--- a/docs/html/development/contributing.rst
+++ b/docs/html/development/contributing.rst
@@ -247,7 +247,7 @@ and they will initiate a vote among the existing maintainers.
     - CI Administration capabilities
     - ReadTheDocs Administration capabilities
 
-.. _`Studies have shown`: https://smartbear.com/smartbear/media/pdfs/wp-cc-11-best-practices-of-peer-code-review.pdf
+.. _`Studies have shown`: https://www.kessler.de/prd/smartbear/BestPracticesForPeerCodeReview.pdf
 .. _`resolve merge conflicts`: https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/
 .. _`Travis CI`: https://travis-ci.org/
 .. _`Appveyor CI`: https://www.appveyor.com/


### PR DESCRIPTION
I opted for a PDF though not sure if it's exactly the same.

If we prefer non-PDF here are couple of options with roughly the same content:
- https://www.ibm.com/developerworks/rational/library/11-proven-practices-for-peer-review/index.html
- https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/

