### PR TITLE
Better names in `PackageFinder`

### DIFF
--- a/docs/html/development/architecture/package-finding.rst
+++ b/docs/html/development/architecture/package-finding.rst
@@ -223,7 +223,7 @@ attributes are needed only for ``CandidateEvaluator``.
 .. _evaluated-candidate-result-class:
 
 The ``EvaluatedCandidatesResult`` class
-*********************************
+***************************************
 
 The ``EvaluatedCandidatesResult`` class is a convenience "container" class that
 encapsulates the result of finding the best candidate for a requirement.

--- a/docs/html/development/architecture/package-finding.rst
+++ b/docs/html/development/architecture/package-finding.rst
@@ -108,7 +108,7 @@ One of ``PackageFinder``'s main top-level methods is
    :ref:`Overview <index-overview>` above.
 2. Constructs a ``CandidateEvaluator`` object and uses that to determine
    the best candidate. It does this by calling the ``CandidateEvaluator``
-   class's ``compute_best_candidate()`` method on the return value of
+   class's ``evaluate_candidates()`` method on the return value of
    ``find_all_candidates()``. This corresponds to steps 4-5 of the Overview.
 
 ``PackageFinder`` also has a ``process_project_url()`` method (called by
@@ -194,7 +194,7 @@ them to a list of "applicable" candidates and orders them by preference.
 The ``CandidateEvaluator`` class also has a ``sort_best_candidate()`` method
 that returns the best (i.e. most preferred) candidate.
 
-Finally, the class has a ``compute_best_candidate()`` method that calls
+Finally, the class has a ``evaluate_candidates()`` method that calls
 ``get_applicable_candidates()`` followed by ``sort_best_candidate()``, and
 then returning a :ref:`EvaluatedCandidatesResult <evaluated-candidate-result-class>`
 object encapsulating both the intermediate and final results of the decision.
@@ -232,8 +232,7 @@ business logic or state-changing methods of its own.) It stores not just the
 final result but also intermediate values used to determine the result.
 
 The class is the return type of both the ``CandidateEvaluator`` class's
-``compute_best_candidate()`` method and the ``PackageFinder`` class's
-``find_best_candidate()`` method.
+``evaluate_candidates()`` method and the ``PackageFinder`` class's
 
 
 .. _`PEP 425`: https://www.python.org/dev/peps/pep-0425/

--- a/docs/html/development/architecture/package-finding.rst
+++ b/docs/html/development/architecture/package-finding.rst
@@ -45,7 +45,7 @@ classes inside the ``index`` package, in the following order:
 * the :ref:`LinkEvaluator <link-evaluator-class>` class,
 * the :ref:`CandidateEvaluator <candidate-evaluator-class>` class,
 * the :ref:`CandidatePreferences <candidate-preferences-class>` class, and
-* the :ref:`BestCandidateResult <best-candidate-result-class>` class.
+* the :ref:`EvaluatedCandidatesResult <evaluated-candidate-result-class>` class.
 
 
 .. _package-finder-class:
@@ -196,7 +196,7 @@ that returns the best (i.e. most preferred) candidate.
 
 Finally, the class has a ``compute_best_candidate()`` method that calls
 ``get_applicable_candidates()`` followed by ``sort_best_candidate()``, and
-then returning a :ref:`BestCandidateResult <best-candidate-result-class>`
+then returning a :ref:`EvaluatedCandidatesResult <evaluated-candidate-result-class>`
 object encapsulating both the intermediate and final results of the decision.
 
 Instances of ``CandidateEvaluator`` are created by the ``PackageFinder``
@@ -220,12 +220,12 @@ preferences specific to ``CandidateEvaluator`` helps maintainers know which
 attributes are needed only for ``CandidateEvaluator``.
 
 
-.. _best-candidate-result-class:
+.. _evaluated-candidate-result-class:
 
-The ``BestCandidateResult`` class
+The ``EvaluatedCandidatesResult`` class
 *********************************
 
-The ``BestCandidateResult`` class is a convenience "container" class that
+The ``EvaluatedCandidatesResult`` class is a convenience "container" class that
 encapsulates the result of finding the best candidate for a requirement.
 (By "container" we mean an object that simply contains data and has no
 business logic or state-changing methods of its own.) It stores not just the

--- a/docs/html/development/architecture/package-finding.rst
+++ b/docs/html/development/architecture/package-finding.rst
@@ -96,7 +96,7 @@ sorting by preference the candidates for install coming from the relevant
 links.
 
 One of ``PackageFinder``'s main top-level methods is
-``find_best_candidate()``. This method does the following two things:
+``find_evaluated_candidates()``. This method does the following two things:
 
 1. Calls its ``find_all_candidates()`` method, which gathers all
    possible package links by reading and parsing the index URL's and
