### PR TITLE
Updated author email in configuration and tests

### DIFF
--- a/.azure-pipelines/jobs/package.yml
+++ b/.azure-pipelines/jobs/package.yml
@@ -16,7 +16,7 @@ jobs:
       versionSpec: '3'
 
   - bash: |
-      git config --global user.email "pypa-dev@googlegroups.com"
+      git config --global user.email "distutils-sig@python.org"
       git config --global user.name "pip"
     displayName: Setup Git credentials
 

--- a/news/8454.bugfix
+++ b/news/8454.bugfix
@@ -1,0 +1,1 @@
+Update author email in config and tests to reflect decommissioning of pypa-dev list.

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     },
 
     author='The pip developers',
-    author_email='pypa-dev@groups.google.com',
+    author_email='distutils-sig@python.org',
 
     package_dir={"": "src"},
     packages=find_packages(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,7 +206,7 @@ def isolate(tmpdir):
     # and cause test failures.
     os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
     os.environ["GIT_AUTHOR_NAME"] = "pip"
-    os.environ["GIT_AUTHOR_EMAIL"] = "pypa-dev@googlegroups.com"
+    os.environ["GIT_AUTHOR_EMAIL"] = "distutils-sig@python.org"
 
     # We want to disable the version check from running in the tests
     os.environ["PIP_DISABLE_PIP_VERSION_CHECK"] = "true"
@@ -218,7 +218,7 @@ def isolate(tmpdir):
     os.makedirs(os.path.join(home_dir, ".config", "git"))
     with open(os.path.join(home_dir, ".config", "git", "config"), "wb") as fp:
         fp.write(
-            b"[user]\n\tname = pip\n\temail = pypa-dev@googlegroups.com\n"
+            b"[user]\n\tname = pip\n\temail = distutils-sig@python.org\n"
         )
 
 

--- a/tests/data/src/sample/setup.py
+++ b/tests/data/src/sample/setup.py
@@ -39,7 +39,7 @@ setup(
 
     # Author details
     author='The Python Packaging Authority',
-    author_email='pypa-dev@googlegroups.com',
+    author_email='distutils-sig@python.org',
 
     # Choose your license
     license='MIT',

--- a/tests/functional/test_vcs_bazaar.py
+++ b/tests/functional/test_vcs_bazaar.py
@@ -55,7 +55,7 @@ def test_export_rev(script, tmpdir):
     create_file(source_dir / 'test_file', 'something new')
     script.run(
         'bzr', 'commit', '-q',
-        '--author', 'pip <pypa-dev@googlegroups.com>',
+        '--author', 'pip <distutils-sig@python.org>',
         '-m', 'change test file', cwd=source_dir,
     )
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -782,7 +782,7 @@ def _git_commit(
         args.append("--all")
 
     new_args = [
-        'git', 'commit', '-q', '--author', 'pip <pypa-dev@googlegroups.com>',
+        'git', 'commit', '-q', '--author', 'pip <distutils-sig@python.org>',
     ]
     new_args.extend(args)
     new_args.extend(['-m', message])
@@ -799,7 +799,7 @@ def _vcs_add(script, version_pkg_path, vcs='git'):
         script.run('hg', 'add', '.', cwd=version_pkg_path)
         script.run(
             'hg', 'commit', '-q',
-            '--user', 'pip <pypa-dev@googlegroups.com>',
+            '--user', 'pip <distutils-sig@python.org>',
             '-m', 'initial version', cwd=version_pkg_path,
         )
     elif vcs == 'svn':
@@ -818,11 +818,11 @@ def _vcs_add(script, version_pkg_path, vcs='git'):
         script.run('bzr', 'init', cwd=version_pkg_path)
         script.run('bzr', 'add', '.', cwd=version_pkg_path)
         script.run(
-            'bzr', 'whoami', 'pip <pypa-dev@googlegroups.com>',
+            'bzr', 'whoami', 'pip <distutils-sig@python.org>',
             cwd=version_pkg_path)
         script.run(
             'bzr', 'commit', '-q',
-            '--author', 'pip <pypa-dev@googlegroups.com>',
+            '--author', 'pip <distutils-sig@python.org>',
             '-m', 'initial version', cwd=version_pkg_path,
         )
     else:

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -2,5 +2,5 @@
 set -e
 
 echo "Setting Git Credentials..."
-git config --global user.email "pypa-dev@googlegroups.com"
+git config --global user.email "distutils-sig@python.org"
 git config --global user.name "pip"


### PR DESCRIPTION
Per https://groups.google.com/d/msg/pypa-dev/rUNsfIbruHM/LCEx-CB5AgAJ
the pypa-dev Google Group is now decommissioned.
Using distutils-sig instead as author/maintainer email.

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>

(Separate from #8353 and #8352 since this needs to be tested more carefully.)