### PR TITLE
Relocate yanked warning into the legacy resolver

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -556,23 +556,7 @@ class CandidateEvaluator(object):
         """
         if not candidates:
             return None
-
         best_candidate = max(candidates, key=self._sort_key)
-
-        # Log a warning per PEP 592 if necessary before returning.
-        link = best_candidate.link
-        if link.is_yanked:
-            reason = link.yanked_reason or '<none given>'
-            msg = (
-                # Mark this as a unicode string to prevent
-                # "UnicodeEncodeError: 'ascii' codec can't encode character"
-                # in Python 2 when the reason contains non-ascii characters.
-                u'The candidate selected for download or install is a '
-                'yanked version: {candidate}\n'
-                'Reason for being yanked: {reason}'
-            ).format(candidate=best_candidate, reason=reason)
-            logger.warning(msg)
-
         return best_candidate
 
     def compute_best_candidate(

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -889,11 +889,11 @@ class PackageFinder(object):
         return candidate_evaluator.compute_best_candidate(candidates)
 
     def find_requirement(self, req, upgrade):
-        # type: (InstallRequirement, bool) -> Optional[Link]
+        # type: (InstallRequirement, bool) -> Optional[InstallationCandidate]
         """Try to find a Link matching req
 
         Expects req, an InstallRequirement and upgrade, a boolean
-        Returns a Link if found,
+        Returns a InstallationCandidate if found,
         Raises DistributionNotFound or BestVersionAlreadyInstalled otherwise
         """
         hashes = req.hashes(trust_internet=False)
@@ -967,7 +967,7 @@ class PackageFinder(object):
             best_candidate.version,
             _format_versions(best_candidate_result.iter_applicable()),
         )
-        return best_candidate.link
+        return best_candidate
 
 
 def _find_name_version_sep(fragment, canonical_name):

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -267,7 +267,22 @@ class Resolver(BaseResolver):
         best_candidate = self.finder.find_requirement(req, upgrade)
         if not best_candidate:
             return None
-        return best_candidate.link
+
+        # Log a warning per PEP 592 if necessary before returning.
+        link = best_candidate.link
+        if link.is_yanked:
+            reason = link.yanked_reason or '<none given>'
+            msg = (
+                # Mark this as a unicode string to prevent
+                # "UnicodeEncodeError: 'ascii' codec can't encode character"
+                # in Python 2 when the reason contains non-ascii characters.
+                u'The candidate selected for download or install is a '
+                'yanked version: {candidate}\n'
+                'Reason for being yanked: {reason}'
+            ).format(candidate=best_candidate, reason=reason)
+            logger.warning(msg)
+
+        return link
 
     def _populate_link(self, req):
         # type: (InstallRequirement) -> None

--- a/tests/lib/index.py
+++ b/tests/lib/index.py
@@ -1,0 +1,14 @@
+from pip._internal.models.candidate import InstallationCandidate
+from pip._internal.models.link import Link
+
+
+def make_mock_candidate(version, yanked_reason=None, hex_digest=None):
+    url = 'https://example.com/pkg-{}.tar.gz'.format(version)
+    if hex_digest is not None:
+        assert len(hex_digest) == 64
+        url += '#sha256={}'.format(hex_digest)
+
+    link = Link(url, yanked_reason=yanked_reason)
+    candidate = InstallationCandidate('mypackage', version, link)
+
+    return candidate

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -48,7 +48,7 @@ def test_no_mpkg(data):
     req = install_req_from_line("pkgwithmpkg")
     found = finder.find_requirement(req, False)
 
-    assert found.url.endswith("pkgwithmpkg-1.0.tar.gz"), found
+    assert found.link.url.endswith("pkgwithmpkg-1.0.tar.gz"), found
 
 
 def test_no_partial_name_match(data):
@@ -57,7 +57,7 @@ def test_no_partial_name_match(data):
     req = install_req_from_line("gmpy")
     found = finder.find_requirement(req, False)
 
-    assert found.url.endswith("gmpy-1.15.tar.gz"), found
+    assert found.link.url.endswith("gmpy-1.15.tar.gz"), found
 
 
 def test_tilde():
@@ -79,23 +79,23 @@ def test_duplicates_sort_ok(data):
     req = install_req_from_line("duplicate")
     found = finder.find_requirement(req, False)
 
-    assert found.url.endswith("duplicate-1.0.tar.gz"), found
+    assert found.link.url.endswith("duplicate-1.0.tar.gz"), found
 
 
 def test_finder_detects_latest_find_links(data):
     """Test PackageFinder detects latest using find-links"""
     req = install_req_from_line('simple', None)
     finder = make_test_finder(find_links=[data.find_links])
-    link = finder.find_requirement(req, False)
-    assert link.url.endswith("simple-3.0.tar.gz")
+    found = finder.find_requirement(req, False)
+    assert found.link.url.endswith("simple-3.0.tar.gz")
 
 
 def test_incorrect_case_file_index(data):
     """Test PackageFinder detects latest using wrong case"""
     req = install_req_from_line('dinner', None)
     finder = make_test_finder(index_urls=[data.find_links3])
-    link = finder.find_requirement(req, False)
-    assert link.url.endswith("Dinner-2.0.tar.gz")
+    found = finder.find_requirement(req, False)
+    assert found.link.url.endswith("Dinner-2.0.tar.gz")
 
 
 @pytest.mark.network
@@ -180,7 +180,7 @@ class TestWheel:
         finder = make_test_finder(find_links=[data.find_links])
         found = finder.find_requirement(req, True)
         assert (
-            found.url.endswith("simple.dist-0.1-py2.py3-none-any.whl")
+            found.link.url.endswith("simple.dist-0.1-py2.py3-none-any.whl")
         ), found
 
     def test_wheel_over_sdist_priority(self, data):
@@ -191,7 +191,8 @@ class TestWheel:
         req = install_req_from_line("priority")
         finder = make_test_finder(find_links=[data.find_links])
         found = finder.find_requirement(req, True)
-        assert found.url.endswith("priority-1.0-py2.py3-none-any.whl"), found
+        assert found.link.url.endswith("priority-1.0-py2.py3-none-any.whl"), \
+            found
 
     def test_existing_over_wheel_priority(self, data):
         """
