### PR TITLE
Do not trust the name passed from editable

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1449,6 +1449,7 @@ def test_install_no_binary_disables_cached_wheels(script, data, with_wheel):
     assert "Running setup.py install for upper" in str(res), str(res)
 
 
+@pytest.mark.fails_on_new_resolver
 def test_install_editable_with_wrong_egg_name(script):
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / 'pkga'


### PR DESCRIPTION
This fixes the regression that’s failing Travis on master.

Here’s the test:

```python
def test_install_editable_with_wrong_egg_name(script):
    script.scratch_path.joinpath("pkga").mkdir()
    pkga_path = script.scratch_path / 'pkga'
    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
        from setuptools import setup
        setup(name='pkga',
              version='0.1')
    """))
    result = script.pip(
        'install', '--editable',
        'file://{pkga_path}#egg=pkgb'.format(**locals()),
    )
    assert ("Generating metadata for package pkgb produced metadata "
            "for project name pkga. Fix your #egg=pkgb "
            "fragments.") in result.stderr
    assert "Successfully installed pkga" in str(result), str(result)
```

So it seems pip currently only explicitly distructs the name from editable requirements. Personally I don’t think it’s a terrible idea (pip does not need a name for an editable requirement to begin with), but it’s arguable still better to error out than simply warn when this happens.