### PR TITLE
When one keyring attempt fails, don't bother with more

### DIFF
--- a/news/8090.bugfix
+++ b/news/8090.bugfix
@@ -1,0 +1,3 @@
+Only attempt to use the keyring once and if it fails, don't try again.
+This prevents spamming users with several keyring unlock prompts when they
+cannot unlock or don't want to do so.

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -44,6 +44,7 @@ except Exception as exc:
 def get_keyring_auth(url, username):
     # type: (str, str) -> Optional[AuthInfo]
     """Return the tuple auth for a given url from keyring."""
+    global keyring
     if not url or not keyring:
         return None
 
@@ -69,6 +70,7 @@ def get_keyring_auth(url, username):
         logger.warning(
             "Keyring is skipped due to an exception: %s", str(exc),
         )
+        keyring = None
     return None
 
 


### PR DESCRIPTION
This makes https://github.com/pypa/pip/issues/8090 much less painful.

This is the first commit from https://github.com/pypa/pip/pull/8687

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
