### PR TITLE
Pass explicit arguments to install_given_req.

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -399,9 +399,9 @@ class InstallCommand(RequirementCommand):
                 root=options.root_path,
                 home=target_temp_dir_path,
                 prefix=options.prefix_path,
-                pycompile=options.compile,
                 warn_script_location=warn_script_location,
                 use_user_site=options.use_user_site,
+                pycompile=options.compile,
             )
 
             lib_locations = get_lib_location_guesses(

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -13,7 +13,7 @@ from .req_install import InstallRequirement
 from .req_set import RequirementSet
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any, List, Sequence
+    from typing import List, Optional, Sequence
 
 __all__ = [
     "RequirementSet", "InstallRequirement",
@@ -36,9 +36,13 @@ class InstallationResult(object):
 def install_given_reqs(
     to_install,  # type: List[InstallRequirement]
     install_options,  # type: List[str]
-    global_options=(),  # type: Sequence[str]
-    *args,  # type: Any
-    **kwargs  # type: Any
+    global_options,  # type: Sequence[str]
+    root,  # type: Optional[str]
+    home,  # type: Optional[str]
+    prefix,  # type: Optional[str]
+    warn_script_location,  # type: bool
+    use_user_site,  # type: bool
+    pycompile,  # type: bool
 ):
     # type: (...) -> List[InstallationResult]
     """
@@ -67,8 +71,12 @@ def install_given_reqs(
                 requirement.install(
                     install_options,
                     global_options,
-                    *args,
-                    **kwargs
+                    root=root,
+                    home=home,
+                    prefix=prefix,
+                    warn_script_location=warn_script_location,
+                    use_user_site=use_user_site,
+                    pycompile=pycompile,
                 )
             except Exception:
                 should_rollback = (


### PR DESCRIPTION
`install_given_reqs` as [one call site](https://github.com/pypa/pip/blob/3ec6b824ddbdef2128238858473bc80c7bf502e8/src/pip/_internal/commands/install.py#L395) and arguments are fowarded to `InstallRequirement.install`.

Make `install_given_reqs` arguments explicit.