### PR TITLE
Correctly apply marker matching logic to all requirements

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -55,7 +55,7 @@ class Candidate(object):
         raise NotImplementedError("Override in subclass")
 
     def iter_dependencies(self):
-        # type: () -> Iterable[Requirement]
+        # type: () -> Iterable[Optional[Requirement]]
         raise NotImplementedError("Override in subclass")
 
     def get_install_requirement(self):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -445,7 +445,7 @@ class ExtrasCandidate(Candidate):
         yield factory.make_requirement_from_candidate(self.base)
 
         for r in self.base.dist.requires(valid_extras):
-            requirement = factory.make_requirement_from_spec_matching_extras(
+            requirement = factory.make_requirement_from_spec(
                 str(r), self.base._ireq, valid_extras,
             )
             if requirement:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -217,7 +217,7 @@ class _InstallRequirementBackedCandidate(Candidate):
         return spec
 
     def iter_dependencies(self):
-        # type: () -> Iterable[Requirement]
+        # type: () -> Iterable[Optional[Requirement]]
         for r in self.dist.requires():
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
         python_dep = self._factory.make_requires_python_requirement(
@@ -343,7 +343,7 @@ class AlreadyInstalledCandidate(Candidate):
         return self.dist.parsed_version
 
     def iter_dependencies(self):
-        # type: () -> Iterable[Requirement]
+        # type: () -> Iterable[Optional[Requirement]]
         for r in self.dist.requires():
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
 
@@ -425,7 +425,7 @@ class ExtrasCandidate(Candidate):
         return self.base.is_installed
 
     def iter_dependencies(self):
-        # type: () -> Iterable[Requirement]
+        # type: () -> Iterable[Optional[Requirement]]
         factory = self.base._factory
 
         # The user may have specified extras that the candidate doesn't
@@ -486,7 +486,7 @@ class RequiresPythonCandidate(Candidate):
         return self._version
 
     def iter_dependencies(self):
-        # type: () -> Iterable[Requirement]
+        # type: () -> Iterable[Optional[Requirement]]
         return ()
 
     def get_install_requirement(self):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -233,8 +233,14 @@ class Factory(object):
             if all(req.is_satisfied_by(c) for req in requirements)
         )
 
-    def make_requirement_from_install_req(self, ireq):
-        # type: (InstallRequirement) -> Requirement
+    def make_requirement_from_install_req(self, ireq, requested_extras):
+        # type: (InstallRequirement, Iterable[str]) -> Optional[Requirement]
+        if not ireq.match_markers(requested_extras):
+            logger.info(
+                "Ignoring %s: markers '%s' don't match your environment",
+                ireq.name, ireq.markers,
+            )
+            return None
         if not ireq.link:
             return SpecifierRequirement(ireq)
         cand = self._make_candidate_from_link(
@@ -253,7 +259,7 @@ class Factory(object):
     def make_requirement_from_spec(self, specifier, comes_from):
         # type: (str, InstallRequirement) -> Requirement
         ireq = self._make_install_req_from_spec(specifier, comes_from)
-        return self.make_requirement_from_install_req(ireq)
+        return self.make_requirement_from_install_req(ireq, ())
 
     def make_requirement_from_spec_matching_extras(
         self,
@@ -263,13 +269,7 @@ class Factory(object):
     ):
         # type: (...) -> Optional[Requirement]
         ireq = self._make_install_req_from_spec(specifier, comes_from)
-        if not ireq.match_markers(requested_extras):
-            logger.info(
-                "Ignoring %s: markers '%s' don't match your environment",
-                ireq.name, ireq.markers,
-            )
-            return None
-        return self.make_requirement_from_install_req(ireq)
+        return self.make_requirement_from_install_req(ireq, requested_extras)
 
     def make_requires_python_requirement(self, specifier):
         # type: (Optional[SpecifierSet]) -> Optional[Requirement]

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -256,12 +256,7 @@ class Factory(object):
         # type: (Candidate) -> ExplicitRequirement
         return ExplicitRequirement(candidate)
 
-    def make_requirement_from_spec(self, specifier, comes_from):
-        # type: (str, InstallRequirement) -> Requirement
-        ireq = self._make_install_req_from_spec(specifier, comes_from)
-        return self.make_requirement_from_install_req(ireq, ())
-
-    def make_requirement_from_spec_matching_extras(
+    def make_requirement_from_spec(
         self,
         specifier,  # type: str
         comes_from,  # type: InstallRequirement

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -147,4 +147,4 @@ class PipProvider(AbstractProvider):
         # type: (Candidate) -> Sequence[Requirement]
         if self._ignore_dependencies:
             return []
-        return list(candidate.iter_dependencies())
+        return [r for r in candidate.iter_dependencies() if r is not None]

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -106,8 +106,6 @@ class Resolver(BaseResolver):
         user_requested = set()  # type: Set[str]
         requirements = []
         for req in root_reqs:
-            if not req.match_markers():
-                continue
             if req.constraint:
                 # Ensure we only accept valid constraints
                 reject_invalid_constraint_types(req)
@@ -120,9 +118,11 @@ class Resolver(BaseResolver):
             else:
                 if req.is_direct and req.name:
                     user_requested.add(canonicalize_name(req.name))
-                requirements.append(
-                    self.factory.make_requirement_from_install_req(req)
+                r = self.factory.make_requirement_from_install_req(
+                    req, requested_extras=(),
                 )
+                if r is not None:
+                    requirements.append(r)
 
         provider = PipProvider(
             factory=self.factory,

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -507,7 +507,6 @@ def test_install_distribution_union_conflicting_extras(script, data):
     assert "Conflict" in result.stderr
 
 
-@pytest.mark.fails_on_new_resolver
 def test_install_unsupported_wheel_link_with_marker(script):
     script.scratch_path.joinpath("with-marker.txt").write_text(
         textwrap.dedent("""\


### PR DESCRIPTION
Fixes `test_install_unsupported_wheel_link_with_marker`.

The realisation I had here is that *all* `InstallRequirement` instances may need to be ignored due to non-matching markers, so instead of checking that only for the spec variant, as we previously did, we should check markers in `make_requirement_from_install_req` instead. This in turn means that all functions that build a `Requirement` may return `None` (since they are all wrappers around `make_requirement_from_install_req`), so I made the decision to change `Candidate.iter_dependencies()` to yield `Optional[Requirement]` (instead of `Requirement`), and filter out the `None` values in the provider instead.