### PR TITLE
Release 20.3.2

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -504,6 +504,7 @@ Simon Cross
 Simon Pichugin
 sinoroc
 sinscary
+socketubs
 Sorin Sbarnea
 Srinivas Nyayapati
 Stavros Korokithakis

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,41 @@
 
 .. towncrier release notes start
 
+20.3.2 (2020-12-15)
+===================
+
+Features
+--------
+
+- New resolver: Resolve direct and pinned (``==`` or ``===``) requirements first
+  to improve resolver performance. (`#9185 <https://github.com/pypa/pip/issues/9185>`_)
+- Add a mechanism to delay resolving certain packages, and use it for setuptools. (`#9249 <https://github.com/pypa/pip/issues/9249>`_)
+
+Bug Fixes
+---------
+
+- New resolver: The "Requirement already satisfied" log is not printed only once
+  for each package during resolution. (`#9117 <https://github.com/pypa/pip/issues/9117>`_)
+- Fix crash when logic for redacting authentication information from URLs
+  in ``--help`` is given a list of strings, instead of a single string. (`#9191 <https://github.com/pypa/pip/issues/9191>`_)
+- New resolver: Correctly implement PEP 592. Do not return yanked versions from
+  an index, unless the version range can only be satisfied by yanked candidates. (`#9203 <https://github.com/pypa/pip/issues/9203>`_)
+- New resolver: Make constraints also apply to package variants with extras, so
+  the resolver correctly avoids backtracking on them. (`#9232 <https://github.com/pypa/pip/issues/9232>`_)
+- New resolver: Discard a candidate if it fails to provide metadata from source,
+  or if the provided metadata is inconsistent, instead of quitting outright. (`#9246 <https://github.com/pypa/pip/issues/9246>`_)
+
+Vendored Libraries
+------------------
+
+- Update vendoring to 20.8
+
+Improved Documentation
+----------------------
+
+- Update documentation to reflect that pip still uses legacy resolver by default in Python 2 environments. (`#9269 <https://github.com/pypa/pip/issues/9269>`_)
+
+
 20.3.1 (2020-12-03)
 ===================
 

--- a/news/9117.bugfix.rst
+++ b/news/9117.bugfix.rst
@@ -1,2 +1,0 @@
-New resolver: The "Requirement already satisfied" log is not printed only once
-for each package during resolution.

--- a/news/9185.feature.rst
+++ b/news/9185.feature.rst
@@ -1,2 +1,0 @@
-New resolver: Resolve direct and pinned (``==`` or ``===``) requirements first
-to improve resolver performance.

--- a/news/9191.bugfix.rst
+++ b/news/9191.bugfix.rst
@@ -1,2 +1,0 @@
-Fix crash when logic for redacting authentication information from URLs
-in ``--help`` is given a list of strings, instead of a single string.

--- a/news/9203.bugfix.rst
+++ b/news/9203.bugfix.rst
@@ -1,2 +1,0 @@
-New resolver: Correctly implement PEP 592. Do not return yanked versions from
-an index, unless the version range can only be satisfied by yanked candidates.

--- a/news/9232.bugfix.rst
+++ b/news/9232.bugfix.rst
@@ -1,2 +1,0 @@
-New resolver: Make constraints also apply to package variants with extras, so
-the resolver correctly avoids backtracking on them.

--- a/news/9246.bugfix.rst
+++ b/news/9246.bugfix.rst
@@ -1,2 +1,0 @@
-New resolver: Discard a candidate if it fails to provide metadata from source,
-or if the provided metadata is inconsistent, instead of quitting outright.

--- a/news/9249.feature.rst
+++ b/news/9249.feature.rst
@@ -1,1 +1,0 @@
-Add a mechanism to delay resolving certain packages, and use it for setuptools.

--- a/news/9269.doc.rst
+++ b/news/9269.doc.rst
@@ -1,1 +1,0 @@
-Update documentation to reflect that pip still uses legacy resolver by default in Python 2 environments.

--- a/news/packaging.vendor.rst
+++ b/news/packaging.vendor.rst
@@ -1,1 +1,0 @@
-Update vendoring to 20.8

--- a/src/pip/__init__.py
+++ b/src/pip/__init__.py
@@ -4,7 +4,7 @@ if MYPY_CHECK_RUNNING:
     from typing import List, Optional
 
 
-__version__ = "20.3.2"
+__version__ = "21.0.dev0"
 
 
 def main(args=None):

--- a/src/pip/__init__.py
+++ b/src/pip/__init__.py
@@ -4,7 +4,7 @@ if MYPY_CHECK_RUNNING:
     from typing import List, Optional
 
 
-__version__ = "21.0.dev0"
+__version__ = "20.3.2"
 
 
 def main(args=None):


### PR DESCRIPTION
This is basically the current `master` branch, so I'm not gonna wait on CI, coz it's gonna fail due to the PyPI outage anyway.