### PR TITLE
Document fast-track deprecation policy

### DIFF
--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -16,7 +16,7 @@ with version numbers.
 Our release months are January, April, July, October. The release date within
 that month will be up to the release manager for that release. If there are
 no changes, then that release month is skipped and the next release will be
-3 month later.
+3 months later.
 
 The release manager may, at their discretion, choose whether or not there
 will be a pre-release period for a release, and if there is may extend that

--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -44,11 +44,11 @@ Certain changes may be fast tracked and have a deprecation period of 3 months.
 This requires at least two members of the pip team to be in favor of doing so,
 and no pip maintainers opposing.
 
-Deprecation will take the form of a warning
-being issued by pip when the feature is used. Longer deprecation periods, or
-deprecation warnings for behavior changes that would not normally be covered by
-this policy, are also possible depending on circumstances, but this is at the
-discretion of the pip maintainers.
+Deprecation will take the form of a warning being issued by pip when the
+feature is used. Longer deprecation periods, or deprecation warnings for
+behavior changes that would not normally be covered by this policy, are also
+possible depending on circumstances, but this is at the discretion of the pip
+maintainers.
 
 Note that the documentation is the sole reference for what counts as agreed
 behavior. If something isn't explicitly mentioned in the documentation, it can

--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -38,11 +38,17 @@ Deprecation Policy
 
 Any change to pip that removes or significantly alters user-visible behavior
 that is described in the pip documentation will be deprecated for a minimum of
-6 months before the change occurs. Deprecation will take the form of a warning
+6 months before the change occurs.
+
+Certain changes may be fast tracked and have a deprecation period of 3 months.
+This requires at least two members of the pip team to be in favor of doing so,
+and no pip maintainers opposing.
+
+Deprecation will take the form of a warning
 being issued by pip when the feature is used. Longer deprecation periods, or
 deprecation warnings for behavior changes that would not normally be covered by
 this policy, are also possible depending on circumstances, but this is at the
-discretion of the pip developers.
+discretion of the pip maintainers.
 
 Note that the documentation is the sole reference for what counts as agreed
 behavior. If something isn't explicitly mentioned in the documentation, it can

--- a/news/8417.removal
+++ b/news/8417.removal
@@ -1,0 +1,1 @@
+Document that certain removals can be fast tracked.


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fixes https://github.com/pypa/pip/issues/8417.

Uses @pradyunsg's suggestion from https://github.com/pypa/pip/issues/8417#issuecomment-660549304 with slight rewording.

* Addition in https://github.com/pypa/pip/commit/8385cb5250e72129210b9b3f4f78665325741003
* Paragraph reflow in https://github.com/pypa/pip/commit/b6fb8b80e247c096d0f96b5980c1f57f3e53902e

Does this need a news fragment or trivial label?
