### PR TITLE
Configure tempdir registry in BaseCommand

### DIFF
--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -13,7 +13,7 @@ from pip._internal.utils.misc import rmtree
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any, Dict, Iterator, Optional, TypeVar
+    from typing import Any, Dict, Iterator, Optional, TypeVar, Union
 
     _T = TypeVar('_T', bound='TempDirectory')
 
@@ -77,6 +77,13 @@ def tempdir_registry():
         _tempdir_registry = old_tempdir_registry
 
 
+class _Default(object):
+    pass
+
+
+_default = _Default()
+
+
 class TempDirectory(object):
     """Helper class that owns and cleans up a temporary directory.
 
@@ -101,16 +108,21 @@ class TempDirectory(object):
     def __init__(
         self,
         path=None,    # type: Optional[str]
-        delete=None,  # type: Optional[bool]
+        delete=_default,  # type: Union[bool, None, _Default]
         kind="temp",  # type: str
         globally_managed=False,  # type: bool
     ):
         super(TempDirectory, self).__init__()
 
-        # If we were given an explicit directory, resolve delete option now.
-        # Otherwise we wait until cleanup and see what tempdir_registry says.
-        if path is not None and delete is None:
-            delete = False
+        if delete is _default:
+            if path is not None:
+                # If we were given an explicit directory, resolve delete option
+                # now.
+                delete = False
+            else:
+                # Otherwise, we wait until cleanup and see what
+                # tempdir_registry says.
+                delete = None
 
         if path is None:
             path = self._create(kind)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 
 import pytest
 import six
-from pip._vendor.contextlib2 import ExitStack
+from pip._vendor.contextlib2 import ExitStack, nullcontext
 from setuptools.wheel import Wheel
 
 from pip._internal.cli.main import main as pip_entry_point
@@ -188,13 +188,18 @@ def isolate(tmpdir):
 
 
 @pytest.fixture(autouse=True)
-def scoped_global_tempdir_manager():
+def scoped_global_tempdir_manager(request):
     """Make unit tests with globally-managed tempdirs easier
 
     Each test function gets its own individual scope for globally-managed
     temporary directories in the application.
     """
-    with global_tempdir_manager():
+    if "no_auto_tempdir_manager" in request.keywords:
+        ctx = nullcontext
+    else:
+        ctx = global_tempdir_manager
+
+    with ctx():
         yield
 
 


### PR DESCRIPTION
As mentioned in [#7608 (comment)](https://github.com/pypa/pip/pull/7608#pullrequestreview-344953733). This will let us configure and use the tempdir registry to apply the `--no-clean` configuration to globally managed temporary directories, and eventually remove the responsibility for managing those directories from `RequirementSet`.

Progresses #7571.