### PR TITLE
Deprecate setup.py install fallback when bdist_wheel fails

### DIFF
--- a/news/8368.removal
+++ b/news/8368.removal
@@ -1,0 +1,2 @@
+Deprecate legacy setup.py install when building a wheel failed for source
+distributions without pyproject.toml

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -376,8 +376,8 @@ class InstallCommand(RequirementCommand):
                 deprecated(
                     reason=(
                         "Could not build wheels for {} which do not use "
-                        "PEP 517. pip will fall back to legacy setup.py "
-                        "install for these.".format(
+                        "PEP 517. pip will fall back to legacy 'setup.py "
+                        "install' for these.".format(
                             ", ".join(r.name for r in legacy_build_failures)
                         )
                     ),

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -356,29 +356,32 @@ class InstallCommand(RequirementCommand):
 
             # If we're using PEP 517, we cannot do a direct install
             # so we fail here.
-            pep517_build_failures = [
-                r for r in build_failures if r.use_pep517
-            ]
-            if pep517_build_failures:
+            pep517_build_failure_names = [
+                r.name   # type: ignore
+                for r in build_failures if r.use_pep517
+            ]  # type: List[str]
+            if pep517_build_failure_names:
                 raise InstallationError(
                     "Could not build wheels for {} which use"
                     " PEP 517 and cannot be installed directly".format(
-                        ", ".join(r.name  # type: ignore
-                                  for r in pep517_build_failures)))
+                        ", ".join(pep517_build_failure_names)
+                    )
+                )
 
             # For now, we just warn about failures building legacy
             # requirements, as we'll fall through to a direct
             # install for those.
-            legacy_build_failures = [
-                r for r in build_failures if not r.use_pep517
-            ]
-            if legacy_build_failures:
+            legacy_build_failure_names = [
+                r.name  # type: ignore
+                for r in build_failures if not r.use_pep517
+            ]  # type: List[str]
+            if legacy_build_failure_names:
                 deprecated(
                     reason=(
                         "Could not build wheels for {} which do not use "
                         "PEP 517. pip will fall back to legacy 'setup.py "
                         "install' for these.".format(
-                            ", ".join(r.name for r in legacy_build_failures)
+                            ", ".join(legacy_build_failure_names)
                         )
                     ),
                     replacement="to fix the wheel build issue reported above",

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -80,7 +80,7 @@ def _should_build(
     if not req.use_pep517 and not is_wheel_installed():
         # we don't build legacy requirements if wheel is not installed
         logger.info(
-            "Using legacy setup.py install for %s, "
+            "Using legacy 'setup.py install' for %s, "
             "since package 'wheel' is not installed.", req.name,
         )
         return False


### PR DESCRIPTION
Towards #8368 