### PR TITLE
Add helper methods for path lookups to test_install_force_reinstall.py and test_uninstall_user.py

### DIFF
--- a/tests/functional/test_install_force_reinstall.py
+++ b/tests/functional/test_install_force_reinstall.py
@@ -33,7 +33,7 @@ def check_force_reinstall(script, specifier, expected):
     # site_packages_path is absolute, but files_created mapping uses
     # relative paths as key.
     fixed_key = os.path.relpath(to_fix, script.base_path)
-    assert fixed_key in result2.files_created, 'force-reinstall failed'
+    result2.did_create(fixed_key, message='force-reinstall failed')
 
     result3 = script.pip('uninstall', 'simplewheel', '-y')
     assert_all_changes(result, result3, [script.venv / 'build', 'cache'])

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -62,7 +62,7 @@ class Tests_UninstallUserSite:
             'install', '--user', '-e', to_install
         )
         egg_link = script.user_site / 'FSPkg.egg-link'
-        assert egg_link in result1.files_created, str(result1.stdout)
+        result1.did_create(egg_link)
 
         # uninstall
         result2 = script.pip('uninstall', '-y', 'FSPkg')


### PR DESCRIPTION
Towards #6050 
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
