### PR TITLE
Fix tabulate col size in case of empty cell

### DIFF
--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -7,7 +7,6 @@ import json
 import logging
 
 from pip._vendor import six
-from pip._vendor.six.moves import map, zip_longest
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.req_command import IndexGroupCommand
@@ -18,13 +17,10 @@ from pip._internal.self_outdated_check import make_link_collector
 from pip._internal.utils.misc import (
     dist_is_editable,
     get_installed_distributions,
+    tabulate,
     write_output,
 )
 from pip._internal.utils.packaging import get_installer
-from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-
-if MYPY_CHECK_RUNNING:
-    from typing import Any, Iterable, List, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -243,21 +239,6 @@ class ListCommand(IndexGroupCommand):
 
         for val in pkg_strings:
             write_output(val)
-
-
-def tabulate(rows):
-    # type: (Iterable[Iterable[Any]]) -> Tuple[List[str], List[int]]
-    """Return a list of formatted rows and a list of column sizes.
-
-    For example::
-
-    >>> tabulate([['foobar', 2000], [0xdeadbeef]])
-    (['foobar     2000', '3735928559'], [10, 4])
-    """
-    rows = [tuple(map(str, row)) for row in rows]
-    sizes = [max(map(len, col)) for col in zip_longest(*rows, fillvalue='')]
-    table = [" ".join(map(str.ljust, row, sizes)) for row in rows]
-    return table, sizes
 
 
 def format_for_columns(pkgs, options):

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -22,7 +22,7 @@ from pip._vendor import pkg_resources
 #       why we ignore the type on this import.
 from pip._vendor.retrying import retry  # type: ignore
 from pip._vendor.six import PY2, text_type
-from pip._vendor.six.moves import input, zip_longest
+from pip._vendor.six.moves import input, map, zip_longest
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib.parse import unquote as urllib_unquote
 
@@ -273,6 +273,21 @@ def format_size(bytes):
         return '{:.1f} kB'.format(bytes / 1000.0)
     else:
         return '{} bytes'.format(int(bytes))
+
+
+def tabulate(rows):
+    # type: (Iterable[Iterable[Any]]) -> Tuple[List[str], List[int]]
+    """Return a list of formatted rows and a list of column sizes.
+
+    For example::
+
+    >>> tabulate([['foobar', 2000], [0xdeadbeef]])
+    (['foobar     2000', '3735928559'], [10, 4])
+    """
+    rows = [tuple(map(str, row)) for row in rows]
+    sizes = [max(map(len, col)) for col in zip_longest(*rows, fillvalue='')]
+    table = [" ".join(map(str.ljust, row, sizes)).rstrip() for row in rows]
+    return table, sizes
 
 
 def is_installable_dir(path):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -50,6 +50,7 @@ from pip._internal.utils.misc import (
     rmtree_errorhandler,
     split_auth_from_netloc,
     split_auth_netloc_from_url,
+    tabulate,
 )
 from pip._internal.utils.setuptools_build import make_setuptools_shim_args
 
@@ -970,3 +971,20 @@ def test_is_console_interactive(monkeypatch, isatty, no_stdin, expected):
 ])
 def test_format_size(size, expected):
     assert format_size(size) == expected
+
+
+@pytest.mark.parametrize(
+    ('rows', 'table', 'sizes'),
+    [([], [], []),
+     ([('I?', 'version', 'sdist', 'wheel'),
+       ('', '1.18.2', 'zip', 'cp38-cp38m-win_amd64'),
+       ('v', 1.18, 'zip')],
+      ['I? version sdist wheel',
+       '   1.18.2  zip   cp38-cp38m-win_amd64',
+       'v  1.18    zip'],
+      [2, 7, 5, 20]),
+     ([('I?', 'version', 'sdist', 'wheel'), (), ('v', '1.18.1', 'zip')],
+      ['I? version sdist wheel', '', 'v  1.18.1  zip'],
+      [2, 7, 5, 5])])
+def test_tabulate(rows, table, sizes):
+    assert tabulate(rows) == (table, sizes)


### PR DESCRIPTION
Previously, the size is no less than `len(str(None)) == 4`.

This commit also add type hint and docstring to the function.

Edit: I'm not sure if this change is trivial, please tell me if news is required.