### PR TITLE
Remove InstallRequirement source_dir parameter

### DIFF
--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -228,12 +228,9 @@ def install_req_from_editable(
 
     parts = parse_req_from_editable(editable_req)
 
-    source_dir = parts.link.file_path if parts.link.scheme == 'file' else None
-
     return InstallRequirement(
         parts.requirement,
         comes_from=comes_from,
-        source_dir=source_dir,
         editable=True,
         link=parts.link,
         constraint=constraint,

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -22,7 +22,8 @@ def make_project(tmpdir, requires=[], backend=None, backend_path=None):
 def test_backend(tmpdir, data):
     """Check we can call a requirement's backend successfully"""
     project_dir = make_project(tmpdir, backend="dummy_backend")
-    req = InstallRequirement(None, None, source_dir=project_dir)
+    req = InstallRequirement(None, None)
+    req.source_dir = project_dir  # make req believe it has been unpacked
     req.load_pyproject_toml()
     env = BuildEnvironment()
     finder = make_test_finder(find_links=[data.backends])
@@ -50,7 +51,8 @@ def test_backend_path(tmpdir, data):
         tmpdir, backend="dummy_backend", backend_path=['.']
     )
     (project_dir / 'dummy_backend.py').write_text(dummy_backend_code)
-    req = InstallRequirement(None, None, source_dir=project_dir)
+    req = InstallRequirement(None, None)
+    req.source_dir = project_dir  # make req believe it has been unpacked
     req.load_pyproject_toml()
 
     env = BuildEnvironment()
@@ -67,7 +69,8 @@ def test_backend_path_and_dep(tmpdir, data):
     (project_dir / 'dummy_internal_backend.py').write_text(
         "from dummy_backend import build_wheel"
     )
-    req = InstallRequirement(None, None, source_dir=project_dir)
+    req = InstallRequirement(None, None)
+    req.source_dir = project_dir  # make req believe it has been unpacked
     req.load_pyproject_toml()
     env = BuildEnvironment()
     finder = make_test_finder(find_links=[data.backends])

--- a/tests/unit/test_pep517.py
+++ b/tests/unit/test_pep517.py
@@ -16,7 +16,8 @@ def test_use_pep517(shared_data, source, expected):
     Test that we choose correctly between PEP 517 and legacy code paths
     """
     src = shared_data.src.joinpath(source)
-    req = InstallRequirement(None, None, source_dir=src)
+    req = InstallRequirement(None, None)
+    req.source_dir = src  # make req believe it has been unpacked
     req.load_pyproject_toml()
     assert req.use_pep517 is expected
 
@@ -30,7 +31,8 @@ def test_disabling_pep517_invalid(shared_data, source, msg):
     Test that we fail if we try to disable PEP 517 when it's not acceptable
     """
     src = shared_data.src.joinpath(source)
-    req = InstallRequirement(None, None, source_dir=src)
+    req = InstallRequirement(None, None)
+    req.source_dir = src  # make req believe it has been unpacked
 
     # Simulate --no-use-pep517
     req.use_pep517 = False
@@ -54,7 +56,8 @@ def test_pep517_parsing_checks_requirements(tmpdir, spec):
         build-backend = "foo"
         """.format(spec)
     ))
-    req = InstallRequirement(None, None, source_dir=tmpdir)
+    req = InstallRequirement(None, None)
+    req.source_dir = tmpdir  # make req believe it has been unpacked
 
     with pytest.raises(InstallationError) as e:
         req.load_pyproject_toml()

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -641,8 +641,8 @@ def test_mismatched_versions(caplog):
     req = InstallRequirement(
         req=Requirement('simplewheel==2.0'),
         comes_from=None,
-        source_dir="/tmp/somewhere",
     )
+    req.source_dir = "/tmp/somewhere"  # make req believe it has been unpacked
     # Monkeypatch!
     req._metadata = {"name": "simplewheel", "version": "1.0"}
     req.assert_source_matches_version()


### PR DESCRIPTION
source_dir is only passed to the InstallRequirement constructor
in the case of editable requirements, and it is built from link,
which is also passed to the same constructor. So we let
InstallRequirement compute source_dir, to remove that burden
from call sites.
