### PR TITLE
Refactor out atexit-managed temp directory

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -33,6 +33,7 @@ from pip._internal.exceptions import (
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
 from pip._internal.utils.misc import get_prog
+from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
@@ -106,6 +107,10 @@ class Command(CommandContextMixIn):
 
     def _main(self, args):
         # type: (List[str]) -> int
+        # Intentionally set as early as possible so globally-managed temporary
+        # directories are available to the rest of the code.
+        self.enter_context(global_tempdir_manager())
+
         options, args = self.parse_args(args)
 
         # Set verbosity so that it can be used elsewhere.

--- a/src/pip/_internal/operations/build/metadata.py
+++ b/src/pip/_internal/operations/build/metadata.py
@@ -1,7 +1,6 @@
 """Metadata generation logic for source distributions.
 """
 
-import atexit
 import logging
 import os
 
@@ -25,9 +24,9 @@ def generate_metadata(install_req):
     build_env = install_req.build_env
     backend = install_req.pep517_backend
 
-    # NOTE: This needs to be refactored to stop using atexit
-    metadata_tmpdir = TempDirectory(kind="modern-metadata")
-    atexit.register(metadata_tmpdir.cleanup)
+    metadata_tmpdir = TempDirectory(
+        kind="modern-metadata", globally_managed=True
+    )
 
     metadata_dir = metadata_tmpdir.path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from pip._vendor.contextlib2 import ExitStack
 from setuptools.wheel import Wheel
 
 from pip._internal.main import main as pip_entry_point
+from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from tests.lib import DATA_DIR, SRC_DIR, TestData
 from tests.lib.certs import make_tls_cert, serialize_cert, serialize_key
@@ -175,6 +176,17 @@ def isolate(tmpdir):
         fp.write(
             b"[user]\n\tname = pip\n\temail = pypa-dev@googlegroups.com\n"
         )
+
+
+@pytest.fixture(autouse=True)
+def scoped_global_tempdir_manager():
+    """Make unit tests with globally-managed tempdirs easier
+
+    Each test function gets its own individual scope for globally-managed
+    temporary directories in the application.
+    """
+    with global_tempdir_manager():
+        yield
 
 
 @pytest.fixture(scope='session')

--- a/tests/unit/test_utils_temp_dir.py
+++ b/tests/unit/test_utils_temp_dir.py
@@ -5,8 +5,13 @@ import tempfile
 
 import pytest
 
+from pip._internal.utils import temp_dir
 from pip._internal.utils.misc import ensure_dir
-from pip._internal.utils.temp_dir import AdjacentTempDirectory, TempDirectory
+from pip._internal.utils.temp_dir import (
+    AdjacentTempDirectory,
+    TempDirectory,
+    global_tempdir_manager,
+)
 
 
 # No need to test symlinked directories on Windows
@@ -188,3 +193,17 @@ def test_adjacent_directory_permission_error(monkeypatch):
         with pytest.raises(OSError):
             with AdjacentTempDirectory(original):
                 pass
+
+
+def test_global_tempdir_manager():
+    with global_tempdir_manager():
+        d = TempDirectory(globally_managed=True)
+        path = d.path
+        assert os.path.exists(path)
+    assert not os.path.exists(path)
+
+
+def test_tempdirectory_asserts_global_tempdir(monkeypatch):
+    monkeypatch.setattr(temp_dir, "_tempdir_manager", None)
+    with pytest.raises(AssertionError):
+        TempDirectory(globally_managed=True)


### PR DESCRIPTION
We now have the ability to create auto-deleted temporary directories without polluting argument lists as much. This will make some refactoring easier. Fixes #6982 as an example.