### PR TITLE
Reduce reliance on .egg-info directories in test suite

### DIFF
--- a/tests/functional/test_install_index.py
+++ b/tests/functional/test_install_index.py
@@ -3,10 +3,8 @@ import textwrap
 
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
-from tests.lib import pyversion
 
-
-def test_find_links_relative_path(script, data):
+def test_find_links_relative_path(script, data, with_wheel):
     """Test find-links as a relative path."""
     result = script.pip(
         'install',
@@ -16,15 +14,15 @@ def test_find_links_relative_path(script, data):
         'packages/',
         cwd=data.root,
     )
-    egg_info_folder = (
-        script.site_packages / 'parent-0.1-py{}.egg-info'.format(pyversion)
+    dist_info_folder = (
+        script.site_packages / 'parent-0.1.dist-info'
     )
     initools_folder = script.site_packages / 'parent'
-    result.did_create(egg_info_folder)
+    result.did_create(dist_info_folder)
     result.did_create(initools_folder)
 
 
-def test_find_links_requirements_file_relative_path(script, data):
+def test_find_links_requirements_file_relative_path(script, data, with_wheel):
     """Test find-links as a relative path to a reqs file."""
     script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
         --no-index
@@ -37,27 +35,27 @@ def test_find_links_requirements_file_relative_path(script, data):
         script.scratch_path / "test-req.txt",
         cwd=data.root,
     )
-    egg_info_folder = (
-        script.site_packages / 'parent-0.1-py{}.egg-info'.format(pyversion)
+    dist_info_folder = (
+        script.site_packages / 'parent-0.1.dist-info'
     )
     initools_folder = script.site_packages / 'parent'
-    result.did_create(egg_info_folder)
+    result.did_create(dist_info_folder)
     result.did_create(initools_folder)
 
 
-def test_install_from_file_index_hash_link(script, data):
+def test_install_from_file_index_hash_link(script, data, with_wheel):
     """
     Test that a pkg can be installed from a file:// index using a link with a
     hash
     """
     result = script.pip('install', '-i', data.index_url(), 'simple==1.0')
-    egg_info_folder = (
-        script.site_packages / 'simple-1.0-py{}.egg-info'.format(pyversion)
+    dist_info_folder = (
+        script.site_packages / 'simple-1.0.dist-info'
     )
-    result.did_create(egg_info_folder)
+    result.did_create(dist_info_folder)
 
 
-def test_file_index_url_quoting(script, data):
+def test_file_index_url_quoting(script, data, with_wheel):
     """
     Test url quoting of file index url with a space
     """
@@ -67,5 +65,5 @@ def test_file_index_url_quoting(script, data):
     )
     result.did_create(script.site_packages / 'simple')
     result.did_create(
-        script.site_packages / 'simple-1.0-py{}.egg-info'.format(pyversion)
+        script.site_packages / 'simple-1.0.dist-info'
     )

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -10,7 +10,6 @@ from tests.lib import (
     create_basic_wheel_for_package,
     need_svn,
     path_to_url,
-    pyversion,
     requirements_file,
 )
 from tests.lib.local_repos import local_checkout
@@ -63,7 +62,7 @@ def arg_recording_sdist_maker(script):
 
 
 @pytest.mark.network
-def test_requirements_file(script):
+def test_requirements_file(script, with_wheel):
     """
     Test installing from a requirements file.
 
@@ -78,12 +77,12 @@ def test_requirements_file(script):
         'install', '-r', script.scratch_path / 'initools-req.txt'
     )
     result.did_create(
-        script.site_packages / 'INITools-0.2-py{}.egg-info'.format(pyversion)
+        script.site_packages / 'INITools-0.2.dist-info'
     )
     result.did_create(script.site_packages / 'initools')
     assert result.files_created[script.site_packages / other_lib_name].dir
-    fn = '{}-{}-py{}.egg-info'.format(
-        other_lib_name, other_lib_version, pyversion)
+    fn = '{}-{}.dist-info'.format(
+        other_lib_name, other_lib_version)
     assert result.files_created[script.site_packages / fn].dir
 
 
@@ -113,15 +112,17 @@ def test_schema_check_in_requirements_file(script):
     ("embedded_rel_path", False),
     ("embedded_rel_path", True),
 ])
-def test_relative_requirements_file(script, data, test_type, editable):
+def test_relative_requirements_file(
+    script, data, test_type, editable, with_wheel
+):
     """
     Test installing from a requirements file with a relative path. For path
     URLs, use an egg= definition.
 
     """
-    egg_info_file = (
+    dist_info_folder = (
         script.site_packages /
-        'FSPkg-0.1.dev0-py{pyversion}.egg-info'.format(**globals())
+        'FSPkg-0.1.dev0.dist-info'
     )
     egg_link_file = (
         script.site_packages / 'FSPkg.egg-link'
@@ -148,7 +149,7 @@ def test_relative_requirements_file(script, data, test_type, editable):
                                script.scratch_path) as reqs_file:
             result = script.pip('install', '-vvv', '-r', reqs_file.name,
                                 cwd=script.scratch_path)
-            result.did_create(egg_info_file)
+            result.did_create(dist_info_folder)
             result.did_create(package_folder)
     else:
         with requirements_file('-e ' + req_path + '\n',
@@ -160,7 +161,7 @@ def test_relative_requirements_file(script, data, test_type, editable):
 
 @pytest.mark.network
 @need_svn
-def test_multiple_requirements_files(script, tmpdir):
+def test_multiple_requirements_files(script, tmpdir, with_wheel):
     """
     Test installing from multiple nested requirements files.
 
@@ -184,8 +185,7 @@ def test_multiple_requirements_files(script, tmpdir):
         'install', '-r', script.scratch_path / 'initools-req.txt'
     )
     assert result.files_created[script.site_packages / other_lib_name].dir
