### PR TITLE
Move fast-dep handling to RequirementPreparer

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -218,6 +218,19 @@ class RequirementCommand(IndexGroupCommand):
         temp_build_dir_path = temp_build_dir.path
         assert temp_build_dir_path is not None
 
+        if '2020-resolver' in options.features_enabled:
+            lazy_wheel = 'fast-deps' in options.features_enabled
+            if lazy_wheel:
+                logger.warning(
+                    'pip is using lazily downloaded wheels using HTTP '
+                    'range requests to obtain dependency information. '
+                    'This experimental feature is enabled through '
+                    '--use-feature=fast-deps and it is not ready for '
+                    'production.'
+                )
+        else:
+            lazy_wheel = False
+
         return RequirementPreparer(
             build_dir=temp_build_dir_path,
             src_dir=options.src_dir,
@@ -229,6 +242,7 @@ class RequirementCommand(IndexGroupCommand):
             finder=finder,
             require_hashes=options.require_hashes,
             use_user_site=use_user_site,
+            lazy_wheel=lazy_wheel,
         )
 
     @staticmethod
@@ -260,16 +274,6 @@ class RequirementCommand(IndexGroupCommand):
         if '2020-resolver' in options.features_enabled:
             import pip._internal.resolution.resolvelib.resolver
 
