### PR TITLE
Generate legacy metadata in temporary directory

### DIFF
--- a/src/pip/_internal/operations/build/metadata_legacy.py
+++ b/src/pip/_internal/operations/build/metadata_legacy.py
@@ -9,69 +9,34 @@ from pip._internal.utils.setuptools_build import make_setuptools_egg_info_args
 from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
-    from typing import List, Optional
-
     from pip._internal.build_env import BuildEnvironment
 
 logger = logging.getLogger(__name__)
 
 
-def _find_egg_info(source_directory):
+def _find_egg_info(directory):
     # type: (str) -> str
-    """Find an .egg-info in `source_directory`.
+    """Find an .egg-info subdirectory in `directory`.
     """
-
-    def looks_like_virtual_env(path):
-        # type: (str) -> bool
-        return (
-            os.path.lexists(os.path.join(path, 'bin', 'python')) or
-            os.path.exists(os.path.join(path, 'Scripts', 'Python.exe'))
-        )
-
-    def locate_egg_info(base):
-        # type: (str) -> List[str]
-        candidates = []  # type: List[str]
-        for root, dirs, files in os.walk(base):
-            for dir_ in vcs.dirnames:
-                if dir_ in dirs:
-                    dirs.remove(dir_)
-            # Iterate over a copy of ``dirs``, since mutating
-            # a list while iterating over it can cause trouble.
-            # (See https://github.com/pypa/pip/pull/462.)
-            for dir_ in list(dirs):
-                if looks_like_virtual_env(os.path.join(root, dir_)):
-                    dirs.remove(dir_)
-                # Also don't search through tests
-                elif dir_ == 'test' or dir_ == 'tests':
-                    dirs.remove(dir_)
-            candidates.extend(os.path.join(root, dir_) for dir_ in dirs)
-        return [f for f in candidates if f.endswith('.egg-info')]
-
-    def depth_of_directory(dir_):
-        # type: (str) -> int
-        return (
-            dir_.count(os.path.sep) +
-            (os.path.altsep and dir_.count(os.path.altsep) or 0)
-        )
-
-    base = source_directory
-    filenames = locate_egg_info(base)
+    filenames = [
+        f for f in os.listdir(directory) if f.endswith(".egg-info")
+    ]
 
     if not filenames:
         raise InstallationError(
-            "Files/directories not found in {}".format(base)
+            "No .egg-info directory found in {}".format(directory)
         )
 
-    # If we have more than one match, we pick the toplevel one.  This
-    # can easily be the case if there is a dist folder which contains
-    # an extracted tarball for testing purposes.
     if len(filenames) > 1:
-        filenames.sort(key=depth_of_directory)
+        raise InstallationError(
+            "More than one .egg-info directory found in {}".format(
+                directory
+            )
+        )
 
-    return os.path.join(base, filenames[0])
+    return os.path.join(directory, filenames[0])
 
 
 def generate_metadata(
@@ -92,14 +57,9 @@ def generate_metadata(
         setup_py_path, details,
     )
 
-    egg_info_dir = None  # type: Optional[str]
-    # For non-editable installs, don't put the .egg-info files at the root,
-    # to avoid confusion due to the source code being considered an installed
-    # egg.
-    if not editable:
-        egg_info_dir = TempDirectory(
-            kind="pip-egg-info", globally_managed=True
-        ).path
+    egg_info_dir = TempDirectory(
+        kind="pip-egg-info", globally_managed=True
+    ).path
 
     args = make_setuptools_egg_info_args(
         setup_py_path,
@@ -115,7 +75,4 @@ def generate_metadata(
         )
 
     # Return the .egg-info directory.
-    if not editable:
-        assert egg_info_dir
-        return _find_egg_info(egg_info_dir)
-    return _find_egg_info(source_dir)
+    return _find_egg_info(egg_info_dir)

--- a/src/pip/_internal/operations/build/metadata_legacy.py
+++ b/src/pip/_internal/operations/build/metadata_legacy.py
@@ -43,7 +43,6 @@ def generate_metadata(
     build_env,  # type: BuildEnvironment
     setup_py_path,  # type: str
     source_dir,  # type: str
-    editable,  # type: bool
     isolated,  # type: bool
     details,  # type: str
 ):

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -729,8 +729,6 @@ class InstallRequirement(object):
                 os.path.abspath(self.unpacked_source_directory)
             )
             for dirpath, dirnames, filenames in os.walk(dir):
-                if 'pip-egg-info' in dirnames:
-                    dirnames.remove('pip-egg-info')
                 for dirname in dirnames:
                     dir_arcname = self._get_archive_name(
                         dirname, parentdir=dirpath, rootdir=dir,

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -516,7 +516,6 @@ class InstallRequirement(object):
                 build_env=self.build_env,
                 setup_py_path=self.setup_py_path,
                 source_dir=self.unpacked_source_directory,
-                editable=self.editable,
                 isolated=self.isolated,
                 details=self.name or "from {}".format(self.link)
             )

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -121,9 +121,9 @@ def make_setuptools_egg_info_args(
     no_user_config,  # type: bool
 ):
     # type: (...) -> List[str]
-    args = make_setuptools_shim_args(setup_py_path)
-    if no_user_config:
-        args += ["--no-user-cfg"]
+    args = make_setuptools_shim_args(
+        setup_py_path, no_user_config=no_user_config
+    )
 
     args += ["egg_info"]
 


### PR DESCRIPTION
Progresses #7555 by getting rid of `pip-egg-info` as mentioned in https://github.com/pypa/pip/pull/7882#issuecomment-605507229.

Pip generates legacy metadata by calling `setup.py egg_info`. For editables, it does that in the source directory, else it does it in a `pip-egg-info` subdirectory of source dir.

To avoid polluting source dir with this `pip-egg-info` if and when we will build in place, use a temporary directory instead.

Question to reviewers: can one think if there was a good reason to generate that `pip-egg-info` inside source dir?

~~If this PR sounds reasonable, one can further think about *always* generating legacy metadata in a temporary directory, even in the editable case. Indeed it looks like `setup.py develop` always runs egg_info even if the directory is already present. This would vastly simplify this area of the code.~~ [update] this simplification in now part of this PR