### PR TITLE
Significantly improve release version validation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -155,9 +155,9 @@ def lint(session):
 # -----------------------------------------------------------------------------
 @nox.session(name="prepare-release")
 def prepare_release(session):
-    version = release.get_version_from_arguments(session.posargs)
+    version = release.get_version_from_arguments(session)
     if not version:
-        session.error("Usage: nox -s prepare-release -- YY.N[.P]")
+        session.error("Usage: nox -s prepare-release -- <version>")
 
     session.log("# Ensure nothing is staged")
     if release.modified_files_in_git("--staged"):
@@ -190,7 +190,7 @@ def prepare_release(session):
 
 @nox.session(name="build-release")
 def build_release(session):
-    version = release.get_version_from_arguments(session.posargs)
+    version = release.get_version_from_arguments(session)
     if not version:
         session.error("Usage: nox -s build-release -- YY.N[.P]")
 
@@ -249,7 +249,7 @@ def build_dists(session):
 
 @nox.session(name="upload-release")
 def upload_release(session):
-    version = release.get_version_from_arguments(session.posargs)
+    version = release.get_version_from_arguments(session)
     if not version:
         session.error("Usage: nox -s upload-release -- YY.N[.P]")
 

--- a/tools/automation/release/check_version.py
+++ b/tools/automation/release/check_version.py
@@ -1,0 +1,43 @@
+"""Checks if the version is acceptable, as per this project's release process.
+"""
+
+import sys
+from datetime import datetime
+from typing import Optional
+
+from packaging.version import InvalidVersion, Version
+
+
+def is_this_a_good_version_number(string: str) -> Optional[str]:
+    try:
+        v = Version(string)
+    except InvalidVersion as e:
+        return str(e)
+
+    if v.local:
+        return "Nope. PyPI refuses local release versions."
+
+    if v.dev:
+        return "No development releases on PyPI. What are you even thinking?"
+
+    if v.is_prerelease and v.pre[0] != "b":
+        return "Only beta releases are allowed. No alphas."
+
+    release = v.release
+    expected_major = datetime.now().year % 100
+
+    if len(release) not in [2, 3]:
+        return "Not of the form: {0}.N or {0}.N.P".format(expected_major)
+
+    return None
+
+
+def main() -> None:
+    problem = is_this_a_good_version_number(sys.argv[1])
+    if problem is not None:
+        print("ERROR:", problem)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #7952 

Notably:

- Allows pre-releases and post-releases.
  - No alpha or dev releases, only beta.
- Uses a subprocess to actually do the version validation (sorry Windows users!)
  - Need `packaging` for validation, but don't want to add that as an extra release process step.
