### PR TITLE
Install directly from wheels, without unpacking into an intermediate directory

### DIFF
--- a/news/6030.feature
+++ b/news/6030.feature
@@ -1,0 +1,1 @@
+Install wheel files directly instead of extracting them to a temp directory.

--- a/src/pip/_internal/models/scheme.py
+++ b/src/pip/_internal/models/scheme.py
@@ -6,12 +6,15 @@ https://docs.python.org/3/install/index.html#alternate-installation.
 """
 
 
+SCHEME_KEYS = ['platlib', 'purelib', 'headers', 'scripts', 'data']
+
+
 class Scheme(object):
     """A Scheme holds paths which are used as the base directories for
     artifacts associated with a Python package.
     """
 
-    __slots__ = ['platlib', 'purelib', 'headers', 'scripts', 'data']
+    __slots__ = SCHEME_KEYS
 
     def __init__(
         self,

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -16,7 +16,7 @@ import stat
 import sys
 import warnings
 from base64 import urlsafe_b64encode
-from itertools import starmap
+from itertools import chain, starmap
 from zipfile import ZipFile
 
 from pip._vendor import pkg_resources
@@ -556,12 +556,11 @@ def install_unpacked_wheel(
             file.save()
             record_installed(file.src_path, file.dest_path, file.changed)
 
-    root_scheme_files = files_to_process(
+    files = files_to_process(
         ensure_text(source, encoding=sys.getfilesystemencoding()),
         ensure_text(lib_dir, encoding=sys.getfilesystemencoding()),
         True,
     )
-    clobber(root_scheme_files)
 
     # Get the defined entry points
     distribution = pkg_resources_distribution_for_wheel(
@@ -606,7 +605,10 @@ def install_unpacked_wheel(
                     is_entrypoint_wrapper, data_scheme_files
                 )
                 data_scheme_files = map(ScriptFile, data_scheme_files)
-            clobber(data_scheme_files)
+
+            files = chain(files, data_scheme_files)
+
+    clobber(files)
 
     def pyc_source_file_paths():
         # type: () -> Iterator[text_type]

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -471,7 +471,6 @@ def install_unpacked_wheel(
         # type: (...) -> None
         for dir, subdirs, files in os.walk(source):
             basedir = dir[len(source):].lstrip(os.path.sep)
-            destdir = os.path.join(dest, basedir)
             if is_base and basedir == '':
                 subdirs[:] = [s for s in subdirs if not s.endswith('.data')]
             for f in files:
@@ -483,7 +482,8 @@ def install_unpacked_wheel(
                 # directory creation is lazy and after the file filtering above
                 # to ensure we don't install empty dirs; empty dirs can't be
                 # uninstalled.
-                ensure_dir(destdir)
+                parent_dir = os.path.dirname(destfile)
+                ensure_dir(parent_dir)
 
                 # copyfile (called below) truncates the destination if it
                 # exists and then writes the new contents. This is fine in most

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -478,7 +478,6 @@ class PipScriptMaker(ScriptMaker):
 
 def install_unpacked_wheel(
     name,  # type: str
-    wheeldir,  # type: str
     wheel_zip,  # type: ZipFile
     wheel_path,  # type: str
     scheme,  # type: Scheme
@@ -492,7 +491,6 @@ def install_unpacked_wheel(
     """Install a wheel.
 
     :param name: Name of the project to install
-    :param wheeldir: Base directory of the unpacked wheel
     :param wheel_zip: open ZipFile for wheel being installed
     :param scheme: Distutils scheme dictating the install directories
     :param req_description: String used in place of the requirement, for