-    fn = '{other_lib_name}-{other_lib_version}-py{pyversion}.egg-info'.format(
-        pyversion=pyversion, **locals())
+    fn = '{other_lib_name}-{other_lib_version}.dist-info'.format(**locals())
     assert result.files_created[script.site_packages / fn].dir
     result.did_create(script.venv / 'src' / 'initools')
 

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -38,7 +38,8 @@ def test_invalid_upgrade_strategy_causes_error(script):
 
 def test_only_if_needed_does_not_upgrade_deps_when_satisfied(
     script,
-    use_new_resolver
+    use_new_resolver,
+    with_wheel
 ):
     """
     It doesn't upgrade a dependency if it already satisfies the requirements.
@@ -50,13 +51,11 @@ def test_only_if_needed_does_not_upgrade_deps_when_satisfied(
     )
 
     assert (
-        (script.site_packages / 'require_simple-1.0-py{pyversion}.egg-info'
-            .format(**globals()))
+        (script.site_packages / 'require_simple-1.0.dist-info')
         not in result.files_deleted
     ), "should have installed require_simple==1.0"
     assert (
-        (script.site_packages / 'simple-2.0-py{pyversion}.egg-info'
-            .format(**globals()))
+        (script.site_packages / 'simple-2.0.dist-info')
         not in result.files_deleted
     ), "should not have uninstalled simple==2.0"
 
@@ -68,7 +67,9 @@ def test_only_if_needed_does_not_upgrade_deps_when_satisfied(
     ), "did not print correct message for not-upgraded requirement"
 
 
-def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(script):
+def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(
+    script, with_wheel
+):
     """
     It does upgrade a dependency if it no longer satisfies the requirements.
 
@@ -79,25 +80,26 @@ def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(script):
     )
 
     assert (
-        (script.site_packages / 'require_simple-1.0-py{pyversion}.egg-info'
-            .format(**globals()))
+        (script.site_packages / 'require_simple-1.0.dist-info')
         not in result.files_deleted
     ), "should have installed require_simple==1.0"
     expected = (
         script.site_packages /
-        'simple-3.0-py{pyversion}.egg-info'.format(**globals())
+        'simple-3.0.dist-info'
     )
     result.did_create(expected, message="should have installed simple==3.0")
     expected = (
         script.site_packages /
-        'simple-1.0-py{pyversion}.egg-info'.format(**globals())
+        'simple-1.0.dist-info'
     )
     assert (
         expected in result.files_deleted
     ), "should have uninstalled simple==1.0"
 
 
