### PR TITLE
Add extra headers option to enhance HTTP requests

### DIFF
--- a/news/4475.feature
+++ b/news/4475.feature
@@ -1,0 +1,16 @@
+Add extra headers option to enhance HTTP requests
+
+Users can supply --extra-headers='{...}' option to pip commands that enhances the
+PipSession object with custom headers.
+
+This enables use of private PyPI servers that use token-based authentication.
+
+Example:
+
+```
+pip install \
+  --extra-headers='{"Authorization": "..."}' \
+  --index-url https://secure.pypi.example.com/simple \
+  --trusted-host secure.pypi.example.com \
+  fizz==1.2.3
+```

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -335,6 +335,17 @@ index_url = partial(
 )  # type: Callable[..., Option]
 
 
+def extra_headers():
+    # type: () -> Option
+    return Option(
+        '--extra-headers',
+        dest='extra_headers',
+        metavar='JSON',
+        default=None,
+        help='Extra HTTP request headers JSON.',
+    )
+
+
 def extra_index_url():
     # type: () -> Option
     return Option(
@@ -969,5 +980,6 @@ index_group = {
         extra_index_url,
         no_index,
         find_links,
+        extra_headers,
     ]
 }  # type: Dict[str, Any]

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -83,14 +83,13 @@ class SessionCommandMixin(CommandContextMixIn):
         """
         Return a dict of extra HTTP request headers from user-provided options.
         """
-        extra_headers_text = getattr(options, 'extra_headers', None)
+        if not options.extra_headers:
+            return None
         try:
-            extra_headers = json.loads(extra_headers_text)
+            return json.loads(options.extra_headers)
         except (TypeError, ValueError):
-            if extra_headers_text:
-                raise CommandError('Could not parse extra headers as JSON')
-            extra_headers = None
-        return extra_headers
+            logger.critical('Could not parse extra headers as JSON')
+            return None
 
     def get_default_session(self, options):
         # type: (Values) -> PipSession

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -230,6 +230,7 @@ class PipSession(requests.Session):
         cache = kwargs.pop("cache", None)
         trusted_hosts = kwargs.pop("trusted_hosts", [])  # type: List[str]
         index_urls = kwargs.pop("index_urls", None)
+        extra_headers = kwargs.pop("extra_headers", None)
 
         super(PipSession, self).__init__(*args, **kwargs)
 
@@ -239,6 +240,10 @@ class PipSession(requests.Session):
 
         # Attach our User Agent to the request
         self.headers["User-Agent"] = user_agent()
+
+        # Attach extra headers to the request
+        if extra_headers:
+            self.headers.update(extra_headers)
 
         # Attach our Authentication handler to the session
         self.auth = MultiDomainBasicAuth(index_urls=index_urls)

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -219,3 +219,11 @@ class TestPipSession:
         actual_level, actual_message = log_records[0]
         assert actual_level == 'WARNING'
         assert 'is not a trusted or secure host' in actual_message
+
+    def test_extra_headers(self):
+        session = PipSession(extra_headers={
+            'Authorization':
+                'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0N'
+                'TY3ODkwIiwibmFtZSI6IlNwYW0gU3BhbSIsImlhdCI6MTUxNjIzOTAyMn0.h1'
+                '98Wld6h_ASlfRZN3ZftXLNkGHIdrdNpXwrEOdLO1U'})
+        assert 'Authorization' in session.headers

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -227,3 +227,11 @@ class TestPipSession:
                 'TY3ODkwIiwibmFtZSI6IlNwYW0gU3BhbSIsImlhdCI6MTUxNjIzOTAyMn0.h1'
                 '98Wld6h_ASlfRZN3ZftXLNkGHIdrdNpXwrEOdLO1U'})
         assert 'Authorization' in session.headers
+
+    def test_bogus_extra_headers(self):
+        bogus_header = \
+            'Authorization=Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdW'\
+            'IiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlNwYW0gU3BhbSIsImlhdCI6MTUxNjIzOT'\
+            'AyMn0.h198Wld6h_ASlfRZN3ZftXLNkGHIdrdNpXwrEOdLO1U'
+        with pytest.raises(ValueError):
+            PipSession(extra_headers=bogus_header)


### PR DESCRIPTION
Users can supply `--extra-headers='{...}'` option to pip commands that enhances the PipSession object with custom headers.

This enables use of private PyPI servers that use token-based authentication.

Example:

```
pip install \
  --extra-headers='{"Authorization": "..."}' \
  --index-url https://secure.pypi.example.com/simple \
  --trusted-host secure.pypi.example.com \
  fizz==1.2.3
```

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
