### PR TITLE
Move wheel.Wheel to models.wheel.Wheel

### DIFF
--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -11,12 +11,13 @@ import os
 
 from pip._vendor.packaging.utils import canonicalize_name
 
+from pip._internal.exceptions import InvalidWheelFilename
 from pip._internal.models.link import Link
+from pip._internal.models.wheel import Wheel
 from pip._internal.utils.compat import expanduser
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import path_to_url
-from pip._internal.wheel import InvalidWheelFilename, Wheel
 
 if MYPY_CHECK_RUNNING:
     from typing import Optional, Set, List, Any

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -14,10 +14,10 @@ from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.status_codes import SUCCESS
+from pip._internal.pep425tags import format_tag
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import get_pip_version
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.wheel import format_tag
 
 if MYPY_CHECK_RUNNING:
     from typing import Any, List, Optional

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -25,6 +25,7 @@ from pip._internal.models.format_control import FormatControl
 from pip._internal.models.link import Link
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
+from pip._internal.models.wheel import Wheel
 from pip._internal.utils.filetypes import WHEEL_EXTENSION
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import build_netloc
@@ -32,7 +33,6 @@ from pip._internal.utils.packaging import check_requires_python
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.unpacking import SUPPORTED_EXTENSIONS
 from pip._internal.utils.urls import url_to_path
-from pip._internal.wheel import Wheel
 
 if MYPY_CHECK_RUNNING:
     from typing import (

--- a/src/pip/_internal/models/wheel.py
+++ b/src/pip/_internal/models/wheel.py
@@ -1,0 +1,79 @@
+"""Represents a wheel file and provides access to the various parts of the
+name that have meaning.
+"""
+import re
+
+from pip._internal.exceptions import InvalidWheelFilename
+from pip._internal.pep425tags import format_tag
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import List
+
+    from pip._internal.pep425tags import Pep425Tag
+
+
+class Wheel(object):
+    """A wheel file"""
+
+    wheel_file_re = re.compile(
+        r"""^(?P<namever>(?P<name>.+?)-(?P<ver>.*?))
+        ((-(?P<build>\d[^-]*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
+        \.whl|\.dist-info)$""",
+        re.VERBOSE
+    )
+
+    def __init__(self, filename):
+        # type: (str) -> None
+        """
+        :raises InvalidWheelFilename: when the filename is invalid for a wheel
+        """
+        wheel_info = self.wheel_file_re.match(filename)
+        if not wheel_info:
+            raise InvalidWheelFilename(
+                "%s is not a valid wheel filename." % filename
+            )
+        self.filename = filename
+        self.name = wheel_info.group('name').replace('_', '-')
+        # we'll assume "_" means "-" due to wheel naming scheme
+        # (https://github.com/pypa/pip/issues/1150)
+        self.version = wheel_info.group('ver').replace('_', '-')
+        self.build_tag = wheel_info.group('build')
+        self.pyversions = wheel_info.group('pyver').split('.')
+        self.abis = wheel_info.group('abi').split('.')
+        self.plats = wheel_info.group('plat').split('.')
+
+        # All the tag combinations from this file
+        self.file_tags = {
+            (x, y, z) for x in self.pyversions
+            for y in self.abis for z in self.plats
+        }
+
+    def get_formatted_file_tags(self):
+        # type: () -> List[str]
+        """Return the wheel's tags as a sorted list of strings."""
+        return sorted(format_tag(tag) for tag in self.file_tags)
+
+    def support_index_min(self, tags):
+        # type: (List[Pep425Tag]) -> int
+        """Return the lowest index that one of the wheel's file_tag combinations
+        achieves in the given list of supported tags.
+
+        For example, if there are 8 supported tags and one of the file tags
+        is first in the list, then return 0.
+
+        :param tags: the PEP 425 tags to check the wheel against, in order
+            with most preferred first.
+
+        :raises ValueError: If none of the wheel's file tags match one of
+            the supported tags.
+        """
+        return min(tags.index(tag) for tag in self.file_tags if tag in tags)
+
+    def supported(self, tags):
+        # type: (List[Pep425Tag]) -> bool
+        """Return whether the wheel is compatible with one of the given tags.
+
+        :param tags: the PEP 425 tags to check the wheel against.
+        """
+        return not self.file_tags.isdisjoint(tags)

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -26,6 +26,15 @@ logger = logging.getLogger(__name__)
 _osx_arch_pat = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
 
 
+def format_tag(file_tag):
+    # type: (Tuple[str, ...]) -> str
+    """Format three tags in the form "<python_tag>-<abi_tag>-<platform_tag>".
+
+    :param file_tag: A 3-tuple of tags (python_tag, abi_tag, platform_tag).
+    """
+    return '-'.join(file_tag)
+
+
 def get_config_var(var):
     # type: (str) -> Optional[str]
     return sysconfig.get_config_var(var)

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -23,6 +23,7 @@ from pip._vendor.pkg_resources import RequirementParseError, parse_requirements
 from pip._internal.exceptions import InstallationError
 from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.models.link import Link
+from pip._internal.models.wheel import Wheel
 from pip._internal.pyproject import make_pyproject_path
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.filetypes import ARCHIVE_EXTENSIONS
@@ -30,7 +31,6 @@ from pip._internal.utils.misc import is_installable_dir, splitext
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import is_url, vcs
-from pip._internal.wheel import Wheel
 
 if MYPY_CHECK_RUNNING:
     from typing import (

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -10,9 +10,9 @@ from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal import pep425tags
 from pip._internal.exceptions import InstallationError
+from pip._internal.models.wheel import Wheel
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.wheel import Wheel
 
 if MYPY_CHECK_RUNNING:
     from typing import Dict, Iterable, List, Optional, Tuple

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -25,13 +25,8 @@ from pip._vendor.distlib.util import get_export_entry
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.six import StringIO
 
-from pip._internal.exceptions import (
-    InstallationError,
-    InvalidWheelFilename,
-    UnsupportedWheel,
-)
+from pip._internal.exceptions import InstallationError, UnsupportedWheel
 from pip._internal.locations import get_major_minor_version
-from pip._internal.pep425tags import format_tag
 from pip._internal.utils.misc import captured_stdout, ensure_dir, hash_file
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -42,7 +37,6 @@ if MYPY_CHECK_RUNNING:
     )
 
     from pip._internal.models.scheme import Scheme
-    from pip._internal.pep425tags import Pep425Tag
 
     InstalledCSVRow = Tuple[str, ...]
 
@@ -664,71 +658,3 @@ def check_compatibility(version, name):
             'Installing from a newer Wheel-Version (%s)',
             '.'.join(map(str, version)),
         )
