### PR TITLE
Move final wheel builder copy operation to wheel command

### DIFF
--- a/news/7517.feature
+++ b/news/7517.feature
@@ -1,0 +1,4 @@
+The build step of ``pip wheel`` now builds all wheels to a cache first,
+then copies them to the wheel directory all at once.
+Before, it built them to a temporary direcory and moved
+them to the wheel directory one by one.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -83,7 +83,7 @@ def build_wheels(
     should_build_legacy = is_wheel_installed()
 
     # Always build PEP 517 requirements
-    build_failures = builder.build(
+    _, build_failures = builder.build(
         pep517_requirements,
         should_unpack=True,
     )

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -161,7 +161,7 @@ class WheelCommand(RequirementCommand):
                     build_options=options.build_options or [],
                     global_options=options.global_options or [],
                 )
-                build_failures = wb.build(
+                _, build_failures = wb.build(
                     requirement_set.requirements.values(),
                     should_unpack=False,
                 )

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -418,7 +418,8 @@ class WheelBuilder(object):
         :param should_unpack: If True, after building the wheel, unpack it
             and replace the sdist with the unpacked version in preparation
             for installation.
-        :return: The list of InstallRequirement that failed to build.
+        :return: The list of InstallRequirement that succeeded to build and
+            the list of InstallRequirement that failed to build.
         """
         buildset = _collect_buildset(
             requirements,

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -479,18 +479,6 @@ class WheelBuilder(object):
                         )
                         # extract the wheel into the dir
                         unpack_file(req.link.file_path, req.source_dir)
-                    else:
-                        # copy from cache to target directory
-                        try:
-                            ensure_dir(self._wheel_dir)
-                            shutil.copy(wheel_file, self._wheel_dir)
-                        except OSError as e:
-                            logger.warning(
-                                "Building wheel for %s failed: %s",
-                                req.name, e,
-                            )
-                            build_failures.append(req)
-                            continue
                     build_successes.append(req)
                 else:
                     build_failures.append(req)

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -319,8 +319,6 @@ class WheelBuilder(object):
         self.preparer = preparer
         self.wheel_cache = wheel_cache
 
-        self._wheel_dir = preparer.wheel_download_dir
-
         self.build_options = build_options or []
         self.global_options = global_options or []
         self.check_binary_allowed = check_binary_allowed
@@ -422,15 +420,6 @@ class WheelBuilder(object):
             for installation.
         :return: The list of InstallRequirement that failed to build.
         """
-        # pip install uses should_unpack=True.
-        # pip install never provides a _wheel_dir.
-        # pip wheel uses should_unpack=False.
-        # pip wheel always provides a _wheel_dir (via the preparer).
-        assert (
-            (should_unpack and not self._wheel_dir) or
-            (not should_unpack and self._wheel_dir)
-        )
-
         buildset = _collect_buildset(
             requirements,
             wheel_cache=self.wheel_cache,

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -26,7 +26,7 @@ class TestWheelCache:
         """
         def build(reqs, **kwargs):
             # Fail the first requirement.
-            return [reqs[0]]
+            return ([], [reqs[0]])
 
         builder = Mock()
         builder.build.side_effect = build


### PR DESCRIPTION
Removes one more non-build concern from `WheelBuilder.build()`.