### PR TITLE
Move wheel cache out of InstallRequirement

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -255,7 +255,6 @@ class RequirementCommand(IndexGroupCommand):
         make_install_req = partial(
             install_req_from_req_string,
             isolated=options.isolated_mode,
-            wheel_cache=wheel_cache,
             use_pep517=use_pep517,
         )
         # The long import name and duplicated invocation is needed to convince
@@ -266,6 +265,7 @@ class RequirementCommand(IndexGroupCommand):
             return pip._internal.resolution.resolvelib.resolver.Resolver(
                 preparer=preparer,
                 finder=finder,
+                wheel_cache=wheel_cache,
                 make_install_req=make_install_req,
                 use_user_site=use_user_site,
                 ignore_dependencies=options.ignore_dependencies,
@@ -279,6 +279,7 @@ class RequirementCommand(IndexGroupCommand):
         return pip._internal.resolution.legacy.resolver.Resolver(
             preparer=preparer,
             finder=finder,
+            wheel_cache=wheel_cache,
             make_install_req=make_install_req,
             use_user_site=use_user_site,
             ignore_dependencies=options.ignore_dependencies,
@@ -295,7 +296,6 @@ class RequirementCommand(IndexGroupCommand):
         options,          # type: Values
         finder,           # type: PackageFinder
         session,          # type: PipSession
-        wheel_cache,      # type: Optional[WheelCache]
         check_supported_wheels=True,  # type: bool
     ):
         # type: (...) -> List[InstallRequirement]
@@ -313,7 +313,6 @@ class RequirementCommand(IndexGroupCommand):
                 req_to_add = install_req_from_parsed_requirement(
                     parsed_req,
                     isolated=options.isolated_mode,
-                    wheel_cache=wheel_cache,
                 )
                 req_to_add.is_direct = True
                 requirement_set.add_requirement(req_to_add)
@@ -322,7 +321,6 @@ class RequirementCommand(IndexGroupCommand):
             req_to_add = install_req_from_line(
                 req, None, isolated=options.isolated_mode,
                 use_pep517=options.use_pep517,
-                wheel_cache=wheel_cache
             )
             req_to_add.is_direct = True
             requirement_set.add_requirement(req_to_add)
@@ -332,7 +330,6 @@ class RequirementCommand(IndexGroupCommand):
                 req,
                 isolated=options.isolated_mode,
                 use_pep517=options.use_pep517,
-                wheel_cache=wheel_cache
             )
             req_to_add.is_direct = True
             requirement_set.add_requirement(req_to_add)
@@ -345,7 +342,6 @@ class RequirementCommand(IndexGroupCommand):
                 req_to_add = install_req_from_parsed_requirement(
                     parsed_req,
                     isolated=options.isolated_mode,
-                    wheel_cache=wheel_cache,
                     use_pep517=options.use_pep517
                 )
                 req_to_add.is_direct = True

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -107,13 +107,7 @@ class DownloadCommand(RequirementCommand):
             globally_managed=True,
         )
 
