### PR TITLE
Move file unpacking out of lower level functions in operations.prepare

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -166,9 +166,7 @@ def unpack_http_url(
             link, downloader, temp_dir.path, hashes
         )
 
-    file = File(from_path, content_type)
-
-    return file
+    return File(from_path, content_type)
 
 
 def _copy2_ignoring_special_files(src, dest):
@@ -243,9 +241,7 @@ def unpack_file_url(
 
     content_type = mimetypes.guess_type(from_path)[0]
 
-    file = File(from_path, content_type)
-
-    return file
+    return File(from_path, content_type)
 
 
 def unpack_url(

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -285,17 +285,19 @@ def unpack_url(
 
     # file urls
     if link.is_file:
-        return unpack_file_url(link, location, download_dir, hashes=hashes)
+        file = unpack_file_url(link, location, download_dir, hashes=hashes)
 
     # http urls
     else:
-        return unpack_http_url(
+        file = unpack_http_url(
             link,
             location,
             downloader,
             download_dir,
             hashes=hashes,
         )
+
+    return file
 
 
 def _download_http_url(

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -213,16 +213,9 @@ def unpack_file_url(
     download_dir=None,  # type: Optional[str]
     hashes=None  # type: Optional[Hashes]
 ):
-    # type: (...) -> Optional[str]
+    # type: (...) -> str
     """Unpack link into location.
     """
-    # If it's a url to a local directory
-    if link.is_existing_dir():
-        if os.path.isdir(location):
-            rmtree(location)
-        _copy_source_tree(link.file_path, location)
-        return None
-
     # If a download dir is specified, is the file already there and valid?
     already_downloaded_path = None
     if download_dir:
@@ -270,6 +263,13 @@ def unpack_url(
     # non-editable vcs urls
     if link.is_vcs:
         unpack_vcs_link(link, location)
+        return None
+
+    # If it's a url to a local directory
+    if link.is_existing_dir():
+        if os.path.isdir(location):
+            rmtree(location)
+        _copy_source_tree(link.file_path, location)
         return None
 
     # file urls

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -141,7 +141,7 @@ class File(object):
         self.content_type = content_type
 
 
-def unpack_http_url(
+def get_http_url(
     link,  # type: Link
     location,  # type: str
     downloader,  # type: Downloader
@@ -210,14 +210,14 @@ def _copy_source_tree(source, target):
     shutil.copytree(source, target, **kwargs)
 
 
-def unpack_file_url(
+def get_file_url(
     link,  # type: Link
     location,  # type: str
     download_dir=None,  # type: Optional[str]
     hashes=None  # type: Optional[Hashes]
 ):
     # type: (...) -> File
-    """Unpack link into location.
+    """Get file and optionally check its hash.
     """
     # If a download dir is specified, is the file already there and valid?
     already_downloaded_path = None
@@ -273,11 +273,11 @@ def unpack_url(
 
     # file urls
     if link.is_file:
-        file = unpack_file_url(link, location, download_dir, hashes=hashes)
+        file = get_file_url(link, location, download_dir, hashes=hashes)
 
     # http urls
     else:
-        file = unpack_http_url(
+        file = get_http_url(
             link,
             location,
             downloader,

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -274,7 +274,7 @@ def unpack_url(
         return None
 
     # file urls
-    elif link.is_file:
+    if link.is_file:
         return unpack_file_url(link, location, download_dir, hashes=hashes)
 
     # http urls

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -216,12 +216,11 @@ def unpack_file_url(
     # type: (...) -> Optional[str]
     """Unpack link into location.
     """
-    link_path = link.file_path
     # If it's a url to a local directory
     if link.is_existing_dir():
         if os.path.isdir(location):
             rmtree(location)
-        _copy_source_tree(link_path, location)
+        _copy_source_tree(link.file_path, location)
         return None
 
     # If a download dir is specified, is the file already there and valid?
@@ -234,7 +233,7 @@ def unpack_file_url(
     if already_downloaded_path:
         from_path = already_downloaded_path
     else:
-        from_path = link_path
+        from_path = link.file_path
 
     # If --require-hashes is off, `hashes` is either empty, the
     # link's embedded hash, or MissingHashes; it is required to

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -143,7 +143,6 @@ class File(object):
 
 def get_http_url(
     link,  # type: Link
-    location,  # type: str
     downloader,  # type: Downloader
     download_dir=None,  # type: Optional[str]
     hashes=None,  # type: Optional[Hashes]
@@ -212,7 +211,6 @@ def _copy_source_tree(source, target):
 
 def get_file_url(
     link,  # type: Link
-    location,  # type: str
     download_dir=None,  # type: Optional[str]
     hashes=None  # type: Optional[Hashes]
 ):
@@ -273,13 +271,12 @@ def unpack_url(
 
     # file urls
     if link.is_file:
-        file = get_file_url(link, location, download_dir, hashes=hashes)
+        file = get_file_url(link, download_dir, hashes=hashes)
 
     # http urls
     else:
         file = get_http_url(
             link,
-            location,
             downloader,
             download_dir,
             hashes=hashes,

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -168,10 +168,6 @@ def unpack_http_url(
 
     file = File(from_path, content_type)
 
-    # unpack the archive to the build dir location. even when only
-    # downloading archives, they have to be unpacked to parse dependencies
-    unpack_file(file.path, location, file.content_type)
-
     return file
 
 
@@ -249,10 +245,6 @@ def unpack_file_url(
 
     file = File(from_path, content_type)
 
-    # unpack the archive to the build dir location. even when only downloading
-    # archives, they have to be unpacked to parse dependencies
-    unpack_file(file.path, location, file.content_type)
-
     return file
 
 
@@ -296,6 +288,10 @@ def unpack_url(
             download_dir,
             hashes=hashes,
         )
+
+    # unpack the archive to the build dir location. even when only downloading
+    # archives, they have to be unpacked to parse dependencies
+    unpack_file(file.path, location, file.content_type)
 
     return file
 


### PR DESCRIPTION
This is a follow up to [#7539 (comment)](https://github.com/pypa/pip/pull/7539#issuecomment-570898546) to start the process of migrating archive unpacking out of lower level functions. In this first PR unpacking is moved from `unpack_file_url` and `unpack_http_url`.