### PR TITLE
Improve user-facing network error message when requesting indexes

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -788,7 +788,10 @@ archives are built with identical packages.
     to use such a package, see :ref:`Controlling
     setup_requires<controlling-setup-requires>`.
 
-.. _`Using pip from your program`:
+Fixing network errors
+=====================
+
+TODO
 
 Fixing conflicting dependencies
 ===============================

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -26,7 +26,7 @@ from pip._internal.exceptions import (
     BadCommand,
     CommandError,
     InstallationError,
-    NetworkConnectionError,
+    NetworkResponseError,
     PreviousBuildDirError,
     SubProcessError,
     UninstallationError,
@@ -222,7 +222,7 @@ class Command(CommandContextMixIn):
 
             return PREVIOUS_BUILD_DIR_ERROR
         except (InstallationError, UninstallationError, BadCommand,
-                SubProcessError, NetworkConnectionError) as exc:
+                SubProcessError, NetworkResponseError) as exc:
             logger.critical(str(exc))
             logger.debug('Exception information:', exc_info=True)
 

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -100,13 +100,13 @@ class PreviousBuildDirError(PipError):
     """Raised when there's a previous conflicting build directory"""
 
 
-class NetworkConnectionError(PipError):
+class NetworkResponseError(PipError):
     """HTTP connection error"""
 
     def __init__(self, error_msg, response=None, request=None):
         # type: (Text, Response, Request) -> None
         """
-        Initialize NetworkConnectionError with  `request` and `response`
+        Initialize NetworkResponseError with  `request` and `response`
         objects.
         """
         self.response = response
@@ -115,7 +115,7 @@ class NetworkConnectionError(PipError):
         if (self.response is not None and not self.request and
                 hasattr(response, 'request')):
             self.request = self.response.request
-        super(NetworkConnectionError, self).__init__(
+        super(NetworkResponseError, self).__init__(
             error_msg, response, request)
 
     def __str__(self):

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from itertools import chain, groupby, repeat
 
-from pip._vendor.six import iteritems
+from pip._vendor.six import ensure_str, iteritems
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -120,7 +120,7 @@ class NetworkResponseError(PipError):
 
     def __str__(self):
         # type: () -> str
-        return str(self.error_msg)
+        return ensure_str(self.error_msg, errors="replace")
 
 
 class InvalidWheelFilename(InstallationError):

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -17,7 +17,7 @@ from pip._vendor.requests.exceptions import RetryError, SSLError
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib import request as urllib_request
 
-from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.exceptions import NetworkResponseError
 from pip._internal.models.link import Link
 from pip._internal.models.search_scope import SearchScope
 from pip._internal.network.utils import raise_for_status
@@ -464,7 +464,7 @@ def _get_html_page(link, session=None):
             'The only supported Content-Type is text/html',
             link, exc.request_desc, exc.content_type,
         )
-    except NetworkConnectionError as exc:
+    except NetworkResponseError as exc:
         _handle_get_page_fail(link, exc)
     except RetryError as exc:
         _handle_get_page_fail(link, exc)

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 
 from pip._vendor import html5lib, requests
 from pip._vendor.distlib.compat import unescape
-from pip._vendor.requests.exceptions import RetryError, SSLError
+from pip._vendor.requests.exceptions import ProxyError, RetryError, SSLError
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 from pip._vendor.six.moves.urllib import request as urllib_request
 
@@ -460,6 +460,16 @@ def _get_html_page(link, session=None):
     except SSLError as exc:
         reason = "There was a problem confirming the ssl certificate"
         logger.warning("Could not fetch URL %s: %s: %s", link, reason, exc)
+    except (requests.ConnectTimeout, ProxyError):
+        template = (
+            "Skipping URL %s since the connection timed out. This is likely "
+            "caused by a misconfigured network or proxy."
+        )
+        logger.warning(template, link)
+        logger.warning(
+            "For help, visit "
+            "https://pip.pypa.io/en/latest/user_guide/#fixing-network-errors"
+        )
     except requests.ConnectionError as exc:
         reason = "connection error"
         logger.warning("Could not fetch URL %s: %s: %s", link, reason, exc)

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -477,8 +477,9 @@ def _get_html_page(link, session=None):
     except requests.Timeout:
         _handle_get_page_fail(link, "timed out")
     else:
-        return _make_html_page(resp,
-                               cache_link_parsing=link.cache_link_parsing)
+        return _make_html_page(
+            resp, cache_link_parsing=link.cache_link_parsing,
+        )
     return None
 
 

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -8,7 +8,7 @@ import os
 from pip._vendor.requests.models import CONTENT_CHUNK_SIZE
 
 from pip._internal.cli.progress_bars import DownloadProgressProvider
