### PR TITLE
Log an informational message when backtracking takes multiple rounds on a specific package

### DIFF
--- a/news/8975.feature.rst
+++ b/news/8975.feature.rst
@@ -1,0 +1,1 @@
+Log an informational message when backtracking takes multiple rounds on a specific package.

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -35,7 +35,7 @@ class PipReporter(BaseReporter):
                 "This is taking longer than usual. You might need to provide the "
                 "dependency resolver with stricter constraints to reduce runtime."
                 "If you want to abort this run, you can press Ctrl + C to do so."
-                "To improve how pip performs, tell us that this happened here: "
+                "To improve how pip performs, tell us what happened here: "
                 "https://pip.pypa.io/surveys/backtracking"
             )
         }

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -21,6 +21,11 @@ class PipReporter(BaseReporter):
         self.backtracks_by_package = defaultdict(int)  # type: DefaultDict[str, int]
 
         self._messages_at_backtrack = {
+            1: (
+                "pip is looking at multiple versions of this package to determine "
+                "which version is compatible with other requirements. "
+                "This could take a while."
+            ),
             8: (
                 "pip is looking at multiple versions of this package to determine "
                 "which version is compatible with other requirements. "

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -1,0 +1,35 @@
+from collections import defaultdict
+from logging import getLogger
+
+from pip._vendor.resolvelib.reporters import BaseReporter
+
+logger = getLogger(__name__)
+
+
+class PipReporter(BaseReporter):
+
+    def __init__(self):
+        self.backtracks_by_package = defaultdict(int)
+
+        self._messages_at_backtrack = {
+            8: (
+                "pip is looking at multiple versions of this package to determine "
+                "which version is compatible with other requirements. "
+                "This could take a while."
+            ),
+            13: (
+                "This is taking longer than usual. You might need to provide the "
+                "dependency resolver with stricter constraints to reduce runtime."
+                "If you want to abort this run, you can press Ctrl + C to do so."
+            )
+        }
+
+    def backtracking(self, candidate):
+        self.backtracks_by_package[candidate.name] += 1
+
+        count = self.backtracks_by_package[candidate.name]
+        if count not in self._messages_at_backtrack:
+            return
+
+        message = self._messages_at_backtrack[count]
+        logger.info(message)

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -35,6 +35,8 @@ class PipReporter(BaseReporter):
                 "This is taking longer than usual. You might need to provide the "
                 "dependency resolver with stricter constraints to reduce runtime."
                 "If you want to abort this run, you can press Ctrl + C to do so."
+                "To improve how pip performs, tell us that this happened here: "
+                "https://pip.pypa.io/surveys/backtracking"
             )
         }
 

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -47,4 +47,4 @@ class PipReporter(BaseReporter):
             return
 
         message = self._messages_at_backtrack[count]
-        logger.info(message)
+        logger.info("INFO: %s", message)

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -3,13 +3,22 @@ from logging import getLogger
 
 from pip._vendor.resolvelib.reporters import BaseReporter
 
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import DefaultDict
+
+    from .base import Candidate
+
+
 logger = getLogger(__name__)
 
 
 class PipReporter(BaseReporter):
 
     def __init__(self):
-        self.backtracks_by_package = defaultdict(int)
+        # type: () -> None
+        self.backtracks_by_package = defaultdict(int)  # type: DefaultDict[str, int]
 
         self._messages_at_backtrack = {
             8: (
@@ -25,6 +34,7 @@ class PipReporter(BaseReporter):
         }
 
     def backtracking(self, candidate):
+        # type: (Candidate) -> None
         self.backtracks_by_package[candidate.name] += 1
 
         count = self.backtracks_by_package[candidate.name]

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -3,7 +3,7 @@ import logging
 
 from pip._vendor import six
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
+from pip._vendor.resolvelib import ResolutionImpossible
 from pip._vendor.resolvelib import Resolver as RLResolver
 
 from pip._internal.exceptions import InstallationError
@@ -11,6 +11,7 @@ from pip._internal.req.req_install import check_invalid_constraint_type
 from pip._internal.req.req_set import RequirementSet
 from pip._internal.resolution.base import BaseResolver
 from pip._internal.resolution.resolvelib.provider import PipProvider
+from pip._internal.resolution.resolvelib.reporter import PipReporter
 from pip._internal.utils.misc import dist_is_editable
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -103,7 +104,7 @@ class Resolver(BaseResolver):
             upgrade_strategy=self.upgrade_strategy,
             user_requested=user_requested,
         )
-        reporter = BaseReporter()
+        reporter = PipReporter()
         resolver = RLResolver(provider, reporter)
 
         try:

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -1048,7 +1048,7 @@ def test_new_resolver_prefers_installed_in_upgrade_if_latest(script):
     assert_installed(script, pkg="2")
 
 
-@pytest.mark.parametrize("N", [10, 20])
+@pytest.mark.parametrize("N", [2, 10, 20])
 def test_new_resolver_presents_messages_when_backtracking_a_lot(script, N):
     # Generate a set of wheels that will definitely cause backtracking.
     for index in range(1, N+1):
@@ -1087,7 +1087,10 @@ def test_new_resolver_presents_messages_when_backtracking_a_lot(script, N):
     )
 
     assert_installed(script, A="1.0.0", B="1.0.0", C="1.0.0")
-    if N >= 8:  # this number is hard-coded in the code too.
+    # These numbers are hard-coded in the code.
+    if N >= 1:
         assert "This could take a while." in result.stdout
-    if N >= 13:  # this number is hard-coded in the code too.
+    if N >= 8:
+        assert result.stdout.count("This could take a while.") >= 2
+    if N >= 13:
         assert "press Ctrl + C" in result.stdout


### PR DESCRIPTION
Closes #8975 
Toward #8713

Deviates from @ei8fdb's suggestion by using different messages when hitting the "trigger" numbers:

> pip is looking at multiple versions of this package to determine
> which version is compatible with other requirements.
> This could take a while.

> This is taking longer than usual. You might need to provide the
> dependency resolver with stricter constraints to reduce runtime.
> If you want to abort this run, you can press Ctrl + C to do so.

Further, this also doesn't constantly print the same message (based on some prototyping + having implemented this) and instead prints it only when the actual "trigger" number occurs.