### PR TITLE
Make WHEEL file errors more explicit

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -681,9 +681,12 @@ def wheel_version(source_dir):
     except UnicodeDecodeError as e:
         raise UnsupportedWheel("error decoding WHEEL: {!r}".format(e))
 
-    try:
-        wheel_data = Parser().parsestr(wheel_text)
+    # FeedParser (used by Parser) does not raise any exceptions. The returned
+    # message may have .defects populated, but for backwards-compatibility we
+    # currently ignore them.
+    wheel_data = Parser().parsestr(wheel_text)
 
+    try:
         version = wheel_data['Wheel-Version'].strip()
         version = tuple(map(int, version.split('.')))
         return version

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -692,8 +692,7 @@ def wheel_version(source_dir):
     version = version_text.strip()
 
     try:
-        version = tuple(map(int, version.split('.')))
-        return version
+        return tuple(map(int, version.split('.')))
     except ValueError:
         raise UnsupportedWheel("invalid Wheel-Version: {!r}".format(version))
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -687,7 +687,8 @@ def wheel_version(source_dir):
     wheel_data = Parser().parsestr(wheel_text)
 
     try:
-        version = wheel_data['Wheel-Version'].strip()
+        version_text = wheel_data["Wheel-Version"]
+        version = version_text.strip()
         version = tuple(map(int, version.split('.')))
         return version
     except Exception:

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -675,8 +675,8 @@ def wheel_version(source_dir):
     dist = dists[0]
 
     try:
-        wheel_data = dist.get_metadata('WHEEL')
-        wheel_data = Parser().parsestr(wheel_data)
+        wheel_text = dist.get_metadata('WHEEL')
+        wheel_data = Parser().parsestr(wheel_text)
 
         version = wheel_data['Wheel-Version'].strip()
         version = tuple(map(int, version.split('.')))

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -686,8 +686,11 @@ def wheel_version(source_dir):
     # currently ignore them.
     wheel_data = Parser().parsestr(wheel_text)
 
+    version_text = wheel_data["Wheel-Version"]
+    if version_text is None:
+        raise UnsupportedWheel("WHEEL is missing Wheel-Version")
+
     try:
-        version_text = wheel_data["Wheel-Version"]
         version = version_text.strip()
         version = tuple(map(int, version.split('.')))
         return version

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -690,8 +690,9 @@ def wheel_version(source_dir):
     if version_text is None:
         raise UnsupportedWheel("WHEEL is missing Wheel-Version")
 
+    version = version_text.strip()
+
     try:
-        version = version_text.strip()
         version = tuple(map(int, version.split('.')))
         return version
     except Exception:

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -656,7 +656,8 @@ def wheel_version(source_dir):
     Otherwise, return None if we couldn't parse / extract it.
     """
     try:
-        dist = [d for d in pkg_resources.find_on_path(None, source_dir)][0]
+        dists = [d for d in pkg_resources.find_on_path(None, source_dir)]
+        dist = dists[0]
 
         wheel_data = dist.get_metadata('WHEEL')
         wheel_data = Parser().parsestr(wheel_data)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -698,7 +698,7 @@ def wheel_version(source_dir):
 
 
 def check_compatibility(version, name):
-    # type: (Optional[Tuple[int, ...]], str) -> None
+    # type: (Tuple[int, ...], str) -> None
     """Raises errors or warns if called with an incompatible Wheel-Version.
 
     Pip should refuse to install a Wheel-Version that's a major series
@@ -710,10 +710,6 @@ def check_compatibility(version, name):
 
     :raises UnsupportedWheel: when an incompatible Wheel-Version is given
     """
-    if not version:
-        raise UnsupportedWheel(
-            "%s is in an unsupported or invalid wheel" % name
-        )
     if version[0] > VERSION_COMPATIBLE[0]:
         raise UnsupportedWheel(
             "%s's Wheel-Version (%s) is not compatible with this version "

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -657,10 +657,9 @@ def install_wheel(
 
 
 def wheel_version(source_dir):
-    # type: (Optional[str]) -> Optional[Tuple[int, ...]]
+    # type: (Optional[str]) -> Tuple[int, ...]
     """Return the Wheel-Version of an extracted wheel, if possible.
