### PR TITLE
Disallow --user installs if site.ENABLE_USER_SITE is False.

### DIFF
--- a/news/8794.bugfix
+++ b/news/8794.bugfix
@@ -1,0 +1,1 @@
+Prevent --user installs if site.ENABLE_USER_SITE is set to False.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -633,6 +633,7 @@ def decide_user_install(
         logger.debug("Non-user install by explicit request")
         return False
 
+    # If we have been asked for a user install explicitly, check compatibility.
     if use_user_site:
         if prefix_path:
             raise CommandError(
@@ -643,6 +644,13 @@ def decide_user_install(
             raise InstallationError(
                 "Can not perform a '--user' install. User site-packages "
                 "are not visible in this virtualenv."
+            )
+        # Catch all remaining cases which honour the site.ENABLE_USER_SITE
+        # value, such as a plain Python installation (e.g. no virtualenv).
+        if not site.ENABLE_USER_SITE:
+            raise InstallationError(
+                "Can not perform a '--user' install. User site-packages "
+                "are disabled for this Python."
             )
         logger.debug("User install by explicit request")
         return True


### PR DESCRIPTION
#8794 highlighted that ``site.ENABLE_USER_SITE`` was being ignored when ``pip install --user`` is being set. This is in contrast to the behaviour for ``virtualenvs`` which raises an ``InstallationError`` since the installed packages wouldn't be on the ``sys.path`` afterwards.

This MR brings about the symmetry by preventing the user from being able to do ``--user`` when ``site.ENABLE_USER_SITE`` is set. I wasn't sure on the best testing strategy for this change, so didn't implement any tests at this point (happy to take advice).