### PR TITLE
Pin pytest whilst pytest-rerunfailures is incompatible with pytest 6.1

### DIFF
--- a/tools/requirements/tests.txt
+++ b/tools/requirements/tests.txt
@@ -5,7 +5,7 @@ enum34; python_version < '3.4'
 freezegun
 mock
 pretend
-pytest
+pytest<6.1.0 # Until https://github.com/pytest-dev/pytest-rerunfailures/issues/128 is fixed
 pytest-cov
 pytest-rerunfailures
 pytest-timeout


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Fixes https://github.com/pypa/pip/issues/8925.

The pytest-rerunfailures plugin is not compatible with the newest pytest 6.1.0, which removed some deprecations.

Temporarily pin to pytest < 6.1.0 until https://github.com/pytest-dev/pytest-rerunfailures/issues/128 is fixed and released.

