### PR TITLE
Simplify checking entrypoints on wheel install

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -713,14 +713,15 @@ def _install_wheel(
     generated_console_scripts = []  # type: List[str]
 
     try:
-        for script_spec in scripts_to_generate:
+        for script_spec in chain(scripts_to_generate, gui_scripts_to_generate):
             _raise_for_invalid_entrypoint(script_spec)
+
+        for script_spec in scripts_to_generate:
             generated_console_scripts.extend(maker.make(script_spec))
 
         generated.extend(generated_console_scripts)
 
         for script_spec in gui_scripts_to_generate:
-            _raise_for_invalid_entrypoint(script_spec)
             generated.extend(maker.make(script_spec, {'gui': True}))
     except MissingCallableSuffix as e:
         entry = e.args[0]

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -457,10 +457,6 @@ class ScriptFile(object):
         self.changed = fix_script(self.dest_path)
 
 
-class MissingCallableSuffix(Exception):
-    pass
-
-
 def _install_wheel(
     name,  # type: str
     wheel_zip,  # type: ZipFile
@@ -705,19 +701,15 @@ def _install_wheel(
 
     generated_console_scripts = []  # type: List[str]
 
-    try:
-        for script_spec in chain(scripts_to_generate, gui_scripts_to_generate):
-            entry = get_export_entry(script_spec)
-            if entry is not None and entry.suffix is None:
-                raise MissingCallableSuffix(str(entry))
-    except MissingCallableSuffix as e:
-        entry = e.args[0]
-        raise InstallationError(
-            "Invalid script entry point: {} for req: {} - A callable "
-            "suffix is required. Cf https://packaging.python.org/"
-            "specifications/entry-points/#use-for-scripts for more "
-            "information.".format(entry, req_description)
-        )
+    for script_spec in chain(scripts_to_generate, gui_scripts_to_generate):
+        entry = get_export_entry(script_spec)
+        if entry is not None and entry.suffix is None:
+            raise InstallationError(
+                "Invalid script entry point: {} for req: {} - A callable "
+                "suffix is required. Cf https://packaging.python.org/"
+                "specifications/entry-points/#use-for-scripts for more "
+                "information.".format(entry, req_description)
+            )
 
     for script_spec in scripts_to_generate:
         generated_console_scripts.extend(maker.make(script_spec))

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -461,13 +461,6 @@ class MissingCallableSuffix(Exception):
     pass
 
 
-def _raise_for_invalid_entrypoint(specification):
-    # type: (str) -> None
-    entry = get_export_entry(specification)
-    if entry is not None and entry.suffix is None:
-        raise MissingCallableSuffix(str(entry))
-
-
 def _install_wheel(
     name,  # type: str
     wheel_zip,  # type: ZipFile
@@ -714,7 +707,9 @@ def _install_wheel(
 
     try:
         for script_spec in chain(scripts_to_generate, gui_scripts_to_generate):
-            _raise_for_invalid_entrypoint(script_spec)
+            entry = get_export_entry(script_spec)
+            if entry is not None and entry.suffix is None:
+                raise MissingCallableSuffix(str(entry))
     except MissingCallableSuffix as e:
         entry = e.args[0]
         raise InstallationError(

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -715,14 +715,6 @@ def _install_wheel(
     try:
         for script_spec in chain(scripts_to_generate, gui_scripts_to_generate):
             _raise_for_invalid_entrypoint(script_spec)
-
-        for script_spec in scripts_to_generate:
-            generated_console_scripts.extend(maker.make(script_spec))
-
-        generated.extend(generated_console_scripts)
-
-        for script_spec in gui_scripts_to_generate:
-            generated.extend(maker.make(script_spec, {'gui': True}))
     except MissingCallableSuffix as e:
         entry = e.args[0]
         raise InstallationError(
@@ -731,6 +723,14 @@ def _install_wheel(
             "specifications/entry-points/#use-for-scripts for more "
             "information.".format(entry, req_description)
         )
+
+    for script_spec in scripts_to_generate:
+        generated_console_scripts.extend(maker.make(script_spec))
+
+    generated.extend(generated_console_scripts)
+
+    for script_spec in gui_scripts_to_generate:
+        generated.extend(maker.make(script_spec, {'gui': True}))
 
     if warn_script_location:
         msg = message_about_scripts_not_on_PATH(generated_console_scripts)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -720,12 +720,13 @@ def _install_wheel(
     generated_console_scripts = []  # type: List[str]
 
     try:
-        generated_console_scripts = maker.make_multiple(scripts_to_generate)
+        for script_spec in scripts_to_generate:
+            generated_console_scripts.extend(maker.make(script_spec))
+
         generated.extend(generated_console_scripts)
 
-        generated.extend(
-            maker.make_multiple(gui_scripts_to_generate, {'gui': True})
-        )
+        for script_spec in gui_scripts_to_generate:
+            generated.extend(maker.make(script_spec, {'gui': True}))
     except MissingCallableSuffix as e:
         entry = e.args[0]
         raise InstallationError(

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -471,7 +471,6 @@ def _raise_for_invalid_entrypoint(specification):
 class PipScriptMaker(ScriptMaker):
     def make(self, specification, options=None):
         # type: (str, Dict[str, Any]) -> List[str]
-        _raise_for_invalid_entrypoint(specification)
         return super(PipScriptMaker, self).make(specification, options)
 
 
@@ -721,11 +720,13 @@ def _install_wheel(
 
     try:
         for script_spec in scripts_to_generate:
+            _raise_for_invalid_entrypoint(script_spec)
             generated_console_scripts.extend(maker.make(script_spec))
 
         generated.extend(generated_console_scripts)
 
         for script_spec in gui_scripts_to_generate:
+            _raise_for_invalid_entrypoint(script_spec)
             generated.extend(maker.make(script_spec, {'gui': True}))
     except MissingCallableSuffix as e:
         entry = e.args[0]

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -699,8 +699,6 @@ def _install_wheel(
 
     gui_scripts_to_generate = list(starmap('{} = {}'.format, gui.items()))
 
-    generated_console_scripts = []  # type: List[str]
-
     for script_spec in chain(scripts_to_generate, gui_scripts_to_generate):
         entry = get_export_entry(script_spec)
         if entry is not None and entry.suffix is None:
@@ -710,6 +708,8 @@ def _install_wheel(
                 "specifications/entry-points/#use-for-scripts for more "
                 "information.".format(entry, req_description)
             )
+
+    generated_console_scripts = []  # type: List[str]
 
     for script_spec in scripts_to_generate:
         generated_console_scripts.extend(maker.make(script_spec))

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -468,12 +468,6 @@ def _raise_for_invalid_entrypoint(specification):
         raise MissingCallableSuffix(str(entry))
 
 
-class PipScriptMaker(ScriptMaker):
-    def make(self, specification, options=None):
-        # type: (str, Dict[str, Any]) -> List[str]
-        return super(PipScriptMaker, self).make(specification, options)
-
-
 def _install_wheel(
     name,  # type: str
     wheel_zip,  # type: ZipFile
@@ -695,7 +689,7 @@ def _install_wheel(
                         record_installed(pyc_record_path, pyc_path)
         logger.debug(stdout.getvalue())
 
-    maker = PipScriptMaker(None, scheme.scripts)
+    maker = ScriptMaker(None, scheme.scripts)
 
     # Ensure old scripts are overwritten.
     # See https://github.com/pypa/pip/issues/1800

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -23,10 +23,6 @@ from pip._internal.operations.build.wheel_legacy import (
     get_legacy_build_wheel_path,
 )
 from pip._internal.operations.install import wheel
-from pip._internal.operations.install.wheel import (
-    MissingCallableSuffix,
-    _raise_for_invalid_entrypoint,
-)
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.misc import hash_file
 from pip._internal.utils.unpacking import unpack_file
@@ -127,19 +123,6 @@ def test_get_entrypoints_no_entrypoints():
     console, gui = wheel.get_entrypoints(distribution)
     assert console == {}
     assert gui == {}
-
-
-def test_raise_for_invalid_entrypoint_ok():
-    _raise_for_invalid_entrypoint("hello = hello:main")
-
-
-@pytest.mark.parametrize("entrypoint", [
-    "hello = hello",
-    "hello = hello:",
-])
-def test_raise_for_invalid_entrypoint_fail(entrypoint):
-    with pytest.raises(MissingCallableSuffix):
-        _raise_for_invalid_entrypoint(entrypoint)
 
 
 @pytest.mark.parametrize("outrows, expected", [
@@ -306,9 +289,10 @@ class TestInstallUnpackedWheel(object):
             extra_data_files={
                 "data/my_data/data_file": "some data",
             },
-            console_scripts=[
-                "sample = sample:main",
-            ],
+            entry_points={
+                "console_scripts": ["sample = sample:main"],
+                "gui_scripts": ["sample2 = sample:main"],
+            },
         ).save_to_dir(tmpdir)
         self.req = Requirement('sample')
         self.src = os.path.join(tmpdir, 'src')
@@ -479,6 +463,31 @@ class TestInstallUnpackedWheel(object):
         exc_text = str(e.value)
         assert os.path.basename(wheel_path) in exc_text
         assert "example" in exc_text
+
+    @pytest.mark.parametrize(
+        "entrypoint", ["hello = hello", "hello = hello:"]
+    )
+    @pytest.mark.parametrize(
+        "entrypoint_type", ["console_scripts", "gui_scripts"]
+    )
+    def test_invalid_entrypoints_fail(
+        self, data, tmpdir, entrypoint, entrypoint_type
+    ):
+        self.prep(data, tmpdir)
+        wheel_path = make_wheel(
+            "simple", "0.1.0", entry_points={entrypoint_type: [entrypoint]}
+        ).save_to_dir(tmpdir)
+        with pytest.raises(InstallationError) as e:
+            wheel.install_wheel(
+                "simple",
+                str(wheel_path),
+                scheme=self.scheme,
+                req_description="simple",
+            )
+
+        exc_text = str(e.value)
+        assert os.path.basename(wheel_path) in exc_text
+        assert entrypoint in exc_text
 
 
 class TestMessageAboutScriptsNotOnPATH(object):


### PR DESCRIPTION
We explicitly check and fail if entrypoint scripts are invalid. This PR just cleans up the code so the logic is not spread so far apart, and separates it from the process of actually generating the entrypoint scripts, so that we can refactor more easily.