### PR TITLE
Change where the 2020 resolver warning is logged

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -10,6 +10,8 @@ import platform
 import sys
 import traceback
 
+from pip._vendor.six import PY2
+
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.command_context import CommandContextMixIn
 from pip._internal.cli.parser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
@@ -203,6 +205,13 @@ class Command(CommandContextMixIn):
                 "has been replaced with --use-feature=2020-resolver instead."
             )
             sys.exit(ERROR)
+
+        if '2020-resolver' in options.features_enabled and not PY2:
+            logger.warning(
+                "--use-feature=2020-resolver no longer has any effect, "
+                "since it is now the default dependency resolver in pip. "
+                "This will become an error in pip 21.0."
+            )
 
         try:
             status = self.run(options, args)

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -208,14 +208,6 @@ class RequirementCommand(IndexGroupCommand):
             else:
                 return "legacy"
 
-        # Warn about the options that are gonna be removed.
-        if '2020-resolver' in options.features_enabled:
-            logger.warning(
-                "--use-feature=2020-resolver no longer has any effect, "
-                "since it is now the default dependency resolver in pip. "
-                "This will become an error in pip 21.0."
-            )
-
         if "legacy-resolver" in options.deprecated_features_enabled:
             return "legacy"
 


### PR DESCRIPTION
This helps avoid duplicating the "hey, 2020-resolver is old now" warning.