### PR TITLE
Support '--use-feature' in requirements files

### DIFF
--- a/news/8601.feature
+++ b/news/8601.feature
@@ -1,0 +1,1 @@
+Support ``--use-feature`` in requirements files

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -100,7 +100,8 @@ def freeze(
                                 '--pre',
                                 '--trusted-host',
                                 '--process-dependency-links',
-                                '--extra-index-url'))):
+                                '--extra-index-url',
+                                '--use-feature'))):
                         line = line.rstrip()
                         if line not in emitted_options:
                             emitted_options.add(line)

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -62,6 +62,7 @@ SUPPORTED_OPTIONS = [
     cmdoptions.require_hashes,
     cmdoptions.pre,
     cmdoptions.trusted_host,
+    cmdoptions.use_new_feature,
 ]  # type: List[Callable[..., optparse.Option]]
 
 # options to be passed to requirements

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -548,6 +548,7 @@ _freeze_req_opts = textwrap.dedent("""\
     --extra-index-url http://ignore
     --find-links http://ignore
     --index-url http://ignore
+    --use-feature 2020-resolver
 """)
 
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -382,6 +382,10 @@ class TestProcessLine(object):
         line_processor("--pre", "file", 1, finder=finder)
         assert finder.allow_all_prereleases
 
+    def test_use_feature(self, line_processor):
+        """--use-feature can be set in requirements files."""
+        line_processor("--use-feature=2020-resolver", "filename", 1)
+
     def test_relative_local_find_links(
         self, line_processor, finder, monkeypatch, tmpdir
     ):


### PR DESCRIPTION
This patch adds support for `--use-feature` in requirements files so that a project that wants all contributors using the same pip features can specify it in the requirements file. For example, to ensure a requirements file uses the new resolver:

```
--use-feature=2020-resolver
boto3
boto3==1.13.13
```

This is a new version of #8293.