### PR TITLE
Do not attempt setup.py clean for failed pep517 builds

### DIFF
--- a/news/6642.bugfix
+++ b/news/6642.bugfix
@@ -1,0 +1,2 @@
+Do not attempt to run ``setup.py clean`` after a ``pep517`` build error,
+since a ``setup.py`` may not exist in that case.

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -231,11 +231,12 @@ def _build_one_inside_env(
                     req.name, e,
                 )
         # Ignore return, we can't do anything else useful.
-        _clean_one(req, global_options)
+        if not req.use_pep517:
+            _clean_one_legacy(req, global_options)
         return None
 
 
-def _clean_one(req, global_options):
+def _clean_one_legacy(req, global_options):
     # type: (InstallRequirement, List[str]) -> bool
     clean_args = make_setuptools_clean_args(
         req.setup_py_path,

--- a/tests/data/packages/pep517_wrapper_buildsys/mybuildsys.py
+++ b/tests/data/packages/pep517_wrapper_buildsys/mybuildsys.py
@@ -8,6 +8,9 @@ from setuptools.build_meta import (get_requires_for_build_sdist,
 
 
 def build_wheel(*a, **kw):
+    if os.environ.get("PIP_TEST_FAIL_BUILD_WHEEL"):
+        raise RuntimeError("Failing build_wheel, as requested.")
+
     # Create the marker file to record that the hook was called
     with open(os.environ['PIP_TEST_MARKER_FILE'], 'wb'):
         pass

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1256,6 +1256,7 @@ def test_cleanup_after_failed_wheel(script, with_wheel):
     shebang = open(script_py, 'r').readline().strip()
     assert shebang != '#!python', shebang
     # OK, assert that we *said* we were cleaning up:
+    # /!\ if in need to change this, also change test_pep517_no_legacy_cleanup
     assert "Running setup.py clean for wheelbrokenafter" in str(res), str(res)
 
 


### PR DESCRIPTION
When a pep517 build fails, pip unconditionally attempts to `setup.py clean`. This PR makes it do that only for legacy builds, since there may not be any `setup.py` in the `pep517`case.

Fixes #6642