### PR TITLE
Fixed useless `else` clause after loop inside `get_version` function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,7 @@ def get_version(rel_path):
             # __version__ = "0.9"
             delim = '"' if '"' in line else "'"
             return line.split(delim)[1]
-    else:
-        raise RuntimeError("Unable to find version string.")
+    raise RuntimeError("Unable to find version string.")
 
 
 long_description = read('README.rst')


### PR DESCRIPTION
Fixed useless `else` clause after loop inside `get_version` function in setup.py
