### PR TITLE
Add option to list config files with pip config

### DIFF
--- a/news/6741.feature
+++ b/news/6741.feature
@@ -1,0 +1,1 @@
+Add a subcommand ``list-files`` to ``pip config`` to list available configuration files and their location

--- a/news/6741.feature
+++ b/news/6741.feature
@@ -1,1 +1,1 @@
-Add a subcommand ``list-files`` to ``pip config`` to list available configuration files and their location
+Add a subcommand ``debug`` to ``pip config`` to list available configuration sources and the key-value pairs defined in them.

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -172,6 +172,7 @@ class ConfigurationCommand(Command):
 
     def list_values(self, options, args):
         self._get_n_args(args, "list", n=0)
+
         for key, value in sorted(self.configuration.items()):
             write_output("%s=%r", key, value)
 
@@ -194,22 +195,36 @@ class ConfigurationCommand(Command):
         self._save_configuration()
 
     def list_config_values(self, options, args):
+        """List config key-value pairs across different config files"""
         self._get_n_args(args, "debug", n=0)
+
+        self.print_env_var_values()
+        # Iterate over config files and print if they exist, and the
+        # key-value pairs present in them if they do
         for variant, files in sorted(self.configuration.iter_config_files()):
             write_output("%s:", variant)
             for fname in files:
                 with indent_log():
                     file_exists = os.path.exists(fname)
-                    write_output("%s, exists: %r ",
+                    write_output("%s, exists: %r",
                                  fname, file_exists)
                     if file_exists:
                         self.print_config_file_values(variant)
 
     def print_config_file_values(self, variant):
+        """Get key-value pairs from the file of a variant"""
         for name, value in self.configuration. \
                 get_values_in_config(variant).items():
             with indent_log():
-                write_output("%s: %s ", name, value)
+                write_output("%s: %s", name, value)
+
+    def print_env_var_values(self):
+        """Get key-values pairs present as environment variables"""
+        write_output("%s:", 'env_var')
+        with indent_log():
+            for key, value in self.configuration.get_environ_vars():
+                env_var = 'PIP_{}'.format(key.upper())
+                write_output("%s=%r", env_var, value)
 
     def open_in_editor(self, options, args):
         editor = self._determine_editor(options)

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -35,7 +35,7 @@ class ConfigurationCommand(Command):
     - get: Get the value associated with name
     - set: Set the name=value
     - unset: Unset the value associated with name
-    - list-files: List the configuration files
+    - debug: List the configuration files and values defined under them
 
     If none of --user, --global and --site are passed, a virtual
     environment configuration file is used if one is active and the file
@@ -107,7 +107,7 @@ class ConfigurationCommand(Command):
             "get": self.get_name,
             "set": self.set_name_value,
             "unset": self.unset_name,
-            "debug": self.list_config_files,
+            "debug": self.list_config_values,
         }
 
         # Determine action
@@ -193,8 +193,8 @@ class ConfigurationCommand(Command):
 
         self._save_configuration()
 
-    def list_config_files(self, options, args):
-        self._get_n_args(args, "list-files", n=0)
+    def list_config_values(self, options, args):
+        self._get_n_args(args, "debug", n=0)
         for variant, files in sorted(self.configuration.iter_config_files()):
             write_output("%s:", variant)
             for fname in files:

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -213,7 +213,7 @@ class ConfigurationCommand(Command):
 
     def print_config_file_values(self, variant):
         """Get key-value pairs from the file of a variant"""
-        for name, value in self.configuration. \
+        for name, value in self.configuration.\
                 get_values_in_config(variant).items():
             with indent_log():
                 write_output("%s: %s", name, value)
@@ -222,7 +222,7 @@ class ConfigurationCommand(Command):
         """Get key-values pairs present as environment variables"""
         write_output("%s:", 'env_var')
         with indent_log():
-            for key, value in self.configuration.get_environ_vars():
+            for key, value in sorted(self.configuration.get_environ_vars()):
                 env_var = 'PIP_{}'.format(key.upper())
                 write_output("%s=%r", env_var, value)
 

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -13,6 +13,7 @@ from pip._internal.configuration import (
     kinds,
 )
 from pip._internal.exceptions import PipError
+from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import get_prog, write_output
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -34,6 +35,7 @@ class ConfigurationCommand(Command):
     - get: Get the value associated with name
     - set: Set the name=value
     - unset: Unset the value associated with name
+    - list-files: List the configuration files
 
     If none of --user, --global and --site are passed, a virtual
     environment configuration file is used if one is active and the file
@@ -49,6 +51,7 @@ class ConfigurationCommand(Command):
         %prog [<file-option>] get name
         %prog [<file-option>] set name value
         %prog [<file-option>] unset name
