### PR TITLE
Canonicalize req name while doing pre-install package search

### DIFF
--- a/news/5021.bugfix
+++ b/news/5021.bugfix
@@ -1,0 +1,1 @@
+Package name should be normalized before we use it to search if it's already installed or not

--- a/news/5021.bugfix
+++ b/news/5021.bugfix
@@ -1,1 +1,1 @@
-Package name should be normalized before we use it to search if it's already installed or not
+Use canonical package names while looking up already installed packages.

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -19,7 +19,6 @@ from pip._internal.models.index import PyPI
 from pip._internal.network.xmlrpc import PipXmlrpcTransport
 from pip._internal.utils.compat import get_terminal_size
 from pip._internal.utils.logging import indent_log
-
 from pip._internal.utils.misc import get_distribution, write_output
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -31,7 +30,6 @@ if MYPY_CHECK_RUNNING:
         'TransformedHit',
         {'name': str, 'summary': str, 'versions': List[str]},
     )
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -19,7 +19,8 @@ from pip._internal.models.index import PyPI
 from pip._internal.network.xmlrpc import PipXmlrpcTransport
 from pip._internal.utils.compat import get_terminal_size
 from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import write_output
+
+from pip._internal.utils.misc import get_distribution, write_output
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -30,6 +31,7 @@ if MYPY_CHECK_RUNNING:
         'TransformedHit',
         {'name': str, 'summary': str, 'versions': List[str]},
     )
+
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +141,7 @@ def print_results(hits, name_column_width=None, terminal_width=None):
         try:
             write_output(line)
             if name in installed_packages:
-                dist = pkg_resources.get_distribution(name)
+                dist = get_distribution(name)
                 with indent_log():
                     if dist.version == latest:
                         write_output('INSTALLED: %s (latest)', dist.version)

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -428,12 +428,16 @@ class InstallRequirement(object):
         """
         if self.req is None:
             return
+
+        # Canonicalize requirement name to use normalized
+        # names while searching for already installed packages
+        no_marker = Requirement(str(self.req))
+        no_marker.marker = None
+        no_marker.name = canonicalize_name(no_marker.name)
         # get_distribution() will resolve the entire list of requirements
         # anyway, and we've already determined that we need the requirement
         # in question, so strip the marker so that we don't try to
         # evaluate it.
-        no_marker = Requirement(str(self.req))
-        no_marker.marker = None
         try:
             self.satisfied_by = pkg_resources.get_distribution(str(no_marker))
         except pkg_resources.DistributionNotFound:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -41,6 +41,7 @@ from pip._internal.utils.misc import (
     display_path,
     dist_in_site_packages,
     dist_in_usersite,
+    get_distribution,
     get_installed_version,
     hide_url,
     redact_auth_from_url,
@@ -429,21 +430,23 @@ class InstallRequirement(object):
         if self.req is None:
             return
 
-        # Canonicalize requirement name to use normalized
-        # names while searching for already installed packages
-        no_marker = Requirement(str(self.req))
-        no_marker.marker = None
-        no_marker.name = canonicalize_name(no_marker.name)
         # get_distribution() will resolve the entire list of requirements
         # anyway, and we've already determined that we need the requirement
         # in question, so strip the marker so that we don't try to
         # evaluate it.
+        no_marker = Requirement(str(self.req))
+        no_marker.marker = None
+
+        # pkg_resources uses the canonical name to look up packages, but
+        # the name passed passed to get_distribution is not canonicalized
+        # so we have to explicitly convert it to a canonical name
+        no_marker.name = canonicalize_name(no_marker.name)
         try:
             self.satisfied_by = pkg_resources.get_distribution(str(no_marker))
         except pkg_resources.DistributionNotFound:
             return
         except pkg_resources.VersionConflict:
-            existing_dist = pkg_resources.get_distribution(
+            existing_dist = get_distribution(
                 self.req.name
             )
             if use_user_site:
@@ -683,13 +686,11 @@ class InstallRequirement(object):
 
         """
         assert self.req
-        try:
-            dist = pkg_resources.get_distribution(self.req.name)
-        except pkg_resources.DistributionNotFound:
+        dist = get_distribution(self.req.name)
+        if not dist:
             logger.warning("Skipping %s as it is not installed.", self.name)
             return None
