### PR TITLE
Stop suggesting use of the /request-review bot

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,16 +10,3 @@ As a reminder, all contributors are expected to follow our [Code of Conduct][coc
 ## Development Documentation
 
 Our [development documentation](https://pip.pypa.io/en/latest/development/) contains details on how to get started with contributing to pip, and details of our development processes.
-
-## Bot Commands
-
-We have a bot monitoring the [pypa/pip](https://github.com/pypa/pip) repository
-to help manage the state of issues and pull requests to keep everything running
-smoothly. Each command given to the bot should be on its own line and is
-generally case sensitive. Multiple commands may be listed in a single comment
-(but they must each be on their own line) and the comments may also include
-other, non command content.
-
-Command | Who can run it | Description
---- | --- | ---
-`/request-review` | anyone | Dismisses all of the current reviews on a pull request, making it appear back in the review queue.


### PR DESCRIPTION
This bot is no longer being used by any contributor and, I'm planning on retiring this functionality from the upstream pypa/browntruck bot itself.
