### PR TITLE
Tweak message when -r is not passed on a requirements.txt

### DIFF
--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -159,7 +159,7 @@ def deduce_helpful_msg(req):
     """
     msg = ""
     if os.path.exists(req):
-        msg = " It does exist."
+        msg = " The path does exist. "
         # Try to parse and check if it is a requirements file.
         try:
             with open(req, 'r') as fp:

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -572,7 +572,7 @@ class TestInstallRequirement(object):
             install_req_from_line(req_file_path)
         err_msg = e.value.args[0]
         assert "Invalid requirement" in err_msg
-        assert "It looks like a path. It does exist." in err_msg
+        assert "It looks like a path. The path does exist." in err_msg
         assert "appears to be a requirements file." in err_msg
         assert "If that is the case, use the '-r' flag to install" in err_msg
 


### PR DESCRIPTION
Changes 

```
Hint: It looks like a path. It does exist.The argument you provided (/tmp/foo.txt) appears to be a requirements file. If that is the case, use the '-r' flag to install the packages specified within it.
```

To

```
Hint: It looks like a path. The path does exist. The argument you provided (/tmp/foo.txt) appears to be a requirements file. If that is the case, use the '-r' flag to install the packages specified within it.
```

---

It's not perfect, but it's an improvement. 🤷🏽‍♂️ 