### PR TITLE
Removed tests_install_cleanup tests using static build dir

### DIFF
--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -4,24 +4,6 @@ from os.path import exists
 import pytest
 
 from pip._internal.cli.status_codes import PREVIOUS_BUILD_DIR_ERROR
-from tests.lib import need_mercurial, windows_workaround_7667
-from tests.lib.local_repos import local_checkout
-
-
-def test_cleanup_after_install(script, data):
-    """
-    Test clean up after installing a package.
-    """
-    script.pip(
-        'install', '--no-index',
-        '--find-links={}'.format(data.find_links),
-        'simple'
-    )
-    build = script.venv_path / "build"
-    src = script.venv_path / "src"
-    assert not exists(build), "build/ dir still exists: {}".format(build)
-    assert not exists(src), "unexpected src/ dir exists: {}" .format(src)
-    script.assert_no_temp()
 
 
 @pytest.mark.network
@@ -35,89 +17,6 @@ def test_no_clean_option_blocks_cleaning_after_install(script, data):
         '--find-links={}'.format(data.find_links), 'simple', expect_temp=True,
     )
     assert exists(build)
-
-
-@pytest.mark.network
-@need_mercurial
-@windows_workaround_7667
-def test_cleanup_after_install_editable_from_hg(script, tmpdir):
-    """
-    Test clean up after cloning from Mercurial.
-
-    """
-    requirement = '{}#egg=ScriptTest'.format(
-        local_checkout('hg+https://bitbucket.org/ianb/scripttest', tmpdir)
-    )
-    script.pip('install', '-e', requirement)
-    build = script.venv_path / 'build'
-    src = script.venv_path / 'src'
-    assert not exists(build), "build/ dir still exists: {}".format(build)
-    assert exists(src), "expected src/ dir doesn't exist: {}".format(src)
-    script.assert_no_temp()
-
-
-def test_cleanup_after_install_from_local_directory(script, data):
-    """
-    Test clean up after installing from a local directory.
-    """
-    to_install = data.packages.joinpath("FSPkg")
-    script.pip('install', to_install)
-    build = script.venv_path / 'build'
-    src = script.venv_path / 'src'
-    assert not exists(build), "unexpected build/ dir exists: {}".format(build)
-    assert not exists(src), "unexpected src/ dir exist: {}".format(src)
-    script.assert_no_temp()
-
-
-def test_cleanup_req_satisfied_no_name(script, data):
-    """
-    Test cleanup when req is already satisfied, and req has no 'name'
-    """
-    # this test confirms Issue #420 is fixed
-    # reqs with no 'name' that were already satisfied were leaving behind tmp
-    # build dirs
-    # 2 examples of reqs that would do this
-    # 1) https://bitbucket.org/ianb/initools/get/tip.zip
-    # 2) parent-0.1.tar.gz
-    dist = data.packages.joinpath("parent-0.1.tar.gz")
-
-    script.pip('install', dist)
-    script.pip('install', dist)
-
-    build = script.venv_path / 'build'
-    assert not exists(build), \
-        "unexpected build/ dir exists: {build}".format(**locals())
-    script.assert_no_temp()
-
-
-def test_cleanup_after_install_exception(script, data):
-    """
-    Test clean up after a 'setup.py install' exception.
-    """
-    # broken==0.2broken fails during install; see packages readme file
-    result = script.pip(
-        'install', '-f', data.find_links, '--no-index', 'broken==0.2broken',
-        expect_error=True,
-    )
-    build = script.venv_path / 'build'
-    assert not exists(build), \
-        "build/ dir still exists: {result.stdout}".format(**locals())
-    script.assert_no_temp()
-
-
-def test_cleanup_after_egg_info_exception(script, data):
-    """
-    Test clean up after a 'setup.py egg_info' exception.
-    """
-    # brokenegginfo fails during egg_info; see packages readme file
-    result = script.pip(
-        'install', '-f', data.find_links, '--no-index', 'brokenegginfo==0.1',
-        expect_error=True,
-    )
-    build = script.venv_path / 'build'
-    assert not exists(build), \
-        "build/ dir still exists: {result.stdout}".format(**locals())
-    script.assert_no_temp()
 
 
 @pytest.mark.network


### PR DESCRIPTION
Fixed and closes https://github.com/pypa/pip/issues/2640

Removing tests in `test_install_cleanup.py`, which are using the old static build directory.