### PR TITLE
Set max_rounds to an incredibly large number

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -132,7 +132,10 @@ class Resolver(BaseResolver):
         resolver = RLResolver(provider, reporter)
 
         try:
-            self._result = resolver.resolve(requirements)
+            try_to_avoid_resolution_too_deep = 2000000
+            self._result = resolver.resolve(
+                requirements, max_rounds=try_to_avoid_resolution_too_deep,
+            )
 
         except ResolutionImpossible as e:
             error = self.factory.get_installation_error(e)


### PR DESCRIPTION
We really don’t want to raise ResolutionTooDeep yet since the metric is not very useful. Try to avoid this until we come up with a better method to count.