### PR TITLE
Manage temp directory deletion centrally

### DIFF
--- a/tests/unit/test_utils_temp_dir.py
+++ b/tests/unit/test_utils_temp_dir.py
@@ -11,6 +11,7 @@ from pip._internal.utils.temp_dir import (
     AdjacentTempDirectory,
     TempDirectory,
     global_tempdir_manager,
+    tempdir_registry,
 )
 
 
@@ -207,3 +208,29 @@ def test_tempdirectory_asserts_global_tempdir(monkeypatch):
     monkeypatch.setattr(temp_dir, "_tempdir_manager", None)
     with pytest.raises(AssertionError):
         TempDirectory(globally_managed=True)
+
+
+deleted_kind = "deleted"
+not_deleted_kind = "not-deleted"
+
+
+@pytest.mark.parametrize("delete,kind,exists", [
+    (None, deleted_kind, False),
+    (True, deleted_kind, False),
+    (False, deleted_kind, True),
+    (None, not_deleted_kind, True),
+    (True, not_deleted_kind, False),
+    (False, not_deleted_kind, True),
+    (None, "unspecified", False),
+    (True, "unspecified", False),
+    (False, "unspecified", True),
+])
+def test_tempdir_registry(kind, delete, exists):
+    with tempdir_registry() as registry:
+        registry.set_delete(deleted_kind, True)
+        registry.set_delete(not_deleted_kind, False)
+
+        with TempDirectory(delete=delete, kind=kind) as d:
+            path = d.path
+            assert os.path.exists(path)
+        assert os.path.exists(path) == exists


### PR DESCRIPTION
This gives us a global toggle that we can use to control whether
temporary directories get deleted from one place (ideally, in the
commands taking --no-clean).

Other issues are preventing us from actually configuring this in our Command classes (as described in #7571), but we can use this implementation when those are unblocked.