### PR TITLE
Disable caching for range requests

### DIFF
--- a/src/pip/_internal/network/lazy_wheel.py
+++ b/src/pip/_internal/network/lazy_wheel.py
@@ -194,8 +194,10 @@ class LazyZipOverHTTP(object):
     def _stream_response(self, start, end, base_headers=HEADERS):
         # type: (int, int, Dict[str, str]) -> Response
         """Return HTTP response to a range request from start to end."""
-        headers = {'Range': 'bytes={}-{}'.format(start, end)}
-        headers.update(base_headers)
+        headers = base_headers.copy()
+        headers['Range'] = 'bytes={}-{}'.format(start, end)
+        # TODO: Get range requests to be correctly cached
+        headers['Cache-Control'] = 'no-cache'
         return self._session.get(self._url, headers=headers, stream=True)
 
     def _merge(self, start, end, left, right):


### PR DESCRIPTION
This fixes corrupted shallow wheels when caching is involved (resolves GH-8701) until we know better on why range responses are not cached correctly.  It would be really nice if this can land as part of the next bugfix release (20.2.2).