### PR TITLE
Support git references with commits that are not on a branch but are fetchable nevertheless

### DIFF
--- a/news/8815.feature
+++ b/news/8815.feature
@@ -1,0 +1,2 @@
+When installing a git URL that refers to a commit that is not available locally
+after git clone, attempt to fetch it from the remote.

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -250,3 +250,30 @@ def test_get_repository_root(script):
 
     root2 = Git.get_repository_root(version_pkg_path.joinpath("tests"))
     assert os.path.normcase(root2) == os.path.normcase(version_pkg_path)
+
+
+def test_resolve_commit_not_on_branch(script, tmp_path):
+    repo_path = tmp_path / "repo"
+    repo_file = repo_path / "file.txt"
+    clone_path = repo_path / "clone"
+    repo_path.mkdir()
+    script.run("git", "init", cwd=str(repo_path))
+    repo_file.write_text(u".")
+    script.run("git", "add", "file.txt", cwd=str(repo_path))
+    script.run("git", "commit", "-m", "initial commit", cwd=str(repo_path))
+    script.run("git", "checkout", "-b", "abranch", cwd=str(repo_path))
+    # create a commit
+    repo_file.write_text(u"..")
+    script.run("git", "commit", "-a", "-m", "commit 1", cwd=str(repo_path))
+    commit = script.run(
+        "git", "rev-parse", "HEAD", cwd=str(repo_path)
+    ).stdout.strip()
+    # make sure our commit is not on a branch
+    script.run("git", "checkout", "master", cwd=str(repo_path))
+    script.run("git", "branch", "-D", "abranch", cwd=str(repo_path))
+    # create a ref that points to our commit
+    (repo_path / ".git" / "refs" / "myrefs").mkdir(parents=True)
+    (repo_path / ".git" / "refs" / "myrefs" / "myref").write_text(commit)
+    # check we can fetch our commit
+    rev_options = Git.make_rev_options(commit)
+    Git().fetch_new(str(clone_path), repo_path.as_uri(), rev_options)

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -258,22 +258,27 @@ def test_resolve_commit_not_on_branch(script, tmp_path):
     clone_path = repo_path / "clone"
     repo_path.mkdir()
     script.run("git", "init", cwd=str(repo_path))
+
     repo_file.write_text(u".")
     script.run("git", "add", "file.txt", cwd=str(repo_path))
     script.run("git", "commit", "-m", "initial commit", cwd=str(repo_path))
     script.run("git", "checkout", "-b", "abranch", cwd=str(repo_path))
+
     # create a commit
     repo_file.write_text(u"..")
     script.run("git", "commit", "-a", "-m", "commit 1", cwd=str(repo_path))
     commit = script.run(
         "git", "rev-parse", "HEAD", cwd=str(repo_path)
     ).stdout.strip()
+
     # make sure our commit is not on a branch
     script.run("git", "checkout", "master", cwd=str(repo_path))
     script.run("git", "branch", "-D", "abranch", cwd=str(repo_path))
+
     # create a ref that points to our commit
     (repo_path / ".git" / "refs" / "myrefs").mkdir(parents=True)
     (repo_path / ".git" / "refs" / "myrefs" / "myref").write_text(commit)
+
     # check we can fetch our commit
     rev_options = Git.make_rev_options(commit)
     Git().fetch_new(str(clone_path), repo_path.as_uri(), rev_options)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -173,8 +173,9 @@ def test_git_resolve_revision_not_found_warning(get_sha_mock, caplog):
     sha = 40 * 'a'
     rev_options = Git.make_rev_options(sha)
 
-    new_options = Git.resolve_revision('.', url, rev_options)
-    assert new_options.rev == sha
+    # resolve_revision with a full sha would fail here because
+    # it attempts a git fetch. This case is now covered by
+    # test_resolve_commit_not_on_branch.
 
     rev_options = Git.make_rev_options(sha[:6])
     new_options = Git.resolve_revision('.', url, rev_options)


### PR DESCRIPTION
We attempt a git fetch when the requested revision looks like a commit and it is not available locally.

closes #8815 
