### PR TITLE
Support Editor env with options in config edit

### DIFF
--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import shlex
 import subprocess
 
 from pip._internal.cli.base_command import Command
@@ -188,7 +189,9 @@ class ConfigurationCommand(Command):
             raise PipError("Could not determine appropriate file.")
 
         try:
-            subprocess.check_call([editor, fname])
+            args = shlex.split(editor)  # editor, opt1, opt2 etc
+            args.append(fname)
+            subprocess.check_call(args)
         except subprocess.CalledProcessError as e:
             raise PipError(
                 "Editor Subprocess exited with exit code {}"


### PR DESCRIPTION
Generally the `EDITOR` env is a single string referring to a program but
nothing prevents user from attaching options within it. To fully conform
to the convention `pip config edit` should split the env first.

Fixes #7392.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: @https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->