### PR TITLE
Reject setup.py projects that don't generate .egg-info

### DIFF
--- a/news/6998.removal
+++ b/news/6998.removal
@@ -1,0 +1,1 @@
+Deprecate setup.py-based builds that do not generate an ``.egg-info`` directory.

--- a/news/8617.removal
+++ b/news/8617.removal
@@ -1,0 +1,1 @@
+Deprecate setup.py-based builds that do not generate an ``.egg-info`` directory.

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -6,7 +6,7 @@ import os
 import sys
 from distutils.util import change_root
 
-from pip._internal.utils.deprecation import deprecated
+from pip._internal.exceptions import InstallationError
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import ensure_dir
 from pip._internal.utils.setuptools_build import make_setuptools_install_args
@@ -106,24 +106,12 @@ def install(
             egg_info_dir = prepend_root(directory)
             break
     else:
-        deprecated(
-            reason=(
-                "{} did not indicate that it installed an "
-                ".egg-info directory. Only setup.py projects "
-                "generating .egg-info directories are supported."
-            ).format(req_description),
-            replacement=(
-                "for maintainers: updating the setup.py of {0}. "
-                "For users: contact the maintainers of {0} to let "
-                "them know to update their setup.py.".format(
-                    req_name
-                )
-            ),
-            gone_in="20.2",
-            issue=6998,
-        )
-        # FIXME: put the record somewhere
-        return True
+        message = (
+            "{} did not indicate that it installed an "
+            ".egg-info directory. Only setup.py projects "
+            "generating .egg-info directories are supported."
+        ).format(req_description)
+        raise InstallationError(message)
 
     new_lines = []
     for line in record_lines:


### PR DESCRIPTION
Closes #6998 

This finalizes a deprecation, since we've not recieved any reports from
users in responses to the deprecation.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
