### PR TITLE
Make winreg import compatible to modern Python

### DIFF
--- a/news/7495.bugfix
+++ b/news/7495.bugfix
@@ -1,0 +1,1 @@
+Make the bundled appdirs compatible with Python 3 on Windows when ``ctypes`` is not available.

--- a/src/pip/_internal/utils/appdirs.py
+++ b/src/pip/_internal/utils/appdirs.py
@@ -204,7 +204,10 @@ def _get_win_folder_from_registry(csidl_name):
     registry for this guarantees us the correct answer for all CSIDL_*
     names.
     """
-    import _winreg
+    if PY2:
+        import _winreg as winreg
+    else:
+        import winreg
 
     shell_folder_name = {
         "CSIDL_APPDATA": "AppData",
@@ -212,11 +215,11 @@ def _get_win_folder_from_registry(csidl_name):
         "CSIDL_LOCAL_APPDATA": "Local AppData",
     }[csidl_name]
 
-    key = _winreg.OpenKey(
-        _winreg.HKEY_CURRENT_USER,
+    key = winreg.OpenKey(
+        winreg.HKEY_CURRENT_USER,
         r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
     )
-    directory, _type = _winreg.QueryValueEx(key, shell_folder_name)
+    directory, _type = winreg.QueryValueEx(key, shell_folder_name)
     return directory
 
 


### PR DESCRIPTION
Fix #7495.

I intend to work on #6040 to eliminate the internal copy next, but figured it’s better to post this quick fix first.