### PR TITLE
Speed up `pip list --outdated`

### DIFF
--- a/news/7962.bugfix
+++ b/news/7962.bugfix
@@ -1,0 +1,1 @@
+`pip list --outdated` version fetching is multi-threaded

--- a/news/7962.bugfix
+++ b/news/7962.bugfix
@@ -1,1 +1,1 @@
-Significantly speedup `pip list --outdated` through parallelizing index interaction.
+Significantly speedup ``pip list --outdated`` through parallelizing index interaction.

--- a/news/7962.bugfix
+++ b/news/7962.bugfix
@@ -1,1 +1,1 @@
-`pip list --outdated` version fetching is multi-threaded
+Significantly speedup `pip list --outdated` through parallelizing index interaction.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import json
 import logging
-from multiprocessing.pool import ThreadPool
+from multiprocessing.dummy import Pool
 
 from pip._vendor import six
 from pip._vendor.requests.adapters import DEFAULT_POOLSIZE
@@ -213,7 +213,7 @@ class ListCommand(IndexGroupCommand):
             # This is done for 2x speed up of requests to pypi.org
             # so that "real time" of this function
             # is almost equal to "user time"
-            pool = ThreadPool(DEFAULT_POOLSIZE)
+            pool = Pool(DEFAULT_POOLSIZE)
 
             for dist in pool.imap_unordered(latest_info, packages):
                 if dist is not None:

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -210,9 +210,9 @@ class ListCommand(IndexGroupCommand):
                 dist.latest_filetype = typ
                 return dist
 
-            # This is done to multithread requests to pypi.org and eventually
-            # get performance boost up to 2x so that "real time" of this 
-            # function is almost equal to "user time"
+            # This is done for 2x speed up of requests to pypi.org
+            # so that "real time" of this function
+            # is almost equal to "user time"
             pool = ThreadPool(DEFAULT_POOLSIZE)
 
             for dist in pool.imap_unordered(latest_info, packages):

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -211,9 +211,8 @@ class ListCommand(IndexGroupCommand):
                 return dist
 
             # This is done to multithread requests to pypi.org and eventually
-            # get performance boost so that "real time" of this function is
-            # almost equal to "user time". Also this gives performance
-            # boost up to 2x
+            # get performance boost up to 2x so that "real time" of this 
+            # function is almost equal to "user time"
             pool = ThreadPool(DEFAULT_POOLSIZE)
 
             for dist in pool.imap_unordered(latest_info, packages):

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import json
 import logging
-from multiprocessing.dummy import Pool
+from multiprocessing.pool import ThreadPool
 
 from pip._vendor import six
 from pip._vendor.requests.adapters import DEFAULT_POOLSIZE
@@ -186,12 +186,13 @@ class ListCommand(IndexGroupCommand):
             finder = self._build_package_finder(options, session)
 
             # Doing multithreading in Python 2 compatible way
-            executor = Pool(DEFAULT_POOLSIZE)
+            executor = ThreadPool(DEFAULT_POOLSIZE)
             all_candidates_list = executor.map(
                 finder.find_all_candidates,
                 [dist.key for dist in packages]
             )
-            executor.terminate()
+            executor.close()
+            executor.join()
 
             for dist, all_candidates in zip(packages, all_candidates_list):
                 typ = 'unknown'

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -210,6 +210,10 @@ class ListCommand(IndexGroupCommand):
                 dist.latest_filetype = typ
                 return dist
 
+            # This is done to multithread requests to pypi.org and eventually
+            # get performance boost so that "real time" of this function is
+            # almost equal to "user time". Also this gives performance
+            # boost up to 2x
             pool = ThreadPool(DEFAULT_POOLSIZE)
 
             for dist in pool.imap_unordered(latest_info, packages):

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -185,7 +185,7 @@ class ListCommand(IndexGroupCommand):
         with self._build_session(options) as session:
             finder = self._build_package_finder(options, session)
 
-            def latest_infos(dist):
+            def latest_info(dist):
                 typ = 'unknown'
                 all_candidates = finder.find_all_candidates(dist.key)
                 if not options.pre:
@@ -212,7 +212,7 @@ class ListCommand(IndexGroupCommand):
 
             pool = ThreadPool(DEFAULT_POOLSIZE)
 
