### PR TITLE
Detect all registered VCS and choose inner-most

### DIFF
--- a/news/3988.bugfix
+++ b/news/3988.bugfix
@@ -1,0 +1,1 @@
+Correctly freeze a VCS editable package when it is nested inside another VCS repository.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -11,7 +11,7 @@ from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib import request as urllib_request
 
-from pip._internal.exceptions import BadCommand
+from pip._internal.exceptions import BadCommand, InstallationError
 from pip._internal.utils.misc import display_path, hide_url
 from pip._internal.utils.subprocess import make_command
 from pip._internal.utils.temp_dir import TempDirectory
@@ -370,20 +370,23 @@ class Git(VersionControl):
         )
 
     @classmethod
-    def controls_location(cls, location):
-        if super(Git, cls).controls_location(location):
-            return True
+    def get_repository_root(cls, location):
+        loc = super(Git, cls).get_repository_root(location)
+        if loc:
+            return loc
         try:
-            r = cls.run_command(['rev-parse'],
+            r = cls.run_command(['rev-parse', '--show-toplevel'],
                                 cwd=location,
                                 show_stdout=False,
-                                on_returncode='ignore',
+                                on_returncode='raise',
                                 log_failed_cmd=False)
-            return not r
         except BadCommand:
             logger.debug("could not determine if %s is under git control "
                          "because git is not available", location)
-            return False
+            return None
+        except InstallationError:
+            return None
+        return r
 
 
 vcs.register(Git)

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -375,11 +375,13 @@ class Git(VersionControl):
         if loc:
             return loc
         try:
-            r = cls.run_command(['rev-parse', '--show-toplevel'],
-                                cwd=location,
-                                show_stdout=False,
-                                on_returncode='raise',
-                                log_failed_cmd=False)
+            r = cls.run_command(
+                ['rev-parse', '--show-toplevel'],
+                cwd=location,
+                show_stdout=False,
+                on_returncode='raise',
+                log_failed_cmd=False,
+            )
         except BadCommand:
             logger.debug("could not determine if %s is under git control "
                          "because git is not available", location)

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -386,7 +386,7 @@ class Git(VersionControl):
             return None
         except InstallationError:
             return None
-        return r
+        return r.strip()
 
 
 vcs.register(Git)

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -388,7 +388,7 @@ class Git(VersionControl):
             return None
         except InstallationError:
             return None
-        return r.strip()
+        return os.path.normpath(r.rstrip('\r\n'))
 
 
 vcs.register(Git)

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -147,8 +147,13 @@ class Mercurial(VersionControl):
                 cwd=location,
                 show_stdout=False,
                 on_returncode='raise',
-                log_failed_cmd=False)
-        except (BadCommand, InstallationError):
+                log_failed_cmd=False,
+            )
+        except BadCommand:
+            logger.debug("could not determine if %s is under hg control "
+                         "because hg is not available", location)
+            return None
+        except InstallationError:
             return None
         return r.strip()
 

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -150,7 +150,7 @@ class Mercurial(VersionControl):
                 log_failed_cmd=False)
         except (BadCommand, InstallationError):
             return None
-        return r
+        return r.strip()
 
 
 vcs.register(Mercurial)

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -155,7 +155,7 @@ class Mercurial(VersionControl):
             return None
         except InstallationError:
             return None
-        return r.strip()
+        return os.path.normpath(r.rstrip('\r\n'))
 
 
 vcs.register(Mercurial)

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -137,19 +137,20 @@ class Mercurial(VersionControl):
         return find_path_to_setup_from_repo_root(location, repo_root)
 
     @classmethod
-    def controls_location(cls, location):
-        if super(Mercurial, cls).controls_location(location):
-            return True
+    def get_repository_root(cls, location):
+        loc = super(Mercurial, cls).get_repository_root(location)
+        if loc:
+            return loc
         try:
