### PR TITLE
Fix crash when generating conflict message from requirements.txt

### DIFF
--- a/news/8625.trivial
+++ b/news/8625.trivial
@@ -1,0 +1,2 @@
+Fix 2020 resolver error message when conflicting packages are specified
+directly in a requirements file.

--- a/tests/functional/test_new_resolver_errors.py
+++ b/tests/functional/test_new_resolver_errors.py
@@ -1,0 +1,26 @@
+from tests.lib import create_basic_wheel_for_package
+
+
+def test_new_resolver_conflict_requirements_file(tmpdir, script):
+    create_basic_wheel_for_package(script, "base", "1.0")
+    create_basic_wheel_for_package(script, "base", "2.0")
+    create_basic_wheel_for_package(
+        script, "pkga", "1.0", depends=["base==1.0"],
+    )
+    create_basic_wheel_for_package(
+        script, "pkgb", "1.0", depends=["base==2.0"],
+    )
+
+    req_file = tmpdir.joinpath("requirements.txt")
+    req_file.write_text("pkga\npkgb")
+
+    result = script.pip(
+        "install", "--use-feature=2020-resolver",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "-r", req_file,
+        expect_error=True,
+    )
+
+    message = "package versions have conflicting dependencies"
+    assert message in result.stderr, str(result)


### PR DESCRIPTION
I’m using `.trivial` for the news file since the feature is not released. Fix #8625.