### PR TITLE
Add helper methods for path lookups to test_{uninstall, wheel}.py

### DIFF
--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -28,9 +28,7 @@ def test_basic_uninstall(script):
 
     """
     result = script.pip('install', 'INITools==0.2')
-    assert join(script.site_packages, 'initools') in result.files_created, (
-        sorted(result.files_created.keys())
-    )
+    result.did_create(join(script.site_packages, 'initools'))
     # the import forces the generation of __pycache__ if the version of python
     # supports it
     script.run('python', '-c', "import initools")
@@ -147,9 +145,7 @@ def test_basic_uninstall_namespace_package(script):
 
     """
     result = script.pip('install', 'pd.requires==0.0.3')
-    assert join(script.site_packages, 'pd') in result.files_created, (
-        sorted(result.files_created.keys())
-    )
+    result.did_create(join(script.site_packages, 'pd'))
     result2 = script.pip('uninstall', 'pd.find', '-y')
     assert join(script.site_packages, 'pd') not in result2.files_deleted, (
         sorted(result2.files_deleted.keys())
@@ -171,16 +167,12 @@ def test_uninstall_overlapping_package(script, data):
     child_pkg = data.packages.joinpath("child-0.1.tar.gz")
 
     result1 = script.pip('install', parent_pkg)
-    assert join(script.site_packages, 'parent') in result1.files_created, (
-        sorted(result1.files_created.keys())
-    )
+    result1.did_create(join(script.site_packages, 'parent'))
     result2 = script.pip('install', child_pkg)
-    assert join(script.site_packages, 'child') in result2.files_created, (
-        sorted(result2.files_created.keys())
-    )
-    assert normpath(
+    result2.did_create(join(script.site_packages, 'child'))
+    result2.did_create(normpath(
         join(script.site_packages, 'parent/plugins/child_plugin.py')
-    ) in result2.files_created, sorted(result2.files_created.keys())
+    ))
     # The import forces the generation of __pycache__ if the version of python
     #  supports it
     script.run('python', '-c', "import parent.plugins.child_plugin, child")
@@ -267,9 +259,7 @@ def test_uninstall_console_scripts(script):
         entry_points={'console_scripts': ['discover = discover:main']},
     )
     result = script.pip('install', pkg_path)
-    assert script.bin / 'discover' + script.exe in result.files_created, (
-        sorted(result.files_created.keys())
-    )
+    result.did_create(script.bin / 'discover' + script.exe)
     result2 = script.pip('uninstall', 'discover', '-y')
     assert_all_changes(result, result2, [script.venv / 'build', 'cache'])
 
@@ -305,9 +295,7 @@ def test_uninstall_easy_installed_console_scripts(script):
     # setuptools >= 42.0.0 deprecates easy_install and prints a warning when
     # used
     result = script.easy_install('discover', allow_stderr_warning=True)
-    assert script.bin / 'discover' + script.exe in result.files_created, (
-        sorted(result.files_created.keys())
-    )
+    result.did_create(script.bin / 'discover' + script.exe)
     result2 = script.pip('uninstall', 'discover', '-y')
     assert_all_changes(
         result,
@@ -374,9 +362,9 @@ def _test_uninstall_editable_with_source_outside_venv(
         expect_stderr=True,
     )
     result2 = script.pip('install', '-e', temp_pkg_dir)
-    assert join(
+    result2.did_create(join(
         script.site_packages, 'pip-test-package.egg-link'
-    ) in result2.files_created, list(result2.files_created.keys())
+    ))
     result3 = script.pip('uninstall', '-y', 'pip-test-package')
     assert_all_changes(
         result,
@@ -476,7 +464,7 @@ def test_uninstall_wheel(script, data):
     package = data.packages.joinpath("simple.dist-0.1-py2.py3-none-any.whl")
     result = script.pip('install', package, '--no-index')
     dist_info_folder = script.site_packages / 'simple.dist-0.1.dist-info'
-    assert dist_info_folder in result.files_created
+    result.did_create(dist_info_folder)
     result2 = script.pip('uninstall', 'simple.dist', '-y')
     assert_all_changes(result, result2, [])
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -58,7 +58,7 @@ def test_pip_wheel_success(script, data):
         .format(filename=re.escape(wheel_file_name)), result.stdout)
     assert re.search(
         r"^\s+Stored in directory: ", result.stdout, re.M)
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
     assert "Successfully built simple" in result.stdout, result.stdout
 
 
@@ -74,7 +74,7 @@ def test_pip_wheel_build_cache(script, data):
     wheel_file_name = 'simple-3.0-py{pyversion[0]}-none-any.whl' \
         .format(**globals())
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
     assert "Successfully built simple" in result.stdout, result.stdout
     # remove target file
     (script.scratch_path / wheel_file_name).unlink()
@@ -84,7 +84,7 @@ def test_pip_wheel_build_cache(script, data):
         'wheel', '--no-index', '-f', data.find_links,
         'simple==3.0',
     )
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
     assert "Successfully built simple" not in result.stdout, result.stdout
 
 
