### PR TITLE
Fix rst syntax in Getting Started guide

### DIFF
--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -53,11 +53,13 @@ It is preferable to run the tests in parallel for better experience during devel
 since the tests can take a long time to finish when run sequentially.
 
 To run tests:
+
 .. code-block:: console
 
     $ tox -e py36 -- -n auto
 
 To run tests without parallelization, run:
+
 .. code-block:: console
 
     $ tox -e py36


### PR DESCRIPTION
The regression was introduced by GH-7878, which is not released so I'm not sure if I need to add the change to the news.