+        %prog [<file-option>] list-files
     """
 
     def __init__(self, name, summary, isolated=False):
@@ -103,7 +106,8 @@ class ConfigurationCommand(Command):
             "edit": self.open_in_editor,
             "get": self.get_name,
             "set": self.set_name_value,
-            "unset": self.unset_name
+            "unset": self.unset_name,
+            "list-files": self.list_config_files,
         }
 
         # Determine action
@@ -189,6 +193,16 @@ class ConfigurationCommand(Command):
         self.configuration.unset_value(key)
 
         self._save_configuration()
+
+    def list_config_files(self, options, args):
+        self._get_n_args(args, "list-files", n=0)
+
+        for variant, files in sorted(self.configuration.iter_config_files()):
+            write_output("%s:", variant)
+            for fname in files:
+                with indent_log():
+                    write_output("%s, exists: %r ",
+                                 fname, os.path.exists(fname))
 
     def open_in_editor(self, options, args):
         editor = self._determine_editor(options)

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -342,7 +342,7 @@ class Configuration(object):
         """Loads configuration from environment variables
         """
         self._config[kinds.ENV_VAR].update(
-            self._normalized_keys(":env:", self._get_environ_vars())
+            self._normalized_keys(":env:", self.get_environ_vars())
         )
 
     def _normalized_keys(self, section, items):
@@ -358,7 +358,7 @@ class Configuration(object):
             normalized[key] = val
         return normalized
 
-    def _get_environ_vars(self):
+    def get_environ_vars(self):
         # type: () -> Iterable[Tuple[str, str]]
         """Returns a generator with all environmental vars with prefix PIP_"""
         for key, val in os.environ.items():

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -280,7 +280,7 @@ class Configuration(object):
         # type: () -> None
         """Loads configuration from configuration files
         """
-        config_files = dict(self._iter_config_files())
+        config_files = dict(self.iter_config_files())
         if config_files[kinds.ENV][0:1] == [os.devnull]:
             logger.debug(
                 "Skipping loading configuration files due to "
@@ -370,7 +370,7 @@ class Configuration(object):
                 yield key[4:].lower(), val
 
     # XXX: This is patched in the tests.
-    def _iter_config_files(self):
+    def iter_config_files(self):
         # type: () -> Iterable[Tuple[Kind, List[str]]]
         """Yields variant and configuration files associated with it.
 

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -401,6 +401,11 @@ class Configuration(object):
         # finally virtualenv configuration first trumping others
         yield kinds.SITE, config_files[kinds.SITE]
 
+    def get_values_in_config(self, variant):
+        # type: (Kind) -> Dict[str, Any]
+        """Get values present in a config file"""
+        return self._config[variant]
+
     def _get_parser_to_modify(self):
         # type: () -> Tuple[str, RawConfigParser]
         # Determine which parser to modify

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -1,11 +1,16 @@
 """Tests for the config command
 """
 
+import re
 import textwrap
 
 import pytest
 
 from pip._internal.cli.status_codes import ERROR
+from pip._internal.configuration import (
+    CONFIG_BASENAME,
+    get_configuration_files,
+)
 from tests.lib.configuration_helpers import ConfigurationMixin, kinds
 
 
@@ -62,3 +67,77 @@ class TestBasicLoading(ConfigurationMixin):
         result = script.pip("config", "set", "isolated", "true",
                             expect_error=True)
         assert "global.isolated" in result.stderr
