### PR TITLE
Move parse_wheel and supporting functions to utils.wheel

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -17,21 +17,20 @@ import stat
 import sys
 import warnings
 from base64 import urlsafe_b64encode
-from email.parser import Parser
 from zipfile import ZipFile
 
 from pip._vendor import pkg_resources
 from pip._vendor.distlib.scripts import ScriptMaker
 from pip._vendor.distlib.util import get_export_entry
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.six import PY2, StringIO, ensure_str
+from pip._vendor.six import StringIO
 
-from pip._internal.exceptions import InstallationError, UnsupportedWheel
+from pip._internal.exceptions import InstallationError
 from pip._internal.locations import get_major_minor_version
 from pip._internal.utils.misc import captured_stdout, ensure_dir, hash_file
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.unpacking import unpack_file
+from pip._internal.utils.wheel import parse_wheel
 
 if MYPY_CHECK_RUNNING:
     from email.message import Message
@@ -43,14 +42,6 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.models.scheme import Scheme
 
     InstalledCSVRow = Tuple[str, ...]
-
-if PY2:
-    from zipfile import BadZipfile as BadZipFile
-else:
-    from zipfile import BadZipFile
-
-
-VERSION_COMPATIBLE = (1, 0)
 
 
 logger = logging.getLogger(__name__)
@@ -621,129 +612,4 @@ def install_wheel(
             req_description=req_description,
             pycompile=pycompile,
             warn_script_location=warn_script_location,
-        )
-
-
-def parse_wheel(wheel_zip, name):
-    # type: (ZipFile, str) -> Tuple[str, Message]
-    """Extract information from the provided wheel, ensuring it meets basic
-    standards.
-
-    Returns the name of the .dist-info directory and the parsed WHEEL metadata.
-    """
-    try:
-        info_dir = wheel_dist_info_dir(wheel_zip, name)
-        metadata = wheel_metadata(wheel_zip, info_dir)
-        version = wheel_version(metadata)
-    except UnsupportedWheel as e:
-        raise UnsupportedWheel(
-            "{} has an invalid wheel, {}".format(name, str(e))
-        )
-
-    check_compatibility(version, name)
-
-    return info_dir, metadata
-
-
-def wheel_dist_info_dir(source, name):
-    # type: (ZipFile, str) -> str
-    """Returns the name of the contained .dist-info directory.
-
-    Raises AssertionError or UnsupportedWheel if not found, >1 found, or
-    it doesn't match the provided name.
-    """
-    # Zip file path separators must be /
-    subdirs = list(set(p.split("/")[0] for p in source.namelist()))
-
-    info_dirs = [s for s in subdirs if s.endswith('.dist-info')]
-
-    if not info_dirs:
-        raise UnsupportedWheel(".dist-info directory not found")
-
-    if len(info_dirs) > 1:
-        raise UnsupportedWheel(
-            "multiple .dist-info directories found: {}".format(
-                ", ".join(info_dirs)
-            )
-        )
-
-    info_dir = info_dirs[0]
-
-    info_dir_name = canonicalize_name(info_dir)
-    canonical_name = canonicalize_name(name)
-    if not info_dir_name.startswith(canonical_name):
-        raise UnsupportedWheel(
-            ".dist-info directory {!r} does not start with {!r}".format(
-                info_dir, canonical_name
-            )
-        )
-
-    # Zip file paths can be unicode or str depending on the zip entry flags,
-    # so normalize it.
-    return ensure_str(info_dir)
-
-
-def wheel_metadata(source, dist_info_dir):
-    # type: (ZipFile, str) -> Message
-    """Return the WHEEL metadata of an extracted wheel, if possible.
-    Otherwise, raise UnsupportedWheel.
-    """
-    try:
-        # Zip file path separators must be /
-        wheel_contents = source.read("{}/WHEEL".format(dist_info_dir))
-        # BadZipFile for general corruption, KeyError for missing entry,
-        # and RuntimeError for password-protected files
-    except (BadZipFile, KeyError, RuntimeError) as e:
-        raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))
-
-    try:
-        wheel_text = ensure_str(wheel_contents)
-    except UnicodeDecodeError as e:
-        raise UnsupportedWheel("error decoding WHEEL: {!r}".format(e))
-
-    # FeedParser (used by Parser) does not raise any exceptions. The returned
-    # message may have .defects populated, but for backwards-compatibility we
-    # currently ignore them.
-    return Parser().parsestr(wheel_text)
-
-
-def wheel_version(wheel_data):
-    # type: (Message) -> Tuple[int, ...]
-    """Given WHEEL metadata, return the parsed Wheel-Version.
-    Otherwise, raise UnsupportedWheel.
-    """
-    version_text = wheel_data["Wheel-Version"]
-    if version_text is None:
-        raise UnsupportedWheel("WHEEL is missing Wheel-Version")
-
-    version = version_text.strip()
-
-    try:
-        return tuple(map(int, version.split('.')))
-    except ValueError:
-        raise UnsupportedWheel("invalid Wheel-Version: {!r}".format(version))
-
-
-def check_compatibility(version, name):
-    # type: (Tuple[int, ...], str) -> None
-    """Raises errors or warns if called with an incompatible Wheel-Version.
-
-    Pip should refuse to install a Wheel-Version that's a major series
-    ahead of what it's compatible with (e.g 2.0 > 1.1); and warn when
-    installing a version only minor version ahead (e.g 1.2 > 1.1).
-
-    version: a 2-tuple representing a Wheel-Version (Major, Minor)
-    name: name of wheel or package to raise exception about
-
-    :raises UnsupportedWheel: when an incompatible Wheel-Version is given
-    """
-    if version[0] > VERSION_COMPATIBLE[0]:
-        raise UnsupportedWheel(
-            "%s's Wheel-Version (%s) is not compatible with this version "
-            "of pip" % (name, '.'.join(map(str, version)))
-        )
-    elif version > VERSION_COMPATIBLE:
-        logger.warning(
-            'Installing from a newer Wheel-Version (%s)',
-            '.'.join(map(str, version)),
         )

