### PR TITLE
Pass individual options to InstallRequirement rather than an options object

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -622,7 +622,7 @@ def warn_deprecated_install_options(requirement_set, options):
     offenders = []
 
     for requirement in requirements:
-        install_options = requirement.options.get("install_options", [])
+        install_options = requirement.install_options
         location_options = parse_distutils_args(install_options)
         if location_options:
             offenders.append(

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -40,10 +40,8 @@ def install(
     # Options specified in requirements file override those
     # specified on the command line, since the last option given
     # to setup.py is the one that is used.
-    global_options = list(global_options) + \
-        install_req.options.get('global_options', [])
-    install_options = list(install_options) + \
-        install_req.options.get('install_options', [])
+    global_options = list(global_options) + install_req.global_options
+    install_options = list(install_options) + install_req.install_options
 
     header_dir = scheme.headers
 

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -238,7 +238,9 @@ def install_req_from_editable(
         constraint=constraint,
         use_pep517=use_pep517,
         isolated=isolated,
-        options=options if options else {},
+        install_options=options.get("install_options", []) if options else [],
+        global_options=options.get("global_options", []) if options else [],
+        hash_options=options.get("hashes", {}) if options else {},
         wheel_cache=wheel_cache,
         extras=parts.extras,
     )
@@ -400,7 +402,9 @@ def install_req_from_line(
     return InstallRequirement(
         parts.requirement, comes_from, link=parts.link, markers=parts.markers,
         use_pep517=use_pep517, isolated=isolated,
-        options=options if options else {},
+        install_options=options.get("install_options", []) if options else [],
+        global_options=options.get("global_options", []) if options else [],
+        hash_options=options.get("hashes", {}) if options else {},
         wheel_cache=wheel_cache,
         constraint=constraint,
         extras=parts.extras,

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -107,7 +107,9 @@ class InstallRequirement(object):
         markers=None,  # type: Optional[Marker]
         use_pep517=None,  # type: Optional[bool]
         isolated=False,  # type: bool
-        options=None,  # type: Optional[Dict[str, Any]]
+        install_options=None,  # type: Optional[List[str]]
+        global_options=None,  # type: Optional[List[str]]
+        hash_options=None,  # type: Optional[Dict[str, List[str]]]
         wheel_cache=None,  # type: Optional[WheelCache]
         constraint=False,  # type: bool
         extras=()  # type: Iterable[str]
@@ -155,7 +157,10 @@ class InstallRequirement(object):
         self._temp_build_dir = None  # type: Optional[TempDirectory]
         # Set to True after successful installation
         self.install_succeeded = None  # type: Optional[bool]
-        self.options = options if options else {}
+        # Supplied options
+        self.install_options = install_options if install_options else []
+        self.global_options = global_options if global_options else []
+        self.hash_options = hash_options if hash_options else {}
         # Set to True after successful preparation of this requirement
         self.prepared = False
         self.is_direct = False
@@ -303,7 +308,7 @@ class InstallRequirement(object):
         URL do not.
 
         """
-        return bool(self.options.get('hashes', {}))
+        return bool(self.hash_options)
 
     def hashes(self, trust_internet=True):
         # type: (bool) -> Hashes
@@ -321,7 +326,7 @@ class InstallRequirement(object):
             downloaded from the internet, as by populate_link()
 
         """
-        good_hashes = self.options.get('hashes', {}).copy()
+        good_hashes = self.hash_options.copy()
         link = self.link if trust_internet else self.original_link
         if link and link.hash:
             good_hashes.setdefault(link.hash_name, []).append(link.hash)

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -59,15 +59,16 @@ def test_deprecation_notice_for_requirement_options(recwarn):
     install_options = []
     req_set = RequirementSet()
 
-    bad_named_req_options = {"install_options": ["--home=/wow"]}
+    bad_named_req_options = ["--home=/wow"]
     bad_named_req = InstallRequirement(
-        Requirement("hello"), "requirements.txt", options=bad_named_req_options
+        Requirement("hello"), "requirements.txt",
+        install_options=bad_named_req_options
     )
     req_set.add_named_requirement(bad_named_req)
 
-    bad_unnamed_req_options = {"install_options": ["--install-lib=/lib"]}
+    bad_unnamed_req_options = ["--install-lib=/lib"]
     bad_unnamed_req = InstallRequirement(
-        None, "requirements2.txt", options=bad_unnamed_req_options
+        None, "requirements2.txt", install_options=bad_unnamed_req_options
     )
     req_set.add_unnamed_requirement(bad_unnamed_req)
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -320,9 +320,8 @@ class TestProcessLine(object):
                '--global-option="yo3" --global-option "yo4"'
         filename = 'filename'
         req = line_processor(line, filename, 1)[0]
-        assert req.options == {
-            'global_options': ['yo3', 'yo4'],
-            'install_options': ['yo1', 'yo2']}
+        assert req.global_options == ['yo3', 'yo4']
+        assert req.install_options == ['yo1', 'yo2']
 
     def test_hash_options(self, line_processor):
         """Test the --hash option: mostly its value storage.
@@ -338,13 +337,13 @@ class TestProcessLine(object):
                 'e5a6c65260e9cb8a7')
         filename = 'filename'
         req = line_processor(line, filename, 1)[0]
-        assert req.options == {'hashes': {
+        assert req.hash_options == {
             'sha256': ['2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e730433'
                        '62938b9824',
                        '486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65'
                        '260e9cb8a7'],
             'sha384': ['59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcd'
-                       'b9c666fa90125a3c79f90397bdf5f6a13de828684f']}}
+                       'b9c666fa90125a3c79f90397bdf5f6a13de828684f']}
 
     def test_set_isolated(self, line_processor, options):
         line = 'SomeProject'


### PR DESCRIPTION
The second of a series of refactorings mentioned in [this conversation](https://python.zulipchat.com/#narrow/stream/218659-pip-development/topic/preparation.20for.20adding.20the.20new.20resolver/near/187419520) on zulip.

I have not changed the signatures of the constructors in `pip._internal.req.constructors`. It's easy enough to do, I'm just not sure if it's needed.