### PR TITLE
Remove redundant entrypoint text normalization

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -121,16 +121,8 @@ def get_entrypoints(filename):
     if not os.path.exists(filename):
         return {}, {}
 
-    # This is done because you can pass a string to entry_points wrappers which
-    # means that they may or may not be valid INI files. The attempt here is to
-    # strip leading and trailing whitespace in order to make them valid INI
-    # files.
     with io.open(filename, encoding="utf-8") as fp:
-        data = io.StringIO()
-        for line in fp:
-            data.write(line.strip())
-            data.write(u"\n")
-        data.seek(0)
+        data = fp.read()
 
     # get the entry points and then the script names
     entry_points = pkg_resources.EntryPoint.parse_map(data)


### PR DESCRIPTION
I wanted to submit this PR separately since the justification requires a little bit of a code dive. I hope that helps!

Currently we do processing in `get_entrypoints` so incoming text is more compatible
with `pkg_resources`. It turns out that `pkg_resources` is already doing the same normalization,
so we can omit it. See `parse_map`, [which calls](https://github.com/pypa/pip/blob/4645ecbdb096373d6711406527b3b1fdc4fb785c/src/pip/_vendor/pkg_resources/__init__.py#L2525) `split_sections`, [which calls](https://github.com/pypa/pip/blob/4645ecbdb096373d6711406527b3b1fdc4fb785c/src/pip/_vendor/pkg_resources/__init__.py#L3199) `split_sections`, which calls `yield_lines`, [where it accepts plain text and strips lines](https://github.com/pypa/pip/blob/4645ecbdb096373d6711406527b3b1fdc4fb785c/src/pip/_vendor/pkg_resources/__init__.py#L2378), as we were doing.

This simplifies `get_entrypoints`, opening the way for us to pass it a plain string (derived from the zip file) instead
of a file path.

Progresses #6030.