### PR TITLE
Updated sphinx to 2.4.0

### DIFF
--- a/tools/requirements/docs.txt
+++ b/tools/requirements/docs.txt
@@ -1,4 +1,4 @@
-sphinx == 2.4.0
+sphinx == 2.4.1
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
 

--- a/tools/requirements/docs.txt
+++ b/tools/requirements/docs.txt
@@ -1,4 +1,4 @@
-sphinx == 2.4.1
+sphinx == 2.4.3
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
 

--- a/tools/requirements/docs.txt
+++ b/tools/requirements/docs.txt
@@ -1,4 +1,4 @@
-sphinx == 2.3.1
+sphinx == 2.4.0
 git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
 git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
News fragment not needed
Fixes #7130 