### PR TITLE
Avoid RequirementSet before reaching the resolver

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -25,7 +25,6 @@ from pip._internal.req.constructors import (
     install_req_from_req_string,
 )
 from pip._internal.req.req_file import parse_requirements
-from pip._internal.req.req_set import RequirementSet
 from pip._internal.self_outdated_check import (
     make_link_collector,
     pip_self_version_check,
@@ -296,15 +295,12 @@ class RequirementCommand(IndexGroupCommand):
         options,          # type: Values
         finder,           # type: PackageFinder
         session,          # type: PipSession
-        check_supported_wheels=True,  # type: bool
     ):
         # type: (...) -> List[InstallRequirement]
         """
         Parse command-line arguments into the corresponding requirements.
         """
-        requirement_set = RequirementSet(
-            check_supported_wheels=check_supported_wheels
-        )
+        requirements = []  # type: List[InstallRequirement]
         for filename in options.constraints:
             for parsed_req in parse_requirements(
                     filename,
@@ -315,7 +311,7 @@ class RequirementCommand(IndexGroupCommand):
                     isolated=options.isolated_mode,
                 )
                 req_to_add.is_direct = True
-                requirement_set.add_requirement(req_to_add)
+                requirements.append(req_to_add)
 
         for req in args:
             req_to_add = install_req_from_line(
@@ -323,7 +319,7 @@ class RequirementCommand(IndexGroupCommand):
                 use_pep517=options.use_pep517,
             )
             req_to_add.is_direct = True
-            requirement_set.add_requirement(req_to_add)
+            requirements.append(req_to_add)
 
         for req in options.editables:
             req_to_add = install_req_from_editable(
@@ -332,7 +328,7 @@ class RequirementCommand(IndexGroupCommand):
                 use_pep517=options.use_pep517,
             )
             req_to_add.is_direct = True
-            requirement_set.add_requirement(req_to_add)
+            requirements.append(req_to_add)
 
         # NOTE: options.require_hashes may be set if --require-hashes is True
         for filename in options.requirements:
@@ -345,10 +341,9 @@ class RequirementCommand(IndexGroupCommand):
                     use_pep517=options.use_pep517
                 )
                 req_to_add.is_direct = True
-                requirement_set.add_requirement(req_to_add)
+                requirements.append(req_to_add)
 
         # If any requirement has hash options, enable hash checking.
-        requirements = requirement_set.all_requirements
         if any(req.has_hash_options for req in requirements):
             options.require_hashes = True
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -297,10 +297,7 @@ class InstallCommand(RequirementCommand):
         )
 
         try:
-            reqs = self.get_requirements(
-                args, options, finder, session,
-                check_supported_wheels=not options.target_dir,
-            )
+            reqs = self.get_requirements(args, options, finder, session)
 
             warn_deprecated_install_options(
                 reqs, options.install_options

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -174,7 +174,7 @@ class Resolver(BaseResolver):
         # based on link type.
         discovered_reqs = []  # type: List[InstallRequirement]
         hash_errors = HashErrors()
-        for req in chain(root_reqs, discovered_reqs):
+        for req in chain(requirement_set.all_requirements, discovered_reqs):
             try:
                 discovered_reqs.extend(self._resolve_one(requirement_set, req))
             except HashError as exc:


### PR DESCRIPTION
Closes #7571 

The `RequirementSet` implementation conflates requirements incorrectly in a lot of places. This means the (new) resolver would get incomplete requirements.

The removes all `RequirementSet.add_requirement()` calls outside of the legacy resolver, so the new resolver can get the unmodified list of requirements specified by the user, allowing for more sophisticated requirement merging.

This will need some additional new resolver tests from #8059 to make sure it has an effect.