### PR TITLE
Raise an exception if revision is empty in git url

### DIFF
--- a/news/7402.bugfix
+++ b/news/7402.bugfix
@@ -1,1 +1,1 @@
-Raise an exception if revision part of URL is empty for URL used in VCS support
+Reject VCS URLs with an empty revision.

--- a/news/7402.bugfix
+++ b/news/7402.bugfix
@@ -1,0 +1,1 @@
+Raise an exception if revision part of URL is empty for URL used in VCS support

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -436,6 +436,12 @@ class VersionControl(object):
         rev = None
         if '@' in path:
             path, rev = path.rsplit('@', 1)
+            if not rev:
+                raise ValueError(
+                    "The URL {!r} has an empty revision (after @) "
+                    "which is not supported. Include a revision after @ "
+                    "or remove @ from the URL.".format(url)
+                )
         url = urllib_parse.urlunsplit((scheme, netloc, path, query, ''))
         return url, rev, user_pass
 

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -11,7 +11,7 @@ import sys
 from pip._vendor import pkg_resources
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
-from pip._internal.exceptions import BadCommand
+from pip._internal.exceptions import BadCommand, InstallationError
 from pip._internal.utils.compat import samefile
 from pip._internal.utils.misc import (
     ask_path_exists,
@@ -437,7 +437,7 @@ class VersionControl(object):
         if '@' in path:
             path, rev = path.rsplit('@', 1)
             if not rev:
-                raise ValueError(
+                raise InstallationError(
                     "The URL {!r} has an empty revision (after @) "
                     "which is not supported. Include a revision after @ "
                     "or remove @ from the URL.".format(url)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -5,7 +5,7 @@ import pytest
 from mock import patch
 from pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.exceptions import BadCommand
+from pip._internal.exceptions import BadCommand, InstallationError
 from pip._internal.utils.misc import hide_url, hide_value
 from pip._internal.vcs import make_vcs_requirement_url
 from pip._internal.vcs.bazaar import Bazaar
@@ -301,7 +301,7 @@ def test_version_control__get_url_rev_and_auth__no_revision(url):
     Test passing a URL to VersionControl.get_url_rev_and_auth() with
     empty revision
     """
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(InstallationError) as excinfo:
         VersionControl.get_url_rev_and_auth(url)
 
     assert 'an empty revision (after @)' in str(excinfo.value)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -292,6 +292,21 @@ def test_version_control__get_url_rev_and_auth__missing_plus(url):
     assert 'malformed VCS url' in str(excinfo.value)
 
 
+@pytest.mark.parametrize('url', [
+    # Test a URL with revision part as empty.
+    'git+https://github.com/MyUser/myProject.git@#egg=py_pkg',
+])
+def test_version_control__get_url_rev_and_auth__no_revision(url):
+    """
+    Test passing a URL to VersionControl.get_url_rev_and_auth() with
+    empty revision
+    """
+    with pytest.raises(ValueError) as excinfo:
+        VersionControl.get_url_rev_and_auth(url)
+
+    assert 'an empty revision (after @)' in str(excinfo.value)
+
+
 @pytest.mark.parametrize('url, expected', [
     # Test http.
     ('bzr+http://bzr.myproject.org/MyProject/trunk/#egg=MyProject',


### PR DESCRIPTION
Fixes and closes #7402 

If URL's listed in [VCS Support of pip install](https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support) of the type `git://git.example.com/MyProject.git@master#egg=MyProject` have a missing revision, e.g. `master` here, raise an exception.

e.g.

```
$ pip install -e git+https://github.com/python/mypy.git@#egg=mypy
Obtaining mypy from git+https://github.com/python/mypy.git@#egg=mypy
ERROR: The URL 'git+https://github.com/python/mypy.git@#egg=mypy' has an empty revision (after @) which is not supported. Include a revision after @ or remove @ from the URL.
```