### PR TITLE
Add missing error logging in WheelBuilder 

### DIFF
--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -367,6 +367,7 @@ class WheelBuilder(object):
                 wheel_name = os.path.basename(wheel_path)
                 dest_path = os.path.join(output_dir, wheel_name)
                 try:
+                    ensure_dir(output_dir)
                     wheel_hash, length = hash_file(wheel_path)
                     shutil.move(wheel_path, dest_path)
                     logger.info('Created wheel for %s: '

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -375,7 +375,11 @@ class WheelBuilder(object):
                                 wheel_hash.hexdigest())
                     logger.info('Stored in directory: %s', output_dir)
                     return dest_path
-                except Exception:
+                except Exception as e:
+                    logger.warning(
+                        "Building wheel for %s failed: %s",
+                        req.name, e,
+                    )
                     pass
             # Ignore return, we can't do anything else useful.
             self._clean_one(req)

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -444,16 +444,6 @@ class WheelBuilder(object):
         with indent_log():
             build_success, build_failure = [], []
             for req, cache_dir in buildset:
-                try:
-                    ensure_dir(cache_dir)
-                except OSError as e:
-                    logger.warning(
-                        "Building wheel for %s failed: %s",
-                        req.name, e,
-                    )
-                    build_failure.append(req)
-                    continue
-
                 wheel_file = self._build_one(req, cache_dir)
                 if wheel_file:
                     if should_unpack:

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -334,6 +334,15 @@ class WheelBuilder(object):
 
         :return: The filename of the built wheel, or None if the build failed.
         """
+        try:
+            ensure_dir(output_dir)
+        except OSError as e:
+            logger.warning(
+                "Building wheel for %s failed: %s",
+                req.name, e,
+            )
+            return None
+
         # Install build deps into temporary directory (PEP 518)
         with req.build_env:
             return self._build_one_inside_env(req, output_dir)
@@ -367,7 +376,6 @@ class WheelBuilder(object):
                 wheel_name = os.path.basename(wheel_path)
                 dest_path = os.path.join(output_dir, wheel_name)
                 try:
-                    ensure_dir(output_dir)
                     wheel_hash, length = hash_file(wheel_path)
                     shutil.move(wheel_path, dest_path)
                     logger.info('Created wheel for %s: '

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -389,7 +389,6 @@ class WheelBuilder(object):
                         "Building wheel for %s failed: %s",
                         req.name, e,
                     )
-                    pass
             # Ignore return, we can't do anything else useful.
             self._clean_one(req)
             return None


### PR DESCRIPTION
Further simplify `WheelBuilder.build()`, and add a missing error report.