### PR TITLE
Nicer Resolver output -- Try 1

### DIFF
--- a/news/8861.bugfix
+++ b/news/8861.bugfix
@@ -1,0 +1,1 @@
+Tweak the output during dependency resolution in the new resolver.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -358,7 +358,7 @@ class RequirementPreparer(object):
         self._downloaded = {}  # type: Dict[str, Tuple[str, str]]
 
         # Previous "header" printed for a link-based InstallRequirement
-        self._previous_requirement_header = None
+        self._previous_requirement_header = ("", "")
 
     @property
     def _download_should_save(self):

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -357,6 +357,9 @@ class RequirementPreparer(object):
         # Memoized downloaded files, as mapping of url: (path, mime type)
         self._downloaded = {}  # type: Dict[str, Tuple[str, str]]
 
+        # Previous "header" printed for a link-based InstallRequirement
+        self._previous_requirement_header = None
+
     @property
     def _download_should_save(self):
         # type: () -> bool
@@ -381,7 +384,9 @@ class RequirementPreparer(object):
             message = "Collecting %s"
             information = str(req.req or req)
 
-        logger.info(message, information)
+        if (message, information) != self._previous_requirement_header:
+            self._previous_requirement_header = (message, information)
+            logger.info(message, information)
 
         if req.original_link_is_in_wheel_cache:
             with indent_log():

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -373,12 +373,15 @@ class RequirementPreparer(object):
 
     def _log_preparing_link(self, req):
         # type: (InstallRequirement) -> None
-        """Log the way the link prepared."""
+        """Provide context for the requirement being prepared."""
         if req.link.is_file:
-            path = req.link.file_path
-            logger.info('Processing %s', display_path(path))
+            message = "Processing %s"
+            information = str(display_path(req.link.file_path))
         else:
-            logger.info('Collecting %s', req.req or req)
+            message = "Collecting %s"
+            information = str(req.req or req)
+
+        logger.info(message, information)
 
     def _get_download_dir(self, link):
         # type: (Link) -> Optional[str]

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -374,7 +374,7 @@ class RequirementPreparer(object):
     def _log_preparing_link(self, req):
         # type: (InstallRequirement) -> None
         """Provide context for the requirement being prepared."""
-        if req.link.is_file:
+        if req.link.is_file and not req.original_link_is_in_wheel_cache:
             message = "Processing %s"
             information = str(display_path(req.link.file_path))
         else:
@@ -382,6 +382,10 @@ class RequirementPreparer(object):
             information = str(req.req or req)
 
         logger.info(message, information)
+
+        if req.original_link_is_in_wheel_cache:
+            with indent_log():
+                logger.info("Using cached %s", req.link.filename)
 
     def _get_download_dir(self, link):
         # type: (Link) -> Optional[str]


### PR DESCRIPTION
Fixes #8860 
Also makes some progress on #8346

---

Before:

```
$ pip install --use-feature=2020-resolver "pyrax==1.9.8"
Collecting pyrax==1.9.8
  Using cached pyrax-1.9.8-py2.py3-none-any.whl (346 kB)
Collecting python-novaclient==2.27.0
  Using cached python_novaclient-2.27.0-py2.py3-none-any.whl (312 kB)
Processing /Users/pradyunsg/Library/Caches/pip/wheels/48/6d/77/9517cb933af254f51a446f1a5ec9c2be3e45f17384940bce68/prettytable-0.7.2-py3-none-any.whl
Collecting iso8601>=0.1.9
  Using cached iso8601-0.1.12-py3-none-any.whl (12 kB)
Collecting six<2,>=1.9.0
  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
Collecting pbr<2.0,>=1.6
  Using cached pbr-1.10.0-py2.py3-none-any.whl (96 kB)
Processing /Users/pradyunsg/Library/Caches/pip/wheels/da/f1/6f/450a8e3042772f552f5316cfbd51552bb13995077e4502ba2f/rackspace_novaclient-2.1-py3-none-any.whl
Processing /Users/pradyunsg/Library/Caches/pip/wheels/45/42/fc/37502e2e6b8c5e745d2ec318c6d1ee9328ead3d704b5584797/ip_associations_python_novaclient_ext-0.2-py3-none-any.whl
Processing /Users/pradyunsg/Library/Caches/pip/wheels/bc/eb/b2/2d27f5c5d3d8caecebbf87ccb272f60ee278d968c1c3a10c85/os_diskconfig_python_novaclient_ext-0.1.3-py3-none-any.whl
Processing /Users/pradyunsg/Library/Caches/pip/wheels/b8/0c/c5/f4087714c89b18994a27c42c01bd9a8ce3bfcccf5d72ff978e/rackspace_auth_openstack-1.3-py3-none-any.whl
Processing /Users/pradyunsg/Library/Caches/pip/wheels/25/01/b7/d60cc1e3f2b4f9e5b359ce1b7fe03f65084020bfb0d4edcca2/os_networksv2_python_novaclient_ext-0.26-py3-none-any.whl
Processing /Users/pradyunsg/Library/Caches/pip/wheels/64/ce/0e/e407508c11ef0d63567a51a86302b44de81b78f602d7e8dc82/rax_scheduled_images_python_novaclient_ext-0.3.1-py3-none-any.whl
Processing /Users/pradyunsg/Library/Caches/pip/wheels/1d/b7/c2/8988a8a46e720cced366730c323604d1dba6644886f9a666aa/rax_default_network_flags_python_novaclient_ext-0.4.0-py3-none-any.whl
Processing /Users/pradyunsg/Library/Caches/pip/wheels/89/7c/51/371c863bd836d32c94f518678e612386ea757e4b195a080c78/os_virtual_interfacesv2_python_novaclient_ext-0.20-py3-none-any.whl
Collecting argparse
  Using cached argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Collecting Babel>=1.3
  Using cached Babel-2.8.0-py2.py3-none-any.whl (8.6 MB)
Collecting pytz>=2015.7
  Using cached pytz-2020.1-py2.py3-none-any.whl (510 kB)
Collecting mock
  Using cached mock-4.0.2-py3-none-any.whl (28 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-4.1.0-py3-none-any.whl (390 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-4.0.0-py3-none-any.whl (397 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.22.0-py2.py3-none-any.whl (397 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.21.0-py2.py3-none-any.whl (395 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.20.0-py2.py3-none-any.whl (394 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.19.1-py2.py3-none-any.whl (394 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.19.0-py2.py3-none-any.whl (394 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.18.0-py2.py3-none-any.whl (393 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.17.0-py2.py3-none-any.whl (382 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.16.0-py2.py3-none-any.whl (376 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.15.1-py2.py3-none-any.whl (385 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.15.0-py2.py3-none-any.whl (378 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.14.0-py2.py3-none-any.whl (372 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.13.1-py2.py3-none-any.whl (381 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-3.13.0-py2.py3-none-any.whl (374 kB)
^C
```

