### PR TITLE
First stab at implementing the resolver provider using pip internals

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -545,6 +545,15 @@ class CandidateEvaluator(object):
             build_tag, pri,
         )
 
+    def sort_applicable_candidates(self, candidates):
+        # type: (List[InstallationCandidate]) -> List[InstallationCandidate]
+        """Return applicable candidates sorted per the instance's sort order.
+
+        This puts the best candidate at the end of the list.
+        """
+        candidates = self.get_applicable_candidates(candidates)
+        return sorted(candidates, key=self._sort_key)
+
     def sort_best_candidate(
         self,
         candidates,    # type: List[InstallationCandidate]

--- a/src/pip/_internal/resolution/resolvelib/models.py
+++ b/src/pip/_internal/resolution/resolvelib/models.py
@@ -30,6 +30,14 @@ class DirectCandidate(object):
         raise NotImplementedError()
 
 
+class EditableCandidate(object):
+    def __init__(self, name, link, version):
+        # type: (str, Link, _BaseVersion) -> None
+        self.name = name
+        self.link = link
+        self.version = version
+
+
 class ExtrasCandidate(object):
     """Wrap a candidate with extras information.
 
@@ -76,3 +84,10 @@ class SingleCandidateRequirement(object):
     def specifier(self):
         # type: () -> SpecifierSet
         return SpecifierSet("=={}".format(self.candidate.version))
+
+
+class EditableRequirement(object):
+    def __init__(self, name, link):
+        # type: (str, Link) -> None
+        self.name = name
+        self.link = link

--- a/src/pip/_internal/resolution/resolvelib/models.py
+++ b/src/pip/_internal/resolution/resolvelib/models.py
@@ -49,7 +49,7 @@ class ExtrasCandidate(object):
     def name(self):
         # type: () -> str
         extras = sorted(self.extras)
-        return "{}[{}]".join(self.candidate.name, ",".join(extras))
+        return "{}[{}]".format(self.candidate.name, ",".join(extras))
 
     @property
     def version(self):

--- a/src/pip/_internal/resolution/resolvelib/models.py
+++ b/src/pip/_internal/resolution/resolvelib/models.py
@@ -1,0 +1,78 @@
+from pip._vendor.packaging.specifiers import SpecifierSet
+
+from pip._internal.models.candidate import InstallationCandidate
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional, Set, Union
+    from pip._vendor.packaging.version import _BaseVersion
+    from pip._internal.models.link import Link
+
+
+class DirectCandidate(object):
+    """Candidate pointing to a direct URL.
+
+    This is used instead of ``InstallationCandidate``to resolve the
+    ``version`` property lazily, avoid building the requirement unnecessarily.
+    """
+    def __init__(self, name, link):
+        # type: (str, Link) -> None
+        self.name = name
+        self.link = link
+        self._version = None  # type: Optional[_BaseVersion]
+
+    @property
+    def version(self):
+        # type: () -> _BaseVersion
+        if self._version is not None:
+            return self._version
+        # TODO: Fetch version lazily by fetching and building from source.
+        raise NotImplementedError()
+
+
+class ExtrasCandidate(object):
+    """Wrap a candidate with extras information.
+
+    This class is used fpr a requirement's candidates when it requests extras,
+    so we can later find extra dependencies with this information.
+    """
+    def __init__(
+        self,
+        candidate,  # type: Union[DirectCandidate, InstallationCandidate]
+        extras,     # type: Set[str]
+    ):
+        # type: (...) -> None
+        self.candidate = candidate
+        self.extras = extras
+
+    @property
+    def name(self):
+        # type: () -> str
+        extras = sorted(self.extras)
+        return "{}[{}]".join(self.candidate.name, ",".join(extras))
+
+    @property
+    def version(self):
+        # type: () -> _BaseVersion
+        return self.candidate.version
+
+
+class SingleCandidateRequirement(object):
+    """A "simulated" requirement that holds only one candidate.
+
+    This type is used as the requirement of an `ExtrasCandidate`, so we can
+    skip finding candidates when resolving it later.
+    """
+    def __init__(self, candidate):
+        # type: (ExtrasCandidate) -> None
+        self.candidate = candidate.candidate
+
+    @property
+    def name(self):
+        # type: () -> str
+        return self.candidate.name
+
+    @property
+    def specifier(self):
+        # type: () -> SpecifierSet
+        return SpecifierSet("=={}".format(self.candidate.version))

--- a/src/pip/_internal/resolution/resolvelib/providers.py
+++ b/src/pip/_internal/resolution/resolvelib/providers.py
@@ -1,0 +1,66 @@
+import operator
+
+from pip._vendor.packaging.requirements import (
+    Requirement as PEP440Requirement,
+)
+from pip._vendor.packaging.utils import canonicalize_name
+
+from pip._internal.resolution.resolvelib.models import (
+    DirectCandidate,
+    ExtrasCandidate,
+    SingleCandidateRequirement,
+)
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Any, List, Union, Sized
+    from pip._internal.index.package_finder import PackageFinder
+    from pip._internal.models.candidate import InstallationCandidate
+    from pip._internal.operations.prepare import RequirementPreparer
+
+    Requirement = Union[PEP440Requirement, SingleCandidateRequirement]
+    Candidate = Union[InstallationCandidate, DirectCandidate, ExtrasCandidate]
+    Dependency = Union[Requirement, Candidate]
+
+
+class Provider(object):
+    def __init__(self, finder, preparer):
+        # type: (PackageFinder, RequirementPreparer) -> None
+        super(Provider, self).__init__()
+        self.finder = finder
+        self.preparer = preparer
+
+    def identify(self, dependency):
+        # type: (Dependency) -> str
+        return canonicalize_name(dependency.name)
+
+    def get_preference(self, resolution, candidates, information):
+        # type: (Any, Sized[Candidate], Any) -> int
+        return len(candidates)
+
+    def find_matches(self, req):
+        # type: (Requirement) -> List[Candidate]
+        if isinstance(req, SingleCandidateRequirement):
+            return [req.candidate]
+
+        if req.url:
+            candidates = [DirectCandidate(req.name, req.url)]
+        else:
+            candidates = self.finder.find_all_candidates(req.name)
+            candidates = sorted(candidates, key=operator.attrgetter("version"))
+
+        if req.extras:
+            candidates = [ExtrasCandidate(c, req.extras) for c in candidates]
+
+        return candidates
+
+    def is_satisfied_by(self, requirement, candidate):
+        # type: (Requirement, Candidate) -> bool
+        if requirement.url:
+            return candidate.link.url == requirement.url
+        return candidate.version in requirement.specifier
+
+    def get_dependencies(self, candidate):
+        # type: (Candidate) -> List[Requirement]
+        # TODO: Implement me.
+        raise NotImplementedError()


### PR DESCRIPTION
This is not intended to be merged, but posted to raise awareness and discussions.

I went through a few iterations on this, but couldn’t really figure out how to directly use `InstallRequirement`, so right now I am using `Requirement` from packaging, `InstallationCandidate` returned by the finder, and some custom PODs to do the job. I implemented the straightforward parts, but the most hairy one awaits: Read metadata from a random candidate (for version and dependencies).

cc @pfmoore 