### PR TITLE
Add --unstable-feature=resolver

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -915,6 +915,19 @@ no_python_version_warning = partial(
 )  # type: Callable[..., Option]
 
 
+unstable_feature = partial(
+    Option,
+    '--unstable-feature',
+    dest='unstable_features',
+    metavar='feature',
+    action='append',
+    default=[],
+    choices=['resolver'],
+    help=SUPPRESS_HELP,  # TODO: Enable this when the resolver actually works.
+    # help='Enable unstable feature(s) that may be backward incompatible.',
+)  # type: Callable[..., Option]
+
+
 ##########
 # groups #
 ##########
@@ -943,6 +956,7 @@ general_group = {
         disable_pip_version_check,
         no_color,
         no_python_version_warning,
+        unstable_feature,
     ]
 }  # type: Dict[str, Any]
 

--- a/src/pip/_internal/resolution/base.py
+++ b/src/pip/_internal/resolution/base.py
@@ -1,0 +1,20 @@
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Callable, List
+    from pip._internal.req.req_install import InstallRequirement
+    from pip._internal.req.req_set import RequirementSet
+
+    InstallRequirementProvider = Callable[
+        [str, InstallRequirement], InstallRequirement
+    ]
+
+
+class BaseResolver(object):
+    def resolve(self, root_reqs, check_supported_wheels):
+        # type: (List[InstallRequirement], bool) -> RequirementSet
+        raise NotImplementedError()
+
+    def get_installation_order(self, req_set):
+        # type: (RequirementSet) -> List[InstallRequirement]
+        raise NotImplementedError()

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -29,6 +29,7 @@ from pip._internal.exceptions import (
     UnsupportedPythonVersion,
 )
 from pip._internal.req.req_set import RequirementSet
+from pip._internal.resolution.base import BaseResolver
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import dist_in_usersite, normalize_version_info
 from pip._internal.utils.packaging import (
@@ -38,17 +39,15 @@ from pip._internal.utils.packaging import (
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Callable, DefaultDict, List, Optional, Set, Tuple
+    from typing import DefaultDict, List, Optional, Set, Tuple
     from pip._vendor import pkg_resources
 
     from pip._internal.distributions import AbstractDistribution
     from pip._internal.index.package_finder import PackageFinder
     from pip._internal.operations.prepare import RequirementPreparer
     from pip._internal.req.req_install import InstallRequirement
+    from pip._internal.resolution.base import InstallRequirementProvider
 
-    InstallRequirementProvider = Callable[
-        [str, InstallRequirement], InstallRequirement
-    ]
     DiscoveredDependencies = DefaultDict[str, List[InstallRequirement]]
 
 logger = logging.getLogger(__name__)
@@ -102,7 +101,7 @@ def _check_dist_requires_python(
         ))
 
 
-class Resolver(object):
+class Resolver(BaseResolver):
     """Resolves which packages need to be installed/uninstalled to perform \
     the requested operation without breaking the requirements of any package.
     """

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -1,0 +1,36 @@
+from pip._internal.resolution.base import BaseResolver
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import List, Optional, Tuple
+
+    from pip._internal.index.package_finder import PackageFinder
+    from pip._internal.operations.prepare import RequirementPreparer
+    from pip._internal.req.req_install import InstallRequirement
+    from pip._internal.req.req_set import RequirementSet
+    from pip._internal.resolution.base import InstallRequirementProvider
+
+
+class Resolver(BaseResolver):
+    def __init__(
+        self,
+        preparer,  # type: RequirementPreparer
+        finder,  # type: PackageFinder
+        make_install_req,  # type: InstallRequirementProvider
+        use_user_site,  # type: bool
+        ignore_dependencies,  # type: bool
+        ignore_installed,  # type: bool
+        ignore_requires_python,  # type: bool
+        force_reinstall,  # type: bool
+        upgrade_strategy,  # type: str
+        py_version_info=None,  # type: Optional[Tuple[int, ...]]
+    ):
+        super(Resolver, self).__init__()
+
+    def resolve(self, root_reqs, check_supported_wheels):
+        # type: (List[InstallRequirement], bool) -> RequirementSet
+        raise NotImplementedError()
+
+    def get_installation_order(self, req_set):
+        # type: (RequirementSet) -> List[InstallRequirement]
+        raise NotImplementedError()


### PR DESCRIPTION
This introduces a new general option `--unstable-feature` that can be used to opt into “preview” features in pip not enabled by default. Currently the only available feature is `resolver`.

Based on #5727, but with a more bare-bone implementation since we have only one user (the resolver) at the moment. Refactoring can always come later :p

The `--unstable-feature` option is hidden from `--help` since the resolver does not yet work. This suppression should be removed when we release the resolver for general/public testing. I am also intentionally *not* providing a news fragment for the same reason—that can be added when we lift the help message suppression.

A stub resolver interface (which would fail on invocation) is provided to respond to the flag. Like #7843, this can be merged standalone, and implementation can be added after other PRs are added to flesh it out.

Fix #7603.