### PR TITLE
Allow py2 deprecation warning from setuptools

### DIFF
--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -4,6 +4,7 @@ import textwrap
 from hashlib import sha256
 
 import pytest
+from pip._vendor.six import PY2
 
 from pip._internal.cli.status_codes import ERROR
 from pip._internal.utils.urls import path_to_url
@@ -474,6 +475,7 @@ def make_wheel_with_python_requires(script, package_name, python_requires):
     package_dir.joinpath('setup.py').write_text(text)
     script.run(
         'python', 'setup.py', 'bdist_wheel', '--universal', cwd=package_dir,
+        allow_stderr_warning=PY2,
     )
 
     file_name = '{}-1.0-py2.py3-none-any.whl'.format(package_name)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -9,6 +9,7 @@ import textwrap
 from os.path import curdir, join, pardir
 
 import pytest
+from pip._vendor.six import PY2
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.models.index import PyPI, TestPyPI
@@ -1565,7 +1566,9 @@ def test_install_incompatible_python_requires_wheel(script, with_wheel):
               version='0.1')
     """))
     script.run(
-        'python', 'setup.py', 'bdist_wheel', '--universal', cwd=pkga_path)
+        'python', 'setup.py', 'bdist_wheel', '--universal',
+        cwd=pkga_path, allow_stderr_warning=PY2,
+    )
     result = script.pip('install', './pkga/dist/pkga-0.1-py2.py3-none-any.whl',
                         expect_error=True)
     assert _get_expected_error_text() in result.stderr, str(result)


### PR DESCRIPTION
This should be able to make master green again.