### PR TITLE
Don't crash on 'check' when METADATA is missing

### DIFF
--- a/news/8676.feature
+++ b/news/8676.feature
@@ -1,0 +1,2 @@
+Improve error message friendliness when an environment has packages with
+corrupted metadata.

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -45,8 +45,8 @@ def create_package_set_from_installed(**kwargs):
         name = canonicalize_name(dist.project_name)
         try:
             package_set[name] = PackageDetails(dist.version, dist.requires())
-        except RequirementParseError as e:
-            # Don't crash on broken metadata
+        except (OSError, RequirementParseError) as e:
+            # Don't crash on unreadable or broken metadata
             logger.warning("Error parsing requirements for %s: %s", name, e)
             problems = True
     return package_set, problems


### PR DESCRIPTION
Fix #8676.

Ideally I’d want to catch only corruption failure for that specific package and carry on with others, but that does not seem feasible without patching `pkg_resources`.

Since we already swallow corrupted metadata exceptions, it is probably not a terrible idea to swallow `OSError` anyway. Hopefully the `importlib.metadata` migration would provide a more useful way to handle these errors.