### PR TITLE
Byte-compile files after installation

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -461,6 +461,10 @@ def install_unpacked_wheel(
                 p for p in subdir_paths if p != '__pycache__'
             ]
             for path in files:
+                if not os.path.isfile(path):
+                    continue
+                if not path.endswith('.py'):
+                    continue
                 yield os.path.join(dir_path, path)
 
     # Compile all of the pyc files that we're going to be installing

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -451,12 +451,32 @@ def install_unpacked_wheel(
     changed = set()  # type: Set[RecordPath]
     generated = []  # type: List[str]
 
+    def pyc_source_file_paths():
+        # type: () -> Iterator[text_type]
+        decoded_source = ensure_text(
+            source, encoding=sys.getfilesystemencoding()
+        )
+        for dir_path, subdir_paths, files in os.walk(decoded_source):
+            subdir_paths[:] = [
+                p for p in subdir_paths if p != '__pycache__'
+            ]
+            for path in files:
+                yield os.path.join(dir_path, path)
+
     # Compile all of the pyc files that we're going to be installing
     if pycompile:
         with captured_stdout() as stdout:
             with warnings.catch_warnings():
                 warnings.filterwarnings('ignore')
-                compileall.compile_dir(source, force=True, quiet=True)
+                for path in pyc_source_file_paths():
+                    # Python 2's `compileall.compile_file` requires a str in
+                    # error cases, so we must convert to the native type.
+                    path_arg = ensure_str(
+                        path, encoding=sys.getfilesystemencoding()
+                    )
+                    compileall.compile_file(
+                        path_arg, force=True, quiet=True
+                    )
         logger.debug(stdout.getvalue())
 
     def record_installed(srcfile, destfile, modified=False):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -452,52 +452,6 @@ def install_unpacked_wheel(
     changed = set()  # type: Set[RecordPath]
     generated = []  # type: List[str]
 
-    def pyc_source_file_paths():
-        # type: () -> Iterator[text_type]
-        decoded_source = ensure_text(
-            source, encoding=sys.getfilesystemencoding()
-        )
-        for dir_path, subdir_paths, files in os.walk(decoded_source):
-            subdir_paths[:] = [
-                p for p in subdir_paths if p != '__pycache__'
-            ]
-            for path in files:
-                if not os.path.isfile(path):
-                    continue
-                if not path.endswith('.py'):
-                    continue
-                yield os.path.join(dir_path, path)
-
-    def pyc_output_path(path):
-        # type: (text_type) -> text_type
-        """Return the path the pyc file would have been written to.
-        """
-        if PY2:
-            if sys.flags.optimize:
-                return path + 'o'
-            else:
-                return path + 'c'
-        else:
-            return importlib.util.cache_from_source(path)
-
-    # Compile all of the pyc files that we're going to be installing
-    if pycompile:
-        with captured_stdout() as stdout:
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore')
-                for path in pyc_source_file_paths():
-                    # Python 2's `compileall.compile_file` requires a str in
-                    # error cases, so we must convert to the native type.
-                    path_arg = ensure_str(
-                        path, encoding=sys.getfilesystemencoding()
-                    )
-                    success = compileall.compile_file(
-                        path_arg, force=True, quiet=True
-                    )
-                    if success:
-                        assert os.path.exists(pyc_output_path(path))
-        logger.debug(stdout.getvalue())
-
     def record_installed(srcfile, destfile, modified=False):
         # type: (text_type, text_type, bool) -> None
         """Map archive RECORD paths to installation RECORD paths."""
@@ -621,6 +575,52 @@ def install_unpacked_wheel(
                 fixer=fixer,
                 filter=filter,
             )
+
+    def pyc_source_file_paths():
+        # type: () -> Iterator[text_type]
+        # We de-duplicate installation paths, since there can be overlap (e.g.
+        # file in .data maps to same location as file in wheel root).
+        # Sorting installation paths makes it easier to reproduce and debug
+        # issues related to permissions on existing files.
+        for installed_path in sorted(set(installed.values())):
+            full_installed_path = os.path.join(lib_dir, installed_path)
+            if not os.path.isfile(full_installed_path):
+                continue
+            if not full_installed_path.endswith('.py'):
+                continue
+            yield full_installed_path
+
+    def pyc_output_path(path):
+        # type: (text_type) -> text_type
+        """Return the path the pyc file would have been written to.
+        """
+        if PY2:
+            if sys.flags.optimize:
+                return path + 'o'
+            else:
+                return path + 'c'
+        else:
+            return importlib.util.cache_from_source(path)
+
+    # Compile all of the pyc files for the installed files
+    if pycompile:
+        with captured_stdout() as stdout:
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore')
+                for path in pyc_source_file_paths():
+                    # Python 2's `compileall.compile_file` requires a str in
+                    # error cases, so we must convert to the native type.
+                    path_arg = ensure_str(
+                        path, encoding=sys.getfilesystemencoding()
+                    )
+                    success = compileall.compile_file(
+                        path_arg, force=True, quiet=True
+                    )
+                    if success:
+                        pyc_path = pyc_output_path(path)
+                        assert os.path.exists(pyc_path)
+                        record_installed(pyc_path, pyc_path)
+        logger.debug(stdout.getvalue())
 
     maker = PipScriptMaker(None, scheme.scripts)
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -258,9 +258,15 @@ class TestInstallUnpackedWheel(object):
     """
 
     def prep(self, data, tmpdir):
+        # Since Path implements __add__, os.path.join returns a Path object.
+        # Passing Path objects to interfaces expecting str (like
+        # `compileall.compile_file`) can cause failures, so we normalize it
+        # to a string here.
+        tmpdir = str(tmpdir)
         self.name = 'sample'
-        self.wheelpath = data.packages.joinpath(
-            'sample-1.2.0-py2.py3-none-any.whl')
+        self.wheelpath = os.path.join(
+            str(data.packages), 'sample-1.2.0-py2.py3-none-any.whl'
+        )
         self.req = Requirement('sample')
         self.src = os.path.join(tmpdir, 'src')
         self.dest = os.path.join(tmpdir, 'dest')


### PR DESCRIPTION
One critical place we depend on extracted wheels is during generation of pyc files.

All high-level interfaces in the standard library expect file paths in their interface. A straightforward way to make that work with direct-from-wheel installs is to byte-compile files after they have been written to disk. In order to avoid re-compiling other files unnecessarily, we switch from `compileall.compile_dir` to `compileall.compile_file` and target the individual files we know we installed for the current wheel.

As a side-effect, this should also address #7808, since generating the pyc files in-place means the temporary wheel extraction directory should no longer be present in the generated pyc files.

Progresses #6030 and #7808.