### PR TITLE
Simplify and optimize getting zip subdirs

### DIFF
--- a/src/pip/_internal/utils/wheel.py
+++ b/src/pip/_internal/utils/wheel.py
@@ -121,7 +121,7 @@ def wheel_dist_info_dir(source, name):
     it doesn't match the provided name.
     """
     # Zip file path separators must be /
-    subdirs = list(set(p.split("/")[0] for p in source.namelist()))
+    subdirs = set(p.split("/", 1)[0] for p in source.namelist())
 
     info_dirs = [s for s in subdirs if s.endswith('.dist-info')]
 


### PR DESCRIPTION
Since we only care about the first path part, we can stop at 1 split. We
do not need a list, so the unnecessary conversion has been dropped.

As discussed in [#8526 (comment)](https://github.com/pypa/pip/pull/8526#discussion_r449372386).