### PR TITLE
Add pytest option to globally switch resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,10 +57,10 @@ jobs:
     - stage: experimental
       env:
       - GROUP=1
-      - PIP_UNSTABLE_FEATURE=resolver
+      - NEW_RESOLVER=1
     - env:
       - GROUP=2
-      - PIP_UNSTABLE_FEATURE=resolver
+      - NEW_RESOLVER=1
 
   fast_finish: true
   allow_failures:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,11 +30,23 @@ if MYPY_CHECK_RUNNING:
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--keep-tmpdir", action="store_true",
-        default=False, help="keep temporary test directories"
+        "--keep-tmpdir",
+        action="store_true",
+        default=False,
+        help="keep temporary test directories",
     )
-    parser.addoption("--use-venv", action="store_true",
-                     help="use venv for virtual environment creation")
+    parser.addoption(
+        "--new-resolver",
+        action="store_true",
+        default=False,
+        help="use new resolver in tests",
+    )
+    parser.addoption(
+        "--use-venv",
+        action="store_true",
+        default=False,
+        help="use venv for virtual environment creation",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -73,6 +85,18 @@ def pytest_collection_modifyitems(config, items):
             raise RuntimeError(
                 "Unknown test type (filename = {})".format(module_path)
             )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def use_new_resolver(request):
+    """Set environment variable to make pip default to the new resolver.
+    """
+    new_resolver = request.config.getoption("--new-resolver")
+    if new_resolver:
+        os.environ["PIP_UNSTABLE_FEATURE"] = "resolver"
+    else:
+        os.environ.pop("PIP_UNSTABLE_FEATURE", None)
+    yield new_resolver
 
 
 @pytest.fixture(scope='session')

--- a/tools/travis/run.sh
+++ b/tools/travis/run.sh
@@ -37,16 +37,24 @@ if [[ -z "$TOXENV" ]]; then
 fi
 echo "TOXENV=${TOXENV}"
 
+if [[ -z "$NEW_RESOLVER" ]]; then
+    RESOLVER_SWITCH=''
+else
+    RESOLVER_SWITCH='--new-resolver'
+fi
+
 # Print the commands run for this test.
 set -x
 if [[ "$GROUP" == "1" ]]; then
     # Unit tests
     tox -- --use-venv -m unit -n auto
     # Integration tests (not the ones for 'pip install')
-    tox -- --use-venv -m integration -n auto --duration=5 -k "not test_install"
+    tox -- -m integration -n auto --duration=5 -k "not test_install" \
+        --use-venv $RESOLVER_SWITCH
 elif [[ "$GROUP" == "2" ]]; then
     # Separate Job for running integration tests for 'pip install'
-    tox -- --use-venv -m integration -n auto --duration=5 -k "test_install"
+    tox -- -m integration -n auto --duration=5 -k "test_install" \
+        --use-venv $RESOLVER_SWITCH
 else
     # Non-Testing Jobs should run once
     tox

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ passenv =
     HTTP_PROXY
     HTTPS_PROXY
     NO_PROXY
-    PIP_UNSTABLE_FEATURE
 setenv =
     # This is required in order to get UTF-8 output inside of the subprocesses
     # that our tests use.


### PR DESCRIPTION
This adds a `--new-resolver` switch to pytest that can be used to control which resolver to use. The actual setup happens in the auto-used `use_new_resolver` fixture, which checks the flag and modify the environment variable accordingly.

The fixture returns a boolean to indicate which resolver is used, which can be used in tests to conditionally test each resolver’s behaviour.