After:

```
$ pip install --use-feature=2020-resolver "pyrax==1.9.8"
Collecting pyrax==1.9.8
  Using cached pyrax-1.9.8-py2.py3-none-any.whl (346 kB)
Collecting python-novaclient==2.27.0
  Using cached python_novaclient-2.27.0-py2.py3-none-any.whl (312 kB)
Collecting PrettyTable<0.8,>=0.7
  Using cached prettytable-0.7.2-py3-none-any.whl
Collecting iso8601>=0.1.9
  Using cached iso8601-0.1.12-py3-none-any.whl (12 kB)
Collecting six<2,>=1.9.0
  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
Collecting pbr<2.0,>=1.6
  Using cached pbr-1.10.0-py2.py3-none-any.whl (96 kB)
Collecting rackspace-novaclient
  Using cached rackspace_novaclient-2.1-py3-none-any.whl
Collecting ip-associations-python-novaclient-ext
  Using cached ip_associations_python_novaclient_ext-0.2-py3-none-any.whl
Collecting os-diskconfig-python-novaclient-ext
  Using cached os_diskconfig_python_novaclient_ext-0.1.3-py3-none-any.whl
Collecting rackspace-auth-openstack
  Using cached rackspace_auth_openstack-1.3-py3-none-any.whl
Collecting os-networksv2-python-novaclient-ext
  Using cached os_networksv2_python_novaclient_ext-0.26-py3-none-any.whl
Collecting rax-scheduled-images-python-novaclient-ext
  Using cached rax_scheduled_images_python_novaclient_ext-0.3.1-py3-none-any.whl
Collecting rax-default-network-flags-python-novaclient-ext
  Using cached rax_default_network_flags_python_novaclient_ext-0.4.0-py3-none-any.whl
Collecting os-virtual-interfacesv2-python-novaclient-ext
  Using cached os_virtual_interfacesv2_python_novaclient_ext-0.20-py3-none-any.whl
Collecting Babel>=1.3
  Using cached Babel-2.8.0-py2.py3-none-any.whl (8.6 MB)
Collecting argparse
  Using cached argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Collecting pytz>=2015.7
  Using cached pytz-2020.1-py2.py3-none-any.whl (510 kB)
Collecting mock
  Using cached mock-4.0.2-py3-none-any.whl (28 kB)
Collecting python-keystoneclient>=1.6.0
  Using cached python_keystoneclient-4.1.0-py3-none-any.whl (390 kB)
  Using cached python_keystoneclient-4.0.0-py3-none-any.whl (397 kB)
  Using cached python_keystoneclient-3.22.0-py2.py3-none-any.whl (397 kB)
  Using cached python_keystoneclient-3.21.0-py2.py3-none-any.whl (395 kB)
  Using cached python_keystoneclient-3.20.0-py2.py3-none-any.whl (394 kB)
  Using cached python_keystoneclient-3.19.1-py2.py3-none-any.whl (394 kB)
  Using cached python_keystoneclient-3.19.0-py2.py3-none-any.whl (394 kB)
  Using cached python_keystoneclient-3.18.0-py2.py3-none-any.whl (393 kB)
  Using cached python_keystoneclient-3.17.0-py2.py3-none-any.whl (382 kB)
  Using cached python_keystoneclient-3.16.0-py2.py3-none-any.whl (376 kB)
  Using cached python_keystoneclient-3.15.1-py2.py3-none-any.whl (385 kB)
  Using cached python_keystoneclient-3.15.0-py2.py3-none-any.whl (378 kB)
  Using cached python_keystoneclient-3.14.0-py2.py3-none-any.whl (372 kB)
  Using cached python_keystoneclient-3.13.1-py2.py3-none-any.whl (381 kB)
  Using cached python_keystoneclient-3.13.0-py2.py3-none-any.whl (374 kB)
  Using cached python_keystoneclient-3.12.0-py2.py3-none-any.whl (374 kB)
^C
```