@@ -292,8 +293,8 @@ def test_finder_priority_file_over_page(data):
     assert all(version.link.scheme == 'https'
                for version in all_versions[1:]), all_versions
 
-    link = finder.find_requirement(req, False)
-    assert link.url.startswith("file://")
+    found = finder.find_requirement(req, False)
+    assert found.link.url.startswith("file://")
 
 
 def test_finder_priority_nonegg_over_eggfragments():
@@ -306,9 +307,9 @@ def test_finder_priority_nonegg_over_eggfragments():
     assert all_versions[0].link.url.endswith('tar.gz')
     assert all_versions[1].link.url.endswith('#egg=bar-1.0')
 
-    link = finder.find_requirement(req, False)
+    found = finder.find_requirement(req, False)
 
-    assert link.url.endswith('tar.gz')
+    assert found.link.url.endswith('tar.gz')
 
     links.reverse()
 
@@ -316,9 +317,9 @@ def test_finder_priority_nonegg_over_eggfragments():
     all_versions = finder.find_all_candidates(req.name)
     assert all_versions[0].link.url.endswith('tar.gz')
     assert all_versions[1].link.url.endswith('#egg=bar-1.0')
-    link = finder.find_requirement(req, False)
+    found = finder.find_requirement(req, False)
 
-    assert link.url.endswith('tar.gz')
+    assert found.link.url.endswith('tar.gz')
 
 
 def test_finder_only_installs_stable_releases(data):
@@ -330,21 +331,21 @@ def test_finder_only_installs_stable_releases(data):
 
     # using a local index (that has pre & dev releases)
     finder = make_test_finder(index_urls=[data.index_url("pre")])
-    link = finder.find_requirement(req, False)
-    assert link.url.endswith("bar-1.0.tar.gz"), link.url
+    found = finder.find_requirement(req, False)
+    assert found.link.url.endswith("bar-1.0.tar.gz"), found.link.url
 
     # using find-links
     links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
 
     finder = make_no_network_finder(links)
