### PR TITLE
Remove old workaround for Ubuntu Python patch

### DIFF
--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -7,7 +7,6 @@ import platform
 import re
 import sys
 import sysconfig
-import warnings
 from collections import OrderedDict
 
 from pip._vendor.six import PY2
@@ -29,11 +28,7 @@ _osx_arch_pat = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
 
 def get_config_var(var):
     # type: (str) -> Optional[str]
-    try:
-        return sysconfig.get_config_var(var)
-    except IOError as e:  # Issue #1074
-        warnings.warn("{}".format(e), RuntimeWarning)
-        return None
+    return sysconfig.get_config_var(var)
 
 
 def get_abbr_impl():

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -77,21 +77,6 @@ class TestPEP425Tags(object):
                 abi_tag = pip._internal.pep425tags.get_abi_tag()
                 assert abi_tag == base + flags
 
-    def test_broken_sysconfig(self):
-        """
-        Test that pep425tags still works when sysconfig is broken.
-        Can be a problem on Python 2.7
-        Issue #1074.
-        """
-        import pip._internal.pep425tags
-
-        def raises_ioerror(var):
-            raise IOError("I have the wrong path!")
-
-        with patch('pip._internal.pep425tags.sysconfig.get_config_var',
-                   raises_ioerror):
-            assert len(pip._internal.pep425tags.get_supported())
-
     def test_no_hyphen_tag(self):
         """
         Test that no tag contains a hyphen.


### PR DESCRIPTION
This was originally implemented for #1074. Essentially:

1. virtualenvs in `/usr/local` on Ubuntu 12.04 LTS were suffering because an unconditional replacement on the path was done in the patched `sysconfig` module available with the system Python.
2. This was fixed in 14.04 LTS [Python 2.7.6](https://launchpad.net/ubuntu/+source/python2.7/2.7.6-8ubuntu0.5) per the diff [here](https://launchpadlibrarian.net/397305257/python2.7_2.7.6-8ubuntu0.5.diff.gz) (line 51409)

Given that 12.04 LTS has been out of support for [2 years](https://lists.ubuntu.com/archives/ubuntu-announce/2017-March/000218.html), let's remove this workaround to avoid having to add this error checking to `packaging.tags` or wrap our usage of the library.

Progresses #6908.