### PR TITLE
Feature: Add completion script for powershell

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -496,6 +496,10 @@ To setup for fish::
 
     python -m pip completion --fish > ~/.config/fish/completions/pip.fish
 
+To setup for powershell::
+
+   python -m pip completion --posh | Out-File -Encoding default -Append $PROFILE
+
 Alternatively, you can use the result of the ``completion`` command directly
 with the eval function of your shell, e.g. by adding the following to your
 startup file::

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -498,7 +498,7 @@ To setup for fish::
 
 To setup for powershell::
 
-   python -m pip completion --posh | Out-File -Encoding default -Append $PROFILE
+   python -m pip completion --powershell | Out-File -Encoding default -Append $PROFILE
 
 Alternatively, you can use the result of the ``completion`` command directly
 with the eval function of your shell, e.g. by adding the following to your

--- a/news/9024.feature.rst
+++ b/news/9024.feature.rst
@@ -1,0 +1,1 @@
+Add support for Powershell autocompletion.

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -43,6 +43,28 @@ COMPLETION_SCRIPTS = {
         end
         complete -fa "(__fish_complete_pip)" -c {prog}
     """,
+    "posh": """
+        if ((Test-Path Function:\\TabExpansion) -and -not `
+            (Test-Path Function:\\_pip_completeBackup)) {{
+            Rename-Item Function:\\TabExpansion _pip_completeBackup
+        }}
+        function TabExpansion($line, $lastWord) {{
+            $lastBlock = [regex]::Split($line, '[|;]')[-1].TrimStart()
+            if ($lastBlock.StartsWith("{prog} ")) {{
+                $Env:COMP_WORDS=$lastBlock
+                $Env:COMP_CWORD=$lastBlock.Split().Length - 1
+                $Env:PIP_AUTO_COMPLETE=1
+                (& {prog}).Split()
+                Remove-Item Env:COMP_WORDS
+                Remove-Item Env:COMP_CWORD
+                Remove-Item Env:PIP_AUTO_COMPLETE
+            }}
+            elseif (Test-Path Function:\\_pip_completeBackup) {{
+                # Fall back on existing tab expansion
+                _pip_completeBackup $line $lastWord
+            }}
+        }}
+    """,
 }
 
 
@@ -75,6 +97,14 @@ class CompletionCommand(Command):
             const="fish",
             dest="shell",
             help="Emit completion code for fish",
+        )
+        self.cmd_opts.add_option(
+            "--posh",
+            "-p",
+            action="store_const",
+            const="posh",
+            dest="shell",
+            help="Emit completion code for powershell",
         )
 
         self.parser.insert_option_group(0, self.cmd_opts)

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -43,7 +43,7 @@ COMPLETION_SCRIPTS = {
         end
         complete -fa "(__fish_complete_pip)" -c {prog}
     """,
-    "posh": """
+    "powershell": """
         if ((Test-Path Function:\\TabExpansion) -and -not `
             (Test-Path Function:\\_pip_completeBackup)) {{
             Rename-Item Function:\\TabExpansion _pip_completeBackup
@@ -99,10 +99,10 @@ class CompletionCommand(Command):
             help="Emit completion code for fish",
         )
         self.cmd_opts.add_option(
-            "--posh",
+            "--powershell",
             "-p",
             action="store_const",
-            const="posh",
+            const="powershell",
             dest="shell",
             help="Emit completion code for powershell",
         )

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -47,25 +47,25 @@ compctl -K _pip_completion pip""",
         "posh",
         """\
 if ((Test-Path Function:\\TabExpansion) -and -not `
-    (Test-Path Function:\\_pip_completeBackup)) {{
+    (Test-Path Function:\\_pip_completeBackup)) {
     Rename-Item Function:\\TabExpansion _pip_completeBackup
-}}
-function TabExpansion($line, $lastWord) {{
+}
+function TabExpansion($line, $lastWord) {
     $lastBlock = [regex]::Split($line, '[|;]')[-1].TrimStart()
-    if ($lastBlock.StartsWith("{prog} ")) {{
+    if ($lastBlock.StartsWith("pip ")) {
         $Env:COMP_WORDS=$lastBlock
         $Env:COMP_CWORD=$lastBlock.Split().Length - 1
         $Env:PIP_AUTO_COMPLETE=1
-        (& {prog}).Split()
+        (& pip).Split()
         Remove-Item Env:COMP_WORDS
         Remove-Item Env:COMP_CWORD
         Remove-Item Env:PIP_AUTO_COMPLETE
-    }}
-    elseif (Test-Path Function:\\_pip_completeBackup) {{
+    }
+    elseif (Test-Path Function:\\_pip_completeBackup) {
         # Fall back on existing tab expansion
         _pip_completeBackup $line $lastWord
-    }}
-}}""",
+    }
+}""",
     ),
 )
 

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -135,7 +135,7 @@ def test_completion_alone(autocomplete_script):
     """
     result = autocomplete_script.pip("completion", allow_stderr_error=True)
     assert (
-        "ERROR: You must pass --bash or --fish or --zsh or --posh" in result.stderr
+        "ERROR: You must pass --bash or --fish or --posh or --zsh" in result.stderr
     ), ("completion alone failed -- " + result.stderr)
 
 

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -44,7 +44,7 @@ function _pip_completion {
 compctl -K _pip_completion pip""",
     ),
     (
-        "posh",
+        "powershell",
         """\
 if ((Test-Path Function:\\TabExpansion) -and -not `
     (Test-Path Function:\\_pip_completeBackup)) {
@@ -135,7 +135,8 @@ def test_completion_alone(autocomplete_script):
     """
     result = autocomplete_script.pip("completion", allow_stderr_error=True)
     assert (
-        "ERROR: You must pass --bash or --fish or --posh or --zsh" in result.stderr
+        "ERROR: You must pass --bash or --fish or --powershell or --zsh"
+        in result.stderr
     ), ("completion alone failed -- " + result.stderr)
 
 
@@ -325,7 +326,7 @@ def test_completion_path_after_option(autocomplete, data):
     )
 
 
-@pytest.mark.parametrize("flag", ["--bash", "--zsh", "--fish", "--posh"])
+@pytest.mark.parametrize("flag", ["--bash", "--zsh", "--fish", "--powershell"])
 def test_completion_uses_same_executable_name(
     autocomplete_script, flag, deprecated_python
 ):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

This patch adds an option `--posh` to `pip completion` and the completion works perfectly on my machine(Windows 10 and Powershell 5.1.19041.1)

Close #9024 

**Things need to be polished or discussed:**

- ~I pick a common short name `--posh` for Powershell, tell me if you prefer the full version: `--powershell`.~
- The completion may work unexpectedly if one adds more than one completion snippets(say `python -m pip` and `pip`). It is caused by the fixed name of the backup function. To overcome this, we need a unique name for each `prog`. As a result, we should feed a second value to the template besides `prog`. But since the current implementation works for most cases so I would like to ask for maintainers' opinion on this.