### PR TITLE
Only check for .dist-info directories at the top-level

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -383,6 +383,7 @@ def install_unpacked_wheel(
                     continue
                 elif (
                     is_base and
+                    basedir == '' and
                     s.endswith('.dist-info')
                 ):
                     assert not info_dir, (

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -472,3 +472,20 @@ def test_wheel_install_fails_with_unrelated_dist_info(script):
         "'simple-0.1.0.dist-info' does not start with 'unrelated'"
         in result.stderr
     )
+
+
+def test_wheel_installs_ok_with_nested_dist_info(script):
+    package = create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.1.0",
+        extra_files={
+            "subdir/unrelated-2.0.0.dist-info/WHEEL": "Wheel-Version: 1.0",
+            "subdir/unrelated-2.0.0.dist-info/METADATA": (
+                "Name: unrelated\nVersion: 2.0.0\n"
+            ),
+        },
+    )
+    script.pip(
+        "install", "--no-cache-dir", "--no-index", package
+    )

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -997,7 +997,7 @@ def create_basic_wheel_for_package(
 
     for fname in files:
         path = script.temp_path / fname
-        path.parent.mkdir(exist_ok=True)
+        path.parent.mkdir(exist_ok=True, parents=True)
         path.write_text(files[fname])
 
     retval = script.scratch_path / archive_name


### PR DESCRIPTION
Previously we were restricting to a single .dist-info directory anywhere
in the unpacked wheel directory. That was incorrect since only a
top-level .dist-info directory indicates a contained "package". Now we
limit our restriction to top-level .dist-info directories, which was the intent in #7494.

As mentioned in [#7494 (comment)](https://github.com/pypa/pip/pull/7494#issuecomment-569445203).

Marking as trivial since this prior change was unreleased.