### PR TITLE
Some more trivial refactorings in WheelBuilder

### DIFF
--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -32,7 +32,7 @@ from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Any, Callable, Iterable, List, Optional, Pattern, Text, Tuple, Union,
+        Any, Callable, Iterable, List, Optional, Pattern, Text, Tuple,
     )
 
     from pip._internal.cache import WheelCache
@@ -323,8 +323,6 @@ class WheelBuilder(object):
         self.build_options = build_options or []
         self.global_options = global_options or []
         self.check_binary_allowed = check_binary_allowed
-        # file names of built wheel names
-        self.wheel_filenames = []  # type: List[Union[bytes, Text]]
 
     def _build_one(
         self,

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -476,10 +476,7 @@ class WheelBuilder(object):
                         # copy from cache to target directory
                         try:
                             ensure_dir(self._wheel_dir)
-                            shutil.copy(
-                                os.path.join(cache_dir, wheel_file),
-                                self._wheel_dir,
-                            )
+                            shutil.copy(wheel_file, self._wheel_dir)
                         except OSError as e:
                             logger.warning(
                                 "Building wheel for %s failed: %s",

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -98,6 +98,18 @@ def test_basic_pip_wheel_downloads_wheels(script, data):
     assert "Saved" in result.stdout, result.stdout
 
 
+def test_pip_wheel_build_relative_cachedir(script, data):
+    """
+    Test 'pip wheel' builds and caches with a non-absolute cache directory.
+    """
+    result = script.pip(
+        'wheel', '--no-index', '-f', data.find_links,
+        '--cache-dir', './cache',
+        'simple==3.0',
+    )
+    assert result.returncode == 0
+
+
 def test_pip_wheel_builds_when_no_binary_set(script, data):
     data.packages.joinpath('simple-3.0-py2.py3-none-any.whl').touch()
     # Check that the wheel package is ignored


### PR DESCRIPTION
Towards disentangling the `pip wheel` and `pip install` cases in `WheelBuilder`.

The individual commits should be easy to follow. Let me know if you prefer smaller PRs.

The third commit may require more reviewer attention, as it removes an `os.path.join` that is useless if I see correctly.