### PR TITLE
Mark certifi as bundled, it's used in the debug command

### DIFF
--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -60,6 +60,7 @@ if DEBUNDLED:
     # Actually alias all of our vendored dependencies.
     vendored("appdirs")
     vendored("cachecontrol")
+    vendored("certifi")
     vendored("colorama")
     vendored("contextlib2")
     vendored("distlib")


### PR DESCRIPTION
As reported in [Debian bug #958396](https://bugs.debian.org/958396), the `debug` command needs `certifi` and it isn't set up in the unbundled vendored aliases.