### PR TITLE
Use str.format style in logging calls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,8 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [
-        'flake8-bugbear==20.1.4'
+        'flake8-bugbear==20.1.4',
+        'flake8-logging-format==0.6.0',
     ]
     exclude: tests/data
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,11 @@ exclude =
     .scratch,
     _vendor,
     data
+enable-extensions = G
+ignore = G200, G202, W504
 per-file-ignores =
+    # G: The plugin logging-format treats every .log and .error as logging.
+    noxfile.py: G
     # B011: Do not call assert False since python -O removes these calls
     tests/*: B011
     # TODO: Remove IOError from except (OSError, IOError) blocks in
@@ -33,6 +37,7 @@ per-file-ignores =
     src/pip/_internal/utils/filesystem.py: B014
     src/pip/_internal/network/cache.py: B014
     src/pip/_internal/utils/misc.py: B014
+
 [mypy]
 follow_imports = silent
 ignore_missing_imports = True

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -230,8 +230,8 @@ class SimpleWheelCache(Cache):
                 continue
             if canonicalize_name(wheel.name) != canonical_package_name:
                 logger.debug(
-                    "Ignoring cached wheel %s for %s as it "
-                    "does not match the expected distribution name %s.",
+                    "Ignoring cached wheel {} for {} as it "
+                    "does not match the expected distribution name {}.",
                     wheel_name, link, package_name,
                 )
                 continue

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -232,7 +232,8 @@ class SimpleWheelCache(Cache):
                 logger.debug(
                     "Ignoring cached wheel %s for %s as it "
                     "does not match the expected distribution name %s.",
-                    wheel_name, link, package_name)
+                    wheel_name, link, package_name,
+                )
                 continue
             if not wheel.supported(supported_tags):
                 # Built for a different python/arch/etc

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -230,11 +230,9 @@ class SimpleWheelCache(Cache):
                 continue
             if canonicalize_name(wheel.name) != canonical_package_name:
                 logger.debug(
-                    "Ignoring cached wheel {} for {} as it "
-                    "does not match the expected distribution name {}.".format(
-                        wheel_name, link, package_name
-                    )
-                )
+                    "Ignoring cached wheel %s for %s as it "
+                    "does not match the expected distribution name %s.",
+                    wheel_name, link, package_name)
                 continue
             if not wheel.supported(supported_tags):
                 # Built for a different python/arch/etc

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -181,7 +181,7 @@ class Command(CommandContextMixIn):
             options.cache_dir = normalize_path(options.cache_dir)
             if not check_path_owner(options.cache_dir):
                 logger.warning(
-                    "The directory '%s' or its parent directory is not owned "
+                    "The directory '{}' or its parent directory is not owned "
                     "or is not writable by the current user. The cache "
                     "has been disabled. Check the permissions and owner of "
                     "that directory. If executing pip with sudo, you may want "
@@ -206,7 +206,7 @@ class Command(CommandContextMixIn):
 
             return ERROR
         except CommandError as exc:
-            logger.critical('%s', exc)
+            logger.critical('{}', exc)
             logger.debug('Exception information:', exc_info=True)
 
             return ERROR

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -12,7 +12,6 @@ pass on state. To be consistent, all options will follow this design.
 
 from __future__ import absolute_import
 
-import logging
 import os
 import textwrap
 import warnings
@@ -34,8 +33,6 @@ if MYPY_CHECK_RUNNING:
     from typing import Any, Callable, Dict, Optional, Tuple
     from optparse import OptionParser, Values
     from pip._internal.cli.parser import ConfigOptionParser
-
-logger = logging.getLogger(__name__)
 
 
 def raise_option_error(parser, option, msg):

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -844,11 +844,11 @@ def _handle_merge_hash(option, opt_str, value, parser):
     try:
         algo, digest = value.split(':', 1)
     except ValueError:
-        parser.error('Arguments to {} must be a hash name '
+        parser.error('Arguments to {} must be a hash name '  # noqa
                      'followed by a value, like --hash=sha256:'
                      'abcde...'.format(opt_str))
     if algo not in STRONG_HASHES:
-        parser.error('Allowed hash algorithms for {} are {}.'.format(
+        parser.error('Allowed hash algorithms for {} are {}.'.format(  # noqa
                      opt_str, ', '.join(STRONG_HASHES)))
     parser.values.hashes.setdefault(algo, []).append(digest)
 

--- a/src/pip/_internal/cli/main.py
+++ b/src/pip/_internal/cli/main.py
@@ -69,7 +69,7 @@ def main(args=None):
         locale.setlocale(locale.LC_ALL, '')
     except locale.Error as e:
         # setlocale can apparently crash if locale are uninitialized
-        logger.debug("Ignoring error %s when setting locale", e)
+        logger.debug("Ignoring error {} when setting locale", e)
     command = create_command(cmd_name, isolated=("--isolated" in cmd_args))
 
     return command.main(cmd_args)

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -164,7 +164,7 @@ class ConfigOptionParser(CustomOptionParser):
             # ignore empty values
             if not val:
                 logger.debug(
-                    "Ignoring configuration key '%s' as it's value is empty.",
+                    "Ignoring configuration key '{}' as it's value is empty.",
                     section_key
                 )
                 continue

--- a/src/pip/_internal/cli/spinners.py
+++ b/src/pip/_internal/cli/spinners.py
@@ -92,7 +92,7 @@ class NonInteractiveSpinner(SpinnerInterface):
         # type: (str) -> None
         assert not self._finished
         self._rate_limiter.reset()
-        logger.info("%s: %s", self._message, status)
+        logger.info("{}: {}", self._message, status)
 
     def spin(self):
         # type: () -> None

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -59,9 +59,8 @@ class CacheCommand(Command):
 
         # Determine action
         if not args or args[0] not in handlers:
-            logger.error("Need an action ({}) to perform.".format(
-                ", ".join(sorted(handlers)))
-            )
+            logger.error("Need an action ({}) to perform.",
+                         ", ".join(sorted(handlers)))
             return ERROR
 
         action = args[0]

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -59,8 +59,10 @@ class CacheCommand(Command):
 
         # Determine action
         if not args or args[0] not in handlers:
-            logger.error("Need an action ({}) to perform.",
-                         ", ".join(sorted(handlers)))
+            logger.error(
+                "Need an action ({}) to perform.",
+                ", ".join(sorted(handlers)),
+            )
             return ERROR
 
         action = args[0]

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -143,8 +143,8 @@ class CacheCommand(Command):
 
         for filename in files:
             os.unlink(filename)
-            logger.debug('Removed %s', filename)
-        logger.info('Files removed: %s', len(files))
+            logger.debug('Removed {}', filename)
+        logger.info('Files removed: {}', len(files))
 
     def purge_cache(self, options, args):
         # type: (Values, List[Any]) -> None

--- a/src/pip/_internal/commands/check.py
+++ b/src/pip/_internal/commands/check.py
@@ -32,7 +32,7 @@ class CheckCommand(Command):
             version = package_set[project_name].version
             for dependency in missing[project_name]:
                 write_output(
-                    "%s %s requires %s, which is not installed.",
+                    "{} {} requires {}, which is not installed.",
                     project_name, version, dependency[0],
                 )
 
@@ -40,7 +40,7 @@ class CheckCommand(Command):
             version = package_set[project_name].version
             for dep_name, dep_version, req in conflicting[project_name]:
                 write_output(
-                    "%s %s has requirement %s, but you have %s %s.",
+                    "{} {} has requirement {}, but you have {} {}.",
                     project_name, version, req, dep_name, dep_version,
                 )
 

--- a/src/pip/_internal/commands/check.py
+++ b/src/pip/_internal/commands/check.py
@@ -6,7 +6,7 @@ from pip._internal.operations.check import (
     check_package_set,
     create_package_set_from_installed,
 )
-from pip._internal.utils.misc import write_output
+from pip._internal.utils.logging import write_output
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 logger = logging.getLogger(__name__)

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -108,9 +108,8 @@ class ConfigurationCommand(Command):
 
         # Determine action
         if not args or args[0] not in handlers:
-            logger.error("Need an action ({}) to perform.".format(
-                ", ".join(sorted(handlers)))
-            )
+            logger.error("Need an action (%s) to perform.",
+                         ", ".join(sorted(handlers)))
             return ERROR
 
         action = args[0]

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -109,7 +109,7 @@ class ConfigurationCommand(Command):
         # Determine action
         if not args or args[0] not in handlers:
             logger.error(
-                "Need an action (%s) to perform.",
+                "Need an action ({}) to perform.",
                 ", ".join(sorted(handlers)),
             )
             return ERROR
@@ -171,13 +171,13 @@ class ConfigurationCommand(Command):
         self._get_n_args(args, "list", n=0)
 
         for key, value in sorted(self.configuration.items()):
-            write_output("%s=%r", key, value)
+            write_output("{}={!r}", key, value)
 
     def get_name(self, options, args):
         key = self._get_n_args(args, "get [name]", n=1)
         value = self.configuration.get_value(key)
 
-        write_output("%s", value)
+        write_output("{}", value)
 
     def set_name_value(self, options, args):
         key, value = self._get_n_args(args, "set [name] [value]", n=2)

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -13,7 +13,8 @@ from pip._internal.configuration import (
     kinds,
 )
 from pip._internal.exceptions import PipError
-from pip._internal.utils.misc import get_prog, write_output
+from pip._internal.utils.logging import write_output
+from pip._internal.utils.misc import get_prog
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -108,8 +108,10 @@ class ConfigurationCommand(Command):
 
         # Determine action
         if not args or args[0] not in handlers:
-            logger.error("Need an action (%s) to perform.",
-                         ", ".join(sorted(handlers)))
+            logger.error(
+                "Need an action (%s) to perform.",
+                ", ".join(sorted(handlers)),
+            )
             return ERROR
 
         action = args[0]
@@ -225,8 +227,9 @@ class ConfigurationCommand(Command):
         try:
             self.configuration.save()
         except Exception:
-            logger.exception("Unable to save configuration. "
-                             "Please report this as a bug.")
+            logger.exception(
+                "Unable to save configuration. Please report this as a bug."
+            )
             raise PipError("Internal Error.")
 
     def _determine_editor(self, options):

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -226,10 +226,8 @@ class ConfigurationCommand(Command):
         try:
             self.configuration.save()
         except Exception:
-            logger.error(
-                "Unable to save configuration. Please report this as a bug.",
-                exc_info=1
-            )
+            logger.exception("Unable to save configuration. "
+                             "Please report this as a bug.")
             raise PipError("Internal Error.")
 
     def _determine_editor(self, options):

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 def show_value(name, value):
     # type: (str, Optional[str]) -> None
-    logger.info('{}: {}'.format(name, value))
+    logger.info('%s: %s', name, value)
 
 
 def show_sys_implementation():
@@ -102,9 +102,9 @@ def get_vendor_version_from_module(module_name):
 
 def show_actual_vendor_versions(vendor_txt_versions):
     # type: (Dict[str, str]) -> None
-    # Logs the actual version and print extra info
-    # if there is a conflict or if the actual version could not be imported.
-
+    """Log the actual version and print extra info if there is
+    a conflict or if the actual version could not be imported.
+    """
     for module_name, expected_version in vendor_txt_versions.items():
         extra_message = ''
         actual_version = get_vendor_version_from_module(module_name)
@@ -115,14 +115,7 @@ def show_actual_vendor_versions(vendor_txt_versions):
         elif actual_version != expected_version:
             extra_message = ' (CONFLICT: vendor.txt suggests version should'\
                             ' be {})'.format(expected_version)
-
-        logger.info(
-            '{name}=={actual}{extra}'.format(
-                name=module_name,
-                actual=actual_version,
-                extra=extra_message
-            )
-        )
+        logger.info('%s==%s%s', module_name, actual_version, extra_message)
 
 
 def show_vendor_versions():

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 def show_value(name, value):
     # type: (str, Optional[str]) -> None
-    logger.info('%s: %s', name, value)
+    logger.info('{}: {}', name, value)
 
 
 def show_sys_implementation():
@@ -115,7 +115,7 @@ def show_actual_vendor_versions(vendor_txt_versions):
         elif actual_version != expected_version:
             extra_message = ' (CONFLICT: vendor.txt suggests version should'\
                             ' be {})'.format(expected_version)
-        logger.info('%s==%s%s', module_name, actual_version, extra_message)
+        logger.info('{}=={}{}', module_name, actual_version, extra_message)
 
 
 def show_vendor_versions():

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -138,6 +138,6 @@ class DownloadCommand(RequirementCommand):
                                for req in requirement_set.requirements.values()
                                if req.successfully_downloaded])
         if downloaded:
-            write_output('Successfully downloaded %s', downloaded)
+            write_output('Successfully downloaded {}', downloaded)
 
         return SUCCESS

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -8,7 +8,8 @@ from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.req_command import RequirementCommand, with_cleanup
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.req.req_tracker import get_requirement_tracker
-from pip._internal.utils.misc import ensure_dir, normalize_path, write_output
+from pip._internal.utils.logging import write_output
+from pip._internal.utils.misc import ensure_dir, normalize_path
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 

--- a/src/pip/_internal/commands/hash.py
+++ b/src/pip/_internal/commands/hash.py
@@ -7,7 +7,8 @@ import sys
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.utils.hashes import FAVORITE_HASH, STRONG_HASHES
-from pip._internal.utils.misc import read_chunks, write_output
+from pip._internal.utils.logging import write_output
+from pip._internal.utils.misc import read_chunks
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:

--- a/src/pip/_internal/commands/hash.py
+++ b/src/pip/_internal/commands/hash.py
@@ -48,7 +48,7 @@ class HashCommand(Command):
 
         algorithm = options.algorithm
         for path in args:
-            write_output('%s:\n--hash=%s:%s',
+            write_output('{}:\n--hash={}:{}',
                          path, algorithm, _hash_of_file(path, algorithm))
         return SUCCESS
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -31,11 +31,11 @@ from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.distutils_args import parse_distutils_args
 from pip._internal.utils.filesystem import test_writable_dir
+from pip._internal.utils.logging import write_output
 from pip._internal.utils.misc import (
     ensure_dir,
     get_installed_version,
     protect_pip_from_modification_on_windows,
-    write_output,
 )
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -505,7 +505,7 @@ class InstallCommand(RequirementCommand):
         try:
             package_set, _dep_info = check_install_conflicts(to_install)
         except Exception:
-            logger.error("Error checking for conflicts.", exc_info=True)
+            logger.exception("Error checking for conflicts.")
             return
         missing, conflicting = _dep_info
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -434,7 +434,7 @@ class InstallCommand(RequirementCommand):
             message = create_env_error_message(
                 error, show_traceback, options.use_user_site,
             )
-            logger.error(message, exc_info=show_traceback)
+            logger.error(message, exc_info=show_traceback)  # noqa
 
             return ERROR
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -426,7 +426,7 @@ class InstallCommand(RequirementCommand):
             installed_desc = ' '.join(items)
             if installed_desc:
                 write_output(
-                    'Successfully installed %s', installed_desc,
+                    'Successfully installed {}', installed_desc,
                 )
         except EnvironmentError as error:
             show_traceback = (self.verbosity >= 1)
@@ -477,14 +477,14 @@ class InstallCommand(RequirementCommand):
                     if os.path.exists(target_item_dir):
                         if not upgrade:
                             logger.warning(
-                                'Target directory %s already exists. Specify '
+                                'Target directory {} already exists. Specify '
                                 '--upgrade to force replacement.',
                                 target_item_dir
                             )
                             continue
                         if os.path.islink(target_item_dir):
                             logger.warning(
-                                'Target directory %s already exists and is '
+                                'Target directory {} already exists and is '
                                 'a link. pip will not automatically replace '
                                 'links, please remove if replacement is '
                                 'desired.',
@@ -514,7 +514,7 @@ class InstallCommand(RequirementCommand):
             version = package_set[project_name][0]
             for dependency in missing[project_name]:
                 logger.critical(
-                    "%s %s requires %s, which is not installed.",
+                    "{} {} requires {}, which is not installed.",
                     project_name, version, dependency[1],
                 )
 
@@ -522,7 +522,7 @@ class InstallCommand(RequirementCommand):
             version = package_set[project_name][0]
             for dep_name, dep_version, req in conflicting[project_name]:
                 logger.critical(
-                    "%s %s has requirement %s, but you'll have %s %s which is "
+                    "{} {} has requirement {}, but you'll have {} {} which is "
                     "incompatible.",
                     project_name, version, req, dep_name, dep_version,
                 )

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -12,11 +12,11 @@ from pip._internal.exceptions import CommandError
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.self_outdated_check import make_link_collector
+from pip._internal.utils.logging import write_output
 from pip._internal.utils.misc import (
     dist_is_editable,
     get_installed_distributions,
     tabulate,
-    write_output,
 )
 from pip._internal.utils.packaging import get_installer
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -239,10 +239,10 @@ class ListCommand(IndexGroupCommand):
         elif options.list_format == 'freeze':
             for dist in packages:
                 if options.verbose >= 1:
-                    write_output("%s==%s (%s)", dist.project_name,
+                    write_output("{}=={} ({})", dist.project_name,
                                  dist.version, dist.location)
                 else:
-                    write_output("%s==%s", dist.project_name, dist.version)
+                    write_output("{}=={}", dist.project_name, dist.version)
         elif options.list_format == 'json':
             write_output(format_for_json(packages, options))
 

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -18,8 +18,7 @@ from pip._internal.exceptions import CommandError
 from pip._internal.models.index import PyPI
 from pip._internal.network.xmlrpc import PipXmlrpcTransport
 from pip._internal.utils.compat import get_terminal_size
-from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import write_output
+from pip._internal.utils.logging import indent_log, write_output
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -142,14 +142,14 @@ def print_results(hits, name_column_width=None, terminal_width=None):
                 dist = pkg_resources.get_distribution(name)
                 with indent_log():
                     if dist.version == latest:
-                        write_output('INSTALLED: %s (latest)', dist.version)
+                        write_output('INSTALLED: {} (latest)', dist.version)
                     else:
-                        write_output('INSTALLED: %s', dist.version)
+                        write_output('INSTALLED: {}', dist.version)
                         if parse_version(latest).pre:
-                            write_output('LATEST:    %s (pre-release; install'
+                            write_output('LATEST:    {} (pre-release; install'
                                          ' with "pip install --pre")', latest)
                         else:
-                            write_output('LATEST:    %s', latest)
+                            write_output('LATEST:    {}', latest)
         except UnicodeEncodeError:
             pass
 

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -9,7 +9,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.utils.misc import write_output
+from pip._internal.utils.logging import write_output
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -72,7 +72,7 @@ def search_packages_info(query):
         [name for name, pkg in zip(query, query_names) if pkg not in installed]
     )
     if missing:
-        logger.warning('Package(s) not found: %s', ', '.join(missing))
+        logger.warning('Package(s) not found: {}', ', '.join(missing))
 
     def get_requiring_packages(package_name):
         # type: (str) -> List[str]
@@ -156,31 +156,31 @@ def print_results(distributions, list_files=False, verbose=False):
         if i > 0:
             write_output("---")
 
-        write_output("Name: %s", dist.get('name', ''))
-        write_output("Version: %s", dist.get('version', ''))
-        write_output("Summary: %s", dist.get('summary', ''))
-        write_output("Home-page: %s", dist.get('home-page', ''))
-        write_output("Author: %s", dist.get('author', ''))
-        write_output("Author-email: %s", dist.get('author-email', ''))
-        write_output("License: %s", dist.get('license', ''))
-        write_output("Location: %s", dist.get('location', ''))
-        write_output("Requires: %s", ', '.join(dist.get('requires', [])))
-        write_output("Required-by: %s", ', '.join(dist.get('required_by', [])))
+        write_output("Name: {}", dist.get('name', ''))
+        write_output("Version: {}", dist.get('version', ''))
+        write_output("Summary: {}", dist.get('summary', ''))
+        write_output("Home-page: {}", dist.get('home-page', ''))
+        write_output("Author: {}", dist.get('author', ''))
+        write_output("Author-email: {}", dist.get('author-email', ''))
+        write_output("License: {}", dist.get('license', ''))
+        write_output("Location: {}", dist.get('location', ''))
+        write_output("Requires: {}", ', '.join(dist.get('requires', [])))
+        write_output("Required-by: {}", ', '.join(dist.get('required_by', [])))
 
         if verbose:
-            write_output("Metadata-Version: %s",
+            write_output("Metadata-Version: {}",
                          dist.get('metadata-version', ''))
-            write_output("Installer: %s", dist.get('installer', ''))
+            write_output("Installer: {}", dist.get('installer', ''))
             write_output("Classifiers:")
             for classifier in dist.get('classifiers', []):
-                write_output("  %s", classifier)
+                write_output("  {}", classifier)
             write_output("Entry-points:")
             for entry in dist.get('entry_points', []):
-                write_output("  %s", entry.strip())
+                write_output("  {}", entry.strip())
         if list_files:
             write_output("Files:")
             for line in dist.get('files', []):
-                write_output("  %s", line.strip())
+                write_output("  {}", line.strip())
             if "files" not in dist:
                 write_output("Cannot locate installed-files.txt")
     return results_printed

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -176,7 +176,7 @@ class WheelCommand(RequirementCommand):
                 shutil.copy(req.local_file_path, options.wheel_dir)
             except OSError as e:
                 logger.warning(
-                    "Building wheel for %s failed: %s",
+                    "Building wheel for {} failed: {}",
                     req.name, e,
                 )
                 build_failures.append(req)

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -244,7 +244,7 @@ class Configuration(object):
         self._ensure_have_load_only()
 
         for fname, parser in self._modified_parsers:
-            logger.info("Writing to %s", fname)
+            logger.info("Writing to {}", fname)
 
             # Ensure directory exists.
             ensure_dir(os.path.dirname(fname))
@@ -260,7 +260,7 @@ class Configuration(object):
         # type: () -> None
         if self.load_only is None:
             raise ConfigurationError("Needed a specific file to be modifying.")
-        logger.debug("Will be working with %s variant only", self.load_only)
+        logger.debug("Will be working with {} variant only", self.load_only)
 
     @property
     def _dictionary(self):
@@ -294,7 +294,7 @@ class Configuration(object):
                 # that variant, not the others.
                 if self.load_only is not None and variant != self.load_only:
                     logger.debug(
-                        "Skipping file '%s' (variant: %s)", fname, variant
+                        "Skipping file '{}' (variant: {})", fname, variant
                     )
                     continue
 
@@ -305,7 +305,7 @@ class Configuration(object):
 
     def _load_file(self, variant, fname):
         # type: (Kind, str) -> RawConfigParser
-        logger.debug("For variant '%s', will try loading '%s'", variant, fname)
+        logger.debug("For variant '{}', will try loading '{}'", variant, fname)
         parser = self._construct_parser(fname)
 
         for section in parser.sections():

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -75,12 +75,12 @@ class SourceDistribution(AbstractDistribution):
                              conflicting)
         if missing:
             logger.warning(
-                "Missing build requirements in pyproject.toml for %s.",
+                "Missing build requirements in pyproject.toml for {}.",
                 self.req,
             )
             logger.warning(
                 "The project does not specify a build backend, and "
-                "pip cannot fall back to setuptools without %s.",
+                "pip cannot fall back to setuptools without {}.",
                 " and ".join(map(repr, sorted(missing)))
             )
         # Install any extra build dependencies that the backend requests.

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -144,7 +144,7 @@ def _get_html_response(url, session):
     if _is_url_like_archive(url):
         _ensure_html_response(url, session=session)
 
-    logger.debug('Getting page %s', redact_auth_from_url(url))
+    logger.debug('Getting page {}', redact_auth_from_url(url))
 
     resp = session.get(
         url,
@@ -409,7 +409,7 @@ def _handle_get_page_fail(
     # type: (...) -> None
     if meth is None:
         meth = logger.debug
-    meth("Could not fetch URL %s: %s - skipping", link, reason)
+    meth("Could not fetch URL {}: {} - skipping", link, reason)
 
 
 def _make_html_page(response, cache_link_parsing=True):
@@ -434,7 +434,7 @@ def _get_html_page(link, session=None):
     # Check for VCS schemes that do not support lookup as web pages.
     vcs_scheme = _match_vcs_scheme(url)
     if vcs_scheme:
-        logger.debug('Cannot look at %s URL %s', vcs_scheme, link)
+        logger.debug('Cannot look at {} URL {}', vcs_scheme, link)
         return None
 
     # Tack index.html onto file:// URLs that point to directories
@@ -445,18 +445,18 @@ def _get_html_page(link, session=None):
         if not url.endswith('/'):
             url += '/'
         url = urllib_parse.urljoin(url, 'index.html')
-        logger.debug(' file: URL is directory, getting %s', url)
+        logger.debug(' file: URL is directory, getting {}', url)
 
     try:
         resp = _get_html_response(url, session=session)
     except _NotHTTP:
         logger.debug(
-            'Skipping page %s because it looks like an archive, and cannot '
+            'Skipping page {} because it looks like an archive, and cannot '
             'be checked by HEAD.', link,
         )
     except _NotHTML as exc:
         logger.warning(
-            'Skipping page %s because the %s request got Content-Type: %s.'
+            'Skipping page {} because the {} request got Content-Type: {}.'
             'The only supported Content-Type is text/html',
             link, exc.request_desc, exc.content_type,
         )
@@ -525,13 +525,13 @@ def group_locations(locations, expand_dir=False):
                     urls.append(url)
                 else:
                     logger.warning(
-                        "Path '%s' is ignored: it is a directory.", path,
+                        "Path '{}' is ignored: it is a directory.", path,
                     )
             elif os.path.isfile(path):
                 sort_path(path)
             else:
                 logger.warning(
-                    "Url '%s' is ignored: it is neither a file "
+                    "Url '{}' is ignored: it is neither a file "
                     "nor a directory.", url,
                 )
         elif is_url(url):
@@ -539,7 +539,7 @@ def group_locations(locations, expand_dir=False):
             urls.append(url)
         else:
             logger.warning(
-                "Url '%s' is ignored. It is either a non-existing "
+                "Url '{}' is ignored. It is either a non-existing "
                 "path or lacks a specific scheme.", url,
             )
 

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -525,9 +525,7 @@ def group_locations(locations, expand_dir=False):
                     urls.append(url)
                 else:
                     logger.warning(
-                        "Path '{0}' is ignored: "
-                        "it is a directory.".format(path),
-                    )
+                        "Path '%s' is ignored: it is a directory.", path)
             elif os.path.isfile(path):
                 sort_path(path)
             else:

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -525,7 +525,8 @@ def group_locations(locations, expand_dir=False):
                     urls.append(url)
                 else:
                     logger.warning(
-                        "Path '%s' is ignored: it is a directory.", path)
+                        "Path '%s' is ignored: it is a directory.", path,
+                    )
             elif os.path.isfile(path):
                 sort_path(path)
             else:

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -79,7 +79,7 @@ def _check_link_requires_python(
         )
     except specifiers.InvalidSpecifier:
         logger.debug(
-            "Ignoring invalid Requires-Python (%r) for link: %s",
+            "Ignoring invalid Requires-Python ({!r}) for link: {}",
             link.requires_python, link,
         )
     else:
@@ -87,14 +87,14 @@ def _check_link_requires_python(
             version = '.'.join(map(str, version_info))
             if not ignore_requires_python:
                 logger.debug(
-                    'Link requires a different Python (%s not in: %r): %s',
+                    'Link requires a different Python ({} not in: {!r}): {}',
                     version, link.requires_python, link,
                 )
                 return False
 
             logger.debug(
-                'Ignoring failed Requires-Python check (%s not in: %r) '
-                'for link: %s',
+                'Ignoring failed Requires-Python check ({} not in: {!r}) '
+                'for link: {}',
                 version, link.requires_python, link,
             )
 
@@ -237,7 +237,7 @@ class LinkEvaluator(object):
             # _log_skipped_link().
             return (False, None)
 
-        logger.debug('Found link %s, version: %s', link, version)
+        logger.debug('Found link {}, version: {}', link, version)
 
         return (True, version)
 
@@ -265,7 +265,7 @@ def filter_unallowed_hashes(
     """
     if not hashes:
         logger.debug(
-            'Given no hashes to check %s links for project %r: '
+            'Given no hashes to check {} links for project {!r}: '
             'discarding no candidates',
             len(candidates),
             project_name,
@@ -304,8 +304,8 @@ def filter_unallowed_hashes(
         )
 
     logger.debug(
-        'Checked %s links for project %r against %s hashes '
-        '(%s matches, %s no digest): %s',
+        'Checked {} links for project {!r} against {} hashes '
+        '({} matches, {} no digest): {}',
         len(candidates),
         project_name,
         hashes.digest_count,
@@ -746,7 +746,7 @@ class PackageFinder(object):
             # the reason contains non-ascii characters.
             #   Also, put the link at the end so the reason is more visible
             # and because the link string is usually very long.
-            logger.debug(u'Skipping link: %s: %s', reason, link)
+            logger.debug(u'Skipping link: {}: {}', reason, link)
             self._logged_links.add(link)
 
     def get_install_candidate(self, link_evaluator, link):
@@ -785,7 +785,7 @@ class PackageFinder(object):
     def process_project_url(self, project_url, link_evaluator):
         # type: (Link, LinkEvaluator) -> List[InstallationCandidate]
         logger.debug(
-            'Fetching project page and analyzing links: %s', project_url,
+            'Fetching project page and analyzing links: {}', project_url,
         )
         html_page = self._link_collector.fetch_page(project_url)
         if html_page is None:
@@ -834,7 +834,7 @@ class PackageFinder(object):
         if file_versions:
             file_versions.sort(reverse=True)
             logger.debug(
-                'Local files found: %s',
+                'Local files found: {}',
                 ', '.join([
                     url_to_path(candidate.link.url)
                     for candidate in file_versions
@@ -917,8 +917,8 @@ class PackageFinder(object):
 
         if installed_version is None and best_candidate is None:
             logger.critical(
-                'Could not find a version that satisfies the requirement %s '
-                '(from versions: %s)',
+                'Could not find a version that satisfies the requirement {} '
+                '(from versions: {})',
                 req,
                 _format_versions(best_candidate_result.iter_all()),
             )
@@ -937,14 +937,14 @@ class PackageFinder(object):
         if not upgrade and installed_version is not None:
             if best_installed:
                 logger.debug(
-                    'Existing installed version (%s) is most up-to-date and '
+                    'Existing installed version ({}) is most up-to-date and '
                     'satisfies requirement',
                     installed_version,
                 )
             else:
                 logger.debug(
-                    'Existing installed version (%s) satisfies requirement '
-                    '(most up-to-date version is %s)',
+                    'Existing installed version ({}) satisfies requirement '
+                    '(most up-to-date version is {})',
                     installed_version,
                     best_candidate.version,
                 )
@@ -953,15 +953,15 @@ class PackageFinder(object):
         if best_installed:
             # We have an existing version, and its the best version
             logger.debug(
-                'Installed version (%s) is most up-to-date (past versions: '
-                '%s)',
+                'Installed version ({}) is most up-to-date (past versions: '
+                '{})',
                 installed_version,
                 _format_versions(best_candidate_result.iter_applicable()),
             )
             raise BestVersionAlreadyInstalled
 
         logger.debug(
-            'Using version %s (newest of versions: %s)',
+            'Using version {} (newest of versions: {})',
             best_candidate.version,
             _format_versions(best_candidate_result.iter_applicable()),
         )

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -95,8 +95,8 @@ class SearchScope(object):
                 # exceptions for malformed URLs
                 if not purl.scheme and not purl.netloc:
                     logger.warning(
-                        'The index url "{}" seems invalid, '
-                        'please provide a scheme.'.format(redacted_index_url))
+                        'The index url "%s" seems invalid, '
+                        'please provide a scheme.', redacted_index_url)
 
                 redacted_index_urls.append(redacted_index_url)
 

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -95,7 +95,7 @@ class SearchScope(object):
                 # exceptions for malformed URLs
                 if not purl.scheme and not purl.netloc:
                     logger.warning(
-                        'The index url "%s" seems invalid, '
+                        'The index url "{}" seems invalid, '
                         'please provide a scheme.', redacted_index_url)
 
                 redacted_index_urls.append(redacted_index_url)

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -36,7 +36,7 @@ except ImportError:
     keyring = None
 except Exception as exc:
     logger.warning(
-        "Keyring is skipped due to an exception: %s", str(exc),
+        "Keyring is skipped due to an exception: {}", str(exc),
     )
     keyring = None
 
@@ -53,21 +53,21 @@ def get_keyring_auth(url, username):
         except AttributeError:
             pass
         else:
-            logger.debug("Getting credentials from keyring for %s", url)
+            logger.debug("Getting credentials from keyring for {}", url)
             cred = get_credential(url, username)
             if cred is not None:
                 return cred.username, cred.password
             return None
 
         if username:
-            logger.debug("Getting password from keyring for %s", url)
+            logger.debug("Getting password from keyring for {}", url)
             password = keyring.get_password(url, username)
             if password:
                 return username, password
 
     except Exception as exc:
         logger.warning(
-            "Keyring is skipped due to an exception: %s", str(exc),
+            "Keyring is skipped due to an exception: {}", str(exc),
         )
     return None
 
@@ -121,7 +121,7 @@ class MultiDomainBasicAuth(AuthBase):
         # Start with the credentials embedded in the url
         username, password = url_user_password
         if username is not None and password is not None:
-            logger.debug("Found credentials in url for %s", netloc)
+            logger.debug("Found credentials in url for {}", netloc)
             return url_user_password
 
         # Find a matching index url for this request
@@ -131,20 +131,20 @@ class MultiDomainBasicAuth(AuthBase):
             index_info = split_auth_netloc_from_url(index_url)
             if index_info:
                 index_url, _, index_url_user_password = index_info
-                logger.debug("Found index url %s", index_url)
+                logger.debug("Found index url {}", index_url)
 
         # If an index URL was found, try its embedded credentials
         if index_url and index_url_user_password[0] is not None:
             username, password = index_url_user_password
             if username is not None and password is not None:
-                logger.debug("Found credentials in index url for %s", netloc)
+                logger.debug("Found credentials in index url for {}", netloc)
                 return index_url_user_password
 
         # Get creds from netrc if we still don't have them
         if allow_netrc:
             netrc_auth = get_netrc_auth(original_url)
             if netrc_auth:
-                logger.debug("Found credentials in netrc for %s", netloc)
+                logger.debug("Found credentials in netrc for {}", netloc)
                 return netrc_auth
 
         # If we don't have a password and keyring is available, use it.
@@ -155,7 +155,7 @@ class MultiDomainBasicAuth(AuthBase):
                 get_keyring_auth(netloc, username)
             )
             if kr_auth:
-                logger.debug("Found credentials in keyring for %s", netloc)
+                logger.debug("Found credentials in keyring for {}", netloc)
                 return kr_auth
 
         return username, password
@@ -288,7 +288,7 @@ class MultiDomainBasicAuth(AuthBase):
         """Response callback to warn about incorrect credentials."""
         if resp.status_code == 401:
             logger.warning(
-                '401 Error, Credentials not correct for %s', resp.request.url,
+                '401 Error, Credentials not correct for {}', resp.request.url,
             )
 
     def save_credentials(self, resp, **kwargs):

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -57,9 +57,9 @@ def _prepare_download(
         logged_url = '{} ({})'.format(logged_url, format_size(total_length))
 
     if is_from_cache(resp):
-        logger.info("Using cached %s", logged_url)
+        logger.info("Using cached {}", logged_url)
     else:
-        logger.info("Downloading %s", logged_url)
+        logger.info("Downloading {}", logged_url)
 
     if logger.getEffectiveLevel() > logging.INFO:
         show_progress = False
@@ -189,7 +189,7 @@ class Downloader(object):
             resp = _http_get_download(self._session, link)
         except requests.HTTPError as e:
             logger.critical(
-                "HTTP error %s while getting %s", e.response.status_code, link
+                "HTTP error {} while getting {}", e.response.status_code, link
             )
             raise
 

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -403,10 +403,10 @@ class PipSession(requests.Session):
         # will not accept it as a valid location to search. We will however
         # log a warning that we are ignoring it.
         logger.warning(
-            "The repository located at %s is not a trusted or secure host and "
+            "The repository located at {} is not a trusted or secure host and "
             "is being ignored. If this repository is available via HTTPS we "
             "recommend you use HTTPS instead, otherwise you may silence "
-            "this warning and allow it anyway with '--trusted-host %s'.",
+            "this warning and allow it anyway with '--trusted-host {}'.",
             origin_host,
             origin_host,
         )

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -43,7 +43,7 @@ class PipXmlrpcTransport(xmlrpc_client.Transport):
             return self.parse_response(response.raw)
         except requests.HTTPError as exc:
             logger.critical(
-                "HTTP error %s while getting %s",
+                "HTTP error {} while getting {}",
                 exc.response.status_code, url,
             )
             raise

--- a/src/pip/_internal/operations/build/metadata.py
+++ b/src/pip/_internal/operations/build/metadata.py
@@ -1,7 +1,6 @@
 """Metadata generation logic for source distributions.
 """
 
-import logging
 import os
 
 from pip._internal.utils.subprocess import runner_with_spinner_message
@@ -11,8 +10,6 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 if MYPY_CHECK_RUNNING:
     from pip._internal.build_env import BuildEnvironment
     from pip._vendor.pep517.wrappers import Pep517HookCaller
-
-logger = logging.getLogger(__name__)
 
 
 def generate_metadata(build_env, backend):

--- a/src/pip/_internal/operations/build/metadata_legacy.py
+++ b/src/pip/_internal/operations/build/metadata_legacy.py
@@ -52,7 +52,7 @@ def generate_metadata(
     Returns the generated metadata directory.
     """
     logger.debug(
-        'Running setup.py (path:%s) egg_info for package %s',
+        'Running setup.py (path:{}) egg_info for package {}',
         setup_py_path, details,
     )
 

--- a/src/pip/_internal/operations/build/wheel.py
+++ b/src/pip/_internal/operations/build/wheel.py
@@ -27,7 +27,7 @@ def build_wheel_pep517(
     if build_options:
         # PEP 517 does not support --build-options
         logger.error('Cannot build wheel for %s using PEP 517 when '
-                     '--build-option is present' % (name,))
+                     '--build-option is present', name)
         return None
     try:
         logger.debug('Destination directory: %s', tempd)

--- a/src/pip/_internal/operations/build/wheel.py
+++ b/src/pip/_internal/operations/build/wheel.py
@@ -26,11 +26,11 @@ def build_wheel_pep517(
     assert metadata_directory is not None
     if build_options:
         # PEP 517 does not support --build-options
-        logger.error('Cannot build wheel for %s using PEP 517 when '
+        logger.error('Cannot build wheel for {} using PEP 517 when '
                      '--build-option is present', name)
         return None
     try:
-        logger.debug('Destination directory: %s', tempd)
+        logger.debug('Destination directory: {}', tempd)
 
         runner = runner_with_spinner_message(
             'Building wheel for {} (PEP 517)'.format(name)
@@ -41,6 +41,6 @@ def build_wheel_pep517(
                 metadata_directory=metadata_directory,
             )
     except Exception:
-        logger.error('Failed building wheel for %s', name)
+        logger.error('Failed building wheel for {}', name)
         return None
     return os.path.join(tempd, wheel_name)

--- a/src/pip/_internal/operations/build/wheel_legacy.py
+++ b/src/pip/_internal/operations/build/wheel_legacy.py
@@ -91,7 +91,7 @@ def build_wheel_legacy(
 
     spin_message = 'Building wheel for {} (setup.py)'.format(name)
     with open_spinner(spin_message) as spinner:
-        logger.debug('Destination directory: %s', tempd)
+        logger.debug('Destination directory: {}', tempd)
 
         try:
             output = call_subprocess(
@@ -101,7 +101,7 @@ def build_wheel_legacy(
             )
         except Exception:
             spinner.finish("error")
-            logger.error('Failed building wheel for %s', name)
+            logger.error('Failed building wheel for {}', name)
             return None
 
         names = os.listdir(tempd)

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -53,7 +53,7 @@ def create_package_set_from_installed(**kwargs):
             package_set[name] = PackageDetails(dist.version, dist.requires())
         except RequirementParseError as e:
             # Don't crash on broken metadata
-            logger.warning("Error parsing requirements for %s: %s", name, e)
+            logger.warning("Error parsing requirements for {}: {}", name, e)
             problems = True
     return package_set, problems
 

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -72,7 +72,7 @@ def freeze(
             # location. We also include the exception message to aid
             # troubleshooting.
             logger.warning(
-                'Could not generate requirement for distribution %r: %s',
+                'Could not generate requirement for distribution {!r}: {}',
                 dist, exc
             )
             continue
@@ -126,8 +126,8 @@ def freeze(
 
                     if not line_req.name:
                         logger.info(
-                            "Skipping line in requirement file [%s] because "
-                            "it's not clear what it would install: %s",
+                            "Skipping line in requirement file [{}] because "
+                            "it's not clear what it would install: {}",
                             req_file_path, line.strip(),
                         )
                         logger.info(
@@ -142,8 +142,8 @@ def freeze(
                             # but has been processed already
                             if not req_files[line_req.name]:
                                 logger.warning(
-                                    "Requirement file [%s] contains %s, but "
-                                    "package %r is not installed",
+                                    "Requirement file [{}] contains {}, but "
+                                    "package {!r} is not installed",
                                     req_file_path,
                                     COMMENT_RE.sub('', line).strip(),
                                     line_req.name
@@ -160,7 +160,7 @@ def freeze(
         # single requirements file or in different requirements files).
         for name, files in six.iteritems(req_files):
             if len(files) > 1:
-                logger.warning("Requirement %s included multiple times [%s]",
+                logger.warning("Requirement {} included multiple times [{}]",
                                name, ', '.join(sorted(set(files))))
 
         yield(
@@ -190,7 +190,7 @@ def get_requirement_info(dist):
     if vcs_backend is None:
         req = dist.as_requirement()
         logger.debug(
-            'No VCS found for editable requirement "%s" in: %r', req,
+            'No VCS found for editable requirement "{}" in: {!r}', req,
             location,
         )
         comments = [
@@ -211,8 +211,8 @@ def get_requirement_info(dist):
 
     except BadCommand:
         logger.warning(
-            'cannot determine version of editable source in %s '
-            '(%s command not found in path)',
+            'cannot determine version of editable source in {} '
+            '({} command not found in path)',
             location,
             vcs_backend.name,
         )
@@ -220,7 +220,7 @@ def get_requirement_info(dist):
 
     except InstallationError as exc:
         logger.warning(
-            "Error when trying to get requirement for VCS system %s, "
+            "Error when trying to get requirement for VCS system {}, "
             "falling back to uneditable format", exc
         )
     else:
@@ -228,7 +228,7 @@ def get_requirement_info(dist):
             return (req, True, [])
 
     logger.warning(
-        'Could not determine repository location of %s', location
+        'Could not determine repository location of {}', location
     )
     comments = ['## !! Could not determine repository location']
 

--- a/src/pip/_internal/operations/install/editable_legacy.py
+++ b/src/pip/_internal/operations/install/editable_legacy.py
@@ -32,7 +32,7 @@ def install_editable(
     """Install a package in editable mode. Most arguments are pass-through
     to setuptools.
     """
-    logger.info('Running setup.py develop for %s', name)
+    logger.info('Running setup.py develop for {}', name)
 
     args = make_setuptools_develop_args(
         setup_py_path,

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -77,7 +77,7 @@ def install(
                 )
 
             if not os.path.exists(record_filename):
-                logger.debug('Record file %s not found', record_filename)
+                logger.debug('Record file {} not found', record_filename)
                 # Signal to the caller that we didn't install the new package
                 return False
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -292,9 +292,7 @@ def get_csv_rows_for_installed(
     installed_rows = []  # type: List[InstalledCSVRow]
     for row in old_csv_rows:
         if len(row) > 3:
-            logger.warning(
-                'RECORD line has more than three elements: {}'.format(row)
-            )
+            logger.warning('RECORD line has more than three elements: %s', row)
         old_record_path = _parse_record_path(row[0])
         new_record_path = installed.pop(old_record_path, old_record_path)
         if new_record_path in changed:

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -292,7 +292,7 @@ def get_csv_rows_for_installed(
     installed_rows = []  # type: List[InstalledCSVRow]
     for row in old_csv_rows:
         if len(row) > 3:
-            logger.warning('RECORD line has more than three elements: %s', row)
+            logger.warning('RECORD line has more than three elements: {}', row)
         old_record_path = _parse_record_path(row[0])
         new_record_path = installed.pop(old_record_path, old_record_path)
         if new_record_path in changed:

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -147,7 +147,7 @@ def _copy2_ignoring_special_files(src, dest):
         # care, but since the destination directory is deleted prior to
         # copy we ignore all of them assuming it is caused by the source.
         logger.warning(
-            "Ignoring special file error '%s' encountered copying %s to %s.",
+            "Ignoring special file error '{}' encountered copying {} to {}.",
             str(e),
             path_to_display(src),
             path_to_display(dest),
@@ -298,13 +298,13 @@ def _check_download_dir(link, download_dir, hashes):
         return None
 
     # If already downloaded, does its hash match?
-    logger.info('File was already downloaded %s', download_path)
+    logger.info('File was already downloaded {}', download_path)
     if hashes:
         try:
             hashes.check_against_path(download_path)
         except HashMismatch:
             logger.warning(
-                'Previously-downloaded file %s has bad hash. '
+                'Previously-downloaded file {} has bad hash. '
                 'Re-downloading.',
                 download_path
             )
@@ -390,9 +390,9 @@ class RequirementPreparer(object):
         # TODO: Breakup into smaller functions
         if link.scheme == 'file':
             path = link.file_path
-            logger.info('Processing %s', display_path(path))
+            logger.info('Processing {}', display_path(path))
         else:
-            logger.info('Collecting %s', req.req or req)
+            logger.info('Collecting {}', req.req or req)
 
         download_dir = self.download_dir
         if link.is_wheel and self.wheel_download_dir:
@@ -475,7 +475,7 @@ class RequirementPreparer(object):
                 )
             except requests.HTTPError as exc:
                 logger.critical(
-                    'Could not install requirement %s because of error %s',
+                    'Could not install requirement {} because of error {}',
                     req,
                     exc,
                 )
@@ -503,7 +503,7 @@ class RequirementPreparer(object):
                     if not os.path.exists(download_location):
                         shutil.copy(local_file.path, download_location)
                         logger.info(
-                            'Saved %s', display_path(download_location)
+                            'Saved {}', display_path(download_location)
                         )
 
             if self._download_should_save:
@@ -521,7 +521,7 @@ class RequirementPreparer(object):
         """
         assert req.editable, "cannot prepare a non-editable req as editable"
 
-        logger.info('Obtaining %s', req)
+        logger.info('Obtaining {}', req)
 
         with indent_log():
             if self.require_hashes:
@@ -557,7 +557,7 @@ class RequirementPreparer(object):
             "is set to {}".format(req.satisfied_by)
         )
         logger.info(
-            'Requirement %s: %s (%s)',
+            'Requirement {}: {} ({})',
             skip_reason, req, req.satisfied_by.version
         )
         with indent_log():

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -53,7 +53,7 @@ def install_given_reqs(
 
     if to_install:
         logger.info(
-            'Installing collected packages: %s',
+            'Installing collected packages: {}',
             ', '.join([req.name for req in to_install]),
         )
 
@@ -62,7 +62,7 @@ def install_given_reqs(
     with indent_log():
         for requirement in to_install:
             if requirement.should_reinstall:
-                logger.info('Attempting uninstall: %s', requirement.name)
+                logger.info('Attempting uninstall: {}', requirement.name)
                 with indent_log():
                     uninstalled_pathset = requirement.uninstall(
                         auto_confirm=True

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -172,8 +172,8 @@ def deduce_helpful_msg(req):
                     " the packages specified within it."
                 ).format(req)
         except RequirementParseError:
-            logger.debug("Cannot parse '{}' as requirements \
-            file".format(req), exc_info=True)
+            logger.debug("Cannot parse '%s' as requirements file",
+                         req, exc_info=True)
     else:
         msg += " File '{}' does not exist.".format(req)
     return msg

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -172,8 +172,9 @@ def deduce_helpful_msg(req):
                     " the packages specified within it."
                 ).format(req)
         except RequirementParseError:
-            logger.debug("Cannot parse '%s' as requirements file",
-                         req, exc_info=True)
+            logger.debug(
+                "Cannot parse '%s' as requirements file", req, exc_info=True
+            )
     else:
         msg += " File '{}' does not exist.".format(req)
     return msg

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -173,7 +173,7 @@ def deduce_helpful_msg(req):
                 ).format(req)
         except RequirementParseError:
             logger.debug(
-                "Cannot parse '%s' as requirements file", req, exc_info=True
+                "Cannot parse '{}' as requirements file", req, exc_info=True
             )
     else:
         msg += " File '{}' does not exist.".format(req)
@@ -288,7 +288,7 @@ def _get_url_from_path(path, name):
         # like a path, try to treat it as a PEP 440 URL req instead.
         return None
     logger.warning(
-        'Requirement %r looks like a filename, but the '
+        'Requirement {!r} looks like a filename, but the '
         'file does not exist',
         name
     )

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -365,7 +365,7 @@ class InstallRequirement(object):
         # FIXME: Is there a better place to create the build_dir? (hg and bzr
         # need this)
         if not os.path.exists(build_dir):
-            logger.debug('Creating directory %s', build_dir)
+            logger.debug('Creating directory {}', build_dir)
             os.makedirs(build_dir)
         actual_build_dir = os.path.join(build_dir, dir_name)
         # `None` indicates that we respect the globally-configured deletion
@@ -409,9 +409,9 @@ class InstallRequirement(object):
 
         # If we're here, there's a mismatch. Log a warning about it.
         logger.warning(
-            'Generating metadata for package %s '
-            'produced metadata for project name %s. Fix your '
-            '#egg=%s fragments.',
+            'Generating metadata for package {} '
+            'produced metadata for project name {}. Fix your '
+            '#egg={} fragments.',
             self.name, metadata_name, self.name
         )
         self.req = Requirement(metadata_name)
@@ -579,13 +579,13 @@ class InstallRequirement(object):
         version = self.metadata['version']
         if self.req.specifier and version not in self.req.specifier:
             logger.warning(
-                'Requested %s, but installing version %s',
+                'Requested {}, but installing version {}',
                 self,
                 version,
             )
         else:
             logger.debug(
-                'Source in %s has version %s, which satisfies requirement %s',
+                'Source in {} has version {}, which satisfies requirement {}',
                 display_path(self.source_dir),
                 version,
                 self,
@@ -620,7 +620,7 @@ class InstallRequirement(object):
         # type: (bool) -> None
         if not self.link:
             logger.debug(
-                "Cannot update repository at %s; repository location is "
+                "Cannot update repository at {}; repository location is "
                 "unknown",
                 self.source_dir,
             )
@@ -678,10 +678,10 @@ class InstallRequirement(object):
         try:
             dist = pkg_resources.get_distribution(self.req.name)
         except pkg_resources.DistributionNotFound:
-            logger.warning("Skipping %s as it is not installed.", self.name)
+            logger.warning("Skipping {} as it is not installed.", self.name)
             return None
         else:
-            logger.info('Found existing installation: %s', dist)
+            logger.info('Found existing installation: {}', dist)
 
         uninstalled_pathset = UninstallPathSet.from_dist(dist)
         uninstalled_pathset.remove(auto_confirm, verbose)
@@ -725,12 +725,12 @@ class InstallRequirement(object):
             if response == 'i':
                 create_archive = False
             elif response == 'w':
-                logger.warning('Deleting %s', display_path(archive_path))
+                logger.warning('Deleting {}', display_path(archive_path))
                 os.remove(archive_path)
             elif response == 'b':
                 dest_file = backup_dir(archive_path)
                 logger.warning(
-                    'Backing up %s to %s',
+                    'Backing up {} to {}',
                     display_path(archive_path),
                     display_path(dest_file),
                 )
@@ -763,7 +763,7 @@ class InstallRequirement(object):
                     filename = os.path.join(dirpath, filename)
                     zip_output.write(filename, file_arcname)
 
-        logger.info('Saved %s', display_path(archive_path))
+        logger.info('Saved {}', display_path(archive_path))
 
     def install(
         self,

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -88,7 +88,7 @@ class RequirementSet(object):
         # If the markers do not match, ignore this requirement.
         if not install_req.match_markers(extras_requested):
             logger.info(
-                "Ignoring %s: markers '%s' don't match your environment",
+                "Ignoring {}: markers '{}' don't match your environment",
                 install_req.name, install_req.markers,
             )
             return [], None
@@ -169,7 +169,7 @@ class RequirementSet(object):
             set(existing_req.extras) | set(install_req.extras)
         ))
         logger.debug(
-            "Setting %s extras to: %s",
+            "Setting {} extras to: {}",
             existing_req, existing_req.extras,
         )
         # Return the existing requirement for addition to the parent and

--- a/src/pip/_internal/req/req_tracker.py
+++ b/src/pip/_internal/req/req_tracker.py
@@ -57,7 +57,7 @@ def get_requirement_tracker():
                 TempDirectory(kind='req-tracker')
             ).path
             ctx.enter_context(update_env_context_manager(PIP_REQ_TRACKER=root))
-            logger.debug("Initialized build tracking at %s", root)
+            logger.debug("Initialized build tracking at {}", root)
 
         with RequirementTracker(root) as tracker:
             yield tracker
@@ -69,11 +69,11 @@ class RequirementTracker(object):
         # type: (str) -> None
         self._root = root
         self._entries = set()  # type: Set[InstallRequirement]
-        logger.debug("Created build tracker: %s", self._root)
+        logger.debug("Created build tracker: {}", self._root)
 
     def __enter__(self):
         # type: () -> RequirementTracker
-        logger.debug("Entered build tracker: %s", self._root)
+        logger.debug("Entered build tracker: {}", self._root)
         return self
 
     def __exit__(
@@ -121,7 +121,7 @@ class RequirementTracker(object):
             fp.write(str(req))
         self._entries.add(req)
 
-        logger.debug('Added %s to build tracker %r', req, self._root)
+        logger.debug('Added {} to build tracker {!r}', req, self._root)
 
     def remove(self, req):
         # type: (InstallRequirement) -> None
@@ -133,14 +133,14 @@ class RequirementTracker(object):
         os.unlink(self._entry_path(req.link))
         self._entries.remove(req)
 
-        logger.debug('Removed %s from build tracker %r', req, self._root)
+        logger.debug('Removed {} from build tracker {!r}', req, self._root)
 
     def cleanup(self):
         # type: () -> None
         for req in set(self._entries):
             self.remove(req)
 
-        logger.debug("Removed build tracker: %r", self._root)
+        logger.debug("Removed build tracker: {!r}", self._root)
 
     @contextlib.contextmanager
     def track(self, req):

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -612,7 +612,8 @@ class UninstallPthEntries(object):
         # If the file doesn't exist, log a warning and return
         if not os.path.isfile(self.file):
             logger.warning(
-                "Cannot remove entries from nonexistent file %s", self.file)
+                "Cannot remove entries from nonexistent file %s", self.file
+            )
             return
         with open(self.file, 'rb') as fh:
             # windows uses '\r\n' with py3k, but uses '\n' with py2.x

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -612,9 +612,7 @@ class UninstallPthEntries(object):
         # If the file doesn't exist, log a warning and return
         if not os.path.isfile(self.file):
             logger.warning(
-                "Cannot remove entries from nonexistent file {}".format(
-                    self.file)
-            )
+                "Cannot remove entries from nonexistent file %s", self.file)
             return
         with open(self.file, 'rb') as fh:
             # windows uses '\r\n' with py3k, but uses '\n' with py2.x

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -295,19 +295,19 @@ class StashedUninstallPathSet(object):
         # type: () -> None
         """Undoes the uninstall by moving stashed files back."""
         for p in self._moves:
-            logger.info("Moving to %s\n from %s", *p)
+            logger.info("Moving to {}\n from {}", *p)
 
         for new_path, path in self._moves:
             try:
-                logger.debug('Replacing %s from %s', new_path, path)
+                logger.debug('Replacing {} from {}', new_path, path)
                 if os.path.isfile(new_path) or os.path.islink(new_path):
                     os.unlink(new_path)
                 elif os.path.isdir(new_path):
                     rmtree(new_path)
                 renames(path, new_path)
             except OSError as ex:
-                logger.error("Failed to restore %s", new_path)
-                logger.debug("Exception: %s", ex)
+                logger.error("Failed to restore {}", new_path)
+                logger.debug("Exception: {}", ex)
 
         self.commit()
 
@@ -374,7 +374,7 @@ class UninstallPathSet(object):
 
         if not self.paths:
             logger.info(
-                "Can't uninstall '%s'. No files were found to uninstall.",
+                "Can't uninstall '{}'. No files were found to uninstall.",
                 self.dist.project_name,
             )
             return
@@ -382,7 +382,7 @@ class UninstallPathSet(object):
         dist_name_version = (
             self.dist.project_name + "-" + self.dist.version
         )
-        logger.info('Uninstalling %s:', dist_name_version)
+        logger.info('Uninstalling {}:', dist_name_version)
 
         with indent_log():
             if auto_confirm or self._allowed_to_proceed(verbose):
@@ -392,12 +392,12 @@ class UninstallPathSet(object):
 
                 for path in sorted(compact(for_rename)):
                     moved.stash(path)
-                    logger.debug('Removing file or directory %s', path)
+                    logger.debug('Removing file or directory {}', path)
 
                 for pth in self.pth.values():
                     pth.remove()
 
-                logger.info('Successfully uninstalled %s', dist_name_version)
+                logger.info('Successfully uninstalled {}', dist_name_version)
 
     def _allowed_to_proceed(self, verbose):
         # type: (bool) -> bool
@@ -435,11 +435,11 @@ class UninstallPathSet(object):
         """Rollback the changes previously made by remove()."""
         if not self._moved_paths.can_rollback:
             logger.error(
-                "Can't roll back %s; was not uninstalled",
+                "Can't roll back {}; was not uninstalled",
                 self.dist.project_name,
             )
             return
-        logger.info('Rolling back uninstall of %s', self.dist.project_name)
+        logger.info('Rolling back uninstall of {}', self.dist.project_name)
         self._moved_paths.rollback()
         for pth in self.pth.values():
             pth.rollback()
@@ -455,7 +455,7 @@ class UninstallPathSet(object):
         dist_path = normalize_path(dist.location)
         if not dist_is_local(dist):
             logger.info(
-                "Not uninstalling %s at %s, outside environment %s",
+                "Not uninstalling {} at {}, outside environment {}",
                 dist.key,
                 dist_path,
                 sys.prefix,
@@ -466,7 +466,7 @@ class UninstallPathSet(object):
                                      sysconfig.get_path("platstdlib")}
                          if p}:
             logger.info(
-                "Not uninstalling %s at %s, as it is in the standard library.",
+                "Not uninstalling {} at {}, as it is in the standard library.",
                 dist.key,
                 dist_path,
             )
@@ -551,7 +551,7 @@ class UninstallPathSet(object):
 
         else:
             logger.debug(
-                'Not sure how to uninstall: %s - Check: %s',
+                'Not sure how to uninstall: {} - Check: {}',
                 dist, dist.location,
             )
 
@@ -607,12 +607,12 @@ class UninstallPthEntries(object):
 
     def remove(self):
         # type: () -> None
-        logger.debug('Removing pth entries from %s:', self.file)
+        logger.debug('Removing pth entries from {}:', self.file)
 
         # If the file doesn't exist, log a warning and return
         if not os.path.isfile(self.file):
             logger.warning(
-                "Cannot remove entries from nonexistent file %s", self.file
+                "Cannot remove entries from nonexistent file {}", self.file
             )
             return
         with open(self.file, 'rb') as fh:
@@ -628,7 +628,7 @@ class UninstallPthEntries(object):
             lines[-1] = lines[-1] + endline.encode("utf-8")
         for entry in self.entries:
             try:
-                logger.debug('Removing entry: %s', entry)
+                logger.debug('Removing entry: {}', entry)
                 lines.remove((entry + endline).encode("utf-8"))
             except ValueError:
                 pass
@@ -639,10 +639,10 @@ class UninstallPthEntries(object):
         # type: () -> bool
         if self._saved_lines is None:
             logger.error(
-                'Cannot roll back changes to %s, none were made', self.file
+                'Cannot roll back changes to {}, none were made', self.file
             )
             return False
-        logger.debug('Rolling %s back to previous state', self.file)
+        logger.debug('Rolling {} back to previous state', self.file)
         with open(self.file, 'wb') as fh:
             fh.writelines(self._saved_lines)
         return True

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -271,16 +271,13 @@ class Resolver(BaseResolver):
         # Log a warning per PEP 592 if necessary before returning.
         link = best_candidate.link
         if link.is_yanked:
-            reason = link.yanked_reason or '<none given>'
-            msg = (
-                # Mark this as a unicode string to prevent
-                # "UnicodeEncodeError: 'ascii' codec can't encode character"
-                # in Python 2 when the reason contains non-ascii characters.
+            # Mark this as a unicode string to prevent
+            # "UnicodeEncodeError: 'ascii' codec can't encode character"
+            # in Python 2 when the reason contains non-ascii characters.
+            logger.warning(
                 u'The candidate selected for download or install is a '
-                'yanked version: {candidate}\n'
-                'Reason for being yanked: {reason}'
-            ).format(candidate=best_candidate, reason=reason)
-            logger.warning(msg)
+                'yanked version: {}\nReason for being yanked: {}',
+                best_candidate, link.yanked_reason or '<none given>')
 
         return link
 

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -81,7 +81,7 @@ def _check_dist_requires_python(
         )
     except specifiers.InvalidSpecifier as exc:
         logger.warning(
-            "Package %r has an invalid Requires-Python: %s",
+            "Package {!r} has an invalid Requires-Python: {}",
             dist.project_name, exc,
         )
         return
@@ -92,8 +92,8 @@ def _check_dist_requires_python(
     version = '.'.join(map(str, version_info))
     if ignore_requires_python:
         logger.debug(
-            'Ignoring failed Requires-Python check for package %r: '
-            '%s not in %r',
+            'Ignoring failed Requires-Python check for package {!r}: '
+            '{} not in {!r}',
             dist.project_name, version, requires_python,
         )
         return
@@ -309,7 +309,7 @@ class Resolver(BaseResolver):
             supported_tags=get_supported(),
         )
         if cache_entry is not None:
-            logger.debug('Using cached wheel link: %s', cache_entry.link)
+            logger.debug('Using cached wheel link: {}', cache_entry.link)
             if req.link is req.original_link and cache_entry.persistent:
                 req.original_link_is_in_wheel_cache = True
             req.link = cache_entry.link
@@ -359,7 +359,7 @@ class Resolver(BaseResolver):
             else:
                 logger.info(
                     'Requirement already satisfied (use --upgrade to upgrade):'
-                    ' %s', req,
+                    ' {}', req,
                 )
 
         return abstract_dist
@@ -427,7 +427,7 @@ class Resolver(BaseResolver):
             if not self.ignore_dependencies:
                 if req_to_install.extras:
                     logger.debug(
-                        "Installing extra requirements: %r",
+                        "Installing extra requirements: {!r}",
                         ','.join(req_to_install.extras),
                     )
                 missing_requested = sorted(
@@ -435,7 +435,7 @@ class Resolver(BaseResolver):
                 )
                 for missing in missing_requested:
                     logger.warning(
-                        "%s does not provide the extra '%s'",
+                        "{} does not provide the extra '{}'",
                         dist, missing
                     )
 

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -435,7 +435,7 @@ class Resolver(BaseResolver):
                 )
                 for missing in missing_requested:
                     logger.warning(
-                        '%s does not provide the extra \'%s\'',
+                        "%s does not provide the extra '%s'",
                         dist, missing
                     )
 

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -230,9 +230,8 @@ class _InstallRequirementBackedCandidate(Candidate):
         try:
             spec = SpecifierSet(requires_python)
         except InvalidSpecifier as e:
-            logger.warning(
-                "Package %r has an invalid Requires-Python: %s", self.name, e,
-            )
+            logger.warning("Package {!r} has an invalid Requires-Python: {}",
+                           self.name, e)
             return None
         return spec
 
@@ -265,7 +264,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
         source_link = link
         cache_entry = factory.get_wheel_cache_entry(link, name)
         if cache_entry is not None:
-            logger.debug("Using cached wheel link: %s", cache_entry.link)
+            logger.debug("Using cached wheel link: {}", cache_entry.link)
             link = cache_entry.link
         ireq = make_install_req_from_link(link, template)
 
@@ -476,7 +475,7 @@ class ExtrasCandidate(Candidate):
         invalid_extras = self.extras.difference(self.base.dist.extras)
         for extra in sorted(invalid_extras):
             logger.warning(
-                "%s %s does not provide the extra '%s'",
+                "{} {} does not provide the extra '{}'",
                 self.base.name,
                 self.version,
                 extra

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -245,7 +245,7 @@ class Factory(object):
         # type: (InstallRequirement, Iterable[str]) -> Optional[Requirement]
         if not ireq.match_markers(requested_extras):
             logger.info(
-                "Ignoring %s: markers '%s' don't match your environment",
+                "Ignoring {}: markers '{}' don't match your environment",
                 ireq.name, ireq.markers,
             )
             return None
@@ -378,7 +378,7 @@ class Factory(object):
             else:
                 req_disp = '{} (from {})'.format(req, parent.name)
             logger.critical(
-                "Could not find a version that satisfies the requirement %s",
+                "Could not find a version that satisfies the requirement {}",
                 req_disp,
             )
             return DistributionNotFound(

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -373,13 +373,13 @@ class Factory(object):
         # satisfied. We just report that case.
         if len(e.causes) == 1:
             req, parent = e.causes[0]
+            if parent is None:
+                req_disp = str(req)
+            else:
+                req_disp = '{} (from {})'.format(req, parent.name)
             logger.critical(
-                "Could not find a version that satisfies " +
-                "the requirement " +
-                str(req) +
-                ("" if parent is None else " (from {})".format(
-                    parent.name
-                ))
+                "Could not find a version that satisfies the requirement %s",
+                req_disp,
             )
             return DistributionNotFound(
                 'No matching distribution found for {}'.format(req)

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -56,7 +56,7 @@ def make_link_collector(
     index_urls = [options.index_url] + options.extra_index_urls
     if options.no_index and not suppress_no_index:
         logger.debug(
-            'Ignoring indexes: %s',
+            'Ignoring indexes: {}',
             ','.join(redact_auth_from_url(url) for url in index_urls),
         )
         index_urls = []
@@ -228,9 +228,9 @@ def pip_self_version_check(session, options):
         # `sys.executable`.
         pip_cmd = "{} -m pip".format(sys.executable)
         logger.warning(
-            "You are using pip version %s; however, version %s is "
+            "You are using pip version {}; however, version {} is "
             "available.\nYou should consider upgrading via the "
-            "'%s install --upgrade pip' command.",
+            "'{} install --upgrade pip' command.",
             pip_version, pypi_version, pip_cmd
         )
     except Exception:

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -122,7 +122,7 @@ def str_to_display(data, desc=None):
         decoded_data = data.decode(encoding)
     except UnicodeDecodeError:
         logger.warning(
-            '%s does not appear to be encoded as %s',
+            '{} does not appear to be encoded as {}',
             desc or 'Bytes object',
             encoding,
         )

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -121,8 +121,11 @@ def str_to_display(data, desc=None):
     try:
         decoded_data = data.decode(encoding)
     except UnicodeDecodeError:
-        logger.warning('%s does not appear to be encoded as %s',
-                       desc or 'Bytes object', encoding)
+        logger.warning(
+            '%s does not appear to be encoded as %s',
+            desc or 'Bytes object',
+            encoding,
+        )
         decoded_data = data.decode(encoding, errors=backslashreplace_decode)
 
     # Make sure we can print the output, by encoding it to the output

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -121,10 +121,8 @@ def str_to_display(data, desc=None):
     try:
         decoded_data = data.decode(encoding)
     except UnicodeDecodeError:
-        if desc is None:
-            desc = 'Bytes object'
-        msg_format = '{} does not appear to be encoded as %s'.format(desc)
-        logger.warning(msg_format, encoding)
+        logger.warning('%s does not appear to be encoded as %s',
+                       desc or 'Bytes object', encoding)
         decoded_data = data.decode(encoding, errors=backslashreplace_decode)
 
     # Make sure we can print the output, by encoding it to the output

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 
-import logging
 import re
 
 from pip._vendor.packaging.tags import (
@@ -22,8 +21,6 @@ if MYPY_CHECK_RUNNING:
     from typing import List, Optional, Tuple
 
     from pip._vendor.packaging.tags import PythonVersion
-
-logger = logging.getLogger(__name__)
 
 _osx_arch_pat = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
 

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -40,7 +40,7 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
         # We use a specially named logger which will handle all of the
         # deprecation messages for pip.
         logger = logging.getLogger("pip._internal.deprecations")
-        logger.warning(str(message))
+        logger.warning(message)
     else:
         _original_showwarning(
             message, category, filename, lineno, file, line,

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -40,7 +40,7 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
         # We use a specially named logger which will handle all of the
         # deprecation messages for pip.
         logger = logging.getLogger("pip._internal.deprecations")
-        logger.warning(message)
+        logger.warning(str(message))
     else:
         _original_showwarning(
             message, category, filename, lineno, file, line,

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -122,7 +122,7 @@ def dist_get_direct_url(dist):
         UnicodeDecodeError
     ) as e:
         logger.warning(
-            "Error parsing %s for %s: %s",
+            "Error parsing {} for {}: {}",
             DIRECT_URL_METADATA_NAME,
             dist.project_name,
             e,

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -68,14 +68,18 @@ class LogMessage:
 
 
 class FormatLogger(logging.Logger):
-    """Logger adapter that uses str.format for messages formatting."""
+    """Logger adapter that uses str.format for messages formatting.
+
+    Skip formatting if no varadic argument is passed to the methods.
+    """
     def __init__(self, name):
         # type: (str) -> None
         super(FormatLogger, self).__init__(name)
 
     def log(self, level, msg, *args, **kwargs):
         # type: (int, str, *Any, **Any) -> None
-        super(FormatLogger, self).log(level, LogMessage(msg, args), **kwargs)
+        message = LogMessage(msg, args) if args else msg
+        super(FormatLogger, self).log(level, message, **kwargs)
 
     def debug(self, msg, *args, **kwargs):
         # type: (str, *Any, **Any) -> None
@@ -104,8 +108,8 @@ class FormatLogger(logging.Logger):
 
 
 _log_state = threading.local()
-subprocess_logger = getLogger('pip.subprocessor')
 logging.setLoggerClass(FormatLogger)
+subprocess_logger = getLogger('pip.subprocessor')
 logger = getLogger(__name__)
 
 
@@ -454,6 +458,6 @@ def setup_logging(verbosity, no_color, user_log_file):
 
 
 def write_output(msg, *args):
-    # type: (str, str) -> None
+    # type: (str, *Any) -> None
     """Thread-safely log msg.format(*args)."""
     logger.info(msg, *args)

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -104,8 +104,9 @@ class FormatLogger(logging.Logger):
 
 
 _log_state = threading.local()
-logging.setLoggerClass(FormatLogger)
 subprocess_logger = getLogger('pip.subprocessor')
+logging.setLoggerClass(FormatLogger)
+logger = getLogger(__name__)
 
 
 class BrokenStdoutLoggingError(Exception):
@@ -450,3 +451,9 @@ def setup_logging(verbosity, no_color, user_log_file):
     })
 
     return level_number
+
+
+def write_output(msg, *args):
+    # type: (str, str) -> None
+    """Thread-safely log msg.format(*args)."""
+    logger.info(msg, *args)

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -11,7 +11,7 @@ import os
 import sys
 from logging import Filter, getLogger
 
-from pip._vendor.six import PY2
+from pip._vendor.six import PY2, python_2_unicode_compatible
 
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
@@ -55,6 +55,7 @@ else:
     colorama = _colorama
 
 
+@python_2_unicode_compatible
 class LogMessage:
     """Lazily interpolated log message formatted using str.format."""
     def __init__(self, message, args):

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -9,7 +9,6 @@ import errno
 import getpass
 import hashlib
 import io
-import logging
 import os
 import posixpath
 import shutil
@@ -527,13 +526,6 @@ def dist_location(dist):
     if egg_link:
         return normalize_path(egg_link)
     return normalize_path(dist.location)
-
-
-def write_output(msg, *args):
-    # type: (str, str) -> None
-    # Make sure utils.logging has set the logger class.
-    # We can't use import to do it because there're be circular import.
-    logging.getLogger(__name__).info(msg, *args)
 
 
 class FakeFile(object):

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -69,9 +69,6 @@ __all__ = ['rmtree', 'display_path', 'backup_dir',
            'get_installed_version', 'remove_auth_from_url']
 
 
-logger = logging.getLogger(__name__)
-
-
 def get_pip_version():
     # type: () -> str
     pip_pkg_dir = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -534,7 +531,9 @@ def dist_location(dist):
 
 def write_output(msg, *args):
     # type: (str, str) -> None
-    logger.info(msg, *args)
+    # Make sure utils.logging has set the logger class.
+    # We can't use import to do it because there're be circular import.
+    logging.getLogger(__name__).info(msg, *args)
 
 
 class FakeFile(object):

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -55,7 +55,7 @@ def get_metadata(dist):
         metadata_name = 'PKG-INFO'
         metadata = dist.get_metadata(metadata_name)
     else:
-        logger.warning("No metadata found in %s", display_path(dist.location))
+        logger.warning("No metadata found in {}", display_path(dist.location))
         metadata = ''
 
     if metadata is None:

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -240,10 +240,8 @@ def call_subprocess(
             ).format(proc.returncode, command_desc)
             raise InstallationError(exc_msg)
         elif on_returncode == 'warn':
-            subprocess_logger.warning(
-                'Command "{}" had error code {} in {}'.format(
-                    command_desc, proc.returncode, cwd)
-            )
+            subprocess_logger.warning('Command "%s" had error code %s in %s',
+                                      command_desc, proc.returncode, cwd)
         elif on_returncode == 'ignore':
             pass
         else:

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -175,7 +175,7 @@ def call_subprocess(
     if command_desc is None:
         command_desc = format_command_args(cmd)
 
-    log_subprocess("Running command %s", command_desc)
+    log_subprocess("Running command {}", command_desc)
     env = os.environ.copy()
     if extra_environ:
         env.update(extra_environ)
@@ -192,7 +192,7 @@ def call_subprocess(
     except Exception as exc:
         if log_failed_cmd:
             subprocess_logger.critical(
-                "Error %s while executing command %s", exc, command_desc,
+                "Error {} while executing command {}", exc, command_desc,
             )
         raise
     all_output = []
@@ -241,7 +241,7 @@ def call_subprocess(
             raise InstallationError(exc_msg)
         elif on_returncode == 'warn':
             subprocess_logger.warning(
-                'Command "%s" had error code %s in %s',
+                'Command "{}" had error code {} in {}',
                 command_desc,
                 proc.returncode,
                 cwd,

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -175,7 +175,7 @@ def call_subprocess(
     if command_desc is None:
         command_desc = format_command_args(cmd)
 
-    log_subprocess("Running command %s", command_desc)
+    log_subprocess("Running command {}", command_desc)
     env = os.environ.copy()
     if extra_environ:
         env.update(extra_environ)

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -175,7 +175,7 @@ def call_subprocess(
     if command_desc is None:
         command_desc = format_command_args(cmd)
 
-    log_subprocess("Running command {}", command_desc)
+    log_subprocess("Running command %s", command_desc)
     env = os.environ.copy()
     if extra_environ:
         env.update(extra_environ)

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -240,8 +240,12 @@ def call_subprocess(
             ).format(proc.returncode, command_desc)
             raise InstallationError(exc_msg)
         elif on_returncode == 'warn':
-            subprocess_logger.warning('Command "%s" had error code %s in %s',
-                                      command_desc, proc.returncode, cwd)
+            subprocess_logger.warning(
+                'Command "%s" had error code %s in %s',
+                command_desc,
+                proc.returncode,
+                cwd,
+            )
         elif on_returncode == 'ignore':
             pass
         else:

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -183,9 +183,8 @@ class TempDirectory(object):
         # scripts, so we canonicalize the path by traversing potential
         # symlinks here.
         path = os.path.realpath(
-            tempfile.mkdtemp(prefix="pip-{}-".format(kind))
-        )
-        logger.debug("Created temporary directory: {}".format(path))
+            tempfile.mkdtemp(prefix="pip-{}-".format(kind)))
+        logger.debug("Created temporary directory: %s", path)
         return path
 
     def cleanup(self):
@@ -267,8 +266,7 @@ class AdjacentTempDirectory(TempDirectory):
         else:
             # Final fallback on the default behavior.
             path = os.path.realpath(
-                tempfile.mkdtemp(prefix="pip-{}-".format(kind))
-            )
+                tempfile.mkdtemp(prefix="pip-{}-".format(kind)))
 
-        logger.debug("Created temporary directory: {}".format(path))
+        logger.debug("Created temporary directory: %s", path)
         return path

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -183,7 +183,8 @@ class TempDirectory(object):
         # scripts, so we canonicalize the path by traversing potential
         # symlinks here.
         path = os.path.realpath(
-            tempfile.mkdtemp(prefix="pip-{}-".format(kind)))
+            tempfile.mkdtemp(prefix="pip-{}-".format(kind))
+        )
         logger.debug("Created temporary directory: %s", path)
         return path
 
@@ -266,7 +267,8 @@ class AdjacentTempDirectory(TempDirectory):
         else:
             # Final fallback on the default behavior.
             path = os.path.realpath(
-                tempfile.mkdtemp(prefix="pip-{}-".format(kind)))
+                tempfile.mkdtemp(prefix="pip-{}-".format(kind))
+            )
 
         logger.debug("Created temporary directory: %s", path)
         return path

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -267,8 +267,7 @@ class AdjacentTempDirectory(TempDirectory):
         else:
             # Final fallback on the default behavior.
             path = os.path.realpath(
-                tempfile.mkdtemp(prefix="pip-{}-".format(kind))
-            )
+                tempfile.mkdtemp(prefix="pip-{}-".format(kind)))
 
         logger.debug("Created temporary directory: %s", path)
         return path

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -185,7 +185,7 @@ class TempDirectory(object):
         path = os.path.realpath(
             tempfile.mkdtemp(prefix="pip-{}-".format(kind))
         )
-        logger.debug("Created temporary directory: %s", path)
+        logger.debug("Created temporary directory: {}", path)
         return path
 
     def cleanup(self):
@@ -269,5 +269,5 @@ class AdjacentTempDirectory(TempDirectory):
             path = os.path.realpath(
                 tempfile.mkdtemp(prefix="pip-{}-".format(kind)))
 
-        logger.debug("Created temporary directory: %s", path)
+        logger.debug("Created temporary directory: {}", path)
         return path

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -175,7 +175,7 @@ def untar_file(filename, location):
         mode = 'r'
     else:
         logger.warning(
-            'Cannot determine compression type for file %s', filename,
+            'Cannot determine compression type for file {}', filename,
         )
         mode = 'r:*'
     tar = tarfile.open(filename, mode)
@@ -207,7 +207,7 @@ def untar_file(filename, location):
                     # Some corrupt tar files seem to produce this
                     # (specifically bad symlinks)
                     logger.warning(
-                        'In the tar file %s the member %s is invalid: %s',
+                        'In the tar file {} the member {} is invalid: {}',
                         filename, member.name, exc,
                     )
                     continue
@@ -218,7 +218,7 @@ def untar_file(filename, location):
                     # Some corrupt tar files seem to produce this
                     # (specifically bad symlinks)
                     logger.warning(
-                        'In the tar file %s the member %s is invalid: %s',
+                        'In the tar file {} the member {} is invalid: {}',
                         filename, member.name, exc,
                     )
                     continue
@@ -266,7 +266,7 @@ def unpack_file(
         # FIXME: handle?
         # FIXME: magic signatures?
         logger.critical(
-            'Cannot unpack file %s (downloaded from %s, content-type: %s); '
+            'Cannot unpack file {} (downloaded from {}, content-type: {}); '
             'cannot detect archive format',
             filename, location, content_type,
         )

--- a/src/pip/_internal/utils/wheel.py
+++ b/src/pip/_internal/utils/wheel.py
@@ -220,6 +220,6 @@ def check_compatibility(version, name):
         )
     elif version > VERSION_COMPATIBLE:
         logger.warning(
-            'Installing from a newer Wheel-Version (%s)',
+            'Installing from a newer Wheel-Version ({})',
             '.'.join(map(str, version)),
         )

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -61,7 +61,7 @@ class Bazaar(VersionControl):
         # type: (str, HiddenText, RevOptions) -> None
         rev_display = rev_options.to_display()
         logger.info(
-            'Checking out %s%s to %s',
+            'Checking out {}{} to {}',
             url,
             rev_display,
             display_path(dest),

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -190,7 +190,7 @@ class Git(VersionControl):
         # the form of a Git commit hash.
         if not looks_like_hash(rev):
             logger.warning(
-                "Did not find branch or tag '%s', assuming revision or ref.",
+                "Did not find branch or tag '{}', assuming revision or ref.",
                 rev,
             )
 
@@ -226,7 +226,7 @@ class Git(VersionControl):
     def fetch_new(self, dest, url, rev_options):
         # type: (str, HiddenText, RevOptions) -> None
         rev_display = rev_options.to_display()
-        logger.info('Cloning %s%s to %s', url, rev_display, display_path(dest))
+        logger.info('Cloning {}{} to {}', url, rev_display, display_path(dest))
         self.run_command(make_command('clone', '-q', url, dest))
 
         if rev_options.rev:
@@ -386,7 +386,7 @@ class Git(VersionControl):
                 log_failed_cmd=False,
             )
         except BadCommand:
-            logger.debug("could not determine if %s is under git control "
+            logger.debug("could not determine if {} is under git control "
                          "because git is not available", location)
             return None
         except SubProcessError:

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -54,7 +54,7 @@ class Mercurial(VersionControl):
         # type: (str, HiddenText, RevOptions) -> None
         rev_display = rev_options.to_display()
         logger.info(
-            'Cloning hg %s%s to %s',
+            'Cloning hg {}{} to {}',
             url,
             rev_display,
             display_path(dest),
@@ -76,7 +76,7 @@ class Mercurial(VersionControl):
                 config.write(config_file)
         except (OSError, configparser.NoSectionError) as exc:
             logger.warning(
-                'Could not switch Mercurial repository to %s: %s', url, exc,
+                'Could not switch Mercurial repository to {}: {}', url, exc,
             )
         else:
             cmd_args = make_command('update', '-q', rev_options.to_args())
@@ -147,7 +147,7 @@ class Mercurial(VersionControl):
                 log_failed_cmd=False,
             )
         except BadCommand:
-            logger.debug("could not determine if %s is under hg control "
+            logger.debug("could not determine if {} is under hg control "
                          "because hg is not available", location)
             return None
         except SubProcessError:

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -122,7 +122,7 @@ class Subversion(VersionControl):
                 # We've traversed up to the root of the filesystem without
                 # finding setup.py
                 logger.warning(
-                    "Could not find setup.py for directory %s (tried all "
+                    "Could not find setup.py for directory {} (tried all "
                     "parent directories)",
                     orig_location,
                 )
@@ -287,7 +287,7 @@ class Subversion(VersionControl):
         """Export the svn repository at the url to the destination location"""
         url, rev_options = self.get_url_rev_options(url)
 
-        logger.info('Exporting svn repository %s to %s', url, location)
+        logger.info('Exporting svn repository {} to {}', url, location)
         with indent_log():
             if os.path.exists(location):
                 # Subversion doesn't like to check out over an existing
@@ -303,7 +303,7 @@ class Subversion(VersionControl):
         # type: (str, HiddenText, RevOptions) -> None
         rev_display = rev_options.to_display()
         logger.info(
-            'Checking out %s%s to %s',
+            'Checking out {}{} to {}',
             url,
             rev_display,
             display_path(dest),

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -123,7 +123,7 @@ def call_subprocess(
     except Exception as exc:
         if log_failed_cmd:
             subprocess_logger.critical(
-                "Error %s while executing command %s", exc, command_desc,
+                "Error {} while executing command {}", exc, command_desc,
             )
         raise
     all_output = []
@@ -183,7 +183,7 @@ def find_path_to_setup_from_repo_root(location, repo_root):
             # We've traversed up to the root of the filesystem without
             # finding setup.py
             logger.warning(
-                "Could not find setup.py for directory %s (tried all "
+                "Could not find setup.py for directory {} (tried all "
                 "parent directories)",
                 orig_location,
             )
@@ -311,11 +311,11 @@ class VcsSupport(object):
     def register(self, cls):
         # type: (Type[VersionControl]) -> None
         if not hasattr(cls, 'name'):
-            logger.warning('Cannot register VCS %s', cls.__name__)
+            logger.warning('Cannot register VCS {}', cls.__name__)
             return
         if cls.name not in self._registry:
             self._registry[cls.name] = cls()
-            logger.debug('Registered VCS backend: %s', cls.name)
+            logger.debug('Registered VCS backend: {}', cls.name)
 
     def unregister(self, name):
         # type: (str) -> None
@@ -333,7 +333,7 @@ class VcsSupport(object):
             repo_path = vcs_backend.get_repository_root(location)
             if not repo_path:
                 continue
-            logger.debug('Determine that %s uses VCS: %s',
+            logger.debug('Determine that {} uses VCS: {}',
                          location, vcs_backend.name)
             vcs_backends[repo_path] = vcs_backend
 
@@ -646,14 +646,14 @@ class VersionControl(object):
             existing_url = self.get_remote_url(dest)
             if self.compare_urls(existing_url, url.secret):
                 logger.debug(
-                    '%s in %s exists, and has correct URL (%s)',
+                    '{} in {} exists, and has correct URL ({})',
                     self.repo_name.title(),
                     display_path(dest),
                     url,
                 )
                 if not self.is_commit_id_equal(dest, rev_options.rev):
                     logger.info(
-                        'Updating %s %s%s',
+                        'Updating {} {}{}',
                         display_path(dest),
                         self.repo_name,
                         rev_display,
@@ -664,7 +664,7 @@ class VersionControl(object):
                 return
 
             logger.warning(
-                '%s %s in %s exists with URL %s',
+                '{} {} in {} exists with URL {}',
                 self.name,
                 self.repo_name,
                 display_path(dest),
@@ -674,7 +674,7 @@ class VersionControl(object):
                       ('s', 'i', 'w', 'b'))
         else:
             logger.warning(
-                'Directory %s already exists, and is not a %s %s.',
+                'Directory {} already exists, and is not a {} {}.',
                 dest,
                 self.name,
                 self.repo_name,
@@ -684,7 +684,7 @@ class VersionControl(object):
                       ('i', 'w', 'b'))
 
         logger.warning(
-            'The plan is to install the %s repository %s',
+            'The plan is to install the {} repository {}',
             self.name,
             url,
         )
@@ -695,7 +695,7 @@ class VersionControl(object):
             sys.exit(-1)
 
         if response == 'w':
-            logger.warning('Deleting %s', display_path(dest))
+            logger.warning('Deleting {}', display_path(dest))
             rmtree(dest)
             self.fetch_new(dest, url, rev_options)
             return
@@ -703,7 +703,7 @@ class VersionControl(object):
         if response == 'b':
             dest_dir = backup_dir(dest)
             logger.warning(
-                'Backing up %s to %s', display_path(dest), dest_dir,
+                'Backing up {} to {}', display_path(dest), dest_dir,
             )
             shutil.move(dest, dest_dir)
             self.fetch_new(dest, url, rev_options)
@@ -712,7 +712,7 @@ class VersionControl(object):
         # Do nothing if the response is "i".
         if response == 's':
             logger.info(
-                'Switching %s %s to %s%s',
+                'Switching {} {} to {}{}',
                 self.repo_name,
                 display_path(dest),
                 url,
@@ -789,7 +789,7 @@ class VersionControl(object):
         """
         Return whether a directory path is a repository directory.
         """
-        logger.debug('Checking in %s for %s (%s)...',
+        logger.debug('Checking in {} for {} ({})...',
                      path, cls.dirname, cls.name)
         return os.path.exists(os.path.join(path, cls.dirname))
 

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -59,7 +59,7 @@ def _should_build(
     if req.is_wheel:
         if need_wheel:
             logger.info(
-                'Skipping %s, due to already being wheel.', req.name,
+                'Skipping {}, due to already being wheel.', req.name,
             )
         return False
 
@@ -75,7 +75,7 @@ def _should_build(
 
     if not check_binary_allowed(req):
         logger.info(
-            "Skipping wheel build for %s, due to binaries "
+            "Skipping wheel build for {}, due to binaries "
             "being disabled for it.", req.name,
         )
         return False
@@ -83,7 +83,7 @@ def _should_build(
     if not req.use_pep517 and not is_wheel_installed():
         # we don't build legacy requirements if wheel is not installed
         logger.info(
-            "Using legacy setup.py install for %s, "
+            "Using legacy setup.py install for {}, "
             "since package 'wheel' is not installed.", req.name,
         )
         return False
@@ -178,7 +178,7 @@ def _build_one(
         ensure_dir(output_dir)
     except OSError as e:
         logger.warning(
-            "Building wheel for %s failed: %s",
+            "Building wheel for {} failed: {}",
             req.name, e,
         )
         return None
@@ -222,15 +222,14 @@ def _build_one_inside_env(
             try:
                 wheel_hash, length = hash_file(wheel_path)
                 shutil.move(wheel_path, dest_path)
-                logger.info('Created wheel for %s: '
-                            'filename=%s size=%d sha256=%s',
-                            req.name, wheel_name, length,
-                            wheel_hash.hexdigest())
-                logger.info('Stored in directory: %s', output_dir)
+                logger.info(
+                    'Created wheel for {}: filename={} size={} sha256={}',
+                    req.name, wheel_name, length, wheel_hash.hexdigest())
+                logger.info('Stored in directory: {}', output_dir)
                 return dest_path
             except Exception as e:
                 logger.warning(
-                    "Building wheel for %s failed: %s",
+                    "Building wheel for {} failed: {}",
                     req.name, e,
                 )
         # Ignore return, we can't do anything else useful.
@@ -246,12 +245,12 @@ def _clean_one_legacy(req, global_options):
         global_options=global_options,
     )
 
-    logger.info('Running setup.py clean for %s', req.name)
+    logger.info('Running setup.py clean for {}', req.name)
     try:
         call_subprocess(clean_args, cwd=req.source_dir)
         return True
     except Exception:
-        logger.error('Failed cleaning build dir for %s', req.name)
+        logger.error('Failed cleaning build dir for {}', req.name)
         return False
 
 
@@ -272,7 +271,7 @@ def build(
 
     # Build the wheels.
     logger.info(
-        'Building wheels for collected packages: %s',
+        'Building wheels for collected packages: {}',
         ', '.join(req.name for req in requirements),
     )
 
@@ -295,12 +294,12 @@ def build(
     # notify success/failure
     if build_successes:
         logger.info(
-            'Successfully built %s',
+            'Successfully built {}',
             ' '.join([req.name for req in build_successes]),
         )
     if build_failures:
         logger.info(
-            'Failed to build %s',
+            'Failed to build {}',
             ' '.join([req.name for req in build_failures]),
         )
     # Return a list of requirements that failed to build

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -125,8 +125,7 @@ def test_console_to_str_warning(monkeypatch):
     some_bytes = b"a\xE9b"
 
     def check_warning(msg, *args, **kwargs):
-        assert msg.startswith(
-            "Subprocess output does not appear to be encoded as")
+        assert args[0] == 'Subprocess output'
 
     monkeypatch.setattr(locale, 'getpreferredencoding', lambda: 'utf-8')
     monkeypatch.setattr(pip_compat.logger, 'warning', check_warning)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -87,7 +87,12 @@ def test_str_to_display__encoding(monkeypatch, data, encoding, expected):
     )
 
 
-def test_str_to_display__decode_error(monkeypatch, caplog):
+def test_str_to_display__decode_error(monkeypatch):
+    def check_warning(msg, *args, **kwargs):
+        assert 'does not appear to be encoded as' in msg
+        assert args == ('Bytes object', 'utf-8')
+
+    monkeypatch.setattr(pip_compat.logger, 'warning', check_warning)
     monkeypatch.setattr(locale, 'getpreferredencoding', lambda: 'utf-8')
     # Encode with an incompatible encoding.
     data = u'ab'.encode('utf-16')
@@ -101,12 +106,6 @@ def test_str_to_display__decode_error(monkeypatch, caplog):
     assert actual == expected, (
         # Show the encoding for easier troubleshooting.
         'encoding: {!r}'.format(locale.getpreferredencoding())
-    )
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
-    assert record.levelname == 'WARNING'
-    assert record.message == (
-        'Bytes object does not appear to be encoded as utf-8'
     )
 
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -125,6 +125,7 @@ def test_console_to_str_warning(monkeypatch):
     some_bytes = b"a\xE9b"
 
     def check_warning(msg, *args, **kwargs):
+        assert 'does not appear to be encoded as' in msg
         assert args[0] == 'Subprocess output'
 
     monkeypatch.setattr(locale, 'getpreferredencoding', lambda: 'utf-8')

--- a/tests/unit/test_resolution_legacy_resolver.py
+++ b/tests/unit/test_resolution_legacy_resolver.py
@@ -276,5 +276,7 @@ class TestYankedWarning(object):
             '(version 1.0 at https://example.com/pkg-1.0.tar.gz)\n'
             'Reason for being yanked: '
         ) + expected_reason
+        # The log record is not unicode but str on Python 2 because
+        # it is deduced from str(utils.logging.FormatLogger).
         message = record.message.decode('utf-8') if PY2 else record.message
         assert message == expected_message

--- a/tests/unit/test_resolution_legacy_resolver.py
+++ b/tests/unit/test_resolution_legacy_resolver.py
@@ -3,6 +3,7 @@ import logging
 import mock
 import pytest
 from pip._vendor import pkg_resources
+from pip._vendor.six import PY2
 
 from pip._internal.exceptions import (
     NoneMetadataError,
@@ -275,4 +276,5 @@ class TestYankedWarning(object):
             '(version 1.0 at https://example.com/pkg-1.0.tar.gz)\n'
             'Reason for being yanked: '
         ) + expected_reason
-        assert record.message == expected_message
+        message = record.message.decode('utf-8') if PY2 else record.message
+        assert message == expected_message


### PR DESCRIPTION
This is trying to resolve GH-7009.  TODOs:

- [x] Adapt the logger to use `str.format`
- [x] Substitute `%` *message* formatting by `{}`
- [ ] Make the tests pass

LoggerAdapter might not be a good idea since one module imported by of utils.logging needs logging to.