### PR TITLE
Allow args for editor via env variable

### DIFF
--- a/news/7392.bugfix
+++ b/news/7392.bugfix
@@ -1,0 +1,1 @@
+Allow editor args to be specified as ``EDITOR`` env variable for editing config via pip config.


### PR DESCRIPTION
This works for the Python3 only as the implementation uses methods
which are only supported by the Python3.

This fixes #7392 

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
