### PR TITLE
Fix redact url in --help

### DIFF
--- a/news/9191.bugfix.rst
+++ b/news/9191.bugfix.rst
@@ -1,2 +1,2 @@
-Handle case of list default values in UpdatingDefaultsHelpFormatter
-Happens because we pass a list from --extra-index-url
+Fix crash when logic for redacting authentication information from URLs
+in ``--help`` is given a list of strings, instead of a single string.

--- a/news/9191.bugfix.rst
+++ b/news/9191.bugfix.rst
@@ -1,0 +1,2 @@
+Handle case of list default values in UpdatingDefaultsHelpFormatter
+Happens because we pass a list from --extra-index-url

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -112,15 +112,23 @@ class UpdatingDefaultsHelpFormatter(PrettyHelpFormatter):
     """
 
     def expand_default(self, option):
-        default_value = None
+        default_values = None
         if self.parser is not None:
             self.parser._update_defaults(self.parser.defaults)
-            default_value = self.parser.defaults.get(option.dest)
+            default_values = self.parser.defaults.get(option.dest)
         help_text = optparse.IndentedHelpFormatter.expand_default(self, option)
 
-        if default_value and option.metavar == 'URL':
-            help_text = help_text.replace(
-                default_value, redact_auth_from_url(default_value))
+        if default_values and option.metavar == 'URL':
+            if isinstance(default_values, string_types):
+                default_values = [default_values]
+
+            # If its not a list, we should abort and just return the help text
+            if not isinstance(default_values, list):
+                default_values = []
+
+            for val in default_values:
+                help_text = help_text.replace(
+                    val, redact_auth_from_url(val))
 
         return help_text
 

--- a/tests/functional/test_help.py
+++ b/tests/functional/test_help.py
@@ -74,6 +74,17 @@ def test_help_command_redact_auth_from_url(script):
     assert 'secret' not in result.stdout
 
 
+def test_help_command_redact_auth_from_url_with_extra_index_url(script):
+    """
+    Test `help` on various subcommands redact auth from url with extra index url
+    """
+    script.environ['PIP_INDEX_URL'] = 'https://user:secret@example.com'
+    script.environ['PIP_EXTRA_INDEX_URL'] = 'https://user:secret@example2.com'
+    result = script.pip('install', '--help')
+    assert result.returncode == SUCCESS
+    assert 'secret' not in result.stdout
+
+
 def test_help_commands_equally_functional(in_memory_pip):
     """
     Test if `pip help` and 'pip --help' behave the same way.


### PR DESCRIPTION
Closes #9191 
Closes #9196

Happened as we pass a list from --extra-index-url values, and we only handled regular strings
Added a test to address this

@pradyunsg @sbidoul 