### PR TITLE
Make unpack_* unit tests into functional tests

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -235,14 +235,6 @@ def unpack_file_url(
             logger.info('Link is a directory, ignoring download_dir')
         return
 
-    # If --require-hashes is off, `hashes` is either empty, the
-    # link's embedded hash, or MissingHashes; it is required to
-    # match. If --require-hashes is on, we are satisfied by any
-    # hash in `hashes` matching: a URL-based or an option-based
-    # one; no internet-sourced hash will be in `hashes`.
-    if hashes:
-        hashes.check_against_path(link_path)
-
     # If a download dir is specified, is the file already there and valid?
     already_downloaded_path = None
     if download_dir:
@@ -254,6 +246,14 @@ def unpack_file_url(
         from_path = already_downloaded_path
     else:
         from_path = link_path
+
+    # If --require-hashes is off, `hashes` is either empty, the
+    # link's embedded hash, or MissingHashes; it is required to
+    # match. If --require-hashes is on, we are satisfied by any
+    # hash in `hashes` matching: a URL-based or an option-based
+    # one; no internet-sourced hash will be in `hashes`.
+    if hashes:
+        hashes.check_against_path(from_path)
 
     content_type = mimetypes.guess_type(from_path)[0]
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1,6 +1,7 @@
 import os.path
 import shutil
 import textwrap
+from hashlib import sha256
 
 import pytest
 
@@ -747,3 +748,22 @@ def test_download_file_url(shared_script, shared_data, tmpdir):
 
     assert downloaded_path.exists()
     assert simple_pkg.read_bytes() == downloaded_path.read_bytes()
+
+
+def test_download_file_url_existing_ok_download(
+    shared_script, shared_data, tmpdir
+):
+    download_dir = tmpdir / 'download'
+    download_dir.mkdir()
+    downloaded_path = download_dir / 'simple-1.0.tar.gz'
+    fake_existing_package = shared_data.packages / 'simple-2.0.tar.gz'
+    shutil.copy(str(fake_existing_package), str(downloaded_path))
+    downloaded_path_bytes = downloaded_path.read_bytes()
+    digest = sha256(downloaded_path_bytes).hexdigest()
+
+    simple_pkg = shared_data.packages / 'simple-1.0.tar.gz'
+    url = "{}#sha256={}".format(path_to_url(simple_pkg), digest)
+
+    shared_script.pip('download', '-d', str(download_dir), url)
+
+    assert downloaded_path_bytes == downloaded_path.read_bytes()

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -767,3 +767,22 @@ def test_download_file_url_existing_ok_download(
     shared_script.pip('download', '-d', str(download_dir), url)
 
     assert downloaded_path_bytes == downloaded_path.read_bytes()
+
+
+def test_download_file_url_existing_bad_download(
+    shared_script, shared_data, tmpdir
+):
+    download_dir = tmpdir / 'download'
+    download_dir.mkdir()
+    downloaded_path = download_dir / 'simple-1.0.tar.gz'
+    fake_existing_package = shared_data.packages / 'simple-2.0.tar.gz'
+    shutil.copy(str(fake_existing_package), str(downloaded_path))
+
+    simple_pkg = shared_data.packages / 'simple-1.0.tar.gz'
+    simple_pkg_bytes = simple_pkg.read_bytes()
+    digest = sha256(simple_pkg_bytes).hexdigest()
+    url = "{}#sha256={}".format(path_to_url(simple_pkg), digest)
+
+    shared_script.pip('download', '-d', str(download_dir), url)
+
+    assert simple_pkg_bytes == downloaded_path.read_bytes()

--- a/tests/lib/path.py
+++ b/tests/lib/path.py
@@ -178,6 +178,11 @@ class Path(_base):
     def join(self, *parts):
         raise RuntimeError('Path.join is invalid, use joinpath instead.')
 
+    def read_bytes(self):
+        # type: () -> bytes
+        with open(self, "rb") as fp:
+            return fp.read()
+
     def read_text(self):
         with open(self, "r") as fp:
             return fp.read()

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -239,22 +239,6 @@ class Test_unpack_file_url(object):
         assert not os.path.isfile(
             os.path.join(self.download_dir, self.dist_file))
 
-    def test_unpack_file_url_download_already_exists(self, tmpdir,
-                                                     data, monkeypatch):
-        self.prep(tmpdir, data)
-        # add in previous download (copy simple-2.0 as simple-1.0)
-        # so we can tell it didn't get overwritten
-        dest_file = os.path.join(self.download_dir, self.dist_file)
-        copy(self.dist_path2, dest_file)
-        with open(self.dist_path2, 'rb') as f:
-            dist_path2_md5 = hashlib.md5(f.read()).hexdigest()
-
-        unpack_file_url(self.dist_url, self.build_dir,
-                        download_dir=self.download_dir)
-        # our hash should be the same, i.e. not overwritten by simple-1.0 hash
-        with open(dest_file, 'rb') as f:
-            assert dist_path2_md5 == hashlib.md5(f.read()).hexdigest()
-
     def test_unpack_file_url_bad_hash(self, tmpdir, data,
                                       monkeypatch):
         """

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -239,13 +239,6 @@ class Test_unpack_file_url(object):
         assert not os.path.isfile(
             os.path.join(self.download_dir, self.dist_file))
 
-    def test_unpack_file_url_and_download(self, tmpdir, data):
-        self.prep(tmpdir, data)
-        unpack_file_url(self.dist_url, self.build_dir,
-                        download_dir=self.download_dir)
-        assert os.path.isdir(os.path.join(self.build_dir, 'simple'))
-        assert os.path.isfile(os.path.join(self.download_dir, self.dist_file))
-
     def test_unpack_file_url_download_already_exists(self, tmpdir,
                                                      data, monkeypatch):
         self.prep(tmpdir, data)

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 import shutil
-from shutil import copy, rmtree
+from shutil import rmtree
 from tempfile import mkdtemp
 
 import pytest
@@ -251,37 +251,6 @@ class Test_unpack_file_url(object):
             unpack_file_url(dist_url,
                             self.build_dir,
                             hashes=Hashes({'md5': ['bogus']}))
-
-    def test_unpack_file_url_download_bad_hash(self, tmpdir, data,
-                                               monkeypatch):
-        """
-        Test when existing download has different hash from the file url
-        fragment
-        """
-        self.prep(tmpdir, data)
-
-        # add in previous download (copy simple-2.0 as simple-1.0 so it's wrong
-        # hash)
-        dest_file = os.path.join(self.download_dir, self.dist_file)
-        copy(self.dist_path2, dest_file)
-
-        with open(self.dist_path, 'rb') as f:
-            dist_path_md5 = hashlib.md5(f.read()).hexdigest()
-        with open(dest_file, 'rb') as f:
-            dist_path2_md5 = hashlib.md5(f.read()).hexdigest()
-
-        assert dist_path_md5 != dist_path2_md5
-
-        url = '{}#md5={}'.format(self.dist_url.url, dist_path_md5)
-        dist_url = Link(url)
-        unpack_file_url(dist_url, self.build_dir,
-                        download_dir=self.download_dir,
-                        hashes=Hashes({'md5': [dist_path_md5]}))
-
-        # confirm hash is for simple1-1.0
-        # the previous bad download has been removed
-        with open(dest_file, 'rb') as f:
-            assert hashlib.md5(f.read()).hexdigest() == dist_path_md5
 
     def test_unpack_file_url_thats_a_dir(self, tmpdir, data):
         self.prep(tmpdir, data)


### PR DESCRIPTION
Previously our http and file "download" tests were tightly coupled to the implementation. These have been replaced with higher-level tests so that we can change the implementation without losing any coverage.

Progresses #7049.