### PR TITLE
Fix pip config docstring to render correctly in docs

### DIFF
--- a/news/8072.doc
+++ b/news/8072.doc
@@ -1,0 +1,1 @@
+Fix pip config docstring so that the subcommands render correctly in the docs

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -19,15 +19,16 @@ logger = logging.getLogger(__name__)
 
 
 class ConfigurationCommand(Command):
-    """Manage local and global configuration.
+    """
+    Manage local and global configuration.
 
     Subcommands:
 
-        list: List the active configuration (or from the file specified)
-        edit: Edit the configuration file in an editor
-        get: Get the value associated with name
-        set: Set the name=value
-        unset: Unset the value associated with name
+    - list: List the active configuration (or from the file specified)
+    - edit: Edit the configuration file in an editor
+    - get: Get the value associated with name
+    - set: Set the name=value
+    - unset: Unset the value associated with name
 
     If none of --user, --global and --site are passed, a virtual
     environment configuration file is used if one is active and the file


### PR DESCRIPTION
Fixes and closes #8072 

The formatting is picked from https://github.com/pypa/pip/blob/master/src/pip/_internal/commands/download.py#L19 and the docs now look like

<img width="846" alt="Screenshot 2020-04-18 at 1 05 20 AM" src="https://user-images.githubusercontent.com/13155849/79607249-8dff4c80-8110-11ea-8d95-3ed747e99102.png">

They pip config doc can also do with some examples as well, but I can perhaps make a separate PR for that.

```
$ pip config set site.proxy 'http://localhost:3128'
Writing to ~/.config/pip/pip.conf
$ pip config get site.proxy
http://localhost:3128
$ pip config list
site.proxy='http://localhost:3128'
```

Edit: Seems like the docstring indentation was changed in https://github.com/pypa/pip/commit/bbd439898b4e71dcea7d6c97bea32db3fe219dd1 but that didn't correct the rendering