### PR TITLE
Create a custom call_subprocess for vcs commands avoiding merging of stdout and stderr, and introduces a new SubprocessError exception

### DIFF
--- a/news/7968.bugfix
+++ b/news/7968.bugfix
@@ -1,0 +1,1 @@
+Look for version string in the entire output of svn --version, not just the first line

--- a/news/7968.bugfix
+++ b/news/7968.bugfix
@@ -1,1 +1,1 @@
-Look for version string in the entire output of svn --version, not just the first line
+The VCS commands run by pip as subprocesses don't merge stdout and stderr anymore, improving the output parsing by subsequent commands.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -28,6 +28,7 @@ from pip._internal.exceptions import (
     CommandError,
     InstallationError,
     PreviousBuildDirError,
+    SubProcessError,
     UninstallationError,
 )
 from pip._internal.utils.deprecation import deprecated
@@ -201,7 +202,8 @@ class Command(CommandContextMixIn):
             logger.debug('Exception information:', exc_info=True)
 
             return PREVIOUS_BUILD_DIR_ERROR
-        except (InstallationError, UninstallationError, BadCommand) as exc:
+        except (InstallationError, UninstallationError, BadCommand,
+                SubProcessError) as exc:
             logger.critical(str(exc))
             logger.debug('Exception information:', exc_info=True)
 

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -84,6 +84,11 @@ class CommandError(PipError):
     """Raised when there is an error in command-line arguments"""
 
 
+class SubProcessError(PipError):
+    """Raised when there is an error raised while executing a
+    command in subprocess"""
+
+
 class PreviousBuildDirError(PipError):
     """Raised when there's a previous conflicting build directory"""
 

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -54,8 +54,7 @@ class Bazaar(VersionControl):
 
         url, rev_options = self.get_url_rev_options(url)
         self.run_command(
-            make_command('export', location, url, rev_options.to_args()),
-            show_stdout=False,
+            make_command('export', location, url, rev_options.to_args())
         )
 
     def fetch_new(self, dest, url, rev_options):
@@ -92,7 +91,7 @@ class Bazaar(VersionControl):
 
     @classmethod
     def get_remote_url(cls, location):