-            lazy_wheel = 'fast-deps' in options.features_enabled
-            if lazy_wheel:
-                logger.warning(
-                    'pip is using lazily downloaded wheels using HTTP '
-                    'range requests to obtain dependency information. '
-                    'This experimental feature is enabled through '
-                    '--use-feature=fast-deps and it is not ready for '
-                    'production.'
-                )
-
             return pip._internal.resolution.resolvelib.resolver.Resolver(
                 preparer=preparer,
                 finder=finder,
@@ -282,7 +286,6 @@ class RequirementCommand(IndexGroupCommand):
                 force_reinstall=force_reinstall,
                 upgrade_strategy=upgrade_strategy,
                 py_version_info=py_version_info,
-                lazy_wheel=lazy_wheel,
             )
         import pip._internal.resolution.legacy.resolver
         return pip._internal.resolution.legacy.resolver.Resolver(

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -259,6 +259,17 @@ class RequirementCommand(IndexGroupCommand):
         # "Resolver" class being redefined.
         if '2020-resolver' in options.features_enabled:
             import pip._internal.resolution.resolvelib.resolver
+
+            lazy_wheel = 'fast-deps' in options.features_enabled
+            if lazy_wheel:
+                logger.warning(
+                    'pip is using lazily downloaded wheels using HTTP '
+                    'range requests to obtain dependency information. '
+                    'This experimental feature is enabled through '
+                    '--use-feature=fast-deps and it is not ready for '
+                    'production.'
+                )
+
             return pip._internal.resolution.resolvelib.resolver.Resolver(
                 preparer=preparer,
                 finder=finder,
@@ -271,7 +282,7 @@ class RequirementCommand(IndexGroupCommand):
                 force_reinstall=force_reinstall,
                 upgrade_strategy=upgrade_strategy,
                 py_version_info=py_version_info,
-                lazy_wheel='fast-deps' in options.features_enabled,
+                lazy_wheel=lazy_wheel,
             )
         import pip._internal.resolution.legacy.resolver
         return pip._internal.resolution.legacy.resolver.Resolver(

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -329,6 +329,7 @@ class RequirementPreparer(object):
         finder,  # type: PackageFinder
         require_hashes,  # type: bool
         use_user_site,  # type: bool
+        lazy_wheel,  # type: bool
     ):
         # type: (...) -> None
         super(RequirementPreparer, self).__init__()
@@ -361,6 +362,9 @@ class RequirementPreparer(object):
 
         # Should install in user site-packages?
         self.use_user_site = use_user_site
+
+        # Should wheels be downloaded lazily?
+        self.use_lazy_wheel = lazy_wheel
 
     @property
     def _download_should_save(self):

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -469,7 +469,6 @@ class RequirementPreparer(object):
         if use_lazy_wheel and remote_wheel and not preparer.require_hashes:
             wheel = Wheel(link.filename)
             name = canonicalize_name(wheel.name)
-            logger.info('Collecting %s', req.req or req)
             # If HTTPRangeRequestUnsupported is raised, fallback silently.
             with indent_log(), suppress(HTTPRangeRequestUnsupported):
                 logger.info(
@@ -484,12 +483,12 @@ class RequirementPreparer(object):
     def prepare_linked_requirement(self, req, parallel_builds=False):
         # type: (InstallRequirement, bool) -> Distribution
         """Prepare a requirement to be obtained from req.link."""
-        wheel_dist = self._fetch_metadata(req)
-        if wheel_dist is not None:
-            return wheel_dist
         assert req.link
         link = req.link
         self._log_preparing_link(req)
+        wheel_dist = self._fetch_metadata(req)
+        if wheel_dist is not None:
+            return wheel_dist
         if link.is_wheel and self.wheel_download_dir:
             # Download wheels to a dedicated dir when doing `pip wheel`.
             download_dir = self.wheel_download_dir

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -486,7 +486,21 @@ class RequirementPreparer(object):
         self._log_preparing_link(req)
         wheel_dist = self._fetch_metadata(link)
         if wheel_dist is not None:
+            req.needs_more_preparation = True
             return wheel_dist
+        return self._prepare_linked_requirement(req, parallel_builds)
+
+    def prepare_linked_requirement_more(self, req, parallel_builds=False):
+        # type: (InstallRequirement, bool) -> None
+        """Prepare a linked requirement more, if needed."""
+        if not req.needs_more_preparation:
+            return
+        self._prepare_linked_requirement(req, parallel_builds)
+
+    def _prepare_linked_requirement(self, req, parallel_builds):
+        # type: (InstallRequirement, bool) -> Distribution
+        assert req.link
+        link = req.link
         if link.is_wheel and self.wheel_download_dir:
             # Download wheels to a dedicated dir when doing `pip wheel`.
             download_dir = self.wheel_download_dir

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -459,12 +459,10 @@ class RequirementPreparer(object):
         # showing the user what the hash should be.
         return req.hashes(trust_internet=False) or MissingHashes()
 
-    def _fetch_metadata(preparer, req):
-        # type: (InstallRequirement) -> Optional[Distribution]
+    def _fetch_metadata(preparer, link):
+        # type: (Link) -> Optional[Distribution]
         """Fetch metadata, using lazy wheel if possible."""
         use_lazy_wheel = preparer.use_lazy_wheel
-        assert req.link
-        link = req.link
         remote_wheel = link.is_wheel and not link.is_file
         if use_lazy_wheel and remote_wheel and not preparer.require_hashes:
             wheel = Wheel(link.filename)
@@ -486,7 +484,7 @@ class RequirementPreparer(object):
         assert req.link
         link = req.link
         self._log_preparing_link(req)
-        wheel_dist = self._fetch_metadata(req)
+        wheel_dist = self._fetch_metadata(link)
         if wheel_dist is not None:
             return wheel_dist
         if link.is_wheel and self.wheel_download_dir:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -213,6 +213,9 @@ class InstallRequirement(object):
         # but after loading this flag should be treated as read only.
         self.use_pep517 = use_pep517
 
+        # This requirement needs more preparation before it can be built
+        self.needs_more_preparation = False
+
     def __str__(self):
         # type: () -> str
         if self.req:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -218,10 +218,8 @@ class _InstallRequirementBackedCandidate(Candidate):
         # type: () -> None
         if self._dist is not None:
             return
-        dist = self._fetch_metadata()
         try:
-            if dist is None:
-                dist = self._prepare_distribution()
+            dist = self._prepare_distribution()
         except HashError as e:
             e.req = self._ireq
             raise
@@ -322,6 +320,9 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
 
     def _prepare_distribution(self):
         # type: () -> Distribution
+        dist = self._fetch_metadata()
+        if dist is not None:
+            return dist
         return self._factory.preparer.prepare_linked_requirement(
             self._ireq, parallel_builds=True,
         )

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -248,8 +248,7 @@ class _InstallRequirementBackedCandidate(Candidate):
                 dist = dist_from_wheel_url(self._name, url, session)
                 self._check_metadata_consistency(dist)
                 self._dist = dist
-        if self._dist is None:
-            self._prepare()
+        self._prepare()
 
     @property
     def dist(self):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -219,12 +219,9 @@ class _InstallRequirementBackedCandidate(Candidate):
         if self._dist is not None:
             return
         dist = self._fetch_metadata()
-        if dist is not None:
-            self._check_metadata_consistency(dist)
-            self._dist = dist
-            return
         try:
-            dist = self._prepare_distribution()
+            if dist is None:
+                dist = self._prepare_distribution()
         except HashError as e:
             e.req = self._ireq
             raise

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -228,15 +228,15 @@ class _InstallRequirementBackedCandidate(Candidate):
         self._check_metadata_consistency(dist)
         self._dist = dist
 
-    def _fetch_metadata(self):
-        # type: () -> Optional[Distribution]
+    def _fetch_metadata(self, req):
+        # type: (InstallRequirement) -> Optional[Distribution]
         """Fetch metadata, using lazy wheel if possible."""
         preparer = self._factory.preparer
         use_lazy_wheel = preparer.use_lazy_wheel
         remote_wheel = self._link.is_wheel and not self._link.is_file
         if use_lazy_wheel and remote_wheel and not preparer.require_hashes:
             assert self._name is not None
-            logger.info('Collecting %s', self._ireq.req or self._ireq)
+            logger.info('Collecting %s', req.req or req)
             # If HTTPRangeRequestUnsupported is raised, fallback silently.
             with indent_log(), suppress(HTTPRangeRequestUnsupported):
                 logger.info(
@@ -320,7 +320,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
 
     def _prepare_distribution(self):
         # type: () -> Distribution
-        dist = self._fetch_metadata()
+        dist = self._fetch_metadata(self._ireq)
         if dist is not None:
             return dist
         return self._factory.preparer.prepare_linked_requirement(

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -248,13 +248,13 @@ class _InstallRequirementBackedCandidate(Candidate):
                 dist = dist_from_wheel_url(self._name, url, session)
                 self._check_metadata_consistency(dist)
                 self._dist = dist
-        self._prepare()
 
     @property
     def dist(self):
         # type: () -> Distribution
         if self._dist is None:
             self._fetch_metadata()
+            self._prepare()
         return self._dist
 
     def _get_requires_python_specifier(self):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -147,7 +147,6 @@ class _InstallRequirementBackedCandidate(Candidate):
         self._name = name
         self._version = version
         self._dist = None  # type: Optional[Distribution]
-        self._prepared = False
 
     def __repr__(self):
         # type: () -> str
@@ -217,7 +216,7 @@ class _InstallRequirementBackedCandidate(Candidate):
 
     def _prepare(self):
         # type: () -> None
-        if self._prepared:
+        if self._dist is not None:
             return
         try:
             dist = self._prepare_distribution()
@@ -228,7 +227,6 @@ class _InstallRequirementBackedCandidate(Candidate):
         assert dist is not None, "Distribution already installed"
         self._check_metadata_consistency(dist)
         self._dist = dist
-        self._prepared = True
 
     def _fetch_metadata(self):
         # type: () -> None

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -232,7 +232,7 @@ class _InstallRequirementBackedCandidate(Candidate):
         # type: () -> Optional[Distribution]
         """Fetch metadata, using lazy wheel if possible."""
         preparer = self._factory.preparer
-        use_lazy_wheel = self._factory.use_lazy_wheel
+        use_lazy_wheel = preparer.use_lazy_wheel
         remote_wheel = self._link.is_wheel and not self._link.is_file
         if use_lazy_wheel and remote_wheel and not preparer.require_hashes:
             assert self._name is not None

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -233,7 +233,9 @@ class _InstallRequirementBackedCandidate(Candidate):
         """Fetch metadata, using lazy wheel if possible."""
         preparer = self._factory.preparer
         use_lazy_wheel = preparer.use_lazy_wheel
-        remote_wheel = self._link.is_wheel and not self._link.is_file
+        assert self._link == req.link
+        link = req.link
+        remote_wheel = link.is_wheel and not link.is_file
         if use_lazy_wheel and remote_wheel and not preparer.require_hashes:
             assert self._name is not None
             logger.info('Collecting %s', req.req or req)
@@ -243,7 +245,7 @@ class _InstallRequirementBackedCandidate(Candidate):
                     'Obtaining dependency information from %s %s',
                     self._name, self._version,
                 )
-                url = self._link.url.split('#', 1)[0]
+                url = link.url.split('#', 1)[0]
                 session = preparer.downloader._session
                 return dist_from_wheel_url(self._name, url, session)
         return None

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -218,6 +218,9 @@ class _InstallRequirementBackedCandidate(Candidate):
         # type: () -> None
         if self._dist is not None:
             return
+        self._fetch_metadata()
+        if self._dist is not None:
+            return
         try:
             dist = self._prepare_distribution()
         except HashError as e:
@@ -253,7 +256,6 @@ class _InstallRequirementBackedCandidate(Candidate):
     def dist(self):
         # type: () -> Distribution
         if self._dist is None:
-            self._fetch_metadata()
             self._prepare()
         return self._dist
 

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -218,8 +218,10 @@ class _InstallRequirementBackedCandidate(Candidate):
         # type: () -> None
         if self._dist is not None:
             return
-        self._fetch_metadata()
-        if self._dist is not None:
+        dist = self._fetch_metadata()
+        if dist is not None:
+            self._check_metadata_consistency(dist)
+            self._dist = dist
             return
         try:
             dist = self._prepare_distribution()
@@ -232,7 +234,7 @@ class _InstallRequirementBackedCandidate(Candidate):
         self._dist = dist
 
     def _fetch_metadata(self):
-        # type: () -> None
+        # type: () -> Optional[Distribution]
         """Fetch metadata, using lazy wheel if possible."""
         preparer = self._factory.preparer
         use_lazy_wheel = self._factory.use_lazy_wheel
@@ -248,9 +250,8 @@ class _InstallRequirementBackedCandidate(Candidate):
                 )
                 url = self._link.url.split('#', 1)[0]
                 session = preparer.downloader._session
-                dist = dist_from_wheel_url(self._name, url, session)
-                self._check_metadata_consistency(dist)
-                self._dist = dist
+                return dist_from_wheel_url(self._name, url, session)
+        return None
 
     @property
     def dist(self):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -82,7 +82,6 @@ class Factory(object):
         ignore_installed,  # type: bool
         ignore_requires_python,  # type: bool
         py_version_info=None,  # type: Optional[Tuple[int, ...]]
-        lazy_wheel=False,  # type: bool
     ):
         # type: (...) -> None
         self._finder = finder
@@ -93,7 +92,6 @@ class Factory(object):
         self._use_user_site = use_user_site
         self._force_reinstall = force_reinstall
         self._ignore_requires_python = ignore_requires_python
-        self.use_lazy_wheel = lazy_wheel
 
         self._link_candidate_cache = {}  # type: Cache[LinkCandidate]
         self._editable_candidate_cache = {}  # type: Cache[EditableCandidate]

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -159,6 +159,9 @@ class Resolver(BaseResolver):
 
             req_set.add_named_requirement(ireq)
 
+        for actual_req in req_set.all_requirements:
+            self.factory.preparer.prepare_linked_requirement_more(actual_req)
+
         return req_set
 
     def get_installation_order(self, req_set):

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -49,7 +49,6 @@ class Resolver(BaseResolver):
         force_reinstall,  # type: bool
         upgrade_strategy,  # type: str
         py_version_info=None,  # type: Optional[Tuple[int, ...]]
-        lazy_wheel=False,  # type: bool
     ):
         super(Resolver, self).__init__()
         assert upgrade_strategy in self._allowed_strategies
