### PR TITLE
Expect deprecation warning for build_dir in tests

### DIFF
--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -41,7 +41,13 @@ def test_cleanup_prevented_upon_build_dir_exception(
         '--build', build,
         expect_error=(not use_new_resolver),
         expect_temp=(not use_new_resolver),
+        expect_stderr=True,
     )
+
+    assert (
+        "The -b/--build/--build-dir/--build-directory "
+        "option is deprecated."
+    ) in result.stderr
 
     if not use_new_resolver:
         assert result.returncode == PREVIOUS_BUILD_DIR_ERROR, str(result)

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -252,7 +252,13 @@ def test_pip_wheel_fail_cause_of_previous_build_dir(
         'simple==3.0',
         expect_error=(not use_new_resolver),
         expect_temp=(not use_new_resolver),
+        expect_stderr=True,
     )
+
+    assert (
+        "The -b/--build/--build-dir/--build-directory "
+        "option is deprecated."
+    ) in result.stderr
 
     # Then I see that the error code is the right one
     if not use_new_resolver:


### PR DESCRIPTION
The deprecation done in #8372 is failing the new resolver tests because we didn’t explicitly expect things in stderr.

This should make master green again.