### PR TITLE
Check stderr first before stdout on VCS Install

### DIFF
--- a/news/8876.bugfix.rst
+++ b/news/8876.bugfix.rst
@@ -1,0 +1,1 @@
+Read stderr output before stdout on VCS install to avoid process freeze with Git

--- a/news/8876.bugfix.rst
+++ b/news/8876.bugfix.rst
@@ -1,1 +1,1 @@
-Read stderr output before stdout on VCS install to avoid process freeze with Git
+Detect both stdout and stderr on VCS install VCS install to avoid process freeze with Git.

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -136,8 +136,9 @@ def call_subprocess(
     while True:
         # The "line" value is a unicode string in Python 2.
         line = None
-        if proc.stdout:
-            line = console_to_str(proc.stdout.readline())
+        if proc.stdout or proc.stderr:
+            line = console_to_str(proc.stderr.readline())
+            line = line or console_to_str(proc.stdout.readline())
         if not line:
             break
         line = line.rstrip()


### PR DESCRIPTION
When working with large amounts of data, Git reports on stderr instead of
stdout. For some reason, on Git for Windows (I have not been able to reproduce
this on Linux), this can cause the subprocess to completely stall while asking
for a return from the stdout. In the context of a `pip install git+https://`,
this results in the Clone step freezing, without providing any errors or
context about what's happening (or what has gone wrong).

This fix circumvents that by first check stderr for output, and then checking
stdout (if none is found).
