### PR TITLE
Use monkeypatch.setenv to mock env vars

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from contextlib import contextmanager
 
 import pytest
@@ -556,3 +557,13 @@ def mock_server():
     test_server = MockServer(server)
     with test_server.context:
         yield test_server
+
+
+@pytest.fixture
+def utc():
+    # time.tzset() is not implemented on some platforms, e.g. Windows.
+    tzset = getattr(time, 'tzset', lambda: None)
+    with patch.dict(os.environ, {'TZ': 'UTC'}):
+        tzset()
+        yield
+    tzset()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 
 import pytest
 import six
+from mock import patch
 from pip._vendor.contextlib2 import ExitStack, nullcontext
 from setuptools.wheel import Wheel
 
@@ -104,11 +105,13 @@ def use_new_resolver(request):
     """Set environment variable to make pip default to the new resolver.
     """
     new_resolver = request.config.getoption("--new-resolver")
+    features = set(os.environ.get("PIP_USE_FEATURE", "").split())
     if new_resolver:
-        os.environ["PIP_USE_FEATURE"] = "2020-resolver"
+        features.add("2020-resolver")
     else:
-        os.environ.pop("PIP_USE_FEATURE", None)
-    yield new_resolver
+        features.discard("2020-resolver")
+    with patch.dict(os.environ, {"PIP_USE_FEATURE", " ".join(features)}):
+        yield new_resolver
 
 
 @pytest.fixture(scope='session')
@@ -151,7 +154,7 @@ def tmpdir(request, tmpdir):
 
 
 @pytest.fixture(autouse=True)
