### PR TITLE
completion descriptions for fish

### DIFF
--- a/news/8964.feature.rst
+++ b/news/8964.feature.rst
@@ -1,0 +1,1 @@
+Add command and flag descriptions to shell completions.

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -5,7 +5,7 @@ import optparse
 import os
 import sys
 from itertools import chain
-from typing import Any, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from pip._internal.cli.main_parser import create_main_parser
 from pip._internal.commands import commands_dict, create_command
@@ -27,9 +27,9 @@ def autocomplete() -> None:
         current = ""
 
     parser = create_main_parser()
-    subcommands = {
+    subcommands: Dict[str,str] = {
         name: command.summary for name, command in commands_dict.items()
-    }  # type: Dict[str, str]
+    }
     options = []
 
     # subcommand
@@ -117,9 +117,10 @@ def autocomplete() -> None:
     sys.exit(1)
 
 
-def output_completion_with_description(name:str, description="") -> None:
-    # type: (str, Optional[str]) -> None
+def output_completion_with_description(name: str, description: str="") -> None:
     """Prints the string for completion with its description in a consistent way."""
+    # Make descriptions oneliners so they're grouped as one.
+    description = " ".join(description.splitlines())
     print(
         "{name}{delimiter}{description}".format(
             name=name, delimiter=DELIMITER, description=description

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -58,7 +58,7 @@ def autocomplete() -> None:
             # if there are no dists installed, fall back to option completion
             if installed:
                 for dist, version in installed:
-                    print("{dist}\t{version}".format(dist=dist, version=version))
+                    output_completion_with_description(name=dist, description=version)
                 sys.exit(1)
 
         subcommand = create_command(subcommand_name)
@@ -88,7 +88,7 @@ def autocomplete() -> None:
             # append '=' to options which require args
             if nargs and label.startswith("--"):
                 label += "="
-            print("{name}\t{help}".format(name=label, help=description))
+            output_completion_with_description(label, description)
     else:
         # show main parser options only when necessary
 
@@ -109,17 +109,15 @@ def autocomplete() -> None:
                     for command in auto_complete_paths(current, completion_type)
                 }
 
-        print(
-            os.linesep.join(
-                "{command_name}\t{description}".format(
-                    command_name=name, description=description.strip(".")
-                )
-                for name, description in subcommands.items()
-                if name.startswith(current)
-            )
-        )
+        for name, description in subcommands.items():
+            if name.startswith(current):
+                output_completion_with_description(name, description)
     sys.exit(1)
 
+
+def output_completion_with_description(name:str , description="") -> None:
+    """Prints the string for completion with its description, delimited by :"""
+    print("{name}:{description}".format(name=name, description=description))
 
 def get_path_completion_type(
     cwords: List[str], cword: int, opts: Iterable[Any]

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -25,7 +25,9 @@ def autocomplete() -> None:
         current = ""
 
     parser = create_main_parser()
-    subcommands = list(commands_dict)
+    subcommands = {
+        name: command.summary for name, command in commands_dict.items()
+    }  # type: Dict[str, str]
     options = []
 
     # subcommand
@@ -97,14 +99,26 @@ def autocomplete() -> None:
         if current.startswith("-"):
             for opt in flattened_opts:
                 if opt.help != optparse.SUPPRESS_HELP:
-                    subcommands += opt._long_opts + opt._short_opts
+                    subcommands.update({name: opt.help for name in opt._long_opts})
+                    subcommands.update({name: opt.help for name in opt._short_opts})
         else:
             # get completion type given cwords and all available options
             completion_type = get_path_completion_type(cwords, cword, flattened_opts)
             if completion_type:
-                subcommands = list(auto_complete_paths(current, completion_type))
+                subcommands = {
+                    command: ""
+                    for command in auto_complete_paths(current, completion_type)
+                }
 
-        print(" ".join([x for x in subcommands if x.startswith(current)]))
+        print(
+            os.linesep.join(
+                "{command_name}\t{description}".format(
+                    command_name=name, description=description
+                )
+                for name, description in subcommands.items()
+                if name.startswith(current)
+            )
+        )
     sys.exit(1)
 
 

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -121,11 +121,7 @@ def output_completion_with_description(name: str, description: str="") -> None:
     """Prints the string for completion with its description in a consistent way."""
     # Make descriptions oneliners so they're grouped as one.
     description = " ".join(description.splitlines())
-    print(
-        "{name}{delimiter}{description}".format(
-            name=name, delimiter=DELIMITER, description=description
-        )
-    )
+    print(name + DELIMITER + description)
 
 def get_path_completion_type(
     cwords: List[str], cword: int, opts: Iterable[Any]

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -12,6 +12,8 @@ from pip._internal.commands import commands_dict, create_command
 from pip._internal.metadata import get_default_environment
 
 
+DELIMITER = "*"
+
 def autocomplete() -> None:
     """Entry Point for completion of main and subcommand options."""
     # Don't complete if user hasn't sourced bash_completion file.
@@ -115,9 +117,14 @@ def autocomplete() -> None:
     sys.exit(1)
 
 
-def output_completion_with_description(name:str , description="") -> None:
-    """Prints the string for completion with its description, delimited by :"""
-    print("{name}:{description}".format(name=name, description=description))
+def output_completion_with_description(name:str, description="") -> None:
+    # type: (str, Optional[str]) -> None
+    """Prints the string for completion with its description in a consistent way."""
+    print(
+        "{name}{delimiter}{description}".format(
+            name=name, delimiter=DELIMITER, description=description
+        )
+    )
 
 def get_path_completion_type(
     cwords: List[str], cword: int, opts: Iterable[Any]

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -17,7 +17,7 @@ COMPLETION_SCRIPTS = {
         {{
             COMPREPLY=( $( COMP_WORDS="${{COMP_WORDS[*]}}" \\
                            COMP_CWORD=$COMP_CWORD \\
-                           PIP_AUTO_COMPLETE=1 $1 2>/dev/null ) )
+                           PIP_AUTO_COMPLETE=1 $1 2>/dev/null | cut -d':' -f1) )
         }}
         complete -o default -F _pip_completion {prog}
     """,
@@ -28,7 +28,7 @@ COMPLETION_SCRIPTS = {
           read -cn cword
           reply=( $( COMP_WORDS="$words[*]" \\
                      COMP_CWORD=$(( cword-1 )) \\
-                     PIP_AUTO_COMPLETE=1 $words[1] 2>/dev/null ))
+                     PIP_AUTO_COMPLETE=1 $words[1] 2>/dev/null |cut -d':' -f1))
         }}
         compctl -K _pip_completion {prog}
     """,
@@ -39,7 +39,7 @@ COMPLETION_SCRIPTS = {
                 math (contains -i -- (commandline -t) $COMP_WORDS)-1 \\
             )
             set -lx PIP_AUTO_COMPLETE 1
-            eval $COMP_WORDS[1]
+            string replace --all ':' \t (eval $COMP_WORDS[1])
         end
         complete -fa "(__fish_complete_pip)" -c {prog}
     """,

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -39,7 +39,7 @@ COMPLETION_SCRIPTS = {
                 math (contains -i -- (commandline -t) $COMP_WORDS)-1 \\
             )
             set -lx PIP_AUTO_COMPLETE 1
-            string split \\  -- (eval $COMP_WORDS[1])
+            eval $COMP_WORDS[1]
         end
         complete -fa "(__fish_complete_pip)" -c {prog}
     """,

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -39,7 +39,7 @@ COMPLETION_SCRIPTS = {
                 math (contains -i -- (commandline -t) $COMP_WORDS)-1 \\
             )
             set -lx PIP_AUTO_COMPLETE 1
-            string replace --all ':' \t (eval $COMP_WORDS[1])
+            string replace ':' \\t -- (eval $COMP_WORDS[1])
         end
         complete -fa "(__fish_complete_pip)" -c {prog}
     """,

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -3,6 +3,7 @@ import textwrap
 from optparse import Values
 from typing import List
 
+from pip._internal.cli.autocompletion import DELIMITER
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.utils.misc import get_prog
@@ -17,7 +18,8 @@ COMPLETION_SCRIPTS = {
         {{
             COMPREPLY=( $( COMP_WORDS="${{COMP_WORDS[*]}}" \\
                            COMP_CWORD=$COMP_CWORD \\
-                           PIP_AUTO_COMPLETE=1 $1 2>/dev/null | cut -d':' -f1) )
+                           PIP_AUTO_COMPLETE=1 $1 2>/dev/null | \\
+                           cut -d'{delimiter}' -f1) )
         }}
         complete -o default -F _pip_completion {prog}
     """,
@@ -28,7 +30,8 @@ COMPLETION_SCRIPTS = {
           read -cn cword
           reply=( $( COMP_WORDS="$words[*]" \\
                      COMP_CWORD=$(( cword-1 )) \\
-                     PIP_AUTO_COMPLETE=1 $words[1] 2>/dev/null |cut -d':' -f1))
+                     PIP_AUTO_COMPLETE=1 $words[1] 2>/dev/null | \\
+                     cut -d'{delimiter}' -f1))
         }}
         compctl -K _pip_completion {prog}
     """,
@@ -39,7 +42,7 @@ COMPLETION_SCRIPTS = {
                 math (contains -i -- (commandline -t) $COMP_WORDS)-1 \\
             )
             set -lx PIP_AUTO_COMPLETE 1
-            string replace ':' \\t -- (eval $COMP_WORDS[1])
+            string replace '{delimiter}' \\t -- (eval $COMP_WORDS[1])
         end
         complete -fa "(__fish_complete_pip)" -c {prog}
     """,
