### PR TITLE
Add unit tests for pip commands not using cwd

### DIFF
--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -258,7 +258,7 @@ def test_check_skip_work_dir_pkg(script):
 
     # Check should not complain about broken requirements
     # when run from package directory
-    result = script.pip('check')
+    result = script.pip('check', cwd=pkg_path)
     expected_lines = (
         "No broken requirements found.",
     )
@@ -286,7 +286,7 @@ def test_check_include_work_dir_pkg(script):
 
     # Check should mention about missing requirement simple
     # when run from package directory
-    result = script.pip('check', expect_error=True)
+    result = script.pip('check', expect_error=True, cwd=pkg_path)
     expected_lines = (
         "simple 1.0 requires missing, which is not installed.",
     )

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -281,11 +281,11 @@ def test_check_include_work_dir_pkg(script):
     script.run('python', 'setup.py', 'egg_info',
                expect_stderr=True, cwd=pkg_path)
 
-    # Add PYTHONPATH env variable
     script.environ.update({'PYTHONPATH': pkg_path})
 
     # Check should mention about missing requirement simple
-    # when run from package directory
+    # when run from package directory, when package directory
+    # is in PYTHONPATH
     result = script.pip('check', expect_error=True, cwd=pkg_path)
     expected_lines = (
         "simple 1.0 requires missing, which is not installed.",

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -819,6 +819,14 @@ def test_freeze_path_multiple(tmpdir, script, data):
     _check_output(result.stdout, expected)
 
 
+def test_freeze_direct_url_archive(script, shared_data, with_wheel):
+    req = "simple @ " + path_to_url(shared_data.packages / "simple-2.0.tar.gz")
+    assert req.startswith("simple @ file://")
+    script.pip("install", req)
+    result = script.pip("freeze")
+    assert req in result.stdout
+
+
 def test_freeze_skip_work_dir_pkg(script):
     """
     Test that freeze should not include package
@@ -833,7 +841,7 @@ def test_freeze_skip_work_dir_pkg(script):
 
     # Freeze should not include package simple when run from package directory
     result = script.pip('freeze', cwd=pkg_path)
-    assert 'simple==1.0' not in result.stdout
+    assert 'simple' not in result.stdout
 
 
 def test_freeze_include_work_dir_pkg(script):
@@ -848,9 +856,9 @@ def test_freeze_include_work_dir_pkg(script):
     script.run('python', 'setup.py', 'egg_info',
                expect_stderr=True, cwd=pkg_path)
 
-    # Add PYTHONPATH env variable
     script.environ.update({'PYTHONPATH': pkg_path})
 
-    # Freeze should include package simple when run from package directory
+    # Freeze should include package simple when run from package directory,
+    # when package directory is in PYTHONPATH
     result = script.pip('freeze', cwd=pkg_path)
     assert 'simple==1.0' in result.stdout

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -832,8 +832,8 @@ def test_freeze_skip_work_dir_pkg(script):
                expect_stderr=True, cwd=pkg_path)
 
     # Freeze should not include package simple when run from package directory
-    result = script.pip('freeze', 'simple', cwd=pkg_path)
-    _check_output(result.stdout, '')
+    result = script.pip('freeze', cwd=pkg_path)
+    assert 'simple==1.0' not in result.stdout
 
 
 def test_freeze_include_work_dir_pkg(script):
@@ -852,8 +852,5 @@ def test_freeze_include_work_dir_pkg(script):
     script.environ.update({'PYTHONPATH': pkg_path})
 
     # Freeze should include package simple when run from package directory
-    result = script.pip('freeze', 'simple', cwd=pkg_path)
-    expected = textwrap.dedent("""\
-            simple==1.0
-            <BLANKLINE>""")
-    _check_output(result.stdout, expected)
+    result = script.pip('freeze', cwd=pkg_path)
+    assert 'simple==1.0' in result.stdout

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1842,6 +1842,8 @@ def test_install_skip_work_dir_pkg(script, data):
     result = script.pip('install', '--find-links',
                         data.find_links, 'simple',
                         expect_stderr=True, cwd=pkg_path)
+
+    assert 'Requirement already satisfied: simple' not in result.stdout
     assert 'Successfully installed simple' in result.stdout
 
 
@@ -1861,10 +1863,10 @@ def test_install_include_work_dir_pkg(script, data):
     # Uninstall will fail with given warning
     script.pip('uninstall', 'simple', '-y')
 
-    # Add PYTHONPATH env variable
     script.environ.update({'PYTHONPATH': pkg_path})
 
-    # Uninstalling the package and installing it again will fail
+    # Uninstalling the package and installing it again will fail,
+    # when package directory is in PYTHONPATH
     result = script.pip('install', '--find-links',
                         data.find_links, 'simple',
                         expect_stderr=True, cwd=pkg_path)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1821,3 +1821,51 @@ def test_install_sends_client_cert(install_args, script, cert_factory, data):
         environ, _ = call_args.args
         assert "SSL_CLIENT_CERT" in environ
         assert environ["SSL_CLIENT_CERT"]
+
+
+def test_install_skip_work_dir_pkg(script, data):
+    """
+    Test that install of a package in working directory
+    should pass on the second attempt after an install
+    and an uninstall
+    """
+
+    # Create a test package and install it
+    pkg_path = create_test_package_with_setup(
+        script, name='simple', version='1.0')
+    script.pip('install', '-e', '.',
+               expect_stderr=True, cwd=pkg_path)
+
+    # Uninstalling the package and installing it again will succeed
+    script.pip('uninstall', 'simple', '-y')
+
+    result = script.pip('install', '--find-links',
+                        data.find_links, 'simple',
+                        expect_stderr=True, cwd=pkg_path)
+    assert 'Successfully installed simple' in result.stdout
+
+
+def test_install_include_work_dir_pkg(script, data):
+    """
+    Test that install of a package in working directory
+    should fail on the second attempt after an install
+    if working directory is added in PYTHONPATH
+    """
+
+    # Create a test package and install it
+    pkg_path = create_test_package_with_setup(
+        script, name='simple', version='1.0')
+    script.pip('install', '-e', '.',
+               expect_stderr=True, cwd=pkg_path)
+
+    # Uninstall will fail with given warning
+    script.pip('uninstall', 'simple', '-y')
+
+    # Add PYTHONPATH env variable
+    script.environ.update({'PYTHONPATH': pkg_path})
+
+    # Uninstalling the package and installing it again will fail
+    result = script.pip('install', '--find-links',
+                        data.find_links, 'simple',
+                        expect_stderr=True, cwd=pkg_path)
+    assert 'Requirement already satisfied: simple' in result.stdout

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -552,9 +552,8 @@ def test_list_skip_work_dir_pkg(script):
     """
 
     # Create a test package and create .egg-info dir
-    pkg_path = create_test_package_with_setup(script,
-                                              name='simple',
-                                              version='1.0')
+    pkg_path = create_test_package_with_setup(
+        script, name='simple', version='1.0')
     script.run('python', 'setup.py', 'egg_info',
                expect_stderr=True, cwd=pkg_path)
 
@@ -567,14 +566,12 @@ def test_list_skip_work_dir_pkg(script):
 def test_list_include_work_dir_pkg(script):
     """
     Test that list should include package in working directory
-    if working directory is added in sys.path
+    if working directory is added in PYTHONPATH
     """
 
     # Create a test package and create .egg-info dir
-    pkg_path = create_test_package_with_setup(script,
-                                              name='simple',
-                                              version='1.0')
-
+    pkg_path = create_test_package_with_setup(
+        script, name='simple', version='1.0')
     script.run('python', 'setup.py', 'egg_info',
                expect_stderr=True, cwd=pkg_path)
 

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -275,7 +275,7 @@ def test_show_skip_work_dir_pkg(script):
                expect_stderr=True, cwd=pkg_path)
 
     # Show should not include package simple when run from package directory
