### PR TITLE
Drop --use-venv from all CI tests

### DIFF
--- a/.azure-pipelines/jobs/test-windows.yml
+++ b/.azure-pipelines/jobs/test-windows.yml
@@ -15,14 +15,12 @@ jobs:
       Python27-x64:
         python.version: '2.7'
         python.architecture: x64
-        useVenv: true
       Python35-x64:
         python.version: '3.5'
         python.architecture: x64
       Python36-x64:
         python.version: '3.6'
         python.architecture: x64
-        useVenv: true
       Python37-x64:
         python.version: '3.7'
         python.architecture: x64
@@ -35,7 +33,6 @@ jobs:
   - template: ../steps/run-tests-windows.yml
     parameters:
       runIntegrationTests: true
-      useVenv: '$(useVenv)'
 
 - job: Test_Secondary
   displayName: Test Secondary

--- a/.azure-pipelines/steps/run-tests-windows.yml
+++ b/.azure-pipelines/steps/run-tests-windows.yml
@@ -1,6 +1,5 @@
 parameters:
   runIntegrationTests:
-  useVenv: false
 
 steps:
 - task: UsePythonVersion@0
@@ -44,11 +43,8 @@ steps:
       # https://bugs.python.org/issue18199
       $env:TEMP = "R:\Temp"
 
-      tox -e py -- $env:USE_VENV_ARG -m integration -n auto --duration=5 --junit-xml=junit/integration-test.xml
+      tox -e py -- -m integration -n auto --duration=5 --junit-xml=junit/integration-test.xml
     displayName: Tox run integration tests
-    env:
-      ${{ if eq(parameters.useVenv, 'true') }}:
-        USE_VENV_ARG: "--use-venv"
 
 - task: PublishTestResults@2
   displayName: Publish Test Results

--- a/tools/travis/run.sh
+++ b/tools/travis/run.sh
@@ -24,8 +24,8 @@ if [[ $TOXENV != docs ]] || [[ $TOXENV != lint ]]; then
 fi
 
 # Export the correct TOXENV when not provided.
-echo "Determining correct TOXENV..."
 if [[ -z "$TOXENV" ]]; then
+    echo "Determining correct TOXENV..."
     if [[ ${TRAVIS_PYTHON_VERSION} == pypy* ]]; then
         export TOXENV=pypy
     else
@@ -34,19 +34,19 @@ if [[ -z "$TOXENV" ]]; then
         _minor=${TRAVIS_PYTHON_VERSION:2:1}
         export TOXENV="py${_major}${_minor}"
     fi
+    echo "TOXENV=${TOXENV}"
 fi
-echo "TOXENV=${TOXENV}"
 
 # Print the commands run for this test.
 set -x
 if [[ "$GROUP" == "1" ]]; then
     # Unit tests
-    tox -- --use-venv -m unit -n auto
+    tox -- -m unit -n auto
     # Integration tests (not the ones for 'pip install')
-    tox -- --use-venv -m integration -n auto --duration=5 -k "not test_install"
+    tox -- -m integration -n auto --duration=5 -k "not test_install"
 elif [[ "$GROUP" == "2" ]]; then
     # Separate Job for running integration tests for 'pip install'
-    tox -- --use-venv -m integration -n auto --duration=5 -k "test_install"
+    tox -- -m integration -n auto --duration=5 -k "test_install"
 else
     # Non-Testing Jobs should run once
     tox


### PR DESCRIPTION
Toward https://github.com/pypa/pip/pull/7997#issuecomment-610948917

This is being done since our test setup is basically borked with venv, and until that is fixed, I think those tests cause more issues than they add significant value (see #7718 and #7356 for context).
