### PR TITLE
Address issue #7280 with a WARNING rather than exception

### DIFF
--- a/news/7280.bugfix
+++ b/news/7280.bugfix
@@ -1,0 +1,2 @@
+When pip is installing or removing a package and is unable to remove a temporary directory on Windows, this is likely due to a Virus Scan operation.
+Warn the user and continue rather than preventing the operation.

--- a/news/7280.bugfix
+++ b/news/7280.bugfix
@@ -1,2 +1,4 @@
-When pip is installing or removing a package and is unable to remove a temporary directory on Windows, this is likely due to a Virus Scan operation.
-Warn the user and continue rather than preventing the operation.
+When pip is installing or removing a package and is unable to remove a temporary directory on Windows,
+this is likely due to a Virus Scan operation.  This fix warns the user and continues rather than
+preventing the operation.  pip still retries the removal, so this happens quite rarely in most Windows
+environments.

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -128,12 +128,7 @@ class TempDirectory(object):
             try:
                 rmtree(self._path)
             except OSError as e:
-                skip_error = (
-                    sys.platform == 'win32' and
-                    e.errno == errno.EACCES and
-                    getattr(e, 'winerror', 0) in {5, 32}
-                )
-                if skip_error:
+                if sys.platform == 'win32' and e.errno == errno.EACCES:
                     logger.warning(
                         "%s (virus scanner may be holding it)."
                         "cannot remove '%s'",

--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -70,7 +70,7 @@ def external_file_opener(conn):
                     lock_action(f)
                 elif action == 'noread':
                     make_unreadable_file(path)
-            except OSError:
+            except (IOError, OSError):
                 traceback.print_exc(None, sys.stderr)
 
             # Indicate the file is opened

--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -64,6 +64,7 @@ def external_file_opener(conn):
             # Open the file
             try:
                 f = open(path, 'r')
+                # NOTE: action is for future use and may be unused
                 if action == 'lock':
                     lock_action(f)
                 elif action == 'noread':

--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -70,7 +70,8 @@ def external_file_opener(conn):
                     lock_action(f)
                 elif action == 'noread':
                     make_unreadable_file(path)
-            except (IOError, OSError):
+            # IOError *is* OSError in modern Python
+            except IOError:
                 traceback.print_exc(None, sys.stderr)
 
             # Indicate the file is opened

--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -1,9 +1,11 @@
 """Helpers for filesystem-dependent tests.
 """
 import os
+import multiprocessing
 import socket
 import subprocess
 import sys
+import traceback
 from functools import partial
 from itertools import chain
 
@@ -32,6 +34,95 @@ def make_unreadable_file(path):
         # leave everything else.
         args = ["icacls", path, "/deny", username + ":(RD)"]
         subprocess.check_call(args)
+
+
+if sys.platform == 'win32':
+    def lock_action(f):
+        pass
+else:
+    def lock_action(f):
+        pass
+
+
+def external_file_opener(conn):
+    """
+    This external process is run with multiprocessing.
+    It waits for a path from the parent, opens it, and then wait for another message before closing it.
+
+    :param conn: bi-directional pipe
+    :return: nothing
+    """
+    f = None
+    try:
+        # Wait for parent to send path
+        msg = conn.recv()
+        if msg is True:
+            # Do nothing - we have been told to exit without a path or action
+            pass
+        else:
+            path, action = msg
+            # Open the file
+            try:
+                f = open(path, 'r')
+                if action == 'lock':
+                    lock_action(f)
+                elif action == 'noread':
+                    make_unreadable_file(path)
+            except OSError as e:
+                traceback.print_exc(None, sys.stderr)
+
+            # Indicate the file is opened
+            conn.send(True)
+            # Now path is open and we wait for signal to exit
+            conn.recv()
+    finally:
+        if f:
+            f.close()
+        conn.close()
+
+
+class FileOpener(object):
+    """
+    Test class acts as a context manager which can open a file from another process, and hold it open
+    to assure that this does not interfere with pip's operations.
+
+    If a path is passed to the FileOpener, it immediately sends a message to the other process to
+    open that path.  An action of "lock" or "noread" can also be sent to the subprocess, resulting
+    in various additional monkey wrenches now and in the future.
+
+    Opening the path and taking the action can be deferred however, so that the FileOpener may
+    function as a pytest fixture if so desired.
+    """
+    def __init__(self,
+                 path=None, # type: Optional(str)
+                 action=None,  # type: Optional(str)
+                 ):
+        self.path = None
+        self.conn, child_conn = multiprocessing.Pipe()
+        self.child = multiprocessing.Process(target=external_file_opener, daemon=True, args=(child_conn,))
+        self.child.start()
+        if path:
+            self.send(path, action)
+
+    def send(self, path, action=None):
+        if self.path is not None:
+            raise AttributeError('path may only be set once')
+        self.path = str(path)
+        self.conn.send( (str(path), action) )
+        return self.conn.recv()
+
+    def cleanup(self):
+        # send a message to the child to exit; it will exit whether the path was sent or not
+        if self.child:
+            self.conn.send(True)
+            self.child.join()
+        self.child = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
 
 
 def get_filelist(base):

--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -70,7 +70,9 @@ def external_file_opener(conn):
                     lock_action(f)
                 elif action == 'noread':
                     make_unreadable_file(path)
-            # IOError *is* OSError in modern Python
+            # IOError is OSError post PEP 3151
+            except OSError:
+                traceback.print_exc(None, sys.stderr)
             except IOError:
                 traceback.print_exc(None, sys.stderr)
 

--- a/tests/unit/test_utils_filesystem.py
+++ b/tests/unit/test_utils_filesystem.py
@@ -1,11 +1,17 @@
 import os
 import shutil
 
+import psutil
 import pytest
 
 from pip._internal.utils.filesystem import copy2_fixed, is_socket
-from tests.lib.filesystem import make_socket_file, make_unreadable_file
+from tests.lib.filesystem import make_socket_file, make_unreadable_file, FileOpener
 from tests.lib.path import Path
+
+
+@pytest.fixture()
+def process():
+    return psutil.Process()
 
 
 def make_file(path):
@@ -27,6 +33,7 @@ def make_dir(path):
 
 
 skip_on_windows = pytest.mark.skipif("sys.platform == 'win32'")
+skip_unless_windows = pytest.mark.skipif("sys.platform != 'win32'")
 
 
 @skip_on_windows
@@ -59,3 +66,50 @@ def test_copy2_fixed_raises_appropriate_errors(create, error_type, tmpdir):
         copy2_fixed(src, dest)
 
     assert not dest.exists()
+
+
+def test_file_opener_no_file(process):
+    # The FileOpener cleans up the subprocess even if the parent never sends the path
+    with FileOpener():
+        pass
+    assert len(process.children()) == 0
+
+
+def test_file_opener_not_found(tmpdir, process):
+    # The FileOpener cleans up the subprocess even if the file cannot be opened
+    path = tmpdir.joinpath('foo.txt')
+    with FileOpener(path):
+        pass
+    assert len(process.children()) == 0
+
+
+def test_file_opener_normal(tmpdir, process):
+    # The FileOpener cleans up the subprocess when the file exists; also tests that path may be deferred
+    path = tmpdir.joinpath('foo.txt')
+    with open(path, 'w') as f:
+        f.write('Hello\n')
+    with FileOpener() as opener:
+        opener.send(path)
+    assert len(process.children()) == 0
+
+
+@skip_unless_windows
+def test_file_opener_produces_unlink_error(tmpdir, process):
+    path = tmpdir.joinpath('foo.txt')
+    with open(path, 'w') as f:
+        f.write('Hello\n')
+    with FileOpener(path):
+        with pytest.raises(OSError):
+            os.unlink(path)
+
+
+@skip_unless_windows
+def test_file_opener_produces_rmtree_error(tmpdir, process):
+    subdir = tmpdir.joinpath('foo')
+    os.mkdir(subdir)
+    path = subdir.joinpath('bar.txt')
+    with open(path, 'w') as f:
+        f.write('Hello\n')
+    with FileOpener(path):
+        with pytest.raises(OSError):
+            shutil.rmtree(subdir)

--- a/tests/unit/test_utils_filesystem.py
+++ b/tests/unit/test_utils_filesystem.py
@@ -5,7 +5,11 @@ import psutil
 import pytest
 
 from pip._internal.utils.filesystem import copy2_fixed, is_socket
-from tests.lib.filesystem import make_socket_file, make_unreadable_file, FileOpener
+from tests.lib.filesystem import (
+    FileOpener,
+    make_socket_file,
+    make_unreadable_file,
+)
 from tests.lib.path import Path
 
 
@@ -69,14 +73,14 @@ def test_copy2_fixed_raises_appropriate_errors(create, error_type, tmpdir):
 
 
 def test_file_opener_no_file(process):
-    # The FileOpener cleans up the subprocess even if the parent never sends the path
+    # FileOpener joins the subprocess even if the parent never sends the path
     with FileOpener():
         pass
     assert len(process.children()) == 0
 
 
 def test_file_opener_not_found(tmpdir, process):
-    # The FileOpener cleans up the subprocess even if the file cannot be opened
+    # The FileOpener cleans up the subprocess when the file cannot be opened
     path = tmpdir.joinpath('foo.txt')
     with FileOpener(path):
         pass
@@ -84,21 +88,24 @@ def test_file_opener_not_found(tmpdir, process):
 
 
 def test_file_opener_normal(tmpdir, process):
-    # The FileOpener cleans up the subprocess when the file exists; also tests that path may be deferred
+    # The FileOpener cleans up the subprocess when the file exists
     path = tmpdir.joinpath('foo.txt')
     with open(path, 'w') as f:
         f.write('Hello\n')
-    with FileOpener() as opener:
-        opener.send(path)
+    with FileOpener(path):
+        pass
     assert len(process.children()) == 0
 
 
 @skip_unless_windows
 def test_file_opener_produces_unlink_error(tmpdir, process):
+    # FileOpener forces an error on Windows when we attempt to remove a file
+    # The initial path may be deferred; which must be tested with an error
     path = tmpdir.joinpath('foo.txt')
     with open(path, 'w') as f:
         f.write('Hello\n')
-    with FileOpener(path):
+    with FileOpener() as opener:
+        opener.send(path)
         with pytest.raises(OSError):
             os.unlink(path)
 

--- a/tests/unit/test_utils_temp_dir.py
+++ b/tests/unit/test_utils_temp_dir.py
@@ -1,7 +1,10 @@
 import itertools
+import logging
 import os
+import shutil
 import stat
 import tempfile
+import time
 
 import pytest
 
@@ -12,6 +15,8 @@ from pip._internal.utils.temp_dir import (
     TempDirectory,
     global_tempdir_manager,
 )
+
+from tests.lib.filesystem import FileOpener
 
 
 # No need to test symlinked directories on Windows
@@ -207,3 +212,33 @@ def test_tempdirectory_asserts_global_tempdir(monkeypatch):
     monkeypatch.setattr(temp_dir, "_tempdir_manager", None)
     with pytest.raises(AssertionError):
         TempDirectory(globally_managed=True)
+
+
+@pytest.mark.skipif("sys.platform != 'win32'")
+def test_temp_dir_warns_if_cannot_clean(caplog):
+    temp_dir = TempDirectory()
+    temp_dir_path = temp_dir.path
+
+    stime = time.time()
+
+    # Capture only at WARNING level and up
+    with caplog.at_level(logging.WARNING, 'pip._internal.utils.temp_dir'):
+        # open a file within the temporary directory in a sub-process, so it cannot be cleaned up
+        with FileOpener() as opener:
+            subpath = os.path.join(temp_dir_path, 'foo.txt')
+            with open(subpath, 'w') as f:
+                f.write('Cannot be deleted')
+            opener.send(subpath)
+            # with the file open, attempt to remove the log directory
+            temp_dir.cleanup()
+
+        # assert that a WARNING was logged and that it contains a note about a potential virus scanner
+        assert 'WARNING' in caplog.text
+        assert 'virus scanner' in caplog.text
+
+    # Assure that the cleanup was properly retried; this fix did not change retries
+    duration = time.time() - stime
+    assert duration >= 2.0
+
+    # Clean-up for failed TempDirectory cleanup
+    shutil.rmtree(temp_dir_path, ignore_errors=True)

--- a/tests/unit/test_utils_temp_dir.py
+++ b/tests/unit/test_utils_temp_dir.py
@@ -15,7 +15,6 @@ from pip._internal.utils.temp_dir import (
     TempDirectory,
     global_tempdir_manager,
 )
-
 from tests.lib.filesystem import FileOpener
 
 
@@ -223,7 +222,7 @@ def test_temp_dir_warns_if_cannot_clean(caplog):
 
     # Capture only at WARNING level and up
     with caplog.at_level(logging.WARNING, 'pip._internal.utils.temp_dir'):
-        # open a file within the temporary directory in a sub-process, so it cannot be cleaned up
+        # open a file within the temporary directory in a sub-process
         with FileOpener() as opener:
             subpath = os.path.join(temp_dir_path, 'foo.txt')
             with open(subpath, 'w') as f:
@@ -232,11 +231,11 @@ def test_temp_dir_warns_if_cannot_clean(caplog):
             # with the file open, attempt to remove the log directory
             temp_dir.cleanup()
 
-        # assert that a WARNING was logged and that it contains a note about a potential virus scanner
+        # assert that a WARNING was logged about virus scanner
         assert 'WARNING' in caplog.text
         assert 'virus scanner' in caplog.text
 
-    # Assure that the cleanup was properly retried; this fix did not change retries
+    # Assure that the cleanup was properly retried
     duration = time.time() - stime
     assert duration >= 2.0
 

--- a/tools/requirements/tests.txt
+++ b/tools/requirements/tests.txt
@@ -2,6 +2,8 @@ cryptography==2.8
 freezegun
 mock
 pretend
+# Below is to count sub-processes and assure child was cleaned up properly
+psutil
 pytest==3.8.2
 pytest-cov
 # Prevent installing 7.0 which has install_requires "pytest >= 3.10".


### PR DESCRIPTION
Fix includes following work:

- New tests capability in `tests/lib/filesystem.py` which opens a file in an external sub-process and holds it open.  This is designed to be usable as either a context opener or a fixture, if so wired, and the open of the file is deferred in order to create just such race conditions as #7280
- This test class has tests in `tests/unit/test_utils_fileystem.py`
- `pip/_internal/temp_dir.py` is patched to convert an EACCES exception on Windows to a warning, and raise in other cases.
- `tests/unit/tests_utils_temp_dir.py` is updated to test this functionality.