### PR TITLE
Cleanup test_new_resolver.py

### DIFF
--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -170,10 +170,8 @@ def test_ignore_dependencies(script):
         "dep",
         "0.1.0",
     )
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index", "--no-deps",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
+        "--no-deps",
         "base"
     )
     assert_installed(script, base="0.1.0")
@@ -319,18 +317,11 @@ def test_requires_python(
         requires_python=requires_python,
     )
 
-    args = [
-        "install",
-        "--unstable-feature=resolver",
-        "--no-cache-dir",
-        "--no-index",
-        "--find-links", script.scratch_path,
-    ]
+    options = []
     if ignore_requires_python:
-        args.append("--ignore-requires-python")
-    args.append("base")
+        options.append("--ignore-requires-python")
 
-    script.pip(*args)
+    script.pip_install_with_new_resolver(options + ["base"])
 
     assert_installed(script, base="0.1.0", dep=dep_version)
 
@@ -395,10 +386,8 @@ def test_ignore_installed(script):
     )
     assert satisfied_output not in result.stdout, str(result)
 
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index", "--ignore-installed",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
+        "--ignore-installed",
         "base",
     )
     assert satisfied_output not in result.stdout, str(result)
@@ -770,10 +759,7 @@ class TestExtraMerge(object):
             extras={"dev": ["dep[dev]"]},
         )
 
-        script.pip(
-            "install", "--unstable-feature=resolver",
-            "--no-cache-dir", "--no-index",
-            "--find-links", script.scratch_path,
+        script.pip_install_with_new_resolver(
             requirement + "[dev]",
         )
         assert_installed(script, pkg="1.0.0", dep="1.0.0", depdev="1.0.0")

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -202,10 +202,7 @@ def test_installs_extras(tmpdir, script, root_dep):
         "dep",
         "0.1.0",
     )
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "-r", req_file,
     )
     assert_installed(script, base="0.1.0", dep="0.1.0")
@@ -512,10 +509,7 @@ def test_new_reolver_skips_marker(script, pkg_deps, root_deps):
     create_basic_wheel_for_package(script, "pkg", "1.0", depends=pkg_deps)
     create_basic_wheel_for_package(script, "dep", "1.0")
 
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         *root_deps
     )
     assert_installed(script, pkg="1.0")
@@ -550,10 +544,7 @@ def test_constraint_no_specifier(script):
     create_basic_wheel_for_package(script, "pkg", "1.0")
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text("pkg")
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "-c", constraints_file,
         "pkg"
     )
@@ -581,10 +572,7 @@ def test_constraint_reject_invalid(script, constraint, error):
     create_basic_wheel_for_package(script, "pkg", "1.0")
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text(constraint)
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "-c", constraints_file,
         "pkg",
         expect_error=True,
@@ -614,9 +602,7 @@ def test_constraint_on_path(script):
     setup_py.write_text(text)
     constraints_txt = script.scratch_path / "constraints.txt"
     constraints_txt.write_text("foo==1.0")
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
+    result = script.pip_install_with_new_resolver(
         "-c", constraints_txt,
         str(script.scratch_path),
         expect_error=True,
@@ -799,10 +785,7 @@ def test_build_directory_error_zazo_19(script):
     create_basic_sdist_for_package(script, "pkg_b", "2.0.0")
     create_basic_sdist_for_package(script, "pkg_b", "1.0.0")
 
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "pkg-a", "pkg-b",
     )
     assert_installed(script, pkg_a="3.0.0", pkg_b="1.0.0")

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -45,7 +45,7 @@ def assert_editable(script, *args):
         "{!r} not all found in {!r}".format(args, script.site_packages_path)
 
 