--- a/src/pip/_internal/utils/wheel.py
+++ b/src/pip/_internal/utils/wheel.py
@@ -1,0 +1,154 @@
+"""Support functions for working with wheel files.
+"""
+
+from __future__ import absolute_import
+
+import logging
+from email.parser import Parser
+from zipfile import ZipFile
+
+from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.six import PY2, ensure_str
+
+from pip._internal.exceptions import UnsupportedWheel
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from email.message import Message
+    from typing import Tuple
+
+if PY2:
+    from zipfile import BadZipfile as BadZipFile
+else:
+    from zipfile import BadZipFile
+
+
+VERSION_COMPATIBLE = (1, 0)
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_wheel(wheel_zip, name):
+    # type: (ZipFile, str) -> Tuple[str, Message]
+    """Extract information from the provided wheel, ensuring it meets basic
+    standards.
+
+    Returns the name of the .dist-info directory and the parsed WHEEL metadata.
+    """
+    try:
+        info_dir = wheel_dist_info_dir(wheel_zip, name)
+        metadata = wheel_metadata(wheel_zip, info_dir)
+        version = wheel_version(metadata)
+    except UnsupportedWheel as e:
+        raise UnsupportedWheel(
+            "{} has an invalid wheel, {}".format(name, str(e))
+        )
+
+    check_compatibility(version, name)
+
+    return info_dir, metadata
+
+
+def wheel_dist_info_dir(source, name):
+    # type: (ZipFile, str) -> str
+    """Returns the name of the contained .dist-info directory.
+
+    Raises AssertionError or UnsupportedWheel if not found, >1 found, or
+    it doesn't match the provided name.
+    """
+    # Zip file path separators must be /
+    subdirs = list(set(p.split("/")[0] for p in source.namelist()))
+
+    info_dirs = [s for s in subdirs if s.endswith('.dist-info')]
+
+    if not info_dirs:
+        raise UnsupportedWheel(".dist-info directory not found")
+
+    if len(info_dirs) > 1:
+        raise UnsupportedWheel(
+            "multiple .dist-info directories found: {}".format(
+                ", ".join(info_dirs)
+            )
+        )
+
+    info_dir = info_dirs[0]
+
+    info_dir_name = canonicalize_name(info_dir)
+    canonical_name = canonicalize_name(name)
+    if not info_dir_name.startswith(canonical_name):
+        raise UnsupportedWheel(
+            ".dist-info directory {!r} does not start with {!r}".format(
+                info_dir, canonical_name
+            )
+        )
+
+    # Zip file paths can be unicode or str depending on the zip entry flags,
+    # so normalize it.
+    return ensure_str(info_dir)
+
+
+def wheel_metadata(source, dist_info_dir):
+    # type: (ZipFile, str) -> Message
+    """Return the WHEEL metadata of an extracted wheel, if possible.
+    Otherwise, raise UnsupportedWheel.
+    """
+    try:
+        # Zip file path separators must be /
+        wheel_contents = source.read("{}/WHEEL".format(dist_info_dir))
+        # BadZipFile for general corruption, KeyError for missing entry,
+        # and RuntimeError for password-protected files
+    except (BadZipFile, KeyError, RuntimeError) as e:
+        raise UnsupportedWheel("could not read WHEEL file: {!r}".format(e))
+
+    try:
+        wheel_text = ensure_str(wheel_contents)
+    except UnicodeDecodeError as e:
+        raise UnsupportedWheel("error decoding WHEEL: {!r}".format(e))
+
+    # FeedParser (used by Parser) does not raise any exceptions. The returned
+    # message may have .defects populated, but for backwards-compatibility we
+    # currently ignore them.
+    return Parser().parsestr(wheel_text)
+
+
+def wheel_version(wheel_data):
+    # type: (Message) -> Tuple[int, ...]
+    """Given WHEEL metadata, return the parsed Wheel-Version.
+    Otherwise, raise UnsupportedWheel.
+    """
+    version_text = wheel_data["Wheel-Version"]
+    if version_text is None:
+        raise UnsupportedWheel("WHEEL is missing Wheel-Version")
+
+    version = version_text.strip()
+
+    try:
+        return tuple(map(int, version.split('.')))
+    except ValueError:
+        raise UnsupportedWheel("invalid Wheel-Version: {!r}".format(version))
+
+
+def check_compatibility(version, name):
+    # type: (Tuple[int, ...], str) -> None
+    """Raises errors or warns if called with an incompatible Wheel-Version.
+
+    Pip should refuse to install a Wheel-Version that's a major series
+    ahead of what it's compatible with (e.g 2.0 > 1.1); and warn when
+    installing a version only minor version ahead (e.g 1.2 > 1.1).
+
+    version: a 2-tuple representing a Wheel-Version (Major, Minor)
+    name: name of wheel or package to raise exception about
+
+    :raises UnsupportedWheel: when an incompatible Wheel-Version is given
+    """
+    if version[0] > VERSION_COMPATIBLE[0]:
+        raise UnsupportedWheel(
+            "%s's Wheel-Version (%s) is not compatible with this version "
+            "of pip" % (name, '.'.join(map(str, version)))
+        )
+    elif version > VERSION_COMPATIBLE:
+        logger.warning(
+            'Installing from a newer Wheel-Version (%s)',
+            '.'.join(map(str, version)),
+        )

--- a/tests/unit/test_utils_wheel.py
+++ b/tests/unit/test_utils_wheel.py
@@ -1,0 +1,143 @@
+import os
+from email import message_from_string
+from io import BytesIO
+from zipfile import ZipFile
+
+import pytest
+from pip._vendor.contextlib2 import ExitStack
+
+from pip._internal.exceptions import UnsupportedWheel
+from pip._internal.utils import wheel
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+from tests.lib import skip_if_python2
+
+if MYPY_CHECK_RUNNING:
+    from tests.lib.path import Path
+
+
+@pytest.fixture
+def zip_dir():
+    def make_zip(path):
+        # type: (Path) -> ZipFile
+        buf = BytesIO()
+        with ZipFile(buf, "w", allowZip64=True) as z:
+            for dirpath, dirnames, filenames in os.walk(path):
+                for filename in filenames:
+                    file_path = os.path.join(path, dirpath, filename)
+                    # Zip files must always have / as path separator
+                    archive_path = os.path.relpath(file_path, path).replace(
+                        os.pathsep, "/"
+                    )
+                    z.write(file_path, archive_path)
+
+        return stack.enter_context(ZipFile(buf, "r", allowZip64=True))
+
+    stack = ExitStack()
+    with stack:
+        yield make_zip
+
+
+def test_wheel_dist_info_dir_found(tmpdir, zip_dir):
+    expected = "simple-0.1.dist-info"
+    dist_info_dir = tmpdir / expected
+    dist_info_dir.mkdir()
+    dist_info_dir.joinpath("WHEEL").touch()
+    assert wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple") == expected
+
+
+def test_wheel_dist_info_dir_multiple(tmpdir, zip_dir):
+    dist_info_dir_1 = tmpdir / "simple-0.1.dist-info"
+    dist_info_dir_1.mkdir()
+    dist_info_dir_1.joinpath("WHEEL").touch()
+    dist_info_dir_2 = tmpdir / "unrelated-0.1.dist-info"
+    dist_info_dir_2.mkdir()
+    dist_info_dir_2.joinpath("WHEEL").touch()
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple")
+    assert "multiple .dist-info directories found" in str(e.value)
+
+
+def test_wheel_dist_info_dir_none(tmpdir, zip_dir):
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple")
+    assert "directory not found" in str(e.value)
+
+
+def test_wheel_dist_info_dir_wrong_name(tmpdir, zip_dir):
+    dist_info_dir = tmpdir / "unrelated-0.1.dist-info"
+    dist_info_dir.mkdir()
+    dist_info_dir.joinpath("WHEEL").touch()
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple")
+    assert "does not start with 'simple'" in str(e.value)
+
+
+def test_wheel_version_ok(tmpdir, data):
+    assert wheel.wheel_version(
+        message_from_string("Wheel-Version: 1.9")
+    ) == (1, 9)
+
+
+def test_wheel_metadata_fails_missing_wheel(tmpdir, zip_dir):
+    dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
+    dist_info_dir.mkdir()
+    dist_info_dir.joinpath("METADATA").touch()
+
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_metadata(zip_dir(tmpdir), dist_info_dir.name)
+    assert "could not read WHEEL file" in str(e.value)
+
+
+@skip_if_python2
+def test_wheel_metadata_fails_on_bad_encoding(tmpdir, zip_dir):
+    dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
+    dist_info_dir.mkdir()
+    dist_info_dir.joinpath("METADATA").touch()
+    dist_info_dir.joinpath("WHEEL").write_bytes(b"\xff")
+
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_metadata(zip_dir(tmpdir), dist_info_dir.name)
+    assert "error decoding WHEEL" in str(e.value)
+
+
+def test_wheel_version_fails_on_no_wheel_version():
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_version(message_from_string(""))
+    assert "missing Wheel-Version" in str(e.value)
+
+
+@pytest.mark.parametrize("version", [
+    ("",),
+    ("1.b",),
+    ("1.",),
+])
+def test_wheel_version_fails_on_bad_wheel_version(version):
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.wheel_version(
+            message_from_string("Wheel-Version: {}".format(version))
+        )
+    assert "invalid Wheel-Version" in str(e.value)
+
+
+def test_check_compatibility():
+    name = 'test'
+    vc = wheel.VERSION_COMPATIBLE
+
+    # Major version is higher - should be incompatible
+    higher_v = (vc[0] + 1, vc[1])
+
+    # test raises with correct error
+    with pytest.raises(UnsupportedWheel) as e:
+        wheel.check_compatibility(higher_v, name)
+    assert 'is not compatible' in str(e)
+
+    # Should only log.warning - minor version is greater
+    higher_v = (vc[0], vc[1] + 1)
+    wheel.check_compatibility(higher_v, name)
+
+    # These should work fine
+    wheel.check_compatibility(wheel.VERSION_COMPATIBLE, name)
+
+    # E.g if wheel to install is 1.0 and we support up to 1.2
+    lower_v = (vc[0], max(0, vc[1] - 1))
+    wheel.check_compatibility(lower_v, name)

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -4,15 +4,11 @@ import logging
 import os
 import textwrap
 from email import message_from_string
