### PR TITLE
Canonicalize name in check_if_exists

### DIFF
--- a/news/8645.bugfix
+++ b/news/8645.bugfix
@@ -1,0 +1,2 @@
+Correctly find already-installed distributions with dot (``.``) in the name
+and uninstall them when needed.


### PR DESCRIPTION
The previous implementation uses both `pkg_resources.get_distribution()` and pip’s own `get_distribution()`, use different name canonicalisation logic. This patch makes `InstallRequirement.check_if_exists()` only use pip's
own `get_distribution()` so different package name forms are matched as expected.

Fix #8645.
