### PR TITLE
Compute utils.compat.HAS_TLS lazily

### DIFF
--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -10,7 +10,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
 from pip._internal.models.index import PyPI
-from pip._internal.utils.compat import HAS_TLS
+from pip._internal.utils.compat import has_tls
 from pip._internal.utils.misc import normalize_path, redact_auth_from_url
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -52,7 +52,7 @@ class SearchScope(object):
 
         # If we don't have TLS enabled, then WARN if anyplace we're looking
         # relies on TLS.
-        if not HAS_TLS:
+        if not has_tls():
             for link in itertools.chain(index_urls, built_find_links):
                 parsed = urllib_parse.urlparse(link)
                 if parsed.scheme == 'https':

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -26,7 +26,7 @@ from pip import __version__
 from pip._internal.network.auth import MultiDomainBasicAuth
 from pip._internal.network.cache import SafeFileCache
 # Import ssl from compat so the initial import occurs in only one place.
-from pip._internal.utils.compat import HAS_TLS, ipaddress, ssl
+from pip._internal.utils.compat import has_tls, ipaddress, ssl
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.glibc import libc_ver
 from pip._internal.utils.misc import (
@@ -153,7 +153,7 @@ def user_agent():
     if platform.machine():
         data["cpu"] = platform.machine()
 
-    if HAS_TLS:
+    if has_tls():
         data["openssl_version"] = ssl.OPENSSL_VERSION
 
     setuptools_version = get_installed_version("setuptools")

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -26,7 +26,7 @@ from pip import __version__
 from pip._internal.network.auth import MultiDomainBasicAuth
 from pip._internal.network.cache import SafeFileCache
 # Import ssl from compat so the initial import occurs in only one place.
-from pip._internal.utils.compat import has_tls, ipaddress, ssl
+from pip._internal.utils.compat import has_tls, ipaddress
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.glibc import libc_ver
 from pip._internal.utils.misc import (
@@ -154,6 +154,7 @@ def user_agent():
         data["cpu"] = platform.machine()
 
     if has_tls():
+        import _ssl as ssl
         data["openssl_version"] = ssl.OPENSSL_VERSION
 
     setuptools_version = get_installed_version("setuptools")

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -14,20 +14,11 @@ import shutil
 import sys
 
 from pip._vendor.six import PY2, text_type
-from pip._vendor.urllib3.util import IS_PYOPENSSL
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     from typing import Optional, Text, Tuple, Union
-
-try:
-    import _ssl  # noqa
-except ImportError:
-    ssl = None
-else:
-    # This additional assignment was needed to prevent a mypy error.
-    ssl = _ssl
 
 try:
     import ipaddress
@@ -47,8 +38,6 @@ __all__ = [
 
 
 logger = logging.getLogger(__name__)
-
-HAS_TLS = (ssl is not None) or IS_PYOPENSSL
 
 if PY2:
     import imp
@@ -87,7 +76,14 @@ else:
 
 def has_tls():
     # type: () -> bool
-    return HAS_TLS
+    try:
+        import _ssl  # noqa: F401  # ignore unused
+        return True
+    except ImportError:
+        pass
+
+    from pip._vendor.urllib3.util import IS_PYOPENSSL
+    return IS_PYOPENSSL
 
 
 def str_to_display(data, desc=None):

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -85,6 +85,11 @@ else:
     backslashreplace_decode = "backslashreplace"
 
 
+def has_tls():
+    # type: () -> bool
+    return HAS_TLS
+
+
 def str_to_display(data, desc=None):
     # type: (Union[bytes, Text], Optional[str]) -> Text
     """


### PR DESCRIPTION
This avoids an unnecessary unconditional import of ssl and urllib3 in
`utils.compat`, which are pretty big contributors to import time for the `main` module (~30ms out of 100ms on my machine).