### PR TITLE
Split relative requirement install tests

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -406,12 +406,15 @@ def test_basic_install_from_local_directory(script, data):
     assert egg_info_folder in result.files_created, str(result)
 
 
-@pytest.mark.parametrize("test_type", [
-    ("rel_path"),
-    ("rel_url"),
-    ("embedded_rel_path"),
+@pytest.mark.parametrize("test_type,editable", [
+    ("rel_path", False),
+    ("rel_path", True),
+    ("rel_url", False),
+    ("rel_url", True),
+    ("embedded_rel_path", False),
+    ("embedded_rel_path", True),
 ])
-def test_basic_install_relative_directory(script, data, test_type):
+def test_basic_install_relative_directory(script, data, test_type, editable):
     """
     Test installing a requirement using a relative path.
     """
@@ -439,14 +442,13 @@ def test_basic_install_relative_directory(script, data, test_type):
     }[test_type]
 
     # Install as either editable or not.
-    if True:
-        # Regular install.
+    if not editable:
         result = script.pip('install', req_path,
                             cwd=script.scratch_path)
         assert egg_info_file in result.files_created, str(result)
         assert package_folder in result.files_created, str(result)
         script.pip('uninstall', '-y', 'fspkg')
-
+    else:
         # Editable install.
         result = script.pip('install', '-e' + req_path,
                             cwd=script.scratch_path)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -447,13 +447,11 @@ def test_basic_install_relative_directory(script, data, test_type, editable):
                             cwd=script.scratch_path)
         assert egg_info_file in result.files_created, str(result)
         assert package_folder in result.files_created, str(result)
-        script.pip('uninstall', '-y', 'fspkg')
     else:
         # Editable install.
         result = script.pip('install', '-e' + req_path,
                             cwd=script.scratch_path)
         assert egg_link_file in result.files_created, str(result)
-        script.pip('uninstall', '-y', 'fspkg')
 
 
 def test_install_quiet(script, data):

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -406,7 +406,12 @@ def test_basic_install_from_local_directory(script, data):
     assert egg_info_folder in result.files_created, str(result)
 
 
-def test_basic_install_relative_directory(script, data):
+@pytest.mark.parametrize("test_type", [
+    ("rel_path"),
+    ("rel_url"),
+    ("embedded_rel_path"),
+])
+def test_basic_install_relative_directory(script, data, test_type):
     """
     Test installing a requirement using a relative path.
     """
@@ -427,9 +432,14 @@ def test_basic_install_relative_directory(script, data):
     )
     embedded_rel_path = script.scratch_path.joinpath(full_rel_path)
 
-    # For each relative path, install as either editable or not using either
-    # URLs with egg links or not.
-    for req_path in (full_rel_path, full_rel_url, embedded_rel_path):
+    req_path = {
+        "rel_path": full_rel_path,
+        "rel_url": full_rel_url,
+        "embedded_rel_path": embedded_rel_path,
+    }[test_type]
+
+    # Install as either editable or not.
+    if True:
         # Regular install.
         result = script.pip('install', req_path,
                             cwd=script.scratch_path)

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -57,12 +57,15 @@ def test_schema_check_in_requirements_file(script):
         )
 
 
-@pytest.mark.parametrize("test_type", [
-    ("rel_path"),
-    ("rel_url"),
-    ("embedded_rel_path"),
+@pytest.mark.parametrize("test_type,editable", [
+    ("rel_path", False),
+    ("rel_path", True),
+    ("rel_url", False),
+    ("rel_url", True),
+    ("embedded_rel_path", False),
+    ("embedded_rel_path", True),
 ])
-def test_relative_requirements_file(script, data, test_type):
+def test_relative_requirements_file(script, data, test_type, editable):
     """
     Test installing from a requirements file with a relative path. For path
     URLs, use an egg= definition.
@@ -89,10 +92,9 @@ def test_relative_requirements_file(script, data, test_type):
         "embedded_rel_path": embedded_rel_path,
     }[test_type]
 
+    req_path = req_path.replace(os.path.sep, '/')
     # Install as either editable or not.
-    if True:
-        req_path = req_path.replace(os.path.sep, '/')
-        # Regular install.
+    if not editable:
         with requirements_file(req_path + '\n',
                                script.scratch_path) as reqs_file:
             result = script.pip('install', '-vvv', '-r', reqs_file.name,
@@ -100,8 +102,7 @@ def test_relative_requirements_file(script, data, test_type):
             assert egg_info_file in result.files_created, str(result)
             assert package_folder in result.files_created, str(result)
             script.pip('uninstall', '-y', 'fspkg')
-
-        # Editable install.
+    else:
         with requirements_file('-e ' + req_path + '\n',
                                script.scratch_path) as reqs_file:
             result = script.pip('install', '-vvv', '-r', reqs_file.name,

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -57,7 +57,12 @@ def test_schema_check_in_requirements_file(script):
         )
 
 
-def test_relative_requirements_file(script, data):
+@pytest.mark.parametrize("test_type", [
+    ("rel_path"),
+    ("rel_url"),
+    ("embedded_rel_path"),
+])
+def test_relative_requirements_file(script, data, test_type):
     """
     Test installing from a requirements file with a relative path. For path
     URLs, use an egg= definition.
@@ -78,9 +83,14 @@ def test_relative_requirements_file(script, data):
     full_rel_url = 'file:' + full_rel_path + '#egg=FSPkg'
     embedded_rel_path = script.scratch_path.joinpath(full_rel_path)
 
-    # For each relative path, install as either editable or not using either
-    # URLs with egg links or not.
-    for req_path in (full_rel_path, full_rel_url, embedded_rel_path):
+    req_path = {
+        "rel_path": full_rel_path,
+        "rel_url": full_rel_url,
+        "embedded_rel_path": embedded_rel_path,
+    }[test_type]
+
+    # Install as either editable or not.
+    if True:
         req_path = req_path.replace(os.path.sep, '/')
         # Regular install.
         with requirements_file(req_path + '\n',

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -101,14 +101,12 @@ def test_relative_requirements_file(script, data, test_type, editable):
                                 cwd=script.scratch_path)
             assert egg_info_file in result.files_created, str(result)
             assert package_folder in result.files_created, str(result)
-            script.pip('uninstall', '-y', 'fspkg')
     else:
         with requirements_file('-e ' + req_path + '\n',
                                script.scratch_path) as reqs_file:
             result = script.pip('install', '-vvv', '-r', reqs_file.name,
                                 cwd=script.scratch_path)
             assert egg_link_file in result.files_created, str(result)
-            script.pip('uninstall', '-y', 'fspkg')
 
 
 @pytest.mark.network


### PR DESCRIPTION
`test_basic_install_relative_directory` and `test_relative_requirements_file` are some of our longest tests (as indicated in our test summary in Azure Pipelines, e.g. [here](https://dev.azure.com/pypa/pip/_build/results?buildId=17275&view=ms.vss-test-web.build-test-results-tab)). This isn't because they're doing anything special, just a simple thing several times, requiring `pip uninstall` in-between runs in the same test.

Now we run the tests individually and can drop the unnecessary `pip uninstall` which saving some time (4s on my machine single-threaded). This also allows these individual tests to be run concurrently when using pytest-xdist.

Progresses #4497.