### PR TITLE
fix normalize path for Windows

### DIFF
--- a/news/7625.bugfix
+++ b/news/7625.bugfix
@@ -1,0 +1,1 @@
+Fix normalizing path on Windows when installing package on another logical disk.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -262,7 +262,11 @@ def _record_to_fs_path(record_path):
 def _fs_to_record_path(path, relative_to=None):
     # type: (text_type, Optional[text_type]) -> RecordPath
     if relative_to is not None:
-        path = os.path.relpath(path, relative_to)
+        # On Windows, do not handle relative paths if they belong to different
+        # logical disks
+        if os.path.splitdrive(path)[0].lower() == \
+                os.path.splitdrive(relative_to)[0].lower():
+            path = os.path.relpath(path, relative_to)
     path = path.replace(os.path.sep, '/')
     return cast('RecordPath', path)
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Fixes #7625 
