### PR TITLE
Requires-Python prototype

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -20,11 +20,13 @@ class PipProvider(AbstractProvider):
         self,
         finder,    # type: PackageFinder
         preparer,  # type: RequirementPreparer
+        ignore_dependencies,  # type: bool
         make_install_req  # type: InstallRequirementProvider
     ):
         # type: (...) -> None
         self._finder = finder
         self._preparer = preparer
+        self._ignore_dependencies = ignore_dependencies
         self._make_install_req = make_install_req
 
     def make_requirement(self, ireq):
@@ -72,6 +74,8 @@ class PipProvider(AbstractProvider):
 
     def get_dependencies(self, candidate):
         # type: (Candidate) -> Sequence[Requirement]
+        if self._ignore_dependencies:
+            return []
         return [
             make_requirement(
                 r,

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -57,9 +57,6 @@ class ExplicitRequirement(Requirement):
 
     def is_satisfied_by(self, candidate):
         # type: (Candidate) -> bool
-        # TODO: Typing - Candidate doesn't have a link attribute
-        #       But I think the following would be better...
-        # return candidate.link == self.candidate.link
         return candidate == self.candidate
 
 
@@ -104,7 +101,6 @@ class SpecifierRequirement(Requirement):
 
     def is_satisfied_by(self, candidate):
         # type: (Candidate) -> bool
-
         assert candidate.name == self.name, \
             "Internal issue: Candidate is not for this requirement " \
             " {} vs {}".format(candidate.name, self.name)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -37,6 +37,7 @@ class Resolver(BaseResolver):
         super(Resolver, self).__init__()
         self.finder = finder
         self.preparer = preparer
+        self.ignore_dependencies = ignore_dependencies
         self.make_install_req = make_install_req
         self._result = None  # type: Optional[Result]
 
@@ -45,6 +46,7 @@ class Resolver(BaseResolver):
         provider = PipProvider(
             finder=self.finder,
             preparer=self.preparer,
+            ignore_dependencies=self.ignore_dependencies,
             make_install_req=self.make_install_req,
         )
         reporter = BaseReporter()

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -43,9 +43,9 @@ class Resolver(BaseResolver):
     def resolve(self, root_reqs, check_supported_wheels):
         # type: (List[InstallRequirement], bool) -> RequirementSet
         provider = PipProvider(
-            self.finder,
-            self.preparer,
-            self.make_install_req,
+            finder=self.finder,
+            preparer=self.preparer,
+            make_install_req=self.make_install_req,
         )
         reporter = BaseReporter()
         resolver = RLResolver(provider, reporter)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -38,6 +38,8 @@ class Resolver(BaseResolver):
         self.finder = finder
         self.preparer = preparer
         self.ignore_dependencies = ignore_dependencies
+        self.ignore_requires_python = ignore_requires_python
+        self.py_version_info = py_version_info
         self.make_install_req = make_install_req
         self._result = None  # type: Optional[Result]
 
@@ -47,6 +49,8 @@ class Resolver(BaseResolver):
             finder=self.finder,
             preparer=self.preparer,
             ignore_dependencies=self.ignore_dependencies,
+            ignore_requires_python=self.ignore_requires_python,
+            py_version_info=self.py_version_info,
             make_install_req=self.make_install_req,
         )
         reporter = BaseReporter()

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -55,4 +55,8 @@ def provider(finder, preparer):
         wheel_cache=None,
         use_pep517=None,
     )
-    yield PipProvider(finder, preparer, make_install_req)
+    yield PipProvider(
+        finder=finder,
+        preparer=preparer,
+        make_install_req=make_install_req,
+    )

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -58,5 +58,6 @@ def provider(finder, preparer):
     yield PipProvider(
         finder=finder,
         preparer=preparer,
+        ignore_dependencies=False,
         make_install_req=make_install_req,
     )

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -59,5 +59,7 @@ def provider(finder, preparer):
         finder=finder,
         preparer=preparer,
         ignore_dependencies=False,
+        ignore_requires_python=False,
+        py_version_info=None,
         make_install_req=make_install_req,
     )


### PR DESCRIPTION
Posted for reviews. This is built on #7888, so we’ll need to get that resolved first.

This implements a `RequiredPythonRequirement` to represent a dist’s `Requires-Python` information, which returns `RequiredPythonCandidate` as a match if it matches the supplied `--python-version` (or `sys.version_info[:3]` by default). I hope the implementation is not too difficult to follow; it mostly consists of passing a `RequiredPythonRequirement` constructor (`make_python_req`) around to use in the candidate class.

There is one unresolved part in the implementation though. `LinkCandidate.get_dependencies()` is currently implemented to return an InstallRequirement collection, but a requirement transformed from Requires-Python does not have the same backend. How do we change the signature?