### PR TITLE
Improve our release process automation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -203,6 +203,10 @@ def build_release(session):
     session.log("# Checkout the tag")
     session.run("git", "checkout", version, external=True, silent=True)
 
+    session.log("# Cleanup build/ before building the wheel")
+    if release.have_files_in_folder("build"):
+        shutil.rmtree("build")
+
     session.log("# Build distributions")
     session.run("python", "setup.py", "sdist", "bdist_wheel", silent=True)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -234,8 +234,8 @@ def upload_release(session):
         )
     # Sanity check: Make sure the files are correctly named.
     expected_distribution_files = [
-        f"pip-{version}-py2.py3-none-any.whl",
-        f"pip-{version}.tar.gz",
+        f"dist/pip-{version}-py2.py3-none-any.whl",
+        f"dist/pip-{version}.tar.gz",
     ]
     if sorted(distribution_files) != sorted(expected_distribution_files):
         session.error(


### PR DESCRIPTION
Looks like the rouge source/ directory that caused the pip 20.0 breakage, came from my local `build/` directory -- circa pypa/wheel#147. Thanks @xavfernandez for figuring that out.

This improves our release process to force an empty build/ directory to avoid such a breakage in the future, and adds an omitted prefix for the expected release filenames.