### PR TITLE
Add methods for path lookups in test_install_{reqs, upgrade}.py

### DIFF
--- a/news/dc9b761d-5d4e-4ea4-9629-0afcc2636cb6.trivial
+++ b/news/dc9b761d-5d4e-4ea4-9629-0afcc2636cb6.trivial
@@ -1,0 +1,1 @@
+Add methods for path lookups in ``test_install_reqs.py`` and ``test_install_upgrade.py``.

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -29,11 +29,10 @@ def test_requirements_file(script):
     result = script.pip(
         'install', '-r', script.scratch_path / 'initools-req.txt'
     )
-    assert (
-        script.site_packages / 'INITools-0.2-py{}.egg-info'.format(
-            pyversion) in result.files_created
+    result.did_create(
+        script.site_packages / 'INITools-0.2-py{}.egg-info'.format(pyversion)
     )
-    assert script.site_packages / 'initools' in result.files_created
+    result.did_create(script.site_packages / 'initools')
     assert result.files_created[script.site_packages / other_lib_name].dir
     fn = '{}-{}-py{}.egg-info'.format(
         other_lib_name, other_lib_version, pyversion)
@@ -101,14 +100,14 @@ def test_relative_requirements_file(script, data, test_type, editable):
                                script.scratch_path) as reqs_file:
             result = script.pip('install', '-vvv', '-r', reqs_file.name,
                                 cwd=script.scratch_path)
-            assert egg_info_file in result.files_created, str(result)
-            assert package_folder in result.files_created, str(result)
+            result.did_create(egg_info_file)
+            result.did_create(package_folder)
     else:
         with requirements_file('-e ' + req_path + '\n',
                                script.scratch_path) as reqs_file:
             result = script.pip('install', '-vvv', '-r', reqs_file.name,
                                 cwd=script.scratch_path)
-            assert egg_link_file in result.files_created, str(result)
+            result.did_create(egg_link_file)
 
 
 @pytest.mark.network
@@ -140,7 +139,7 @@ def test_multiple_requirements_files(script, tmpdir):
     fn = '{other_lib_name}-{other_lib_version}-py{pyversion}.egg-info'.format(
         pyversion=pyversion, **locals())
     assert result.files_created[script.site_packages / fn].dir
-    assert script.venv / 'src' / 'initools' in result.files_created
+    result.did_create(script.venv / 'src' / 'initools')
 
 
 def test_package_in_constraints_and_dependencies(script, data):
@@ -195,13 +194,9 @@ def test_install_local_editable_with_extras(script, data):
     res = script.pip_install_local(
         '-e', to_install + '[bar]', allow_stderr_warning=True
     )
-    assert script.site_packages / 'easy-install.pth' in res.files_updated, (
-        str(res)
-    )
-    assert (
-        script.site_packages / 'LocalExtras.egg-link' in res.files_created
-    ), str(res)
-    assert script.site_packages / 'simple' in res.files_created, str(res)
+    res.did_update(script.site_packages / 'easy-install.pth')
+    res.did_create(script.site_packages / 'LocalExtras.egg-link')
+    res.did_create(script.site_packages / 'simple')
 
 
 def test_install_collected_dependencies_first(script):
@@ -285,7 +280,7 @@ def test_install_option_in_requirements_file(script, data, virtualenv):
         expect_stderr=True)
 
     package_dir = script.scratch / 'home1' / 'lib' / 'python' / 'simple'
-    assert package_dir in result.files_created
+    result.did_create(package_dir)
 
 
 def test_constraints_not_installed_by_default(script, data):
@@ -415,7 +410,7 @@ def test_install_with_extras_from_constraints(script, data):
     )
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', 'LocalExtras')
-    assert script.site_packages / 'simple' in result.files_created
+    result.did_create(script.site_packages / 'simple')
 
 
 @pytest.mark.fails_on_new_resolver
@@ -426,7 +421,7 @@ def test_install_with_extras_from_install(script, data):
     )
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', 'LocalExtras[baz]')
-    assert script.site_packages / 'singlemodule.py' in result.files_created
+    result.did_create(script.site_packages / 'singlemodule.py')
 
 
 @pytest.mark.fails_on_new_resolver
@@ -438,8 +433,8 @@ def test_install_with_extras_joined(script, data):
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', 'LocalExtras[baz]'
     )
-    assert script.site_packages / 'simple' in result.files_created
-    assert script.site_packages / 'singlemodule.py' in result.files_created
+    result.did_create(script.site_packages / 'simple')
+    result.did_create(script.site_packages / 'singlemodule.py')
 
 
 @pytest.mark.fails_on_new_resolver
