### PR TITLE
Reduce usage of RequirementSet in commands

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -272,7 +272,6 @@ class RequirementCommand(IndexGroupCommand):
 
     def populate_requirement_set(
         self,
-        requirement_set,  # type: RequirementSet
         args,             # type: List[str]
         options,          # type: Values
         finder,           # type: PackageFinder

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -25,6 +25,7 @@ from pip._internal.req.constructors import (
     install_req_from_req_string,
 )
 from pip._internal.req.req_file import parse_requirements
+from pip._internal.req.req_set import RequirementSet
 from pip._internal.self_outdated_check import (
     make_link_collector,
     pip_self_version_check,
@@ -39,7 +40,6 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.cache import WheelCache
     from pip._internal.models.target_python import TargetPython
     from pip._internal.req.req_install import InstallRequirement
-    from pip._internal.req.req_set import RequirementSet
     from pip._internal.req.req_tracker import RequirementTracker
     from pip._internal.utils.temp_dir import (
         TempDirectory,
@@ -278,11 +278,15 @@ class RequirementCommand(IndexGroupCommand):
         finder,           # type: PackageFinder
         session,          # type: PipSession
         wheel_cache,      # type: Optional[WheelCache]
+        check_supported_wheels=True,  # type: bool
     ):
         # type: (...) -> List[InstallRequirement]
         """
         Marshal cmd line args into a requirement set.
         """
+        requirement_set = RequirementSet(
+            check_supported_wheels=check_supported_wheels
+        )
         for filename in options.constraints:
             for req_to_add in parse_requirements(
                     filename,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -38,6 +38,7 @@ if MYPY_CHECK_RUNNING:
 
     from pip._internal.cache import WheelCache
     from pip._internal.models.target_python import TargetPython
+    from pip._internal.req.req_install import InstallRequirement
     from pip._internal.req.req_set import RequirementSet
     from pip._internal.req.req_tracker import RequirementTracker
     from pip._internal.utils.temp_dir import (
@@ -278,7 +279,7 @@ class RequirementCommand(IndexGroupCommand):
         session,          # type: PipSession
         wheel_cache,      # type: Optional[WheelCache]
     ):
-        # type: (...) -> None
+        # type: (...) -> List[InstallRequirement]
         """
         Marshal cmd line args into a requirement set.
         """
@@ -335,6 +336,8 @@ class RequirementCommand(IndexGroupCommand):
                 raise CommandError(
                     'You must give at least one requirement to %(name)s '
                     '(see "pip help %(name)s")' % opts)
+
+        return requirements
 
     @staticmethod
     def trace_basic_info(finder):

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -270,7 +270,7 @@ class RequirementCommand(IndexGroupCommand):
             py_version_info=py_version_info,
         )
 
-    def populate_requirement_set(
+    def get_requirements(
         self,
         args,             # type: List[str]
         options,          # type: Values
@@ -281,7 +281,7 @@ class RequirementCommand(IndexGroupCommand):
     ):
         # type: (...) -> List[InstallRequirement]
         """
-        Marshal cmd line args into a requirement set.
+        Parse command-line arguments into the corresponding requirements.
         """
         requirement_set = RequirementSet(
             check_supported_wheels=check_supported_wheels

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -320,10 +320,7 @@ class RequirementCommand(IndexGroupCommand):
                 requirement_set.add_requirement(req_to_add)
 
         # If any requirement has hash options, enable hash checking.
-        requirements = (
-            requirement_set.unnamed_requirements +
-            list(requirement_set.requirements.values())
-        )
+        requirements = requirement_set.all_requirements
         if any(req.has_hash_options for req in requirements):
             options.require_hashes = True
 

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -101,7 +101,7 @@ class DownloadCommand(RequirementCommand):
         with get_requirement_tracker() as req_tracker, TempDirectory(
             options.build_dir, delete=build_delete, kind="download"
         ) as directory:
-            reqs = self.populate_requirement_set(
+            reqs = self.get_requirements(
                 args,
                 options,
                 finder,

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -9,7 +9,6 @@ import os
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.req_command import RequirementCommand, with_cleanup
-from pip._internal.req import RequirementSet
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.misc import ensure_dir, normalize_path, write_output
 from pip._internal.utils.temp_dir import TempDirectory
@@ -102,8 +101,6 @@ class DownloadCommand(RequirementCommand):
         with get_requirement_tracker() as req_tracker, TempDirectory(
             options.build_dir, delete=build_delete, kind="download"
         ) as directory:
-
-            requirement_set = RequirementSet()
             reqs = self.populate_requirement_set(
                 args,
                 options,

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -133,7 +133,7 @@ class DownloadCommand(RequirementCommand):
             self.trace_basic_info(finder)
 
             requirement_set = resolver.resolve(
-                reqs, requirement_set.check_supported_wheels
+                reqs, check_supported_wheels=True
             )
 
             downloaded = ' '.join([

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -133,7 +133,8 @@ class DownloadCommand(RequirementCommand):
             self.trace_basic_info(finder)
 
             requirement_set = resolver.resolve(
-                requirement_set, requirement_set.check_supported_wheels
+                requirement_set.all_requirements,
+                requirement_set.check_supported_wheels,
             )
 
             downloaded = ' '.join([

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -132,7 +132,9 @@ class DownloadCommand(RequirementCommand):
 
             self.trace_basic_info(finder)
 
-            requirement_set = resolver.resolve(requirement_set)
+            requirement_set = resolver.resolve(
+                requirement_set, requirement_set.check_supported_wheels
+            )
 
             downloaded = ' '.join([
                 req.name for req in requirement_set.successfully_downloaded

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -105,7 +105,6 @@ class DownloadCommand(RequirementCommand):
 
             requirement_set = RequirementSet()
             reqs = self.populate_requirement_set(
-                requirement_set,
                 args,
                 options,
                 finder,

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -104,7 +104,7 @@ class DownloadCommand(RequirementCommand):
         ) as directory:
 
             requirement_set = RequirementSet()
-            self.populate_requirement_set(
+            reqs = self.populate_requirement_set(
                 requirement_set,
                 args,
                 options,
@@ -133,8 +133,7 @@ class DownloadCommand(RequirementCommand):
             self.trace_basic_info(finder)
 
             requirement_set = resolver.resolve(
-                requirement_set.all_requirements,
-                requirement_set.check_supported_wheels,
+                reqs, requirement_set.check_supported_wheels
             )
 
             downloaded = ' '.join([

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -132,7 +132,7 @@ class DownloadCommand(RequirementCommand):
 
             self.trace_basic_info(finder)
 
-            resolver.resolve(requirement_set)
+            requirement_set = resolver.resolve(requirement_set)
 
             downloaded = ' '.join([
                 req.name for req in requirement_set.successfully_downloaded

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -616,10 +616,7 @@ def warn_deprecated_install_options(requirement_set, options):
         # type: (Iterable[str]) -> List[str]
         return ["--{}".format(name.replace("_", "-")) for name in option_names]
 
-    requirements = (
-        requirement_set.unnamed_requirements +
-        list(requirement_set.requirements.values())
-    )
+    requirements = requirement_set.all_requirements
 
     offenders = []
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -328,7 +328,7 @@ class InstallCommand(RequirementCommand):
 
                 self.trace_basic_info(finder)
 
-                resolver.resolve(requirement_set)
+                requirement_set = resolver.resolve(requirement_set)
 
                 try:
                     pip_req = requirement_set.get_requirement("pip")

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -296,7 +296,7 @@ class InstallCommand(RequirementCommand):
             )
 
             try:
-                self.populate_requirement_set(
+                reqs = self.populate_requirement_set(
                     requirement_set, args, options, finder, session,
                     wheel_cache
                 )
@@ -329,8 +329,7 @@ class InstallCommand(RequirementCommand):
                 self.trace_basic_info(finder)
 
                 requirement_set = resolver.resolve(
-                    requirement_set.all_requirements,
-                    requirement_set.check_supported_wheels,
+                    reqs, requirement_set.check_supported_wheels
                 )
 
                 try:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -30,7 +30,7 @@ from pip._internal.exceptions import (
 )
 from pip._internal.locations import distutils_scheme
 from pip._internal.operations.check import check_install_conflicts
-from pip._internal.req import RequirementSet, install_given_reqs
+from pip._internal.req import install_given_reqs
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.distutils_args import parse_distutils_args
@@ -291,10 +291,6 @@ class InstallCommand(RequirementCommand):
         with get_requirement_tracker() as req_tracker, TempDirectory(
             options.build_dir, delete=build_delete, kind="install"
         ) as directory:
-            requirement_set = RequirementSet(
-                check_supported_wheels=not options.target_dir,
-            )
-
             try:
                 reqs = self.populate_requirement_set(
                     args, options, finder, session,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -298,7 +298,7 @@ class InstallCommand(RequirementCommand):
             try:
                 reqs = self.populate_requirement_set(
                     requirement_set, args, options, finder, session,
-                    wheel_cache
+                    wheel_cache, check_supported_wheels=not options.target_dir,
                 )
 
                 warn_deprecated_install_options(

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -292,7 +292,7 @@ class InstallCommand(RequirementCommand):
             options.build_dir, delete=build_delete, kind="install"
         ) as directory:
             try:
-                reqs = self.populate_requirement_set(
+                reqs = self.get_requirements(
                     args, options, finder, session,
                     wheel_cache, check_supported_wheels=not options.target_dir,
                 )

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -302,7 +302,7 @@ class InstallCommand(RequirementCommand):
                 )
 
                 warn_deprecated_install_options(
-                    requirement_set, options.install_options
+                    reqs, options.install_options
                 )
 
                 preparer = self.make_requirement_preparer(
@@ -607,16 +607,14 @@ def decide_user_install(
     return True
 
 
-def warn_deprecated_install_options(requirement_set, options):
-    # type: (RequirementSet, Optional[List[str]]) -> None
+def warn_deprecated_install_options(requirements, options):
+    # type: (List[InstallRequirement], Optional[List[str]]) -> None
     """If any location-changing --install-option arguments were passed for
     requirements or on the command-line, then show a deprecation warning.
     """
     def format_options(option_names):
         # type: (Iterable[str]) -> List[str]
         return ["--{}".format(name.replace("_", "-")) for name in option_names]
-
-    requirements = requirement_set.all_requirements
 
     offenders = []
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -329,7 +329,8 @@ class InstallCommand(RequirementCommand):
                 self.trace_basic_info(finder)
 
                 requirement_set = resolver.resolve(
-                    requirement_set, requirement_set.check_supported_wheels
+                    requirement_set.all_requirements,
+                    requirement_set.check_supported_wheels,
                 )
 
                 try:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -329,7 +329,7 @@ class InstallCommand(RequirementCommand):
                 self.trace_basic_info(finder)
 
                 requirement_set = resolver.resolve(
-                    reqs, requirement_set.check_supported_wheels
+                    reqs, check_supported_wheels=not options.target_dir
                 )
 
                 try:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -328,7 +328,9 @@ class InstallCommand(RequirementCommand):
 
                 self.trace_basic_info(finder)
 
-                requirement_set = resolver.resolve(requirement_set)
+                requirement_set = resolver.resolve(
+                    requirement_set, requirement_set.check_supported_wheels
+                )
 
                 try:
                     pip_req = requirement_set.get_requirement("pip")

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -297,7 +297,7 @@ class InstallCommand(RequirementCommand):
 
             try:
                 reqs = self.populate_requirement_set(
-                    requirement_set, args, options, finder, session,
+                    args, options, finder, session,
                     wheel_cache, check_supported_wheels=not options.target_dir,
                 )
 

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -158,7 +158,9 @@ class WheelCommand(RequirementCommand):
 
                 self.trace_basic_info(finder)
 
-                requirement_set = resolver.resolve(requirement_set)
+                requirement_set = resolver.resolve(
+                    requirement_set, requirement_set.check_supported_wheels
+                )
 
                 reqs_to_build = [
                     r for r in requirement_set.requirements.values()

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -13,7 +13,6 @@ from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.req_command import RequirementCommand, with_cleanup
 from pip._internal.exceptions import CommandError, PreviousBuildDirError
-from pip._internal.req import RequirementSet
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.misc import ensure_dir, normalize_path
 from pip._internal.utils.temp_dir import TempDirectory
@@ -128,9 +127,6 @@ class WheelCommand(RequirementCommand):
         with get_requirement_tracker() as req_tracker, TempDirectory(
             options.build_dir, delete=build_delete, kind="wheel"
         ) as directory:
-
-            requirement_set = RequirementSet()
-
             try:
                 reqs = self.populate_requirement_set(
                     args, options, finder, session,

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -128,7 +128,7 @@ class WheelCommand(RequirementCommand):
             options.build_dir, delete=build_delete, kind="wheel"
         ) as directory:
             try:
-                reqs = self.populate_requirement_set(
+                reqs = self.get_requirements(
                     args, options, finder, session,
                     wheel_cache
                 )

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -159,7 +159,7 @@ class WheelCommand(RequirementCommand):
                 self.trace_basic_info(finder)
 
                 requirement_set = resolver.resolve(
-                    reqs, requirement_set.check_supported_wheels
+                    reqs, check_supported_wheels=True
                 )
 
                 reqs_to_build = [

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -132,7 +132,7 @@ class WheelCommand(RequirementCommand):
             requirement_set = RequirementSet()
 
             try:
-                self.populate_requirement_set(
+                reqs = self.populate_requirement_set(
                     requirement_set, args, options, finder, session,
                     wheel_cache
                 )
@@ -159,8 +159,7 @@ class WheelCommand(RequirementCommand):
                 self.trace_basic_info(finder)
 
                 requirement_set = resolver.resolve(
-                    requirement_set.all_requirements,
-                    requirement_set.check_supported_wheels,
+                    reqs, requirement_set.check_supported_wheels
                 )
 
                 reqs_to_build = [

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -158,7 +158,7 @@ class WheelCommand(RequirementCommand):
 
                 self.trace_basic_info(finder)
 
-                resolver.resolve(requirement_set)
+                requirement_set = resolver.resolve(requirement_set)
 
                 reqs_to_build = [
                     r for r in requirement_set.requirements.values()

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -133,7 +133,7 @@ class WheelCommand(RequirementCommand):
 
             try:
                 reqs = self.populate_requirement_set(
-                    requirement_set, args, options, finder, session,
+                    args, options, finder, session,
                     wheel_cache
                 )
 

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -159,7 +159,8 @@ class WheelCommand(RequirementCommand):
                 self.trace_basic_info(finder)
 
                 requirement_set = resolver.resolve(
-                    requirement_set, requirement_set.check_supported_wheels
+                    requirement_set.all_requirements,
+                    requirement_set.check_supported_wheels,
                 )
 
                 reqs_to_build = [

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -147,8 +147,8 @@ class Resolver(object):
         self._discovered_dependencies = \
             defaultdict(list)  # type: DiscoveredDependencies
 
-    def resolve(self, requirement_set, check_supported_wheels):
-        # type: (RequirementSet, bool) -> RequirementSet
+    def resolve(self, root_reqs, check_supported_wheels):
+        # type: (List[InstallRequirement], bool) -> RequirementSet
         """Resolve what operations need to be done
 
         As a side-effect of this method, the packages (and their dependencies)
@@ -159,7 +159,6 @@ class Resolver(object):
         possible to move the preparation to become a step separated from
         dependency resolution.
         """
-        root_reqs = requirement_set.all_requirements
         requirement_set = RequirementSet(
             check_supported_wheels=check_supported_wheels
         )

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -159,10 +159,7 @@ class Resolver(object):
         possible to move the preparation to become a step separated from
         dependency resolution.
         """
-        root_reqs = (
-            requirement_set.unnamed_requirements +
-            list(requirement_set.requirements.values())
-        )
+        root_reqs = requirement_set.all_requirements
         requirement_set = RequirementSet(
             check_supported_wheels=check_supported_wheels
         )

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -147,8 +147,8 @@ class Resolver(object):
         self._discovered_dependencies = \
             defaultdict(list)  # type: DiscoveredDependencies
 
-    def resolve(self, requirement_set):
-        # type: (RequirementSet) -> RequirementSet
+    def resolve(self, requirement_set, check_supported_wheels):
+        # type: (RequirementSet, bool) -> RequirementSet
         """Resolve what operations need to be done
 
         As a side-effect of this method, the packages (and their dependencies)
@@ -163,7 +163,6 @@ class Resolver(object):
             requirement_set.unnamed_requirements +
             list(requirement_set.requirements.values())
         )
-        check_supported_wheels = requirement_set.check_supported_wheels
         requirement_set = RequirementSet(
             check_supported_wheels=check_supported_wheels
         )

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -159,8 +159,6 @@ class Resolver(object):
         possible to move the preparation to become a step separated from
         dependency resolution.
         """
-        # If any top-level requirement has a hash specified, enter
-        # hash-checking mode, which requires hashes from all.
         root_reqs = (
             requirement_set.unnamed_requirements +
             list(requirement_set.requirements.values())

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -196,3 +196,8 @@ class RequirementSet(object):
             return self.requirements[project_name]
 
         raise KeyError("No project with the name %r" % name)
+
+    @property
+    def all_requirements(self):
+        # type: () -> List[InstallRequirement]
+        return self.unnamed_requirements + list(self.requirements.values())

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -10,7 +10,6 @@ from pip._internal.commands.install import (
     warn_deprecated_install_options,
 )
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.req.req_set import RequirementSet
 
 
 class TestDecideUserInstall:
@@ -47,8 +46,7 @@ class TestDecideUserInstall:
 
 def test_deprecation_notice_for_pip_install_options(recwarn):
     install_options = ["--prefix=/hello"]
-    req_set = RequirementSet()
-    warn_deprecated_install_options(req_set, install_options)
+    warn_deprecated_install_options([], install_options)
 
     assert len(recwarn) == 1
     message = recwarn[0].message.args[0]
@@ -57,21 +55,20 @@ def test_deprecation_notice_for_pip_install_options(recwarn):
 
 def test_deprecation_notice_for_requirement_options(recwarn):
     install_options = []
-    req_set = RequirementSet()
 
     bad_named_req_options = {"install_options": ["--home=/wow"]}
     bad_named_req = InstallRequirement(
         Requirement("hello"), "requirements.txt", options=bad_named_req_options
     )
-    req_set.add_named_requirement(bad_named_req)
 
     bad_unnamed_req_options = {"install_options": ["--install-lib=/lib"]}
     bad_unnamed_req = InstallRequirement(
         None, "requirements2.txt", options=bad_unnamed_req_options
     )
-    req_set.add_unnamed_requirement(bad_unnamed_req)
 
-    warn_deprecated_install_options(req_set, install_options)
+    warn_deprecated_install_options(
+        [bad_named_req, bad_unnamed_req], install_options
+    )
 
     assert len(recwarn) == 1
     message = recwarn[0].message.args[0]

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -129,7 +129,7 @@ class TestRequirementSet(object):
         reqset.add_requirement(req)
         finder = make_test_finder(find_links=[data.find_links])
         with self._basic_resolver(finder) as resolver:
-            resolver.resolve(reqset)
+            reqset = resolver.resolve(reqset)
         # This is hacky but does test both case in py2 and py3
         if sys.version_info[:2] == (2, 7):
             assert reqset.has_requirement('simple')

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -112,7 +112,7 @@ class TestRequirementSet(object):
                 r"pip can't proceed with [\s\S]*%s[\s\S]*%s" %
                 (req, build_dir.replace('\\', '\\\\')),
                 resolver.resolve,
-                reqset,
+                reqset.all_requirements,
                 True,
             )
 
@@ -130,7 +130,7 @@ class TestRequirementSet(object):
         reqset.add_requirement(req)
         finder = make_test_finder(find_links=[data.find_links])
         with self._basic_resolver(finder) as resolver:
-            reqset = resolver.resolve(reqset, True)
+            reqset = resolver.resolve(reqset.all_requirements, True)
         # This is hacky but does test both case in py2 and py3
         if sys.version_info[:2] == (2, 7):
             assert reqset.has_requirement('simple')
@@ -156,7 +156,7 @@ class TestRequirementSet(object):
                 r'    simple==1.0 --hash=sha256:393043e672415891885c9a2a0929b1'
                 r'af95fb866d6ca016b42d2e6ce53619b653$',
                 resolver.resolve,
-                reqset,
+                reqset.all_requirements,
                 True,
             )
 
@@ -211,7 +211,7 @@ class TestRequirementSet(object):
                 r"    file://.*{sep}data{sep}packages{sep}FSPkg "
                 r"\(from -r file \(line 2\)\)".format(sep=sep),
                 resolver.resolve,
-                reqset,
+                reqset.all_requirements,
                 True,
             )
 
@@ -240,7 +240,7 @@ class TestRequirementSet(object):
                 r'    simple .* \(from -r file \(line 1\)\)\n'
                 r'    simple2>1.0 .* \(from -r file \(line 2\)\)',
                 resolver.resolve,
-                reqset,
+                reqset.all_requirements,
                 True,
             )
 
@@ -262,7 +262,7 @@ class TestRequirementSet(object):
                 r'             Got        393043e672415891885c9a2a0929b1af95fb'
                 r'866d6ca016b42d2e6ce53619b653$',
                 resolver.resolve,
-                reqset,
+                reqset.all_requirements,
                 True,
             )
 
@@ -285,7 +285,7 @@ class TestRequirementSet(object):
                 r'versions pinned.*\n'
                 r'    TopoRequires from .*$',
                 resolver.resolve,
-                reqset,
+                reqset.all_requirements,
                 True,
             )
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -113,6 +113,7 @@ class TestRequirementSet(object):
                 (req, build_dir.replace('\\', '\\\\')),
                 resolver.resolve,
                 reqset,
+                True,
             )
 
     # TODO: Update test when Python 2.7 is dropped.
@@ -129,7 +130,7 @@ class TestRequirementSet(object):
         reqset.add_requirement(req)
         finder = make_test_finder(find_links=[data.find_links])
         with self._basic_resolver(finder) as resolver:
-            reqset = resolver.resolve(reqset)
+            reqset = resolver.resolve(reqset, True)
         # This is hacky but does test both case in py2 and py3
         if sys.version_info[:2] == (2, 7):
             assert reqset.has_requirement('simple')
@@ -155,7 +156,8 @@ class TestRequirementSet(object):
                 r'    simple==1.0 --hash=sha256:393043e672415891885c9a2a0929b1'
                 r'af95fb866d6ca016b42d2e6ce53619b653$',
                 resolver.resolve,
-                reqset
+                reqset,
+                True,
             )
 
     def test_missing_hash_with_require_hashes_in_reqs_file(self, data, tmpdir):
@@ -210,6 +212,7 @@ class TestRequirementSet(object):
                 r"\(from -r file \(line 2\)\)".format(sep=sep),
                 resolver.resolve,
                 reqset,
+                True,
             )
 
     def test_unpinned_hash_checking(self, data):
@@ -238,6 +241,7 @@ class TestRequirementSet(object):
                 r'    simple2>1.0 .* \(from -r file \(line 2\)\)',
                 resolver.resolve,
                 reqset,
+                True,
             )
 
     def test_hash_mismatch(self, data):
@@ -259,6 +263,7 @@ class TestRequirementSet(object):
                 r'866d6ca016b42d2e6ce53619b653$',
                 resolver.resolve,
                 reqset,
+                True,
             )
 
     def test_unhashed_deps_on_require_hashes(self, data):
@@ -281,6 +286,7 @@ class TestRequirementSet(object):
                 r'    TopoRequires from .*$',
                 resolver.resolve,
                 reqset,
+                True,
             )
 
     def test_hashed_deps_on_require_hashes(self):

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -169,7 +169,7 @@ class TestRequirementSet(object):
         command = create_command('install')
         with requirements_file('--require-hashes', tmpdir) as reqs_file:
             options, args = command.parse_args(['-r', reqs_file])
-            command.populate_requirement_set(
+            command.get_requirements(
                 args, options, finder, session, wheel_cache=None,
             )
         assert options.require_hashes

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -164,14 +164,13 @@ class TestRequirementSet(object):
         """--require-hashes in a requirements file should make its way to the
         RequirementSet.
         """
-        req_set = RequirementSet()
         finder = make_test_finder(find_links=[data.find_links])
         session = finder._link_collector.session
         command = create_command('install')
         with requirements_file('--require-hashes', tmpdir) as reqs_file:
             options, args = command.parse_args(['-r', reqs_file])
             command.populate_requirement_set(
-                req_set, args, options, finder, session, wheel_cache=None,
+                args, options, finder, session, wheel_cache=None,
             )
         assert options.require_hashes
 


### PR DESCRIPTION
Previously we were using a RequirementSet to hold all of our parsed InstallRequirements, passing it to Resolver to mutate, and then reading from the updated RequirementSet to get our installed/downloaded InstallRequirements.

Now we only expose RequirementSet as the result of Resolver.resolve, and hide it as an implementation detail for holding parsed InstallRequirements. This means when implementing the new resolver we now only need to worry about translating InstallRequirements before invoking it and not both InstallRequirements and a RequirementSet.

Fixes #7571 and fixes #7638.