### PR TITLE
Test `wheel.get_entrypoints` when none are expected

### DIFF
--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -107,6 +107,12 @@ def test_get_entrypoints(tmpdir, console_scripts):
     )
 
 
+def test_get_entrypoints_no_entrypoints(tmpdir):
+    console, gui = wheel.get_entrypoints(str(tmpdir / 'entry_points.txt'))
+    assert console == {}
+    assert gui == {}
+
+
 def test_raise_for_invalid_entrypoint_ok():
     _raise_for_invalid_entrypoint("hello = hello:main")
 


### PR DESCRIPTION
We didn't have an existing unit test for this function, and I want to make some changes in this area.

This was cherry-picked from #8531, so that PR can be made shorter/easier to review.