### PR TITLE
Remove unnecessary config for isort 5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,6 @@ skip =
 multi_line_output = 3
 known_third_party =
     pip._vendor
-known_first_party =
-    pip
-    tests
-default_section = THIRDPARTY
 include_trailing_comma = true
 
 [flake8]


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Follow up to https://github.com/pypa/pip/pull/8902.

We can remove `known_first_party` and `default_section = THIRDPARTY` with isort 5.

https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/#module-placement-changes-known_third_party-known_first_party-default_section-etc says:

> isort has completely rewritten its logic for placing modules in 5.0.0 to ensure the same behavior across environments. You can see the details of this change [here](https://github.com/pycqa/isort/issues/1147). The TL;DR of which is that isort has now changed from `default_section=FIRSTPARTY` to `default_section=THIRDPARTY`. If you all already setting the default section to third party, your config is probably in good shape. If not, you can either use the old finding approach with `--magic-placement` in the CLI or `old_finders=True` in your config, or preferably, you are able to remove all placement options and isort will determine it correctly. If it doesn't, you should be able to just specify your projects modules with `known_first_party` and be done with it.

So `default_section = THIRDPARTY` is now the default and can be removed from config.

---

> You can see the details of this change [here](https://github.com/pycqa/isort/issues/1147).

says:

> * `FIRSTPARTY`: import name starts with `.`
> * `FIRSTPARTY`: import code exists within the files isort is told to sort.
> * `FIRSTPARTY`: import code exists in same directory as any files isort is told to sort.

So `pip` and `tests` match first party and this can now be removed from config:

```cfg
known_first_party =	
    pip	
    tests
```