### PR TITLE
Add .python-version file created by pyenv-virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ tests/data/common_wheels/
 *~
 .*.sw?
 .env/
+.python-version
 
 # For IntelliJ IDEs (basically PyCharm)
 .idea/

--- a/news/b6480a01-0482-4bb2-b61b-5bb4d450c03f.trivial
+++ b/news/b6480a01-0482-4bb2-b61b-5bb4d450c03f.trivial
@@ -1,0 +1,1 @@
+Add .python-version to .gitignore. This avoids git to track this file accidently


### PR DESCRIPTION
I use `pyenv-virtualenv`. It has a small cool feature, which allows automatic activation of environment whenever I check out in the src directory. However, for that, it creates a file named `.python-version` in the src directory. `git` sees that file. Since the file is user-specific related to venv, it can be added to the `.gitignore`.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
