### PR TITLE
Rewrite protect_pip_from_modification_on_windows 

### DIFF
--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -27,7 +27,11 @@ from pip._internal.models.wheel import Wheel
 from pip._internal.pyproject import make_pyproject_path
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.filetypes import ARCHIVE_EXTENSIONS
-from pip._internal.utils.misc import is_installable_dir, splitext
+from pip._internal.utils.misc import (
+    is_installable_dir,
+    splitext,
+    looks_like_path as _looks_like_path,
+)
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import is_url, vcs
@@ -239,26 +243,6 @@ def install_req_from_editable(
         wheel_cache=wheel_cache,
         extras=parts.extras,
     )
-
-
-def _looks_like_path(name):
-    # type: (str) -> bool
-    """Checks whether the string "looks like" a path on the filesystem.
-
-    This does not check whether the target actually exists, only judge from the
-    appearance.
-
-    Returns true if any of the following conditions is true:
-    * a path separator is found (either os.path.sep or os.path.altsep);
-    * a dot is found (which represents the current directory).
-    """
-    if os.path.sep in name:
-        return True
-    if os.path.altsep is not None and os.path.altsep in name:
-        return True
-    if name.startswith("."):
-        return True
-    return False
 
 
 def _get_url_from_path(path, name):

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -30,7 +30,7 @@ from pip._internal.utils.filetypes import ARCHIVE_EXTENSIONS
 from pip._internal.utils.misc import (
     is_installable_dir,
     splitext,
-    looks_like_path as _looks_like_path,
+    looks_like_path,
 )
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import path_to_url
@@ -255,7 +255,7 @@ def _get_url_from_path(path, name):
     The function checks if the path is a file. If false, if the path has
     an @, it will treat it as a PEP 440 URL requirement and return the path.
     """
-    if _looks_like_path(name) and os.path.isdir(path):
+    if looks_like_path(name) and os.path.isdir(path):
         if is_installable_dir(path):
             return path_to_url(path)
         raise InstallationError(
@@ -267,7 +267,7 @@ def _get_url_from_path(path, name):
     if os.path.isfile(path):
         return path_to_url(path)
     urlreq_parts = name.split('@', 1)
-    if len(urlreq_parts) >= 2 and not _looks_like_path(urlreq_parts[0]):
+    if len(urlreq_parts) >= 2 and not looks_like_path(urlreq_parts[0]):
         # If the path contains '@' and the part before it does not look
         # like a path, try to treat it as a PEP 440 URL req instead.
         return None

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -829,6 +829,26 @@ def hide_url(url):
     return HiddenText(url, redacted=redacted)
 
 
+def looks_like_path(name):
+    # type: (str) -> bool
+    """Checks whether the string "looks like" a path on the filesystem.
+
+    This does not check whether the target actually exists, only judge from the
+    appearance.
+
+    Returns true if any of the following conditions is true:
+    * a path separator is found (either os.path.sep or os.path.altsep);
+    * a dot is found (which represents the current directory).
+    """
+    if os.path.sep in name:
+        return True
+    if os.path.altsep is not None and os.path.altsep in name:
+        return True
+    if name.startswith("."):
+        return True
+    return False
+
+
 def protect_pip_from_modification_on_windows(modifying_pip):
     # type: (bool) -> None
     """Protection of pip.exe from modification on Windows

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -25,7 +25,6 @@ from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req import InstallRequirement, RequirementSet
 from pip._internal.req.constructors import (
     _get_url_from_path,
-    _looks_like_path,
     install_req_from_editable,
     install_req_from_line,
     install_req_from_req_string,
@@ -33,6 +32,7 @@ from pip._internal.req.constructors import (
 )
 from pip._internal.req.req_file import ParsedLine, get_line_parser, handle_line
 from pip._internal.req.req_tracker import get_requirement_tracker
+from pip._internal.utils.misc import looks_like_path
 from pip._internal.utils.urls import path_to_url
 from tests.lib import assert_raises_regexp, make_test_finder, requirements_file
 
@@ -655,8 +655,8 @@ def test_mismatched_versions(caplog):
     # Test wheel
     (('simple-0.1-py2.py3-none-any.whl'), False),
 ])
-def test_looks_like_path(args, expected):
-    assert _looks_like_path(args) == expected
+def testlooks_like_path(args, expected):
+    assert looks_like_path(args) == expected
 
 
 @pytest.mark.skipif(
@@ -670,8 +670,8 @@ def test_looks_like_path(args, expected):
     # Test absolute paths
     (('C:\\absolute\\path'), True),
 ])
-def test_looks_like_path_win(args, expected):
-    assert _looks_like_path(args) == expected
+def testlooks_like_path_win(args, expected):
+    assert looks_like_path(args) == expected
 
 
 @pytest.mark.parametrize('args, mock_returns, expected', [


### PR DESCRIPTION
Follow up on #7358 to implement a better logic with less edge cases. The implementation is put in its own module and functions so it can be improved on in the future.

The logic I have in mind is:

* Check whether the command (`sys.argv[0]`) looks like a path. If it does not (and therefore will be resolved by the shell as a command), use `shutil.which` to resolve it.
* Check if the path is a file (to exclude the `python src\pip` case).
* Check if the file is named like a pip wrapper script.
* Emit the error.