### PR TITLE
Canonicalise project name from InstallationCandidate

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -156,10 +156,19 @@ class _InstallRequirementBackedCandidate(Candidate):
             # These should be "proper" errors, not just asserts, as they
             # can result from user errors like a requirement "foo @ URL"
             # when the project at URL has a name of "bar" in its metadata.
-            assert (self._name is None or
-                    self._name == canonicalize_name(self._dist.project_name))
-            assert (self._version is None or
-                    self._version == self.dist.parsed_version)
+            assert (
+                self._name is None or
+                self._name == canonicalize_name(self._dist.project_name)
+            ), "Name mismatch: {!r} vs {!r}".format(
+                self._name, canonicalize_name(self._dist.project_name),
+            )
+            assert (
+                self._version is None or
+                self._version == self._dist.parsed_version
+            ), "Version mismatch: {!r} vs {!r}".format(
+                self._version, self._dist.parsed_version,
+            )
+
         return self._dist
 
     def _get_requires_python_specifier(self):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -1,3 +1,4 @@
+from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.pkg_resources import (
     DistributionNotFound,
     VersionConflict,
@@ -121,7 +122,7 @@ class Factory(object):
                 link=ican.link,
                 extras=extras,
                 parent=parent,
-                name=ican.name,
+                name=canonicalize_name(ican.name),
                 version=ican.version,
             )
         return self._make_candidate_from_dist(


### PR DESCRIPTION
I found this when reading the experiemental CI job failures on Travis. Many of the tests are failing due to name mismatches in `_InstallRequirementBackedCandidate.dist`. Not sure why this is the case, but I’m putting on a `canonicalize_name` call to make it work for now. Hopefully pypa/packaging#290 will help us refactor some of these calls out when it lands in master.

Relevent error logs: https://travis-ci.org/github/pypa/pip/jobs/671946053#L371