### PR TITLE
Always read InstallRequirement.extras

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -55,7 +55,7 @@ class SpecifierRequirement(Requirement):
         assert ireq.link is None, "This is a link, not a specifier"
         self._ireq = ireq
         self._factory = factory
-        self.extras = ireq.req.extras
+        self.extras = set(ireq.extras)
 
     def __str__(self):
         # type: () -> str

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -194,16 +194,14 @@ def test_new_resolver_ignore_dependencies(script):
     [
         "base[add]",
         "base[add] >= 0.1.0",
-        pytest.param(  # Non-standard syntax. To deprecate, see pypa/pip#8288.
-            "base >= 0.1.0[add]",
-            marks=pytest.mark.skipif(
-                "sys.platform == 'win32'",
-                reason="script.pip() does not handle >= on Windows",
-            ),
-        ),
+        # Non-standard syntax. To deprecate, see pypa/pip#8288.
+        "base >= 0.1.0[add]",
     ],
 )
-def test_new_resolver_installs_extras(script, root_dep):
+def test_new_resolver_installs_extras(tmpdir, script, root_dep):
+    req_file = tmpdir.joinpath("requirements.txt")
+    req_file.write_text(root_dep)
+
     create_basic_wheel_for_package(
         script,
         "base",
@@ -219,7 +217,7 @@ def test_new_resolver_installs_extras(script, root_dep):
         "install", "--unstable-feature=resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
-        root_dep,
+        "-r", req_file,
     )
     assert_installed(script, base="0.1.0", dep="0.1.0")
 


### PR DESCRIPTION
I can’t even write a test for this because `script.pip()` interprets `>=` incorrectly. Arrgh.

Close #8285.