### PR TITLE
Always close stderr after subprocess completion in call_subprocess()

### DIFF
--- a/news/9156.bugfix.rst
+++ b/news/9156.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ResourceWarning in VCS subprocesses

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -150,6 +150,8 @@ def call_subprocess(
     finally:
         if proc.stdout:
             proc.stdout.close()
+        if proc.stderr:
+            proc.stderr.close()
 
     proc_had_error = (
         proc.returncode and proc.returncode not in extra_ok_returncodes


### PR DESCRIPTION
When running Python with warnings enabled, fixes warnings of the form:

    .../site-packages/pip/_internal/vcs/versioncontrol.py:773: ResourceWarning: unclosed file <_io.BufferedReader name=12>
      return call_subprocess(cmd, cwd,

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
