### PR TITLE
Add a reason why we're xfail-ing this test

### DIFF
--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -191,7 +191,12 @@ def test_freeze_svn(script, tmpdir):
 
 
 @pytest.mark.git
-@pytest.mark.xfail
+@pytest.mark.xfail(
+    condition=True,
+    reason="xfail means editable is not in output",
+    run=True,
+    strict=True,
+)
 def test_freeze_exclude_editable(script, tmpdir):
     """
     Test excluding editable from freezing list.


### PR DESCRIPTION
I was trying to figure out whether the new resolver should fix various xfail-ed tests, and found this weird one. This test uses xfail to test the negation of what’s described in the test, i.e. the assertion should “fail” if the command does what we expect.

* Expectation: `--exlucde-editable` should make output not include the editable requirement.
* Test written as: Use `--exlucde-editable`, and assert the output contains the editable requirement

I think this is a terrible way to write a test, but it’s also quite involved to rewrite it. So I left some comments and a Git commit message to save future maintainers (including myself) sometime when they encounter this thing 🙁 