### PR TITLE
Create Virtual Environment on pip Install with --user Option

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -635,6 +635,12 @@ def decide_user_install(
                 "Can not combine '--user' and '--prefix' as they imply "
                 "different installation locations"
             )
+        if not running_under_virtualenv():
+                # create_virtualenv()
+                raise InstallationError(
+                    "Can not perform a '--user' install. "
+                    "Virtualenv folder is not visible"
+                )
         if virtualenv_no_global():
             raise InstallationError(
                 "Can not perform a '--user' install. User site-packages "
@@ -755,4 +761,10 @@ def create_env_error_message(error, show_traceback, using_user_site):
             parts.append(permissions_part)
         parts.append(".\n")
 
-    return "".join(parts).strip() + "\n"
+def create_virtualenv():
+    """
+    Find existing virtualenv wrapper
+    Activate wrapper, and if not found
+    Create the virtualenv wrapper and activate it
+    """
+    ## To be implemented for macos, linux and windows


### PR DESCRIPTION
While installing packages using pip with --user option, pip should check whether the user has activated a virtualenv.

In case the env is not found, pip should prompt the user to install and activate a valid python virtual environment.

Please reach out to me and let me know if anything is not clear.
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
