### PR TITLE
Basic skeleton to start pkg_resources migration

### DIFF
--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -1,0 +1,15 @@
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import List, Optional
+
+    from .base import BaseEnvironment
+
+
+def get_environment(paths=None):
+    # type: (Optional[List[str]]) -> BaseEnvironment
+    from .pkg_resources import Environment
+
+    if paths is None:
+        return Environment.default()
+    return Environment.from_paths(paths)

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -6,10 +6,27 @@ if MYPY_CHECK_RUNNING:
     from .base import BaseEnvironment
 
 
-def get_environment(paths=None):
-    # type: (Optional[List[str]]) -> BaseEnvironment
+def get_default_environment():
+    # type: () -> BaseEnvironment
+    """Get the default representation for the current environment.
+
+    This returns an Environment instance from the chosen backend. The default
+    Environment instance should be built from ``sys.path`` and may use caching
+    to share instance state accorss calls.
+    """
     from .pkg_resources import Environment
 
-    if paths is None:
-        return Environment.default()
+    return Environment.default()
+
+
+def get_environment(paths):
+    # type: (Optional[List[str]]) -> BaseEnvironment
+    """Get a representation of the environment specified by ``paths``.
+
+    This returns an Environment instance from the chosen backend based on the
+    given import paths. The backend must build a fresh instance representing
+    the state of installed distributions when this function is called.
+    """
+    from .pkg_resources import Environment
+
     return Environment.from_paths(paths)

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -1,0 +1,29 @@
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import List, Optional
+
+
+class BaseDistribution:
+    @property
+    def installer(self):
+        # type: () -> str
+        raise NotImplementedError()
+
+
+class BaseEnvironment:
+    """An environment containing distributions to introspect."""
+
+    @classmethod
+    def default(cls):
+        # type: () -> BaseEnvironment
+        raise NotImplementedError()
+
+    @classmethod
+    def from_paths(cls, paths):
+        # type: (List[str]) -> BaseEnvironment
+        raise NotImplementedError()
+
+    def get_distribution(self, name):
+        # type: (str) -> Optional[BaseDistribution]
+        raise NotImplementedError()

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -42,7 +42,7 @@ class BaseEnvironment:
 
     @classmethod
     def from_paths(cls, paths):
-        # type: (List[str]) -> BaseEnvironment
+        # type: (Optional[List[str]]) -> BaseEnvironment
         raise NotImplementedError()
 
     def get_distribution(self, name):

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -47,10 +47,12 @@ class BaseEnvironment:
 
     def get_distribution(self, name):
         # type: (str) -> Optional[BaseDistribution]
+        """Given a requirement name, return the installed distributions."""
         raise NotImplementedError()
 
     def iter_distributions(self):
         # type: () -> Iterator[BaseDistribution]
+        """Iterate through installed distributions."""
         raise NotImplementedError()
 
     def iter_installed_distributions(
@@ -62,6 +64,17 @@ class BaseEnvironment:
         user_only=False,  # type: bool
     ):
         # type: (...) -> Iterator[BaseDistribution]
+        """Return a list of installed distributions.
+
+        :param local_only: If True (default), only return installations
+        local to the current virtualenv, if in a virtualenv.
+        :param skip: An iterable of canonicalized project names to ignore;
+            defaults to ``stdlib_pkgs``.
+        :param include_editables: If False, don't report editables.
+        :param editables_only: If True, only report editables.
+        :param user_only: If True, only report installations in the user
+        site directory.
+        """
         it = self.iter_distributions()
         if local_only:
             it = (d for d in it if d.local)

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -1,7 +1,7 @@
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.utils.misc import dist_in_usersite, dist_is_editable, dist_is_local
+from pip._internal.utils import misc  # TODO: Move definition here.
 from pip._internal.utils.packaging import get_installer
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -29,17 +29,17 @@ class Distribution(BaseDistribution):
     @property
     def editable(self):
         # type: () -> bool
-        return dist_is_editable(self._dist)
+        return misc.dist_is_editable(self._dist)
 
     @property
     def local(self):
         # type: () -> bool
