### PR TITLE
Improve local pre-commit experience

### DIFF
--- a/.pre-commit-config-slow.yaml
+++ b/.pre-commit-config-slow.yaml
@@ -1,0 +1,7 @@
+# Slow pre-commit checks we don't want to run locally with each commit.
+
+repos:
+- repo: https://github.com/mgedmin/check-manifest
+  rev: '0.43'
+  hooks:
+  - id: check-manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,8 +97,3 @@ repos:
     entry: NEWS fragment files must be named *.(process|removal|feature|bugfix|vendor|doc|trivial).rst
     exclude: ^news/(.gitignore|.*\.(process|removal|feature|bugfix|vendor|doc|trivial).rst)
     files: ^news/
-
-- repo: https://github.com/mgedmin/check-manifest
-  rev: '0.43'
-  hooks:
-  - id: check-manifest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,6 +17,7 @@ exclude .appveyor.yml
 exclude .travis.yml
 exclude .readthedocs.yml
 exclude .pre-commit-config.yaml
+exclude .pre-commit-config-slow.yaml
 exclude tox.ini
 exclude noxfile.py
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -149,6 +149,9 @@ def lint(session):
         args = ["--all-files", "--show-diff-on-failure"]
 
     session.run("pre-commit", "run", *args)
+    session.run(
+        "pre-commit", "run", "-c", ".pre-commit-config-slow.yaml", *args
+    )
 
 
 @nox.session

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ commands_pre =
 deps = pre-commit
 commands =
    pre-commit run [] --all-files --show-diff-on-failure
+   pre-commit run [] -c .pre-commit-config-slow.yaml --all-files --show-diff-on-failure
 
 [testenv:vendoring]
 basepython = python3


### PR DESCRIPTION
Introduce a "slow" pre-commit config that is run always in CI, but not locally with each commit.

So far there is only the manifest check. All other checks are reasonably fast when being run when a commit includes only a few files.

closes #9332