### PR TITLE
Tidy up link collector constructor imports

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -13,6 +13,7 @@ from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.command_context import CommandContextMixIn
 from pip._internal.exceptions import CommandError, PreviousBuildDirError
+from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.network.download import Downloader
@@ -25,10 +26,7 @@ from pip._internal.req.constructors import (
     install_req_from_req_string,
 )
 from pip._internal.req.req_file import parse_requirements
-from pip._internal.self_outdated_check import (
-    make_link_collector,
-    pip_self_version_check,
-)
+from pip._internal.self_outdated_check import pip_self_version_check
 from pip._internal.utils.temp_dir import tempdir_kinds
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -387,7 +385,7 @@ class RequirementCommand(IndexGroupCommand):
         :param ignore_requires_python: Whether to ignore incompatible
             "Requires-Python" values in links. Defaults to False.
         """
-        link_collector = make_link_collector(session, options=options)
+        link_collector = LinkCollector.create(session, options=options)
         selection_prefs = SelectionPreferences(
             allow_yanked=True,
             format_control=options.format_control,

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -9,9 +9,9 @@ from pip._internal.cli import cmdoptions
 from pip._internal.cli.req_command import IndexGroupCommand
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.exceptions import CommandError
+from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
-from pip._internal.self_outdated_check import make_link_collector
 from pip._internal.utils.misc import (
     dist_is_editable,
     get_installed_distributions,
@@ -123,7 +123,7 @@ class ListCommand(IndexGroupCommand):
         """
         Create a package finder appropriate to this list command.
         """
-        link_collector = make_link_collector(session, options=options)
+        link_collector = LinkCollector.create(session, options=options)
 
         # Pass allow_yanked=False to ignore yanked versions.
         selection_prefs = SelectionPreferences(

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -18,6 +18,7 @@ from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib import request as urllib_request
 
 from pip._internal.models.link import Link
+from pip._internal.models.search_scope import SearchScope
 from pip._internal.utils.filetypes import ARCHIVE_EXTENSIONS
 from pip._internal.utils.misc import pairwise, redact_auth_from_url
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -25,6 +26,7 @@ from pip._internal.utils.urls import path_to_url, url_to_path
 from pip._internal.vcs import is_url, vcs
 
 if MYPY_CHECK_RUNNING:
+    from optparse import Values
     from typing import (
         Callable, Iterable, List, MutableMapping, Optional,
         Protocol, Sequence, Tuple, TypeVar, Union,
@@ -33,7 +35,6 @@ if MYPY_CHECK_RUNNING:
 
     from pip._vendor.requests import Response
 
-    from pip._internal.models.search_scope import SearchScope
     from pip._internal.network.session import PipSession
 
     HTMLElement = xml.etree.ElementTree.Element
@@ -599,6 +600,33 @@ class LinkCollector(object):
         # type: (...) -> None
         self.search_scope = search_scope
         self.session = session
+
+    @classmethod
+    def create(cls, session, options, suppress_no_index=False):
+        # type: (PipSession, Values, bool) -> LinkCollector
+        """
+        :param session: The Session to use to make requests.
+        :param suppress_no_index: Whether to ignore the --no-index option
+            when constructing the SearchScope object.
+        """
+        index_urls = [options.index_url] + options.extra_index_urls
+        if options.no_index and not suppress_no_index:
+            logger.debug(
+                'Ignoring indexes: %s',
+                ','.join(redact_auth_from_url(url) for url in index_urls),
+            )
+            index_urls = []
+
+        # Make sure find_links is a list before passing to create().
+        find_links = options.find_links or []
+
+        search_scope = SearchScope.create(
+            find_links=find_links, index_urls=index_urls,
+        )
+        link_collector = LinkCollector(
+            session=session, search_scope=search_scope,
+        )
+        return link_collector
 
     @property
     def find_links(self):

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -13,24 +13,18 @@ from pip._vendor.six import ensure_binary
 
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
-from pip._internal.models.search_scope import SearchScope
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.utils.filesystem import (
     adjacent_tmp_file,
     check_path_owner,
     replace,
 )
-from pip._internal.utils.misc import (
-    ensure_dir,
-    get_installed_version,
-    redact_auth_from_url,
-)
+from pip._internal.utils.misc import ensure_dir, get_installed_version
 from pip._internal.utils.packaging import get_installer
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     import optparse
-    from optparse import Values
     from typing import Any, Dict, Text, Union
 
     from pip._internal.network.session import PipSession
@@ -40,37 +34,6 @@ SELFCHECK_DATE_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 logger = logging.getLogger(__name__)
-
-
-def make_link_collector(
-    session,  # type: PipSession
-    options,  # type: Values
-    suppress_no_index=False,  # type: bool
-):
-    # type: (...) -> LinkCollector
-    """
-    :param session: The Session to use to make requests.
-    :param suppress_no_index: Whether to ignore the --no-index option
-        when constructing the SearchScope object.
-    """
-    index_urls = [options.index_url] + options.extra_index_urls
-    if options.no_index and not suppress_no_index:
-        logger.debug(
-            'Ignoring indexes: %s',
-            ','.join(redact_auth_from_url(url) for url in index_urls),
-        )
-        index_urls = []
-
-    # Make sure find_links is a list before passing to create().
-    find_links = options.find_links or []
-
-    search_scope = SearchScope.create(
-        find_links=find_links, index_urls=index_urls,
-    )
-
-    link_collector = LinkCollector(session=session, search_scope=search_scope)
-
-    return link_collector
 
 
 def _get_statefile_name(key):
@@ -185,7 +148,7 @@ def pip_self_version_check(session, options):
         # Refresh the version if we need to or just see if we need to warn
         if pypi_version is None:
             # Lets use PackageFinder to see what the latest pip version is
-            link_collector = make_link_collector(
+            link_collector = LinkCollector.create(
                 session,
                 options=options,
                 suppress_no_index=True,

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -13,6 +13,7 @@ from pip._vendor.six.moves.urllib import request as urllib_request
 
 from pip._internal.index.collector import (
     HTMLPage,
+    LinkCollector,
     _clean_link,
     _clean_url_path,
     _determine_base_url,
@@ -652,3 +653,76 @@ class TestLinkCollector(object):
         assert caplog.record_tuples == [
             ('pip._internal.index.collector', logging.DEBUG, expected_message),
         ]
+
+
+@pytest.mark.parametrize(
+    'find_links, no_index, suppress_no_index, expected', [
+        (['link1'], False, False,
+         (['link1'], ['default_url', 'url1', 'url2'])),
+        (['link1'], False, True, (['link1'], ['default_url', 'url1', 'url2'])),
+        (['link1'], True, False, (['link1'], [])),
+        # Passing suppress_no_index=True suppresses no_index=True.
+        (['link1'], True, True, (['link1'], ['default_url', 'url1', 'url2'])),
+        # Test options.find_links=False.
+        (False, False, False, ([], ['default_url', 'url1', 'url2'])),
+    ],
+)
+def test_link_collector_create(
+    find_links, no_index, suppress_no_index, expected,
+):
+    """
+    :param expected: the expected (find_links, index_urls) values.
+    """
+    expected_find_links, expected_index_urls = expected
+    session = PipSession()
+    options = pretend.stub(
+        find_links=find_links,
+        index_url='default_url',
+        extra_index_urls=['url1', 'url2'],
+        no_index=no_index,
+    )
+    link_collector = LinkCollector.create(
+        session, options=options, suppress_no_index=suppress_no_index,
+    )
+
+    assert link_collector.session is session
+
+    search_scope = link_collector.search_scope
+    assert search_scope.find_links == expected_find_links
+    assert search_scope.index_urls == expected_index_urls
+
+
+@patch('pip._internal.utils.misc.expanduser')
+def test_link_collector_create_find_links_expansion(
+    mock_expanduser, tmpdir,
+):
+    """
+    Test "~" expansion in --find-links paths.
+    """
+    # This is a mock version of expanduser() that expands "~" to the tmpdir.
+    def expand_path(path):
+        if path.startswith('~/'):
+            path = os.path.join(tmpdir, path[2:])
+        return path
+
+    mock_expanduser.side_effect = expand_path
+
+    session = PipSession()
+    options = pretend.stub(
+        find_links=['~/temp1', '~/temp2'],
+        index_url='default_url',
+        extra_index_urls=[],
+        no_index=False,
+    )
+    # Only create temp2 and not temp1 to test that "~" expansion only occurs
+    # when the directory exists.
+    temp2_dir = os.path.join(tmpdir, 'temp2')
+    os.mkdir(temp2_dir)
+
+    link_collector = LinkCollector.create(session, options=options)
+
+    search_scope = link_collector.search_scope
+    # Only ~/temp2 gets expanded. Also, the path is normalized when expanded.
+    expected_temp2_dir = os.path.normcase(temp2_dir)
+    assert search_scope.find_links == ['~/temp1', expected_temp2_dir]
+    assert search_scope.index_urls == ['default_url']

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -6,90 +6,16 @@ import sys
 import freezegun
 import pretend
 import pytest
-from mock import patch
 from pip._vendor import pkg_resources
 
 from pip._internal import self_outdated_check
 from pip._internal.models.candidate import InstallationCandidate
-from pip._internal.network.session import PipSession
 from pip._internal.self_outdated_check import (
     SelfCheckState,
     logger,
-    make_link_collector,
     pip_self_version_check,
 )
 from tests.lib.path import Path
-
-
-@pytest.mark.parametrize(
-    'find_links, no_index, suppress_no_index, expected', [
-        (['link1'], False, False,
-         (['link1'], ['default_url', 'url1', 'url2'])),
-        (['link1'], False, True, (['link1'], ['default_url', 'url1', 'url2'])),
-        (['link1'], True, False, (['link1'], [])),
-        # Passing suppress_no_index=True suppresses no_index=True.
-        (['link1'], True, True, (['link1'], ['default_url', 'url1', 'url2'])),
-        # Test options.find_links=False.
-        (False, False, False, ([], ['default_url', 'url1', 'url2'])),
-    ],
-)
-def test_make_link_collector(
-    find_links, no_index, suppress_no_index, expected,
-):
-    """
-    :param expected: the expected (find_links, index_urls) values.
-    """
-    expected_find_links, expected_index_urls = expected
-    session = PipSession()
-    options = pretend.stub(
-        find_links=find_links,
-        index_url='default_url',
-        extra_index_urls=['url1', 'url2'],
-        no_index=no_index,
-    )
-    link_collector = make_link_collector(
-        session, options=options, suppress_no_index=suppress_no_index,
-    )
-
-    assert link_collector.session is session
-
-    search_scope = link_collector.search_scope
-    assert search_scope.find_links == expected_find_links
-    assert search_scope.index_urls == expected_index_urls
-
-
-@patch('pip._internal.utils.misc.expanduser')
-def test_make_link_collector__find_links_expansion(mock_expanduser, tmpdir):
-    """
-    Test "~" expansion in --find-links paths.
-    """
-    # This is a mock version of expanduser() that expands "~" to the tmpdir.
-    def expand_path(path):
-        if path.startswith('~/'):
-            path = os.path.join(tmpdir, path[2:])
-        return path
-
-    mock_expanduser.side_effect = expand_path
-
-    session = PipSession()
-    options = pretend.stub(
-        find_links=['~/temp1', '~/temp2'],
-        index_url='default_url',
-        extra_index_urls=[],
-        no_index=False,
-    )
-    # Only create temp2 and not temp1 to test that "~" expansion only occurs
-    # when the directory exists.
-    temp2_dir = os.path.join(tmpdir, 'temp2')
-    os.mkdir(temp2_dir)
-
-    link_collector = make_link_collector(session, options=options)
-
-    search_scope = link_collector.search_scope
-    # Only ~/temp2 gets expanded. Also, the path is normalized when expanded.
-    expected_temp2_dir = os.path.normcase(temp2_dir)
-    assert search_scope.find_links == ['~/temp1', expected_temp2_dir]
-    assert search_scope.index_urls == ['default_url']
 
 
 class MockBestCandidateResult(object):


### PR DESCRIPTION
`make_link_collector()` was in `self_outdated_check`, a module responsible for checking whether the currently-running pip is outdated, but is imported by things that has nothing to do with this outdated check.

This patch moves the function to be a class method in `LinkCollector` so the module hierarchy makes more sense.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
