### PR TITLE
[fast-deps] Parallelize wheel download

### DIFF
--- a/news/8771.feature.rst
+++ b/news/8771.feature.rst
@@ -1,0 +1,1 @@
+Download distributions in parallel when fast-deps feature is enabled.


### PR DESCRIPTION
Example output:

```console
$ pip --use-feature=2020-resolver --use-feature=fast-deps install scipy
WARNING: pip is using lazily downloaded wheels using HTTP range requests to obtain dependency information. This experimental feature is enabled through --use-feature=fast-deps and it is not ready for production.
Collecting scipy
  Obtaining dependency information from scipy 1.5.2
Collecting numpy>=1.14.5
  Obtaining dependency information from numpy 1.19.1
Downloading 2 files (40.3 MB)
   |████████████████████████████████| 40.3 MB 822 kB/s 
Installing collected packages: numpy, scipy
Successfully installed numpy-1.19.1 scipy-1.5.2
```