+
+    def test_env_var_values(self, script):
+        """Test that pip configuration set with environment variables
+        is correctly displayed under "env_var".
+        """
+
+        env_vars = {
+            "PIP_DEFAULT_TIMEOUT": "60",
+            "PIP_FIND_LINKS": "http://mirror.example.com"
+        }
+        script.environ.update(env_vars)
+
+        result = script.pip("config", "debug")
+        assert "PIP_DEFAULT_TIMEOUT='60'" in result.stdout
+        assert "PIP_FIND_LINKS='http://mirror.example.com'" in result.stdout
+        assert re.search(r"env_var:\n(  .+\n)+", result.stdout)
+
+    def test_env_values(self, script):
+        """Test that custom pip configuration using the environment variable
+        PIP_CONFIG_FILE is correctly displayed under "env". This configuration
+        takes place of per-user configuration file displayed under "user".
+        """
+
+        config_file = script.scratch_path / "test-pip.cfg"
+        script.environ['PIP_CONFIG_FILE'] = str(config_file)
+        config_file.write_text(textwrap.dedent("""\
+            [global]
+            timeout = 60
+
+            [freeze]
+            timeout = 10
+            """))
+
+        result = script.pip("config", "debug")
+        assert "{}, exists: True".format(config_file) in result.stdout
+        assert "global.timeout: 60" in result.stdout
+        assert "freeze.timeout: 10" in result.stdout
+        assert re.search(r"env:\n(  .+\n)+", result.stdout)
+
+    def test_user_values(self, script,):
+        """Test that the user pip configuration set using --user
+        is correctly displayed under "user".  This configuration takes place
+        of custom path location using the environment variable PIP_CONFIG_FILE
+        displayed under "env".
+        """
+
+        # Use new config file
+        new_config_file = get_configuration_files()[kinds.USER][1]
+
+        script.pip("config", "--user", "set", "global.timeout", "60")
+        script.pip("config", "--user", "set", "freeze.timeout", "10")
+
+        result = script.pip("config", "debug")
+        assert "{}, exists: True".format(new_config_file) in result.stdout
+        assert "global.timeout: 60" in result.stdout
+        assert "freeze.timeout: 10" in result.stdout
+        assert re.search(r"user:\n(  .+\n)+", result.stdout)
+
+    def test_site_values(self, script, virtualenv):
+        """Test that the current environment configuration set using --site
+        is correctly displayed under "site".
+        """
+
+        # Site config file will be inside the virtualenv
+        site_config_file = virtualenv.location / CONFIG_BASENAME
+
+        script.pip("config", "--site", "set", "global.timeout", "60")
+        script.pip("config", "--site", "set", "freeze.timeout", "10")
+
+        result = script.pip("config", "debug")
+        assert "{}, exists: True".format(site_config_file) in result.stdout
+        assert "global.timeout: 60" in result.stdout
+        assert "freeze.timeout: 10" in result.stdout
+        assert re.search(r"site:\n(  .+\n)+", result.stdout)

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -141,3 +141,15 @@ class TestBasicLoading(ConfigurationMixin):
         assert "global.timeout: 60" in result.stdout
         assert "freeze.timeout: 10" in result.stdout
         assert re.search(r"site:\n(  .+\n)+", result.stdout)
+
+    def test_global_config_file(self, script):
+        """Test that the system-wide  configuration can be identified"""
+
+        # We cannot  write to system-wide files which might have permissions
+        # defined in a way that the tox virtualenvcannot write to those
+        # locations. Additionally we cannot patch those paths since pip config
+        # commands runs inside a subprocess.
+        # So we just check if the file can be identified
+        global_config_file = get_configuration_files()[kinds.GLOBAL][0]
+        result = script.pip("config", "debug")
+        assert "{}, exists:".format(global_config_file) in result.stdout

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -387,7 +387,7 @@ class TestOptionsConfigFiles(object):
         cp = pip._internal.configuration.Configuration(isolated=False)
 
         files = []
-        for _, val in cp._iter_config_files():
+        for _, val in cp.iter_config_files():
             files.extend(val)
 
         assert len(files) == 4


### PR DESCRIPTION
Fixes and closes #6741 

Add option to list config files per variant and whether they actually exist

```
$ pip config list-files
env:
global:
  /Library/Application Support/pip/pip.conf, exists: False 
site:
  /Users/devesh/pip/.env/pip.conf, exists: True 
user:
  /Users/devesh/.pip/pip.conf, exists: False 
  /Users/devesh/.config/pip/pip.conf, exists: False 
```

This is a preliminary output, but we need to decide on some things before we finalize something

Edit: An updated format with all values for a config file listed under it is now added:

If `PIP_CONFIG_FILE` is set
```
$ pip config debug
env_var:
  PIP_CONFIG_FILE='/Users/devesh/Desktop/pip.cfg'
  PIP_DEFAULT_TIMEOUT='60'
env:
  /Users/devesh/Desktop/pip.cfg, exists: True
    global.timeout: 60
    global.index-url: https://download.zope.org/ppix
global:
  /Library/Application Support/pip/pip.conf, exists: True
    global.timeout: 60
    freeze.timeout: 10
site:
  /Users/devesh/pip/.env/pip.conf, exists: True
    global.no-cache-dir: false
    install.no-compile: no
    install.no-warn-script-location: false
```

If `PIP_CONFIG_FILE` is not set:

```
$ pip config debug
env_var:
  PIP_DEFAULT_TIMEOUT='60'
env:
global:
  /Library/Application Support/pip/pip.conf, exists: True
    global.timeout: 60
    freeze.timeout: 10
site:
  /Users/devesh/pip/.env/pip.conf, exists: True
    global.no-cache-dir: false
    install.no-compile: no
    install.no-warn-script-location: false
    a.b: 1
user:
  /Users/devesh/.pip/pip.conf, exists: False
  /Users/devesh/.config/pip/pip.conf, exists: True
    global.find-links: 
    http://download.example.com
    install.find-links: 
    http://mirror1.example.com
    http://mirror2.example.com
    install.trusted-host: 
    http://mirror1.example.com
    http://mirror2.example.com
```