### PR TITLE
Present a nicer error in pip search

### DIFF
--- a/news/9315.feature.rst
+++ b/news/9315.feature.rst
@@ -1,0 +1,1 @@
+Improve presentation of XMLRPC errors in pip search.

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -79,7 +79,14 @@ class SearchCommand(Command, SessionCommandMixin):
 
         transport = PipXmlrpcTransport(index_url, session)
         pypi = xmlrpc_client.ServerProxy(index_url, transport)
-        hits = pypi.search({'name': query, 'summary': query}, 'or')
+        try:
+            hits = pypi.search({'name': query, 'summary': query}, 'or')
+        except xmlrpc_client.Fault as fault:
+            message = "XMLRPC request failed [code: {code}]\n{string}".format(
+                code=fault.faultCode,
+                string=fault.faultString,
+            )
+            raise CommandError(message)
         return hits
 
 


### PR DESCRIPTION
Before:

```
ERROR: Exception:
Traceback (most recent call last):
  File "/Users/pradyunsg/Projects/pip/.venv/lib/python3.8/site-packages/pip/_internal/cli/base_command.py", line 224, in _main
    status = self.run(options, args)
  File "/Users/pradyunsg/Projects/pip/.venv/lib/python3.8/site-packages/pip/_internal/commands/search.py", line 62, in run
    pypi_hits = self.search(query, options)
  File "/Users/pradyunsg/Projects/pip/.venv/lib/python3.8/site-packages/pip/_internal/commands/search.py", line 82, in search
    hits = pypi.search({'name': query, 'summary': query}, 'or')
  File "/Users/pradyunsg/.pyenv/versions/3.8.3/lib/python3.8/xmlrpc/client.py", line 1109, in __call__
    return self.__send(self.__name, args)
  File "/Users/pradyunsg/.pyenv/versions/3.8.3/lib/python3.8/xmlrpc/client.py", line 1450, in __request
    response = self.__transport.request(
  File "/Users/pradyunsg/Projects/pip/.venv/lib/python3.8/site-packages/pip/_internal/network/xmlrpc.py", line 46, in request
    return self.parse_response(response.raw)
  File "/Users/pradyunsg/.pyenv/versions/3.8.3/lib/python3.8/xmlrpc/client.py", line 1341, in parse_response
    return u.close()
  File "/Users/pradyunsg/.pyenv/versions/3.8.3/lib/python3.8/xmlrpc/client.py", line 655, in close
    raise Fault(**self._stack[0])
xmlrpc.client.Fault: <Fault -32500: 'RuntimeError: This API has been temporarily disabled due to unmanageable load and will be deprecated in the near future. Please use the Simple or JSON API instead.'>
```

After:

```
ERROR: XMLRPC request failed [code: -32500]
RuntimeError: This API has been temporarily disabled due to unmanageable load and will be deprecated in the near future. Please use the Simple or JSON API instead.
```

---

@pypa/warehouse-admins Thoughts on updating the error message to be something like:

```
RuntimeError: PyPI's XMLRPC API has been temporarily disabled due to unmanageable load and will be deprecated in the near future. See https://status.python.org/incidents/grk0k7sz6zkp for more information.
```