### PR TITLE
PEP 660 (build_editable) support

### DIFF
--- a/news/8212.feature.rst
+++ b/news/8212.feature.rst
@@ -1,0 +1,2 @@
+Support editable installs for projects that have a ``pyproject.toml`` and use a
+build backend that supports :pep:`660`.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -367,22 +367,22 @@ class InstallCommand(RequirementCommand):
                 global_options=[],
             )
 
-            # If we're using PEP 517, we cannot do a direct install
+            # If we're using PEP 517, we cannot do a legacy setup.py install
             # so we fail here.
             pep517_build_failure_names: List[str] = [
                 r.name for r in build_failures if r.use_pep517  # type: ignore
             ]
             if pep517_build_failure_names:
                 raise InstallationError(
-                    "Could not build wheels for {} which use"
-                    " PEP 517 and cannot be installed directly".format(
+                    "Could not build wheels for {}, which is required to "
+                    "install pyproject.toml-based projects".format(
                         ", ".join(pep517_build_failure_names)
                     )
                 )
 
             # For now, we just warn about failures building legacy
-            # requirements, as we'll fall through to a direct
-            # install for those.
+            # requirements, as we'll fall through to a setup.py install for
+            # those.
             for r in build_failures:
                 if not r.use_pep517:
                     r.legacy_install_reason = 8368

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -306,6 +306,12 @@ class InstallCommand(RequirementCommand):
         try:
             reqs = self.get_requirements(args, options, finder, session)
 
+            # Only when installing is it permitted to use PEP 660.
+            # In other circumstances (pip wheel, pip download) we generate
+            # regular (i.e. non editable) metadata and wheels.
+            for req in reqs:
+                req.permit_editable_wheels = True
+
             reject_location_related_install_options(reqs, options.install_options)
 
             preparer = self.make_requirement_preparer(

--- a/src/pip/_internal/operations/build/metadata.py
+++ b/src/pip/_internal/operations/build/metadata.py
@@ -23,7 +23,9 @@ def generate_metadata(build_env: BuildEnvironment, backend: Pep517HookCaller) ->
         # Note that Pep517HookCaller implements a fallback for
         # prepare_metadata_for_build_wheel, so we don't have to
         # consider the possibility that this hook doesn't exist.
-        runner = runner_with_spinner_message("Preparing wheel metadata")
+        runner = runner_with_spinner_message(
+            "Preparing wheel metadata (pyproject.toml)"
+        )
         with backend.subprocess_runner(runner):
             distinfo_dir = backend.prepare_metadata_for_build_wheel(metadata_dir)
 

--- a/src/pip/_internal/operations/build/metadata_editable.py
+++ b/src/pip/_internal/operations/build/metadata_editable.py
@@ -1,0 +1,32 @@
+"""Metadata generation logic for source distributions.
+"""
+
+import os
+
+from pip._vendor.pep517.wrappers import Pep517HookCaller
+
+from pip._internal.build_env import BuildEnvironment
+from pip._internal.utils.subprocess import runner_with_spinner_message
+from pip._internal.utils.temp_dir import TempDirectory
+
+
+def generate_editable_metadata(
+    build_env: BuildEnvironment, backend: Pep517HookCaller
+) -> str:
+    """Generate metadata using mechanisms described in PEP 660.
+
+    Returns the generated metadata directory.
+    """
+    metadata_tmpdir = TempDirectory(kind="modern-metadata", globally_managed=True)
+
+    metadata_dir = metadata_tmpdir.path
+
+    with build_env:
+        # Note that Pep517HookCaller implements a fallback for
+        # prepare_metadata_for_build_wheel/editable, so we don't have to
+        # consider the possibility that this hook doesn't exist.
+        runner = runner_with_spinner_message("Preparing editable metadata")
+        with backend.subprocess_runner(runner):
+            distinfo_dir = backend.prepare_metadata_for_build_editable(metadata_dir)
+
+    return os.path.join(metadata_dir, distinfo_dir)

--- a/src/pip/_internal/operations/build/metadata_editable.py
+++ b/src/pip/_internal/operations/build/metadata_editable.py
@@ -25,7 +25,9 @@ def generate_editable_metadata(
         # Note that Pep517HookCaller implements a fallback for
         # prepare_metadata_for_build_wheel/editable, so we don't have to
         # consider the possibility that this hook doesn't exist.
-        runner = runner_with_spinner_message("Preparing editable metadata")
+        runner = runner_with_spinner_message(
+            "Preparing editable metadata (pyproject.toml)"
+        )
         with backend.subprocess_runner(runner):
             distinfo_dir = backend.prepare_metadata_for_build_editable(metadata_dir)
 

--- a/src/pip/_internal/operations/build/metadata_legacy.py
+++ b/src/pip/_internal/operations/build/metadata_legacy.py
@@ -5,6 +5,7 @@ import logging
 import os
 
 from pip._internal.build_env import BuildEnvironment
+from pip._internal.cli.spinners import open_spinner
 from pip._internal.exceptions import InstallationError
 from pip._internal.utils.setuptools_build import make_setuptools_egg_info_args
 from pip._internal.utils.subprocess import call_subprocess
@@ -54,11 +55,13 @@ def generate_metadata(
     )
 
     with build_env:
-        call_subprocess(
-            args,
-            cwd=source_dir,
-            command_desc="python setup.py egg_info",
-        )
+        with open_spinner("Preparing metadata (setup.py)") as spinner:
+            call_subprocess(
+                args,
+                cwd=source_dir,
+                command_desc="python setup.py egg_info",
+                spinner=spinner,
+            )
 
     # Return the .egg-info directory.
     return _find_egg_info(egg_info_dir)

--- a/src/pip/_internal/operations/build/wheel.py
+++ b/src/pip/_internal/operations/build/wheel.py
@@ -23,7 +23,9 @@ def build_wheel_pep517(
     try:
         logger.debug("Destination directory: %s", tempd)
 
-        runner = runner_with_spinner_message(f"Building wheel for {name} (PEP 517)")
+        runner = runner_with_spinner_message(
+            f"Building wheel for {name} (pyproject.toml)"
+        )
         with backend.subprocess_runner(runner):
             wheel_name = backend.build_wheel(
                 tempd,

--- a/src/pip/_internal/operations/build/wheel_editable.py
+++ b/src/pip/_internal/operations/build/wheel_editable.py
@@ -1,0 +1,46 @@
+import logging
+import os
+from typing import Optional
+
+from pip._vendor.pep517.wrappers import HookMissing, Pep517HookCaller
+
+from pip._internal.utils.subprocess import runner_with_spinner_message
+
+logger = logging.getLogger(__name__)
+
+
+def build_wheel_editable(
+    name: str,
+    backend: Pep517HookCaller,
+    metadata_directory: str,
+    tempd: str,
+) -> Optional[str]:
+    """Build one InstallRequirement using the PEP 660 build process.
+
+    Returns path to wheel if successfully built. Otherwise, returns None.
+    """
+    assert metadata_directory is not None
+    try:
+        logger.debug("Destination directory: %s", tempd)
+
+        runner = runner_with_spinner_message(
+            f"Building editable for {name} (pyproject.toml)"
+        )
+        with backend.subprocess_runner(runner):
+            try:
+                wheel_name = backend.build_editable(
+                    tempd,
+                    metadata_directory=metadata_directory,
+                )
+            except HookMissing as e:
+                logger.error(
+                    "Cannot build editable %s because the build "
+                    "backend does not have the %s hook",
+                    name,
+                    e,
+                )
+                return None
+    except Exception:
+        logger.error("Failed building editable for %s", name)
+        return None
+    return os.path.join(tempd, wheel_name)

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -22,7 +22,6 @@ from pip._internal.exceptions import InstallationError
 from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
-from pip._internal.pyproject import make_pyproject_path
 from pip._internal.req.req_file import ParsedRequirement
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.filetypes import is_archive_file
@@ -75,21 +74,6 @@ def parse_editable(editable_req: str) -> Tuple[Optional[str], str, Set[str]]:
     url_no_extras, extras = _strip_extras(url)
 
     if os.path.isdir(url_no_extras):
-        setup_py = os.path.join(url_no_extras, "setup.py")
-        setup_cfg = os.path.join(url_no_extras, "setup.cfg")
-        if not os.path.exists(setup_py) and not os.path.exists(setup_cfg):
-            msg = (
-                'File "setup.py" or "setup.cfg" not found. Directory cannot be '
-                "installed in editable mode: {}".format(os.path.abspath(url_no_extras))
-            )
-            pyproject_path = make_pyproject_path(url_no_extras)
-            if os.path.isfile(pyproject_path):
-                msg += (
-                    '\n(A "pyproject.toml" file was found, but editable '
-                    "mode currently requires a setuptools-based build.)"
-                )
-            raise InstallationError(msg)
-
         # Treating it as code that has already been checked out
         url_no_extras = path_to_url(url_no_extras)
 
@@ -197,6 +181,7 @@ def install_req_from_editable(
     options: Optional[Dict[str, Any]] = None,
     constraint: bool = False,
     user_supplied: bool = False,
+    permit_editable_wheels: bool = False,
 ) -> InstallRequirement:
 
     parts = parse_req_from_editable(editable_req)
@@ -206,6 +191,7 @@ def install_req_from_editable(
         comes_from=comes_from,
         user_supplied=user_supplied,
         editable=True,
+        permit_editable_wheels=permit_editable_wheels,
         link=parts.link,
         constraint=constraint,
         use_pep517=use_pep517,

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -528,6 +528,10 @@ class InstallRequirement:
                 # At this point we have determined that the build_editable hook
                 # is missing, and there is a setup.py or setup.cfg
                 # so we fallback to the legacy metadata generation
+                logger.info(
+                    "Build backend does not support editables, "
+                    "falling back to setup.py egg_info."
+                )
             else:
                 self.supports_pyproject_editable = True
                 return metadata_directory

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -82,6 +82,7 @@ def make_install_req_from_editable(
         use_pep517=template.use_pep517,
         isolated=template.isolated,
         constraint=template.constraint,
+        permit_editable_wheels=template.permit_editable_wheels,
         options=dict(
             install_options=template.install_options,
             global_options=template.global_options,

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from pip._internal.models.direct_url import ArchiveInfo, DirectUrl, DirInfo, VcsInfo
 from pip._internal.models.link import Link
+from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import vcs
 
 
@@ -26,6 +27,13 @@ def direct_url_as_pep440_direct_reference(direct_url: DirectUrl, name: str) -> s
     if fragments:
         requirement += "#" + "&".join(fragments)
     return requirement
+
+
+def direct_url_for_editable(source_dir: str) -> DirectUrl:
+    return DirectUrl(
+        url=path_to_url(source_dir),
+        info=DirInfo(editable=True),
+    )
 
 
 def direct_url_from_link(

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -644,7 +644,7 @@ def test_install_from_local_directory_with_no_setup_py(script, data):
     assert "Neither 'setup.py' nor 'pyproject.toml' found." in result.stderr
 
 
-def test_editable_install__local_dir_no_setup_py(script, data, deprecated_python):
+def test_editable_install__local_dir_no_setup_py(script, data):
     """
     Test installing in editable mode from a local directory with no setup.py.
     """
@@ -652,16 +652,12 @@ def test_editable_install__local_dir_no_setup_py(script, data, deprecated_python
     assert not result.files_created
 
     msg = result.stderr
-    if deprecated_python:
-        assert 'File "setup.py" or "setup.cfg" not found. ' in msg
-    else:
-        assert msg.startswith('ERROR: File "setup.py" or "setup.cfg" not found. ')
+    assert msg.startswith("ERROR: File 'setup.py' or 'setup.cfg' not found ")
+    assert "cannot be installed in editable mode" in msg
     assert "pyproject.toml" not in msg
 
 
-def test_editable_install__local_dir_no_setup_py_with_pyproject(
-    script, deprecated_python
-):
+def test_editable_install__local_dir_no_setup_py_with_pyproject(script):
     """
     Test installing in editable mode from a local directory with no setup.py
     but that does have pyproject.toml.
@@ -675,11 +671,9 @@ def test_editable_install__local_dir_no_setup_py_with_pyproject(
     assert not result.files_created
 
     msg = result.stderr
-    if deprecated_python:
-        assert 'File "setup.py" or "setup.cfg" not found. ' in msg
-    else:
-        assert msg.startswith('ERROR: File "setup.py" or "setup.cfg" not found. ')
-    assert 'A "pyproject.toml" file was found' in msg
+    assert "has a 'pyproject.toml'" in msg
+    assert "does not have a 'setup.py' nor a 'setup.cfg'" in msg
+    assert "cannot be installed in editable mode" in msg
 
 
 @pytest.mark.network

--- a/tests/functional/test_pep660.py
+++ b/tests/functional/test_pep660.py
@@ -1,0 +1,209 @@
+import os
+
+import tomli_w
+
+from pip._internal.utils.urls import path_to_url
+
+SETUP_PY = """
+from setuptools import setup
+
+setup()
+"""
+
+SETUP_CFG = """
+[metadata]
+name = project
+version = 1.0.0
+"""
+
+BACKEND_WITHOUT_PEP660 = """
+from setuptools.build_meta import (
+    build_wheel as _build_wheel,
+    prepare_metadata_for_build_wheel as _prepare_metadata_for_build_wheel,
+    get_requires_for_build_wheel as _get_requires_for_build_wheel,
+)
+
+def get_requires_for_build_wheel(config_settings=None):
+    with open("log.txt", "a") as f:
+        print(":get_requires_for_build_wheel called", file=f)
+    return _get_requires_for_build_wheel(config_settings)
+
+def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    with open("log.txt", "a") as f:
+        print(":prepare_metadata_for_build_wheel called", file=f)
+    return _prepare_metadata_for_build_wheel(metadata_directory, config_settings)
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    with open("log.txt", "a") as f:
+        print(":build_wheel called", file=f)
+    return _build_wheel(wheel_directory, config_settings, metadata_directory)
+"""
+
+# fmt: off
+BACKEND_WITH_PEP660 = BACKEND_WITHOUT_PEP660 + """
+def get_requires_for_build_editable(config_settings=None):
+    with open("log.txt", "a") as f:
+        print(":get_requires_for_build_editable called", file=f)
+    return _get_requires_for_build_wheel(config_settings)
+
+def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+    with open("log.txt", "a") as f:
+        print(":prepare_metadata_for_build_editable called", file=f)
+    return _prepare_metadata_for_build_wheel(metadata_directory, config_settings)
+
+def build_editable(wheel_directory, config_settings=None, metadata_directory=None):
+    with open("log.txt", "a") as f:
+        print(":build_editable called", file=f)
+    return _build_wheel(wheel_directory, config_settings, metadata_directory)
+"""
+# fmt: on
+
+
+def _make_project(tmpdir, backend_code, with_setup_py):
+    project_dir = tmpdir / "project"
+    project_dir.mkdir()
+    project_dir.joinpath("setup.cfg").write_text(SETUP_CFG)
+    if with_setup_py:
+        project_dir.joinpath("setup.py").write_text(SETUP_PY)
+    if backend_code:
+        buildsys = {"requires": ["setuptools", "wheel"]}
+        buildsys["build-backend"] = "test_backend"
+        buildsys["backend-path"] = ["."]
+        data = tomli_w.dumps({"build-system": buildsys})
+        project_dir.joinpath("pyproject.toml").write_text(data)
+        project_dir.joinpath("test_backend.py").write_text(backend_code)
+    project_dir.joinpath("log.txt").touch()
+    return project_dir
+
+
+def _assert_hook_called(project_dir, hook):
+    log = project_dir.joinpath("log.txt").read_text()
+    assert f":{hook} called" in log, f"{hook} has not been called"
+
+
+def _assert_hook_not_called(project_dir, hook):
+    log = project_dir.joinpath("log.txt").read_text()
+    assert f":{hook} called" not in log, f"{hook} should not have been called"
+
+
+def test_install_pep517_basic(tmpdir, script, with_wheel):
+    """
+    Check that the test harness we have in this file is sane.
+    """
+    project_dir = _make_project(tmpdir, BACKEND_WITHOUT_PEP660, with_setup_py=False)
+    script.pip(
+        "install",
+        "--use-feature=in-tree-build",
+        "--no-index",
+        "--no-build-isolation",
+        project_dir,
+    )
+    _assert_hook_called(project_dir, "prepare_metadata_for_build_wheel")
+    _assert_hook_called(project_dir, "build_wheel")
+
+
+def test_install_pep660_basic(tmpdir, script, with_wheel):
+    """
+    Test with backend that supports build_editable.
+    """
+    project_dir = _make_project(tmpdir, BACKEND_WITH_PEP660, with_setup_py=False)
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--no-build-isolation",
+        "--editable",
+        project_dir,
+    )
+    _assert_hook_called(project_dir, "prepare_metadata_for_build_editable")
+    _assert_hook_called(project_dir, "build_editable")
+    assert (
+        result.test_env.site_packages.joinpath("project.egg-link")
+        not in result.files_created
+    ), "a .egg-link file should not have been created"
+
+
+def test_install_no_pep660_setup_py_fallback(tmpdir, script, with_wheel):
+    """
+    Test that we fall back to setuptools develop when using a backend that
+    does not support build_editable .
+    """
+    project_dir = _make_project(tmpdir, BACKEND_WITHOUT_PEP660, with_setup_py=True)
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--no-build-isolation",
+        "--editable",
+        project_dir,
+        allow_stderr_warning=False,
+    )
+    assert (
+        result.test_env.site_packages.joinpath("project.egg-link")
+        in result.files_created
+    ), "a .egg-link file should have been created"
+
+
+def test_install_no_pep660_setup_cfg_fallback(tmpdir, script, with_wheel):
+    """
+    Test that we fall back to setuptools develop when using a backend that
+    does not support build_editable .
+    """
+    project_dir = _make_project(tmpdir, BACKEND_WITHOUT_PEP660, with_setup_py=False)
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--no-build-isolation",
+        "--editable",
+        project_dir,
+        allow_stderr_warning=False,
+    )
+    print(result.stdout, result.stderr)
+    assert (
+        result.test_env.site_packages.joinpath("project.egg-link")
+        in result.files_created
+    ), ".egg-link file should have been created"
+
+
+def test_wheel_editable_pep660_basic(tmpdir, script, with_wheel):
+    """
+    Test 'pip wheel' of an editable pep 660 project.
+    It must *not* call prepare_metadata_for_build_editable.
+    """
+    project_dir = _make_project(tmpdir, BACKEND_WITH_PEP660, with_setup_py=False)
+    wheel_dir = tmpdir / "dist"
+    script.pip(
+        "wheel",
+        "--no-index",
+        "--no-build-isolation",
+        "--editable",
+        project_dir,
+        "-w",
+        wheel_dir,
+    )
+    _assert_hook_not_called(project_dir, "prepare_metadata_for_build_editable")
+    _assert_hook_not_called(project_dir, "build_editable")
+    _assert_hook_called(project_dir, "prepare_metadata_for_build_wheel")
+    _assert_hook_called(project_dir, "build_wheel")
+    assert len(os.listdir(str(wheel_dir))) == 1, "a wheel should have been created"
+
+
+def test_download_editable_pep660_basic(tmpdir, script, with_wheel):
+    """
+    Test 'pip download' of an editable pep 660 project.
+    It must *not* call prepare_metadata_for_build_editable.
+    """
+    project_dir = _make_project(tmpdir, BACKEND_WITH_PEP660, with_setup_py=False)
+    reqs_file = tmpdir / "requirements.txt"
+    reqs_file.write_text(f"-e {path_to_url(project_dir)}\n")
+    download_dir = tmpdir / "download"
+    script.pip(
+        "download",
+        "--no-index",
+        "--no-build-isolation",
+        "-r",
+        reqs_file,
+        "-d",
+        download_dir,
+    )
+    _assert_hook_not_called(project_dir, "prepare_metadata_for_build_editable")
+    _assert_hook_called(project_dir, "prepare_metadata_for_build_wheel")
+    assert len(os.listdir(str(download_dir))) == 1, "a zip should have been created"


### PR DESCRIPTION
I wanted to experiment a little bit too with the `build_wheel_for_editable` concept, just to see how well it fits in the pip code base. I'm sharing in case anyone is interested. This is ~~totally~~ draft and not well tested.

- [x] install --editable 
  - [x]  backend has `build_wheel_for_editable`
  - [x] backend does not have `build_wheel_for_editable` - fallback to `setup.py develop`
  - [x] backend does not have `build_wheel_for_editable` - error if no setup.py
  - [x] update to latest PEP 660
  - [x] support get_requires_for_build_editable
  - [x] support prepare_metadata_for_editable
  - [x] fallback if hook not present
  - [x] make sure pip wheel -e does *not* use any editable hook
- [x] uninstall
- [x] update pip freeze (done in #10249)
- [x] update pip list (done in #10249)
- [x] in log message `Building wheel for * (PEP 517) ... done`, mention we are in editable mode?

