### PR TITLE
Trace a better error message on installation failure due to invalid .data files in wheels

### DIFF
--- a/news/8654.bugfix
+++ b/news/8654.bugfix
@@ -1,0 +1,2 @@
+Trace a better error message on installation failure due to invalid ``.data``
+files in wheels.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -592,7 +592,19 @@ def _install_wheel(
                 ).format(wheel_path, record_path)
                 raise InstallationError(message)
 
-            scheme_path = scheme_paths[scheme_key]
+            try:
+                scheme_path = scheme_paths[scheme_key]
+            except KeyError:
+                valid_scheme_keys = ", ".join(sorted(scheme_paths))
+                message = (
+                    "Unknown scheme key used in {}: {} (for file {!r}). .data"
+                    " directory contents should be in subdirectories named"
+                    " with a valid scheme key ({})"
+                ).format(
+                    wheel_path, scheme_key, record_path, valid_scheme_keys
+                )
+                raise InstallationError(message)
+
             dest_path = os.path.join(scheme_path, dest_subpath)
             assert_no_path_traversal(scheme_path, dest_path)
             return ZipBackedFile(record_path, dest_path, zip_file)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -583,7 +583,15 @@ def _install_wheel(
         def make_data_scheme_file(record_path):
             # type: (RecordPath) -> File
             normed_path = os.path.normpath(record_path)
-            _, scheme_key, dest_subpath = normed_path.split(os.path.sep, 2)
+            try:
+                _, scheme_key, dest_subpath = normed_path.split(os.path.sep, 2)
+            except ValueError:
+                message = (
+                    "Unexpected file in {}: {!r}. .data directory contents"
+                    " should be named like: '<scheme key>/<path>'."
+                ).format(wheel_path, record_path)
+                raise InstallationError(message)
+
             scheme_path = scheme_paths[scheme_key]
             dest_path = os.path.join(scheme_path, dest_subpath)
             assert_no_path_traversal(scheme_path, dest_path)

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -681,3 +681,21 @@ def test_correct_package_name_while_creating_wheel_bug(script, package_name):
     package = create_basic_wheel_for_package(script, package_name, '1.0')
     wheel_name = os.path.basename(package)
     assert wheel_name == 'simple_package-1.0-py2.py3-none-any.whl'
+
+
+@pytest.mark.parametrize("name", ["purelib", "abc"])
+def test_wheel_with_file_in_data_dir_has_reasonable_error(
+    script, tmpdir, name
+):
+    """Normally we expect entities in the .data directory to be in a
+    subdirectory, but if they are not then we should show a reasonable error
+    message that includes the path.
+    """
+    wheel_path = make_wheel(
+        "simple", "0.1.0", extra_data_files={name: "hello world"}
+    ).save_to_dir(tmpdir)
+
+    result = script.pip(
+        "install", "--no-index", str(wheel_path), expect_error=True
+    )
+    assert "simple-0.1.0.data/{}".format(name) in result.stderr

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -699,3 +699,18 @@ def test_wheel_with_file_in_data_dir_has_reasonable_error(
         "install", "--no-index", str(wheel_path), expect_error=True
     )
     assert "simple-0.1.0.data/{}".format(name) in result.stderr
+
+
+def test_wheel_with_unknown_subdir_in_data_dir_has_reasonable_error(
+    script, tmpdir
+):
+    wheel_path = make_wheel(
+        "simple",
+        "0.1.0",
+        extra_data_files={"unknown/hello.txt": "hello world"}
+    ).save_to_dir(tmpdir)
+
+    result = script.pip(
+        "install", "--no-index", str(wheel_path), expect_error=True
+    )
+    assert "simple-0.1.0.data/unknown/hello.txt" in result.stderr


### PR DESCRIPTION
This explicitly handles erroneous files in the `.data` directory of wheels.

Before:

```
ERROR: Exception:
Traceback (most recent call last):
  File "/tmp/venv/lib/python3.6/site-packages/pip/_internal/cli/base_command.py", line 216, in _main
    status = self.run(options, args)
  File "/tmp/venv/lib/python3.6/site-packages/pip/_internal/cli/req_command.py", line 182, in wrapper
    return func(self, options, args)
  File "/tmp/venv/lib/python3.6/site-packages/pip/_internal/commands/install.py", line 421, in run
    pycompile=options.compile,
  File "/tmp/venv/lib/python3.6/site-packages/pip/_internal/req/__init__.py", line 90, in install_given_reqs
    pycompile=pycompile,
  File "/tmp/venv/lib/python3.6/site-packages/pip/_internal/req/req_install.py", line 831, in install
    requested=self.user_supplied,
  File "/tmp/venv/lib/python3.6/site-packages/pip/_internal/operations/install/wheel.py", line 830, in install_wheel
    requested=requested,
  File "/tmp/venv/lib/python3.6/site-packages/pip/_internal/operations/install/wheel.py", line 658, in _install_wheel
    for file in files:
  File "/tmp/venv/lib/python3.6/site-packages/pip/_internal/operations/install/wheel.py", line 587, in make_data_scheme_file
    _, scheme_key, dest_subpath = normed_path.split(os.path.sep, 2)
ValueError: not enough values to unpack (expected 3, got 2)
```

After:

```
ERROR: For req: python-apt==0.0.0. Unexpected file in /home/chris/.cache/pip/wheels/ff/46/14/4b2fa60308f0a0cf20345e549cb154c557f117417af56cf5f7/python_apt-0.0.0-cp38-cp38-linux_x86_64.whl: 'python_apt-0.0.0.data/purelib'. .data directory contents should be named like: '<scheme key>/<path>'.
```

While updating this error message, I noticed the very next line was subject to throwing a similarly confusing error. That has also been updated.

Fixes #8654.