-def test_eager_does_upgrade_dependecies_when_currently_satisfied(script):
+def test_eager_does_upgrade_dependecies_when_currently_satisfied(
+    script, with_wheel
+):
     """
     It does upgrade a dependency even if it already satisfies the requirements.
 
@@ -109,17 +111,19 @@ def test_eager_does_upgrade_dependecies_when_currently_satisfied(script):
 
     assert (
         (script.site_packages /
-            'require_simple-1.0-py{pyversion}.egg-info'.format(**globals()))
+            'require_simple-1.0.dist-info')
         not in result.files_deleted
     ), "should have installed require_simple==1.0"
     assert (
         (script.site_packages /
-            'simple-2.0-py{pyversion}.egg-info'.format(**globals()))
+            'simple-2.0.dist-info')
         in result.files_deleted
     ), "should have uninstalled simple==2.0"
 
 
-def test_eager_does_upgrade_dependecies_when_no_longer_satisfied(script):
+def test_eager_does_upgrade_dependecies_when_no_longer_satisfied(
+    script, with_wheel
+):
     """
     It does upgrade a dependency if it no longer satisfies the requirements.
 
@@ -130,24 +134,21 @@ def test_eager_does_upgrade_dependecies_when_no_longer_satisfied(script):
     )
 
     assert (
-        (script.site_packages /
-            'require_simple-1.0-py{pyversion}.egg-info'.format(**globals()))
+        (script.site_packages / 'require_simple-1.0.dist-info')
         not in result.files_deleted
     ), "should have installed require_simple==1.0"
     result.did_create(
-        script.site_packages /
-        'simple-3.0-py{pyversion}.egg-info'.format(**globals()),
+        script.site_packages / 'simple-3.0.dist-info',
         message="should have installed simple==3.0"
     )
     assert (
-        script.site_packages /
-        'simple-1.0-py{pyversion}.egg-info'.format(**globals())
+        script.site_packages / 'simple-1.0.dist-info'
         in result.files_deleted
     ), "should have uninstalled simple==1.0"
 
 
 @pytest.mark.network
-def test_upgrade_to_specific_version(script):
+def test_upgrade_to_specific_version(script, with_wheel):
     """
     It does upgrade to specific version requested.
 
@@ -158,18 +159,16 @@ def test_upgrade_to_specific_version(script):
         'pip install with specific version did not upgrade'
     )
     assert (
-        script.site_packages / 'INITools-0.1-py{pyversion}.egg-info'
-        .format(**globals())
+        script.site_packages / 'INITools-0.1.dist-info'
         in result.files_deleted
     )
     result.did_create(
-        script.site_packages / 'INITools-0.2-py{pyversion}.egg-info'
-        .format(**globals())
+        script.site_packages / 'INITools-0.2.dist-info'
     )
 
 
 @pytest.mark.network
-def test_upgrade_if_requested(script):
+def test_upgrade_if_requested(script, with_wheel):
     """
     And it does upgrade if requested.
 
@@ -179,7 +178,7 @@ def test_upgrade_if_requested(script):
     assert result.files_created, 'pip install --upgrade did not upgrade'
     result.did_not_create(
         script.site_packages /
-        'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
+        'INITools-0.1.dist-info'
     )
 
 
@@ -327,7 +326,7 @@ def test_uninstall_rollback(script, data):
 
 
 @pytest.mark.network