-        urls = cls.run_command(['info'], show_stdout=False, cwd=location)
+        urls = cls.run_command(['info'], cwd=location)
         for line in urls.splitlines():
             line = line.strip()
             for x in ('checkout of branch: ',
@@ -107,7 +106,7 @@ class Bazaar(VersionControl):
     @classmethod
     def get_revision(cls, location):
         revision = cls.run_command(
-            ['revno'], show_stdout=False, cwd=location,
+            ['revno'], cwd=location,
         )
         return revision.splitlines()[-1]
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -11,7 +11,7 @@ from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib import request as urllib_request
 
-from pip._internal.exceptions import BadCommand, InstallationError
+from pip._internal.exceptions import BadCommand, SubProcessError
 from pip._internal.utils.misc import display_path, hide_url
 from pip._internal.utils.subprocess import make_command
 from pip._internal.utils.temp_dir import TempDirectory
@@ -78,7 +78,7 @@ class Git(VersionControl):
 
     def get_git_version(self):
         VERSION_PFX = 'git version '
-        version = self.run_command(['version'], show_stdout=False)
+        version = self.run_command(['version'])
         if version.startswith(VERSION_PFX):
             version = version[len(VERSION_PFX):].split()[0]
         else:
@@ -101,7 +101,7 @@ class Git(VersionControl):
         # and to suppress the message to stderr.
         args = ['symbolic-ref', '-q', 'HEAD']
         output = cls.run_command(
-            args, extra_ok_returncodes=(1, ), show_stdout=False, cwd=location,
+            args, extra_ok_returncodes=(1, ), cwd=location,
         )
         ref = output.strip()
 
@@ -120,7 +120,7 @@ class Git(VersionControl):
             self.unpack(temp_dir.path, url=url)
             self.run_command(
                 ['checkout-index', '-a', '-f', '--prefix', location],
-                show_stdout=False, cwd=temp_dir.path
+                cwd=temp_dir.path
             )
 
     @classmethod
@@ -135,7 +135,7 @@ class Git(VersionControl):
         """
         # Pass rev to pre-filter the list.
         output = cls.run_command(['show-ref', rev], cwd=dest,
-                                 show_stdout=False, on_returncode='ignore')
+                                 on_returncode='ignore')
         refs = {}
         for line in output.strip().splitlines():
             try:
@@ -286,7 +286,7 @@ class Git(VersionControl):
         # exits with return code 1 if there are no matching lines.
         stdout = cls.run_command(
             ['config', '--get-regexp', r'remote\..*\.url'],
-            extra_ok_returncodes=(1, ), show_stdout=False, cwd=location,
+            extra_ok_returncodes=(1, ), cwd=location,
         )
         remotes = stdout.splitlines()
         try:
@@ -306,7 +306,7 @@ class Git(VersionControl):
         if rev is None:
             rev = 'HEAD'
         current_rev = cls.run_command(
-            ['rev-parse', rev], show_stdout=False, cwd=location,
+            ['rev-parse', rev], cwd=location,
         )
         return current_rev.strip()
 
@@ -319,7 +319,7 @@ class Git(VersionControl):
         # find the repo root
         git_dir = cls.run_command(
             ['rev-parse', '--git-dir'],
-            show_stdout=False, cwd=location).strip()
+            cwd=location).strip()
         if not os.path.isabs(git_dir):
             git_dir = os.path.join(location, git_dir)
         repo_root = os.path.abspath(os.path.join(git_dir, '..'))
@@ -378,7 +378,6 @@ class Git(VersionControl):
             r = cls.run_command(
                 ['rev-parse', '--show-toplevel'],
                 cwd=location,
-                show_stdout=False,
                 on_returncode='raise',
                 log_failed_cmd=False,
             )
@@ -386,7 +385,7 @@ class Git(VersionControl):
             logger.debug("could not determine if %s is under git control "
                          "because git is not available", location)
             return None
-        except InstallationError:
+        except SubProcessError:
             return None
         return os.path.normpath(r.rstrip('\r\n'))
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -134,8 +134,13 @@ class Git(VersionControl):
           rev: the revision name.
         """
         # Pass rev to pre-filter the list.
-        output = cls.run_command(['show-ref', rev], cwd=dest,
-                                 on_returncode='ignore')
+
+        output = ''
+        try:
+            output = cls.run_command(['show-ref', rev], cwd=dest)
+        except SubProcessError:
+            pass
+
         refs = {}
         for line in output.strip().splitlines():
             try:
@@ -378,7 +383,6 @@ class Git(VersionControl):
             r = cls.run_command(
                 ['rev-parse', '--show-toplevel'],
                 cwd=location,
-                on_returncode='raise',
                 log_failed_cmd=False,
             )
         except BadCommand:

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -8,7 +8,7 @@ import os
 
 from pip._vendor.six.moves import configparser
 
-from pip._internal.exceptions import BadCommand, InstallationError
+from pip._internal.exceptions import BadCommand, SubProcessError
 from pip._internal.utils.misc import display_path
 from pip._internal.utils.subprocess import make_command
 from pip._internal.utils.temp_dir import TempDirectory
@@ -47,7 +47,7 @@ class Mercurial(VersionControl):
             self.unpack(temp_dir.path, url=url)
 
             self.run_command(
-                ['archive', location], show_stdout=False, cwd=temp_dir.path
+                ['archive', location], cwd=temp_dir.path
             )
 
     def fetch_new(self, dest, url, rev_options):
@@ -92,7 +92,7 @@ class Mercurial(VersionControl):
     def get_remote_url(cls, location):
         url = cls.run_command(
             ['showconfig', 'paths.default'],
-            show_stdout=False, cwd=location).strip()
+            cwd=location).strip()
         if cls._is_local_repository(url):
             url = path_to_url(url)
         return url.strip()
@@ -103,8 +103,7 @@ class Mercurial(VersionControl):
         Return the repository-local changeset revision number, as an integer.
         """
         current_revision = cls.run_command(
-            ['parents', '--template={rev}'],
-            show_stdout=False, cwd=location).strip()
+            ['parents', '--template={rev}'], cwd=location).strip()
         return current_revision
 
     @classmethod
@@ -115,7 +114,7 @@ class Mercurial(VersionControl):
         """
         current_rev_hash = cls.run_command(
             ['parents', '--template={node}'],
-            show_stdout=False, cwd=location).strip()
+            cwd=location).strip()
         return current_rev_hash
 
     @classmethod
