### PR TITLE
[fast-deps] Add a hook for batch downloading

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -16,7 +16,6 @@ from pip._internal.exceptions import CommandError, PreviousBuildDirError
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
-from pip._internal.network.download import Downloader
 from pip._internal.network.session import PipSession
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req.constructors import (
@@ -213,8 +212,6 @@ class RequirementCommand(IndexGroupCommand):
         """
         Create a RequirementPreparer instance for the given parameters.
         """
-        downloader = Downloader(session, progress_bar=options.progress_bar)
-
         temp_build_dir_path = temp_build_dir.path
         assert temp_build_dir_path is not None
 
@@ -239,7 +236,7 @@ class RequirementCommand(IndexGroupCommand):
             build_isolation=options.build_isolation,
             req_tracker=req_tracker,
             session=session,
-            downloader=downloader,
+            progress_bar=options.progress_bar,
             finder=finder,
             require_hashes=options.require_hashes,
             use_user_site=use_user_site,

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -151,8 +151,9 @@ class Downloader(object):
         self._session = session
         self._progress_bar = progress_bar
 
-    def __call__(self, link, location):
+    def download_one(self, link, location):
         # type: (Link, str) -> Tuple[str, str]
+        """Download the file given by link into location."""
         try:
             resp = _http_get_download(self._session, link)
         except NetworkConnectionError as e:
@@ -168,3 +169,9 @@ class Downloader(object):
             for chunk in chunks:
                 content_file.write(chunk)
             return content_file.name, resp.headers.get('Content-Type', '')
+
+    def download_many(self, links, location):
+        # type: (Iterable[Link], str) -> Iterable[Tuple[str, Tuple[str, str]]]
+        """Download the files given by links into location."""
+        for link in links:
+            yield link.url, self.download_one(link, location)

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -164,11 +164,14 @@ class Downloader(object):
             raise
 
         filename = _get_http_response_filename(resp, link)
+        filepath = os.path.join(location, filename)
+
         chunks = _prepare_download(resp, link, self._progress_bar)
-        with open(os.path.join(location, filename), 'wb') as content_file:
+        with open(filepath, 'wb') as content_file:
             for chunk in chunks:
                 content_file.write(chunk)
-            return content_file.name, resp.headers.get('Content-Type', '')
+        content_type = resp.headers.get('Content-Type', '')
+        return filepath, content_type
 
     def download_many(self, links, location):
         # type: (Iterable[Link], str) -> Iterable[Tuple[str, Tuple[str, str]]]

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -160,8 +160,10 @@ class Resolver(BaseResolver):
 
             req_set.add_named_requirement(ireq)
 
-        for actual_req in req_set.all_requirements:
-            self.factory.preparer.prepare_linked_requirement_more(actual_req)
+        self.factory.preparer.prepare_linked_requirements_more([
+            req for req in req_set.all_requirements
+            if req.needs_more_preparation
+        ])
 
         return req_set
 

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -160,11 +160,8 @@ class Resolver(BaseResolver):
 
             req_set.add_named_requirement(ireq)
 
-        self.factory.preparer.prepare_linked_requirements_more([
-            req for req in req_set.all_requirements
-            if req.needs_more_preparation
-        ])
-
+        reqs = req_set.all_requirements
+        self.factory.preparer.prepare_linked_requirements_more(reqs)
         return req_set
 
     def get_installation_order(self, req_set):

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -79,7 +79,7 @@ def test_download_http_url__no_directory_traversal(mock_raise_for_status,
 
     download_dir = tmpdir.joinpath('download')
     os.mkdir(download_dir)
-    file_path, content_type = downloader(link, download_dir)
+    file_path, content_type = downloader.download_one(link, download_dir)
     # The file should be downloaded to download_dir.
     actual = os.listdir(download_dir)
     assert actual == ['out_dir_file']

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -10,11 +10,7 @@ from pip._internal.exceptions import HashMismatch
 from pip._internal.models.link import Link
 from pip._internal.network.download import Downloader
 from pip._internal.network.session import PipSession
-from pip._internal.operations.prepare import (
-    _copy_source_tree,
-    _download_http_url,
-    unpack_url,
-)
+from pip._internal.operations.prepare import _copy_source_tree, unpack_url
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.urls import path_to_url
 from tests.lib.filesystem import (
@@ -83,12 +79,7 @@ def test_download_http_url__no_directory_traversal(mock_raise_for_status,
 
     download_dir = tmpdir.joinpath('download')
     os.mkdir(download_dir)
-    file_path, content_type = _download_http_url(
-        link,
-        downloader,
-        download_dir,
-        hashes=None,
-    )
+    file_path, content_type = downloader(link, download_dir)
     # The file should be downloaded to download_dir.
     actual = os.listdir(download_dir)
     assert actual == ['out_dir_file']

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -35,7 +35,7 @@ def test_unpack_url_with_urllib_response_without_content_type(data):
 
     session = Mock()
     session.get = _fake_session_get
-    downloader = Downloader(session, progress_bar="on")
+    download = Downloader(session, progress_bar="on")
 
     uri = path_to_url(data.packages.joinpath("simple-1.0.tar.gz"))
     link = Link(uri)
@@ -44,7 +44,7 @@ def test_unpack_url_with_urllib_response_without_content_type(data):
         unpack_url(
             link,
             temp_dir,
-            downloader=downloader,
+            download=download,
             download_dir=None,
         )
         assert set(os.listdir(temp_dir)) == {
@@ -75,11 +75,11 @@ def test_download_http_url__no_directory_traversal(mock_raise_for_status,
         'content-disposition': 'attachment;filename="../out_dir_file"'
     }
     session.get.return_value = resp
-    downloader = Downloader(session, progress_bar="on")
+    download = Downloader(session, progress_bar="on")
 
     download_dir = tmpdir.joinpath('download')
     os.mkdir(download_dir)
-    file_path, content_type = downloader.download_one(link, download_dir)
+    file_path, content_type = download(link, download_dir)
     # The file should be downloaded to download_dir.
     actual = os.listdir(download_dir)
     assert actual == ['out_dir_file']
@@ -178,11 +178,11 @@ class Test_unpack_url(object):
         self.dist_path2 = data.packages.joinpath(self.dist_file2)
         self.dist_url = Link(path_to_url(self.dist_path))
         self.dist_url2 = Link(path_to_url(self.dist_path2))
-        self.no_downloader = Mock(side_effect=AssertionError)
+        self.no_download = Mock(side_effect=AssertionError)
 
     def test_unpack_url_no_download(self, tmpdir, data):
         self.prep(tmpdir, data)
-        unpack_url(self.dist_url, self.build_dir, self.no_downloader)
+        unpack_url(self.dist_url, self.build_dir, self.no_download)
         assert os.path.isdir(os.path.join(self.build_dir, 'simple'))
         assert not os.path.isfile(
             os.path.join(self.download_dir, self.dist_file))
@@ -198,7 +198,7 @@ class Test_unpack_url(object):
         with pytest.raises(HashMismatch):
             unpack_url(dist_url,
                        self.build_dir,
-                       downloader=self.no_downloader,
+                       download=self.no_download,
                        hashes=Hashes({'md5': ['bogus']}))
 
     def test_unpack_url_thats_a_dir(self, tmpdir, data):
@@ -206,7 +206,7 @@ class Test_unpack_url(object):
         dist_path = data.packages.joinpath("FSPkg")
         dist_url = Link(path_to_url(dist_path))
         unpack_url(dist_url, self.build_dir,
-                   downloader=self.no_downloader,
+                   download=self.no_download,
                    download_dir=self.download_dir)
         assert os.path.isdir(os.path.join(self.build_dir, 'fspkg'))
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -18,7 +18,6 @@ from pip._internal.exceptions import (
     InvalidWheelFilename,
     PreviousBuildDirError,
 )
-from pip._internal.network.download import Downloader
 from pip._internal.network.session import PipSession
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req import InstallRequirement, RequirementSet
@@ -87,7 +86,7 @@ class TestRequirementSet(object):
                 build_isolation=True,
                 req_tracker=tracker,
                 session=session,
-                downloader=Downloader(session, progress_bar="on"),
+                progress_bar='on',
                 finder=finder,
                 require_hashes=require_hashes,
                 use_user_site=False,


### PR DESCRIPTION
This is the first stab at GH-8697 and aim to:

* Add a separate hook to pass all links wheels whose downloads are postponed to Downloader, thus e.g. UI handling can be encapsulated at Downloader.download_many
* Memoize the downloaded files by the call above so that _prepare_linked_requirement can use them naturally use them

@pradyunsg and @chrahunt, I hope this is going in the correct direction of what we discussed.