### PR TITLE
Fix docs for trusted-host in config file

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -649,8 +649,8 @@ which can be written on multiple lines:
         http://mirror2.example.com
 
     trusted-host =
-        http://mirror1.example.com
-        http://mirror2.example.com
+        mirror1.example.com
+        mirror2.example.com
 
 This enables users to add additional values in the order of entry for such command line arguments.
 


### PR DESCRIPTION
I had a `trusted-host` defined in my `pip.conf` like so:

`trusted-host = https://pypi.org`

However when running `pip install curio` I still got the error:
```Could not fetch URL https://pypi.org/simple/curio/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/curio/ (Caused by SSLError(SSLError(1, u'[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:727)'),)) - skipping```

Dropping the `https://` and simply defining it as `trusted-host = pypi.org` fixed the issue and allowed me to install successfully. This matches the usage in a popular [stackoverflow answer](https://stackoverflow.com/a/29751768) where the `https://` is also not present.