### PR TITLE
Swap venv and virtualenv checks

### DIFF
--- a/news/7718.bugfix
+++ b/news/7718.bugfix
@@ -1,0 +1,2 @@
+Correctly detect global site-packages availability of virtual environments
+created by PyPA’s virtualenv>=20.0.

--- a/src/pip/_internal/utils/virtualenv.py
+++ b/src/pip/_internal/utils/virtualenv.py
@@ -105,11 +105,12 @@ def virtualenv_no_global():
     # type: () -> bool
     """Returns a boolean, whether running in venv with no system site-packages.
     """
+    # PEP 405 compliance needs to be checked first since virtualenv >=20 would
+    # return True for both checks, but is only able to use the PEP 405 config.
+    if _running_under_venv():
+        return _no_global_under_venv()
 
     if _running_under_regular_virtualenv():
         return _no_global_under_regular_virtualenv()
-
-    if _running_under_venv():
-        return _no_global_under_venv()
 
     return False


### PR DESCRIPTION
Extracted from #7718.

Environments created by pypa/virtualenv >=20 can pass both `real_prefix` and `base_prefix` checks, but are only able to use the `pyvenv.cfg` values, not the legacy `no-global-site-packages.txt`. This patch swap the checks to test for venv (PEP 405) first, so the new virtualenv implementation uses the correct code path and reads `pyvenv.cfg`.