### PR TITLE
Show constraint in error message

### DIFF
--- a/news/9300.bugfix.rst
+++ b/news/9300.bugfix.rst
@@ -1,0 +1,2 @@
+New resolver: Show relevant entries from user-supplied constraint files in the
+error message to improve debuggability.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -122,7 +122,7 @@ class Resolver(BaseResolver):
             )
 
         except ResolutionImpossible as e:
-            error = self.factory.get_installation_error(e)
+            error = self.factory.get_installation_error(e, constraints)
             six.raise_from(error, e)
 
         req_set = RequirementSet(check_supported_wheels=check_supported_wheels)

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -357,7 +357,7 @@ def test_constraints_local_editable_install_causes_error(
         assert 'Could not satisfy constraints' in result.stderr, str(result)
     else:
         # Because singlemodule only has 0.0.1 available.
-        assert 'No matching distribution found' in result.stderr, str(result)
+        assert 'Cannot install singlemodule 0.0.1' in result.stderr, str(result)
 
 
 @pytest.mark.network
@@ -386,7 +386,7 @@ def test_constraints_local_install_causes_error(
         assert 'Could not satisfy constraints' in result.stderr, str(result)
     else:
         # Because singlemodule only has 0.0.1 available.
-        assert 'No matching distribution found' in result.stderr, str(result)
+        assert 'Cannot install singlemodule 0.0.1' in result.stderr, str(result)
 
 
 def test_constraints_constrain_to_local_editable(

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -687,7 +687,7 @@ def test_new_resolver_constraint_on_dependency(script):
 @pytest.mark.parametrize(
     "constraint_version, expect_error, message",
     [
-        ("1.0", True, "ERROR: No matching distribution found for foo 2.0"),
+        ("1.0", True, "Cannot install foo 2.0"),
         ("2.0", False, "Successfully installed foo-2.0"),
     ],
 )

--- a/tests/functional/test_new_resolver_errors.py
+++ b/tests/functional/test_new_resolver_errors.py
@@ -24,3 +24,24 @@ def test_new_resolver_conflict_requirements_file(tmpdir, script):
 
     message = "package versions have conflicting dependencies"
     assert message in result.stderr, str(result)
+
+
+def test_new_resolver_conflict_constraints_file(tmpdir, script):
+    create_basic_wheel_for_package(script, "pkg", "1.0")
+
+    constrats_file = tmpdir.joinpath("constraints.txt")
+    constrats_file.write_text("pkg!=1.0")
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir", "--no-index",
+        "--find-links", script.scratch_path,
+        "-c", constrats_file,
+        "pkg==1.0",
+        expect_error=True,
+    )
+
+    assert "ResolutionImpossible" in result.stderr, str(result)
+
+    message = "The user requested (constraint) pkg!=1.0"
+    assert message in result.stdout, str(result)


### PR DESCRIPTION
Currently the *No matching distribution* and *ResolutionImpossible* errors do not consider constraints, which may lead to hard-to-understand messages like the one in #9299.

This patch add relevant constraints to the list of conflicts, so the user can easily find whether the constraint is the cause.

Previous:

```console
$ pip install -c constriants.txt virtualenv==20.0.0  # constraints.txt contains "six==1.10.0".
ERROR: Could not find a version that satisfies the requirement six<2,>=1.12.0 (from virtualenv)
ERROR: No matching distribution found for six<2,>=1.12.0

$ pip install apache-airflow[devel_ci]==2.0.0rc3 -c https://raw.githubusercontent.com/apache/airflow/constraints-master/constraints-3.6.txt
...
The conflict is caused by:
    nteract-scrapbook[all] 0.4.1 depends on pyarrow
    nteract-scrapbook 0.4.1 depends on pyarrow
    papermill[all] 2.2.2 depends on pyarrow; extra == "all"
    google-cloud-bigquery[bqstorage,pandas] 2.4.0 depends on pyarrow<3.0dev and >=1.0.0; extra == "bqstorage"
```

With this patch:

```console
$ pip install -c constriants.txt virtualenv==20.0.0  # constraints.txt contains "six==1.10.0".
...
The conflict is caused by:
    virtualenv 20.0.0 depends on six<2 and >=1.12.0
    The user requested constraint six==1.10.0

$ pip install apache-airflow[devel_ci]==2.0.0rc3 -c https://raw.githubusercontent.com/apache/airflow/constraints-master/constraints-3.6.txt
...
The conflict is caused by:
    nteract-scrapbook[all] 0.4.1 depends on pyarrow
    nteract-scrapbook 0.4.1 depends on pyarrow
    papermill[all] 2.2.2 depends on pyarrow; extra == "all"
    google-cloud-bigquery[bqstorage,pandas] 2.4.0 depends on pyarrow<3.0dev and >=1.0.0; extra == "bqstorage"
    The user requested constraint pyarrow==0.17.1
```