### PR TITLE
Modify AIX platform_tag so it provides PEP425 needs

### DIFF
--- a/news/6922.feature
+++ b/news/6922.feature
@@ -1,0 +1,12 @@
+Add support for proper PEP425 tagging for the AIX platform.
+
+The tag format is "AIX.{}.{:04d}.{}".format(vrtl, bd, sz)
+The fileset bos.mp64 values for VRMF and Builddate
+are the imputs for the run-time values.
+For the "build" values the VRM values are obtained
+from the configuration variable BUILD_GNU_TYPE.
+When available the configuration variable AIX_BUILDDATE
+provides the builddate, otherwise a fixed constant
+vrtl is calculated from the VRMF value of bos.mp64
+
+patch by M. Felt

--- a/src/pip/_internal/_AIX_platform.py
+++ b/src/pip/_internal/_AIX_platform.py
@@ -3,31 +3,56 @@
 import sys
 from subprocess import check_output
 from sysconfig import get_config_var
-from ._typing import MYPY_CHECK_RUNNING
 
-if MYPY_CHECK_RUNNING:
-    from typing import Optional
+# from ._typing import MYPY_CHECK_RUNNING
 
+"""
+AIX filesets are identified by four decimal values aka VRMF.
+V (version) is the value returned by "uname -v"
+R (release) is the value returned by "uname -r"
+M and F values are not available via uname
+There is a fifth, lessor known value: builddate that
+is expressed as YYWW (Year WeekofYear)
+
+The fileset bos.mp64 contains the AIX kernel and it's
+VRMF and builddate are equivalent to installed
+levels of the runtime environment.
+The program lslpp is used to get these values.
+The pep425 platform tag for AIX becomes:
+AIX.VRTL.YYWW.SZ, e.g., AIX.6107.1415.32
+
+The routines here convert VRMF values to VRTL and
+adding BUILDDATE and bitness for comparision with
+other AIX platform tags
+"""
+
+_bgt = get_config_var("BUILD_GNU_TYPE")
 
 _is_32bit = sys.maxsize == 2147483647
 
 
-def aix_tag(vrtl, bd):
+def _aix_tag(vrtl, bd):
     # type: (int, int) -> str
     sz = 32 if _is_32bit else 64
     return "AIX.{:04d}.{}.{}".format(vrtl, bd, sz)
 
 
-def aix_ver(bgt=""):
-    # type: (Optional[str]) -> int
-    if bgt == "":
-        bgt = get_config_var("BUILD_GNU_TYPE")
-    assert bgt
-    v, r, tl = bgt.split(".")[:3]
-    return int("{}{}{:02d}".format(v, r, int(tl)))
+# extract vrtl from the VRMF string
+def _aix_vrtl(vrmf):
+    # type: (str) -> int
+    v, r, tl = vrmf.split(".")[:3]
+    return int("{}{}{:02d}".format(v[-1], r, int(tl)))
 
 
-def _builddate():
+# extract vrtl from the BUILD_GNU_TYPE as an int
+def _aix_bgt():
+    # type: () -> int
+    assert(_bgt)
+    return(_aix_vrtl(_bgt))
+
+
+# return the AIX_BUILDDATE, or 9898 if not defined
+def _aix_bd():
     # type: () -> int
     bd = get_config_var("AIX_BUILDDATE")
     # if bd == "" or None set Builddate value to an impossible value
@@ -40,41 +65,20 @@ def _builddate():
 
 def aix_buildtag():
     # type: () -> str
-    return aix_tag(aix_ver(), _builddate())
+    return _aix_tag(_aix_bgt(), _aix_bd())
 
 
-def aix_pep425():
+def _aix_platform():
     # type: () -> str
