### PR TITLE
Remove the version part from the dist-info directory name

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -70,17 +70,18 @@ def _get_dist(metadata_directory):
     """
     dist_dir = metadata_directory.rstrip(os.sep)
 
+    # Build a PathMetadata object, from path to metadata. :wink:
+    base_dir, dist_dir_name = os.path.split(dist_dir)
+    metadata = pkg_resources.PathMetadata(base_dir, dist_dir)
+
     # Determine the correct Distribution object type.
     if dist_dir.endswith(".egg-info"):
         dist_cls = pkg_resources.Distribution
+        dist_name = os.path.splitext(dist_dir_name)[0]
     else:
         assert dist_dir.endswith(".dist-info")
         dist_cls = pkg_resources.DistInfoDistribution
-
-    # Build a PathMetadata object, from path to metadata. :wink:
-    base_dir, dist_dir_name = os.path.split(dist_dir)
-    dist_name = os.path.splitext(dist_dir_name)[0]
-    metadata = pkg_resources.PathMetadata(base_dir, dist_dir)
+        dist_name = os.path.splitext(dist_dir_name)[0].split("-")[0]
 
     return dist_cls(
         base_dir,


### PR DESCRIPTION
[Discussion on Zulip](https://python.zulipchat.com/#narrow/stream/218659-pip-development/topic/pip.20gets.20wrong.20name.20from.20dist-info):

Tzu-ping Chung: Line 82 parses the dist name from the `*.dist-info` directory’s location. But isn’t the dist-info supposed to be named like `{project}-{version}.dist-info`? This line only strips the extension, but that should not be the project name.

----

Paul Moore: All the tests pass if you fix it with
```
dist_name = os.path.splitext(dist_dir_name)[0].split("-")[0]
```
so I'd just do that :slight_smile:

----

Tzu-ping Chung: I think `.egg-info` does not have the version part though? We’ll need different logic for them if that’s the case.