### PR TITLE
do not suppress --no-input argument

### DIFF
--- a/news/2429.feature
+++ b/news/2429.feature
@@ -1,0 +1,1 @@
+No longer suppress pip's command line ``--no-input`` flag.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -226,12 +226,11 @@ log = partial(
 
 no_input = partial(
     Option,
-    # Don't ask for input
     '--no-input',
     dest='no_input',
     action='store_true',
     default=False,
-    help=SUPPRESS_HELP
+    help="Immediately exit if interactive input is required"
 )  # type: Callable[..., Option]
 
 proxy = partial(


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
This PR removes suppression of the `--no-input` argument, which has existed in pip since [2010](https://github.com/pypa/pip/commit/4d33521822d02404a7697e93ccf0a11f5602d941).

Unit tests already exist for this argument. https://github.com/pypa/pip/blob/3f4bb75fa4cdd57673c91d3bde4a6094d0276321/tests/unit/test_options.py#L341-L345

After 5 years, nobody has raised any objections on #2429 for why this option is hidden. I recently was made aware of the `--no-input` flag, and would never have known about it had @chrahunt not mentioned it. I plan to use it in pipx to resolve https://github.com/pipxproject/pipx/issues/219.