### PR TITLE
Explicitly state that pip/_vendor/vendor.txt should be available

### DIFF
--- a/news/8327.vendor.rst
+++ b/news/8327.vendor.rst
@@ -1,0 +1,2 @@
+Fix devendoring instructions to explicitly state that ``vendor.txt`` should not be removed.
+It is mandatory for ``pip debug`` command.

--- a/src/pip/_vendor/README.rst
+++ b/src/pip/_vendor/README.rst
@@ -132,7 +132,7 @@ semi-supported method (that we don't test in our CI) and requires a bit of
 extra work on your end in order to solve the problems described above.
 
 1. Delete everything in ``pip/_vendor/`` **except** for
-   ``pip/_vendor/__init__.py``.
+   ``pip/_vendor/__init__.py`` and ``pip/_vendor/vendor.txt``.
 2. Generate wheels for each of pip's dependencies (and any of their
    dependencies) using your patched copies of these libraries. These must be
    placed somewhere on the filesystem that pip can access (``pip/_vendor`` is


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
