### PR TITLE
Effectively disable the wheel cache if not writable

### DIFF
--- a/news/7488.bugfix
+++ b/news/7488.bugfix
@@ -1,0 +1,2 @@
+Effectively disable the wheel cache when it is not writable, as is the
+case with the http cache.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -31,6 +31,7 @@ from pip._internal.exceptions import (
     UninstallationError,
 )
 from pip._internal.utils.deprecation import deprecated
+from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
 from pip._internal.utils.misc import get_prog
 from pip._internal.utils.temp_dir import global_tempdir_manager
@@ -167,6 +168,18 @@ class Command(CommandContextMixIn):
                     'Could not find an activated virtualenv (required).'
                 )
                 sys.exit(VIRTUALENV_NOT_FOUND)
+
+        if options.cache_dir:
+            if not check_path_owner(options.cache_dir):
+                logger.warning(
+                    "The directory '%s' or its parent directory is not owned "
+                    "or is not writable by the current user. The cache "
+                    "has been disabled. Check the permissions and owner of "
+                    "that directory. If executing pip with sudo, you may want "
+                    "sudo's -H flag.",
+                    options.cache_dir,
+                )
+                options.cache_dir = None
 
         try:
             status = self.run(options, args)

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -11,7 +11,6 @@ from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.req_command import RequirementCommand
 from pip._internal.req import RequirementSet
 from pip._internal.req.req_tracker import get_requirement_tracker
-from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.misc import ensure_dir, normalize_path, write_output
 from pip._internal.utils.temp_dir import TempDirectory
 
@@ -99,16 +98,6 @@ class DownloadCommand(RequirementCommand):
             target_python=target_python,
         )
         build_delete = (not (options.no_clean or options.build_dir))
-        if options.cache_dir and not check_path_owner(options.cache_dir):
-            logger.warning(
-                "The directory '%s' or its parent directory is not owned "
-                "by the current user and caching wheels has been "
-                "disabled. check the permissions and owner of that "
-                "directory. If executing pip with sudo, you may want "
-                "sudo's -H flag.",
-                options.cache_dir,
-            )
-            options.cache_dir = None
 
         with get_requirement_tracker() as req_tracker, TempDirectory(
             options.build_dir, delete=build_delete, kind="download"

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -34,7 +34,7 @@ from pip._internal.req import RequirementSet, install_given_reqs
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.distutils_args import parse_distutils_args
-from pip._internal.utils.filesystem import check_path_owner, test_writable_dir
+from pip._internal.utils.filesystem import test_writable_dir
 from pip._internal.utils.misc import (
     ensure_dir,
     get_installed_version,
@@ -329,17 +329,6 @@ class InstallCommand(RequirementCommand):
         )
         build_delete = (not (options.no_clean or options.build_dir))
         wheel_cache = WheelCache(options.cache_dir, options.format_control)
-
-        if options.cache_dir and not check_path_owner(options.cache_dir):
-            logger.warning(
-                "The directory '%s' or its parent directory is not owned "
-                "by the current user and caching wheels has been "
-                "disabled. check the permissions and owner of that "
-                "directory. If executing pip with sudo, you may want "
-                "sudo's -H flag.",
-                options.cache_dir,
-            )
-            options.cache_dir = None
 
         with get_requirement_tracker() as req_tracker, TempDirectory(
             options.build_dir, delete=build_delete, kind="install"

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -27,7 +27,6 @@ from pip._internal.network.auth import MultiDomainBasicAuth
 from pip._internal.network.cache import SafeFileCache
 # Import ssl from compat so the initial import occurs in only one place.
 from pip._internal.utils.compat import has_tls, ipaddress
-from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.glibc import libc_ver
 from pip._internal.utils.misc import (
     build_url_from_netloc,
@@ -263,19 +262,6 @@ class PipSession(requests.Session):
             # order to prevent hammering the service.
             backoff_factor=0.25,
         )
-
-        # Check to ensure that the directory containing our cache directory
-        # is owned by the user current executing pip. If it does not exist
-        # we will check the parent directory until we find one that does exist.
-        if cache and not check_path_owner(cache):
-            logger.warning(
-                "The directory '%s' or its parent directory is not owned by "
-                "the current user and the cache has been disabled. Please "
-                "check the permissions and owner of that directory. If "
-                "executing pip with sudo, you may want sudo's -H flag.",
-                cache,
-            )
-            cache = None
 
         # We want to _only_ cache responses on securely fetched origins. We do
         # this because we can't validate the response of an insecurely fetched

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -120,6 +120,7 @@ def test_pip_wheel_builds_when_no_binary_set(script, data):
     assert "Building wheel for simple" in str(res), str(res)
 
 
+@pytest.mark.skipif("sys.platform == 'win32'")
 def test_pip_wheel_readonly_cache(script, data, tmpdir):
     cache_dir = tmpdir / "cache"
     cache_dir.mkdir()
@@ -133,7 +134,7 @@ def test_pip_wheel_readonly_cache(script, data, tmpdir):
         allow_stderr_warning=True,
     )
     assert res.returncode == 0
-    assert "caching wheels has been disabled" in str(res), str(res)
+    assert "The cache has been disabled." in str(res), str(res)
 
 
 def test_pip_wheel_builds_editable_deps(script, data):

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -120,6 +120,22 @@ def test_pip_wheel_builds_when_no_binary_set(script, data):
     assert "Building wheel for simple" in str(res), str(res)
 
 
+def test_pip_wheel_readonly_cache(script, data, tmpdir):
+    cache_dir = tmpdir / "cache"
+    cache_dir.mkdir()
+    os.chmod(cache_dir, 0o400)  # read-only cache
+    # Check that the wheel package is ignored
+    res = script.pip(
+        'wheel', '--no-index',
+        '-f', data.find_links,
+        '--cache-dir', cache_dir,
+        'simple==3.0',
+        allow_stderr_warning=True,
+    )
+    assert res.returncode == 0
+    assert "caching wheels has been disabled" in str(res), str(res)
+
+
 def test_pip_wheel_builds_editable_deps(script, data):
     """
     Test 'pip wheel' finds and builds dependencies of editables


### PR DESCRIPTION
Move the test for cache writeability from the `install` command to the `WheelCache` object.

The test was ineffective in the install command because it was done after creating the wheel cache object. The test was also missing in the `wheel` and `freeze` commands.

The test is in `WheelCache` and not `Cache` to avoid a double warning via `Cache` and `SimpleWheelCache`.

I also considered putting the check in the option parser, but at that point the logger is not fully initialized and warning was not colored.

Fixes #7488