### PR TITLE
Allow prereleases in Requires-Python check

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -120,7 +120,7 @@ class RequiresPythonRequirement(Requirement):
         # type: (SpecifierSet) -> Sequence[Candidate]
         assert len(constraint) == 0, \
             "RequiresPythonRequirement cannot have constraints"
-        if self._candidate.version in self.specifier:
+        if self.specifier.contains(self._candidate.version, prereleases=True):
             return [self._candidate]
         return []
 


### PR DESCRIPTION
Same as #8079 #8185, the previous implementation will fail the Requires-Python check on prerelease Python versions (e.g. 3.9.0a5)