### PR TITLE
DO NOT sort the returned matches by version

### DIFF
--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -669,7 +669,6 @@ def test_download_exit_status_code_when_blank_requirements_file(script):
     script.pip('download', '-r', 'blank.txt')
 
 
-@pytest.mark.fails_on_new_resolver
 def test_download_prefer_binary_when_tarball_higher_than_wheel(script, data):
     fake_wheel(data, 'source-0.8-py2.py3-none-any.whl')
     result = script.pip(


### PR DESCRIPTION
Bug found by the unit test introduced in #7996.

A higher version is not always preferred over the lower; the user may be explicitly preferring lower versions by specifying --prefer-binary or similar flags.

`PackageFinder` already takes these into account and orders the matches. Don't break it.
