### PR TITLE
Add --no-backtracking option for new resolver

### DIFF
--- a/news/9258.feature.rst
+++ b/news/9258.feature.rst
@@ -1,0 +1,1 @@
+New resolver: Add ``--no-backtracking`` option to enable failfast debugging.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -927,6 +927,17 @@ use_deprecated_feature = partial(
     ),
 )  # type: Callable[..., Option]
 
+disable_backtracking = partial(
+    Option,
+    '--no-backtracking',
+    dest='disable_backtracking',
+    action='store_true',
+    default=False,
+    help='Do not attempt to backtrack to resolve package conflicts. This will '
+         'cause conflicts which may be otherwise automatically solveable to '
+         'fail fast and require manual intervention!',
+)  # type: Callable[..., Option]
+
 
 ##########
 # groups #

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -56,6 +56,7 @@ class DownloadCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.no_build_isolation())
         self.cmd_opts.add_option(cmdoptions.use_pep517())
         self.cmd_opts.add_option(cmdoptions.no_use_pep517())
+        self.cmd_opts.add_option(cmdoptions.disable_backtracking())
 
         self.cmd_opts.add_option(
             '-d', '--dest', '--destination-dir', '--destination-directory',
@@ -128,7 +129,8 @@ class DownloadCommand(RequirementCommand):
         self.trace_basic_info(finder)
 
         requirement_set = resolver.resolve(
-            reqs, check_supported_wheels=True
+            reqs, check_supported_wheels=True,
+            should_backtrack=not options.disable_backtracking
         )
 
         downloaded = []  # type: List[str]

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -216,6 +216,7 @@ class InstallCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.prefer_binary())
         self.cmd_opts.add_option(cmdoptions.require_hashes())
         self.cmd_opts.add_option(cmdoptions.progress_bar())
+        self.cmd_opts.add_option(cmdoptions.disable_backtracking())
 
         index_opts = cmdoptions.make_option_group(
             cmdoptions.index_group,
@@ -318,7 +319,8 @@ class InstallCommand(RequirementCommand):
             self.trace_basic_info(finder)
 
             requirement_set = resolver.resolve(
-                reqs, check_supported_wheels=not options.target_dir
+                reqs, check_supported_wheels=not options.target_dir,
+                should_backtrack=not options.disable_backtracking
             )
 
             try:

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -80,6 +80,7 @@ class WheelCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.no_deps())
         self.cmd_opts.add_option(cmdoptions.build_dir())
         self.cmd_opts.add_option(cmdoptions.progress_bar())
