### PR TITLE
Fix temporary backup files cleanup on windows

### DIFF
--- a/news/2863.bugfix
+++ b/news/2863.bugfix
@@ -1,0 +1,5 @@
+Handle permission access errors from FILE_SHARE_DELETE sharing violation on
+windows when upgrading an in-use .exe, .dll file.
+
+Move such files to a .pip-trash directory and schedule delete on next reboot
+if possible.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -187,7 +187,8 @@ def rmtree_errorhandler(func, path, exc_info, **kwargs):
 
     if sys.platform == "win32" and isinstance(exc_val, OSError) \
             and exc_val.errno == errno.EACCES \
-            and func == os.unlink and trashdir is not None:
+            and (func == os.unlink or func == os.remove) \
+            and trashdir is not None:
         # On win32 a loaded .exe, .dll, ... cannot be unlinked, but it can be
         # renamed and scheduled for removal at next reboot. Move and rename to
         # a unique filename in `trashdir` (must be on the same volume as

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -194,9 +194,16 @@ class TempDirectory(object):
         """
         self._deleted = True
         if os.path.exists(self._path):
+            dname, basename = os.path.split(self._path)
+            # use a trash dir next to `_path`, do not create it yet though,
+            # the rmtree will create it if necessary,
+            trashdir = os.path.join(dname, ".pip-trash")
             # Make sure to pass unicode on Python 2 to make the contents also
             # use unicode, ensuring non-ASCII names and can be represented.
-            rmtree(ensure_text(self._path))
+            rmtree(ensure_text(self._path), trashdir=ensure_text(trashdir))
+            if os.path.isdir(trashdir):
+                # clean trash that might be removable now (from previous runs)
+                rmtree(ensure_text(trashdir), ignore_errors=True)
 
 
 class AdjacentTempDirectory(TempDirectory):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Fixes gh-2863

Handle permission access errors from FILE_SHARE_DELETE sharing violation
by moving such file to a .pip-trash directory and schedule delete on
next reboot if possible.

This could also allow in-place pip upgrade on windows (gh-1299) if the `protect_pip_from_modification_on_windows` is removed.