-def isolate(tmpdir):
+def isolate(tmpdir, monkeypatch):
     """
     Isolate our tests so that things like global configuration files and the
     like do not affect our test results.
@@ -174,45 +177,51 @@ def isolate(tmpdir):
     if sys.platform == 'win32':
         # Note: this will only take effect in subprocesses...
         home_drive, home_path = os.path.splitdrive(home_dir)
-        os.environ.update({
-            'USERPROFILE': home_dir,
-            'HOMEDRIVE': home_drive,
-            'HOMEPATH': home_path,
-        })
+        monkeypatch.setenv('USERPROFILE', home_dir)
+        monkeypatch.setenv('HOMEDRIVE', home_drive)
+        monkeypatch.setenv('HOMEPATH', home_path)
         for env_var, sub_path in (
             ('APPDATA', 'AppData/Roaming'),
             ('LOCALAPPDATA', 'AppData/Local'),
         ):
             path = os.path.join(home_dir, *sub_path.split('/'))
-            os.environ[env_var] = path
+            monkeypatch.setenv(env_var, path)
             os.makedirs(path)
     else:
         # Set our home directory to our temporary directory, this should force
         # all of our relative configuration files to be read from here instead
         # of the user's actual $HOME directory.
-        os.environ["HOME"] = home_dir
+        monkeypatch.setenv("HOME", home_dir)
         # Isolate ourselves from XDG directories
-        os.environ["XDG_DATA_HOME"] = os.path.join(home_dir, ".local", "share")
-        os.environ["XDG_CONFIG_HOME"] = os.path.join(home_dir, ".config")
-        os.environ["XDG_CACHE_HOME"] = os.path.join(home_dir, ".cache")
-        os.environ["XDG_RUNTIME_DIR"] = os.path.join(home_dir, ".runtime")
-        os.environ["XDG_DATA_DIRS"] = ":".join([
+        monkeypatch.setenv("XDG_DATA_HOME", os.path.join(
+            home_dir, ".local", "share",
+        ))
+        monkeypatch.setenv("XDG_CONFIG_HOME", os.path.join(
+            home_dir, ".config",
+        ))
+        monkeypatch.setenv("XDG_CACHE_HOME", os.path.join(home_dir, ".cache"))
+        monkeypatch.setenv("XDG_RUNTIME_DIR", os.path.join(
+            home_dir, ".runtime",
+        ))
+        monkeypatch.setenv("XDG_DATA_DIRS", os.pathsep.join([
             os.path.join(fake_root, "usr", "local", "share"),
             os.path.join(fake_root, "usr", "share"),
-        ])
-        os.environ["XDG_CONFIG_DIRS"] = os.path.join(fake_root, "etc", "xdg")
+        ]))
+        monkeypatch.setenv("XDG_CONFIG_DIRS", os.path.join(
+            fake_root, "etc", "xdg",
+        ))
 
     # Configure git, because without an author name/email git will complain
     # and cause test failures.
-    os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
-    os.environ["GIT_AUTHOR_NAME"] = "pip"
-    os.environ["GIT_AUTHOR_EMAIL"] = "distutils-sig@python.org"
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "pip")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "distutils-sig@python.org")
 
     # We want to disable the version check from running in the tests
-    os.environ["PIP_DISABLE_PIP_VERSION_CHECK"] = "true"
+    monkeypatch.setenv("PIP_DISABLE_PIP_VERSION_CHECK", "true")
 
     # Make sure tests don't share a requirements tracker.
-    os.environ.pop('PIP_REQ_TRACKER', None)
+    monkeypatch.delenv("PIP_REQ_TRACKER", False)
 
     # FIXME: Windows...
     os.makedirs(os.path.join(home_dir, ".config", "git"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ def use_new_resolver(request):
         features.add("2020-resolver")
     else:
         features.discard("2020-resolver")
-    with patch.dict(os.environ, {"PIP_USE_FEATURE", " ".join(features)}):
+    with patch.dict(os.environ, {"PIP_USE_FEATURE": " ".join(features)}):
         yield new_resolver
 
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -492,10 +492,7 @@ class PipTestEnvironment(TestFileEnvironment):
         kwargs.setdefault("cwd", self.scratch_path)
 
         # Setup our environment
-        environ = kwargs.get("environ")
-        if environ is None:
-            environ = os.environ.copy()
-
+        environ = kwargs.setdefault("environ", os.environ.copy())
         environ["PATH"] = Path.pathsep.join(
             [self.bin_path] + [environ.get("PATH", [])],
         )
@@ -504,7 +501,6 @@ class PipTestEnvironment(TestFileEnvironment):
         environ["PYTHONDONTWRITEBYTECODE"] = "1"
         # Make sure we get UTF-8 on output, even on Windows...
         environ["PYTHONIOENCODING"] = "UTF-8"
-        kwargs["environ"] = environ
 
         # Whether all pip invocations should expect stderr
         # (useful for Python version deprecation)

--- a/tests/lib/configuration_helpers.py
+++ b/tests/lib/configuration_helpers.py
@@ -14,18 +14,6 @@ from pip._internal.utils.misc import ensure_dir
 kinds = pip._internal.configuration.kinds
 
 
-def reset_os_environ(old_environ):
-    """
-    Reset os.environ while preserving the same underlying mapping.
-    """
-    # Preserving the same mapping is preferable to assigning a new mapping
-    # because the latter has interfered with test isolation by, for example,
-    # preventing time.tzset() from working in subsequent tests after
-    # changing os.environ['TZ'] in those tests.
-    os.environ.clear()
-    os.environ.update(old_environ)
-
-
 class ConfigurationMixin(object):
 
     def setup(self):
@@ -34,13 +22,9 @@ class ConfigurationMixin(object):
         )
         self._files_to_clear = []
 
-        self._old_environ = os.environ.copy()
-
     def teardown(self):
         for fname in self._files_to_clear:
             fname.stop()
-
-        reset_os_environ(self._old_environ)
 
     def patch_configuration(self, variant, di):
         old = self.configuration._load_config_files

--- a/tests/lib/options_helpers.py
+++ b/tests/lib/options_helpers.py
@@ -1,12 +1,9 @@
 """Provides helper classes for testing option handling in pip
 """
 
-import os
-
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.commands import CommandInfo, commands_dict
-from tests.lib.configuration_helpers import reset_os_environ
 
 
 class FakeCommand(Command):
@@ -23,11 +20,9 @@ class FakeCommand(Command):
 class AddFakeCommandMixin(object):
 
     def setup(self):
-        self.environ_before = os.environ.copy()
         commands_dict['fake'] = CommandInfo(
             'tests.lib.options_helpers', 'FakeCommand', 'fake summary',
         )
 
     def teardown(self):
-        reset_os_environ(self.environ_before)
         commands_dict.pop('fake')

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import time
 
 import pytest
 from mock import Mock, patch
@@ -10,6 +9,12 @@ from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.utils import temp_dir
 from pip._internal.utils.logging import BrokenStdoutLoggingError
 from pip._internal.utils.temp_dir import TempDirectory
+
+
+@pytest.fixture
+def fixed_time(utc):
+    with patch('time.time', lambda: 1547704837.040001):
+        yield
 
 
 class FakeCommand(Command):
@@ -91,67 +96,40 @@ def test_handle_pip_version_check_called(mock_handle_version_check):
     mock_handle_version_check.assert_called_once()
 
 
-class Test_base_command_logging(object):
+def test_log_command_success(fixed_time, tmpdir):
+    """Test the --log option logs when command succeeds."""
+    cmd = FakeCommand()
+    log_path = tmpdir.joinpath('log')
+    cmd.main(['fake', '--log', log_path])
+    with open(log_path) as f:
+        assert f.read().rstrip() == '2019-01-17T06:00:37,040 fake'
+
+
+def test_log_command_error(fixed_time, tmpdir):
+    """Test the --log option logs when command fails."""
+    cmd = FakeCommand(error=True)
+    log_path = tmpdir.joinpath('log')
+    cmd.main(['fake', '--log', log_path])
+    with open(log_path) as f:
+        assert f.read().startswith('2019-01-17T06:00:37,040 fake')
+
+
+def test_log_file_command_error(fixed_time, tmpdir):
+    """Test the --log-file option logs (when there's an error)."""
+    cmd = FakeCommand(error=True)
+    log_file_path = tmpdir.joinpath('log_file')
+    cmd.main(['fake', '--log-file', log_file_path])
+    with open(log_file_path) as f:
+        assert f.read().startswith('2019-01-17T06:00:37,040 fake')
+
+
+def test_log_unicode_messages(fixed_time, tmpdir):
+    """Tests that logging bytestrings and unicode objects
+    don't break logging.
     """
-    Test `pip.base_command.Command` setting up logging consumers based on
-    options
-    """
-
-    def setup(self):
-        self.old_time = time.time
-        time.time = lambda: 1547704837.040001
-        self.old_tz = os.environ.get('TZ')
-        os.environ['TZ'] = 'UTC'
-        # time.tzset() is not implemented on some platforms (notably, Windows).
-        if hasattr(time, 'tzset'):
-            time.tzset()
-
-    def teardown(self):
-        if self.old_tz:
-            os.environ['TZ'] = self.old_tz
-        else:
-            del os.environ['TZ']
-        if 'tzset' in dir(time):
-            time.tzset()
-        time.time = self.old_time
-
-    def test_log_command_success(self, tmpdir):
-        """
-        Test the --log option logs when command succeeds
-        """
-        cmd = FakeCommand()
-        log_path = tmpdir.joinpath('log')
-        cmd.main(['fake', '--log', log_path])
-        with open(log_path) as f:
-            assert f.read().rstrip() == '2019-01-17T06:00:37,040 fake'
-
-    def test_log_command_error(self, tmpdir):
-        """
-        Test the --log option logs when command fails
-        """
-        cmd = FakeCommand(error=True)
-        log_path = tmpdir.joinpath('log')
-        cmd.main(['fake', '--log', log_path])
-        with open(log_path) as f:
-            assert f.read().startswith('2019-01-17T06:00:37,040 fake')
-
-    def test_log_file_command_error(self, tmpdir):
-        """
-        Test the --log-file option logs (when there's an error).
-        """
-        cmd = FakeCommand(error=True)
-        log_file_path = tmpdir.joinpath('log_file')
-        cmd.main(['fake', '--log-file', log_file_path])
-        with open(log_file_path) as f:
-            assert f.read().startswith('2019-01-17T06:00:37,040 fake')
-
-    def test_unicode_messages(self, tmpdir):
-        """
-        Tests that logging bytestrings and unicode objects don't break logging
-        """
-        cmd = FakeCommandWithUnicode()
-        log_path = tmpdir.joinpath('log')
-        cmd.main(['fake_unicode', '--log', log_path])
+    cmd = FakeCommandWithUnicode()
+    log_path = tmpdir.joinpath('log')
+    cmd.main(['fake_unicode', '--log', log_path])
 
 
 @pytest.mark.no_auto_tempdir_manager

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,8 +1,6 @@
 """Tests for all things related to the configuration
 """
 
-import os
-
 import pytest
 from mock import MagicMock
 
@@ -31,48 +29,48 @@ class TestConfigurationLoading(ConfigurationMixin):
         self.configuration.load()
         assert self.configuration.get_value("test.hello") == "3"
 
-    def test_environment_config_loading(self):
+    def test_environment_config_loading(self, monkeypatch):
         contents = """
             [test]
             hello = 4
         """
 
         with self.tmpfile(contents) as config_file:
-            os.environ["PIP_CONFIG_FILE"] = config_file
+            monkeypatch.setenv("PIP_CONFIG_FILE", config_file)
 
             self.configuration.load()
             assert self.configuration.get_value("test.hello") == "4", \
                 self.configuration._config
 
-    def test_environment_var_loading(self):
-        os.environ["PIP_HELLO"] = "5"
+    def test_environment_var_loading(self, monkeypatch):
+        monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
         assert self.configuration.get_value(":env:.hello") == "5"
 
     @pytest.mark.skipif("sys.platform == 'win32'")
-    def test_environment_var_does_not_load_lowercase(self):
-        os.environ["pip_hello"] = "5"
+    def test_environment_var_does_not_load_lowercase(self, monkeypatch):
+        monkeypatch.setenv("pip_hello", "5")
 
         self.configuration.load()
         with pytest.raises(ConfigurationError):
             self.configuration.get_value(":env:.hello")
 
-    def test_environment_var_does_not_load_version(self):
-        os.environ["PIP_VERSION"] = "True"
+    def test_environment_var_does_not_load_version(self, monkeypatch):
+        monkeypatch.setenv("PIP_VERSION", "True")
 
         self.configuration.load()
 
         with pytest.raises(ConfigurationError):
             self.configuration.get_value(":env:.version")
 
-    def test_environment_config_errors_if_malformed(self):
+    def test_environment_config_errors_if_malformed(self, monkeypatch):
         contents = """
             test]
             hello = 4
         """
         with self.tmpfile(contents) as config_file:
-            os.environ["PIP_CONFIG_FILE"] = config_file
+            monkeypatch.setenv("PIP_CONFIG_FILE", config_file)
             with pytest.raises(ConfigurationError) as err:
                 self.configuration.load()
 
@@ -130,36 +128,36 @@ class TestConfigurationPrecedence(ConfigurationMixin):
 
         assert self.configuration.get_value("test.hello") == "2"
 
-    def test_env_not_overriden_by_environment_var(self):
+    def test_env_not_overriden_by_environment_var(self, monkeypatch):
         self.patch_configuration(kinds.ENV, {"test.hello": "1"})
-        os.environ["PIP_HELLO"] = "5"
+        monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "1"
         assert self.configuration.get_value(":env:.hello") == "5"
 
-    def test_site_not_overriden_by_environment_var(self):
+    def test_site_not_overriden_by_environment_var(self, monkeypatch):
         self.patch_configuration(kinds.SITE, {"test.hello": "2"})
-        os.environ["PIP_HELLO"] = "5"
+        monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "2"
         assert self.configuration.get_value(":env:.hello") == "5"
 
-    def test_user_not_overriden_by_environment_var(self):
+    def test_user_not_overriden_by_environment_var(self, monkeypatch):
         self.patch_configuration(kinds.USER, {"test.hello": "3"})
-        os.environ["PIP_HELLO"] = "5"
+        monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "3"
         assert self.configuration.get_value(":env:.hello") == "5"
 
-    def test_global_not_overriden_by_environment_var(self):
+    def test_global_not_overriden_by_environment_var(self, monkeypatch):
         self.patch_configuration(kinds.GLOBAL, {"test.hello": "4"})
-        os.environ["PIP_HELLO"] = "5"
+        monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,7 +1,5 @@
 import errno
 import logging
-import os
-import time
 from threading import Thread
 
 import pytest
@@ -33,24 +31,7 @@ def _make_broken_pipe_error():
 
 
 class TestIndentingFormatter(object):
-    """
-    Test `pip._internal.utils.logging.IndentingFormatter`.
-    """
-
-    def setup(self):
-        self.old_tz = os.environ.get('TZ')
-        os.environ['TZ'] = 'UTC'
-        # time.tzset() is not implemented on some platforms (notably, Windows).
-        if hasattr(time, 'tzset'):
-            time.tzset()
-
-    def teardown(self):
-        if self.old_tz:
-            os.environ['TZ'] = self.old_tz
-        else:
-            del os.environ['TZ']
-        if 'tzset' in dir(time):
-            time.tzset()
+    """Test ``pip._internal.utils.logging.IndentingFormatter``."""
 
     def make_record(self, msg, level_name):
         level_number = getattr(logging, level_name)
@@ -72,7 +53,7 @@ class TestIndentingFormatter(object):
         ('ERROR', 'ERROR: hello\nworld'),
         ('CRITICAL', 'ERROR: hello\nworld'),
     ])
-    def test_format(self, level_name, expected):
+    def test_format(self, level_name, expected, utc):
         """
         Args:
           level_name: a logging level name (e.g. "WARNING").
@@ -89,7 +70,7 @@ class TestIndentingFormatter(object):
          '2019-01-17T06:00:37,040 WARNING: hello\n'
          '2019-01-17T06:00:37,040 world'),
     ])
