### PR TITLE
Justify lack of encoding when reading record file

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -871,6 +871,9 @@ class InstallRequirement(object):
                 else:
                     return change_root(root, path)
 
+            # We intentionally do not use any encoding to read the file because
+            # setuptools writes the file using distutils.file_util.write_file,
+            # which does not specify an encoding.
             with open(record_filename) as f:
                 for line in f:
                     directory = os.path.dirname(line)


### PR DESCRIPTION
During legacy installs we pass a path to setuptools which it should use to create a file with the paths of the installed files. As seen [here](https://github.com/pypa/setuptools/blob/1d03fdc94c3676a5b675ec7d818d48c6a772fb49/setuptools/command/easy_install.py#L433-L437) in setuptools and [here](https://github.com/python/cpython/blob/bb815499af855b1759c02535f8d7a9d0358e74e8/Lib/distutils/file_util.py#L229-L238) in CPython, this file is written without any encoding specified so the best we can do here is not specify any encoding either.

Explicitly indicating this will make it easier to review any changes to this code later.