-def test_new_resolver_can_install(script):
+def test_can_install(script):
     create_basic_wheel_for_package(
         script,
         "simple",
@@ -60,7 +60,7 @@ def test_new_resolver_can_install(script):
     assert_installed(script, simple="0.1.0")
 
 
-def test_new_resolver_can_install_with_version(script):
+def test_can_install_with_version(script):
     create_basic_wheel_for_package(
         script,
         "simple",
@@ -75,7 +75,7 @@ def test_new_resolver_can_install_with_version(script):
     assert_installed(script, simple="0.1.0")
 
 
-def test_new_resolver_picks_latest_version(script):
+def test_picks_latest_version(script):
     create_basic_wheel_for_package(
         script,
         "simple",
@@ -95,7 +95,7 @@ def test_new_resolver_picks_latest_version(script):
     assert_installed(script, simple="0.2.0")
 
 
-def test_new_resolver_picks_installed_version(script):
+def test_picks_installed_version(script):
     create_basic_wheel_for_package(
         script,
         "simple",
@@ -124,7 +124,7 @@ def test_new_resolver_picks_installed_version(script):
     assert_installed(script, simple="0.1.0")
 
 
-def test_new_resolver_picks_installed_version_if_no_match_found(script):
+def test_picks_installed_version_if_no_match_found(script):
     create_basic_wheel_for_package(
         script,
         "simple",
@@ -152,7 +152,7 @@ def test_new_resolver_picks_installed_version_if_no_match_found(script):
     assert_installed(script, simple="0.1.0")
 
 
-def test_new_resolver_installs_dependencies(script):
+def test_installs_dependencies(script):
     create_basic_wheel_for_package(
         script,
         "base",
@@ -173,7 +173,7 @@ def test_new_resolver_installs_dependencies(script):
     assert_installed(script, base="0.1.0", dep="0.1.0")
 
 
-def test_new_resolver_ignore_dependencies(script):
+def test_ignore_dependencies(script):
     create_basic_wheel_for_package(
         script,
         "base",
@@ -204,7 +204,7 @@ def test_new_resolver_ignore_dependencies(script):
         "base >= 0.1.0[add]",
     ],
 )
-def test_new_resolver_installs_extras(tmpdir, script, root_dep):
+def test_installs_extras(tmpdir, script, root_dep):
     req_file = tmpdir.joinpath("requirements.txt")
     req_file.write_text(root_dep)
 
@@ -228,7 +228,7 @@ def test_new_resolver_installs_extras(tmpdir, script, root_dep):
     assert_installed(script, base="0.1.0", dep="0.1.0")
 
 
-def test_new_resolver_installs_extras_warn_missing(script):
+def test_installs_extras_warn_missing(script):
     create_basic_wheel_for_package(
         script,
         "base",
@@ -252,7 +252,7 @@ def test_new_resolver_installs_extras_warn_missing(script):
     assert_installed(script, base="0.1.0", dep="0.1.0")
 
 
-def test_new_resolver_installed_message(script):
+def test_installed_message(script):
     create_basic_wheel_for_package(script, "A", "1.0")
     result = script.pip(
         "install", "--unstable-feature=resolver",
@@ -264,7 +264,7 @@ def test_new_resolver_installed_message(script):
     assert "Successfully installed A-1.0" in result.stdout, str(result)
 
 
-def test_new_resolver_no_dist_message(script):
+def test_no_dist_message(script):
     create_basic_wheel_for_package(script, "A", "1.0")
     result = script.pip(
         "install", "--unstable-feature=resolver",
@@ -287,7 +287,7 @@ def test_new_resolver_no_dist_message(script):
     assert "No matching distribution found for b" in result.stderr, str(result)
 
 
-def test_new_resolver_installs_editable(script):
+def test_installs_editable(script):
     create_basic_wheel_for_package(
         script,
         "base",
@@ -322,7 +322,7 @@ def test_new_resolver_installs_editable(script):
         (">=2", True, "0.2.0"),
     ],
 )
-def test_new_resolver_requires_python(
+def test_requires_python(
     script,
     requires_python,
     ignore_requires_python,
@@ -362,7 +362,7 @@ def test_new_resolver_requires_python(
     assert_installed(script, base="0.1.0", dep=dep_version)
 
 
-def test_new_resolver_requires_python_error(script):
+def test_requires_python_error(script):
     create_basic_wheel_for_package(
         script,
         "base",
@@ -384,7 +384,7 @@ def test_new_resolver_requires_python_error(script):
     assert message in result.stderr, str(result)
 
 
-def test_new_resolver_installed(script):
+def test_installed(script):
     create_basic_wheel_for_package(
         script,
         "base",
@@ -418,7 +418,7 @@ def test_new_resolver_installed(script):
     )
 
 
-def test_new_resolver_ignore_installed(script):
+def test_ignore_installed(script):
     create_basic_wheel_for_package(
         script,
         "base",
@@ -446,7 +446,7 @@ def test_new_resolver_ignore_installed(script):
     )
 
 
-def test_new_resolver_only_builds_sdists_when_needed(script):
+def test_only_builds_sdists_when_needed(script):
     create_basic_wheel_for_package(
         script,
         "base",
@@ -484,7 +484,7 @@ def test_new_resolver_only_builds_sdists_when_needed(script):
     assert_installed(script, base="0.1.0", dep="0.2.0")
 
 
-def test_new_resolver_install_different_version(script):
+def test_install_different_version(script):
     create_basic_wheel_for_package(script, "base", "0.1.0")
     create_basic_wheel_for_package(script, "base", "0.2.0")
 
@@ -511,7 +511,7 @@ def test_new_resolver_install_different_version(script):
     assert_installed(script, base="0.2.0")
 
 
-def test_new_resolver_force_reinstall(script):
+def test_force_reinstall(script):
     create_basic_wheel_for_package(script, "base", "0.1.0")
 
     script.pip(
@@ -553,7 +553,7 @@ def test_new_resolver_force_reinstall(script):
     ],
     ids=["default", "exact-pre", "explicit-pre", "no-stable"],
 )
-def test_new_resolver_handles_prerelease(
+def test_handles_prerelease(
     script,
     available_versions,
     pip_args,
@@ -602,7 +602,7 @@ def test_new_reolver_skips_marker(script, pkg_deps, root_deps):
         ["pkg<2.0"],
     ]
 )
-def test_new_resolver_constraints(script, constraints):
+def test_constraints(script, constraints):
     create_basic_wheel_for_package(script, "pkg", "1.0")
     create_basic_wheel_for_package(script, "pkg", "2.0")
     create_basic_wheel_for_package(script, "pkg", "3.0")
@@ -619,7 +619,7 @@ def test_new_resolver_constraints(script, constraints):
     assert_not_installed(script, "constraint_only")
 
 
-def test_new_resolver_constraint_no_specifier(script):
+def test_constraint_no_specifier(script):
     "It's allowed (but useless...) for a constraint to have no specifier"
     create_basic_wheel_for_package(script, "pkg", "1.0")
     constraints_file = script.scratch_path / "constraints.txt"
@@ -651,7 +651,7 @@ def test_new_resolver_constraint_no_specifier(script):
         ),
     ],
 )
-def test_new_resolver_constraint_reject_invalid(script, constraint, error):
+def test_constraint_reject_invalid(script, constraint, error):
     create_basic_wheel_for_package(script, "pkg", "1.0")
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text(constraint)
@@ -667,7 +667,7 @@ def test_new_resolver_constraint_reject_invalid(script, constraint, error):
     assert error in result.stderr, str(result)
 
 
-def test_new_resolver_constraint_on_dependency(script):
+def test_constraint_on_dependency(script):
     create_basic_wheel_for_package(script, "base", "1.0", depends=["dep"])
     create_basic_wheel_for_package(script, "dep", "1.0")
     create_basic_wheel_for_package(script, "dep", "2.0")
@@ -685,7 +685,7 @@ def test_new_resolver_constraint_on_dependency(script):
     assert_installed(script, dep="2.0")
 
 
-def test_new_resolver_constraint_on_path(script):
+def test_constraint_on_path(script):
     setup_py = script.scratch_path / "setup.py"
     text = "from setuptools import setup\nsetup(name='foo', version='2.0')"
     setup_py.write_text(text)
@@ -703,7 +703,7 @@ def test_new_resolver_constraint_on_path(script):
     assert msg in result.stderr, str(result)
 
 
-def test_new_resolver_upgrade_needs_option(script):
+def test_upgrade_needs_option(script):
     # Install pkg 1.0.0
     create_basic_wheel_for_package(script, "pkg", "1.0.0")
     script.pip(
@@ -744,7 +744,7 @@ def test_new_resolver_upgrade_needs_option(script):
     assert_installed(script, pkg="2.0.0")
 
 
-def test_new_resolver_upgrade_strategy(script):
+def test_upgrade_strategy(script):
     create_basic_wheel_for_package(script, "base", "1.0.0", depends=["dep"])
     create_basic_wheel_for_package(script, "dep", "1.0.0")
     script.pip(
@@ -836,7 +836,7 @@ class TestExtraMerge(object):
             _wheel_from_index,
         ],
     )
-    def test_new_resolver_extra_merge_in_package(
+    def test_extra_merge_in_package(
         self, monkeypatch, script, pkg_builder,
     ):
         create_basic_wheel_for_package(script, "depdev", "1.0.0")
@@ -864,7 +864,7 @@ class TestExtraMerge(object):
 
 
 @pytest.mark.xfail(reason="pre-existing build directory")
-def test_new_resolver_build_directory_error_zazo_19(script):
+def test_build_directory_error_zazo_19(script):
     """https://github.com/pradyunsg/zazo/issues/19#issuecomment-631615674
 
     This will first resolve like this:

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -699,6 +699,7 @@ class TestExtraMerge(object):
     extras, one listed as required and the other as in extra.
     """
 
+    @staticmethod
     def _local_with_setup(script, name, version, requires, extras):
         """Create the package as a local source directory to install from path.
         """
@@ -710,6 +711,7 @@ class TestExtraMerge(object):
             extras_require=extras,
         )
 
+    @staticmethod
     def _direct_wheel(script, name, version, requires, extras):
         """Create the package as a wheel to install from path directly.
         """
@@ -721,6 +723,7 @@ class TestExtraMerge(object):
             extras=extras,
         )
 
+    @staticmethod
     def _wheel_from_index(script, name, version, requires, extras):
         """Create the package as a wheel to install from index.
         """

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -57,10 +57,7 @@ def test_can_install(script):
         "simple",
         "0.1.0",
     )
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "simple"
     )
     assert_installed(script, simple="0.1.0")
@@ -72,10 +69,7 @@ def test_can_install_with_version(script):
         "simple",
         "0.1.0",
     )
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "simple==0.1.0"
     )
     assert_installed(script, simple="0.1.0")
@@ -92,10 +86,7 @@ def test_picks_latest_version(script):
         "simple",
         "0.2.0",
     )
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "simple"
     )
     assert_installed(script, simple="0.2.0")
@@ -112,18 +103,12 @@ def test_picks_installed_version(script):
         "simple",
         "0.2.0",
     )
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "simple==0.1.0"
     )
     assert_installed(script, simple="0.1.0")
 
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "simple"
     )
     assert "Collecting" not in result.stdout, "Should not fetch new version"
