### PR TITLE
Bump cache key after it was poisoned by virtualenv 20.x

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+        key: pre-commit|2020-02-14|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Pre-configure global Git settings
       run: |
         git config --global user.email "pypa-dev@googlegroups.com"


### PR DESCRIPTION
The symlinks issue has been fixed as of virtualenv 20.0.2, however caches built by virtualenv 20.0.0 and 20.0.1 will continue showing this error

Resolves #7749
