### PR TITLE
Build ireq line from parent for installed dist

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -82,11 +82,15 @@ def make_install_req_from_editable(link, parent):
 
 def make_install_req_from_dist(dist, parent):
     # type: (Distribution, InstallRequirement) -> InstallRequirement
+    project_name = canonicalize_name(dist.project_name)
+    if parent.req:
+        line = str(parent.req)
+    elif parent.link:
+        line = "{} @ {}".format(project_name, parent.link.url)
+    else:
+        line = "{}=={}".format(project_name, dist.parsed_version)
     ireq = install_req_from_line(
-        "{}=={}".format(
-            canonicalize_name(dist.project_name),
-            dist.parsed_version,
-        ),
+        line,
         comes_from=parent.comes_from,
         use_pep517=parent.use_pep517,
         isolated=parent.isolated,

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -357,7 +357,6 @@ def test_new_resolver_installed(script):
         "dep",
         "0.1.0",
     )
-    satisfied_output = "Requirement already satisfied: base==0.1.0 in"
 
     result = script.pip(
         "install", "--unstable-feature=resolver",
@@ -365,15 +364,16 @@ def test_new_resolver_installed(script):
         "--find-links", script.scratch_path,
         "base",
     )
-    assert satisfied_output not in result.stdout, str(result)
+    assert "Requirement already satisfied" not in result.stdout, str(result)
 
     result = script.pip(
         "install", "--unstable-feature=resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
-        "base",
+        "base>=0.1.0",
     )
-    assert satisfied_output in result.stdout, str(result)
+    assert "Requirement already satisfied: base>=0.1.0" in result.stdout, \
+        str(result)
     assert script.site_packages / "base" not in result.files_updated, (
         "base 0.1.0 reinstalled"
     )
@@ -385,7 +385,7 @@ def test_new_resolver_ignore_installed(script):
         "base",
         "0.1.0",
     )
-    satisfied_output = "Requirement already satisfied: base==0.1.0 in"
+    satisfied_output = "Requirement already satisfied"
 
     result = script.pip(
         "install", "--unstable-feature=resolver",

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -370,9 +370,9 @@ def test_new_resolver_installed(script):
         "install", "--unstable-feature=resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
-        "base>=0.1.0",
+        "base~=0.1.0",
     )
-    assert "Requirement already satisfied: base>=0.1.0" in result.stdout, \
+    assert "Requirement already satisfied: base~=0.1.0" in result.stdout, \
         str(result)
     assert script.site_packages / "base" not in result.files_updated, (
         "base 0.1.0 reinstalled"


### PR DESCRIPTION
Similar to #8005, the line should be based on the parent InstallRequirement if possible. (I don’t think we’ll ever reach the final `else:` block because the InstallRequirement should have either `req` or `url` set, but I guess it does not hurt?