### PR TITLE
[fast-deps] Make range requests closer to chunk size

### DIFF
--- a/src/pip/_internal/network/lazy_wheel.py
+++ b/src/pip/_internal/network/lazy_wheel.py
@@ -109,8 +109,10 @@ class LazyZipOverHTTP(object):
         all bytes until EOF are returned.  Fewer than
         size bytes may be returned if EOF is reached.
         """
+        download_size = max(size, self._chunk_size)
         start, length = self.tell(), self._length
-        stop = start + size if 0 <= size <= length-start else length
+        stop = length if size < 0 else min(start+download_size, length)
+        start = max(0, stop-download_size)
         self._download(start, stop-1)
         return self._file.read(size)
 


### PR DESCRIPTION
This addresses the discovery in https://github.com/pypa/pip/issues/8670#issuecomment-667644636.  It is pretty stably reproducible on my network, I've run the before-after `pip install tensorflow` with early exit right after new resolver resolution for 3 times and the execution duration is consistent (30&ndash;31s before and 19.5&ndash;20s after patching).

Regarding the news file, I'm thinking about marking this as trivial since the feature is rather experimental and I am not entirely sure if this always make it faster for all requirement sets.  If this can be merged before the bugfix release it would be nice too!
