### PR TITLE
Skip svn tests if svnadmin is not available.

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1105,7 +1105,9 @@ def need_bzr(fn):
 def need_svn(fn):
     return pytest.mark.svn(need_executable(
         'Subversion', ('svn', '--version')
-    )(fn))
+    )(need_executable(
+        'Subversion Admin', ('svnadmin', '--version')
+    )(fn)))
 
 
 def need_mercurial(fn):


### PR DESCRIPTION
Fixes #7823.