### PR TITLE
Always use UTF-8 to read pyvenv.cfg

### DIFF
--- a/news/8717.bugfix
+++ b/news/8717.bugfix
@@ -1,0 +1,1 @@
+Always use UTF-8 to read ``pyvenv.cfg`` to match the built-in ``venv``.

--- a/src/pip/_internal/utils/virtualenv.py
+++ b/src/pip/_internal/utils/virtualenv.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import io
 import logging
 import os
 import re
@@ -51,7 +52,9 @@ def _get_pyvenv_cfg_lines():
     """
     pyvenv_cfg_file = os.path.join(sys.prefix, 'pyvenv.cfg')
     try:
-        with open(pyvenv_cfg_file) as f:
+        # Although PEP 405 does not specify, the built-in venv module always
+        # writes with UTF-8. (pypa/pip#8717)
+        with io.open(pyvenv_cfg_file, encoding='utf-8') as f:
             return f.read().splitlines()  # avoids trailing newlines
     except IOError:
         return None


### PR DESCRIPTION
Fix #8717.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
