### PR TITLE
Mockup partial wheel download during resolvelib resolution

### DIFF
--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -4,6 +4,7 @@ import cgi
 import logging
 import mimetypes
 import os
+from zipfile import ZipFile
 
 from pip._vendor import requests
 from pip._vendor.requests.models import CONTENT_CHUNK_SIZE
@@ -18,16 +19,42 @@ from pip._internal.utils.misc import (
     splitext,
 )
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+from pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
 
 if MYPY_CHECK_RUNNING:
-    from typing import Iterable, Optional
+    from typing import Dict, Iterable, Optional, Tuple
 
+    from pip._vendor.pkg_resources import Distribution
     from pip._vendor.requests.models import Response
 
     from pip._internal.models.link import Link
     from pip._internal.network.session import PipSession
+    from pip._internal.utils.hashes import Hashes
 
 logger = logging.getLogger(__name__)
+
+# We use Accept-Encoding: identity here because requests defaults to
+# accepting compressed responses. This breaks in a variety of ways
+# depending on how the server is configured:
+# - Some servers will notice that the file isn't a compressible file
+#   and will leave the file alone and with an empty Content-Encoding
+# - Some servers will notice that the file is already compressed and
+#   leave the file alone, adding a Content-Encoding: gzip header
+# - Some servers won't notice anything at all and will take a file
+#   that's already been compressed and compress it again and set
+#   the Content-Encoding: gzip header
+# By setting this to request only the identity encoding we're hoping to
+# eliminate the third case. Hopefully there does not exist a server
+# which when given a file will notice it is already compressed and that
+# you're not asking for a compressed file and will then decompress it
+# before sending because if that's the case I don't think it'll ever be
+# possible to make this work.
+HEADERS = {'Accept-Encoding': 'identity'}
+
+
+def _get_range_headers(size):
+    # type: (int) -> Dict[str, str]
+    return {'Accept-Encoding': 'identity', 'Range': 'bytes=-{}'.format(size)}
 
 
 def _get_http_response_size(resp):
@@ -129,72 +156,50 @@ def _get_http_response_filename(resp, link):
     return filename
 
 
-def _http_get_download(session, link):
-    # type: (PipSession, Link) -> Response
-    target_url = link.url.split('#', 1)[0]
-    resp = session.get(
-        target_url,
-        # We use Accept-Encoding: identity here because requests
-        # defaults to accepting compressed responses. This breaks in
-        # a variety of ways depending on how the server is configured.
-        # - Some servers will notice that the file isn't a compressible
-        #   file and will leave the file alone and with an empty
-        #   Content-Encoding
-        # - Some servers will notice that the file is already
-        #   compressed and will leave the file alone and will add a
-        #   Content-Encoding: gzip header
-        # - Some servers won't notice anything at all and will take
-        #   a file that's already been compressed and compress it again
-        #   and set the Content-Encoding: gzip header
-        # By setting this to request only the identity encoding We're
-        # hoping to eliminate the third case. Hopefully there does not
-        # exist a server which when given a file will notice it is
-        # already compressed and that you're not asking for a
-        # compressed file and will then decompress it before sending
-        # because if that's the case I don't think it'll ever be
-        # possible to make this work.
-        headers={"Accept-Encoding": "identity"},
-        stream=True,
-    )
-    resp.raise_for_status()
-    return resp
-
-
-class Download(object):
-    def __init__(
-        self,
-        response,  # type: Response
-        filename,  # type: str
-        chunks,  # type: Iterable[bytes]
-    ):
-        # type: (...) -> None
-        self.response = response
-        self.filename = filename
-        self.chunks = chunks
-
-
 class Downloader(object):
-    def __init__(
-        self,
-        session,  # type: PipSession
-        progress_bar,  # type: str
-    ):
-        # type: (...) -> None
+    def __init__(self, session, progress_bar):
+        # type: (PipSession, str) -> None
         self._session = session
         self._progress_bar = progress_bar
 
-    def __call__(self, link):
-        # type: (Link) -> Download
+    def _download(self, link, headers):
+        # type: (Link, Dict[str, str]) -> Tuple[Response, str, Iterable[bytes]]
+        url = link.url.split('#', 1)[0]
+        resp = self._session.get(url, headers=headers, stream=True)
         try:
