### PR TITLE
fix(tests/lib): Catch `subprocess.CalledProcessError` in need_executable

### DIFF
--- a/news/7924.bugfix
+++ b/news/7924.bugfix
@@ -1,0 +1,1 @@
+Catch ``subprocess.CalledProcessError`` when checking for the presence of executable within ``need_executable`` using pytest.

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1079,7 +1079,7 @@ def need_executable(name, check_cmd):
     def wrapper(fn):
         try:
             subprocess.check_output(check_cmd)
-        except OSError:
+        except (OSError, subprocess.CalledProcessError):
             return pytest.mark.skip(
                 reason='{name} is not available'.format(name=name))(fn)
         return fn


### PR DESCRIPTION
This fixes https://github.com/pypa/pip/issues/7924

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
