### PR TITLE
Add a vendoring session to noxfile.py

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -152,9 +152,6 @@ def lint(session):
 
 @nox.session
 def vendoring(session):
-    # Required, otherwise we interpret --no-binary :all: as
-    # "do not build wheels", which fails for PEP 517 requirements
-    session.install("-U", "pip>=19.3.1")
     session.install("vendoring")
 
     session.run("vendoring", "sync", ".", "-v")

--- a/noxfile.py
+++ b/noxfile.py
@@ -150,6 +150,16 @@ def lint(session):
     session.run("pre-commit", "run", *args)
 
 
+@nox.session
+def vendoring(session):
+    # Required, otherwise we interpret --no-binary :all: as
+    # "do not build wheels", which fails for PEP 517 requirements
+    session.install("-U", "pip>=19.3.1")
+    session.install("vendoring")
+
+    session.run("vendoring", "sync", ".", "-v")
+
+
 # -----------------------------------------------------------------------------
 # Release Commands
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
A simple nox session to run vendoring. Unlike the tox version, this doesn't run a `git diff` when completed, so it's intended for manual use, not for CI checks.

It could be enhanced to handle that case as well, but I don't see the benefit unless we're planning on switching CI to use nox, and we can make that change when we do.

@pradyunsg Does this warrant a news entry? I'm inclined to think not, as noxfile changes typically haven't appeared in `NEWS.rst`.