### PR TITLE
Fix trivial news file generation on windows

### DIFF
--- a/docs/html/development/contributing.rst
+++ b/docs/html/development/contributing.rst
@@ -112,7 +112,7 @@ as trivial a contributor simply needs to add a randomly named, empty file to
 the ``news/`` directory with the extension of ``.trivial.rst``. If you are on a
 POSIX like operating system, one can be added by running
 ``touch news/$(uuidgen).trivial.rst``. On Windows, the same result can be
-achieved in Powershell using ``New-Item "news/$([guid]::NewGuid()).trivial"``.
+achieved in Powershell using ``New-Item "news/$([guid]::NewGuid()).trivial.rst"``.
 Core committers may also add a "trivial" label to the PR which will accomplish
 the same thing.
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
