### PR TITLE
Move wheel version check to install_unpacked_wheel

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -814,9 +814,6 @@ class InstallRequirement(object):
             return
 
         if self.is_wheel:
-            version = wheel.wheel_version(self.source_dir)
-            wheel.check_compatibility(version, self.name)
-
             self.move_wheel_files(
                 self.source_dir,
                 scheme=scheme,

--- a/src/pip/_internal/wheel.py
+++ b/src/pip/_internal/wheel.py
@@ -318,10 +318,15 @@ def install_unpacked_wheel(
     :param pycompile: Whether to byte-compile installed Python files
     :param warn_script_location: Whether to check that scripts are installed
         into a directory on PATH
+    :raises UnsupportedWheel: when the directory holds an unpacked wheel with
+        incompatible Wheel-Version
     """
     # TODO: Investigate and break this up.
     # TODO: Look into moving this into a dedicated class for representing an
     #       installation.
+
+    version = wheel_version(wheeldir)
+    check_compatibility(version, name)
 
     if root_is_purelib(name, wheeldir):
         lib_dir = scheme.purelib


### PR DESCRIPTION
This helps in several ways:

1. makes it easier to test the correct behavior of wheel installation via
   `install_unpacked_wheel` independent of `InstallRequirement`
2. is easier to understand, since `install_unpacked_wheel` itself should
   know which Wheel version(s) it supports
3. reduces the scope of `check_compatibility` and `wheel_version`, which
   will make it easier to move `wheel` to `operations.install.wheel`