### PR TITLE
Refactor operations.prepare.prepare_linked_requirement

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -471,7 +471,8 @@ class RequirementPreparer(object):
             try:
                 local_file = unpack_url(
                     link, req.source_dir, self.downloader, download_dir,
-                    hashes=self._get_linked_req_hashes(req))
+                    hashes=self._get_linked_req_hashes(req)
+                )
             except requests.HTTPError as exc:
                 raise InstallationError(
                     'Could not install requirement {} because of HTTP '
@@ -492,7 +493,8 @@ class RequirementPreparer(object):
                     logger.info('Link is a directory, ignoring download_dir')
                 elif local_file:
                     download_location = os.path.join(
-                        download_dir, link.filename)
+                        download_dir, link.filename
+                    )
                     if not os.path.exists(download_location):
                         shutil.copy(local_file.path, download_location)
                         download_path = display_path(download_location)

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -376,29 +376,26 @@ class RequirementPreparer(object):
             "Could not find or access download directory '{}'"
             .format(self.download_dir))
 
-    def prepare_linked_requirement(
-        self,
-        req,  # type: InstallRequirement
-        parallel_builds=False,  # type: bool
-    ):
-        # type: (...) -> AbstractDistribution
-        """Prepare a requirement that would be obtained from req.link
-        """
-        assert req.link
-        link = req.link
-
-        # TODO: Breakup into smaller functions
-        if link.scheme == 'file':
-            path = link.file_path
+    def _log_preparing_link(self, req):
+        # type: (InstallRequirement) -> None
+        """Log the way the link prepared."""
+        if req.link.is_file:
+            path = req.link.file_path
             logger.info('Processing %s', display_path(path))
         else:
             logger.info('Collecting %s', req.req or req)
 
-        download_dir = self.download_dir
+    def prepare_linked_requirement(self, req, parallel_builds=False):
+        # type: (InstallRequirement, bool) -> AbstractDistribution
+        """Prepare a requirement to be obtained from req.link."""
+        assert req.link
+        link = req.link
+        self._log_preparing_link(req)
         if link.is_wheel and self.wheel_download_dir:
-            # when doing 'pip wheel` we download wheels to a
-            # dedicated dir.
+            # Download wheels to a dedicated dir when doing `pip wheel`.
             download_dir = self.wheel_download_dir
+        else:
+            download_dir = self.download_dir
 
         if link.is_wheel:
             if download_dir:


### PR DESCRIPTION
Break `operations.prepare.prepare_linked_requirement`
into smaller (not small enough IMHO) methods.

This *not* meant to solve GH-7815 completely.  I agree with https://github.com/pypa/pip/issues/7815#issuecomment-605614152 that we should somehow put the `populate_link` in the same place for the logic to be easier to parse.

Rather, this is purely to make the method easier for me to read to proceed with more experiments on the downloading process.

As for the stylistic changes with the placement of the closing parentheses, I don't really have a strong opinion on them; although I'd be happier if they're not used for single-line argument list.