@@ -450,8 +445,8 @@ def test_install_with_extras_editable_joined(script, data):
     )
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', 'LocalExtras[baz]')
-    assert script.site_packages / 'simple' in result.files_created
-    assert script.site_packages / 'singlemodule.py' in result.files_created
+    result.did_create(script.site_packages / 'simple')
+    result.did_create(script.site_packages / 'singlemodule.py')
 
 
 def test_install_distribution_full_union(script, data):
@@ -459,8 +454,8 @@ def test_install_distribution_full_union(script, data):
     result = script.pip_install_local(
         to_install, to_install + "[bar]", to_install + "[baz]")
     assert 'Running setup.py install for LocalExtras' in result.stdout
-    assert script.site_packages / 'simple' in result.files_created
-    assert script.site_packages / 'singlemodule.py' in result.files_created
+    result.did_create(script.site_packages / 'simple')
+    result.did_create(script.site_packages / 'singlemodule.py')
 
 
 def test_install_distribution_duplicate_extras(script, data):
@@ -481,7 +476,7 @@ def test_install_distribution_union_with_constraints(script, data):
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', to_install + '[baz]')
     assert 'Running setup.py install for LocalExtras' in result.stdout
-    assert script.site_packages / 'singlemodule.py' in result.files_created
+    result.did_create(script.site_packages / 'singlemodule.py')
 
 
 @pytest.mark.fails_on_new_resolver
@@ -571,8 +566,8 @@ def test_install_options_local_to_package(script, data):
     simple = test_simple / 'lib' / 'python' / 'simple'
     bad = test_simple / 'lib' / 'python' / 'initools'
     good = script.site_packages / 'initools'
-    assert simple in result.files_created
+    result.did_create(simple)
     assert result.files_created[simple].dir
-    assert bad not in result.files_created
-    assert good in result.files_created
+    result.did_not_create(bad)
+    result.did_create(good)
     assert result.files_created[good].dir

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -82,7 +82,7 @@ def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(script):
         script.site_packages /
         'simple-3.0-py{pyversion}.egg-info'.format(**globals())
     )
