### PR TITLE
Deprecate requirements format "base=>1.0[extra]"

### DIFF
--- a/news/8288.removal
+++ b/news/8288.removal
@@ -1,0 +1,1 @@
+Add deprecation warning for invalid requirements format "base>=1.0[extra]"

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -23,6 +23,7 @@ from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.pyproject import make_pyproject_path
 from pip._internal.req.req_install import InstallRequirement
+from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filetypes import ARCHIVE_EXTENSIONS
 from pip._internal.utils.misc import is_installable_dir, splitext
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -370,6 +371,17 @@ def parse_req_from_line(name, line_source):
             if add_msg:
                 msg += '\nHint: {}'.format(add_msg)
             raise InstallationError(msg)
+        else:
+            # Deprecate extras after specifiers: "name>=1.0[extras]"
+            # This currently works by accident because _strip_extras() parses
+            # any extras in the end of the string and those are saved in
+            # RequirementParts
+            for spec in req.specifier:
+                spec_str = str(spec)
+                if spec_str.endswith(']'):
+                    msg = "Extras after version '{}'.".format(spec_str)
+                    replace = "moving the extras before version specifiers"
+                    deprecated(msg, replacement=replace, gone_in="21.0")
     else:
         req = None
 

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -104,6 +104,27 @@ def test_nonexistent_options_listed_in_order(script, data):
     assert matches == ['nonexistent', 'nope']
 
 
+def test_install_deprecated_extra(script, data):
+    """
+    Warn about deprecated order of specifiers and extras.
+
+    Test uses a requirements file to avoid a testing issue where
+    the specifier gets interpreted as shell redirect.
+    """
+    script.scratch_path.joinpath("requirements.txt").write_text(
+        "requires_simple_extra>=0.1[extra]"
+    )
+    simple = script.site_packages / 'simple'
+
+    result = script.pip(
+        'install', '--no-index', '--find-links=' + data.find_links,
+        '-r', script.scratch_path / 'requirements.txt', expect_stderr=True,
+    )
+
+    result.did_create(simple)
+    assert ("DEPRECATION: Extras after version" in result.stderr)
+
+
 def test_install_special_extra(script):
     # Check that uppercase letters and '-' are dealt with
     # make a dummy project


### PR DESCRIPTION
Note: I'm new to pip code and it was not obvious where this should be done: feel free to point me to another direction. I chose this spot in `parse_req_from_line()` because there's other validation right next to it. 

There's currently no "gone_in" defined for the deprecation: let me know if there's a policy I should follow here.

The bug also has my comments on some other weirdness that may or may not be related bugs.

Fixes #8288

--- 
This requirements format does not conform to PEP-508. Add deprecation
warning and fix the corresponding test.

Note that the actual added check ensures the specifier is compliant
with PEP-440 (the specifier version is invalid "1.0[extra]").
