### PR TITLE
Remove pip._internal.operations.prepare._copy_file

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -105,6 +105,7 @@ def unpack_vcs_link(link, location):
 def _copy_file(filename, download_location):
     # type: (str, str) -> None
     copy = True
+    assert not os.path.exists(download_location)
     if os.path.exists(download_location):
         response = ask_path_exists(
             'The file {} exists. (i)gnore, (w)ipe, (b)ackup, (a)abort'.format(
@@ -512,13 +513,12 @@ class RequirementPreparer(object):
             if download_dir:
                 if link.is_existing_dir():
                     logger.info('Link is a directory, ignoring download_dir')
-                elif local_file and not os.path.exists(
-                    os.path.join(download_dir, link.filename)
-                ):
+                elif local_file:
                     download_location = os.path.join(
                         download_dir, link.filename
                     )
-                    _copy_file(local_file.path, download_location)
+                    if not os.path.exists(download_location):
+                        _copy_file(local_file.path, download_location)
 
             if self._download_should_save:
                 # Make a .zip of the source_dir we already created.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -101,8 +101,7 @@ def unpack_vcs_link(link, location):
 
 def _copy_file(filename, download_location):
     # type: (str, str) -> None
-    copy = True
-    if copy:
+    if True:
         shutil.copy(filename, download_location)
         logger.info('Saved %s', display_path(download_location))
 

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -8,7 +8,6 @@ import logging
 import mimetypes
 import os
 import shutil
-import sys
 
 from pip._vendor import requests
 from pip._vendor.six import PY2
@@ -29,8 +28,6 @@ from pip._internal.utils.filesystem import copy2_fixed
 from pip._internal.utils.hashes import MissingHashes
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
-    ask_path_exists,
-    backup_dir,
     display_path,
     hide_url,
     path_to_display,
@@ -105,29 +102,6 @@ def unpack_vcs_link(link, location):
 def _copy_file(filename, download_location):
     # type: (str, str) -> None
     copy = True
-    assert not os.path.exists(download_location)
-    if os.path.exists(download_location):
-        response = ask_path_exists(
-            'The file {} exists. (i)gnore, (w)ipe, (b)ackup, (a)abort'.format(
-                display_path(download_location)
-            ),
-            ('i', 'w', 'b', 'a'),
-        )
-        if response == 'i':
-            copy = False
-        elif response == 'w':
-            logger.warning('Deleting %s', display_path(download_location))
-            os.remove(download_location)
-        elif response == 'b':
-            dest_file = backup_dir(download_location)
-            logger.warning(
-                'Backing up %s to %s',
-                display_path(download_location),
-                display_path(dest_file),
-            )
-            shutil.move(download_location, dest_file)
-        elif response == 'a':
-            sys.exit(-1)
     if copy:
         shutil.copy(filename, download_location)
         logger.info('Saved %s', display_path(download_location))

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -99,12 +99,6 @@ def unpack_vcs_link(link, location):
     vcs_backend.unpack(location, url=hide_url(link.url))
 
 
-def _copy_file(filename, download_location):
-    # type: (str, str) -> None
-    shutil.copy(filename, download_location)
-    logger.info('Saved %s', display_path(download_location))
-
-
 class File(object):
     def __init__(self, path, content_type):
         # type: (str, str) -> None
@@ -490,7 +484,10 @@ class RequirementPreparer(object):
                         download_dir, link.filename
                     )
                     if not os.path.exists(download_location):
-                        _copy_file(local_file.path, download_location)
+                        shutil.copy(local_file.path, download_location)
+                        logger.info(
+                            'Saved %s', display_path(download_location)
+                        )
 
             if self._download_should_save:
                 # Make a .zip of the source_dir we already created.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -101,9 +101,8 @@ def unpack_vcs_link(link, location):
 
 def _copy_file(filename, download_location):
     # type: (str, str) -> None
-    if True:
-        shutil.copy(filename, download_location)
-        logger.info('Saved %s', display_path(download_location))
+    shutil.copy(filename, download_location)
+    logger.info('Saved %s', display_path(download_location))
 
 
 class File(object):

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -102,10 +102,9 @@ def unpack_vcs_link(link, location):
     vcs_backend.unpack(location, url=hide_url(link.url))
 
 
-def _copy_file(filename, location, link):
-    # type: (str, str, Link) -> None
+def _copy_file(filename, download_location):
+    # type: (str, str) -> None
     copy = True
-    download_location = os.path.join(location, link.filename)
     if os.path.exists(download_location):
         response = ask_path_exists(
             'The file {} exists. (i)gnore, (w)ipe, (b)ackup, (a)abort'.format(
@@ -516,7 +515,10 @@ class RequirementPreparer(object):
                 elif local_file and not os.path.exists(
                     os.path.join(download_dir, link.filename)
                 ):
-                    _copy_file(local_file.path, download_dir, link)
+                    download_location = os.path.join(
+                        download_dir, link.filename
+                    )
+                    _copy_file(local_file.path, download_location)
 
             if self._download_should_save:
                 # Make a .zip of the source_dir we already created.


### PR DESCRIPTION
Turns out the bulk of this function wasn't actually used.

This removes an untested function and reduces our total lines of code.