### PR TITLE
Fix a merge issue that didn't get caught by Brown Truck

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -187,7 +187,7 @@ class _InstallRequirementBackedCandidate(Candidate):
         return "{} {} (from {})".format(
             self.name,
             self.version,
-            self.link.file_path if self.link.is_file else self.link
+            self._link.file_path if self._link.is_file else self._link
         )
 
     def _prepare_abstract_distribution(self):


### PR DESCRIPTION
A problem with #8394 caused by another PR that got merged first. Didn't cause a merge conflict, so it didn't get picked up by Brown Truck.