### PR TITLE
Fix tests/functional/test_install_check.py, when run with new resolver

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -21,7 +21,6 @@ from pip._internal.locations import distutils_scheme
 from pip._internal.operations.check import check_install_conflicts
 from pip._internal.req import install_given_reqs
 from pip._internal.req.req_tracker import get_requirement_tracker
-from pip._internal.utils.datetime import today_is_later_than
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.distutils_args import parse_distutils_args
 from pip._internal.utils.filesystem import test_writable_dir
@@ -557,19 +556,6 @@ class InstallCommand(RequirementCommand):
                 "We recommend you use --use-feature=2020-resolver to test "
                 "your packages with the new resolver before it becomes the "
                 "default.\n"
-            )
-        elif not today_is_later_than(year=2020, month=7, day=31):
-            # NOTE: trailing newlines here are intentional
-            parts.append(
-                "Pip will install or upgrade your package(s) and its "
-                "dependencies without taking into account other packages you "
-                "already have installed. This may cause an uncaught "
-                "dependency conflict.\n"
-            )
-            form_link = "https://forms.gle/cWKMoDs8sUVE29hz9"
-            parts.append(
-                "If you would like pip to take your other packages into "
-                "account, please tell us here: {}\n".format(form_link)
             )
 
         # NOTE: There is some duplication here, with commands/check.py

--- a/tests/functional/test_install_check.py
+++ b/tests/functional/test_install_check.py
@@ -1,8 +1,10 @@
 from tests.lib import create_test_package_with_setup
 
 
-def contains_expected_lines(string, expected_lines):
-    return set(expected_lines) <= set(string.splitlines())
+def assert_contains_expected_lines(string, expected_lines):
+    lines = string.splitlines()
+    for expected_line in expected_lines:
+        assert any(line.endswith(expected_line) for line in lines)
 
 
 def test_check_install_canonicalization(script):
@@ -38,7 +40,7 @@ def test_check_install_canonicalization(script):
         "pkga 1.0 requires SPECIAL.missing, which is not installed.",
     ]
     # Deprecated python versions produce an extra warning on stderr
-    assert contains_expected_lines(result.stderr, expected_lines)
+    assert_contains_expected_lines(result.stderr, expected_lines)
     assert result.returncode == 0
 
     # Install the second missing package and expect that there is no warning
@@ -55,7 +57,7 @@ def test_check_install_canonicalization(script):
     expected_lines = [
         "No broken requirements found.",
     ]
-    assert contains_expected_lines(result.stdout, expected_lines)
+    assert_contains_expected_lines(result.stdout, expected_lines)
     assert result.returncode == 0
 
 
@@ -85,12 +87,10 @@ def test_check_install_does_not_warn_for_out_of_graph_issues(script):
     result = script.pip(
         'install', '--no-index', pkg_conflict_path, allow_stderr_error=True,
     )
-    assert contains_expected_lines(result.stderr, [
+    assert_contains_expected_lines(result.stderr, [
         "broken 1.0 requires missing, which is not installed.",
-        (
-            "broken 1.0 requires conflict<1.0, but "
-            "you'll have conflict 1.0 which is incompatible."
-        ),
+        "broken 1.0 requires conflict<1.0, "
+        "but you'll have conflict 1.0 which is incompatible."
     ])
 
     # Install unrelated package
@@ -105,4 +105,4 @@ def test_check_install_does_not_warn_for_out_of_graph_issues(script):
         "broken 1.0 requires missing, which is not installed.",
         "broken 1.0 has requirement conflict<1.0, but you have conflict 1.0.",
     ]
-    assert contains_expected_lines(result.stdout, expected_lines)
+    assert_contains_expected_lines(result.stdout, expected_lines)


### PR DESCRIPTION
This fixes new resolver's tests [failures today](https://travis-ci.org/github/pypa/pip/jobs/713970845) triggered by 1b2ae22e7b0b2d1963bec769d4f070bfbc6d932a.  The real reason is that at the beginning of each error log, `ERROR: ` is appended, and we shouldn't rely on which sentence shows up first in a message.