### PR TITLE
fix(network/auth): Asks for password when it is None

### DIFF
--- a/news/7998.bugfix
+++ b/news/7998.bugfix
@@ -1,0 +1,1 @@
+Prompt the user for password if the keyring backend doesn't return one

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -219,7 +219,7 @@ class MultiDomainBasicAuth(AuthBase):
         if not username:
             return None, None
         auth = get_keyring_auth(netloc, username)
-        if auth:
+        if auth and auth[0] is not None and auth[1] is not None:
             return auth[0], auth[1], False
         password = ask_password("Password: ")
         return username, password, True

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -123,6 +123,26 @@ def test_keyring_get_password_after_prompt(monkeypatch):
     assert actual == ("user", "user!netloc", False)
 
 
+def test_keyring_get_password_after_prompt_when_none(monkeypatch):
+    keyring = KeyringModuleV1()
+    monkeypatch.setattr('pip._internal.network.auth.keyring', keyring)
+    auth = MultiDomainBasicAuth()
+
+    def ask_input(prompt):
+        assert prompt == "User for unknown.com: "
+        return "user"
+
+    def ask_password(prompt):
+        assert prompt == "Password: "
+        return "fake_password"
+
+    monkeypatch.setattr('pip._internal.network.auth.ask_input', ask_input)
+    monkeypatch.setattr(
+        'pip._internal.network.auth.ask_password', ask_password)
+    actual = auth._prompt_for_password("unknown.com")
+    assert actual == ("user", "fake_password", True)
+
+
 def test_keyring_get_password_username_in_index(monkeypatch):
     keyring = KeyringModuleV1()
     monkeypatch.setattr('pip._internal.network.auth.keyring', keyring)


### PR DESCRIPTION
When `get_keyring_auth` provides the password as None, the
user should be prompt to ask the password.

This fixes #7998

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
