### PR TITLE
Use sys.executable to format upgrade message

### DIFF
--- a/news/7376.feature
+++ b/news/7376.feature
@@ -1,0 +1,2 @@
+Suggest a more robust command to upgrade pip itself to avoid confusion when the
+current pip command is not available as ``pip``.

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -18,7 +18,6 @@ from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.search_scope import SearchScope
 from pip._internal.models.selection_prefs import SelectionPreferences
-from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.filesystem import (
     adjacent_tmp_file,
     check_path_owner,
@@ -225,12 +224,11 @@ def pip_self_version_check(session, options):
         if not local_version_is_older:
             return
 
-        # Advise "python -m pip" on Windows to avoid issues
-        # with overwriting pip.exe.
-        if WINDOWS:
-            pip_cmd = "python -m pip"
-        else:
-            pip_cmd = "pip"
+        # We cannot tell how the current pip is available in the current
+        # command context, so be pragmatic here and suggest the command
+        # that's always available. This doea not accomodate spaces in
+        # `sys.executable`.
+        pip_cmd = "{} -m pip".format(sys.executable)
         logger.warning(
             "You are using pip version %s; however, version %s is "
             "available.\nYou should consider upgrading via the "

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -226,7 +226,7 @@ def pip_self_version_check(session, options):
 
         # We cannot tell how the current pip is available in the current
         # command context, so be pragmatic here and suggest the command
-        # that's always available. This doea not accomodate spaces in
+        # that's always available. This does not accommodate spaces in
         # `sys.executable`.
         pip_cmd = "{} -m pip".format(sys.executable)
         logger.warning(


### PR DESCRIPTION
Fix #7376.

Note this still fails if `sys.executable` contains space. This is really  difficult to fix because `shlex.quote()` does not work on Windows, and is not available in Python 2.7 anyway. But various parts of ecosystem also do not work well with a prefix with space, so this is probably not the most significant problem.

There are a couple of potential improvements available:

* Maybe use `sys.argv[0]` on non-Windows?
* Manually look through `PATH` and prettify to value? (Say if `sys.executable` is `/usr/local/bin/python3.7` and `PATH` has `/usr/local/bin` we can kind of safely suggest `python3.7`).