### PR TITLE
Rollout flags (--use-feature, --use-deprecated)

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -204,6 +204,13 @@ class Command(CommandContextMixIn):
                 issue=8333,
             )
 
+        if 'resolver' in options.unstable_features:
+            logger.critical(
+                "--unstable-feature=resolver is no longer supported, and "
+                "has been replaced with --use-feature=2020-resolver instead."
+            )
+            sys.exit(ERROR)
+
         try:
             status = self.run(options, args)
             assert isinstance(status, int)

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -922,7 +922,7 @@ use_new_feature = partial(
 
 use_deprecated_feature = partial(
     Option,
-    '--deprecated-feature',
+    '--use-deprecated',
     dest='deprecated_features_enabled',
     metavar='feature',
     action='append',

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -906,8 +906,31 @@ unstable_feature = partial(
     action='append',
     default=[],
     choices=['resolver'],
-    help=SUPPRESS_HELP,  # TODO: Enable this when the resolver actually works.
-    # help='Enable unstable feature(s) that may be backward incompatible.',
+    help=SUPPRESS_HELP,  # TODO: drop this in pip 20.3
+)  # type: Callable[..., Option]
+
+use_new_feature = partial(
+    Option,
+    '--use-feature',
+    dest='features_enabled',
+    metavar='feature',
+    action='append',
+    default=[],
+    choices=['2020-resolver'],
+    help='Enable new functionality, that may be backward incompatible.',
+)  # type: Callable[..., Option]
+
+use_deprecated_feature = partial(
+    Option,
+    '--deprecated-feature',
+    dest='deprecated_features_enabled',
+    metavar='feature',
+    action='append',
+    default=[],
+    choices=[],
+    help=(
+        'Enable deprecated functionality, that will be removed in the future.'
+    ),
 )  # type: Callable[..., Option]
 
 
@@ -939,6 +962,8 @@ general_group = {
         no_color,
         no_python_version_warning,
         unstable_feature,
+        use_new_feature,
+        use_deprecated_feature,
     ]
 }  # type: Dict[str, Any]
 

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -259,7 +259,7 @@ class RequirementCommand(IndexGroupCommand):
         # The long import name and duplicated invocation is needed to convince
         # Mypy into correctly typechecking. Otherwise it would complain the
         # "Resolver" class being redefined.
-        if 'resolver' in options.unstable_features:
+        if '2020-resolver' in options.features_enabled:
             import pip._internal.resolution.resolvelib.resolver
             return pip._internal.resolution.resolvelib.resolver.Resolver(
                 preparer=preparer,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,9 +105,9 @@ def use_new_resolver(request):
     """
     new_resolver = request.config.getoption("--new-resolver")
     if new_resolver:
-        os.environ["PIP_UNSTABLE_FEATURE"] = "resolver"
+        os.environ["PIP_USE_FEATURE"] = "2020-resolver"
     else:
-        os.environ.pop("PIP_UNSTABLE_FEATURE", None)
+        os.environ.pop("PIP_USE_FEATURE", None)
     yield new_resolver
 
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -405,7 +405,7 @@ def test_vcs_url_urlquote_normalization(script, tmpdir):
     )
 
 
-@pytest.mark.parametrize("resolver", ["", "--unstable-feature=resolver"])
+@pytest.mark.parametrize("resolver", ["", "--use-feature=2020-resolver"])
 def test_basic_install_from_local_directory(script, data, resolver):
     """
     Test installing from a local directory.

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -52,7 +52,7 @@ def test_new_resolver_can_install(script):
         "0.1.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "simple"
@@ -67,7 +67,7 @@ def test_new_resolver_can_install_with_version(script):
         "0.1.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "simple==0.1.0"
@@ -87,7 +87,7 @@ def test_new_resolver_picks_latest_version(script):
         "0.2.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "simple"
@@ -107,7 +107,7 @@ def test_new_resolver_picks_installed_version(script):
         "0.2.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "simple==0.1.0"
@@ -115,7 +115,7 @@ def test_new_resolver_picks_installed_version(script):
     assert_installed(script, simple="0.1.0")
 
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "simple"
@@ -136,7 +136,7 @@ def test_new_resolver_picks_installed_version_if_no_match_found(script):
         "0.2.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "simple==0.1.0"
@@ -144,7 +144,7 @@ def test_new_resolver_picks_installed_version_if_no_match_found(script):
     assert_installed(script, simple="0.1.0")
 
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "simple"
     )
@@ -165,7 +165,7 @@ def test_new_resolver_installs_dependencies(script):
         "0.1.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base"
@@ -186,7 +186,7 @@ def test_new_resolver_ignore_dependencies(script):
         "0.1.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index", "--no-deps",
         "--find-links", script.scratch_path,
         "base"
@@ -220,7 +220,7 @@ def test_new_resolver_installs_extras(tmpdir, script, root_dep):
         "0.1.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "-r", req_file,
@@ -241,7 +241,7 @@ def test_new_resolver_installs_extras_warn_missing(script):
         "0.1.0",
     )
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base[add,missing]",
@@ -255,7 +255,7 @@ def test_new_resolver_installs_extras_warn_missing(script):
 def test_new_resolver_installed_message(script):
     create_basic_wheel_for_package(script, "A", "1.0")
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "A",
@@ -267,7 +267,7 @@ def test_new_resolver_installed_message(script):
 def test_new_resolver_no_dist_message(script):
     create_basic_wheel_for_package(script, "A", "1.0")
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "B",
@@ -298,7 +298,7 @@ def test_new_resolver_installs_editable(script):
         version="0.1.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base",
