### PR TITLE
Cache AlreadyInstalledCandidate

### DIFF
--- a/news/9117.bugfix.rst
+++ b/news/9117.bugfix.rst
@@ -1,0 +1,2 @@
+New resolver: The "Requirement already satisfied" log is not printed only once
+for each package during resolution.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -96,6 +96,8 @@ class Factory(object):
 
         self._link_candidate_cache = {}  # type: Cache[LinkCandidate]
         self._editable_candidate_cache = {}  # type: Cache[EditableCandidate]
+        self._installed_candidate_cache = {
+        }  # type: Dict[str, AlreadyInstalledCandidate]
 
         if not ignore_installed:
             self._installed_dists = {
@@ -117,7 +119,11 @@ class Factory(object):
         template,  # type: InstallRequirement
     ):
         # type: (...) -> Candidate
-        base = AlreadyInstalledCandidate(dist, template, factory=self)
+        try:
+            base = self._installed_candidate_cache[dist.key]
+        except KeyError:
+            base = AlreadyInstalledCandidate(dist, template, factory=self)
+            self._installed_candidate_cache[dist.key] = base
         if extras:
             return ExtrasCandidate(base, extras)
         return base


### PR DESCRIPTION
Since the "Requirement already satisfied" message is printed during candidate preparation, instantiating the candidate multiple times result in excessive logging during intensive backtracking. By caching the already-installed candidates, each package is only prepared, and thus only logged once.

Close #9117.

This does *not* make the resolver any faster (multiple issues can be used to track this optimisation, e.g. #9215). The patch only fixes the repetitive logging.