### PR TITLE
Fix docs: comment stripping comes _after_ line continuation processing

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -149,7 +149,7 @@ treated as a comment.
 A line ending in an unescaped ``\`` is treated as a line continuation
 and the newline following it is effectively ignored.
 
-Comments are stripped *before* line continuations are processed.
+Comments are stripped *after* line continuations are processed.
 
 To interpret the requirements file in UTF-8 format add a comment
 ``# -*- coding: utf-8 -*-`` to the first or second line of the file.


### PR DESCRIPTION
Fixes #7728 