### PR TITLE
Improve docs on pinning version numbers

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -688,15 +688,25 @@ Pinning the versions of your dependencies in the requirements file
 protects you from bugs or incompatibilities in newly released versions::
 
     SomePackage == 1.2.3
-    DependencyOfSomePackage == 4.5.6
+    DependencyOfSomePackage == 4.5.6  # via SomePackage
 
-Using :ref:`pip freeze` to generate the requirements file will ensure that not
-only the top-level dependencies are included but their sub-dependencies as
-well, and so on. Perform the installation using :ref:`--no-deps
+You can do it by hand by putting in requirements file pinned versions of
+packages and *their* requirements. Use the help of :ref:`pip show` to get to
+know ``Version`` that has been resolved and packages that your package
+``Requires``.
+
+You can pin your sub-dependencies in
+:ref:`constraints file <Constraints Files>` to avoid installing not needed
+packages in case of e.g. missing drop of requirement in upgraded package.
+
+You can also use :ref:`pip freeze` to generate the requirements file, but note
+that this way you are losing information what is you top-level- or
+sub-dependency and that you may include package from your environment that your
+application doesn't really need. Perform the installation using :ref:`--no-deps
 <install_--no-deps>` for an extra dose of insurance against installing
 anything not explicitly listed.
 
-This strategy is easy to implement and works across OSes and architectures.
+This strategy works across OSes and architectures.
 However, it trusts PyPI and the certificate authority chain. It
 also relies on indices and find-links locations not allowing
 packages to change without a version increase. (PyPI does protect

--- a/news/7820.doc
+++ b/news/7820.doc
@@ -1,0 +1,1 @@
+Improve docs on pinning version numbers


### PR DESCRIPTION
Second take (see #7807) on improving Pinned Version Numbers documentation in User Guide.

* Added comment `# via SomePackage` as a good practice example of preserving cause of presence of package,
* added suggestion for pinning version numbers by hand using `pip show`,
* added suggestion for putting sub-dependencies in constraints file to avoid installing not needed package,
* added warnings about using pip freeze generation.

Although #7811 and #6925 would make those changes not needed, in my opinion they express best practices for pip's features as they are today and help its users to avoid pitfalls.