### PR TITLE
New resolver: Installed candidate

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -154,7 +154,7 @@ class LinkCandidate(Candidate):
         return self._ireq
 
 
-class InstalledCandidate(Candidate):
+class AlreadyInstalledCandidate(Candidate):
     def __init__(
         self,
         dist,  # type: Distribution
@@ -219,8 +219,12 @@ class ExtrasCandidate(Candidate):
     version 2.0. Having those candidates depend on foo=1.0 and foo=2.0
     respectively forces the resolver to recognise that this is a conflict.
     """
-    def __init__(self, base, extras):
-        # type: (Union[InstalledCandidate, LinkCandidate], Set[str]) -> None
+    def __init__(
+        self,
+        base,  # type: Union[AlreadyInstalledCandidate, LinkCandidate]
+        extras,  # type: Set[str]
+    ):
+        # type: (...) -> None
         self.base = base
         self.extras = extras
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -1,6 +1,17 @@
+from pip._vendor.pkg_resources import (
+    DistributionNotFound,
+    VersionConflict,
+    get_distribution,
+)
+
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
-from .candidates import ExtrasCandidate, LinkCandidate, RequiresPythonCandidate
+from .candidates import (
+    ExtrasCandidate,
+    InstalledCandidate,
+    LinkCandidate,
+    RequiresPythonCandidate,
+)
 from .requirements import (
     ExplicitRequirement,
     NoMatchRequirement,
@@ -11,8 +22,10 @@ if MYPY_CHECK_RUNNING:
     from typing import Dict, Optional, Set, Tuple
 
     from pip._vendor.packaging.specifiers import SpecifierSet
+    from pip._vendor.pkg_resources import Distribution
 
     from pip._internal.index.package_finder import PackageFinder
+    from pip._internal.models.candidate import InstallationCandidate
     from pip._internal.models.link import Link
     from pip._internal.operations.prepare import RequirementPreparer
     from pip._internal.req.req_install import InstallRequirement
@@ -27,6 +40,7 @@ class Factory(object):
         finder,  # type: PackageFinder
         preparer,  # type: RequirementPreparer
         make_install_req,  # type: InstallRequirementProvider
+        ignore_installed,  # type: bool
         ignore_requires_python,  # type: bool
         py_version_info=None,  # type: Optional[Tuple[int, ...]]
     ):
@@ -34,33 +48,78 @@ class Factory(object):
         self.finder = finder
         self.preparer = preparer
         self._python_candidate = RequiresPythonCandidate(py_version_info)
-        self._ignore_requires_python = ignore_requires_python
         self._make_install_req_from_spec = make_install_req
-        self._candidate_cache = {}  # type: Dict[Link, LinkCandidate]
+        self._ignore_installed = ignore_installed
+        self._ignore_requires_python = ignore_requires_python
+        self._link_candidate_cache = {}  # type: Dict[Link, LinkCandidate]
 
-    def make_candidate(
+    def _make_candidate_from_dist(
+        self,
+        dist,  # type: Distribution
+        extras,  # type: Set[str]
+        parent,  # type: InstallRequirement
+    ):
+        # type: (...) -> Candidate
+        base = InstalledCandidate(dist, parent, factory=self)
+        if extras:
+            return ExtrasCandidate(base, extras)
+        return base
+
+    def _make_candidate_from_link(
         self,
         link,    # type: Link
         extras,  # type: Set[str]
         parent,  # type: InstallRequirement
     ):
         # type: (...) -> Candidate
-        if link not in self._candidate_cache:
-            self._candidate_cache[link] = LinkCandidate(
+        if link not in self._link_candidate_cache:
+            self._link_candidate_cache[link] = LinkCandidate(
                 link, parent, factory=self,
             )
-        base = self._candidate_cache[link]
+        base = self._link_candidate_cache[link]
         if extras:
             return ExtrasCandidate(base, extras)
         return base
 
+    def _get_installed_distribution(self, name, version):
+        # type: (str, str) -> Optional[Distribution]
+        if self._ignore_installed:
+            return None
+        specifier = "{}=={}".format(name, version)
+        try:
+            dist = get_distribution(specifier)
+        except (DistributionNotFound, VersionConflict):
+            return None
+        return dist
+
+    def make_candidate_from_ican(
+        self,
+        ican,  # type: InstallationCandidate
+        extras,  # type: Set[str]
+        parent,  # type: InstallRequirement
+    ):
+        # type: (...) -> Candidate
+        dist = self._get_installed_distribution(ican.name, ican.version)
+        if dist is None:
+            return self._make_candidate_from_link(
+                link=ican.link,
+                extras=extras,
+                parent=parent,
+            )
+        return self._make_candidate_from_dist(
+            dist=dist,
+            extras=extras,
+            parent=parent,
+        )
+
     def make_requirement_from_install_req(self, ireq):
         # type: (InstallRequirement) -> Requirement
         if ireq.link:
-            cand = self.make_candidate(ireq.link, extras=set(), parent=ireq)
+            cand = self._make_candidate_from_link(
+                ireq.link, extras=set(), parent=ireq,
+            )
             return ExplicitRequirement(cand)
-        else:
-            return SpecifierRequirement(ireq, factory=self)
+        return SpecifierRequirement(ireq, factory=self)
 
     def make_requirement_from_spec(self, specifier, comes_from):
         # type: (str, InstallRequirement) -> Requirement

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -7,8 +7,8 @@ from pip._vendor.pkg_resources import (
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 from .candidates import (
+    AlreadyInstalledCandidate,
     ExtrasCandidate,
-    InstalledCandidate,
     LinkCandidate,
     RequiresPythonCandidate,
 )
@@ -60,7 +60,7 @@ class Factory(object):
         parent,  # type: InstallRequirement
     ):
         # type: (...) -> Candidate
-        base = InstalledCandidate(dist, parent, factory=self)
+        base = AlreadyInstalledCandidate(dist, parent, factory=self)
         if extras:
             return ExtrasCandidate(base, extras)
         return base

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -79,8 +79,8 @@ class SpecifierRequirement(Requirement):
             hashes=self._ireq.hashes(trust_internet=False),
         )
         return [
-            self._factory.make_candidate(
-                link=ican.link,
+            self._factory.make_candidate_from_ican(
+                ican=ican,
                 extras=self.extras,
                 parent=self._ireq,
             )

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -43,6 +43,7 @@ class Resolver(BaseResolver):
             finder=finder,
             preparer=preparer,
             make_install_req=make_install_req,
+            ignore_installed=ignore_installed,
             ignore_requires_python=ignore_requires_python,
             py_version_info=py_version_info,
         )

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -52,6 +52,7 @@ def factory(finder, preparer):
         finder=finder,
         preparer=preparer,
         make_install_req=install_req_from_line,
+        ignore_installed=False,
         ignore_requires_python=False,
         py_version_info=None,
     )


### PR DESCRIPTION
WIP, posted for visibility and discussion.

Thi implements an `InstalledCandidate` class, and `SpecifierRequirement.find_matches` is modified to return it instead of `LinkCandidate` if a matching distribution is found in the environment (`pkg_resources.get_distribution`). I added a simple test and it seems to work.

Some initial observations for discussion:

* We’d want to finish the facory refactor (#7910) first, this has some conflicts.
* `make_candidate_from_link` and `make_candidate_from_dist` is almost identical except the first argument (the line to parse for `InstallRequirement.req`). Maybe they should live in the factory as well?
* I removed `ExtraCandidate.link` because it causes Mypy errors (`InstalledCandidate` does not have a link), and I don’t see that attribute used anywhere.
* Do we want to cache `InstalledCandidate` as well? The creation is fairly cheap (it does not actually prepare anything). Is object identity a problem?
* Can an `ExplicitRequirement` contain an `InstallationCandidate`? Currently it can only hold a `LinkCandidate` (representing something like `foo @ https://url-to-foo`). IIUC direct references are always re-installed, so the answer is probably no?
* The `upgrade_reason` flag would affect `skip_reason`, and I can already see a potential problem to pass it from the resolver all the way down into `InstalledCandidate.__init__()`.