@@ -141,10 +126,7 @@ def test_picks_installed_version_if_no_match_found(script):
         "simple",
         "0.2.0",
     )
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "simple==0.1.0"
     )
     assert_installed(script, simple="0.1.0")
@@ -170,10 +152,7 @@ def test_installs_dependencies(script):
         "dep",
         "0.1.0",
     )
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "base"
     )
     assert_installed(script, base="0.1.0", dep="0.1.0")
@@ -246,10 +225,7 @@ def test_installs_extras_warn_missing(script):
         "dep",
         "0.1.0",
     )
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "base[add,missing]",
         expect_stderr=True,
     )
@@ -260,10 +236,7 @@ def test_installs_extras_warn_missing(script):
 
 def test_installed_message(script):
     create_basic_wheel_for_package(script, "A", "1.0")
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "A",
         expect_stderr=False,
     )
@@ -272,10 +245,7 @@ def test_installed_message(script):
 
 def test_no_dist_message(script):
     create_basic_wheel_for_package(script, "A", "1.0")
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "B",
         expect_error=True,
         expect_stderr=True,
@@ -305,10 +275,7 @@ def test_installs_editable(script):
         name="dep",
         version="0.1.0",
     )
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "base",
         "--editable", source_dir,
     )
@@ -375,10 +342,7 @@ def test_requires_python_error(script):
         "0.1.0",
         requires_python="<2",
     )
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "base",
         expect_error=True,
     )
