### PR TITLE
Type annotations for hash, show and wheel in commands

### DIFF
--- a/src/pip/_internal/commands/hash.py
+++ b/src/pip/_internal/commands/hash.py
@@ -1,6 +1,3 @@
-# The following comment should be removed at some point in the future.
-# mypy: disallow-untyped-defs=False
-
 from __future__ import absolute_import
 
 import hashlib
@@ -8,9 +5,14 @@ import logging
 import sys
 
 from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import ERROR
+from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.utils.hashes import FAVORITE_HASH, STRONG_HASHES
 from pip._internal.utils.misc import read_chunks, write_output
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from optparse import Values
+    from typing import Any, List, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +29,9 @@ class HashCommand(Command):
     ignore_require_venv = True
 
     def __init__(self, *args, **kw):
-        super(HashCommand, self).__init__(*args, **kw)
+        # type: (List[Any], Dict[Any, Any]) -> None
+        # https://github.com/python/mypy/issues/4335
+        super(HashCommand, self).__init__(*args, **kw)  # type: ignore
         self.cmd_opts.add_option(
             '-a', '--algorithm',
             dest='algorithm',
@@ -39,6 +43,7 @@ class HashCommand(Command):
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
+        # type: (Values, List[Any]) -> int
         if not args:
             self.parser.print_usage(sys.stderr)
             return ERROR
@@ -47,9 +52,11 @@ class HashCommand(Command):
         for path in args:
             write_output('%s:\n--hash=%s:%s',
                          path, algorithm, _hash_of_file(path, algorithm))
+        return SUCCESS
 
 
 def _hash_of_file(path, algorithm):
+    # type: (str, str) -> str
     """Return the hash digest of a file."""
     with open(path, 'rb') as archive:
         hash = hashlib.new(algorithm)

--- a/src/pip/_internal/commands/hash.py
+++ b/src/pip/_internal/commands/hash.py
@@ -12,7 +12,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     from optparse import Values
-    from typing import Any, List, Dict
+    from typing import Any, List
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +29,8 @@ class HashCommand(Command):
     ignore_require_venv = True
 
     def __init__(self, *args, **kw):
-        # type: (List[Any], Dict[Any, Any]) -> None
-        # https://github.com/python/mypy/issues/4335
-        super(HashCommand, self).__init__(*args, **kw)  # type: ignore
+        # type: (*Any, **Any) -> None
+        super(HashCommand, self).__init__(*args, **kw)
         self.cmd_opts.add_option(
             '-a', '--algorithm',
             dest='algorithm',
@@ -43,7 +42,7 @@ class HashCommand(Command):
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
-        # type: (Values, List[Any]) -> int
+        # type: (Values, List[str]) -> int
         if not args:
             self.parser.print_usage(sys.stderr)
             return ERROR

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -94,10 +94,6 @@ def search_packages_info(query):
             'required_by': get_requiring_packages(dist.project_name)
         }
         file_list = None
-        # Set metadata to empty string to avoid metadata being typed as
-        # Optional[Any] in function calls using metadata below
-        # and since dist.get_metadata returns us a str, the default
-        # value of empty string should be valid
         metadata = ''
         if isinstance(dist, pkg_resources.DistInfoDistribution):
             # RECORDs should be part of .dist-info metadatas

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -31,9 +31,8 @@ class ShowCommand(Command):
     ignore_require_venv = True
 
     def __init__(self, *args, **kw):
-        # type: (List[Any], Dict[Any, Any]) -> None
-        # https://github.com/python/mypy/issues/4335
-        super(ShowCommand, self).__init__(*args, **kw)  # type: ignore
+        # type: (*Any, **Any) -> None
+        super(ShowCommand, self).__init__(*args, **kw)
         self.cmd_opts.add_option(
             '-f', '--files',
             dest='files',
@@ -44,7 +43,7 @@ class ShowCommand(Command):
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
-        # type: (Values, List[Any]) -> int
+        # type: (Values, List[str]) -> int
         if not args:
             logger.warning('ERROR: Please provide a package name or names.')
             return ERROR
@@ -58,7 +57,7 @@ class ShowCommand(Command):
 
 
 def search_packages_info(query):
-    # type: (List[Any]) -> Iterator[Dict[str, Any]]
+    # type: (List[str]) -> Iterator[Dict[str, str]]
     """
     Gather details from installed distributions. Print distribution name,
     version, location, and installed files. Installed files requires a
@@ -95,6 +94,10 @@ def search_packages_info(query):
             'required_by': get_requiring_packages(dist.project_name)
         }
         file_list = None
+        # Set metadata to empty string to avoid metadata being typed as
+        # Optional[Any] in function calls using metadata below
+        # and since dist.get_metadata returns us a str, the default
+        # value of empty string should be valid
         metadata = ''
         if isinstance(dist, pkg_resources.DistInfoDistribution):
             # RECORDs should be part of .dist-info metadatas
@@ -148,7 +151,7 @@ def search_packages_info(query):
 
 
 def print_results(distributions, list_files=False, verbose=False):
-    # type: (Iterator[Dict[str, Any]], bool, bool) -> bool
+    # type: (Iterator[Dict[str, str]], bool, bool) -> bool
     """
     Print the information from installed distributions found.
     """

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-# The following comment should be removed at some point in the future.
-# mypy: disallow-untyped-defs=False
-
 from __future__ import absolute_import
 
 import logging
@@ -12,6 +9,7 @@ import shutil
 from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.req_command import RequirementCommand, with_cleanup
+from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.exceptions import CommandError
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.misc import ensure_dir, normalize_path
@@ -21,7 +19,7 @@ from pip._internal.wheel_builder import build, should_build_for_wheel_command
 
 if MYPY_CHECK_RUNNING:
     from optparse import Values
-    from typing import Any, List
+    from typing import Any, List, Dict
 
 
 logger = logging.getLogger(__name__)
@@ -50,7 +48,9 @@ class WheelCommand(RequirementCommand):
       %prog [options] <archive url/path> ..."""
 
     def __init__(self, *args, **kw):
-        super(WheelCommand, self).__init__(*args, **kw)
+        # type: (List[Any], Dict[Any, Any]) -> None
+        # https://github.com/python/mypy/issues/4335
+        super(WheelCommand, self).__init__(*args, **kw)  # type: ignore
 
         cmd_opts = self.cmd_opts
 
@@ -112,7 +112,7 @@ class WheelCommand(RequirementCommand):
 
     @with_cleanup
     def run(self, options, args):
-        # type: (Values, List[Any]) -> None
+        # type: (Values, List[Any]) -> int
         cmdoptions.check_install_build_global(options)
 
         session = self.get_default_session(options)
@@ -188,3 +188,5 @@ class WheelCommand(RequirementCommand):
             raise CommandError(
                 "Failed to build one or more wheels"
             )
+
+        return SUCCESS

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -19,7 +19,7 @@ from pip._internal.wheel_builder import build, should_build_for_wheel_command
 
 if MYPY_CHECK_RUNNING:
     from optparse import Values
-    from typing import Any, List, Dict
+    from typing import Any, List
 
 
 logger = logging.getLogger(__name__)
@@ -48,9 +48,8 @@ class WheelCommand(RequirementCommand):
       %prog [options] <archive url/path> ..."""
 
     def __init__(self, *args, **kw):
-        # type: (List[Any], Dict[Any, Any]) -> None
-        # https://github.com/python/mypy/issues/4335
-        super(WheelCommand, self).__init__(*args, **kw)  # type: ignore
+        # type: (*Any, **Any) -> None
+        super(WheelCommand, self).__init__(*args, **kw)
 
         cmd_opts = self.cmd_opts
 
@@ -112,7 +111,7 @@ class WheelCommand(RequirementCommand):
 
     @with_cleanup
     def run(self, options, args):
-        # type: (Values, List[Any]) -> int
+        # type: (Values, List[str]) -> int
         cmdoptions.check_install_build_global(options)
 
         session = self.get_default_session(options)


### PR DESCRIPTION
Towards #4748 

Added type annotations to `pip._internal.commands.hash`, `pip._internal.commands.show` and `pip._internal.commands.wheel`