### PR TITLE
Set the requirement context on hash error

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -5,7 +5,7 @@ from pip._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 
-from pip._internal.exceptions import MetadataInconsistent
+from pip._internal.exceptions import HashError, MetadataInconsistent
 from pip._internal.req.constructors import (
     install_req_from_editable,
     install_req_from_line,
@@ -171,7 +171,12 @@ class _InstallRequirementBackedCandidate(Candidate):
         if self._dist is not None:
             return
 
-        abstract_dist = self._prepare_abstract_distribution()
+        try:
+            abstract_dist = self._prepare_abstract_distribution()
+        except HashError as e:
+            e.req = self._ireq
+            raise
+
         self._dist = abstract_dist.get_pkg_resources_distribution()
         assert self._dist is not None, "Distribution already installed"
 


### PR DESCRIPTION
This improves the message shown by the hash error to include the requirement that caused it.

This partially addresses `test_hashed_install_failure_later_flag`. The behaviour is still different from the legacy resolver’s, which collects all hash errors and raise an aggregated `HashErrors` exception instead.

Before:

```
Hashes are required in --require-hashes mode, but they are missing from some requirements.
Here is a list of those requirements along with the hashes their downloaded archives actually had.
Add lines like these to your requirements files to prevent tampering. (If you did not enable
--require-hashes manually, note that it turns on automatically when any package has a hash.)

    unknown package --hash=sha256:9ee5702ccd5d16d54ac9dcfce4a7c8ac90020cfe4e6b494ca44c68492add364c
```

After:

```
Hashes are required in --require-hashes mode, but they are missing from some requirements.
Here is a list of those requirements along with the hashes their downloaded archives actually had.
Add lines like these to your requirements files to prevent tampering. (If you did not enable
--require-hashes manually, note that it turns on automatically when any package has a hash.)

    package-a==0.1.0 --hash=sha256:9ee5702ccd5d16d54ac9dcfce4a7c8ac90020cfe4e6b494ca44c68492add364c
```