### PR TITLE
Pass revision to 'hg clone' command when cloning Mercurial repository. 

### DIFF
--- a/news/8222.feature
+++ b/news/8222.feature
@@ -1,0 +1,1 @@
+Pass revision to 'hg clone' command when cloning Mercurial repository.

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -59,10 +59,8 @@ class Mercurial(VersionControl):
             rev_display,
             display_path(dest),
         )
-        self.run_command(make_command('clone', '--noupdate', '-q', url, dest))
         self.run_command(
-            make_command('update', '-q', rev_options.to_args()),
-            cwd=dest,
+            make_command('clone', '-q', rev_options.to_args(), url, dest)
         )
 
     def switch(self, dest, url, rev_options):
@@ -84,7 +82,8 @@ class Mercurial(VersionControl):
 
     def update(self, dest, url, rev_options):
         # type: (str, HiddenText, RevOptions) -> None
-        self.run_command(['pull', '-q'], cwd=dest)
+        cmd_args = make_command('pull', '-q', rev_options.to_args())
+        self.run_command(cmd_args, cwd=dest)
         cmd_args = make_command('update', '-q', rev_options.to_args())
         self.run_command(cmd_args, cwd=dest)
 

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -38,7 +38,7 @@ class Mercurial(VersionControl):
 
     @staticmethod
     def get_base_rev_args(rev):
-        return [rev]
+        return ['-r', rev]
 
     def export(self, location, url):
         # type: (str, HiddenText) -> None

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -57,7 +57,7 @@ def test_rev_options_repr():
     # First check VCS-specific RevOptions behavior.
     (Bazaar, [], ['-r', '123'], {}),
     (Git, ['HEAD'], ['123'], {}),
-    (Mercurial, [], ['123'], {}),
+    (Mercurial, [], ['-r', '123'], {}),
     (Subversion, [], ['-r', '123'], {}),
     # Test extra_args.  For this, test using a single VersionControl class.
     (Git, ['HEAD', 'opt1', 'opt2'], ['123', 'opt1', 'opt2'],


### PR DESCRIPTION
This ensures that only the required changesets are pulled from the server.

Some servers don’t advertise all changesets by default. An example is
Heptapod, to ensure that changesets with so-called "topics" are only cloned by
clients which know how to handle them. Passing the revision enables that these
changesets can be cloned anyway. Whether they have a "topic" or not is not
relevant to us.