### PR TITLE
feat(pip/_internal/*): Use custom raise_for_status method

### DIFF
--- a/news/5380.feature
+++ b/news/5380.feature
@@ -1,0 +1,1 @@
+Refine error messages to avoid showing Python tracebacks when an HTTP error occurs.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -26,6 +26,7 @@ from pip._internal.exceptions import (
     BadCommand,
     CommandError,
     InstallationError,
+    NetworkConnectionError,
     PreviousBuildDirError,
     SubProcessError,
     UninstallationError,
@@ -221,7 +222,7 @@ class Command(CommandContextMixIn):
 
             return PREVIOUS_BUILD_DIR_ERROR
         except (InstallationError, UninstallationError, BadCommand,
-                SubProcessError) as exc:
+                SubProcessError, NetworkConnectionError) as exc:
             logger.critical(str(exc))
             logger.debug('Exception information:', exc_info=True)
 

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -99,6 +99,23 @@ class PreviousBuildDirError(PipError):
     """Raised when there's a previous conflicting build directory"""
 
 
+class NetworkConnectionError(PipError):
+    """HTTP connection error"""
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize NetworkConnectionError with  `request` and `response`
+        objects.
+        """
+        response = kwargs.pop('response', None)
+        self.response = response
+        self.request = kwargs.pop('request', None)
+        if (response is not None and not self.request and
+                hasattr(response, 'request')):
+            self.request = self.response.request
+        super(NetworkConnectionError, self).__init__(*args, **kwargs)
+
+
 class InvalidWheelFilename(InstallationError):
     """Invalid wheel filename."""
 

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -9,9 +9,10 @@ from pip._vendor.six import iteritems
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any, Optional, List, Dict
+    from typing import Any, Optional, List, Dict, Text
 
     from pip._vendor.pkg_resources import Distribution
+    from pip._vendor.requests.models import Response, Request
     from pip._vendor.six import PY3
     from pip._vendor.six.moves import configparser
 
@@ -102,18 +103,24 @@ class PreviousBuildDirError(PipError):
 class NetworkConnectionError(PipError):
     """HTTP connection error"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, error_msg, response=None, request=None):
+        # type: (Text, Response, Request) -> None
         """
         Initialize NetworkConnectionError with  `request` and `response`
         objects.
         """
-        response = kwargs.pop('response', None)
         self.response = response
-        self.request = kwargs.pop('request', None)
-        if (response is not None and not self.request and
+        self.request = request
+        self.error_msg = error_msg
+        if (self.response is not None and not self.request and
                 hasattr(response, 'request')):
             self.request = self.response.request
-        super(NetworkConnectionError, self).__init__(*args, **kwargs)
+        super(NetworkConnectionError, self).__init__(
+            error_msg, response, request)
+
+    def __str__(self):
+        # type: () -> str
+        return str(self.error_msg)
 
 
 class InvalidWheelFilename(InstallationError):

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -11,7 +11,11 @@ from pip._internal.cli.progress_bars import DownloadProgressProvider
 from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.models.index import PyPI
 from pip._internal.network.cache import is_from_cache
-from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
+from pip._internal.network.utils import (
+    HEADERS,
+    raise_for_status,
+    response_chunks,
+)
 from pip._internal.utils.misc import (
     format_size,
     redact_auth_from_url,
@@ -165,6 +169,7 @@ class Downloader(object):
         try:
             resp = _http_get_download(self._session, link)
         except NetworkConnectionError as e:
+            assert e.response is not None
             logger.critical(
                 "HTTP error %s while getting %s", e.response.status_code, link
             )

--- a/src/pip/_internal/network/lazy_wheel.py
+++ b/src/pip/_internal/network/lazy_wheel.py
@@ -10,7 +10,11 @@ from zipfile import BadZipfile, ZipFile
 from pip._vendor.requests.models import CONTENT_CHUNK_SIZE
 from pip._vendor.six.moves import range
 
-from pip._internal.network.utils import HEADERS, response_chunks
+from pip._internal.network.utils import (
+    HEADERS,
+    raise_for_status,
+    response_chunks,
+)
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
 
@@ -51,7 +55,7 @@ class LazyZipOverHTTP(object):
     def __init__(self, url, session, chunk_size=CONTENT_CHUNK_SIZE):
         # type: (str, PipSession, int) -> None
         head = session.head(url, headers=HEADERS)
-        head.raise_for_status()
+        raise_for_status(head)
         assert head.status_code == 200
         self._session, self._url, self._chunk_size = session, url, chunk_size
         self._length = int(head.headers['Content-Length'])

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -1,5 +1,6 @@
 from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
 
+from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -25,6 +26,33 @@ if MYPY_CHECK_RUNNING:
 # before sending because if that's the case I don't think it'll ever be
 # possible to make this work.
 HEADERS = {'Accept-Encoding': 'identity'}  # type: Dict[str, str]
+
+
+def raise_for_status(resp):
+    # type: (Response) -> None
+    http_error_msg = u''
+    if isinstance(resp.reason, bytes):
+        # We attempt to decode utf-8 first because some servers
+        # choose to localize their reason strings. If the string
+        # isn't utf-8, we fall back to iso-8859-1 for all other
+        # encodings.
+        try:
+            reason = resp.reason.decode('utf-8')
+        except UnicodeDecodeError:
+            reason = resp.reason.decode('iso-8859-1')
+    else:
+        reason = resp.reason
+
+    if 400 <= resp.status_code < 500:
+        http_error_msg = u'%s Client Error: %s for url: %s' % (
+            resp.status_code, reason, resp.url)
+
+    elif 500 <= resp.status_code < 600:
+        http_error_msg = u'%s Server Error: %s for url: %s' % (
+            resp.status_code, reason, resp.url)
+
+    if http_error_msg:
+        raise NetworkConnectionError(http_error_msg, response=resp)
 
 
 def response_chunks(response, chunk_size=CONTENT_CHUNK_SIZE):

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -44,6 +44,7 @@ class PipXmlrpcTransport(xmlrpc_client.Transport):
             self.verbose = verbose
             return self.parse_response(response.raw)
         except NetworkConnectionError as exc:
+            assert exc.response
             logger.critical(
                 "HTTP error %s while getting %s",
                 exc.response.status_code, url,

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -9,7 +9,6 @@ import mimetypes
 import os
 import shutil
 
-from pip._vendor import requests
 from pip._vendor.six import PY2
 
 from pip._internal.distributions import (
@@ -21,6 +20,7 @@ from pip._internal.exceptions import (
     HashMismatch,
     HashUnpinned,
     InstallationError,
+    NetworkConnectionError,
     PreviousBuildDirError,
     VcsHashUnsupported,
 )
@@ -468,7 +468,7 @@ class RequirementPreparer(object):
                     link, req.source_dir, self.downloader, download_dir,
                     hashes=self._get_linked_req_hashes(req)
                 )
-            except requests.HTTPError as exc:
+            except NetworkConnectionError as exc:
                 raise InstallationError(
                     'Could not install requirement {} because of HTTP '
                     'error {} for URL {}'.format(req, exc, link)

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -18,6 +18,7 @@ from pip._internal.exceptions import (
     RequirementsFileParseError,
 )
 from pip._internal.models.search_scope import SearchScope
+from pip._internal.network.utils import raise_for_status
 from pip._internal.utils.encoding import auto_decode
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import get_url_scheme
@@ -551,7 +552,7 @@ def get_file_content(url, session, comes_from=None):
     if scheme in ['http', 'https']:
         # FIXME: catch some errors
         resp = session.get(url)
-        resp.raise_for_status()
+        raise_for_status(resp)
         return resp.url, resp.text
 
     elif scheme == 'file':

--- a/tests/lib/requests_mocks.py
+++ b/tests/lib/requests_mocks.py
@@ -25,6 +25,7 @@ class MockResponse(object):
         self.raw = FakeStream(contents)
         self.content = contents
         self.request = None
+        self.reason = None
         self.status_code = 200
         self.connection = None
         self.url = None

--- a/tests/lib/requests_mocks.py
+++ b/tests/lib/requests_mocks.py
@@ -31,9 +31,6 @@ class MockResponse(object):
         self.headers = {'Content-Length': len(contents)}
         self.history = []
 
-    def raise_for_status(self):
-        pass
-
 
 class MockConnection(object):
 

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.network.utils import raise_for_status
+from tests.lib.requests_mocks import MockResponse
+
+
+@pytest.mark.parametrize(("status_code", "error_type"), [
+    (401, "Client Error"),
+    (501, "Server Error"),
+])
+def test_raise_for_status_raises_exception(status_code, error_type):
+    contents = b'downloaded'
+    resp = MockResponse(contents)
+    resp.status_code = status_code
+    resp.url = "http://www.example.com/whatever.tgz"
+    resp.reason = "Network Error"
+    with pytest.raises(NetworkConnectionError) as exc:
+        raise_for_status(resp)
+        assert str(exc.info) == (
+            "{} {}: Network Error for url:"
+            " http://www.example.com/whatever.tgz".format(
+                status_code, error_type)
+        )
+
+
+def test_raise_for_status_does_not_raises_exception():
+    contents = b'downloaded'
+    resp = MockResponse(contents)
+    resp.status_code = 201
+    resp.url = "http://www.example.com/whatever.tgz"
+    resp.reason = "No error"
+    return_value = raise_for_status(resp)
+    assert return_value is None

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -4,7 +4,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 import pytest
-from mock import Mock
+from mock import Mock, patch
 
 from pip._internal.exceptions import HashMismatch
 from pip._internal.models.link import Link
@@ -58,7 +58,9 @@ def test_unpack_url_with_urllib_response_without_content_type(data):
         rmtree(temp_dir)
 
 
-def test_download_http_url__no_directory_traversal(tmpdir):
+@patch("pip._internal.network.download.raise_for_status")
+def test_download_http_url__no_directory_traversal(mock_raise_for_status,
+                                                   tmpdir):
     """
     Test that directory traversal doesn't happen on download when the
     Content-Disposition header contains a filename with a ".." path part.
@@ -90,6 +92,7 @@ def test_download_http_url__no_directory_traversal(tmpdir):
     # The file should be downloaded to download_dir.
     actual = os.listdir(download_dir)
     assert actual == ['out_dir_file']
+    mock_raise_for_status.assert_called_once_with(resp)
 
 
 @pytest.fixture


### PR DESCRIPTION
This inherits the behaviour of `requests.Response.raise_for_status`  and define our own custom `raise_for_status` method, with main difference in the final exception raised.

Towards https://github.com/pypa/pip/issues/5380