### PR TITLE
_vendor/README.rst: vendor.txt needed for debug

### DIFF
--- a/news/8327.bugfix
+++ b/news/8327.bugfix
@@ -1,0 +1,1 @@
+The pip debug command takes module versions from vendor.txt even when they are debundled.  Enhance the debug command output to instead show the location, name, and version of the debundled modules when appropriate.

--- a/src/pip/_vendor/README.rst
+++ b/src/pip/_vendor/README.rst
@@ -127,7 +127,7 @@ semi-supported method (that we don't test in our CI) and requires a bit of
 extra work on your end in order to solve the problems described above.
 
 1. Delete everything in ``pip/_vendor/`` **except** for
-   ``pip/_vendor/__init__.py``.
+   ``pip/_vendor/__init__.py`` and ``pip/_vendor/vendor.txt``.
 
 2. Generate wheels for each of pip's dependencies (and any of their
    dependencies) using your patched copies of these libraries. These must be


### PR DESCRIPTION
The debug command parses vendor.txt, so it's needed when debundling.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
