### PR TITLE
Correctly implement yanking logic

### DIFF
--- a/news/9203.bugfix.rst
+++ b/news/9203.bugfix.rst
@@ -1,0 +1,2 @@
+New resolver: Correctly implement PEP 592. Do not return yanked versions from
+an index, unless the version range can only be satisfied by yanked candidates.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -193,8 +193,17 @@ class Factory(object):
                 specifier=specifier,
                 hashes=hashes,
             )
+            icans = list(result.iter_applicable())
+
+            # PEP 592: Yanked releases must be ignored unless only yanked
+            # releases can satisfy the version range. So if this is false,
+            # all yanked icans need to be skipped.
+            all_yanked = all(ican.link.is_yanked for ican in icans)
+
             # PackageFinder returns earlier versions first, so we reverse.
-            for ican in reversed(list(result.iter_applicable())):
+            for ican in reversed(icans):
+                if not all_yanked and ican.link.is_yanked:
+                    continue
                 yield self._make_candidate_from_link(
                     link=ican.link,
                     extras=extras,


### PR DESCRIPTION
Do not return yanked versions from an index, unless the version range can only be satisfied by yanked candidates.

This should fix the trouble described in https://github.com/pypa/pip/issues/9203#issuecomment-738664507. I *don’t* think this is enough for #8262 since it still involves prereleases. But that’s for another day (and if I’m understanding the code correctly, need to involve changes in `PackageFinder`).

I’m not sure what way is best to test this. Yanking only works with indexes, and I’m not sure how to run one for a unit test 😥 