### PR TITLE
[2020-resolver] List downloaded distributions before exiting 

### DIFF
--- a/news/8696.bugfix
+++ b/news/8696.bugfix
@@ -1,0 +1,3 @@
+List downloaded distributions before exiting ``pip download``
+when using the new resolver to make the behavior the same as
+that on the legacy resolver.

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -134,10 +134,12 @@ class DownloadCommand(RequirementCommand):
             reqs, check_supported_wheels=True
         )
 
-        downloaded = ' '.join([req.name  # type: ignore
-                               for req in requirement_set.requirements.values()
-                               if req.successfully_downloaded])
+        downloaded = []  # type: List[str]
+        for req in requirement_set.requirements.values():
+            if not req.editable and req.satisfied_by is None:
+                assert req.name is not None
+                downloaded.append(req.name)
         if downloaded:
-            write_output('Successfully downloaded %s', downloaded)
+            write_output('Successfully downloaded %s', ' '.join(downloaded))
 
         return SUCCESS

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -179,15 +179,6 @@ class InstallRequirement(object):
         # e.g. dependencies, extras or constraints.
         self.user_supplied = user_supplied
 
-        # Set by the legacy resolver when the requirement has been downloaded
-        # TODO: This introduces a strong coupling between the resolver and the
-        #       requirement (the coupling was previously between the resolver
-        #       and the requirement set). This should be refactored to allow
-        #       the requirement to decide for itself when it has been
-        #       successfully downloaded - but that is more tricky to get right,
-        #       se we are making the change in stages.
-        self.successfully_downloaded = False
-
         self.isolated = isolated
         self.build_env = NoOpBuildEnvironment()  # type: BuildEnvironment
 

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -444,12 +444,6 @@ class Resolver(BaseResolver):
                 for subreq in dist.requires(available_requested):
                     add_req(subreq, extras_requested=available_requested)
 
-            if not req_to_install.editable and not req_to_install.satisfied_by:
-                # XXX: --no-install leads this to report 'Successfully
-                # downloaded' for only non-editable reqs, even though we took
-                # action on them.
-                req_to_install.successfully_downloaded = True
-
         return more_reqs
 
     def get_installation_order(self, req_set):


### PR DESCRIPTION
This unifies the behavior of pip download (listing downloaded distributions before exiting) and fixes GH-8696.