### PR TITLE
Distribute and install py.typed to provide type information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         exclude=["contrib", "docs", "tests*", "tasks"],
     ),
     package_data={
+        "pip": ["py.typed"],
         "pip._vendor": ["vendor.txt"],
         "pip._vendor.certifi": ["*.pem"],
         "pip._vendor.requests": ["*.pem"],

--- a/src/pip/py.typed
+++ b/src/pip/py.typed
@@ -1,0 +1,4 @@
+pip is a command line program. While it is implemented in Python, and so is
+available for import, you must not use pip's internal APIs in this way. Typing
+information is provided as a convenience only and is not a gaurantee. Expect
+unannounced changes to the API and types in releases.


### PR DESCRIPTION
Complies with PEP 561:
https://www.python.org/dev/peps/pep-0561/#packaging-type-information

By distributing and installing the py.typed file, mypy will use pip's
type information when imported into other projects. For example, the
pip-tools project can use pip's types and mypy to help verify
correctness.

mypy docs:
https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages
