### PR TITLE
test server: Don't mask invalid signals on py38

### DIFF
--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -47,7 +47,7 @@ else:
         try:
             mask = signal.valid_signals()
         except AttributeError:
-            mask = range(1, signal.NSIG)
+            mask = set(range(1, signal.NSIG))
 
         old_mask = signal.pthread_sigmask(signal.SIG_SETMASK, mask)
         try:

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -42,9 +42,14 @@ else:
     def blocked_signals():
         """Block all signals for e.g. starting a worker thread.
         """
-        old_mask = signal.pthread_sigmask(
-            signal.SIG_SETMASK, range(1, signal.NSIG)
-        )
+        # valid_signals() was added in Python 3.8 (and not using it results
+        # in a warning on pthread_sigmask() call)
+        try:
+            mask = signal.valid_signals()
+        except AttributeError:
+            mask = range(1, signal.NSIG)
+
+        old_mask = signal.pthread_sigmask(signal.SIG_SETMASK, mask)
         try:
             yield
         finally:


### PR DESCRIPTION
This removes warnings from test output in python 3.8:

  /usr/lib/python3.8/signal.py:60: RuntimeWarning:
  invalid signal number 32, please use valid_signals()
