### PR TITLE
Add a debugging reporter to the new resolver

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -1,0 +1,30 @@
+import logging
+
+from pip._vendor.resolvelib.reporters import BaseReporter
+
+logger = logging.getLogger(__name__)
+
+
+class PipDebuggingReporter(BaseReporter):
+    """A basic reporter that does a debug log for every event it sees."""
+
+    def starting(self):
+        logger.debug("Reporter.starting()")
+
+    def starting_round(self, index):
+        logger.debug("Reporter.starting_round(%r)", index)
+
+    def ending_round(self, index, state):
+        logger.debug("Reporter.ending_round(%r, state)", index)
+
+    def ending(self, state):
+        logger.debug("Reporter.ending(state)")
+
+    def adding_requirement(self, requirement, parent):
+        logger.debug("Reporter.adding_requirement(%r, %r)", requirement, parent)
+
+    def backtracking(self, candidate):
+        logger.debug("Reporter.backtracking(%r)", candidate)
+
+    def pinning(self, candidate):
+        logger.debug("Reporter.pinning(%r)", candidate)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -3,7 +3,7 @@ import logging
 
 from pip._vendor import six
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
+from pip._vendor.resolvelib import ResolutionImpossible
 from pip._vendor.resolvelib import Resolver as RLResolver
 
 from pip._internal.exceptions import InstallationError
@@ -11,6 +11,7 @@ from pip._internal.req.req_install import check_invalid_constraint_type
 from pip._internal.req.req_set import RequirementSet
 from pip._internal.resolution.base import BaseResolver
 from pip._internal.resolution.resolvelib.provider import PipProvider
+from pip._internal.resolution.resolvelib.reporter import PipDebuggingReporter
 from pip._internal.utils.misc import dist_is_editable
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -103,7 +104,7 @@ class Resolver(BaseResolver):
             upgrade_strategy=self.upgrade_strategy,
             user_requested=user_requested,
         )
-        reporter = BaseReporter()
+        reporter = PipDebuggingReporter()
         resolver = RLResolver(provider, reporter)
 
         try:


### PR DESCRIPTION
🌈 

This is obviously not optimized and will make log files a bit bigger, but any opinions against this (given that we're not printing the "state" table)?