### PR TITLE
Add license requirement to _vendor/README.rst

### DIFF
--- a/src/pip/_vendor/README.rst
+++ b/src/pip/_vendor/README.rst
@@ -8,7 +8,7 @@ Vendoring Policy
 * Vendored libraries **MUST** be released copies of libraries available on
   PyPI.
 
-* Libraries to be vendored **MUST** be available under a license that allows
+* Vendored libraries **MUST** be available under a license that allows
   them to be integrated into ``pip``, which is released under the MIT license.
 
 * Vendored libraries **MUST** be accompanied with LICENSE files.

--- a/src/pip/_vendor/README.rst
+++ b/src/pip/_vendor/README.rst
@@ -8,6 +8,9 @@ Vendoring Policy
 * Vendored libraries **MUST** be released copies of libraries available on
   PyPI.
 
+* Libraries to be vendored **MUST** be available under a license that allows
+  them to be integrated into ``pip``, which is released under the MIT license.
+
 * Vendored libraries **MUST** be accompanied with LICENSE files.
 
 * The versions of libraries vendored in pip **MUST** be reflected in


### PR DESCRIPTION
Originally posted in GH-8330:

> As pip is licensed under MIT, I believe packages shipped along (i.e. vendored) with pip must be released under MIT-compatible licenses, i.e. permissive licenses. [...] I am not a lawyer so there's a high chance that I am wrong though [...] I think our vendoring policy might want to require libraries to be vendored must be available under a MIT-compatible license. If this is agreed upon, I'll file a PR to clarify it.

~~I also added a lint commit to this PR, but if it's not agreed upon, I can easily drop it.~~  Edit: the linting is moved to GH-8456.  Furthermore, I'm not sure if this should be a trivial or documentation change.