### PR TITLE
Handle temp dir cleanup errors gracefully

### DIFF
--- a/news/7567.feature
+++ b/news/7567.feature
@@ -1,0 +1,1 @@
+Handle temporary directory cleanup errors more gracefully.

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -188,6 +188,10 @@ class TempDirectory(object):
         logger.debug("Created temporary directory: %s", path)
         return path
 
+    def _handle_cleanup_error(self, func, path, excinfo):
+        # type: (Any, str, Any) -> Any
+        logger.warning("Failed to clean up %s (%s)", path, excinfo[1])
+
     def cleanup(self):
         # type: () -> None
         """Remove the temporary directory created and reset state
@@ -196,7 +200,7 @@ class TempDirectory(object):
         if os.path.exists(self._path):
             # Make sure to pass unicode on Python 2 to make the contents also
             # use unicode, ensuring non-ASCII names and can be represented.
-            rmtree(ensure_text(self._path))
+            rmtree(ensure_text(self._path), onerror=self._handle_cleanup_error)
 
 
 class AdjacentTempDirectory(TempDirectory):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -357,7 +357,7 @@ def test_rmtree_errorhandler_readonly_directory(tmpdir):
     # Make sure mock_func is called with the given path
     mock_func = Mock()
     rmtree_errorhandler(mock_func, path, None)
-    mock_func.assert_called_with(path)
+    mock_func.assert_called_with(path, onerror=None)
 
     # Make sure the path is now writable
     assert os.stat(path).st_mode & stat.S_IWRITE


### PR DESCRIPTION
Close #7567. Instead of blowing up in the user’s face when a temporary directory fails to clean up, this adds an `onerror` hook to `rmtree` that logs the failure as a warning, and gracefully carry on.