-    Otherwise, return None or raise UnsupportedWheel if we couldn't
-    parse / extract it.
+    Otherwise, raise UnsupportedWheel if we couldn't parse / extract it.
     """
     try:
         dists = [d for d in pkg_resources.find_on_path(None, source_dir)]
@@ -695,8 +694,8 @@ def wheel_version(source_dir):
     try:
         version = tuple(map(int, version.split('.')))
         return version
-    except Exception:
-        return None
+    except ValueError:
+        raise UnsupportedWheel("invalid Wheel-Version: {!r}".format(version))
 
 
 def check_compatibility(version, name):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -678,8 +678,8 @@ def wheel_version(source_dir):
         wheel_text = dist.get_metadata('WHEEL')
     except (IOError, OSError) as e:
         raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))
-    except Exception:
-        return None
+    except UnicodeDecodeError as e:
+        raise UnsupportedWheel("error decoding WHEEL: {!r}".format(e))
 
     try:
         wheel_data = Parser().parsestr(wheel_text)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -676,6 +676,12 @@ def wheel_version(source_dir):
 
     try:
         wheel_text = dist.get_metadata('WHEEL')
+    except (IOError, OSError) as e:
+        raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))
+    except Exception:
+        return None
+
+    try:
         wheel_data = Parser().parsestr(wheel_text)
 
         version = wheel_data['Wheel-Version'].strip()

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -669,9 +669,12 @@ def wheel_version(source_dir):
             "could not find a contained distribution due to: {!r}".format(e)
         )
 
-    try:
-        dist = dists[0]
+    if not dists:
+        raise UnsupportedWheel("no contained distribution found")
 
+    dist = dists[0]
+
+    try:
         wheel_data = dist.get_metadata('WHEEL')
         wheel_data = Parser().parsestr(wheel_data)
 

--- a/tests/lib/path.py
+++ b/tests/lib/path.py
@@ -183,6 +183,11 @@ class Path(_base):
         with open(self, "rb") as fp:
             return fp.read()
 
+    def write_bytes(self, content):
+        # type: (bytes) -> None
+        with open(self, "wb") as f:
+            f.write(content)
+
     def read_text(self):
         with open(self, "r") as fp:
             return fp.read()

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -192,14 +192,11 @@ def test_get_csv_rows_for_installed__long_lines(tmpdir, caplog):
 
 def test_wheel_version(tmpdir, data):
     future_wheel = 'futurewheel-1.9-py2.py3-none-any.whl'
-    broken_wheel = 'brokenwheel-1.0-py2.py3-none-any.whl'
     future_version = (1, 9)
 
     unpack_file(data.packages.joinpath(future_wheel), tmpdir + 'future')
-    unpack_file(data.packages.joinpath(broken_wheel), tmpdir + 'broken')
 
     assert wheel.wheel_version(tmpdir + 'future') == future_version
-    assert not wheel.wheel_version(tmpdir + 'broken')
 
 
 def test_wheel_version_fails_on_error(monkeypatch):
@@ -214,6 +211,16 @@ def test_wheel_version_fails_no_dists(tmpdir):
     with pytest.raises(UnsupportedWheel) as e:
         wheel.wheel_version(str(tmpdir))
     assert "no contained distribution found" in str(e.value)
+
+
+def test_wheel_version_fails_missing_wheel(tmpdir):
+    dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
+    dist_info_dir.mkdir()
+    dist_info_dir.joinpath("METADATA").touch()
+
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_version(str(tmpdir))
+    assert "could not read WHEEL file" in str(e.value)
 
 
 def test_check_compatibility():

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -210,6 +210,12 @@ def test_wheel_version_fails_on_error(monkeypatch):
     assert repr(err) in str(e.value)
 
 
+def test_wheel_version_fails_no_dists(tmpdir):
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_version(str(tmpdir))
+    assert "no contained distribution found" in str(e.value)
+
+
 def test_check_compatibility():
     name = 'test'
     vc = wheel.VERSION_COMPATIBLE

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -246,6 +246,24 @@ def test_wheel_version_fails_on_no_wheel_version(tmpdir):
     assert "missing Wheel-Version" in str(e.value)
 
 
+@pytest.mark.parametrize("version", [
+    ("",),
+    ("1.b",),
+    ("1.",),
+])
+def test_wheel_version_fails_on_bad_wheel_version(tmpdir, version):
+    dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
+    dist_info_dir.mkdir()
+    dist_info_dir.joinpath("METADATA").touch()
+    dist_info_dir.joinpath("WHEEL").write_text(
+        "Wheel-Version: {}".format(version)
+    )
+
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_version(str(tmpdir))
+    assert "invalid Wheel-Version" in str(e.value)
+
+
 def test_check_compatibility():
     name = 'test'
     vc = wheel.VERSION_COMPATIBLE

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -5,7 +5,8 @@ import os
 import textwrap
 
 import pytest
-from mock import patch
+from mock import Mock, patch
+from pip._vendor import pkg_resources
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.exceptions import UnsupportedWheel
@@ -199,6 +200,14 @@ def test_wheel_version(tmpdir, data):
 
     assert wheel.wheel_version(tmpdir + 'future') == future_version
     assert not wheel.wheel_version(tmpdir + 'broken')
+
+
+def test_wheel_version_fails_on_error(monkeypatch):
+    err = RuntimeError("example")
+    monkeypatch.setattr(pkg_resources, "find_on_path", Mock(side_effect=err))
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_version(".")
+    assert repr(err) in str(e.value)
 
 
 def test_check_compatibility():

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -235,6 +235,17 @@ def test_wheel_version_fails_on_bad_encoding(tmpdir):
     assert "error decoding WHEEL" in str(e.value)
 
 
+def test_wheel_version_fails_on_no_wheel_version(tmpdir):
+    dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
+    dist_info_dir.mkdir()
+    dist_info_dir.joinpath("METADATA").touch()
+    dist_info_dir.joinpath("WHEEL").touch()
+
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_version(str(tmpdir))
+    assert "missing Wheel-Version" in str(e.value)
+
+
 def test_check_compatibility():
     name = 'test'
     vc = wheel.VERSION_COMPATIBLE


### PR DESCRIPTION
Removes an `except Exception` that was glossing over what could actually go wrong during parsing and extraction of `Wheel-Version` from the `WHEEL` metadata file. We should be able to transition this code much more easily to direct parsing of `WHEEL` (instead of using `pkg_resources`) and re-purpose it for reading from a zipfile directly.

The only change in behavior is an improvement in our error messages.