### PR TITLE
Ignore require-virtualenv in `pip list`

### DIFF
--- a/news/8603.feature
+++ b/news/8603.feature
@@ -1,0 +1,1 @@
+Ignore require-virtualenv in ``pip list``

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -39,6 +39,7 @@ class ListCommand(IndexGroupCommand):
     Packages are listed in a case-insensitive sorted order.
     """
 
+    ignore_require_venv = True
     usage = """
       %prog [options]"""
 


### PR DESCRIPTION
Allow pip list to function when `PIP_REQUIRE_VIRTUALENV=true`. This allows inspection of system site-packages.

Fixes https://github.com/pypa/pip/issues/8602