@@ -800,7 +798,6 @@ def install_wheel(
         unpack_file(wheel_path, unpacked_dir.path)
         install_unpacked_wheel(
             name=name,
-            wheeldir=unpacked_dir.path,
             wheel_zip=z,
             wheel_path=wheel_path,
             scheme=scheme,

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -680,10 +680,10 @@ def install_unpacked_wheel(
                     if success:
                         pyc_path = pyc_output_path(path)
                         assert os.path.exists(pyc_path)
-                        record_installed(
-                            _fs_to_record_path(pyc_path, wheeldir),
-                            pyc_path,
+                        pyc_record_path = cast(
+                            "RecordPath", pyc_path.replace(os.path.sep, "/")
                         )
+                        record_installed(pyc_record_path, pyc_path)
         logger.debug(stdout.getvalue())
 
     maker = PipScriptMaker(None, scheme.scripts)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -548,14 +548,6 @@ def install_unpacked_wheel(
                 destfile = os.path.join(dest, basedir, f)
                 yield DiskFile(srcfile, destfile)
 
-    def clobber(
-            files,  # type: Iterable[File]
-    ):
-        # type: (...) -> None
-        for file in files:
-            file.save()
-            record_installed(file.src_path, file.dest_path, file.changed)
-
     files = files_to_process(
         ensure_text(source, encoding=sys.getfilesystemencoding()),
         ensure_text(lib_dir, encoding=sys.getfilesystemencoding()),
@@ -608,7 +600,9 @@ def install_unpacked_wheel(
 
             files = chain(files, data_scheme_files)
 
-    clobber(files)
+    for file in files:
+        file.save()
+        record_installed(file.src_path, file.dest_path, file.changed)
 
     def pyc_source_file_paths():
         # type: () -> Iterator[text_type]

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -469,8 +469,6 @@ def install_unpacked_wheel(
             filter=None  # type: Optional[Callable[[text_type], bool]]
     ):
         # type: (...) -> None
-        ensure_dir(dest)  # common for the 'include' path
-
         for dir, subdirs, files in os.walk(source):
             basedir = dir[len(source):].lstrip(os.path.sep)
             destdir = os.path.join(dest, basedir)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -35,12 +35,10 @@ from pip._internal.utils.misc import (
     hash_file,
     partition,
 )
-from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.unpacking import (
     current_umask,
     set_extracted_file_to_default_mode_plus_executable,
-    unpack_file,
     zip_item_is_executable,
 )
 from pip._internal.utils.wheel import (
@@ -476,7 +474,7 @@ class PipScriptMaker(ScriptMaker):
         return super(PipScriptMaker, self).make(specification, options)
 
 
-def install_unpacked_wheel(
+def _install_wheel(
     name,  # type: str
     wheel_zip,  # type: ZipFile
     wheel_path,  # type: str
@@ -792,11 +790,8 @@ def install_wheel(
     requested=False,  # type: bool
 ):
     # type: (...) -> None
-    with TempDirectory(
-        kind="unpacked-wheel"
-    ) as unpacked_dir, ZipFile(wheel_path, allowZip64=True) as z:
-        unpack_file(wheel_path, unpacked_dir.path)
-        install_unpacked_wheel(
+    with ZipFile(wheel_path, allowZip64=True) as z:
+        _install_wheel(
             name=name,
             wheel_zip=z,
             wheel_path=wheel_path,

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -105,13 +105,12 @@ def csv_io_kwargs(mode):
 
 
 def fix_script(path):
-    # type: (text_type) -> Optional[bool]
+    # type: (text_type) -> bool
     """Replace #!python with #!/path/to/python
     Return True if file was changed.
     """
     # XXX RECORD hashes will need to be updated
-    if not os.path.isfile(path):
-        return None
+    assert os.path.isfile(path)
 
     with open(path, 'rb') as script:
         firstline = script.readline()


### PR DESCRIPTION
Over the past several days, we have removed almost all code that requires a wheel to be extracted to a temporary directory before installation. In this last piece, we separate out the file-specific operations from wheel installation and then replace it with code to read directly from the wheel file.

This is a pretty big PR. I have tried to show a clear progression commit-by-commit, along with justifications for individual decisions. Please let me know if I can do anything to make this easier to review!

A few followups will be needed:

1. [x] We should guard against leading `/` and path traversals (e.g. `../..`), similar to what we do in [`unpacking.unzip_file`](https://github.com/pypa/pip/blob/2f9b50c097fa5e655cd2978b682fc79ed2e6295f/src/pip/_internal/utils/unpacking.py#L129).
2. [ ] We will probably need to set the permissions of installed files similar to what we do for [generated files](https://github.com/pypa/pip/blob/2f9b50c097fa5e655cd2978b682fc79ed2e6295f/src/pip/_internal/operations/install/wheel.py#L676).

I think we can handle those in separate PRs, to keep this one focused, but I am also OK if we want to incorporate them in this one. I can work on those shortly regardless.

Closes #6030.