### PR TITLE
Skip installing if the version matches locally

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -60,6 +60,11 @@ class Candidate(object):
         raise NotImplementedError("Override in subclass")
 
     @property
+    def is_editable(self):
+        # type: () -> bool
+        raise NotImplementedError("Override in subclass")
+
+    @property
     def source_link(self):
         # type: () -> Optional[Link]
         raise NotImplementedError("Override in subclass")

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -11,7 +11,7 @@ from pip._internal.req.constructors import (
     install_req_from_line,
 )
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.misc import normalize_version_info
+from pip._internal.utils.misc import dist_is_editable, normalize_version_info
 from pip._internal.utils.packaging import get_requires_python
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -261,6 +261,8 @@ class _InstallRequirementBackedCandidate(Candidate):
 
 
 class LinkCandidate(_InstallRequirementBackedCandidate):
+    is_editable = False
+
     def __init__(
         self,
         link,          # type: Link
@@ -299,6 +301,8 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
 
 
 class EditableCandidate(_InstallRequirementBackedCandidate):
+    is_editable = True
+
     def __init__(
         self,
         link,          # type: Link
@@ -375,6 +379,11 @@ class AlreadyInstalledCandidate(Candidate):
     def version(self):
         # type: () -> _BaseVersion
         return self.dist.parsed_version
+
+    @property
+    def is_editable(self):
+        # type: () -> bool
+        return dist_is_editable(self.dist)
 
     def format_for_error(self):
         # type: () -> str
@@ -466,8 +475,13 @@ class ExtrasCandidate(Candidate):
 
     @property
     def is_installed(self):
-        # type: () -> _BaseVersion
+        # type: () -> bool
         return self.base.is_installed
+
+    @property
+    def is_editable(self):
+        # type: () -> bool
+        return self.base.is_editable
 
     @property
     def source_link(self):

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -249,7 +249,6 @@ def test_uninstall_before_upgrade_from_url(script):
 
 
 @pytest.mark.network
-@pytest.mark.fails_on_new_resolver
 def test_upgrade_to_same_version_from_url(script):
     """
     When installing from a URL the same version that is already installed, no


### PR DESCRIPTION
This check only applies to explicit requirements since we avoid downloading the dist from finder altogether when there is a matching installation (although the check wouldn’t change the behaviour in that case anyway).

We can do this when we build the `ExplicitRequirement` instead, like how we did for `SpecifierRequirement`, but that would require us to resolve the direct requirement’s version eagerly, which I don’t want to.

The implemented approach checks the version only after resolution, at which point the distribution is already built anyway and the operation is cheap.

Edit: Close #8359.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
