### PR TITLE
Disallow explicitly passing install-location-related arguments in --install-options

### DIFF
--- a/news/7309.removal
+++ b/news/7309.removal
@@ -1,0 +1,1 @@
+Disallow passing install-location-related arguments in ``--install-options``.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -21,7 +21,6 @@ from pip._internal.locations import distutils_scheme
 from pip._internal.operations.check import check_install_conflicts
 from pip._internal.req import install_given_reqs
 from pip._internal.req.req_tracker import get_requirement_tracker
-from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.distutils_args import parse_distutils_args
 from pip._internal.utils.filesystem import test_writable_dir
 from pip._internal.utils.misc import (
@@ -639,20 +638,12 @@ def warn_deprecated_install_options(requirements, options):
     if not offenders:
         return
 
-    deprecated(
-        reason=(
-            "Location-changing options found in --install-option: {}. "
-            "This configuration may cause unexpected behavior and is "
-            "unsupported.".format(
-                "; ".join(offenders)
-            )
-        ),
-        replacement=(
-            "using pip-level options like --user, --prefix, --root, and "
-            "--target"
-        ),
-        gone_in="20.2",
-        issue=7309,
+    raise CommandError(
+        "Location-changing options found in --install-option: {}."
+        " This is unsupported, use pip-level options like --user,"
+        " --prefix, --root, and --target instead.".format(
+            "; ".join(offenders)
+        )
     )
 
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -289,7 +289,7 @@ class InstallCommand(RequirementCommand):
         try:
             reqs = self.get_requirements(args, options, finder, session)
 
-            warn_deprecated_install_options(
+            reject_location_related_install_options(
                 reqs, options.install_options
             )
 
@@ -605,7 +605,7 @@ def decide_user_install(
     return True
 
 
-def warn_deprecated_install_options(requirements, options):
+def reject_location_related_install_options(requirements, options):
     # type: (List[InstallRequirement], Optional[List[str]]) -> None
     """If any location-changing --install-option arguments were passed for
     requirements or on the command-line, then show a deprecation warning.

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -7,7 +7,7 @@ from pip._vendor.packaging.requirements import Requirement
 from pip._internal.commands.install import (
     create_env_error_message,
     decide_user_install,
-    warn_deprecated_install_options,
+    reject_location_related_install_options,
 )
 from pip._internal.exceptions import CommandError
 from pip._internal.req.req_install import InstallRequirement
@@ -45,15 +45,15 @@ class TestDecideUserInstall:
         assert decide_user_install(use_user_site=None) is result
 
 
-def test_deprecation_notice_for_pip_install_options():
+def test_rejection_for_pip_install_options():
     install_options = ["--prefix=/hello"]
     with pytest.raises(CommandError) as e:
-        warn_deprecated_install_options([], install_options)
+        reject_location_related_install_options([], install_options)
 
     assert "['--prefix'] from command line" in str(e.value)
 
 
-def test_deprecation_notice_for_requirement_options():
+def test_rejection_for_location_requirement_options():
     install_options = []
 
     bad_named_req_options = ["--home=/wow"]
@@ -68,7 +68,7 @@ def test_deprecation_notice_for_requirement_options():
     )
 
     with pytest.raises(CommandError) as e:
-        warn_deprecated_install_options(
+        reject_location_related_install_options(
             [bad_named_req, bad_unnamed_req], install_options
         )
 

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -9,6 +9,7 @@ from pip._internal.commands.install import (
     decide_user_install,
     warn_deprecated_install_options,
 )
+from pip._internal.exceptions import CommandError
 from pip._internal.req.req_install import InstallRequirement
 
 
@@ -44,16 +45,15 @@ class TestDecideUserInstall:
         assert decide_user_install(use_user_site=None) is result
 
 
-def test_deprecation_notice_for_pip_install_options(recwarn):
+def test_deprecation_notice_for_pip_install_options():
     install_options = ["--prefix=/hello"]
-    warn_deprecated_install_options([], install_options)
+    with pytest.raises(CommandError) as e:
+        warn_deprecated_install_options([], install_options)
 
-    assert len(recwarn) == 1
-    message = recwarn[0].message.args[0]
-    assert "['--prefix'] from command line" in message
+    assert "['--prefix'] from command line" in str(e.value)
 
 
-def test_deprecation_notice_for_requirement_options(recwarn):
+def test_deprecation_notice_for_requirement_options():
     install_options = []
 
     bad_named_req_options = ["--home=/wow"]
@@ -67,18 +67,16 @@ def test_deprecation_notice_for_requirement_options(recwarn):
         None, "requirements2.txt", install_options=bad_unnamed_req_options
     )
 
-    warn_deprecated_install_options(
-        [bad_named_req, bad_unnamed_req], install_options
-    )
-
-    assert len(recwarn) == 1
-    message = recwarn[0].message.args[0]
+    with pytest.raises(CommandError) as e:
+        warn_deprecated_install_options(
+            [bad_named_req, bad_unnamed_req], install_options
+        )
 
     assert (
         "['--install-lib'] from <InstallRequirement> (from requirements2.txt)"
-        in message
+        in str(e.value)
     )
-    assert "['--home'] from hello (from requirements.txt)" in message
+    assert "['--home'] from hello (from requirements.txt)" in str(e.value)
 
 
 @pytest.mark.parametrize('error, show_traceback, using_user_site, expected', [


### PR DESCRIPTION
This converts our deprecation warning into a hard failure.

Closes #7309.