### PR TITLE
Support '--unstable-feature' in requirements files

### DIFF
--- a/news/8293.feature
+++ b/news/8293.feature
@@ -1,0 +1,1 @@
+Support ``--unstable-feature`` in requirements files

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -63,6 +63,7 @@ SUPPORTED_OPTIONS = [
     cmdoptions.require_hashes,
     cmdoptions.pre,
     cmdoptions.trusted_host,
+    cmdoptions.unstable_feature,
     cmdoptions.always_unzip,  # Deprecated
 ]  # type: List[Callable[..., optparse.Option]]
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -382,6 +382,10 @@ class TestProcessLine(object):
         # noop, but confirm it can be set
         line_processor("--always-unzip", "file", 1, finder=finder)
 
+    def test_unstable_feature(self, line_processor):
+        """--unstable-feature can be set in requirements files."""
+        line_processor("--unstable-feature=resolver", "filename", 1)
+
     def test_set_finder_allow_all_prereleases(self, line_processor, finder):
         line_processor("--pre", "file", 1, finder=finder)
         assert finder.allow_all_prereleases


### PR DESCRIPTION
This patch adds support for `--unstable-feature` in requirements files so that a project that wants all contributers using the same pip features can specify it in the requirements file. For example, to ensure a requirements file uses the new resolver:

```
--unstable-feature=resolver
boto3
boto3==1.13.13
```

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->