### PR TITLE
Fix pip cache docstring to render correctly in docs

### DIFF
--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -30,7 +30,7 @@ class CacheCommand(Command):
     - remove: Remove one or more package from the cache.
     - purge: Remove all items from the cache.
 
-    <pattern> can be a glob expression or a package name.
+    ``<pattern>`` can be a glob expression or a package name.
     """
 
     ignore_require_venv = True

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -24,13 +24,13 @@ class CacheCommand(Command):
 
     Subcommands:
 
-        dir: Show the cache directory.
-        info: Show information about the cache.
-        list: List filenames of packages stored in the cache.
-        remove: Remove one or more package from the cache.
-        purge: Remove all items from the cache.
+    - dir: Show the cache directory.
+    - info: Show information about the cache.
+    - list: List filenames of packages stored in the cache.
+    - remove: Remove one or more package from the cache.
+    - purge: Remove all items from the cache.
 
-        <pattern> can be a glob expression or a package name.
+    <pattern> can be a glob expression or a package name.
     """
 
     ignore_require_venv = True


### PR DESCRIPTION
Applying the changes done in https://github.com/pypa/pip/pull/8073 to `pip cache` docstring to fix it's formatting