### PR TITLE
Fix pip's machinery for creating an isolated build environment so that user installed packages do not override the stdlib

### DIFF
--- a/news/8214.bugfix
+++ b/news/8214.bugfix
@@ -1,0 +1,1 @@
+Fix installing packages which have a pyproject.toml when enum34 is installed.

--- a/news/8214.removal
+++ b/news/8214.removal
@@ -1,0 +1,2 @@
+Removes the ability to run pip via ``python src/pip/`` from a checkout without
+setting PYTHONPATH first.

--- a/src/pip/__main__.py
+++ b/src/pip/__main__.py
@@ -18,7 +18,10 @@ if __package__ == '':
     # Resulting path is the name of the wheel itself
     # Add that to sys.path so we can import pip
     path = os.path.dirname(os.path.dirname(__file__))
-    sys.path.insert(0, path)
+    # __package__ could have also been the empty string if pip was invoked
+    # with the path to the pip directory.  ie: as python /path/to/pip/.
+    if path.endswith('.whl'):
+        sys.path.insert(0, path)
 
 from pip._internal.cli.main import main as _main  # isort:skip # noqa
 


### PR DESCRIPTION
Because pip ships with an `__main__.py` file, one valid way to invoke it
is: `python /usr/lib/python3.6/site-packages/pip/`.  This results in
`__package__` being the empty string   This, in turn, triggers the code to
add the pip wheel to sys.path.  Unfortunately, while this is fine to do
when it's restricted to a wheel just containing pip, it isn't okay to do
when it is site-packages as that will mean that other things in
site-packages could end up overriding things in the stdlib
(*cough*enum34*cough*).

Check file extension to limit when we end up adding the extra path to
sys.path.

Fixed #8214
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
