### PR TITLE
Add 'pip cache dir' command to show cache directory

### DIFF
--- a/news/7350.feature
+++ b/news/7350.feature
@@ -1,0 +1,1 @@
+Add ``pip cache dir`` to show the cache directory.

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -24,6 +24,7 @@ class CacheCommand(Command):
 
     Subcommands:
 
+        dir: Show the cache directory.
         info: Show information about the cache.
         list: List filenames of packages stored in the cache.
         remove: Remove one or more package from the cache.
@@ -33,6 +34,7 @@ class CacheCommand(Command):
     """
 
     usage = """
+        %prog dir
         %prog info
         %prog list [<pattern>]
         %prog remove <pattern>
@@ -42,6 +44,7 @@ class CacheCommand(Command):
     def run(self, options, args):
         # type: (Values, List[Any]) -> int
         handlers = {
+            "dir": self.get_cache_dir,
             "info": self.get_cache_info,
             "list": self.list_cache_items,
             "remove": self.remove_cache_items,
@@ -65,6 +68,13 @@ class CacheCommand(Command):
             return ERROR
 
         return SUCCESS
+
+    def get_cache_dir(self, options, args):
+        # type: (Values, List[Any]) -> None
+        if args:
+            raise CommandError('Too many arguments')
+
+        logger.info(options.cache_dir)
 
     def get_cache_info(self, options, args):
         # type: (Values, List[Any]) -> None

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -101,6 +101,16 @@ def test_cache_dir(script, cache_dir):
     assert os.path.normcase(cache_dir) == result.stdout.strip()
 
 
+def test_cache_dir_too_many_args(script, cache_dir):
+    result = script.pip('cache', 'dir', 'aaa', expect_error=True)
+
+    assert result.stdout == ''
+
+    # This would be `result.stderr == ...`, but pip prints deprecation
+    # warnings on Python 2.7, so we check if the _line_ is in stderr.
+    assert 'ERROR: Too many arguments' in result.stderr.splitlines()
+
+
 @pytest.mark.usefixtures("populate_wheel_cache")
 def test_cache_info(script, wheel_cache_dir, wheel_cache_files):
     result = script.pip('cache', 'info')
@@ -215,7 +225,7 @@ def test_cache_purge_too_many_args(script, wheel_cache_files):
                         expect_error=True)
     assert result.stdout == ''
 
-    # This would be `result.stderr == ...`, but Pip prints deprecation
+    # This would be `result.stderr == ...`, but pip prints deprecation
     # warnings on Python 2.7, so we check if the _line_ is in stderr.
     assert 'ERROR: Too many arguments' in result.stderr.splitlines()
 

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -95,6 +95,12 @@ def remove_matches_wheel(wheel_cache_dir):
     return _remove_matches_wheel
 
 
+def test_cache_dir(script, cache_dir):
+    result = script.pip('cache', 'dir')
+
+    assert os.path.normcase(cache_dir) == result.stdout.strip()
+
+
 @pytest.mark.usefixtures("populate_wheel_cache")
 def test_cache_info(script, wheel_cache_dir, wheel_cache_files):
     result = script.pip('cache', 'info')


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Fixes https://github.com/pypa/pip/issues/7350.

Print out the path to pip's cache directory, which is different depending on OS.

For example on macOS:

```console
$ pip cache dir
/Users/hugo/Library/Caches/pip
$ pip cache dir 123
ERROR: Too many arguments
```

This will allow CIs like GitHub Actions to cache pip downloads with much less config, hopefully increasing use of caching, and should reduce the load and cost of running PyPI.

Others would benefit from this, and some have been resorting to using pip's private, internal API:

* https://stackoverflow.com/a/48956368/724176
* https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program
