### PR TITLE
Fix Windows folder writable detection

### DIFF
--- a/news/8013.bugfix
+++ b/news/8013.bugfix
@@ -1,0 +1,1 @@
+Fix Windows folder writable detection.

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -158,10 +158,13 @@ def _test_writable_dir_win(path):
         file = os.path.join(path, name)
         try:
             fd = os.open(file, os.O_RDWR | os.O_CREAT | os.O_EXCL)
+        # Python 2 doesn't support FileExistsError and PermissionError.
         except OSError as e:
+            # exception FileExistsError
             if e.errno == errno.EEXIST:
                 continue
-            if e.errno == errno.EPERM:
+            # exception PermissionError
+            if e.errno == errno.EPERM or e.errno == errno.EACCES:
                 # This could be because there's a directory with the same name.
                 # But it's highly unlikely there's a directory called that,
                 # so we'll assume it's because the parent dir is not writable.


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Fixes #8013
