### PR TITLE
New Resolver: Raise UnsupportedPythonVersion for Requires-Python mismatch

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -1,7 +1,8 @@
 import functools
 
+from pip._vendor import six
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.resolvelib import BaseReporter
+from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
 from pip._vendor.resolvelib import Resolver as RLResolver
 
 from pip._internal.req.req_set import RequirementSet
@@ -64,7 +65,14 @@ class Resolver(BaseResolver):
             self.factory.make_requirement_from_install_req(r)
             for r in root_reqs
         ]
-        self._result = resolver.resolve(requirements)
+
+        try:
+            self._result = resolver.resolve(requirements)
+        except ResolutionImpossible as e:
+            error = self.factory.get_installation_error(e)
+            if not error:
+                raise
+            six.raise_from(error, e)
 
         req_set = RequirementSet(check_supported_wheels=check_supported_wheels)
         for candidate in self._result.mapping.values():

--- a/src/pip/_vendor/resolvelib/__init__.py
+++ b/src/pip/_vendor/resolvelib/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "AbstractProvider",
     "AbstractResolver",
     "BaseReporter",
+    "InconsistentCandidate",
     "Resolver",
     "RequirementsConflicted",
     "ResolutionError",
@@ -16,6 +17,7 @@ __version__ = "0.2.3.dev0"
 from .providers import AbstractProvider, AbstractResolver
 from .reporters import BaseReporter
 from .resolvers import (
+    InconsistentCandidate,
     RequirementsConflicted,
     Resolver,
     ResolutionError,

--- a/src/pip/_vendor/resolvelib/__init__.py
+++ b/src/pip/_vendor/resolvelib/__init__.py
@@ -11,7 +11,7 @@ __all__ = [
     "ResolutionTooDeep",
 ]
 
-__version__ = "0.2.3.dev0"
+__version__ = "0.3.0"
 
 
 from .providers import AbstractProvider, AbstractResolver

--- a/src/pip/_vendor/resolvelib/reporters.py
+++ b/src/pip/_vendor/resolvelib/reporters.py
@@ -22,3 +22,15 @@ class BaseReporter(object):
     def ending(self, state):
         """Called before the resolution ends successfully.
         """
+
+    def adding_requirement(self, requirement):
+        """Called when the resolver adds a new requirement into the resolve criteria.
+        """
+
+    def backtracking(self, candidate):
+        """Called when the resolver rejects a candidate during backtracking.
+        """
+
+    def pinning(self, candidate):
+        """Called when adding a candidate to the potential solution.
+        """

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -17,9 +17,8 @@ requests==2.22.0
     chardet==3.0.4
     idna==2.8
     urllib3==1.25.7
+resolvelib==0.3.0
 retrying==1.3.3
 setuptools==44.0.0
 six==1.14.0
 webencodings==0.5.1
-
-git+https://github.com/sarugaku/resolvelib.git@726834de469bfcb8b#egg=resolvelib

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -22,4 +22,4 @@ setuptools==44.0.0
 six==1.14.0
 webencodings==0.5.1
 
-git+https://github.com/sarugaku/resolvelib.git@fbc8bb28d6cff98b2#egg=resolvelib
+git+https://github.com/sarugaku/resolvelib.git@726834de469bfcb8b#egg=resolvelib

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 import pytest
 
@@ -228,6 +229,28 @@ def test_new_resolver_requires_python(
     script.pip(*args)
 
     assert_installed(script, base="0.1.0", dep=dep_version)
+
+
+def test_new_resolver_requires_python_error(script):
+    create_basic_wheel_for_package(
+        script,
+        "base",
+        "0.1.0",
+        requires_python="<2",
+    )
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "base",
+        expect_error=True,
+    )
+
+    message = (
+        "Package 'base' requires a different Python: "
+        "{}.{}.{} not in '<2'".format(*sys.version_info[:3])
+    )
+    assert message in result.stderr, str(result)
 
 
 def test_new_resolver_installed(script):


### PR DESCRIPTION
Implement a `RequiresPythonRequirement` that is specialised in carrying Requires-Python information, instead of reusing ExplicitRequirement. This allows us to keep the original Requires-Python value to use for error reporting.

Some extra structure is added to raise the correct pip exceptions. This should be useful down the road.