### PR TITLE
Add flake8-bugbear plugin to pre-commit and fix "tests" accordingly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,9 @@ repos:
   rev: 3.8.1
   hooks:
   - id: flake8
+    additional_dependencies: [
+        'flake8-bugbear==20.1.4'
+    ]
     exclude: tests/data
 
 - repo: https://github.com/timothycrosley/isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,17 @@ exclude =
     .scratch,
     _vendor,
     data
-select = E,W,F
-ignore = W504
-
+    # TODO: Remove when fixing flake8 warnings
+    src/pip/*
+# B = bugbear
+# E = pycodestyle errors
+# F = flake8 pyflakes
+# W = pycodestyle warnings
+# B9 = bugbear opinions
+select = B, E, W, F, B9
+per-file-ignores =
+    # B011: Do not call assert False since python -O removes these calls
+    tests/*: B011
 [mypy]
 follow_imports = silent
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,17 +23,11 @@ exclude =
     .scratch,
     _vendor,
     data
-    # TODO: Remove when fixing flake8 warnings
-    src/pip/*
-# B = bugbear
-# E = pycodestyle errors
-# F = flake8 pyflakes
-# W = pycodestyle warnings
-# B9 = bugbear opinions
-select = B, E, W, F, B9
 per-file-ignores =
     # B011: Do not call assert False since python -O removes these calls
     tests/*: B011
+    # TODO: Remove this when fixing flake8-bugbear warnings in source
+    src/pip/*: B007,B008,B009,B014,B305
 [mypy]
 follow_imports = silent
 ignore_missing_imports = True

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1358,7 +1358,7 @@ def test_install_builds_wheels(script, data, with_wheel):
     # Must have installed it all
     assert expected in str(res), str(res)
     wheels = []
-    for top, dirs, files in os.walk(wheels_cache):
+    for _, _, files in os.walk(wheels_cache):
         wheels.extend(files)
     # and built wheels for upper and wheelbroken
     assert "Building wheel for upper" in str(res), str(res)

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -6,7 +6,8 @@ from pip._internal.req import InstallRequirement
 from tests.lib import make_test_finder, path_to_url, windows_workaround_7667
 
 
-def make_project(tmpdir, requires=[], backend=None, backend_path=None):
+def make_project(tmpdir, requires=None, backend=None, backend_path=None):
+    requires = requires or []
     project_dir = tmpdir / 'project'
     project_dir.mkdir()
     buildsys = {'requires': requires}

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -41,7 +41,7 @@ def do_commit(script, dest):
 def add_commits(script, dest, count):
     """Return a list of the commit hashes from oldest to newest."""
     shas = []
-    for index in range(count):
+    for _ in range(count):
         sha = do_commit(script, dest)
         shas.append(sha)
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -264,9 +264,11 @@ class TestPipResult(object):
         def __str__(self):
             return str(self._impl)
 
-    def assert_installed(self, pkg_name, editable=True, with_files=[],
-                         without_files=[], without_egg_link=False,
+    def assert_installed(self, pkg_name, editable=True, with_files=None,
+                         without_files=None, without_egg_link=False,
                          use_user_site=False, sub_dir=False):
+        with_files = with_files or []
+        without_files = without_files or []
         e = self.test_env
 
         if editable:

--- a/tests/unit/resolution_resolvelib/test_requirement.py
+++ b/tests/unit/resolution_resolvelib/test_requirement.py
@@ -50,14 +50,14 @@ def test_cases(data):
 
 def test_new_resolver_requirement_has_name(test_cases, factory):
     """All requirements should have a name"""
-    for spec, name, matches in test_cases:
+    for spec, name, _ in test_cases:
         req = factory.make_requirement_from_spec(spec, comes_from=None)
         assert req.name == name
 
 
 def test_new_resolver_correct_number_of_matches(test_cases, factory):
     """Requirements should return the correct number of candidates"""
-    for spec, name, match_count in test_cases:
+    for spec, _, match_count in test_cases:
         req = factory.make_requirement_from_spec(spec, comes_from=None)
         matches = factory.find_candidates([req], SpecifierSet())
         assert len(list(matches)) == match_count
@@ -66,7 +66,7 @@ def test_new_resolver_correct_number_of_matches(test_cases, factory):
 def test_new_resolver_candidates_match_requirement(test_cases, factory):
     """Candidates returned from find_candidates should satisfy the requirement
     """
-    for spec, name, matches in test_cases:
+    for spec, _, _ in test_cases:
         req = factory.make_requirement_from_spec(spec, comes_from=None)
         for c in factory.find_candidates([req], SpecifierSet()):
             assert isinstance(c, Candidate)

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -561,7 +561,7 @@ class TestParseRequirements(object):
         """
         # this requirements file just contains a comment previously this has
         # failed in py3: https://github.com/pypa/pip/issues/760
-        for req in parse_reqfile(
+        for _ in parse_reqfile(
                 'https://raw.githubusercontent.com/pypa/'
                 'pip-test-package/master/'
                 'tests/req_just_comment.txt', session=PipSession()):

--- a/tests/unit/test_utils_wheel.py
+++ b/tests/unit/test_utils_wheel.py
@@ -21,7 +21,7 @@ def zip_dir():
         # type: (Path) -> ZipFile
         buf = BytesIO()
         with ZipFile(buf, "w", allowZip64=True) as z:
-            for dirpath, dirnames, filenames in os.walk(path):
+            for dirpath, _, filenames in os.walk(path):
                 for filename in filenames:
                     file_path = os.path.join(path, dirpath, filename)
                     # Zip files must always have / as path separator

--- a/tests/yaml/linter.py
+++ b/tests/yaml/linter.py
@@ -68,7 +68,7 @@ def lint_yml(yml_file, verbose=False):
     check_dict(data, required=['cases'], optional=['base'])
     base = data.get("base", {})
     cases = data["cases"]
-    for i, case_template in enumerate(cases):
+    for _, case_template in enumerate(cases):
         case = base.copy()
         case.update(case_template)
         lint_case(case, verbose)


### PR DESCRIPTION
Towards https://github.com/pypa/pip/issues/5537

This adds [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) plugin to pre-commit, and fixes the relevant errors just in the `tests` folder.

If the direction of this PR looks good, a follow up PR will remove warnings from `src/pip/_internal` folder for `flake8-bugbear`