### PR TITLE
Build local directories in-place with feature flag

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -808,7 +808,15 @@ You can install local projects by specifying the project path to pip:
 During regular installation, pip will copy the entire project directory to a
 temporary location and install from there. The exception is that pip will
 exclude .tox and .nox directories present in the top level of the project from
-being copied.
+being copied. This approach is the cause of several performance and correctness
+issues, so it is planned that pip 21.3 will change to install directly from the
+local project directory. Depending on the build backend used by the project,
+this may generate secondary build artifacts in the project directory, such as
+the ``.egg-info`` and ``build`` directories in the case of the setuptools
+backend.
+
+To opt in to the future behavior, specify the ``--use-feature=in-tree-build``
+option in pip's command line.
 
 
 .. _`editable-installs`:

--- a/news/9091.feature.rst
+++ b/news/9091.feature.rst
@@ -1,0 +1,4 @@
+Add a feature ``--use-feature=in-tree-build`` to build local projects in-place
+when installing. This is expected to become the default behavior in pip 21.3;
+see `Installing from local packages <https://pip.pypa.io/en/stable/user_guide/#installing-from-local-packages>`_
+for more information.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -951,7 +951,7 @@ use_new_feature = partial(
     metavar="feature",
     action="append",
     default=[],
-    choices=["2020-resolver", "fast-deps"],
+    choices=["2020-resolver", "fast-deps", "in-tree-build"],
     help="Enable new functionality, that may be backward incompatible.",
 )  # type: Callable[..., Option]
 

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -245,6 +245,7 @@ class RequirementCommand(IndexGroupCommand):
             require_hashes=options.require_hashes,
             use_user_site=use_user_site,
             lazy_wheel=lazy_wheel,
+            in_tree_build="in-tree-build" in options.features_enabled,
         )
 
     @classmethod

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -581,6 +581,28 @@ def test_install_from_local_directory_with_symlinks_to_directories(
     result.did_create(dist_info_folder)
 
 
+def test_install_from_local_directory_with_in_tree_build(
+    script, data, with_wheel
+):
+    """
+    Test installing from a local directory with --use-feature=in-tree-build.
+    """
+    to_install = data.packages.joinpath("FSPkg")
+    args = ["install", "--use-feature=in-tree-build", to_install]
+
+    in_tree_build_dir = to_install / "build"
+    assert not in_tree_build_dir.exists()
+    result = script.pip(*args)
+    fspkg_folder = script.site_packages / 'fspkg'
+    dist_info_folder = (
+        script.site_packages /
+        'FSPkg-0.1.dev0.dist-info'
+    )
+    result.did_create(fspkg_folder)
+    result.did_create(dist_info_folder)
+    assert in_tree_build_dir.exists()
+
+
 @pytest.mark.skipif("sys.platform == 'win32' or sys.version_info < (3,)")
 def test_install_from_local_directory_with_socket_file(
     script, data, tmpdir, with_wheel

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -89,6 +89,7 @@ class TestRequirementSet:
                 require_hashes=require_hashes,
                 use_user_site=False,
                 lazy_wheel=False,
+                in_tree_build=False,
             )
             yield Resolver(
                 preparer=preparer,


### PR DESCRIPTION
Adds back a minimal version of #7882 behind a flag `--use-feature=in-tree-build` (as suggested in https://github.com/pypa/pip/issues/7555#issuecomment-664830047).

This is my first contribution to the pip codebase, so this is currently missing docs and tests. I will figure out some tests later. Would appreciate advice on the appropriate way to document this.

cc @sbidoul 

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
