### PR TITLE
Update docs for less common news extension

### DIFF
--- a/docs/html/development/contributing.rst
+++ b/docs/html/development/contributing.rst
@@ -109,22 +109,22 @@ A trivial change is anything that does not warrant an entry in the news file.
 Some examples are: Code refactors that don't change anything as far as the
 public is concerned, typo fixes, white space modification, etc. To mark a PR
 as trivial a contributor simply needs to add a randomly named, empty file to
-the ``news/`` directory with the extension of ``.trivial``. If you are on a
+the ``news/`` directory with the extension of ``.trivial.rst``. If you are on a
 POSIX like operating system, one can be added by running
-``touch news/$(uuidgen).trivial``. On Windows, the same result can be achieved
-in Powershell using ``New-Item "news/$([guid]::NewGuid()).trivial"``. Core
-committers may also add a "trivial" label to the PR which will accomplish the
-same thing.
+``touch news/$(uuidgen).trivial.rst``. On Windows, the same result can be
+achieved in Powershell using ``New-Item "news/$([guid]::NewGuid()).trivial"``.
+Core committers may also add a "trivial" label to the PR which will accomplish
+the same thing.
 
 Upgrading, removing, or adding a new vendored library gets a special mention
-using a ``news/<library>.vendor`` file. This is in addition to any features,
+using a ``news/<library>.vendor.rst`` file. This is in addition to any features,
 bugfixes, or other kinds of news that pulling in this library may have. This
 uses the library name as the key so that updating the same library twice doesn't
 produce two news file entries.
 
 Changes to the processes, policies, or other non code related changed that are
-otherwise notable can be done using a ``news/<name>.process`` file. This is not
-typically used, but can be used for things like changing version schemes,
+otherwise notable can be done using a ``news/<name>.process.rst`` file. This is
+not typically used, but can be used for things like changing version schemes,
 updating deprecation policy, etc.
 
 


### PR DESCRIPTION
Namely trivial, vendor and process.  These were missed during the trasition to *.rst news fragment.

This follows up on GH-8147.  Interestingly though, the news/pr check fails for this one.