-def test_should_not_install_always_from_cache(script):
+def test_should_not_install_always_from_cache(script, with_wheel):
     """
     If there is an old cached package, pip should download the newer version
     Related to issue #175
@@ -337,16 +336,16 @@ def test_should_not_install_always_from_cache(script):
     result = script.pip('install', 'INITools==0.1')
     result.did_not_create(
         script.site_packages /
-        'INITools-0.2-py{pyversion}.egg-info'.format(**globals())
+        'INITools-0.2.dist-info'
     )
     result.did_create(
         script.site_packages /
-        'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
+        'INITools-0.1.dist-info'
     )
 
 
 @pytest.mark.network
-def test_install_with_ignoreinstalled_requested(script):
+def test_install_with_ignoreinstalled_requested(script, with_wheel):
     """
     Test old conflicting package is completely ignored
     """
@@ -356,11 +355,11 @@ def test_install_with_ignoreinstalled_requested(script):
     # both the old and new metadata should be present.
     assert os.path.exists(
         script.site_packages_path /
-        'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
+        'INITools-0.1.dist-info'
     )
     assert os.path.exists(
         script.site_packages_path /
-        'INITools-0.3-py{pyversion}.egg-info'.format(**globals())
+        'INITools-0.3.dist-info'
     )
 
 

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -115,6 +115,7 @@ class Tests_UserSite:
             'install', '--user', 'INITools==0.1', '--no-binary=:all:')
 
         # usersite has 0.1
+        # we still test for egg-info because no-binary implies setup.py install
         egg_info_folder = (
             script.user_site /
             'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
@@ -142,6 +143,7 @@ class Tests_UserSite:
             'install', '--user', 'INITools==0.1', '--no-binary=:all:')
 
         # usersite has 0.1
+        # we still test for egg-info because no-binary implies setup.py install
         egg_info_folder = (
             script.user_site /
             'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
@@ -173,6 +175,7 @@ class Tests_UserSite:
             'install', '--user', '--upgrade', 'INITools', '--no-binary=:all:')
 
         # usersite has 0.3.1
+        # we still test for egg-info because no-binary implies setup.py install
         egg_info_folder = (
             script.user_site /
             'INITools-0.3.1-py{pyversion}.egg-info'.format(**globals())
@@ -207,6 +210,7 @@ class Tests_UserSite:
             'install', '--user', 'INITools==0.1', '--no-binary=:all:')
 
         # usersite has 0.1
+        # we still test for egg-info because no-binary implies setup.py install
         egg_info_folder = (
             script.user_site /
             'INITools-0.1-py{pyversion}.egg-info'.format(**globals())

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -160,7 +160,7 @@ def test_install_editable_from_git_with_https(script, tmpdir):
 
 
 @pytest.mark.network
-def test_install_noneditable_git(script, tmpdir):
+def test_install_noneditable_git(script, tmpdir, with_wheel):
     """
     Test installing from a non-editable git URL with a given tag.
     """
@@ -169,14 +169,14 @@ def test_install_noneditable_git(script, tmpdir):
         'git+https://github.com/pypa/pip-test-package.git'
         '@0.1.1#egg=pip-test-package'
     )
-    egg_info_folder = (
+    dist_info_folder = (
         script.site_packages /
-        'pip_test_package-0.1.1-py{pyversion}.egg-info'.format(**globals())
+        'pip_test_package-0.1.1.dist-info'
     )
     result.assert_installed('piptestpackage',
                             without_egg_link=True,
                             editable=False)
-    result.did_create(egg_info_folder)
+    result.did_create(dist_info_folder)
 
 
 def test_git_with_sha1_revisions(script):

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -340,8 +340,8 @@ def test_install_user_wheel(script, shared_data, with_wheel, tmpdir):
         'install', 'has.script==1.0', '--user', '--no-index',
         '--find-links', tmpdir,
     )
-    egg_info_folder = script.user_site / 'has.script-1.0.dist-info'
-    result.did_create(egg_info_folder)
+    dist_info_folder = script.user_site / 'has.script-1.0.dist-info'
+    result.did_create(dist_info_folder)
     script_file = script.user_bin / 'script.py'
     result.did_create(script_file)
 

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -43,6 +43,7 @@ class Tests_UninstallUserSite:
         assert_all_changes(result2, result3, [script.venv / 'build', 'cache'])
 
         # site still has 0.2 (can't look in result1; have to check)
+        # keep checking for egg-info because no-binary implies setup.py install
         egg_info_folder = (
             script.base_path / script.site_packages /
             'pip_test_package-0.1-py{pyversion}.egg-info'.format(**globals())


### PR DESCRIPTION
Make more tests run with `with_wheel` and test that a `.dist-info` directory is created instead of `.egg-info`.

This PR is an hopefully easier to review chunk of #8560.
Towards #8559.