### PR TITLE
CI: Move MacOS tests to GitHub Actions

### DIFF
--- a/.azure-pipelines/macos.yml
+++ b/.azure-pipelines/macos.yml
@@ -1,7 +1,0 @@
-variables:
-  CI: true
-
-jobs:
-- template: jobs/package.yml
-  parameters:
-    vmImage: macos-10.14

--- a/.azure-pipelines/macos.yml
+++ b/.azure-pipelines/macos.yml
@@ -2,10 +2,6 @@ variables:
   CI: true
 
 jobs:
-- template: jobs/test.yml
-  parameters:
-    vmImage: macos-10.14
-
 - template: jobs/package.yml
   parameters:
     vmImage: macos-10.14

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,7 +19,6 @@ jobs:
         os:
         - Ubuntu
         - Windows
-        - MacOS
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -135,4 +135,4 @@ jobs:
         -m integration
         --verbose
         --numprocesses auto
-        --duration=5
+        --durations=5

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: CI
+name: MacOS
 
 on:
   push:
@@ -11,12 +11,8 @@ on:
 
 jobs:
   dev-tools:
-    name: Quality Check / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}-latest
-
-    strategy:
-      matrix:
-        os: [MacOS]
+    name: Quality Check
+    runs-on: macos-latest
 
     steps:
     # Caches
@@ -39,7 +35,7 @@ jobs:
     # Setup
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
@@ -50,12 +46,8 @@ jobs:
     - run: python -m tox -e "lint,docs"
 
   packaging:
-    name: Packaging / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}-latest
-
-    strategy:
-      matrix:
-        os: [MacOS]
+    name: Packaging
+    runs-on: macos-latest
 
     steps:
     # Caches
@@ -74,7 +66,7 @@ jobs:
         git config --global user.name "pip"
     - uses: actions/checkout@v2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install tox and nox
@@ -91,15 +83,14 @@ jobs:
       run: nox -s build-release -- 99.9
 
   tests:
-    name: Tests / ${{ matrix.python }} / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}-latest
+    name: Tests / ${{ matrix.python }}
+    runs-on: macos-latest
 
     needs: dev-tools
 
     strategy:
       fail-fast: false
       matrix:
-        os: [MacOS]
         python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
@@ -114,7 +105,7 @@ jobs:
           ${{ runner.os }}-
     # Setup
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,138 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  schedule:
+  # Run every Friday at 18:02 UTC
+  - cron: 2 18 * * 5
+
+jobs:
+  dev-tools:
+    name: Quality Check / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+
+    strategy:
+      matrix:
+        os: [MacOS]
+
+    steps:
+    # Caches
+    - name: pip cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('tools/requirements/tests.txt') }}-${{ hashFiles('tools/requirements/docs.txt') }}-${{ hashFiles('tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+    - name: Set PY (for pre-commit cache)
+      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+    - name: pre-commit cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|2020-02-14|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+    # Setup
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install tox
+      run: python -m pip install tox
+
+    # Main check
+    - run: python -m tox -e "lint,docs"
+
+  packaging:
+    name: Packaging / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+
+    strategy:
+      matrix:
+        os: [MacOS]
+
+    steps:
+    # Caches
+    - name: pip cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('tools/requirements/tests.txt') }}-${{ hashFiles('tools/requirements/docs.txt') }}-${{ hashFiles('tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+    # Setup
+    - name: Set up git credentials
+      run: |
+        git config --global user.email "pypa-dev@googlegroups.com"
+        git config --global user.name "pip"
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install tox and nox
+      run: python -m pip install tox nox
+
+    # Main check
+    - name: Check vendored packages
+      run: python -m tox -e "vendoring"
+
+    - name: Prepare dummy release
+      run: nox -s prepare-release -- 99.9
+
+    - name: Generate distributions for the dummy release
+      run: nox -s build-release -- 99.9
+
+  tests:
+    name: Tests / ${{ matrix.python }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+
+    needs: dev-tools
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [MacOS]
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    # Caches
+    - name: pip cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('tools/requirements/tests.txt') }}-${{ hashFiles('tools/requirements/docs.txt') }}-${{ hashFiles('tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+    # Setup
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Install tox
+      run: python -m pip install tox 'virtualenv<20'
+
+    # Main check
+    - name: Run unit tests
+      run: >-
+        python -m tox -e py --
+        -m unit
+        --verbose
+        --numprocesses auto
+
+    - name: Run integration tests
+      run: >-
+        python -m tox -e py --
+        -m integration
+        --verbose
+        --numprocesses auto
+        --duration=5


### PR DESCRIPTION
Closes #9030.

This PR moves our CI pipeline for testing MacOS to GitHub Actions. We'll have 5 workers, which isn't enough for even 1 PR running fully-parallel, but it should still be faster than our Azure Pipelines Windows runs.