-    result = script.pip('show', 'simple', cwd=pkg_path)
+    result = script.pip('show', 'simple', expect_error=True, cwd=pkg_path)
     assert 'WARNING: Package(s) not found: simple' in result.stderr
 
 

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -291,10 +291,10 @@ def test_show_include_work_dir_pkg(script):
     script.run('python', 'setup.py', 'egg_info',
                expect_stderr=True, cwd=pkg_path)
 
-    # Add PYTHONPATH env variable
     script.environ.update({'PYTHONPATH': pkg_path})
 
-    # Show should include package simple when run from package directory
+    # Show should include package simple when run from package directory,
+    # when package directory is in PYTHONPATH
     result = script.pip('show', 'simple', cwd=pkg_path)
     lines = result.stdout.splitlines()
     assert 'Name: simple' in lines


### PR DESCRIPTION
Follow-up of https://github.com/pypa/pip/pull/7955 . Fixes and closes #7731, closes https://github.com/pypa/pip/issues/2926, closes https://github.com/pypa/pip/issues/3710 and closes https://github.com/pypa/pip/issues/7971

Add unit tests for check, freeze, show and install to verify that  the behaviour of `python -m pip` is same as `pip` when run from the current working directory, and verifying that adding current working directory to PYTHONPATH displays the appropriate behaviour with `python -m pip`