### PR TITLE
Docs: CSS 'hyphens: auto' doesn't work properly on Chrome

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ recursive-include  src/pip/_vendor *LICENSE*
 recursive-include  src/pip/_vendor *COPYING*
 
 include docs/docutils.conf
+include docs/html/custom.css
 
 exclude .coveragerc
 exclude .mailmap

--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -169,7 +169,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['custom.css']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -300,3 +300,7 @@ for fname in raw_subcommands:
     )
 
     man_pages.append((fname_base, outname, description, u'pip developers', 1))
+
+
+def setup(app):
+    app.add_css_file('custom.css')

--- a/docs/html/custom.css
+++ b/docs/html/custom.css
@@ -1,0 +1,6 @@
+div.body p, div.body dd, div.body li, div.body blockquote {
+    -moz-hyphens: none !important;
+    -ms-hyphens: none !important;
+    -webkit-hyphens: none !important;
+    hyphens: none !important;
+}


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

# Before

There's a problem in Chrome (and Opera) that `hyphens: auto` doesn't work properly (macOS/newest Chrome 85/newest Opera 70).

Here's a page I was recently looking at https://pip.pypa.io/en/stable/development/release-process/ and you can see more often than not the hyphenation is broken:

![image](https://user-images.githubusercontent.com/1324225/93103247-16305080-f6b5-11ea-9e02-7ede8cfdcd4d.png)

Newest Firefox 80 and Safari 13.1 work okay (let me know if you'd like screenshots).

# After

This PR suggests adding some custom CSS to use `hyphens: none` instead, so no hyphens and no broken hyphenation:

![image](https://user-images.githubusercontent.com/1324225/93105683-09f9c280-f6b8-11ea-9b54-27d33b1f22b9.png)

Let me know if you'd like before/after screenshots on other operating systems/browsers.

---

Does this need a news fragment or trivial label?

