### PR TITLE
Type annotations for completion and debug in commands

### DIFF
--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -1,13 +1,16 @@
-# The following comment should be removed at some point in the future.
-# mypy: disallow-untyped-defs=False
-
 from __future__ import absolute_import
 
 import sys
 import textwrap
 
 from pip._internal.cli.base_command import Command
+from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.utils.misc import get_prog
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Any, List
+    from optparse import Values
 
 BASE_COMPLETION = """
 # pip {shell} completion start{script}# pip {shell} completion end
@@ -54,6 +57,7 @@ class CompletionCommand(Command):
     ignore_require_venv = True
 
     def __init__(self, *args, **kw):
+        # type: (*Any, **Any) -> None
         super(CompletionCommand, self).__init__(*args, **kw)
 
         cmd_opts = self.cmd_opts
@@ -80,6 +84,7 @@ class CompletionCommand(Command):
         self.parser.insert_option_group(0, cmd_opts)
 
     def run(self, options, args):
+        #  type: (Values, List[Any]) -> int
         """Prints the completion code of the given shell"""
         shells = COMPLETION_SCRIPTS.keys()
         shell_options = ['--' + shell for shell in sorted(shells)]
@@ -89,7 +94,9 @@ class CompletionCommand(Command):
                     prog=get_prog())
             )
             print(BASE_COMPLETION.format(script=script, shell=options.shell))
+            return SUCCESS
         else:
             sys.stderr.write(
                 'ERROR: You must pass {}\n' .format(' or '.join(shell_options))
             )
+            return ERROR

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -84,7 +84,7 @@ class CompletionCommand(Command):
         self.parser.insert_option_group(0, cmd_opts)
 
     def run(self, options, args):
-        #  type: (Values, List[Any]) -> int
+        #  type: (Values, List[str]) -> int
         """Prints the completion code of the given shell"""
         shells = COMPLETION_SCRIPTS.keys()
         shell_options = ['--' + shell for shell in sorted(shells)]

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -4,7 +4,7 @@ import sys
 import textwrap
 
 from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import ERROR, SUCCESS
+from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.utils.misc import get_prog
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -99,4 +99,4 @@ class CompletionCommand(Command):
             sys.stderr.write(
                 'ERROR: You must pass {}\n' .format(' or '.join(shell_options))
             )
-            return ERROR
+            return SUCCESS

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -1,6 +1,3 @@
-# The following comment should be removed at some point in the future.
-# mypy: disallow-untyped-defs=False
-
 from __future__ import absolute_import
 
 import locale
@@ -67,7 +64,6 @@ def create_vendor_txt_map():
 
 def get_module_from_module_name(module_name):
     # type: (str) -> ModuleType
-
     # Module name can be uppercase in vendor.txt for some reason...
     module_name = module_name.lower()
     # PATCH: setuptools is actually only pkg_resources.
@@ -85,7 +81,6 @@ def get_module_from_module_name(module_name):
 
 def get_vendor_version_from_module(module_name):
     # type: (str) -> str
-
     module = get_module_from_module_name(module_name)
     version = getattr(module, '__version__', None)
 
@@ -169,6 +164,7 @@ def show_tags(options):
 
 
 def ca_bundle_info(config):
+    # type: (Dict[str, str]) -> str
     levels = set()
     for key, value in config.items():
         levels.add(key.split('.')[0])
@@ -197,6 +193,7 @@ class DebugCommand(Command):
     ignore_require_venv = True
 
     def __init__(self, *args, **kw):
+        # type: (*Any, **Any) -> None
         super(DebugCommand, self).__init__(*args, **kw)
 
         cmd_opts = self.cmd_opts

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -80,7 +80,7 @@ def get_module_from_module_name(module_name):
 
 
 def get_vendor_version_from_module(module_name):
-    # type: (str) -> str
+    # type: (str) -> Optional[str]
     module = get_module_from_module_name(module_name)
     version = getattr(module, '__version__', None)
 

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -202,7 +202,7 @@ class DebugCommand(Command):
         self.parser.config.load()
 
     def run(self, options, args):
-        # type: (Values, List[Any]) -> int
+        # type: (Values, List[str]) -> int
         logger.warning(
             "This command is only meant for debugging. "
             "Do not use this with automation for parsing and getting these "

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -107,9 +107,10 @@ def test_completion_alone(autocomplete_script):
     """
     Test getting completion for none shell, just pip completion
     """
-    result = autocomplete_script.pip('completion', allow_stderr_error=True)
+    result = autocomplete_script.pip('completion', expect_error=True)
     assert 'ERROR: You must pass --bash or --fish or --zsh' in result.stderr, \
            'completion alone failed -- ' + result.stderr
+    assert result.returncode == 1
 
 
 def test_completion_for_un_snippet(autocomplete):
@@ -314,3 +315,4 @@ def test_completion_uses_same_executable_name(
         executable_name, 'completion', flag, expect_stderr=deprecated_python,
     )
     assert executable_name in result.stdout
+    assert result.returncode == 0

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -107,10 +107,9 @@ def test_completion_alone(autocomplete_script):
     """
     Test getting completion for none shell, just pip completion
     """
-    result = autocomplete_script.pip('completion', expect_error=True)
+    result = autocomplete_script.pip('completion', allow_stderr_error=True)
     assert 'ERROR: You must pass --bash or --fish or --zsh' in result.stderr, \
            'completion alone failed -- ' + result.stderr
-    assert result.returncode == 1
 
 
 def test_completion_for_un_snippet(autocomplete):
@@ -315,4 +314,3 @@ def test_completion_uses_same_executable_name(
         executable_name, 'completion', flag, expect_stderr=deprecated_python,
     )
     assert executable_name in result.stdout
-    assert result.returncode == 0


### PR DESCRIPTION
Towards #4748 

Added type annotations to `pip._internal.commands.completion` and ` pip._internal.commands.debug`