### PR TITLE
New resolver: implement --user

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -4,8 +4,13 @@ from pip._internal.exceptions import (
     InstallationError,
     UnsupportedPythonVersion,
 )
-from pip._internal.utils.misc import get_installed_distributions
+from pip._internal.utils.misc import (
+    dist_in_site_packages,
+    dist_in_usersite,
+    get_installed_distributions,
+)
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+from pip._internal.utils.virtualenv import running_under_virtualenv
 
 from .candidates import (
     AlreadyInstalledCandidate,
@@ -49,6 +54,7 @@ class Factory(object):
         finder,  # type: PackageFinder
         preparer,  # type: RequirementPreparer
         make_install_req,  # type: InstallRequirementProvider
+        use_user_site,  # type: bool
         force_reinstall,  # type: bool
         ignore_installed,  # type: bool
         ignore_requires_python,  # type: bool
@@ -62,6 +68,7 @@ class Factory(object):
         self.preparer = preparer
         self._python_candidate = RequiresPythonCandidate(py_version_info)
         self._make_install_req_from_spec = make_install_req
+        self._use_user_site = use_user_site
         self._force_reinstall = force_reinstall
         self._ignore_requires_python = ignore_requires_python
         self._upgrade_strategy = upgrade_strategy
@@ -199,7 +206,32 @@ class Factory(object):
     def should_reinstall(self, candidate):
         # type: (Candidate) -> bool
         # TODO: Are there more cases this needs to return True? Editable?
-        return candidate.name in self._installed_dists
+        dist = self._installed_dists.get(candidate.name)
+        if dist is None:  # Not installed, no uninstallation required.
+            return False
+
+        # We're installing into global site. The current installation must
+        # be uninstalled, no matter it's in global or user site, because the
+        # user site installation has precedence over global.
+        if not self._use_user_site:
+            return True
+
+        # We're installing into user site. Remove the user site installation.
+        if dist_in_usersite(dist):
+            return True
+
+        # We're installing into user site, but the installed incompatible
+        # package is in global site. We can't uninstall that, and would let
+        # the new user installation to "shadow" it. But shadowing won't work
+        # in virtual environments, so we error out.
+        if running_under_virtualenv() and dist_in_site_packages(dist):
+            raise InstallationError(
+                "Will not install to the user site because it will "
+                "lack sys.path precedence to {} in {}".format(
+                    dist.project_name, dist.location,
+                )
+            )
+        return False
 
     def _report_requires_python_error(
         self,

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -50,6 +50,7 @@ class Resolver(BaseResolver):
             finder=finder,
             preparer=preparer,
             make_install_req=make_install_req,
+            use_user_site=use_user_site,
             force_reinstall=force_reinstall,
             ignore_installed=ignore_installed,
             ignore_requires_python=ignore_requires_python,

--- a/tests/functional/test_new_resolver_user.py
+++ b/tests/functional/test_new_resolver_user.py
@@ -1,0 +1,223 @@
+import os
+import textwrap
+
+import pytest
+
+from tests.lib import create_basic_wheel_for_package
+
+
+@pytest.mark.incompatible_with_test_venv
+def test_new_resolver_install_user(script):
+    create_basic_wheel_for_package(script, "base", "0.1.0")
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--user",
+        "base",
+    )
+    assert script.user_site / "base" in result.files_created, str(result)
+
+
+@pytest.mark.incompatible_with_test_venv
+def test_new_resolver_install_user_satisfied_by_global_site(script):
+    """
+    An install a matching version to user site should re-use a global site
+    installation if it satisfies.
+    """
+    create_basic_wheel_for_package(script, "base", "1.0.0")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base==1.0.0",
+    )
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--user",
+        "base==1.0.0",
+    )
+
+    assert script.user_site / "base" not in result.files_created, str(result)
+
+
+@pytest.mark.incompatible_with_test_venv
+def test_new_resolver_install_user_conflict_in_user_site(script):
+    """
+    Installing a different version in user site should uninstall an existing
+    different version in user site.
+    """
+    create_basic_wheel_for_package(script, "base", "1.0.0")
+    create_basic_wheel_for_package(script, "base", "2.0.0")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--user",
+        "base==2.0.0",
+    )
+
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--user",
+        "base==1.0.0",
+    )
+
+    base_1_dist_info = script.user_site / "base-1.0.0.dist-info"
+    base_2_dist_info = script.user_site / "base-2.0.0.dist-info"
+
+    assert base_1_dist_info in result.files_created, str(result)
+    assert base_2_dist_info not in result.files_created, str(result)
+
+
+@pytest.mark.incompatible_with_test_venv
+def test_new_resolver_install_user_in_virtualenv_with_conflict_fails(script):
+    create_basic_wheel_for_package(script, "base", "1.0.0")
+    create_basic_wheel_for_package(script, "base", "2.0.0")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base==2.0.0",
+    )
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--user",
+        "base==1.0.0",
+        expect_error=True,
+    )
+
+    error_message = (
+        "Will not install to the user site because it will lack sys.path "
+        "precedence to base in {}"
+    ).format(os.path.normcase(script.site_packages_path))
+    assert error_message in result.stderr
+
+
+@pytest.fixture()
+def patch_dist_in_site_packages(virtualenv):
+    # Since the tests are run from a virtualenv, and to avoid the "Will not
+    # install to the usersite because it will lack sys.path precedence..."
+    # error: Monkey patch `dist_in_site_packages` in the resolver module so
+    # it's possible to install a conflicting distribution in the user site.
+    virtualenv.sitecustomize = textwrap.dedent("""
+        def dist_in_site_packages(dist):
+            return False
+
+        from pip._internal.resolution.resolvelib import factory
+        factory.dist_in_site_packages = dist_in_site_packages
+    """)
+
+
+@pytest.mark.incompatible_with_test_venv
+@pytest.mark.usefixtures("patch_dist_in_site_packages")
+def test_new_resolver_install_user_reinstall_global_site(script):
+    """
+    Specifying --force-reinstall makes a different version in user site,
+    ignoring the matching installation in global site.
+    """
+    create_basic_wheel_for_package(script, "base", "1.0.0")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base==1.0.0",
+    )
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--user",
+        "--force-reinstall",
+        "base==1.0.0",
+    )
+
+    assert script.user_site / "base" in result.files_created, str(result)
+
+    site_packages_content = set(os.listdir(script.site_packages_path))
+    assert "base" in site_packages_content
+
+
+@pytest.mark.incompatible_with_test_venv
+@pytest.mark.usefixtures("patch_dist_in_site_packages")
+def test_new_resolver_install_user_conflict_in_global_site(script):
+    """
+    Installing a different version in user site should ignore an existing
+    different version in global site, and simply add to the user site.
+    """
+    create_basic_wheel_for_package(script, "base", "1.0.0")
+    create_basic_wheel_for_package(script, "base", "2.0.0")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base==1.0.0",
+    )
+
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--user",
+        "base==2.0.0",
+    )
+
+    base_2_dist_info = script.user_site / "base-2.0.0.dist-info"
+    assert base_2_dist_info in result.files_created, str(result)
+
+    site_packages_content = set(os.listdir(script.site_packages_path))
+    assert "base-1.0.0.dist-info" in site_packages_content
+
+
+@pytest.mark.incompatible_with_test_venv
+@pytest.mark.usefixtures("patch_dist_in_site_packages")
+def test_new_resolver_install_user_conflict_in_global_and_user_sites(script):
+    """
+    Installing a different version in user site should ignore an existing
+    different version in global site, but still upgrade the user site.
+    """
+    create_basic_wheel_for_package(script, "base", "1.0.0")
+    create_basic_wheel_for_package(script, "base", "2.0.0")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base==2.0.0",
+    )
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--user",
+        "--force-reinstall",
+        "base==2.0.0",
+    )
+
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--user",
+        "base==1.0.0",
+    )
+
+    base_1_dist_info = script.user_site / "base-1.0.0.dist-info"
+    base_2_dist_info = script.user_site / "base-2.0.0.dist-info"
+
+    assert base_1_dist_info in result.files_created, str(result)
+    assert base_2_dist_info in result.files_deleted, str(result)
+
+    site_packages_content = set(os.listdir(script.site_packages_path))
+    assert "base-2.0.0.dist-info" in site_packages_content

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -52,6 +52,7 @@ def factory(finder, preparer):
         finder=finder,
         preparer=preparer,
         make_install_req=install_req_from_line,
+        use_user_site=False,
         force_reinstall=False,
         ignore_installed=False,
         ignore_requires_python=False,


### PR DESCRIPTION
The first three commits are from #7990.

I think the `use_user_site` implementation is best covered by existing tests. Let’s see what Travis thinks… if this works we should have less failing tests than in #7990.