### PR TITLE
Move operations.prepare.Downloader (and friends) to network.download.Downloader

### DIFF
--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -180,7 +180,7 @@ class Link(KeyBasedCompareMixin):
 
     @property
     def show_url(self):
-        # type: () -> Optional[str]
+        # type: () -> str
         return posixpath.basename(self._url.split('#', 1)[0].split('?', 1)[0])
 
     @property

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -1,0 +1,16 @@
+"""Download files with progress indicators.
+"""
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional
+
+    from pip._vendor.requests.models import Response
+
+
+def _get_http_response_size(resp):
+    # type: (Response) -> Optional[int]
+    try:
+        return int(resp.headers['content-length'])
+    except (ValueError, KeyError, TypeError):
+        return None

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -1,6 +1,7 @@
 """Download files with progress indicators.
 """
 import logging
+import os
 
 from pip._vendor.requests.models import CONTENT_CHUNK_SIZE
 
@@ -71,3 +72,11 @@ def _prepare_download(
     return DownloadProgressProvider(
         progress_bar, max=total_length
     )(chunks)
+
+
+def sanitize_content_filename(filename):
+    # type: (str) -> str
+    """
+    Sanitize the "filename" value from a Content-Disposition header.
+    """
+    return os.path.basename(filename)

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -1,11 +1,24 @@
 """Download files with progress indicators.
 """
+import logging
+
+from pip._vendor.requests.models import CONTENT_CHUNK_SIZE
+
+from pip._internal.models.index import PyPI
+from pip._internal.network.cache import is_from_cache
+from pip._internal.network.utils import response_chunks
+from pip._internal.utils.misc import format_size, redact_auth_from_url
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+from pip._internal.utils.ui import DownloadProgressProvider
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional
+    from typing import Iterable, Optional
 
     from pip._vendor.requests.models import Response
+
+    from pip._internal.models.link import Link
+
+logger = logging.getLogger(__name__)
 
 
 def _get_http_response_size(resp):
@@ -14,3 +27,47 @@ def _get_http_response_size(resp):
         return int(resp.headers['content-length'])
     except (ValueError, KeyError, TypeError):
         return None
+
+
+def _prepare_download(
+    resp,  # type: Response
+    link,  # type: Link
+    progress_bar  # type: str
+):
+    # type: (...) -> Iterable[bytes]
+    total_length = _get_http_response_size(resp)
+
+    if link.netloc == PyPI.file_storage_domain:
+        url = link.show_url
+    else:
+        url = link.url_without_fragment
+
+    logged_url = redact_auth_from_url(url)
+
+    if total_length:
+        logged_url = '{} ({})'.format(logged_url, format_size(total_length))
+
+    if is_from_cache(resp):
+        logger.info("Using cached %s", logged_url)
+    else:
+        logger.info("Downloading %s", logged_url)
+
+    if logger.getEffectiveLevel() > logging.INFO:
+        show_progress = False
+    elif is_from_cache(resp):
+        show_progress = False
+    elif not total_length:
+        show_progress = True
+    elif total_length > (40 * 1000):
+        show_progress = True
+    else:
+        show_progress = False
+
+    chunks = response_chunks(resp, CONTENT_CHUNK_SIZE)
+
+    if not show_progress:
+        return chunks
+
+    return DownloadProgressProvider(
+        progress_bar, max=total_length
+    )(chunks)

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -1,5 +1,6 @@
 """Download files with progress indicators.
 """
+import cgi
 import logging
 import os
 
@@ -80,3 +81,18 @@ def sanitize_content_filename(filename):
     Sanitize the "filename" value from a Content-Disposition header.
     """
     return os.path.basename(filename)
+
+
+def parse_content_disposition(content_disposition, default_filename):
+    # type: (str, str) -> str
+    """
+    Parse the "filename" value from a Content-Disposition header, and
+    return the default filename if the result is empty.
+    """
+    _type, params = cgi.parse_header(content_disposition)
+    filename = params.get('filename')
+    if filename:
+        # We need to sanitize the filename to prevent directory traversal
+        # in case the filename contains ".." path parts.
+        filename = sanitize_content_filename(filename)
+    return filename or default_filename

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -28,8 +28,8 @@ from pip._internal.exceptions import (
     VcsHashUnsupported,
 )
 from pip._internal.network.download import (
+    _get_http_response_filename,
     _prepare_download,
-    parse_content_disposition,
 )
 from pip._internal.network.session import PipSession
 from pip._internal.utils.compat import expanduser
@@ -45,7 +45,6 @@ from pip._internal.utils.misc import (
     normalize_path,
     path_to_display,
     rmtree,
-    splitext,
 )
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -305,30 +304,6 @@ def unpack_url(
             download_dir,
             hashes=hashes,
         )
-
-
-def _get_http_response_filename(resp, link):
-    # type: (Response, Link) -> str
-    """Get an ideal filename from the given HTTP response, falling back to
-    the link filename if not provided.
-    """
-    filename = link.filename  # fallback
-    # Have a look at the Content-Disposition header for a better guess
-    content_disposition = resp.headers.get('content-disposition')
-    if content_disposition:
-        filename = parse_content_disposition(content_disposition, filename)
-    ext = splitext(filename)[1]  # type: Optional[str]
-    if not ext:
-        ext = mimetypes.guess_extension(
-            resp.headers.get('content-type', '')
-        )
-        if ext:
-            filename += ext
-    if not ext and link.url != resp.url:
-        ext = os.path.splitext(resp.url)[1]
-        if ext:
-            filename += ext
-    return filename
 
 
 def _http_get_download(session, link):

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -5,7 +5,6 @@
 # mypy: strict-optional=False
 # mypy: disallow-untyped-defs=False
 
-import cgi
 import logging
 import mimetypes
 import os
@@ -30,7 +29,7 @@ from pip._internal.exceptions import (
 )
 from pip._internal.network.download import (
     _prepare_download,
-    sanitize_content_filename,
+    parse_content_disposition,
 )
 from pip._internal.network.session import PipSession
 from pip._internal.utils.compat import expanduser
@@ -306,21 +305,6 @@ def unpack_url(
             download_dir,
             hashes=hashes,
         )
-
-
-def parse_content_disposition(content_disposition, default_filename):
-    # type: (str, str) -> str
-    """
-    Parse the "filename" value from a Content-Disposition header, and
-    return the default filename if the result is empty.
-    """
-    _type, params = cgi.parse_header(content_disposition)
-    filename = params.get('filename')
-    if filename:
-        # We need to sanitize the filename to prevent directory traversal
-        # in case the filename contains ".." path parts.
-        filename = sanitize_content_filename(filename)
-    return filename or default_filename
 
 
 def _get_http_response_filename(resp, link):

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -30,6 +30,7 @@ from pip._internal.exceptions import (
 )
 from pip._internal.models.index import PyPI
 from pip._internal.network.cache import is_from_cache
+from pip._internal.network.download import _get_http_response_size
 from pip._internal.network.session import PipSession
 from pip._internal.network.utils import response_chunks
 from pip._internal.utils.compat import expanduser
@@ -107,14 +108,6 @@ def unpack_vcs_link(link, location):
     vcs_backend = vcs.get_backend_for_scheme(link.scheme)
     assert vcs_backend is not None
     vcs_backend.unpack(location, url=hide_url(link.url))
-
-
-def _get_http_response_size(resp):
-    # type: (Response) -> Optional[int]
-    try:
-        return int(resp.headers['content-length'])
-    except (ValueError, KeyError, TypeError):
-        return None
 
 
 def _prepare_download(

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -28,7 +28,10 @@ from pip._internal.exceptions import (
     PreviousBuildDirError,
     VcsHashUnsupported,
 )
-from pip._internal.network.download import _prepare_download
+from pip._internal.network.download import (
+    _prepare_download,
+    sanitize_content_filename,
+)
 from pip._internal.network.session import PipSession
 from pip._internal.utils.compat import expanduser
 from pip._internal.utils.filesystem import copy2_fixed
@@ -303,14 +306,6 @@ def unpack_url(
             download_dir,
             hashes=hashes,
         )
-
-
-def sanitize_content_filename(filename):
-    # type: (str) -> str
-    """
-    Sanitize the "filename" value from a Content-Disposition header.
-    """
-    return os.path.basename(filename)
 
 
 def parse_content_disposition(content_disposition, default_filename):

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -12,7 +12,6 @@ import shutil
 import sys
 
 from pip._vendor import requests
-from pip._vendor.requests.models import Response
 from pip._vendor.six import PY2
 
 from pip._internal.distributions import (
@@ -27,11 +26,7 @@ from pip._internal.exceptions import (
     PreviousBuildDirError,
     VcsHashUnsupported,
 )
-from pip._internal.network.download import (
-    _get_http_response_filename,
-    _http_get_download,
-    _prepare_download,
-)
+from pip._internal.network.download import Downloader
 from pip._internal.utils.compat import expanduser
 from pip._internal.utils.filesystem import copy2_fixed
 from pip._internal.utils.hashes import MissingHashes
@@ -53,7 +48,7 @@ from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Callable, Iterable, List, Optional, Tuple,
+        Callable, List, Optional, Tuple,
     )
 
     from mypy_extensions import TypedDict
@@ -304,46 +299,6 @@ def unpack_url(
             downloader,
             download_dir,
             hashes=hashes,
-        )
-
-
-class Download(object):
-    def __init__(
-        self,
-        response,  # type: Response
-        filename,  # type: str
-        chunks,  # type: Iterable[bytes]
-    ):
-        # type: (...) -> None
-        self.response = response
-        self.filename = filename
-        self.chunks = chunks
-
-
-class Downloader(object):
-    def __init__(
-        self,
-        session,  # type: PipSession
-        progress_bar,  # type: str
-    ):
-        # type: (...) -> None
-        self._session = session
-        self._progress_bar = progress_bar
-
-    def __call__(self, link):
-        # type: (Link) -> Download
-        try:
-            resp = _http_get_download(self._session, link)
-        except requests.HTTPError as e:
-            logger.critical(
-                "HTTP error %s while getting %s", e.response.status_code, link
-            )
-            raise
-
-        return Download(
-            resp,
-            _get_http_response_filename(resp, link),
-            _prepare_download(resp, link, self._progress_bar),
         )
 
 

--- a/tests/lib/requests_mocks.py
+++ b/tests/lib/requests_mocks.py
@@ -1,0 +1,58 @@
+"""Helper classes as mocks for requests objects.
+"""
+
+from io import BytesIO
+
+
+class FakeStream(object):
+
+    def __init__(self, contents):
+        self._io = BytesIO(contents)
+
+    def read(self, size, decode_content=None):
+        return self._io.read(size)
+
+    def stream(self, size, decode_content=None):
+        yield self._io.read(size)
+
+    def release_conn(self):
+        pass
+
+
+class MockResponse(object):
+
+    def __init__(self, contents):
+        self.raw = FakeStream(contents)
+        self.content = contents
+        self.request = None
+        self.status_code = 200
+        self.connection = None
+        self.url = None
+        self.headers = {}
+        self.history = []
+
+    def raise_for_status(self):
+        pass
+
+
+class MockConnection(object):
+
+    def _send(self, req, **kwargs):
+        raise NotImplementedError("_send must be overridden for tests")
+
+    def send(self, req, **kwargs):
+        resp = self._send(req, **kwargs)
+        for cb in req.hooks.get("response", []):
+            cb(resp)
+        return resp
+
+
+class MockRequest(object):
+
+    def __init__(self, url):
+        self.url = url
+        self.headers = {}
+        self.hooks = {}
+
+    def register_hook(self, event_name, callback):
+        self.hooks.setdefault(event_name, []).append(callback)

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -1,0 +1,36 @@
+import pytest
+import logging
+
+from pip._internal.models.link import Link
+from pip._internal.network.download import _prepare_download
+from tests.lib.requests_mocks import MockResponse
+
+
+@pytest.mark.parametrize("url, headers, from_cache, expected", [
+    ('http://example.com/foo.tgz', {}, False,
+        "Downloading http://example.com/foo.tgz"),
+    ('http://example.com/foo.tgz', {'content-length': 2}, False,
+        "Downloading http://example.com/foo.tgz (2 bytes)"),
+    ('http://example.com/foo.tgz', {'content-length': 2}, True,
+        "Using cached http://example.com/foo.tgz (2 bytes)"),
+    ('https://files.pythonhosted.org/foo.tgz', {}, False,
+        "Downloading foo.tgz"),
+    ('https://files.pythonhosted.org/foo.tgz', {'content-length': 2}, False,
+        "Downloading foo.tgz (2 bytes)"),
+    ('https://files.pythonhosted.org/foo.tgz', {'content-length': 2}, True,
+        "Using cached foo.tgz"),
+])
+def test_prepare_download__log(caplog, url, headers, from_cache, expected):
+    caplog.set_level(logging.INFO)
+    resp = MockResponse(b'')
+    resp.url = url
+    resp.headers = headers
+    if from_cache:
+        resp.from_cache = from_cache
+    link = Link(url)
+    _prepare_download(resp, link, progress_bar="on")
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == 'INFO'
+    assert expected in record.message

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -6,6 +6,7 @@ import pytest
 from pip._internal.models.link import Link
 from pip._internal.network.download import (
     _prepare_download,
+    parse_content_disposition,
     sanitize_content_filename,
 )
 from tests.lib.requests_mocks import MockResponse
@@ -77,3 +78,15 @@ def test_sanitize_content_filename__platform_dependent(
     else:
         expected = non_win_expected
     assert sanitize_content_filename(filename) == expected
+
+
+@pytest.mark.parametrize("content_disposition, default_filename, expected", [
+    ('attachment;filename="../file"', 'df', 'file'),
+])
+def test_parse_content_disposition(
+    content_disposition,
+    default_filename,
+    expected
+):
+    actual = parse_content_disposition(content_disposition, default_filename)
+    assert actual == expected

--- a/tests/unit/test_networking_auth.py
+++ b/tests/unit/test_networking_auth.py
@@ -4,11 +4,7 @@ import pytest
 
 import pip._internal.network.auth
 from pip._internal.network.auth import MultiDomainBasicAuth
-from tests.unit.test_operations_prepare import (
-    MockConnection,
-    MockRequest,
-    MockResponse,
-)
+from tests.lib.requests_mocks import MockConnection, MockRequest, MockResponse
 
 
 @pytest.mark.parametrize(["input_url", "url", "username", "password"], [

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -1,7 +1,6 @@
 import hashlib
 import os
 import shutil
-import sys
 from shutil import copy, rmtree
 from tempfile import mkdtemp
 
@@ -16,7 +15,6 @@ from pip._internal.operations.prepare import (
     _copy_source_tree,
     _download_http_url,
     parse_content_disposition,
-    sanitize_content_filename,
     unpack_file_url,
     unpack_http_url,
 )
@@ -106,44 +104,6 @@ def test_unpack_http_url_bad_downloaded_checksum(mock_unpack_file):
 
     finally:
         rmtree(download_dir)
-
-
-@pytest.mark.parametrize("filename, expected", [
-    ('dir/file', 'file'),
-    ('../file', 'file'),
-    ('../../file', 'file'),
-    ('../', ''),
-    ('../..', '..'),
-    ('/', ''),
-])
-def test_sanitize_content_filename(filename, expected):
-    """
-    Test inputs where the result is the same for Windows and non-Windows.
-    """
-    assert sanitize_content_filename(filename) == expected
-
-
-@pytest.mark.parametrize("filename, win_expected, non_win_expected", [
-    ('dir\\file', 'file', 'dir\\file'),
-    ('..\\file', 'file', '..\\file'),
-    ('..\\..\\file', 'file', '..\\..\\file'),
-    ('..\\', '', '..\\'),
-    ('..\\..', '..', '..\\..'),
-    ('\\', '', '\\'),
-])
-def test_sanitize_content_filename__platform_dependent(
-    filename,
-    win_expected,
-    non_win_expected
-):
-    """
-    Test inputs where the result is different for Windows and non-Windows.
-    """
-    if sys.platform == 'win32':
-        expected = win_expected
-    else:
-        expected = non_win_expected
-    assert sanitize_content_filename(filename) == expected
 
 
 @pytest.mark.parametrize("content_disposition, default_filename, expected", [

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -1,5 +1,4 @@
 import hashlib
-import logging
 import os
 import shutil
 import sys
@@ -16,7 +15,6 @@ from pip._internal.operations.prepare import (
     Downloader,
     _copy_source_tree,
     _download_http_url,
-    _prepare_download,
     parse_content_disposition,
     sanitize_content_filename,
     unpack_file_url,
@@ -192,36 +190,6 @@ def test_download_http_url__no_directory_traversal(tmpdir):
     # The file should be downloaded to download_dir.
     actual = os.listdir(download_dir)
     assert actual == ['out_dir_file']
-
-
-@pytest.mark.parametrize("url, headers, from_cache, expected", [
-    ('http://example.com/foo.tgz', {}, False,
-        "Downloading http://example.com/foo.tgz"),
-    ('http://example.com/foo.tgz', {'content-length': 2}, False,
-        "Downloading http://example.com/foo.tgz (2 bytes)"),
-    ('http://example.com/foo.tgz', {'content-length': 2}, True,
-        "Using cached http://example.com/foo.tgz (2 bytes)"),
-    ('https://files.pythonhosted.org/foo.tgz', {}, False,
-        "Downloading foo.tgz"),
-    ('https://files.pythonhosted.org/foo.tgz', {'content-length': 2}, False,
-        "Downloading foo.tgz (2 bytes)"),
-    ('https://files.pythonhosted.org/foo.tgz', {'content-length': 2}, True,
-        "Using cached foo.tgz"),
-])
-def test_prepare_download__log(caplog, url, headers, from_cache, expected):
-    caplog.set_level(logging.INFO)
-    resp = MockResponse(b'')
-    resp.url = url
-    resp.headers = headers
-    if from_cache:
-        resp.from_cache = from_cache
-    link = Link(url)
-    _prepare_download(resp, link, progress_bar="on")
-
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
-    assert record.levelname == 'INFO'
-    assert expected in record.message
 
 
 @pytest.fixture

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -14,7 +14,6 @@ from pip._internal.operations.prepare import (
     Downloader,
     _copy_source_tree,
     _download_http_url,
-    parse_content_disposition,
     unpack_file_url,
     unpack_http_url,
 )
@@ -104,18 +103,6 @@ def test_unpack_http_url_bad_downloaded_checksum(mock_unpack_file):
 
     finally:
         rmtree(download_dir)
-
-
-@pytest.mark.parametrize("content_disposition, default_filename, expected", [
-    ('attachment;filename="../file"', 'df', 'file'),
-])
-def test_parse_content_disposition(
-    content_disposition,
-    default_filename,
-    expected
-):
-    actual = parse_content_disposition(content_disposition, default_filename)
-    assert actual == expected
 
 
 def test_download_http_url__no_directory_traversal(tmpdir):


### PR DESCRIPTION
This will let us move the construction of the `Downloader` out of `RequirementPreparer` without creating a dependency on `operations.prepare`.

Progresses #7049.