@@ -403,19 +367,13 @@ def test_installed(script):
         "0.1.0",
     )
 
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "base",
     )
     assert "Requirement already satisfied" not in result.stdout, str(result)
 
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
-        "base~=0.1.0",
+    result = script.pip_install_with_new_resolver(
+        "base~=1.0",
     )
     assert "Requirement already satisfied: base~=0.1.0" in result.stdout, \
         str(result)
@@ -432,10 +390,7 @@ def test_ignore_installed(script):
     )
     satisfied_output = "Requirement already satisfied"
 
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "base",
     )
     assert satisfied_output not in result.stdout, str(result)
@@ -472,19 +427,13 @@ def test_only_builds_sdists_when_needed(script):
         "0.2.0",
     )
     # We only ever need to check dep 0.2.0 as it's the latest version
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "base"
     )
     assert_installed(script, base="0.1.0", dep="0.2.0")
 
     # We merge criteria here, as we have two "dep" requirements
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "base", "dep"
     )
     assert_installed(script, base="0.1.0", dep="0.2.0")
@@ -494,18 +443,12 @@ def test_install_different_version(script):
     create_basic_wheel_for_package(script, "base", "0.1.0")
     create_basic_wheel_for_package(script, "base", "0.2.0")
 
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "base==0.1.0",
     )
 
     # This should trigger an uninstallation of base.
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "base==0.2.0",
     )
 
