### PR TITLE
New Resolver: Correctly uninstall existing distribution before installing

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -43,6 +43,7 @@ class Resolver(BaseResolver):
             finder=finder,
             preparer=preparer,
             make_install_req=make_install_req,
+            force_reinstall=force_reinstall,
             ignore_installed=ignore_installed,
             ignore_requires_python=ignore_requires_python,
             py_version_info=py_version_info,
@@ -68,8 +69,10 @@ class Resolver(BaseResolver):
         req_set = RequirementSet(check_supported_wheels=check_supported_wheels)
         for candidate in self._result.mapping.values():
             ireq = provider.get_install_requirement(candidate)
-            if ireq is not None:
-                req_set.add_named_requirement(ireq)
+            if ireq is None:
+                continue
+            ireq.should_reinstall = self.factory.should_reinstall(candidate)
+            req_set.add_named_requirement(ireq)
 
         return req_set
 

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -328,3 +328,57 @@ def test_new_resolver_only_builds_sdists_when_needed(script):
         "base", "dep"
     )
     assert_installed(script, base="0.1.0", dep="0.2.0")
+
+
+@pytest.mark.xfail(reason="upgrade install not implemented")
+def test_new_resolver_install_different_version(script):
+    create_basic_wheel_for_package(script, "base", "0.1.0")
+    create_basic_wheel_for_package(script, "base", "0.2.0")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base==0.1.0",
+    )
+
+    # This should trigger an uninstallation of base.
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base==0.2.0",
+    )
+
+    assert "Uninstalling base-0.1.0" in result.stdout, str(result)
+    assert "Successfully uninstalled base-0.1.0" in result.stdout, str(result)
+    assert script.site_packages / "base" in result.files_updated, (
+        "base not upgraded"
+    )
+    assert_installed(script, base="0.2.0")
+
+
+@pytest.mark.xfail(reason="force reinstall not implemented")
+def test_new_resolver_force_reinstall(script):
+    create_basic_wheel_for_package(script, "base", "0.1.0")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base",
+    )
+
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--force-reinstall",
+        "base",
+    )
+
+    assert "Uninstalling base-0.1.0" not in result.stdout, str(result)
+    assert script.site_packages / "base" in result.files_updated, (
+        "base not upgraded"
+    )
+    assert_installed(script, base="0.2.0")

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -52,6 +52,7 @@ def factory(finder, preparer):
         finder=finder,
         preparer=preparer,
         make_install_req=install_req_from_line,
+        force_reinstall=False,
         ignore_installed=False,
         ignore_requires_python=False,
         py_version_info=None,


### PR DESCRIPTION
I traced the old resolver’s implementation, and AFAICT the only thing needed to trigger uninstallation is to set `InstallRequirement.should_reinstall`. This flag is only used during the installation phase. So instead of checking them during the resolution, I just set them when the resolution is finished, during the `RequirementSet` construction.

Instead of repetively use `pkg_resources.get_distribution()`, I refactored the implementation to read out the entire installation state on `Factory.__init__`, and use it throughout the resolution. I *think* this is also useful for `use_user_site` since `get_installed_distributions()` directly supports filtering user site packages (although I’m not yet sure what the flag means exactly).