### PR TITLE
Moar CI cleanups

### DIFF
--- a/.azure-pipelines/jobs/test.yml
+++ b/.azure-pipelines/jobs/test.yml
@@ -12,8 +12,8 @@ jobs:
       "2.7":
         python.version: '2.7'
         python.architecture: x64
-      "3.6":
-        python.version: '3.6'
+      "3.8":
+        python.version: '3.8'
         python.architecture: x64
     maxParallel: 2
 
@@ -32,11 +32,11 @@ jobs:
       "3.5":
         python.version: '3.5'
         python.architecture: x64
+      "3.6":
+        python.version: '3.6'
+        python.architecture: x64
       "3.7":
         python.version: '3.7'
-        python.architecture: x64
-      "3.8":
-        python.version: '3.8'
         python.architecture: x64
     maxParallel: 4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,6 @@ jobs:
       env: TOXENV=docs
     - env: TOXENV=lint
     - env: TOXENV=vendoring
-    # Latest CPython
-    - env: GROUP=1
-      python: 2.7
-    - env: GROUP=2
-      python: 2.7
-    - env: GROUP=1
-    - env: GROUP=2
 
     # Complete checking for ensuring compatibility
     # PyPy
@@ -38,19 +31,6 @@ jobs:
       python: pypy2.7-7.1.1
     - env: GROUP=2
       python: pypy2.7-7.1.1
-    # Other Supported CPython
-    - env: GROUP=1
-      python: 3.7
-    - env: GROUP=2
-      python: 3.7
-    - env: GROUP=1
-      python: 3.6
-    - env: GROUP=2
-      python: 3.6
-    - env: GROUP=1
-      python: 3.5
-    - env: GROUP=2
-      python: 3.5
 
     # Test experimental stuff that are not part of the standard pip usage.
     # Helpful for developers working on them to see how they're doing.

--- a/docs/html/development/ci.rst
+++ b/docs/html/development/ci.rst
@@ -66,9 +66,9 @@ Services
 pip test suite and checks are distributed on three different platforms that
 provides free executors for open source packages:
 
-  - `Travis CI`_ (Used for Linux)
-  - `Azure DevOps CI`_ (Linux, MacOS & Windows tests)
-  - `GitHub Actions`_ (Linux, MacOS & Windows tests)
+  - `GitHub Actions`_ (Used for code quality and development tasks)
+  - `Azure DevOps CI`_ (Used for tests)
+  - `Travis CI`_ (Used for PyPy tests)
 
 .. _`Travis CI`: https://travis-ci.org/
 .. _`Azure DevOps CI`: https://azure.microsoft.com/en-us/services/devops/
@@ -81,13 +81,13 @@ Current run tests
 Developer tasks
 ---------------
 
-======== =============== ================ ================== ============
-   OS          docs            lint           vendoring        packages
-======== =============== ================ ================== ============
-Linux     Travis, Github  Travis, Github    Travis, Github      Azure
-Windows                                                         Azure
-MacOS                                                           Azure
-======== =============== ================ ================== ============
+======== =============== ================ ================== =============
+   OS          docs            lint           vendoring        packaging
+======== =============== ================ ================== =============
+Linux     Travis, Github  Travis, Github    Travis, Github       Azure
+Windows       Github           Github           Github           Azure
+MacOS         Github           Github           Github           Azure
+======== =============== ================ ================== =============
 
 Actual testing
 --------------
@@ -137,15 +137,15 @@ Actual testing
 |           |          +-------+---------------+-----------------+
 |           |          | PyPy3 |               |                 |
 |   Linux   +----------+-------+---------------+-----------------+
-|           |          | CP2.7 | Travis,Azure  |  Travis,Azure   |
+|           |          | CP2.7 |   Azure       |   Azure         |
 |           |          +-------+---------------+-----------------+
-|           |          | CP3.5 | Travis,Azure  |  Travis,Azure   |
+|           |          | CP3.5 |   Azure       |   Azure         |
 |           |          +-------+---------------+-----------------+
-|           |          | CP3.6 | Travis,Azure  |  Travis,Azure   |
+|           |          | CP3.6 |   Azure       |   Azure         |
 |           |          +-------+---------------+-----------------+
-|           |   x64    | CP3.7 | Travis,Azure  |  Travis,Azure   |
+|           |   x64    | CP3.7 |   Azure       |   Azure         |
 |           |          +-------+---------------+-----------------+
-|           |          | CP3.8 |   Travis      |   Travis        |
+|           |          | CP3.8 |   Azure       |   Azure         |
 |           |          +-------+---------------+-----------------+
 |           |          | PyPy  |   Travis      |   Travis        |
 |           |          +-------+---------------+-----------------+
@@ -173,7 +173,7 @@ Actual testing
 |           |          +-------+---------------+-----------------+
 |           |   x64    | CP3.7 |   Azure       |   Azure         |
 |           |          +-------+---------------+-----------------+
-|           |          | CP3.8 |               |                 |
+|           |          | CP3.8 |   Azure       |   Azure         |
 |           |          +-------+---------------+-----------------+
 |           |          | PyPy  |               |                 |
 |           |          +-------+---------------+-----------------+


### PR DESCRIPTION
* Remove duplicate jobs from Travis CI
* Update Azure Pipelines to use Python 3.8 for "primary" on Ubuntu / MacOS
* Update CI documentation to reflect current realities
