### PR TITLE
Wheel cache link look up in the new resolver

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -244,7 +244,6 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             link = cache_entry.link
         ireq = make_install_req_from_link(link, parent)
 
-        # TODO: Is this logic setting original_link_is_in_wheel_cache correct?
         if (cache_entry is not None and
                 cache_entry.persistent and
                 parent.link is parent.original_link):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -238,9 +238,21 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
         version=None,  # type: Optional[_BaseVersion]
     ):
         # type: (...) -> None
+        cache_entry = factory.get_wheel_cache_entry(link, name)
+        if cache_entry is not None:
+            logger.debug("Using cached wheel link: %s", cache_entry.link)
+            link = cache_entry.link
+        ireq = make_install_req_from_link(link, parent)
+
+        # TODO: Is this logic setting original_link_is_in_wheel_cache correct?
+        if (cache_entry is not None and
+                cache_entry.persistent and
+                parent.link is parent.original_link):
+            ireq.original_link_is_in_wheel_cache = True
+
         super(LinkCandidate, self).__init__(
             link=link,
-            ireq=make_install_req_from_link(link, parent),
+            ireq=ireq,
             factory=factory,
             name=name,
             version=version,

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -230,7 +230,7 @@ class Factory(object):
         because cached wheels, always built locally, have different hashes
         than the files downloaded from the index server and thus throw false
         hash mismatches. Furthermore, cached wheels at present have
-        undeterministic contents due to file modification times.
+        nondeterministic contents due to file modification times.
         """
         if self._wheel_cache is None or self.preparer.require_hashes:
             return None

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -101,11 +101,11 @@ class Factory(object):
 
     def _make_candidate_from_link(
         self,
-        link,          # type: Link
-        extras,        # type: Set[str]
-        parent,        # type: InstallRequirement
-        name=None,     # type: Optional[str]
-        version=None,  # type: Optional[_BaseVersion]
+        link,  # type: Link
+        extras,  # type: Set[str]
+        parent,  # type: InstallRequirement
+        name,  # type: Optional[str]
+        version,  # type: Optional[_BaseVersion]
     ):
         # type: (...) -> Candidate
         # TODO: Check already installed candidate, and use it if the link and
@@ -176,15 +176,16 @@ class Factory(object):
 
     def make_requirement_from_install_req(self, ireq):
         # type: (InstallRequirement) -> Requirement
-        if ireq.link:
-            # TODO: Get name and version from ireq, if possible?
-            #       Specifically, this might be needed in "name @ URL"
-            #       syntax - need to check where that syntax is handled.
-            candidate = self._make_candidate_from_link(
-                ireq.link, extras=set(ireq.extras), parent=ireq,
-            )
-            return self.make_requirement_from_candidate(candidate)
-        return SpecifierRequirement(ireq, factory=self)
+        if not ireq.link:
+            return SpecifierRequirement(ireq, factory=self)
+        cand = self._make_candidate_from_link(
+            ireq.link,
+            extras=set(ireq.extras),
+            parent=ireq,
+            name=canonicalize_name(ireq.name) if ireq.name else None,
+            version=None,
+        )
+        return self.make_requirement_from_candidate(cand)
 
     def make_requirement_from_candidate(self, candidate):
         # type: (Candidate) -> ExplicitRequirement

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -88,6 +88,7 @@ class Resolver(BaseResolver):
             finder=finder,
             preparer=preparer,
             make_install_req=make_install_req,
+            wheel_cache=wheel_cache,
             use_user_site=use_user_site,
             force_reinstall=force_reinstall,
             ignore_installed=ignore_installed,

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -52,6 +52,7 @@ def factory(finder, preparer):
         finder=finder,
         preparer=preparer,
         make_install_req=install_req_from_line,
+        wheel_cache=None,
         use_user_site=False,
         force_reinstall=False,
         ignore_installed=False,


### PR DESCRIPTION
Very much a work in progress. I managed to fix `test_pip_wheel_build_cache`, but not `test_install_git_sha_cached`. I’m not even sure if the latter one is actually related to the wheel cache now.

I’m also having trouble implementing PEP 610 (equivalent of #7612). `test_install_find_links_no_direct_url` does not pass, and I can’t figure out if my `original_link_is_in_wheel_cache` is sane. Are these two the same thing? I have no idea :(