### PR TITLE
Azure Pipielines: Replace soon-unsupported macOS 10.13 with 10.14

### DIFF
--- a/.azure-pipelines/macos.yml
+++ b/.azure-pipelines/macos.yml
@@ -1,8 +1,8 @@
 jobs:
 - template: jobs/test.yml
   parameters:
-    vmImage: xcode9-macos10.13
+    vmImage: macos-10.14
 
 - template: jobs/package.yml
   parameters:
-    vmImage: xcode9-macos10.13
+    vmImage: macos-10.14


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Azure DevOps Blog:

> We have decided to remove the macOS-10.13 image because less than 5% of users use macOS High Sierra 10.13 and there is a later macOS version image – macOS-10.14 available. In addition, we will be adding the latest macOS version – Catalina or macOS-10.15 on February 3, 2020.

* https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/

More about upcoming changes:

* https://devblogs.microsoft.com/devops/azure-pipelines-hosted-pools-updates/

---

Does this need a news entry or a trivial file/label?