### PR TITLE
Warn if package url is a vcs or an archive url with invalid scheme

### DIFF
--- a/news/8128.feature
+++ b/news/8128.feature
@@ -1,0 +1,1 @@
+Warn if package url is a vcs or an archive url with invalid scheme

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -434,7 +434,8 @@ def _get_html_page(link, session=None):
     # Check for VCS schemes that do not support lookup as web pages.
     vcs_scheme = _match_vcs_scheme(url)
     if vcs_scheme:
-        logger.warning('Cannot look at %s URL %s', vcs_scheme, link)
+        logger.warning('Cannot look at %s URL %s because it does not support '
+                       'lookup as web pages.', vcs_scheme, link)
         return None
 
     # Tack index.html onto file:// URLs that point to directories

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -453,7 +453,7 @@ def _get_html_page(link, session=None):
     except _NotHTTP:
         logger.warning(
             'Skipping page %s because it looks like an archive, and cannot '
-            'be checked by HEAD.', link,
+            'be checked by a HTTP HEAD request.', link,
         )
     except _NotHTML as exc:
         logger.warning(

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -434,7 +434,7 @@ def _get_html_page(link, session=None):
     # Check for VCS schemes that do not support lookup as web pages.
     vcs_scheme = _match_vcs_scheme(url)
     if vcs_scheme:
-        logger.debug('Cannot look at %s URL %s', vcs_scheme, link)
+        logger.warning('Cannot look at %s URL %s', vcs_scheme, link)
         return None
 
     # Tack index.html onto file:// URLs that point to directories
@@ -450,7 +450,7 @@ def _get_html_page(link, session=None):
     try:
         resp = _get_html_response(url, session=session)
     except _NotHTTP:
-        logger.debug(
+        logger.warning(
             'Skipping page %s because it looks like an archive, and cannot '
             'be checked by HEAD.', link,
         )

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -496,7 +496,8 @@ def test_get_html_page_invalid_scheme(caplog, url, vcs_scheme):
         (
             "pip._internal.index.collector",
             logging.WARNING,
-            "Cannot look at {} URL {}".format(vcs_scheme, url),
+            "Cannot look at {} URL {} because it does not support "
+            "lookup as web pages.".format(vcs_scheme, url),
         ),
     ]
 

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -94,7 +94,7 @@ def test_get_html_page_invalid_content_type_archive(caplog, url):
     assert ('pip._internal.index.collector',
             logging.WARNING,
             'Skipping page {} because it looks like an archive, and cannot '
-            'be checked by HEAD.'.format(
+            'be checked by a HTTP HEAD request.'.format(
                 url)) \
         in caplog.record_tuples
 


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/8128