### PR TITLE
Improve SVN version parser

### DIFF
--- a/news/8665.bugfix
+++ b/news/8665.bugfix
@@ -1,0 +1,1 @@
+Fix SVN version detection for alternative SVN distributions.

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -213,6 +213,8 @@ class Subversion(VersionControl):
         #      compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0
         #   svn, version 1.7.14 (r1542130)
         #      compiled Mar 28 2018, 08:49:13 on x86_64-pc-linux-gnu
+        #   svn, version 1.12.0-SlikSvn (SlikSvn/1.12.0)
+        #      compiled May 28 2019, 13:44:56 on x86_64-microsoft-windows6.2
         version_prefix = 'svn, version '
         version = self.run_command(['--version'])
 
@@ -220,7 +222,7 @@ class Subversion(VersionControl):
             return ()
 
         version = version[len(version_prefix):].split()[0]
-        version_list = version.split('.')
+        version_list = version.partition('-')[0].split('.')
         try:
             parsed_version = tuple(map(int, version_list))
         except ValueError:

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -443,6 +443,9 @@ def test_subversion__call_vcs_version():
     ('svn, version 1.10.3 (r1842928)\n'
      '   compiled Feb 25 2019, 14:20:39 on x86_64-apple-darwin17.0.0',
      (1, 10, 3)),
+    ('svn, version 1.12.0-SlikSvn (SlikSvn/1.12.0)\n'
+     '   compiled May 28 2019, 13:44:56 on x86_64-microsoft-windows6.2',
+     (1, 12, 0)),
     ('svn, version 1.9.7 (r1800392)', (1, 9, 7)),
     ('svn, version 1.9.7a1 (r1800392)', ()),
     ('svn, version 1.9 (r1800392)', (1, 9)),


### PR DESCRIPTION
SVN has multiple distributions on Windows, e.g. SlikSVN, CollabNet. Some of them suffix the version with a `-{distro}` part, which causes the previous implementation to fail.

This patch removes that final part and make the version logic work.

I hit this when working on reducing network tests in the test suite. (I kind of wonder the fact that nobody ever noticed this before is indicative maybe we can afford to drop SVN support altogether.)