### PR TITLE
Make mypy happy with beta release automation

### DIFF
--- a/tools/automation/release/check_version.py
+++ b/tools/automation/release/check_version.py
@@ -20,7 +20,7 @@ def is_this_a_good_version_number(string: str) -> Optional[str]:
     if v.dev:
         return "No development releases on PyPI. What are you even thinking?"
 
-    if v.is_prerelease and v.pre[0] != "b":
+    if v.pre and v.pre[0] != "b":
         return "Only beta releases are allowed. No alphas."
 
     release = v.release


### PR DESCRIPTION
The linting issue was originally found in https://github.com/pypa/pip/pull/8137#issuecomment-619403842:

    mypy.....................................................................Failed
    - hook id: mypy
    - exit code: 1

    tools/automation/release/check_version.py:23: error: Value of type "Optional[Tuple[str, int]]" is not indexable
    Found 1 error in 1 file (checked 135 source files)

This seems only to affect mypy on Python 3.8.  Edit: this makes me start to wonder if we want to run lint on all testing environments, since linting time will take a small proportion in testing time if we do it.  That'd be a bit redundant though.