### PR TITLE
Remove redundant expect_error=False in tests

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -398,7 +398,7 @@ def test_basic_install_from_local_directory(script, data):
     Test installing from a local directory.
     """
     to_install = data.packages.joinpath("FSPkg")
-    result = script.pip('install', to_install, expect_error=False)
+    result = script.pip('install', to_install)
     fspkg_folder = script.site_packages / 'fspkg'
     egg_info_folder = (
         script.site_packages / 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
@@ -454,7 +454,7 @@ def test_install_quiet(script, data):
     #   https://github.com/pypa/pip/issues/3418
     #   https://github.com/docker-library/python/issues/83
     to_install = data.packages.joinpath("FSPkg")
-    result = script.pip('install', '-qqq', to_install, expect_error=False)
+    result = script.pip('install', '-qqq', to_install)
     assert result.stdout == ""
     assert result.stderr == ""
 
@@ -476,7 +476,7 @@ def test_hashed_install_success(script, data, tmpdir):
             '{simple} --hash=sha256:393043e672415891885c9a2a0929b1af95fb866d6c'
             'a016b42d2e6ce53619b653'.format(simple=file_url),
             tmpdir) as reqs_file:
-        script.pip_install_local('-r', reqs_file.resolve(), expect_error=False)
+        script.pip_install_local('-r', reqs_file.resolve())
 
 
 def test_hashed_install_failure(script, tmpdir):
@@ -537,7 +537,7 @@ def test_install_from_local_directory_with_symlinks_to_directories(
     Test installing from a local directory containing symlinks to directories.
     """
     to_install = data.packages.joinpath("symlinks")
