### PR TITLE
Replace custom URL parsing with url_to_path()

### DIFF
--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -21,7 +21,7 @@ from pip._internal.models.search_scope import SearchScope
 from pip._internal.network.utils import raise_for_status
 from pip._internal.utils.encoding import auto_decode
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
-from pip._internal.utils.urls import get_url_scheme
+from pip._internal.utils.urls import get_url_scheme, url_to_path
 
 if MYPY_CHECK_RUNNING:
     from optparse import Values
@@ -572,16 +572,7 @@ def get_file_content(url, session, comes_from=None):
                 'Requirements file {} references URL {}, '
                 'which is local'.format(comes_from, url)
             )
-
-        path = url.split(':', 1)[1]
-        path = path.replace('\\', '/')
-        match = _url_slash_drive_re.match(path)
-        if match:
-            path = match.group(1) + ':' + path.split('|', 1)[1]
-        path = urllib_parse.unquote(path)
-        if path.startswith('/'):
-            path = '/' + path.lstrip('/')
-        url = path
+        url = url_to_path(url)
 
     try:
         with open(url, 'rb') as f:
@@ -591,6 +582,3 @@ def get_file_content(url, session, comes_from=None):
             'Could not open requirements file: {}'.format(exc)
         )
     return url, content
-
-
-_url_slash_drive_re = re.compile(r'/*([a-z])\|', re.I)


### PR DESCRIPTION
I encountered this while looking into #8765 and #8828. The requirements file parser contains this buggy hand-rolled logic to convert a `file://` to a local filesystem path. `pip._internal.utils.urls.url_to_path()` (and `urllib.request.url2pathname()` it calls underneath) can do everything it does better, and can handle more edge cases on Windows.

For additional information, the current hand-rolled implementation did not change since [the initial commit in this repository](https://github.com/pypa/pip/blob/c2000d7de68ef955a85cf8f5f6e78d4f25c10103/pyinstall.py#L1991-L2000).