### PR TITLE
Raise error if --user and --target arguments are used together

### DIFF
--- a/news/7249.feature
+++ b/news/7249.feature
@@ -1,0 +1,1 @@
+Raise error if --user and --target are used together in command

--- a/news/7249.feature
+++ b/news/7249.feature
@@ -1,1 +1,0 @@
-Raise error if --user and --target are used together in command

--- a/news/7249.feature
+++ b/news/7249.feature
@@ -1,1 +1,1 @@
-Raise error if --user and --target are used together in command
+Raise error if --user and --target are used together in pip install

--- a/src/pip/_internal/cli/main_parser.py
+++ b/src/pip/_internal/cli/main_parser.py
@@ -83,6 +83,17 @@ def parse_command(args):
     # the subcommand name
     cmd_name = args_else[0]
 
+    validate_command_args(cmd_name, args_else)
+
+    # all the args without the subcommand
+    cmd_args = args[:]
+    cmd_args.remove(cmd_name)
+
+    return cmd_name, cmd_args
+
+
+def validate_command_args(cmd_name, args_else):
+    # type: (str, List[str]) -> None
     if cmd_name not in commands_dict:
         guess = get_similar_commands(cmd_name)
 
@@ -92,8 +103,6 @@ def parse_command(args):
 
         raise CommandError(' - '.join(msg))
 
-    # all the args without the subcommand
-    cmd_args = args[:]
-    cmd_args.remove(cmd_name)
-
-    return cmd_name, cmd_args
+    if set(['--user', '--target']).issubset(set(args_else)):
+        error_msg = '--user and --target cant not be used together.'
+        raise CommandError(error_msg)

--- a/src/pip/_internal/cli/main_parser.py
+++ b/src/pip/_internal/cli/main_parser.py
@@ -83,17 +83,6 @@ def parse_command(args):
     # the subcommand name
     cmd_name = args_else[0]
 
-    validate_command_args(cmd_name, args_else)
-
-    # all the args without the subcommand
-    cmd_args = args[:]
-    cmd_args.remove(cmd_name)
-
-    return cmd_name, cmd_args
-
-
-def validate_command_args(cmd_name, args_else):
-    # type: (str, List[str]) -> None
     if cmd_name not in commands_dict:
         guess = get_similar_commands(cmd_name)
 
@@ -103,6 +92,8 @@ def validate_command_args(cmd_name, args_else):
 
         raise CommandError(' - '.join(msg))
 
-    if set(['--user', '--target']).issubset(set(args_else)):
-        error_msg = '--user and --target cant not be used together.'
-        raise CommandError(error_msg)
+    # all the args without the subcommand
+    cmd_args = args[:]
+    cmd_args.remove(cmd_name)
+
+    return cmd_name, cmd_args

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -237,6 +237,9 @@ class InstallCommand(RequirementCommand):
     @with_cleanup
     def run(self, options, args):
         # type: (Values, List[Any]) -> int
+        if options.use_user_site and options.target_dir is not None:
+            raise CommandError("Can not combine '--user' and '--target'")
+
         cmdoptions.check_install_build_global(options)
         upgrade_strategy = "to-satisfy-only"
         if options.upgrade:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -847,6 +847,27 @@ def test_install_package_with_target(script):
     assert singlemodule_py in result.files_updated, str(result)
 
 
+def test_install_package_to_usersite_with_target_must_fail(script):
+    """
+    Test that installing package to usersite with target
+    must raise error
+    """
+    target_dir = script.scratch_path / 'target'
+    result = script.pip_install_local(
+        '--user', '-t', target_dir, "simple==1.0", expect_error=True
+    )
+    assert "Can not combine '--user' and '--target'" in result.stderr, (
+        str(result)
+    )
+
+    result = script.pip_install_local(
+        '--user', '--target', target_dir, "simple==1.0", expect_error=True
+    )
+    assert "Can not combine '--user' and '--target'" in result.stderr, (
+        str(result)
+    )
+
+
 def test_install_nonlocal_compatible_wheel(script, data):
     target_dir = script.scratch_path / 'target'
 


### PR DESCRIPTION
closes #7249 

This PR adds a validation which runs while parsing the command and throws a `CommandError` if `--user` and `--target` args are used together in same command.