### PR TITLE
Move should_build filtering to wheel and install commands

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -52,7 +52,7 @@ if MYPY_CHECK_RUNNING:
 
     from pip._internal.models.format_control import FormatControl
     from pip._internal.req.req_install import InstallRequirement
-    from pip._internal.wheel_builder import BinaryAllowedPredicate, BuildResult
+    from pip._internal.wheel_builder import BinaryAllowedPredicate
 
 
 logger = logging.getLogger(__name__)
@@ -68,51 +68,6 @@ def is_wheel_installed():
         return False
 
     return True
-
-
-def build_wheels(
-    builder,              # type: WheelBuilder
-    pep517_requirements,  # type: List[InstallRequirement]
-    legacy_requirements,  # type: List[InstallRequirement]
-    wheel_cache,           # type: WheelCache
-    build_options,         # type: List[str]
-    global_options,        # type: List[str]
-    check_binary_allowed,  # type: BinaryAllowedPredicate
-):
-    # type: (...) -> BuildResult
-    """
-    Build wheels for requirements, depending on whether wheel is installed.
-    """
-    # We don't build wheels for legacy requirements if wheel is not installed.
-    should_build_legacy = is_wheel_installed()
-
-    # Always build PEP 517 requirements
-    pep517_build_successes, pep517_build_failures = builder.build(
-        pep517_requirements,
-        should_unpack=True,
-        wheel_cache=wheel_cache,
-        build_options=build_options,
-        global_options=global_options,
-        check_binary_allowed=check_binary_allowed,
-    )
-
-    if should_build_legacy:
-        # We don't care about failures building legacy
-        # requirements, as we'll fall through to a direct
-        # install for those.
-        legacy_build_successes, legacy_build_failures = builder.build(
-            legacy_requirements,
-            should_unpack=True,
-            wheel_cache=wheel_cache,
-            build_options=build_options,
-            global_options=global_options,
-            check_binary_allowed=check_binary_allowed,
-        )
-
-    return (
-        pep517_build_successes + legacy_build_successes,
-        pep517_build_failures + legacy_build_failures,
-    )
 
 
 def get_check_binary_allowed(format_control):

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -44,10 +44,7 @@ from pip._internal.utils.misc import (
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.virtualenv import virtualenv_no_global
-from pip._internal.wheel_builder import (
-    WheelBuilder,
-    should_build_for_install_command,
-)
+from pip._internal.wheel_builder import build, should_build_for_install_command
 
 if MYPY_CHECK_RUNNING:
     from optparse import Values
@@ -356,8 +353,7 @@ class InstallCommand(RequirementCommand):
                     )
                 ]
 
