### PR TITLE
Remove dead code related to InstallRequirement build directories

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -412,8 +412,9 @@ class InstallRequirement(object):
             ])
         )
 
-        if self.source_dir is not None:
-            return
+        assert self.source_dir is not None
+
+        return
 
         assert self._temp_build_dir
         assert (


### PR DESCRIPTION
Going back a few years, `InstallRequirement._ideal_build_dir` has been a string. As a result, the second half of `move_to_correct_build_directory` couldn't've been executed, because it was asserting `self._ideal_build_dir.path`, which is not an attribute on strings.

See:

1. `self._ideal_build_dir` is only set in [`InstallRequirement.ensure_build_location(build_dir)`](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/req/req_install.py#L373), to the value of the `build_dir` parameter
1. Calls to `InstallRequirement.ensure_build_location(build_dir)`:
   1. From [`move_to_correct_build_directory` itself](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/req/req_install.py#L429), but we can leave that aside as it is after the invalid assertion in question
   1. From [`WheelBuilder.build`](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/wheel_builder.py#L488-L490) with `RequirementPreparer.build_dir` which is set to a string [here](https://github.com/pypa/pip/blob/master/src/pip/_internal/cli/req_command.py#L168)
   1. From [`InstallRequirement.ensure_has_source_dir`](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/req/req_install.py#L678) which itself is only called from
      1. `RequirementPreparer.prepare_linked_requirement` [here](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/operations/prepare.py#L626) with `self.build_dir` (already established as a string)
      1. `RequirementPreparer.prepare_editable_requirement` [here](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/operations/prepare.py#L739) with `self.src_dir`, which is a string per
         1. construction with `options.src_dir` [here](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/cli/req_command.py#L169), the value of which is only ever a string per the only locations it is set
            1. [`DownloadCommand.run`](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/commands/download.py#L89)
            1. [`WheelCommand.run`](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/commands/wheel.py#L152)
            1. [`InstallCommand.run`](https://github.com/pypa/pip/blob/5ba702894a169e44640916f0616243a6632f95e1/src/pip/_internal/commands/install.py#L294)