### PR TITLE
Test message check fixes

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1744,16 +1744,17 @@ def test_user_config_accepted(script):
 @pytest.mark.parametrize(
     'install_args, expected_message', [
         ([], 'Requirement already satisfied: pip'),
-        (['--upgrade'], 'Requirement already up-to-date: pip in'),
+        (['--upgrade'], 'Requirement already {}: pip in'),
     ]
 )
 @pytest.mark.parametrize("use_module", [True, False])
-@pytest.mark.fails_on_new_resolver
 def test_install_pip_does_not_modify_pip_when_satisfied(
-        script, install_args, expected_message, use_module):
+        script, install_args, expected_message, use_module, use_new_resolver):
     """
     Test it doesn't upgrade the pip if it already satisfies the requirement.
     """
+    variation = "satisfied" if use_new_resolver else "up-to-date"
+    expected_message = expected_message.format(variation)
     result = script.pip_install_local(
         'pip', *install_args, use_module=use_module
     )

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -36,8 +36,10 @@ def test_invalid_upgrade_strategy_causes_error(script):
     assert "invalid choice" in result.stderr
 
 
-@pytest.mark.fails_on_new_resolver
-def test_only_if_needed_does_not_upgrade_deps_when_satisfied(script):
+def test_only_if_needed_does_not_upgrade_deps_when_satisfied(
+    script,
+    use_new_resolver
+):
     """
     It doesn't upgrade a dependency if it already satisfies the requirements.
 
@@ -57,9 +59,12 @@ def test_only_if_needed_does_not_upgrade_deps_when_satisfied(script):
             .format(**globals()))
         not in result.files_deleted
     ), "should not have uninstalled simple==2.0"
+
+    msg = "Requirement already satisfied"
+    if not use_new_resolver:
+        msg = msg + ", skipping upgrade: simple"
     assert (
-        "Requirement already satisfied, skipping upgrade: simple"
-        in result.stdout
+        msg in result.stdout
     ), "did not print correct message for not-upgraded requirement"
 
 
@@ -178,8 +183,7 @@ def test_upgrade_if_requested(script):
     )
 
 
-@pytest.mark.fails_on_new_resolver
-def test_upgrade_with_newest_already_installed(script, data):
+def test_upgrade_with_newest_already_installed(script, data, use_new_resolver):
     """
     If the newest version of a package is already installed, the package should
     not be reinstalled and the user should be informed.
@@ -189,7 +193,11 @@ def test_upgrade_with_newest_already_installed(script, data):
         'install', '--upgrade', '-f', data.find_links, '--no-index', 'simple'
     )
     assert not result.files_created, 'simple upgraded when it should not have'
-    assert 'already up-to-date' in result.stdout, result.stdout
+    if use_new_resolver:
+        msg = "Requirement already satisfied"
+    else:
+        msg = "already up-to-date"
+    assert msg in result.stdout, result.stdout
 
 
 @pytest.mark.network


### PR DESCRIPTION
This fixes a number of tests where the only issue is that the new resolver gives a different message than the old resolver. I've taken the view that changing the test to reflect what the new resolver says is acceptable, at least in the short term.

It's *very* arguable that the correct approach is actually to make the new resolver give the "correct" message, but it's not clear to me that this would be straightforward to do, and as we have a UX project working on the broarder task of improving pip's messages, it seems reasonable to make a tactical fix for now. If nothing else, the test code will pinpoint where and how the messages differ between the two resolvers, and we can use that as a starting point for any further improvements.

It's not obvious to me to what extent the existing messages are based on implementation details of the old resolver (in which case, it's fair game to change them based on implementation details of the new resolver) or on a conscious decision to display a particular message to the user (in which case we probably should make more effort to review if the new message is an acceptable alternative). But my inclination is to address that sort of question in follow-up PRs, once we have the test suite failures dealt with.

Opinions, anyone? @pradyunsg @uranusjr @brainwane @ei8fdb @nlhkabu 