### PR TITLE
Mbardwell/feature/block index

### DIFF
--- a/news/7723.feature
+++ b/news/7723.feature
@@ -1,0 +1,1 @@
+This change will add a --block-index-url option

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -359,6 +359,19 @@ no_index = partial(
 )  # type: Callable[..., Option]
 
 
+def block_index_url():
+    # type: () -> Option
+    return Option(
+        '--block-index-url',
+        dest='block_index_urls',
+        metavar='URL',
+        action='append',
+        default=[],
+        help="Block URLs of package indexes Should follow the "
+             "same rules as --index-url.",
+    )
+
+
 def find_links():
     # type: () -> Option
     return Option(
@@ -952,6 +965,7 @@ index_group = {
         index_url,
         extra_index_url,
         no_index,
+        block_index_url,
         find_links,
     ]
 }  # type: Dict[str, Any]

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -71,6 +71,9 @@ class SessionCommandMixin(CommandContextMixIn):
                 index_urls.append(url)
         urls = getattr(options, "extra_index_urls", None)
         if urls:
+            url = getattr(options, "block_index_urls", None)
+            if url in urls:
+                urls.remove(url)
             index_urls.extend(urls)
         # Return None rather than an empty list
         return index_urls or None

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -60,6 +60,7 @@ ENV_VAR_RE = re.compile(r'(?P<var>\$\{(?P<name>[A-Z0-9_]+)\})')
 SUPPORTED_OPTIONS = [
     cmdoptions.index_url,
     cmdoptions.extra_index_url,
+    cmdoptions.block_index_url,
     cmdoptions.no_index,
     cmdoptions.constraints,
     cmdoptions.requirements,
@@ -233,6 +234,8 @@ def handle_line(
             index_urls = []
         if line.opts.extra_index_urls:
             index_urls.extend(line.opts.extra_index_urls)
+        if line.opts.block_index_urls in index_urls:
+            index_urls.remove(line.opts.block_index_urls)
         if line.opts.find_links:
             # FIXME: it would be nice to keep track of the source
             # of the find_links: support a find-links local path

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -57,6 +57,10 @@ def make_link_collector(
         when constructing the SearchScope object.
     """
     index_urls = [options.index_url] + options.extra_index_urls
+    try:
+        [index_urls.remove(x) for x in options.block_index_urls]
+    except ValueError:
+        pass
     if options.no_index and not suppress_no_index:
         logger.debug(
             'Ignoring indexes: %s',

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -368,6 +368,10 @@ class TestProcessLine(object):
         line_processor("--extra-index-url=url", "file", 1, finder=finder)
         assert finder.index_urls == ['url']
 
+    def test_set_finder_block_index_urls(self, line_processor, finder):
+        line_processor("--block-index-url=url", "file", 1, finder=finder)
+        assert finder.index_urls == ['url']
+
     def test_set_finder_trusted_host(
         self, line_processor, caplog, session, finder
     ):


### PR DESCRIPTION
Related to #7723 

This change will add a --block-index-url option

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
