### PR TITLE
Use better temporary files mechanism

### DIFF
--- a/news/7699.bugfix
+++ b/news/7699.bugfix
@@ -1,0 +1,2 @@
+Use better mechanism for handling temporary files, when recording metadata
+about installed files (RECORD) and the installer (INSTALLER).

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -17,7 +17,7 @@ from pip._internal.utils.compat import get_path_uid
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING, cast
 
 if MYPY_CHECK_RUNNING:
-    from typing import BinaryIO, Iterator
+    from typing import Any, BinaryIO, Iterator
 
     class NamedTemporaryFileResult(BinaryIO):
         @property
@@ -85,16 +85,22 @@ def is_socket(path):
 
 
 @contextmanager
-def adjacent_tmp_file(path):
-    # type: (str) -> Iterator[NamedTemporaryFileResult]
-    """Given a path to a file, open a temp file next to it securely and ensure
-    it is written to disk after the context reaches its end.
+def adjacent_tmp_file(path, **kwargs):
+    # type: (str, **Any) -> Iterator[NamedTemporaryFileResult]
+    """Return a file-like object pointing to a tmp file next to path.
+
+    The file is created securely and is ensured to be written to disk
+    after the context reaches its end.
+
+    kwargs will be passed to tempfile.NamedTemporaryFile to control
+    the way the temporary file will be opened.
     """
     with NamedTemporaryFile(
         delete=False,
         dir=os.path.dirname(path),
         prefix=os.path.basename(path),
         suffix='.tmp',
+        **kwargs
     ) as f:
         result = cast('NamedTemporaryFileResult', f)
         try:

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -141,7 +141,7 @@ def call_get_csv_rows_for_installed(tmpdir, text):
     generated = []
     lib_dir = '/lib/dir'
 
-    with wheel.open_for_csv(path, 'r') as f:
+    with open(path, **wheel.csv_io_kwargs('r')) as f:
         reader = csv.reader(f)
         outrows = wheel.get_csv_rows_for_installed(
             reader, installed=installed, changed=changed,


### PR DESCRIPTION
One thing I don't understand though, is why the output CSV file need to be opened as `w+` instead of just `w`.

This should be able to fix GH-7699.