### PR TITLE
Simplify getting info directories for wheel installation

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -379,11 +379,6 @@ def install_unpacked_wheel(
                 for s in subdirs:
                     if s.endswith('.dist-info'):
                         destsubdir = os.path.join(dest, s)
-                        assert not info_dirs, (
-                            'Multiple .dist-info directories: {}, '.format(
-                                destsubdir
-                            ) + ', '.join(info_dirs)
-                        )
                         info_dirs.append(destsubdir)
                 subdirs[:] = [s for s in subdirs if not s.endswith('.data')]
             for f in files:
@@ -439,6 +434,12 @@ def install_unpacked_wheel(
 
     assert info_dirs, "{} .dist-info directory not found".format(
         req_description
+    )
+
+    assert len(info_dirs) == 1, (
+        '{} multiple .dist-info directories found: {}'.format(
+            req_description, ', '.join(info_dirs)
+        )
     )
 
     info_dir = info_dirs[0]

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -374,8 +374,6 @@ def install_unpacked_wheel(
         for dir, subdirs, files in os.walk(source):
             basedir = dir[len(source):].lstrip(os.path.sep)
             destdir = os.path.join(dest, basedir)
-            if is_base and basedir.split(os.path.sep, 1)[0].endswith('.data'):
-                continue
             if is_base and basedir == '':
                 data_dirs.extend(s for s in subdirs if s.endswith('.data'))
                 for s in subdirs:
@@ -387,6 +385,7 @@ def install_unpacked_wheel(
                             ) + ', '.join(info_dir)
                         )
                         info_dir.append(destsubdir)
+                subdirs[:] = [s for s in subdirs if not s.endswith('.data')]
             for f in files:
                 # Skip unwanted files
                 if filter and filter(f):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -378,8 +378,7 @@ def install_unpacked_wheel(
                 data_dirs.extend(s for s in subdirs if s.endswith('.data'))
                 for s in subdirs:
                     if s.endswith('.dist-info'):
-                        destsubdir = os.path.join(dest, s)
-                        info_dirs.append(destsubdir)
+                        info_dirs.append(s)
                 subdirs[:] = [s for s in subdirs if not s.endswith('.data')]
             for f in files:
                 # Skip unwanted files
@@ -444,16 +443,16 @@ def install_unpacked_wheel(
 
     info_dir = info_dirs[0]
 
-    info_dir_name = canonicalize_name(os.path.basename(info_dir))
+    info_dir_name = canonicalize_name(info_dir)
     canonical_name = canonicalize_name(name)
     if not info_dir_name.startswith(canonical_name):
         raise UnsupportedWheel(
             "{} .dist-info directory {!r} does not start with {!r}".format(
-                req_description, os.path.basename(info_dir), canonical_name
+                req_description, info_dir, canonical_name
             )
         )
 
-    dest_info_dir = info_dir
+    dest_info_dir = os.path.join(lib_dir, info_dir)
 
     # Get the defined entry points
     ep_file = os.path.join(dest_info_dir, 'entry_points.txt')

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -356,13 +356,11 @@ def install_unpacked_wheel(
         source,  # type: str
     ):
         # type: (...) -> None
-        for dir, subdirs, files in os.walk(source):
-            basedir = dir[len(source):].lstrip(os.path.sep)
-            if basedir == '':
-                data_dirs.extend(s for s in subdirs if s.endswith('.data'))
-                for s in subdirs:
-                    if s.endswith('.dist-info'):
-                        info_dirs.append(s)
+        subdirs = os.listdir(source)
+        data_dirs.extend(s for s in subdirs if s.endswith('.data'))
+        for s in subdirs:
+            if s.endswith('.dist-info'):
+                info_dirs.append(s)
 
     def record_installed(srcfile, destfile, modified=False):
         # type: (str, str, bool) -> None
@@ -437,7 +435,7 @@ def install_unpacked_wheel(
                     changed = fixer(destfile)
                 record_installed(srcfile, destfile, changed)
 
-    populate_dirs(source, True)
+    populate_dirs(source)
 
     clobber(source, lib_dir, True)
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -334,7 +334,7 @@ def install_unpacked_wheel(
 
     source = wheeldir.rstrip(os.path.sep) + os.path.sep
     subdirs = os.listdir(source)
-    info_dirs = []  # type: List[str]
+    info_dirs = [s for s in subdirs if s.endswith('.dist-info')]
     data_dirs = [s for s in subdirs if s.endswith('.data')]
 
     # Record details of the files moved
@@ -352,15 +352,6 @@ def install_unpacked_wheel(
                 warnings.filterwarnings('ignore')
                 compileall.compile_dir(source, force=True, quiet=True)
         logger.debug(stdout.getvalue())
-
-    def populate_dirs(
-        source,  # type: str
-    ):
-        # type: (...) -> None
-        subdirs = os.listdir(source)
-        for s in subdirs:
-            if s.endswith('.dist-info'):
-                info_dirs.append(s)
 
     def record_installed(srcfile, destfile, modified=False):
         # type: (str, str, bool) -> None
@@ -434,8 +425,6 @@ def install_unpacked_wheel(
                 if fixer:
                     changed = fixer(destfile)
                 record_installed(srcfile, destfile, changed)
-
-    populate_dirs(source)
 
     clobber(source, lib_dir, True)
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -377,11 +377,9 @@ def install_unpacked_wheel(
             if is_base and basedir.split(os.path.sep, 1)[0].endswith('.data'):
                 continue
             if is_base and basedir == '':
+                data_dirs.extend(s for s in subdirs if s.endswith('.data'))
                 for s in subdirs:
-                    if s.endswith('.data'):
-                        data_dirs.append(s)
-                        continue
-                    elif s.endswith('.dist-info'):
+                    if s.endswith('.dist-info'):
                         destsubdir = os.path.join(dest, basedir, s)
                         assert not info_dir, (
                             'Multiple .dist-info directories: {}, '.format(

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -354,13 +354,11 @@ def install_unpacked_wheel(
 
     def populate_dirs(
         source,  # type: str
-        dest,  # type: str
         is_base,  # type: bool
     ):
         # type: (...) -> None
         for dir, subdirs, files in os.walk(source):
             basedir = dir[len(source):].lstrip(os.path.sep)
-            destdir = os.path.join(dest, basedir)
             if is_base and basedir == '':
                 data_dirs.extend(s for s in subdirs if s.endswith('.data'))
                 for s in subdirs:
@@ -440,7 +438,7 @@ def install_unpacked_wheel(
                     changed = fixer(destfile)
                 record_installed(srcfile, destfile, changed)
 
-    populate_dirs(source, lib_dir, True)
+    populate_dirs(source, True)
 
     clobber(source, lib_dir, True)
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -453,8 +453,10 @@ def install_unpacked_wheel(
             )
         )
 
+    dest_info_dir = info_dir
+
     # Get the defined entry points
-    ep_file = os.path.join(info_dir, 'entry_points.txt')
+    ep_file = os.path.join(dest_info_dir, 'entry_points.txt')
     console, gui = get_entrypoints(ep_file)
 
     def is_entrypoint_wrapper(name):
@@ -604,16 +606,16 @@ def install_unpacked_wheel(
             logger.warning(msg)
 
     # Record pip as the installer
-    installer = os.path.join(info_dir, 'INSTALLER')
-    temp_installer = os.path.join(info_dir, 'INSTALLER.pip')
+    installer = os.path.join(dest_info_dir, 'INSTALLER')
+    temp_installer = os.path.join(dest_info_dir, 'INSTALLER.pip')
     with open(temp_installer, 'wb') as installer_file:
         installer_file.write(b'pip\n')
     shutil.move(temp_installer, installer)
     generated.append(installer)
 
     # Record details of all files installed
-    record = os.path.join(info_dir, 'RECORD')
-    temp_record = os.path.join(info_dir, 'RECORD.pip')
+    record = os.path.join(dest_info_dir, 'RECORD')
+    temp_record = os.path.join(dest_info_dir, 'RECORD.pip')
     with open_for_csv(record, 'r') as record_in:
         with open_for_csv(temp_record, 'w+') as record_out:
             reader = csv.reader(record_in)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -378,11 +378,11 @@ def install_unpacked_wheel(
                 continue
             if is_base and basedir == '':
                 for s in subdirs:
-                    destsubdir = os.path.join(dest, basedir, s)
-                    if destsubdir.endswith('.data'):
+                    if s.endswith('.data'):
                         data_dirs.append(s)
                         continue
                     elif s.endswith('.dist-info'):
+                        destsubdir = os.path.join(dest, basedir, s)
                         assert not info_dir, (
                             'Multiple .dist-info directories: {}, '.format(
                                 destsubdir

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -354,12 +354,11 @@ def install_unpacked_wheel(
 
     def populate_dirs(
         source,  # type: str
-        is_base,  # type: bool
     ):
         # type: (...) -> None
         for dir, subdirs, files in os.walk(source):
             basedir = dir[len(source):].lstrip(os.path.sep)
-            if is_base and basedir == '':
+            if basedir == '':
                 data_dirs.extend(s for s in subdirs if s.endswith('.data'))
                 for s in subdirs:
                     if s.endswith('.dist-info'):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -376,22 +376,19 @@ def install_unpacked_wheel(
             destdir = os.path.join(dest, basedir)
             if is_base and basedir.split(os.path.sep, 1)[0].endswith('.data'):
                 continue
-            for s in subdirs:
-                destsubdir = os.path.join(dest, basedir, s)
-                if is_base and basedir == '' and destsubdir.endswith('.data'):
-                    data_dirs.append(s)
-                    continue
-                elif (
-                    is_base and
-                    basedir == '' and
-                    s.endswith('.dist-info')
-                ):
-                    assert not info_dir, (
-                        'Multiple .dist-info directories: {}, '.format(
-                            destsubdir
-                        ) + ', '.join(info_dir)
-                    )
-                    info_dir.append(destsubdir)
+            if is_base and basedir == '':
+                for s in subdirs:
+                    destsubdir = os.path.join(dest, basedir, s)
+                    if destsubdir.endswith('.data'):
+                        data_dirs.append(s)
+                        continue
+                    elif s.endswith('.dist-info'):
+                        assert not info_dir, (
+                            'Multiple .dist-info directories: {}, '.format(
+                                destsubdir
+                            ) + ', '.join(info_dir)
+                        )
+                        info_dir.append(destsubdir)
             for f in files:
                 # Skip unwanted files
                 if filter and filter(f):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -332,9 +332,10 @@ def install_unpacked_wheel(
     else:
         lib_dir = scheme.platlib
 
-    info_dirs = []  # type: List[str]
-    data_dirs = []
     source = wheeldir.rstrip(os.path.sep) + os.path.sep
+    subdirs = os.listdir(source)
+    info_dirs = []  # type: List[str]
+    data_dirs = [s for s in subdirs if s.endswith('.data')]
 
     # Record details of the files moved
     #   installed = files copied from the wheel to the destination
@@ -357,7 +358,6 @@ def install_unpacked_wheel(
     ):
         # type: (...) -> None
         subdirs = os.listdir(source)
-        data_dirs.extend(s for s in subdirs if s.endswith('.data'))
         for s in subdirs:
             if s.endswith('.dist-info'):
                 info_dirs.append(s)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -352,6 +352,21 @@ def install_unpacked_wheel(
                 compileall.compile_dir(source, force=True, quiet=True)
         logger.debug(stdout.getvalue())
 
+    def populate_dirs(
+        source,  # type: str
+        dest,  # type: str
+        is_base,  # type: bool
+    ):
+        # type: (...) -> None
+        for dir, subdirs, files in os.walk(source):
+            basedir = dir[len(source):].lstrip(os.path.sep)
+            destdir = os.path.join(dest, basedir)
+            if is_base and basedir == '':
+                data_dirs.extend(s for s in subdirs if s.endswith('.data'))
+                for s in subdirs:
+                    if s.endswith('.dist-info'):
+                        info_dirs.append(s)
+
     def record_installed(srcfile, destfile, modified=False):
         # type: (str, str, bool) -> None
         """Map archive RECORD paths to installation RECORD paths."""
@@ -375,10 +390,6 @@ def install_unpacked_wheel(
             basedir = dir[len(source):].lstrip(os.path.sep)
             destdir = os.path.join(dest, basedir)
             if is_base and basedir == '':
-                data_dirs.extend(s for s in subdirs if s.endswith('.data'))
-                for s in subdirs:
-                    if s.endswith('.dist-info'):
-                        info_dirs.append(s)
                 subdirs[:] = [s for s in subdirs if not s.endswith('.data')]
             for f in files:
                 # Skip unwanted files
@@ -428,6 +439,8 @@ def install_unpacked_wheel(
                 if fixer:
                     changed = fixer(destfile)
                 record_installed(srcfile, destfile, changed)
+
+    populate_dirs(source, lib_dir, True)
 
     clobber(source, lib_dir, True)
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -380,7 +380,7 @@ def install_unpacked_wheel(
                 data_dirs.extend(s for s in subdirs if s.endswith('.data'))
                 for s in subdirs:
                     if s.endswith('.dist-info'):
-                        destsubdir = os.path.join(dest, basedir, s)
+                        destsubdir = os.path.join(dest, s)
                         assert not info_dir, (
                             'Multiple .dist-info directories: {}, '.format(
                                 destsubdir

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -451,7 +451,7 @@ def test_wheel_install_fails_with_extra_dist_info(script):
     result = script.pip(
         "install", "--no-cache-dir", "--no-index", package, expect_error=True
     )
-    assert "Multiple .dist-info directories" in result.stderr
+    assert "multiple .dist-info directories" in result.stderr
 
 
 def test_wheel_install_fails_with_unrelated_dist_info(script):


### PR DESCRIPTION
No behavior change. This separates the steps of getting the unpacked wheel info from the copying of files.

Next, we'll pull "getting wheel info" into a separate function which can be used in place of `wheel_version` and `root_is_purelib` as well as from `distributions.wheel.WheelDistribution`.