### PR TITLE
Include Requires-Python dep even with --no-deps

### DIFF
--- a/news/8758.bugfix
+++ b/news/8758.bugfix
@@ -1,0 +1,2 @@
+New resolver: Correctly respect ``Requires-Python`` metadata to reject
+incompatible packages in ``--no-deps`` mode.


### PR DESCRIPTION
Previous implementation would skip the Python version dependency introduced by `Requires-Python:` when `--no-deps` is passed. This fixes that.

I also did some minor refactorings to keep flake8 happy.