### PR TITLE
Remove appveyor CI references from docs

### DIFF
--- a/docs/html/development/architecture/anatomy.rst
+++ b/docs/html/development/architecture/anatomy.rst
@@ -25,7 +25,6 @@ The ``README``, license, ``pyproject.toml``, ``setup.py``, and so on are in the 
 * ``setup.cfg``
 * ``setup.py``
 * ``tox.ini`` -- ``pip`` uses Tox, an automation tool, configured by this `tox.ini`_ file. ``tox.ini`` describes a few environments ``pip`` uses during development for simplifying how tests are run (complicated situation there). Example: ``tox -e -py36``. We can run tests for different versions of Python by changing “36” to “27” or similar.
-* ``.appveyor.yml``
 * ``.coveragerc``
 * ``.gitattributes``
 * ``.gitignore``

--- a/docs/html/development/contributing.rst
+++ b/docs/html/development/contributing.rst
@@ -39,8 +39,11 @@ separately, as a "formatting cleanup" PR, if needed.
 Automated Testing
 =================
 
-All pull requests and merges to 'master' branch are tested using `Travis CI`_
-based on our `.travis.yml`_ file.
+All pull requests and merges to 'master' branch are tested using `Travis CI`_,
+`Azure Pipelines`_ and `GitHub Actions`_ based on our `.travis.yml`_,
+`.azure-pipelines`_ and `.github/workflows`_ files. More details about pip's
+Continuous Integration can be found in the `CI Documentation`_
+
 
 You can find the status and results to the CI runs for your PR on GitHub's web
 UI for the pull request. You can also find links to the CI services' pages for
@@ -257,5 +260,10 @@ will initiate a vote among the existing maintainers.
 .. _`Studies have shown`: https://www.kessler.de/prd/smartbear/BestPracticesForPeerCodeReview.pdf
 .. _`resolve merge conflicts`: https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line
 .. _`Travis CI`: https://travis-ci.org/
+.. _`Azure Pipelines`: https://azure.microsoft.com/en-in/services/devops/pipelines/
+.. _`GitHub Actions`: https://github.com/features/actions
 .. _`.travis.yml`: https://github.com/pypa/pip/blob/master/.travis.yml
+.. _`.azure-pipelines`: https://github.com/pypa/pip/blob/master/.azure-pipelines
+.. _`.github/workflows`: https://github.com/pypa/pip/blob/master/.github/workflows
+.. _`CI Documentation`: https://pip.pypa.io/en/latest/development/ci/
 .. _`towncrier`: https://pypi.org/project/towncrier/

--- a/docs/html/development/contributing.rst
+++ b/docs/html/development/contributing.rst
@@ -40,7 +40,7 @@ Automated Testing
 =================
 
 All pull requests and merges to 'master' branch are tested using `Travis CI`_
-and `Appveyor CI`_ based on our `.travis.yml`_ and `.appveyor.yml`_ files.
+based on our `.travis.yml`_ file.
 
 You can find the status and results to the CI runs for your PR on GitHub's web
 UI for the pull request. You can also find links to the CI services' pages for
@@ -257,7 +257,5 @@ will initiate a vote among the existing maintainers.
 .. _`Studies have shown`: https://www.kessler.de/prd/smartbear/BestPracticesForPeerCodeReview.pdf
 .. _`resolve merge conflicts`: https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line
 .. _`Travis CI`: https://travis-ci.org/
-.. _`Appveyor CI`: https://www.appveyor.com/
 .. _`.travis.yml`: https://github.com/pypa/pip/blob/master/.travis.yml
-.. _`.appveyor.yml`: https://github.com/pypa/pip/blob/master/.appveyor.yml
 .. _`towncrier`: https://pypi.org/project/towncrier/


### PR DESCRIPTION
Removing references of Appveyor CI from docs, which was removed in https://github.com/pypa/pip/pull/7564 , as suggested in https://github.com/pypa/pip/pull/8107#discussion_r413235770