### PR TITLE
Include editable locations in JSON output of list

### DIFF
--- a/news/7664.feature.rst
+++ b/news/7664.feature.rst
@@ -1,0 +1,3 @@
+Include ``location`` field for editable distribution entries in
+``pip list --json``, so the fields outputted match the default "columns"
+format.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -309,8 +309,9 @@ def format_for_json(packages, options):
             'name': dist.project_name,
             'version': str(dist.version),
         }
-        if options.verbose >= 1:
+        if options.verbose >= 1 or dist_is_editable(dist):
             info['location'] = dist.location
+        if options.verbose >= 1:
             info['installer'] = get_installer(dist)
         if options.outdated:
             info['latest_version'] = str(dist.latest_version)

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -160,11 +160,17 @@ def test_uptodate_flag(script, data):
         'list', '-f', data.find_links, '--no-index', '--uptodate',
         '--format=json',
     )
-    assert {"name": "simple", "version": "1.0"} \
-        not in json.loads(result.stdout)  # 3.0 is latest
-    assert {"name": "pip-test-package", "version": "0.1.1"} \
-        in json.loads(result.stdout)  # editables included
-    assert {"name": "simple2", "version": "3.0"} in json.loads(result.stdout)
+    json_result = json.loads(result.stdout)
+
+    # 3.0 is latest
+    assert "simple" not in {d["name"] for d in json_result}
+    # editables included
+    assert {
+        "name": "pip-test-package",
+        "version": "0.1.1",
+        "location": str(script.venv_path / "src" / "pip-test-package"),
+    } in json_result
+    assert {"name": "simple2", "version": "3.0"} in json_result
 
 
 @pytest.mark.network
@@ -212,15 +218,25 @@ def test_outdated_flag(script, data):
         'list', '-f', data.find_links, '--no-index', '--outdated',
         '--format=json',
     )
-    assert {"name": "simple", "version": "1.0",
-            "latest_version": "3.0", "latest_filetype": "sdist"} \
-        in json.loads(result.stdout)
-    assert dict(name="simplewheel", version="1.0",
-                latest_version="2.0", latest_filetype="wheel") \
-        in json.loads(result.stdout)
-    assert dict(name="pip-test-package", version="0.1",
-                latest_version="0.1.1", latest_filetype="sdist") \
-        in json.loads(result.stdout)
+    assert {
+        "name": "simple",
+        "version": "1.0",
+        "latest_version": "3.0",
+        "latest_filetype": "sdist",
+    } in json.loads(result.stdout)
+    assert {
+        "name": "simplewheel",
+        "version": "1.0",
+        "latest_version": "2.0",
+        "latest_filetype": "wheel",
+    } in json.loads(result.stdout)
+    assert {
+        "name": "pip-test-package",
+        "version": "0.1",
+        "location": str(script.venv_path / "src" / "pip-test-package"),
+        "latest_version": "0.1.1",
+        "latest_filetype": "sdist",
+    } in json.loads(result.stdout)
     assert "simple2" not in {p["name"] for p in json.loads(result.stdout)}
 
 

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -168,7 +168,9 @@ def test_uptodate_flag(script, data):
     assert {
         "name": "pip-test-package",
         "version": "0.1.1",
-        "location": str(script.venv_path / "src" / "pip-test-package"),
+        "location": os.path.normcase(
+            str(script.venv_path / "src" / "pip-test-package")
+        ),
     } in json_result
     assert {"name": "simple2", "version": "3.0"} in json_result
 
@@ -233,7 +235,9 @@ def test_outdated_flag(script, data):
     assert {
         "name": "pip-test-package",
         "version": "0.1",
-        "location": str(script.venv_path / "src" / "pip-test-package"),
+        "location": os.path.normcase(
+            str(script.venv_path / "src" / "pip-test-package")
+        ),
         "latest_version": "0.1.1",
         "latest_filetype": "sdist",
     } in json.loads(result.stdout)

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -506,12 +506,12 @@ def test_uninstall_setuptools_develop_install(script, data):
     script.run('python', 'setup.py', 'install',
                expect_stderr=True, cwd=pkg_path)
     list_result = script.pip('list', '--format=json')
+    egg_name = "FSPkg-0.1.dev0-py{0}.{1}.egg".format(*sys.version_info)
     assert {
         "name": os.path.normcase("FSPkg"),
         "version": "0.1.dev0",
-        "location": str(
-            script.site_packages_path /
-            "FSPkg-0.1.dev0-py{0}.{1}.egg".format(*sys.version_info)
+        "location": os.path.normcase(
+            str(script.site_packages_path / egg_name)
         ),
     } in json.loads(list_result.stdout), str(list_result)
     # Uninstall both develop and install
@@ -543,7 +543,7 @@ def test_uninstall_editable_and_pip_install(script, data):
     assert {
         "name": "FSPkg",
         "version": "0.1.dev0",
-        "location": str(script.site_packages_path),
+        "location": os.path.normcase(str(script.site_packages_path)),
     } in json.loads(list_result.stdout)
     # Uninstall both develop and install
     uninstall = script.pip('uninstall', 'FSPkg', '-y')

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -506,8 +506,14 @@ def test_uninstall_setuptools_develop_install(script, data):
     script.run('python', 'setup.py', 'install',
                expect_stderr=True, cwd=pkg_path)
     list_result = script.pip('list', '--format=json')
-    assert {"name": os.path.normcase("FSPkg"), "version": "0.1.dev0"} \
-        in json.loads(list_result.stdout), str(list_result)
+    assert {
+        "name": os.path.normcase("FSPkg"),
+        "version": "0.1.dev0",
+        "location": str(
+            script.site_packages_path /
+            "FSPkg-0.1.dev0-py{0}.{1}.egg".format(*sys.version_info)
+        ),
+    } in json.loads(list_result.stdout), str(list_result)
     # Uninstall both develop and install
     uninstall = script.pip('uninstall', 'FSPkg', '-y')
     assert any(filename.endswith('.egg')
@@ -534,8 +540,11 @@ def test_uninstall_editable_and_pip_install(script, data):
     script.pip('install', '--ignore-installed', '.',
                expect_stderr=True, cwd=pkg_path)
     list_result = script.pip('list', '--format=json')
-    assert {"name": "FSPkg", "version": "0.1.dev0"} \
-        in json.loads(list_result.stdout)
+    assert {
+        "name": "FSPkg",
+        "version": "0.1.dev0",
+        "location": str(script.site_packages_path),
+    } in json.loads(list_result.stdout)
     # Uninstall both develop and install
     uninstall = script.pip('uninstall', 'FSPkg', '-y')
     assert not any(filename.endswith('.egg-link')


### PR DESCRIPTION
Fix #7664. This matches the JSON format with the default columns format.

Probably need to come up with a test to make sure the two formats match.