### PR TITLE
WIP: Do not upgrade the installed version when an explicit URL for that version is given

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -36,6 +36,19 @@ class ExplicitRequirement(Requirement):
 
     def is_satisfied_by(self, candidate):
         # type: (Candidate) -> bool
+
+        # Allow an already installed copy of the project with the same
+        # version to satisfy the requirement as well.
+        # TODO: Can we avoid the direct reference to the
+        # candidates module here?
+        from .candidates import AlreadyInstalledCandidate
+        if (
+            isinstance(candidate, AlreadyInstalledCandidate) and
+            candidate.name == self.candidate.name and
+            candidate.version == self.candidate.version
+        ):
+            return True
+
         return candidate == self.candidate
 
 


### PR DESCRIPTION
This is currently incomplete, and I'm not sure how to fix it.

The problem is that when we have an explicit requirement, and we call `find_candidates`, we need to return an `AlreadyInstalledCandidate` in order to signal that it's the installed version we want to keep. But the `AlreadyInstalledCandidate` doesn't satisfy the explicit requirement for the link candidate! The current code returns the link candidate, but as a result we install that (reinstalling what's currently installed).

This is the point of `test_upgrade_to_same_version_from_url`, so not reinstalling is definitely deliberate behaviour even though it's "only" an optimisation.

The history here is commit https://github.com/pypa/pip/commit/e51fdce95d8d03abe38c89d94e713e0369f15883, which apparently addresses https://github.com/pypa/pip/issues/14. While the details are not clear to me (it's a long time ago!) there's a potential real-world situation that might be relevant - trying to install a URL for something that's installed in site-packages, when the user does not have write permission in site-packages, will fail with the new resolver, but succeed (by doing nothing) in the old resolver.

My feeling is that this is probably something we should simply drop. The behaviour around "upgrade" and reinstalling is muddy enough already that I don't think it's worth the effort to replicate this one quirk over any other. So I'm thinking we simply mark the test as something that works differently in the new resolver and move on.

The PR here gets as far as returning the `AlreadyInstalledCandidate`, but I haven't even started to address the fact that doing so violates the invariant in `test_new_resolver_candidates_match_requirement` (which I *do* think we should keep intact). I'm mostly posting it as a record of where I got to.

Longer term, we should probably open a tracking ticket to cover "Fixing all the stuff around how upgrades work". It'll give us something to replace #988 in our hearts 🙂 