### PR TITLE
Cleanup WheelCache cleanup

### DIFF
--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -15,7 +15,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._internal.exceptions import InvalidWheelFilename
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
-from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import path_to_url
 
@@ -264,7 +264,9 @@ class EphemWheelCache(SimpleWheelCache):
 
     def __init__(self, format_control):
         # type: (FormatControl) -> None
-        self._temp_dir = TempDirectory(kind="ephem-wheel-cache")
+        self._temp_dir = TempDirectory(
+            kind=tempdir_kinds.EPHEM_WHEEL_CACHE
+        )
 
         super(EphemWheelCache, self).__init__(
             self._temp_dir.path, format_control

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -265,7 +265,8 @@ class EphemWheelCache(SimpleWheelCache):
     def __init__(self, format_control):
         # type: (FormatControl) -> None
         self._temp_dir = TempDirectory(
-            kind=tempdir_kinds.EPHEM_WHEEL_CACHE
+            kind=tempdir_kinds.EPHEM_WHEEL_CACHE,
+            globally_managed=True,
         )
 
         super(EphemWheelCache, self).__init__(
@@ -274,7 +275,7 @@ class EphemWheelCache(SimpleWheelCache):
 
     def cleanup(self):
         # type: () -> None
-        self._temp_dir.cleanup()
+        pass
 
 
 class WheelCache(Cache):

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -171,10 +171,6 @@ class Cache(object):
         """
         raise NotImplementedError()
 
-    def cleanup(self):
-        # type: () -> None
-        pass
-
 
 class SimpleWheelCache(Cache):
     """A cache of wheels for future installs.

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -273,10 +273,6 @@ class EphemWheelCache(SimpleWheelCache):
             self._temp_dir.path, format_control
         )
 
-    def cleanup(self):
-        # type: () -> None
-        pass
-
 
 class WheelCache(Cache):
     """Wraps EphemWheelCache and SimpleWheelCache into a single Cache
@@ -325,8 +321,3 @@ class WheelCache(Cache):
             package_name=package_name,
             supported_tags=supported_tags,
         )
-
-    def cleanup(self):
-        # type: () -> None
-        self._wheel_cache.cleanup()
-        self._ephem_cache.cleanup()

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -156,7 +156,11 @@ class IndexGroupCommand(Command, SessionCommandMixin):
             pip_self_version_check(session, options)
 
 
-KEEPABLE_TEMPDIR_TYPES = [tempdir_kinds.BUILD_ENV, tempdir_kinds.REQ_BUILD]
+KEEPABLE_TEMPDIR_TYPES = [
+    tempdir_kinds.BUILD_ENV,
+    tempdir_kinds.EPHEM_WHEEL_CACHE,
+    tempdir_kinds.REQ_BUILD,
+]
 
 
 def with_cleanup(func):

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -96,8 +96,5 @@ class FreezeCommand(Command):
             exclude_editable=options.exclude_editable,
         )
 
-        try:
-            for line in freeze(**freeze_kwargs):
-                sys.stdout.write(line + '\n')
-        finally:
-            wheel_cache.cleanup()
+        for line in freeze(**freeze_kwargs):
+            sys.stdout.write(line + '\n')

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -447,7 +447,6 @@ class InstallCommand(RequirementCommand):
                 # Clean up
                 if not options.no_clean:
                     requirement_set.cleanup_files()
-                    wheel_cache.cleanup()
 
         if options.target_dir:
             self._handle_target_dir(

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -194,4 +194,3 @@ class WheelCommand(RequirementCommand):
             finally:
                 if not options.no_clean:
                     requirement_set.cleanup_files()
-                    wheel_cache.cleanup()

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 # globally-managed.
 tempdir_kinds = enum(
     BUILD_ENV="build-env",
+    EPHEM_WHEEL_CACHE="ephem-wheel-cache",
     REQ_BUILD="req-build",
 )
 


### PR DESCRIPTION
This is just a minor cleanup enabled by the work in #7677.

Instead of explicitly cleaning up the temporary directory associated with our wheel cache, we manage it globally so it is cleaned up after our normal processing.