### PR TITLE
URL links need to be reinstalled as versions cant be checked properly

### DIFF
--- a/news/8197.bugfix
+++ b/news/8197.bugfix
@@ -1,0 +1,1 @@
+Force reinstall of packages being retrieved from a url as versions are not correctly checked

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -428,6 +428,10 @@ class InstallRequirement(object):
         no_marker.marker = None
         try:
             self.satisfied_by = pkg_resources.get_distribution(str(no_marker))
+            # We cant check url versions properly so force reinstall
+            if self.req.url:
+                self.should_reinstall = True
+                self.satisfied_by = None
         except pkg_resources.DistributionNotFound:
             return
         except pkg_resources.VersionConflict:


### PR DESCRIPTION
- If a requirement is being installed from a URL we can't check the version properly so force reinstall

**NOTES**
- This affects packages installed via a `requirements.txt` file or `setup.py - install_requires` file
- Installing a package via `pip install git+URL` from the command line is not be affected as version is parsed correctly

**BENEFITS**
- Avoids the silent bug where a user expects a package to be installed with a specified version or branch 

**CONSIDERATIONS**
- Will make installation slower if the URL version has NOT changed as it will reinstall anyway

**ISSUE**
- https://github.com/pypa/pip/issues/8197