-        reqs = self.get_requirements(
-            args,
-            options,
-            finder,
-            session,
-            None
-        )
+        reqs = self.get_requirements(args, options, finder, session)
 
         preparer = self.make_requirement_preparer(
             temp_build_dir=directory,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -299,7 +299,7 @@ class InstallCommand(RequirementCommand):
         try:
             reqs = self.get_requirements(
                 args, options, finder, session,
-                wheel_cache, check_supported_wheels=not options.target_dir,
+                check_supported_wheels=not options.target_dir,
             )
 
             warn_deprecated_install_options(

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -133,10 +133,7 @@ class WheelCommand(RequirementCommand):
             globally_managed=True,
         )
 
-        reqs = self.get_requirements(
-            args, options, finder, session,
-            wheel_cache
-        )
+        reqs = self.get_requirements(args, options, finder, session)
 
         preparer = self.make_requirement_preparer(
             temp_build_dir=directory,

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -147,7 +147,7 @@ class HashError(InstallationError):
         triggering requirement.
 
         :param req: The InstallRequirement that provoked this error, with
-            populate_link() having already been called
+            its link already populated by the resolver's _populate_link().
 
         """
         return '    {}'.format(self._requirement_name())

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -118,7 +118,8 @@ def freeze(
                         else:
                             line = line[len('--editable'):].strip().lstrip('=')
                         line_req = install_req_from_editable(
-                            line, isolated=isolated,
+                            line,
+                            isolated=isolated,
                         )
                     else:
                         line_req = install_req_from_line(

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -118,15 +118,12 @@ def freeze(
                         else:
                             line = line[len('--editable'):].strip().lstrip('=')
                         line_req = install_req_from_editable(
-                            line,
-                            isolated=isolated,
-                            wheel_cache=wheel_cache,
+                            line, isolated=isolated,
                         )
                     else:
                         line_req = install_req_from_line(
                             COMMENT_RE.sub('', line).strip(),
                             isolated=isolated,
-                            wheel_cache=wheel_cache,
                         )
 
                     if not line_req.name:

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -36,7 +36,6 @@ if MYPY_CHECK_RUNNING:
     from typing import (
         Any, Dict, Optional, Set, Tuple, Union,
     )
-    from pip._internal.cache import WheelCache
     from pip._internal.req.req_file import ParsedRequirement
 
 
@@ -223,7 +222,6 @@ def install_req_from_editable(
     use_pep517=None,  # type: Optional[bool]
     isolated=False,  # type: bool
     options=None,  # type: Optional[Dict[str, Any]]
-    wheel_cache=None,  # type: Optional[WheelCache]
     constraint=False  # type: bool
 ):
     # type: (...) -> InstallRequirement
@@ -242,7 +240,6 @@ def install_req_from_editable(
         install_options=options.get("install_options", []) if options else [],
         global_options=options.get("global_options", []) if options else [],
         hash_options=options.get("hashes", {}) if options else {},
-        wheel_cache=wheel_cache,
         extras=parts.extras,
     )
 
@@ -387,7 +384,6 @@ def install_req_from_line(
     use_pep517=None,  # type: Optional[bool]
     isolated=False,  # type: bool
     options=None,  # type: Optional[Dict[str, Any]]
-    wheel_cache=None,  # type: Optional[WheelCache]
     constraint=False,  # type: bool
     line_source=None,  # type: Optional[str]
 ):
@@ -406,7 +402,6 @@ def install_req_from_line(
         install_options=options.get("install_options", []) if options else [],
         global_options=options.get("global_options", []) if options else [],
         hash_options=options.get("hashes", {}) if options else {},
-        wheel_cache=wheel_cache,
         constraint=constraint,
         extras=parts.extras,
     )
@@ -416,7 +411,6 @@ def install_req_from_req_string(
     req_string,  # type: str
     comes_from=None,  # type: Optional[InstallRequirement]
     isolated=False,  # type: bool
-    wheel_cache=None,  # type: Optional[WheelCache]
     use_pep517=None  # type: Optional[bool]
 ):
     # type: (...) -> InstallRequirement
@@ -439,15 +433,13 @@ def install_req_from_req_string(
         )
 
     return InstallRequirement(
-        req, comes_from, isolated=isolated, wheel_cache=wheel_cache,
-        use_pep517=use_pep517
+        req, comes_from, isolated=isolated, use_pep517=use_pep517
     )
 
 
 def install_req_from_parsed_requirement(
     parsed_req,  # type: ParsedRequirement
     isolated=False,  # type: bool
-    wheel_cache=None,  # type: Optional[WheelCache]
     use_pep517=None  # type: Optional[bool]
 ):
     # type: (...) -> InstallRequirement
@@ -458,7 +450,6 @@ def install_req_from_parsed_requirement(
             use_pep517=use_pep517,
             constraint=parsed_req.constraint,
             isolated=isolated,
-            wheel_cache=wheel_cache
         )
 
     else:
@@ -468,7 +459,6 @@ def install_req_from_parsed_requirement(
             use_pep517=use_pep517,
             isolated=isolated,
             options=parsed_req.options,
-            wheel_cache=wheel_cache,
             constraint=parsed_req.constraint,
             line_source=parsed_req.line_source,
         )

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -264,8 +264,9 @@ class Resolver(BaseResolver):
         # type: (InstallRequirement) -> None
         """Ensure that if a link can be found for this, that it is found.
 
-        Note that req.link may still be None - if Upgrade is False and the
-        requirement is already installed.
+        Note that req.link may still be None - if the requirement is already
+        installed and not needed to be upgraded based on the return value of
+        _is_upgrade_allowed().
 
         If preparer.require_hashes is True, don't use the wheel cache, because
         cached wheels, always built locally, have different hashes than the

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -30,7 +30,6 @@ def make_install_req_from_link(link, parent):
         comes_from=parent.comes_from,
         use_pep517=parent.use_pep517,
         isolated=parent.isolated,
-        wheel_cache=parent._wheel_cache,
         constraint=parent.constraint,
         options=dict(
             install_options=parent.install_options,

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -16,6 +16,7 @@ if MYPY_CHECK_RUNNING:
 
     from pip._vendor.resolvelib.resolvers import Result
 
+    from pip._internal.cache import WheelCache
     from pip._internal.index.package_finder import PackageFinder
     from pip._internal.operations.prepare import RequirementPreparer
     from pip._internal.req.req_install import InstallRequirement
@@ -27,6 +28,7 @@ class Resolver(BaseResolver):
         self,
         preparer,  # type: RequirementPreparer
         finder,  # type: PackageFinder
+        wheel_cache,  # type: Optional[WheelCache]
         make_install_req,  # type: InstallRequirementProvider
         use_user_site,  # type: bool
         ignore_dependencies,  # type: bool

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -14,6 +14,7 @@ def resolver(preparer, finder):
     resolver = Resolver(
         preparer=preparer,
         finder=finder,
+        wheel_cache=None,
         make_install_req=mock.Mock(),
         use_user_site="not-used",
         ignore_dependencies="not-used",

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -74,7 +74,6 @@ class TestRequirementSet(object):
         make_install_req = partial(
             install_req_from_req_string,
             isolated=False,
-            wheel_cache=None,
             use_pep517=None,
         )
 
@@ -95,6 +94,7 @@ class TestRequirementSet(object):
                 preparer=preparer,
                 make_install_req=make_install_req,
                 finder=finder,
+                wheel_cache=None,
                 use_user_site=False, upgrade_strategy="to-satisfy-only",
                 ignore_dependencies=False, ignore_installed=False,
                 ignore_requires_python=False, force_reinstall=False,
@@ -176,9 +176,7 @@ class TestRequirementSet(object):
         command = create_command('install')
         with requirements_file('--require-hashes', tmpdir) as reqs_file:
             options, args = command.parse_args(['-r', reqs_file])
-            command.get_requirements(
-                args, options, finder, session, wheel_cache=None,
-            )
+            command.get_requirements(args, options, finder, session)
         assert options.require_hashes
 
     def test_unsupported_hashes(self, data):


### PR DESCRIPTION
In #7796 it was discussed how the “link is yanked” warning should not live inside the finder, since the new resolver may not actually end up using that found link. It was later discovered `InstallRequirement.populate_link()` is also not the correct location to log this, since an `InstallRequirement` with link populated (i.e. turned into a candidate) may still be discarded when the resolver backtracks.

The next idea is to put that logging code into a separate method for the resolver to call. However, the current implementation of `populate_link()` eagerly checks the link against the wheel cache, and replace the link if that cache hits. So to make the idea possible, the resolver also needs to invoke the cache look-up step.

With that conclusion, this refactoring removed the `wheel_cache` attribute from `InstallRequirement` (since it is not used anywhere else), and puts it on `Resolver` instead. `populate_link()` (the only usage of the wheel cache) is also moved to the resolver, and will be broken down in a later PR to move the yanked link warning.