### PR TITLE
resolver: stabilize output for tests (& users)

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -421,7 +421,7 @@ class Factory(object):
             triggers.append(trigger)
 
         if triggers:
-            info = text_join(triggers)
+            info = text_join(sorted(triggers))
         else:
             info = "the requested packages"
 


### PR DESCRIPTION
Otherwise the `test_install_distribution_union_with_versions` test can end
up with either:

    Cannot install localextras[bar] 0.0.2 and localextras[baz] 0.0.1 because these package versions have conflicting dependencies.

or

    Cannot install localextras[baz] 0.0.2 and localextras[bar] 0.0.1 because these package versions have conflicting dependencies.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
