### PR TITLE
Move install_succeeded for editable installs

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -648,8 +648,6 @@ class InstallRequirement(object):
                     cwd=self.unpacked_source_directory,
                 )
 
-        self.install_succeeded = True
-
     def update_editable(self, obtain=True):
         # type: (bool) -> None
         if not self.link:
@@ -813,6 +811,7 @@ class InstallRequirement(object):
                 home=home,
                 use_user_site=use_user_site,
             )
+            self.install_succeeded = True
             return
 
         if self.is_wheel:


### PR DESCRIPTION
This aligns it with wheel installation and reinforces that it is the
very last thing that happens before we return (so we can potentially
refactor it out later).