### PR TITLE
Rename pep425tags -> utils.compatibility_tags

### DIFF
--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -1,6 +1,9 @@
 import sys
 
-from pip._internal.pep425tags import get_supported, version_info_to_nodot
+from pip._internal.utils.compatibility_tags import (
+    get_supported,
+    version_info_to_nodot,
+)
 from pip._internal.utils.misc import normalize_version_info
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -34,10 +37,10 @@ class TargetPython(object):
         :param py_version_info: An optional tuple of ints representing the
             Python version information to use (e.g. `sys.version_info[:3]`).
             This can have length 1, 2, or 3 when provided.
-        :param abi: A string or None. This is passed to pep425tags.py's
+        :param abi: A string or None. This is passed to compatibility_tags.py's
             get_supported() function as is.
         :param implementation: A string or None. This is passed to
-            pep425tags.py's get_supported() function as is.
+            compatibility_tags.py's get_supported() function as is.
         """
         # Store the given py_version_info for when we call get_supported().
         self._given_py_version_info = py_version_info

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -16,7 +16,6 @@ from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pep517.wrappers import Pep517HookCaller
 
-from pip._internal import pep425tags
 from pip._internal.build_env import NoOpBuildEnvironment
 from pip._internal.exceptions import InstallationError
 from pip._internal.locations import get_scheme
@@ -31,6 +30,7 @@ from pip._internal.operations.install.legacy import install as install_legacy
 from pip._internal.operations.install.wheel import install_wheel
 from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
 from pip._internal.req.req_uninstall import UninstallPathSet
+from pip._internal.utils import compatibility_tags
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.logging import indent_log
@@ -258,7 +258,7 @@ class InstallRequirement(object):
             self.link = finder.find_requirement(self, upgrade)
         if self._wheel_cache is not None and not require_hashes:
             old_link = self.link
-            supported_tags = pep425tags.get_supported()
+            supported_tags = compatibility_tags.get_supported()
             self.link = self._wheel_cache.get(
                 link=self.link,
                 package_name=self.name,

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -8,9 +8,9 @@ from collections import OrderedDict
 
 from pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal import pep425tags
 from pip._internal.exceptions import InstallationError
 from pip._internal.models.wheel import Wheel
+from pip._internal.utils import compatibility_tags
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -102,7 +102,7 @@ class RequirementSet(object):
         # single requirements file.
         if install_req.link and install_req.link.is_wheel:
             wheel = Wheel(install_req.link.filename)
-            tags = pep425tags.get_supported()
+            tags = compatibility_tags.get_supported()
             if (self.check_supported_wheels and not wheel.supported(tags)):
                 raise InstallationError(
                     "{} is not a supported wheel on this platform.".format(

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -1,4 +1,6 @@
-"""Generate and work with PEP 425 Compatibility Tags."""
+"""Generate and work with PEP 425 Compatibility Tags.
+"""
+
 from __future__ import absolute_import
 
 import logging

--- a/tests/functional/test_debug.py
+++ b/tests/functional/test_debug.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pip._internal import pep425tags
+from pip._internal.utils import compatibility_tags
 
 
 @pytest.mark.parametrize('expected_text', [
@@ -42,7 +42,7 @@ def test_debug__tags(script, args):
     result = script.pip(*args, allow_stderr_warning=True)
     stdout = result.stdout
 
-    tags = pep425tags.get_supported()
+    tags = compatibility_tags.get_supported()
     expected_tag_header = 'Compatible tags: {}'.format(len(tags))
     assert expected_tag_header in stdout
 

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -7,7 +7,7 @@ from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.tags import Tag
 from pkg_resources import parse_version
 
-import pip._internal.pep425tags
+import pip._internal.utils.compatibility_tags
 from pip._internal.exceptions import (
     BestVersionAlreadyInstalled,
     DistributionNotFound,
@@ -171,7 +171,7 @@ class TestWheel:
         Test finding supported wheel.
         """
         monkeypatch.setattr(
-            pip._internal.pep425tags,
+            pip._internal.utils.compatibility_tags,
             "get_supported",
             lambda **kw: [('py2', 'none', 'any')],
         )

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -21,7 +21,7 @@ from pip._internal.models.search_scope import SearchScope
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
-from pip._internal.pep425tags import get_supported
+from pip._internal.utils.compatibility_tags import get_supported
 from pip._internal.utils.hashes import Hashes
 from tests.lib import CURRENT_PY_VERSION_INFO
 

--- a/tests/unit/test_models_wheel.py
+++ b/tests/unit/test_models_wheel.py
@@ -1,9 +1,9 @@
 import pytest
 from pip._vendor.packaging.tags import Tag
 
-from pip._internal import pep425tags
 from pip._internal.exceptions import InvalidWheelFilename
 from pip._internal.models.wheel import Wheel
