### PR TITLE
Make wheel install test packages more explicit

### DIFF
--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -41,11 +41,13 @@ def test_install_from_broken_wheel(script, data):
                                 editable=False)
 
 
-def test_basic_install_from_wheel(script, data, tmpdir):
+def test_basic_install_from_wheel(script, shared_data, tmpdir):
     """
     Test installing from a wheel (that has a script)
     """
-    shutil.copy(data.packages / "has.script-1.0-py2.py3-none-any.whl", tmpdir)
+    shutil.copy(
+        shared_data.packages / "has.script-1.0-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'has.script==1.0', '--no-index',
         '--find-links', tmpdir,
@@ -58,14 +60,16 @@ def test_basic_install_from_wheel(script, data, tmpdir):
     assert script_file in result.files_created
 
 
-def test_basic_install_from_wheel_with_extras(script, data, tmpdir):
+def test_basic_install_from_wheel_with_extras(script, shared_data, tmpdir):
     """
     Test installing from a wheel with extras.
     """
     shutil.copy(
-        data.packages / "complex_dist-0.1-py2.py3-none-any.whl", tmpdir
+        shared_data.packages / "complex_dist-0.1-py2.py3-none-any.whl", tmpdir
     )
-    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
+    shutil.copy(
+        shared_data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'complex-dist[simple]', '--no-index',
         '--find-links', tmpdir,
@@ -115,11 +119,13 @@ def test_install_from_wheel_with_headers(script, data):
                                                       result.stdout)
 
 
-def test_install_wheel_with_target(script, data, with_wheel, tmpdir):
+def test_install_wheel_with_target(script, shared_data, with_wheel, tmpdir):
     """
     Test installing a wheel using pip install --target
     """
-    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
+    shutil.copy(
+        shared_data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir
+    )
     target_dir = script.scratch_path / 'target'
     result = script.pip(
         'install', 'simple.dist==0.1', '-t', target_dir,
@@ -165,12 +171,14 @@ def test_install_wheel_with_target_and_data_files(script, data, with_wheel):
             not in result.files_created), str(result)
 
 
-def test_install_wheel_with_root(script, data, tmpdir):
+def test_install_wheel_with_root(script, shared_data, tmpdir):
     """
     Test installing a wheel using pip install --root
     """
     root_dir = script.scratch_path / 'root'
-    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
+    shutil.copy(
+        shared_data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'simple.dist==0.1', '--root', root_dir,
         '--no-index', '--find-links', tmpdir,
@@ -178,12 +186,14 @@ def test_install_wheel_with_root(script, data, tmpdir):
     assert Path('scratch') / 'root' in result.files_created
 
 
-def test_install_wheel_with_prefix(script, data, tmpdir):
+def test_install_wheel_with_prefix(script, shared_data, tmpdir):
     """
     Test installing a wheel using pip install --prefix
     """
     prefix_dir = script.scratch_path / 'prefix'
-    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
+    shutil.copy(
+        shared_data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'simple.dist==0.1', '--prefix', prefix_dir,
         '--no-index', '--find-links', tmpdir,
@@ -242,11 +252,13 @@ def test_wheel_record_lines_in_deterministic_order(script, data):
 
 
 @pytest.mark.incompatible_with_test_venv
-def test_install_user_wheel(script, data, with_wheel, tmpdir):
+def test_install_user_wheel(script, shared_data, with_wheel, tmpdir):
     """
     Test user install from wheel (that has a script)
     """
-    shutil.copy(data.packages / "has.script-1.0-py2.py3-none-any.whl", tmpdir)
+    shutil.copy(
+        shared_data.packages / "has.script-1.0-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'has.script==1.0', '--user', '--no-index',
         '--find-links', tmpdir,
@@ -257,12 +269,13 @@ def test_install_user_wheel(script, data, with_wheel, tmpdir):
     assert script_file in result.files_created, str(result)
 
 
-def test_install_from_wheel_gen_entrypoint(script, data, tmpdir):
+def test_install_from_wheel_gen_entrypoint(script, shared_data, tmpdir):
     """
     Test installing scripts (entry points are generated)
     """
     shutil.copy(
-        data.packages / "script.wheel1a-0.1-py2.py3-none-any.whl", tmpdir
+        shared_data.packages / "script.wheel1a-0.1-py2.py3-none-any.whl",
+        tmpdir,
     )
     result = script.pip(
         'install', 'script.wheel1a==0.1', '--no-index',
@@ -278,12 +291,15 @@ def test_install_from_wheel_gen_entrypoint(script, data, tmpdir):
         assert bool(os.access(script.base_path / wrapper_file, os.X_OK))
 
 
-def test_install_from_wheel_gen_uppercase_entrypoint(script, data, tmpdir):
+def test_install_from_wheel_gen_uppercase_entrypoint(
+    script, shared_data, tmpdir
+):
     """
     Test installing scripts with uppercase letters in entry point names
     """
     shutil.copy(
-        data.packages / "console_scripts_uppercase-1.0-py2.py3-none-any.whl",
+        shared_data.packages /
+        "console_scripts_uppercase-1.0-py2.py3-none-any.whl",
         tmpdir,
     )
     result = script.pip(
@@ -301,12 +317,13 @@ def test_install_from_wheel_gen_uppercase_entrypoint(script, data, tmpdir):
         assert bool(os.access(script.base_path / wrapper_file, os.X_OK))
 
 
-def test_install_from_wheel_with_legacy(script, data, tmpdir):
+def test_install_from_wheel_with_legacy(script, shared_data, tmpdir):
     """
     Test installing scripts (legacy scripts are preserved)
     """
     shutil.copy(
-        data.packages / "script.wheel2a-0.1-py2.py3-none-any.whl", tmpdir
+        shared_data.packages / "script.wheel2a-0.1-py2.py3-none-any.whl",
+        tmpdir,
     )
     result = script.pip(
         'install', 'script.wheel2a==0.1', '--no-index',
@@ -320,13 +337,15 @@ def test_install_from_wheel_with_legacy(script, data, tmpdir):
     assert legacy_file2 in result.files_created
 
 
-def test_install_from_wheel_no_setuptools_entrypoint(script, data, tmpdir):
+def test_install_from_wheel_no_setuptools_entrypoint(
+    script, shared_data, tmpdir
+):
     """
     Test that when we generate scripts, any existing setuptools wrappers in
     the wheel are skipped.
     """
     shutil.copy(
-        data.packages / "script.wheel1-0.1-py2.py3-none-any.whl", tmpdir
+        shared_data.packages / "script.wheel1-0.1-py2.py3-none-any.whl", tmpdir
     )
     result = script.pip(
         'install', 'script.wheel1==0.1', '--no-index',
@@ -347,13 +366,13 @@ def test_install_from_wheel_no_setuptools_entrypoint(script, data, tmpdir):
     assert wrapper_helper not in result.files_created
 
 
-def test_skipping_setuptools_doesnt_skip_legacy(script, data, tmpdir):
+def test_skipping_setuptools_doesnt_skip_legacy(script, shared_data, tmpdir):
     """
     Test installing scripts (legacy scripts are preserved even when we skip
     setuptools wrappers)
     """
     shutil.copy(
-        data.packages / "script.wheel2-0.1-py2.py3-none-any.whl", tmpdir
+        shared_data.packages / "script.wheel2-0.1-py2.py3-none-any.whl", tmpdir
     )
     result = script.pip(
         'install', 'script.wheel2==0.1', '--no-index',
@@ -369,12 +388,12 @@ def test_skipping_setuptools_doesnt_skip_legacy(script, data, tmpdir):
     assert wrapper_helper not in result.files_created
 
 
-def test_install_from_wheel_gui_entrypoint(script, data, tmpdir):
+def test_install_from_wheel_gui_entrypoint(script, shared_data, tmpdir):
     """
     Test installing scripts (gui entry points are generated)
     """
     shutil.copy(
-        data.packages / "script.wheel3-0.1-py2.py3-none-any.whl", tmpdir
+        shared_data.packages / "script.wheel3-0.1-py2.py3-none-any.whl", tmpdir
     )
     result = script.pip(
         'install', 'script.wheel3==0.1', '--no-index',
@@ -387,11 +406,13 @@ def test_install_from_wheel_gui_entrypoint(script, data, tmpdir):
     assert wrapper_file in result.files_created
 
 
-def test_wheel_compiles_pyc(script, data, tmpdir):
+def test_wheel_compiles_pyc(script, shared_data, tmpdir):
     """
     Test installing from wheel with --compile on
     """
-    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
+    shutil.copy(
+        shared_data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir
+    )
     script.pip(
         "install", "--compile", "simple.dist==0.1", "--no-index",
         "--find-links", tmpdir,
@@ -409,11 +430,13 @@ def test_wheel_compiles_pyc(script, data, tmpdir):
     assert any(exists)
 
 
-def test_wheel_no_compiles_pyc(script, data, tmpdir):
+def test_wheel_no_compiles_pyc(script, shared_data, tmpdir):
     """
     Test installing from wheel with --compile on
     """
-    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
+    shutil.copy(
+        shared_data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir
+    )
     script.pip(
         "install", "--no-compile", "simple.dist==0.1", "--no-index",
         "--find-links", tmpdir,

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -47,7 +47,7 @@ def test_basic_install_from_wheel(script, data):
     """
     result = script.pip(
         'install', 'has.script==1.0', '--no-index',
-        '--find-links=' + data.find_links,
+        '--find-links', data.find_links,
     )
     dist_info_folder = script.site_packages / 'has.script-1.0.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
@@ -63,7 +63,7 @@ def test_basic_install_from_wheel_with_extras(script, data):
     """
     result = script.pip(
         'install', 'complex-dist[simple]', '--no-index',
-        '--find-links=' + data.find_links,
+        '--find-links', data.find_links,
     )
     dist_info_folder = script.site_packages / 'complex_dist-0.1.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
@@ -117,7 +117,7 @@ def test_install_wheel_with_target(script, data, with_wheel):
     target_dir = script.scratch_path / 'target'
     result = script.pip(
         'install', 'simple.dist==0.1', '-t', target_dir,
-        '--no-index', '--find-links=' + data.find_links,
+        '--no-index', '--find-links', data.find_links,
     )
     assert Path('scratch') / 'target' / 'simpledist' in result.files_created, (
         str(result)
@@ -166,7 +166,7 @@ def test_install_wheel_with_root(script, data):
     root_dir = script.scratch_path / 'root'
     result = script.pip(
         'install', 'simple.dist==0.1', '--root', root_dir,
-        '--no-index', '--find-links=' + data.find_links,
+        '--no-index', '--find-links', data.find_links,
     )
     assert Path('scratch') / 'root' in result.files_created
 
@@ -178,7 +178,7 @@ def test_install_wheel_with_prefix(script, data):
     prefix_dir = script.scratch_path / 'prefix'
     result = script.pip(
         'install', 'simple.dist==0.1', '--prefix', prefix_dir,
-        '--no-index', '--find-links=' + data.find_links,
+        '--no-index', '--find-links', data.find_links,
     )
     lib = distutils.sysconfig.get_python_lib(prefix=Path('scratch') / 'prefix')
     assert lib in result.files_created, str(result)
@@ -238,7 +238,7 @@ def test_install_user_wheel(script, data, with_wheel):
     """
     result = script.pip(
         'install', 'has.script==1.0', '--user', '--no-index',
-        '--find-links=' + data.find_links,
+        '--find-links', data.find_links,
     )
     egg_info_folder = script.user_site / 'has.script-1.0.dist-info'
     assert egg_info_folder in result.files_created, str(result)
@@ -252,7 +252,7 @@ def test_install_from_wheel_gen_entrypoint(script, data):
     """
     result = script.pip(
         'install', 'script.wheel1a==0.1', '--no-index',
-        '--find-links=' + data.find_links,
+        '--find-links', data.find_links,
     )
     if os.name == 'nt':
         wrapper_file = script.bin / 't1.exe'
@@ -270,7 +270,7 @@ def test_install_from_wheel_gen_uppercase_entrypoint(script, data):
     """
     result = script.pip(
         'install', 'console-scripts-uppercase==1.0', '--no-index',
-        '--find-links=' + data.find_links,
+        '--find-links', data.find_links,
     )
     if os.name == 'nt':
         # Case probably doesn't make any difference on NT
@@ -289,7 +289,7 @@ def test_install_from_wheel_with_legacy(script, data):
     """
     result = script.pip(
         'install', 'script.wheel2a==0.1', '--no-index',
-        '--find-links=' + data.find_links,
+        '--find-links', data.find_links,
     )
 
     legacy_file1 = script.bin / 'testscript1.bat'
@@ -306,7 +306,7 @@ def test_install_from_wheel_no_setuptools_entrypoint(script, data):
     """
     result = script.pip(
         'install', 'script.wheel1==0.1', '--no-index',
-        '--find-links=' + data.find_links,
+        '--find-links', data.find_links,
     )
     if os.name == 'nt':
         wrapper_file = script.bin / 't1.exe'
@@ -330,7 +330,7 @@ def test_skipping_setuptools_doesnt_skip_legacy(script, data):
     """
     result = script.pip(
         'install', 'script.wheel2==0.1', '--no-index',
-        '--find-links=' + data.find_links,
+        '--find-links', data.find_links,
     )
 
     legacy_file1 = script.bin / 'testscript1.bat'
@@ -348,7 +348,7 @@ def test_install_from_wheel_gui_entrypoint(script, data):
     """
     result = script.pip(
         'install', 'script.wheel3==0.1', '--no-index',
-        '--find-links=' + data.find_links,
+        '--find-links', data.find_links,
     )
     if os.name == 'nt':
         wrapper_file = script.bin / 't1.exe'
@@ -363,7 +363,7 @@ def test_wheel_compiles_pyc(script, data):
     """
     script.pip(
         "install", "--compile", "simple.dist==0.1", "--no-index",
-        "--find-links=" + data.find_links
+        "--find-links", data.find_links
     )
     # There are many locations for the __init__.pyc file so attempt to find
     #   any of them
@@ -384,7 +384,7 @@ def test_wheel_no_compiles_pyc(script, data):
     """
     script.pip(
         "install", "--no-compile", "simple.dist==0.1", "--no-index",
-        "--find-links=" + data.find_links
+        "--find-links", data.find_links
     )
     # There are many locations for the __init__.pyc file so attempt to find
     #   any of them

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -41,13 +41,14 @@ def test_install_from_broken_wheel(script, data):
                                 editable=False)
 
 
-def test_basic_install_from_wheel(script, data):
+def test_basic_install_from_wheel(script, data, tmpdir):
     """
     Test installing from a wheel (that has a script)
     """
+    shutil.copy(data.packages / "has.script-1.0-py2.py3-none-any.whl", tmpdir)
     result = script.pip(
         'install', 'has.script==1.0', '--no-index',
-        '--find-links', data.find_links,
+        '--find-links', tmpdir,
     )
     dist_info_folder = script.site_packages / 'has.script-1.0.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
@@ -57,13 +58,17 @@ def test_basic_install_from_wheel(script, data):
     assert script_file in result.files_created
 
 
-def test_basic_install_from_wheel_with_extras(script, data):
+def test_basic_install_from_wheel_with_extras(script, data, tmpdir):
     """
     Test installing from a wheel with extras.
     """
+    shutil.copy(
+        data.packages / "complex_dist-0.1-py2.py3-none-any.whl", tmpdir
+    )
+    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
     result = script.pip(
         'install', 'complex-dist[simple]', '--no-index',
-        '--find-links', data.find_links,
+        '--find-links', tmpdir,
     )
     dist_info_folder = script.site_packages / 'complex_dist-0.1.dist-info'
     assert dist_info_folder in result.files_created, (dist_info_folder,
@@ -110,14 +115,15 @@ def test_install_from_wheel_with_headers(script, data):
                                                       result.stdout)
 
 
-def test_install_wheel_with_target(script, data, with_wheel):
+def test_install_wheel_with_target(script, data, with_wheel, tmpdir):
     """
     Test installing a wheel using pip install --target
     """
+    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
     target_dir = script.scratch_path / 'target'
     result = script.pip(
         'install', 'simple.dist==0.1', '-t', target_dir,
-        '--no-index', '--find-links', data.find_links,
+        '--no-index', '--find-links', tmpdir,
     )
     assert Path('scratch') / 'target' / 'simpledist' in result.files_created, (
         str(result)
@@ -159,32 +165,34 @@ def test_install_wheel_with_target_and_data_files(script, data, with_wheel):
             not in result.files_created), str(result)
 
 
-def test_install_wheel_with_root(script, data):
+def test_install_wheel_with_root(script, data, tmpdir):
     """
     Test installing a wheel using pip install --root
     """
     root_dir = script.scratch_path / 'root'
+    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
     result = script.pip(
         'install', 'simple.dist==0.1', '--root', root_dir,
-        '--no-index', '--find-links', data.find_links,
+        '--no-index', '--find-links', tmpdir,
     )
     assert Path('scratch') / 'root' in result.files_created
 
 
-def test_install_wheel_with_prefix(script, data):
+def test_install_wheel_with_prefix(script, data, tmpdir):
     """
     Test installing a wheel using pip install --prefix
     """
     prefix_dir = script.scratch_path / 'prefix'
+    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
     result = script.pip(
         'install', 'simple.dist==0.1', '--prefix', prefix_dir,
-        '--no-index', '--find-links', data.find_links,
+        '--no-index', '--find-links', tmpdir,
     )
     lib = distutils.sysconfig.get_python_lib(prefix=Path('scratch') / 'prefix')
     assert lib in result.files_created, str(result)
 
 
-def test_install_from_wheel_installs_deps(script, data):
+def test_install_from_wheel_installs_deps(script, data, tmpdir):
     """
     Test can install dependencies of wheels
     """
@@ -192,13 +200,14 @@ def test_install_from_wheel_installs_deps(script, data):
     package = data.packages.joinpath(
         "requires_source-1.0-py2.py3-none-any.whl"
     )
+    shutil.copy(data.packages / "source-1.0.tar.gz", tmpdir)
     result = script.pip(
-        'install', '--no-index', '--find-links', data.find_links, package,
+        'install', '--no-index', '--find-links', tmpdir, package,
     )
     result.assert_installed('source', editable=False)
 
 
-def test_install_from_wheel_no_deps(script, data):
+def test_install_from_wheel_no_deps(script, data, tmpdir):
     """
     Test --no-deps works with wheel installs
     """
@@ -206,8 +215,9 @@ def test_install_from_wheel_no_deps(script, data):
     package = data.packages.joinpath(
         "requires_source-1.0-py2.py3-none-any.whl"
     )
+    shutil.copy(data.packages / "source-1.0.tar.gz", tmpdir)
     result = script.pip(
-        'install', '--no-index', '--find-links', data.find_links, '--no-deps',
+        'install', '--no-index', '--find-links', tmpdir, '--no-deps',
         package,
     )
     pkg_folder = script.site_packages / 'source'
@@ -232,13 +242,14 @@ def test_wheel_record_lines_in_deterministic_order(script, data):
 
 
 @pytest.mark.incompatible_with_test_venv
-def test_install_user_wheel(script, data, with_wheel):
+def test_install_user_wheel(script, data, with_wheel, tmpdir):
     """
     Test user install from wheel (that has a script)
     """
+    shutil.copy(data.packages / "has.script-1.0-py2.py3-none-any.whl", tmpdir)
     result = script.pip(
         'install', 'has.script==1.0', '--user', '--no-index',
-        '--find-links', data.find_links,
+        '--find-links', tmpdir,
     )
     egg_info_folder = script.user_site / 'has.script-1.0.dist-info'
     assert egg_info_folder in result.files_created, str(result)
@@ -246,13 +257,16 @@ def test_install_user_wheel(script, data, with_wheel):
     assert script_file in result.files_created, str(result)
 
 
-def test_install_from_wheel_gen_entrypoint(script, data):
+def test_install_from_wheel_gen_entrypoint(script, data, tmpdir):
     """
     Test installing scripts (entry points are generated)
     """
+    shutil.copy(
+        data.packages / "script.wheel1a-0.1-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'script.wheel1a==0.1', '--no-index',
-        '--find-links', data.find_links,
+        '--find-links', tmpdir,
     )
     if os.name == 'nt':
         wrapper_file = script.bin / 't1.exe'
@@ -264,13 +278,17 @@ def test_install_from_wheel_gen_entrypoint(script, data):
         assert bool(os.access(script.base_path / wrapper_file, os.X_OK))
 
 
-def test_install_from_wheel_gen_uppercase_entrypoint(script, data):
+def test_install_from_wheel_gen_uppercase_entrypoint(script, data, tmpdir):
     """
     Test installing scripts with uppercase letters in entry point names
     """
+    shutil.copy(
+        data.packages / "console_scripts_uppercase-1.0-py2.py3-none-any.whl",
+        tmpdir,
+    )
     result = script.pip(
         'install', 'console-scripts-uppercase==1.0', '--no-index',
-        '--find-links', data.find_links,
+        '--find-links', tmpdir,
     )
     if os.name == 'nt':
         # Case probably doesn't make any difference on NT
@@ -283,13 +301,16 @@ def test_install_from_wheel_gen_uppercase_entrypoint(script, data):
         assert bool(os.access(script.base_path / wrapper_file, os.X_OK))
 
 
-def test_install_from_wheel_with_legacy(script, data):
+def test_install_from_wheel_with_legacy(script, data, tmpdir):
     """
     Test installing scripts (legacy scripts are preserved)
     """
+    shutil.copy(
+        data.packages / "script.wheel2a-0.1-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'script.wheel2a==0.1', '--no-index',
-        '--find-links', data.find_links,
+        '--find-links', tmpdir,
     )
 
     legacy_file1 = script.bin / 'testscript1.bat'
@@ -299,14 +320,17 @@ def test_install_from_wheel_with_legacy(script, data):
     assert legacy_file2 in result.files_created
 
 
-def test_install_from_wheel_no_setuptools_entrypoint(script, data):
+def test_install_from_wheel_no_setuptools_entrypoint(script, data, tmpdir):
     """
     Test that when we generate scripts, any existing setuptools wrappers in
     the wheel are skipped.
     """
+    shutil.copy(
+        data.packages / "script.wheel1-0.1-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'script.wheel1==0.1', '--no-index',
-        '--find-links', data.find_links,
+        '--find-links', tmpdir,
     )
     if os.name == 'nt':
         wrapper_file = script.bin / 't1.exe'
@@ -323,14 +347,17 @@ def test_install_from_wheel_no_setuptools_entrypoint(script, data):
     assert wrapper_helper not in result.files_created
 
 
-def test_skipping_setuptools_doesnt_skip_legacy(script, data):
+def test_skipping_setuptools_doesnt_skip_legacy(script, data, tmpdir):
     """
     Test installing scripts (legacy scripts are preserved even when we skip
     setuptools wrappers)
     """
+    shutil.copy(
+        data.packages / "script.wheel2-0.1-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'script.wheel2==0.1', '--no-index',
-        '--find-links', data.find_links,
+        '--find-links', tmpdir,
     )
 
     legacy_file1 = script.bin / 'testscript1.bat'
@@ -342,13 +369,16 @@ def test_skipping_setuptools_doesnt_skip_legacy(script, data):
     assert wrapper_helper not in result.files_created
 
 
-def test_install_from_wheel_gui_entrypoint(script, data):
+def test_install_from_wheel_gui_entrypoint(script, data, tmpdir):
     """
     Test installing scripts (gui entry points are generated)
     """
+    shutil.copy(
+        data.packages / "script.wheel3-0.1-py2.py3-none-any.whl", tmpdir
+    )
     result = script.pip(
         'install', 'script.wheel3==0.1', '--no-index',
-        '--find-links', data.find_links,
+        '--find-links', tmpdir,
     )
     if os.name == 'nt':
         wrapper_file = script.bin / 't1.exe'
@@ -357,13 +387,14 @@ def test_install_from_wheel_gui_entrypoint(script, data):
     assert wrapper_file in result.files_created
 
 
-def test_wheel_compiles_pyc(script, data):
+def test_wheel_compiles_pyc(script, data, tmpdir):
     """
     Test installing from wheel with --compile on
     """
+    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
     script.pip(
         "install", "--compile", "simple.dist==0.1", "--no-index",
-        "--find-links", data.find_links
+        "--find-links", tmpdir,
     )
     # There are many locations for the __init__.pyc file so attempt to find
     #   any of them
@@ -378,13 +409,14 @@ def test_wheel_compiles_pyc(script, data):
     assert any(exists)
 
 
-def test_wheel_no_compiles_pyc(script, data):
+def test_wheel_no_compiles_pyc(script, data, tmpdir):
     """
     Test installing from wheel with --compile on
     """
+    shutil.copy(data.packages / "simple.dist-0.1-py2.py3-none-any.whl", tmpdir)
     script.pip(
         "install", "--no-compile", "simple.dist==0.1", "--no-index",
-        "--find-links", data.find_links
+        "--find-links", tmpdir,
     )
     # There are many locations for the __init__.pyc file so attempt to find
     #   any of them


### PR DESCRIPTION
Any test using `--find-links data.find_links` is potentially using several
packages. By copying only packages we need, we can more
easily see the packages that each test depends on.

This also helps with a few other optimizations:

1. because pip isn't given any `data` argument, we can switch to `shared_data` which avoids a copy - some examples implemented in this PR
2. it will be easier to refactor these tests to use programmatically-generated wheels instead of the pre-generated data we use now