### PR TITLE
New resolver fix candidate ordering

### DIFF
--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -901,3 +901,25 @@ def test_new_resolver_build_directory_error_zazo_19(script):
         "pkg-a", "pkg-b",
     )
     assert_installed(script, pkg_a="3.0.0", pkg_b="1.0.0")
+
+
+def test_new_resolver_upgrade_same_version(script):
+    create_basic_wheel_for_package(script, "pkg", "2")
+    create_basic_wheel_for_package(script, "pkg", "1")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "pkg",
+    )
+    assert_installed(script, pkg="2")
+
+    script.pip(
+        "install", "--unstable-feature=resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "--upgrade",
+        "pkg",
+    )
+    assert_installed(script, pkg="2")


### PR DESCRIPTION
Since #8319, we’re now relying on the candidate ordering from the finder (because we need it to handle the yanked and binary preference logic for us). But this means that the logic that always yields the installed candidate first does not work anymore (see added test case). This fix puts the installed candidate at the correct position if possible.

Note: I found this problem while looking into on `test_upgrade_with_newest_already_installed`.