+        self.cmd_opts.add_option(cmdoptions.disable_backtracking())
 
         self.cmd_opts.add_option(
             '--global-option',
@@ -152,7 +153,8 @@ class WheelCommand(RequirementCommand):
         self.trace_basic_info(finder)
 
         requirement_set = resolver.resolve(
-            reqs, check_supported_wheels=True
+            reqs, check_supported_wheels=True,
+            should_backtrack=not options.disable_backtracking
         )
 
         reqs_to_build = []  # type: List[InstallRequirement]

--- a/src/pip/_internal/resolution/base.py
+++ b/src/pip/_internal/resolution/base.py
@@ -12,8 +12,8 @@ if MYPY_CHECK_RUNNING:
 
 
 class BaseResolver(object):
-    def resolve(self, root_reqs, check_supported_wheels):
-        # type: (List[InstallRequirement], bool) -> RequirementSet
+    def resolve(self, root_reqs, check_supported_wheels, should_backtrack):
+        # type: (List[InstallRequirement], bool, bool) -> RequirementSet
         raise NotImplementedError()
 
     def get_installation_order(self, req_set):

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -149,8 +149,9 @@ class Resolver(BaseResolver):
         self._discovered_dependencies = \
             defaultdict(list)  # type: DiscoveredDependencies
 
-    def resolve(self, root_reqs, check_supported_wheels):
-        # type: (List[InstallRequirement], bool) -> RequirementSet
+    def resolve(self, root_reqs, check_supported_wheels, should_backtrack):
+        # type: (List[InstallRequirement], bool, bool) -> RequirementSet
+        # pylint: disable=unused-argument
         """Resolve what operations need to be done
 
         As a side-effect of this method, the packages (and their dependencies)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -75,8 +75,8 @@ class Resolver(BaseResolver):
         self.upgrade_strategy = upgrade_strategy
         self._result = None  # type: Optional[Result]
 
-    def resolve(self, root_reqs, check_supported_wheels):
-        # type: (List[InstallRequirement], bool) -> RequirementSet
+    def resolve(self, root_reqs, check_supported_wheels, should_backtrack):
+        # type: (List[InstallRequirement], bool, bool) -> RequirementSet
 
         constraints = {}  # type: Dict[str, Constraint]
         user_requested = set()  # type: Set[str]
@@ -120,6 +120,7 @@ class Resolver(BaseResolver):
             try_to_avoid_resolution_too_deep = 2000000
             self._result = resolver.resolve(
                 requirements, max_rounds=try_to_avoid_resolution_too_deep,
+                should_backtrack=should_backtrack,
             )
 
         except ResolutionImpossible as e:

--- a/src/pip/_vendor/resolvelib/__init__.py
+++ b/src/pip/_vendor/resolvelib/__init__.py
@@ -11,7 +11,7 @@ __all__ = [
     "ResolutionTooDeep",
 ]
 
-__version__ = "0.5.3"
+__version__ = "0.5.4.dev0"
 
 
 from .providers import AbstractProvider, AbstractResolver

--- a/src/pip/_vendor/resolvelib/resolvers.py
+++ b/src/pip/_vendor/resolvelib/resolvers.py
@@ -297,7 +297,7 @@ class Resolution(object):
         # No way to backtrack anymore.
         return False
 
-    def resolve(self, requirements, max_rounds):
+    def resolve(self, requirements, max_rounds, should_backtrack):
         if self._states:
             raise RuntimeError("already resolved")
 
@@ -341,7 +341,7 @@ class Resolution(object):
             if failure_causes:
                 # Backtrack if pinning fails. The backtrack process puts us in
                 # an unpinned state, so we can work on it in the next round.
-                success = self._backtrack()
+                success = self._backtrack() if should_backtrack else False
 
                 # Dead ends everywhere. Give up.
                 if not success:
@@ -413,7 +413,7 @@ class Resolver(AbstractResolver):
 
     base_exception = ResolverException
 
-    def resolve(self, requirements, max_rounds=100):
+    def resolve(self, requirements, max_rounds=100, should_backtrack=True):
         """Take a collection of constraints, spit out the resolution result.
 
         The return value is a representation to the final resolution result. It
@@ -442,5 +442,9 @@ class Resolver(AbstractResolver):
             `max_rounds` argument.
         """
         resolution = Resolution(self.provider, self.reporter)
-        state = resolution.resolve(requirements, max_rounds=max_rounds)
+        state = resolution.resolve(
+            requirements,
+            max_rounds=max_rounds,
+            should_backtrack=should_backtrack,
+        )
         return _build_result(state)

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -16,7 +16,7 @@ requests==2.25.0
     chardet==3.0.4
     idna==2.10
     urllib3==1.26.2
-resolvelib==0.5.3
+git+https://github.com/thekevjames/resolvelib.git@add-no-backtracking-option
 retrying==1.3.3
 setuptools==44.0.0
 six==1.15.0

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -121,6 +121,7 @@ class TestRequirementSet(object):
                 resolver.resolve,
                 reqset.all_requirements,
                 True,
+                True,
             )
 
     # TODO: Update test when Python 2.7 is dropped.
@@ -137,7 +138,7 @@ class TestRequirementSet(object):
         reqset.add_requirement(req)
         finder = make_test_finder(find_links=[data.find_links])
         with self._basic_resolver(finder) as resolver:
-            reqset = resolver.resolve(reqset.all_requirements, True)
+            reqset = resolver.resolve(reqset.all_requirements, True, True)
         # This is hacky but does test both case in py2 and py3
         if sys.version_info[:2] == (2, 7):
             assert reqset.has_requirement('simple')
@@ -164,6 +165,7 @@ class TestRequirementSet(object):
                 r'af95fb866d6ca016b42d2e6ce53619b653$',
                 resolver.resolve,
                 reqset.all_requirements,
+                True,
                 True,
             )
 
@@ -217,6 +219,7 @@ class TestRequirementSet(object):
                 resolver.resolve,
                 reqset.all_requirements,
                 True,
+                True,
             )
 
     def test_unpinned_hash_checking(self, data):
@@ -246,6 +249,7 @@ class TestRequirementSet(object):
                 resolver.resolve,
                 reqset.all_requirements,
                 True,
+                True,
             )
 
     def test_hash_mismatch(self, data):
@@ -267,6 +271,7 @@ class TestRequirementSet(object):
                 r'866d6ca016b42d2e6ce53619b653$',
                 resolver.resolve,
                 reqset.all_requirements,
+                True,
                 True,
             )
 
@@ -290,6 +295,7 @@ class TestRequirementSet(object):
                 r'    TopoRequires from .*$',
                 resolver.resolve,
                 reqset.all_requirements,
+                True,
                 True,
             )
 


### PR DESCRIPTION
Adds a new option `--no-backtracking` to the new resolver. Off by
default (no change to default behaviour), enabling this option prevents
us from running the backtracking behaviour when pinning fails and
instead skip directly to the error reporting.

This can be especially useful in a CI situation, where the developer is
interested in knowing about conflicts up front in order to manually
solve them, or is worried about allowing for a potentially large amount
of time spent in backtracking.

My goal here is mostly to help with the various issues such as #9254,
#9215, and #9187 -- being able to enable this flag is very useful for helping
in reducing backtracking (as per the recommendations in [the guide](https://pip.pypa.io/en/latest/user_guide/#possible-ways-to-reduce-backtracking-occurring)).
Options 2, 3, and 4 of that guide mostly amount to "determine which
packages have conflicts and update your constraints/requirements files to
avoid those issues". By being able to "fail fast", we allow users who are
interested in using any of those options to take advantage of the awesome
`ResolutionImpossible` debug output without having to wait for what could
potentially be hours worth of attempts from the resolver (see linked issues).

Still TODO:
- [ ] relies on an unmerged change to `resolvelib` (sarugaku/resolvelib#66)
  -- that'll need to get merged and released as `resolvelib==0.5.4` (or
  greater), then re-vendored.