-        return dist_is_local(self._dist)
+        return misc.dist_is_local(self._dist)
 
     @property
     def in_usersite(self):
         # type: () -> bool
-        return dist_in_usersite(self._dist)
+        return misc.dist_in_usersite(self._dist)
 
 
 class Environment(BaseEnvironment):
@@ -57,14 +57,42 @@ class Environment(BaseEnvironment):
         # type: (List[str]) -> BaseEnvironment
         return cls(pkg_resources.WorkingSet(paths))
 
+    def _search_distribution(self, name):
+        # type: (str) -> Optional[BaseDistribution]
+        """Find a distribution matching the ``name`` in the environment.
+
+        This searches from *all* distributions available in the environment, to
+        match the behavior of ``pkg_resources.get_distribution()``.
+        """
+        canonical_name = canonicalize_name(name)
+        for dist in self.iter_distributions():
+            if dist.canonical_name == canonical_name:
+                return dist
+        return None
+
     def get_distribution(self, name):
         # type: (str) -> Optional[BaseDistribution]
-        req = pkg_resources.Requirement(name)
+
+        # Search the distribution by looking through the working set.
+        dist = self._search_distribution(name)
+        if dist:
+            return dist
+
+        # If distribution could not be found, call working_set.require to
+        # update the working set, and try to find the distribution again.
+        # This might happen for e.g. when you install a package twice, once
+        # using setup.py develop and again using setup.py install. Now when
+        # running pip uninstall twice, the package gets removed from the
+        # working set in the first uninstall, so we have to populate the
+        # working set again so that pip knows about it and the packages gets
+        # picked up and is successfully uninstalled the second time too.
         try:
-            dist = self._ws.find(req)
+            # We didn't pass in any version specifiers, so this can never
+            # raise pkg_resources.VersionConflict.
+            self._ws.require(name)
         except pkg_resources.DistributionNotFound:
             return None
-        return Distribution(dist)
+        return self._search_distribution(name)
 
     def iter_distributions(self):
         # type: () -> Iterator[BaseDistribution]

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -54,7 +54,7 @@ class Environment(BaseEnvironment):
 
     @classmethod
     def from_paths(cls, paths):
-        # type: (List[str]) -> BaseEnvironment
+        # type: (Optional[List[str]]) -> BaseEnvironment
         return cls(pkg_resources.WorkingSet(paths))
 
     def _search_distribution(self, name):

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -1,12 +1,14 @@
 from pip._vendor import pkg_resources
+from pip._vendor.packaging.utils import canonicalize_name
 
+from pip._internal.utils.misc import dist_in_usersite, dist_is_editable, dist_is_local
 from pip._internal.utils.packaging import get_installer
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 from .base import BaseDistribution, BaseEnvironment
 
 if MYPY_CHECK_RUNNING:
-    from typing import List, Optional
+    from typing import Iterator, List, Optional
 
 
 class Distribution(BaseDistribution):
@@ -15,10 +17,29 @@ class Distribution(BaseDistribution):
         self._dist = dist
 
     @property
+    def canonical_name(self):
+        # type: () -> str
+        return canonicalize_name(self._dist.project_name)
+
+    @property
     def installer(self):
         # type: () -> str
-        # TODO: Move get_installer() implementation here.
         return get_installer(self._dist)
+
+    @property
+    def editable(self):
+        # type: () -> bool
+        return dist_is_editable(self._dist)
+
+    @property
+    def local(self):
+        # type: () -> bool
+        return dist_is_local(self._dist)
+
+    @property
+    def in_usersite(self):
+        # type: () -> bool
+        return dist_in_usersite(self._dist)
 
 
 class Environment(BaseEnvironment):
@@ -44,3 +65,8 @@ class Environment(BaseEnvironment):
         except pkg_resources.DistributionNotFound:
             return None
         return Distribution(dist)
