### PR TITLE
Use the project name to look up constraints

### DIFF
--- a/news/9232.bugfix.rst
+++ b/news/9232.bugfix.rst
@@ -1,2 +1,2 @@
 New resolver: Make constraints also apply to package variants with extras, so
-the resolver correctly avoids baktracking on them.
+the resolver correctly avoids backtracking on them.

--- a/news/9232.bugfix.rst
+++ b/news/9232.bugfix.rst
@@ -1,0 +1,2 @@
+New resolver: Make constraints also apply to package variants with extras, so
+the resolver correctly avoids baktracking on them.

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -68,8 +68,24 @@ class Constraint(object):
 
 class Requirement(object):
     @property
+    def project_name(self):
+        # type: () -> str
+        """The "project name" of a requirement.
+
+        This is different from ``name`` if this requirement contains extras,
+        in which case ``name`` would contain the ``[...]`` part, while this
+        refers to the name of the project.
+        """
+        raise NotImplementedError("Subclass should override")
+
+    @property
     def name(self):
         # type: () -> str
+        """The name identifying this requirement in the resolver.
+
+        This is different from ``project_name`` if this requirement contains
+        extras, where ``project_name`` would not contain the ``[...]`` part.
+        """
         raise NotImplementedError("Subclass should override")
 
     def is_satisfied_by(self, candidate):
@@ -87,8 +103,24 @@ class Requirement(object):
 
 class Candidate(object):
     @property
+    def project_name(self):
+        # type: () -> str
+        """The "project name" of the candidate.
+
+        This is different from ``name`` if this candidate contains extras,
+        in which case ``name`` would contain the ``[...]`` part, while this
+        refers to the name of the project.
+        """
+        raise NotImplementedError("Override in subclass")
+
+    @property
     def name(self):
         # type: () -> str
+        """The name identifying this candidate in the resolver.
+
+        This is different from ``project_name`` if this candidate contains
+        extras, where ``project_name`` would not contain the ``[...]`` part.
+        """
         raise NotImplementedError("Override in subclass")
 
     @property

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -175,12 +175,17 @@ class _InstallRequirementBackedCandidate(Candidate):
         return self._source_link
 
     @property
-    def name(self):
+    def project_name(self):
         # type: () -> str
         """The normalised name of the project the candidate refers to"""
         if self._name is None:
             self._name = canonicalize_name(self.dist.project_name)
         return self._name
+
+    @property
+    def name(self):
+        # type: () -> str
+        return self.project_name
 
     @property
     def version(self):
@@ -390,9 +395,14 @@ class AlreadyInstalledCandidate(Candidate):
         return not self.__eq__(other)
 
     @property
-    def name(self):
+    def project_name(self):
         # type: () -> str
         return canonicalize_name(self.dist.project_name)
+
+    @property
+    def name(self):
+        # type: () -> str
+        return self.project_name
 
     @property
     def version(self):
@@ -482,10 +492,15 @@ class ExtrasCandidate(Candidate):
         return not self.__eq__(other)
 
     @property
+    def project_name(self):
+        # type: () -> str
+        return self.base.project_name
+
+    @property
     def name(self):
         # type: () -> str
         """The normalised name of the project the candidate refers to"""
-        return format_name(self.base.name, self.extras)
+        return format_name(self.base.project_name, self.extras)
 
     @property
     def version(self):
@@ -572,10 +587,15 @@ class RequiresPythonCandidate(Candidate):
         return "Python {}".format(self._version)
 
     @property
-    def name(self):
+    def project_name(self):
         # type: () -> str
         # Avoid conflicting with the PyPI package "Python".
         return "<Python from Requires-Python>"
+
+    @property
+    def name(self):
+        # type: () -> str
+        return self.project_name
 
     @property
     def version(self):

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -30,6 +30,16 @@ if MYPY_CHECK_RUNNING:
 
 
 class PipProvider(AbstractProvider):
+    """Pip's provider implementation for resolvelib.
+
+    :params constraints: A mapping of constraints specified by the user. Keys
+        are canonicalized project names.
+    :params ignore_dependencies: Whether the user specified ``--no-deps``.
+    :params upgrade_strategy: The user-specified upgrade strategy.
+    :params user_requested: A set of canonicalized package names that the user
+        supplied for pip to install/upgrade.
+    """
+
     def __init__(
         self,
         factory,  # type: Factory
@@ -113,7 +123,7 @@ class PipProvider(AbstractProvider):
         # type: (Sequence[Requirement]) -> Iterable[Candidate]
         if not requirements:
             return []
-        name = requirements[0].name
+        name = requirements[0].project_name
 
         def _eligible_for_upgrade(name):
             # type: (str) -> bool

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -29,6 +29,12 @@ class ExplicitRequirement(Requirement):
         )
 
     @property
+    def project_name(self):
+        # type: () -> str
+        # No need to canonicalise - the candidate did this
+        return self.candidate.project_name
+
+    @property
     def name(self):
         # type: () -> str
         # No need to canonicalise - the candidate did this
@@ -66,10 +72,14 @@ class SpecifierRequirement(Requirement):
         )
 
     @property
+    def project_name(self):
+        # type: () -> str
+        return canonicalize_name(self._ireq.req.name)
+
+    @property
     def name(self):
         # type: () -> str
-        canonical_name = canonicalize_name(self._ireq.req.name)
-        return format_name(canonical_name, self._extras)
+        return format_name(self.project_name, self._extras)
 
     def format_for_error(self):
         # type: () -> str
@@ -120,6 +130,11 @@ class RequiresPythonRequirement(Requirement):
             class_name=self.__class__.__name__,
             specifier=str(self.specifier),
         )
+
+    @property
+    def project_name(self):
+        # type: () -> str
+        return self._candidate.project_name
 
     @property
     def name(self):


### PR DESCRIPTION
Fix #9232.

User-specified constraints only contain the project name without extras, but a constraint a project A would also apply to A’s extra variants. This introduces a new `project_name` property on `Requirement` and `Candidate` classes for this lookup.
