### PR TITLE
Change the recommended env path from venv to .env in the contributing docs

### DIFF
--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -40,8 +40,8 @@ You can then invoke your local source tree pip normally.
 
 .. code-block:: console
 
-    $ virtualenv venv # You can also use "python -m venv venv" from python3.3+
-    $ source venv/bin/activate
+    $ virtualenv .env # You can also use "python -m venv .env" from python3.3+
+    $ source .env/bin/activate
     $ python -m pip install -e .
     $ python -m pip --version
 


### PR DESCRIPTION
Currently, the docs suggests new users to create a virtual environment in the `venv` folder but the current `.gitignore` ignores `.env/`. This difference puts new users in a state where they have a git tree full of files from the virtual environment as soon as they follow the docs.

Of course we could just as easily change the `.gitignore`, I'm not sure if either approach is much better than the other

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
