### PR TITLE
Implement ignore_dependencies in new resolver

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -20,11 +20,13 @@ class PipProvider(AbstractProvider):
         self,
         finder,    # type: PackageFinder
         preparer,  # type: RequirementPreparer
+        ignore_dependencies,  # type: bool
         make_install_req  # type: InstallRequirementProvider
     ):
         # type: (...) -> None
         self._finder = finder
         self._preparer = preparer
+        self._ignore_dependencies = ignore_dependencies
         self._make_install_req = make_install_req
 
     def make_requirement(self, ireq):
@@ -72,6 +74,8 @@ class PipProvider(AbstractProvider):
 
     def get_dependencies(self, candidate):
         # type: (Candidate) -> Sequence[Requirement]
+        if self._ignore_dependencies:
+            return []
         return [
             make_requirement(
                 r,

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -57,9 +57,6 @@ class ExplicitRequirement(Requirement):
 
     def is_satisfied_by(self, candidate):
         # type: (Candidate) -> bool
-        # TODO: Typing - Candidate doesn't have a link attribute
-        #       But I think the following would be better...
-        # return candidate.link == self.candidate.link
         return candidate == self.candidate
 
 
@@ -104,7 +101,6 @@ class SpecifierRequirement(Requirement):
 
     def is_satisfied_by(self, candidate):
         # type: (Candidate) -> bool
-
         assert candidate.name == self.name, \
             "Internal issue: Candidate is not for this requirement " \
             " {} vs {}".format(candidate.name, self.name)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -37,6 +37,7 @@ class Resolver(BaseResolver):
         super(Resolver, self).__init__()
         self.finder = finder
         self.preparer = preparer
+        self.ignore_dependencies = ignore_dependencies
         self.make_install_req = make_install_req
         self._result = None  # type: Optional[Result]
 
@@ -45,6 +46,7 @@ class Resolver(BaseResolver):
         provider = PipProvider(
             finder=self.finder,
             preparer=self.preparer,
+            ignore_dependencies=self.ignore_dependencies,
             make_install_req=self.make_install_req,
         )
         reporter = BaseReporter()

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -43,9 +43,9 @@ class Resolver(BaseResolver):
     def resolve(self, root_reqs, check_supported_wheels):
         # type: (List[InstallRequirement], bool) -> RequirementSet
         provider = PipProvider(
-            self.finder,
-            self.preparer,
-            self.make_install_req,
+            finder=self.finder,
+            preparer=self.preparer,
+            make_install_req=self.make_install_req,
         )
         reporter = BaseReporter()
         resolver = RLResolver(provider, reporter)

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -89,3 +89,25 @@ def test_new_resolver_installs_dependencies(script):
         "base"
     )
     assert_installed(script, base="0.1.0", dep="0.1.0")
+
+
+def test_new_resolver_ignore_dependencies(script):
+    create_basic_wheel_for_package(
+        script,
+        "base",
+        "0.1.0",
+        depends=["dep"],
+    )
+    create_basic_wheel_for_package(
+        script,
+        "dep",
+        "0.1.0",
+    )
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index", "--no-deps",
+        "--find-links", script.scratch_path,
+        "base"
+    )
+    assert_installed(script, base="0.1.0")
+    assert_not_installed(script, "dep")

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -9,7 +9,15 @@ def assert_installed(script, **kwargs):
         (val['name'], val['version'])
         for val in json.loads(ret.stdout)
     )
-    assert set(kwargs.items()) <= installed
+    assert all(item in installed for item in kwargs.items()), \
+        "{!r} not all in {!r}".format(kwargs, installed)
+
+
+def assert_not_installed(script, *args):
+    ret = script.pip("list", "--format=json")
+    installed = set(val["name"] for val in json.loads(ret.stdout))
+    assert all(a not in installed for a in args), \
+        "{!r} contained in {!r}".format(args, installed)
 
 
 def test_new_resolver_can_install(script):

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -55,4 +55,8 @@ def provider(finder, preparer):
         wheel_cache=None,
         use_pep517=None,
     )
-    yield PipProvider(finder, preparer, make_install_req)
+    yield PipProvider(
+        finder=finder,
+        preparer=preparer,
+        make_install_req=make_install_req,
+    )

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -58,5 +58,6 @@ def provider(finder, preparer):
     yield PipProvider(
         finder=finder,
         preparer=preparer,
+        ignore_dependencies=False,
         make_install_req=make_install_req,
     )


### PR DESCRIPTION
The title says the most, and I added a couple of refactoring commits.

This one seems straightforward, but there is a potential catch. `Candidate.get_dependencies()` has a side effect of preparing the ireq; this flag skipping that would mean that ireqs the resolver returns would be unprepared. Would this be an issue at install-time?