### PR TITLE
Cache find best candidate

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -863,6 +863,7 @@ class PackageFinder(object):
             hashes=hashes,
         )
 
+    @lru_cache(maxsize=None)
     def find_best_candidate(
         self,
         project_name,       # type: str

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -39,7 +39,12 @@ class Hashes(object):
         :param hashes: A dict of algorithm names pointing to lists of allowed
             hex digests
         """
-        self._allowed = {} if hashes is None else hashes
+        allowed = {}
+        if hashes is not None:
+            for alg, keys in hashes.items():
+                # Make sure values are always sorted (to ease equality checks)
+                allowed[alg] = sorted(keys)
+        self._allowed = allowed
 
     def __and__(self, other):
         # type: (Hashes) -> Hashes
@@ -127,6 +132,22 @@ class Hashes(object):
     def __bool__(self):
         # type: () -> bool
         return self.__nonzero__()
+
+    def __eq__(self, other):
+        # type: (object) -> bool
+        if not isinstance(other, Hashes):
+            return NotImplemented
+        return self._allowed == other._allowed
+
+    def __hash__(self):
+        # type: () -> int
+        return hash(
+            ",".join(sorted(
+                ":".join((alg, digest))
+                for alg, digest_list in self._allowed.items()
+                for digest in digest_list
+            ))
+        )
 
 
 class MissingHashes(Hashes):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -541,6 +541,16 @@ class TestHashes(object):
         assert not Hashes()
         assert not Hashes({})
 
+    def test_equality(self):
+        assert Hashes() == Hashes()
+        assert Hashes({'sha256': ['abcd']}) == Hashes({'sha256': ['abcd']})
+        assert Hashes({'sha256': ['ab', 'cd']}) == Hashes({'sha256': ['cd', 'ab']})
+
+    def test_hash(self):
+        cache = {}
+        cache[Hashes({'sha256': ['ab', 'cd']})] = 42
+        assert cache[Hashes({'sha256': ['ab', 'cd']})] == 42
+
 
 class TestEncoding(object):
     """Tests for pip._internal.utils.encoding"""


### PR DESCRIPTION
 Cache find_best_candidate results

This is possible because self.make_candidate_evaluator only depends
on:
- the function arguments which are keys to the cache
- self._target_python which never changes during a pip resolution
- self._candidate_prefs which never changes during a pip resolution

On a fresh install, pip install <a package with ~ 100 dependencies>
runs on my machine in:

master (a0e34e9)
=======================

0m33.058s
0m34.105s
0m32.426s

This commit
===========

0m15.860s
0m16.254s
0m15.910s

pip 20.2.4 - legacy resolver
============================

0m15.145s
0m15.040s
0m15.152s