-from io import BytesIO
-from zipfile import ZipFile
 
 import pytest
 from mock import patch
-from pip._vendor.contextlib2 import ExitStack
 from pip._vendor.packaging.requirements import Requirement
 
-from pip._internal.exceptions import UnsupportedWheel
 from pip._internal.locations import get_scheme
 from pip._internal.models.scheme import Scheme
 from pip._internal.operations.build.wheel_legacy import (
@@ -25,12 +21,8 @@ from pip._internal.operations.install.wheel import (
 )
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.misc import hash_file
-from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.unpacking import unpack_file
-from tests.lib import DATA_DIR, assert_paths_equal, skip_if_python2
-
-if MYPY_CHECK_RUNNING:
-    from tests.lib.path import Path
+from tests.lib import DATA_DIR, assert_paths_equal
 
 
 def call_get_legacy_build_wheel_path(caplog, names):
@@ -197,110 +189,6 @@ def test_get_csv_rows_for_installed__long_lines(tmpdir, caplog):
     assert messages == expected
 
 
-@pytest.fixture
-def zip_dir():
-    def make_zip(path):
-        # type: (Path) -> ZipFile
-        buf = BytesIO()
-        with ZipFile(buf, "w", allowZip64=True) as z:
-            for dirpath, dirnames, filenames in os.walk(path):
-                for filename in filenames:
-                    file_path = os.path.join(path, dirpath, filename)
-                    # Zip files must always have / as path separator
-                    archive_path = os.path.relpath(file_path, path).replace(
-                        os.pathsep, "/"
-                    )
-                    z.write(file_path, archive_path)
-
-        return stack.enter_context(ZipFile(buf, "r", allowZip64=True))
-
-    stack = ExitStack()
-    with stack:
-        yield make_zip
-
-
-def test_wheel_dist_info_dir_found(tmpdir, zip_dir):
-    expected = "simple-0.1.dist-info"
-    dist_info_dir = tmpdir / expected
-    dist_info_dir.mkdir()
-    dist_info_dir.joinpath("WHEEL").touch()
-    assert wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple") == expected
-
-
-def test_wheel_dist_info_dir_multiple(tmpdir, zip_dir):
-    dist_info_dir_1 = tmpdir / "simple-0.1.dist-info"
-    dist_info_dir_1.mkdir()
-    dist_info_dir_1.joinpath("WHEEL").touch()
-    dist_info_dir_2 = tmpdir / "unrelated-0.1.dist-info"
-    dist_info_dir_2.mkdir()
-    dist_info_dir_2.joinpath("WHEEL").touch()
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple")
-    assert "multiple .dist-info directories found" in str(e.value)
-
-
-def test_wheel_dist_info_dir_none(tmpdir, zip_dir):
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple")
-    assert "directory not found" in str(e.value)
-
-
-def test_wheel_dist_info_dir_wrong_name(tmpdir, zip_dir):
-    dist_info_dir = tmpdir / "unrelated-0.1.dist-info"
-    dist_info_dir.mkdir()
-    dist_info_dir.joinpath("WHEEL").touch()
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_dist_info_dir(zip_dir(tmpdir), "simple")
-    assert "does not start with 'simple'" in str(e.value)
-
-
-def test_wheel_version_ok(tmpdir, data):
-    assert wheel.wheel_version(
-        message_from_string("Wheel-Version: 1.9")
-    ) == (1, 9)
-
-
-def test_wheel_metadata_fails_missing_wheel(tmpdir, zip_dir):
-    dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
-    dist_info_dir.mkdir()
-    dist_info_dir.joinpath("METADATA").touch()
-
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(zip_dir(tmpdir), dist_info_dir.name)
-    assert "could not read WHEEL file" in str(e.value)
-
-
-@skip_if_python2
-def test_wheel_metadata_fails_on_bad_encoding(tmpdir, zip_dir):
-    dist_info_dir = tmpdir / "simple-0.1.0.dist-info"
-    dist_info_dir.mkdir()
-    dist_info_dir.joinpath("METADATA").touch()
-    dist_info_dir.joinpath("WHEEL").write_bytes(b"\xff")
-
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_metadata(zip_dir(tmpdir), dist_info_dir.name)
-    assert "error decoding WHEEL" in str(e.value)
-
-
-def test_wheel_version_fails_on_no_wheel_version():
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_version(message_from_string(""))
-    assert "missing Wheel-Version" in str(e.value)
-
-
-@pytest.mark.parametrize("version", [
-    ("",),
-    ("1.b",),
-    ("1.",),
-])
-def test_wheel_version_fails_on_bad_wheel_version(version):
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.wheel_version(
-            message_from_string("Wheel-Version: {}".format(version))
-        )
-    assert "invalid Wheel-Version" in str(e.value)
-
-
 @pytest.mark.parametrize("text,expected", [
     ("Root-Is-Purelib: true", True),
     ("Root-Is-Purelib: false", False),
@@ -311,30 +199,6 @@ def test_wheel_version_fails_on_bad_wheel_version(version):
 ])
 def test_wheel_root_is_purelib(text, expected):
     assert wheel.wheel_root_is_purelib(message_from_string(text)) == expected
-
-
-def test_check_compatibility():
-    name = 'test'
-    vc = wheel.VERSION_COMPATIBLE
-
-    # Major version is higher - should be incompatible
-    higher_v = (vc[0] + 1, vc[1])
-
-    # test raises with correct error
-    with pytest.raises(UnsupportedWheel) as e:
-        wheel.check_compatibility(higher_v, name)
-    assert 'is not compatible' in str(e)
-
-    # Should only log.warning - minor version is greater
-    higher_v = (vc[0], vc[1] + 1)
-    wheel.check_compatibility(higher_v, name)
-
-    # These should work fine
-    wheel.check_compatibility(wheel.VERSION_COMPATIBLE, name)
-
-    # E.g if wheel to install is 1.0 and we support up to 1.2
-    lower_v = (vc[0], max(0, vc[1] - 1))
-    wheel.check_compatibility(lower_v, name)
 
 
 class TestWheelFile(object):


### PR DESCRIPTION
In order to parse metadata from wheel files directly we want to reuse
parse_wheel. Moving it out helps avoid creating an unnecessary
dependence on operations.install.wheel.

No behavior change here, just moving the functions and related tests.

Cherry picked from #7539 to reduce size/scope of that PR.