### PR TITLE
Add a testing case for a future check integrity flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 *.eggs
 *.egg-info/
 MANIFEST
+pip-wheel-metadata/
 
 # Documentation
 docs/build/

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.lib import create_test_package_with_setup
 
 

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -294,6 +294,10 @@ def test_check_include_work_dir_pkg(script):
     assert result.returncode == 1
 
 
+@pytest.mark.xfail(
+    reason='Not yet implemented: https://github.com/pypa/pip/pull/8633',
+    strict=True,
+)
 def test_check_integrity_errors_on_missing_files(data, script, tmpdir):
     """Ensure that pip check detects a missing file post-install."""
     to_install = data.packages.joinpath("pip-test-package-0.1.tar.gz")

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -292,3 +292,22 @@ def test_check_include_work_dir_pkg(script):
     )
     assert matches_expected_lines(result.stdout, expected_lines)
     assert result.returncode == 1
+
+
+def test_check_integrity_errors_on_missing_files(data, script, tmpdir):
+    """
+    Work-in-progress failing test for a flag that detects broken packages
+    """
+    to_install = data.packages.joinpath("pip-test-package-0.1.tar.gz")
+    result = script.pip_install_local(to_install)
+    assert 'Successfully installed pip-test-package' in result.stdout
+
+    target = script.site_packages_path / "piptestpackage/__init__.py"
+    target.unlink()
+
+    result = script.pip('check --integrity')
+    expected_lines = (
+        "piptestpackage is missing the __init__.py file",
+    )
+    assert matches_expected_lines(result.stdout, expected_lines)
+    assert result.returncode == 1

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -295,9 +295,7 @@ def test_check_include_work_dir_pkg(script):
 
 
 def test_check_integrity_errors_on_missing_files(data, script, tmpdir):
-    """
-    Work-in-progress failing test for a flag that detects broken packages
-    """
+    """Ensure that pip check detects a missing file post-install."""
     to_install = data.packages.joinpath("pip-test-package-0.1.tar.gz")
     result = script.pip_install_local(to_install)
     assert 'Successfully installed pip-test-package' in result.stdout

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -307,7 +307,7 @@ def test_check_integrity_errors_on_missing_files(data, script, tmpdir):
     target = script.site_packages_path / "piptestpackage/__init__.py"
     target.unlink()
 
-    result = script.pip('check --integrity')
+    result = script.pip('check --integrity', expect_error=True)
     expected_lines = (
         "piptestpackage is missing the __init__.py file",
     )

--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -304,8 +304,7 @@ def test_check_integrity_errors_on_missing_files(data, script, tmpdir):
     result = script.pip_install_local(to_install)
     assert 'Successfully installed pip-test-package' in result.stdout
 
-    target = script.site_packages_path / "piptestpackage/__init__.py"
-    target.unlink()
+    (script.site_packages_path / "piptestpackage/__init__.py").unlink()
 
     result = script.pip('check --integrity', expect_error=True)
     expected_lines = (


### PR DESCRIPTION
Hello all!

I was working on the EuroPython Packaging Sprint today and found issue #8579.

While the discussion is still young, I tried to come up with a failing test case for what the issue proposes.

Given this is my first attempt at working with pip code itself, I'm not at all familiar with the codebase and there are probably cleaner ways to achieve my goal. Also, the semantics of this new checking - a flag? a subcommand? - must be discussed. I simply guessed a `check --integrity`. What I tried to do was:

1. Install a package
2. Delete one of its files
3. Run `check --integrity`
4. Assert it returned an error

Feedback is very much appreciated!

Thanks