### PR TITLE
Support custom authentication handlers for private pypi.

### DIFF
--- a/news/4475.feature
+++ b/news/4475.feature
@@ -1,0 +1,1 @@
+Support for custom authentication handlers via --auth-plugin option.

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -97,6 +97,7 @@ class SessionCommandMixin(CommandContextMixIn):
             retries=retries if retries is not None else options.retries,
             trusted_hosts=options.trusted_hosts,
             index_urls=self._get_index_urls(options),
+            auth_class=options.auth_class,
         )
 
         # Handle custom ca-bundles from the user

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -238,6 +238,9 @@ class PipSession(requests.Session):
         cache = kwargs.pop("cache", None)
         trusted_hosts = kwargs.pop("trusted_hosts", [])  # type: List[str]
         index_urls = kwargs.pop("index_urls", None)
+        auth_class = kwargs.pop("auth_class", None)
+        if auth_class is None:
+            auth_class = MultiDomainBasicAuth
 
         super(PipSession, self).__init__(*args, **kwargs)
 
@@ -249,7 +252,7 @@ class PipSession(requests.Session):
         self.headers["User-Agent"] = user_agent()
 
         # Attach our Authentication handler to the session
-        self.auth = MultiDomainBasicAuth(index_urls=index_urls)
+        self.auth = auth_class(index_urls=index_urls)
 
         # Create our urllib3.Retry instance which will allow us to customize
         # how we handle retries.


### PR DESCRIPTION
PR for #4475

MultiDomainBasicAuth is no longer the only option, it's just the default implementation.
Use `--auth` option to specify the plugin/handler that should be used.
Help message for this option lists all available/installed authentication plugins.

A plugin consists of:
- a module that implements `class Auth`, and
- an entrypoint, such as `"pip.auth_plugins": "win-sso=pip-win-sso-auth"`