-    def test_format_with_timestamp(self, level_name, expected):
+    def test_format_with_timestamp(self, level_name, expected, utc):
         record = self.make_record('hello\nworld', level_name=level_name)
         f = IndentingFormatter(fmt="%(message)s", add_timestamp=True)
         assert f.format(record) == expected
@@ -99,7 +80,7 @@ class TestIndentingFormatter(object):
         ('ERROR', 'DEPRECATION: hello\nworld'),
         ('CRITICAL', 'DEPRECATION: hello\nworld'),
     ])
-    def test_format_deprecated(self, level_name, expected):
+    def test_format_deprecated(self, level_name, expected, utc):
         """
         Test that logged deprecation warnings coming from deprecated()
         don't get another prefix.
@@ -110,7 +91,7 @@ class TestIndentingFormatter(object):
         f = IndentingFormatter(fmt="%(message)s")
         assert f.format(record) == expected
 
-    def test_thread_safety_base(self):
+    def test_thread_safety_base(self, utc):
         record = self.make_record(
             'DEPRECATION: hello\nworld', level_name='WARNING',
         )
@@ -126,7 +107,7 @@ class TestIndentingFormatter(object):
         thread.join()
         assert results[0] == results[1]
 
-    def test_thread_safety_indent_log(self):
+    def test_thread_safety_indent_log(self, utc):
         record = self.make_record(
             'DEPRECATION: hello\nworld', level_name='WARNING',
         )

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -600,16 +600,14 @@ class TestMessageAboutScriptsNotOnPATH(object):
         )
         assert retval is None
 
-    def test_missing_PATH_env_treated_as_empty_PATH_env(self):
+    def test_missing_PATH_env_treated_as_empty_PATH_env(self, monkeypatch):
         scripts = ['a/b/foo']
 
-        env = os.environ.copy()
-        del env['PATH']
-        with patch.dict('os.environ', env, clear=True):
-            retval_missing = wheel.message_about_scripts_not_on_PATH(scripts)
+        monkeypatch.delenv('PATH')
+        retval_missing = wheel.message_about_scripts_not_on_PATH(scripts)
 
-        with patch.dict('os.environ', {'PATH': ''}):
-            retval_empty = wheel.message_about_scripts_not_on_PATH(scripts)
+        monkeypatch.setenv('PATH', '')
+        retval_empty = wheel.message_about_scripts_not_on_PATH(scripts)
 
         assert retval_missing == retval_empty
 


### PR DESCRIPTION
IMHO it'd be more reliable to let pytest perform the setup and teardown of the environment variables.