### PR TITLE
Note to avoid certain characters in user/password for proxy

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -94,6 +94,8 @@ pip can be configured to connect through a proxy server in various ways:
 * using the environment variable ``PIP_USER_AGENT_USER_DATA`` to include
   a JSON-encoded string in the user-agent variable used in pip's requests.
 
+User and password fields should not contain the following characters `[`, `]`,
+`#`, `?` as they are given special meaning by the underlying urllib.
 
 .. _`Requirements Files`:
 

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -95,7 +95,7 @@ pip can be configured to connect through a proxy server in various ways:
   a JSON-encoded string in the user-agent variable used in pip's requests.
 
 User and password fields should not contain the following characters `[`, `]`,
-`#`, `?` as they are given special meaning by the underlying urllib.
+`#`, `?` as these symbols are reserved in the underlying libraries.
 
 .. _`Requirements Files`:
 

--- a/news/7722.trivial
+++ b/news/7722.trivial
@@ -1,0 +1,1 @@
+Pull request #7722 to improve documentation


### PR DESCRIPTION
The urllib which handles the requests and proxy settings gives special meaning to
the following characters "[", "]" (IPv6 address), "#" (url fragment), "?" (query parameter).
Using them in username or password for proxy causes pip to fail in various ways.

Refer to line 440 in urllib/parse.py 
https://github.com/python/cpython/blob/f3fda374685dffa31ebda9e681e00ef7032b8a1d/Lib/urllib/parse.py#L440

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
