### PR TITLE
cache Tag __hash__ value for a 10% resolve speedup

### DIFF
--- a/news/8480.bugfix
+++ b/news/8480.bugfix
@@ -1,0 +1,1 @@
+Improve the performance of v1 and v2 resolves by caching the return value of __hash__ for the Tag object.

--- a/src/pip/_vendor/packaging/tags.py
+++ b/src/pip/_vendor/packaging/tags.py
@@ -59,13 +59,14 @@ _32_BIT_INTERPRETER = sys.maxsize <= 2 ** 32
 
 class Tag(object):
 
-    __slots__ = ["_interpreter", "_abi", "_platform"]
+    __slots__ = ["_interpreter", "_abi", "_platform", "_hash"]
 
     def __init__(self, interpreter, abi, platform):
         # type: (str, str, str) -> None
         self._interpreter = interpreter.lower()
         self._abi = abi.lower()
         self._platform = platform.lower()
+        self._hash = hash((self._interpreter, self._abi, self._platform))
 
     @property
     def interpreter(self):
@@ -95,7 +96,7 @@ class Tag(object):
 
     def __hash__(self):
         # type: () -> int
-        return hash((self._interpreter, self._abi, self._platform))
+        return self._hash
 
     def __str__(self):
         # type: () -> str


### PR DESCRIPTION
### Problem

Via profiling, I found that `pip._internal.models.wheel.Wheel.supported()` was taking a while, and that over 2/3rds of its runtime was calling the `__hash__` method on the `Tag` object.

### Solution

- Add `_hash` slot to `Tag` class and return it in `__hash__()`.

### Result
A 6% speedup for the v1 resolver, and a 10% speedup for the v2 resolver when resolving `tensorflow==1.14.0`
```bash
> git checkout master
> rm -rf tmp/ ~/Library/Caches/pip && time pip download -d tmp/ tensorflow==1.14.0 &>/dev/null
10.69s user 3.57s system 78% cpu 18.043 total
> rm -rf tmp/ ~/Library/Caches/pip && time pip download --unstable-feature=resolver -d tmp/ tensorflow==1.14.0 &>/dev/null
15.07s user 3.57s system 85% cpu 21.682 total
> git checkout -
> rm -rf tmp/ ~/Library/Caches/pip && time pip download -d tmp/ tensorflow==1.14.0 &>/dev/null
9.33s user 3.69s system 76% cpu 16.914 total
> rm -rf tmp/ ~/Library/Caches/pip && time pip download --unstable-feature=resolver -d tmp/ tensorflow==1.14.0 &>/dev/null
12.82s user 3.70s system 84% cpu 19.550 total
```