### PR TITLE
New resolver: Use requirement line to populate LinkCandidate._ireq

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -41,8 +41,12 @@ logger = logging.getLogger(__name__)
 def make_install_req_from_link(link, parent):
     # type: (Link, InstallRequirement) -> InstallRequirement
     assert not parent.editable, "parent is editable"
-    return install_req_from_line(
-        link.url,
+    if parent.req:
+        line = str(parent.req)
+    else:
+        line = link.url
+    ireq = install_req_from_line(
+        line,
         comes_from=parent.comes_from,
         use_pep517=parent.use_pep517,
         isolated=parent.isolated,
@@ -53,6 +57,10 @@ def make_install_req_from_link(link, parent):
             hashes=parent.hash_options
         ),
     )
+    if ireq.link is None:
+        ireq.link = link
+    # TODO: Handle wheel cache resolution.
+    return ireq
 
 
 def make_install_req_from_editable(link, parent):


### PR DESCRIPTION
I was looking into a freeze test error (`test_freeze_with_requirement_option_multiple`), and realised how we built the candidate’s InstallRequirement is broken after merging PEP 610. This is because we were populating the InstallRequirement with the link’s URL as `line`, which makes PEP 610 records the URL in `direct_url.json`, and in turn causes `pip freeze` to use that URL in the output.

The solution here is to use the `parent.req` as the line instead. This tells the PEP 610 implementation to *not* treat this as a direct URL, unless `parent.req` is itself a direct URL.

cc @sbidoul it’d be nice if you could verify whether I’m understanding the PEP 610 implementation correctly.