### PR TITLE
Warn if an invalid URL is passed with --index-url

### DIFF
--- a/news/7430.bugfix
+++ b/news/7430.bugfix
@@ -1,0 +1,1 @@
+Warn if an invalid URL is passed with --index-url

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -86,14 +86,15 @@ class SearchScope(object):
                 # Parse the URL
                 purl = urllib_parse.urlsplit(redacted_index_url)
 
-                # URL is generally invalid if scheme and netlock is missing
+                # URL is generally invalid if scheme and netloc is missing
                 # there are issues with Python and URL parsing, so this test
                 # is a bit crude. See bpo-20271, bpo-23505. Python doesn't
                 # always parse invalid URLs correctly - it should raise
                 # exceptions for malformed URLs
                 if not purl.scheme and not purl.netloc:
-                    logger.warning('index-url {} is invalid.'.format(
-                        redacted_index_url))
+                    logger.warning(
+                        'The index url "{}" seems invalid, '
+                        'please provide a scheme.'.format(redacted_index_url))
 
                 redacted_index_urls.append(redacted_index_url)
 

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -77,11 +77,29 @@ class SearchScope(object):
     def get_formatted_locations(self):
         # type: () -> str
         lines = []
+        redacted_index_urls = []
         if self.index_urls and self.index_urls != [PyPI.simple_url]:
-            lines.append(
-                'Looking in indexes: {}'.format(', '.join(
-                    redact_auth_from_url(url) for url in self.index_urls))
-            )
+            for url in self.index_urls:
+
+                redacted_index_url = redact_auth_from_url(url)
+
+                # Parse the URL
+                purl = urllib_parse.urlsplit(redacted_index_url)
+
+                # URL is generally invalid if scheme and netlock is missing
+                # there are issues with Python and URL parsing, so this test
+                # is a bit crude. See bpo-20271, bpo-23505. Python doesn't
+                # always parse invalid URLs correctly - it should raise
+                # exceptions for malformed URLs
+                if not purl.scheme and not purl.netloc:
+                    logger.warning('index-url {} is invalid.'.format(
+                        redacted_index_url))
+
+                redacted_index_urls.append(redacted_index_url)
+
+            lines.append('Looking in indexes: {}'.format(
+                ', '.join(redacted_index_urls)))
+
         if self.find_links:
             lines.append(
                 'Looking in links: {}'.format(', '.join(

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1769,6 +1769,30 @@ def test_ignore_yanked_file(script, data):
     assert 'Successfully installed simple-2.0\n' in result.stdout, str(result)
 
 
+def test_invalid_index_url_argument(script):
+    """
+    Test the behaviour of an invalid --index-url argument
+    """
+
+    result = script.pip('install', '--index-url', '--user',
+                        TestPyPI.simple_url, 'simple',
+                        expect_error=True)
+
+    assert 'WARNING: index-url --user is invalid.' in \
+           result.stderr, str(result)
+
+
+def test_valid_index_url_argument(script):
+    """
+    Test the behaviour of an valid --index-url argument
+    """
+
+    result = script.pip('install', '--no-deps', '--index-url',
+                        TestPyPI.simple_url, 'simple')
+
+    assert 'Successfully installed simple' in result.stdout, str(result)
+
+
 def test_install_yanked_file_and_print_warning(script, data):
     """
     Test install a "yanked" file and print a warning.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1769,28 +1769,29 @@ def test_ignore_yanked_file(script, data):
     assert 'Successfully installed simple-2.0\n' in result.stdout, str(result)
 
 
-def test_invalid_index_url_argument(script):
+def test_invalid_index_url_argument(script, shared_data):
     """
     Test the behaviour of an invalid --index-url argument
     """
 
     result = script.pip('install', '--index-url', '--user',
-                        TestPyPI.simple_url, 'simple',
+                        shared_data.find_links3, "Dinner",
                         expect_error=True)
 
-    assert 'WARNING: index-url --user is invalid.' in \
-           result.stderr, str(result)
+    assert 'WARNING: The index url "--user" seems invalid, ' \
+           'please provide a scheme.' in result.stderr, str(result)
 
 
-def test_valid_index_url_argument(script):
+def test_valid_index_url_argument(script, shared_data):
     """
     Test the behaviour of an valid --index-url argument
     """
 
-    result = script.pip('install', '--no-deps', '--index-url',
-                        TestPyPI.simple_url, 'simple')
+    result = script.pip('install', '--index-url',
+                        shared_data.find_links3,
+                        "Dinner")
 
-    assert 'Successfully installed simple' in result.stdout, str(result)
+    assert 'Successfully installed Dinner' in result.stdout, str(result)
 
 
 def test_install_yanked_file_and_print_warning(script, data):


### PR DESCRIPTION
Fixes and Closes #7430 

The idea was taken from https://github.com/pypa/pip/blob/master/src/pip/_vendor/distlib/util.py#L192 

```
$ pip install --index-url --user https://test.pypi.org/simple/ reretrieve
WARNING: index-url --user is invalid.
Collecting https://test.pypi.org/simple/
  Using cached https://test.pypi.org/simple/ (3.4 MB)
  ERROR: Cannot unpack file /private/var/folders/xg/blp845_s0xn093dyrtgy936h0000gp/T/pip-unpack-82nw6u8k/simple (downloaded from /private/var/folders/xg/blp845_s0xn093dyrtgy936h0000gp/T/pip-req-build-w612tjr_, content-type: text/html; charset=UTF-8); cannot detect archive format
ERROR: Cannot determine archive format of /private/var/folders/xg/blp845_s0xn093dyrtgy936h0000gp/T/pip-req-build-w612tjr_
```