### PR TITLE
Don't list packages in current directory

### DIFF
--- a/news/7731.bugfix
+++ b/news/7731.bugfix
@@ -1,0 +1,1 @@
+Avoid using the current directory for check, freeze, install, list and show commands, when invoked as 'python -m pip <command>'

--- a/src/pip/__main__.py
+++ b/src/pip/__main__.py
@@ -3,6 +3,13 @@ from __future__ import absolute_import
 import os
 import sys
 
+# Remove '' and current working directory from the first entry
+# of sys.path, if present to avoid using current directory
+# in pip commands check, freeze, install, list and show,
+# when invoked as python -m pip <command>
+if sys.path[0] in ('', os.getcwd()):
+    sys.path.pop(0)
+
 # If we are running from a wheel, add the wheel to sys.path
 # This allows the usage python pip-*.whl/pip install pip-*.whl
 if __package__ == '':


### PR DESCRIPTION
Fixes and closes #7731, closes https://github.com/pypa/pip/issues/2926, closes https://github.com/pypa/pip/issues/3710 and closes https://github.com/pypa/pip/issues/7971

Also added tests which does the following:

**Test 1**
1. Create a package with `setup.py`
2. Run `python setup.py egg_info` from the package directory.
3. Run `python -m pip list` from the package directory.
4. Assert that the package is not present in the output

**Test 2**

1. Create a package with `setup.py`
2. Run `python setup.py egg_info` from the package directory.
3. Add current directory to PYTHONPATH
3. Run `python -m pip list` from the package directory.
4. Assert that the package is present in the output