### PR TITLE
Fix the link on new-resolver dependency conflicts

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -453,5 +453,5 @@ class Factory(object):
         return DistributionNotFound(
             "ResolutionImpossible For help visit: "
             "https://pip.pypa.io/en/stable/user_guide/"
-            "#dependency-conflicts-resolution-impossible"
+            "#fixing-conflicting-dependencies"
         )


### PR DESCRIPTION
Changes

```
ERROR: ResolutionImpossible For help visit: https://pip.pypa.io/en/stable/user_guide/#dependency-conflicts-resolution-impossible
```

To

```
ERROR: ResolutionImpossible For help visit: https://pip.pypa.io/en/stable/user_guide/#fixing-conflicting-dependencies
```
