### PR TITLE
Read RECORD from wheel file directly during install

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -647,15 +647,15 @@ def install_unpacked_wheel(
     record_text = distribution.get_metadata('RECORD')
     record_rows = list(csv.reader(record_text.splitlines()))
 
-    # Record details of all files installed
-    record_path = os.path.join(dest_info_dir, 'RECORD')
-
     rows = get_csv_rows_for_installed(
         record_rows,
         installed=installed,
         changed=changed,
         generated=generated,
         lib_dir=lib_dir)
+
+    # Record details of all files installed
+    record_path = os.path.join(dest_info_dir, 'RECORD')
 
     with _generate_file(record_path, **csv_io_kwargs('w')) as record_file:
         # The type mypy infers for record_file is different for Python 3

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -644,10 +644,11 @@ def install_unpacked_wheel(
             pass
         generated.append(requested_path)
 
+    record_text = distribution.get_metadata('RECORD')
+    record_rows = list(csv.reader(record_text.splitlines()))
+
     # Record details of all files installed
     record_path = os.path.join(dest_info_dir, 'RECORD')
-    with open(record_path, **csv_io_kwargs('r')) as record_file:
-        record_rows = list(csv.reader(record_file))
 
     rows = get_csv_rows_for_installed(
         record_rows,


### PR DESCRIPTION
Previously, we were reading `RECORD` from disk after copying it to the installation destination. This is a little roundabout, and makes it harder to refactor our wheel installation logic since it must happen after copying the files over. Now we read `RECORD` from the wheel directly, so we can be much more flexible in our approach.

Progresses #6030.