### PR TITLE
Simplify abi3 usage in pep425tags

### DIFF
--- a/news/7327.removal
+++ b/news/7327.removal
@@ -1,0 +1,2 @@
+Use literal "abi3" for wheel tag on CPython 3.x, to align with PEP 384
+which only defines it for this platform.

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -13,12 +13,11 @@ from collections import OrderedDict
 from pip._vendor.six import PY2
 
 import pip._internal.utils.glibc
-from pip._internal.utils.compat import get_extension_suffixes
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Tuple, Callable, List, Optional, Union, Dict, Set
+        Tuple, Callable, List, Optional, Union, Dict
     )
 
     Pep425Tag = Tuple[str, str, str]

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -10,6 +10,8 @@ import sysconfig
 import warnings
 from collections import OrderedDict
 
+from pip._vendor.six import PY2
+
 import pip._internal.utils.glibc
 from pip._internal.utils.compat import get_extension_suffixes
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -361,12 +363,10 @@ def get_supported(
     if abi:
         abis[0:0] = [abi]
 
-    abi3s = set()  # type: Set[str]
-    for suffix in get_extension_suffixes():
-        if suffix.startswith('.abi'):
-            abi3s.add(suffix.split('.', 2)[1])
+    supports_abi3 = not PY2 and impl == "cp"
 
-    abis.extend(sorted(list(abi3s)))
+    if supports_abi3:
+        abis.append("abi3")
 
     abis.append('none')
 
@@ -419,13 +419,13 @@ def get_supported(
             supported.append(('%s%s' % (impl, versions[0]), abi, arch))
 
     # abi3 modules compatible with older version of Python
-    for version in versions[1:]:
-        # abi3 was introduced in Python 3.2
-        if version in {'31', '30'}:
-            break
-        for abi in abi3s:   # empty set if not Python 3
+    if supports_abi3:
+        for version in versions[1:]:
+            # abi3 was introduced in Python 3.2
+            if version in {'31', '30'}:
+                break
             for arch in arches:
-                supported.append(("%s%s" % (impl, version), abi, arch))
+                supported.append(("%s%s" % (impl, version), "abi3", arch))
 
     # Has binaries, does not use the Python API:
     for arch in arches:

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -43,7 +43,6 @@ except ImportError:
 __all__ = [
     "ipaddress", "uses_pycache", "console_to_str",
     "get_path_uid", "stdlib_pkgs", "WINDOWS", "samefile", "get_terminal_size",
-    "get_extension_suffixes",
 ]
 
 
@@ -187,19 +186,6 @@ def get_path_uid(path):
                 "%s is a symlink; Will not return uid for symlinks" % path
             )
     return file_uid
-
-
-if PY2:
-    from imp import get_suffixes
-
-    def get_extension_suffixes():
-        return [suffix[0] for suffix in get_suffixes()]
-
-else:
-    from importlib.machinery import EXTENSION_SUFFIXES
-
-    def get_extension_suffixes():
-        return EXTENSION_SUFFIXES
 
 
 def expanduser(path):


### PR DESCRIPTION
The justification for this change is similar to #7355 - our documentation states that we try our best given the user inputs for applicable wheel tag calculation. Over-complicating (and potentially over-generalizing) the inclusion criteria for abi3 in `pep425tags.get_platforms` makes it harder to integrate with `packaging.tags`, which itself should represent the best-ordered and most full set of tags.

Closes #7327 and progresses #6908.