### PR TITLE
Add --exclude option to pip freeze and pip list commands

### DIFF
--- a/news/4256.feature.rst
+++ b/news/4256.feature.rst
@@ -1,0 +1,1 @@
+Add ``--exclude`` option to ``pip freeze`` and ``pip list`` commands to explicitly exclude packages from the output.

--- a/news/4256.removal.rst
+++ b/news/4256.removal.rst
@@ -1,0 +1,2 @@
+``pip freeze`` will stop filtering the ``pip``, ``setuptools``, ``distribute`` and ``wheel`` packages from ``pip freeze`` output in a future version.
+To keep the previous behavior, users should use the new ``--exclude`` option.

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -74,6 +74,7 @@ class FreezeCommand(Command):
             dest='exclude_editable',
             action='store_true',
             help='Exclude editable package from output.')
+        self.cmd_opts.add_option(cmdoptions.list_exclude())
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -84,6 +85,9 @@ class FreezeCommand(Command):
         skip = set(stdlib_pkgs)
         if not options.freeze_all:
             skip.update(DEV_PKGS)
+
+        if options.excludes:
+            skip.update(options.excludes)
 
         cmdoptions.check_list_path_option(options)
 

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -12,6 +12,7 @@ from pip._internal.exceptions import CommandError
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
+from pip._internal.utils.compat import stdlib_pkgs
 from pip._internal.utils.misc import (
     dist_is_editable,
     get_installed_distributions,
@@ -114,6 +115,7 @@ class ListCommand(IndexGroupCommand):
             help='Include editable package from output.',
             default=True,
         )
+        self.cmd_opts.add_option(cmdoptions.list_exclude())
         index_opts = cmdoptions.make_option_group(
             cmdoptions.index_group, self.parser
         )
@@ -147,12 +149,17 @@ class ListCommand(IndexGroupCommand):
 
         cmdoptions.check_list_path_option(options)
 
+        skip = set(stdlib_pkgs)
+        if options.excludes:
+            skip.update(options.excludes)
+
         packages = get_installed_distributions(
             local_only=options.local,
             user_only=options.user,
             editables_only=options.editable,
             include_editables=options.include_editable,
             paths=options.path,
+            skip=skip,
         )
 
         # get_not_required must be called firstly in order to find and

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from tests.lib import create_test_package_with_setup
+from tests.lib import create_test_package_with_setup, wheel
 from tests.lib.path import Path
 
 
@@ -92,6 +92,19 @@ def test_local_columns_flag(simple_script):
     assert 'Version' in result.stdout
     assert 'simple (1.0)' not in result.stdout
     assert 'simple     1.0' in result.stdout, str(result)
+
+
+def test_multiple_exclude_and_normalization(script, tmpdir):
+    req_path = wheel.make_wheel(
+        name="Normalizable_Name", version="1.0").save_to_dir(tmpdir)
+    script.pip("install", "--no-index", req_path)
+    result = script.pip("list")
+    print(result.stdout)
+    assert "Normalizable-Name" in result.stdout
+    assert "pip" in result.stdout
+    result = script.pip("list", "--exclude", "normalizablE-namE", "--exclude", "pIp")
+    assert "Normalizable-Name" not in result.stdout
+    assert "pip" not in result.stdout
 
 
 @pytest.mark.network


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
