### PR TITLE
Disallow failures for tests we expect to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
 
   fast_finish: true
   allow_failures:
-    - stage: experimental
+    - env: GROUP=3 NEW_RESOLVER=1
 
 before_install: tools/travis/setup.sh
 install: travis_retry tools/travis/install.sh


### PR DESCRIPTION
Since we’re skipping tests with `fails_on_new_resolver` in group 1 and 2, disallowing them to fail would help us catch regressions.