### PR TITLE
Only include dependencies if the markers match

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -3,7 +3,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Sequence, Set
+    from typing import Iterable, Optional, Sequence, Set
 
     from pip._internal.req.req_install import InstallRequirement
     from pip._vendor.packaging.specifiers import SpecifierSet
@@ -49,8 +49,8 @@ class Candidate(object):
         # type: () -> bool
         raise NotImplementedError("Override in subclass")
 
-    def get_dependencies(self):
-        # type: () -> Sequence[Requirement]
+    def iter_dependencies(self):
+        # type: () -> Iterable[Requirement]
         raise NotImplementedError("Override in subclass")
 
     def get_install_requirement(self):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -418,7 +418,11 @@ class ExtrasCandidate(Candidate):
             )
 
         for r in self.base.dist.requires(valid_extras):
-            yield factory.make_requirement_from_spec(str(r), self.base._ireq)
+            requirement = factory.make_requirement_from_spec_matching_extras(
+                str(r), self.base._ireq, valid_extras,
+            )
+            if requirement:
+                yield requirement
 
         # Add a dependency on the exact base.
         # (See note 2b in the class docstring)

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -29,7 +29,7 @@ from .requirements import (
 )
 
 if MYPY_CHECK_RUNNING:
-    from typing import Dict, Iterator, Optional, Set, Tuple, TypeVar
+    from typing import Dict, Iterable, Iterator, Optional, Set, Tuple, TypeVar
 
     from pip._vendor.packaging.specifiers import SpecifierSet
     from pip._vendor.packaging.version import _BaseVersion
@@ -185,6 +185,18 @@ class Factory(object):
     def make_requirement_from_spec(self, specifier, comes_from):
         # type: (str, InstallRequirement) -> Requirement
         ireq = self._make_install_req_from_spec(specifier, comes_from)
+        return self.make_requirement_from_install_req(ireq)
+
+    def make_requirement_from_spec_matching_extras(
+        self,
+        specifier,  # type: str
+        comes_from,  # type: InstallRequirement
+        requested_extras=(),  # type: Iterable[str]
+    ):
+        # type: (...) -> Optional[Requirement]
+        ireq = self._make_install_req_from_spec(specifier, comes_from)
+        if not ireq.match_markers(requested_extras):
+            return None
         return self.make_requirement_from_install_req(ireq)
 
     def make_requires_python_requirement(self, specifier):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -1,4 +1,5 @@
 import collections
+import logging
 
 from pip._vendor import six
 from pip._vendor.packaging.utils import canonicalize_name
@@ -48,6 +49,9 @@ if MYPY_CHECK_RUNNING:
     C = TypeVar("C")
     Cache = Dict[Link, C]
     VersionCandidates = Dict[_BaseVersion, Candidate]
+
+
+logger = logging.getLogger(__name__)
 
 
 class Factory(object):
@@ -196,6 +200,10 @@ class Factory(object):
         # type: (...) -> Optional[Requirement]
         ireq = self._make_install_req_from_spec(specifier, comes_from)
         if not ireq.match_markers(requested_extras):
+            logger.info(
+                "Ignoring %s: markers '%s' don't match your environment",
+                ireq.name, ireq.markers,
+            )
             return None
         return self.make_requirement_from_install_req(ireq)
 

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -132,4 +132,4 @@ class PipProvider(AbstractProvider):
         # type: (Candidate) -> Sequence[Requirement]
         if self._ignore_dependencies:
             return []
-        return candidate.get_dependencies()
+        return list(candidate.iter_dependencies())

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -105,6 +105,8 @@ class Resolver(BaseResolver):
         user_requested = set()  # type: Set[str]
         requirements = []
         for req in root_reqs:
+            if not req.match_markers():
+                continue
             if req.constraint:
                 # Ensure we only accept valid constraints
                 reject_invalid_constraint_types(req)


### PR DESCRIPTION
WIP. Minimal reprod:

```
pip install --unstable-feature=resolver "django>2.0;python_version>='3'" "django<2.0;python_verion<'3'"
```

We need to check markers and only pull in dependencies if the markers match.

The current implementation is terrible. I need to refactor it.