### PR TITLE
Remove new resolver marker from tests that should pass

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -148,7 +148,6 @@ def test_pep518_with_user_pip(script, pip_src, data, common_wheels):
     )
 
 
-@pytest.mark.fails_on_new_resolver
 def test_pep518_with_extra_and_markers(script, data, common_wheels):
     script.pip(
         'wheel', '--no-index',

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -136,7 +136,6 @@ def test_install_special_extra(script):
         pytest.param('[extra2]', '1.0', marks=pytest.mark.xfail),
         pytest.param('[extra1,extra2]', '1.0', marks=pytest.mark.xfail),
     ])
-@pytest.mark.fails_on_new_resolver
 def test_install_extra_merging(script, data, extra_to_install, simple_version):
     # Check that extra specifications in the extras section are honoured.
     pkga_path = script.scratch_path / 'pkga'

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -189,7 +189,6 @@ def test_respect_order_in_requirements_file(script, data):
     )
 
 
-@pytest.mark.fails_on_new_resolver
 def test_install_local_editable_with_extras(script, data):
     to_install = data.packages.joinpath("LocalExtras")
     res = script.pip_install_local(


### PR DESCRIPTION
Base direct candidate from extras has been implemented in #8291, these should pass:

* `test_install_extra_merging`
* `test_install_local_editable_with_extras`

Marker filtering has been implemented in #8239, this should pass:

* `test_pep518_with_extra_and_markers`