### PR TITLE
Block user from unfinished parts of the resolver

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -4,6 +4,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.resolvelib import BaseReporter
 from pip._vendor.resolvelib import Resolver as RLResolver
 
+from pip._internal.exceptions import InstallationError
 from pip._internal.req.req_set import RequirementSet
 from pip._internal.resolution.base import BaseResolver
 from pip._internal.resolution.resolvelib.provider import PipProvider
@@ -53,6 +54,11 @@ class Resolver(BaseResolver):
 
     def resolve(self, root_reqs, check_supported_wheels):
         # type: (List[InstallRequirement], bool) -> RequirementSet
+
+        # FIXME: Implement constraints.
+        if any(r.constraint for r in root_reqs):
+            raise InstallationError("Constraints are not yet supported.")
+
         provider = PipProvider(
             factory=self.factory,
             ignore_dependencies=self.ignore_dependencies,
@@ -109,7 +115,11 @@ class Resolver(BaseResolver):
 
             # FIXME: This check will fail if there are unbreakable cycles.
             # Implement something to forcifully break them up to continue.
-            assert progressed, "Order calculation stuck in dependency loop."
+            if not progressed:
+                raise InstallationError(
+                    "Could not determine installation order due to cicular "
+                    "dependency."
+                )
 
         sorted_items = sorted(
             req_set.requirements.items(),


### PR DESCRIPTION
This should emit a relatively friendly error message when the user does something the new resolver does not yet handle.

Toward #7951.