@@ -97,7 +97,7 @@ def test_basic_pip_wheel_downloads_wheels(script, data):
     )
     wheel_file_name = 'simple.dist-0.1-py2.py3-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
     assert "Saved" in result.stdout, result.stdout
 
 
@@ -152,7 +152,7 @@ def test_pip_wheel_builds_editable_deps(script, data):
     wheel_file_name = 'simple-1.0-py{pyversion[0]}-none-any.whl' \
         .format(**globals())
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
 
 
 def test_pip_wheel_builds_editable(script, data):
@@ -167,7 +167,7 @@ def test_pip_wheel_builds_editable(script, data):
     wheel_file_name = 'simplewheel-1.0-py{pyversion[0]}-none-any.whl' \
         .format(**globals())
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
 
 
 def test_pip_wheel_fail(script, data):
@@ -182,10 +182,7 @@ def test_pip_wheel_fail(script, data):
     wheel_file_name = 'wheelbroken-0.1-py{pyversion[0]}-none-any.whl' \
         .format(**globals())
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path not in result.files_created, (
-        wheel_file_path,
-        result.files_created,
-    )
+    result.did_not_create(wheel_file_path)
     assert "FakeError" in result.stderr, result.stderr
     assert "Failed to build wheelbroken" in result.stdout, result.stdout
     assert result.returncode != 0
@@ -220,7 +217,7 @@ def test_pip_wheel_source_deps(script, data):
     wheel_file_name = 'source-1.0-py{pyversion[0]}-none-any.whl' \
         .format(**globals())
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
     assert "Successfully built source" in result.stdout, result.stdout
 
 
@@ -261,7 +258,7 @@ def test_pip_wheel_with_pep518_build_reqs(script, data, common_wheels):
     wheel_file_name = 'pep518-3.0-py{pyversion[0]}-none-any.whl' \
         .format(**globals())
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
     assert "Successfully built pep518" in result.stdout, result.stdout
     assert "Installing build dependencies" in result.stdout, result.stdout
 
@@ -275,7 +272,7 @@ def test_pip_wheel_with_pep518_build_reqs_no_isolation(script, data):
     wheel_file_name = 'pep518-3.0-py{pyversion[0]}-none-any.whl' \
         .format(**globals())
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
     assert "Successfully built pep518" in result.stdout, result.stdout
     assert "Installing build dependencies" not in result.stdout, result.stdout
 
@@ -322,7 +319,7 @@ def test_pep517_wheels_are_not_confused_with_other_files(script, tmpdir, data):
     wheel_file_name = 'withpyproject-0.0.1-py{pyversion[0]}-none-any.whl' \
         .format(**globals())
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)
 
 
 def test_legacy_wheels_are_not_confused_with_other_files(script, tmpdir, data):
@@ -337,4 +334,4 @@ def test_legacy_wheels_are_not_confused_with_other_files(script, tmpdir, data):
     wheel_file_name = 'simplewheel-1.0-py{pyversion[0]}-none-any.whl' \
         .format(**globals())
     wheel_file_path = script.scratch / wheel_file_name
-    assert wheel_file_path in result.files_created, result.stdout
+    result.did_create(wheel_file_path)


### PR DESCRIPTION
Towards #6050
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
