### PR TITLE
Ensure wheel download dir is present at the beginning of wheel command

### DIFF
--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -15,7 +15,7 @@ from pip._internal.cli.req_command import RequirementCommand
 from pip._internal.exceptions import CommandError, PreviousBuildDirError
 from pip._internal.req import RequirementSet
 from pip._internal.req.req_tracker import get_requirement_tracker
-from pip._internal.utils.misc import ensure_dir
+from pip._internal.utils.misc import ensure_dir, normalize_path
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.wheel_builder import WheelBuilder
@@ -122,6 +122,7 @@ class WheelCommand(RequirementCommand):
         build_delete = (not (options.no_clean or options.build_dir))
         wheel_cache = WheelCache(options.cache_dir, options.format_control)
 
+        options.wheel_dir = normalize_path(options.wheel_dir)
         ensure_dir(options.wheel_dir)
 
         with get_requirement_tracker() as req_tracker, TempDirectory(

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -122,6 +122,8 @@ class WheelCommand(RequirementCommand):
         build_delete = (not (options.no_clean or options.build_dir))
         wheel_cache = WheelCache(options.cache_dir, options.format_control)
 
+        ensure_dir(options.wheel_dir)
+
         with get_requirement_tracker() as req_tracker, TempDirectory(
             options.build_dir, delete=build_delete, kind="wheel"
         ) as directory:
@@ -172,7 +174,6 @@ class WheelCommand(RequirementCommand):
                     assert req.local_file_path
                     # copy from cache to target directory
                     try:
-                        ensure_dir(options.wheel_dir)
                         shutil.copy(req.local_file_path, options.wheel_dir)
                     except OSError as e:
                         logger.warning(

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -29,11 +29,7 @@ from pip._internal.exceptions import (
     UnsupportedPythonVersion,
 )
 from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import (
-    dist_in_usersite,
-    ensure_dir,
-    normalize_version_info,
-)
+from pip._internal.utils.misc import dist_in_usersite, normalize_version_info
 from pip._internal.utils.packaging import (
     check_requires_python,
     get_requires_python,
@@ -163,10 +159,6 @@ class Resolver(object):
         possible to move the preparation to become a step separated from
         dependency resolution.
         """
-        # make the wheelhouse
-        if self.preparer.wheel_download_dir:
-            ensure_dir(self.preparer.wheel_download_dir)
-
         # If any top-level requirement has a hash specified, enter
         # hash-checking mode, which requires hashes from all.
         root_reqs = (

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -35,7 +35,6 @@ from pip._internal.utils.misc import (
     backup_dir,
     display_path,
     hide_url,
-    normalize_path,
     path_to_display,
     rmtree,
 )
@@ -372,8 +371,6 @@ class RequirementPreparer(object):
         # Where still-packed .whl files should be written to. If None, they are
         # written to the download_dir parameter. Separate to download_dir to
         # permit only keeping wheel archives for pip wheel.
-        if wheel_download_dir:
-            wheel_download_dir = normalize_path(wheel_download_dir)
         self.wheel_download_dir = wheel_download_dir
 
         # NOTE


### PR DESCRIPTION
Similar to what is done in the [download](https://github.com/pypa/pip/blob/dc860e865ed54a19a4eac5f7fba5808df5e2bafb/src/pip/_internal/commands/download.py#L88-L90) command.

Following https://github.com/pypa/pip/pull/7517#discussion_r361532799