### PR TITLE
Remove VCS export feature

### DIFF
--- a/news/9273.bugfix.rst
+++ b/news/9273.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a regression that made ``pip wheel`` do a VCS export instead of a VCS clone
+for editable requirements. This broke VCS requirements that need the VCS
+information to build correctly.

--- a/news/9337.bugfix.rst
+++ b/news/9337.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``pip download`` of editable VCS requirements that need VCS information
+to build correctly.

--- a/news/9338.removal.rst
+++ b/news/9338.removal.rst
@@ -1,0 +1,2 @@
+Remove the VCS export feature that was used only with editable VCS
+requirements and had correctness issues.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -570,7 +570,7 @@ class RequirementPreparer(object):
                     'hash.'.format(req)
                 )
             req.ensure_has_source_dir(self.src_dir)
-            req.update_editable(self.download_dir is None)
+            req.update_editable()
 
             dist = _get_prepared_distribution(
                 req, self.req_tracker, self.finder, self.build_isolation,

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -617,8 +617,8 @@ class InstallRequirement(object):
             )
 
     # For editable installations
-    def update_editable(self, obtain=True):
-        # type: (bool) -> None
+    def update_editable(self):
+        # type: () -> None
         if not self.link:
             logger.debug(
                 "Cannot update repository at %s; repository location is "
@@ -651,10 +651,7 @@ class InstallRequirement(object):
                     )
                 deprecated(reason, replacement, gone_in="21.0", issue=7554)
             hidden_url = hide_url(self.link.url)
-            if obtain:
-                vcs_backend.obtain(self.source_dir, url=hidden_url)
-            else:
-                vcs_backend.export(self.source_dir, url=hidden_url)
+            vcs_backend.obtain(self.source_dir, url=hidden_url)
         else:
             assert 0, (
                 'Unexpected version control type (in {}): {}'.format(

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -169,6 +169,25 @@ def test_pip_wheel_builds_editable(script, data):
     result.did_create(wheel_file_path)
 
 
+@pytest.mark.network
+def test_pip_wheel_git_editable_keeps_clone(script, tmpdir):
+    """
+    Test that `pip wheel -e giturl` preserves a git clone in src.
+    """
+    script.pip(
+        'wheel',
+        '--no-deps',
+        '-e',
+        'git+https://github.com/pypa/pip-test-package#egg=pip-test-package',
+        '--src',
+        tmpdir / 'src',
+        '--wheel-dir',
+        tmpdir,
+    )
+    assert (tmpdir / 'src' / 'pip-test-package').exists()
+    assert (tmpdir / 'src' / 'pip-test-package' / '.git').exists()
+
+
 def test_pip_wheel_builds_editable_does_not_create_zip(script, data, tmpdir):
     """
     Test 'pip wheel' of editables does not create zip files


### PR DESCRIPTION
Make `pip download` of editable requirements do a regular VCS clone/checkout instead of a VCS export.

See discussion about alternative approaches in #9338.

Fixes #9273 
Fixes #9337 
Fixes #9338 

~Just a failing test for now.~