### PR TITLE
Make sure the explicit URL points a valid wheel

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -659,6 +659,11 @@ class PackageFinder(object):
         )
 
     @property
+    def target_python(self):
+        # type: () -> TargetPython
+        return self._target_python
+
+    @property
     def search_scope(self):
         # type: () -> SearchScope
         return self._link_collector.search_scope

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -927,6 +927,7 @@ def test_install_nonlocal_compatible_wheel(script, data):
     assert result.returncode == ERROR
 
 
+@pytest.mark.fails_on_new_resolver
 def test_install_nonlocal_compatible_wheel_path(script, data):
     target_dir = script.scratch_path / 'target'
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -927,7 +927,6 @@ def test_install_nonlocal_compatible_wheel(script, data):
     assert result.returncode == ERROR
 
 
-@pytest.mark.fails_on_new_resolver
 def test_install_nonlocal_compatible_wheel_path(script, data):
     target_dir = script.scratch_path / 'target'
 

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -519,7 +519,6 @@ def test_install_unsupported_wheel_link_with_marker(script):
     assert len(result.files_created) == 0
 
 
-@pytest.mark.fails_on_new_resolver
 def test_install_unsupported_wheel_file(script, data):
     # Trying to install a local wheel with an incompatible version/type
     # should fail.


### PR DESCRIPTION
Fixes:

* `test_install_nonlocal_compatible_wheel_path`
* `test_install_unsupported_wheel_file`