### PR TITLE
Add examples on how to install package extras and sdists to docs

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -895,7 +895,7 @@ Examples
     ::
 
       $ pip install SomePackage[PDF]
-      $ pip install git+https://git.repo/some_pkg.git#egg=SomePackage[PDF]
+      $ pip install "SomePackage[PDF] @ git+https://git.repo/SomePackage@master#subdirectory=subdir_path"
       $ pip install .[PDF]  # project in current directory
       $ pip install SomePackage[PDF]==3.0
       $ pip install SomePackage[PDF,EPUB]  # multiple extras
@@ -913,8 +913,11 @@ Examples
 
     ::
 
-      $ pip install SomeProject==1.0.4@http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl
-      $ pip install "SomeProject==1.0.4 @ http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl"
+      $ pip install SomeProject@http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl
+      $ pip install "SomeProject @ http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl"
+      $ pip install SomeProject@http://my.package.repo//1.2.3.tar.gz
+      $ pip install SomeProject@git+https://git.repo/some_pkg.git@1.3.1
+      $ pip install SomeProject@git+https://git.repo/some_pkg.git@1.3.1#7921be1537eac1e97bc40179a57f0349c2aee67d
 
 
 #. Install from alternative package repositories.

--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -880,6 +880,13 @@ Examples
       $ pip install -e path/to/project       # project in another directory
 
 
+#. Install a project from VCS
+
+    ::
+
+      $ pip install SomeProject@git+https://git.repo/some_pkg.git@1.3.1
+
+
 #. Install a project from VCS in "editable" mode. See the sections on :ref:`VCS Support <VCS Support>` and :ref:`Editable Installs <editable-installs>`.
 
     ::
@@ -916,8 +923,6 @@ Examples
       $ pip install SomeProject@http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl
       $ pip install "SomeProject @ http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl"
       $ pip install SomeProject@http://my.package.repo//1.2.3.tar.gz
-      $ pip install SomeProject@git+https://git.repo/some_pkg.git@1.3.1
-      $ pip install SomeProject@git+https://git.repo/some_pkg.git@1.3.1#7921be1537eac1e97bc40179a57f0349c2aee67d
 
 
 #. Install from alternative package repositories.

--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -920,9 +920,9 @@ Examples
 
     ::
 
-      $ pip install SomeProject@http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl
-      $ pip install "SomeProject @ http://my.package.repo//SomeProject-1.2.3-py33-none-any.whl"
-      $ pip install SomeProject@http://my.package.repo//1.2.3.tar.gz
+      $ pip install SomeProject@http://my.package.repo/SomeProject-1.2.3-py33-none-any.whl
+      $ pip install "SomeProject @ http://my.package.repo/SomeProject-1.2.3-py33-none-any.whl"
+      $ pip install SomeProject@http://my.package.repo/1.2.3.tar.gz
 
 
 #. Install from alternative package repositories.

--- a/news/8576.doc
+++ b/news/8576.doc
@@ -1,1 +1,1 @@
-Add how to install package extras from git branch and  source distributions in pip docs
+Document how to install package extras from git branch and source distributions.

--- a/news/8576.doc
+++ b/news/8576.doc
@@ -1,0 +1,1 @@
+Add how to install package extras from git branch and  source distributions in pip docs


### PR DESCRIPTION
I added the following examples to solve #8576 

- how to install package extras from a git branch. 
- how to install from sdist from a remote git 
- how to install package from a particular tag from a remote git
- how to install package from a particular tag and commit hash from a remote git

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
