### PR TITLE
only support tags containing current minor version on mac platform

### DIFF
--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -337,9 +337,9 @@ def _mac_platforms(arch):
         name, major, minor, actual_arch = match.groups()
         tpl = '{}_{}_%i_%s'.format(name, major)
         arches = []
-        for m in reversed(range(int(minor) + 1)):
-            for a in get_darwin_arches(int(major), m, actual_arch):
-                arches.append(tpl % (m, a))
+        minor = int(minor)
+        for a in get_darwin_arches(int(major), minor, actual_arch):
+            arches.append(tpl % (minor, a))
     else:
         # arch pattern didn't match (?!)
         arches = [arch]


### PR DESCRIPTION
I recently upgraded to catalina 10.15 and got 2 segmentation faults when installing packages or launching app:

```python
❯ python /Users/dongweiming/lyanna/venv/src/aiomcache/setup.py develop
...
[1]    93545 segmentation fault  python3.8 /Users/dongweiming/lyanna/venv/src/aiomcache/setup.py develop
# Solved after upgrading cython, Still segmentation fault
❯ python app.py
[1]    10396 segmentation fault  python app.py
# Solved after upgrading yaml
```

finally found the reason: pip cache uses packages compiled at 10.14, which is no longer available at 10.15:

```bash
❯ pip install cython==0.29.13 
Processing /Users/dongweiming/Library/Caches/pip/wheels/5b/1e/17/15dd6d435ec0644967eb8e1493af09ae28cd9418
4c6f416d02/Cython-0.29.13-cp38-cp38-macosx_10_14_x86_64.whl  #  use containing the wrong minor version package
❯ sw_vers -productVersion                                                            
10.15.1
```

so i delete `Cython-0.29.13-cp38-cp38-macosx_10_14_x86_64.whl ` and reinstall it, everything is ok. After upgrading, the old version of the package cache should no longer be used