-    """
-    AIX filesets are identified by four decimal values aka VRMF.
-    V (version) is the value returned by "uname -v"
-    R (release) is the value returned by "uname -r"
-    M and F values are not available via uname
-    There is a fifth, lessor known value: builddate that
-    is expressed as YYWW (Year WeekofYear)
-
-    The fileset bos.mp64 contains the AIX kernel and it's
-    VRMF and builddate are equivalent to installed
-    levels of the runtime environment.
-    The program lslpp is used to get these values.
-    The pep425 platform tag for AIX becomes:
-    AIX.VRTL.YYWW.SZ, e.g., AIX.6107.1415.32
-    """
-    # p = run(["/usr/bin/lslpp", "-Lqc", "bos.mp64"],
-    #       capture_output=True, text=True)
-    result = check_output(["/usr/bin/lslpp", "-Lqc", "bos.mp64"])
-    result = result.decode("utf-8").strip().split(":")  # type: ignore
-
-    (lpp, vrmf, bd) = list(result[index] for index in [0, 2, -1])
+    vrmf = ""
+    tmp = check_output(["/usr/bin/lslpp", "-Lqc", "bos.mp64"])
+    tmp = tmp.decode("utf-8").strip().split(":")  # type: ignore
+    lpp, vrmf, bd = list(tmp[index] for index in [0, 2, -1])  # type: ignore
     assert lpp == "bos.mp64", "%s != %s" % (lpp, "bos.mp64")
-    v, r, tl = map(int, vrmf.split(".")[:3])
-    # vers = tuple(map(int, v, r, tl))
-    # return aix_tag(vers, int(bd))
-    # return aix_tag(v, r, tl, int(bd))
-    return aix_tag(aix_ver(vrmf), int(bd))
+    return _aix_tag(_aix_vrtl(vrmf), int(bd))
 
 
 def get_platform():
     # type: () -> str
     """Return AIX platform tag"""
-    return aix_pep425()
+    return _aix_platform()

--- a/src/pip/_internal/_AIX_platform.py
+++ b/src/pip/_internal/_AIX_platform.py
@@ -1,84 +1,82 @@
 """Shared AIX support functions."""
 
 import sys
-from subprocess import check_output
+import subprocess
 from sysconfig import get_config_var
 
-# from ._typing import MYPY_CHECK_RUNNING
+from ._typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:  # pragma: no cover
+    from typing import List
 
 """
-AIX filesets are identified by four decimal values aka VRMF.
-V (version) is the value returned by "uname -v"
-R (release) is the value returned by "uname -r"
-M and F values are not available via uname
-There is a fifth, lessor known value: builddate that
-is expressed as YYWW (Year WeekofYear)
+AIX filesets are identified by four decimal values: V.R.M.F.
+V (version) and R (release) can be retreived using ``uname``
+M(aintenance) and F(ix) values are not available via uname
+For determining ABI compatibility the values V.R.M
+are essential - suplemented by a final value known as
+`builddate` that is expressed as YYWW (Year WeekofYear)
 
-The fileset bos.mp64 contains the AIX kernel and it's
-VRMF and builddate are equivalent to installed
-levels of the runtime environment.
-The program lslpp is used to get these values.
-The pep425 platform tag for AIX becomes:
-AIX.VRTL.YYWW.SZ, e.g., AIX.6107.1415.32
+The values for V.R.M of the system Python was built on are available in
+the variable sysconfig.get_config_var("BUILD_GNU_TYPE"). The system builddate
+value may be available in sys.config.get_config_var("AIX_BUILDDATE")
+When all of these values on a running system are greater or equal to the
+values of the build system then the bdist modules are binary compatible
+with the AIX kernel.
 
-The routines here convert VRMF values to VRTL and
-adding BUILDDATE and bitness for comparision with
-other AIX platform tags
+For pep425 purposes the AIX platform tag becomes:
+"AIX.{}.{:04d}.{}".format(vmtl, builddate, bitsize)
+e.g., "AIX.6107.1415.32" for AIX 6.1 TL7 bd 1415, 32-bit
+and, "AIX.6107.1415.64" for AIX 6.1 TL7 bd 1415, 64-bit
 """
 
+# _bd - set to impossible setting year98-week98 if None
+_tmp = str(get_config_var("AIX_BUILDDATE"))
+_bd = 9898 if (_tmp == "None") else int(_tmp)
 _bgt = get_config_var("BUILD_GNU_TYPE")
-
 _is_32bit = sys.maxsize == 2147483647
 
 
 def _aix_tag(vrtl, bd):
     # type: (int, int) -> str
     sz = 32 if _is_32bit else 64