@@ -64,7 +63,6 @@ class Resolver(BaseResolver):
             ignore_installed=ignore_installed,
             ignore_requires_python=ignore_requires_python,
             py_version_info=py_version_info,
-            lazy_wheel=lazy_wheel,
         )
         self.ignore_dependencies = ignore_dependencies
         self.upgrade_strategy = upgrade_strategy

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -52,14 +52,6 @@ class Resolver(BaseResolver):
         lazy_wheel=False,  # type: bool
     ):
         super(Resolver, self).__init__()
-        if lazy_wheel:
-            logger.warning(
-                'pip is using lazily downloaded wheels using HTTP '
-                'range requests to obtain dependency information. '
-                'This experimental feature is enabled through '
-                '--use-feature=fast-deps and it is not ready for production.'
-            )
-
         assert upgrade_strategy in self._allowed_strategies
 
         self.factory = Factory(

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -89,6 +89,7 @@ class TestRequirementSet(object):
                 finder=finder,
                 require_hashes=require_hashes,
                 use_user_site=False,
+                lazy_wheel=False,
             )
             yield Resolver(
                 preparer=preparer,


### PR DESCRIPTION
This PR moves our new fast-dep lazy wheel handling to `RequirementPreparer`, addressing comments on #8532 that I neglected to follow up on in #8588.

To hopefully support that this approach will leave us happy and carefree, in the last commit I also added a hook to download lazy wheels once we're certain we're going to install them (as an alternative to #8638).