### PR TITLE
New Resolver: Always return an install candidate last (i.e. most preferred) if matches

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -60,7 +60,7 @@ class Factory(object):
 
         if not ignore_installed:
             self._installed_dists = {
-                dist.project_name: dist
+                canonicalize_name(dist.project_name): dist
                 for dist in get_installed_distributions()
             }
         else:

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -109,9 +109,9 @@ class Factory(object):
         # type: (InstallRequirement, Set[str]) -> Iterator[Candidate]
         name = canonicalize_name(ireq.req.name)
         if not self._force_reinstall:
-            dist = self._installed_dists.get(name)
+            installed_dist = self._installed_dists.get(name)
         else:
-            dist = None
+            installed_dist = None
 
         found = self.finder.find_best_candidate(
             project_name=ireq.req.name,
@@ -119,7 +119,8 @@ class Factory(object):
             hashes=ireq.hashes(trust_internet=False),
         )
         for ican in found.iter_applicable():
-            if dist is not None and dist.parsed_version == ican.version:
+            if (installed_dist is not None and
+                    installed_dist.parsed_version == ican.version):
                 continue
             yield self._make_candidate_from_link(
                 link=ican.link,
@@ -131,9 +132,10 @@ class Factory(object):
 
         # Return installed distribution if it matches the specifier. This is
         # done last so the resolver will prefer it over downloading links.
-        if dist is not None and dist.parsed_version in ireq.req.specifier:
+        if (installed_dist is not None and
+                installed_dist.parsed_version in ireq.req.specifier):
             yield self._make_candidate_from_dist(
-                dist=dist,
+                dist=installed_dist,
                 extras=extras,
                 parent=ireq,
             )

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -94,19 +94,8 @@ class SpecifierRequirement(Requirement):
 
     def find_matches(self):
         # type: () -> Sequence[Candidate]
-        found = self._factory.finder.find_best_candidate(
-            project_name=self._ireq.req.name,
-            specifier=self._ireq.req.specifier,
-            hashes=self._ireq.hashes(trust_internet=False),
-        )
-        return [
-            self._factory.make_candidate_from_ican(
-                ican=ican,
-                extras=self.extras,
-                parent=self._ireq,
-            )
-            for ican in found.iter_applicable()
-        ]
+        it = self._factory.iter_found_candidates(self._ireq, self.extras)
+        return list(it)
 
     def is_satisfied_by(self, candidate):
         # type: (Candidate) -> bool

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -88,6 +88,63 @@ def test_new_resolver_picks_latest_version(script):
     assert_installed(script, simple="0.2.0")
 
 
+def test_new_resolver_picks_installed_version(script):
+    create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.1.0",
+    )
+    create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.2.0",
+    )
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "simple==0.1.0"
+    )
+    assert_installed(script, simple="0.1.0")
+
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "simple"
+    )
+    assert "Collecting" not in result.stdout, "Should not fetch new version"
+    assert_installed(script, simple="0.1.0")
+
+
+def test_new_resolver_picks_installed_version_if_no_match_found(script):
+    create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.1.0",
+    )
+    create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.2.0",
+    )
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "simple==0.1.0"
+    )
+    assert_installed(script, simple="0.1.0")
+
+    result = script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "simple"
+    )
+    assert "Collecting" not in result.stdout, "Should not fetch new version"
+    assert_installed(script, simple="0.1.0")
+
+
 def test_new_resolver_installs_dependencies(script):
     create_basic_wheel_for_package(
         script,


### PR DESCRIPTION
This rewrites how a SpecifierRequirement generates candidates, so it

* Always return an `AlreadyInstalledCandidate` (as long as the version satisfies the specifier), even if `PackageFinder` does not return a candidate for the same version.
* Always put the `AlreadyInstalledCandidate` last, so it’s preferred over `LinkCandidate`, preventing version changes if possible.