### PR TITLE
Avoid preparing metadata when `pip download` with `--ignore-requires-python --no-deps` 

### DIFF
--- a/news/1884-0.feature.rst
+++ b/news/1884-0.feature.rst
@@ -1,0 +1,1 @@
+Avoid preparing metadata when both ``--no-deps`` and ``--ignore-requires-python`` are provided to ``pip download``.

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -143,8 +143,8 @@ class Candidate(object):
         # type: () -> Optional[Link]
         raise NotImplementedError("Override in subclass")
 
-    def iter_dependencies(self, with_requires):
-        # type: (bool) -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, with_requires, ignore_requires_python):
+        # type: (bool, bool) -> Iterable[Optional[Requirement]]
         raise NotImplementedError("Override in subclass")
 
     def get_install_requirement(self):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -252,12 +252,13 @@ class _InstallRequirementBackedCandidate(Candidate):
             return None
         return self._factory.make_requires_python_requirement(spec)
 
-    def iter_dependencies(self, with_requires):
-        # type: (bool) -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, with_requires, ignore_requires_python):
+        # type: (bool, bool) -> Iterable[Optional[Requirement]]
         requires = self.dist.requires() if with_requires else ()
         for r in requires:
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
-        yield self._get_requires_python_dependency()
+        if not ignore_requires_python:
+            yield self._get_requires_python_dependency()
 
     def get_install_requirement(self):
         # type: () -> Optional[InstallRequirement]
@@ -418,8 +419,8 @@ class AlreadyInstalledCandidate(Candidate):
         # type: () -> str
         return "{} {} (Installed)".format(self.name, self.version)
 
-    def iter_dependencies(self, with_requires):
-        # type: (bool) -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, with_requires, ignore_requires_python):
+        # type: (bool, bool) -> Iterable[Optional[Requirement]]
         if not with_requires:
             return
         for r in self.dist.requires():
@@ -529,8 +530,8 @@ class ExtrasCandidate(Candidate):
         # type: () -> Optional[Link]
         return self.base.source_link
 
-    def iter_dependencies(self, with_requires):
-        # type: (bool) -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, with_requires, ignore_requires_python):
+        # type: (bool, bool) -> Iterable[Optional[Requirement]]
         factory = self.base._factory
 
         # Add a dependency on the exact base
@@ -606,8 +607,8 @@ class RequiresPythonCandidate(Candidate):
         # type: () -> str
         return "Python {}".format(self.version)
 
-    def iter_dependencies(self, with_requires):
-        # type: (bool) -> Iterable[Optional[Requirement]]
+    def iter_dependencies(self, with_requires, ignore_requires_python):
+        # type: (bool, bool) -> Iterable[Optional[Requirement]]
         return ()
 
     def get_install_requirement(self):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -81,7 +81,6 @@ class Factory(object):
         use_user_site,  # type: bool
         force_reinstall,  # type: bool
         ignore_installed,  # type: bool
-        ignore_requires_python,  # type: bool
         py_version_info=None,  # type: Optional[Tuple[int, ...]]
     ):
         # type: (...) -> None
@@ -92,7 +91,6 @@ class Factory(object):
         self._make_install_req_from_spec = make_install_req
         self._use_user_site = use_user_site
         self._force_reinstall = force_reinstall
-        self._ignore_requires_python = ignore_requires_python
 
         self._link_candidate_cache = {}  # type: Cache[LinkCandidate]
         self._editable_candidate_cache = {}  # type: Cache[EditableCandidate]
@@ -298,7 +296,7 @@ class Factory(object):
 
     def make_requires_python_requirement(self, specifier):
         # type: (Optional[SpecifierSet]) -> Optional[Requirement]
-        if self._ignore_requires_python or specifier is None:
+        if specifier is None:
             return None
         return RequiresPythonRequirement(specifier, self._python_candidate)
 

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -45,6 +45,7 @@ class PipProvider(AbstractProvider):
         factory,  # type: Factory
         constraints,  # type: Dict[str, Constraint]
         ignore_dependencies,  # type: bool
+        ignore_requires_python,  # type: bool
         upgrade_strategy,  # type: str
         user_requested,  # type: Set[str]
     ):
@@ -52,6 +53,7 @@ class PipProvider(AbstractProvider):
         self._factory = factory
         self._constraints = constraints
         self._ignore_dependencies = ignore_dependencies
