### PR TITLE
Read wheel metadata from wheel directly

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -18,6 +18,7 @@ import sys
 import warnings
 from base64 import urlsafe_b64encode
 from email.parser import Parser
+from zipfile import ZipFile
 
 from pip._vendor import pkg_resources
 from pip._vendor.distlib.scripts import ScriptMaker
@@ -286,6 +287,7 @@ class PipScriptMaker(ScriptMaker):
 def install_unpacked_wheel(
     name,  # type: str
     wheeldir,  # type: str
+    wheel_zip,  # type: ZipFile
     scheme,  # type: Scheme
     req_description,  # type: str
     pycompile=True,  # type: bool
@@ -296,6 +298,7 @@ def install_unpacked_wheel(
 
     :param name: Name of the project to install
     :param wheeldir: Base directory of the unpacked wheel
+    :param wheel_zip: open ZipFile for wheel being installed
     :param scheme: Distutils scheme dictating the install directories
     :param req_description: String used in place of the requirement, for
         logging
@@ -612,11 +615,12 @@ def install_wheel(
     # type: (...) -> None
     with TempDirectory(
         path=_temp_dir_for_testing, kind="unpacked-wheel"
-    ) as unpacked_dir:
+    ) as unpacked_dir, ZipFile(wheel_path, allowZip64=True) as z:
         unpack_file(wheel_path, unpacked_dir.path)
         install_unpacked_wheel(
             name=name,
             wheeldir=unpacked_dir.path,
+            wheel_zip=z,
             scheme=scheme,
             req_description=req_description,
             pycompile=pycompile,

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -673,9 +673,12 @@ def wheel_metadata(source, dist_info_dir):
     """
     try:
         with open(os.path.join(source, dist_info_dir, "WHEEL"), "rb") as f:
-            wheel_text = ensure_str(f.read())
+            wheel_contents = f.read()
     except (IOError, OSError) as e:
         raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))
+
+    try:
+        wheel_text = ensure_str(wheel_contents)
     except UnicodeDecodeError as e:
         raise UnsupportedWheel("error decoding WHEEL: {!r}".format(e))
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -37,7 +37,7 @@ if MYPY_CHECK_RUNNING:
     from email.message import Message
     from typing import (
         Dict, List, Optional, Sequence, Tuple, IO, Text, Any,
-        Iterable, Callable, Set, Union,
+        Iterable, Callable, Set,
     )
 
     from pip._internal.models.scheme import Scheme
@@ -672,24 +672,17 @@ def wheel_dist_info_dir(source, name):
 
 
 def wheel_metadata(source, dist_info_dir):
-    # type: (Union[str, ZipFile], str) -> Message
+    # type: (ZipFile, str) -> Message
     """Return the WHEEL metadata of an extracted wheel, if possible.
     Otherwise, raise UnsupportedWheel.
     """
-    if isinstance(source, ZipFile):
-        try:
-            # Zip file path separators must be /
-            wheel_contents = source.read("{}/WHEEL".format(dist_info_dir))
-            # BadZipFile for general corruption, KeyError for missing entry,
-            # and RuntimeError for password-protected files
-        except (BadZipFile, KeyError, RuntimeError) as e:
-            raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))
-    else:
-        try:
-            with open(os.path.join(source, dist_info_dir, "WHEEL"), "rb") as f:
-                wheel_contents = f.read()
-        except (IOError, OSError) as e:
-            raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))
+    try:
+        # Zip file path separators must be /
+        wheel_contents = source.read("{}/WHEEL".format(dist_info_dir))
+        # BadZipFile for general corruption, KeyError for missing entry,
+        # and RuntimeError for password-protected files
+    except (BadZipFile, KeyError, RuntimeError) as e:
+        raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))
 
     try:
         wheel_text = ensure_str(wheel_contents)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -321,16 +321,7 @@ def install_unpacked_wheel(
 
     source = wheeldir.rstrip(os.path.sep) + os.path.sep
 
-    try:
-        info_dir = wheel_dist_info_dir(wheel_zip, name)
-        metadata = wheel_metadata(wheel_zip, info_dir)
-        version = wheel_version(metadata)
-    except UnsupportedWheel as e:
-        raise UnsupportedWheel(
-            "{} has an invalid wheel, {}".format(name, str(e))
-        )
-
-    check_compatibility(version, name)
+    info_dir, metadata = parse_wheel(wheel_zip, name)
 
     if wheel_root_is_purelib(metadata):
         lib_dir = scheme.purelib
@@ -631,6 +622,27 @@ def install_wheel(
             pycompile=pycompile,
             warn_script_location=warn_script_location,
         )
+
+
+def parse_wheel(wheel_zip, name):
+    # type: (ZipFile, str) -> Tuple[str, Message]
+    """Extract information from the provided wheel, ensuring it meets basic
+    standards.
+
+    Returns the name of the .dist-info directory and the parsed WHEEL metadata.
+    """
+    try:
+        info_dir = wheel_dist_info_dir(wheel_zip, name)
+        metadata = wheel_metadata(wheel_zip, info_dir)
+        version = wheel_version(metadata)
+    except UnsupportedWheel as e:
+        raise UnsupportedWheel(
+            "{} has an invalid wheel, {}".format(name, str(e))
+        )
+
+    check_compatibility(version, name)
+
+    return info_dir, metadata
 
 
 def wheel_dist_info_dir(source, name):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -629,17 +629,14 @@ def install_wheel(
 
 
 def wheel_dist_info_dir(source, name):
-    # type: (Union[str, ZipFile], str) -> str
+    # type: (ZipFile, str) -> str
     """Returns the name of the contained .dist-info directory.
 
     Raises AssertionError or UnsupportedWheel if not found, >1 found, or
     it doesn't match the provided name.
     """
-    if isinstance(source, ZipFile):
-        # Zip file path separators must be /
-        subdirs = list(set(p.split("/")[0] for p in source.namelist()))
-    else:
-        subdirs = os.listdir(source)
+    # Zip file path separators must be /
+    subdirs = list(set(p.split("/")[0] for p in source.namelist()))
 
     info_dirs = [s for s in subdirs if s.endswith('.dist-info')]
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -234,15 +234,15 @@ def zip_or_dir(request, zip_dir):
     return get_zip_or_dir
 
 
-def test_wheel_dist_info_dir_found(tmpdir, zip_or_dir):
+def test_wheel_dist_info_dir_found(tmpdir, zip_dir):
     expected = "simple-0.1.dist-info"
     dist_info_dir = tmpdir / expected
     dist_info_dir.mkdir()
     dist_info_dir.joinpath("WHEEL").touch()
-    assert wheel.wheel_dist_info_dir(zip_or_dir(tmpdir), "simple") == expected
+    assert wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple") == expected
 
 
-def test_wheel_dist_info_dir_multiple(tmpdir, zip_or_dir):
+def test_wheel_dist_info_dir_multiple(tmpdir, zip_dir):
     dist_info_dir_1 = tmpdir / "simple-0.1.dist-info"
     dist_info_dir_1.mkdir()
     dist_info_dir_1.joinpath("WHEEL").touch()
@@ -250,22 +250,22 @@ def test_wheel_dist_info_dir_multiple(tmpdir, zip_or_dir):
     dist_info_dir_2.mkdir()
     dist_info_dir_2.joinpath("WHEEL").touch()
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_dist_info_dir(zip_or_dir(tmpdir), "simple")
+        wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple")
     assert "multiple .dist-info directories found" in str(e.value)
 
 
-def test_wheel_dist_info_dir_none(tmpdir, zip_or_dir):
+def test_wheel_dist_info_dir_none(tmpdir, zip_dir):
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_dist_info_dir(zip_or_dir(tmpdir), "simple")
+        wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple")
     assert "directory not found" in str(e.value)
 
 
-def test_wheel_dist_info_dir_wrong_name(tmpdir, zip_or_dir):
+def test_wheel_dist_info_dir_wrong_name(tmpdir, zip_dir):
     dist_info_dir = tmpdir / "unrelated-0.1.dist-info"
     dist_info_dir.mkdir()
     dist_info_dir.joinpath("WHEEL").touch()
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_dist_info_dir(zip_or_dir(tmpdir), "simple")
+        wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple")
     assert "does not start with 'simple'" in str(e.value)
 
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -192,13 +192,19 @@ def test_get_csv_rows_for_installed__long_lines(tmpdir, caplog):
 
 def test_wheel_dist_info_dir_found(tmpdir):
     expected = "simple-0.1.dist-info"
-    tmpdir.joinpath(expected).mkdir()
+    dist_info_dir = tmpdir / expected
+    dist_info_dir.mkdir()
+    dist_info_dir.joinpath("WHEEL").touch()
     assert wheel.wheel_dist_info_dir(str(tmpdir), "simple") == expected
 
 
 def test_wheel_dist_info_dir_multiple(tmpdir):
-    tmpdir.joinpath("simple-0.1.dist-info").mkdir()
-    tmpdir.joinpath("unrelated-0.1.dist-info").mkdir()
+    dist_info_dir_1 = tmpdir / "simple-0.1.dist-info"
+    dist_info_dir_1.mkdir()
+    dist_info_dir_1.joinpath("WHEEL").touch()
+    dist_info_dir_2 = tmpdir / "unrelated-0.1.dist-info"
+    dist_info_dir_2.mkdir()
+    dist_info_dir_2.joinpath("WHEEL").touch()
     with pytest.raises(UnsupportedWheel) as e:
         wheel.wheel_dist_info_dir(str(tmpdir), "simple")
     assert "multiple .dist-info directories found" in str(e.value)
@@ -211,7 +217,9 @@ def test_wheel_dist_info_dir_none(tmpdir):
 
 
 def test_wheel_dist_info_dir_wrong_name(tmpdir):
-    tmpdir.joinpath("unrelated-0.1.dist-info").mkdir()
+    dist_info_dir = tmpdir / "unrelated-0.1.dist-info"
+    dist_info_dir.mkdir()
+    dist_info_dir.joinpath("WHEEL").touch()
     with pytest.raises(UnsupportedWheel) as e:
         wheel.wheel_dist_info_dir(str(tmpdir), "simple")
     assert "does not start with 'simple'" in str(e.value)

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -30,8 +30,6 @@ from pip._internal.utils.unpacking import unpack_file
 from tests.lib import DATA_DIR, assert_paths_equal, skip_if_python2
 
 if MYPY_CHECK_RUNNING:
-    from typing import Union
-
     from tests.lib.path import Path
 
 
@@ -221,19 +219,6 @@ def zip_dir():
         yield make_zip
 
 
-@pytest.fixture(params=[True, False])
-def zip_or_dir(request, zip_dir):
-    """Test both with directory and zip file representing directory.
-    """
-    def get_zip_or_dir(path):
-        # type: (Path) -> Union[str, ZipFile]
-        if request.param:
-            return zip_dir(path)
-        return str(path)
-
-    return get_zip_or_dir
-
-
 def test_wheel_dist_info_dir_found(tmpdir, zip_dir):
     expected = "simple-0.1.dist-info"
     dist_info_dir = tmpdir / expected
@@ -275,25 +260,25 @@ def test_wheel_version_ok(tmpdir, data):
     ) == (1, 9)
 
 
-def test_wheel_metadata_fails_missing_wheel(tmpdir, zip_or_dir):
+def test_wheel_metadata_fails_missing_wheel(tmpdir, zip_dir):
     dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
     dist_info_dir.mkdir()
     dist_info_dir.joinpath("METADATA").touch()
 
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(zip_or_dir(tmpdir), dist_info_dir.name)
+        wheel.wheel_metadata(zip_dir(tmpdir), dist_info_dir.name)
     assert "could not read WHEEL file" in str(e.value)
 
 
 @skip_if_python2
-def test_wheel_metadata_fails_on_bad_encoding(tmpdir, zip_or_dir):
+def test_wheel_metadata_fails_on_bad_encoding(tmpdir, zip_dir):
     dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
     dist_info_dir.mkdir()
     dist_info_dir.joinpath("METADATA").touch()
     dist_info_dir.joinpath("WHEEL").write_bytes(b"\xff")
 
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(zip_or_dir(tmpdir), dist_info_dir.name)
+        wheel.wheel_metadata(zip_dir(tmpdir), dist_info_dir.name)
     assert "error decoding WHEEL" in str(e.value)
 
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -275,25 +275,25 @@ def test_wheel_version_ok(tmpdir, data):
     ) == (1, 9)
 
 
-def test_wheel_metadata_fails_missing_wheel(tmpdir):
+def test_wheel_metadata_fails_missing_wheel(tmpdir, zip_or_dir):
     dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
     dist_info_dir.mkdir()
     dist_info_dir.joinpath("METADATA").touch()
 
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(str(tmpdir), dist_info_dir.name)
+        wheel.wheel_metadata(zip_or_dir(tmpdir), dist_info_dir.name)
     assert "could not read WHEEL file" in str(e.value)
 
 
 @skip_if_python2
-def test_wheel_metadata_fails_on_bad_encoding(tmpdir):
+def test_wheel_metadata_fails_on_bad_encoding(tmpdir, zip_or_dir):
     dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
     dist_info_dir.mkdir()
     dist_info_dir.joinpath("METADATA").touch()
     dist_info_dir.joinpath("WHEEL").write_bytes(b"\xff")
 
     with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(str(tmpdir), dist_info_dir.name)
+        wheel.wheel_metadata(zip_or_dir(tmpdir), dist_info_dir.name)
     assert "error decoding WHEEL" in str(e.value)
 
 


### PR DESCRIPTION
More preliminary work for direct-from-wheel metadata reading. Now instead of reading
metadata from the unpacked wheel files on disk, we read it from a ZipFile which wraps
the wheel file itself.

In order to ensure a compatible implementation, tests pass in each step as we incrementally:

1. make each function work for both zip and directory
2. remove directory-based implementation

Progresses #6030 and the simplification of wheel builder mentioned in [#7483 (comment)](https://github.com/pypa/pip/pull/7483#issuecomment-565808194).