### PR TITLE
Run linters/docs on Windows and macOS

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         os:
         - ubuntu-18.04
+        - windows-latest
+        - macos-latest
         env:
         - TOXENV: docs
         - TOXENV: lint
@@ -33,11 +35,14 @@ jobs:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Pre-configure global Git settings
-      run: >-
-        tools/travis/setup.sh
+      run: |
+        git config --global user.email "pypa-dev@googlegroups.com"
+        git config --global user.name "pip"
     - name: Update setuptools and tox dependencies
-      run: >-
-        tools/travis/install.sh
+      run: |
+        python -m pip install --upgrade setuptools
+        python -m pip install --upgrade tox tox-venv
+        python -m pip freeze --all
     - name: 'Initialize tox envs: ${{ matrix.env.TOXENV }}'
       run: >-
         python -m tox --notest --skip-missing-interpreters false

--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -273,17 +273,26 @@ man_pages = [
     )
 ]
 
+
+def to_document_name(path, base_dir):
+    """Convert a provided path to a Sphinx "document name".
+    """
+    relative_path = os.path.relpath(path, base_dir)
+    root, _ = os.path.splitext(relative_path)
+    return root.replace(os.sep, '/')
+
+
 # Here, we crawl the entire man/commands/ directory and list every file with
 # appropriate name and details
-man_dir = os.path.join(docs_dir, 'man/')
+man_dir = os.path.join(docs_dir, 'man')
 raw_subcommands = glob.glob(os.path.join(man_dir, 'commands/*.rst'))
 if not raw_subcommands:
     raise FileNotFoundError(
         'The individual subcommand manpages could not be found!'
     )
 for fname in raw_subcommands:
-    fname_base = fname[len(man_dir):-4]
-    outname = 'pip-' + fname_base[9:]
+    fname_base = to_document_name(fname, man_dir)
+    outname = 'pip-' + fname_base.split('/')[1]
     description = u'description of {} command'.format(
         outname.replace('-', ' ')
     )

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -257,12 +257,13 @@ else:
             return cr
         cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
         if not cr:
-            try:
-                fd = os.open(os.ctermid(), os.O_RDONLY)
-                cr = ioctl_GWINSZ(fd)
-                os.close(fd)
-            except Exception:
-                pass
+            if sys.platform != "win32":
+                try:
+                    fd = os.open(os.ctermid(), os.O_RDONLY)
+                    cr = ioctl_GWINSZ(fd)
+                    os.close(fd)
+                except Exception:
+                    pass
         if not cr:
             cr = (os.environ.get('LINES', 25), os.environ.get('COLUMNS', 80))
         return int(cr[1]), int(cr[0])

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -4,6 +4,7 @@ import os.path
 import random
 import shutil
 import stat
+import sys
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 
@@ -29,7 +30,7 @@ def check_path_owner(path):
     # type: (str) -> bool
     # If we don't have a way to check the effective uid of this process, then
     # we'll just assume that we own the directory.
-    if not hasattr(os, "geteuid"):
+    if sys.platform == "win32" or not hasattr(os, "geteuid"):
         return True
 
     previous = None

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import os
 import re
+import sys
 import warnings
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -26,6 +27,8 @@ def glibc_version_string_confstr():
     # to be broken or missing. This strategy is used in the standard library
     # platform module:
     # https://github.com/python/cpython/blob/fcf1d003bf4f0100c9d0921ff3d70e1127ca1b71/Lib/platform.py#L175-L183
+    if sys.platform == "win32":
+        return None
     try:
         # os.confstr("CS_GNU_LIBC_VERSION") returns a string like "glibc 2.17":
         _, version = os.confstr("CS_GNU_LIBC_VERSION").split()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -570,12 +570,14 @@ class TestGlibc(object):
                     # Didn't find the warning we were expecting
                     assert False
 
+    @pytest.mark.skipif("sys.platform == 'win32'")
     def test_glibc_version_string(self, monkeypatch):
         monkeypatch.setattr(
             os, "confstr", lambda x: "glibc 2.20", raising=False,
         )
         assert glibc_version_string() == "2.20"
 
+    @pytest.mark.skipif("sys.platform == 'win32'")
     def test_glibc_version_string_confstr(self, monkeypatch):
         monkeypatch.setattr(
             os, "confstr", lambda x: "glibc 2.20", raising=False,


### PR DESCRIPTION
This ensures that contributors on any of the major platforms can run our
linting and doc building checks without any changes.