### PR TITLE
Intentionally delay resolving setuptools

### DIFF
--- a/news/9249.feature.rst
+++ b/news/9249.feature.rst
@@ -1,0 +1,1 @@
+Add a mechanism to delay resolving certain packages, and use it for setuptools.

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -117,7 +117,18 @@ class PipProvider(AbstractProvider):
         restrictive = _get_restrictive_rating(req for req, _ in information)
         transitive = all(parent is not None for _, parent in information)
         key = next(iter(candidates)).name if candidates else ""
-        return (restrictive, transitive, key)
+
+        # HACK: Setuptools have a very long and solid backward compatibility
+        # track record, and extremely few projects would request a narrow,
+        # non-recent version range of it since that would break a lot things.
+        # (Most projects specify it only to request for an installer feature,
+        # which does not work, but that's another topic.) Intentionally
+        # delaying Setuptools helps reduce branches the resolver has to check.
+        # This serves as a temporary fix for issues like "apache-airlfow[all]"
+        # while we work on "proper" branch pruning techniques.
+        delay_this = (key == "setuptools")
+
+        return (delay_this, restrictive, transitive, key)
 
     def find_matches(self, requirements):
         # type: (Sequence[Requirement]) -> Iterable[Candidate]


### PR DESCRIPTION
Inspired by the workaround described in https://github.com/pypa/pip/issues/9187#issuecomment-740947080

Not sure how the news fragment should be worded on this one.