### PR TITLE
Add a travis job to test the new resolver known failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,9 @@ jobs:
     - env:
       - GROUP=2
       - NEW_RESOLVER=1
+    - env:
+      - GROUP=3
+      - NEW_RESOLVER=1
 
   fast_finish: true
   allow_failures:

--- a/tools/travis/run.sh
+++ b/tools/travis/run.sh
@@ -55,6 +55,10 @@ elif [[ "$GROUP" == "2" ]]; then
     # Separate Job for running integration tests for 'pip install'
     tox -- -m integration -n auto --duration=5 -k "test_install" \
         --use-venv $RESOLVER_SWITCH
+elif [[ "$GROUP" == "3" ]]; then
+    # Separate Job for tests that fail with the new resolver
+    tox -- -m fails_on_new_resolver -n auto --duration=5 \
+        --use-venv $RESOLVER_SWITCH --new-resolver-runtests
 else
     # Non-Testing Jobs should run once
     tox


### PR DESCRIPTION
This adds a third job to the "experimental" group in Travis. We now have 3 experimental jobs:

1. Group 1: Unit tests and non-install tests under the new resolver (should pass).
2. Group 2: Install tests under the new resolver (should pass).
3. Group 3: Tests known to fail under the new resolver (should fail, hopefully the number of tests goes down over time).

I didn't make the first two mandatory. That seems unnecessary at the moment, but it does mean that we should check those tests explicitly before merging a change to the new resolver, if we want to catch regressions.