### PR TITLE
Fix "src/pip" to respect flake8-bugbear

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,13 @@ exclude =
 per-file-ignores =
     # B011: Do not call assert False since python -O removes these calls
     tests/*: B011
-    # TODO: Remove this when fixing flake8-bugbear warnings in source
-    src/pip/*: B007,B008,B009,B014,B305
+    # TODO: Remove IOError from except (OSError, IOError) blocks in
+    # these files when Python 2 is removed.
+    # In Python 3, IOError have been merged into OSError
+    # https://github.com/PyCQA/flake8-bugbear/issues/110
+    src/pip/_internal/utils/filesystem.py: B014
+    src/pip/_internal/network/cache.py: B014
+    src/pip/_internal/utils/misc.py: B014
 [mypy]
 follow_imports = silent
 ignore_missing_imports = True

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -835,7 +835,7 @@ always_unzip = partial(
 # TODO: Move into a class that inherits from partial, currently does not
 # work as mypy complains functools.partial is a generic class.
 # This way we know we can ignore this option in docs auto generation
-setattr(always_unzip, 'deprecated', True)
+setattr(always_unzip, 'deprecated', True)  # noqa: B010
 
 
 def _handle_merge_hash(option, opt_str, value, parser):

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -167,7 +167,9 @@ class DownloadProgressMixin(object):
     def iter(self, it):  # type: ignore
         for x in it:
             yield x
-            self.next(len(x))
+            # B305 is incorrectly raised here
+            # https://github.com/PyCQA/flake8-bugbear/issues/59
+            self.next(len(x))  # noqa: B305
         self.finish()
 
 

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -22,6 +22,7 @@ if MYPY_CHECK_RUNNING:
     from types import ModuleType
     from typing import List, Optional, Dict
     from optparse import Values
+    from pip._internal.configuration import Configuration
 
 logger = logging.getLogger(__name__)
 
@@ -164,9 +165,9 @@ def show_tags(options):
 
 
 def ca_bundle_info(config):
-    # type: (Dict[str, str]) -> str
+    # type: (Configuration) -> str
     levels = set()
-    for key in config:
+    for key, _ in config.items():
         levels.add(key.split('.')[0])
 
     if not levels:

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -87,8 +87,12 @@ def get_vendor_version_from_module(module_name):
 
     if not version:
         # Try to find version in debundled module info
+        # The type for module.__file__ is Optional[str] in
+        # Python 2, and str in Python 3. The type: ignore is
+        # added to account for Python 2, instead of a cast
+        # and should be removed once we drop Python 2 support
         pkg_set = pkg_resources.WorkingSet(
-            [os.path.dirname(getattr(module, '__file__', None))]
+            [os.path.dirname(module.__file__)]  # type: ignore
         )
         package = pkg_set.find(pkg_resources.Requirement.parse(module_name))
         version = getattr(package, 'version', None)

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -87,7 +87,7 @@ def get_vendor_version_from_module(module_name):
     if not version:
         # Try to find version in debundled module info
         pkg_set = pkg_resources.WorkingSet(
-            [os.path.dirname(getattr(module, '__file__'))]
+            [os.path.dirname(getattr(module, '__file__', None))]
         )
         package = pkg_set.find(pkg_resources.Requirement.parse(module_name))
         version = getattr(package, 'version', None)
@@ -166,7 +166,7 @@ def show_tags(options):
 def ca_bundle_info(config):
     # type: (Dict[str, str]) -> str
     levels = set()
-    for key, value in config.items():
+    for key in config:
         levels.add(key.split('.')[0])
 
     if not levels:

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -155,7 +155,7 @@ def _test_writable_dir_win(path):
     # and we can't use tempfile: http://bugs.python.org/issue22107
     basename = 'accesstest_deleteme_fishfingers_custard_'
     alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789'
-    for i in range(10):
+    for _ in range(10):
         name = basename + ''.join(random.choice(alphabet) for _ in range(6))
         file = os.path.join(path, name)
         try:
@@ -190,7 +190,7 @@ def find_files(path, pattern):
     """Returns a list of absolute paths of files beneath path, recursively,
     with filenames which match the UNIX-style shell glob pattern."""
     result = []  # type: List[str]
-    for root, dirs, files in os.walk(path):
+    for root, _, files in os.walk(path):
         matches = fnmatch.filter(files, pattern)
         result.extend(os.path.join(root, f) for f in matches)
     return result

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -17,7 +17,7 @@ import stat
 import sys
 from collections import deque
 
-from pip._vendor import pkg_resources, six
+from pip._vendor import pkg_resources
 # NOTE: retrying is not annotated in typeshed as on 2017-07-17, which is
 #       why we ignore the type on this import.
 from pip._vendor.retrying import retry  # type: ignore
@@ -545,13 +545,7 @@ class FakeFile(object):
 
     def readline(self):
         try:
-            try:
-                return next(self._gen)
-            except NameError:
-                # flake8-bugbear B305 suggests using six.next for
-                # Python 2 compatibility. This along with the try/except
-                # block can be removed once we drop Python 2 support
-                return six.next(self._gen)
+            return next(self._gen)
         except StopIteration:
             return ''
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -17,7 +17,7 @@ import stat
 import sys
 from collections import deque
 
-from pip._vendor import pkg_resources
+from pip._vendor import pkg_resources, six
 # NOTE: retrying is not annotated in typeshed as on 2017-07-17, which is
 #       why we ignore the type on this import.
 from pip._vendor.retrying import retry  # type: ignore
@@ -548,7 +548,10 @@ class FakeFile(object):
             try:
                 return next(self._gen)
             except NameError:
-                return self._gen.next()
+                # flake8-bugbear B305 suggests using six.next for
+                # Python 2 compatibility. This along with the try/except
+                # block can be removed once we drop Python 2 support
+                return six.next(self._gen)
         except StopIteration:
             return ''
 

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -56,7 +56,7 @@ class Subversion(VersionControl):
         # Note: taken from setuptools.command.egg_info
         revision = 0
 
-        for base, dirs, files in os.walk(location):
+        for base, dirs, _ in os.walk(location):
             if cls.dirname not in dirs:
                 dirs[:] = []
                 continue    # no sense walking uncontrolled subdirs

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -23,7 +23,7 @@ from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
     from typing import (
-        Any, Callable, Iterable, List, Optional, Pattern, Tuple,
+        Any, Callable, Iterable, List, Optional, Tuple,
     )
 
     from pip._internal.cache import WheelCache
@@ -34,11 +34,11 @@ if MYPY_CHECK_RUNNING:
 
 logger = logging.getLogger(__name__)
 
+_egg_info_re = re.compile(r'([a-z0-9_.]+)-([a-z0-9_.!+-]+)', re.IGNORECASE)
 
-def _contains_egg_info(
-        s, _egg_info_re=re.compile(r'([a-z0-9_.]+)-([a-z0-9_.!+-]+)',
-                                   re.IGNORECASE)):
-    # type: (str, Pattern[str]) -> bool
+
+def _contains_egg_info(s):
+    # type: (str) -> bool
     """Determine whether the string looks like an egg_info.
 
     :param s: The string to parse. E.g. foo-2.1


### PR DESCRIPTION
Towards #5537  (Follow-up of https://github.com/pypa/pip/pull/8398)

This should finish adding of `flake8-bugbear` to pip, apart from some ignores which can be removed once Python2 support is dropped.