### PR TITLE
add --unstable-feature=regex_link_parsing for a 12% resolve speedup

### DIFF
--- a/news/8488.feature
+++ b/news/8488.feature
@@ -1,0 +1,1 @@
+The ``--unstable-feature=regex_link_parsing`` option is added, which uses regular expressions to find href links instead of parsing with html5lib. Turning on this option increased resolve performance by 12% on ``tensorflow==1.14.0``.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -919,7 +919,7 @@ unstable_feature = partial(
     metavar='feature',
     action='append',
     default=[],
-    choices=['resolver'],
+    choices=['resolver', 'regex_link_parsing'],
     help=SUPPRESS_HELP,  # TODO: Enable this when the resolver actually works.
     # help='Enable unstable feature(s) that may be backward incompatible.',
 )  # type: Callable[..., Option]

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -394,6 +394,8 @@ class RequirementCommand(IndexGroupCommand):
             allow_all_prereleases=options.pre,
             prefer_binary=options.prefer_binary,
             ignore_requires_python=ignore_requires_python,
+            use_regex_link_parsing=(
+                'regex_link_parsing' in options.unstable_features),
         )
 
         return PackageFinder.create(

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -129,6 +129,8 @@ class ListCommand(IndexGroupCommand):
         selection_prefs = SelectionPreferences(
             allow_yanked=False,
             allow_all_prereleases=options.pre,
+            use_regex_link_parsing=(
+                'regex_link_parsing' in options.unstable_features),
         )
 
         return PackageFinder.create(

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -593,6 +593,7 @@ class PackageFinder(object):
         format_control=None,  # type: Optional[FormatControl]
         candidate_prefs=None,         # type: CandidatePreferences
         ignore_requires_python=None,  # type: Optional[bool]
+        use_regex_link_parsing=False,  # type: bool
     ):
         # type: (...) -> None
         """
@@ -620,6 +621,8 @@ class PackageFinder(object):
 
         # These are boring links that have already been logged somehow.
         self._logged_links = set()  # type: Set[Link]
+
+        self._use_regex_link_parsing = use_regex_link_parsing
 
     # Don't include an allow_yanked default value to make sure each call
     # site considers whether yanked releases are allowed. This also causes
@@ -656,6 +659,7 @@ class PackageFinder(object):
             allow_yanked=selection_prefs.allow_yanked,
             format_control=selection_prefs.format_control,
             ignore_requires_python=selection_prefs.ignore_requires_python,
+            use_regex_link_parsing=selection_prefs.use_regex_link_parsing,
         )
 
     @property
@@ -791,7 +795,7 @@ class PackageFinder(object):
         if html_page is None:
             return []
 
-        page_links = list(parse_links(html_page))
+        page_links = list(parse_links(html_page, self._use_regex_link_parsing))
 
         with indent_log():
             package_links = self.evaluate_links(

--- a/src/pip/_internal/models/selection_prefs.py
+++ b/src/pip/_internal/models/selection_prefs.py
@@ -12,7 +12,8 @@ class SelectionPreferences(object):
     """
 
     __slots__ = ['allow_yanked', 'allow_all_prereleases', 'format_control',
-                 'prefer_binary', 'ignore_requires_python']
+                 'prefer_binary', 'ignore_requires_python',
+                 'use_regex_link_parsing']
 
     # Don't include an allow_yanked default value to make sure each call
     # site considers whether yanked releases are allowed. This also causes
@@ -25,6 +26,7 @@ class SelectionPreferences(object):
         format_control=None,          # type: Optional[FormatControl]
         prefer_binary=False,          # type: bool
         ignore_requires_python=None,  # type: Optional[bool]
+        use_regex_link_parsing=False,  # type: bool
     ):
         # type: (...) -> None
         """Create a SelectionPreferences object.
@@ -47,3 +49,4 @@ class SelectionPreferences(object):
         self.format_control = format_control
         self.prefer_binary = prefer_binary
         self.ignore_requires_python = ignore_requires_python
+        self.use_regex_link_parsing = use_regex_link_parsing


### PR DESCRIPTION
### TODO
- [ ] complete the regex parsing implementation and ensure it passes all the tests

### Problem

In performing some profiling (with [`py-spy`](https://pypi.org/project/py-spy/)) for #8448 and #8480, I found that calling `pip._internal.models.wheel.Wheel.supported()` and `pip._internal.index.collector.parse_links()` (specifically `html5lib.parse()`) took up almost the entire time of finding candidates.

I previously worked on this method in #7729, which was an optimization that [`pex`](github.com/pantsbuild/pex/) version 1 had made before moving to invoking pip as a subprocess in pex versions >=2.

### Solution

- Create a new option `--unstable-feature=regex_link_parsing` to use an experimental parser that uses regular expressions instead of `html5lib`.

### Result
A 12% decrease in the mean time to download `tensorflow==1.14.0` and all of its dependencies over 6 runs.
```bash
> for i in $(seq 6); do rm -rf tmp/ ~/Library/Caches/pip && time pip download --unstable-feature=resolver --unstable-feature=regex_link_parsing -d tmp/ tensorflow==1.14.0 &>/dev/null; done
13.11s user 3.61s system 76% cpu 21.752 total
12.97s user 3.55s system 85% cpu 19.358 total
12.92s user 3.41s system 85% cpu 19.136 total
12.84s user 3.38s system 85% cpu 19.076 total
12.72s user 3.36s system 86% cpu 18.623 total
12.90s user 3.39s system 85% cpu 18.989 total
> for i in $(seq 6); do rm -rf tmp/ ~/Library/Caches/pip && time pip download --unstable-feature=resolver -d tmp/ tensorflow==1.14.0 &>/dev/null; done
15.32s user 4.00s system 82% cpu 23.333 total
14.87s user 3.48s system 88% cpu 20.844 total
14.83s user 3.60s system 86% cpu 21.310 total
15.21s user 3.62s system 88% cpu 21.372 total
15.41s user 3.78s system 82% cpu 23.381 total
14.83s user 3.40s system 86% cpu 21.020 total
```