### PR TITLE
Delete tmpdir with rmtree to handle Unicode paths

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def tmpdir(request, tmpdir):
     # This should prevent us from needing a multiple gigabyte temporary
     # directory while running the tests.
     if not request.config.getoption("--keep-tmpdir"):
-        tmpdir.remove(ignore_errors=True)
+        shutil.rmtree(six.text_type(tmpdir), ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
pytest (rather `py.path.local`) does not handle non-ASCII paths properly on Windows with Python 2, but Python's builtin `shutil.rmtree()` does.

This becomes a problem when writing a test case for #7138. The test data for it (a non-ASCII data file) would choke pytest and fail on clean-up for any tests using the test data.