### PR TITLE
Add ability to run pip with options for yaml tests

### DIFF
--- a/tests/functional/test_yaml.py
+++ b/tests/functional/test_yaml.py
@@ -113,7 +113,7 @@ def handle_install_request(script, requirement, options):
         # Check which packages got installed
         retval["install"] = []
 
-        for path in result.files_created:
+        for path in os.listdir(script.site_packages_path):
             if path.endswith(".dist-info"):
                 name, version = (
                     os.path.basename(path)[:-len(".dist-info")]

--- a/tests/functional/test_yaml.py
+++ b/tests/functional/test_yaml.py
@@ -153,10 +153,10 @@ def handle_install_request(script, requirement, options):
 def test_yaml_based(script, case):
     available = case.get("available", [])
     requests = case.get("request", [])
-    transaction = case.get("transaction", [])
+    responses = case.get("response", [])
 
-    assert len(requests) == len(transaction), (
-        "Expected requests and transaction counts to be same"
+    assert len(requests) == len(responses), (
+        "Expected requests and responses counts to be same"
     )
 
     # Create a custom index of all the packages that are supposed to be
@@ -171,7 +171,7 @@ def test_yaml_based(script, case):
         create_basic_wheel_for_package(script, **package)
 
     # use scratch path for index
-    for request, expected in zip(requests, transaction):
+    for request, response in zip(requests, responses):
 
         # Perform the requested action
         if 'install' in request:
@@ -183,6 +183,5 @@ def test_yaml_based(script, case):
             assert False, "Unsupported request {!r}".format(request)
 
         result = effect["_result_object"]
-        del effect["_result_object"]
 
-        assert effect == expected, str(result)
+        assert effect['install'] == response['state'], str(result)

--- a/tests/functional/test_yaml.py
+++ b/tests/functional/test_yaml.py
@@ -103,9 +103,8 @@ def handle_install_request(script, requirement, options):
     args.append("--verbose")
 
     result = script.pip(*args,
-        allow_stderr_error=True,
-        allow_stderr_warning=True,
-    )
+                        allow_stderr_error=True,
+                        allow_stderr_warning=True)
 
     retval = {
         "_result_object": result,

--- a/tests/yaml/install/circular.yml
+++ b/tests/yaml/install/circular.yml
@@ -10,8 +10,8 @@ cases:
 -
   request:
     - install: A
-  transaction:
-    - install:
+  response:
+    - state:
       - A 1.0.0
       - B 1.0.0
       - C 1.0.0
@@ -19,8 +19,8 @@ cases:
 -
   request:
     - install: B
-  transaction:
-    - install:
+  response:
+    - state:
       - A 1.0.0
       - B 1.0.0
       - C 1.0.0
@@ -28,8 +28,8 @@ cases:
 -
   request:
     - install: C
-  transaction:
-    - install:
+  response:
+    - state:
       - A 1.0.0
       - B 1.0.0
       - C 1.0.0
@@ -37,8 +37,8 @@ cases:
 -
   request:
     - install: D
-  transaction:
-    - install:
+  response:
+    - state:
       - A 1.0.0
       - B 1.0.0
       - C 1.0.0

--- a/tests/yaml/install/conflicting_diamond.yml
+++ b/tests/yaml/install/conflicting_diamond.yml
@@ -8,7 +8,7 @@ cases:
     - D 2.0.0
   request:
     - install: A
-  transaction:
+  response:
     - conflicting:
       - required_by: [A 1.0.0, B 1.0.0]
         selector: D == 1.0.0

--- a/tests/yaml/install/conflicting_triangle.yml
+++ b/tests/yaml/install/conflicting_triangle.yml
@@ -8,8 +8,8 @@ cases:
   request:
     - install: A
     - install: B
-  transaction:
-    - install:
+  response:
+    - state:
       - A 1.0.0
       - C 1.0.0
     - conflicting:

--- a/tests/yaml/install/extras.yml
+++ b/tests/yaml/install/extras.yml
@@ -15,24 +15,24 @@ cases:
 -
   request:
     - install: B
-  transaction:
-    - install:
+  response:
+    - state:
       - B 1.0.0
       - D 1.0.0
       - E 1.0.0
 -
   request:
     - install: C
-  transaction:
-    - install:
+  response:
+    - state:
       - C 1.0.0
       - D 1.0.0
       - F 1.0.0
 -
   request:
     - install: A
-  transaction:
-    - install:
+  response:
+    - state:
       - A 1.0.0
       - B 1.0.0
       - C 1.0.0

--- a/tests/yaml/install/non_pinned.yml
+++ b/tests/yaml/install/non_pinned.yml
@@ -11,14 +11,14 @@ cases:
 -
   request:
     - install: A >= 2.0.0
-  transaction:
-    - install:
+  response:
+    - state:
       - A 2.0.0
       - B 2.1.0
 -
   request:
     - install: A < 2.0.0
-  transaction:
-    - install:
+  response:
+    - state:
       - A 1.0.0
       - B 1.0.0

--- a/tests/yaml/install/pinned.yml
+++ b/tests/yaml/install/pinned.yml
@@ -9,21 +9,21 @@ cases:
 -
   request:
     - install: B
-  transaction:
-    - install:
+  response:
+    - state:
       - A 2.0.0
       - B 2.0.0
 -
   request:
     - install: B == 2.0.0
-  transaction:
-    - install:
+  response:
+    - state:
       - A 2.0.0
       - B 2.0.0
 -
   request:
     - install: B == 1.0.0
-  transaction:
-    - install:
+  response:
+    - state:
       - A 1.0.0
       - B 1.0.0

--- a/tests/yaml/install/simple.yml
+++ b/tests/yaml/install/simple.yml
@@ -9,6 +9,14 @@ cases:
 -
   request:
     - install: simple
+    - uninstall: simple
+  response:
+    - state:
+      - simple 0.2.0
+    - state: null
+-
+  request:
+    - install: simple
     - install: dep
   response:
     - state:

--- a/tests/yaml/install/simple.yml
+++ b/tests/yaml/install/simple.yml
@@ -19,3 +19,10 @@ cases:
     - install:
       - base 0.1.0
       - dep 0.1.0
+-
+  request:
+    - install: base
+      options: --no-deps
+  transaction:
+    - install:
+      - base 0.1.0

--- a/tests/yaml/install/simple.yml
+++ b/tests/yaml/install/simple.yml
@@ -9,8 +9,12 @@ cases:
 -
   request:
     - install: simple
+    - install: dep
   response:
     - state:
+      - simple 0.2.0
+    - state:
+      - dep 0.1.0
       - simple 0.2.0
 -
   request:

--- a/tests/yaml/install/simple.yml
+++ b/tests/yaml/install/simple.yml
@@ -9,20 +9,20 @@ cases:
 -
   request:
     - install: simple
-  transaction:
-    - install:
+  response:
+    - state:
       - simple 0.2.0
 -
   request:
     - install: base
-  transaction:
-    - install:
+  response:
+    - state:
       - base 0.1.0
       - dep 0.1.0
 -
   request:
     - install: base
       options: --no-deps
-  transaction:
-    - install:
+  response:
+    - state:
       - base 0.1.0


### PR DESCRIPTION
This PR adds the ability to run pip with options for the yaml tests, as well as `pip uninstall`.  Also (as discussed with @pradyunsg) a better yaml-syntax was is implemented.  For example:
```
cases:
-
  request:
    - install: A
       options: --no-deps
    - uninstall: A
  response:
    - state:
      - A 1.0.0
    - state: null
```
Each of the request items (currently `install` and `uninstall`) correspond to response items (`state`).  Also, the example illustrates the usage of additional options.