### PR TITLE
Docs: Reference 'pip cache' in 'pip install' caching section

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -565,7 +565,7 @@ While this cache attempts to minimize network activity, it does not prevent
 network access altogether. If you want a local install solution that
 circumvents accessing PyPI, see :ref:`Installing from local packages`.
 
-The default location for the cache directory depends on the Operating System:
+The default location for the cache directory depends on the operating system:
 
 Unix
   :file:`~/.cache/pip` and it respects the ``XDG_CACHE_HOME`` directory.
@@ -573,6 +573,9 @@ macOS
   :file:`~/Library/Caches/pip`.
 Windows
   :file:`<CSIDL_LOCAL_APPDATA>\\pip\\Cache`
+
+Run ``pip cache dir`` to show the cache directory and see :ref:`pip cache` to
+inspect and manage pip’s cache.
 
 
 .. _`Wheel cache`:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

For https://pip.pypa.io/en/stable/reference/pip_install/#caching

* Mention the new `pip cache dir` command and link to the `pip cache` section:

  * https://pip.pypa.io/en/stable/reference/pip_cache/

---

Needs a `trivial` label?