+
+    def iter_distributions(self):
+        # type: () -> Iterator[BaseDistribution]
+        for dist in self._ws:
+            yield Distribution(dist)

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -1,0 +1,46 @@
+from pip._vendor import pkg_resources
+
+from pip._internal.utils.packaging import get_installer
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+from .base import BaseDistribution, BaseEnvironment
+
+if MYPY_CHECK_RUNNING:
+    from typing import List, Optional
+
+
+class Distribution(BaseDistribution):
+    def __init__(self, dist):
+        # type: (pkg_resources.Distribution) -> None
+        self._dist = dist
+
+    @property
+    def installer(self):
+        # type: () -> str
+        # TODO: Move get_installer() implementation here.
+        return get_installer(self._dist)
+
+
+class Environment(BaseEnvironment):
+    def __init__(self, ws):
+        # type: (pkg_resources.WorkingSet) -> None
+        self._ws = ws
+
+    @classmethod
+    def default(cls):
+        # type: () -> BaseEnvironment
+        return cls(pkg_resources.working_set)
+
+    @classmethod
+    def from_paths(cls, paths):
+        # type: (List[str]) -> BaseEnvironment
+        return cls(pkg_resources.WorkingSet(paths))
+
+    def get_distribution(self, name):
+        # type: (str) -> Optional[BaseDistribution]
+        req = pkg_resources.Requirement(name)
+        try:
+            dist = self._ws.find(req)
+        except pkg_resources.DistributionNotFound:
+            return None
+        return Distribution(dist)

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -10,10 +10,10 @@ from pip._vendor.six import ensure_binary
 
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
+from pip._internal.metadata import get_environment
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.utils.filesystem import adjacent_tmp_file, check_path_owner, replace
-from pip._internal.utils.misc import ensure_dir, get_distribution, get_installed_version
-from pip._internal.utils.packaging import get_installer
+from pip._internal.utils.misc import ensure_dir, get_installed_version
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -103,10 +103,8 @@ def was_installed_by_pip(pkg):
     This is used not to display the upgrade message when pip is in fact
     installed by system package manager, such as dnf on Fedora.
     """
-    dist = get_distribution(pkg)
-    if not dist:
-        return False
-    return "pip" == get_installer(dist)
+    dist = get_environment().get_distribution(pkg)
+    return dist is not None and "pip" == dist.installer
 
 
 def pip_self_version_check(session, options):

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -10,7 +10,7 @@ from pip._vendor.six import ensure_binary
 
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
-from pip._internal.metadata import get_environment
+from pip._internal.metadata import get_default_environment
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.utils.filesystem import adjacent_tmp_file, check_path_owner, replace
 from pip._internal.utils.misc import ensure_dir, get_installed_version
@@ -103,7 +103,7 @@ def was_installed_by_pip(pkg):
     This is used not to display the upgrade message when pip is in fact
     installed by system package manager, such as dnf on Fedora.
     """