@@ -85,7 +88,7 @@ class CompletionCommand(Command):
         shell_options = ["--" + shell for shell in sorted(shells)]
         if options.shell in shells:
             script = textwrap.dedent(
-                COMPLETION_SCRIPTS.get(options.shell, "").format(prog=get_prog())
+                COMPLETION_SCRIPTS.get(options.shell, "").format(delimiter=DELIMITER, prog=get_prog())
             )
             print(BASE_COMPLETION.format(script=script, shell=options.shell))
             return SUCCESS

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -17,8 +17,11 @@ _pip_completion()
                    PIP_AUTO_COMPLETE=1 $1 2>/dev/null | \\
                    cut -d'{delimiter}' -f1) )
 }}
-complete -o default -F _pip_completion pip"""),
-    ('fish', """\
+complete -o default -F _pip_completion pip""",
+    ),
+    (
+        "fish",
+        """\
 function __fish_complete_pip
     set -lx COMP_WORDS (commandline -o) ""
     set -lx COMP_CWORD ( \\
@@ -27,8 +30,11 @@ function __fish_complete_pip
     set -lx PIP_AUTO_COMPLETE 1
     string replace '{delimiter}' \\t -- (eval $COMP_WORDS[1])
 end
-complete -fa "(__fish_complete_pip)" -c pip"""),
-    ('zsh', """\
+complete -fa "(__fish_complete_pip)" -c pip""",
+    ),
+    (
+        "zsh",
+        """\
 function _pip_completion {{
   local words cword
   read -Ac words
@@ -38,7 +44,8 @@ function _pip_completion {{
              PIP_AUTO_COMPLETE=1 $words[1] 2>/dev/null | \\
              cut -d'{delimiter}' -f1))
 }}
-compctl -K _pip_completion pip"""),
+compctl -K _pip_completion pip""",
+    ),
 )
 
 
