### PR TITLE
Add a config for the issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,10 +3,10 @@ blank_issues_enabled: true  # default
 contact_links:
 - name: '💬 IRC: #pypa @ Freenode'
   url: https://webchat.freenode.net/#pypa
-  about: Chat with devs.
+  about: Chat with devs
 - name: 🤷💻🤦 Discourse
   url: https://discuss.python.org/c/packaging
-  about: Please ask typical Q&A here.
+  about: Please ask typical Q&A here
 - name: 📝 PyPA Code of Conduct
   url: https://www.pypa.io/en/latest/code-of-conduct/
   about: ❤ Be nice to other members of the community. ☮ Behave.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,9 @@ contact_links:
   about: Chat with devs
 - name: 🤷💻🤦 Discourse
   url: https://discuss.python.org/c/packaging
-  about: Please ask typical Q&A here
+  about: |
+    Please ask typical Q&A here: general ideas for Python packaging,
+    questions about structuring projects and so on
 - name: 📝 PyPA Code of Conduct
   url: https://www.pypa.io/en/latest/code-of-conduct/
   about: ❤ Be nice to other members of the community. ☮ Behave.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true  # default
+contact_links:
+- name: '💬 IRC: #pypa @ Freenode'
+  url: https://webchat.freenode.net/#pypa
+  about: Chat with devs.
+- name: 🤷💻🤦 Discourse
+  url: https://discuss.python.org/c/packaging
+  about: Please ask typical Q&A here.
+- name: 🔐 Security Policy
+  url: https://pypi.org/security/
+  about: Please learn how to report security vulnerabilities here.
+- name: 📝 PyPA Code of Conduct
+  url: https://www.pypa.io/en/latest/code-of-conduct/
+  about: ❤ Be nice to other members of the community. ☮ Behave.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 # Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: true  # default
 contact_links:
-- name: '💬 IRC: #pypa @ Freenode'
-  url: https://webchat.freenode.net/#pypa
-  about: Chat with devs
 - name: 🤷💻🤦 Discourse
   url: https://discuss.python.org/c/packaging
   about: |
     Please ask typical Q&A here: general ideas for Python packaging,
     questions about structuring projects and so on
+- name: '💬 IRC: #pypa @ Freenode'
+  url: https://webchat.freenode.net/#pypa
+  about: Chat with devs
 - name: 📝 PyPA Code of Conduct
   url: https://www.pypa.io/en/latest/code-of-conduct/
   about: ❤ Be nice to other members of the community. ☮ Behave.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,9 +7,6 @@ contact_links:
 - name: 🤷💻🤦 Discourse
   url: https://discuss.python.org/c/packaging
   about: Please ask typical Q&A here.
-- name: 🔐 Security Policy
-  url: https://pypi.org/security/
-  about: Please learn how to report security vulnerabilities here.
 - name: 📝 PyPA Code of Conduct
   url: https://www.pypa.io/en/latest/code-of-conduct/
   about: ❤ Be nice to other members of the community. ☮ Behave.


### PR DESCRIPTION
This introduces a basic config for https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser. Can be adjusted later as per project needs.