### PR TITLE
Avoid AssertionError in pip freeze with editable direct URLs

### DIFF
--- a/news/8996.bugfix.rst
+++ b/news/8996.bugfix.rst
@@ -1,0 +1,3 @@
+Do not fail in pip freeze when encountering a ``direct_url.jso`` metadata file
+with editable=True. Render it as a non-editable ``file://`` URL until modern
+editable installs are standardized and supported.

--- a/news/8996.bugfix.rst
+++ b/news/8996.bugfix.rst
@@ -1,3 +1,3 @@
-Do not fail in pip freeze when encountering a ``direct_url.jso`` metadata file
+Do not fail in pip freeze when encountering a ``direct_url.json`` metadata file
 with editable=True. Render it as a non-editable ``file://`` URL until modern
 editable installs are standardized and supported.

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -43,10 +43,6 @@ def direct_url_as_pep440_direct_reference(direct_url, name):
             fragments.append(direct_url.info.hash)
     else:
         assert isinstance(direct_url.info, DirInfo)
-        # pip should never reach this point for editables, since
-        # pip freeze inspects the editable project location to produce
-        # the requirement string
-        assert not direct_url.info.editable
         requirement += direct_url.url
     if direct_url.subdirectory:
         fragments.append("subdirectory=" + direct_url.subdirectory)

--- a/tests/unit/test_direct_url_helpers.py
+++ b/tests/unit/test_direct_url_helpers.py
@@ -55,6 +55,21 @@ def test_as_pep440_requirement_dir():
     )
 
 
+def test_as_pep440_requirement_editable_dir():
+    # direct_url_as_pep440_direct_reference behaves the same
+    # irrespective of the editable flag. It's the responsibility of
+    # callers to render it as editable
+    direct_url = DirectUrl(
+        url="file:///home/user/project",
+        info=DirInfo(editable=True),
+    )
+    direct_url.validate()
+    assert (
+        direct_url_as_pep440_direct_reference(direct_url, "pkg") ==
+        "pkg @ file:///home/user/project"
+    )
+
+
 def test_as_pep440_requirement_vcs():
     direct_url = DirectUrl(
         url="https:///g.c/u/p.git",


### PR DESCRIPTION
Do not fail in pip freeze when encountering a direct_url.json metadata file with
editable=True. Render it as a non-editable ``file://`` URL until modern
editable installs are standardized and supported.

Fixes #8996 