### PR TITLE
Defining multiple values for supported options

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -440,7 +440,9 @@ and ``--no-cache-dir``, falsy values have to be used:
     no-compile = no
     no-warn-script-location = false
 
-Appending options like ``--find-links`` can be written on multiple lines:
+It is possible to append values to a section within a configuration file such as the pip.ini file.
+This is applicable to appending options like ``--find-links`` or ``--trusted-host``,
+which can be written on multiple lines:
 
 .. code-block:: ini
 
@@ -452,6 +454,13 @@ Appending options like ``--find-links`` can be written on multiple lines:
     find-links =
         http://mirror1.example.com
         http://mirror2.example.com
+
+    [install]
+    trusted-host =
+        http://mirror1.example.com
+        http://mirror2.example.com
+
+This enables users to add additional values in the order of entry for such command line arguments.
 
 
 Environment Variables

--- a/news/7803.doc
+++ b/news/7803.doc
@@ -1,0 +1,1 @@
+Added example of defining multiple values for options which support them


### PR DESCRIPTION
Fixes and closes https://github.com/pypa/pip/issues/7803 and https://github.com/pypa/pip/issues/7804

Added example of defining multiple values for options which support them like ``--find-links`` or ``--trusted-host``

