### PR TITLE
Document keyring support for index basic-auth

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -83,7 +83,8 @@ Keyring Support
 ---------------
 
 pip also supports credentials stored in your keyring using the `keyring`_
-library.
+library. Note that ``keyring`` will need to be installed separately, as pip
+does not come with it included.
 
 .. code-block:: shell
 

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -79,6 +79,21 @@ as the "username" and do not provide a password, for example -
 ``https://0123456789abcdef@pypi.company.com``
 
 
+Keyring Support
+---------------
+
+pip also supports credentials stored in your keyring using the `keyring`_
+library.
+
+.. code-block:: shell
+
+   pip install keyring
+   echo your-password | keyring set pypi.company.com your-username
+   pip install your-package --extra-index-url https://pypi.company.com/
+
+.. _keyring: https://pypi.org/project/keyring/
+
+
 Using a Proxy Server
 ====================
 

--- a/news/8636.doc
+++ b/news/8636.doc
@@ -1,0 +1,1 @@
+Add note and example on keyring support for index basic-auth


### PR DESCRIPTION
Keyring's only documentation is in [the change-notes](https://pip.pypa.io/en/stable/news/?highlight=keyring#id153) following it's implementation in #5952. This documents it enough for new users to be able to use it.

Request for comment: should I include a brief summary on what keyrings are, and how they're secure?