@@ -112,7 +112,7 @@ One of ``PackageFinder``'s main top-level methods is
    ``find_all_candidates()``. This corresponds to steps 4-5 of the Overview.
 
 ``PackageFinder`` also has a ``process_project_url()`` method (called by
-``find_best_candidate()``) to process a `PEP 503`_ "simple repository"
+``find_evaluated_candidates()``) to process a `PEP 503`_ "simple repository"
 project page. This method fetches and parses the HTML from a PEP 503 project
 page URL, extracts the anchor elements and creates ``Link`` objects from
 them, and then evaluates those links.
@@ -233,6 +233,7 @@ final result but also intermediate values used to determine the result.
 
 The class is the return type of both the ``CandidateEvaluator`` class's
 ``evaluate_candidates()`` method and the ``PackageFinder`` class's
+``find_evaluated_candidates()`` method.
 
 
 .. _`PEP 425`: https://www.python.org/dev/peps/pep-0425/

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -338,7 +338,8 @@ class CandidatePreferences(object):
 
 
 class EvaluatedCandidatesResult(object):
-    """A collection of candidates, returned by `PackageFinder.find_best_candidate`.
+    """A collection of candidates, returned by `PackageFinder`'s
+    `find_evaluated_candidates` method.
 
     This class is only intended to be instantiated by CandidateEvaluator's
     `evaluate_candidates()` method.
@@ -865,7 +866,7 @@ class PackageFinder(object):
             hashes=hashes,
         )
 
