### PR TITLE
Tie-break requirements with package name

### DIFF
--- a/news/9100.feature.rst
+++ b/news/9100.feature.rst
@@ -1,0 +1,1 @@
+The new resolver now resolves packages in a deterministic order.

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -57,7 +57,8 @@ class PipProvider(AbstractProvider):
     ):
         # type: (...) -> Any
         transitive = all(parent is not None for _, parent in information)
-        return (transitive, bool(candidates))
+        key = next(iter(candidates)).name if candidates else ""
+        return (transitive, key)
 
     def find_matches(self, requirements):
         # type: (Sequence[Requirement]) -> Iterable[Candidate]


### PR DESCRIPTION
This makes the ordering deterministic to improve debugging and user experience.