-            for dist in pool.imap_unordered(latest_infos, packages):
+            for dist in pool.imap_unordered(latest_info, packages):
                 if dist is not None:
                     yield dist
 

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -104,6 +104,8 @@ def indent_log(num=2):
     A context manager which will cause the log output to be indented for any
     log messages emitted inside it.
     """
+    # For thread-safety
+    _log_state.indentation = get_indentation()
     _log_state.indentation += num
     try:
         yield

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -52,7 +52,6 @@ else:
 
 
 _log_state = threading.local()
-_log_state.indentation = 0
 subprocess_logger = getLogger('pip.subprocessor')
 
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -12,7 +12,7 @@ from pip._internal.utils.logging import (
     BrokenStdoutLoggingError,
     ColorizedStreamHandler,
     IndentingFormatter,
-    indent_log
+    indent_log,
 )
 from pip._internal.utils.misc import captured_stderr, captured_stdout
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -2,6 +2,7 @@ import errno
 import logging
 import os
 import time
+from threading import Thread
 
 import pytest
 from mock import patch
@@ -11,6 +12,7 @@ from pip._internal.utils.logging import (
     BrokenStdoutLoggingError,
     ColorizedStreamHandler,
     IndentingFormatter,
+    indent_log
 )
 from pip._internal.utils.misc import captured_stderr, captured_stdout
 
@@ -107,6 +109,47 @@ class TestIndentingFormatter(object):
         )
         f = IndentingFormatter(fmt="%(message)s")
         assert f.format(record) == expected
+
+    def test_thread_safety_base(self):
+        actual = "Initial content"
+
+        record = self.make_record(
+            'DEPRECATION: hello\nworld', level_name='WARNING',
+        )
+        f = IndentingFormatter(fmt="%(message)s")
+
+        def thread_function():
+            nonlocal actual, f
+            actual = f.format(record)
+
+        thread_function()
+        expected = actual
+        actual = "Another initial content"
+        thread = Thread(target=thread_function)
+        thread.start()
+        thread.join()
+        assert actual == expected
+
+    def test_thread_safety_indent_log(self):
+        actual = "Initial content"
+
+        record = self.make_record(
+            'DEPRECATION: hello\nworld', level_name='WARNING',
+        )
+        f = IndentingFormatter(fmt="%(message)s")
+
+        def thread_function():
+            nonlocal actual, f
+            with indent_log():
+                actual = f.format(record)
+
+        thread_function()
+        expected = actual
+        actual = "Another initial content"
+        thread = Thread(target=thread_function)
+        thread.start()
+        thread.join()
+        assert actual == expected
 
 
 class TestColorizedStreamHandler(object):

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -111,45 +111,37 @@ class TestIndentingFormatter(object):
         assert f.format(record) == expected
 
     def test_thread_safety_base(self):
-        actual = "Initial content"
-
         record = self.make_record(
             'DEPRECATION: hello\nworld', level_name='WARNING',
         )
         f = IndentingFormatter(fmt="%(message)s")
+        results = []
 
         def thread_function():
-            nonlocal actual, f
-            actual = f.format(record)
+            results.append(f.format(record))
 
         thread_function()
-        expected = actual
-        actual = "Another initial content"
         thread = Thread(target=thread_function)
         thread.start()
         thread.join()
-        assert actual == expected
+        assert results[0] == results[1]
 
     def test_thread_safety_indent_log(self):
-        actual = "Initial content"
-
         record = self.make_record(
             'DEPRECATION: hello\nworld', level_name='WARNING',
         )
         f = IndentingFormatter(fmt="%(message)s")
+        results = []
 
         def thread_function():
-            nonlocal actual, f
             with indent_log():
-                actual = f.format(record)
+                results.append(f.format(record))
 
         thread_function()
-        expected = actual
-        actual = "Another initial content"
         thread = Thread(target=thread_function)
         thread.start()
         thread.join()
-        assert actual == expected
+        assert results[0] == results[1]
 
 
 class TestColorizedStreamHandler(object):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fixes #7964

This thing is working way too slow now. The problem is that it fetches all versions in one thread.