### PR TITLE
fix un-vendored support; add missing entry for appdirs

### DIFF
--- a/news/7690.bugfix
+++ b/news/7690.bugfix
@@ -1,0 +1,1 @@
+Fix an 'appdirs' related import error in case pip is installed debundled i.e., without vendored dependencies.

--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -58,6 +58,7 @@ if DEBUNDLED:
     sys.path[:] = glob.glob(os.path.join(WHEEL_DIR, "*.whl")) + sys.path
 
     # Actually alias all of our vendored dependencies.
+    vendored("appdirs")
     vendored("cachecontrol")
     vendored("colorama")
     vendored("contextlib2")


### PR DESCRIPTION
pip has started to use the vendored appdirs directly since #7501
but didn't add an alias for the unbundled case.

This adds the missing alias.

----

Before the fix:
```
$ pip
Traceback (most recent call last):
  File "C:\msys64\mingw64\bin\pip-script.py", line 11, in <module>
    load_entry_point('pip==20.0.2', 'console_scripts', 'pip')()
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pkg_resources/__init__.py", line 490, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2853, in load_entry_point
    return ep.load()
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2444, in load
    return self.resolve()
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2450, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pip/_internal/cli/main.py", line 10, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pip/_internal/cli/autocompletion.py", line 9, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pip/_internal/cli/main_parser.py", line 7, in <module>
    from pip._internal.cli import cmdoptions
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pip/_internal/cli/cmdoptions.py", line 25, in <module>
    from pip._internal.locations import USER_CACHE_DIR, get_src_prefix
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pip/_internal/locations.py", line 19, in <module>
    from pip._internal.utils import appdirs
  File "C:/msys64/mingw64/lib/python3.8/site-packages/pip/_internal/utils/appdirs.py", line 13, in <module>
    from pip._vendor import appdirs as _appdirs
ImportError
```