### PR TITLE
Improve message when the wheel package is absent

### DIFF
--- a/news/8178.bugfix
+++ b/news/8178.bugfix
@@ -1,0 +1,2 @@
+Avoid unncessary message about the wheel package not being installed
+when a wheel would not have been built. Additionally, clarify the message.

--- a/news/8178.bugfix
+++ b/news/8178.bugfix
@@ -1,2 +1,2 @@
-Avoid unncessary message about the wheel package not being installed
+Avoid unnecessary message about the wheel package not being installed
 when a wheel would not have been built. Additionally, clarify the message.

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -82,7 +82,7 @@ def _should_build(
     if not req.use_pep517 and not is_wheel_installed():
         # we don't build legacy requirements if wheel is not installed
         logger.info(
-            "Could not build wheels for %s, "
+            "Using legacy setup.py install for %s, "
             "since package 'wheel' is not installed.", req.name,
         )
         return False

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -69,14 +69,6 @@ def _should_build(
     # From this point, this concerns the pip install command only
     # (need_wheel=False).
 
-    if not req.use_pep517 and not is_wheel_installed():
-        # we don't build legacy requirements if wheel is not installed
-        logger.info(
-            "Could not build wheels for %s, "
-            "since package 'wheel' is not installed.", req.name,
-        )
-        return False
-
     if req.editable or not req.source_dir:
         return False
 
@@ -84,6 +76,14 @@ def _should_build(
         logger.info(
             "Skipping wheel build for %s, due to binaries "
             "being disabled for it.", req.name,
+        )
+        return False
+
+    if not req.use_pep517 and not is_wheel_installed():
+        # we don't build legacy requirements if wheel is not installed
+        logger.info(
+            "Could not build wheels for %s, "
+            "since package 'wheel' is not installed.", req.name,
         )
         return False
 


### PR DESCRIPTION
Fixes #8178 

- avoid uselessly reporting about the `wheel` package being absent when a wheel would not have been built for another reason
- clarify the message "Could not build wheel" -> "Using legacy setup.py install"

This progresses #8102 too.