-from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.exceptions import NetworkResponseError
 from pip._internal.models.index import PyPI
 from pip._internal.network.cache import is_from_cache
 from pip._internal.network.utils import (
@@ -168,7 +168,7 @@ class Downloader(object):
         # type: (Link) -> Download
         try:
             resp = _http_get_download(self._session, link)
-        except NetworkConnectionError as e:
+        except NetworkResponseError as e:
             assert e.response is not None
             logger.critical(
                 "HTTP error %s while getting %s", e.response.status_code, link

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -169,10 +169,7 @@ class Downloader(object):
         try:
             resp = _http_get_download(self._session, link)
         except NetworkResponseError as e:
-            assert e.response is not None
-            logger.critical(
-                "HTTP error %s while getting %s", e.response.status_code, link
-            )
+            logger.critical("HTTP error %s while getting %s", e.status, link)
             raise
 
         return Download(

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -39,7 +39,7 @@ def raise_for_status(resp):
         try:
             reason = resp.reason.decode('utf-8')
         except UnicodeDecodeError:
-            reason = resp.reason.decode('iso-8859-1')
+            reason = resp.reason.decode('iso-8859-1', errors='replace')
     else:
         reason = resp.reason
 

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -1,6 +1,6 @@
 from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
 
-from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.exceptions import NetworkResponseError
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -52,7 +52,7 @@ def raise_for_status(resp):
             resp.status_code, reason, resp.url)
 
     if http_error_msg:
-        raise NetworkConnectionError(http_error_msg, response=resp)
+        raise NetworkResponseError(http_error_msg, response=resp)
 
 
 def response_chunks(response, chunk_size=CONTENT_CHUNK_SIZE):

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -44,9 +44,5 @@ class PipXmlrpcTransport(xmlrpc_client.Transport):
             self.verbose = verbose
             return self.parse_response(response.raw)
         except NetworkResponseError as exc:
-            assert exc.response
-            logger.critical(
-                "HTTP error %s while getting %s",
-                exc.response.status_code, url,
-            )
+            logger.critical("HTTP error %s while getting %s", exc.status, url)
             raise

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -8,7 +8,7 @@ import logging
 from pip._vendor.six.moves import xmlrpc_client  # type: ignore
 from pip._vendor.six.moves.urllib import parse as urllib_parse
 
-from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.exceptions import NetworkResponseError
 from pip._internal.network.utils import raise_for_status
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -43,7 +43,7 @@ class PipXmlrpcTransport(xmlrpc_client.Transport):
             raise_for_status(response)
             self.verbose = verbose
             return self.parse_response(response.raw)
-        except NetworkConnectionError as exc:
+        except NetworkResponseError as exc:
             assert exc.response
             logger.critical(
                 "HTTP error %s while getting %s",

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -21,7 +21,7 @@ from pip._internal.exceptions import (
     HashMismatch,
     HashUnpinned,
     InstallationError,
-    NetworkConnectionError,
+    NetworkResponseError,
     PreviousBuildDirError,
     VcsHashUnsupported,
 )
@@ -527,7 +527,7 @@ class RequirementPreparer(object):
                     link, req.source_dir, self.downloader, download_dir,
                     hashes=self._get_linked_req_hashes(req)
                 )
-            except NetworkConnectionError as exc:
+            except NetworkResponseError as exc:
                 raise InstallationError(
                     'Could not install requirement {} because of HTTP '
                     'error {} for URL {}'.format(req, exc, link)

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -11,7 +11,7 @@ from mock import Mock, patch
 from pip._vendor import html5lib, requests
 from pip._vendor.six.moves.urllib import request as urllib_request
 
-from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.exceptions import NetworkResponseError
 from pip._internal.index.collector import (
     HTMLPage,
     LinkCollector,
@@ -457,7 +457,7 @@ def test_request_http_error(mock_raise_for_status, caplog):
     link = Link('http://localhost')
     session = Mock(PipSession)
     session.get.return_value = Mock()
-    mock_raise_for_status.side_effect = NetworkConnectionError('Http error')
+    mock_raise_for_status.side_effect = NetworkResponseError('Http error')
     assert _get_html_page(link, session=session) is None
     assert (
         'Could not fetch URL http://localhost: Http error - skipping'

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.exceptions import NetworkResponseError
 from pip._internal.network.utils import raise_for_status
 from tests.lib.requests_mocks import MockResponse
 
@@ -15,7 +15,7 @@ def test_raise_for_status_raises_exception(status_code, error_type):
     resp.status_code = status_code
     resp.url = "http://www.example.com/whatever.tgz"
     resp.reason = "Network Error"
-    with pytest.raises(NetworkConnectionError) as exc:
+    with pytest.raises(NetworkResponseError) as exc:
         raise_for_status(resp)
         assert str(exc.info) == (
             "{} {}: Network Error for url:"


### PR DESCRIPTION
Fix #8641.

* [x] Make sense of each exception classes
* [x] Make each exception print a message the user can see (warning? error?)
* [ ] Add some documentation to link to in the user-facing error message
* [ ] Improve the user-facing message
* [ ] (Optional) Hide the ugly retry log if the user-facing message describes the situation well enough.