### PR TITLE
Decouple finding, processing, and saving files when installing wheels

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -536,11 +536,11 @@ def install_unpacked_wheel(
                     s for s in subdirs if not s.endswith('.data')
                 ]
             for f in files:
-                # Skip unwanted files
-                if filter and filter(f):
-                    continue
                 srcfile = os.path.join(dir, f)
                 destfile = os.path.join(dest, basedir, f)
+                # Skip unwanted files
+                if filter and filter(srcfile):
+                    continue
                 yield File(srcfile, destfile)
 
     def clobber(
@@ -564,10 +564,11 @@ def install_unpacked_wheel(
     )
     console, gui = get_entrypoints(distribution)
 
-    def is_entrypoint_wrapper(name):
+    def is_entrypoint_wrapper(path):
         # type: (text_type) -> bool
         # EP, EP.exe and EP-script.py are scripts generated for
         # entry point EP by setuptools
+        name = os.path.basename(path)
         if name.lower().endswith('.exe'):
             matchname = name[:-4]
         elif name.lower().endswith('-script.py'):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -471,7 +471,6 @@ def install_unpacked_wheel(
         # type: (...) -> None
         for dir, subdirs, files in os.walk(source):
             basedir = dir[len(source):].lstrip(os.path.sep)
-            destdir = os.path.join(dest, basedir)
             if is_base and basedir == '':
                 subdirs[:] = [s for s in subdirs if not s.endswith('.data')]
             for f in files:
@@ -483,7 +482,8 @@ def install_unpacked_wheel(
                 # directory creation is lazy and after the file filtering above
                 # to ensure we don't install empty dirs; empty dirs can't be
                 # uninstalled.
-                ensure_dir(destdir)
+                parent_dir = os.path.dirname(destfile)
+                ensure_dir(parent_dir)
 
                 # copyfile (called below) truncates the destination if it
                 # exists and then writes the new contents. This is fine in most

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -468,31 +468,33 @@ def install_unpacked_wheel(
         if modified:
             changed.add(_fs_to_record_path(destfile))
 
+    def files_to_process(
+        source,  # type: text_type
+        dest,  # type: text_type
+        is_base,  # type: bool
+        filter=None,  # type: Optional[Callable[[text_type], bool]]
+    ):
+        # type: (...) -> Iterable[File]
+        for dir, subdirs, files in os.walk(source):
+            basedir = dir[len(source):].lstrip(os.path.sep)
+            if is_base and basedir == '':
+                subdirs[:] = [
+                    s for s in subdirs if not s.endswith('.data')
+                ]
+            for f in files:
+                # Skip unwanted files
+                if filter and filter(f):
+                    continue
+                srcfile = os.path.join(dir, f)
+                destfile = os.path.join(dest, basedir, f)
+                yield File(srcfile, destfile)
+
     def clobber(
-            source,  # type: text_type
-            dest,  # type: text_type
-            is_base,  # type: bool
+            files,  # type: Iterator[File]
             fixer=None,  # type: Optional[Callable[[text_type], Any]]
-            filter=None  # type: Optional[Callable[[text_type], bool]]
     ):
         # type: (...) -> None
-        def files_to_process():
-            # type: () -> Iterable[File]
-            for dir, subdirs, files in os.walk(source):
-                basedir = dir[len(source):].lstrip(os.path.sep)
-                if is_base and basedir == '':
-                    subdirs[:] = [
-                        s for s in subdirs if not s.endswith('.data')
-                    ]
-                for f in files:
-                    # Skip unwanted files
-                    if filter and filter(f):
-                        continue
-                    srcfile = os.path.join(dir, f)
-                    destfile = os.path.join(dest, basedir, f)
-                    yield File(srcfile, destfile)
-
-        for f in files_to_process():
+        for f in files:
             # directory creation is lazy and after the file filtering above
             # to ensure we don't install empty dirs; empty dirs can't be
             # uninstalled.
@@ -537,11 +539,12 @@ def install_unpacked_wheel(
                 changed = fixer(f.dest_path)
             record_installed(f.src_path, f.dest_path, changed)
 
-    clobber(
+    root_scheme_files = files_to_process(
         ensure_text(source, encoding=sys.getfilesystemencoding()),
         ensure_text(lib_dir, encoding=sys.getfilesystemencoding()),
         True,
     )
+    clobber(root_scheme_files)
 
     # Get the defined entry points
     distribution = pkg_resources_distribution_for_wheel(
@@ -578,15 +581,15 @@ def install_unpacked_wheel(
                 filter = is_entrypoint_wrapper
             full_datadir_path = os.path.join(wheeldir, datadir, subdir)
             dest = getattr(scheme, subdir)
-            clobber(
+            data_scheme_files = files_to_process(
                 ensure_text(
                     full_datadir_path, encoding=sys.getfilesystemencoding()
                 ),
                 ensure_text(dest, encoding=sys.getfilesystemencoding()),
                 False,
-                fixer=fixer,
                 filter=filter,
             )
+            clobber(data_scheme_files, fixer=fixer)
 
     def pyc_source_file_paths():
         # type: () -> Iterator[text_type]

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -96,13 +96,13 @@ def csv_io_kwargs(mode):
 
 
 def fix_script(path):
-    # type: (text_type) -> Optional[bool]
+    # type: (text_type) -> bool
     """Replace #!python with #!/path/to/python
     Return True if file was changed.
     """
     # XXX RECORD hashes will need to be updated
     if not os.path.isfile(path):
-        return None
+        return False
 
     with open(path, 'rb') as script:
         firstline = script.readline()

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -538,14 +538,6 @@ def install_unpacked_wheel(
                 destfile = os.path.join(dest, basedir, f)
                 yield File(srcfile, destfile)
 
-    def clobber(
-            files,  # type: Iterator[File]
-    ):
-        # type: (...) -> None
-        for f in files:
-            f.save()
-            record_installed(f.src_path, f.dest_path, f.changed)
-
     files = files_to_process(
         ensure_text(source, encoding=sys.getfilesystemencoding()),
         ensure_text(lib_dir, encoding=sys.getfilesystemencoding()),
@@ -600,7 +592,9 @@ def install_unpacked_wheel(
 
             files = chain(files, data_scheme_files)
 
-    clobber(files)
+    for file in files:
+        file.save()
+        record_installed(file.src_path, file.dest_path, file.changed)
 
     def pyc_source_file_paths():
         # type: () -> Iterator[text_type]

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -16,7 +16,7 @@ import stat
 import sys
 import warnings
 from base64 import urlsafe_b64encode
-from itertools import starmap
+from itertools import chain, starmap
 from zipfile import ZipFile
 
 from pip._vendor import pkg_resources
@@ -546,12 +546,11 @@ def install_unpacked_wheel(
             f.save()
             record_installed(f.src_path, f.dest_path, f.changed)
 
-    root_scheme_files = files_to_process(
+    files = files_to_process(
         ensure_text(source, encoding=sys.getfilesystemencoding()),
         ensure_text(lib_dir, encoding=sys.getfilesystemencoding()),
         True,
     )
-    clobber(root_scheme_files)
 
     # Get the defined entry points
     distribution = pkg_resources_distribution_for_wheel(
@@ -598,7 +597,10 @@ def install_unpacked_wheel(
                 data_scheme_files = map(
                     ScriptFile.from_file, data_scheme_files
                 )
-            clobber(data_scheme_files)
+
+            files = chain(files, data_scheme_files)
+
+    clobber(files)
 
     def pyc_source_file_paths():
         # type: () -> Iterator[text_type]

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -469,8 +469,6 @@ def install_unpacked_wheel(
             filter=None  # type: Optional[Callable[[text_type], bool]]
     ):
         # type: (...) -> None
-        ensure_dir(dest)  # common for the 'include' path
-
         for dir, subdirs, files in os.walk(source):
             basedir = dir[len(source):].lstrip(os.path.sep)
             destdir = os.path.join(dest, basedir)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -559,10 +559,11 @@ def install_unpacked_wheel(
     )
     console, gui = get_entrypoints(distribution)
 
-    def is_entrypoint_wrapper(path):
-        # type: (text_type) -> bool
+    def not_entrypoint_wrapper(file):
+        # type: (File) -> bool
         # EP, EP.exe and EP-script.py are scripts generated for
         # entry point EP by setuptools
+        path = file.src_path
         name = os.path.basename(path)
         if name.lower().endswith('.exe'):
             matchname = name[:-4]
@@ -573,7 +574,7 @@ def install_unpacked_wheel(
         else:
             matchname = name
         # Ignore setuptools-generated scripts
-        return (matchname in console or matchname in gui)
+        return not (matchname in console or matchname in gui)
 
     # Zip file path separators must be /
     subdirs = set(p.split("/", 1)[0] for p in wheel_zip.namelist())
@@ -591,10 +592,9 @@ def install_unpacked_wheel(
                 False,
             )
             if subdir == 'scripts':
-                data_scheme_files = [
-                    f for f in data_scheme_files
-                    if not is_entrypoint_wrapper(f.src_path)
-                ]
+                data_scheme_files = filter(
+                    not_entrypoint_wrapper, data_scheme_files
+                )
                 data_scheme_files = map(
                     ScriptFile.from_file, data_scheme_files
                 )

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -469,16 +469,24 @@ def install_unpacked_wheel(
             filter=None  # type: Optional[Callable[[text_type], bool]]
     ):
         # type: (...) -> None
-        for dir, subdirs, files in os.walk(source):
-            basedir = dir[len(source):].lstrip(os.path.sep)
-            if is_base and basedir == '':
-                subdirs[:] = [s for s in subdirs if not s.endswith('.data')]
-            for f in files:
-                # Skip unwanted files
-                if filter and filter(f):
-                    continue
-                srcfile = os.path.join(dir, f)
-                destfile = os.path.join(dest, basedir, f)
+        def files_to_process():
+            # type: () -> Iterable[Tuple[text_type, text_type]]
+            for dir, subdirs, files in os.walk(source):
+                basedir = dir[len(source):].lstrip(os.path.sep)
+                if is_base and basedir == '':
+                    subdirs[:] = [
+                        s for s in subdirs if not s.endswith('.data')
+                    ]
+                for f in files:
+                    # Skip unwanted files
+                    if filter and filter(f):
+                        continue
+                    srcfile = os.path.join(dir, f)
+                    destfile = os.path.join(dest, basedir, f)
+                    yield srcfile, destfile
+
+        if True:  # this just preserves indentation for a cleaner commit diff
+            for srcfile, destfile in files_to_process():
                 # directory creation is lazy and after the file filtering above
                 # to ensure we don't install empty dirs; empty dirs can't be
                 # uninstalled.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -394,6 +394,47 @@ class File(object):
         self.src_path = src_path
         self.dest_path = dest_path
 
+    def save(self):
+        # type: () -> None
+        # directory creation is lazy and after the file filtering above
+        # to ensure we don't install empty dirs; empty dirs can't be
+        # uninstalled.
+        parent_dir = os.path.dirname(self.dest_path)
+        ensure_dir(parent_dir)
+
+        # copyfile (called below) truncates the destination if it
+        # exists and then writes the new contents. This is fine in most
+        # cases, but can cause a segfault if pip has loaded a shared
+        # object (e.g. from pyopenssl through its vendored urllib3)
+        # Since the shared object is mmap'd an attempt to call a
+        # symbol in it will then cause a segfault. Unlinking the file
+        # allows writing of new contents while allowing the process to
+        # continue to use the old copy.
+        if os.path.exists(self.dest_path):
+            os.unlink(self.dest_path)
+
+        # We use copyfile (not move, copy, or copy2) to be extra sure
+        # that we are not moving directories over (copyfile fails for
+        # directories) as well as to ensure that we are not copying
+        # over any metadata because we want more control over what
+        # metadata we actually copy over.
+        shutil.copyfile(self.src_path, self.dest_path)
+
+        # Copy over the metadata for the file, currently this only
+        # includes the atime and mtime.
+        st = os.stat(self.src_path)
+        if hasattr(os, "utime"):
+            os.utime(self.dest_path, (st.st_atime, st.st_mtime))
+
+        # If our file is executable, then make our destination file
+        # executable.
+        if os.access(self.src_path, os.X_OK):
+            st = os.stat(self.src_path)
+            permissions = (
+                st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+            )
+            os.chmod(self.dest_path, permissions)
+
 
 class MissingCallableSuffix(Exception):
     pass
@@ -495,45 +536,7 @@ def install_unpacked_wheel(
     ):
         # type: (...) -> None
         for f in files:
-            # directory creation is lazy and after the file filtering above
-            # to ensure we don't install empty dirs; empty dirs can't be
-            # uninstalled.
-            parent_dir = os.path.dirname(f.dest_path)
-            ensure_dir(parent_dir)
-
-            # copyfile (called below) truncates the destination if it
-            # exists and then writes the new contents. This is fine in most
-            # cases, but can cause a segfault if pip has loaded a shared
-            # object (e.g. from pyopenssl through its vendored urllib3)
-            # Since the shared object is mmap'd an attempt to call a
-            # symbol in it will then cause a segfault. Unlinking the file
-            # allows writing of new contents while allowing the process to
-            # continue to use the old copy.
-            if os.path.exists(f.dest_path):
-                os.unlink(f.dest_path)
-
-            # We use copyfile (not move, copy, or copy2) to be extra sure
-            # that we are not moving directories over (copyfile fails for
-            # directories) as well as to ensure that we are not copying
-            # over any metadata because we want more control over what
-            # metadata we actually copy over.
-            shutil.copyfile(f.src_path, f.dest_path)
-
-            # Copy over the metadata for the file, currently this only
-            # includes the atime and mtime.
-            st = os.stat(f.src_path)
-            if hasattr(os, "utime"):
-                os.utime(f.dest_path, (st.st_atime, st.st_mtime))
-
-            # If our file is executable, then make our destination file
-            # executable.
-            if os.access(f.src_path, os.X_OK):
-                st = os.stat(f.src_path)
-                permissions = (
-                    st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-                )
-                os.chmod(f.dest_path, permissions)
-
+            f.save()
             changed = False
             if fixer:
                 changed = fixer(f.dest_path)


### PR DESCRIPTION
In order to install files directly from a wheel, we are required to read the files and file attributes from the zip and write them to disk. Previously, our logic related to saving files was mixed up in our logic for filtering files and editing installed files. All of this was packed into `clobber`, which was called from 2 places with varying arguments.

Now `clobber` is gone. The responsibility for finding files has been extracted into `files_to_process` and simplified. Filtering files and editing files has been moved to the 1 place we actually needed to do it, and saving files has been isolated into its own method.

In a later PR we can adapt `files_to_process` to read from the wheel zip and `File.save` to extract file attributes and data from the wheel zip, which should be the last two blockers for this capability.

Progresses #6030.