-    def find_best_candidate(
+    def find_evaluated_candidates(
         self,
         project_name,       # type: str
         specifier=None,     # type: Optional[specifiers.BaseSpecifier]
@@ -897,10 +898,10 @@ class PackageFinder(object):
         Raises DistributionNotFound or BestVersionAlreadyInstalled otherwise
         """
         hashes = req.hashes(trust_internet=False)
-        best_candidate_result = self.find_best_candidate(
+        evaluated_candidates = self.find_evaluated_candidates(
             req.name, specifier=req.specifier, hashes=hashes,
         )
-        best_candidate = best_candidate_result.best_candidate
+        best_candidate = evaluated_candidates.best_candidate
 
         installed_version = None    # type: Optional[_BaseVersion]
         if req.satisfied_by is not None:
@@ -922,7 +923,7 @@ class PackageFinder(object):
                 'Could not find a version that satisfies the requirement %s '
                 '(from versions: %s)',
                 req,
-                _format_versions(best_candidate_result.iter_all()),
+                _format_versions(evaluated_candidates.iter_all()),
             )
 
             raise DistributionNotFound(
@@ -958,14 +959,14 @@ class PackageFinder(object):
                 'Installed version (%s) is most up-to-date (past versions: '
                 '%s)',
                 installed_version,
-                _format_versions(best_candidate_result.iter_applicable()),
+                _format_versions(evaluated_candidates.iter_applicable()),
             )
             raise BestVersionAlreadyInstalled
 
         logger.debug(
             'Using version %s (newest of versions: %s)',
             best_candidate.version,
-            _format_versions(best_candidate_result.iter_applicable()),
+            _format_versions(evaluated_candidates.iter_applicable()),
         )
         return best_candidate.link
 

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -341,7 +341,7 @@ class EvaluatedCandidatesResult(object):
     """A collection of candidates, returned by `PackageFinder.find_best_candidate`.
 
     This class is only intended to be instantiated by CandidateEvaluator's
-    `compute_best_candidate()` method.
+    `evaluate_candidates()` method.
     """
 
     def __init__(
@@ -575,7 +575,7 @@ class CandidateEvaluator(object):
 
         return best_candidate
 
-    def compute_best_candidate(
+    def evaluate_candidates(
         self,
         candidates,      # type: List[InstallationCandidate]
     ):
@@ -886,7 +886,7 @@ class PackageFinder(object):
             specifier=specifier,
             hashes=hashes,
         )
-        return candidate_evaluator.compute_best_candidate(candidates)
+        return candidate_evaluator.evaluate_candidates(candidates)
 
     def find_requirement(self, req, upgrade):
         # type: (InstallRequirement, bool) -> Optional[Link]

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -52,7 +52,7 @@ if MYPY_CHECK_RUNNING:
     )
 
 
-__all__ = ['FormatControl', 'BestCandidateResult', 'PackageFinder']
+__all__ = ['FormatControl', 'EvaluatedCandidatesResult', 'PackageFinder']
 
 
 logger = logging.getLogger(__name__)
@@ -337,7 +337,7 @@ class CandidatePreferences(object):
         self.prefer_binary = prefer_binary
 
 
-class BestCandidateResult(object):
+class EvaluatedCandidatesResult(object):
     """A collection of candidates, returned by `PackageFinder.find_best_candidate`.
 
     This class is only intended to be instantiated by CandidateEvaluator's
@@ -579,15 +579,15 @@ class CandidateEvaluator(object):
         self,
         candidates,      # type: List[InstallationCandidate]
     ):
-        # type: (...) -> BestCandidateResult
+        # type: (...) -> EvaluatedCandidatesResult
         """
-        Compute and return a `BestCandidateResult` instance.
+        Compute and return a `EvaluatedCandidatesResult` instance.
         """
         applicable_candidates = self.get_applicable_candidates(candidates)
 
         best_candidate = self.sort_best_candidate(applicable_candidates)
 
-        return BestCandidateResult(
+        return EvaluatedCandidatesResult(
             candidates,
             applicable_candidates=applicable_candidates,
             best_candidate=best_candidate,
@@ -871,14 +871,14 @@ class PackageFinder(object):
         specifier=None,     # type: Optional[specifiers.BaseSpecifier]
         hashes=None,        # type: Optional[Hashes]
     ):
-        # type: (...) -> BestCandidateResult
+        # type: (...) -> EvaluatedCandidatesResult
         """Find matches for the given project and specifier.
 
         :param specifier: An optional object implementing `filter`
             (e.g. `packaging.specifiers.SpecifierSet`) to filter applicable
             versions.
 
-        :return: A `BestCandidateResult` instance.
+        :return: A `EvaluatedCandidatesResult` instance.
         """
         candidates = self.find_all_candidates(project_name)
         candidate_evaluator = self.make_candidate_evaluator(

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -65,7 +65,7 @@ class SpecifierRequirement(Requirement):
 
     def find_matches(self):
         # type: () -> Sequence[Candidate]
-        found = self._factory.finder.find_best_candidate(
+        found = self._factory.finder.find_evaluated_candidates(
             project_name=self._ireq.req.name,
             specifier=self._ireq.req.specifier,
             hashes=self._ireq.hashes(trust_internet=False),

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -204,7 +204,7 @@ def pip_self_version_check(session, options):
                 link_collector=link_collector,
                 selection_prefs=selection_prefs,
             )
-            best_candidate = finder.find_best_candidate("pip").best_candidate
+            best_candidate = finder.find_evaluated_candidates("pip").best_candidate
             if best_candidate is None:
                 return
             pypi_version = str(best_candidate.version)

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -204,7 +204,9 @@ def pip_self_version_check(session, options):
                 link_collector=link_collector,
                 selection_prefs=selection_prefs,
             )
-            best_candidate = finder.find_evaluated_candidates("pip").best_candidate
+            best_candidate = (
+                finder.find_evaluated_candidates("pip").best_candidate
+            )
             if best_candidate is None:
                 return
             pypi_version = str(best_candidate.version)

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -381,7 +381,7 @@ class TestCandidateEvaluator:
         actual_versions = [str(c.version) for c in actual]
         assert actual_versions == expected_versions
 
-    def test_compute_best_candidate(self):
+    def test_evaluate_candidates(self):
         specifier = SpecifierSet('<= 1.11')
         versions = ['1.10', '1.11', '1.12']
         candidates = [
@@ -391,7 +391,7 @@ class TestCandidateEvaluator:
             'my-project',
             specifier=specifier,
         )
-        result = evaluator.compute_best_candidate(candidates)
+        result = evaluator.evaluate_candidates(candidates)
 
         assert result._candidates == candidates
         expected_applicable = candidates[:2]
@@ -403,7 +403,7 @@ class TestCandidateEvaluator:
 
         assert result.best_candidate is expected_applicable[1]
 
-    def test_compute_best_candidate__none_best(self):
+    def test_evaluate_candidates__none_best(self):
         """
         Test returning a None best candidate.
         """
@@ -416,7 +416,7 @@ class TestCandidateEvaluator:
             'my-project',
             specifier=specifier,
         )
-        result = evaluator.compute_best_candidate(candidates)
+        result = evaluator.evaluate_candidates(candidates)
 
         assert result._candidates == candidates
         assert result._applicable_candidates == []

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -114,7 +114,7 @@ class MockPackageFinder(object):
     def create(cls, *args, **kwargs):
         return cls()
 
-    def find_all_candidates(self, project_name):
+    def find_evaluated_candidates(self, project_name):
         return MockEvaluatedCandidatesResult(self.INSTALLATION_CANDIDATES[0])
 
 

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -92,7 +92,7 @@ def test_make_link_collector__find_links_expansion(mock_expanduser, tmpdir):
     assert search_scope.index_urls == ['default_url']
 
 
-class MockBestCandidateResult(object):
+class MockEvaluatedCandidatesResult(object):
     def __init__(self, best):
         self.best_candidate = best
 
@@ -114,8 +114,8 @@ class MockPackageFinder(object):
     def create(cls, *args, **kwargs):
         return cls()
 
-    def find_best_candidate(self, project_name):
-        return MockBestCandidateResult(self.INSTALLATION_CANDIDATES[0])
+    def find_all_candidates(self, project_name):
+        return MockEvaluatedCandidatesResult(self.INSTALLATION_CANDIDATES[0])
 
 
 class MockDistribution(object):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Based on a discussion w/ @pfmoore and @uranusjr about how using `find_best_candidate` for the new resolver feels wrong, since we're not actually using the "best" choice made by `CandidateEvaluator` since that's actually not the correct approach to dependency resolution.
