### PR TITLE
Allow legacy version in wheel metadata

### DIFF
--- a/news/9188.bugfix.rst
+++ b/news/9188.bugfix.rst
@@ -1,0 +1,1 @@
+Allow legacy versions when verifying wheel version from file name.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, Optional, Tuple, Uni
 from pip._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version, _BaseVersion
+from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.exceptions import HashError, MetadataInconsistent
@@ -277,7 +278,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             assert name == wheel_name, f"{name!r} != {wheel_name!r} for wheel"
             # Version may not be present for PEP 508 direct URLs
             if version is not None:
-                wheel_version = Version(wheel.version)
+                wheel_version = parse_version(wheel.version)
                 assert version == wheel_version, "{!r} != {!r} for wheel {}".format(
                     version, wheel_version, name
                 )


### PR DESCRIPTION
Fix #9188.

I took a look at the code that crashed and realised it was only performing a sanity check (and is arguably not even necessary if you walk through all the code paths that go through it). Although it’s likely a good idea to start requiring PEP 440 versions for wheels, IMO it should not be done in this part, but when the wheel is actually downloaded.

This PR simply makes the check more lax to pass the sanity check. I’ll open another issue to work on logic to implement PEP 440 enforcement if it is accepted as a good idea.