### PR TITLE
Simplify install.py by moving build_wheels to wheel_builder

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -38,6 +38,7 @@ from pip._internal.utils.filesystem import check_path_owner, test_writable_dir
 from pip._internal.utils.misc import (
     ensure_dir,
     get_installed_version,
+    is_wheel_installed,
     protect_pip_from_modification_on_windows,
     write_output,
 )
@@ -56,18 +57,6 @@ if MYPY_CHECK_RUNNING:
 
 
 logger = logging.getLogger(__name__)
-
-
-def is_wheel_installed():
-    """
-    Return whether the wheel package is installed.
-    """
-    try:
-        import wheel  # noqa: F401
-    except ImportError:
-        return False
-
-    return True
 
 
 def build_wheels(

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -421,11 +421,14 @@ class InstallCommand(RequirementCommand):
 
                 # If we're using PEP 517, we cannot do a direct install
                 # so we fail here.
-                if build_failures:
+                pep517_build_failures = [
+                    r for r in build_failures if r.use_pep517
+                ]
+                if pep517_build_failures:
                     raise InstallationError(
                         "Could not build wheels for {} which use"
                         " PEP 517 and cannot be installed directly".format(
-                            ", ".join(r.name for r in build_failures)))
+                            ", ".join(r.name for r in pep517_build_failures)))
 
                 to_install = resolver.get_installation_order(
                     requirement_set

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -878,3 +878,15 @@ def hash_file(path, blocksize=1 << 20):
             length += len(block)
             h.update(block)
     return h, length
+
+
+def is_wheel_installed():
+    """
+    Return whether the wheel package is installed.
+    """
+    try:
+        import wheel  # noqa: F401
+    except ImportError:
+        return False
+
+    return True

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -12,7 +12,7 @@ import shutil
 from pip._internal.models.link import Link
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.marker_files import has_delete_marker_file
-from pip._internal.utils.misc import ensure_dir, hash_file
+from pip._internal.utils.misc import ensure_dir, hash_file, is_wheel_installed
 from pip._internal.utils.setuptools_build import (
     make_setuptools_bdist_wheel_args,
     make_setuptools_clean_args,
@@ -77,6 +77,10 @@ def should_build(
     if need_wheel:
         # i.e. pip wheel, not pip install
         return True
+
+    if not req.use_pep517 and not is_wheel_installed():
+        # we don't build legacy requirements if wheel is not installed
+        return False
 
     if req.editable or not req.source_dir:
         return False

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -1,77 +1,16 @@
 import errno
 
 import pytest
-from mock import Mock, call, patch
+from mock import patch
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.commands.install import (
-    build_wheels,
     create_env_error_message,
     decide_user_install,
     warn_deprecated_install_options,
 )
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.req.req_set import RequirementSet
-
-
-class TestWheelCache:
-
-    def check_build_wheels(
-        self,
-        pep517_requirements,
-        legacy_requirements,
-    ):
-        """
-        Return: (mock_calls, return_value).
-        """
-        def build(reqs, **kwargs):
-            # Fail the first requirement.
-            return [reqs[0]]
-
-        builder = Mock()
-        builder.build.side_effect = build
-
-        build_failures = build_wheels(
-            builder=builder,
-            pep517_requirements=pep517_requirements,
-            legacy_requirements=legacy_requirements,
-        )
-
-        return (builder.build.mock_calls, build_failures)
-
-    @patch('pip._internal.commands.install.is_wheel_installed')
-    def test_build_wheels__wheel_installed(self, is_wheel_installed):
-        is_wheel_installed.return_value = True
-
-        mock_calls, build_failures = self.check_build_wheels(
-            pep517_requirements=['a', 'b'],
-            legacy_requirements=['c', 'd'],
-        )
-
-        # Legacy requirements were built.
-        assert mock_calls == [
-            call(['a', 'b'], should_unpack=True),
-            call(['c', 'd'], should_unpack=True),
-        ]
-
-        # Legacy build failures are not included in the return value.
-        assert build_failures == ['a']
-
-    @patch('pip._internal.commands.install.is_wheel_installed')
-    def test_build_wheels__wheel_not_installed(self, is_wheel_installed):
-        is_wheel_installed.return_value = False
-
-        mock_calls, build_failures = self.check_build_wheels(
-            pep517_requirements=['a', 'b'],
-            legacy_requirements=['c', 'd'],
-        )
-
-        # Legacy requirements were not built.
-        assert mock_calls == [
-            call(['a', 'b'], should_unpack=True),
-        ]
-
-        assert build_failures == ['a']
 
 
 class TestDecideUserInstall:


### PR DESCRIPTION
`build_wheels()` has two purposes:
1. avoid building legacy wheels if `wheel` is not installed
2. filtering out build errors for legacy requirements

I simplify 1. by moving the decision to `should_build`, and 2. is achived by filtering build failures. 

This will further facilitate the transformation of WheelBuilder to simple functions.

TODO 
- [x] add test coverage for the new `should_build` behaviour