### PR TITLE
Add a generic network exception to be raised

### DIFF
--- a/news/5380.bugfix
+++ b/news/5380.bugfix
@@ -1,0 +1,1 @@
+Raise user friendly errors on network failures

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -1,4 +1,5 @@
 from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
+from pip._vendor.urllib3.exceptions import NewConnectionError, ReadTimeoutError
 
 from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -95,3 +96,8 @@ def response_chunks(response, chunk_size=CONTENT_CHUNK_SIZE):
             if not chunk:
                 break
             yield chunk
+    except (NewConnectionError, ReadTimeoutError) as exc:
+        raise NetworkConnectionError(
+            "Failed to get address for host! Check your network connectivity "
+            "and DNS settings.\nDetails: {}".format(exc)
+        )


### PR DESCRIPTION
Towards https://github.com/pypa/pip/issues/5380

The other PR may be created for removing the usage of `raise_for_status`.
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