-                wheel_builder = WheelBuilder(preparer)
-                _, build_failures = wheel_builder.build(
+                _, build_failures = build(
                     reqs_to_build,
                     should_unpack=True,
                     wheel_cache=wheel_cache,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -355,7 +355,6 @@ class InstallCommand(RequirementCommand):
 
                 _, build_failures = build(
                     reqs_to_build,
-                    should_unpack=True,
                     wheel_cache=wheel_cache,
                     build_options=[],
                     global_options=[],

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -38,6 +38,7 @@ from pip._internal.utils.filesystem import test_writable_dir
 from pip._internal.utils.misc import (
     ensure_dir,
     get_installed_version,
+    is_wheel_installed,
     protect_pip_from_modification_on_windows,
     write_output,
 )
@@ -56,18 +57,6 @@ if MYPY_CHECK_RUNNING:
 
 
 logger = logging.getLogger(__name__)
-
-
-def is_wheel_installed():
-    """
-    Return whether the wheel package is installed.
-    """
-    try:
-        import wheel  # noqa: F401
-    except ImportError:
-        return False
-
-    return True
 
 
 def get_check_binary_allowed(format_control):

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -168,7 +168,6 @@ class WheelCommand(RequirementCommand):
                 # build wheels
                 build_successes, build_failures = build(
                     reqs_to_build,
-                    should_unpack=False,
                     wheel_cache=wheel_cache,
                     build_options=options.build_options or [],
                     global_options=options.global_options or [],

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -18,10 +18,7 @@ from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.misc import ensure_dir, normalize_path
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.wheel_builder import (
-    WheelBuilder,
-    should_build_for_wheel_command,
-)
+from pip._internal.wheel_builder import build, should_build_for_wheel_command
 
 if MYPY_CHECK_RUNNING:
     from optparse import Values
@@ -169,8 +166,7 @@ class WheelCommand(RequirementCommand):
                 ]
 
                 # build wheels
-                wb = WheelBuilder(preparer)
-                build_successes, build_failures = wb.build(
+                build_successes, build_failures = build(
                     reqs_to_build,
                     should_unpack=False,
                     wheel_cache=wheel_cache,

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -18,7 +18,10 @@ from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.misc import ensure_dir, normalize_path
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.wheel_builder import WheelBuilder
+from pip._internal.wheel_builder import (
+    WheelBuilder,
+    should_build_for_wheel_command,
+)
 
 if MYPY_CHECK_RUNNING:
     from optparse import Values
@@ -160,10 +163,15 @@ class WheelCommand(RequirementCommand):
 
                 resolver.resolve(requirement_set)
 
+                reqs_to_build = [
+                    r for r in requirement_set.requirements.values()
+                    if should_build_for_wheel_command(r)
+                ]
+
                 # build wheels
                 wb = WheelBuilder(preparer)
                 build_successes, build_failures = wb.build(
-                    requirement_set.requirements.values(),
+                    reqs_to_build,
                     should_unpack=False,
                     wheel_cache=wheel_cache,
                     build_options=options.build_options or [],

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -878,3 +878,15 @@ def hash_file(path, blocksize=1 << 20):
             length += len(block)
             h.update(block)
     return h, length
+
+
+def is_wheel_installed():
+    """
+    Return whether the wheel package is installed.
+    """
+    try:
+        import wheel  # noqa: F401
+    except ImportError:
+        return False
+
+    return True

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -48,7 +48,7 @@ def _contains_egg_info(
     return bool(_egg_info_re.search(s))
 
 
-def should_build(
+def _should_build(
     req,  # type: InstallRequirement
     need_wheel,  # type: bool
     check_binary_allowed,  # type: BinaryAllowedPredicate
@@ -93,7 +93,7 @@ def should_build_for_wheel_command(
     req,  # type: InstallRequirement
 ):
     # type: (...) -> bool
-    return should_build(
+    return _should_build(
         req, need_wheel=True, check_binary_allowed=_always_true
     )
 
@@ -103,19 +103,19 @@ def should_build_for_install_command(
     check_binary_allowed,  # type: BinaryAllowedPredicate
 ):
     # type: (...) -> bool
-    return should_build(
+    return _should_build(
         req, need_wheel=False, check_binary_allowed=check_binary_allowed
     )
 
 
-def should_cache(
+def _should_cache(
     req,  # type: InstallRequirement
     check_binary_allowed,  # type: BinaryAllowedPredicate
 ):
     # type: (...) -> Optional[bool]
     """
     Return whether a built InstallRequirement can be stored in the persistent
-    wheel cache, assuming the wheel cache is available, and should_build()
+    wheel cache, assuming the wheel cache is available, and _should_build()
     has determined a wheel needs to be built.
     """
     if not should_build_for_install_command(
@@ -156,7 +156,7 @@ def _get_cache_dir(
     cache_available = bool(wheel_cache.cache_dir)
     if (
         cache_available and
-        should_cache(req, check_binary_allowed)
+        _should_cache(req, check_binary_allowed)
     ):
         cache_dir = wheel_cache.get_path_for_link(req.link)
     else:

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -82,6 +82,25 @@ def should_build(
     return True
 
 
+def should_build_for_wheel_command(
+    req,  # type: InstallRequirement
+):
+    # type: (...) -> Optional[bool]
+    return should_build(
+        req, need_wheel=True, check_binary_allowed=_always_true
+    )
+
+
+def should_build_for_install_command(
+    req,  # type: InstallRequirement
+    check_binary_allowed,  # type: BinaryAllowedPredicate
+):
+    # type: (...) -> Optional[bool]
+    return should_build(
+        req, need_wheel=False, check_binary_allowed=check_binary_allowed
+    )
+
+
 def should_cache(
     req,  # type: InstallRequirement
     check_binary_allowed,  # type: BinaryAllowedPredicate

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -260,7 +260,6 @@ def _clean_one_legacy(req, global_options):
 
 def build(
     requirements,  # type: Iterable[InstallRequirement]
-    should_unpack,  # type: bool
     wheel_cache,  # type: WheelCache
     build_options,  # type: List[str]
     global_options,  # type: List[str]
@@ -269,9 +268,6 @@ def build(
     # type: (...) -> BuildResult
     """Build wheels.
 
-    :param should_unpack: If True, after building the wheel, unpack it
-        and replace the sdist with the unpacked version in preparation
-        for installation.
     :return: The list of InstallRequirement that succeeded to build and
         the list of InstallRequirement that failed to build.
     """
@@ -281,9 +277,6 @@ def build(
 
     if not requirements:
         return [], []
-
-    # TODO by @pradyunsg
-    # Should break up this method into 2 separate methods.
 
     # Build the wheels.
     logger.info(

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -53,7 +53,7 @@ def should_build(
     need_wheel,  # type: bool
     check_binary_allowed,  # type: BinaryAllowedPredicate
 ):
-    # type: (...) -> Optional[bool]
+    # type: (...) -> bool
     """Return whether an InstallRequirement should be built into a wheel."""
     if req.constraint:
         # never build requirements that are merely constraints
@@ -92,7 +92,7 @@ def should_build(
 def should_build_for_wheel_command(
     req,  # type: InstallRequirement
 ):
-    # type: (...) -> Optional[bool]
+    # type: (...) -> bool
     return should_build(
         req, need_wheel=True, check_binary_allowed=_always_true
     )
@@ -102,7 +102,7 @@ def should_build_for_install_command(
     req,  # type: InstallRequirement
     check_binary_allowed,  # type: BinaryAllowedPredicate
 ):
-    # type: (...) -> Optional[bool]
+    # type: (...) -> bool
     return should_build(
         req, need_wheel=False, check_binary_allowed=check_binary_allowed
     )

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -118,17 +118,16 @@ def should_cache(
     wheel cache, assuming the wheel cache is available, and should_build()
     has determined a wheel needs to be built.
     """
-    if not should_build(
-        req, need_wheel=False, check_binary_allowed=check_binary_allowed
+    if not should_build_for_install_command(
+        req, check_binary_allowed=check_binary_allowed
     ):
-        # never cache if pip install (need_wheel=False) would not have built
+        # never cache if pip install would not have built
         # (editable mode, etc)
         return False
 
     if req.link and req.link.is_vcs:
-        # VCS checkout. Build wheel just for this run
-        # unless it points to an immutable commit hash in which
-        # case it can be cached.
+        # VCS checkout. Do not cache
+        # unless it points to an immutable commit hash.
         assert not req.editable
         assert req.source_dir
         vcs_backend = vcs.get_backend_for_scheme(req.link.scheme)
@@ -137,14 +136,11 @@ def should_cache(
             return True
         return False
 
-    link = req.link
-    base, ext = link.splitext()
+    base, ext = req.link.splitext()
     if _contains_egg_info(base):
         return True
 
-    # Otherwise, build the wheel just for this run using the ephemeral
-    # cache since we are either in the case of e.g. a local directory, or
-    # no cache directory is available to use.
+    # Otherwise, do not cache.
     return False
 
 

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -13,7 +13,7 @@ from pip._internal.models.link import Link
 from pip._internal.operations.build.wheel import build_wheel_pep517
 from pip._internal.operations.build.wheel_legacy import build_wheel_legacy
 from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import ensure_dir, hash_file
+from pip._internal.utils.misc import ensure_dir, hash_file, is_wheel_installed
 from pip._internal.utils.setuptools_build import make_setuptools_clean_args
 from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory
@@ -68,6 +68,13 @@ def should_build(
     if need_wheel:
         # i.e. pip wheel, not pip install
         return True
+
+    # From this point, this concerns the pip install command only
+    # (need_wheel=False).
+
+    if not req.use_pep517 and not is_wheel_installed():
+        # we don't build legacy requirements if wheel is not installed
+        return False
 
     if req.editable or not req.source_dir:
         return False

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -152,22 +152,15 @@ def _collect_buildset(
     requirements,  # type: Iterable[InstallRequirement]
     wheel_cache,  # type: WheelCache
     check_binary_allowed,  # type: BinaryAllowedPredicate
-    need_wheel,  # type: bool
 ):
     # type: (...) -> List[Tuple[InstallRequirement, str]]
-    """Return the list of InstallRequirement that need to be built,
+    """Return the list of InstallRequirement,
     with the persistent or temporary cache directory where the built
     wheel needs to be stored.
     """
     buildset = []
     cache_available = bool(wheel_cache.cache_dir)
     for req in requirements:
-        if not should_build(
-            req,
-            need_wheel=need_wheel,
-            check_binary_allowed=check_binary_allowed,
-        ):
-            continue
         if (
             cache_available and
             should_cache(req, check_binary_allowed)
@@ -312,7 +305,6 @@ class WheelBuilder(object):
             requirements,
             wheel_cache=wheel_cache,
             check_binary_allowed=check_binary_allowed,
-            need_wheel=not should_unpack,
         )
         if not buildset:
             return [], []

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -1,79 +1,16 @@
 import errno
 
 import pytest
-from mock import Mock, patch
+from mock import patch
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.commands.install import (
-    build_wheels,
     create_env_error_message,
     decide_user_install,
     warn_deprecated_install_options,
 )
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.req.req_set import RequirementSet
-
-
-class TestWheelCache:
-
-    def check_build_wheels(
-        self,
-        pep517_requirements,
-        legacy_requirements,
-    ):
-        """
-        Return: (mock_calls, return_value).
-        """
-        built_reqs = []
-
-        def build(reqs, **kwargs):
-            # Fail the first requirement.
-            built_reqs.append(reqs)
-            return ([], [reqs[0]])
-
-        builder = Mock()
-        builder.build.side_effect = build
-
-        build_failures = build_wheels(
-            builder=builder,
-            pep517_requirements=pep517_requirements,
-            legacy_requirements=legacy_requirements,
-            wheel_cache=Mock(cache_dir=None),
-            build_options=[],
-            global_options=[],
-            check_binary_allowed=None,
-        )
-
-        return (built_reqs, build_failures)
-
-    @patch('pip._internal.commands.install.is_wheel_installed')
-    def test_build_wheels__wheel_installed(self, is_wheel_installed):
-        is_wheel_installed.return_value = True
-
-        built_reqs, build_failures = self.check_build_wheels(
-            pep517_requirements=['a', 'b'],
-            legacy_requirements=['c', 'd'],
-        )
-
-        # Legacy requirements were built.
-        assert built_reqs == [['a', 'b'], ['c', 'd']]
-
-        # Legacy build failures are not included in the return value.
-        assert build_failures == ['a']
-
-    @patch('pip._internal.commands.install.is_wheel_installed')
-    def test_build_wheels__wheel_not_installed(self, is_wheel_installed):
-        is_wheel_installed.return_value = False
-
-        built_reqs, build_failures = self.check_build_wheels(
-            pep517_requirements=['a', 'b'],
-            legacy_requirements=['c', 'd'],
-        )
-
-        # Legacy requirements were not built.
-        assert built_reqs == [['a', 'b']]
-
-        assert build_failures == ['a']
 
 
 class TestDecideUserInstall:

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -77,7 +77,7 @@ class ReqMock:
     ],
 )
 def test_should_build(req, need_wheel, disallow_binaries, expected):
-    should_build = wheel_builder.should_build(
+    should_build = wheel_builder._should_build(
         req,
         need_wheel,
         check_binary_allowed=lambda req: not disallow_binaries,
@@ -89,7 +89,7 @@ def test_should_build(req, need_wheel, disallow_binaries, expected):
 def test_should_build_legacy_wheel_not_installed(is_wheel_installed):
     is_wheel_installed.return_value = False
     legacy_req = ReqMock(use_pep517=False)
-    should_build = wheel_builder.should_build(
+    should_build = wheel_builder._should_build(
         legacy_req,
         need_wheel=False,
         check_binary_allowed=lambda req: True,
@@ -101,7 +101,7 @@ def test_should_build_legacy_wheel_not_installed(is_wheel_installed):
 def test_should_build_legacy_wheel_installed(is_wheel_installed):
     is_wheel_installed.return_value = True
     legacy_req = ReqMock(use_pep517=False)
-    should_build = wheel_builder.should_build(
+    should_build = wheel_builder._should_build(
         legacy_req,
         need_wheel=False,
         check_binary_allowed=lambda req: True,
@@ -130,10 +130,10 @@ def test_should_cache(
     def check_binary_allowed(req):
         return not disallow_binaries
 
-    should_cache = wheel_builder.should_cache(
+    should_cache = wheel_builder._should_cache(
         req, check_binary_allowed
     )
-    if not wheel_builder.should_build(
+    if not wheel_builder._should_build(
         req, need_wheel=False, check_binary_allowed=check_binary_allowed
     ):
         # never cache if pip install (need_wheel=False) would not have built)
@@ -150,14 +150,14 @@ def test_should_cache_git_sha(script, tmpdir):
     # a link referencing a sha should be cached
     url = "git+https://g.c/o/r@" + commit + "#egg=mypkg"
     req = ReqMock(link=Link(url), source_dir=repo_path)
-    assert wheel_builder.should_cache(
+    assert wheel_builder._should_cache(
         req, check_binary_allowed=lambda r: True,
     )
 
     # a link not referencing a sha should not be cached
     url = "git+https://g.c/o/r@master#egg=mypkg"
     req = ReqMock(link=Link(url), source_dir=repo_path)
-    assert not wheel_builder.should_cache(
+    assert not wheel_builder._should_cache(
         req, check_binary_allowed=lambda r: True,
     )
 

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from mock import Mock, patch
+from mock import patch
 
 from pip._internal import wheel_builder
 from pip._internal.models.link import Link
@@ -207,23 +207,3 @@ def test_format_command_result__empty_output(caplog, log_level):
         "Command arguments: arg1 arg2",
         'Command output: None',
     ]
-
-
-class TestWheelBuilder(object):
-
-    def test_skip_building_wheels(self, caplog):
-        wb = wheel_builder.WheelBuilder(preparer=Mock())
-        wb._build_one = mock_build_one = Mock()
-
-        wheel_req = Mock(is_wheel=True, editable=False, constraint=False)
-        with caplog.at_level(logging.INFO):
-            wb.build(
-                [wheel_req],
-                should_unpack=False,
-                wheel_cache=Mock(cache_dir=None),
-                build_options=[],
-                global_options=[],
-            )
-
-        assert "due to already being wheel" in caplog.text
-        assert mock_build_one.mock_calls == []

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from mock import Mock
+from mock import Mock, patch
 
 from pip._internal import wheel_builder
 from pip._internal.models.link import Link
@@ -39,6 +39,7 @@ class ReqMock:
         link=None,
         constraint=False,
         source_dir="/tmp/pip-install-123/pendulum",
+        use_pep517=True,
     ):
         self.name = name
         self.is_wheel = is_wheel
@@ -46,6 +47,7 @@ class ReqMock:
         self.link = link
         self.constraint = constraint
         self.source_dir = source_dir
+        self.use_pep517 = use_pep517
 
 
 @pytest.mark.parametrize(
@@ -81,6 +83,30 @@ def test_should_build(req, need_wheel, disallow_binaries, expected):
         check_binary_allowed=lambda req: not disallow_binaries,
     )
     assert should_build is expected
+
+
+@patch("pip._internal.wheel_builder.is_wheel_installed")
+def test_should_build_legacy_wheel_not_installed(is_wheel_installed):
+    is_wheel_installed.return_value = False
+    legacy_req = ReqMock(use_pep517=False)
+    should_build = wheel_builder.should_build(
+        legacy_req,
+        need_wheel=False,
+        check_binary_allowed=lambda req: True,
+    )
+    assert not should_build
+
+
+@patch("pip._internal.wheel_builder.is_wheel_installed")
+def test_should_build_legacy_wheel_installed(is_wheel_installed):
+    is_wheel_installed.return_value = True
+    legacy_req = ReqMock(use_pep517=False)
+    should_build = wheel_builder.should_build(
+        legacy_req,
+        need_wheel=False,
+        check_binary_allowed=lambda req: True,
+    )
+    assert should_build
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This follows the path started in #7514, and in particular https://github.com/pypa/pip/pull/7514#issuecomment-569116677. In a nutshell, it moves the `should_build` decision out of the `build` function to `wheel` and `install` commands, further reducing the responsibility of `build` to, well, building.