### PR TITLE
Do not update `no_clean` option value in install/wheel

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -23,11 +23,7 @@ from pip._internal.cli import cmdoptions
 from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.req_command import RequirementCommand, with_cleanup
 from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.exceptions import (
-    CommandError,
-    InstallationError,
-    PreviousBuildDirError,
-)
+from pip._internal.exceptions import CommandError, InstallationError
 from pip._internal.locations import distutils_scheme
 from pip._internal.operations.check import check_install_conflicts
 from pip._internal.req import install_given_reqs
@@ -438,9 +434,6 @@ class InstallCommand(RequirementCommand):
                 logger.error(message, exc_info=show_traceback)
 
                 return ERROR
-            except PreviousBuildDirError:
-                options.no_clean = True
-                raise
 
         if options.target_dir:
             self._handle_target_dir(

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -12,7 +12,7 @@ import shutil
 from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.req_command import RequirementCommand, with_cleanup
-from pip._internal.exceptions import CommandError, PreviousBuildDirError
+from pip._internal.exceptions import CommandError
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.misc import ensure_dir, normalize_path
 from pip._internal.utils.temp_dir import TempDirectory
@@ -127,7 +127,7 @@ class WheelCommand(RequirementCommand):
         with get_requirement_tracker() as req_tracker, TempDirectory(
             options.build_dir, delete=build_delete, kind="wheel"
         ) as directory:
-            try:
+            if True:  # Keep block indented temporarily, for a cleaner commit
                 reqs = self.get_requirements(
                     args, options, finder, session,
                     wheel_cache
@@ -186,6 +186,3 @@ class WheelCommand(RequirementCommand):
                     raise CommandError(
                         "Failed to build one or more wheels"
                     )
-            except PreviousBuildDirError:
-                options.no_clean = True
-                raise

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -127,62 +127,61 @@ class WheelCommand(RequirementCommand):
         with get_requirement_tracker() as req_tracker, TempDirectory(
             options.build_dir, delete=build_delete, kind="wheel"
         ) as directory:
-            if True:  # Keep block indented temporarily, for a cleaner commit
-                reqs = self.get_requirements(
-                    args, options, finder, session,
-                    wheel_cache
-                )
+            reqs = self.get_requirements(
+                args, options, finder, session,
+                wheel_cache
+            )
 
-                preparer = self.make_requirement_preparer(
-                    temp_build_dir=directory,
-                    options=options,
-                    req_tracker=req_tracker,
-                    session=session,
-                    finder=finder,
-                    wheel_download_dir=options.wheel_dir,
-                    use_user_site=False,
-                )
+            preparer = self.make_requirement_preparer(
+                temp_build_dir=directory,
+                options=options,
+                req_tracker=req_tracker,
+                session=session,
+                finder=finder,
+                wheel_download_dir=options.wheel_dir,
+                use_user_site=False,
+            )
 
-                resolver = self.make_resolver(
-                    preparer=preparer,
-                    finder=finder,
-                    options=options,
-                    wheel_cache=wheel_cache,
-                    ignore_requires_python=options.ignore_requires_python,
-                    use_pep517=options.use_pep517,
-                )
+            resolver = self.make_resolver(
+                preparer=preparer,
+                finder=finder,
+                options=options,
+                wheel_cache=wheel_cache,
+                ignore_requires_python=options.ignore_requires_python,
+                use_pep517=options.use_pep517,
+            )
 
-                self.trace_basic_info(finder)
+            self.trace_basic_info(finder)
 
-                requirement_set = resolver.resolve(
-                    reqs, check_supported_wheels=True
-                )
+            requirement_set = resolver.resolve(
+                reqs, check_supported_wheels=True
+            )
 
-                reqs_to_build = [
-                    r for r in requirement_set.requirements.values()
-                    if should_build_for_wheel_command(r)
-                ]
+            reqs_to_build = [
+                r for r in requirement_set.requirements.values()
+                if should_build_for_wheel_command(r)
+            ]
 
-                # build wheels
-                build_successes, build_failures = build(
-                    reqs_to_build,
-                    wheel_cache=wheel_cache,
-                    build_options=options.build_options or [],
-                    global_options=options.global_options or [],
-                )
-                for req in build_successes:
-                    assert req.link and req.link.is_wheel
-                    assert req.local_file_path
-                    # copy from cache to target directory
-                    try:
-                        shutil.copy(req.local_file_path, options.wheel_dir)
-                    except OSError as e:
-                        logger.warning(
-                            "Building wheel for %s failed: %s",
-                            req.name, e,
-                        )
-                        build_failures.append(req)
-                if len(build_failures) != 0:
-                    raise CommandError(
-                        "Failed to build one or more wheels"
+            # build wheels
+            build_successes, build_failures = build(
+                reqs_to_build,
+                wheel_cache=wheel_cache,
+                build_options=options.build_options or [],
+                global_options=options.global_options or [],
+            )
+            for req in build_successes:
+                assert req.link and req.link.is_wheel
+                assert req.local_file_path
+                # copy from cache to target directory
+                try:
+                    shutil.copy(req.local_file_path, options.wheel_dir)
+                except OSError as e:
+                    logger.warning(
+                        "Building wheel for %s failed: %s",
+                        req.name, e,
                     )
+                    build_failures.append(req)
+            if len(build_failures) != 0:
+                raise CommandError(
+                    "Failed to build one or more wheels"
+                )


### PR DESCRIPTION
After a recent refactoring of our temporary directory cleanup (#7696), `no_clean` is only read prior to these `except` handlers, so we don't need to update its value anymore.

This makes the code easier to reason about (less mutability) and lets us get rid of a level of indentation.
in `WheelCommand`.