### PR TITLE
Revendor resolvelib 0.3.0

### DIFF
--- a/news/8034.vendor
+++ b/news/8034.vendor
@@ -1,0 +1,1 @@
+Upgrade resolvelib to 0.3.0

--- a/src/pip/_vendor/resolvelib/__init__.py
+++ b/src/pip/_vendor/resolvelib/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "AbstractProvider",
     "AbstractResolver",
     "BaseReporter",
+    "InconsistentCandidate",
     "Resolver",
     "RequirementsConflicted",
     "ResolutionError",
@@ -10,12 +11,13 @@ __all__ = [
     "ResolutionTooDeep",
 ]
 
-__version__ = "0.2.3.dev0"
+__version__ = "0.3.0"
 
 
 from .providers import AbstractProvider, AbstractResolver
 from .reporters import BaseReporter
 from .resolvers import (
+    InconsistentCandidate,
     RequirementsConflicted,
     Resolver,
     ResolutionError,

--- a/src/pip/_vendor/resolvelib/reporters.py
+++ b/src/pip/_vendor/resolvelib/reporters.py
@@ -22,3 +22,15 @@ class BaseReporter(object):
     def ending(self, state):
         """Called before the resolution ends successfully.
         """
+
+    def adding_requirement(self, requirement):
+        """Called when the resolver adds a new requirement into the resolve criteria.
+        """
+
+    def backtracking(self, candidate):
+        """Called when the resolver rejects a candidate during backtracking.
+        """
+
+    def pinning(self, candidate):
+        """Called when adding a candidate to the potential solution.
+        """

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -17,9 +17,8 @@ requests==2.22.0
     chardet==3.0.4
     idna==2.8
     urllib3==1.25.7
+resolvelib==0.3.0
 retrying==1.3.3
 setuptools==44.0.0
 six==1.14.0
 webencodings==0.5.1
-
-git+https://github.com/sarugaku/resolvelib.git@fbc8bb28d6cff98b2#egg=resolvelib


### PR DESCRIPTION
Revendoring the latest version of resolvelib. This may not be needed, as one of @uranusjr's PRs includes it, but I was testing the revendoring process, so I thought I'd submit it anyway.

If the new version of resolvelib gets merged via another route, this can be discarded.