### PR TITLE
Drop NEWS entry for a debundling change

### DIFF
--- a/news/7690.bugfix
+++ b/news/7690.bugfix
@@ -1,1 +1,0 @@
-Fix an 'appdirs' related import error in case pip is installed debundled i.e., without vendored dependencies.

--- a/news/7690.vendor
+++ b/news/7690.vendor
@@ -1,0 +1,1 @@
+Update semi-supported debundling script to reflect that appdirs is vendored.


### PR DESCRIPTION
Related to #7690 

Dropping the NEWS entry for the debundling-related change, as per precedence set in https://github.com/pypa/pip/pull/4661.