### PR TITLE
List full path of wheel files in cache

### DIFF
--- a/news/8355.feature
+++ b/news/8355.feature
@@ -1,0 +1,1 @@
+Add option ``--format`` to subcommand ``list`` of ``pip  cache``, with ``abspath`` choice to output the full path of a wheel file.

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -37,10 +37,20 @@ class CacheCommand(Command):
     usage = """
         %prog dir
         %prog info
-        %prog list [<pattern>]
+        %prog list [<pattern>] [--abspath]
         %prog remove <pattern>
         %prog purge
     """
+
+    def add_options(self):
+        # type: () -> None
+        self.cmd_opts.add_option(
+            '--abspath',
+            dest='abspath',
+            action='store_true',
+            help='List the absolute path of wheels')
+
+        self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options, args):
         # type: (Values, List[Any]) -> int
@@ -118,15 +128,20 @@ class CacheCommand(Command):
         files = self._find_wheels(options, pattern)
 
         if not files:
-            logger.info('Nothing cached.')
+            if not options.abspath:
+                logger.info('Nothing cached.')
             return
 
         results = []
         for filename in files:
             wheel = os.path.basename(filename)
             size = filesystem.format_file_size(filename)
-            results.append(' - {} ({})'.format(wheel, size))
-        logger.info('Cache contents:\n')
+            if options.abspath:
+                results.append(filename)
+            else:
+                results.append(' - {} ({})'.format(wheel, size))
+        if not options.abspath:
+            logger.info('Cache contents:\n')
         logger.info('\n'.join(sorted(results)))
 
     def remove_cache_items(self, options, args):

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -72,7 +72,7 @@ def list_matches_wheel(wheel_name, result):
 
 def list_matches_wheel_abspath(wheel_name, result):
     """Returns True if any line in `result`, which should be the output of
-    a `pip cache list --abspath` call, is a valid path and belongs to
+    a `pip cache list --format=abspath` call, is a valid path and belongs to
     `wheel_name`.
 
     E.g., If wheel_name is `foo-1.2.3` it searches for a line starting with
@@ -147,9 +147,9 @@ def test_cache_list(script):
 
 @pytest.mark.usefixtures("populate_wheel_cache")
 def test_cache_list_abspath(script):
-    """Running `pip cache list --abspath` should return full
+    """Running `pip cache list --format=abspath` should return full
     paths of exactly what the populate_wheel_cache fixture adds."""
-    result = script.pip('cache', 'list', '--abspath')
+    result = script.pip('cache', 'list', '--format=abspath')
 
     assert list_matches_wheel_abspath('yyy-1.2.3', result)
     assert list_matches_wheel_abspath('zzz-4.5.6', result)
@@ -167,9 +167,9 @@ def test_cache_list_with_empty_cache(script):
 
 @pytest.mark.usefixtures("empty_wheel_cache")
 def test_cache_list_with_empty_cache_abspath(script):
-    """Running `pip cache list --abspath` with an empty cache should not
+    """Running `pip cache list --format=abspath` with an empty cache should not
     print anything and exit."""
-    result = script.pip('cache', 'list', '--abspath')
+    result = script.pip('cache', 'list', '--format=abspath')
     assert result.stdout.strip() == ""
 
 
@@ -193,9 +193,10 @@ def test_cache_list_name_match(script):
 
 @pytest.mark.usefixtures("populate_wheel_cache")
 def test_cache_list_name_match_abspath(script):
-    """Running `pip cache list zzz --abspath` should list paths of
+    """Running `pip cache list zzz --format=abspath` should list paths of
     zzz-4.5.6, zzz-4.5.7, zzz-7.8.9, but nothing else."""
-    result = script.pip('cache', 'list', 'zzz', '--abspath', '--verbose')
+    result = script.pip('cache', 'list', 'zzz', '--format=abspath',
+                        '--verbose')
 
     assert not list_matches_wheel_abspath('yyy-1.2.3', result)
     assert list_matches_wheel_abspath('zzz-4.5.6', result)
@@ -217,9 +218,10 @@ def test_cache_list_name_and_version_match(script):
 
 @pytest.mark.usefixtures("populate_wheel_cache")
 def test_cache_list_name_and_version_match_abspath(script):
-    """Running `pip cache list zzz-4.5.6 --abspath` should list path of
+    """Running `pip cache list zzz-4.5.6 --format=abspath` should list path of
     zzz-4.5.6, but nothing else."""
-    result = script.pip('cache', 'list', 'zzz-4.5.6', '--abspath', '--verbose')
+    result = script.pip('cache', 'list', 'zzz-4.5.6', '--format=abspath',
+                        '--verbose')
 
     assert not list_matches_wheel_abspath('yyy-1.2.3', result)
     assert list_matches_wheel_abspath('zzz-4.5.6', result)


### PR DESCRIPTION
Closes #8355 

Add an option `--not-accessed-since` to subcommands `list` and `purge` of `pip cache`
to list and remove wheels older than x days from current time.

cc @xavfernandez since the main idea was inspired from their PR https://github.com/pypa/pip/pull/3146 , so I would appreciate thoughts on whether it's in the right direction

**EDIT**:
Based on further discussion about baking in a specific cache eviction mechanism not the correct way going forward, and letting the user decide based on the output to consume it and use in their own cache eviction script, I have gone ahead and updated the PR to include the `--abspath` option.

```
$ pip cache list --abspath
/Users/devesh/Library/Caches/pip/wheels/01/d8/aa/eef4a6fa336467a340674ec0a6d5133c0e8a2725c730cb884b/pip-20.2.dev0-py2.py3-none-any.whl
/Users/devesh/Library/Caches/pip/wheels/08/9b/f4/87ddd64472107c95aa33211eb85c53c564d911a61567f29fb5/twine-3.1.2.dev81+ge55869a.d20200511-cp38-none-any.whl
/Users/devesh/Library/Caches/pip/wheels/0c/88/ac/41500883ea902d3409a83a827870a726346b5ebfd0523e91df/distlib-0.3.0-py2-none-any.whl
<snip>
```

```
$ pip cache list --abspath
$
```