### PR TITLE
Redact passwords from index-url during download

### DIFF
--- a/news/6783.bugfix
+++ b/news/6783.bugfix
@@ -1,0 +1,2 @@
+Fix passwords being visible in the index-url in
+"Downloading <url>" message.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -46,6 +46,7 @@ from pip._internal.utils.misc import (
     hide_url,
     normalize_path,
     path_to_display,
+    redact_auth_from_url,
     rmtree,
     splitext,
 )
@@ -131,12 +132,16 @@ def _download_url(
     else:
         url = link.url_without_fragment
 
+    redacted_url = redact_auth_from_url(url)
+
     if total_length:
-        logger.info("Downloading %s (%s)", url, format_size(total_length))
+        logger.info(
+            "Downloading %s (%s)", redacted_url, format_size(total_length)
+        )
     elif is_from_cache(resp):
-        logger.info("Using cached %s", url)
+        logger.info("Using cached %s", redacted_url)
     else:
-        logger.info("Downloading %s", url)
+        logger.info("Downloading %s", redacted_url)
 
     if logger.getEffectiveLevel() > logging.INFO:
         show_progress = False


### PR DESCRIPTION
Made changes in _download_url so that it relies on redact_auth_from_url from misc to redact passwords.

Closes https://github.com/pypa/pip/issues/6783

Supersedes #6834.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
