### PR TITLE
Use Command context helper to cleanup requirement tracker

### DIFF
--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -98,7 +98,9 @@ class DownloadCommand(RequirementCommand):
         )
         build_delete = (not (options.no_clean or options.build_dir))
 
-        with get_requirement_tracker() as req_tracker, TempDirectory(
+        req_tracker = self.enter_context(get_requirement_tracker())
+
+        with TempDirectory(
             options.build_dir, delete=build_delete, kind="download"
         ) as directory:
             reqs = self.get_requirements(

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -288,7 +288,9 @@ class InstallCommand(RequirementCommand):
         build_delete = (not (options.no_clean or options.build_dir))
         wheel_cache = WheelCache(options.cache_dir, options.format_control)
 
-        with get_requirement_tracker() as req_tracker, TempDirectory(
+        req_tracker = self.enter_context(get_requirement_tracker())
+
+        with TempDirectory(
             options.build_dir, delete=build_delete, kind="install"
         ) as directory:
             try:

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -124,7 +124,9 @@ class WheelCommand(RequirementCommand):
         options.wheel_dir = normalize_path(options.wheel_dir)
         ensure_dir(options.wheel_dir)
 
-        with get_requirement_tracker() as req_tracker, TempDirectory(
+        req_tracker = self.enter_context(get_requirement_tracker())
+
+        with TempDirectory(
             options.build_dir, delete=build_delete, kind="wheel"
         ) as directory:
             try:


### PR DESCRIPTION
The lifetime of the requirement tracker will be essentially the same,
but now we have more flexibility on where in the code we create it.

In a followup we can do the same thing with the temporary build directory and remove the
`with` statement (and its indentation) entirely from these commands, freeing us to refactor and reorder the statements in these functions.