### PR TITLE
documentation: mention zulip in developer docs

### DIFF
--- a/docs/html/development/index.rst
+++ b/docs/html/development/index.rst
@@ -8,6 +8,7 @@ testing, and documentation.
 
 You can also join ``#pypa`` (general packaging discussion and user support) and
 ``#pypa-dev`` (discussion about development of packaging tools) `on Freenode`_,
+the ``pip development`` stream on https://python.zulipchat.com,
 or the `pypa-dev mailing list`_, to ask questions or get involved.
 
 .. toctree::


### PR DESCRIPTION
The developer documentation refers contributors to freenode and the
mailing list, but does not mention zulip. Add zulip to the list of
communication channels.



<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->