### PR TITLE
Fix logging of cached response

### DIFF
--- a/news/7393.bugfix
+++ b/news/7393.bugfix
@@ -1,0 +1,1 @@
+Fix the logging of cached HTTP response shown as downloading.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -134,16 +134,15 @@ def _prepare_download(
     else:
         url = link.url_without_fragment
 
-    redacted_url = redact_auth_from_url(url)
+    logged_url = redact_auth_from_url(url)
 
     if total_length:
-        logger.info(
-            "Downloading %s (%s)", redacted_url, format_size(total_length)
-        )
-    elif is_from_cache(resp):
-        logger.info("Using cached %s", redacted_url)
+        logged_url = '{} ({})'.format(logged_url, format_size(total_length))
+
+    if is_from_cache(resp):
+        logger.info("Using cached %s", logged_url)
     else:
-        logger.info("Downloading %s", redacted_url)
+        logger.info("Downloading %s", logged_url)
 
     if logger.getEffectiveLevel() > logging.INFO:
         show_progress = False

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import os
 import shutil
 import sys
@@ -16,6 +17,7 @@ from pip._internal.operations.prepare import (
     Downloader,
     _copy_source_tree,
     _download_http_url,
+    _prepare_download,
     parse_content_disposition,
     sanitize_content_filename,
     unpack_file_url,
@@ -244,6 +246,36 @@ def test_download_http_url__no_directory_traversal(tmpdir):
     # The file should be downloaded to download_dir.
     actual = os.listdir(download_dir)
     assert actual == ['out_dir_file']
+
+
+@pytest.mark.parametrize("url, headers, from_cache, expected", [
+    ('http://example.com/foo.tgz', {}, False,
+        "Downloading http://example.com/foo.tgz"),
+    ('http://example.com/foo.tgz', {'content-length': 2}, False,
+        "Downloading http://example.com/foo.tgz (2 bytes)"),
+    ('http://example.com/foo.tgz', {'content-length': 2}, True,
+        "Using cached http://example.com/foo.tgz (2 bytes)"),
+    ('https://files.pythonhosted.org/foo.tgz', {}, False,
+        "Downloading foo.tgz"),
+    ('https://files.pythonhosted.org/foo.tgz', {'content-length': 2}, False,
+        "Downloading foo.tgz (2 bytes)"),
+    ('https://files.pythonhosted.org/foo.tgz', {'content-length': 2}, True,
+        "Using cached foo.tgz"),
+])
+def test_prepare_download__log(caplog, url, headers, from_cache, expected):
+    caplog.set_level(logging.INFO)
+    resp = MockResponse(b'')
+    resp.url = url
+    resp.headers = headers
+    if from_cache:
+        resp.from_cache = from_cache
+    link = Link(url)
+    _prepare_download(resp, link, progress_bar="on")
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == 'INFO'
+    assert expected in record.message
 
 
 @pytest.fixture


### PR DESCRIPTION
Cached responses often (always ?) provide a length meaning they were
never logged as such.

Not sure if a test is needed: it would involve passing a mocked response to `_prepare_download` and checking if the caplogs contains "Using cached"...
