### PR TITLE
Use valid wheel for functional download tests

### DIFF
--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -7,15 +7,16 @@ import pytest
 
 from pip._internal.cli.status_codes import ERROR
 from pip._internal.utils.urls import path_to_url
+from tests.lib import create_really_basic_wheel
 from tests.lib.path import Path
 from tests.lib.server import file_response
 
 
 def fake_wheel(data, wheel_path):
-    shutil.copy(
-        data.packages.joinpath('simple.dist-0.1-py2.py3-none-any.whl'),
-        data.packages.joinpath(wheel_path),
-    )
+    wheel_name = os.path.basename(wheel_path)
+    name, version, rest = wheel_name.split("-", 2)
+    wheel_data = create_really_basic_wheel(name, version)
+    data.packages.joinpath(wheel_path).write_bytes(wheel_data)
 
 
 @pytest.mark.network


### PR DESCRIPTION
Previously we were copying an existing wheel to a file with a
different distribution name. When using stricter metadata parsing this
would fail, so now we use a more conformant dummy wheel function.

Cherry picked from #7539 to reduce size/scope of that PR.