### PR TITLE
Use lazy wheel to obtain dep info for new resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,21 +41,21 @@ jobs:
     - env:
       - GROUP=1
       - NEW_RESOLVER=1
-      - LAZY_WHEEL=1
+      - FAST_DEPS=1
     - env:
       - GROUP=2
       - NEW_RESOLVER=1
     - env:
       - GROUP=2
       - NEW_RESOLVER=1
-      - LAZY_WHEEL=1
+      - FAST_DEPS=1
     - env:
       - GROUP=3
       - NEW_RESOLVER=1
     - env:
       - GROUP=3
       - NEW_RESOLVER=1
-      - LAZY_WHEEL=1
+      - FAST_DEPS=1
 
   fast_finish: true
   allow_failures:
@@ -65,7 +65,7 @@ jobs:
     - env:
       - GROUP=3
       - NEW_RESOLVER=1
-      - LAZY_WHEEL=1
+      - FAST_DEPS=1
 
 before_install: tools/travis/setup.sh
 install: travis_retry tools/travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,17 +39,33 @@ jobs:
       - GROUP=1
       - NEW_RESOLVER=1
     - env:
+      - GROUP=1
+      - NEW_RESOLVER=1
+      - LAZY_WHEEL=1
+    - env:
       - GROUP=2
+      - NEW_RESOLVER=1
+    - env:
+      - GROUP=2
+      - NEW_RESOLVER=1
+      - LAZY_WHEEL=1
+    - env:
+      - GROUP=3
       - NEW_RESOLVER=1
     - env:
       - GROUP=3
       - NEW_RESOLVER=1
+      - LAZY_WHEEL=1
 
   fast_finish: true
   allow_failures:
     - env:
       - GROUP=3
       - NEW_RESOLVER=1
+    - env:
+      - GROUP=3
+      - NEW_RESOLVER=1
+      - LAZY_WHEEL=1
 
 before_install: tools/travis/setup.sh
 install: travis_retry tools/travis/install.sh

--- a/news/8532.feature
+++ b/news/8532.feature
@@ -1,0 +1,3 @@
+Allow the new resolver to obtain dependency information through wheels
+lazily downloaded using HTTP range requests.  To enable this feature,
+invoke ``pip`` with ``--use-feature=lazy-wheel``.

--- a/news/8532.feature
+++ b/news/8532.feature
@@ -1,3 +1,3 @@
 Allow the new resolver to obtain dependency information through wheels
 lazily downloaded using HTTP range requests.  To enable this feature,
-invoke ``pip`` with ``--use-feature=lazy-wheel``.
+invoke ``pip`` with ``--use-feature=fast-deps``.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -916,7 +916,7 @@ use_new_feature = partial(
     metavar='feature',
     action='append',
     default=[],
-    choices=['2020-resolver', 'lazy-wheel'],
+    choices=['2020-resolver', 'fast-deps'],
     help='Enable new functionality, that may be backward incompatible.',
 )  # type: Callable[..., Option]
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -916,7 +916,7 @@ use_new_feature = partial(
     metavar='feature',
     action='append',
     default=[],
-    choices=['2020-resolver'],
+    choices=['2020-resolver', 'lazy-wheel'],
     help='Enable new functionality, that may be backward incompatible.',
 )  # type: Callable[..., Option]
 

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -271,7 +271,7 @@ class RequirementCommand(IndexGroupCommand):
                 force_reinstall=force_reinstall,
                 upgrade_strategy=upgrade_strategy,
                 py_version_info=py_version_info,
