### PR TITLE
Flake8: use extend-ignore to avoid redefining defaults

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,10 +24,8 @@ exclude =
     _vendor,
     data
 enable-extensions = G
-ignore =
+extend-ignore =
     G200, G202,
-    # pycodestyle checks ignored in the default configuration
-    E121, E123, E126, E133, E226, E241, E242, E704, W503, W504, W505,
     # black adds spaces around ':'
     E203,
 per-file-ignores =


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

From https://github.com/pypa/pip/pull/8906#discussion_r493914274.

Using Flake8's `ignore` means the defaults are cleared and need to be redefined.

Instead, use `extend-ignore` to keep the defaults and extend them.

cc @webknjaz @pradyunsg