### PR TITLE
Get entrypoints directly from wheel during installation

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -121,8 +121,8 @@ def wheel_root_is_purelib(metadata):
     return metadata.get("Root-Is-Purelib", "").lower() == "true"
 
 
-def get_entrypoints(filename, distribution):
-    # type: (str, Distribution) -> Tuple[Dict[str, str], Dict[str, str]]
+def get_entrypoints(distribution):
+    # type: (Distribution) -> Tuple[Dict[str, str], Dict[str, str]]
     # get the entry points and then the script names
     try:
         console = distribution.get_entry_map('console_scripts')
@@ -458,8 +458,7 @@ def install_unpacked_wheel(
     distribution = pkg_resources_distribution_for_wheel(
         wheel_zip, name, wheel_path
     )
-    ep_file = os.path.join(dest_info_dir, 'entry_points.txt')
-    console, gui = get_entrypoints(ep_file, distribution)
+    console, gui = get_entrypoints(distribution)
 
     def is_entrypoint_wrapper(name):
         # type: (text_type) -> bool

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -452,8 +452,6 @@ def install_unpacked_wheel(
         True,
     )
 
-    dest_info_dir = os.path.join(lib_dir, info_dir)
-
     # Get the defined entry points
     distribution = pkg_resources_distribution_for_wheel(
         wheel_zip, name, wheel_path
@@ -623,6 +621,8 @@ def install_unpacked_wheel(
             yield f
         os.chmod(f.name, generated_file_mode)
         replace(f.name, path)
+
+    dest_info_dir = os.path.join(lib_dir, info_dir)
 
     # Record pip as the installer
     installer_path = os.path.join(dest_info_dir, 'INSTALLER')

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -91,15 +91,17 @@ def test_get_legacy_build_wheel_path__multiple_names(caplog):
     ],
 )
 def test_get_entrypoints(tmpdir, console_scripts):
+    entry_points_text = u"""
+        [console_scripts]
+        {}
+        [section]
+        common:one = module:func
+        common:two = module:other_func
+    """.format(console_scripts)
+
     entry_points = tmpdir.joinpath("entry_points.txt")
     with io.open(str(entry_points), "w", encoding="utf-8") as fp:
-        fp.write(u"""
-            [console_scripts]
-            {}
-            [section]
-            common:one = module:func
-            common:two = module:other_func
-        """.format(console_scripts))
+        fp.write(entry_points_text)
 
     assert wheel.get_entrypoints(str(entry_points)) == (
         dict([console_scripts.split(' = ')]),

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -2,7 +2,6 @@
 
 """Tests for wheel binary packages and .dist-info."""
 import csv
-import io
 import logging
 import os
 import textwrap
@@ -92,7 +91,7 @@ def test_get_legacy_build_wheel_path__multiple_names(caplog):
         pytest.param(u"進入點 = 套件.模組:函式", marks=skip_if_python2),
     ],
 )
-def test_get_entrypoints(tmpdir, console_scripts):
+def test_get_entrypoints(console_scripts):
     entry_points_text = u"""
         [console_scripts]
         {}
@@ -112,25 +111,19 @@ def test_get_entrypoints(tmpdir, console_scripts):
         wheel_zip, "simple", "<in memory>"
     )
 
-    entry_points = tmpdir.joinpath("entry_points.txt")
-    with io.open(str(entry_points), "w", encoding="utf-8") as fp:
-        fp.write(entry_points_text)
-
-    assert wheel.get_entrypoints(str(entry_points), distribution) == (
+    assert wheel.get_entrypoints(distribution) == (
         dict([console_scripts.split(' = ')]),
         {},
     )
 
 
-def test_get_entrypoints_no_entrypoints(tmpdir):
+def test_get_entrypoints_no_entrypoints():
     wheel_zip = make_wheel("simple", "0.1.0").as_zipfile()
     distribution = pkg_resources_distribution_for_wheel(
         wheel_zip, "simple", "<in memory>"
     )
 
-    console, gui = wheel.get_entrypoints(
-        str(tmpdir / 'entry_points.txt'), distribution
-    )
+    console, gui = wheel.get_entrypoints(distribution)
     assert console == {}
     assert gui == {}
 


### PR DESCRIPTION
As part of our wheel installation, we must get the entry points from the package metadata and generate wrapper scripts for each. Originally, we would get the entry points by parsing "entry_points.txt", which had been extracted to disk along with the rest of the wheel contents. Now, we retrieve the entry points directly using a `pkg_resources.Distribution`. This relies on work we did several months ago to create a `pkg_resources.Distribution` that extracts and uses the package metadata in memory.

This change has been broken into several commits to aid review, please check them out!

Progresses #6030.