### PR TITLE
Remove "universal" from "bdist_wheel" configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,8 +101,5 @@ exclude_lines =
     # Can be set to exclude e.g. `if PY2:` on Python 3
     ${PIP_CI_COVERAGE_EXCLUDES}
 
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE.txt


### PR DESCRIPTION
Since dropping Python 2 support, the wheel is no longer universal. See
the wheel docs:
https://wheel.readthedocs.io/en/stable/user_guide.html#building-wheels

> If your project … is expected to work on both Python 2 and 3, you will
> want to tell wheel to produce universal wheels by adding this to your
> setup.cfg file:
