### PR TITLE
Fix `tmpdir` fixture when user contains backslash

### DIFF
--- a/news/8808.bugfix
+++ b/news/8808.bugfix
@@ -1,0 +1,1 @@
+Demonstrate ``tmpdir()`` test failures when ``$LOGNAME`` contains a backslash on posix systems.


### PR DESCRIPTION
On some *nix systems bound to AD domains, the `$USER` environment is of the form `DOMAIN\username`, which generates a `tmpdir` pytest fixture with paths like:

    /tmp/pytest-of-DOMAN\username/pytest-XX/test_nameX

When passed into pip commands, these paths get translated into:

    /tmp/pytest-of-DOMANusername/pytest-XX/test_nameX

The backslash also breaks the `shutil.rmtree()` at the end of the fixture, causing failures in future test runs.

So, replace all backslashes with forward slashes, which should work on nix and Windows machines