### PR TITLE
Fix generated file mode to use bitwise AND

### DIFF
--- a/news/8164.bugfix
+++ b/news/8164.bugfix
@@ -1,1 +1,1 @@
-Get generated file mode by performing bitwise AND with the negation of current umask
+Fix metadata permission issues when umask has the executable bit set.

--- a/news/8164.bugfix
+++ b/news/8164.bugfix
@@ -1,0 +1,1 @@
+Get generated file mode by performing bitwise AND with the negation of current umask

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -567,7 +567,7 @@ def install_unpacked_wheel(
         if msg is not None:
             logger.warning(msg)
 
-    generated_file_mode = 0o666 - current_umask()
+    generated_file_mode = 0o666 & ~current_umask()
 
     @contextlib.contextmanager
     def _generate_file(path, **kwargs):

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -278,9 +278,8 @@ class TestInstallUnpackedWheel(object):
         """Test that the files created after install honor the permissions
         set when the user sets a custom umask"""
 
-        prev_umask = os.umask(0)
+        prev_umask = os.umask(user_mask)
         try:
-            os.umask(user_mask)
             self.prep(data, tmpdir)
             wheel.install_wheel(
                 self.name,


### PR DESCRIPTION
Fixes and closes #8164 

Taking a bitwise AND with the negation of current umask, instead of subtracting the value.

https://unix.stackexchange.com/questions/430616/why-do-some-umask-values-not-take-effect