### PR TITLE
Enable --no-input option by adding docs and tests

### DIFF
--- a/news/7688.doc
+++ b/news/7688.doc
@@ -1,0 +1,1 @@
+Add ``--no-input`` option to pip docs

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -243,7 +243,7 @@ no_input = partial(
     dest='no_input',
     action='store_true',
     default=False,
-    help=SUPPRESS_HELP
+    help="Disable prompting for input."
 )  # type: Callable[..., Option]
 
 proxy = partial(

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -242,8 +242,9 @@ def test_prompt_for_authentication(script, data, cert_factory):
         result = script.pip('install', "--index-url", url,
                             "--cert", cert_path, "--client-cert", cert_path,
                             'simple', expect_error=True)
-    print(result)
-    assert 'User for {}:{}'.format(server.host, server.port) in result.stdout
+
+    assert 'User for {}:{}'.format(server.host, server.port) in \
+           result.stdout, str(result)
 
 
 def test_do_not_prompt_for_authentication(script, data, cert_factory):

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -210,3 +210,19 @@ def file_response(path):
             return [f.read()]
 
     return responder
+
+
+def authorization_response(path):
+    def responder(environ, start_response):
+        # type: (Environ, StartResponse) -> Body
+
+        start_response(
+            "401 Unauthorized", [
+                ("WWW-Authenticate", "Basic"),
+            ],
+        )
+
+        with open(path, 'rb') as f:
+            return [f.read()]
+
+    return responder


### PR DESCRIPTION
Fixes and closes https://github.com/pypa/pip/issues/7688 , towards #2429 

Added tests to verify the behaviour of authentication prompts, with and without the `--no-input` flag, and added help text to enable the option in docs and in `--help`

```
$ pip --help
.....
General Options:
.....
  --no-input                  Disable prompting for input.
```