### PR TITLE
Globally manage temp build dir in requirement commands

### DIFF
--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -100,9 +100,14 @@ class DownloadCommand(RequirementCommand):
 
         req_tracker = self.enter_context(get_requirement_tracker())
 
-        with TempDirectory(
-            options.build_dir, delete=build_delete, kind="download"
-        ) as directory:
+        directory = TempDirectory(
+            options.build_dir,
+            delete=build_delete,
+            kind="download",
+            globally_managed=True,
+        )
+
+        if True:  # Temporary, to keep commit clean
             reqs = self.get_requirements(
                 args,
                 options,

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -107,43 +107,42 @@ class DownloadCommand(RequirementCommand):
             globally_managed=True,
         )
 
-        if True:  # Temporary, to keep commit clean
-            reqs = self.get_requirements(
-                args,
-                options,
-                finder,
-                session,
-                None
-            )
+        reqs = self.get_requirements(
+            args,
+            options,
+            finder,
+            session,
+            None
+        )
 
-            preparer = self.make_requirement_preparer(
-                temp_build_dir=directory,
-                options=options,
-                req_tracker=req_tracker,
-                session=session,
-                finder=finder,
-                download_dir=options.download_dir,
-                use_user_site=False,
-            )
+        preparer = self.make_requirement_preparer(
+            temp_build_dir=directory,
+            options=options,
+            req_tracker=req_tracker,
+            session=session,
+            finder=finder,
+            download_dir=options.download_dir,
+            use_user_site=False,
+        )
 
-            resolver = self.make_resolver(
-                preparer=preparer,
-                finder=finder,
-                options=options,
-                py_version_info=options.python_version,
-            )
+        resolver = self.make_resolver(
+            preparer=preparer,
+            finder=finder,
+            options=options,
+            py_version_info=options.python_version,
+        )
 
-            self.trace_basic_info(finder)
+        self.trace_basic_info(finder)
 
-            requirement_set = resolver.resolve(
-                reqs, check_supported_wheels=True
-            )
+        requirement_set = resolver.resolve(
+            reqs, check_supported_wheels=True
+        )
 
-            downloaded = ' '.join([
-                req.name for req in requirement_set.requirements.values()
-                if req.successfully_downloaded
-            ])
-            if downloaded:
-                write_output('Successfully downloaded %s', downloaded)
+        downloaded = ' '.join([
+            req.name for req in requirement_set.requirements.values()
+            if req.successfully_downloaded
+        ])
+        if downloaded:
+            write_output('Successfully downloaded %s', downloaded)
 
         return requirement_set

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -286,9 +286,14 @@ class InstallCommand(RequirementCommand):
 
         req_tracker = self.enter_context(get_requirement_tracker())
 
-        with TempDirectory(
-            options.build_dir, delete=build_delete, kind="install"
-        ) as directory:
+        directory = TempDirectory(
+            options.build_dir,
+            delete=build_delete,
+            kind="install",
+            globally_managed=True,
+        )
+
+        if True:  # Temporary, to keep commit clean
             try:
                 reqs = self.get_requirements(
                     args, options, finder, session,

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -126,9 +126,14 @@ class WheelCommand(RequirementCommand):
 
         req_tracker = self.enter_context(get_requirement_tracker())
 
-        with TempDirectory(
-            options.build_dir, delete=build_delete, kind="wheel"
-        ) as directory:
+        directory = TempDirectory(
+            options.build_dir,
+            delete=build_delete,
+            kind="wheel",
+            globally_managed=True,
+        )
+
+        if True:  # Temporary, to keep commit clean
             reqs = self.get_requirements(
                 args, options, finder, session,
                 wheel_cache

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -133,62 +133,61 @@ class WheelCommand(RequirementCommand):
             globally_managed=True,
         )
 
-        if True:  # Temporary, to keep commit clean
-            reqs = self.get_requirements(
-                args, options, finder, session,
-                wheel_cache
-            )
+        reqs = self.get_requirements(
+            args, options, finder, session,
+            wheel_cache
+        )
 
-            preparer = self.make_requirement_preparer(
-                temp_build_dir=directory,
-                options=options,
-                req_tracker=req_tracker,
-                session=session,
-                finder=finder,
-                wheel_download_dir=options.wheel_dir,
-                use_user_site=False,
-            )
+        preparer = self.make_requirement_preparer(
+            temp_build_dir=directory,
+            options=options,
+            req_tracker=req_tracker,
+            session=session,
+            finder=finder,
+            wheel_download_dir=options.wheel_dir,
+            use_user_site=False,
+        )
 
-            resolver = self.make_resolver(
-                preparer=preparer,
-                finder=finder,
-                options=options,
-                wheel_cache=wheel_cache,
-                ignore_requires_python=options.ignore_requires_python,
-                use_pep517=options.use_pep517,
-            )
+        resolver = self.make_resolver(
+            preparer=preparer,
+            finder=finder,
+            options=options,
+            wheel_cache=wheel_cache,
+            ignore_requires_python=options.ignore_requires_python,
+            use_pep517=options.use_pep517,
+        )
 
-            self.trace_basic_info(finder)
+        self.trace_basic_info(finder)
 
-            requirement_set = resolver.resolve(
-                reqs, check_supported_wheels=True
-            )
+        requirement_set = resolver.resolve(
+            reqs, check_supported_wheels=True
+        )
 
-            reqs_to_build = [
-                r for r in requirement_set.requirements.values()
-                if should_build_for_wheel_command(r)
-            ]
+        reqs_to_build = [
+            r for r in requirement_set.requirements.values()
+            if should_build_for_wheel_command(r)
+        ]
 
-            # build wheels
-            build_successes, build_failures = build(
-                reqs_to_build,
-                wheel_cache=wheel_cache,
-                build_options=options.build_options or [],
-                global_options=options.global_options or [],
-            )
-            for req in build_successes:
-                assert req.link and req.link.is_wheel
-                assert req.local_file_path
-                # copy from cache to target directory
-                try:
-                    shutil.copy(req.local_file_path, options.wheel_dir)
-                except OSError as e:
-                    logger.warning(
-                        "Building wheel for %s failed: %s",
-                        req.name, e,
-                    )
-                    build_failures.append(req)
-            if len(build_failures) != 0:
-                raise CommandError(
-                    "Failed to build one or more wheels"
+        # build wheels
+        build_successes, build_failures = build(
+            reqs_to_build,
+            wheel_cache=wheel_cache,
+            build_options=options.build_options or [],
+            global_options=options.global_options or [],
+        )
+        for req in build_successes:
+            assert req.link and req.link.is_wheel
+            assert req.local_file_path
+            # copy from cache to target directory
+            try:
+                shutil.copy(req.local_file_path, options.wheel_dir)
+            except OSError as e:
+                logger.warning(
+                    "Building wheel for %s failed: %s",
+                    req.name, e,
                 )
+                build_failures.append(req)
+        if len(build_failures) != 0:
+            raise CommandError(
+                "Failed to build one or more wheels"
+            )


### PR DESCRIPTION
This lets us remove the indentation associated with the `with`
statement and eventually refactor these functions more easily, since the bulk of the code isn't under a block.

I split the actual change into its own commit so it's easier to see vs the dedent.