-            resp = _http_get_download(self._session, link)
+            resp.raise_for_status()
         except requests.HTTPError as e:
             logger.critical(
-                "HTTP error %s while getting %s", e.response.status_code, link
-            )
+                "HTTP error %s while getting %s", e.response.status_code, link)
             raise
+        return (resp, _get_http_response_filename(resp, link),
+                _prepare_download(resp, link, self._progress_bar))
 
-        return Download(
-            resp,
-            _get_http_response_filename(resp, link),
-            _prepare_download(resp, link, self._progress_bar),
-        )
+    def download_partial(self, link, tmpdir, name, size=8000):
+        # type: (Link, str, str, int) -> Distribution
+        response, filename, chunks = self._download(
+            link, _get_range_headers(size))
+        file_path = os.path.join(tmpdir, filename)
+        with open(file_path, 'wb') as content_file:
+            for chunk in chunks:
+                content_file.write(chunk)
+        try:
+            with ZipFile(file_path) as wheel:
+                return pkg_resources_distribution_for_wheel(
+                    wheel, name, file_path)
+        except OSError:
+            assert response.status_code == 206
+            total_size = int(response.headers['Content-Range'].split('/')[-1])
+            return self.download_partial(
+                link, tmpdir, name, min(size*2, total_size))
+
+    def download(self, link, tmpdir, hashes):
+        # type: (Link, str, Optional[Hashes]) -> Tuple[str, str]
+        response, filename, chunks = self._download(link, HEADERS)
+        file_path = os.path.join(tmpdir, filename)
+        with open(file_path, 'wb') as content_file:
+            for chunk in chunks:
+                content_file.write(chunk)
+        if hashes:
+            hashes.check_against_path(file_path)
+        return file_path, response.headers.get('content-type', '')

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -39,9 +39,7 @@ from pip._internal.utils.unpacking import unpack_file
 from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
-    from typing import (
-        Callable, List, Optional, Tuple,
-    )
+    from typing import Callable, List, Optional
 
     from mypy_extensions import TypedDict
 
@@ -126,9 +124,8 @@ def get_http_url(
         content_type = mimetypes.guess_type(from_path)[0]
     else:
         # let's download to a tmp dir
-        from_path, content_type = _download_http_url(
-            link, downloader, temp_dir.path, hashes
-        )
+        from_path, content_type = downloader.download(
+            link, temp_dir.path, hashes)
 
     return File(from_path, content_type)
 
@@ -264,27 +261,6 @@ def unpack_url(
     unpack_file(file.path, location, file.content_type)
 
     return file
-
-
-def _download_http_url(
-    link,  # type: Link
-    downloader,  # type: Downloader
-    temp_dir,  # type: str
-    hashes,  # type: Optional[Hashes]
-):
-    # type: (...) -> Tuple[str, str]
-    """Download link url into temp_dir using provided session"""
-    download = downloader(link)
-
-    file_path = os.path.join(temp_dir, download.filename)
-    with open(file_path, 'wb') as content_file:
-        for chunk in download.chunks:
-            content_file.write(chunk)
-
-    if hashes:
-        hashes.check_against_path(file_path)
-
-    return file_path, download.response.headers.get('content-type', '')
 
 
 def _check_download_dir(link, download_dir, hashes):


### PR DESCRIPTION
This is open to facilitate discussions relevant GH-7819.  I believe that dry run could be done by injecting `print` and `exit` after the resolution is complete, so I'll focus on the matter of real installation:

1. For pure-python wheel this (the idea) is kinda nice.  For project released under GPL the metadata is somewhere in the last 32 kB, and it's 8 kB for others (GPL is long :smile:).
2. The trick doesn't seem to work with extensions, or at least not with manylinux, although IIRC rarely one will have multiple extension requirements at the same time for parallel to make sense.  Edit: I'm gonna investigate this tomorrow, but there might be something with the wheel reparation (auditwheel) maybe?
3. If hashing is required, of course this doesn't work.

After resolution, the undownloaded wheels can be downloaded in parallel, which warranties a higher number (> 5 vs < 5 I guess) of packages to download at the same time.

For local test run, I used `oslo-utils=1.4.0` for pure-python with heavy backtracking and `axuy` for something depending on extension modules (`numpy` in this case).

cc @pradyunsg, @cosmicexplorer, @ofek and @dholth specifically for opinions on the approach.