### PR TITLE
install: Update extra-index-url in session from requirements file

### DIFF
--- a/news/8103.bugfix
+++ b/news/8103.bugfix
@@ -1,2 +1,2 @@
 Propagate ``--extra-index-url`` from requirements file properly to session auth,
-in order that keyrings and other auths will work as expected.
+so that keyring auth will work as expected.

--- a/news/8103.bugfix
+++ b/news/8103.bugfix
@@ -1,0 +1,2 @@
+Propagate ``--extra-index-url`` from requirements file properly to session auth,
+in order that keyrings and other auths will work as expected.

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -305,6 +305,14 @@ class PipSession(requests.Session):
         for host in trusted_hosts:
             self.add_trusted_host(host, suppress_logging=True)
 
+    def update_index_urls(self, new_index_urls):
+        # type: (List[str]) -> None
+        """
+        :param new_index_urls: New index urls to update the authentication
+            handler with.
+        """
+        self.auth.index_urls = new_index_urls
+
     def add_trusted_host(self, host, source=None, suppress_logging=False):
         # type: (str, Optional[str], bool) -> None
         """

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -256,6 +256,10 @@ def handle_option_line(
                 value = relative_to_reqs_file
             find_links.append(value)
 
+        if session:
+            # We need to update the auth urls in session
+            session.update_index_urls(index_urls)
+
         search_scope = SearchScope(
             find_links=find_links,
             index_urls=index_urls,

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -341,17 +341,22 @@ class TestProcessLine(object):
         line_processor("--no-index", "file", 1, finder=finder)
         assert finder.index_urls == []
 
-    def test_set_finder_index_url(self, line_processor, finder):
-        line_processor("--index-url=url", "file", 1, finder=finder)
+    def test_set_finder_index_url(self, line_processor, finder, session):
+        line_processor(
+            "--index-url=url", "file", 1, finder=finder, session=session)
         assert finder.index_urls == ['url']
+        assert session.auth.index_urls == ['url']
 
     def test_set_finder_find_links(self, line_processor, finder):
         line_processor("--find-links=url", "file", 1, finder=finder)
         assert finder.find_links == ['url']
 
-    def test_set_finder_extra_index_urls(self, line_processor, finder):
-        line_processor("--extra-index-url=url", "file", 1, finder=finder)
+    def test_set_finder_extra_index_urls(
+            self, line_processor, finder, session):
+        line_processor(
+            "--extra-index-url=url", "file", 1, finder=finder, session=session)
         assert finder.index_urls == ['url']
+        assert session.auth.index_urls == ['url']
 
     def test_set_finder_trusted_host(
         self, line_processor, caplog, session, finder


### PR DESCRIPTION
Resolves #8103 
@pfmoore you are welcome to take a look :smile:

Not sure how to test this though, maybe just check that `session.auth.index_urls` is updated as expected in a test?
