### PR TITLE
Remove redundant expanduser for download_dir in preparer

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -25,7 +25,6 @@ from pip._internal.exceptions import (
     PreviousBuildDirError,
     VcsHashUnsupported,
 )
-from pip._internal.utils.compat import expanduser
 from pip._internal.utils.filesystem import copy2_fixed
 from pip._internal.utils.hashes import MissingHashes
 from pip._internal.utils.logging import indent_log
@@ -364,8 +363,6 @@ class RequirementPreparer(object):
 
         # Where still-packed archives should be written to. If None, they are
         # not saved, and are deleted immediately after unpacking.
-        if download_dir:
-            download_dir = expanduser(download_dir)
         self.download_dir = download_dir
 
         # Where still-packed .whl files should be written to. If None, they are


### PR DESCRIPTION
Following from https://github.com/pypa/pip/pull/7524#issuecomment-569837883

Since
- the `download_dir` preparer attribute is only set by the download command
- `download_dir` is normalized at the beginning of the download command
- `normalize_path` includes `expanduser`

Therefore expanduser in the preparer is redundant
