### PR TITLE
Ignore WARNING emitted by setuptools during test

### DIFF
--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -276,7 +276,9 @@ def test_uninstall_easy_installed_console_scripts(script):
     """
     Test uninstalling package with console_scripts that is easy_installed.
     """
-    result = script.easy_install('discover')
+    # setuptools >= 42.0.0 deprecates easy_install and prints a warning when
+    # used
+    result = script.easy_install('discover', allow_stderr_warning=True)
     assert script.bin / 'discover' + script.exe in result.files_created, (
         sorted(result.files_created.keys())
     )


### PR DESCRIPTION
Setuptools 42.0.0, released a few hours ago, deprecates `easy_install` (see pypa/setuptools#1909 and [CHANGES](https://github.com/pypa/setuptools/blob/d155aa0d61690b7013de968b912a001d18f5cfdd/CHANGES.rst#v4200)). This caused a test in which we invoke `easy_install` to start failing, since it was tracing:

> `WARNING: The easy_install command is deprecated and will be removed in a future version.`