### PR TITLE
Don't use cElementTree on Python 3

### DIFF
--- a/news/8278.bugfix
+++ b/news/8278.bugfix
@@ -1,1 +1,0 @@
-htmlib5 no longer imports deprecated xml.etree.cElementTree on Python 3.

--- a/news/8278.bugfix
+++ b/news/8278.bugfix
@@ -1,0 +1,1 @@
+htmlib5 no longer imports deprecated xml.etree.cElementTree on Python 3.

--- a/news/8278.vendor
+++ b/news/8278.vendor
@@ -1,0 +1,1 @@
+Vendored htmlib5 no longer imports deprecated xml.etree.cElementTree on Python 3.

--- a/src/pip/_vendor/README.rst
+++ b/src/pip/_vendor/README.rst
@@ -100,8 +100,9 @@ Modifications
 * ``setuptools`` is completely stripped to only keep ``pkg_resources``
 * ``pkg_resources`` has been modified to import its dependencies from ``pip._vendor``
 * ``packaging`` has been modified to import its dependencies from ``pip._vendor``
-* ``html5lib`` has been modified to import six from ``pip._vendor`` and
-  to prefer importing from ``collections.abc`` instead of ``collections``.
+* ``html5lib`` has been modified to import six from ``pip._vendor``, to prefer
+  importing from ``collections.abc`` instead of ``collections`` and does not import
+  ``xml.etree.cElementTree`` on Python 3.
 * ``CacheControl`` has been modified to import its dependencies from ``pip._vendor``
 * ``requests`` has been modified to import its other dependencies from ``pip._vendor``
   and to *not* load ``simplejson`` (all platforms) and ``pyopenssl`` (Windows).

--- a/src/pip/_vendor/html5lib/_utils.py
+++ b/src/pip/_vendor/html5lib/_utils.py
@@ -2,12 +2,15 @@ from __future__ import absolute_import, division, unicode_literals
 
 from types import ModuleType
 
-from pip._vendor.six import text_type
+from pip._vendor.six import text_type, PY3
 
-try:
-    import xml.etree.cElementTree as default_etree
-except ImportError:
+if PY3:
     import xml.etree.ElementTree as default_etree
+else:
+    try:
+        import xml.etree.cElementTree as default_etree
+    except ImportError:
+        import xml.etree.ElementTree as default_etree
 
 
 __all__ = ["default_etree", "MethodDispatcher", "isSurrogatePair",

--- a/tools/automation/vendoring/patches/html5lib.patch
+++ b/tools/automation/vendoring/patches/html5lib.patch
@@ -28,4 +28,28 @@ index dcfac220..d8b53004 100644
 +    from collections import MutableMapping
  from xml.dom import minidom, Node
  import weakref
+
+diff --git a/src/pip/_vendor/html5lib/_utils.py b/src/pip/_vendor/html5lib/_utils.py
+index 0703afb3..96eb17b2 100644
+--- a/src/pip/_vendor/html5lib/_utils.py
++++ b/src/pip/_vendor/html5lib/_utils.py
+@@ -2,12 +2,15 @@ from __future__ import absolute_import, division, unicode_literals
  
+ from types import ModuleType
+ 
+-from pip._vendor.six import text_type
++from pip._vendor.six import text_type, PY3
+ 
+-try:
+-    import xml.etree.cElementTree as default_etree
+-except ImportError:
++if PY3:
+     import xml.etree.ElementTree as default_etree
++else:
++    try:
++        import xml.etree.cElementTree as default_etree
++    except ImportError:
++        import xml.etree.ElementTree as default_etree
+ 
+ 
+ __all__ = ["default_etree", "MethodDispatcher", "isSurrogatePair",


### PR DESCRIPTION
It's been deprecated and will be removed in 3.9 or 3.10. 3.9.0b1 doesn't
have cElementTree. I'd like to bring it back with a deprecation warning
to drop in 3.10.

See: https://github.com/python/cpython/pull/19921
Signed-off-by: Christian Heimes <christian@python.org>

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
