### PR TITLE
Deprecate support for Python 3.5

### DIFF
--- a/news/8181.removal
+++ b/news/8181.removal
@@ -1,0 +1,1 @@
+Deprecate support for Python 3.5

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -158,7 +158,19 @@ class Command(CommandContextMixIn):
                     "1st, 2020. Please upgrade your Python as Python 2.7 "
                     "is no longer maintained. "
                 ) + message
-            deprecated(message, replacement=None, gone_in=None)
+            deprecated(message, replacement=None, gone_in="21.0")
+
+        if (
+            sys.version_info[:2] == (3, 5) and
+            not options.no_python_version_warning
+        ):
+            message = (
+                "Python 3.5 reached the end of its life on September "
+                "13th, 2020. Please upgrade your Python as Python 3.5 "
+                "is no longer maintained. pip 21.0 will drop support "
+                "for Python 3.5 in January 2021."
+            )
+            deprecated(message, replacement=None, gone_in="21.0")
 
         # TODO: Try to get these passing down from the command?
         #       without resorting to os.environ to hold these.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -470,8 +470,8 @@ def in_memory_pip():
 
 @pytest.fixture(scope="session")
 def deprecated_python():
-    """Used to indicate whether pip deprecated this python version"""
-    return sys.version_info[:2] in [(2, 7)]
+    """Used to indicate whether pip deprecated this Python version"""
+    return sys.version_info[:2] in [(2, 7), (3, 5)]
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

In https://github.com/pypa/pip/issues/8181#issuecomment-647214563, it looks like there's consensus for dropping Python 3.5 in pip 21.0 (January 2021).

As has been done previously, this adds a deprecation warning when running pip on Python 3.5.

It's not urgent, but this _could_ be included in tomorrow's 20.2.3 release (https://github.com/pypa/pip/issues/8511#issuecomment-675361596), which would give two more months of warning than waiting for pip 20.3 in October.

If so, need to change the message from past to future tense, for example:

```diff
-                "Python 3.5 reached the end of its life on September "
+                "Python 3.5 will reach the end of its life on September "
                 "13th, 2020. Please upgrade your Python as Python 3.5 "
-                "is no longer maintained. pip 21.0 will drop support "
-                "for Python 3.5 in January 2021."
+                "won't be maintained after September 2020. pip 21.0 will "
+                "drop support for Python 3.5 in January 2021."
```

---

Also updated `gone_in` for 2.7 (https://github.com/pypa/pip/issues/6148#issuecomment-616213532).

