### PR TITLE
#7280: increase retry wait for rmtree

### DIFF
--- a/news/7280.bugfix
+++ b/news/7280.bugfix
@@ -1,0 +1,1 @@
+Increase retry wait for rmtree to allow more time for virus scanners to release files on windows.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -132,8 +132,8 @@ def get_prog():
     return 'pip'
 
 
-# Retry every half second for up to 3 seconds
-@retry(stop_max_delay=3000, wait_fixed=500)
+# Retry every half second for up to 12 seconds
+@retry(stop_max_delay=12000, wait_fixed=500)
 def rmtree(dir, ignore_errors=False):
     # type: (str, bool) -> None
     shutil.rmtree(dir, ignore_errors=ignore_errors,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -366,11 +366,11 @@ def test_rmtree_retries(tmpdir, monkeypatch):
     rmtree('foo')
 
 
-def test_rmtree_retries_for_3sec(tmpdir, monkeypatch):
+def test_rmtree_retries_for_12sec(tmpdir, monkeypatch):
     """
-    Test pip._internal.utils.rmtree will retry failures for no more than 3 sec
+    Test pip._internal.utils.rmtree will retry failures for no more than 12 sec
     """
-    monkeypatch.setattr(shutil, 'rmtree', Failer(duration=5).call)
+    monkeypatch.setattr(shutil, 'rmtree', Failer(duration=14).call)
     with pytest.raises(OSError):
         rmtree('foo')
 


### PR DESCRIPTION
to address #7280 - increase retry wait for rmtree to allow more time for virus scanners to release files on windows.