### PR TITLE
Allow empty specifier in constraints

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -74,8 +74,7 @@ class Resolver(BaseResolver):
         requirements = []
         for req in root_reqs:
             if req.constraint:
-                assert req.name
-                assert req.specifier
+                assert req.name, "constraint should have a name"
                 name = canonicalize_name(req.name)
                 if name in constraints:
                     constraints[name] = constraints[name] & req.specifier


### PR DESCRIPTION
A test `test_constrained_to_url_install_same_url` is currently failing because it supplies a constraint with an empty specifier, which evaluates to false, failing the assertion. (A constraint with an empty specifier won’t actually do anything, so why is this allowed…? But apparently it is allowed.)

`InstallRequirement`’s type hints say `req.specifier` is always `SpecifierSet`, i.e. the assertion is not needed, so I simply dropped it.