@@ -346,7 +346,7 @@ def test_new_resolver_requires_python(
 
     args = [
         "install",
-        "--unstable-feature=resolver",
+        "--use-feature=2020-resolver",
         "--no-cache-dir",
         "--no-index",
         "--find-links", script.scratch_path,
@@ -368,7 +368,7 @@ def test_new_resolver_requires_python_error(script):
         requires_python="<2",
     )
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base",
@@ -396,7 +396,7 @@ def test_new_resolver_installed(script):
     )
 
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base",
@@ -404,7 +404,7 @@ def test_new_resolver_installed(script):
     assert "Requirement already satisfied" not in result.stdout, str(result)
 
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base~=0.1.0",
@@ -426,7 +426,7 @@ def test_new_resolver_ignore_installed(script):
     satisfied_output = "Requirement already satisfied"
 
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base",
@@ -434,7 +434,7 @@ def test_new_resolver_ignore_installed(script):
     assert satisfied_output not in result.stdout, str(result)
 
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index", "--ignore-installed",
         "--find-links", script.scratch_path,
         "base",
@@ -467,7 +467,7 @@ def test_new_resolver_only_builds_sdists_when_needed(script):
     )
     # We only ever need to check dep 0.2.0 as it's the latest version
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base"
@@ -476,7 +476,7 @@ def test_new_resolver_only_builds_sdists_when_needed(script):
 
     # We merge criteria here, as we have two "dep" requirements
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base", "dep"
@@ -489,7 +489,7 @@ def test_new_resolver_install_different_version(script):
     create_basic_wheel_for_package(script, "base", "0.2.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base==0.1.0",
@@ -497,7 +497,7 @@ def test_new_resolver_install_different_version(script):
 
     # This should trigger an uninstallation of base.
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base==0.2.0",
@@ -516,7 +516,7 @@ def test_new_resolver_force_reinstall(script):
     create_basic_wheel_for_package(script, "base", "0.1.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base==0.1.0",
@@ -525,7 +525,7 @@ def test_new_resolver_force_reinstall(script):
     # This should trigger an uninstallation of base due to --force-reinstall,
     # even though the installed version matches.
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--force-reinstall",
@@ -564,7 +564,7 @@ def test_new_resolver_handles_prerelease(
     for version in available_versions:
         create_basic_wheel_for_package(script, "pkg", version)
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         *pip_args
@@ -586,7 +586,7 @@ def test_new_reolver_skips_marker(script, pkg_deps, root_deps):
     create_basic_wheel_for_package(script, "dep", "1.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         *root_deps
@@ -611,7 +611,7 @@ def test_new_resolver_constraints(script, constraints):
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text("\n".join(constraints))
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "-c", constraints_file,
@@ -627,7 +627,7 @@ def test_new_resolver_constraint_no_specifier(script):
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text("pkg")
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "-c", constraints_file,
@@ -658,7 +658,7 @@ def test_new_resolver_constraint_reject_invalid(script, constraint, error):
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text(constraint)
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "-c", constraints_file,
@@ -677,7 +677,7 @@ def test_new_resolver_constraint_on_dependency(script):
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text("dep==2.0")
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "-c", constraints_file,
@@ -694,7 +694,7 @@ def test_new_resolver_constraint_on_path(script):
     constraints_txt = script.scratch_path / "constraints.txt"
     constraints_txt.write_text("foo==1.0")
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "-c", constraints_txt,
         str(script.scratch_path),
@@ -709,7 +709,7 @@ def test_new_resolver_upgrade_needs_option(script):
     # Install pkg 1.0.0
     create_basic_wheel_for_package(script, "pkg", "1.0.0")
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "pkg",
@@ -720,7 +720,7 @@ def test_new_resolver_upgrade_needs_option(script):
 
     # This should not upgrade because we don't specify --upgrade
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "pkg",
@@ -731,7 +731,7 @@ def test_new_resolver_upgrade_needs_option(script):
 
     # This should upgrade
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--upgrade",
@@ -751,7 +751,7 @@ def test_new_resolver_upgrade_strategy(script):
     create_basic_wheel_for_package(script, "base", "1.0.0", depends=["dep"])
     create_basic_wheel_for_package(script, "dep", "1.0.0")
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base",
@@ -765,7 +765,7 @@ def test_new_resolver_upgrade_strategy(script):
     create_basic_wheel_for_package(script, "dep", "2.0.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--upgrade",
@@ -779,7 +779,7 @@ def test_new_resolver_upgrade_strategy(script):
 
     create_basic_wheel_for_package(script, "base", "3.0.0", depends=["dep"])
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--upgrade", "--upgrade-strategy=eager",
@@ -858,7 +858,7 @@ class TestExtraMerge(object):
         )
 
         script.pip(
-            "install", "--unstable-feature=resolver",
+            "install", "--use-feature=2020-resolver",
             "--no-cache-dir", "--no-index",
             "--find-links", script.scratch_path,
             requirement + "[dev]",
@@ -897,7 +897,7 @@ def test_new_resolver_build_directory_error_zazo_19(script):
     create_basic_sdist_for_package(script, "pkg_b", "1.0.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "pkg-a", "pkg-b",
@@ -910,7 +910,7 @@ def test_new_resolver_upgrade_same_version(script):
     create_basic_wheel_for_package(script, "pkg", "1")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "pkg",
@@ -918,7 +918,7 @@ def test_new_resolver_upgrade_same_version(script):
     assert_installed(script, pkg="2")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--upgrade",
@@ -934,7 +934,7 @@ def test_new_resolver_local_and_req(script):
         version="0.1.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         source_dir, "pkg!=0.1.0",
         expect_error=True,

--- a/tests/functional/test_new_resolver_user.py
+++ b/tests/functional/test_new_resolver_user.py
@@ -10,7 +10,7 @@ from tests.lib import create_basic_wheel_for_package
 def test_new_resolver_install_user(script):
     create_basic_wheel_for_package(script, "base", "0.1.0")
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--user",
@@ -28,13 +28,13 @@ def test_new_resolver_install_user_satisfied_by_global_site(script):
     create_basic_wheel_for_package(script, "base", "1.0.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base==1.0.0",
     )
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--user",
@@ -54,7 +54,7 @@ def test_new_resolver_install_user_conflict_in_user_site(script):
     create_basic_wheel_for_package(script, "base", "2.0.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--user",
@@ -62,7 +62,7 @@ def test_new_resolver_install_user_conflict_in_user_site(script):
     )
 
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--user",
@@ -82,13 +82,13 @@ def test_new_resolver_install_user_in_virtualenv_with_conflict_fails(script):
     create_basic_wheel_for_package(script, "base", "2.0.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base==2.0.0",
     )
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--user",
@@ -128,13 +128,13 @@ def test_new_resolver_install_user_reinstall_global_site(script):
     create_basic_wheel_for_package(script, "base", "1.0.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base==1.0.0",
     )
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--user",
@@ -159,14 +159,14 @@ def test_new_resolver_install_user_conflict_in_global_site(script):
     create_basic_wheel_for_package(script, "base", "2.0.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base==1.0.0",
     )
 
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--user",
@@ -191,13 +191,13 @@ def test_new_resolver_install_user_conflict_in_global_and_user_sites(script):
     create_basic_wheel_for_package(script, "base", "2.0.0")
 
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "base==2.0.0",
     )
     script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--user",
@@ -206,7 +206,7 @@ def test_new_resolver_install_user_conflict_in_global_and_user_sites(script):
     )
 
     result = script.pip(
-        "install", "--unstable-feature=resolver",
+        "install", "--use-feature=2020-resolver",
         "--no-cache-dir", "--no-index",
         "--find-links", script.scratch_path,
         "--user",

--- a/tests/functional/test_yaml.py
+++ b/tests/functional/test_yaml.py
@@ -88,7 +88,7 @@ def handle_request(script, action, requirement, options, new_resolver=False):
     if action == 'install':
         args = ['install']
         if new_resolver:
-            args.append("--unstable-feature=resolver")
+            args.append("--use-feature=2020-resolver")
         args.extend(["--no-index", "--find-links",
                      path_to_url(script.scratch_path)])
     elif action == 'uninstall':


### PR DESCRIPTION
This implements the feature rollout approach we have concensus on (from #8371) and handles everything except the warnings for #8513.

AFAICT, there's gonna be 2 more follow up PRs to this:

- Implementing the warnings mentioned in #8513.
- Properly documenting how this would work with pip's deprecation policy.

Since we'd have a dedicated documentation PR, I suggest we skip the changelog entry for this PR.