### PR TITLE
New resolver no deps extras install self

### DIFF
--- a/news/8677.bugfix
+++ b/news/8677.bugfix
@@ -1,0 +1,2 @@
+New resolver: Correctly include the base package when specified with extras
+in ``--no-deps`` mode.

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -69,8 +69,8 @@ class Candidate(object):
         # type: () -> Optional[Link]
         raise NotImplementedError("Override in subclass")
 
-    def iter_dependencies(self):
-        # type: () -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, ignore_dependencies):
+        # type: (bool) -> Iterable[Optional[Requirement]]
         raise NotImplementedError("Override in subclass")
 
     def get_install_requirement(self):

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -69,7 +69,7 @@ class Candidate(object):
         # type: () -> Optional[Link]
         raise NotImplementedError("Override in subclass")
 
-    def iter_dependencies(self, ignore_dependencies):
+    def iter_dependencies(self, with_requires):
         # type: (bool) -> Iterable[Optional[Requirement]]
         raise NotImplementedError("Override in subclass")
 

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -275,8 +275,10 @@ class _InstallRequirementBackedCandidate(Candidate):
             return None
         return spec
 
-    def iter_dependencies(self):
-        # type: () -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, ignore_dependencies):
+        # type: (bool) -> Iterable[Optional[Requirement]]
+        if ignore_dependencies:
+            return
         for r in self.dist.requires():
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
         python_dep = self._factory.make_requires_python_requirement(
@@ -420,8 +422,10 @@ class AlreadyInstalledCandidate(Candidate):
         # type: () -> str
         return "{} {} (Installed)".format(self.name, self.version)
 
-    def iter_dependencies(self):
-        # type: () -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, ignore_dependencies):
+        # type: (bool) -> Iterable[Optional[Requirement]]
+        if ignore_dependencies:
+            return
         for r in self.dist.requires():
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
 
@@ -519,9 +523,15 @@ class ExtrasCandidate(Candidate):
         # type: () -> Optional[Link]
         return self.base.source_link
 
-    def iter_dependencies(self):
-        # type: () -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, ignore_dependencies):
+        # type: (bool) -> Iterable[Optional[Requirement]]
         factory = self.base._factory
+
+        # Add a dependency on the exact base
+        # (See note 2b in the class docstring)
+        yield factory.make_requirement_from_candidate(self.base)
+        if ignore_dependencies:
+            return
 
         # The user may have specified extras that the candidate doesn't
         # support. We ignore any unsupported extras here.
@@ -534,10 +544,6 @@ class ExtrasCandidate(Candidate):
                 self.version,
                 extra
             )
-
-        # Add a dependency on the exact base
-        # (See note 2b in the class docstring)
-        yield factory.make_requirement_from_candidate(self.base)
 
         for r in self.base.dist.requires(valid_extras):
             requirement = factory.make_requirement_from_spec(
@@ -585,8 +591,8 @@ class RequiresPythonCandidate(Candidate):
         # type: () -> str
         return "Python {}".format(self.version)
 
-    def iter_dependencies(self):
-        # type: () -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, ignore_dependencies):
+        # type: (bool) -> Iterable[Optional[Requirement]]
         return ()
 
     def get_install_requirement(self):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -275,9 +275,9 @@ class _InstallRequirementBackedCandidate(Candidate):
             return None
         return spec
 
-    def iter_dependencies(self, ignore_dependencies):
+    def iter_dependencies(self, with_requires):
         # type: (bool) -> Iterable[Optional[Requirement]]
-        if ignore_dependencies:
+        if not with_requires:
             return
         for r in self.dist.requires():
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
@@ -422,9 +422,9 @@ class AlreadyInstalledCandidate(Candidate):
         # type: () -> str
         return "{} {} (Installed)".format(self.name, self.version)
 
-    def iter_dependencies(self, ignore_dependencies):
+    def iter_dependencies(self, with_requires):
         # type: (bool) -> Iterable[Optional[Requirement]]
-        if ignore_dependencies:
+        if not with_requires:
             return
         for r in self.dist.requires():
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
@@ -523,14 +523,14 @@ class ExtrasCandidate(Candidate):
         # type: () -> Optional[Link]
         return self.base.source_link
 
-    def iter_dependencies(self, ignore_dependencies):
+    def iter_dependencies(self, with_requires):
         # type: (bool) -> Iterable[Optional[Requirement]]
         factory = self.base._factory
 
         # Add a dependency on the exact base
         # (See note 2b in the class docstring)
         yield factory.make_requirement_from_candidate(self.base)
-        if ignore_dependencies:
+        if not with_requires:
             return
 
         # The user may have specified extras that the candidate doesn't
@@ -591,7 +591,7 @@ class RequiresPythonCandidate(Candidate):
         # type: () -> str
         return "Python {}".format(self.version)
 
-    def iter_dependencies(self, ignore_dependencies):
+    def iter_dependencies(self, with_requires):
         # type: (bool) -> Iterable[Optional[Requirement]]
         return ()
 

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -145,8 +145,9 @@ class PipProvider(AbstractProvider):
 
     def get_dependencies(self, candidate):
         # type: (Candidate) -> Sequence[Requirement]
+        with_requires = not self._ignore_dependencies
         return [
             r
-            for r in candidate.iter_dependencies(self._ignore_dependencies)
+            for r in candidate.iter_dependencies(with_requires)
             if r is not None
         ]

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -145,6 +145,8 @@ class PipProvider(AbstractProvider):
 
     def get_dependencies(self, candidate):
         # type: (Candidate) -> Sequence[Requirement]
-        if self._ignore_dependencies:
-            return []
-        return [r for r in candidate.iter_dependencies() if r is not None]
+        return [
+            r
+            for r in candidate.iter_dependencies(self._ignore_dependencies)
+            if r is not None
+        ]

--- a/tests/yaml/extras.yml
+++ b/tests/yaml/extras.yml
@@ -40,3 +40,10 @@ cases:
       - E 1.0.0
       - F 1.0.0
   skip: old
+-
+  request:
+    - install: D[extra_1]
+      options: --no-deps
+  response:
+    - state:
+      - D 1.0.0


### PR DESCRIPTION
Fix #8677. `iter_dependencies(ignore_dependencies=True)` feels weird, but I can’t think of a better argument name.