### PR TITLE
feat(): Add logs for pip environment when installing

### DIFF
--- a/news/3166.feature
+++ b/news/3166.feature
@@ -1,1 +1,1 @@
-Logs information about pip environment when installing a package.
+Log debugging information about pip, in ``pip install --verbose``.

--- a/news/3166.feature
+++ b/news/3166.feature
@@ -1,0 +1,1 @@
+Logs information about pip environment when installing a package.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -27,6 +27,7 @@ from pip._internal.utils.filesystem import test_writable_dir
 from pip._internal.utils.misc import (
     ensure_dir,
     get_installed_version,
+    get_pip_version,
     protect_pip_from_modification_on_windows,
     write_output,
 )
@@ -239,6 +240,7 @@ class InstallCommand(RequirementCommand):
 
         install_options = options.install_options or []
 
+        logger.debug("Using {}".format(get_pip_version()))
         options.use_user_site = decide_user_install(
             options.use_user_site,
             prefix_path=options.prefix_path,

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1904,7 +1904,8 @@ def test_install_verify_package_name_normalization(script, package_name):
         package_name) in result.stdout
 
 
-def test_install_logs_pip_version_in_debug(script):
-    result = script.pip('install', '-v', 'INITools==0.2')
+def test_install_logs_pip_version_in_debug(script, shared_data):
+    fake_package = shared_data.packages / 'simple-2.0.tar.gz'
+    result = script.pip('install', '-v', fake_package)
     pattern = "Using pip .* from .*"
     assert_re_match(pattern, result.stdout)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1902,3 +1902,9 @@ def test_install_verify_package_name_normalization(script, package_name):
     result = script.pip('install', package_name)
     assert 'Requirement already satisfied: {}'.format(
         package_name) in result.stdout
+
+
+def test_install_logs_pip_version_in_debug(script):
+    result = script.pip('install', '-v', 'INITools==0.2')
+    pattern = "Using pip .* from .*"
+    assert_re_match(pattern, result.stdout)


### PR DESCRIPTION
Towards #3166 

Now, when the installation is performed the logs are shown as

```
(pip-env) gutsytechster@prashant:~/Documents/Projects/Open-Source-Projects/pip$ pip install django
Collecting django
  Using cached Django-3.0.6-py3-none-any.whl (7.5 MB)
Requirement already satisfied: pytz in /home/gutsytechster/miniconda3/envs/pip-env/lib/python3.6/site-packages (from django) (2020.1)
Requirement already satisfied: asgiref~=3.2 in /home/gutsytechster/miniconda3/envs/pip-env/lib/python3.6/site-packages (from django) (3.2.7)
Requirement already satisfied: sqlparse>=0.2.2 in /home/gutsytechster/miniconda3/envs/pip-env/lib/python3.6/site-packages (from django) (0.3.1)
pip 20.2.dev0 from /home/gutsytechster/miniconda3/envs/pip-env/lib/python3.6/site-packages/pip (python 3.6)
Installing collected packages: django
Successfully installed django-3.0.6
```
Please focus on last third line. Also, I'd like to get reviews about, if it should go as `logger.info` or as`logger.debug`.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
