### PR TITLE
POC: Prefer to reuse a version once it is pinned

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -111,9 +111,9 @@ class Resolver(BaseResolver):
             user_requested=user_requested,
         )
         if "PIP_RESOLVER_DEBUG" in os.environ:
-            reporter = PipDebuggingReporter()
+            reporter = PipDebuggingReporter(factory=self.factory)
         else:
-            reporter = PipReporter()
+            reporter = PipReporter(factory=self.factory)
         resolver = RLResolver(provider, reporter)
 
         try:

--- a/src/pip/_vendor/resolvelib/reporters.py
+++ b/src/pip/_vendor/resolvelib/reporters.py
@@ -33,5 +33,5 @@ class BaseReporter(object):
     def backtracking(self, candidate):
         """Called when rejecting a candidate during backtracking."""
 
-    def pinning(self, candidate):
+    def pinning(self, candidate, requirements):
         """Called when adding a candidate to the potential solution."""

--- a/src/pip/_vendor/resolvelib/resolvers.py
+++ b/src/pip/_vendor/resolvelib/resolvers.py
@@ -209,20 +209,22 @@ class Resolution(object):
                 causes.append(e.criterion)
                 continue
 
+            requirements = list(criterion.iter_requirement())
+
             # Check the newly-pinned candidate actually works. This should
             # always pass under normal circumstances, but in the case of a
             # faulty provider, we will raise an error to notify the implementer
             # to fix find_matches() and/or is_satisfied_by().
             satisfied = all(
                 self._p.is_satisfied_by(r, candidate)
-                for r in criterion.iter_requirement()
+                for r in requirements
             )
             if not satisfied:
                 raise InconsistentCandidate(candidate, criterion)
 
             # Put newly-pinned candidate at the end. This is essential because
             # backtracking looks at this mapping to get the last pin.
-            self._r.pinning(candidate)
+            self._r.pinning(candidate, requirements)
             self.state.mapping.pop(name, None)
             self.state.mapping[name] = candidate
             self.state.criteria.update(criteria)


### PR DESCRIPTION
A pattern I see in excessive backtracking examples is that pip tries to perform the same backtracking on dependencies of different version of a project. Say A depends on B depends on C, and multiple B versions need to be checked due to its C specifier conflicts with another project’s. pip would try multiple versions of A, but for each of them must start with the highest possible B and go down, each time landing on the same B eventually.

This patch adds a mechanism to “remember” the last successful B version for a given B version range, and use that first the next the same version range is seen. This may in theory make pip land on an inferior result when a better one is available (maybe an older B somehow can have a newer C that works), but this is worth the price IMO.

The implementation presented here is a very hacky proof of concept, and not intended for merge. We can discuss how this can be best implemented (I assume resolvelib needs to change) if we decide this is a good idea.