### PR TITLE
Refactor wheel info extraction during install

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -117,6 +117,11 @@ def root_is_purelib(name, wheeldir):
     return False
 
 
+def wheel_root_is_purelib(metadata):
+    # type: (Message) -> bool
+    return metadata.get("Root-Is-Purelib", "").lower() == "true"
+
+
 def get_entrypoints(filename):
     # type: (str) -> Tuple[Dict[str, str], Dict[str, str]]
     if not os.path.exists(filename):
@@ -360,7 +365,7 @@ def install_unpacked_wheel(
 
     check_compatibility(version, name)
 
-    if root_is_purelib(name, wheeldir):
+    if wheel_root_is_purelib(metadata):
         lib_dir = scheme.purelib
     else:
         lib_dir = scheme.platlib

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -315,7 +315,7 @@ def install_unpacked_wheel(
 
     try:
         info_dir = wheel_dist_info_dir(source, name)
-        metadata = wheel_metadata(wheeldir)
+        metadata = wheel_metadata(source, info_dir)
         version = wheel_version(metadata)
     except UnsupportedWheel as e:
         raise UnsupportedWheel(
@@ -658,27 +658,13 @@ def wheel_dist_info_dir(source, name):
     return info_dir
 
 
-def wheel_metadata(source_dir):
-    # type: (Optional[str]) -> Message
+def wheel_metadata(source, dist_info_dir):
+    # type: (str, str) -> Message
     """Return the WHEEL metadata of an extracted wheel, if possible.
     Otherwise, raise UnsupportedWheel.
     """
     try:
-        dists = [d for d in pkg_resources.find_on_path(None, source_dir)]
-    except Exception as e:
-        raise UnsupportedWheel(
-            "could not find a contained distribution due to: {!r}".format(e)
-        )
-
-    if not dists:
-        raise UnsupportedWheel("no contained distribution found")
-
-    dist = dists[0]
-
-    dist_info_dir = os.path.basename(dist.egg_info)
-
-    try:
-        with open(os.path.join(source_dir, dist_info_dir, "WHEEL"), "rb") as f:
+        with open(os.path.join(source, dist_info_dir, "WHEEL"), "rb") as f:
             wheel_text = ensure_str(f.read())
     except (IOError, OSError) as e:
         raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -23,7 +23,7 @@ from pip._vendor import pkg_resources
 from pip._vendor.distlib.scripts import ScriptMaker
 from pip._vendor.distlib.util import get_export_entry
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.six import StringIO
+from pip._vendor.six import StringIO, ensure_str
 
 from pip._internal.exceptions import InstallationError, UnsupportedWheel
 from pip._internal.locations import get_major_minor_version
@@ -662,8 +662,11 @@ def wheel_metadata(source_dir):
 
     dist = dists[0]
 
+    dist_info_dir = os.path.basename(dist.egg_info)
+
     try:
-        wheel_text = dist.get_metadata('WHEEL')
+        with open(os.path.join(source_dir, dist_info_dir, "WHEEL"), "rb") as f:
+            wheel_text = ensure_str(f.read())
     except (IOError, OSError) as e:
         raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))
     except UnicodeDecodeError as e:

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -634,15 +634,15 @@ def wheel_dist_info_dir(source, req_description, name):
     subdirs = os.listdir(source)
     info_dirs = [s for s in subdirs if s.endswith('.dist-info')]
 
-    assert info_dirs, "{} .dist-info directory not found".format(
-        req_description
-    )
+    if not info_dirs:
+        raise UnsupportedWheel(".dist-info directory not found")
 
-    assert len(info_dirs) == 1, (
-        '{} multiple .dist-info directories found: {}'.format(
-            req_description, ', '.join(info_dirs)
+    if len(info_dirs) > 1:
+        raise UnsupportedWheel(
+            "multiple .dist-info directories found: {}".format(
+                ", ".join(info_dirs)
+            )
         )
-    )
 
     info_dir = info_dirs[0]
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -312,9 +312,9 @@ def install_unpacked_wheel(
     #       installation.
 
     source = wheeldir.rstrip(os.path.sep) + os.path.sep
-    info_dir = wheel_dist_info_dir(source, req_description, name)
 
     try:
+        info_dir = wheel_dist_info_dir(source, req_description, name)
         metadata = wheel_metadata(wheeldir)
         version = wheel_version(metadata)
     except UnsupportedWheel as e:
@@ -650,8 +650,8 @@ def wheel_dist_info_dir(source, req_description, name):
     canonical_name = canonicalize_name(name)
     if not info_dir_name.startswith(canonical_name):
         raise UnsupportedWheel(
-            "{} .dist-info directory {!r} does not start with {!r}".format(
-                req_description, info_dir, canonical_name
+            ".dist-info directory {!r} does not start with {!r}".format(
+                info_dir, canonical_name
             )
         )
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -98,25 +98,6 @@ def fix_script(path):
     return None
 
 
-dist_info_re = re.compile(r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>.+?))?)
-                                \.dist-info$""", re.VERBOSE)
-
-
-def root_is_purelib(name, wheeldir):
-    # type: (str, str) -> bool
-    """True if the extracted wheel in wheeldir should go into purelib."""
-    name_folded = name.replace("-", "_")
-    for item in os.listdir(wheeldir):
-        match = dist_info_re.match(item)
-        if match and match.group('name') == name_folded:
-            with open(os.path.join(wheeldir, item, 'WHEEL')) as wheel:
-                for line in wheel:
-                    line = line.lower().rstrip()
-                    if line == "root-is-purelib: true":
-                        return True
-    return False
-
-
 def wheel_root_is_purelib(metadata):
     # type: (Message) -> bool
     return metadata.get("Root-Is-Purelib", "").lower() == "true"

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -314,7 +314,7 @@ def install_unpacked_wheel(
     source = wheeldir.rstrip(os.path.sep) + os.path.sep
 
     try:
-        info_dir = wheel_dist_info_dir(source, req_description, name)
+        info_dir = wheel_dist_info_dir(source, name)
         metadata = wheel_metadata(wheeldir)
         version = wheel_version(metadata)
     except UnsupportedWheel as e:
@@ -624,8 +624,8 @@ def install_wheel(
         )
 
 
-def wheel_dist_info_dir(source, req_description, name):
-    # type: (str, str, str) -> str
+def wheel_dist_info_dir(source, name):
+    # type: (str, str) -> str
     """Returns the name of the contained .dist-info directory.
 
     Raises AssertionError or UnsupportedWheel if not found, >1 found, or

--- a/tests/data/packages/plat_wheel-1.7/plat_wheel-1.7.dist-info/WHEEL
+++ b/tests/data/packages/plat_wheel-1.7/plat_wheel-1.7.dist-info/WHEEL
@@ -1,4 +1,0 @@
-Wheel-Version: 0.1
-Packager: bdist_wheel
-Root-Is-Purelib: false
-

--- a/tests/data/packages/plat_wheel-_invalidversion_/plat_wheel-_invalidversion_.dist-info/WHEEL
+++ b/tests/data/packages/plat_wheel-_invalidversion_/plat_wheel-_invalidversion_.dist-info/WHEEL
@@ -1,4 +1,0 @@
-Wheel-Version: 0.1
-Packager: bdist_wheel
-Root-Is-Purelib: false
-

--- a/tests/data/packages/pure_wheel-1.7/pure_wheel-1.7.dist-info/WHEEL
+++ b/tests/data/packages/pure_wheel-1.7/pure_wheel-1.7.dist-info/WHEEL
@@ -1,4 +1,0 @@
-Wheel-Version: 0.1
-Packager: bdist_wheel
-Root-Is-Purelib: true
-

--- a/tests/data/packages/pure_wheel-_invalidversion_/pure_wheel-_invalidversion_.dist-info/WHEEL
+++ b/tests/data/packages/pure_wheel-_invalidversion_/pure_wheel-_invalidversion_.dist-info/WHEEL
@@ -1,4 +1,0 @@
-Wheel-Version: 0.1
-Packager: bdist_wheel
-Root-Is-Purelib: true
-

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -256,6 +256,18 @@ def test_wheel_version_fails_on_bad_wheel_version(version):
     assert "invalid Wheel-Version" in str(e.value)
 
 
+@pytest.mark.parametrize("text,expected", [
+    ("Root-Is-Purelib: true", True),
+    ("Root-Is-Purelib: false", False),
+    ("Root-Is-Purelib: hello", False),
+    ("", False),
+    ("root-is-purelib: true", True),
+    ("root-is-purelib: True", True),
+])
+def test_wheel_root_is_purelib(text, expected):
+    assert wheel.wheel_root_is_purelib(message_from_string(text)) == expected
+
+
 def test_check_compatibility():
     name = 'test'
     vc = wheel.VERSION_COMPATIBLE

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -218,14 +218,10 @@ def test_wheel_dist_info_dir_wrong_name(tmpdir):
     assert "does not start with 'simple'" in str(e.value)
 
 
-def test_wheel_version(tmpdir, data):
-    future_wheel = 'futurewheel-1.9-py2.py3-none-any.whl'
-    future_version = (1, 9)
-
-    unpack_file(data.packages.joinpath(future_wheel), tmpdir + 'future')
-
-    metadata = wheel.wheel_metadata(tmpdir + 'future')
-    assert wheel.wheel_version(metadata) == future_version
+def test_wheel_version_ok(tmpdir, data):
+    assert wheel.wheel_version(
+        message_from_string("Wheel-Version: 1.9")
+    ) == (1, 9)
 
 
 def test_wheel_metadata_fails_on_error(monkeypatch):

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -300,22 +300,6 @@ class TestWheelFile(object):
         unpack_file(filepath, tmpdir)
         assert os.path.isdir(os.path.join(tmpdir, 'meta-1.0.dist-info'))
 
-    def test_purelib_platlib(self, data):
-        """
-        Test the "wheel is purelib/platlib" code.
-        """
-        packages = [
-            ("pure_wheel", data.packages.joinpath("pure_wheel-1.7"), True),
-            ("plat_wheel", data.packages.joinpath("plat_wheel-1.7"), False),
-            ("pure_wheel", data.packages.joinpath(
-                "pure_wheel-_invalidversion_"), True),
-            ("plat_wheel", data.packages.joinpath(
-                "plat_wheel-_invalidversion_"), False),
-        ]
-
-        for name, path, expected in packages:
-            assert wheel.root_is_purelib(name, path) == expected
-
 
 class TestInstallUnpackedWheel(object):
     """

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -200,13 +200,13 @@ def test_wheel_dist_info_dir_found(tmpdir):
 def test_wheel_dist_info_dir_multiple(tmpdir):
     tmpdir.joinpath("simple-0.1.dist-info").mkdir()
     tmpdir.joinpath("unrelated-0.1.dist-info").mkdir()
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(UnsupportedWheel) as e:
         wheel.wheel_dist_info_dir(str(tmpdir), "", "simple")
     assert "multiple .dist-info directories found" in str(e.value)
 
 
 def test_wheel_dist_info_dir_none(tmpdir):
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(UnsupportedWheel) as e:
         wheel.wheel_dist_info_dir(str(tmpdir), "", "simple")
     assert "directory not found" in str(e.value)
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -194,27 +194,27 @@ def test_get_csv_rows_for_installed__long_lines(tmpdir, caplog):
 def test_wheel_dist_info_dir_found(tmpdir):
     expected = "simple-0.1.dist-info"
     tmpdir.joinpath(expected).mkdir()
-    assert wheel.wheel_dist_info_dir(str(tmpdir), "", "simple") == expected
+    assert wheel.wheel_dist_info_dir(str(tmpdir), "simple") == expected
 
 
 def test_wheel_dist_info_dir_multiple(tmpdir):
     tmpdir.joinpath("simple-0.1.dist-info").mkdir()
     tmpdir.joinpath("unrelated-0.1.dist-info").mkdir()
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_dist_info_dir(str(tmpdir), "", "simple")
+        wheel.wheel_dist_info_dir(str(tmpdir), "simple")
     assert "multiple .dist-info directories found" in str(e.value)
 
 
 def test_wheel_dist_info_dir_none(tmpdir):
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_dist_info_dir(str(tmpdir), "", "simple")
+        wheel.wheel_dist_info_dir(str(tmpdir), "simple")
     assert "directory not found" in str(e.value)
 
 
 def test_wheel_dist_info_dir_wrong_name(tmpdir):
     tmpdir.joinpath("unrelated-0.1.dist-info").mkdir()
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_dist_info_dir(str(tmpdir), "", "simple")
+        wheel.wheel_dist_info_dir(str(tmpdir), "simple")
     assert "does not start with 'simple'" in str(e.value)
 
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -6,8 +6,7 @@ import textwrap
 from email import message_from_string
 
 import pytest
-from mock import Mock, patch
-from pip._vendor import pkg_resources
+from mock import patch
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.exceptions import UnsupportedWheel
@@ -224,27 +223,13 @@ def test_wheel_version_ok(tmpdir, data):
     ) == (1, 9)
 
 
-def test_wheel_metadata_fails_on_error(monkeypatch):
-    err = RuntimeError("example")
-    monkeypatch.setattr(pkg_resources, "find_on_path", Mock(side_effect=err))
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(".")
-    assert repr(err) in str(e.value)
-
-
-def test_wheel_metadata_fails_no_dists(tmpdir):
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(str(tmpdir))
-    assert "no contained distribution found" in str(e.value)
-
-
 def test_wheel_metadata_fails_missing_wheel(tmpdir):
     dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
     dist_info_dir.mkdir()
     dist_info_dir.joinpath("METADATA").touch()
 
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(str(tmpdir))
+        wheel.wheel_metadata(str(tmpdir), dist_info_dir.name)
     assert "could not read WHEEL file" in str(e.value)
 
 
@@ -256,7 +241,7 @@ def test_wheel_metadata_fails_on_bad_encoding(tmpdir):
     dist_info_dir.joinpath("WHEEL").write_bytes(b"\xff")
 
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(str(tmpdir))
+        wheel.wheel_metadata(str(tmpdir), dist_info_dir.name)
     assert "error decoding WHEEL" in str(e.value)
 
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -191,6 +191,33 @@ def test_get_csv_rows_for_installed__long_lines(tmpdir, caplog):
     assert messages == expected
 
 
+def test_wheel_dist_info_dir_found(tmpdir):
+    expected = "simple-0.1.dist-info"
+    tmpdir.joinpath(expected).mkdir()
+    assert wheel.wheel_dist_info_dir(str(tmpdir), "", "simple") == expected
+
+
+def test_wheel_dist_info_dir_multiple(tmpdir):
+    tmpdir.joinpath("simple-0.1.dist-info").mkdir()
+    tmpdir.joinpath("unrelated-0.1.dist-info").mkdir()
+    with pytest.raises(AssertionError) as e:
+        wheel.wheel_dist_info_dir(str(tmpdir), "", "simple")
+    assert "multiple .dist-info directories found" in str(e.value)
+
+
+def test_wheel_dist_info_dir_none(tmpdir):
+    with pytest.raises(AssertionError) as e:
+        wheel.wheel_dist_info_dir(str(tmpdir), "", "simple")
+    assert "directory not found" in str(e.value)
+
+
+def test_wheel_dist_info_dir_wrong_name(tmpdir):
+    tmpdir.joinpath("unrelated-0.1.dist-info").mkdir()
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_dist_info_dir(str(tmpdir), "", "simple")
+    assert "does not start with 'simple'" in str(e.value)
+
+
 def test_wheel_version(tmpdir, data):
     future_wheel = 'futurewheel-1.9-py2.py3-none-any.whl'
     future_version = (1, 9)

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -3,6 +3,7 @@ import csv
 import logging
 import os
 import textwrap
+from email import message_from_string
 
 import pytest
 from mock import Mock, patch
@@ -236,15 +237,9 @@ def test_wheel_metadata_fails_on_bad_encoding(tmpdir):
     assert "error decoding WHEEL" in str(e.value)
 
 
-def test_wheel_version_fails_on_no_wheel_version(tmpdir):
-    dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
-    dist_info_dir.mkdir()
-    dist_info_dir.joinpath("METADATA").touch()
-    dist_info_dir.joinpath("WHEEL").touch()
-
-    metadata = wheel.wheel_metadata(str(tmpdir))
+def test_wheel_version_fails_on_no_wheel_version():
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_version(metadata)
+        wheel.wheel_version(message_from_string(""))
     assert "missing Wheel-Version" in str(e.value)
 
 
@@ -253,17 +248,11 @@ def test_wheel_version_fails_on_no_wheel_version(tmpdir):
     ("1.b",),
     ("1.",),
 ])
-def test_wheel_version_fails_on_bad_wheel_version(tmpdir, version):
-    dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
-    dist_info_dir.mkdir()
-    dist_info_dir.joinpath("METADATA").touch()
-    dist_info_dir.joinpath("WHEEL").write_text(
-        "Wheel-Version: {}".format(version)
-    )
-
-    metadata = wheel.wheel_metadata(str(tmpdir))
+def test_wheel_version_fails_on_bad_wheel_version(version):
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_version(metadata)
+        wheel.wheel_version(
+            message_from_string("Wheel-Version: {}".format(version))
+        )
     assert "invalid Wheel-Version" in str(e.value)
 
 


### PR DESCRIPTION
This reorganizes and extracts some shared functionality out of `install_unpacked_wheel` into separate functions.

In addition to setting us up for extracting metadata directly from wheel files (and installing directly from wheel files), this also:

1. removes one custom usage of `pkg_resources`
2. aligns our extraction of the wheel .dist-info directory for Wheel-Version validation, Path-Is-Purelib determination, and RECORD/INSTALLER installation location (where previously they were using 3 different approaches)
3. removes an ad-hoc parsing of `*.dist-info/WHEEL` that was being done for Path-Is-Purelib

Progresses #7413, #6030, and the simplification of wheel builder mentioned in [#7483 (comment)](https://github.com/pypa/pip/pull/7483#issuecomment-565808194).