### PR TITLE
Parallelize pip list --outdated and --uptodate

### DIFF
--- a/news/8504.feature
+++ b/news/8504.feature
@@ -1,0 +1,1 @@
+Parallelize network operations in ``pip list``.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -19,6 +19,7 @@ from pip._internal.utils.misc import (
     write_output,
 )
 from pip._internal.utils.packaging import get_installer
+from pip._internal.utils.parallel import map_multithread
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -223,7 +224,7 @@ class ListCommand(IndexGroupCommand):
                 dist.latest_filetype = typ
                 return dist
 
-            for dist in map(latest_info, packages):
+            for dist in map_multithread(latest_info, packages):
                 if dist is not None:
                     yield dist
 


### PR DESCRIPTION
This reverses GH-8167 and parallelizes the networking operations done by `pip list --outdated` and `pip list --uptodate`.  It would be lovely if this can make it before the next beta release (GH-8206).

I wonder if we should roll this out an an unstable feature or just keep it as-is.  Currently sometimes Control C needs to be issued twice for the command to be terminated properly.