@@ -60,9 +67,7 @@ def test_completion_for_supported_shells(script_with_launchers, shell, completio
     """
     Test getting completion for bash shell
     """
-    result = script_with_launchers.pip(
-        'completion', '--' + shell, use_module=False
-    )
+    result = script_with_launchers.pip("completion", "--" + shell, use_module=False)
     assert completion.format(delimiter=DELIMITER) in result.stdout, str(result.stdout)
 
 
@@ -95,7 +100,10 @@ def autocomplete(autocomplete_script, monkeypatch):
 
 
 def options(autocomplete_output):
-    return [line.partition(DELIMITER)[0] for line in autocomplete_output.splitlines()]
+    return {
+        line.partition(DELIMITER)[0]: line.partition(DELIMITER)[2]
+        for line in autocomplete_output.splitlines()
+    }
 
 
 def test_completion_for_unknown_shell(autocomplete_script):
@@ -122,8 +130,9 @@ def test_completion_for_un_snippet(autocomplete):
     Test getting completion for ``un`` should return uninstall
     """
 
-    res, env = autocomplete('pip un', '1')
-    assert options(res.stdout) == ['uninstall'], res.stdout
+    res, env = autocomplete("pip un", "1")
+    assert list(options(res.stdout)) == ["uninstall"], res.stdout
+    assert options(res.stdout)["uninstall"] == "Uninstall packages."
 
 
 def test_completion_for_default_parameters(autocomplete):
@@ -132,7 +141,12 @@ def test_completion_for_default_parameters(autocomplete):
     """
 
     res, env = autocomplete("pip --", "1")
-    assert "--help" in res.stdout, "autocomplete function could not complete ``--``"
+    assert "--help" in options(
+        res.stdout
+    ), "autocomplete function could not complete ``--``"
+    assert (
+        options(res.stdout)["--help"] == "Show help."
+    ), "autocomplete function could not show option description"
 
 
 def test_completion_option_for_command(autocomplete):
@@ -142,6 +156,9 @@ def test_completion_option_for_command(autocomplete):
 
     res, env = autocomplete("pip search --", "2")
     assert "--help" in res.stdout, "autocomplete function could not complete ``--``"
+    assert (
+        options(res.stdout)["--help"] == "Show help."
+    ), "autocomplete function could not show long option description"
 
 
 def test_completion_short_option(autocomplete):
@@ -151,8 +168,12 @@ def test_completion_short_option(autocomplete):
 
     res, env = autocomplete("pip -", "1")
 
-    assert '-h' in options(res.stdout),\
-           "autocomplete function could not complete short options after ``-``"
+    assert "-h" in options(
+        res.stdout
+    ), "autocomplete function could not complete short options after ``-``"
+    assert (
+        options(res.stdout)["-h"] == "Show help."
+    ), "autocomplete function could not show short option description"
 
 
 def test_completion_short_option_for_command(autocomplete):
@@ -163,8 +184,9 @@ def test_completion_short_option_for_command(autocomplete):
 
     res, env = autocomplete("pip search -", "2")
 
-    assert '-h' in options(res.stdout),\
-           "autocomplete function could not complete short options after ``-``"
+    assert "-h" in options(
+        res.stdout
+    ), "autocomplete function could not complete short options after ``-``"
 
 
 def test_completion_files_after_option(autocomplete, data):

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -99,7 +99,8 @@ def autocomplete(autocomplete_script, monkeypatch):
     return do_autocomplete
 
 
-def options(autocomplete_output):
+def option_descriptions(autocomplete_output):
+    """Parse a dict of option_name: description from the autocomplete output"""
     return {
         line.partition(DELIMITER)[0]: line.partition(DELIMITER)[2]
         for line in autocomplete_output.splitlines()
@@ -131,8 +132,8 @@ def test_completion_for_un_snippet(autocomplete):
     """
 
     res, env = autocomplete("pip un", "1")
-    assert list(options(res.stdout)) == ["uninstall"], res.stdout
-    assert options(res.stdout)["uninstall"] == "Uninstall packages."
+    assert list(option_descriptions(res.stdout)) == ["uninstall"], res.stdout
+    assert option_descriptions(res.stdout)["uninstall"] == "Uninstall packages."
 
 
 def test_completion_for_default_parameters(autocomplete):
@@ -141,11 +142,11 @@ def test_completion_for_default_parameters(autocomplete):
     """
 
     res, env = autocomplete("pip --", "1")
-    assert "--help" in options(
+    assert "--help" in option_descriptions(
         res.stdout
     ), "autocomplete function could not complete ``--``"
     assert (
-        options(res.stdout)["--help"] == "Show help."
+        option_descriptions(res.stdout)["--help"] == "Show help."
     ), "autocomplete function could not show option description"
 
 
@@ -157,7 +158,7 @@ def test_completion_option_for_command(autocomplete):
     res, env = autocomplete("pip search --", "2")
     assert "--help" in res.stdout, "autocomplete function could not complete ``--``"
     assert (
-        options(res.stdout)["--help"] == "Show help."
+        option_descriptions(res.stdout)["--help"] == "Show help."
     ), "autocomplete function could not show long option description"
 
 
@@ -168,11 +169,11 @@ def test_completion_short_option(autocomplete):
 
     res, env = autocomplete("pip -", "1")
 
-    assert "-h" in options(
+    assert "-h" in option_descriptions(
         res.stdout
     ), "autocomplete function could not complete short options after ``-``"
     assert (
-        options(res.stdout)["-h"] == "Show help."
+        option_descriptions(res.stdout)["-h"] == "Show help."
     ), "autocomplete function could not show short option description"
 
 
@@ -184,7 +185,7 @@ def test_completion_short_option_for_command(autocomplete):
 
     res, env = autocomplete("pip search -", "2")
 
-    assert "-h" in options(
+    assert "-h" in option_descriptions(
         res.stdout
     ), "autocomplete function could not complete short options after ``-``"
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Added descriptions to fish completions to start progress on #5481 
Couldn't quite get zsh working so for now it cuts them off (so does bash but that's the end behaviour)

![image](https://user-images.githubusercontent.com/6463334/95375818-d8f06480-08e8-11eb-9af3-c77654c0bab2.png)
![image](https://user-images.githubusercontent.com/6463334/95376539-ece89600-08e9-11eb-9c48-b707f2732dee.png)

To packages completed by `show`/`uninstall` I added the version numbers, don't know if it adds or confuses but I think it's neat
![image](https://user-images.githubusercontent.com/6463334/95375872-ed346180-08e8-11eb-94b2-1672db823ec5.png)
