### PR TITLE
New resolver: Carry extras info in ExplicitRequirement

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -405,6 +405,8 @@ class ExtrasCandidate(Candidate):
         ]
         # Add a dependency on the exact base.
         # (See note 2b in the class docstring)
+        # FIXME: This does not work if the base candidate is specified by
+        # link, e.g. "pip install .[dev]" will fail.
         spec = "{}=={}".format(self.base.name, self.base.version)
         deps.append(factory.make_requirement_from_spec(spec, self.base._ireq))
         return deps

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -152,7 +152,7 @@ class Factory(object):
             #       Specifically, this might be needed in "name @ URL"
             #       syntax - need to check where that syntax is handled.
             cand = self._make_candidate_from_link(
-                ireq.link, extras=set(), parent=ireq,
+                ireq.link, extras=set(ireq.extras), parent=ireq,
             )
             return ExplicitRequirement(cand)
         return SpecifierRequirement(ireq, factory=self)

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -573,7 +573,13 @@ class TestExtraMerge(object):
 
     @pytest.mark.parametrize(
         "pkg_builder",
-        [_local_with_setup, _direct_wheel, _wheel_from_index],
+        [
+            pytest.param(
+                _local_with_setup, marks=pytest.mark.xfail(strict=True),
+            ),
+            _direct_wheel,
+            _wheel_from_index,
+        ],
     )
     def test_new_resolver_extra_merge_in_package(
         self, monkeypatch, script, pkg_builder,

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -529,3 +529,74 @@ def test_new_resolver_handles_prerelease(
         *pip_args
     )
     assert_installed(script, pkg=expected_version)
+
+
+class TestExtraMerge(object):
+    """
+    Test installing a package that depends the same package with different
+    extras, one listed as required and the other as in extra.
+    """
+
+    def _local_with_setup(script, name, version, requires, extras):
+        """Create the package as a local source directory to install from path.
+        """
+        return create_test_package_with_setup(
+            script,
+            name=name,
+            version=version,
+            install_requires=requires,
+            extras_require=extras,
+        )
+
+    def _direct_wheel(script, name, version, requires, extras):
+        """Create the package as a wheel to install from path directly.
+        """
+        return create_basic_wheel_for_package(
+            script,
+            name=name,
+            version=version,
+            depends=requires,
+            extras=extras,
+        )
+
+    def _wheel_from_index(script, name, version, requires, extras):
+        """Create the package as a wheel to install from index.
+        """
+        create_basic_wheel_for_package(
+            script,
+            name=name,
+            version=version,
+            depends=requires,
+            extras=extras,
+        )
+        return name
+
+    @pytest.mark.parametrize(
+        "pkg_builder",
+        [_local_with_setup, _direct_wheel, _wheel_from_index],
+    )
+    def test_new_resolver_extra_merge_in_package(
+        self, monkeypatch, script, pkg_builder,
+    ):
+        create_basic_wheel_for_package(script, "depdev", "1.0.0")
+        create_basic_wheel_for_package(
+            script,
+            "dep",
+            "1.0.0",
+            extras={"dev": ["depdev"]},
+        )
+        requirement = pkg_builder(
+            script,
+            name="pkg",
+            version="1.0.0",
+            requires=["dep"],
+            extras={"dev": ["dep[dev]"]},
+        )
+
+        script.pip(
+            "install", "--unstable-feature=resolver",
+            "--no-cache-dir", "--no-index",
+            "--find-links", script.scratch_path,
+            requirement + "[dev]",
+        )
+        assert_installed(script, pkg="1.0.0", dep="1.0.0", depdev="1.0.0")


### PR DESCRIPTION
See https://github.com/pypa/pip/issues/7714#issuecomment-619497351

The main problem is that we forgot to pass the extras when building an ExplicitRequirement, so the info get lost.

The fix led me to another issue that we were not building the non-extras requirement correctly in `get_dependencies()`. The previous implementation always builds a SpecifierRequirement, which is not correct. The fix simply delegates the logic to `factory.make_requirement_from_install_req()` which chooses the correct class automatically.