### PR TITLE
Do not depend on cached download for copying downloaded file

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -166,10 +166,9 @@ def unpack_http_url(
         unpack_file(from_path, location, content_type)
 
         # a download dir is specified; let's copy the archive there
-        if download_dir and not already_downloaded_path:
-            assert not os.path.exists(
-                os.path.join(download_dir, link.filename)
-            )
+        if download_dir and not os.path.exists(
+            os.path.join(download_dir, link.filename)
+        ):
             _copy_file(from_path, download_dir, link)
 
 
@@ -263,8 +262,9 @@ def unpack_file_url(
     unpack_file(from_path, location, content_type)
 
     # a download dir is specified and not already downloaded
-    if download_dir and not already_downloaded_path:
-        assert not os.path.exists(os.path.join(download_dir, link.filename))
+    if download_dir and not os.path.exists(
+        os.path.join(download_dir, link.filename)
+    ):
         _copy_file(from_path, download_dir, link)
 
 

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -167,6 +167,9 @@ def unpack_http_url(
 
         # a download dir is specified; let's copy the archive there
         if download_dir and not already_downloaded_path:
+            assert not os.path.exists(
+                os.path.join(download_dir, link.filename)
+            )
             _copy_file(from_path, download_dir, link)
 
 
@@ -261,6 +264,7 @@ def unpack_file_url(
 
     # a download dir is specified and not already downloaded
     if download_dir and not already_downloaded_path:
+        assert not os.path.exists(os.path.join(download_dir, link.filename))
         _copy_file(from_path, download_dir, link)
 
 


### PR DESCRIPTION
Previously we depended on the result of the check for a cached download in order to decide whether we would copy the downloaded file. Now we do not. This will allow us to eventually extract the copying of the downloaded file out of `unpack_file_url` and `unpack_http_url`.