### PR TITLE
Remove obsolete "# type: ignore" comments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ follow_imports = silent
 ignore_missing_imports = True
 disallow_untyped_defs = True
 disallow_any_generics = True
+warn_unused_ignores = True
 
 [mypy-pip/_vendor/*]
 follow_imports = skip

--- a/src/pip/_internal/cli/main_parser.py
+++ b/src/pip/_internal/cli/main_parser.py
@@ -68,7 +68,7 @@ def parse_command(args):
 
     # --version
     if general_options.version:
-        sys.stdout.write(parser.version)  # type: ignore
+        sys.stdout.write(parser.version)
         sys.stdout.write(os.linesep)
         sys.exit()
 

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -36,12 +36,7 @@ def show_value(name, value):
 def show_sys_implementation():
     # type: () -> None
     logger.info('sys.implementation:')
-    if hasattr(sys, 'implementation'):
-        implementation = sys.implementation  # type: ignore
-        implementation_name = implementation.name
-    else:
-        implementation_name = ''
-
+    implementation_name = sys.implementation.name
     with indent_log():
         show_value('name', implementation_name)
 
@@ -88,13 +83,7 @@ def get_vendor_version_from_module(module_name):
 
     if not version:
         # Try to find version in debundled module info
-        # The type for module.__file__ is Optional[str] in
-        # Python 2, and str in Python 3. The type: ignore is
-        # added to account for Python 2, instead of a cast
-        # and should be removed once we drop Python 2 support
-        pkg_set = pkg_resources.WorkingSet(
-            [os.path.dirname(module.__file__)]  # type: ignore
-        )
+        pkg_set = pkg_resources.WorkingSet([os.path.dirname(module.__file__)])
         package = pkg_set.find(pkg_resources.Requirement.parse(module_name))
         version = getattr(package, 'version', None)
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -92,8 +92,7 @@ def rehash(path, blocksize=1 << 20):
     digest = 'sha256=' + urlsafe_b64encode(
         h.digest()
     ).decode('latin1').rstrip('=')
-    # unicode/str python2 issues
-    return (digest, str(length))  # type: ignore
+    return (digest, str(length))
 
 
 def csv_io_kwargs(mode):

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -409,9 +409,7 @@ def get_line_parser(finder):
 
         args_str, options_str = break_args_options(line)
 
-        # https://github.com/python/mypy/issues/1174
-        opts, _ = parser.parse_args(
-            shlex.split(options_str), defaults)  # type: ignore
+        opts, _ = parser.parse_args(shlex.split(options_str), defaults)
 
         return args_str, opts
 
@@ -433,7 +431,7 @@ def break_args_options(line):
         else:
             args.append(token)
             options.pop(0)
-    return ' '.join(args), ' '.join(options)  # type: ignore
+    return ' '.join(args), ' '.join(options)
 
 
 class OptionParsingError(Exception):

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -192,8 +192,7 @@ def untar_file(filename, location):
         for member in tar.getmembers():
             fn = member.name
             if leading:
-                # https://github.com/python/mypy/issues/1174
-                fn = split_leading_dir(fn)[1]  # type: ignore
+                fn = split_leading_dir(fn)[1]
             path = os.path.join(location, fn)
             if not is_within_directory(location, path):
                 message = (
@@ -234,8 +233,7 @@ def untar_file(filename, location):
                     shutil.copyfileobj(fp, destfp)
                 fp.close()
                 # Update the timestamp (useful for cython compiled files)
-                # https://github.com/python/typeshed/issues/2673
-                tar.utime(member, path)  # type: ignore
+                tar.utime(member, path)
                 # member have any execute permissions for user/group/world?
                 if member.mode & 0o111:
                     set_extracted_file_to_default_mode_plus_executable(path)


### PR DESCRIPTION
Obsolete since dropping Python 2 support.

Add the mypy setting "warn_unused_ignores = True" to catch these
earlier.