-
-
-class Wheel(object):
-    """A wheel file"""
-
-    # TODO: Maybe move the class into the models sub-package
-
-    wheel_file_re = re.compile(
-        r"""^(?P<namever>(?P<name>.+?)-(?P<ver>.*?))
-        ((-(?P<build>\d[^-]*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
-        \.whl|\.dist-info)$""",
-        re.VERBOSE
-    )
-
-    def __init__(self, filename):
-        # type: (str) -> None
-        """
-        :raises InvalidWheelFilename: when the filename is invalid for a wheel
-        """
-        wheel_info = self.wheel_file_re.match(filename)
-        if not wheel_info:
-            raise InvalidWheelFilename(
-                "%s is not a valid wheel filename." % filename
-            )
-        self.filename = filename
-        self.name = wheel_info.group('name').replace('_', '-')
-        # we'll assume "_" means "-" due to wheel naming scheme
-        # (https://github.com/pypa/pip/issues/1150)
-        self.version = wheel_info.group('ver').replace('_', '-')
-        self.build_tag = wheel_info.group('build')
-        self.pyversions = wheel_info.group('pyver').split('.')
-        self.abis = wheel_info.group('abi').split('.')
-        self.plats = wheel_info.group('plat').split('.')
-
-        # All the tag combinations from this file
-        self.file_tags = {
-            (x, y, z) for x in self.pyversions
-            for y in self.abis for z in self.plats
-        }
-
-    def get_formatted_file_tags(self):
-        # type: () -> List[str]
-        """Return the wheel's tags as a sorted list of strings."""
-        return sorted(format_tag(tag) for tag in self.file_tags)
-
-    def support_index_min(self, tags):
-        # type: (List[Pep425Tag]) -> int
-        """Return the lowest index that one of the wheel's file_tag combinations
-        achieves in the given list of supported tags.
-
-        For example, if there are 8 supported tags and one of the file tags
-        is first in the list, then return 0.
-
-        :param tags: the PEP 425 tags to check the wheel against, in order
-            with most preferred first.
-
-        :raises ValueError: If none of the wheel's file tags match one of
-            the supported tags.
-        """
-        return min(tags.index(tag) for tag in self.file_tags if tag in tags)
-
-    def supported(self, tags):
-        # type: (List[Pep425Tag]) -> bool
-        """Return whether the wheel is compatible with one of the given tags.
-
-        :param tags: the PEP 425 tags to check the wheel against.
-        """
-        return not self.file_tags.isdisjoint(tags)

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -678,7 +678,6 @@ class Wheel(object):
     """A wheel file"""
 
     # TODO: Maybe move the class into the models sub-package
