### PR TITLE
Use interpreter_name and interpreter_version from packaging.tags

### DIFF
--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -9,13 +9,12 @@ import json
 import logging
 import os
 
-from pip._vendor.packaging.tags import interpreter_version
+from pip._vendor.packaging.tags import interpreter_name, interpreter_version
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import InvalidWheelFilename
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
-from pip._internal.pep425tags import interpreter_name
 from pip._internal.utils.compat import expanduser
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -9,12 +9,13 @@ import json
 import logging
 import os
 
+from pip._vendor.packaging.tags import interpreter_version
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import InvalidWheelFilename
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
-from pip._internal.pep425tags import interpreter_name, interpreter_version
+from pip._internal.pep425tags import interpreter_name
 from pip._internal.utils.compat import expanduser
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -9,6 +9,7 @@ import sys
 import sysconfig
 from collections import OrderedDict
 
+from pip._vendor.packaging.tags import interpreter_version
 from pip._vendor.six import PY2
 
 import pip._internal.utils.glibc
@@ -63,18 +64,6 @@ def version_info_to_nodot(version_info):
     return ''.join(map(str, version_info[:2]))
 
 
-def get_impl_ver():
-    # type: () -> str
-    """Return implementation version."""
-    impl_ver = get_config_var("py_version_nodot")
-    if not impl_ver or get_abbr_impl() == 'pp':
-        impl_ver = ''.join(map(str, get_impl_version_info()))
-    return impl_ver
-
-
-interpreter_version = get_impl_ver
-
-
 def get_impl_version_info():
     # type: () -> Tuple[int, ...]
     """Return sys.version_info-like tuple for use in decrementing the minor
@@ -126,7 +115,7 @@ def get_abi_tag():
                 'Py_UNICODE_SIZE', lambda: sys.maxunicode == 0x10ffff,
                 expected=4, warn=is_cpython):
             u = 'u'
-        abi = '%s%s%s%s%s' % (impl, get_impl_ver(), d, m, u)
+        abi = '%s%s%s%s%s' % (impl, interpreter_version(), d, m, u)
     elif soabi and soabi.startswith('cpython-'):
         abi = 'cp' + soabi.split('-')[1]
     elif soabi:

--- a/src/pip/_internal/pep425tags.py
+++ b/src/pip/_internal/pep425tags.py
@@ -9,7 +9,7 @@ import sys
 import sysconfig
 from collections import OrderedDict
 
-from pip._vendor.packaging.tags import interpreter_version
+from pip._vendor.packaging.tags import interpreter_name, interpreter_version
 from pip._vendor.six import PY2
 
 import pip._internal.utils.glibc
@@ -41,23 +41,6 @@ def get_config_var(var):
     return sysconfig.get_config_var(var)
 
 
-def get_abbr_impl():
-    # type: () -> str
-    """Return abbreviated implementation name."""
-    if hasattr(sys, 'pypy_version_info'):
-        pyimpl = 'pp'
-    elif sys.platform.startswith('java'):
-        pyimpl = 'jy'
-    elif sys.platform == 'cli':
-        pyimpl = 'ip'
-    else:
-        pyimpl = 'cp'
-    return pyimpl
-
-
-interpreter_name = get_abbr_impl
-
-
 def version_info_to_nodot(version_info):
     # type: (Tuple[int, ...]) -> str
     # Only use up to the first two numbers.
@@ -68,7 +51,7 @@ def get_impl_version_info():
     # type: () -> Tuple[int, ...]
     """Return sys.version_info-like tuple for use in decrementing the minor
     version."""
-    if get_abbr_impl() == 'pp':
+    if interpreter_name() == 'pp':
         # as per https://github.com/pypa/pip/issues/2882
         # attrs exist only on pypy
         return (sys.version_info[0],
@@ -96,7 +79,7 @@ def get_abi_tag():
     """Return the ABI tag based on SOABI (if available) or emulate SOABI
     (CPython 2, PyPy)."""
     soabi = get_config_var('SOABI')
-    impl = get_abbr_impl()
+    impl = interpreter_name()
     abi = None  # type: Optional[str]
 
     if not soabi and impl in {'cp', 'pp'} and hasattr(sys, 'maxunicode'):
@@ -385,7 +368,7 @@ def get_supported(
     current_version = versions[0]
     other_versions = versions[1:]
 
-    impl = impl or get_abbr_impl()
+    impl = impl or interpreter_name()
 
     abis = []  # type: List[str]
 

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -2,6 +2,7 @@ import sys
 
 import pytest
 from mock import patch
+from pip._vendor.packaging.tags import interpreter_version
 
 from pip._internal import pep425tags
 
@@ -53,8 +54,7 @@ class TestPEP425Tags(object):
         import pip._internal.pep425tags
 
         config_vars.update({'SOABI': None})
-        base = pip._internal.pep425tags.get_abbr_impl() + \
-            pip._internal.pep425tags.get_impl_ver()
+        base = pip._internal.pep425tags.get_abbr_impl() + interpreter_version()
 
         if sys.version_info >= (3, 8):
             # Python 3.8 removes the m flag, so don't look for it.

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 from mock import patch
-from pip._vendor.packaging.tags import interpreter_version
+from pip._vendor.packaging.tags import interpreter_name, interpreter_version
 
 from pip._internal import pep425tags
 
@@ -54,7 +54,7 @@ class TestPEP425Tags(object):
         import pip._internal.pep425tags
 
         config_vars.update({'SOABI': None})
-        base = pip._internal.pep425tags.get_abbr_impl() + interpreter_version()
+        base = interpreter_name() + interpreter_version()
 
         if sys.version_info >= (3, 8):
             # Python 3.8 removes the m flag, so don't look for it.


### PR DESCRIPTION
`packaging.tags` provides utility functions for getting interpreter name and version, so use those instead of our own.

Progresses #6908. Split from #7354.