### PR TITLE
Fix new resolver upgrades when not needed to

### DIFF
--- a/news/8963.bugfix.rst
+++ b/news/8963.bugfix.rst
@@ -1,0 +1,2 @@
+Correctly search for installed distributions in new resolver logic in order
+to not miss packages (virtualenv packages from system-wide-packages for example)

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -98,9 +98,15 @@ class Factory(object):
         self._editable_candidate_cache = {}  # type: Cache[EditableCandidate]
 
         if not ignore_installed:
+            packages = get_installed_distributions(
+                local_only=False,
+                include_editables=True,
+                editables_only=False,
+                user_only=False,
+                paths=None,
+            )
             self._installed_dists = {
-                canonicalize_name(dist.project_name): dist
-                for dist in get_installed_distributions()
+                canonicalize_name(p.key): p for p in packages
             }
         else:
             self._installed_dists = {}


### PR DESCRIPTION
Closes #8963 
Seems like the new resolver did not get the already installed requirements correctly...
I changed it to the way it works in `_search_distribution` in `misc.py:489`

I did not add tests, as I am not sure what is the correct way to test this