### PR TITLE
Set encoding for tar file and use unicode path for unpacking

### DIFF
--- a/news/7667.bugfix
+++ b/news/7667.bugfix
@@ -1,0 +1,1 @@
+Fix extraction of files with utf-8 encoded paths from tars.


### PR DESCRIPTION
When tarfile.TarFile decodes filenames in Python 2.7 by default it uses
sys.getfilesystemencoding. On Windows this returns "mbcs", which is
lossy when converting from proper utf-8 to bytes (results in '?' for out
of range characters).

We now pass an encoding to tarfile.open which will be used instead.
Since the encoding argument is only ever used for the PAX format, and
since the PAX format guarantees utf-8 encoded information, this should
work in all circumstances.

For filesystem APIs in Python 2, the type of the path object passed
dictates the underlying Windows API that is called. For `str` it is the
`*A` (for ANSI) APIs. For `unicode` it is the `*W` (for Wide character)
APIs. To use the second set of APIs, which properly handles unicode
filenames, we convert the byte path to utf-8.

Fixes #7667.