### PR TITLE
Re-think error swallowing for de-vendored packages #5354

### DIFF
--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -32,15 +32,11 @@ def vendored(modulename):
     try:
         __import__(modulename, globals(), locals(), level=0)
     except ImportError:
-        # We can just silently allow import failures to pass here. If we
-        # got to this point it means that ``import pip._vendor.whatever``
-        # failed and so did ``import whatever``. Since we're importing this
-        # upfront in an attempt to alias imports, not erroring here will
-        # just mean we get a regular import error whenever pip *actually*
-        # tries to import one of these modules to use it, which actually
-        # gives us a better error message than we would have otherwise
-        # gotten.
-        pass
+        # This error used to be silenced in earlier variants of this file, to instead
+        # raise the error when pip actually tries to use the missing module. 
+        # Based on inputs in #5354, this was changed to explicitly raise the error.
+        # Re-raising the exception without modifying it is an intentional choice. 
+        raise
     else:
         sys.modules[vendored_name] = sys.modules[modulename]
         base, head = vendored_name.rsplit(".", 1)


### PR DESCRIPTION
As discussed in #5354 instead of swallowing an error during vending and raising an error when pip attempts to use the missing module, we now raise the error immediately without modification for better error output and development experience. I implemented the solution outlined by @pradyunsg in #5354 

Regarding testing : How would the maintainers expect this to be tested? 
I do not see any tests explicitly for the vendored function and am unsure the file in which this would be tested in.  
One test I am considering would trigger an exception in some vendored package and then asserts in the test that an exception is raised. Another would be to call vendored on a non-existent module or one with missing dependencies and check the error.  