### PR TITLE
Remove confusing comment from operations.prepare

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -416,10 +416,6 @@ class RequirementPreparer(object):
             logger.info('Collecting %s', req.req or req)
 
         with indent_log():
-            # @@ if filesystem packages are not marked
-            # editable in a req, a non deterministic error
-            # occurs when the script attempts to unpack the
-            # build directory
             # Since source_dir is only set for editable requirements.
             assert req.source_dir is None
             req.ensure_has_source_dir(self.build_dir)


### PR DESCRIPTION
prepare_linked_requirements only handles non-editable requirements, so
this comment seems like its been misplaced over several years of
refactoring.