### PR TITLE
Add mypy type annotations to cache, xmlrpc in network and format_control in models module

### DIFF
--- a/src/pip/_internal/models/format_control.py
+++ b/src/pip/_internal/models/format_control.py
@@ -1,6 +1,3 @@
-# The following comment should be removed at some point in the future.
-# mypy: strict-optional=False
-
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import CommandError
@@ -42,7 +39,7 @@ class FormatControl(object):
 
     @staticmethod
     def handle_mutual_excludes(value, target, other):
-        # type: (str, Optional[Set[str]], Optional[Set[str]]) -> None
+        # type: (str, Set[str], Set[str]) -> None
         if value.startswith('-'):
             raise CommandError(
                 "--no-binary / --only-binary option requires 1 argument."

--- a/src/pip/_internal/network/cache.py
+++ b/src/pip/_internal/network/cache.py
@@ -1,9 +1,6 @@
 """HTTP cache implementation.
 """
 
-# The following comment should be removed at some point in the future.
-# mypy: disallow-untyped-defs=False
-
 import os
 from contextlib import contextmanager
 
@@ -16,7 +13,7 @@ from pip._internal.utils.misc import ensure_dir
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional
+    from typing import Optional, Iterator
 
 
 def is_from_cache(response):
@@ -26,6 +23,7 @@ def is_from_cache(response):
 
 @contextmanager
 def suppressed_cache_errors():
+    # type: () -> Iterator[None]
     """If we can't access the cache then we can just skip caching and process
     requests as if caching wasn't enabled.
     """

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -12,7 +12,7 @@ from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Dict
+    from typing import Dict
     from pip._internal.network.session import PipSession
 
 logger = logging.getLogger(__name__)
@@ -24,14 +24,14 @@ class PipXmlrpcTransport(xmlrpc_client.Transport):
     """
 
     def __init__(self, index_url, session, use_datetime=False):
-        # type: (str, PipSession, Optional[bool]) -> None
+        # type: (str, PipSession, bool) -> None
         xmlrpc_client.Transport.__init__(self, use_datetime)
         index_parts = urllib_parse.urlparse(index_url)
         self._scheme = index_parts.scheme
         self._session = session
 
     def request(self, host, handler, request_body, verbose=False):
-        # type: (str, str, Dict[str, str], Optional[bool]) -> None
+        # type: (str, str, Dict[str, str], bool) -> None
         parts = (self._scheme, host, handler, None, None, None)
         url = urllib_parse.urlunparse(parts)
         try:

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -1,9 +1,6 @@
 """xmlrpclib.Transport implementation
 """
 
-# The following comment should be removed at some point in the future.
-# mypy: disallow-untyped-defs=False
-
 import logging
 
 from pip._vendor import requests
@@ -11,6 +8,12 @@ from pip._vendor import requests
 #       why we ignore the type on this import
 from pip._vendor.six.moves import xmlrpc_client  # type: ignore
 from pip._vendor.six.moves.urllib import parse as urllib_parse
+
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Optional, Dict
+    from pip._internal.network.session import PipSession
 
 logger = logging.getLogger(__name__)
 
@@ -21,12 +24,14 @@ class PipXmlrpcTransport(xmlrpc_client.Transport):
     """
 
     def __init__(self, index_url, session, use_datetime=False):
+        # type: (str, PipSession, Optional[bool]) -> None
         xmlrpc_client.Transport.__init__(self, use_datetime)
         index_parts = urllib_parse.urlparse(index_url)
         self._scheme = index_parts.scheme
         self._session = session
 
     def request(self, host, handler, request_body, verbose=False):
+        # type: (str, str, Dict[str, str], Optional[bool]) -> None
         parts = (self._scheme, host, handler, None, None, None)
         url = urllib_parse.urlunparse(parts)
         try:


### PR DESCRIPTION
Towards #4748

Added type annotations to `pip._internal.models.format_control`, `pip._internal.network.cache` and `pip._internal.network.xmlrpc`