### PR TITLE
Rework `get_installation_order` to allow for dependency cycles

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -15,7 +15,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from .factory import Factory
 
 if MYPY_CHECK_RUNNING:
-    from typing import Dict, List, Optional, Tuple
+    from typing import Dict, List, Optional, Set, Tuple
 
     from pip._vendor.resolvelib.resolvers import Result
     from pip._vendor.resolvelib.structs import Graph
@@ -157,7 +157,7 @@ def get_topological_weights(graph):
 
     When assigning weight, the longer path (i.e. larger length) is preferred.
     """
-    path = []  # type: List[Optional[str]]
+    path = set()  # type: Set[Optional[str]]
     weights = {}  # type: Dict[Optional[str], int]
 
     def visit(node):
@@ -167,11 +167,10 @@ def get_topological_weights(graph):
             return
 
         # Time to visit the children!
-        path.append(node)
+        path.add(node)
         for child in graph.iter_children(node):
             visit(child)
-        popped = path.pop()
-        assert popped == node, "Sanity check failed. Please file a bug report."
+        path.remove(node)
 
         last_known_parent_count = weights.get(node, 0)
         weights[node] = max(last_known_parent_count, len(path))

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -129,6 +129,13 @@ class Resolver(BaseResolver):
         graph = self._result.graph
         weights = get_topological_weights(graph)
 
+        sorted_items = sorted(
+            req_set.requirements.items(),
+            key=functools.partial(_req_set_item_sorter, weights=weights),
+            reverse=True,
+        )
+        return [ireq for _, ireq in sorted_items]
+
 
 def get_topological_weights(graph):
     # type: (Graph) -> Dict[str, int]

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -114,11 +114,11 @@ class Resolver(BaseResolver):
 
     def get_installation_order(self, req_set):
         # type: (RequirementSet) -> List[InstallRequirement]
-        """Create a list that orders given requirements for installation.
+        """Get order for installation of requirements in RequirementSet.
 
-        The returned list should contain all requirements in ``req_set``,
-        so the caller can loop through it and have a requirement installed
-        before the requiring thing.
+        The returned list contains a requirement before another that depends on
+        it. This helps ensure that the environment is kept consistent as they
+        get installed one-by-one.
 
         The current implementation walks the resolved dependency graph, and
         make sure every node has a greater "weight" than all its parents.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -151,13 +151,6 @@ class Resolver(BaseResolver):
                     "dependency."
                 )
 
-        sorted_items = sorted(
-            req_set.requirements.items(),
-            key=functools.partial(_req_set_item_sorter, weights=weights),
-            reverse=True,
-        )
-        return [ireq for _, ireq in sorted_items]
-
 
 def _req_set_item_sorter(
     item,     # type: Tuple[str, InstallRequirement]

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -26,6 +26,21 @@ def resolver(preparer, finder):
     return resolver
 
 
+def _make_graph(edges):
+    """Build graph from edge declarations.
+    """
+
+    graph = DirectedGraph()
+    for parent, child in edges:
+        parent = canonicalize_name(parent) if parent else None
+        child = canonicalize_name(child) if child else None
+        for v in (parent, child):
+            if v not in graph:
+                graph.add(v)
+        graph.connect(parent, child)
+    return graph
+
+
 @pytest.mark.parametrize(
     "edges, ordered_reqs",
     [
@@ -59,15 +74,7 @@ def resolver(preparer, finder):
     ],
 )
 def test_new_resolver_get_installation_order(resolver, edges, ordered_reqs):
-    # Build graph from edge declarations.
-    graph = DirectedGraph()
-    for parent, child in edges:
-        parent = canonicalize_name(parent) if parent else None
-        child = canonicalize_name(child) if child else None
-        for v in (parent, child):
-            if v not in graph:
-                graph.add(v)
-        graph.connect(parent, child)
+    graph = _make_graph(edges)
 
     # Mapping values and criteria are not used in test, so we stub them out.
     mapping = {vertex: None for vertex in graph if vertex is not None}

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -40,9 +40,9 @@ def resolver(preparer, finder):
         (
             [
                 (None, "toporequires"),
-                (None, "toporequire2"),
-                (None, "toporequire3"),
-                (None, "toporequire4"),
+                (None, "toporequires2"),
+                (None, "toporequires3"),
+                (None, "toporequires4"),
                 ("toporequires2", "toporequires"),
                 ("toporequires3", "toporequires"),
                 ("toporequires4", "toporequires"),

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -6,7 +6,10 @@ from pip._vendor.resolvelib.structs import DirectedGraph
 
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.req.req_set import RequirementSet
-from pip._internal.resolution.resolvelib.resolver import Resolver
+from pip._internal.resolution.resolvelib.resolver import (
+    Resolver,
+    get_topological_weights,
+)
 
 
 @pytest.fixture()
@@ -87,3 +90,147 @@ def test_new_resolver_get_installation_order(resolver, edges, ordered_reqs):
     ireqs = resolver.get_installation_order(reqset)
     req_strs = [str(r.req) for r in ireqs]
     assert req_strs == ordered_reqs
+
+
+@pytest.mark.parametrize(
+    "name, edges, expected_weights",
+    [
+        (
+            # From https://github.com/pypa/pip/pull/8127#discussion_r414564664
+            "deep second edge",
+            [
+                (None, "one"),
+                (None, "two"),
+                ("one", "five"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+            ],
+            {None: 0, "one": 1, "two": 1, "three": 2, "four": 3, "five": 4},
+        ),
+        (
+            "linear",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+        (
+            "linear AND root -> two",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+                (None, "two"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+        (
+            "linear AND root -> three",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+                (None, "three"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+        (
+            "linear AND root -> four",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+                (None, "four"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+        (
+            "linear AND root -> five",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+                (None, "five"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+        (
+            "linear AND one -> four",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+                ("one", "four"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+        (
+            "linear AND two -> four",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+                ("two", "four"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+        (
+            "linear AND four -> one (cycle)",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+                ("four", "one"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+        (
+            "linear AND four -> two (cycle)",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+                ("four", "two"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+        (
+            "linear AND four -> three (cycle)",
+            [
+                (None, "one"),
+                ("one", "two"),
+                ("two", "three"),
+                ("three", "four"),
+                ("four", "five"),
+                ("four", "three"),
+            ],
+            {None: 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5},
+        ),
+    ],
+)
+def test_new_resolver_topological_weights(name, edges, expected_weights):
+    graph = _make_graph(edges)
+
+    weights = get_topological_weights(graph)
+    assert weights == expected_weights


### PR DESCRIPTION
Switches our ordering strategy to "weight" nodes to be based on: The length of the longest path, from root to the node (ignoring any paths containing cycles).

Our graph is a directed cyclic graph, so, that's fun to think about. :)