@@ -520,19 +463,13 @@ def test_install_different_version(script):
 def test_force_reinstall(script):
     create_basic_wheel_for_package(script, "base", "0.1.0")
 
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "base==0.1.0",
     )
 
     # This should trigger an uninstallation of base due to --force-reinstall,
     # even though the installed version matches.
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "--force-reinstall",
         "base==0.1.0",
     )
@@ -567,10 +504,7 @@ def test_handles_prerelease(
 ):
     for version in available_versions:
         create_basic_wheel_for_package(script, "pkg", version)
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         *pip_args
     )
     assert_installed(script, pkg=expected_version)
@@ -613,11 +547,8 @@ def test_constraints(script, constraints):
     create_basic_wheel_for_package(script, "pkg", "2.0")
     create_basic_wheel_for_package(script, "pkg", "3.0")
     constraints_file = script.scratch_path / "constraints.txt"
-    constraints_file.write_text("\n".join(constraints))
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    constraints_file.write_text(constraints)
+    script.pip_install_with_new_resolver(
         "-c", constraints_file,
         "pkg"
     )
@@ -680,10 +611,7 @@ def test_constraint_on_dependency(script):
     create_basic_wheel_for_package(script, "dep", "3.0")
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text("dep==2.0")
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "-c", constraints_file,
         "base"
     )
@@ -712,10 +640,7 @@ def test_constraint_on_path(script):
 def test_upgrade_needs_option(script):
     # Install pkg 1.0.0
     create_basic_wheel_for_package(script, "pkg", "1.0.0")
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "pkg",
     )
 
@@ -723,10 +648,7 @@ def test_upgrade_needs_option(script):
     create_basic_wheel_for_package(script, "pkg", "2.0.0")
 
     # This should not upgrade because we don't specify --upgrade
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "pkg",
     )
 
@@ -734,10 +656,7 @@ def test_upgrade_needs_option(script):
     assert_installed(script, pkg="1.0.0")
 
     # This should upgrade
-    result = script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    result = script.pip_install_with_new_resolver(
         "--upgrade",
         "PKG",  # Deliberately uppercase to check canonicalization
     )
@@ -753,10 +672,7 @@ def test_upgrade_needs_option(script):
 def test_upgrade_strategy(script):
     create_basic_wheel_for_package(script, "base", "1.0.0", depends=["dep"])
     create_basic_wheel_for_package(script, "dep", "1.0.0")
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "base",
     )
 
@@ -767,10 +683,7 @@ def test_upgrade_strategy(script):
     create_basic_wheel_for_package(script, "base", "2.0.0", depends=["dep"])
     create_basic_wheel_for_package(script, "dep", "2.0.0")
 
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "--upgrade",
         "base",
     )
@@ -781,10 +694,7 @@ def test_upgrade_strategy(script):
     assert_installed(script, dep="1.0.0")
 
     create_basic_wheel_for_package(script, "base", "3.0.0", depends=["dep"])
-    script.pip(
-        "install", "--unstable-feature=resolver",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
+    script.pip_install_with_new_resolver(
         "--upgrade", "--upgrade-strategy=eager",
         "base",
     )

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -12,6 +12,9 @@ from tests.lib import (
 )
 
 
+#
+# Helpers
+#
 def assert_installed(script, **kwargs):
     ret = script.pip('list', '--format=json')
     installed = set(
@@ -45,6 +48,9 @@ def assert_editable(script, *args):
         "{!r} not all found in {!r}".format(args, script.site_packages_path)
 
 
+#
+# Actual tests follow!
+#
 def test_can_install(script):
     create_basic_wheel_for_package(
         script,

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -655,6 +655,14 @@ class PipTestEnvironment(TestFileEnvironment):
             *args, **kwargs
         )
 
+    def pip_install_with_new_resolver(self, *args, **kwargs):
+        return self.pip(
+            "install", "--unstable-feature=resolver",
+            "--no-cache-dir", "--no-index",
+            "--find-links", self.scratch_path,
+            *args, **kwargs
+        )
+
     def easy_install(self, *args, **kwargs):
         args = ('-m', 'easy_install') + args
         return self.run('python', *args, **kwargs)


### PR DESCRIPTION
This PR:

- drops `new_resolver` from the test names (covered by the file they're in)
- adds a helper for making invocations easier/more concise
- decorates staticmethods

It's a draft PR since it's slightly out of date, and I didn't want to have a branch loitering without some place to track/store the state of it. :)