### PR TITLE
Only do the ensure_text() dance on Windows

### DIFF
--- a/news/8658.bugfix.rst
+++ b/news/8658.bugfix.rst
@@ -1,0 +1,2 @@
+Only converts Windows path to unicode on Python 2 to avoid regressions when a
+POSIX environment does not configure the file system encoding correctly.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -137,7 +137,7 @@ def get_prog():
 # Retry every half second for up to 3 seconds
 @retry(stop_max_delay=3000, wait_fixed=500)
 def rmtree(dir, ignore_errors=False):
-    # type: (Text, bool) -> None
+    # type: (AnyStr, bool) -> None
     shutil.rmtree(dir, ignore_errors=ignore_errors,
                   onerror=rmtree_errorhandler)
 

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from pip._vendor.contextlib2 import ExitStack
 from pip._vendor.six import ensure_text
 
+from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.misc import enum, rmtree
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -193,10 +194,17 @@ class TempDirectory(object):
         """Remove the temporary directory created and reset state
         """
         self._deleted = True
-        if os.path.exists(self._path):
-            # Make sure to pass unicode on Python 2 to make the contents also
-            # use unicode, ensuring non-ASCII names and can be represented.
+        if not os.path.exists(self._path):
+            return
+        # Make sure to pass unicode on Python 2 to make the contents also
+        # use unicode, ensuring non-ASCII names and can be represented.
+        # This is only done on Windows because POSIX platforms use bytes
+        # natively for paths, and the bytes-text conversion omission avoids
+        # errors caused by the environment configuring encodings incorrectly.
+        if WINDOWS:
             rmtree(ensure_text(self._path))
+        else:
+            rmtree(self._path)
 
 
 class AdjacentTempDirectory(TempDirectory):


### PR DESCRIPTION
POSIX is problematic when the environment is not configured properly. Fix #8658.