-    link = finder.find_requirement(req, False)
-    assert link.url == "https://foo/bar-1.0.tar.gz"
+    found = finder.find_requirement(req, False)
+    assert found.link.url == "https://foo/bar-1.0.tar.gz"
 
     links.reverse()
 
     finder = make_no_network_finder(links)
-    link = finder.find_requirement(req, False)
-    assert link.url == "https://foo/bar-1.0.tar.gz"
+    found = finder.find_requirement(req, False)
+    assert found.link.url == "https://foo/bar-1.0.tar.gz"
 
 
 def test_finder_only_installs_data_require(data):
@@ -383,21 +384,21 @@ def test_finder_installs_pre_releases(data):
         index_urls=[data.index_url("pre")],
         allow_all_prereleases=True,
     )
-    link = finder.find_requirement(req, False)
-    assert link.url.endswith("bar-2.0b1.tar.gz"), link.url
+    found = finder.find_requirement(req, False)
+    assert found.link.url.endswith("bar-2.0b1.tar.gz"), found.link.url
 
     # using find-links
     links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
 
     finder = make_no_network_finder(links, allow_all_prereleases=True)
-    link = finder.find_requirement(req, False)
-    assert link.url == "https://foo/bar-2.0b1.tar.gz"
+    found = finder.find_requirement(req, False)
+    assert found.link.url == "https://foo/bar-2.0b1.tar.gz"
 
     links.reverse()
 
     finder = make_no_network_finder(links, allow_all_prereleases=True)
-    link = finder.find_requirement(req, False)
-    assert link.url == "https://foo/bar-2.0b1.tar.gz"
+    found = finder.find_requirement(req, False)
+    assert found.link.url == "https://foo/bar-2.0b1.tar.gz"
 
 
 def test_finder_installs_dev_releases(data):
@@ -412,8 +413,8 @@ def test_finder_installs_dev_releases(data):
         index_urls=[data.index_url("dev")],
         allow_all_prereleases=True,
     )
-    link = finder.find_requirement(req, False)
-    assert link.url.endswith("bar-2.0.dev1.tar.gz"), link.url
+    found = finder.find_requirement(req, False)
+    assert found.link.url.endswith("bar-2.0.dev1.tar.gz"), found.link.url
 
 
 def test_finder_installs_pre_releases_with_version_spec():
@@ -424,14 +425,14 @@ def test_finder_installs_pre_releases_with_version_spec():
     links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
 
     finder = make_no_network_finder(links)
-    link = finder.find_requirement(req, False)
-    assert link.url == "https://foo/bar-2.0b1.tar.gz"
+    found = finder.find_requirement(req, False)
+    assert found.link.url == "https://foo/bar-2.0b1.tar.gz"
 
     links.reverse()
 
     finder = make_no_network_finder(links)
-    link = finder.find_requirement(req, False)
-    assert link.url == "https://foo/bar-2.0b1.tar.gz"
+    found = finder.find_requirement(req, False)
+    assert found.link.url == "https://foo/bar-2.0b1.tar.gz"
 
 
 class TestLinkEvaluator(object):


### PR DESCRIPTION
This is the first (easy) half toward fixing #8123. We know from the linked issue that we should log the message when we are sure the candidate will be installed, but before resolving the wheel cache. In th legacy resolver, this means sticking the warning inside `_populate_link()`, after the (remote) link is found, but before it got resolved against the wheel cache.

But the mesage needs to access not only the link found, but also why link is found (i.e. the `InstallationCandidate` that points to it), which is not available at the call site of `PackageFinder.find_requirement()`.

So the PR contains two parts (reflected by the two commits). The first part makes `PackageFinder.find_requirement()` to return the best candidate instead, and introduced a wrapper in the legacy resolver to get the link. The second moves the yanked warning into the wrapper function in the legacy resolver, which is called before the link is pinned for installation later, but before it got replaced by the cache entry.

With the relocation done, what’s left is to implement the warning in the new resolver. Which is the difficult part, as described in the linked issue.