### PR TITLE
Cache parse_links() by --find-links html page url

### DIFF
--- a/news/7729.feature
+++ b/news/7729.feature
@@ -1,0 +1,3 @@
+Cache the result of parse_links() to avoid re-tokenizing a find-links page multiple times over a pip run.
+
+This change significantly improves resolve performance when --find-links points to a very large html page.

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -30,6 +30,7 @@ class Link(KeyBasedCompareMixin):
         comes_from=None,       # type: Optional[Union[str, HTMLPage]]
         requires_python=None,  # type: Optional[str]
         yanked_reason=None,    # type: Optional[Text]
+        cache_link_parsing=True,  # type: bool
     ):
         # type: (...) -> None
         """
@@ -46,6 +47,11 @@ class Link(KeyBasedCompareMixin):
             a simple repository HTML link. If the file has been yanked but
             no reason was provided, this should be the empty string. See
             PEP 592 for more information and the specification.
+        :param cache_link_parsing: A flag that is used elsewhere to determine
+                                   whether resources retrieved from this link
+                                   should be cached. PyPI index urls should
+                                   generally have this set to False, for
+                                   example.
         """
 
         # url can be a UNC windows share
@@ -62,6 +68,8 @@ class Link(KeyBasedCompareMixin):
         self.yanked_reason = yanked_reason
 
         super(Link, self).__init__(key=url, defining_class=Link)
+
+        self.cache_link_parsing = cache_link_parsing
 
     def __str__(self):
         # type: () -> str


### PR DESCRIPTION
`pip._internal.index.collector.parse_links()` can take a nontrivial amount of time for large `--find-links` html repos. This cost is paid every single time a `--find-links` page is consulted (once per transitive requirement resolved), and can therefore become quite lengthy for large resolves. See pantsbuild/pex#887 and pantsbuild/pex#888 for further background on how we arrived at this issue while overcoming blockers to https://github.com/pantsbuild/pants upgrading to pex version 2, which uses pip to resolve and fetch wheels.

This change caches the result of invoking `parse_links()` for a `--find-links` html repo, keyed by the `HTMLPage`'s `url`. This means that other code in pip calling `parse_links()` can safely expect to idempotently resolve a set of links from an html page from any other thread, for example, without having to share any state between threads.

To reproduce the pathological behavior and demonstrate that this fix improves performance, check out this branch and execute this script:
```bash
#!/bin/bash

set -euxo pipefail

function generate-large-find-links-page {
  echo '<html><head><meta charset="utf-8"><head><body>'
  set +x
  for i in $(seq 50000); do
    echo '<a href="nonexistent-0.5.0.whl">nonexistent-0.5.0.whl</a>'
  done
  for w in *.whl *.tar.gz; do
    echo "<a href=\"${w}\">${w}</a>"
  done
  set -x
  echo '</body></html>'
}

python setup.py bdist_wheel

mkdir -pv tmp-whls/
pushd tmp-whls/
pip download tensorflow==1.14.0
generate-large-find-links-page > large-find-links-page.html
popd

time PYTHONPATH="$(pwd)/$(echo dist/*.whl)" python -m pip \
     -vvv download --no-index --find-links=./tmp-whls/large-find-links-page.html \
     tensorflow==1.14.0

time pip \
     -vvv download --no-index --find-links=./tmp-whls/large-find-links-page.html \
     tensorflow==1.14.0
```
