### PR TITLE
Replace InstallRequirement.conflicts_with with InstallRequirement.should_reinstall

### DIFF
--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -208,7 +208,6 @@ class Resolver(object):
         # Don't uninstall the conflict if doing a user install and the
         # conflict is not a user install.
         if not self.use_user_site or dist_in_usersite(req.satisfied_by):
-            req.conflicts_with = req.satisfied_by
             req.should_reinstall = True
         req.satisfied_by = None
 

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -209,6 +209,7 @@ class Resolver(object):
         # conflict is not a user install.
         if not self.use_user_site or dist_in_usersite(req.satisfied_by):
             req.conflicts_with = req.satisfied_by
+            req.should_reinstall = True
         req.satisfied_by = None
 
     def _check_skip_installed(self, req_to_install):

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -58,10 +58,7 @@ def install_given_reqs(
     with indent_log():
         for requirement in to_install:
             if requirement.conflicts_with:
-                logger.info(
-                    'Found existing installation: %s',
-                    requirement.conflicts_with,
-                )
+                logger.info('Attempting uninstall: %s', requirement.name)
                 with indent_log():
                     uninstalled_pathset = requirement.uninstall(
                         auto_confirm=True

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -57,7 +57,7 @@ def install_given_reqs(
 
     with indent_log():
         for requirement in to_install:
-            if requirement.conflicts_with:
+            if requirement.should_reinstall:
                 logger.info('Attempting uninstall: %s', requirement.name)
                 with indent_log():
                     uninstalled_pathset = requirement.uninstall(
@@ -72,7 +72,7 @@ def install_given_reqs(
                 )
             except Exception:
                 should_rollback = (
-                    requirement.conflicts_with and
+                    requirement.should_reinstall and
                     not requirement.install_succeeded
                 )
                 # if install did not succeed, rollback previous uninstall
@@ -81,7 +81,7 @@ def install_given_reqs(
                 raise
             else:
                 should_commit = (
-                    requirement.conflicts_with and
+                    requirement.should_reinstall and
                     requirement.install_succeeded
                 )
                 if should_commit:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -158,9 +158,6 @@ class InstallRequirement(object):
         # This holds the pkg_resources.Distribution object if this requirement
         # is already available:
         self.satisfied_by = None
-        # This hold the pkg_resources.Distribution object if this requirement
-        # conflicts with another installed distribution:
-        self.conflicts_with = None
         # Whether the installation process should try to uninstall an existing
         # distribution before installing this requirement.
         self.should_reinstall = False
@@ -435,7 +432,7 @@ class InstallRequirement(object):
         # type: (bool) -> None
         """Find an installed distribution that satisfies or conflicts
         with this requirement, and set self.satisfied_by or
-        self.conflicts_with appropriately.
+        self.should_reinstall appropriately.
         """
         if self.req is None:
             return
@@ -455,7 +452,6 @@ class InstallRequirement(object):
             )
             if use_user_site:
                 if dist_in_usersite(existing_dist):
-                    self.conflicts_with = existing_dist
                     self.should_reinstall = True
                 elif (running_under_virtualenv() and
                         dist_in_site_packages(existing_dist)):
@@ -465,11 +461,9 @@ class InstallRequirement(object):
                         (existing_dist.project_name, existing_dist.location)
                     )
             else:
-                self.conflicts_with = existing_dist
                 self.should_reinstall = True
         else:
             if self.editable and self.satisfied_by:
-                self.conflicts_with = self.satisfied_by
                 self.should_reinstall = True
                 # when installing editables, nothing pre-existing should ever
                 # satisfy

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -695,6 +695,8 @@ class InstallRequirement(object):
         except pkg_resources.DistributionNotFound:
             logger.warning("Skipping %s as it is not installed.", self.name)
             return None
+        else:
+            logger.info('Found existing installation: %s', dist)
 
         uninstalled_pathset = UninstallPathSet.from_dist(dist)
         uninstalled_pathset.remove(auto_confirm, verbose)

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -161,6 +161,9 @@ class InstallRequirement(object):
         # This hold the pkg_resources.Distribution object if this requirement
         # conflicts with another installed distribution:
         self.conflicts_with = None
+        # Whether the installation process should try to uninstall an existing
+        # distribution before installing this requirement.
+        self.should_reinstall = False
         # Temporary build location
         self._temp_build_dir = None  # type: Optional[TempDirectory]
         # Set to True after successful installation
@@ -453,6 +456,7 @@ class InstallRequirement(object):
             if use_user_site:
                 if dist_in_usersite(existing_dist):
                     self.conflicts_with = existing_dist
+                    self.should_reinstall = True
                 elif (running_under_virtualenv() and
                         dist_in_site_packages(existing_dist)):
                     raise InstallationError(
@@ -462,9 +466,11 @@ class InstallRequirement(object):
                     )
             else:
                 self.conflicts_with = existing_dist
+                self.should_reinstall = True
         else:
             if self.editable and self.satisfied_by:
                 self.conflicts_with = self.satisfied_by
+                self.should_reinstall = True
                 # when installing editables, nothing pre-existing should ever
                 # satisfy
                 self.satisfied_by = None


### PR DESCRIPTION
This makes `InstallRequirement` simpler. We only used this member as a flag, and didn't actually use the `pkg_resources.Distribution`.