### PR TITLE
Add `--ignore-requires-python` support to pip download.

### DIFF
--- a/news/1884.feature.rst
+++ b/news/1884.feature.rst
@@ -1,0 +1,1 @@
+Add ``--ignore-requires-python`` support to pip download.

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -56,6 +56,7 @@ class DownloadCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.no_build_isolation())
         self.cmd_opts.add_option(cmdoptions.use_pep517())
         self.cmd_opts.add_option(cmdoptions.no_use_pep517())
+        self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
 
         self.cmd_opts.add_option(
             '-d', '--dest', '--destination-dir', '--destination-directory',
@@ -96,6 +97,7 @@ class DownloadCommand(RequirementCommand):
             options=options,
             session=session,
             target_python=target_python,
+            ignore_requires_python=options.ignore_requires_python,
         )
 
         req_tracker = self.enter_context(get_requirement_tracker())
@@ -122,6 +124,7 @@ class DownloadCommand(RequirementCommand):
             preparer=preparer,
             finder=finder,
             options=options,
+            ignore_requires_python=options.ignore_requires_python,
             py_version_info=options.python_version,
         )
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -530,6 +530,34 @@ def test_download__python_version_used_for_python_requires(
     script.pip(*args)  # no exception
 
 
+def test_download_ignore_requires_python_dont_fail_with_wrong_python(
+    script,
+    with_wheel,
+):
+    """
+    Test that --ignore-requires-python ignores Requires-Python check.
+    """
+    wheel_path = make_wheel_with_python_requires(
+        script,
+        "mypackage",
+        python_requires="==999",
+    )
+    wheel_dir = os.path.dirname(wheel_path)
+
+    result = script.pip(
+        "download",
+        "--ignore-requires-python",
+        "--no-index",
+        "--find-links",
+        wheel_dir,
+        "--only-binary=:all:",
+        "--dest",
+        ".",
+        "mypackage==1.0",
+    )
+    result.did_create(Path('scratch') / 'mypackage-1.0-py2.py3-none-any.whl')
+
+
 def test_download_specify_abi(script, data):
     """
     Test using "pip download --abi" to download a .whl archive


### PR DESCRIPTION
Required for: #1884