-    return "AIX.{:04d}.{}.{}".format(vrtl, bd, sz)
+    return "AIX.{}.{:04d}.{}".format(vrtl, bd, sz)
 
 
-# extract vrtl from the VRMF string
+# compute vrtl from the VRMF string
 def _aix_vrtl(vrmf):
     # type: (str) -> int
     v, r, tl = vrmf.split(".")[:3]
     return int("{}{}{:02d}".format(v[-1], r, int(tl)))
 
 
-# extract vrtl from the BUILD_GNU_TYPE as an int
-def _aix_bgt():
-    # type: () -> int
-    assert(_bgt)
-    return(_aix_vrtl(_bgt))
-
-
-# return the AIX_BUILDDATE, or 9898 if not defined
-def _aix_bd():
-    # type: () -> int
-    bd = get_config_var("AIX_BUILDDATE")
-    # if bd == "" or None set Builddate value to an impossible value
-    # year XX98-week98
-    if not bd:
-        return 9898
-    else:
-        return int(bd)
-
-
-def aix_buildtag():
-    # type: () -> str
-    return _aix_tag(_aix_bgt(), _aix_bd())
-
-
-def _aix_platform():
-    # type: () -> str
-    vrmf = ""
-    tmp = check_output(["/usr/bin/lslpp", "-Lqc", "bos.mp64"])
+def _aix_bosmp64():
+    # type: () -> List[str]
+    """
+    The fileset bos.mp64 is the AIX kernel. It's VRMF and builddate
+    reflect the current levels of the runtime environment.
+    """
+    tmp = subprocess.check_output(["/usr/bin/lslpp", "-Lqc", "bos.mp64"])
     tmp = tmp.decode("utf-8").strip().split(":")  # type: ignore
-    lpp, vrmf, bd = list(tmp[index] for index in [0, 2, -1])  # type: ignore
+    # lpp, vrmf, bd = list(tmp[index] for index in [0, 2, -1])  # type: ignore
+    # e.g., ['bos.mp64', '7.1.4.34', '1806']
+    return list(tmp[index] for index in [0, 2, -1])
+
+
+def aix_platform():
+    # type: () -> str
+    lpp, vrmf, bd = _aix_bosmp64()
     assert lpp == "bos.mp64", "%s != %s" % (lpp, "bos.mp64")
     return _aix_tag(_aix_vrtl(vrmf), int(bd))
 
 
-def get_platform():
+# extract vrtl from the BUILD_GNU_TYPE as an int
+def _aix_bgt():
+    # type: () -> int
+    assert _bgt
+    return _aix_vrtl(_bgt)
+
+
+def aix_buildtag():
     # type: () -> str
-    """Return AIX platform tag"""
-    return _aix_platform()
+    return _aix_tag(_aix_bgt(), _bd)

