### PR TITLE
Change docs link from PEP 301 to PEP 503

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -506,7 +506,7 @@ Finding Packages
 pip searches for packages on `PyPI`_ using the
 `HTTP simple interface <https://pypi.org/simple/>`_,
 which is documented `here <https://setuptools.readthedocs.io/en/latest/easy_install.html#package-index-api>`_
-and `there <https://www.python.org/dev/peps/pep-0301/>`_.
+and `there <https://www.python.org/dev/peps/pep-0503/>`_.
 
 pip offers a number of package index options for modifying how packages are
 found.


### PR DESCRIPTION
[The "Finding Packages" section](https://pip.pypa.io/en/stable/reference/pip_install/#finding-packages) of the `pip install` reference docs currently links to PEP 301, claiming that the simple interface is documented there.  It is not.  The correct PEP to link to is PEP 503.  This PR updates the link to point to the correct PEP.