@@ -131,7 +130,7 @@ class Mercurial(VersionControl):
         """
         # find the repo root
         repo_root = cls.run_command(
-            ['root'], show_stdout=False, cwd=location).strip()
+            ['root'], cwd=location).strip()
         if not os.path.isabs(repo_root):
             repo_root = os.path.abspath(os.path.join(location, repo_root))
         return find_path_to_setup_from_repo_root(location, repo_root)
@@ -145,7 +144,6 @@ class Mercurial(VersionControl):
             r = cls.run_command(
                 ['root'],
                 cwd=location,
-                show_stdout=False,
                 on_returncode='raise',
                 log_failed_cmd=False,
             )
@@ -153,7 +151,7 @@ class Mercurial(VersionControl):
             logger.debug("could not determine if %s is under hg control "
                          "because hg is not available", location)
             return None
-        except InstallationError:
+        except SubProcessError:
             return None
         return os.path.normpath(r.rstrip('\r\n'))
 

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -144,7 +144,6 @@ class Mercurial(VersionControl):
             r = cls.run_command(
                 ['root'],
                 cwd=location,
-                on_returncode='raise',
                 log_failed_cmd=False,
             )
         except BadCommand:

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -25,7 +25,7 @@ _svn_info_xml_url_re = re.compile(r'<url>(.*)</url>')
 
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Tuple, Text
+    from typing import Optional, Tuple
     from pip._internal.utils.subprocess import CommandArgs
     from pip._internal.utils.misc import HiddenText
     from pip._internal.vcs.versioncontrol import AuthInfo, RevOptions
@@ -215,17 +215,7 @@ class Subversion(VersionControl):
         #   svn, version 1.7.14 (r1542130)
         #      compiled Mar 28 2018, 08:49:13 on x86_64-pc-linux-gnu
         version_prefix = 'svn, version '
-        cmd_output = self.run_command(['--version'], show_stdout=False)
-
-        # Split the output by newline, and find the first line where
-        # version_prefix is present
-        output_lines = cmd_output.split('\n')
-        version = ''  # type: Text
-
-        for line in output_lines:
-            if version_prefix in line:
-                version = line
-                break
+        version = self.run_command(['--version'], show_stdout=True)
 
         if not version.startswith(version_prefix):
             return ()

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -25,7 +25,7 @@ _svn_info_xml_url_re = re.compile(r'<url>(.*)</url>')
 
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Tuple
+    from typing import Optional, Tuple, Text
     from pip._internal.utils.subprocess import CommandArgs
     from pip._internal.utils.misc import HiddenText
     from pip._internal.vcs.versioncontrol import AuthInfo, RevOptions
@@ -215,7 +215,18 @@ class Subversion(VersionControl):
         #   svn, version 1.7.14 (r1542130)
         #      compiled Mar 28 2018, 08:49:13 on x86_64-pc-linux-gnu
         version_prefix = 'svn, version '
-        version = self.run_command(['--version'], show_stdout=False)
+        cmd_output = self.run_command(['--version'], show_stdout=False)
+
+        # Split the output by newline, and find the first line where
+        # version_prefix is present
+        output_lines = cmd_output.split('\n')
+        version = ''  # type: Text
+
+        for line in output_lines:
+            if version_prefix in line:
+                version = line
+                break
+
         if not version.startswith(version_prefix):
             return ()
 

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -132,7 +132,7 @@ class Subversion(VersionControl):
 
     @classmethod
     def _get_svn_url_rev(cls, location):
-        from pip._internal.exceptions import InstallationError
+        from pip._internal.exceptions import SubProcessError
 
         entries_path = os.path.join(location, cls.dirname, 'entries')
         if os.path.exists(entries_path):
@@ -165,13 +165,12 @@ class Subversion(VersionControl):
                 # are only potentially needed for remote server requests.
                 xml = cls.run_command(
                     ['info', '--xml', location],
-                    show_stdout=False,
                 )
                 url = _svn_info_xml_url_re.search(xml).group(1)
                 revs = [
                     int(m.group(1)) for m in _svn_info_xml_rev_re.finditer(xml)
                 ]
-            except InstallationError:
+            except SubProcessError:
                 url, revs = None, []
 
         if revs:
@@ -215,7 +214,7 @@ class Subversion(VersionControl):
         #   svn, version 1.7.14 (r1542130)
         #      compiled Mar 28 2018, 08:49:13 on x86_64-pc-linux-gnu
         version_prefix = 'svn, version '
-        version = self.run_command(['--version'], show_stdout=True)
+        version = self.run_command(['--version'])
 
         if not version.startswith(version_prefix):
             return ()
@@ -298,7 +297,7 @@ class Subversion(VersionControl):
                 'export', self.get_remote_call_options(),
                 rev_options.to_args(), url, location,
             )
-            self.run_command(cmd_args, show_stdout=False)
+            self.run_command(cmd_args)
 
     def fetch_new(self, dest, url, rev_options):
         # type: (str, HiddenText, RevOptions) -> None

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -443,6 +443,18 @@ def test_subversion__call_vcs_version():
     ('svn, version 1.10.3 (r1842928)\n'
      '   compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0',
      (1, 10, 3)),
+    ('Warning: Failed to set locale category LC_NUMERIC to en_IN.\n'
+     'Warning: Failed to set locale category LC_TIME to en_IN.\n'
+     'svn, version 1.10.3 (r1842928)\n'
+     '   compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0',
+     (1, 10, 3)),
+    ('Warning: Failed to set locale category LC_NUMERIC to en_IN.\n'
+     'Warning: Failed to set locale category LC_TIME to en_IN.\n'
+     'svn, version 1.10.3 (r1842928)\n'
+     '   compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0'
+     'svn, version 1.11.3 (r1842928)\n'
+     '   compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0',
+     (1, 10, 3)),
     ('svn, version 1.9.7 (r1800392)', (1, 9, 7)),
     ('svn, version 1.9.7a1 (r1800392)', ()),
     ('svn, version 1.9 (r1800392)', (1, 9)),

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -443,18 +443,6 @@ def test_subversion__call_vcs_version():
     ('svn, version 1.10.3 (r1842928)\n'
      '   compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0',
      (1, 10, 3)),
-    ('Warning: Failed to set locale category LC_NUMERIC to en_IN.\n'
-     'Warning: Failed to set locale category LC_TIME to en_IN.\n'
-     'svn, version 1.10.3 (r1842928)\n'
-     '   compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0',
-     (1, 10, 3)),
-    ('Warning: Failed to set locale category LC_NUMERIC to en_IN.\n'
-     'Warning: Failed to set locale category LC_TIME to en_IN.\n'
-     'svn, version 1.10.3 (r1842928)\n'
-     '   compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0'
-     'svn, version 1.11.3 (r1842928)\n'
-     '   compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0',
-     (1, 10, 3)),
     ('svn, version 1.9.7 (r1800392)', (1, 9, 7)),
     ('svn, version 1.9.7a1 (r1800392)', ()),
     ('svn, version 1.9 (r1800392)', (1, 9)),


### PR DESCRIPTION
Fixes and Closes https://github.com/pypa/pip/issues/7968 , Closes https://github.com/pypa/pip/issues/7841 , Closes https://github.com/pypa/pip/issues/7711 and Closes https://github.com/pypa/pip/issues/7545

It's not always guaranteed that the version string in the output of `svn --version` is present in the first line, which is currently what the code assumes, for e.g.

```
$ svn --version 
Warning: Failed to set locale category LC_NUMERIC to en_IN.
Warning: Failed to set locale category LC_TIME to en_IN.
Warning: Failed to set locale category LC_COLLATE to en_IN.
Warning: Failed to set locale category LC_MONETARY to en_IN.
Warning: Failed to set locale category LC_MESSAGES to en_IN.
svn, version 1.13.0 (r1867053)
   compiled Feb 19 2020, 02:08:03 on x86_64-apple-darwin19.3.0

Copyright (C) 2019 The Apache Software Foundation.
This software consists of contributions made by many people;
see the NOTICE file for more information.
Subversion is open source software, see http://subversion.apache.org/

The following repository access (RA) modules are available:

* ra_svn : Module for accessing a repository using the svn network protocol.
  - with Cyrus SASL authentication
  - handles 'svn' scheme
* ra_local : Module for accessing a repository on local disk.
  - handles 'file' scheme
* ra_serf : Module for accessing a repository via WebDAV protocol using serf.
  - using serf 1.3.9 (compiled with 1.3.9)
  - handles 'http' scheme
  - handles 'https' scheme

The following authentication credential caches are available:

* Mac OS X Keychain
```

This happens because we were using `utils.subproces.call_subprocess` in vcs, which merges stdout and stderr. 

This change creates a custom `call_subprocess` for vcs commands to avoid merging stdout and stderr,  and introduces a new `SubprocessError` exception to replace the older `InstallationError` being raised before.