-        else:
-            logger.info('Found existing installation: %s', dist)
+        logger.info('Found existing installation: %s', dist)
 
         uninstalled_pathset = UninstallPathSet.from_dist(dist)
         uninstalled_pathset.remove(auto_confirm, verbose)

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -429,7 +429,6 @@ class InstallRequirement(object):
         """
         if self.req is None:
             return
-
         # get_distribution() will resolve the entire list of requirements
         # anyway, and we've already determined that we need the requirement
         # in question, so strip the marker so that we don't try to

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -7,7 +7,6 @@ import logging
 import os.path
 import sys
 
-from pip._vendor import pkg_resources
 from pip._vendor.packaging import version as packaging_version
 from pip._vendor.six import ensure_binary
 
@@ -19,7 +18,11 @@ from pip._internal.utils.filesystem import (
     check_path_owner,
     replace,
 )
-from pip._internal.utils.misc import ensure_dir, get_installed_version
+from pip._internal.utils.misc import (
+    ensure_dir,
+    get_distribution,
+    get_installed_version,
+)
 from pip._internal.utils.packaging import get_installer
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -110,11 +113,10 @@ def was_installed_by_pip(pkg):
     This is used not to display the upgrade message when pip is in fact
     installed by system package manager, such as dnf on Fedora.
     """
-    try:
-        dist = pkg_resources.get_distribution(pkg)
-        return "pip" == get_installer(dist)
-    except pkg_resources.DistributionNotFound:
+    dist = get_distribution(pkg)
+    if not dist:
         return False
+    return "pip" == get_installer(dist)
 
 
 def pip_self_version_check(session, options):

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -18,9 +18,9 @@ import sys
 from collections import deque
 
 from pip._vendor import pkg_resources
+from pip._vendor.packaging.utils import canonicalize_name
 # NOTE: retrying is not annotated in typeshed as on 2017-07-17, which is
 #       why we ignore the type on this import.
-from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.retrying import retry  # type: ignore
 from pip._vendor.six import PY2, text_type
 from pip._vendor.six.moves import input, map, zip_longest

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1884,7 +1884,10 @@ def test_install_skip_work_dir_pkg(script, data):
     assert 'Successfully installed simple' in result.stdout
 
 
-def test_install_verify_package_name_normalization(script):
+@pytest.mark.parametrize('package_name', ('simple-package', 'simple_package',
+                                          'simple.package'))
+def test_install_verify_package_name_normalization(script, package_name):
+
     """
     Test that install of a package again using a name which
     normalizes to the original package name, is a no-op
@@ -1896,6 +1899,6 @@ def test_install_verify_package_name_normalization(script):
                         expect_stderr=True, cwd=pkg_path)
     assert 'Successfully installed simple-package' in result.stdout
 
-    result = script.pip('install', 'simple.package')
-    assert 'Requirement already satisfied: simple.package' in result.stdout
-
+    result = script.pip('install', package_name)
+    assert 'Requirement already satisfied: {}'.format(
+        package_name) in result.stdout

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1882,3 +1882,20 @@ def test_install_skip_work_dir_pkg(script, data):
 
     assert 'Requirement already satisfied: simple' not in result.stdout
     assert 'Successfully installed simple' in result.stdout
+
+
+def test_install_verify_package_name_normalization(script):
+    """
+    Test that install of a package again using a name which
+    normalizes to the original package name, is a no-op
+    since the package is already installed
+    """
+    pkg_path = create_test_package_with_setup(
+        script, name='simple-package', version='1.0')
+    result = script.pip('install', '-e', '.',
+                        expect_stderr=True, cwd=pkg_path)
+    assert 'Successfully installed simple-package' in result.stdout
+
+    result = script.pip('install', 'simple.package')
+    assert 'Requirement already satisfied: simple.package' in result.stdout
+

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -168,7 +168,8 @@ def test_latest_prerelease_install_message(caplog, monkeypatch):
 
     dist = pretend.stub(version="1.0.0")
     get_dist = pretend.call_recorder(lambda x: dist)
-    monkeypatch.setattr("pip._vendor.pkg_resources.get_distribution", get_dist)
+    monkeypatch.setattr("pip._internal.commands.search.get_distribution",
+                        get_dist)
     with caplog.at_level(logging.INFO):
         print_results(hits)
 

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -6,7 +6,6 @@ import sys
 import freezegun
 import pretend
 import pytest
-from pip._vendor import pkg_resources
 
 from pip._internal import self_outdated_check
 from pip._internal.models.candidate import InstallationCandidate
@@ -98,7 +97,7 @@ def test_pip_self_version_check(monkeypatch, stored_time, installed_ver,
                         pretend.call_recorder(lambda *a, **kw: None))
     monkeypatch.setattr(logger, 'debug',
                         pretend.call_recorder(lambda s, exc_info=None: None))
-    monkeypatch.setattr(pkg_resources, 'get_distribution',
+    monkeypatch.setattr(self_outdated_check, 'get_distribution',
                         lambda name: MockDistribution(installer))
 
     fake_state = pretend.stub(


### PR DESCRIPTION
Fixes and closes #5021 

Package name should be normalized before we use it to search if it's already installed or not. This will avoid cases like for e.g. `pip install fluent.logger` running install again, if `pip install fluent-logger` was already run,  by ensuring that `fluent.logger` is normalized to `fluent-logger`