### PR TITLE
Enhance debug output for debundled case

### DIFF
--- a/news/8327.bugfix
+++ b/news/8327.bugfix
@@ -1,0 +1,1 @@
+The pip debug command takes module versions from vendor.txt even when they are debundled.  Enhance the debug command output to instead show the location, name, and version of the debundled modules when appropriate.

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -61,11 +61,14 @@ def create_vendor_txt_map():
     # Transform into "module" -> version dict.
     return dict(line.split('==', 1) for line in lines)  # type: ignore
 
+
 def create_debundle_txt_map():
     # type: () -> Dict[str, str]
     wheels = [fn for fn in os.listdir(pip._vendor.WHEEL_DIR)]
     # Transform into "module" -> version dict.
-    return dict((wheel.split('-')[0], wheel.split('-')[1]) for wheel in wheels) # type: ignore
+    return dict((wheel.split('-')[0],
+        wheel.split('-')[1]) for wheel in wheels)  # type: ignore
+
 
 def get_module_from_module_name(module_name):
     # type: (str) -> ModuleType
@@ -133,11 +136,13 @@ def show_vendor_versions():
     with indent_log():
         show_actual_vendor_versions(vendor_txt_versions)
 
+
 def show_debundled_versions():
     # type: () -> None
     logger.info('debundled wheel versions:')
     debundle_txt_versions = create_debundle_txt_map()
-    for module_name, installed_version in sorted(debundle_txt_versions.items()):
+    for module_name, installed_version in sorted(
+            debundle_txt_versions.items()):
         with indent_log():
             logger.info(
                 '{name}=={actual}'.format(
@@ -145,6 +150,7 @@ def show_debundled_versions():
                     actual=installed_version,
                 )
             )
+
 
 def show_tags(options):
     # type: (Values) -> None

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -61,6 +61,11 @@ def create_vendor_txt_map():
     # Transform into "module" -> version dict.
     return dict(line.split('==', 1) for line in lines)  # type: ignore
 
+def create_debundle_txt_map():
+    # type: () -> Dict[str, str]
+    wheels = [fn for fn in os.listdir(pip._vendor.WHEEL_DIR)]
+    # Transform into "module" -> version dict.
+    return dict((wheel.split('-')[0], wheel.split('-')[1]) for wheel in wheels) # type: ignore
 
 def get_module_from_module_name(module_name):
     # type: (str) -> ModuleType
@@ -128,6 +133,18 @@ def show_vendor_versions():
     with indent_log():
         show_actual_vendor_versions(vendor_txt_versions)
 
+def show_debundled_versions():
+    # type: () -> None
+    logger.info('debundled wheel versions:')
+    debundle_txt_versions = create_debundle_txt_map()
+    for module_name, installed_version in sorted(debundle_txt_versions.items()):
+        with indent_log():
+            logger.info(
+                '{name}=={actual}'.format(
+                    name=module_name,
+                    actual=installed_version,
+                )
+            )
 
 def show_tags(options):
     # type: (Values) -> None
@@ -224,7 +241,11 @@ class DebugCommand(Command):
         show_value("pip._vendor.certifi.where()", where())
         show_value("pip._vendor.DEBUNDLED", pip._vendor.DEBUNDLED)
 
-        show_vendor_versions()
+        if not pip._vendor.DEBUNDLED:
+            show_vendor_versions()
+        else:
+            show_value("pip._vendor.WHEEL_DIR", pip._vendor.WHEEL_DIR)
+            show_debundled_versions()
 
         show_tags(options)
 

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -67,7 +67,7 @@ def create_debundle_txt_map():
     wheels = [fn for fn in os.listdir(pip._vendor.WHEEL_DIR)]
     # Transform into "module" -> version dict.
     return dict((wheel.split('-')[0],
-        wheel.split('-')[1]) for wheel in wheels)  # type: ignore
+            wheel.split('-')[1]) for wheel in wheels)  # type: ignore
 
 
 def get_module_from_module_name(module_name):

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -67,7 +67,7 @@ def create_debundle_txt_map():
     wheels = [fn for fn in os.listdir(pip._vendor.WHEEL_DIR)]
     # Transform into "module" -> version dict.
     return dict((wheel.split('-')[0],
-            wheel.split('-')[1]) for wheel in wheels)  # type: ignore
+                wheel.split('-')[1]) for wheel in wheels)  # type: ignore
 
 
 def get_module_from_module_name(module_name):


### PR DESCRIPTION
As mentioned in #8327, the debug output for the vendored modules would be more correct when debundled if the actual names/versions of the modules was listed.  