### PR TITLE
Only allow one top-level .dist-info directory in wheels

### DIFF
--- a/news/7487.removal
+++ b/news/7487.removal
@@ -1,0 +1,2 @@
+Wheel processing no longer permits wheels containing more than one top-level
+.dist-info directory.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -22,7 +22,6 @@ from email.parser import Parser
 from pip._vendor import pkg_resources
 from pip._vendor.distlib.scripts import ScriptMaker
 from pip._vendor.distlib.util import get_export_entry
-from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.six import StringIO
 
 from pip._internal.exceptions import InstallationError, UnsupportedWheel
@@ -381,8 +380,7 @@ def install_unpacked_wheel(
                     continue
                 elif (
                     is_base and
-                    s.endswith('.dist-info') and
-                    canonicalize_name(s).startswith(canonicalize_name(name))
+                    s.endswith('.dist-info')
                 ):
                     assert not info_dir, (
                         'Multiple .dist-info directories: {}, '.format(

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -1,6 +1,7 @@
 import distutils
 import glob
 import os
+import shutil
 
 import pytest
 
@@ -451,3 +452,23 @@ def test_wheel_install_fails_with_extra_dist_info(script):
         "install", "--no-cache-dir", "--no-index", package, expect_error=True
     )
     assert "Multiple .dist-info directories" in result.stderr
+
+
+def test_wheel_install_fails_with_unrelated_dist_info(script):
+    package = create_basic_wheel_for_package(script, "simple", "0.1.0")
+    new_name = "unrelated-2.0.0-py2.py3-none-any.whl"
+    new_package = os.path.join(os.path.dirname(package), new_name)
+    shutil.move(package, new_package)
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        new_package,
+        expect_error=True,
+    )
+
+    assert (
+        "'simple-0.1.0.dist-info' does not start with 'unrelated'"
+        in result.stderr
+    )

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -921,8 +921,9 @@ def create_test_package_with_setup(script, **setup_kwargs):
     return pkg_path
 
 
-def create_basic_wheel_for_package(script, name, version,
-                                   depends=None, extras=None):
+def create_basic_wheel_for_package(
+    script, name, version, depends=None, extras=None, extra_files=None
+):
     if depends is None:
         depends = []
     if extras is None:
@@ -965,6 +966,9 @@ def create_basic_wheel_for_package(script, name, version,
         # Have an empty RECORD because we don't want to be checking hashes.
         "{dist_info}/RECORD": ""
     }
+
+    if extra_files:
+        files.update(extra_files)
 
     # Some useful shorthands
     archive_name = "{name}-{version}-py2.py3-none-any.whl".format(


### PR DESCRIPTION
Original justification is in the linked issue. The current improvement is small, but this will be a useful simplification later when refactoring to install directly from wheel files since we can search directly for metadata files by matching on e.g. `^[^/]+\.dist-info/WHEEL$`.

For any impacted packages (i.e. [intel-tensorflow](https://pypi.org/project/intel-tensorflow/)), a workaround could be to put the non-primary `.dist-info` into `*.data/purelib`.

Fixes #7487.