### PR TITLE
Mark tests using remote svn and hg as xfail

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -758,6 +758,7 @@ def test_install_using_install_option_and_editable(script, tmpdir):
     result.did_create(script_file)
 
 
+@pytest.mark.xfail
 @pytest.mark.network
 @need_mercurial
 @windows_workaround_7667

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -159,6 +159,7 @@ def test_relative_requirements_file(
             result.did_create(egg_link_file)
 
 
+@pytest.mark.xfail
 @pytest.mark.network
 @need_svn
 def test_multiple_requirements_files(script, tmpdir, with_wheel):

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -45,6 +45,7 @@ class Tests_UserSite:
         project_name = result.stdout.strip()
         assert 'INITools' == project_name, project_name
 
+    @pytest.mark.xfail
     @pytest.mark.network
     @need_svn
     @pytest.mark.incompatible_with_test_venv

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -307,6 +307,7 @@ def test_uninstall_easy_installed_console_scripts(script):
     )
 
 
+@pytest.mark.xfail
 @pytest.mark.network
 @need_svn
 def test_uninstall_editable_from_svn(script, tmpdir):
@@ -372,6 +373,7 @@ def _test_uninstall_editable_with_source_outside_venv(
     )
 
 
+@pytest.mark.xfail
 @pytest.mark.network
 @need_svn
 def test_uninstall_from_reqs_file(script, tmpdir):


### PR DESCRIPTION
colorstudy.com has been down for a few days now.  TBH I'm not sure how long will GitHub keep supporting SVN checkouts, but for the moment I think it is OK.

Edit: This doesn't seem to work.  Is it OK to mark the 4 subversion tests as xfail?