### PR TITLE
Remove unnecessary unlink in unpack_http_url

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -163,9 +163,6 @@ def unpack_http_url(
         if download_dir and not already_downloaded_path:
             _copy_file(from_path, download_dir, link)
 
-        if not already_downloaded_path:
-            os.unlink(from_path)
-
 
 def _copy2_ignoring_special_files(src, dest):
     # type: (str, str) -> None


### PR DESCRIPTION
The file is downloaded into a TempDirectory which will get cleaned up at
the end of the `with` block, so no need to explicitly unlink the file.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