-                lazy_wheel='lazy-wheel' in options.features_enabled,
+                lazy_wheel='fast-deps' in options.features_enabled,
             )
         import pip._internal.resolution.legacy.resolver
         return pip._internal.resolution.legacy.resolver.Resolver(

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -271,6 +271,7 @@ class RequirementCommand(IndexGroupCommand):
                 force_reinstall=force_reinstall,
                 upgrade_strategy=upgrade_strategy,
                 py_version_info=py_version_info,
+                lazy_wheel='lazy-wheel' in options.features_enabled,
             )
         import pip._internal.resolution.legacy.resolver
         return pip._internal.resolution.legacy.resolver.Resolver(

--- a/src/pip/_internal/network/lazy_wheel.py
+++ b/src/pip/_internal/network/lazy_wheel.py
@@ -1,6 +1,6 @@
 """Lazy ZIP over HTTP"""
 
-__all__ = ['dist_from_wheel_url']
+__all__ = ['HTTPRangeRequestUnsupported', 'dist_from_wheel_url']
 
 from bisect import bisect_left, bisect_right
 from contextlib import contextmanager
@@ -23,13 +23,18 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.network.session import PipSession
 
 
+class HTTPRangeRequestUnsupported(RuntimeError):
+    pass
+
+
 def dist_from_wheel_url(name, url, session):
     # type: (str, str, PipSession) -> Distribution
     """Return a pkg_resources.Distribution from the given wheel URL.
 
     This uses HTTP range requests to only fetch the potion of the wheel
     containing metadata, just enough for the object to be constructed.
-    If such requests are not supported, RuntimeError is raised.
+    If such requests are not supported, HTTPRangeRequestUnsupported
+    is raised.
     """
     with LazyZipOverHTTP(url, session) as wheel:
         # For read-only ZIP files, ZipFile only needs methods read,
@@ -45,7 +50,8 @@ class LazyZipOverHTTP(object):
 
     This uses HTTP range requests to lazily fetch the file's content,
     which is supposed to be fed to ZipFile.  If such requests are not
-    supported by the server, raise RuntimeError during initialization.
+    supported by the server, raise HTTPRangeRequestUnsupported
+    during initialization.
     """
 
     def __init__(self, url, session, chunk_size=CONTENT_CHUNK_SIZE):
@@ -60,7 +66,7 @@ class LazyZipOverHTTP(object):
         self._left = []  # type: List[int]
         self._right = []  # type: List[int]
         if 'bytes' not in head.headers.get('Accept-Ranges', 'none'):
-            raise RuntimeError('range request is not supported')
+            raise HTTPRangeRequestUnsupported('range request is not supported')
         self._check_zip()
 
     @property

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -304,12 +304,11 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
     def iter_dependencies(self):
         # type: () -> Iterable[Optional[Requirement]]
         dist = None  # type: Optional[Distribution]
-        preparer, req = self._factory.preparer, self._ireq
+        preparer, lazy_wheel = self._factory.preparer, self._factory.lazy_wheel
         remote_wheel = self._link.is_wheel and not self._link.is_file
-        # TODO: Opt-in as unstable feature.
-        if remote_wheel and not preparer.require_hashes:
+        if lazy_wheel and remote_wheel and not preparer.require_hashes:
             assert self._name is not None
-            logger.info('Collecting %s', req.req or req)
+            logger.info('Collecting %s', self._ireq.req or self._ireq)
             # If RuntimeError is raised, fallback to self.dist.
             with indent_log(), suppress(RuntimeError):
                 logger.info(

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -82,6 +82,7 @@ class Factory(object):
         ignore_installed,  # type: bool
         ignore_requires_python,  # type: bool
         py_version_info=None,  # type: Optional[Tuple[int, ...]]
+        lazy_wheel=False,  # type: bool
     ):
         # type: (...) -> None
         self._finder = finder
@@ -92,6 +93,7 @@ class Factory(object):
         self._use_user_site = use_user_site
         self._force_reinstall = force_reinstall
         self._ignore_requires_python = ignore_requires_python
+        self.lazy_wheel = lazy_wheel
 
         self._link_candidate_cache = {}  # type: Cache[LinkCandidate]
         self._editable_candidate_cache = {}  # type: Cache[EditableCandidate]

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -49,6 +49,7 @@ class Resolver(BaseResolver):
         force_reinstall,  # type: bool
         upgrade_strategy,  # type: str
         py_version_info=None,  # type: Optional[Tuple[int, ...]]
+        lazy_wheel=False,  # type: bool
     ):
         super(Resolver, self).__init__()
 
@@ -64,6 +65,7 @@ class Resolver(BaseResolver):
             ignore_installed=ignore_installed,
             ignore_requires_python=ignore_requires_python,
             py_version_info=py_version_info,
+            lazy_wheel=lazy_wheel,
         )
         self.ignore_dependencies = ignore_dependencies
         self.upgrade_strategy = upgrade_strategy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,12 @@ def pytest_addoption(parser):
         help="run the skipped tests for the new resolver",
     )
     parser.addoption(
+        "--lazy-wheel",
+        action="store_true",
+        default=False,
+        help="use lazy wheels in tests (only affect new resolver)",
+    )
+    parser.addoption(
         "--use-venv",
         action="store_true",
         default=False,
@@ -102,12 +108,16 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(scope="session", autouse=True)
 def use_new_resolver(request):
     """Set environment variable to make pip default to the new resolver.
+
+    Lazy wheel, an optimization, is also decided here.
     """
     new_resolver = request.config.getoption("--new-resolver")
-    if new_resolver:
-        os.environ["PIP_USE_FEATURE"] = "2020-resolver"
-    else:
+    if not new_resolver:
         os.environ.pop("PIP_USE_FEATURE", None)
+    elif request.config.getoption("--lazy-wheel"):
+        os.environ["PIP_USE_FEATURE"] = "2020-resolver lazy-wheel"
+    else:
+        os.environ["PIP_USE_FEATURE"] = "2020-resolver"
     yield new_resolver
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def pytest_addoption(parser):
         help="run the skipped tests for the new resolver",
     )
     parser.addoption(
-        "--lazy-wheel",
+        "--fast-deps",
         action="store_true",
         default=False,
         help="use lazy wheels in tests (only affect new resolver)",
@@ -114,8 +114,8 @@ def use_new_resolver(request):
     new_resolver = request.config.getoption("--new-resolver")
     if not new_resolver:
         os.environ.pop("PIP_USE_FEATURE", None)
-    elif request.config.getoption("--lazy-wheel"):
-        os.environ["PIP_USE_FEATURE"] = "2020-resolver lazy-wheel"
+    elif request.config.getoption("--fast-deps"):
+        os.environ["PIP_USE_FEATURE"] = "2020-resolver fast-deps"
     else:
         os.environ["PIP_USE_FEATURE"] = "2020-resolver"
     yield new_resolver

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -3,7 +3,10 @@ from zipfile import BadZipfile
 from pip._vendor.pkg_resources import Requirement
 from pytest import fixture, mark, raises
 
-from pip._internal.network.lazy_wheel import dist_from_wheel_url
+from pip._internal.network.lazy_wheel import (
+    HTTPRangeRequestUnsupported,
+    dist_from_wheel_url,
+)
 from pip._internal.network.session import PipSession
 from tests.lib.requests_mocks import MockResponse
 
@@ -39,7 +42,7 @@ def test_dist_from_wheel_url(session):
 def test_dist_from_wheel_url_no_range(session, monkeypatch):
     """Test handling when HTTP range requests are not supported."""
     monkeypatch.setattr(session, 'head', lambda *a, **kw: MockResponse(b''))
-    with raises(RuntimeError):
+    with raises(HTTPRangeRequestUnsupported):
         dist_from_wheel_url('mypy', MYPY_0_782_WHL, session)
 
 

--- a/tools/travis/run.sh
+++ b/tools/travis/run.sh
@@ -43,6 +43,12 @@ else
     RESOLVER_SWITCH='--new-resolver'
 fi
 
+if [[ -z "$LAZY_WHEEL" ]]; then
+    LAZY_WHEEL_SWITCH=''
+else
+    LAZY_WHEEL_SWITCH='--lazy-wheel'
+fi
+
 # Print the commands run for this test.
 set -x
 if [[ "$GROUP" == "1" ]]; then
@@ -50,15 +56,15 @@ if [[ "$GROUP" == "1" ]]; then
     tox -- --use-venv -m unit -n auto
     # Integration tests (not the ones for 'pip install')
     tox -- -m integration -n auto --duration=5 -k "not test_install" \
-        --use-venv $RESOLVER_SWITCH
+        --use-venv $RESOLVER_SWITCH $LAZY_WHEEL_SWITCH
 elif [[ "$GROUP" == "2" ]]; then
     # Separate Job for running integration tests for 'pip install'
     tox -- -m integration -n auto --duration=5 -k "test_install" \
-        --use-venv $RESOLVER_SWITCH
+        --use-venv $RESOLVER_SWITCH $LAZY_WHEEL_SWITCH
 elif [[ "$GROUP" == "3" ]]; then
     # Separate Job for tests that fail with the new resolver
     tox -- -m fails_on_new_resolver -n auto --duration=5 \
-        --use-venv $RESOLVER_SWITCH --new-resolver-runtests
+        --use-venv $RESOLVER_SWITCH --new-resolver-runtests $LAZY_WHEEL_SWITCH
 else
     # Non-Testing Jobs should run once
     tox

--- a/tools/travis/run.sh
+++ b/tools/travis/run.sh
@@ -43,10 +43,10 @@ else
     RESOLVER_SWITCH='--new-resolver'
 fi
 
-if [[ -z "$LAZY_WHEEL" ]]; then
-    LAZY_WHEEL_SWITCH=''
+if [[ -z "$FAST_DEPS" ]]; then
+    FAST_DEPS_SWITCH=''
 else
-    LAZY_WHEEL_SWITCH='--lazy-wheel'
+    FAST_DEPS_SWITCH='--fast-deps'
 fi
 
 # Print the commands run for this test.
@@ -56,15 +56,15 @@ if [[ "$GROUP" == "1" ]]; then
     tox -- --use-venv -m unit -n auto
     # Integration tests (not the ones for 'pip install')
     tox -- -m integration -n auto --duration=5 -k "not test_install" \
-        --use-venv $RESOLVER_SWITCH $LAZY_WHEEL_SWITCH
+        --use-venv $RESOLVER_SWITCH $FAST_DEPS_SWITCH
 elif [[ "$GROUP" == "2" ]]; then
     # Separate Job for running integration tests for 'pip install'
     tox -- -m integration -n auto --duration=5 -k "test_install" \
-        --use-venv $RESOLVER_SWITCH $LAZY_WHEEL_SWITCH
+        --use-venv $RESOLVER_SWITCH $FAST_DEPS_SWITCH
 elif [[ "$GROUP" == "3" ]]; then
     # Separate Job for tests that fail with the new resolver
     tox -- -m fails_on_new_resolver -n auto --duration=5 \
-        --use-venv $RESOLVER_SWITCH --new-resolver-runtests $LAZY_WHEEL_SWITCH
+        --use-venv $RESOLVER_SWITCH --new-resolver-runtests $FAST_DEPS_SWITCH
 else
     # Non-Testing Jobs should run once
     tox


### PR DESCRIPTION
This PR is created to continue the path to implement GH-7819 (this is half way there).  I file this a bit early to iron out the UX that we'd want to have.  At the time of writing, the patch produce something like the following, which IMHO a bit too verbose
<details><summary>Installation of django-rest-swagger</summary><p>

```console
$ pip install django-rest-swagger --no-cache
Collecting django-rest-swagger
  Obtaining dependency information from django-rest-swagger 2.2.0
Collecting openapi-codec>=1.3.1
  Downloading openapi-codec-1.3.2.tar.gz (6.3 kB)
Collecting coreapi>=2.3.0
  Obtaining dependency information from coreapi 2.3.3
Collecting itypes
  Obtaining dependency information from itypes 1.2.0
Collecting coreschema
  Downloading coreschema-0.0.4.tar.gz (10 kB)
Collecting uritemplate
  Obtaining dependency information from uritemplate 3.0.1
Collecting djangorestframework>=3.5.4
  Obtaining dependency information from djangorestframework 3.11.0
Collecting jinja2
  Obtaining dependency information from jinja2 2.11.2
Collecting MarkupSafe>=0.23
  Obtaining dependency information from markupsafe 1.1.1
Collecting django>=1.11
  Obtaining dependency information from django 3.0.8
Collecting sqlparse>=0.2.2
  Obtaining dependency information from sqlparse 0.3.1
Collecting asgiref~=3.2
  Obtaining dependency information from asgiref 3.2.10
Collecting pytz
  Obtaining dependency information from pytz 2020.1
Collecting simplejson
  Downloading simplejson-3.17.0.tar.gz (83 kB)
     |████████████████████████████████| 83 kB 666 kB/s 
Collecting requests
  Obtaining dependency information from requests 2.24.0
Collecting chardet<4,>=3.0.2
  Obtaining dependency information from chardet 3.0.4
Collecting idna<3,>=2.5
  Obtaining dependency information from idna 2.10
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1
  Obtaining dependency information from urllib3 1.25.9
Collecting certifi>=2017.4.17
  Obtaining dependency information from certifi 2020.6.20
Collecting django-rest-swagger
  Downloading django_rest_swagger-2.2.0-py2.py3-none-any.whl (495 kB)
     |████████████████████████████████| 495 kB 329 kB/s 
Collecting coreapi>=2.3.0
  Downloading coreapi-2.3.3-py2.py3-none-any.whl (25 kB)
Collecting itypes
  Downloading itypes-1.2.0-py2.py3-none-any.whl (4.8 kB)
Collecting uritemplate
  Downloading uritemplate-3.0.1-py2.py3-none-any.whl (15 kB)
Collecting djangorestframework>=3.5.4
  Downloading djangorestframework-3.11.0-py3-none-any.whl (911 kB)
     |████████████████████████████████| 911 kB 315 kB/s 
Collecting jinja2
  Downloading Jinja2-2.11.2-py2.py3-none-any.whl (125 kB)
     |████████████████████████████████| 125 kB 691 kB/s 
Collecting MarkupSafe>=0.23
  Downloading MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl (32 kB)
Collecting django>=1.11
  Downloading Django-3.0.8-py3-none-any.whl (7.5 MB)
     |████████████████████████████████| 7.5 MB 624 kB/s 
Collecting sqlparse>=0.2.2
  Downloading sqlparse-0.3.1-py2.py3-none-any.whl (40 kB)
     |████████████████████████████████| 40 kB 1.5 MB/s 
Collecting asgiref~=3.2
  Downloading asgiref-3.2.10-py3-none-any.whl (19 kB)
Collecting pytz
  Downloading pytz-2020.1-py2.py3-none-any.whl (510 kB)
     |████████████████████████████████| 510 kB 73 kB/s 
Collecting requests
  Downloading requests-2.24.0-py2.py3-none-any.whl (61 kB)
     |████████████████████████████████| 61 kB 1.0 MB/s 
Collecting chardet<4,>=3.0.2
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133 kB)
     |████████████████████████████████| 133 kB 827 kB/s 
Collecting idna<3,>=2.5
  Downloading idna-2.10-py2.py3-none-any.whl (58 kB)
     |████████████████████████████████| 58 kB 1.1 MB/s 
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1
  Downloading urllib3-1.25.9-py2.py3-none-any.whl (126 kB)
     |████████████████████████████████| 126 kB 820 kB/s 
Collecting certifi>=2017.4.17
  Downloading certifi-2020.6.20-py2.py3-none-any.whl (156 kB)
     |████████████████████████████████| 156 kB 706 kB/s 
Using legacy setup.py install for openapi-codec, since package 'wheel' is not installed.
Using legacy setup.py install for coreschema, since package 'wheel' is not installed.
Using legacy setup.py install for simplejson, since package 'wheel' is not installed.
Installing collected packages: MarkupSafe, urllib3, jinja2, idna, chardet, certifi, uritemplate, sqlparse, requests, pytz, itypes, coreschema, asgiref, django, coreapi, simplejson, openapi-codec, djangorestframework, django-rest-swagger
    Running setup.py install for coreschema ... done
    Running setup.py install for simplejson ... done
    Running setup.py install for openapi-codec ... done
Successfully installed MarkupSafe-1.1.1 asgiref-3.2.10 certifi-2020.6.20 chardet-3.0.4 coreapi-2.3.3 coreschema-0.0.4 django-3.0.8 django-rest-swagger-2.2.0 djangorestframework-3.11.0 idna-2.10 itypes-1.2.0 jinja2-2.11.2 openapi-codec-1.3.2 pytz-2020.1 requests-2.24.0 simplejson-3.17.0 sqlparse-0.3.1 uritemplate-3.0.1 urllib3-1.25.9
```

</p></details>

cc @cosmicexplorer for review and other thoughts on the lazy wheel

cc @nlhkabu and @ei8fdb for the UI/UX

TODOs:
- [x] Make all tests passes
- [x] Make the optimization available only as an opt-in via `--use-feature`
- [x] Add functional tests for the opt-in