### PR TITLE
Canonicalise package name in tests.lib.create_basic_wheel_for_package

### DIFF
--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -587,3 +587,16 @@ def test_wheel_install_fails_with_badly_encoded_metadata(script):
     assert "Error decoding metadata for" in result.stderr
     assert "simple-0.1.0-py2.py3-none-any.whl" in result.stderr
     assert "METADATA" in result.stderr
+
+
+@pytest.mark.parametrize(
+    'package_name',
+    ['simple-package', 'simple_package'],
+)
+def test_correct_package_name_while_creating_wheel_bug(script, package_name):
+    """Check that the package name is correctly named while creating
+    a .whl file with a given format
+    """
+    package = create_basic_wheel_for_package(script, package_name, '1.0')
+    wheel_name = os.path.basename(package)
+    assert wheel_name == 'simple_package-1.0-py2.py3-none-any.whl'

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -994,6 +994,9 @@ def create_basic_wheel_for_package(
     if extra_files is None:
         extra_files = {}
 
+    # Fix wheel distribution name by replacing runs of non-alphanumeric
+    # characters with an underscore _ as per PEP 491
+    name = re.sub(r"[^\w\d.]+", "_", name, re.UNICODE)
     archive_name = "{}-{}-py2.py3-none-any.whl".format(name, version)
     archive_path = script.scratch_path / archive_name
 


### PR DESCRIPTION
Fixes and closes https://github.com/pypa/pip/issues/8064

Use a canonical package name while creating the wheel file name in `tests.lib.create_basic_wheel_for_package` using [PEP 491 Escaping and Unicode](https://www.python.org/dev/peps/pep-0491/#escaping-and-unicode). 

Since it's a bug fix in the unit tests and won't affect the end-user, marking it as trivial.
