### PR TITLE
Remove unused comes_from argument of parse_requirements

### DIFF
--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -47,7 +47,6 @@ def get_processed_req_from_line(line, fname='file', lineno=1):
     parsed_line = ParsedLine(
         fname,
         lineno,
-        fname,
         args_str,
         opts,
         False,


### PR DESCRIPTION
No caller of `parse_requirements` ever passes the `comes_from` argument.
Its use is unclear and if it was meant as a base url, it is probably broken.
I therefore propose to remove it to clarify the code and avoid confusion with other uses of the `comes_from` term elsewhere.