### PR TITLE
Update warning tense: the next pip will be released after Pytho…

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -125,9 +125,9 @@ class Command(CommandContextMixIn):
             )
             if platform.python_implementation() == "CPython":
                 message = (
-                    "Python 2.7 will reach the end of its life on January "
+                    "Python 2.7 reached the end of its life on January "
                     "1st, 2020. Please upgrade your Python as Python 2.7 "
-                    "won't be maintained after that date. "
+                    "is no longer maintained. "
                 ) + message
             deprecated(message, replacement=None, gone_in=None)
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

pip 20.0 will be released after 2020-01-01, so use the past tense in the Python 2.7 deprecation warning.
