### PR TITLE
[fast-deps] Add a hook to download all "skipped" wheels

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -223,38 +223,31 @@ def unpack_url(
     # type: (...) -> Optional[File]
     """Unpack link into location, downloading if required.
 
-    :param hashes: A Hashes object, one of whose embedded hashes must match,
-        or HashMismatch will be raised. If the Hashes is empty, no matches are
-        required, and unhashable types of requirements (like VCS ones, which
-        would ordinarily raise HashUnsupported) are allowed.
+    One of embedded hashes in the given Hashes object must match,
+    or HashMismatch will be raised. If the Hashes is empty, no matches
+    are required, and unhashable types of requirements (like VCS ones,
+    which would ordinarily raise HashUnsupported) are allowed.
     """
-    # non-editable vcs urls
+    # Non-editable VCS URL
     if link.is_vcs:
         unpack_vcs_link(link, location)
         return None
 
-    # If it's a url to a local directory
+    # URL to a local directory
     if link.is_existing_dir():
         if os.path.isdir(location):
             rmtree(location)
         _copy_source_tree(link.file_path, location)
         return None
 
-    # file urls
     if link.is_file:
         file = get_file_url(link, download_dir, hashes=hashes)
-
-    # http urls
     else:
-        file = get_http_url(
-            link,
-            downloader,
-            download_dir,
-            hashes=hashes,
-        )
+        file = get_http_url(link, downloader, download_dir, hashes=hashes)
 
-    # unpack the archive to the build dir location. even when only downloading
-    # archives, they have to be unpacked to parse dependencies, except wheels
+    # Unpack the archive to the build directory unless it is a wheel.
+    # Even if the command is download, archives still have to be
+    # unpacked to parse dependencies.
     if not link.is_wheel:
         unpack_file(file.path, location, file.content_type)
 

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -286,7 +286,7 @@ class _InstallRequirementBackedCandidate(Candidate):
             yield python_dep
 
     def get_install_requirement(self):
-        # type: () -> Optional[InstallRequirement]
+        # type: () -> InstallRequirement
         self._prepare()
         return self._ireq
 
@@ -426,7 +426,7 @@ class AlreadyInstalledCandidate(Candidate):
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
 
     def get_install_requirement(self):
-        # type: () -> Optional[InstallRequirement]
+        # type: () -> None
         return None
 
 
@@ -547,7 +547,7 @@ class ExtrasCandidate(Candidate):
                 yield requirement
 
     def get_install_requirement(self):
-        # type: () -> Optional[InstallRequirement]
+        # type: () -> None
         # We don't return anything here, because we always
         # depend on the base candidate, and we'll get the
         # install requirement from that.
@@ -590,5 +590,5 @@ class RequiresPythonCandidate(Candidate):
         return ()
 
     def get_install_requirement(self):
-        # type: () -> Optional[InstallRequirement]
+        # type: () -> None
         return None

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -10,11 +10,7 @@ from pip._internal.exceptions import HashMismatch
 from pip._internal.models.link import Link
 from pip._internal.network.download import Downloader
 from pip._internal.network.session import PipSession
-from pip._internal.operations.prepare import (
-    _copy_source_tree,
-    _download_http_url,
-    unpack_url,
-)
+from pip._internal.operations.prepare import _copy_source_tree, unpack_url
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.urls import path_to_url
 from tests.lib.filesystem import (
@@ -83,12 +79,7 @@ def test_download_http_url__no_directory_traversal(mock_raise_for_status,
 
     download_dir = tmpdir.joinpath('download')
     os.mkdir(download_dir)
-    file_path, content_type = _download_http_url(
-        link,
-        downloader,
-        download_dir,
-        hashes=None,
-    )
+    file_path, content_type = downloader(link, download_dir)
     # The file should be downloaded to download_dir.
     actual = os.listdir(download_dir)
     assert actual == ['out_dir_file']


### PR DESCRIPTION
This creates a hook to explicitly download distributions of requirements whose metadata are obtain from their wheels lazily (GH-8588) so that

1. It is possible to supply the required distributions to a worker pool for parallel download
2. Something like `pip install --dry-run` can be cleanly implemented by interject an interruption right before the download

Although a decent amount of refactoring occurred, this should only affects the behavior of the `fast-deps` feature.