### PR TITLE
Delay TempDirectory.delete resolution to cleanup

### DIFF
--- a/tests/unit/test_utils_temp_dir.py
+++ b/tests/unit/test_utils_temp_dir.py
@@ -234,3 +234,17 @@ def test_tempdir_registry(kind, delete, exists):
             path = d.path
             assert os.path.exists(path)
         assert os.path.exists(path) == exists
+
+
+@pytest.mark.parametrize("should_delete", [True, False])
+def test_tempdir_registry_lazy(should_delete):
+    """
+    Test the registry entry can be updated after a temp dir is created,
+    to change whether a kind should be deleted or not.
+    """
+    with tempdir_registry() as registry:
+        with TempDirectory(delete=None, kind="test-for-lazy") as d:
+            path = d.path
+            registry.set_delete("test-for-lazy", should_delete)
+            assert os.path.exists(path)
+        assert os.path.exists(path) == (not should_delete)


### PR DESCRIPTION
Quoting @chrahunt in https://github.com/pypa/pip/issues/7571#issuecomment-571893409:

> One issue with globally managing the temporary build directory is that `InstallCommand` and `WheelCommand` catch a `PreviousBuildDirError` and then explicitly set `options.no_clean`. This prevents us from taking a straightforward approach for configuring global tempdir handling if `options.no_clean` is set.

From my reading of the implementation, the problem is that the temp directory relies on the registry to decide whether it should clean up, but that decision is made on instantiation, so the `PreviousBuildDirError` handler cannot affect that decision. This patch would delay that decision until cleanup time instead, so the `PreviousBuildDirError` handler can be kept to tell the registry to stop the cleanup.

Feel free to close this if you think this is not the way to go.