### PR TITLE
New resolver not raising DistributionNotFound

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -6,7 +6,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
 from pip._vendor.resolvelib import Resolver as RLResolver
 
-from pip._internal.exceptions import InstallationError
+from pip._internal.exceptions import DistributionNotFound, InstallationError
 from pip._internal.req.req_set import RequirementSet
 from pip._internal.resolution.base import BaseResolver
 from pip._internal.resolution.resolvelib.provider import PipProvider
@@ -155,11 +155,10 @@ class Resolver(BaseResolver):
                             parent.name
                         ))
                     )
-                raise InstallationError(
+                raise DistributionNotFound(
                     "No matching distribution found for " +
                     ", ".join([r.name for r, _ in e.causes])
                 )
-                raise
             six.raise_from(error, e)
 
         req_set = RequirementSet(check_supported_wheels=check_supported_wheels)

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 import textwrap
 
@@ -7,7 +8,6 @@ import pytest
 from tests.lib.server import file_response, package_page
 
 
-@pytest.mark.fails_on_new_resolver
 def test_options_from_env_vars(script):
     """
     Test if ConfigOptionParser reads env vars (e.g. not using PyPI here)
@@ -16,10 +16,11 @@ def test_options_from_env_vars(script):
     script.environ['PIP_NO_INDEX'] = '1'
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
     assert "Ignoring indexes:" in result.stdout, str(result)
-    assert (
-        "DistributionNotFound: No matching distribution found for INITools"
-        in result.stdout
-    )
+    assert re.search(
+        "DistributionNotFound: No matching distribution found for "
+        "(?i:INITools)",
+        result.stdout
+    ), str(result)
 
 
 def test_command_line_options_override_env_vars(script, virtualenv):
@@ -44,7 +45,6 @@ def test_command_line_options_override_env_vars(script, virtualenv):
 
 
 @pytest.mark.network
-@pytest.mark.fails_on_new_resolver
 def test_env_vars_override_config_file(script, virtualenv):
     """
     Test that environmental variables override settings in config files.
@@ -61,10 +61,11 @@ def test_env_vars_override_config_file(script, virtualenv):
         no-index = 1
         """))
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
-    assert (
-        "DistributionNotFound: No matching distribution found for INITools"
-        in result.stdout
-    )
+    assert re.search(
+        "DistributionNotFound: No matching distribution found for "
+        "(?i:INITools)",
+        result.stdout
+    ), str(result)
     script.environ['PIP_NO_INDEX'] = '0'
     virtualenv.clear()
     result = script.pip('install', '-vvv', 'INITools')
@@ -176,7 +177,6 @@ def test_config_file_override_stack(
     assert requests[3]["PATH_INFO"] == "/files/INITools-0.2.tar.gz"
 
 
-@pytest.mark.fails_on_new_resolver
 def test_options_from_venv_config(script, virtualenv):
     """
     Test if ConfigOptionParser reads a virtualenv-local config file
@@ -189,10 +189,11 @@ def test_options_from_venv_config(script, virtualenv):
         f.write(conf)
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
     assert "Ignoring indexes:" in result.stdout, str(result)
-    assert (
-        "DistributionNotFound: No matching distribution found for INITools"
-        in result.stdout
-    )
+    assert re.search(
+        "DistributionNotFound: No matching distribution found for "
+        "(?i:INITools)",
+        result.stdout
+    ), str(result)
 
 
 def test_install_no_binary_via_config_disables_cached_wheels(

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -1,5 +1,4 @@
 import os
-import re
 import tempfile
 import textwrap
 
@@ -16,11 +15,9 @@ def test_options_from_env_vars(script):
     script.environ['PIP_NO_INDEX'] = '1'
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
     assert "Ignoring indexes:" in result.stdout, str(result)
-    assert re.search(
-        "DistributionNotFound: No matching distribution found for "
-        "(?i:INITools)",
-        result.stdout
-    ), str(result)
+    msg = "DistributionNotFound: No matching distribution found for INITools"
+    # Case insensitive as the new resolver canonicalises the project name
+    assert msg.lower() in result.stdout.lower(), str(result)
 
 
 def test_command_line_options_override_env_vars(script, virtualenv):
@@ -61,11 +58,9 @@ def test_env_vars_override_config_file(script, virtualenv):
         no-index = 1
         """))
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
-    assert re.search(
-        "DistributionNotFound: No matching distribution found for "
-        "(?i:INITools)",
-        result.stdout
-    ), str(result)
+    msg = "DistributionNotFound: No matching distribution found for INITools"
+    # Case insensitive as the new resolver canonicalises the project name
+    assert msg.lower() in result.stdout.lower(), str(result)
     script.environ['PIP_NO_INDEX'] = '0'
     virtualenv.clear()
     result = script.pip('install', '-vvv', 'INITools')
@@ -189,11 +184,9 @@ def test_options_from_venv_config(script, virtualenv):
         f.write(conf)
     result = script.pip('install', '-vvv', 'INITools', expect_error=True)
     assert "Ignoring indexes:" in result.stdout, str(result)
-    assert re.search(
-        "DistributionNotFound: No matching distribution found for "
-        "(?i:INITools)",
-        result.stdout
-    ), str(result)
+    msg = "DistributionNotFound: No matching distribution found for INITools"
+    # Case insensitive as the new resolver canonicalises the project name
+    assert msg.lower() in result.stdout.lower(), str(result)
 
 
 def test_install_no_binary_via_config_disables_cached_wheels(


### PR DESCRIPTION
A more complete fix for #8298. The case difference was masking the fact that the new resolver is raising the wrong exception when it can't find a distribution.