### PR TITLE
Add support for $EDITOR with arguments

### DIFF
--- a/news/9010.feature.rst
+++ b/news/9010.feature.rst
@@ -1,0 +1,2 @@
+Add support for $EDITOR with arguments
+

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shlex
 import subprocess
 
 from pip._internal.cli.base_command import Command
@@ -233,7 +234,7 @@ class ConfigurationCommand(Command):
             raise PipError("Could not determine appropriate file.")
 
         try:
-            subprocess.check_call([editor, fname])
+            subprocess.check_call(shlex.split(editor) + [fname])
         except subprocess.CalledProcessError as e:
             raise PipError(
                 "Editor Subprocess exited with exit code {}"


### PR DESCRIPTION
"pip config edit" doesn't work if "$EDITOR" also provides an argument for the editor. This commit fixes that.
The common example is "EDITOR=code -w", which is useful to have vscode as the editor for "git commit".
The "-w" ensures that the "code" process doesn't exit until the tab for the edited file is closed.

I need a PR number to create the NEWS fragment (since there is no issue) so will add that immediately after opening the PR