### PR TITLE
Explicitly set newline when rewriting for release

### DIFF
--- a/tools/automation/release/__init__.py
+++ b/tools/automation/release/__init__.py
@@ -3,7 +3,6 @@
 These are written according to the order they are called in.
 """
 
-import io
 import os
 import subprocess
 from typing import List, Optional, Set
@@ -70,7 +69,7 @@ def generate_authors(filename: str) -> None:
     authors = get_author_list()
 
     # Write our authors to the AUTHORS file
-    with io.open(filename, "w", encoding="utf-8") as fp:
+    with open(filename, "w", encoding="utf-8", newline="\n") as fp:
         fp.write(u"\n".join(authors))
         fp.write(u"\n")
 
@@ -86,7 +85,7 @@ def generate_news(session: Session, version: str) -> None:
 
 
 def update_version_file(version: str, filepath: str) -> None:
-    with open(filepath, "w", encoding="utf-8") as f:
+    with open(filepath, "w", encoding="utf-8", newline="\n") as f:
         f.write('__version__ = "{}"\n'.format(version))
 
 


### PR DESCRIPTION
Set the newline to always be `\n`. This is probably fine because we are committing the files immediately anyway, and Git would perform the necessary normalisation on checkout for people running `core.autocrlf` with `true` or `input`.