### PR TITLE
Add some functional tests for the new resolver

### DIFF
--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -1,4 +1,5 @@
 import json
+
 from tests.lib import create_basic_wheel_for_package
 
 
@@ -9,10 +10,10 @@ def assert_installed(script, **kwargs):
         for val in json.loads(ret.stdout)
     )
     assert set(kwargs.items()) <= installed
-        
+
 
 def test_new_resolver_can_install(script):
-    package = create_basic_wheel_for_package(
+    create_basic_wheel_for_package(
         script,
         "simple",
         "0.1.0",
@@ -27,7 +28,7 @@ def test_new_resolver_can_install(script):
 
 
 def test_new_resolver_can_install_with_version(script):
-    package = create_basic_wheel_for_package(
+    create_basic_wheel_for_package(
         script,
         "simple",
         "0.1.0",
@@ -42,12 +43,12 @@ def test_new_resolver_can_install_with_version(script):
 
 
 def test_new_resolver_picks_latest_version(script):
-    package = create_basic_wheel_for_package(
+    create_basic_wheel_for_package(
         script,
         "simple",
         "0.1.0",
     )
-    package = create_basic_wheel_for_package(
+    create_basic_wheel_for_package(
         script,
         "simple",
         "0.2.0",
@@ -60,14 +61,15 @@ def test_new_resolver_picks_latest_version(script):
     )
     assert_installed(script, simple="0.2.0")
 
+
 def test_new_resolver_installs_dependencies(script):
-    package = create_basic_wheel_for_package(
+    create_basic_wheel_for_package(
         script,
         "base",
         "0.1.0",
         depends=["dep"],
     )
-    package = create_basic_wheel_for_package(
+    create_basic_wheel_for_package(
         script,
         "dep",
         "0.1.0",

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -1,0 +1,81 @@
+import json
+from tests.lib import create_basic_wheel_for_package
+
+
+def assert_installed(script, **kwargs):
+    ret = script.pip('list', '--format=json')
+    installed = set(
+        (val['name'], val['version'])
+        for val in json.loads(ret.stdout)
+    )
+    assert set(kwargs.items()) <= installed
+        
+
+def test_new_resolver_can_install(script):
+    package = create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.1.0",
+    )
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "simple"
+    )
+    assert_installed(script, simple="0.1.0")
+
+
+def test_new_resolver_can_install_with_version(script):
+    package = create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.1.0",
+    )
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "simple==0.1.0"
+    )
+    assert_installed(script, simple="0.1.0")
+
+
+def test_new_resolver_picks_latest_version(script):
+    package = create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.1.0",
+    )
+    package = create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.2.0",
+    )
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "simple"
+    )
+    assert_installed(script, simple="0.2.0")
+
+def test_new_resolver_installs_dependencies(script):
+    package = create_basic_wheel_for_package(
+        script,
+        "base",
+        "0.1.0",
+        depends=["dep"],
+    )
+    package = create_basic_wheel_for_package(
+        script,
+        "dep",
+        "0.1.0",
+    )
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base"
+    )
+    assert_installed(script, base="0.1.0", dep="0.1.0")


### PR DESCRIPTION
This PR just adds some basic tests and a framework for adding more, specifically to test the behaviour of the new resolver.

As we add functionality to the new resolver (e.g. support for extras), we can put test cases in here. All the tests are named `test_new_resolver_*`, so the new resolver can easily be checked using `tox -e py38 -- -k test_new_resolver_`.