### PR TITLE
Better document the requirements file format

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -156,10 +156,14 @@ The following options are supported:
   *  :ref:`-i, --index-url <install_--index-url>`
   *  :ref:`--extra-index-url <install_--extra-index-url>`
   *  :ref:`--no-index <install_--no-index>`
+  *  :ref:`-c, --constraint <install_--constraint>`
+  *  :ref:`-r, --requirement <install_--requirement>`
+  *  :ref:`-e, --editable <install_--editable>`
   *  :ref:`-f, --find-links <install_--find-links>`
   *  :ref:`--no-binary <install_--no-binary>`
   *  :ref:`--only-binary <install_--only-binary>`
   *  :ref:`--require-hashes <install_--require-hashes>`
+  *  :ref:`--pre <install_--pre>`
   *  :ref:`--trusted-host <--trusted-host>`
 
 For example, to specify :ref:`--no-index <install_--no-index>` and two

--- a/news/7385.doc
+++ b/news/7385.doc
@@ -1,0 +1,1 @@
+Better document the requirements file format

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -58,19 +58,19 @@ COMMENT_RE = re.compile(r'(^|\s+)#.*$')
 ENV_VAR_RE = re.compile(r'(?P<var>\$\{(?P<name>[A-Z0-9_]+)\})')
 
 SUPPORTED_OPTIONS = [
-    cmdoptions.constraints,
-    cmdoptions.editable,
-    cmdoptions.requirements,
-    cmdoptions.no_index,
     cmdoptions.index_url,
-    cmdoptions.find_links,
     cmdoptions.extra_index_url,
-    cmdoptions.always_unzip,
+    cmdoptions.no_index,
+    cmdoptions.constraints,
+    cmdoptions.requirements,
+    cmdoptions.editable,
+    cmdoptions.find_links,
     cmdoptions.no_binary,
     cmdoptions.only_binary,
+    cmdoptions.require_hashes,
     cmdoptions.pre,
     cmdoptions.trusted_host,
-    cmdoptions.require_hashes,
+    cmdoptions.always_unzip,  # Deprecated
 ]  # type: List[Callable[..., optparse.Option]]
 
 # options to be passed to requirements


### PR DESCRIPTION
Change the documentation for the requirements file format so that it matches the [implementation].

Before this change the documentation included an incomplete list of supported options.

This change adds the missing options and changes the order to match, so that the two locations are easier to keep in sync. After this change the list in the documentation matches `SUPPORTED_OPTIONS` in `src/pip/_internal/req/req_file.py`.

[implementation]: https://github.com/pypa/pip/blob/master/src/pip/_internal/req/req_file.py#L60

Addresses https://github.com/pypa/pip/issues/7385