### PR TITLE
Tidy up handling of unexpected forms of constraint

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -2,7 +2,6 @@ import functools
 import logging
 
 from pip._vendor import six
-from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
 from pip._vendor.resolvelib import Resolver as RLResolver
@@ -19,6 +18,7 @@ from .factory import Factory
 if MYPY_CHECK_RUNNING:
     from typing import Dict, List, Optional, Set, Tuple
 
+    from pip._vendor.packaging.specifiers import SpecifierSet
     from pip._vendor.resolvelib.resolvers import Result
     from pip._vendor.resolvelib.structs import Graph
 
@@ -109,12 +109,11 @@ class Resolver(BaseResolver):
                 # Ensure we only accept valid constraints
                 reject_invalid_constraint_types(req)
 
-                specifier = req.specifier or SpecifierSet()
                 name = canonicalize_name(req.name)
                 if name in constraints:
-                    constraints[name] = constraints[name] & specifier
+                    constraints[name] = constraints[name] & req.specifier
                 else:
-                    constraints[name] = specifier
+                    constraints[name] = req.specifier
             else:
                 requirements.append(
                     self.factory.make_requirement_from_install_req(req)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -11,6 +11,7 @@ from pip._internal.exceptions import InstallationError
 from pip._internal.req.req_set import RequirementSet
 from pip._internal.resolution.base import BaseResolver
 from pip._internal.resolution.resolvelib.provider import PipProvider
+from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 from .factory import Factory
@@ -29,6 +30,37 @@ if MYPY_CHECK_RUNNING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def reject_invalid_constraint_types(req):
+    # type: (InstallRequirement) -> None
+
+    # Check for unsupported forms
+    problem = ""
+    if not req.name:
+        problem = "Unnamed requirements are not allowed as constraints"
+    elif req.link:
+        problem = "Links are not allowed as constraints"
+    elif req.extras:
+        problem = "Constraints cannot have extras"
+
+    if problem:
+        deprecated(
+            reason=(
+                "Constraints are only allowed to take the form of a package "
+                "name and a version specifier. Other forms were originally "
+                "permitted as an accident of the implementation, but were "
+                "undocumented. The new implementation of the resolver no "
+                "longer supports these forms."
+            ),
+            replacement=(
+                "replacing the constraint with a requirement."
+            ),
+            # No plan yet for when the new resolver becomes default
+            gone_in=None,
+            issue=8210
+        )
+        raise InstallationError(problem)
 
 
 class Resolver(BaseResolver):
@@ -74,23 +106,9 @@ class Resolver(BaseResolver):
         requirements = []
         for req in root_reqs:
             if req.constraint:
-                # TODO: Add warnings to accompany these errors, explaining
-                # that these were undocumented behaviour of the old resolver
-                # and will be removed in the new resolver. We need to consider
-                # how we remember to remove these warnings when the new
-                # resolver becomes the default...
-                if not req.name:
-                    raise InstallationError(
-                        "Unnamed requirements are not allowed as constraints"
-                    )
-                if req.link:
-                    raise InstallationError(
-                        "Links are not allowed as constraints"
-                    )
-                if req.extras:
-                    raise InstallationError(
-                        "Constraints cannot have extras"
-                    )
+                # Ensure we only accept valid constraints
+                reject_invalid_constraint_types(req)
+
                 specifier = req.specifier or SpecifierSet()
                 name = canonicalize_name(req.name)
                 if name in constraints:


### PR DESCRIPTION
Fix some edge cases of constraints in the new resolver:

1. Constraints with no specifier are allowed (but useless).
2. Unnamed constraints are not allowed.
3. Links are not allowed as constraints.
4. Constraints cannot have extras.

As per discussions on #8210, we may need to consider adding a new feature that provides a documented way of achieving what people are currently doing with the (undocumented) ability to specify links as constraints in the old resolver.