### PR TITLE
Allow verbose/quiet level to be specified via config file and env var

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -442,6 +442,15 @@ and ``--no-cache-dir``, falsy values have to be used:
     no-compile = no
     no-warn-script-location = false
 
+For options which can be repeated like ``--verbose`` and ``--quiet``,
+a non-negative integer can be used to represent the level to be specified:
+
+.. code-block:: ini
+
+    [global]
+    quiet = 0
+    verbose = 2
+
 It is possible to append values to a section within a configuration file such as the pip.ini file.
 This is applicable to appending options like ``--find-links`` or ``--trusted-host``,
 which can be written on multiple lines:
@@ -487,6 +496,15 @@ multiple values. For example::
 is the same as calling::
 
     pip install --find-links=http://mirror1.example.com --find-links=http://mirror2.example.com
+
+Options that do not take a value, but can be repeated (such as ``--verbose``)
+can be specified using the number of repetitions, so::
+
+    export PIP_VERBOSE=3
+
+is the same as calling::
+
+    pip install -vvv
 
 .. note::
 

--- a/news/8578.bugfix
+++ b/news/8578.bugfix
@@ -1,0 +1,4 @@
+Allow specifying verbosity and quiet level via configuration files
+and environment variables. Previously these options were treated as
+boolean values when read from there while through CLI the level can be
+specified.


### PR DESCRIPTION
This allows options of action `count` to be specified via configuration files as well as environmental variables.  The affected options include `verbose` and `quiet`.  If this patch is merged, for example the following will be equivalent:

    pip -vvv
    PIP_VERBOSE=3 pip