+from pip._internal.utils import compatibility_tags
 
 
 class TestWheelFile(object):
@@ -75,7 +75,7 @@ class TestWheelFile(object):
         """
         Wheels built for macOS 10.6 are supported on 10.9
         """
-        tags = pep425tags.get_supported(
+        tags = compatibility_tags.get_supported(
             '27', platform='macosx_10_9_intel', impl='cp'
         )
         w = Wheel('simple-0.1-cp27-none-macosx_10_6_intel.whl')
@@ -87,7 +87,7 @@ class TestWheelFile(object):
         """
         Wheels built for macOS 10.9 are not supported on 10.6
         """
-        tags = pep425tags.get_supported(
+        tags = compatibility_tags.get_supported(
             '27', platform='macosx_10_6_intel', impl='cp'
         )
         w = Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
@@ -97,22 +97,22 @@ class TestWheelFile(object):
         """
         Multi-arch wheels (intel) are supported on components (i386, x86_64)
         """
-        universal = pep425tags.get_supported(
+        universal = compatibility_tags.get_supported(
             '27', platform='macosx_10_5_universal', impl='cp'
         )
-        intel = pep425tags.get_supported(
+        intel = compatibility_tags.get_supported(
             '27', platform='macosx_10_5_intel', impl='cp'
         )
-        x64 = pep425tags.get_supported(
+        x64 = compatibility_tags.get_supported(
             '27', platform='macosx_10_5_x86_64', impl='cp'
         )
-        i386 = pep425tags.get_supported(
+        i386 = compatibility_tags.get_supported(
             '27', platform='macosx_10_5_i386', impl='cp'
         )
-        ppc = pep425tags.get_supported(
+        ppc = compatibility_tags.get_supported(
             '27', platform='macosx_10_5_ppc', impl='cp'
         )
-        ppc64 = pep425tags.get_supported(
+        ppc64 = compatibility_tags.get_supported(
             '27', platform='macosx_10_5_ppc64', impl='cp'
         )
 
@@ -135,10 +135,10 @@ class TestWheelFile(object):
         """
         Single-arch wheels (x86_64) are not supported on multi-arch (intel)
         """
-        universal = pep425tags.get_supported(
+        universal = compatibility_tags.get_supported(
             '27', platform='macosx_10_5_universal', impl='cp'
         )
-        intel = pep425tags.get_supported(
+        intel = compatibility_tags.get_supported(
             '27', platform='macosx_10_5_intel', impl='cp'
         )
 

--- a/tests/unit/test_utils_compatibility_tags.py
+++ b/tests/unit/test_utils_compatibility_tags.py
@@ -3,7 +3,7 @@ import sysconfig
 import pytest
 from mock import patch
 
-from pip._internal import pep425tags
+from pip._internal.utils import compatibility_tags
 
 
 @pytest.mark.parametrize('version_info, expected', [
@@ -17,11 +17,11 @@ from pip._internal import pep425tags
     ((3, 10), '310'),
 ])
 def test_version_info_to_nodot(version_info, expected):
-    actual = pep425tags.version_info_to_nodot(version_info)
+    actual = compatibility_tags.version_info_to_nodot(version_info)
     assert actual == expected
 
 
-class TestPEP425Tags(object):
+class Testcompatibility_tags(object):
 
     def mock_get_config_var(self, **kwd):
         """
@@ -39,12 +39,12 @@ class TestPEP425Tags(object):
         """
         Test that no tag contains a hyphen.
         """
-        import pip._internal.pep425tags
+        import pip._internal.utils.compatibility_tags
 
         mock_gcf = self.mock_get_config_var(SOABI='cpython-35m-darwin')
 
         with patch('sysconfig.get_config_var', mock_gcf):
-            supported = pip._internal.pep425tags.get_supported()
+            supported = pip._internal.utils.compatibility_tags.get_supported()
 
         for tag in supported:
             assert '-' not in tag.interpreter
@@ -63,7 +63,7 @@ class TestManylinux2010Tags(object):
         Specifying manylinux2010 implies manylinux1.
         """
         groups = {}
-        supported = pep425tags.get_supported(platform=manylinux2010)
+        supported = compatibility_tags.get_supported(platform=manylinux2010)
         for tag in supported:
             groups.setdefault(
                 (tag.interpreter, tag.abi), []
@@ -87,7 +87,7 @@ class TestManylinux2014Tags(object):
         Specifying manylinux2014 implies manylinux2010/manylinux1.
         """
         groups = {}
-        supported = pep425tags.get_supported(platform=manylinuxA)
+        supported = compatibility_tags.get_supported(platform=manylinuxA)
         for tag in supported:
             groups.setdefault(
                 (tag.interpreter, tag.abi), []


### PR DESCRIPTION
Well, it's cleaner IMO.