+        self._ignore_requires_python = ignore_requires_python
         self._upgrade_strategy = upgrade_strategy
         self._user_requested = user_requested
 
@@ -167,8 +169,9 @@ class PipProvider(AbstractProvider):
     def get_dependencies(self, candidate):
         # type: (Candidate) -> Sequence[Requirement]
         with_requires = not self._ignore_dependencies
+        ignore_requires_python = self._ignore_requires_python
         return [
             r
-            for r in candidate.iter_dependencies(with_requires)
+            for r in candidate.iter_dependencies(with_requires, ignore_requires_python)
             if r is not None
         ]

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -68,10 +68,10 @@ class Resolver(BaseResolver):
             use_user_site=use_user_site,
             force_reinstall=force_reinstall,
             ignore_installed=ignore_installed,
-            ignore_requires_python=ignore_requires_python,
             py_version_info=py_version_info,
         )
         self.ignore_dependencies = ignore_dependencies
+        self.ignore_requires_python = ignore_requires_python
         self.upgrade_strategy = upgrade_strategy
         self._result = None  # type: Optional[Result]
 
@@ -107,6 +107,7 @@ class Resolver(BaseResolver):
             factory=self.factory,
             constraints=constraints,
             ignore_dependencies=self.ignore_dependencies,
+            ignore_requires_python=self.ignore_requires_python,
             upgrade_strategy=self.upgrade_strategy,
             user_requested=user_requested,
         )

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -57,7 +57,6 @@ def factory(finder, preparer):
         use_user_site=False,
         force_reinstall=False,
         ignore_installed=False,
-        ignore_requires_python=False,
         py_version_info=None,
     )
 
@@ -68,6 +67,7 @@ def provider(factory):
         factory=factory,
         constraints={},
         ignore_dependencies=False,
+        ignore_requires_python=False,
         upgrade_strategy="to-satisfy-only",
         user_requested=set(),
     )


### PR DESCRIPTION
Depends on: #9305
Originated in: #1884 

The goal of this PR is to avoid calling `Candidate._prepare()` when it's not necessary. 

Without this change, the following call chain happens:

```
Candidate.iter_dependencies()
-> Candidate._get_requires_python_dependency()
-> Candidate._prepare()   <<<<< heavy unnecessary work
-> Factory.make_requires_python_requirement()
-> if self._ignore_requires_python and return None
```


```
  File "/dev/pip/src/pip/_internal/commands/download.py", line 130, in run
    requirement_set = resolver.resolve(
  File "/dev/pip/src/pip/_internal/resolution/resolvelib/resolver.py", line 121, in resolve
    self._result = resolver.resolve(
  File "/dev/pip/src/pip/_vendor/resolvelib/resolvers.py", line 445, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "/dev/pip/src/pip/_vendor/resolvelib/resolvers.py", line 339, in resolve
    failure_causes = self._attempt_to_pin_criterion(name, criterion)
  File "/dev/pip/src/pip/_vendor/resolvelib/resolvers.py", line 207, in _attempt_to_pin_criterion
    criteria = self._get_criteria_to_update(candidate)
  File "/dev/pip/src/pip/_vendor/resolvelib/resolvers.py", line 198, in _get_criteria_to_update
    for r in self._p.get_dependencies(candidate):
  File "/dev/pip/src/pip/_internal/resolution/resolvelib/provider.py", line 170, in get_dependencies
    return [
  File "/dev/pip/src/pip/_internal/resolution/resolvelib/provider.py", line 170, in <listcomp>
    return [
  File "/dev/pip/src/pip/_internal/resolution/resolvelib/candidates.py", line 264, in iter_dependencies
    yield self._get_requires_python_dependency()
  File "/dev/pip/src/pip/_internal/resolution/resolvelib/candidates.py", line 245, in _get_requires_python_dependency
    requires_python = get_requires_python(self.dist)
  File "/dev/pip/src/pip/_internal/resolution/resolvelib/candidates.py", line 240, in dist
    self._prepare()
  File "/dev/pip/src/pip/_internal/resolution/resolvelib/candidates.py", line 225, in _prepare

```

In other words, if this check was done earlier - we can avoid running candidate `setup.py` when `--ignore-requires-python` is given.

Another argument might be that this check doesn't belong to the `Factory`, and similar to `iter_dependencies(with_requires)` should be passed down to `Candidate` from `Provider.get_dependencies()`.