### PR TITLE
Deprecate git+git@ form of VCS requirements

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -409,7 +409,6 @@ Here are the supported forms::
     [-e] git+ssh://git.example.com/MyProject#egg=MyProject
     [-e] git+git://git.example.com/MyProject#egg=MyProject
     [-e] git+file:///home/user/projects/MyProject#egg=MyProject
-    -e git+git@git.example.com:MyProject#egg=MyProject
 
 Passing a branch name, a commit hash, a tag name or a git ref is possible like so::
 

--- a/news/7543.removal
+++ b/news/7543.removal
@@ -1,0 +1,4 @@
+Support for the ``git+git@`` form of VCS requirement is being deprecated and
+will be removed in pip 21.0. Switch to ``git+https://`` or
+``git+ssh://``. ``git+git://`` also works but its use is discouraged as it is
+insecure.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -30,6 +30,7 @@ from pip._internal.operations.install.legacy import install as install_legacy
 from pip._internal.operations.install.wheel import install_wheel
 from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
 from pip._internal.req.req_uninstall import UninstallPathSet
+from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.marker_files import (
@@ -633,6 +634,18 @@ class InstallRequirement(object):
         vc_type, url = self.link.url.split('+', 1)
         vcs_backend = vcs.get_backend(vc_type)
         if vcs_backend:
+            if not self.link.is_vcs:
+                reason = (
+                    "This form of VCS requirement is being deprecated: {}."
+                ).format(
+                    self.link.url
+                )
+                replacement = None
+                if self.link.url.startswith("git+git@"):
+                    replacement = (
+                        "git+https:// or git+ssh://"
+                    )
+                deprecated(reason, replacement, gone_in="21.0")
             hidden_url = hide_url(self.link.url)
             if obtain:
                 vcs_backend.obtain(self.source_dir, url=hidden_url)

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -647,7 +647,7 @@ class InstallRequirement(object):
                         "git+ssh://git@example.com/..., "
                         "or the insecure git+git://git@example.com/..."
                     )
-                deprecated(reason, replacement, gone_in="21.0")
+                deprecated(reason, replacement, gone_in="21.0", issue=7554)
             hidden_url = hide_url(self.link.url)
             if obtain:
                 vcs_backend.obtain(self.source_dir, url=hidden_url)

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -643,7 +643,9 @@ class InstallRequirement(object):
                 replacement = None
                 if self.link.url.startswith("git+git@"):
                     replacement = (
-                        "git+https:// or git+ssh://"
+                        "git+https://git@example.com/..., "
+                        "git+ssh://git@example.com/..., "
+                        "or the insecure git+git://git@example.com/..."
                     )
                 deprecated(reason, replacement, gone_in="21.0")
             hidden_url = hide_url(self.link.url)


### PR DESCRIPTION
See #6293, #2038 

The `git+git@` form of VCS pseudo-URL seems to be supported for editable installs only. Everywhere else, proper URLs are required.

This might be accidental and due to a less strict VCS URL detection mechanism for editable installs.

Since this creates bugs (in pip freeze) and confusion, let's progressively require proper URLs for editable installs too.

I propose a 1 year deprecation period. 