-    result = script.pip('install', to_install, expect_error=False)
+    result = script.pip('install', to_install)
     pkg_folder = script.site_packages / 'symlinks'
     egg_info_folder = (
         script.site_packages / 'symlinks-0.1.dev0-py%s.egg-info' % pyversion
@@ -563,7 +563,7 @@ def test_install_from_local_directory_with_socket_file(script, data, tmpdir):
     socket_file_path = os.path.join(to_install, "example")
     make_socket_file(socket_file_path)
 
-    result = script.pip("install", "--verbose", to_install, expect_error=False)
+    result = script.pip("install", "--verbose", to_install)
     assert package_folder in result.files_created, str(result.stdout)
     assert egg_info_file in result.files_created, str(result)
     assert str(socket_file_path) in result.stderr
@@ -650,7 +650,7 @@ def test_install_curdir(script, data):
     egg_info = join(run_from, "FSPkg.egg-info")
     if os.path.isdir(egg_info):
         rmtree(egg_info)
-    result = script.pip('install', curdir, cwd=run_from, expect_error=False)
+    result = script.pip('install', curdir, cwd=run_from)
     fspkg_folder = script.site_packages / 'fspkg'
     egg_info_folder = (
         script.site_packages / 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
@@ -664,7 +664,7 @@ def test_install_pardir(script, data):
     Test installing parent directory ('..').
     """
     run_from = data.packages.joinpath("FSPkg", "fspkg")
-    result = script.pip('install', pardir, cwd=run_from, expect_error=False)
+    result = script.pip('install', pardir, cwd=run_from)
     fspkg_folder = script.site_packages / 'fspkg'
     egg_info_folder = (
         script.site_packages / 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
@@ -1237,7 +1237,7 @@ def test_install_log(script, data, tmpdir):
 
 def test_install_topological_sort(script, data):
     args = ['install', 'TopoRequires4', '--no-index', '-f', data.packages]
-    res = str(script.pip(*args, expect_error=False))
+    res = str(script.pip(*args))
     order1 = 'TopoRequires, TopoRequires2, TopoRequires3, TopoRequires4'
     order2 = 'TopoRequires, TopoRequires3, TopoRequires2, TopoRequires4'
     assert order1 in res or order2 in res, res
@@ -1407,8 +1407,7 @@ def test_double_install(script):
     """
     Test double install passing with two same version requirements
     """
-    result = script.pip('install', 'pip', 'pip',
-                        expect_error=False)
+    result = script.pip('install', 'pip', 'pip')
     msg = "Double requirement given: pip (already in pip, name='pip')"
     assert msg not in result.stderr
 
@@ -1564,7 +1563,7 @@ def test_installed_files_recorded_in_deterministic_order(script, data):
     order, to make installs reproducible.
     """
     to_install = data.packages.joinpath("FSPkg")
-    result = script.pip('install', to_install, expect_error=False)
+    result = script.pip('install', to_install)
     fspkg_folder = script.site_packages / 'fspkg'
     egg_info = 'FSPkg-0.1.dev0-py%s.egg-info' % pyversion
     installed_files_path = (

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -61,7 +61,7 @@ def test_cleanup_after_install_from_local_directory(script, data):
     Test clean up after installing from a local directory.
     """
     to_install = data.packages.joinpath("FSPkg")
-    script.pip('install', to_install, expect_error=False)
+    script.pip('install', to_install)
     build = script.venv_path / 'build'
     src = script.venv_path / 'src'
     assert not exists(build), "unexpected build/ dir exists: %s" % build

--- a/tests/functional/test_install_compat.py
+++ b/tests/functional/test_install_compat.py
@@ -55,4 +55,4 @@ def test_setup_py_with_dos_line_endings(script, data):
     Refs https://github.com/pypa/pip/issues/237
     """
     to_install = data.packages.joinpath("LineEndings")
-    script.pip('install', to_install, expect_error=False)
+    script.pip('install', to_install)

--- a/tests/functional/test_install_index.py
+++ b/tests/functional/test_install_index.py
@@ -63,8 +63,7 @@ def test_file_index_url_quoting(script, data):
     """
     index_url = data.index_url(urllib_parse.quote("in dex"))
     result = script.pip(
-        'install', '-vvv', '--index-url', index_url, 'simple',
-        expect_error=False,
+        'install', '-vvv', '--index-url', index_url, 'simple'
     )
     assert (script.site_packages / 'simple') in result.files_created, (
         str(result.stdout)

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -179,9 +179,7 @@ def test_respect_order_in_requirements_file(script, data):
 def test_install_local_editable_with_extras(script, data):
     to_install = data.packages.joinpath("LocalExtras")
     res = script.pip_install_local(
-        '-e', to_install + '[bar]',
-        expect_error=False,
-        expect_stderr=True,
+        '-e', to_install + '[bar]', allow_stderr_warning=True
     )
     assert script.site_packages / 'easy-install.pth' in res.files_updated, (
         str(res)
@@ -373,17 +371,19 @@ def test_double_install_spurious_hash_mismatch(
         # Install a package (and build its wheel):
         result = script.pip_install_local(
             '--find-links', data.find_links,
-            '-r', reqs_file.resolve(), expect_error=False)
+            '-r', reqs_file.resolve(),
+        )
         assert 'Successfully installed simple-1.0' in str(result)
 
         # Uninstall it:
-        script.pip('uninstall', '-y', 'simple', expect_error=False)
+        script.pip('uninstall', '-y', 'simple')
 
         # Then install it again. We should not hit a hash mismatch, and the
         # package should install happily.
         result = script.pip_install_local(
             '--find-links', data.find_links,
-            '-r', reqs_file.resolve(), expect_error=False)
+            '-r', reqs_file.resolve(),
+        )
         assert 'Successfully installed simple-1.0' in str(result)
 
 
@@ -490,8 +490,7 @@ def test_install_unsupported_wheel_link_with_marker(script):
         )
     )
     result = script.pip(
-        'install', '-r', script.scratch_path / 'with-marker.txt',
-        expect_error=False,
+        'install', '-r', script.scratch_path / 'with-marker.txt'
     )
 
     assert ("Ignoring asdf: markers 'sys_platform == \"xyz\"' don't match "

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -67,7 +67,6 @@ class Tests_UserSite:
         result = script.pip(
             'install', '-vvv', '--user', curdir,
             cwd=run_from,
-            expect_error=False,
         )
 
         fspkg_folder = script.user_site / 'fspkg'

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -23,8 +23,7 @@ def test_install_from_future_wheel_version(script, data):
 
     package = data.packages.joinpath("futurewheel-1.9-py2.py3-none-any.whl")
     result = script.pip(
-        'install', package, '--no-index', expect_error=False,
-        expect_stderr=True,
+        'install', package, '--no-index', expect_stderr=True
     )
     result.assert_installed('futurewheel', without_egg_link=True,
                             editable=False)
@@ -49,7 +48,6 @@ def test_basic_install_from_wheel(script, data):
     result = script.pip(
         'install', 'has.script==1.0', '--no-index',
         '--find-links=' + data.find_links,
-        expect_error=False,
     )
     dist_info_folder = script.site_packages / 'has.script-1.0.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
@@ -66,7 +64,6 @@ def test_basic_install_from_wheel_with_extras(script, data):
     result = script.pip(
         'install', 'complex-dist[simple]', '--no-index',
         '--find-links=' + data.find_links,
-        expect_error=False,
     )
     dist_info_folder = script.site_packages / 'complex_dist-0.1.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
@@ -83,7 +80,7 @@ def test_basic_install_from_wheel_file(script, data):
     Test installing directly from a wheel file.
     """
     package = data.packages.joinpath("simple.dist-0.1-py2.py3-none-any.whl")
-    result = script.pip('install', package, '--no-index', expect_error=False)
+    result = script.pip('install', package, '--no-index')
     dist_info_folder = script.site_packages / 'simple.dist-0.1.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
                                                       result.files_created,
@@ -106,7 +103,7 @@ def test_install_from_wheel_with_headers(script, data):
     Test installing from a wheel file with headers
     """
     package = data.packages.joinpath("headers.dist-0.1-py2.py3-none-any.whl")
-    result = script.pip('install', package, '--no-index', expect_error=False)
+    result = script.pip('install', package, '--no-index')
     dist_info_folder = script.site_packages / 'headers.dist-0.1.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
                                                       result.files_created,
@@ -152,8 +149,7 @@ def test_install_wheel_with_target_and_data_files(script, data, with_wheel):
     )
     result = script.pip('install', package,
                         '-t', target_dir,
-                        '--no-index',
-                        expect_error=False)
+                        '--no-index')
 
     assert (Path('scratch') / 'prjwithdatafile' / 'packages1' / 'README.txt'
             in result.files_created), str(result)
@@ -257,7 +253,6 @@ def test_install_from_wheel_gen_entrypoint(script, data):
     result = script.pip(
         'install', 'script.wheel1a==0.1', '--no-index',
         '--find-links=' + data.find_links,
-        expect_error=False,
     )
     if os.name == 'nt':
         wrapper_file = script.bin / 't1.exe'
@@ -276,7 +271,6 @@ def test_install_from_wheel_gen_uppercase_entrypoint(script, data):
     result = script.pip(
         'install', 'console-scripts-uppercase==1.0', '--no-index',
         '--find-links=' + data.find_links,
-        expect_error=False,
     )
     if os.name == 'nt':
         # Case probably doesn't make any difference on NT
@@ -296,7 +290,6 @@ def test_install_from_wheel_with_legacy(script, data):
     result = script.pip(
         'install', 'script.wheel2a==0.1', '--no-index',
         '--find-links=' + data.find_links,
-        expect_error=False,
     )
 
     legacy_file1 = script.bin / 'testscript1.bat'
@@ -314,7 +307,6 @@ def test_install_from_wheel_no_setuptools_entrypoint(script, data):
     result = script.pip(
         'install', 'script.wheel1==0.1', '--no-index',
         '--find-links=' + data.find_links,
-        expect_error=False,
     )
     if os.name == 'nt':
         wrapper_file = script.bin / 't1.exe'
@@ -339,7 +331,6 @@ def test_skipping_setuptools_doesnt_skip_legacy(script, data):
     result = script.pip(
         'install', 'script.wheel2==0.1', '--no-index',
         '--find-links=' + data.find_links,
-        expect_error=False,
     )
 
     legacy_file1 = script.bin / 'testscript1.bat'
@@ -358,7 +349,6 @@ def test_install_from_wheel_gui_entrypoint(script, data):
     result = script.pip(
         'install', 'script.wheel3==0.1', '--no-index',
         '--find-links=' + data.find_links,
-        expect_error=False,
     )
     if os.name == 'nt':
         wrapper_file = script.bin / 't1.exe'
@@ -414,7 +404,7 @@ def test_install_from_wheel_uninstalls_old_version(script, data):
     package = data.packages.joinpath("simplewheel-1.0-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index')
     package = data.packages.joinpath("simplewheel-2.0-py2.py3-none-any.whl")
-    result = script.pip('install', package, '--no-index', expect_error=False)
+    result = script.pip('install', package, '--no-index')
     dist_info_folder = script.site_packages / 'simplewheel-2.0.dist-info'
     assert dist_info_folder in result.files_created
     dist_info_folder = script.site_packages / 'simplewheel-1.0.dist-info'

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -170,11 +170,11 @@ def test_uninstall_overlapping_package(script, data):
     parent_pkg = data.packages.joinpath("parent-0.1.tar.gz")
     child_pkg = data.packages.joinpath("child-0.1.tar.gz")
 
-    result1 = script.pip('install', parent_pkg, expect_error=False)
+    result1 = script.pip('install', parent_pkg)
     assert join(script.site_packages, 'parent') in result1.files_created, (
         sorted(result1.files_created.keys())
     )
-    result2 = script.pip('install', child_pkg, expect_error=False)
+    result2 = script.pip('install', child_pkg)
     assert join(script.site_packages, 'child') in result2.files_created, (
         sorted(result2.files_created.keys())
     )
@@ -184,7 +184,7 @@ def test_uninstall_overlapping_package(script, data):
     # The import forces the generation of __pycache__ if the version of python
     #  supports it
     script.run('python', '-c', "import parent.plugins.child_plugin, child")
-    result3 = script.pip('uninstall', '-y', 'child', expect_error=False)
+    result3 = script.pip('uninstall', '-y', 'child')
     assert join(script.site_packages, 'child') in result3.files_deleted, (
         sorted(result3.files_created.keys())
     )

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -57,7 +57,7 @@ class Tests_UninstallUserSite:
         # install
         to_install = data.packages.joinpath("FSPkg")
         result1 = script.pip(
-            'install', '--user', '-e', to_install, expect_error=False,
+            'install', '--user', '-e', to_install
         )
         egg_link = script.user_site / 'FSPkg.egg-link'
         assert egg_link in result1.files_created, str(result1.stdout)


### PR DESCRIPTION
This is the default, so there is no need to specify it explicitly.