### PR TITLE
Mitigate Windows test failures due to PAX-format wheel release

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -27,6 +27,7 @@ from tests.lib import (
     requirements_file,
     skip_if_not_python2,
     skip_if_python2,
+    windows_workaround_7667,
 )
 from tests.lib.filesystem import make_socket_file
 from tests.lib.local_repos import local_checkout
@@ -726,6 +727,7 @@ def test_install_using_install_option_and_editable(script, tmpdir):
 
 @pytest.mark.network
 @need_mercurial
+@windows_workaround_7667
 def test_install_global_option_using_editable(script, tmpdir):
     """
     Test using global distutils options, but in an editable installation
@@ -1333,6 +1335,7 @@ def test_install_no_binary_disables_building_wheels(script, data, with_wheel):
 
 
 @pytest.mark.network
+@windows_workaround_7667
 def test_install_no_binary_builds_pep_517_wheel(script, data, with_wheel):
     to_install = data.packages.joinpath('pep517_setup_and_pyproject')
     res = script.pip(
@@ -1347,6 +1350,7 @@ def test_install_no_binary_builds_pep_517_wheel(script, data, with_wheel):
 
 
 @pytest.mark.network
+@windows_workaround_7667
 def test_install_no_binary_uses_local_backend(
         script, data, with_wheel, tmpdir):
     to_install = data.packages.joinpath('pep517_wrapper_buildsys')

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -5,7 +5,7 @@ import pytest
 
 from pip._internal.cli.status_codes import PREVIOUS_BUILD_DIR_ERROR
 from pip._internal.utils.marker_files import write_delete_marker_file
-from tests.lib import need_mercurial
+from tests.lib import need_mercurial, windows_workaround_7667
 from tests.lib.local_repos import local_checkout
 
 
@@ -40,6 +40,7 @@ def test_no_clean_option_blocks_cleaning_after_install(script, data):
 
 @pytest.mark.network
 @need_mercurial
+@windows_workaround_7667
 def test_cleanup_after_install_editable_from_hg(script, tmpdir):
     """
     Test clean up after cloning from Mercurial.

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -3,7 +3,7 @@ from pip._vendor import pytoml
 
 from pip._internal.build_env import BuildEnvironment
 from pip._internal.req import InstallRequirement
-from tests.lib import make_test_finder, path_to_url
+from tests.lib import make_test_finder, path_to_url, windows_workaround_7667
 
 
 def make_project(tmpdir, requires=[], backend=None, backend_path=None):
@@ -249,6 +249,7 @@ def test_explicit_setuptools_backend(script, tmpdir, data, common_wheels):
 
 
 @pytest.mark.network
+@windows_workaround_7667
 def test_pep517_and_build_options(script, tmpdir, data, common_wheels):
     """Backend generated requirements are installed in the build env"""
     project_dir, name = make_pyproject_with_setup(tmpdir)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1116,3 +1116,10 @@ def need_mercurial(fn):
 
 skip_if_python2 = pytest.mark.skipif(PY2, reason="Non-Python 2 only")
 skip_if_not_python2 = pytest.mark.skipif(not PY2, reason="Python 2 only")
+
+
+# Workaround for test failures after new wheel release.
+windows_workaround_7667 = pytest.mark.skipif(
+    "sys.platform == 'win32' and sys.version_info < (3,)",
+    reason="Workaround for #7667",
+)


### PR DESCRIPTION
#7668 should solve this, but it needs more attention. In the meantime to unblock existing PRs we can skip the relevant tests on Windows on Python 2.

Fixes #7671.