### PR TITLE
Improve deprecation message for issue 8368

### DIFF
--- a/news/8752.feature
+++ b/news/8752.feature
@@ -1,0 +1,3 @@
+Make the ``setup.py install`` deprecation warning less noisy. We warn only
+when ``setup.py install`` succeeded and ``setup.py bdist_wheel`` failed, as
+situations where both fails are most probably irrelevant to this deprecation.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -21,7 +21,6 @@ from pip._internal.locations import distutils_scheme
 from pip._internal.operations.check import check_install_conflicts
 from pip._internal.req import install_given_reqs
 from pip._internal.req.req_tracker import get_requirement_tracker
-from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.distutils_args import parse_distutils_args
 from pip._internal.utils.filesystem import test_writable_dir
 from pip._internal.utils.misc import (
@@ -371,23 +370,9 @@ class InstallCommand(RequirementCommand):
             # For now, we just warn about failures building legacy
             # requirements, as we'll fall through to a direct
             # install for those.
-            legacy_build_failure_names = [
-                r.name  # type: ignore
-                for r in build_failures if not r.use_pep517
-            ]  # type: List[str]
-            if legacy_build_failure_names:
-                deprecated(
-                    reason=(
-                        "Could not build wheels for {} which do not use "
-                        "PEP 517. pip will fall back to legacy 'setup.py "
-                        "install' for these.".format(
-                            ", ".join(legacy_build_failure_names)
-                        )
-                    ),
-                    replacement="to fix the wheel build issue reported above",
-                    gone_in="21.0",
-                    issue=8368,
-                )
+            for r in build_failures:
+                if not r.use_pep517:
+                    r.legacy_install_reason = 8368
 
             to_install = resolver.get_installation_order(
                 requirement_set

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -860,20 +860,20 @@ class InstallRequirement(object):
         except Exception:
             self.install_succeeded = True
             raise
-        else:
-            if self.legacy_install_reason == 8368:
-                deprecated(
-                    reason=(
-                        "{} was installed using the legacy 'setup.py install' "
-                        "method, because a wheel could not be built for it.".
-                        format(self.name)
-                    ),
-                    replacement="to fix the wheel build issue reported above",
-                    gone_in="21.0",
-                    issue=8368,
-                )
 
         self.install_succeeded = success
+
+        if success and self.legacy_install_reason == 8368:
+            deprecated(
+                reason=(
+                    "{} was installed using the legacy 'setup.py install' "
+                    "method, because a wheel could not be built for it.".
+                    format(self.name)
+                ),
+                replacement="to fix the wheel build issue reported above",
+                gone_in="21.0",
+                issue=8368,
+            )
 
 
 def check_invalid_constraint_type(req):

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -121,6 +121,7 @@ class InstallRequirement(object):
         self.comes_from = comes_from
         self.constraint = constraint
         self.editable = editable
+        self.legacy_install_reason = None  # type: Optional[int]
 
         # source_dir is the local directory where the linked requirement is
         # located, or unpacked. In case unpacking is needed, creating and
@@ -859,6 +860,18 @@ class InstallRequirement(object):
         except Exception:
             self.install_succeeded = True
             raise
+        else:
+            if self.legacy_install_reason == 8368:
+                deprecated(
+                    reason=(
+                        "{} was installed using the legacy 'setup.py install' "
+                        "method, because a wheel could not be built for it.".
+                        format(self.name)
+                    ),
+                    replacement="to fix the wheel build issue reported above",
+                    gone_in="21.0",
+                    issue=8368,
+                )
 
         self.install_succeeded = success
 


### PR DESCRIPTION
When `setup.py install` fails and `setup.py bdist_wheel` failed too, it is most probably for the same reason.
Reporting a deprecation warning about the failed wheel build in that case is causing noise in reports for #8368. What we are really interested in is reports about packages that can install via `setup.py install` but fail building a wheel.

This PR makes the deprecation look like this:

```console
$ pip install -f pip/tests/data/packages/ wheelbroken
Looking in links: pip/tests/data/packages/
Processing ./pip/tests/data/packages/wheelbroken-0.1.tar.gz
Building wheels for collected packages: wheelbroken
  Building wheel for wheelbroken (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/sbi-local/.virtualenvs/tempenv-04a2234147f66/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-7y0wc2c_/wheelbroken/setup.py'"'"'; __file__='"'"'/tmp/pip-install-7y0wc2c_/wheelbroken/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-gswzfp2o
       cwd: /tmp/pip-install-7y0wc2c_/wheelbroken/
  Complete output (5 lines):
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-install-7y0wc2c_/wheelbroken/setup.py", line 8, in <module>
      raise FakeError('this package designed to fail on bdist_wheel')
  __main__.FakeError: this package designed to fail on bdist_wheel
  ----------------------------------------
  ERROR: Failed building wheel for wheelbroken
  Running setup.py clean for wheelbroken
Failed to build wheelbroken
Installing collected packages: wheelbroken
    Running setup.py install for wheelbroken ... done
  DEPRECATION: wheelbroken was installed using the legacy 'setup.py install' method, because a wheel could not be built for it. pip 21.0 will remove support for this functionality. A possible replacement is to fix the wheel build issue reported above. You can find discussion regarding this at https://github.com/pypa/pip/issues/8368.
Successfully installed wheelbroken-0.1
```
