### PR TITLE
_should_cache does not depend on check_binary_allowed

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -358,7 +358,6 @@ class InstallCommand(RequirementCommand):
                     wheel_cache=wheel_cache,
                     build_options=[],
                     global_options=[],
-                    check_binary_allowed=check_binary_allowed,
                 )
 
                 # If we're using PEP 517, we cannot do a direct install

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -113,35 +113,17 @@ def test_should_build_legacy_wheel_installed(is_wheel_installed):
 
 
 @pytest.mark.parametrize(
-    "req, disallow_binaries, expected",
+    "req, expected",
     [
-        (ReqMock(editable=True), False, False),
-        (ReqMock(source_dir=None), False, False),
-        (ReqMock(link=Link("git+https://g.c/org/repo")), False, False),
-        (ReqMock(link=Link("https://g.c/dist.tgz")), False, False),
-        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), False, True),
-        (ReqMock(editable=True), True, False),
-        (ReqMock(source_dir=None), True, False),
-        (ReqMock(link=Link("git+https://g.c/org/repo")), True, False),
-        (ReqMock(link=Link("https://g.c/dist.tgz")), True, False),
-        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), True, False),
+        (ReqMock(editable=True), False),
+        (ReqMock(source_dir=None), False),
+        (ReqMock(link=Link("git+https://g.c/org/repo")), False),
+        (ReqMock(link=Link("https://g.c/dist.tgz")), False),
+        (ReqMock(link=Link("https://g.c/dist-2.0.4.tgz")), True),
     ],
 )
-def test_should_cache(
-    req, disallow_binaries, expected
-):
-    def check_binary_allowed(req):
-        return not disallow_binaries
-
-    should_cache = wheel_builder._should_cache(
-        req, check_binary_allowed
-    )
-    if not wheel_builder.should_build_for_install_command(
-        req, check_binary_allowed=check_binary_allowed
-    ):
-        # never cache if pip install would not have built)
-        assert not should_cache
-    assert should_cache is expected
+def test_should_cache(req, expected):
+    assert wheel_builder._should_cache(req) is expected
 
 
 def test_should_cache_git_sha(script, tmpdir):
@@ -153,16 +135,12 @@ def test_should_cache_git_sha(script, tmpdir):
     # a link referencing a sha should be cached
     url = "git+https://g.c/o/r@" + commit + "#egg=mypkg"
     req = ReqMock(link=Link(url), source_dir=repo_path)
-    assert wheel_builder._should_cache(
-        req, check_binary_allowed=lambda r: True,
-    )
+    assert wheel_builder._should_cache(req)
 
     # a link not referencing a sha should not be cached
     url = "git+https://g.c/o/r@master#egg=mypkg"
     req = ReqMock(link=Link(url), source_dir=repo_path)
-    assert not wheel_builder._should_cache(
-        req, check_binary_allowed=lambda r: True,
-    )
+    assert not wheel_builder._should_cache(req)
 
 
 def test_format_command_result__INFO(caplog):


### PR DESCRIPTION
In practice, the `check_binary_allowed` argument of `_should_cache` always returns True, so we can remove the it.

**Why:**

`_should_cache` is only called by `_get_cache_dir` which in turn is only called by `build`.

In pip install mode, `_get_cache_dir` is never called when `check_binary_allowed` returns False because in that case `should_build_for_install_command` has returned False before and the build was skipped.

In pip wheel mode, `check_binary_allowed` always returns True (because it is not passed to the build function).

So `_should_cache` can use `_always_true` for `check_binary_allowed`.

**Alternative:**

Alternatively, we could have passed `check_binary_allowed` to `build` in pip wheel mode. The only difference is that wheels built locally from *legacy* packages would then not be cached, when pip wheel is used with `--no-binary`. Wheels built from PEP 517 packages would still be cached, because `check_binary_allowed` [always returns True for them](https://github.com/pypa/pip/blob/6b51ee1a39fc14d7bf9eab95954d67fa2105b4d1/src/pip/_internal/commands/install.py#L65-L66), and pip install caches them too.
