### PR TITLE
Fix version where direct references were added

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -269,7 +269,7 @@ Since version 6.0, pip also supports specifiers containing `environment markers
   SomeProject ==5.4 ; python_version < '2.7'
   SomeProject; sys_platform == 'win32'
 
-Since version 19.1, pip also supports `direct references
+Since version 19.3, pip also supports `direct references
 <https://www.python.org/dev/peps/pep-0440/#direct-references>`__ like so:
 
  ::


### PR DESCRIPTION
It seems to me that the direct references are supported since version 19.3 not 19.1.

Versions 19.2 and 19.1 have nothing about them in their documentation and also [the commit](https://github.com/pypa/pip/commit/16af35c61345866d582b43abfc649a0d79b16c9c) which added this is not available in tags older than 19.3.