### PR TITLE
Add black to our pre-commit configuration, but don't use it!

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,42 @@ repos:
   - id: trailing-whitespace
     exclude: .patch
 
+- repo: https://github.com/psf/black
+  rev: 20.8b1
+  hooks:
+  - id: black
+    exclude: |
+      (?x)
+        ^docs/|
+        ^src/pip/_internal/cli|
+        ^src/pip/_internal/commands|
+        ^src/pip/_internal/distributions|
+        ^src/pip/_internal/index|
+        ^src/pip/_internal/models|
+        ^src/pip/_internal/network|
+        ^src/pip/_internal/operations|
+        ^src/pip/_internal/req|
+        ^src/pip/_internal/resolution|
+        ^src/pip/_internal/utils|
+        ^src/pip/_internal/vcs|
+        ^src/pip/_internal/\w+\.py$|
+        ^src/pip/__main__.py$|
+        ^tools/|
+        # Tests
+        ^tests/conftest.py|
+        ^tests/yaml|
+        ^tests/lib|
+        ^tests/data|
+        ^tests/unit|
+        ^tests/functional/(?!test_install)|
+        ^tests/functional/test_install|
+        # Files in the root of the repository
+        ^setup.py|
+        ^noxfile.py|
+        # A blank ignore, to avoid merge conflicts later.
+        ^$
+
+
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.8.3
   hooks:


### PR DESCRIPTION
Built on top of #8906

Each of the lines in the "exclude" pattern will get a dedicated PR to remove it and would blacken that part of the codebase.

This should let us introduce it to the codebase incrementally. :)