### PR TITLE
Make release task build dists @ clean tmp checkout

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -206,9 +206,8 @@ def build_release(session):
     session.log("# Checkout the tag")
     session.run("git", "checkout", version, external=True, silent=True)
 
-    session.log("# Cleanup build/ before building the wheel")
-    if release.have_files_in_folder("build"):
-        shutil.rmtree("build")
+    session.log("# Wipe Git-untracked files before building the wheel")
+    session.run("git", "clean", "-fxd", external=True, silent=True)
 
     session.log("# Build distributions")
     session.run("python", "setup.py", "sdist", "bdist_wheel", silent=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -206,8 +206,9 @@ def build_release(session):
     session.log("# Checkout the tag")
     session.run("git", "checkout", version, external=True, silent=True)
 
-    session.log("# Wipe Git-untracked files before building the wheel")
-    session.run("git", "clean", "-fxd", external=True, silent=True)
+    session.log("# Cleanup build/ before building the wheel")
+    if release.have_files_in_folder("build"):
+        shutil.rmtree("build")
 
     session.log("# Build distributions")
     session.run("python", "setup.py", "sdist", "bdist_wheel", silent=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,6 @@
 import glob
 import os
 import shutil
-import subprocess
 import sys
 
 import nox
@@ -226,25 +225,10 @@ def build_dists(session):
         "# Check if there's any Git-untracked files before building the wheel",
     )
 
-    def get_git_untracked_files():
-        """List all local file paths that aren't tracked by Git."""
-        git_ls_files_cmd = (
-            "git", "ls-files", "--ignored", "--exclude-standard",
-            "--others", "--", ".",
-        )
-        # session.run doesn't seem to return any output:
-        ls_files_out = subprocess.check_output(git_ls_files_cmd, text=True)
-        ls_files_out_lines = ls_files_out.splitlines()
-        for file_name in ls_files_out_lines:
-            if file_name.strip():  # it's useless if empty
-                continue
-
-            yield file_name
-
     has_forbidden_git_untracked_files = any(
         # Don't report the environment this session is running in
         not untracked_file.startswith('.nox/build-release/')
-        for untracked_file in get_git_untracked_files()
+        for untracked_file in release.get_git_untracked_files()
     )
     if has_forbidden_git_untracked_files:
         session.error(

--- a/noxfile.py
+++ b/noxfile.py
@@ -276,7 +276,7 @@ def build_dists(session):
     )
     if has_git_untracked_files:
         session.error(
-            "There are untracked files in the Git repo workdir. "
+            "There are untracked files in the working directory. "
             "Remove them and try again",
         )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -204,14 +204,17 @@ def workdir(nox_session, dir_path: pathlib.Path):
 
 
 @contextlib.contextmanager
-def mk_tmp_git_checkout(nox_session, target_commitish: str):
+def isolated_temporary_checkout(
+        nox_session: nox.sessions.Session,
+        target_ref: str,
+) -> pathlib.Path:
     """Make a clean checkout of a given version in tmp dir."""
     with tempfile.TemporaryDirectory() as tmp_dir_path:
         tmp_dir = pathlib.Path(tmp_dir_path)
-        git_checkout_dir = tmp_dir / f'pip-build-{target_commitish}'
+        git_checkout_dir = tmp_dir / f'pip-build-{target_ref}'
         nox_session.run(
             'git', 'worktree', 'add', '--force', '--checkout',
-            str(git_checkout_dir), str(target_commitish),
+            str(git_checkout_dir), str(target_ref),
             external=True, silent=True,
         )
 
@@ -241,7 +244,7 @@ def build_release(session):
     session.log("# Install dependencies")
     session.install("setuptools", "wheel", "twine")
 
-    with mk_tmp_git_checkout(session, version) as build_dir_path:
+    with isolated_temporary_checkout(session, version) as build_dir_path:
         session.log(
             "# Start the build in an isolated, "
             f"temporary Git checkout at {build_dir_path!s}",

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,6 +7,7 @@
 import glob
 import os
 import shutil
+import subprocess
 import sys
 
 import nox
@@ -209,6 +210,27 @@ def build_release(session):
     session.log("# Cleanup build/ before building the wheel")
     if release.have_files_in_folder("build"):
         shutil.rmtree("build")
+
+    session.log(
+        "# Check if there's any Git-untracked files before building the wheel",
+    )
+    has_git_untracked_files = any(
+        bool(l) for l in
+        # session.run doesn't seem to return any output
+        subprocess.check_output(
+            (
+                "git", "ls-files", "--ignored", "--exclude-standard",
+                "--others", "--", ".",
+            ),
+            text=True,
+        ).split('\n')
+        if not l.startswith('.nox/build-release/')  # exclude nox env file
+    )
+    if has_git_untracked_files:
+        session.error(
+            "There are untracked files in the Git repo workdir. "
+            "Remove them and try again",
+        )
 
     session.log("# Build distributions")
     session.run("python", "setup.py", "sdist", "bdist_wheel", silent=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -259,10 +259,6 @@ def build_release(session):
 
 
 def build_dists(session):
-    session.log("# Cleanup build/ before building the wheel")
-    if release.have_files_in_folder("build"):
-        shutil.rmtree("build")
-
     session.log(
         "# Check if there's any Git-untracked files before building the wheel",
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -196,13 +196,11 @@ def workdir(nox_session, dir_path: pathlib.Path):
     """Temporarily chdir when entering CM and chdir back on exit."""
     orig_dir = pathlib.Path.cwd()
 
-    nox_session.log(f"# Changing dir to {dir_path}")
-    os.chdir(dir_path)
+    nox_session.chdir(dir_path)
     try:
         yield dir_path
     finally:
-        nox_session.log(f"# Changing dir back to {orig_dir}")
-        os.chdir(orig_dir)
+        nox_session.chdir(orig_dir)
 
 
 @contextlib.contextmanager

--- a/noxfile.py
+++ b/noxfile.py
@@ -205,10 +205,7 @@ def workdir(nox_session, dir_path: pathlib.Path):
 
 @contextlib.contextmanager
 def mk_tmp_git_checkout(nox_session, target_commitish: str):
-    """Make a clean checkout of a given version in tmp dir.
-
-    This is a context manager that cleans up after itself.
-    """
+    """Make a clean checkout of a given version in tmp dir."""
     with tempfile.TemporaryDirectory() as tmp_dir_path:
         tmp_dir = pathlib.Path(tmp_dir_path)
         git_checkout_dir = tmp_dir / f'pip-build-{target_commitish}'

--- a/noxfile.py
+++ b/noxfile.py
@@ -209,9 +209,6 @@ def mk_tmp_git_checkout(nox_session, target_commitish: str):
     with tempfile.TemporaryDirectory() as tmp_dir_path:
         tmp_dir = pathlib.Path(tmp_dir_path)
         git_checkout_dir = tmp_dir / f'pip-build-{target_commitish}'
-        nox_session.log(
-            f"# Creating a temporary Git checkout at {git_checkout_dir!s}",
-        )
         nox_session.run(
             'git', 'worktree', 'add', '--force', '--checkout',
             str(git_checkout_dir), str(target_commitish),
@@ -245,6 +242,10 @@ def build_release(session):
     session.install("setuptools", "wheel", "twine")
 
     with mk_tmp_git_checkout(session, version) as build_dir_path:
+        session.log(
+            "# Start the build in an isolated, "
+            f"temporary Git checkout at {build_dir_path!s}",
+        )
         with workdir(session, build_dir_path):
             build_dists(session)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -253,6 +253,7 @@ def build_release(session):
 
         tmp_dist_dir = build_dir_path / 'dist'
         session.log(f"# Copying dists from {tmp_dist_dir}")
+        shutil.rmtree('dist', ignore_errors=True)  # remove empty `dist/`
         shutil.copytree(tmp_dist_dir, 'dist')
 
 

--- a/tools/automation/release/__init__.py
+++ b/tools/automation/release/__init__.py
@@ -169,3 +169,19 @@ def isolated_temporary_checkout(
                 str(git_checkout_dir),
                 external=True, silent=True,
             )
+
+
+def get_git_untracked_files() -> Iterator[str]:
+    """List all local file paths that aren't tracked by Git."""
+    git_ls_files_cmd = (
+        "git", "ls-files",
+        "--ignored", "--exclude-standard",
+        "--others", "--", ".",
+    )
+    # session.run doesn't seem to return any output:
+    ls_files_out = subprocess.check_output(git_ls_files_cmd, text=True)
+    for file_name in ls_files_out.splitlines():
+        if file_name.strip():  # it's useless if empty
+            continue
+
+        yield file_name


### PR DESCRIPTION
This is a follow-up of (and includes the commits from) #7631.

I did some hacking and submitting some PoC for the initial feedback.

The idea here is to checkout the given git ref under `/tmp`, build there and copy only the final dists back to the normal workdir.