### PR TITLE
Use git's partial clone feature to speed up pip

### DIFF
--- a/news/9086.feature.rst
+++ b/news/9086.feature.rst
@@ -1,0 +1,1 @@
+When a revision is specified in a Git URL, use git's partial clone feature to speed up source retrieval.


### PR DESCRIPTION
Clone with --filter=blob:none - as it fetches all
metadata, but only dynamically fetches the blobs as
needed by checkout. Since typically, pip only needs the blobs for
a single revision, this can be a big improvement, especially
when fetching from repositories with a lot of history,
particularly on slower network connections.

Added unit test for the rev-less path. Confirmed that both
of the if/else paths are tested by the unit tests.