-            cls.run_command(
-                ['identify'],
+            r = cls.run_command(
+                ['root'],
                 cwd=location,
                 show_stdout=False,
                 on_returncode='raise',
                 log_failed_cmd=False)
-            return True
         except (BadCommand, InstallationError):
-            return False
+            return None
+        return r
 
 
 vcs.register(Mercurial)

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -232,12 +232,20 @@ class VcsSupport(object):
         Return a VersionControl object if a repository of that type is found
         at the given directory.
         """
+        candidates = {}
         for vcs_backend in self._registry.values():
-            if vcs_backend.controls_location(location):
-                logger.debug('Determine that %s uses VCS: %s',
-                             location, vcs_backend.name)
-                return vcs_backend
-        return None
+            root = vcs_backend.get_repository_root(location)
+            if not root:
+                continue
+            logger.debug('Determine that %s uses VCS: %s',
+                         location, vcs_backend.name)
+            candidates[root] = vcs_backend
+
+        # Choose the VCS in the inner-most directory (i.e. path to root
+        # is longest).
+        if not candidates:
+            return None
+        return candidates[max(candidates, key=len)]
 
     def get_backend_for_scheme(self, scheme):
         # type: (str) -> Optional[VersionControl]
@@ -687,14 +695,18 @@ class VersionControl(object):
         return os.path.exists(os.path.join(path, cls.dirname))
 
     @classmethod
-    def controls_location(cls, location):
-        # type: (str) -> bool
+    def get_repository_root(cls, location):
+        # type: (str) -> Optional[str]
         """
-        Check if a location is controlled by the vcs.
+        Return the "root" (top-level) directory controlled by the vcs,
+        or ``None`` if the directory is not in any.
+
         It is meant to be overridden to implement smarter detection
         mechanisms for specific vcs.
 
-        This can do more than is_repository_directory() alone.  For example,
-        the Git override checks that Git is actually available.
+        This can do more than is_repository_directory() alone. For
+        example, the Git override checks that Git is actually available.
         """
-        return cls.is_repository_directory(location)
+        if cls.is_repository_directory(location):
+            return location
+        return None

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -245,7 +245,7 @@ class VcsSupport(object):
             return None
 
         # Choose the VCS in the inner-most directory. Since all repository
-        # roots found here would be either ``location``` or one of its
+        # roots found here would be either `location` or one of its
         # parents, the longest path should have the most path components,
         # i.e. the backend representing the inner-most repository.
         inner_most_repo_path = max(vcs_backends, key=len)
@@ -703,7 +703,7 @@ class VersionControl(object):
         # type: (str) -> Optional[str]
         """
         Return the "root" (top-level) directory controlled by the vcs,
-        or ``None`` if the directory is not in any.
+        or `None` if the directory is not in any.
 
         It is meant to be overridden to implement smarter detection
         mechanisms for specific vcs.

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -238,3 +238,15 @@ def test_is_immutable_rev_checkout(script):
     assert not Git().is_immutable_rev_checkout(
         "git+https://g.c/o/r@master", version_pkg_path
     )
+
+
+def test_get_repository_root(script):
+    version_pkg_path = _create_test_package(script)
+    tests_path = version_pkg_path.joinpath("tests")
+    tests_path.mkdir()
+
+    root1 = Git.get_repository_root(version_pkg_path)
+    assert root1 == version_pkg_path
+
+    root2 = Git.get_repository_root(version_pkg_path.joinpath("tests"))
+    assert root2 == version_pkg_path

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -246,7 +246,7 @@ def test_get_repository_root(script):
     tests_path.mkdir()
 
     root1 = Git.get_repository_root(version_pkg_path)
-    assert root1 == version_pkg_path
+    assert os.path.normcase(root1) == os.path.normcase(version_pkg_path)
 
     root2 = Git.get_repository_root(version_pkg_path.joinpath("tests"))
-    assert root2 == version_pkg_path
+    assert os.path.normcase(root2) == os.path.normcase(version_pkg_path)

--- a/tests/functional/test_vcs_mercurial.py
+++ b/tests/functional/test_vcs_mercurial.py
@@ -1,7 +1,8 @@
 from pip._internal.vcs.mercurial import Mercurial
-from tests.lib import _create_test_package
+from tests.lib import _create_test_package, need_mercurial
 
 
+@need_mercurial
 def test_get_repository_root(script):
     version_pkg_path = _create_test_package(script, vcs="hg")
     tests_path = version_pkg_path.joinpath("tests")

--- a/tests/functional/test_vcs_mercurial.py
+++ b/tests/functional/test_vcs_mercurial.py
@@ -1,3 +1,5 @@
+import os
+
 from pip._internal.vcs.mercurial import Mercurial
 from tests.lib import _create_test_package, need_mercurial
 
@@ -9,7 +11,7 @@ def test_get_repository_root(script):
     tests_path.mkdir()
 
     root1 = Mercurial.get_repository_root(version_pkg_path)
-    assert root1 == version_pkg_path
+    assert os.path.normcase(root1) == os.path.normcase(version_pkg_path)
 
     root2 = Mercurial.get_repository_root(version_pkg_path.joinpath("tests"))
-    assert root2 == version_pkg_path
+    assert os.path.normcase(root2) == os.path.normcase(version_pkg_path)

--- a/tests/functional/test_vcs_mercurial.py
+++ b/tests/functional/test_vcs_mercurial.py
@@ -1,0 +1,14 @@
+from pip._internal.vcs.mercurial import Mercurial
+from tests.lib import _create_test_package
+
+
+def test_get_repository_root(script):
+    version_pkg_path = _create_test_package(script, vcs="hg")
+    tests_path = version_pkg_path.joinpath("tests")
+    tests_path.mkdir()
+
+    root1 = Mercurial.get_repository_root(version_pkg_path)
+    assert root1 == version_pkg_path
+
+    root2 = Mercurial.get_repository_root(version_pkg_path.joinpath("tests"))
+    assert root2 == version_pkg_path


### PR DESCRIPTION
Fix #3988.

The idea (as describe in https://github.com/pypa/pip/issues/3988#issuecomment-250692379) is to test all VCS, and choose the one that controls the inner-most directory as root. Git provides this value via `git rev-parse --show-toplevel`, and Mercurial `hg root`.

The implementation seems to work from my limited testing, but there are still much to do. A test, at least. And the VCS code modified in this PR probably could use some refactoring as well.