### PR TITLE
Make _git_commit test helper args explicit

### DIFF
--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -34,7 +34,7 @@ def checkout_new_branch(script, repo_dir, branch):
 
 
 def do_commit(script, dest):
-    _git_commit(script, dest, message='test commit', args=['--allow-empty'])
+    _git_commit(script, dest, message='test commit', allow_empty=True)
     return get_head_sha(script, dest)
 
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -720,7 +720,6 @@ def _git_commit(
     env_or_script,
     repo_dir,
     message=None,
-    args=None,
     allow_empty=False,
     stage_modified=False,
 ):
@@ -731,12 +730,11 @@ def _git_commit(
       env_or_script: pytest's `script` or `env` argument.
       repo_dir: a path to a Git repository.
       message: an optional commit message.
-      args: optional additional options to pass to git-commit.
     """
     if message is None:
         message = 'test commit'
-    if args is None:
-        args = []
+
+    args = []
 
     if allow_empty:
         args.append("--allow-empty")

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -716,8 +716,7 @@ def _create_main_file(dir_path, name=None, output=None):
     dir_path.joinpath(filename).write_text(text)
 
 
-def _git_commit(env_or_script, repo_dir, message=None, args=None,
-                expect_stderr=False):
+def _git_commit(env_or_script, repo_dir, message=None, args=None):
     """
     Run git-commit.
 
@@ -737,7 +736,7 @@ def _git_commit(env_or_script, repo_dir, message=None, args=None,
     ]
     new_args.extend(args)
     new_args.extend(['-m', message])
-    env_or_script.run(*new_args, cwd=repo_dir, expect_stderr=expect_stderr)
+    env_or_script.run(*new_args, cwd=repo_dir)
 
 
 def _vcs_add(script, version_pkg_path, vcs='git'):
@@ -876,8 +875,7 @@ def _change_test_package_version(script, version_pkg_path):
     )
     # Pass -a to stage the change to the main file.
     _git_commit(
-        script, version_pkg_path, message='messed version', args=['-a'],
-        expect_stderr=True,
+        script, version_pkg_path, message='messed version', args=['-a']
     )
 
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -717,7 +717,12 @@ def _create_main_file(dir_path, name=None, output=None):
 
 
 def _git_commit(
-    env_or_script, repo_dir, message=None, args=None, allow_empty=False
+    env_or_script,
+    repo_dir,
+    message=None,
+    args=None,
+    allow_empty=False,
+    stage_modified=False,
 ):
     """
     Run git-commit.
@@ -735,6 +740,9 @@ def _git_commit(
 
     if allow_empty:
         args.append("--allow-empty")
+
+    if stage_modified:
+        args.append("--all")
 
     new_args = [
         'git', 'commit', '-q', '--author', 'pip <pypa-dev@googlegroups.com>',
@@ -880,7 +888,7 @@ def _change_test_package_version(script, version_pkg_path):
     )
     # Pass -a to stage the change to the main file.
     _git_commit(
-        script, version_pkg_path, message='messed version', args=['-a']
+        script, version_pkg_path, message='messed version', stage_modified=True
     )
 
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -716,7 +716,9 @@ def _create_main_file(dir_path, name=None, output=None):
     dir_path.joinpath(filename).write_text(text)
 
 
-def _git_commit(env_or_script, repo_dir, message=None, args=None):
+def _git_commit(
+    env_or_script, repo_dir, message=None, args=None, allow_empty=False
+):
     """
     Run git-commit.
 
@@ -730,6 +732,9 @@ def _git_commit(env_or_script, repo_dir, message=None, args=None):
         message = 'test commit'
     if args is None:
         args = []
+
+    if allow_empty:
+        args.append("--allow-empty")
 
     new_args = [
         'git', 'commit', '-q', '--author', 'pip <pypa-dev@googlegroups.com>',

--- a/tests/lib/git_submodule_helpers.py
+++ b/tests/lib/git_submodule_helpers.py
@@ -31,7 +31,9 @@ def _pull_in_submodule_changes_to_module(env, module_path, rel_path):
     submodule_path = module_path / rel_path
     env.run('git', 'pull', '-q', 'origin', 'master', cwd=submodule_path)
     # Pass -a to stage the submodule changes that were just pulled in.
-    _git_commit(env, module_path, message='submodule change', args=['-a'])
+    _git_commit(
+        env, module_path, message='submodule change', stage_modified=True
+    )
 
 
 def _create_test_package_with_submodule(env, rel_path):


### PR DESCRIPTION
This simplifies our interface to git, which will make it easier to trade
out our subprocess-based invocations in the future.