### PR TITLE
Record on the requirement whether it has been successfully downloaded

### DIFF
--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -133,7 +133,8 @@ class DownloadCommand(RequirementCommand):
             )
 
             downloaded = ' '.join([
-                req.name for req in requirement_set.successfully_downloaded
+                req.name for req in requirement_set.requirements.values()
+                if req.successfully_downloaded
             ])
             if downloaded:
                 write_output('Successfully downloaded %s', downloaded)

--- a/src/pip/_internal/legacy_resolve.py
+++ b/src/pip/_internal/legacy_resolve.py
@@ -395,7 +395,7 @@ class Resolver(object):
                 # XXX: --no-install leads this to report 'Successfully
                 # downloaded' for only non-editable reqs, even though we took
                 # action on them.
-                requirement_set.successfully_downloaded.append(req_to_install)
+                req_to_install.successfully_downloaded = True
 
         return more_reqs
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -165,6 +165,15 @@ class InstallRequirement(object):
         self.prepared = False
         self.is_direct = False
 
+        # Set by the legacy resolver when the requirement has been downloaded
+        # TODO: This introduces a strong coupling between the resolver and the
+        #       requirement (the coupling was previously between the resolver
+        #       and the requirement set). This should be refactored to allow
+        #       the requirement to decide for itself when it has been
+        #       successfully downloaded - but that is more tricky to get right,
+        #       se we are making the change in stages.
+        self.successfully_downloaded = False
+
         self.isolated = isolated
         self.build_env = NoOpBuildEnvironment()  # type: BuildEnvironment
 

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -32,7 +32,6 @@ class RequirementSet(object):
         self.check_supported_wheels = check_supported_wheels
 
         self.unnamed_requirements = []  # type: List[InstallRequirement]
-        self.successfully_downloaded = []  # type: List[InstallRequirement]
 
     def __str__(self):
         # type: () -> str


### PR DESCRIPTION
This moves the information about whether a requirement has been successfully downloaded out of the requirement set and onto the requirement itself.

The code that determines whether a requirement has been "successfully downloaded" is in the resolver, so this initial refactoring doesn't reduce the coupling between the resolver and the client code (the `pip download` command) very much. However, it does move the information the client needs from the `RequirementSet` (which we're trying to mke into an implementation detail of the resolver) to the requirement itself (which is what logically owns the information).

A subsequent PR could then put the responsibility for determining when the requirement has been successfully downloaded onto the requirement itself.