### PR TITLE
POC: Type-safe name canonicalization

### DIFF
--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -25,6 +25,7 @@ if MYPY_CHECK_RUNNING:
     from pip._vendor.packaging.tags import Tag
 
     from pip._internal.models.format_control import FormatControl
+    from pip._internal.utils.packaging import CanonicalName
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ class Cache(object):
         return parts
 
     def _get_candidates(self, link, canonical_package_name):
-        # type: (Link, Optional[str]) -> List[Any]
+        # type: (Link, Optional[CanonicalName]) -> List[Any]
         can_not_cache = (
             not self.cache_dir or
             not canonical_package_name or

--- a/src/pip/_internal/models/format_control.py
+++ b/src/pip/_internal/models/format_control.py
@@ -1,13 +1,15 @@
 # The following comment should be removed at some point in the future.
 # mypy: strict-optional=False
 
-from pip._vendor.packaging.utils import canonicalize_name
-
 from pip._internal.exceptions import CommandError
+from pip._internal.utils.packaging import canonicalize_name
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Set, FrozenSet
+    from typing import FrozenSet, Literal, Optional, Set, Union
+    from pip._internal.utils.packaging import CanonicalName
+
+    Value = Union[CanonicalName, Literal[":all:"]]
 
 
 class FormatControl(object):
@@ -15,7 +17,7 @@ class FormatControl(object):
     """
 
     def __init__(self, no_binary=None, only_binary=None):
-        # type: (Optional[Set[str]], Optional[Set[str]]) -> None
+        # type: (Optional[Set[Value]], Optional[Set[Value]]) -> None
         if no_binary is None:
             no_binary = set()
         if only_binary is None:
@@ -42,7 +44,7 @@ class FormatControl(object):
 
     @staticmethod
     def handle_mutual_excludes(value, target, other):
-        # type: (str, Optional[Set[str]], Optional[Set[str]]) -> None
+        # type: (str, Optional[Set[Value]], Optional[Set[Value]]) -> None
         if value.startswith('-'):
             raise CommandError(
                 "--no-binary / --only-binary option requires 1 argument."
@@ -65,7 +67,7 @@ class FormatControl(object):
             target.add(name)
 
     def get_allowed_formats(self, canonical_name):
-        # type: (str) -> FrozenSet[str]
+        # type: (CanonicalName) -> FrozenSet[str]
         result = {"binary", "source"}
         if canonical_name in self.only_binary:
             result.discard('source')

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -4,16 +4,18 @@ import logging
 from email.parser import FeedParser
 
 from pip._vendor import pkg_resources
-from pip._vendor.packaging import specifiers, version
+from pip._vendor.packaging import specifiers, utils, version
 
 from pip._internal.exceptions import NoneMetadataError
 from pip._internal.utils.misc import display_path
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Tuple
+    from typing import NewType, Optional, Tuple
     from email.message import Message
     from pip._vendor.pkg_resources import Distribution
+
+    CanonicalName = NewType("CanonicalName", str)
 
 
 logger = logging.getLogger(__name__)
@@ -92,3 +94,11 @@ def get_installer(dist):
             if line.strip():
                 return line.strip()
     return ''
+
+
+if MYPY_CHECK_RUNNING:
+    def canonicalize_name(s):
+        # type: (str) -> CanonicalName
+        return CanonicalName(utils.canonicalize_name(s))
+else:
+    canonicalize_name = utils.canonicalize_name


### PR DESCRIPTION
This is a proof of concept for #7974.

I introduced a wrapper function `pip._internal.utils.packaging.canonicalize_name()` to return a new type `CanonicalName`, and tried that on `FormatControl`. Seems to work pretty well, it initially reported quite a few type errors, and I could convert the required hints quite easily by following the error messages.