### PR TITLE
Split find_matches into generation and sorting

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -44,6 +44,11 @@ class Candidate(object):
         # type: () -> _BaseVersion
         raise NotImplementedError("Override in subclass")
 
+    @property
+    def is_installed(self):
+        # type: () -> bool
+        raise NotImplementedError("Override in subclass")
+
     def get_dependencies(self):
         # type: () -> Sequence[Requirement]
         raise NotImplementedError("Override in subclass")

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -101,15 +101,10 @@ def make_install_req_from_dist(dist, parent):
     return ireq
 
 
-def is_already_installed(cand):
-    # type: (Candidate) -> bool
-    # For an ExtrasCandidate, we check the base
-    if isinstance(cand, ExtrasCandidate):
-        cand = cand.base
-    return isinstance(cand, AlreadyInstalledCandidate)
-
-
 class _InstallRequirementBackedCandidate(Candidate):
+    # These are not installed
+    is_installed = False
+
     def __init__(
         self,
         link,          # type: Link
@@ -279,6 +274,8 @@ class EditableCandidate(_InstallRequirementBackedCandidate):
 
 
 class AlreadyInstalledCandidate(Candidate):
+    is_installed = True
+
     def __init__(
         self,
         dist,  # type: Distribution
@@ -400,6 +397,11 @@ class ExtrasCandidate(Candidate):
         # type: () -> _BaseVersion
         return self.base.version
 
+    @property
+    def is_installed(self):
+        # type: () -> _BaseVersion
+        return self.base.is_installed
+
     def get_dependencies(self):
         # type: () -> Sequence[Requirement]
         factory = self.base._factory
@@ -436,6 +438,8 @@ class ExtrasCandidate(Candidate):
 
 
 class RequiresPythonCandidate(Candidate):
+    is_installed = False
+
     def __init__(self, py_version_info):
         # type: (Optional[Tuple[int, ...]]) -> None
         if py_version_info is not None:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -101,6 +101,14 @@ def make_install_req_from_dist(dist, parent):
     return ireq
 
 
+def is_already_installed(cand):
+    # type: (Candidate) -> bool
+    # For an ExtrasCandidate, we check the base
+    if isinstance(cand, ExtrasCandidate):
+        cand = cand.base
+    return isinstance(cand, AlreadyInstalledCandidate)
+
+
 class _InstallRequirementBackedCandidate(Candidate):
     def __init__(
         self,

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -120,7 +120,7 @@ class Factory(object):
         # requirement needs to return only one candidate per version, so we
         # implement that logic here so that requirements using this helper
         # don't all have to do the same thing later.
-        seen_versions = set()
+        seen_versions = set()  # type: Set[_BaseVersion]
 
         # Yield the installed version, if it matches, unless the user
         # specified `--force-reinstall`, when we want the version from

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -114,6 +114,12 @@ class Factory(object):
     def iter_found_candidates(self, ireq, extras):
         # type: (InstallRequirement, Set[str]) -> Iterator[Candidate]
         name = canonicalize_name(ireq.req.name)
+
+        # We use this to ensure that we only yield a single candidate for
+        # each version (the finder's preferred one for that version). The
+        # requirement needs to return only one candidate per version, so we
+        # implement that logic here so that requirements using this helper
+        # don't all have to do the same thing later.
         seen_versions = set()
 
         # Yield the installed version, if it matches, unless the user

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -79,7 +79,6 @@ class PipProvider(AbstractProvider):
             if self._upgrade_strategy == "eager":
                 return True
             elif self._upgrade_strategy == "only-if-needed":
-                print(name, self.roots)
                 return (name in self.roots)
             return False
 

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -3,13 +3,34 @@ from pip._vendor.resolvelib.providers import AbstractProvider
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
+from .candidates import is_already_installed
+
 if MYPY_CHECK_RUNNING:
-    from typing import Any, Dict, Optional, Sequence, Tuple, Union
+    from typing import Any, Dict, Optional, Sequence, Set, Tuple, Union
 
     from pip._internal.req.req_install import InstallRequirement
+    from pip._vendor.packaging.version import _BaseVersion
 
     from .base import Requirement, Candidate
     from .factory import Factory
+
+# Notes on the relationship between the provider, the factory, and the
+# candidate and requirement classes.
+#
+# The provider is a direct implementation of the resolvelib class. Its role
+# is to deliver the API that resolvelib expects.
+#
+# Rather than work with completely abstract "requirement" and "candidate"
+# concepts as resolvelib does, pip has concrete classes implementing these two
+# ideas. The API of Requirement and Candidate objects are defined in the base
+# classes, but essentially map fairly directly to the equivalent provider
+# methods. In particular, `find_matches` and `is_satisfied_by` are
+# requirement methods, and `get_dependencies` is a candidate method.
+#
+# The factory is the interface to pip's internal mechanisms. It is stateless,
+# and is created by the resolver and held as a property of the provider. It is
+# responsible for creating Requirement and Candidate objects, and provides
+# services to those objects (access to pip's finder and preparer).
 
 
 class PipProvider(AbstractProvider):
@@ -18,11 +39,66 @@ class PipProvider(AbstractProvider):
         factory,  # type: Factory
         constraints,  # type: Dict[str, SpecifierSet]
         ignore_dependencies,  # type: bool
+        upgrade_strategy,  # type: str
+        roots,  # type: Set[str]
     ):
         # type: (...) -> None
         self._factory = factory
         self._constraints = constraints
         self._ignore_dependencies = ignore_dependencies
+        self._upgrade_strategy = upgrade_strategy
+        self.roots = roots
+
+    def sort_matches(self, matches):
+        # type: (Sequence[Candidate]) -> Sequence[Candidate]
+
+        # The requirement is responsible for returning a sequence of potential
+        # candidates, one per version. The provider handles the logic of
+        # deciding the order in which these candidates should be passed to
+        # the resolver.
+
+        # The `matches` argument is a sequence of candidates, one per version,
+        # which are potential options to be installed. The requirement will
+        # have already sorted out whether to give us an already-installed
+        # candidate or a version from PyPI (i.e., it will deal with options
+        # like --force-reinstall and --ignore-installed).
+
+        # We now work out the correct order.
+        #
+        # 1. If no other considerations apply, later versions take priority.
+        # 2. An already installed distribution is preferred over any other,
+        #    unless the user has requested an upgrade.
+        #    Upgrades are allowed when:
+        #    * The --upgrade flag is set, and
+        #      - The project was specified on the command line, or
+        #      - The project is a dependency and the "eager" upgrade strategy
+        #        was requested.
+
+        def _eligible_for_upgrade(name):
+            # type: (str) -> bool
+            if self._upgrade_strategy == "eager":
+                return True
+            elif self._upgrade_strategy == "only-if-needed":
+                print(name, self.roots)
+                return (name in self.roots)
+            return False
+
+        def keep_installed(c):
+            # type: (Candidate) -> int
+            """Give priority to an installed version?"""
+            if not is_already_installed(c):
+                return 0
+
+            if _eligible_for_upgrade(c.name):
+                return 0
+
+            return 1
+
+        def key(c):
+            # type: (Candidate) -> Tuple[int, _BaseVersion]
+            return (keep_installed(c), c.version)
+
+        return sorted(matches, key=key)
 
     def get_install_requirement(self, c):
         # type: (Candidate) -> Optional[InstallRequirement]
@@ -45,7 +121,8 @@ class PipProvider(AbstractProvider):
     def find_matches(self, requirement):
         # type: (Requirement) -> Sequence[Candidate]
         constraint = self._constraints.get(requirement.name, SpecifierSet())
-        return requirement.find_matches(constraint)
+        matches = requirement.find_matches(constraint)
+        return self.sort_matches(matches)
 
     def is_satisfied_by(self, requirement, candidate):
         # type: (Requirement, Candidate) -> bool

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -76,6 +76,10 @@ class SpecifierRequirement(Requirement):
 
     def find_matches(self, constraint):
         # type: (SpecifierSet) -> Sequence[Candidate]
+
+        # We should only return one candidate per version, but
+        # iter_found_candidates does that for us, so we don't need
+        # to do anything special here.
         return [
             c
             for c in self._factory.iter_found_candidates(

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -69,7 +69,7 @@ class Resolver(BaseResolver):
         # type: (List[InstallRequirement], bool) -> RequirementSet
 
         constraints = {}  # type: Dict[str, SpecifierSet]
-        roots = set()
+        user_requested = set()
         requirements = []
         for req in root_reqs:
             if req.constraint:
@@ -82,7 +82,7 @@ class Resolver(BaseResolver):
                     constraints[name] = req.specifier
             else:
                 if req.is_direct and req.name:
-                    roots.add(canonicalize_name(req.name))
+                    user_requested.add(canonicalize_name(req.name))
                 requirements.append(
                     self.factory.make_requirement_from_install_req(req)
                 )
@@ -92,7 +92,7 @@ class Resolver(BaseResolver):
             constraints=constraints,
             ignore_dependencies=self.ignore_dependencies,
             upgrade_strategy=self.upgrade_strategy,
-            roots=roots,
+            user_requested=user_requested,
         )
         reporter = BaseReporter()
         resolver = RLResolver(provider, reporter)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 
 class Resolver(BaseResolver):
+    _allowed_strategies = {"eager", "only-if-needed", "to-satisfy-only"}
+
     def __init__(
         self,
         preparer,  # type: RequirementPreparer
@@ -47,6 +49,9 @@ class Resolver(BaseResolver):
         py_version_info=None,  # type: Optional[Tuple[int, ...]]
     ):
         super(Resolver, self).__init__()
+
+        assert upgrade_strategy in self._allowed_strategies
+
         self.factory = Factory(
             finder=finder,
             preparer=preparer,
@@ -54,23 +59,17 @@ class Resolver(BaseResolver):
             force_reinstall=force_reinstall,
             ignore_installed=ignore_installed,
             ignore_requires_python=ignore_requires_python,
-            upgrade_strategy=upgrade_strategy,
             py_version_info=py_version_info,
         )
         self.ignore_dependencies = ignore_dependencies
+        self.upgrade_strategy = upgrade_strategy
         self._result = None  # type: Optional[Result]
 
     def resolve(self, root_reqs, check_supported_wheels):
         # type: (List[InstallRequirement], bool) -> RequirementSet
 
-        # The factory should not have retained state from any previous usage.
-        # In theory this could only happen if self was reused to do a second
-        # resolve, which isn't something we do at the moment. We assert here
-        # in order to catch the issue if that ever changes.
-        # The persistent state that we care about is `root_reqs`.
-        assert len(self.factory.root_reqs) == 0, "Factory is being re-used"
-
         constraints = {}  # type: Dict[str, SpecifierSet]
+        roots = set()
         requirements = []
         for req in root_reqs:
             if req.constraint:
@@ -82,6 +81,8 @@ class Resolver(BaseResolver):
                 else:
                     constraints[name] = req.specifier
             else:
+                if req.is_direct and req.name:
+                    roots.add(canonicalize_name(req.name))
                 requirements.append(
                     self.factory.make_requirement_from_install_req(req)
                 )
@@ -90,6 +91,8 @@ class Resolver(BaseResolver):
             factory=self.factory,
             constraints=constraints,
             ignore_dependencies=self.ignore_dependencies,
+            upgrade_strategy=self.upgrade_strategy,
+            roots=roots,
         )
         reporter = BaseReporter()
         resolver = RLResolver(provider, reporter)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -69,7 +69,7 @@ class Resolver(BaseResolver):
         # type: (List[InstallRequirement], bool) -> RequirementSet
 
         constraints = {}  # type: Dict[str, SpecifierSet]
-        user_requested = set()
+        user_requested = set()  # type: Set[str]
         requirements = []
         for req in root_reqs:
             if req.constraint:

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -55,7 +55,6 @@ def factory(finder, preparer):
         force_reinstall=False,
         ignore_installed=False,
         ignore_requires_python=False,
-        upgrade_strategy="to-satisfy-only",
         py_version_info=None,
     )
 
@@ -66,4 +65,6 @@ def provider(factory):
         factory=factory,
         constraints={},
         ignore_dependencies=False,
+        upgrade_strategy="to-satisfy-only",
+        roots=set(),
     )

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -66,5 +66,5 @@ def provider(factory):
         constraints={},
         ignore_dependencies=False,
         upgrade_strategy="to-satisfy-only",
-        roots=set(),
+        user_requested=set(),
     )


### PR DESCRIPTION
OK, this refactors find_matches so that the factory is only responsible for generating a list of acceptable matches, and it's the provider's job to sort them. This means that the set of "root" requirements (the ones input by the user) are no longer needed in the factory and can be saved on the provider, restoring the factory to its role of acting as a stateless interface to the finder, preparer, etc.

The code is still pretty messy. I'm fairly sure that this is mainly because the behaviour we're trying to implement is messy, so I don't think it's something we can eliminate totally. But I've been working on this for a while now, and I may well be too close to it to see obvious simplifications, so I'd appreciate any suggestions on that score.

I'm pretty sure that (style aside) this is OK to go, so IMO it's ready for review.