--- a/src/pip/_internal/_AIX_platform.py
+++ b/src/pip/_internal/_AIX_platform.py
@@ -1,0 +1,80 @@
+"""Shared AIX support functions."""
+
+import sys
+from subprocess import check_output
+from sysconfig import get_config_var
+from ._typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional
+
+
+_is_32bit = sys.maxsize == 2147483647
+
+
+def aix_tag(vrtl, bd):
+    # type: (int, int) -> str
+    sz = 32 if _is_32bit else 64
+    return "AIX.{:04d}.{}.{}".format(vrtl, bd, sz)
+
+
+def aix_ver(bgt=""):
+    # type: (Optional[str]) -> int
+    if bgt == "":
+        bgt = get_config_var("BUILD_GNU_TYPE")
+    assert bgt
+    v, r, tl = bgt.split(".")[:3]
+    return int("{}{}{:02d}".format(v, r, int(tl)))
+
+
+def _builddate():
+    # type: () -> int
+    bd = get_config_var("AIX_BUILDDATE")
+    # if bd == "" or None set Builddate value to an impossible value
+    # year XX98-week98
+    if not bd:
+        return 9898
+    else:
+        return int(bd)
+
+
+def aix_buildtag():
+    # type: () -> str
+    return aix_tag(aix_ver(), _builddate())
+
+
+def aix_pep425():
+    # type: () -> str
+    """
+    AIX filesets are identified by four decimal values aka VRMF.
+    V (version) is the value returned by "uname -v"
+    R (release) is the value returned by "uname -r"
+    M and F values are not available via uname
+    There is a fifth, lessor known value: builddate that
+    is expressed as YYWW (Year WeekofYear)
+
+    The fileset bos.mp64 contains the AIX kernel and it's
+    VRMF and builddate are equivalent to installed
+    levels of the runtime environment.
+    The program lslpp is used to get these values.
+    The pep425 platform tag for AIX becomes:
+    AIX.VRTL.YYWW.SZ, e.g., AIX.6107.1415.32
+    """
+    # p = run(["/usr/bin/lslpp", "-Lqc", "bos.mp64"],
+    #       capture_output=True, text=True)
+    result = check_output(["/usr/bin/lslpp", "-Lqc", "bos.mp64"])
+    result = result.decode("utf-8").strip().split(":")  # type: ignore
+
+    (lpp, vrmf, bd) = list(result[index] for index in [0, 2, -1])
+    assert lpp == "bos.mp64", "%s != %s" % (lpp, "bos.mp64")
+    v, r, tl = map(int, vrmf.split(".")[:3])
+    # vers = tuple(map(int, v, r, tl))
+    # return aix_tag(vers, int(bd))
+    # return aix_tag(v, r, tl, int(bd))
+    return aix_tag(aix_ver(vrmf), int(bd))
+
+
+def get_platform():
+    # type: () -> str
+    """Return AIX platform tag"""
+    return aix_pep425()

--- a/src/pip/_internal/_AIX_platform.py
+++ b/src/pip/_internal/_AIX_platform.py
@@ -34,15 +34,14 @@ and, "AIX-6107-1415-64" for AIX 6.1 TL7 bd 1415, 64-bit
 _tmp = str(get_config_var("AIX_BUILDDATE"))
 _bd = 9898 if (_tmp == "None") else int(_tmp)
 _bgt = get_config_var("BUILD_GNU_TYPE")
-_is_32bit = sys.maxsize == 2147483647
+_sz = 32 if sys.maxsize == 2147483647 else 64
 
 
 def _aix_tag(v, bd):
     # type: (List[int], int) -> str
     # v is used as variable name so line below passes pep8 length test
     # v[version, release, technology_level]
-    sz = 32 if _is_32bit else 64
-    return "AIX-{:1x}{:1d}{:02d}-{:04d}-{}".format(v[0], v[1], v[2], bd, sz)
+    return "AIX-{:1x}{:1d}{:02d}-{:04d}-{}".format(v[0], v[1], v[2], bd, _sz)
 
 
 # compute vrtl from the VRMF string

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -163,8 +163,8 @@ def get_platform():
     # support module while CPython catches up.
     if result[:3] == "aix":
         try:
-            from ._AIX_platform import get_platform
-            result = get_platform()
+            from ._AIX_platform import aix_platform
+            result = aix_platform()
         except ImportError:
             # The AIX module is not avaliable, leave `result` asis
             pass

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -156,7 +156,19 @@ def get_platform():
 
     # XXX remove distutils dependency
     result = distutils.util.get_platform().replace('.', '_').replace('-', '_')
-    if result == "linux_x86_64" and _is_running_32bit():
+
+    # AIX tag with PEP425 support starts as "AIX"
+    # without pep425 support it starts as "aix"
+    # rather than provide the tag in this file it comes from a seperate
+    # support module while CPython catches up.
+    if result[:3] == "aix":
+        try:
+            from ._AIX_platform import get_platform
+            result = get_platform()
+        except ImportError:
+            # The AIX module is not avaliable, leave `result` asis
+            pass
+    elif result == "linux_x86_64" and _is_running_32bit():
         # 32 bit Python program (running on a 64 bit Linux): pip should only
         # install and run 32 bit compiled extensions in that case.
         result = "linux_i686"


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
sysconfig.get_platform() does not provide an adequate PEP425 tag.

This support file (_AIX_platform.py) provides a tag that is adequate for bdist usage.
The module is only called when CPython is still returning the old tag that startswith("aix").

The new tag format is: "AIX.{}.{:04d}.{}".format(vrtl, bd, sz)