### PR TITLE
New Resolver: Make sure candidates are prepared after resolution

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -207,6 +207,7 @@ class _InstallRequirementBackedCandidate(Candidate):
 
     def get_install_requirement(self):
         # type: () -> Optional[InstallRequirement]
+        self.dist  # HACK? Ensure the candidate is correctly prepared.
         return self._ireq
 
 


### PR DESCRIPTION
This works because `self.dist` triggers a prepare method, but looks like a hack. Not sure how to do this best :(