-    dist = get_environment().get_distribution(pkg)
+    dist = get_default_environment().get_distribution(pkg)
     return dist is not None and "pip" == dist.installer
 
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -405,9 +405,14 @@ def get_installed_distributions(
 
     Left for compatibility until direct pkg_resources uses are refactored out.
     """
-    from pip._internal.metadata import get_environment
+    from pip._internal.metadata import get_default_environment, get_environment
     from pip._internal.metadata.pkg_resources import Distribution as _Dist
-    dists = get_environment(paths).iter_installed_distributions(
+
+    if paths is None:
+        env = get_default_environment()
+    else:
+        env = get_environment(paths)
+    dists = env.iter_installed_distributions(
         local_only=local_only,
         skip=skip,
         include_editables=include_editables,
@@ -426,9 +431,9 @@ def get_distribution(req_name):
 
     Left for compatibility until direct pkg_resources uses are refactored out.
     """
-    from pip._internal.metadata import get_environment
+    from pip._internal.metadata import get_default_environment
     from pip._internal.metadata.pkg_resources import Distribution as _Dist
-    dist = get_environment().get_distribution(req_name)
+    dist = get_default_environment().get_distribution(req_name)
     if dist is None:
         return None
     return cast(_Dist, dist)._dist

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -57,6 +57,14 @@ class MockDistribution:
             raise NotImplementedError('nope')
 
 
+class MockEnvironment(object):
+    def __init__(self, installer):
+        self.installer = installer
+
+    def get_distribution(self, name):
+        return MockDistribution(self.installer)
+
+
 def _options():
     ''' Some default options that we pass to
     self_outdated_check.pip_self_version_check '''
@@ -97,8 +105,8 @@ def test_pip_self_version_check(monkeypatch, stored_time, installed_ver,
                         pretend.call_recorder(lambda *a, **kw: None))
     monkeypatch.setattr(logger, 'debug',
                         pretend.call_recorder(lambda s, exc_info=None: None))
-    monkeypatch.setattr(self_outdated_check, 'get_distribution',
-                        lambda name: MockDistribution(installer))
+    monkeypatch.setattr(self_outdated_check, 'get_environment',
+                        lambda: MockEnvironment(installer))
 
     fake_state = pretend.stub(
         state={"last_check": stored_time, 'pypi_version': installed_ver},

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -105,7 +105,7 @@ def test_pip_self_version_check(monkeypatch, stored_time, installed_ver,
                         pretend.call_recorder(lambda *a, **kw: None))
     monkeypatch.setattr(logger, 'debug',
                         pretend.call_recorder(lambda s, exc_info=None: None))
-    monkeypatch.setattr(self_outdated_check, 'get_environment',
+    monkeypatch.setattr(self_outdated_check, 'get_default_environment',
                         lambda: MockEnvironment(installer))
 
     fake_state = pretend.stub(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -196,21 +196,21 @@ class TestsGetDistributions:
             pass
 
     workingset = MockWorkingSet((
-        Mock(test_name="global", key="global"),
-        Mock(test_name="editable", key="editable"),
-        Mock(test_name="normal", key="normal"),
-        Mock(test_name="user", key="user"),
+        Mock(test_name="global", project_name="global"),
+        Mock(test_name="editable", project_name="editable"),
+        Mock(test_name="normal", project_name="normal"),
+        Mock(test_name="user", project_name="user"),
     ))
 
     workingset_stdlib = MockWorkingSet((
-        Mock(test_name='normal', key='argparse'),
-        Mock(test_name='normal', key='wsgiref')
+        Mock(test_name='normal', project_name='argparse'),
+        Mock(test_name='normal', project_name='wsgiref')
     ))
 
     workingset_freeze = MockWorkingSet((
-        Mock(test_name='normal', key='pip'),
-        Mock(test_name='normal', key='setuptools'),
-        Mock(test_name='normal', key='distribute')
+        Mock(test_name='normal', project_name='pip'),
+        Mock(test_name='normal', project_name='setuptools'),
+        Mock(test_name='normal', project_name='distribute')
     ))
 
     def dist_is_editable(self, dist):
@@ -290,9 +290,13 @@ class TestsGetDistributions:
     @pytest.mark.parametrize(
         "working_set, req_name",
         itertools.chain(
-            itertools.product([workingset], (d.key for d in workingset)),
             itertools.product(
-                [workingset_stdlib], (d.key for d in workingset_stdlib),
+                [workingset],
+                (d.project_name for d in workingset),
+            ),
+            itertools.product(
+                [workingset_stdlib],
+                (d.project_name for d in workingset_stdlib),
             ),
         ),
     )
@@ -312,7 +316,7 @@ class TestsGetDistributions:
         with patch("pip._vendor.pkg_resources.working_set", working_set):
             dist = get_distribution(req_name)
         assert dist is not None
-        assert dist.key == req_name
+        assert dist.project_name == req_name
 
     @patch('pip._vendor.pkg_resources.working_set', workingset)
     def test_get_distribution_nonexist(


### PR DESCRIPTION
This implements the basic shim structure I mentioned in https://github.com/pypa/pip/issues/7413#issuecomment-618095265. I moved the `lru_cache()` shim to `utils.compat` since it’s useful for `get_environment()`.

One *very* trivial change is made in `self_outed_check` to demostrate how the end result would look like in essence.

I think (hope?) this would be enough for someone to run with the idea and start refactoring. I think the logical next refactor would be to change `AbstractDistribution` to return `BaseDistribution` instead, and modify the prepare code. After that, usages in the new resolver can switch.