### PR TITLE
Simplify _should_cache

### DIFF
--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -118,11 +118,8 @@ def _should_cache(
     wheel cache, assuming the wheel cache is available, and _should_build()
     has determined a wheel needs to be built.
     """
-    if not should_build_for_install_command(
-        req, check_binary_allowed=_always_true
-    ):
-        # never cache if pip install would not have built
-        # (editable mode, etc)
+    if req.editable or not req.source_dir:
+        # never cache editable requirements
         return False
 
     if req.link and req.link.is_vcs:


### PR DESCRIPTION
The condition "never cache if pip install would not have built"
can be simplified to "do not cache editable requirements".
This is easier to read, and avoids a double warning if the 'wheel'
package is not installed.

Note the test for `req.source_dir` is copied as is from `_should_build` so the code is equivalent.
I suspect it is not necessary, but this can be left for a future refactoring.

Towards #8102 