### PR TITLE
Update packaging to version 20.8

### DIFF
--- a/news/packaging.vendor.rst
+++ b/news/packaging.vendor.rst
@@ -1,0 +1,1 @@
+Update vendoring to 20.8

--- a/src/pip/_vendor/packaging/__about__.py
+++ b/src/pip/_vendor/packaging/__about__.py
@@ -3,17 +3,6 @@
 # for complete details.
 from __future__ import absolute_import, division, print_function
 
-from .__about__ import (
-    __author__,
-    __copyright__,
-    __email__,
-    __license__,
-    __summary__,
-    __title__,
-    __uri__,
-    __version__,
-)
-
 __all__ = [
     "__title__",
     "__summary__",
@@ -24,3 +13,15 @@ __all__ = [
     "__license__",
     "__copyright__",
 ]
+
+__title__ = "packaging"
+__summary__ = "Core utilities for Python packages"
+__uri__ = "https://github.com/pypa/packaging"
+
+__version__ = "20.8"
+
+__author__ = "Donald Stufft and individual contributors"
+__email__ = "donald@stufft.io"
+
+__license__ = "BSD-2-Clause or Apache-2.0"
+__copyright__ = "2014-2019 %s" % __author__

--- a/src/pip/_vendor/packaging/requirements.py
+++ b/src/pip/_vendor/packaging/requirements.py
@@ -22,7 +22,7 @@ else:  # pragma: no cover
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import List
+    from typing import List, Optional as TOptional, Set
 
 
 class InvalidRequirement(ValueError):
@@ -109,7 +109,7 @@ class Requirement(object):
                 )
             )
 
-        self.name = req.name
+        self.name = req.name  # type: str
         if req.url:
             parsed_url = urlparse.urlparse(req.url)
             if parsed_url.scheme == "file":
@@ -119,12 +119,12 @@ class Requirement(object):
                 not parsed_url.scheme and not parsed_url.netloc
             ):
                 raise InvalidRequirement("Invalid URL: {0}".format(req.url))
-            self.url = req.url
+            self.url = req.url  # type: TOptional[str]
         else:
             self.url = None
-        self.extras = set(req.extras.asList() if req.extras else [])
-        self.specifier = SpecifierSet(req.specifier)
-        self.marker = req.marker if req.marker else None
+        self.extras = set(req.extras.asList() if req.extras else [])  # type: Set[str]
+        self.specifier = SpecifierSet(req.specifier)  # type: SpecifierSet
+        self.marker = req.marker if req.marker else None  # type: TOptional[Marker]
 
     def __str__(self):
         # type: () -> str

--- a/src/pip/_vendor/packaging/tags.py
+++ b/src/pip/_vendor/packaging/tags.py
@@ -410,7 +410,7 @@ def _mac_binary_formats(version, cpu_arch):
     if cpu_arch in {"arm64", "x86_64"}:
         formats.append("universal2")
 
-    if cpu_arch in {"x86_64", "i386", "ppc64", "ppc"}:
+    if cpu_arch in {"x86_64", "i386", "ppc64", "ppc", "intel"}:
         formats.append("universal")
 
     return formats
@@ -827,11 +827,7 @@ def interpreter_version(**kwargs):
 
 def _version_nodot(version):
     # type: (PythonVersion) -> str
-    if any(v >= 10 for v in version):
-        sep = "_"
-    else:
-        sep = ""
-    return sep.join(map(str, version))
+    return "".join(map(str, version))
 
 
 def sys_tags(**kwargs):

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -7,7 +7,7 @@ distro==1.5.0
 html5lib==1.1
 ipaddress==1.0.23  # Only needed on 2.6 and 2.7
 msgpack==1.0.0
-packaging==20.7
+packaging==20.8
 pep517==0.9.1
 progress==1.5
 pyparsing==2.4.7


### PR DESCRIPTION
To account for Python 3.10, update the packaging version to 20.8.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

closes: https://github.com/pypa/pip/issues/9272
