### PR TITLE
Add downloaded/local archive path to InstallRequirement

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -627,13 +627,16 @@ def install_wheel(
     req_description,  # type: str
     pycompile=True,  # type: bool
     warn_script_location=True,  # type: bool
+    _temp_dir_for_testing=None,  # type: Optional[str]
 ):
     # type: (...) -> None
-    with TempDirectory(kind="unpacked-wheel") as unpacked_dir:
-        unpack_file(wheel_path, unpacked_dir)
+    with TempDirectory(
+        path=_temp_dir_for_testing, kind="unpacked-wheel"
+    ) as unpacked_dir:
+        unpack_file(wheel_path, unpacked_dir.path)
         install_unpacked_wheel(
             name=name,
-            wheeldir=unpacked_dir,
+            wheeldir=unpacked_dir.path,
             scheme=scheme,
             req_description=req_description,
             pycompile=pycompile,

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -28,7 +28,9 @@ from pip._vendor.six import StringIO
 from pip._internal.exceptions import InstallationError, UnsupportedWheel
 from pip._internal.locations import get_major_minor_version
 from pip._internal.utils.misc import captured_stdout, ensure_dir, hash_file
+from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+from pip._internal.utils.unpacking import unpack_file
 
 if MYPY_CHECK_RUNNING:
     from typing import (
@@ -616,6 +618,27 @@ def install_unpacked_wheel(
             for row in sorted_outrows(outrows):
                 writer.writerow(row)
     shutil.move(temp_record, record)
+
+
+def install_wheel(
+    name,  # type: str
+    wheel_path,  # type: str
+    scheme,  # type: Scheme
+    req_description,  # type: str
+    pycompile=True,  # type: bool
+    warn_script_location=True,  # type: bool
+):
+    # type: (...) -> None
+    with TempDirectory(kind="unpacked-wheel") as unpacked_dir:
+        unpack_file(wheel_path, unpacked_dir)
+        install_unpacked_wheel(
+            name=name,
+            wheeldir=unpacked_dir,
+            scheme=scheme,
+            req_description=req_description,
+            pycompile=pycompile,
+            warn_script_location=warn_script_location,
+        )
 
 
 def wheel_version(source_dir):

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -137,6 +137,10 @@ class InstallRequirement(object):
             # PEP 508 URL requirement
             link = Link(req.url)
         self.link = self.original_link = link
+        # Path to any downloaded or already-existing package.
+        self.local_file_path = None  # type: Optional[str]
+        if self.link and self.link.is_file:
+            self.local_file_path = self.link.file_path
 
         if extras:
             self.extras = extras

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -27,7 +27,7 @@ from pip._internal.operations.build.metadata_legacy import \
     generate_metadata as generate_metadata_legacy
 from pip._internal.operations.install.editable_legacy import \
     install as install_editable_legacy
-from pip._internal.operations.install.wheel import install_unpacked_wheel
+from pip._internal.operations.install.wheel import install_wheel
 from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
 from pip._internal.req.req_uninstall import UninstallPathSet
 from pip._internal.utils.deprecation import deprecated
@@ -774,9 +774,10 @@ class InstallRequirement(object):
             return
 
         if self.is_wheel:
-            install_unpacked_wheel(
+            assert self.local_file_path
+            install_wheel(
                 self.name,
-                self.source_dir,
+                self.local_file_path,
                 scheme=scheme,
                 req_description=str(self.req),
                 pycompile=pycompile,

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -460,6 +460,7 @@ class WheelBuilder(object):
                         )
                         # Update the link for this.
                         req.link = Link(path_to_url(wheel_file))
+                        req.local_file_path = req.link.file_path
                         assert req.link.is_wheel
                         # extract the wheel into the dir
                         unpack_file(req.link.file_path, req.source_dir)

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -260,7 +260,6 @@ class TestInstallUnpackedWheel(object):
         self.req = Requirement('sample')
         self.src = os.path.join(tmpdir, 'src')
         self.dest = os.path.join(tmpdir, 'dest')
-        unpack_file(self.wheelpath, self.src)
         self.scheme = Scheme(
             purelib=os.path.join(self.dest, 'lib'),
             platlib=os.path.join(self.dest, 'lib'),
@@ -290,9 +289,9 @@ class TestInstallUnpackedWheel(object):
 
     def test_std_install(self, data, tmpdir):
         self.prep(data, tmpdir)
-        wheel.install_unpacked_wheel(
+        wheel.install_wheel(
             self.name,
-            self.src,
+            self.wheelpath,
             scheme=self.scheme,
             req_description=str(self.req),
         )
@@ -309,9 +308,9 @@ class TestInstallUnpackedWheel(object):
             isolated=False,
             prefix=prefix,
         )
-        wheel.install_unpacked_wheel(
+        wheel.install_wheel(
             self.name,
-            self.src,
+            self.wheelpath,
             scheme=scheme,
             req_description=str(self.req),
         )
@@ -330,11 +329,12 @@ class TestInstallUnpackedWheel(object):
             self.src_dist_info, 'empty_dir', 'empty_dir')
         os.makedirs(src_empty_dir)
         assert os.path.isdir(src_empty_dir)
-        wheel.install_unpacked_wheel(
+        wheel.install_wheel(
             self.name,
-            self.src,
+            self.wheelpath,
             scheme=self.scheme,
             req_description=str(self.req),
+            _temp_dir_for_testing=self.src,
         )
         self.assert_installed()
         assert not os.path.isdir(


### PR DESCRIPTION
Makes the downloaded archive available on `InstallRequirement`, which allows us to separate different phases of package processing. As an example, we now install directly from a wheel file (from the perspective of `InstallRequirement`) instead of from an unpacked wheel in `source_dir`.

Progresses #7049.