### PR TITLE
Remove unnecessary InstallRequirement cleanup in install_given_reqs

### DIFF
--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -86,7 +86,6 @@ def install_given_reqs(
                 )
                 if should_commit:
                     uninstalled_pathset.commit()
-            requirement.remove_temporary_source()
 
             installed.append(InstallationResult(requirement.name))
 


### PR DESCRIPTION
`InstallCommand.run`:

- [calls `install_given_reqs`](https://github.com/pypa/pip/blob/0292938f89cc930b0f3bfcab3eb27887666872a8/src/pip/_internal/commands/install.py#L448) (sole caller)
- [calls `RequirementSet.cleanup_files`](https://github.com/pypa/pip/blob/0292938f89cc930b0f3bfcab3eb27887666872a8/src/pip/_internal/commands/install.py#L502)
   - [calls `InstallRequirement.remove_temporary_source`](https://github.com/pypa/pip/blob/0292938f89cc930b0f3bfcab3eb27887666872a8/src/pip/_internal/req/req_set.py#L209) for each `InstallRequirement`

so a call to `InstallRequirement.remove_temporary_source` in `install_given_reqs` is not necessary and has been removed.

We have test coverage affirming this still works as expected in [`tests/functional/test_install_cleanup.py`](https://github.com/pypa/pip/blob/0292938f89cc930b0f3bfcab3eb27887666872a8/tests/functional/test_install_cleanup.py).

Progresses #2779.