-    # TODO: Maybe move the install code into this class
 
     wheel_file_re = re.compile(
         r"""^(?P<namever>(?P<name>.+?)-(?P<ver>.*?))

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -31,6 +31,7 @@ from pip._internal.exceptions import (
     UnsupportedWheel,
 )
 from pip._internal.locations import get_major_minor_version
+from pip._internal.pep425tags import format_tag
 from pip._internal.utils.misc import captured_stdout, ensure_dir, hash_file
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -663,15 +664,6 @@ def check_compatibility(version, name):
             'Installing from a newer Wheel-Version (%s)',
             '.'.join(map(str, version)),
         )
-
-
-def format_tag(file_tag):
-    # type: (Tuple[str, ...]) -> str
-    """Format three tags in the form "<python_tag>-<abi_tag>-<platform_tag>".
-
-    :param file_tag: A 3-tuple of tags (python_tag, abi_tag, platform_tag).
-    """
-    return '-'.join(file_tag)
 
 
 class Wheel(object):

--- a/tests/unit/test_models_wheel.py
+++ b/tests/unit/test_models_wheel.py
@@ -1,0 +1,179 @@
+import pytest
+
+from pip._internal import pep425tags
+from pip._internal.exceptions import InvalidWheelFilename
+from pip._internal.models.wheel import Wheel
+
+
+class TestWheelFile(object):
+
+    def test_std_wheel_pattern(self):
+        w = Wheel('simple-1.1.1-py2-none-any.whl')
+        assert w.name == 'simple'
+        assert w.version == '1.1.1'
+        assert w.pyversions == ['py2']
+        assert w.abis == ['none']
+        assert w.plats == ['any']
+
+    def test_wheel_pattern_multi_values(self):
+        w = Wheel('simple-1.1-py2.py3-abi1.abi2-any.whl')
+        assert w.name == 'simple'
+        assert w.version == '1.1'
+        assert w.pyversions == ['py2', 'py3']
+        assert w.abis == ['abi1', 'abi2']
+        assert w.plats == ['any']
+
+    def test_wheel_with_build_tag(self):
+        # pip doesn't do anything with build tags, but theoretically, we might
+        # see one, in this case the build tag = '4'
+        w = Wheel('simple-1.1-4-py2-none-any.whl')
+        assert w.name == 'simple'
+        assert w.version == '1.1'
+        assert w.pyversions == ['py2']
+        assert w.abis == ['none']
+        assert w.plats == ['any']
+
+    def test_single_digit_version(self):
+        w = Wheel('simple-1-py2-none-any.whl')
+        assert w.version == '1'
+
+    def test_non_pep440_version(self):
+        w = Wheel('simple-_invalid_-py2-none-any.whl')
+        assert w.version == '-invalid-'
+
+    def test_missing_version_raises(self):
+        with pytest.raises(InvalidWheelFilename):
+            Wheel('Cython-cp27-none-linux_x86_64.whl')
+
+    def test_invalid_filename_raises(self):
+        with pytest.raises(InvalidWheelFilename):
+            Wheel('invalid.whl')
+
+    def test_supported_single_version(self):
+        """
+        Test single-version wheel is known to be supported
+        """
+        w = Wheel('simple-0.1-py2-none-any.whl')
+        assert w.supported(tags=[('py2', 'none', 'any')])
+
+    def test_supported_multi_version(self):
+        """
+        Test multi-version wheel is known to be supported
+        """
+        w = Wheel('simple-0.1-py2.py3-none-any.whl')
+        assert w.supported(tags=[('py3', 'none', 'any')])
+
+    def test_not_supported_version(self):
+        """
+        Test unsupported wheel is known to be unsupported
+        """
+        w = Wheel('simple-0.1-py2-none-any.whl')
+        assert not w.supported(tags=[('py1', 'none', 'any')])
+
+    def test_supported_osx_version(self):
+        """
+        Wheels built for macOS 10.6 are supported on 10.9
+        """
+        tags = pep425tags.get_supported(
+            '27', platform='macosx_10_9_intel', impl='cp'
+        )
+        w = Wheel('simple-0.1-cp27-none-macosx_10_6_intel.whl')
+        assert w.supported(tags=tags)
+        w = Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
+        assert w.supported(tags=tags)
+
+    def test_not_supported_osx_version(self):
+        """
+        Wheels built for macOS 10.9 are not supported on 10.6
+        """
+        tags = pep425tags.get_supported(
+            '27', platform='macosx_10_6_intel', impl='cp'
+        )
+        w = Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
+        assert not w.supported(tags=tags)
+
+    def test_supported_multiarch_darwin(self):
+        """
+        Multi-arch wheels (intel) are supported on components (i386, x86_64)
+        """
+        universal = pep425tags.get_supported(
+            '27', platform='macosx_10_5_universal', impl='cp'
+        )
+        intel = pep425tags.get_supported(
+            '27', platform='macosx_10_5_intel', impl='cp'
+        )
+        x64 = pep425tags.get_supported(
+            '27', platform='macosx_10_5_x86_64', impl='cp'
+        )
+        i386 = pep425tags.get_supported(
+            '27', platform='macosx_10_5_i386', impl='cp'
+        )
+        ppc = pep425tags.get_supported(
+            '27', platform='macosx_10_5_ppc', impl='cp'
+        )
+        ppc64 = pep425tags.get_supported(
+            '27', platform='macosx_10_5_ppc64', impl='cp'
+        )
+
+        w = Wheel('simple-0.1-cp27-none-macosx_10_5_intel.whl')
+        assert w.supported(tags=intel)
+        assert w.supported(tags=x64)
+        assert w.supported(tags=i386)
+        assert not w.supported(tags=universal)
+        assert not w.supported(tags=ppc)
+        assert not w.supported(tags=ppc64)
+        w = Wheel('simple-0.1-cp27-none-macosx_10_5_universal.whl')
+        assert w.supported(tags=universal)
+        assert w.supported(tags=intel)
+        assert w.supported(tags=x64)
+        assert w.supported(tags=i386)
+        assert w.supported(tags=ppc)
+        assert w.supported(tags=ppc64)
+
+    def test_not_supported_multiarch_darwin(self):
+        """
+        Single-arch wheels (x86_64) are not supported on multi-arch (intel)
+        """
+        universal = pep425tags.get_supported(
+            '27', platform='macosx_10_5_universal', impl='cp'
+        )
+        intel = pep425tags.get_supported(
+            '27', platform='macosx_10_5_intel', impl='cp'
+        )
+
+        w = Wheel('simple-0.1-cp27-none-macosx_10_5_i386.whl')
+        assert not w.supported(tags=intel)
+        assert not w.supported(tags=universal)
+        w = Wheel('simple-0.1-cp27-none-macosx_10_5_x86_64.whl')
+        assert not w.supported(tags=intel)
+        assert not w.supported(tags=universal)
+
+    def test_support_index_min(self):
+        """
+        Test results from `support_index_min`
+        """
+        tags = [
+            ('py2', 'none', 'TEST'),
+            ('py2', 'TEST', 'any'),
+            ('py2', 'none', 'any'),
+        ]
+        w = Wheel('simple-0.1-py2-none-any.whl')
+        assert w.support_index_min(tags=tags) == 2
+        w = Wheel('simple-0.1-py2-none-TEST.whl')
+        assert w.support_index_min(tags=tags) == 0
+
+    def test_support_index_min__none_supported(self):
+        """
+        Test a wheel not supported by the given tags.
+        """
+        w = Wheel('simple-0.1-py2-none-any.whl')
+        with pytest.raises(ValueError):
+            w.support_index_min(tags=[])
+
+    def test_version_underscore_conversion(self):
+        """
+        Test that we convert '_' to '-' for versions parsed out of wheel
+        filenames
+        """
+        w = Wheel('simple-0.1_1-py2-none-any.whl')
+        assert w.version == '0.1-1'

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -6,6 +6,15 @@ from mock import patch
 from pip._internal import pep425tags
 
 
+@pytest.mark.parametrize('file_tag, expected', [
+    (('py27', 'none', 'any'), 'py27-none-any'),
+    (('cp33', 'cp32dmu', 'linux_x86_64'), 'cp33-cp32dmu-linux_x86_64'),
+])
+def test_format_tag(file_tag, expected):
+    actual = pep425tags.format_tag(file_tag)
+    assert actual == expected
+
+
 @pytest.mark.parametrize('version_info, expected', [
     ((2,), '2'),
     ((2, 8), '28'),

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -8,12 +8,11 @@ import pytest
 from mock import patch
 from pip._vendor.packaging.requirements import Requirement
 
-from pip._internal import pep425tags, wheel
+from pip._internal import wheel
 from pip._internal.commands.wheel import WheelCommand
-from pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
+from pip._internal.exceptions import UnsupportedWheel
 from pip._internal.locations import get_scheme
 from pip._internal.models.scheme import Scheme
-from pip._internal.models.wheel import Wheel
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.misc import hash_file
 from pip._internal.utils.unpacking import unpack_file
@@ -227,169 +226,6 @@ def test_check_compatibility():
 
 class TestWheelFile(object):
 
-    def test_std_wheel_pattern(self):
-        w = Wheel('simple-1.1.1-py2-none-any.whl')
-        assert w.name == 'simple'
-        assert w.version == '1.1.1'
-        assert w.pyversions == ['py2']
-        assert w.abis == ['none']
-        assert w.plats == ['any']
-
-    def test_wheel_pattern_multi_values(self):
-        w = Wheel('simple-1.1-py2.py3-abi1.abi2-any.whl')
-        assert w.name == 'simple'
-        assert w.version == '1.1'
-        assert w.pyversions == ['py2', 'py3']
-        assert w.abis == ['abi1', 'abi2']
-        assert w.plats == ['any']
-
-    def test_wheel_with_build_tag(self):
-        # pip doesn't do anything with build tags, but theoretically, we might
-        # see one, in this case the build tag = '4'
-        w = Wheel('simple-1.1-4-py2-none-any.whl')
-        assert w.name == 'simple'
-        assert w.version == '1.1'
-        assert w.pyversions == ['py2']
-        assert w.abis == ['none']
-        assert w.plats == ['any']
-
-    def test_single_digit_version(self):
-        w = Wheel('simple-1-py2-none-any.whl')
-        assert w.version == '1'
-
-    def test_non_pep440_version(self):
-        w = Wheel('simple-_invalid_-py2-none-any.whl')
-        assert w.version == '-invalid-'
-
-    def test_missing_version_raises(self):
-        with pytest.raises(InvalidWheelFilename):
-            Wheel('Cython-cp27-none-linux_x86_64.whl')
-
-    def test_invalid_filename_raises(self):
-        with pytest.raises(InvalidWheelFilename):
-            Wheel('invalid.whl')
-
-    def test_supported_single_version(self):
-        """
-        Test single-version wheel is known to be supported
-        """
-        w = Wheel('simple-0.1-py2-none-any.whl')
-        assert w.supported(tags=[('py2', 'none', 'any')])
-
-    def test_supported_multi_version(self):
-        """
-        Test multi-version wheel is known to be supported
-        """
-        w = Wheel('simple-0.1-py2.py3-none-any.whl')
-        assert w.supported(tags=[('py3', 'none', 'any')])
-
-    def test_not_supported_version(self):
-        """
-        Test unsupported wheel is known to be unsupported
-        """
-        w = Wheel('simple-0.1-py2-none-any.whl')
-        assert not w.supported(tags=[('py1', 'none', 'any')])
-
-    def test_supported_osx_version(self):
-        """
-        Wheels built for macOS 10.6 are supported on 10.9
-        """
-        tags = pep425tags.get_supported(
-            '27', platform='macosx_10_9_intel', impl='cp'
-        )
-        w = Wheel('simple-0.1-cp27-none-macosx_10_6_intel.whl')
-        assert w.supported(tags=tags)
-        w = Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
-        assert w.supported(tags=tags)
-
-    def test_not_supported_osx_version(self):
-        """
-        Wheels built for macOS 10.9 are not supported on 10.6
-        """
-        tags = pep425tags.get_supported(
-            '27', platform='macosx_10_6_intel', impl='cp'
-        )
-        w = Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
-        assert not w.supported(tags=tags)
-
-    def test_supported_multiarch_darwin(self):
-        """
-        Multi-arch wheels (intel) are supported on components (i386, x86_64)
-        """
-        universal = pep425tags.get_supported(
-            '27', platform='macosx_10_5_universal', impl='cp'
-        )
-        intel = pep425tags.get_supported(
-            '27', platform='macosx_10_5_intel', impl='cp'
-        )
-        x64 = pep425tags.get_supported(
-            '27', platform='macosx_10_5_x86_64', impl='cp'
-        )
-        i386 = pep425tags.get_supported(
-            '27', platform='macosx_10_5_i386', impl='cp'
-        )
-        ppc = pep425tags.get_supported(
-            '27', platform='macosx_10_5_ppc', impl='cp'
-        )
-        ppc64 = pep425tags.get_supported(
-            '27', platform='macosx_10_5_ppc64', impl='cp'
-        )
-
-        w = Wheel('simple-0.1-cp27-none-macosx_10_5_intel.whl')
-        assert w.supported(tags=intel)
-        assert w.supported(tags=x64)
-        assert w.supported(tags=i386)
-        assert not w.supported(tags=universal)
-        assert not w.supported(tags=ppc)
-        assert not w.supported(tags=ppc64)
-        w = Wheel('simple-0.1-cp27-none-macosx_10_5_universal.whl')
-        assert w.supported(tags=universal)
-        assert w.supported(tags=intel)
-        assert w.supported(tags=x64)
-        assert w.supported(tags=i386)
-        assert w.supported(tags=ppc)
-        assert w.supported(tags=ppc64)
-
-    def test_not_supported_multiarch_darwin(self):
-        """
-        Single-arch wheels (x86_64) are not supported on multi-arch (intel)
-        """
-        universal = pep425tags.get_supported(
-            '27', platform='macosx_10_5_universal', impl='cp'
-        )
-        intel = pep425tags.get_supported(
-            '27', platform='macosx_10_5_intel', impl='cp'
-        )
-
-        w = Wheel('simple-0.1-cp27-none-macosx_10_5_i386.whl')
-        assert not w.supported(tags=intel)
-        assert not w.supported(tags=universal)
-        w = Wheel('simple-0.1-cp27-none-macosx_10_5_x86_64.whl')
-        assert not w.supported(tags=intel)
-        assert not w.supported(tags=universal)
-
-    def test_support_index_min(self):
-        """
-        Test results from `support_index_min`
-        """
-        tags = [
-            ('py2', 'none', 'TEST'),
-            ('py2', 'TEST', 'any'),
-            ('py2', 'none', 'any'),
-        ]
-        w = Wheel('simple-0.1-py2-none-any.whl')
-        assert w.support_index_min(tags=tags) == 2
-        w = Wheel('simple-0.1-py2-none-TEST.whl')
-        assert w.support_index_min(tags=tags) == 0
-
-    def test_support_index_min__none_supported(self):
-        """
-        Test a wheel not supported by the given tags.
-        """
-        w = Wheel('simple-0.1-py2-none-any.whl')
-        with pytest.raises(ValueError):
-            w.support_index_min(tags=[])
-
     def test_unpack_wheel_no_flatten(self, tmpdir):
         filepath = os.path.join(DATA_DIR, 'packages',
                                 'meta-1.0-py2.py3-none-any.whl')
@@ -411,14 +247,6 @@ class TestWheelFile(object):
 
         for name, path, expected in packages:
             assert wheel.root_is_purelib(name, path) == expected
-
-    def test_version_underscore_conversion(self):
-        """
-        Test that we convert '_' to '-' for versions parsed out of wheel
-        filenames
-        """
-        w = Wheel('simple-0.1_1-py2-none-any.whl')
-        assert w.version == '0.1-1'
 
 
 class TestInstallUnpackedWheel(object):

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -18,6 +18,7 @@ from pip._internal.utils.misc import hash_file
 from pip._internal.utils.unpacking import unpack_file
 from pip._internal.wheel import (
     MissingCallableSuffix,
+    Wheel,
     _raise_for_invalid_entrypoint,
 )
 from pip._internal.wheel_builder import get_legacy_build_wheel_path
@@ -227,7 +228,7 @@ def test_check_compatibility():
 class TestWheelFile(object):
 
     def test_std_wheel_pattern(self):
-        w = wheel.Wheel('simple-1.1.1-py2-none-any.whl')
+        w = Wheel('simple-1.1.1-py2-none-any.whl')
         assert w.name == 'simple'
         assert w.version == '1.1.1'
         assert w.pyversions == ['py2']
@@ -235,7 +236,7 @@ class TestWheelFile(object):
         assert w.plats == ['any']
 
     def test_wheel_pattern_multi_values(self):
-        w = wheel.Wheel('simple-1.1-py2.py3-abi1.abi2-any.whl')
+        w = Wheel('simple-1.1-py2.py3-abi1.abi2-any.whl')
         assert w.name == 'simple'
         assert w.version == '1.1'
         assert w.pyversions == ['py2', 'py3']
@@ -245,7 +246,7 @@ class TestWheelFile(object):
     def test_wheel_with_build_tag(self):
         # pip doesn't do anything with build tags, but theoretically, we might
         # see one, in this case the build tag = '4'
-        w = wheel.Wheel('simple-1.1-4-py2-none-any.whl')
+        w = Wheel('simple-1.1-4-py2-none-any.whl')
         assert w.name == 'simple'
         assert w.version == '1.1'
         assert w.pyversions == ['py2']
@@ -253,40 +254,40 @@ class TestWheelFile(object):
         assert w.plats == ['any']
 
     def test_single_digit_version(self):
-        w = wheel.Wheel('simple-1-py2-none-any.whl')
+        w = Wheel('simple-1-py2-none-any.whl')
         assert w.version == '1'
 
     def test_non_pep440_version(self):
-        w = wheel.Wheel('simple-_invalid_-py2-none-any.whl')
+        w = Wheel('simple-_invalid_-py2-none-any.whl')
         assert w.version == '-invalid-'
 
     def test_missing_version_raises(self):
         with pytest.raises(InvalidWheelFilename):
-            wheel.Wheel('Cython-cp27-none-linux_x86_64.whl')
+            Wheel('Cython-cp27-none-linux_x86_64.whl')
 
     def test_invalid_filename_raises(self):
         with pytest.raises(InvalidWheelFilename):
-            wheel.Wheel('invalid.whl')
+            Wheel('invalid.whl')
 
     def test_supported_single_version(self):
         """
         Test single-version wheel is known to be supported
         """
-        w = wheel.Wheel('simple-0.1-py2-none-any.whl')
+        w = Wheel('simple-0.1-py2-none-any.whl')
         assert w.supported(tags=[('py2', 'none', 'any')])
 
     def test_supported_multi_version(self):
         """
         Test multi-version wheel is known to be supported
         """
-        w = wheel.Wheel('simple-0.1-py2.py3-none-any.whl')
+        w = Wheel('simple-0.1-py2.py3-none-any.whl')
         assert w.supported(tags=[('py3', 'none', 'any')])
 
     def test_not_supported_version(self):
         """
         Test unsupported wheel is known to be unsupported
         """
-        w = wheel.Wheel('simple-0.1-py2-none-any.whl')
+        w = Wheel('simple-0.1-py2-none-any.whl')
         assert not w.supported(tags=[('py1', 'none', 'any')])
 
     def test_supported_osx_version(self):
@@ -296,9 +297,9 @@ class TestWheelFile(object):
         tags = pep425tags.get_supported(
             '27', platform='macosx_10_9_intel', impl='cp'
         )
-        w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_6_intel.whl')
+        w = Wheel('simple-0.1-cp27-none-macosx_10_6_intel.whl')
         assert w.supported(tags=tags)
-        w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
+        w = Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
         assert w.supported(tags=tags)
 
     def test_not_supported_osx_version(self):
@@ -308,7 +309,7 @@ class TestWheelFile(object):
         tags = pep425tags.get_supported(
             '27', platform='macosx_10_6_intel', impl='cp'
         )
-        w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
+        w = Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
         assert not w.supported(tags=tags)
 
     def test_supported_multiarch_darwin(self):
@@ -334,14 +335,14 @@ class TestWheelFile(object):
             '27', platform='macosx_10_5_ppc64', impl='cp'
         )
 
-        w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_5_intel.whl')
+        w = Wheel('simple-0.1-cp27-none-macosx_10_5_intel.whl')
         assert w.supported(tags=intel)
         assert w.supported(tags=x64)
         assert w.supported(tags=i386)
         assert not w.supported(tags=universal)
         assert not w.supported(tags=ppc)
         assert not w.supported(tags=ppc64)
-        w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_5_universal.whl')
+        w = Wheel('simple-0.1-cp27-none-macosx_10_5_universal.whl')
         assert w.supported(tags=universal)
         assert w.supported(tags=intel)
         assert w.supported(tags=x64)
@@ -360,10 +361,10 @@ class TestWheelFile(object):
             '27', platform='macosx_10_5_intel', impl='cp'
         )
 
-        w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_5_i386.whl')
+        w = Wheel('simple-0.1-cp27-none-macosx_10_5_i386.whl')
         assert not w.supported(tags=intel)
         assert not w.supported(tags=universal)
-        w = wheel.Wheel('simple-0.1-cp27-none-macosx_10_5_x86_64.whl')
+        w = Wheel('simple-0.1-cp27-none-macosx_10_5_x86_64.whl')
         assert not w.supported(tags=intel)
         assert not w.supported(tags=universal)
 
@@ -376,16 +377,16 @@ class TestWheelFile(object):
             ('py2', 'TEST', 'any'),
             ('py2', 'none', 'any'),
         ]
-        w = wheel.Wheel('simple-0.1-py2-none-any.whl')
+        w = Wheel('simple-0.1-py2-none-any.whl')
         assert w.support_index_min(tags=tags) == 2
-        w = wheel.Wheel('simple-0.1-py2-none-TEST.whl')
+        w = Wheel('simple-0.1-py2-none-TEST.whl')
         assert w.support_index_min(tags=tags) == 0
 
     def test_support_index_min__none_supported(self):
         """
         Test a wheel not supported by the given tags.
         """
-        w = wheel.Wheel('simple-0.1-py2-none-any.whl')
+        w = Wheel('simple-0.1-py2-none-any.whl')
         with pytest.raises(ValueError):
             w.support_index_min(tags=[])
 
@@ -416,7 +417,7 @@ class TestWheelFile(object):
         Test that we convert '_' to '-' for versions parsed out of wheel
         filenames
         """
-        w = wheel.Wheel('simple-0.1_1-py2-none-any.whl')
+        w = Wheel('simple-0.1_1-py2-none-any.whl')
         assert w.version == '0.1-1'
 
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -24,15 +24,6 @@ from pip._internal.wheel_builder import get_legacy_build_wheel_path
 from tests.lib import DATA_DIR, assert_paths_equal
 
 
-@pytest.mark.parametrize('file_tag, expected', [
-    (('py27', 'none', 'any'), 'py27-none-any'),
-    (('cp33', 'cp32dmu', 'linux_x86_64'), 'cp33-cp32dmu-linux_x86_64'),
-])
-def test_format_tag(file_tag, expected):
-    actual = wheel.format_tag(file_tag)
-    assert actual == expected
-
-
 def call_get_legacy_build_wheel_path(caplog, names):
     wheel_path = get_legacy_build_wheel_path(
         names=names,

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -13,12 +13,12 @@ from pip._internal.commands.wheel import WheelCommand
 from pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
 from pip._internal.locations import get_scheme
 from pip._internal.models.scheme import Scheme
+from pip._internal.models.wheel import Wheel
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.misc import hash_file
 from pip._internal.utils.unpacking import unpack_file
 from pip._internal.wheel import (
     MissingCallableSuffix,
-    Wheel,
     _raise_for_invalid_entrypoint,
 )
 from pip._internal.wheel_builder import get_legacy_build_wheel_path


### PR DESCRIPTION
Handles a TODO in the class and will make it easier to move `wheel` to `operations.install.wheel`.