-    result.did_create(expected, "should have installed simple==3.0")
+    result.did_create(expected, message="should have installed simple==3.0")
     expected = (
         script.site_packages /
         'simple-1.0-py{pyversion}.egg-info'.format(**globals())
@@ -132,7 +132,7 @@ def test_eager_does_upgrade_dependecies_when_no_longer_satisfied(script):
     result.did_create(
         script.site_packages /
         'simple-3.0-py{pyversion}.egg-info'.format(**globals()),
-        "should have installed simple==3.0"
+        message="should have installed simple==3.0"
     )
     assert (
         script.site_packages /
@@ -199,10 +199,7 @@ def test_upgrade_force_reinstall_newest(script):
     version if --force-reinstall is supplied.
     """
     result = script.pip('install', 'INITools')
-    result.did_create(
-        script.site_packages / 'initools',
-        sorted(result.files_created.keys())
-    )
+    result.did_create(script.site_packages / 'initools')
     result2 = script.pip(
         'install', '--upgrade', '--force-reinstall', 'INITools'
     )
@@ -218,10 +215,7 @@ def test_uninstall_before_upgrade(script):
 
     """
     result = script.pip('install', 'INITools==0.2')
-    result.did_create(
-        script.site_packages / 'initools',
-        sorted(result.files_created.keys())
-    )
+    result.did_create(script.site_packages / 'initools')
     result2 = script.pip('install', 'INITools==0.3')
     assert result2.files_created, 'upgrade to INITools 0.3 failed'
     result3 = script.pip('uninstall', 'initools', '-y')
@@ -235,10 +229,7 @@ def test_uninstall_before_upgrade_from_url(script):
 
     """
     result = script.pip('install', 'INITools==0.2')
-    result.did_create(
-        script.site_packages / 'initools',
-        sorted(result.files_created.keys())
-    )
+    result.did_create(script.site_packages / 'initools')
     result2 = script.pip(
         'install',
         'https://files.pythonhosted.org/packages/source/I/INITools/INITools-'
@@ -258,10 +249,7 @@ def test_upgrade_to_same_version_from_url(script):
 
     """
     result = script.pip('install', 'INITools==0.3')
-    result.did_create(
-        script.site_packages / 'initools',
-        sorted(result.files_created.keys())
-    )
+    result.did_create(script.site_packages / 'initools')
     result2 = script.pip(
         'install',
         'https://files.pythonhosted.org/packages/source/I/INITools/INITools-'
@@ -315,10 +303,7 @@ def test_uninstall_rollback(script, data):
     result = script.pip(
         'install', '-f', data.find_links, '--no-index', 'broken==0.1'
     )
-    result.did_create(
-        script.site_packages / 'broken.py',
-        list(result.files_created.keys())
-    )
+    result.did_create(script.site_packages / 'broken.py')
     result2 = script.pip(
         'install', '-f', data.find_links, '--no-index', 'broken===0.2broken',
         expect_error=True,

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -82,9 +82,7 @@ def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(script):
         script.site_packages /
         'simple-3.0-py{pyversion}.egg-info'.format(**globals())
     )
-    assert (
-        expected in result.files_created
-    ), "should have installed simple==3.0"
+    result.did_create(expected, "should have installed simple==3.0")
     expected = (
         script.site_packages /
         'simple-1.0-py{pyversion}.egg-info'.format(**globals())
@@ -131,11 +129,11 @@ def test_eager_does_upgrade_dependecies_when_no_longer_satisfied(script):
             'require_simple-1.0-py{pyversion}.egg-info'.format(**globals()))
         not in result.files_deleted
     ), "should have installed require_simple==1.0"
-    assert (
+    result.did_create(
         script.site_packages /
-        'simple-3.0-py{pyversion}.egg-info'.format(**globals())
-        in result.files_created
-    ), "should have installed simple==3.0"
+        'simple-3.0-py{pyversion}.egg-info'.format(**globals()),
+        "should have installed simple==3.0"
+    )
     assert (
         script.site_packages /
         'simple-1.0-py{pyversion}.egg-info'.format(**globals())
@@ -159,10 +157,9 @@ def test_upgrade_to_specific_version(script):
         .format(**globals())
         in result.files_deleted
     )
-    assert (
+    result.did_create(
         script.site_packages / 'INITools-0.2-py{pyversion}.egg-info'
         .format(**globals())
-        in result.files_created
     )
 
 
@@ -175,10 +172,9 @@ def test_upgrade_if_requested(script):
     script.pip('install', 'INITools==0.1')
     result = script.pip('install', '--upgrade', 'INITools')
     assert result.files_created, 'pip install --upgrade did not upgrade'
-    assert (
+    result.did_not_create(
         script.site_packages /
         'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
-        not in result.files_created
     )
 
 
@@ -203,7 +199,8 @@ def test_upgrade_force_reinstall_newest(script):
     version if --force-reinstall is supplied.
     """
     result = script.pip('install', 'INITools')
-    assert script.site_packages / 'initools' in result.files_created, (
+    result.did_create(
+        script.site_packages / 'initools',
         sorted(result.files_created.keys())
     )
     result2 = script.pip(
@@ -221,7 +218,8 @@ def test_uninstall_before_upgrade(script):
 
     """
     result = script.pip('install', 'INITools==0.2')
-    assert script.site_packages / 'initools' in result.files_created, (
+    result.did_create(
+        script.site_packages / 'initools',
         sorted(result.files_created.keys())
     )
     result2 = script.pip('install', 'INITools==0.3')
@@ -237,7 +235,8 @@ def test_uninstall_before_upgrade_from_url(script):
 
     """
     result = script.pip('install', 'INITools==0.2')
-    assert script.site_packages / 'initools' in result.files_created, (
+    result.did_create(
+        script.site_packages / 'initools',
         sorted(result.files_created.keys())
     )
     result2 = script.pip(
@@ -259,7 +258,8 @@ def test_upgrade_to_same_version_from_url(script):
 
     """
     result = script.pip('install', 'INITools==0.3')
-    assert script.site_packages / 'initools' in result.files_created, (
+    result.did_create(
+        script.site_packages / 'initools',
         sorted(result.files_created.keys())
     )
     result2 = script.pip(
@@ -315,8 +315,9 @@ def test_uninstall_rollback(script, data):
     result = script.pip(
         'install', '-f', data.find_links, '--no-index', 'broken==0.1'
     )
-    assert script.site_packages / 'broken.py' in result.files_created, list(
-        result.files_created.keys()
+    result.did_create(
+        script.site_packages / 'broken.py',
+        list(result.files_created.keys())
     )
     result2 = script.pip(
         'install', '-f', data.find_links, '--no-index', 'broken===0.2broken',
@@ -342,15 +343,13 @@ def test_should_not_install_always_from_cache(script):
     script.pip('install', 'INITools==0.2')
     script.pip('uninstall', '-y', 'INITools')
     result = script.pip('install', 'INITools==0.1')
-    assert (
+    result.did_not_create(
         script.site_packages /
         'INITools-0.2-py{pyversion}.egg-info'.format(**globals())
-        not in result.files_created
     )
-    assert (
+    result.did_create(
         script.site_packages /
         'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
-        in result.files_created
     )
 
 


### PR DESCRIPTION
Towards #6050

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
