### PR TITLE
remove proxy module tests/lib/scripttest.py in favour of importing fr…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from setuptools.wheel import Wheel
 from pip._internal.cli.main import main as pip_entry_point
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from tests.lib import DATA_DIR, SRC_DIR, TestData, PipTestEnvironment
+from tests.lib import DATA_DIR, SRC_DIR, PipTestEnvironment, TestData
 from tests.lib.certs import make_tls_cert, serialize_cert, serialize_key
 from tests.lib.path import Path
 from tests.lib.server import make_mock_server, server_running

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,9 @@ from setuptools.wheel import Wheel
 from pip._internal.cli.main import main as pip_entry_point
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from tests.lib import DATA_DIR, SRC_DIR, TestData
+from tests.lib import DATA_DIR, SRC_DIR, TestData, PipTestEnvironment
 from tests.lib.certs import make_tls_cert, serialize_cert, serialize_key
 from tests.lib.path import Path
-from tests.lib.scripttest import PipTestEnvironment
 from tests.lib.server import make_mock_server, server_running
 from tests.lib.venv import VirtualEnvironment
 
@@ -370,7 +369,7 @@ def script(tmpdir, virtualenv, script_factory):
     Return a PipTestEnvironment which is unique to each test function and
     will execute all commands inside of the unique virtual environment for this
     test function. The returned object is a
-    ``tests.lib.scripttest.PipTestEnvironment``.
+    ``tests.lib.PipTestEnvironment``.
     """
     return script_factory(tmpdir.joinpath("workspace"), virtualenv)
 

--- a/tests/lib/scripttest.py
+++ b/tests/lib/scripttest.py
@@ -1,3 +1,0 @@
-from __future__ import absolute_import
-
-from . import PipTestEnvironment  # noqa


### PR DESCRIPTION
In this PR, I remove "proxy module" `tests/lib/scripttest.py`.  The module doesn't do anything, except import `PipTestEnvironment` from `tests/lib/__init__.py`.  This object is only used in `tests/conftest.py` where we can import it directly also.  Except for the simplifying the code, I'm doing this because the module name `scipttest` in problematic, as the tests also depend on the `scripttest` package (which defines a (global) `scripttest` module).

It took me a while to figure out why I wasn't able to run the tests directly (I was getting cirular import errors because of this name conflict).