### PR TITLE
Fix some test failures related to message differences

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -410,11 +410,12 @@ class ExtrasCandidate(Candidate):
         # support. We ignore any unsupported extras here.
         valid_extras = self.extras.intersection(self.base.dist.extras)
         invalid_extras = self.extras.difference(self.base.dist.extras)
-        if invalid_extras:
+        for extra in sorted(invalid_extras):
             logger.warning(
-                "Invalid extras specified in %s: %s",
-                self.name,
-                ','.join(sorted(invalid_extras))
+                "%s %s does not provide the extra '%s'",
+                self.base.name,
+                self.version,
+                extra
             )
 
         deps = [

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1741,7 +1741,7 @@ def test_user_config_accepted(script):
 
 @pytest.mark.parametrize(
     'install_args, expected_message', [
-        ([], 'Requirement already satisfied: pip in'),
+        ([], 'Requirement already satisfied: pip'),
         (['--upgrade'], 'Requirement already up-to-date: pip in'),
     ]
 )

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 from os.path import join
 
@@ -100,11 +101,11 @@ def test_nonexistent_options_listed_in_order(script, data):
         '--find-links=' + data.find_links,
         'simplewheel[nonexistent, nope]', expect_stderr=True,
     )
-    msg = (
-        "  WARNING: simplewheel 2.0 does not provide the extra 'nonexistent'\n"
-        "  WARNING: simplewheel 2.0 does not provide the extra 'nope'"
+    matches = re.findall(
+        "WARNING: simplewheel 2.0 does not provide the extra '([a-z]*)'",
+        result.stderr
     )
-    assert msg in result.stderr
+    assert matches == ['nonexistent', 'nope']
 
 
 def test_install_special_extra(script):

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -208,8 +208,8 @@ def test_new_resolver_installs_extras(script):
         "base[add,missing]",
         expect_stderr=True,
     )
-    assert "WARNING: Invalid extras specified" in result.stderr, str(result)
-    assert ": missing" in result.stderr, str(result)
+    assert "does not provide the extra" in result.stderr, str(result)
+    assert "missing" in result.stderr, str(result)
     assert_installed(script, base="0.1.0", dep="0.1.0")
 
 


### PR DESCRIPTION
Fixing some of the test failures because of message discrepancies between the old and new resolvers.

Fixes

* `test_install_pip_does_not_modify_pip_when_satisfied[upgrade=False]`
* `test_nonexistent_extra_warns_user_no_wheel`
* `test_nonexistent_extra_warns_user_with_wheel`
* `test_nonexistent_options_listed_in_order`
