### PR TITLE
Fix cache bug with legacy cache entries

### DIFF
--- a/news/7490.trivial
+++ b/news/7490.trivial
@@ -1,0 +1,1 @@
+Fix unrelease bug from #7319.

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -139,14 +139,12 @@ class Cache(object):
         path = self.get_path_for_link(link)
         if os.path.isdir(path):
             for candidate in os.listdir(path):
-                candidates.append((candidate, os.path.join(path, candidate)))
+                candidates.append((candidate, path))
         # TODO remove legacy path lookup in pip>=21
         legacy_path = self.get_path_for_link_legacy(link)
         if os.path.isdir(legacy_path):
             for candidate in os.listdir(legacy_path):
-                candidates.append(
-                    (candidate, os.path.join(legacy_path, candidate))
-                )
+                candidates.append((candidate, legacy_path))
         return candidates
 
     def get_path_for_link_legacy(self, link):
@@ -225,7 +223,7 @@ class SimpleWheelCache(Cache):
             return link
 
         canonical_package_name = canonicalize_name(package_name)
-        for wheel_name, wheel_path in self._get_candidates(
+        for wheel_name, wheel_dir in self._get_candidates(
             link, canonical_package_name
         ):
             try:
@@ -247,14 +245,15 @@ class SimpleWheelCache(Cache):
                 (
                     wheel.support_index_min(supported_tags),
                     wheel_name,
-                    wheel_path,
+                    wheel_dir,
                 )
             )
 
         if not candidates:
             return link
 
-        return Link(path_to_url(min(candidates)[2]))
+        _, wheel_name, wheel_dir = min(candidates)
+        return Link(path_to_url(os.path.join(wheel_dir, wheel_name)))
 
 
 class EphemWheelCache(SimpleWheelCache):

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -39,7 +39,9 @@ def test_wheel_name_filter(tmpdir):
     with open(os.path.join(cache_path, "package-1.0-py3-none-any.whl"), "w"):
         pass
     # package matches wheel name
-    assert wc.get(link, "package", [("py3", "none", "any")]) is not link
+    cached_link = wc.get(link, "package", [("py3", "none", "any")])
+    assert cached_link is not link
+    assert os.path.exists(cached_link.file_path)
     # package2 does not match wheel name
     assert wc.get(link, "package2", [("py3", "none", "any")]) is link
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -71,3 +71,21 @@ def test_get_path_for_link_legacy(tmpdir):
         pass
     expected_candidates = {"test-pyx-none-any.whl", "test-pyz-none-any.whl"}
     assert set(wc._get_candidates(link, "test")) == expected_candidates
+
+
+def test_get_with_legacy_entry_only(tmpdir):
+    """
+    Test that an existing cache entry that was created with the legacy hashing
+    mechanism is actually returned in WheelCache.get().
+    """
+    wc = WheelCache(tmpdir, FormatControl())
+    link = Link("https://g.c/o/r")
+    legacy_path = wc.get_path_for_link_legacy(link)
+    ensure_dir(legacy_path)
+    with open(os.path.join(legacy_path, "test-1.0.0-py3-none-any.whl"), "w"):
+        pass
+    cached_link = wc.get(link, "test", [("py3", "none", "any")])
+    assert (
+        os.path.normcase(os.path.dirname(cached_link.file_path)) ==
+        os.path.normcase(legacy_path)
+    )

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -58,7 +58,7 @@ def test_cache_hash():
 def test_get_path_for_link_legacy(tmpdir):
     """
     Test that an existing cache entry that was created with the legacy hashing
-    mechanism is used.
+    mechanism is returned by WheelCache._get_candidates().
     """
     wc = WheelCache(tmpdir, FormatControl())
     link = Link("https://g.c/o/r")
@@ -66,13 +66,16 @@ def test_get_path_for_link_legacy(tmpdir):
     legacy_path = wc.get_path_for_link_legacy(link)
     assert path != legacy_path
     ensure_dir(path)
-    with open(os.path.join(path, "test-pyz-none-any.whl"), "w"):
+    with open(os.path.join(path, "test-1.0.0-pyz-none-any.whl"), "w"):
         pass
     ensure_dir(legacy_path)
-    with open(os.path.join(legacy_path, "test-pyx-none-any.whl"), "w"):
+    with open(os.path.join(legacy_path, "test-1.0.0-pyx-none-any.whl"), "w"):
         pass
-    expected_candidates = {"test-pyx-none-any.whl", "test-pyz-none-any.whl"}
-    assert set(wc._get_candidates(link, "test")) == expected_candidates
+    expected_candidates = {
+        "test-1.0.0-pyx-none-any.whl", "test-1.0.0-pyz-none-any.whl"
+    }
+    candidates = {c[0] for c in wc._get_candidates(link, "test")}
+    assert candidates == expected_candidates
 
 
 def test_get_with_legacy_entry_only(tmpdir):


### PR DESCRIPTION
Fix an unreleased bug from #7319, in the handling of legacy cache entries.

The bug manifests itself when only a legacy cache entry exist for a given link, in which case pip would error like this:

```
$ pip install wrapt
Processing /home/sbi-local/.cache/pip/wheels/23/5f/62/304b411f20be41821465a82bc98baabc5e68c3cdd1eb99db71/wrapt-1.11.2-cp37-cp37m-linux_x86_64.whl
ERROR: Could not install packages due to an EnvironmentError: [Errno 2] No such file or directory: '/home/sbi-local/.cache/pip/wheels/23/5f/62/304b411f20be41821465a82bc98baabc5e68c3cdd1eb99db71/wrapt-1.11.2-cp37-cp37m-linux_x86_64.whl'
```

This is because `_get_candidates` returned cached wheel names and not their cache directory, with the cache directory later being reconstructed in `_link_for_candidate`. I fix this by returning a `wheel_name, wheel_path` tuple so callers do not need to do any guesswork to find the path.