### PR TITLE
Fix direct URL by always passing the template’s URL values into candidate

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -57,8 +57,8 @@ def make_install_req_from_link(link, template):
             hashes=template.hash_options
         ),
     )
-    if ireq.link is None:
-        ireq.link = link
+    ireq.original_link = template.original_link
+    ireq.link = link
     return ireq
 
 

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -59,7 +59,6 @@ def make_install_req_from_link(link, template):
     )
     if ireq.link is None:
         ireq.link = link
-    # TODO: Handle wheel cache resolution.
     return ireq
 
 

--- a/tests/functional/test_install_direct_url.py
+++ b/tests/functional/test_install_direct_url.py
@@ -1,7 +1,5 @@
 import re
 
-import pytest
-
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
 from tests.lib import _create_test_package, path_to_url
 
@@ -32,7 +30,6 @@ def test_install_vcs_editable_no_direct_url(script, with_wheel):
     assert not _get_created_direct_url(result, "testpkg")
 
 
-@pytest.mark.fails_on_new_resolver
 def test_install_vcs_non_editable_direct_url(script, with_wheel):
     pkg_path = _create_test_package(script, name="testpkg")
     url = path_to_url(pkg_path)


### PR DESCRIPTION
Should fix `test_install_vcs_non_editable_direct_url`, but this must not break any passing tests…