### PR TITLE
WIP: Correctly detect if executable with os.stat()

### DIFF
--- a/news/6364.bugfix
+++ b/news/6364.bugfix
@@ -1,0 +1,1 @@
+Correctly set executable permissions in cases where /tmp is mounted 'noexec.'

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -398,9 +398,12 @@ def install_unpacked_wheel(
                     os.utime(destfile, (st.st_atime, st.st_mtime))
 
                 # If our file is executable, then make our destination file
-                # executable.
-                if os.access(srcfile, os.X_OK):
-                    st = os.stat(srcfile)
+                # executable.  Issue #6364: we make the destination executable
+                # if any -x flags are set on srcfile rather than using
+                # os.access(), which will always return False if srcfile
+                # is in a directory mounted 'noexec.'
+                st = os.stat(srcfile)
+                if st.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
                     permissions = (
                         st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
                     )

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -398,7 +398,8 @@ def install_unpacked_wheel(
                     os.utime(destfile, (st.st_atime, st.st_mtime))
 
                 # If our file is executable, then make our destination file
-                # executable.  Issue #6364: we make the destination executable
+                # executable.  Account for cases where the tmpdir
+                # is mounted 'noexec'; we make the destination executable
                 # if any -x flags are set on srcfile rather than using
                 # os.access(), which will always return False if srcfile
                 # is in a directory mounted 'noexec.'


### PR DESCRIPTION
Closes #6364.

Use `os.stat()` rather than `os.access()` to correctly determine if `srcfile` has any executable bits set.  `os.access()` will always return False in cases where the directory is mounted noexec, which can lead to a false negative and the resulting script not being executable.

**WIP**: working on adding tests as described at https://github.com/pypa/pip/issues/6364#issuecomment-507074729.

This fix does seem to work if modifying the `run_test` script from the link above, e.g. `pip install --upgrade /pip`; using this development version of pip including this commit, installing the local version results in the script having correct executable permissions.
