### PR TITLE
Change when we warn about dependency conflicts during `pip install`

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -373,13 +373,13 @@ class InstallCommand(RequirementCommand):
             )
 
             # Check for conflicts in the package set we're installing.
+            conflicts = None  # type: Optional[ConflictDetails]
             should_warn_about_conflicts = (
                 not options.ignore_dependencies and
                 options.warn_about_conflicts
             )
             if should_warn_about_conflicts:
                 conflicts = self._determine_conflicts(to_install)
-                self._warn_about_conflicts(conflicts)
 
             # Don't warn about script install locations if
             # --target has been specified
@@ -421,6 +421,10 @@ class InstallCommand(RequirementCommand):
                 except Exception:
                     pass
                 items.append(item)
+
+            if conflicts is not None:
+                self._warn_about_conflicts(conflicts)
+
             installed_desc = ' '.join(items)
             if installed_desc:
                 write_output(

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -517,7 +517,7 @@ class InstallCommand(RequirementCommand):
         # type: (ConflictDetails) -> None
         package_set, (missing, conflicting) = conflict_details
 
-        # NOTE: There is some duplication here from pip check
+        # NOTE: There is some duplication here, with commands/check.py
         for project_name in missing:
             version = package_set[project_name][0]
             for dependency in missing[project_name]:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -40,6 +40,7 @@ if MYPY_CHECK_RUNNING:
     from typing import Iterable, List, Optional
 
     from pip._internal.models.format_control import FormatControl
+    from pip._internal.operations.check import ConflictDetails
     from pip._internal.req.req_install import InstallRequirement
     from pip._internal.wheel_builder import BinaryAllowedPredicate
 
@@ -371,13 +372,14 @@ class InstallCommand(RequirementCommand):
                 requirement_set
             )
 
-            # Consistency Checking of the package set we're installing.
+            # Check for conflicts in the package set we're installing.
             should_warn_about_conflicts = (
                 not options.ignore_dependencies and
                 options.warn_about_conflicts
             )
             if should_warn_about_conflicts:
-                self._warn_about_conflicts(to_install)
+                conflicts = self._determine_conflicts(to_install)
+                self._warn_about_conflicts(conflicts)
 
             # Don't warn about script install locations if
             # --target has been specified
@@ -498,14 +500,22 @@ class InstallCommand(RequirementCommand):
                     target_item_dir
                 )
 
-    def _warn_about_conflicts(self, to_install):
-        # type: (List[InstallRequirement]) -> None
+    def _determine_conflicts(self, to_install):
+        # type: (List[InstallRequirement]) -> Optional[ConflictDetails]
         try:
-            package_set, _dep_info = check_install_conflicts(to_install)
+            conflict_details = check_install_conflicts(to_install)
         except Exception:
-            logger.error("Error checking for conflicts.", exc_info=True)
-            return
-        missing, conflicting = _dep_info
+            logger.error(
+                "Error while checking for conflicts. Please file an issue on "
+                "pip's issue tracker: https://github.com/pypa/pip/issues/new",
+                exc_info=True
+            )
+            return None
+        return conflict_details
+
+    def _warn_about_conflicts(self, conflict_details):
+        # type: (ConflictDetails) -> None
+        package_set, (missing, conflicting) = conflict_details
 
         # NOTE: There is some duplication here from pip check
         for project_name in missing:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -507,7 +507,7 @@ class InstallCommand(RequirementCommand):
     def _determine_conflicts(self, to_install):
         # type: (List[InstallRequirement]) -> Optional[ConflictDetails]
         try:
-            conflict_details = check_install_conflicts(to_install)
+            return check_install_conflicts(to_install)
         except Exception:
             logger.error(
                 "Error while checking for conflicts. Please file an issue on "
@@ -515,7 +515,6 @@ class InstallCommand(RequirementCommand):
                 exc_info=True
             )
             return None
