### PR TITLE
warn before overwriting files owned by previously installed wheels

### DIFF
--- a/news/4625.bugfix
+++ b/news/4625.bugfix
@@ -1,0 +1,1 @@
+Warn when a file owned by another distribution is overwritten.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -30,6 +30,7 @@ from pip._internal.locations import get_major_minor_version
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filesystem import adjacent_tmp_file, replace
+from pip._internal.utils.messages import oxford_comma_join
 from pip._internal.utils.misc import captured_stdout, ensure_dir, hash_file
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -407,15 +408,18 @@ def _report_file_owner_conflicts(lib_dir, name, source_dir, info_dir):
                 # There are no other owners for this file.
                 continue
             destfile = os.path.join(lib_dir, basedir, f)
-            for owner in files_from_other_owners[partial_src]:
-                deprecated(
-                    reason=('Overwriting or removing {} for {} '
-                            'which is also owned by {}'.format(
-                                destfile, name, owner)),
-                    replacement=None,
-                    gone_in="21.0",
-                    issue="4625",
-                )
+            deprecated(
+                reason=(
+                    'Overwriting or removing {} for {} '
+                    'which is also owned by {}'.format(
+                        destfile, name,
+                        oxford_comma_join(
+                            sorted(files_from_other_owners[partial_src])),
+                    )),
+                replacement=None,
+                gone_in="21.0",
+                issue=4625,
+            )
 
 
 def install_unpacked_wheel(

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -399,7 +399,7 @@ def _report_file_owner_conflicts(lib_dir, name, source_dir, info_dir):
         # we don't need to scan the source.
         return
 
-    for dir, subdirs, files in os.walk(source_dir):
+    for dir, _subdirs, files in os.walk(source_dir):
         basedir = dir[len(source_dir):].lstrip(os.path.sep)
         for f in files:
             partial_src = os.path.join(basedir, f)

--- a/src/pip/_internal/utils/messages.py
+++ b/src/pip/_internal/utils/messages.py
@@ -1,0 +1,26 @@
+"""
+Utility functions for building messages.
+"""
+
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import List
+
+
+def oxford_comma_join(values, conjunction='and'):
+    # type: (List[str], str) -> str
+    "Join a list of strings for output in a message."
+    if not values:
+        return ''
+    if len(values) == 1:
+        return values[0]
+    comma = ''
+    if len(values) > 2:
+        comma = ','
+    return '{}{} {} {}'.format(
+        ', '.join(values[:-1]),
+        comma,
+        conjunction,
+        values[-1],
+    )

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -756,9 +756,5 @@ def test_report_file_owner_conflicts_multiple(script, tmpdir):
     assert msg in result.stderr
 
     msg = 'Overwriting or removing {} for {} which is also owned by {}'.format(
-        full_path, 'wheel3', 'wheel1 1.0')
-    assert msg in result.stderr
-
-    msg = 'Overwriting or removing {} for {} which is also owned by {}'.format(
-        full_path, 'wheel3', 'wheel2 2.0')
+        full_path, 'wheel3', 'wheel1 1.0 and wheel2 2.0')
     assert msg in result.stderr

--- a/tests/unit/test_messages.py
+++ b/tests/unit/test_messages.py
@@ -1,0 +1,23 @@
+"""Tests for pip._internal.messages
+"""
+
+import pytest
+
+from pip._internal.utils.messages import oxford_comma_join
+
+
+@pytest.mark.parametrize("test_input,expected",
+                         [([], ''),
+                          (['a'], 'a'),
+                          (['a', 'b'], 'a and b'),
+                          (['a', 'b', 'c'], 'a, b, and c')])
+def test_oxford_comma_join_implicit_conjunction(test_input, expected):
+    assert expected == oxford_comma_join(test_input)
+
+
+@pytest.mark.parametrize("test_input,conjunction,expected",
+                         [(['a', 'b'], 'and', 'a and b',),
+                          (['a', 'b'], 'or', 'a or b')])
+def test_oxford_comma_join_explicit_conjunction(
+        test_input, conjunction, expected):
+    assert expected == oxford_comma_join(test_input, conjunction)


### PR DESCRIPTION
Before installing a wheel, look for other distributions that have also
written files into the same top level directory. Warn if any of the
same files will be modified by the new wheel.

Addresses #4625



<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->