### PR TITLE
pass cert down to subcommand when installing requirements

### DIFF
--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -193,6 +193,8 @@ class BuildEnvironment(object):
             args.extend(['--trusted-host', host])
         if finder.allow_all_prereleases:
             args.append('--pre')
+        if finder.cert:
+            args.extend(['--cert', finder.cert])
         args.append('--')
         args.extend(requirements)
         with open_spinner(message) as spinner:

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -702,7 +702,7 @@ class PackageFinder(object):
 
     @property
     def cert(self):
-        # type: () -> str or None
+        # type: () -> Optional[str]
         return getattr(self._link_collector.session, "verify", None)
 
     @property

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -701,6 +701,11 @@ class PackageFinder(object):
             yield build_netloc(*host_port)
 
     @property
+    def cert(self):
+        # type: () -> str or None
+        return getattr(self._link_collector.session, "verify", None)
+
+    @property
     def allow_all_prereleases(self):
         # type: () -> bool
         return self._candidate_prefs.allow_all_prereleases

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -703,7 +703,8 @@ class PackageFinder(object):
     @property
     def cert(self):
         # type: () -> Optional[str]
-        return getattr(self._link_collector.session, "verify", None)
+        verify = self._link_collector.session.verify
+        return verify if type(verify) is str else None
 
     @property
     def allow_all_prereleases(self):


### PR DESCRIPTION
This PR is to demonstrate what I believe may be the fix for a forthcoming bug ticket.

Partially addresses #5502 (`--cert`).