### PR TITLE
Deprecate setup.py install fallback when wheel package is absent

### DIFF
--- a/news/8559.removal
+++ b/news/8559.removal
@@ -1,0 +1,2 @@
+Deprecate call to 'setup.py install' when 'wheel' is absent for source
+distributions without pyproject.toml

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -9,6 +9,7 @@ import shutil
 from pip._internal.models.link import Link
 from pip._internal.operations.build.wheel import build_wheel_pep517
 from pip._internal.operations.build.wheel_legacy import build_wheel_legacy
+from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import ensure_dir, hash_file, is_wheel_installed
 from pip._internal.utils.setuptools_build import make_setuptools_clean_args
@@ -79,9 +80,18 @@ def _should_build(
 
     if not req.use_pep517 and not is_wheel_installed():
         # we don't build legacy requirements if wheel is not installed
-        logger.info(
-            "Using legacy 'setup.py install' for %s, "
-            "since package 'wheel' is not installed.", req.name,
+        deprecated(
+            reason=(
+                "Cannot build a wheel for {} which do not use PEP 517 "
+                "since package 'wheel' is not installed. "
+                "pip will fall back to legacy 'setup.py install' for this "
+                "package.".format(req.name)
+            ),
+            replacement=(
+                "to install the 'wheel' package or enable --use-pep517"
+            ),
+            gone_in="21.0",
+            issue=8559,
         )
         return False
 

--- a/src/pip/_vendor/distlib/util.py
+++ b/src/pip/_vendor/distlib/util.py
@@ -701,7 +701,7 @@ class ExportEntry(object):
     __hash__ = object.__hash__
 
 
-ENTRY_RE = re.compile(r'''(?P<name>(\w|[-.+])+)
+ENTRY_RE = re.compile(r'''(?P<name>(\w|[-.+:])+)
                       \s*=\s*(?P<callable>(\w+)([:\.]\w+)*)
                       \s*(\[\s*(?P<flags>[\w-]+(=\w+)?(,\s*\w+(=\w+)?)*)\s*\])?
                       ''', re.VERBOSE)

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -407,7 +407,7 @@ def test_constraints_constrain_to_local(script, data, use_new_resolver):
     if use_new_resolver:
         assert 'Links are not allowed as constraints' in result.stderr
     else:
-        assert 'Running setup.py install for singlemodule' in result.stdout
+        assert 'Successfully installed singlemodule' in result.stdout
 
 
 def test_constrained_to_url_install_same_url(script, data, use_new_resolver):
@@ -423,7 +423,7 @@ def test_constrained_to_url_install_same_url(script, data, use_new_resolver):
     if use_new_resolver:
         assert 'Links are not allowed as constraints' in result.stderr
     else:
-        assert ('Running setup.py install for singlemodule'
+        assert ('Successfully installed singlemodule'
                 in result.stdout), str(result)
 
 
@@ -531,7 +531,7 @@ def test_install_distribution_full_union(script, data):
     to_install = data.packages.joinpath("LocalExtras")
     result = script.pip_install_local(
         to_install, to_install + "[bar]", to_install + "[baz]")
-    assert 'Running setup.py install for LocalExtras' in result.stdout
+    assert 'Successfully installed LocalExtras' in result.stdout
     result.did_create(script.site_packages / 'simple')
     result.did_create(script.site_packages / 'singlemodule.py')
 
@@ -563,7 +563,7 @@ def test_install_distribution_union_with_constraints(
         msg = 'Unnamed requirements are not allowed as constraints'
         assert msg in result.stderr
     else:
-        assert 'Running setup.py install for LocalExtras' in result.stdout
+        assert 'Successfully installed LocalExtras' in result.stdout
         result.did_create(script.site_packages / 'singlemodule.py')
 
 

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -311,7 +311,7 @@ def test_uninstall_rollback(script, data):
     )
     result.did_create(script.site_packages / 'broken.py')
     result2 = script.pip(
-        'install', '-f', data.find_links, '--no-index', 'broken===0.2broken',
+        'install', '-f', data.find_links, '--no-index', 'brokenwheel==0.1',
         expect_error=True,
     )
     assert result2.returncode == 1, str(result2)

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -191,8 +191,8 @@ def test_uninstall_overlapping_package(script, data):
 
 
 @pytest.mark.parametrize("console_scripts",
-                         ["test_ = distutils_install",
-                          "test_:test_ = distutils_install"])
+                         ["test_ = thescript:main",
+                          "test_:test_ = thescript:main"])
 def test_uninstall_entry_point_colon_in_name(script, console_scripts):
     """
     Test uninstall package with two or more entry points in the same section,
@@ -205,10 +205,11 @@ def test_uninstall_entry_point_colon_in_name(script, console_scripts):
         version='0.1',
         entry_points={"console_scripts": [console_scripts, ],
                       "pip_test.ep":
-                      ["ep:name1 = distutils_install",
-                       "ep:name2 = distutils_install"]
+                      ["ep:name1 = thescript:main",
+                       "ep:name2 = thescript:main"]
                       }
     )
+    (pkg_path / "thescript.py").write_text("def main(): pass")
     script_name = script.bin_path.joinpath(
         console_scripts.split('=')[0].strip()
     )
@@ -235,8 +236,9 @@ def test_uninstall_gui_scripts(script):
         script,
         name=pkg_name,
         version='0.1',
-        entry_points={"gui_scripts": ["test_ = distutils_install", ], }
+        entry_points={"gui_scripts": ["test_ = thescript:main", ], }
     )
+    (pkg_path / "thescript.py").write_text("def main(): pass")
     script_name = script.bin_path.joinpath('test_')
     if sys.platform == 'win32':
         script_name += '.exe'
@@ -273,10 +275,11 @@ def test_uninstall_console_scripts_uppercase_name(script):
         version='0.1',
         entry_points={
             "console_scripts": [
-                "Test = distutils_install",
+                "Test = thescript:main",
             ],
         },
     )
+    (pkg_path / "thescript.py").write_text("def main(): pass")
     script_name = script.bin_path.joinpath('Test' + script.exe)
 
     script.pip('install', pkg_path)


### PR DESCRIPTION
Towards #8559 

TODO
- [ ] review tests that check the absence of `setup.py install` in output
- [ ] do we need to patch distlib or drop that test that checks a script can have `:` in its name?
- [ ] search for `egg-info` in tests and verify all occurences are pertinent
- [ ] tests that do `virtualenv.clear()` need to keep `wheel` installed in the cleared virtualenv (should fix `test_env_vars_override_config_file`, `test_config_file_override_stack`) 
