### PR TITLE
Remove __future__ imports

### DIFF
--- a/src/pip/__main__.py
+++ b/src/pip/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 import sys
 

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -1,7 +1,5 @@
 """Base Command class, and related routines"""
 
-from __future__ import absolute_import, print_function
-
 import logging
 import logging.config
 import optparse

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -10,8 +10,6 @@ pass on state. To be consistent, all options will follow this design.
 # The following comment should be removed at some point in the future.
 # mypy: strict-optional=False
 
-from __future__ import absolute_import
-
 import os
 import textwrap
 import warnings

--- a/src/pip/_internal/cli/main.py
+++ b/src/pip/_internal/cli/main.py
@@ -1,7 +1,5 @@
 """Primary application entrypoint.
 """
-from __future__ import absolute_import
-
 import locale
 import logging
 import os

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -3,8 +3,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
-from __future__ import absolute_import
-
 import logging
 import optparse
 import shutil

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import itertools
 import sys
 from signal import SIGINT, default_int_handler, signal

--- a/src/pip/_internal/cli/spinners.py
+++ b/src/pip/_internal/cli/spinners.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division
-
 import contextlib
 import itertools
 import logging

--- a/src/pip/_internal/cli/status_codes.py
+++ b/src/pip/_internal/cli/status_codes.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 SUCCESS = 0
 ERROR = 1
 UNKNOWN_ERROR = 2

--- a/src/pip/_internal/commands/__init__.py
+++ b/src/pip/_internal/commands/__init__.py
@@ -9,8 +9,6 @@ Package containing all pip commands
 # return type of difflib.get_close_matches to be reported
 # as List[Sequence[str]] whereas it should have been List[str]
 
-from __future__ import absolute_import
-
 import importlib
 from collections import OrderedDict, namedtuple
 

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import os
 import textwrap

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 import textwrap
 

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import locale
 import logging
 import os

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import os
 

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 
 from pip._internal.cache import WheelCache

--- a/src/pip/_internal/commands/hash.py
+++ b/src/pip/_internal/commands/hash.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import hashlib
 import logging
 import sys

--- a/src/pip/_internal/commands/help.py
+++ b/src/pip/_internal/commands/help.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.exceptions import CommandError

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import errno
 import logging
 import operator

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 import logging
 

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import shutil
 import sys

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import os
 from email.parser import FeedParser

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.cli.base_command import Command

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-
 import logging
 import os
 import shutil

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -1,7 +1,5 @@
 """Exceptions used throughout package"""
 
-from __future__ import absolute_import
-
 from itertools import chain, groupby, repeat
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -3,8 +3,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: strict-optional=False
 
-from __future__ import absolute_import
-
 import logging
 import re
 

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -3,8 +3,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: strict-optional=False
 
-from __future__ import absolute_import
-
 import os
 import os.path
 import platform

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import collections
 import logging
 import os

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -1,8 +1,6 @@
 """Support for installing and building the "wheel" binary package format.
 """
 
-from __future__ import absolute_import
-
 import collections
 import compileall
 import contextlib

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import io
 import os
 from collections import namedtuple

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import collections
 import logging
 

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -2,8 +2,6 @@
 Requirements file parsing
 """
 
-from __future__ import absolute_import
-
 import optparse
 import os
 import re

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -1,8 +1,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: strict-optional=False
 
-from __future__ import absolute_import
-
 import logging
 import os
 import shutil

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 from collections import OrderedDict
 

--- a/src/pip/_internal/req/req_tracker.py
+++ b/src/pip/_internal/req/req_tracker.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import contextlib
 import errno
 import hashlib

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import csv
 import functools
 import logging

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import datetime
 import hashlib
 import json

--- a/src/pip/_internal/utils/appdirs.py
+++ b/src/pip/_internal/utils/appdirs.py
@@ -6,8 +6,6 @@ The intention is to rewrite current usages gradually, keeping the tests pass,
 and eventually drop this after all usages are changed.
 """
 
-from __future__ import absolute_import
-
 import os
 
 from pip._vendor import appdirs as _appdirs

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -4,8 +4,6 @@ distributions."""
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
-from __future__ import absolute_import, division
-
 import codecs
 import functools
 import locale

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -1,8 +1,6 @@
 """Generate and work with PEP 425 Compatibility Tags.
 """
 
-from __future__ import absolute_import
-
 import re
 
 from pip._vendor.packaging.tags import (

--- a/src/pip/_internal/utils/datetime.py
+++ b/src/pip/_internal/utils/datetime.py
@@ -1,8 +1,6 @@
 """For when pip wants to check the date or time.
 """
 
-from __future__ import absolute_import
-
 import datetime
 
 

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -5,8 +5,6 @@ A module that implements tooling to enable easy warnings about deprecations.
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
-from __future__ import absolute_import
-
 import logging
 import warnings
 

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -1,8 +1,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: strict-optional=False
 
-from __future__ import absolute_import
-
 import os
 import sys
 

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import hashlib
 
 from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -1,8 +1,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
-from __future__ import absolute_import
-
 import contextlib
 import errno
 import logging

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -2,8 +2,6 @@
 # mypy: strict-optional=False
 # mypy: disallow-untyped-defs=False
 
-from __future__ import absolute_import
-
 import contextlib
 import errno
 import getpass

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 from email.parser import FeedParser
 

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import os
 import shlex

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import errno
 import itertools
 import logging

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -1,8 +1,6 @@
 """Utilities related archives.
 """
 
-from __future__ import absolute_import
-
 import logging
 import os
 import shutil

--- a/src/pip/_internal/utils/virtualenv.py
+++ b/src/pip/_internal/utils/virtualenv.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import io
 import logging
 import os

--- a/src/pip/_internal/utils/wheel.py
+++ b/src/pip/_internal/utils/wheel.py
@@ -1,8 +1,6 @@
 """Support functions for working with wheel files.
 """
 
-from __future__ import absolute_import
-
 import logging
 from email.parser import Parser
 from zipfile import BadZipFile, ZipFile

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -1,8 +1,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
-from __future__ import absolute_import
-
 import logging
 import os
 from urllib import parse as urllib_parse

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -1,8 +1,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
-from __future__ import absolute_import
-
 import logging
 import os.path
 import re

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -1,8 +1,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
-from __future__ import absolute_import
-
 import configparser
 import logging
 import os

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -1,8 +1,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
-from __future__ import absolute_import
-
 import logging
 import os
 import re

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -1,7 +1,5 @@
 """Handles all VCS (version control) support"""
 
-from __future__ import absolute_import
-
 import errno
 import logging
 import os

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 import re
 import shutil

--- a/tests/lib/git_submodule_helpers.py
+++ b/tests/lib/git_submodule_helpers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import textwrap
 
 from tests.lib import _create_main_file, _git_commit

--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 import subprocess
 from urllib import request as urllib_request

--- a/tests/lib/path.py
+++ b/tests/lib/path.py
@@ -1,8 +1,6 @@
 # flake8: noqa
 # -*- coding: utf-8 -*-
 # Author: Aziz Köksal
-from __future__ import absolute_import
-
 import glob
 import os
 

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -1,6 +1,4 @@
 """Test the test support."""
-from __future__ import absolute_import
-
 import filecmp
 import re
 import sys

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import compileall
 import shutil
 import sys


### PR DESCRIPTION
Unnecessary since dropping Python 2.
