### PR TITLE
Cache from status code 302

### DIFF
--- a/src/pip/_vendor/cachecontrol/adapter.py
+++ b/src/pip/_vendor/cachecontrol/adapter.py
@@ -92,8 +92,8 @@ class CacheControlAdapter(HTTPAdapter):
 
                 response = cached_response
 
-            # We always cache the 301 responses
-            elif response.status == 301:
+            # We always cache the 301 and 302 responses
+            elif response.status in (301, 302):
                 self.controller.cache_response(request, response)
             else:
                 # Wrap the response file with a wrapper that will cache the

--- a/src/pip/_vendor/cachecontrol/controller.py
+++ b/src/pip/_vendor/cachecontrol/controller.py
@@ -37,7 +37,7 @@ class CacheController(object):
         self.cache = DictCache() if cache is None else cache
         self.cache_etags = cache_etags
         self.serializer = serializer or Serializer()
-        self.cacheable_status_codes = status_codes or (200, 203, 300, 301)
+        self.cacheable_status_codes = status_codes or (200, 203, 300, 301, 302)
 
     @classmethod
     def _urlnorm(cls, uri):


### PR DESCRIPTION
On issue #8643 log we can see that github response with a 302 status
code [0]. From my point of view status code 302 is similary to 301 that
already is accepted by pip, so shouldn't represent a problem
support 302 status code to cache.

[0] https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302

