### PR TITLE
Add note explaining the Docs PR deploy

### DIFF
--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -129,7 +129,7 @@ To build it locally, run:
 
 The built documentation can be found in the ``docs/build`` folder.
 
-For each Pull Request made the documentation is deployed following this link
+For each Pull Request made the documentation is deployed following this link:
 
 .. code-block:: console
 

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -129,9 +129,11 @@ To build it locally, run:
 
 The built documentation can be found in the ``docs/build`` folder.
 
-.. note::
-   For each Pull Request made the documentation is deployed following this link
-   ``http://pip--<PR-NUMBER>.org.readthedocs.build/en/<PR-NUMBER>``.
+For each Pull Request made the documentation is deployed following this link
+
+.. code-block:: console
+
+    http://pip--<PR-NUMBER>.org.readthedocs.build/en/<PR-NUMBER>
 
 
 What Next?

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -129,6 +129,11 @@ To build it locally, run:
 
 The built documentation can be found in the ``docs/build`` folder.
 
+.. note::
+   For each Pull Request made the documentation is deployed following this link
+   ``http://pip--<PR-NUMBER>.org.readthedocs.build/en/<PR-NUMBER>``.
+
+
 What Next?
 ==========
 

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -131,7 +131,7 @@ The built documentation can be found in the ``docs/build`` folder.
 
 For each Pull Request made the documentation is deployed following this link:
 
-.. code-block:: console
+.. code-block:: none
 
     https://pip--<PR-NUMBER>.org.readthedocs.build/en/<PR-NUMBER>
 

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -133,7 +133,7 @@ For each Pull Request made the documentation is deployed following this link:
 
 .. code-block:: console
 
-    http://pip--<PR-NUMBER>.org.readthedocs.build/en/<PR-NUMBER>
+    https://pip--<PR-NUMBER>.org.readthedocs.build/en/<PR-NUMBER>
 
 
 What Next?


### PR DESCRIPTION
Add a note to explain that documentation is
deployed readthedocs for each PR.

Closes #8621

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
