### PR TITLE
Fix invalid header path when `--root` is set

### DIFF
--- a/news/8477.bugfix.rst
+++ b/news/8477.bugfix.rst
@@ -1,0 +1,2 @@
+Install libs, headers and data files in the correct location when
+``--root`` is specified.

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -48,8 +48,6 @@ def install(
 ):
     # type: (...) -> bool
 
-    header_dir = scheme.headers
-
     with TempDirectory(kind="record") as temp_dir:
         try:
             record_filename = os.path.join(temp_dir.path, 'install-record.txt')
@@ -60,11 +58,11 @@ def install(
                 record_filename=record_filename,
                 root=root,
                 prefix=prefix,
-                header_dir=header_dir,
                 home=home,
                 use_user_site=use_user_site,
                 no_user_config=isolated,
                 pycompile=pycompile,
+                scheme=scheme,
             )
 
             runner = runner_with_spinner_message(
@@ -103,7 +101,7 @@ def install(
     for line in record_lines:
         directory = os.path.dirname(line)
         if directory.endswith('.egg-info'):
-            egg_info_dir = prepend_root(directory)
+            egg_info_dir = directory
             break
     else:
         message = (

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -1,5 +1,6 @@
 import sys
 
+from pip._internal.models.scheme import Scheme
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -140,11 +141,11 @@ def make_setuptools_install_args(
     record_filename,  # type: str
     root,  # type: Optional[str]
     prefix,  # type: Optional[str]
-    header_dir,  # type: Optional[str]
     home,  # type: Optional[str]
     use_user_site,  # type: bool
     no_user_config,  # type: bool
-    pycompile  # type: bool
+    pycompile,  # type: bool
+    scheme,  # type: Scheme
 ):
     # type: (...) -> List[str]
     assert not (use_user_site and prefix)
@@ -159,8 +160,12 @@ def make_setuptools_install_args(
     args += ["install", "--record", record_filename]
     args += ["--single-version-externally-managed"]
 
-    if root is not None:
-        args += ["--root", root]
+    args += ["--install-purelib", scheme.purelib,
+             "--install-platlib", scheme.platlib,
+             "--install-headers", scheme.headers,
+             "--install-scripts", scheme.scripts,
+             "--install-data", scheme.data]
+
     if prefix is not None:
         args += ["--prefix", prefix]
     if home is not None:
@@ -172,9 +177,6 @@ def make_setuptools_install_args(
         args += ["--compile"]
     else:
         args += ["--no-compile"]
-
-    if header_dir:
-        args += ["--install-headers", header_dir]
 
     args += install_options
 


### PR DESCRIPTION
When we invoke setuptools with a `--root`, the header directory we take
from the Scheme object already contains the root as a prefix. Passing
both `--root` and `--install-headers` will result in setuptools adding
the root prefix twice in the header path.

As the Scheme object already has all directories relative to `--root`,
we can pass these separately with the `--install-*` setuptools
arguments and drop the `--root` argument.

Closes: #8477 

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
