### PR TITLE
Use my nickname instead of real name

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -20,7 +20,6 @@ Dustin Ingram       <di@di.codes>                           <di@users.noreply.gi
 Endoh Takanao                                               <djmchl@gmail.com>
 Erik M. Bray                                                <embray@stsci.edu>
 Gabriel de Perthuis                                         <g2p.code@gmail.com>
-Geoffrey Lehée                                              <geoffrey@lehee.name>
 Hsiaoming Yang                                              <lepture@me.com>
 Igor Kuzmitshov     <kuzmiigo@gmail.com>                    <igor@qubit.com>
 Ilya Baryshev                                               <baryshev@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -218,7 +218,6 @@ Gabriel Curio
 Gabriel de Perthuis
 Garry Polley
 gdanielson
-Geoffrey Lehée
 Geoffrey Sneddon
 George Song
 Georgi Valkov
@@ -551,6 +550,7 @@ Tony Zhaocheng Tan
 TonyBeswick
 toonarmycaptain
 Toshio Kuratomi
+toxinu
 Travis Swicegood
 Tzu-ping Chung
 Valentin Haenel


### PR DESCRIPTION
It may be an unusual pull request but I would like to replace my real name with my nickname in the `AUTHORS.rst` file. I hope it doesn't make any fuse.