### PR TITLE
Prevent infinite recursion with pip wheel with $TMPDIR in $PWD

### DIFF
--- a/news/7872.bugfix
+++ b/news/7872.bugfix
@@ -1,0 +1,1 @@
+Prevent an infinite recursion with ``pip wheel`` when ``$TMPDIR`` is within the source directory.

--- a/tests/data/src/extension/setup.py
+++ b/tests/data/src/extension/setup.py
@@ -1,0 +1,4 @@
+from setuptools import Extension, setup
+
+module = Extension('extension', sources=['extension.c'])
+setup(name='extension', version='0.0.1', ext_modules = [module])

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -289,6 +289,17 @@ def test_pip_wheel_with_user_set_in_config(script, data, common_wheels):
     assert "Successfully built withpyproject" in result.stdout, result.stdout
 
 
+def test_pip_wheel_ext_module_with_tmpdir_inside(script, data, common_wheels):
+    tmpdir = data.src / 'extension/tmp'
+    tmpdir.mkdir()
+    script.environ['TMPDIR'] = str(tmpdir)
+    result = script.pip(
+        'wheel', data.src / 'extension',
+        '--no-index', '-f', common_wheels
+    )
+    assert "Successfully built extension" in result.stdout, result.stdout
+
+
 @pytest.mark.network
 def test_pep517_wheels_are_not_confused_with_other_files(script, tmpdir, data):
     """Check correct wheels are copied. (#6196)


### PR DESCRIPTION
During a build of extension module within `pip wheel` the source directory is
recursively copied in a temporary directory.

See https://github.com/pypa/pip/issues/7555

When the temporary directory is inside the source directory
(for example by setting `TMPDIR=$PWD/tmp`) this caused an infinite recursion
that ended in:

    [Errno 36] File name too long

We prevent that buy never copying the target to the target in _copy_source_tree.

Fixes https://github.com/pypa/pip/issues/7872

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
