### PR TITLE
Further reduce responsibility of WheelBuilder

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -74,6 +74,7 @@ def build_wheels(
     builder,              # type: WheelBuilder
     pep517_requirements,  # type: List[InstallRequirement]
     legacy_requirements,  # type: List[InstallRequirement]
+    wheel_cache,           # type: WheelCache
     build_options,         # type: List[str]
     global_options,        # type: List[str]
     check_binary_allowed,  # type: BinaryAllowedPredicate
@@ -89,6 +90,7 @@ def build_wheels(
     _, build_failures = builder.build(
         pep517_requirements,
         should_unpack=True,
+        wheel_cache=wheel_cache,
         build_options=build_options,
         global_options=global_options,
         check_binary_allowed=check_binary_allowed,
@@ -101,6 +103,7 @@ def build_wheels(
         builder.build(
             legacy_requirements,
             should_unpack=True,
+            wheel_cache=wheel_cache,
             build_options=build_options,
             global_options=global_options,
             check_binary_allowed=check_binary_allowed,
@@ -405,11 +408,12 @@ class InstallCommand(RequirementCommand):
                     else:
                         legacy_requirements.append(req)
 
-                wheel_builder = WheelBuilder(preparer, wheel_cache)
+                wheel_builder = WheelBuilder(preparer)
                 build_failures = build_wheels(
                     builder=wheel_builder,
                     pep517_requirements=pep517_requirements,
                     legacy_requirements=legacy_requirements,
+                    wheel_cache=wheel_cache,
                     build_options=[],
                     global_options=[],
                     check_binary_allowed=check_binary_allowed,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -74,6 +74,9 @@ def build_wheels(
     builder,              # type: WheelBuilder
     pep517_requirements,  # type: List[InstallRequirement]
     legacy_requirements,  # type: List[InstallRequirement]
+    build_options,         # type: List[str]
+    global_options,        # type: List[str]
+    check_binary_allowed,  # type: BinaryAllowedPredicate
 ):
     # type: (...) -> List[InstallRequirement]
     """
@@ -86,6 +89,9 @@ def build_wheels(
     _, build_failures = builder.build(
         pep517_requirements,
         should_unpack=True,
+        build_options=build_options,
+        global_options=global_options,
+        check_binary_allowed=check_binary_allowed,
     )
 
     if should_build_legacy:
@@ -95,6 +101,9 @@ def build_wheels(
         builder.build(
             legacy_requirements,
             should_unpack=True,
+            build_options=build_options,
+            global_options=global_options,
+            check_binary_allowed=check_binary_allowed,
         )
 
     return build_failures
@@ -396,16 +405,14 @@ class InstallCommand(RequirementCommand):
                     else:
                         legacy_requirements.append(req)
 
-                wheel_builder = WheelBuilder(
-                    preparer, wheel_cache,
-                    build_options=[], global_options=[],
-                    check_binary_allowed=check_binary_allowed,
-                )
-
+                wheel_builder = WheelBuilder(preparer, wheel_cache)
                 build_failures = build_wheels(
                     builder=wheel_builder,
                     pep517_requirements=pep517_requirements,
                     legacy_requirements=legacy_requirements,
+                    build_options=[],
+                    global_options=[],
+                    check_binary_allowed=check_binary_allowed,
                 )
 
                 # If we're using PEP 517, we cannot do a direct install

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -158,14 +158,12 @@ class WheelCommand(RequirementCommand):
                 resolver.resolve(requirement_set)
 
                 # build wheels
-                wb = WheelBuilder(
-                    preparer, wheel_cache,
-                    build_options=options.build_options or [],
-                    global_options=options.global_options or [],
-                )
+                wb = WheelBuilder(preparer, wheel_cache)
                 build_successes, build_failures = wb.build(
                     requirement_set.requirements.values(),
                     should_unpack=False,
+                    build_options=options.build_options or [],
+                    global_options=options.global_options or [],
                 )
                 for req in build_successes:
                     assert req.link and req.link.is_wheel

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -158,10 +158,11 @@ class WheelCommand(RequirementCommand):
                 resolver.resolve(requirement_set)
 
                 # build wheels
-                wb = WheelBuilder(preparer, wheel_cache)
+                wb = WheelBuilder(preparer)
                 build_successes, build_failures = wb.build(
                     requirement_set.requirements.values(),
                     should_unpack=False,
+                    wheel_cache=wheel_cache,
                     build_options=options.build_options or [],
                     global_options=options.global_options or [],
                 )

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -160,6 +160,97 @@ def _always_true(_):
     return True
 
 
+def _build_one(
+    req,  # type: InstallRequirement
+    output_dir,  # type: str
+    build_options,  # type: List[str]
+    global_options,  # type: List[str]
+):
+    # type: (...) -> Optional[str]
+    """Build one wheel.
+
+    :return: The filename of the built wheel, or None if the build failed.
+    """
+    try:
+        ensure_dir(output_dir)
+    except OSError as e:
+        logger.warning(
+            "Building wheel for %s failed: %s",
+            req.name, e,
+        )
+        return None
+
+    # Install build deps into temporary directory (PEP 518)
+    with req.build_env:
+        return _build_one_inside_env(
+            req, output_dir, build_options, global_options
+        )
+
+
+def _build_one_inside_env(
+    req,  # type: InstallRequirement
+    output_dir,  # type: str
+    build_options,  # type: List[str]
+    global_options,  # type: List[str]
+):
+    # type: (...) -> Optional[str]
+    with TempDirectory(kind="wheel") as temp_dir:
+        if req.use_pep517:
+            wheel_path = build_wheel_pep517(
+                name=req.name,
+                backend=req.pep517_backend,
+                metadata_directory=req.metadata_directory,
+                build_options=build_options,
+                tempd=temp_dir.path,
+            )
+        else:
+            wheel_path = build_wheel_legacy(
+                name=req.name,
+                setup_py_path=req.setup_py_path,
+                source_dir=req.unpacked_source_directory,
+                global_options=global_options,
+                build_options=build_options,
+                tempd=temp_dir.path,
+            )
+
+        if wheel_path is not None:
+            wheel_name = os.path.basename(wheel_path)
+            dest_path = os.path.join(output_dir, wheel_name)
+            try:
+                wheel_hash, length = hash_file(wheel_path)
+                shutil.move(wheel_path, dest_path)
+                logger.info('Created wheel for %s: '
+                            'filename=%s size=%d sha256=%s',
+                            req.name, wheel_name, length,
+                            wheel_hash.hexdigest())
+                logger.info('Stored in directory: %s', output_dir)
+                return dest_path
+            except Exception as e:
+                logger.warning(
+                    "Building wheel for %s failed: %s",
+                    req.name, e,
+                )
+        # Ignore return, we can't do anything else useful.
+        _clean_one(req, global_options)
+        return None
+
+
+def _clean_one(req, global_options):
+    # type: (InstallRequirement, List[str]) -> bool
+    clean_args = make_setuptools_clean_args(
+        req.setup_py_path,
+        global_options=global_options,
+    )
+
+    logger.info('Running setup.py clean for %s', req.name)
+    try:
+        call_subprocess(clean_args, cwd=req.source_dir)
+        return True
+    except Exception:
+        logger.error('Failed cleaning build dir for %s', req.name)
+        return False
+
+
 class WheelBuilder(object):
     """Build wheels from a RequirementSet."""
 
@@ -171,96 +262,6 @@ class WheelBuilder(object):
         # type: (...) -> None
         self.preparer = preparer
         self.wheel_cache = wheel_cache
-
-    def _build_one(
-        self,
-        req,  # type: InstallRequirement
-        output_dir,  # type: str
-        build_options,  # type: List[str]
-        global_options,  # type: List[str]
-    ):
-        # type: (...) -> Optional[str]
-        """Build one wheel.
-
-        :return: The filename of the built wheel, or None if the build failed.
-        """
-        try:
-            ensure_dir(output_dir)
-        except OSError as e:
-            logger.warning(
-                "Building wheel for %s failed: %s",
-                req.name, e,
-            )
-            return None
-
-        # Install build deps into temporary directory (PEP 518)
-        with req.build_env:
-            return self._build_one_inside_env(
-                req, output_dir, build_options, global_options
-            )
-
-    def _build_one_inside_env(
-        self,
-        req,  # type: InstallRequirement
-        output_dir,  # type: str
-        build_options,  # type: List[str]
-        global_options,  # type: List[str]
-    ):
-        # type: (...) -> Optional[str]
-        with TempDirectory(kind="wheel") as temp_dir:
-            if req.use_pep517:
-                wheel_path = build_wheel_pep517(
-                    name=req.name,
-                    backend=req.pep517_backend,
-                    metadata_directory=req.metadata_directory,
-                    build_options=build_options,
-                    tempd=temp_dir.path,
-                )
-            else:
-                wheel_path = build_wheel_legacy(
-                    name=req.name,
-                    setup_py_path=req.setup_py_path,
-                    source_dir=req.unpacked_source_directory,
-                    global_options=global_options,
-                    build_options=build_options,
-                    tempd=temp_dir.path,
-                )
-
-            if wheel_path is not None:
-                wheel_name = os.path.basename(wheel_path)
-                dest_path = os.path.join(output_dir, wheel_name)
-                try:
-                    wheel_hash, length = hash_file(wheel_path)
-                    shutil.move(wheel_path, dest_path)
-                    logger.info('Created wheel for %s: '
-                                'filename=%s size=%d sha256=%s',
-                                req.name, wheel_name, length,
-                                wheel_hash.hexdigest())
-                    logger.info('Stored in directory: %s', output_dir)
-                    return dest_path
-                except Exception as e:
-                    logger.warning(
-                        "Building wheel for %s failed: %s",
-                        req.name, e,
-                    )
-            # Ignore return, we can't do anything else useful.
-            self._clean_one(req, global_options)
-            return None
-
-    def _clean_one(self, req, global_options):
-        # type: (InstallRequirement, List[str]) -> bool
-        clean_args = make_setuptools_clean_args(
-            req.setup_py_path,
-            global_options=global_options,
-        )
-
-        logger.info('Running setup.py clean for %s', req.name)
-        try:
-            call_subprocess(clean_args, cwd=req.source_dir)
-            return True
-        except Exception:
-            logger.error('Failed cleaning build dir for %s', req.name)
-            return False
 
     def build(
         self,
@@ -304,7 +305,7 @@ class WheelBuilder(object):
         with indent_log():
             build_successes, build_failures = [], []
             for req, cache_dir in buildset:
-                wheel_file = self._build_one(
+                wheel_file = _build_one(
                     req, cache_dir, build_options, global_options
                 )
                 if wheel_file:

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -257,16 +257,15 @@ class WheelBuilder(object):
     def __init__(
         self,
         preparer,  # type: RequirementPreparer
-        wheel_cache,  # type: WheelCache
     ):
         # type: (...) -> None
         self.preparer = preparer
-        self.wheel_cache = wheel_cache
 
     def build(
         self,
         requirements,  # type: Iterable[InstallRequirement]
         should_unpack,  # type: bool
+        wheel_cache,  # type: WheelCache
         build_options,  # type: List[str]
         global_options,  # type: List[str]
         check_binary_allowed=None,  # type: Optional[BinaryAllowedPredicate]
@@ -286,7 +285,7 @@ class WheelBuilder(object):
 
         buildset = _collect_buildset(
             requirements,
-            wheel_cache=self.wheel_cache,
+            wheel_cache=wheel_cache,
             check_binary_allowed=check_binary_allowed,
             need_wheel=not should_unpack,
         )

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -38,6 +38,7 @@ class TestWheelCache:
             builder=builder,
             pep517_requirements=pep517_requirements,
             legacy_requirements=legacy_requirements,
+            wheel_cache=Mock(cache_dir=None),
             build_options=[],
             global_options=[],
             check_binary_allowed=None,

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -194,7 +194,12 @@ class TestWheelBuilder(object):
 
         wheel_req = Mock(is_wheel=True, editable=False, constraint=False)
         with caplog.at_level(logging.INFO):
-            wb.build([wheel_req], should_unpack=False)
+            wb.build(
+                [wheel_req],
+                should_unpack=False,
+                build_options=[],
+                global_options=[],
+            )
 
         assert "due to already being wheel" in caplog.text
         assert mock_build_one.mock_calls == []

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -186,10 +186,7 @@ def test_format_command_result__empty_output(caplog, log_level):
 class TestWheelBuilder(object):
 
     def test_skip_building_wheels(self, caplog):
-        wb = wheel_builder.WheelBuilder(
-            preparer=Mock(),
-            wheel_cache=Mock(cache_dir=None),
-        )
+        wb = wheel_builder.WheelBuilder(preparer=Mock())
         wb._build_one = mock_build_one = Mock()
 
         wheel_req = Mock(is_wheel=True, editable=False, constraint=False)
@@ -197,6 +194,7 @@ class TestWheelBuilder(object):
             wb.build(
                 [wheel_req],
                 should_unpack=False,
+                wheel_cache=Mock(cache_dir=None),
                 build_options=[],
                 global_options=[],
             )


### PR DESCRIPTION
Refactoring to move `wheel_cache`, `build_options`, `global_options` and `check_binary_allowed` from `WheelBuilder` to arguments of the `build()` method.

The only remaining one (`preparer`) will go away when the `should_unpack` code path is moved to the `install` command.

Towards build() becoming a pure function.