### PR TITLE
Use packaging.version to check version equality

### DIFF
--- a/news/9083.bugfix.rst
+++ b/news/9083.bugfix.rst
@@ -1,0 +1,3 @@
+New resolver: Check version equality with ``packaging.version`` to avoid edge
+cases if a wheel used different version normalization logic in its filename
+and metadata.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -283,9 +283,10 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             )
             # Version may not be present for PEP 508 direct URLs
             if version is not None:
-                assert str(version) == wheel.version, (
+                wheel_version = Version(wheel.version)
+                assert version == wheel_version, (
                     "{!r} != {!r} for wheel {}".format(
-                        version, wheel.version, name
+                        version, wheel_version, name
                     )
                 )
 


### PR DESCRIPTION
Fix #9083. I’m 99.999% sure the fix is correct, but didn’t include a test since it’s late here and I have to get up early tomorrow. I’ll leave this to someone with more time 🙂 