### PR TITLE
Ignore require-virtualenv in `pip cache`

### DIFF
--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -32,6 +32,7 @@ class CacheCommand(Command):
         <pattern> can be a glob expression or a package name.
     """
 
+    ignore_require_venv = True
     usage = """
         %prog info
         %prog list [<pattern>]


### PR DESCRIPTION
Pointed out by @uranusjr during a discussion about this new command.