-        return conflict_details
 
     def _warn_about_conflicts(self, conflict_details):
         # type: (ConflictDetails) -> None

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -29,6 +29,7 @@ if MYPY_CHECK_RUNNING:
     MissingDict = Dict[str, List[Missing]]
     ConflictingDict = Dict[str, List[Conflicting]]
     CheckResult = Tuple[MissingDict, ConflictingDict]
+    ConflictDetails = Tuple[PackageSet, CheckResult]
 
 PackageDetails = namedtuple('PackageDetails', ['version', 'requires'])
 
@@ -99,7 +100,7 @@ def check_package_set(package_set, should_ignore=None):
 
 
 def check_install_conflicts(to_install):
-    # type: (List[InstallRequirement]) -> Tuple[PackageSet, CheckResult]
+    # type: (List[InstallRequirement]) -> ConflictDetails
     """For checking if the dependency graph would be consistent after \
     installing given requirements
     """


### PR DESCRIPTION
Toward #8546

This changes the location of the warnings about installation conflicts.

Before:

```sh-session
$ pip install flake8-import-order==0.17.1 flake8==3.5.0                            
Collecting flake8-import-order==0.17.1
  Using cached flake8_import_order-0.17.1-py2.py3-none-any.whl (17 kB)
Collecting flake8==3.5.0
  Using cached flake8-3.5.0-py2.py3-none-any.whl (69 kB)
Requirement already satisfied: setuptools in /Users/pradyunsg/.virtualenvs/tmp-dc0525085a0c2c3/lib/python3.8/site-packages (from flake8-import-order==0.17.1) (46.1.3)
Collecting pycodestyle
  Using cached pycodestyle-2.6.0-py2.py3-none-any.whl (41 kB)
Collecting pyflakes<1.7.0,>=1.5.0
  Using cached pyflakes-1.6.0-py2.py3-none-any.whl (227 kB)
Collecting mccabe<0.7.0,>=0.6.0
  Using cached mccabe-0.6.1-py2.py3-none-any.whl (8.6 kB)
ERROR: flake8 3.5.0 has requirement pycodestyle<2.4.0,>=2.0.0, but you'll have pycodestyle 2.6.0 which is incompatible.
Installing collected packages: pycodestyle, flake8-import-order, pyflakes, mccabe, flake8
Successfully installed flake8-3.5.0 flake8-import-order-0.17.1 mccabe-0.6.1 pycodestyle-2.6.0 pyflakes-1.6.0
```

After

```sh-session
$ pip install flake8-import-order==0.17.1 flake8==3.5.0                            
Collecting flake8-import-order==0.17.1
  Using cached flake8_import_order-0.17.1-py2.py3-none-any.whl (17 kB)
Collecting flake8==3.5.0
  Using cached flake8-3.5.0-py2.py3-none-any.whl (69 kB)
Collecting pycodestyle
  Using cached pycodestyle-2.6.0-py2.py3-none-any.whl (41 kB)
Requirement already satisfied: setuptools in /Users/pradyunsg/.virtualenvs/tmp-dc0525085a0c2c3/lib/python3.8/site-packages (from flake8-import-order==0.17.1) (46.1.3)
Collecting pyflakes<1.7.0,>=1.5.0
  Using cached pyflakes-1.6.0-py2.py3-none-any.whl (227 kB)
Collecting mccabe<0.7.0,>=0.6.0
  Using cached mccabe-0.6.1-py2.py3-none-any.whl (8.6 kB)
Installing collected packages: pycodestyle, flake8-import-order, pyflakes, mccabe, flake8
ERROR: flake8 3.5.0 has requirement pycodestyle<2.4.0,>=2.0.0, but you'll have pycodestyle 2.6.0 which is incompatible.
Successfully installed flake8-3.5.0 flake8-import-order-0.17.1 mccabe-0.6.1 pycodestyle-2.6.0 pyflakes-1.6.0
```

The change in position of the ERROR line is the main change in this PR. The reason I want to make this change, is to better position this error when the "Installing collected packages" step produces a lot of output (eg: setup.py install runs, wheel builds etc).
