### PR TITLE
Drop u prefix from str literals

### DIFF
--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -239,8 +239,8 @@ latex_documents = [
     (
         'index',
         'pip.tex',
-        u'pip Documentation',
-        u'pip developers',
+        'pip Documentation',
+        'pip developers',
         'manual',
     ),
 ]
@@ -269,8 +269,8 @@ man_pages = [
     (
         'index',
         'pip',
-        u'package manager for Python packages',
-        u'pip developers',
+        'package manager for Python packages',
+        'pip developers',
         1
     )
 ]
@@ -295,11 +295,11 @@ if not raw_subcommands:
 for fname in raw_subcommands:
     fname_base = to_document_name(fname, man_dir)
     outname = 'pip-' + fname_base.split('/')[1]
-    description = u'description of {} command'.format(
+    description = 'description of {} command'.format(
         outname.replace('-', ' ')
     )
 
-    man_pages.append((fname_base, outname, description, u'pip developers', 1))
+    man_pages.append((fname_base, outname, description, 'pip developers', 1))
 
 # -- Options for docs_feedback_sphinxext --------------------------------------
 

--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # pip documentation build configuration file, created by
 # sphinx-quickstart on Tue Apr 22 22:08:49 2008
 #

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -125,7 +125,7 @@ class BlueEmojiBar(IncrementalBar):
     suffix = "%(percent)d%%"
     bar_prefix = " "
     bar_suffix = " "
-    phases = ("\U0001F539", "\U0001F537", "\U0001F535")  # type: Any
+    phases = ("\U0001F539", "\U0001F537", "\U0001F535")
 
 
 class DownloadProgressMixin(object):

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -125,7 +125,7 @@ class BlueEmojiBar(IncrementalBar):
     suffix = "%(percent)d%%"
     bar_prefix = " "
     bar_suffix = " "
-    phases = (u"\U0001F539", u"\U0001F537", u"\U0001F535")  # type: Any
+    phases = ("\U0001F539", "\U0001F537", "\U0001F535")  # type: Any
 
 
 class DownloadProgressMixin(object):

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 import os
 import shutil

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -161,10 +161,7 @@ class LinkEvaluator(object):
         version = None
         if link.is_yanked and not self._allow_yanked:
             reason = link.yanked_reason or '<none given>'
-            # Mark this as a unicode string to prevent "UnicodeEncodeError:
-            # 'ascii' codec can't encode character" in Python 2 when
-            # the reason contains non-ascii characters.
-            return (False, u'yanked for reason: {}'.format(reason))
+            return (False, 'yanked for reason: {}'.format(reason))
 
         if link.egg_fragment:
             egg_info = link.egg_fragment
@@ -738,12 +735,9 @@ class PackageFinder(object):
     def _log_skipped_link(self, link, reason):
         # type: (Link, str) -> None
         if link not in self._logged_links:
-            # Mark this as a unicode string to prevent "UnicodeEncodeError:
-            # 'ascii' codec can't encode character" in Python 2 when
-            # the reason contains non-ascii characters.
-            #   Also, put the link at the end so the reason is more visible
-            # and because the link string is usually very long.
-            logger.debug(u'Skipping link: %s: %s', reason, link)
+            # Put the link at the end so the reason is more visible and because
+            # the link string is usually very long.
+            logger.debug('Skipping link: %s: %s', reason, link)
             self._logged_links.add(link)
 
     def get_install_candidate(self, link_evaluator, link):

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -30,7 +30,7 @@ HEADERS = {'Accept-Encoding': 'identity'}  # type: Dict[str, str]
 
 def raise_for_status(resp):
     # type: (Response) -> None
-    http_error_msg = u''
+    http_error_msg = ''
     if isinstance(resp.reason, bytes):
         # We attempt to decode utf-8 first because some servers
         # choose to localize their reason strings. If the string
@@ -44,11 +44,11 @@ def raise_for_status(resp):
         reason = resp.reason
 
     if 400 <= resp.status_code < 500:
-        http_error_msg = u'%s Client Error: %s for url: %s' % (
+        http_error_msg = '%s Client Error: %s for url: %s' % (
             resp.status_code, reason, resp.url)
 
     elif 500 <= resp.status_code < 600:
-        http_error_msg = u'%s Server Error: %s for url: %s' % (
+        http_error_msg = '%s Server Error: %s for url: %s' % (
             resp.status_code, reason, resp.url)
 
     if http_error_msg:

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -276,7 +276,7 @@ class Resolver(BaseResolver):
                 # Mark this as a unicode string to prevent
                 # "UnicodeEncodeError: 'ascii' codec can't encode character"
                 # in Python 2 when the reason contains non-ascii characters.
-                u'The candidate selected for download or install is a '
+                'The candidate selected for download or install is a '
                 'yanked version: {candidate}\n'
                 'Reason for being yanked: {reason}'
             ).format(candidate=best_candidate, reason=reason)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -189,14 +189,14 @@ class Resolver(BaseResolver):
                 # The reason can contain non-ASCII characters, Unicode
                 # is required for Python 2.
                 msg = (
-                    u'The candidate selected for download or install is a '
-                    u'yanked version: {name!r} candidate (version {version} '
-                    u'at {link})\nReason for being yanked: {reason}'
+                    'The candidate selected for download or install is a '
+                    'yanked version: {name!r} candidate (version {version} '
+                    'at {link})\nReason for being yanked: {reason}'
                 ).format(
                     name=candidate.name,
                     version=candidate.version,
                     link=link,
-                    reason=link.yanked_reason or u'<none given>',
+                    reason=link.yanked_reason or '<none given>',
                 )
                 logger.warning(msg)
 

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -90,7 +90,7 @@ def make_subprocess_output_error(
         # Use a unicode string to avoid "UnicodeEncodeError: 'ascii'
         # codec can't encode character ..." in Python 2 when a format
         # argument (e.g. `output`) has a non-ascii character.
-        u'Command errored out with exit status {exit_status}:\n'
+        'Command errored out with exit status {exit_status}:\n'
         ' command: {command_display}\n'
         '     cwd: {cwd_display}\n'
         'Complete output ({line_count} lines):\n{output}{divider}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -496,7 +496,7 @@ def cert_factory(tmpdir_factory):
         """
         output_path = Path(str(tmpdir_factory.mktemp("certs"))) / "cert.pem"
         # Must be Text on PY2.
-        cert, key = make_tls_cert(u"localhost")
+        cert, key = make_tls_cert("localhost")
         with open(str(output_path), "wb") as f:
             f.write(serialize_cert(cert))
             f.write(serialize_key(key))

--- a/tests/functional/test_fast_deps.py
+++ b/tests/functional/test_fast_deps.py
@@ -54,7 +54,7 @@ def test_build_wheel_with_deps(data, script):
 def test_require_hash(script, tmp_path):
     reqs = tmp_path / 'requirements.txt'
     reqs.write_text(
-        u'idna==2.10'
+        'idna==2.10'
         ' --hash=sha256:'
         'b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0'
         ' --hash=sha256:'
@@ -71,7 +71,7 @@ def test_require_hash(script, tmp_path):
 @mark.network
 def test_hash_mismatch(script, tmp_path):
     reqs = tmp_path / 'requirements.txt'
-    reqs.write_text(u'idna==2.10 --hash=sha256:irna')
+    reqs.write_text('idna==2.10 --hash=sha256:irna')
     result = script.pip(
         'download', '--use-feature=fast-deps', '-r', str(reqs),
         expect_error=True,

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import csv
 import distutils
 import glob

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -80,7 +80,7 @@ def test_new_resolver_hash_intersect(script, requirements_template, message):
         "--requirement", requirements_txt,
     )
 
-    assert message.format(name=u"base") in result.stdout, str(result)
+    assert message.format(name="base") in result.stdout, str(result)
 
 
 def test_new_resolver_hash_intersect_from_constraint(script):
@@ -116,7 +116,7 @@ def test_new_resolver_hash_intersect_from_constraint(script):
     message = (
         "Checked 2 links for project {name!r} against 1 hashes "
         "(1 matches, 0 no digest): discarding 1 non-matches"
-    ).format(name=u"base")
+    ).format(name="base")
     assert message in result.stdout, str(result)
 
 

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -259,13 +259,13 @@ def test_resolve_commit_not_on_branch(script, tmp_path):
     repo_path.mkdir()
     script.run("git", "init", cwd=str(repo_path))
 
-    repo_file.write_text(u".")
+    repo_file.write_text(".")
     script.run("git", "add", "file.txt", cwd=str(repo_path))
     script.run("git", "commit", "-m", "initial commit", cwd=str(repo_path))
     script.run("git", "checkout", "-b", "abranch", cwd=str(repo_path))
 
     # create a commit
-    repo_file.write_text(u"..")
+    repo_file.write_text("..")
     script.run("git", "commit", "-a", "-m", "commit 1", cwd=str(repo_path))
     commit = script.run(
         "git", "rev-parse", "HEAD", cwd=str(repo_path)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -306,7 +306,7 @@ class TestPipResult(object):
             if not (egg_link_contents.endswith('\n.') and
                     egg_link_contents[:-2].endswith(pkg_dir)):
                 raise TestFailure(textwrap.dedent(
-                    u'''\
+                    '''\
                     Incorrect egg_link file {egg_link_file!r}
                     Expected ending: {expected_ending!r}
                     ------- Actual contents -------

--- a/tests/lib/path.py
+++ b/tests/lib/path.py
@@ -1,5 +1,4 @@
 # flake8: noqa
-# -*- coding: utf-8 -*-
 # Author: Aziz Köksal
 import glob
 import os

--- a/tests/lib/path.py
+++ b/tests/lib/path.py
@@ -72,7 +72,7 @@ class Path(str):
         return Path(path + str(self))
 
     def __repr__(self):
-        return u"Path({inner})".format(inner=str.__repr__(self))
+        return "Path({inner})".format(inner=str.__repr__(self))
 
     def __hash__(self):
         return str.__hash__(self)

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -168,7 +168,7 @@ def text_html_response(text):
 
 def html5_page(text):
     # type: (str) -> str
-    return dedent(u"""
+    return dedent("""
     <!DOCTYPE html>
     <html>
       <body>

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -240,7 +240,7 @@ def record_file_maker_wrapper(
     if record_callback is not _default:
         records = record_callback(records)
 
-    with StringIO(newline=u"") as buf:
+    with StringIO(newline="") as buf:
         writer = csv23.writer(buf)
         for record in records:
             writer.writerow(map(ensure_text, record))

--- a/tests/unit/test_appdirs.py
+++ b/tests/unit/test_appdirs.py
@@ -70,7 +70,7 @@ class TestUserCacheDir:
             return
 
         def my_get_win_folder(csidl_name):
-            return u"\u00DF\u00E4\u03B1\u20AC"
+            return "\u00DF\u00E4\u03B1\u20AC"
 
         monkeypatch.setattr(_appdirs, "_get_win_folder", my_get_win_folder)
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -47,7 +47,7 @@ def test_cache_hash():
     assert h == "72aa79d3315c181d2cc23239d7109a782de663b6f89982624d8c1e86"
     h = _hash_dict({"url": "https://g.c/o/r", "subdirectory": "sd"})
     assert h == "8b13391b6791bf7f3edeabb41ea4698d21bcbdbba7f9c7dc9339750d"
-    h = _hash_dict({"subdirectory": u"/\xe9e"})
+    h = _hash_dict({"subdirectory": "/\xe9e"})
     assert h == "f83b32dfa27a426dec08c21bf006065dd003d0aac78e7fc493d9014d"
 
 

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -382,14 +382,14 @@ def test_clean_link(url, clean_url):
     ('<a href="/pkg4-1.0.tar.gz" data-yanked="version &lt 1"></a>',
         'version < 1'),
     # Test a yanked reason with a non-ascii character.
-    (u'<a href="/pkg-1.0.tar.gz" data-yanked="curlyquote \u2018"></a>',
-        u'curlyquote \u2018'),
+    ('<a href="/pkg-1.0.tar.gz" data-yanked="curlyquote \u2018"></a>',
+        'curlyquote \u2018'),
 ])
 def test_parse_links__yanked_reason(anchor_html, expected):
     html = (
         # Mark this as a unicode string for Python 2 since anchor_html
         # can contain non-ascii.
-        u'<html><head><meta charset="utf-8"><head>'
+        '<html><head><meta charset="utf-8"><head>'
         '<body>{}</body></html>'
     ).format(anchor_html)
     html_bytes = html.encode('utf-8')
@@ -552,7 +552,7 @@ def make_fake_html_response(url):
     """
     Create a fake requests.Response object.
     """
-    html = dedent(u"""\
+    html = dedent("""\
     <html><head><meta name="api-version" value="2" /></head>
     <body>
     <a href="/abc-1.0.tar.gz#md5=000000000">abc-1.0.tar.gz</a>

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -54,11 +54,9 @@ def test_get_path_uid_symlink_without_NOFOLLOW(tmpdir, monkeypatch):
 
 
 @pytest.mark.parametrize('data, expected', [
-    ('abc', u'abc'),
-    # Test text (unicode in Python 2) input.
-    (u'abc', u'abc'),
+    ('abc', 'abc'),
     # Test text input with non-ascii characters.
-    (u'déf', u'déf'),
+    ('déf', 'déf'),
 ])
 def test_str_to_display(data, expected):
     actual = str_to_display(data)
@@ -70,13 +68,13 @@ def test_str_to_display(data, expected):
 
 @pytest.mark.parametrize('data, encoding, expected', [
     # Test str input with non-ascii characters.
-    ('déf', 'utf-8', u'déf'),
+    ('déf', 'utf-8', 'déf'),
     # Test bytes input with non-ascii characters:
-    (u'déf'.encode('utf-8'), 'utf-8', u'déf'),
+    ('déf'.encode('utf-8'), 'utf-8', 'déf'),
     # Test a Windows encoding.
-    (u'déf'.encode('cp1252'), 'cp1252', u'déf'),
+    ('déf'.encode('cp1252'), 'cp1252', 'déf'),
     # Test a Windows encoding with incompatibly encoded text.
-    (u'déf'.encode('utf-8'), 'cp1252', u'dÃ©f'),
+    ('déf'.encode('utf-8'), 'cp1252', 'dÃ©f'),
 ])
 def test_str_to_display__encoding(monkeypatch, data, encoding, expected):
     monkeypatch.setattr(locale, 'getpreferredencoding', lambda: encoding)
@@ -90,7 +88,7 @@ def test_str_to_display__encoding(monkeypatch, data, encoding, expected):
 def test_str_to_display__decode_error(monkeypatch, caplog):
     monkeypatch.setattr(locale, 'getpreferredencoding', lambda: 'utf-8')
     # Encode with an incompatible encoding.
-    data = u'ab'.encode('utf-16')
+    data = 'ab'.encode('utf-16')
     actual = str_to_display(data)
     # Keep the expected value endian safe
     if sys.byteorder == "little":

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import locale
 import os
 import sys

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -131,9 +131,9 @@ class TestLinkEvaluator:
         ('bad metadata', False,
          (False, 'yanked for reason: bad metadata')),
         # Test a unicode string with a non-ascii character.
-        (u'curly quote: \u2018', True, (True, '1.12')),
-        (u'curly quote: \u2018', False,
-         (False, u'yanked for reason: curly quote: \u2018')),
+        ('curly quote: \u2018', True, (True, '1.12')),
+        ('curly quote: \u2018', False,
+         (False, 'yanked for reason: curly quote: \u2018')),
     ])
     def test_evaluate_link__allow_yanked(
         self, yanked_reason, allow_yanked, expected,

--- a/tests/unit/test_resolution_legacy_resolver.py
+++ b/tests/unit/test_resolution_legacy_resolver.py
@@ -245,7 +245,7 @@ class TestYankedWarning(object):
         # Test no reason given.
         ('', '<none given>'),
         # Test a unicode string with a non-ascii character.
-        (u'curly quote: \u2018', u'curly quote: \u2018'),
+        ('curly quote: \u2018', 'curly quote: \u2018'),
     ])
     def test_sort_best_candidate__yanked_reason(
         self, caplog, monkeypatch, yanked_reason, expected_reason,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -419,12 +419,12 @@ def test_rmtree_retries_for_3sec(tmpdir, monkeypatch):
 
 if sys.byteorder == "little":
     expected_byte_string = (
-        u"b'\\xff\\xfe/\\x00p\\x00a\\x00t\\x00h\\x00/"
+        "b'\\xff\\xfe/\\x00p\\x00a\\x00t\\x00h\\x00/"
         "\\x00d\\x00\\xe9\\x00f\\x00'"
     )
 elif sys.byteorder == "big":
     expected_byte_string = (
-        u"b'\\xfe\\xff\\x00/\\x00p\\x00a\\x00t\\x00h\\"
+        "b'\\xfe\\xff\\x00/\\x00p\\x00a\\x00t\\x00h\\"
         "x00/\\x00d\\x00\\xe9\\x00f'"
     )
 
@@ -432,12 +432,12 @@ elif sys.byteorder == "big":
 @pytest.mark.parametrize('path, fs_encoding, expected', [
     (None, None, None),
     # Test passing a text (unicode) string.
-    (u'/path/déf', None, u'/path/déf'),
+    ('/path/déf', None, '/path/déf'),
     # Test a bytes object with a non-ascii character.
-    (u'/path/déf'.encode('utf-8'), 'utf-8', u'/path/déf'),
+    ('/path/déf'.encode('utf-8'), 'utf-8', '/path/déf'),
     # Test a bytes object with a character that can't be decoded.
-    (u'/path/déf'.encode('utf-8'), 'ascii', u"b'/path/d\\xc3\\xa9f'"),
-    (u'/path/déf'.encode('utf-16'), 'utf-8', expected_byte_string),
+    ('/path/déf'.encode('utf-8'), 'ascii', "b'/path/d\\xc3\\xa9f'"),
+    ('/path/déf'.encode('utf-16'), 'utf-8', expected_byte_string),
 ])
 def test_path_to_display(monkeypatch, path, fs_encoding, expected):
     monkeypatch.setattr(sys, 'getfilesystemencoding', lambda: fs_encoding)
@@ -572,17 +572,17 @@ class TestEncoding(object):
         assert auto_decode(data) == "Django==1.4.2"
 
     def test_auto_decode_no_bom(self):
-        assert auto_decode(b'foobar') == u'foobar'
+        assert auto_decode(b'foobar') == 'foobar'
 
     def test_auto_decode_pep263_headers(self):
-        latin1_req = u'# coding=latin1\n# Pas trop de café'
+        latin1_req = '# coding=latin1\n# Pas trop de café'
         assert auto_decode(latin1_req.encode('latin1')) == latin1_req
 
     def test_auto_decode_no_preferred_encoding(self):
         om, em = Mock(), Mock()
         om.return_value = 'ascii'
         em.return_value = None
-        data = u'data'
+        data = 'data'
         with patch('sys.getdefaultencoding', om):
             with patch('locale.getpreferredencoding', em):
                 ret = auto_decode(data.encode(sys.getdefaultencoding()))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 util tests
 

--- a/tests/unit/test_utils_subprocess.py
+++ b/tests/unit/test_utils_subprocess.py
@@ -61,7 +61,7 @@ def test_make_subprocess_output_error__non_ascii_command_arg(monkeypatch):
         # Check in Python 2 that the str (bytes object) with the non-ascii
         # character has the encoding we expect. (This comes from the source
         # code encoding at the top of the file.)
-        assert cmd_args[1].decode('utf-8') == u'déf'
+        assert cmd_args[1].decode('utf-8') == 'déf'
 
     # We need to monkeypatch so the encoding will be correct on Windows.
     monkeypatch.setattr(locale, 'getpreferredencoding', lambda: 'utf-8')
@@ -71,13 +71,13 @@ def test_make_subprocess_output_error__non_ascii_command_arg(monkeypatch):
         lines=[],
         exit_status=1,
     )
-    expected = dedent(u"""\
+    expected = dedent("""\
     Command errored out with exit status 1:
      command: foo 'déf'
          cwd: /path/to/cwd
     Complete output (0 lines):
     ----------------------------------------""")
-    assert actual == expected, u'actual: {}'.format(actual)
+    assert actual == expected, 'actual: {}'.format(actual)
 
 
 @pytest.mark.skipif("sys.version_info < (3,)")
@@ -115,7 +115,7 @@ def test_make_subprocess_output_error__non_ascii_cwd_python_2(
     Test a str (bytes object) cwd with a non-ascii character in Python 2.
     """
     cmd_args = ['test']
-    cwd = u'/path/to/cwd/déf'.encode(encoding)
+    cwd = '/path/to/cwd/déf'.encode(encoding)
     monkeypatch.setattr(sys, 'getfilesystemencoding', lambda: encoding)
     actual = make_subprocess_output_error(
         cmd_args=cmd_args,
@@ -123,13 +123,13 @@ def test_make_subprocess_output_error__non_ascii_cwd_python_2(
         lines=[],
         exit_status=1,
     )
-    expected = dedent(u"""\
+    expected = dedent("""\
     Command errored out with exit status 1:
      command: test
          cwd: /path/to/cwd/déf
     Complete output (0 lines):
     ----------------------------------------""")
-    assert actual == expected, u'actual: {}'.format(actual)
+    assert actual == expected, 'actual: {}'.format(actual)
 
 
 # This test is mainly important for checking unicode in Python 2.
@@ -137,21 +137,21 @@ def test_make_subprocess_output_error__non_ascii_line():
     """
     Test a line with a non-ascii character.
     """
-    lines = [u'curly-quote: \u2018\n']
+    lines = ['curly-quote: \u2018\n']
     actual = make_subprocess_output_error(
         cmd_args=['test'],
         cwd='/path/to/cwd',
         lines=lines,
         exit_status=1,
     )
-    expected = dedent(u"""\
+    expected = dedent("""\
     Command errored out with exit status 1:
      command: test
          cwd: /path/to/cwd
     Complete output (1 lines):
     curly-quote: \u2018
     ----------------------------------------""")
-    assert actual == expected, u'actual: {}'.format(actual)
+    assert actual == expected, 'actual: {}'.format(actual)
 
 
 class FakeSpinner(SpinnerInterface):

--- a/tests/unit/test_utils_subprocess.py
+++ b/tests/unit/test_utils_subprocess.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import locale
 import sys
 from logging import DEBUG, ERROR, INFO, WARNING

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Tests for wheel binary packages and .dist-info."""
 import csv
 import logging

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -81,13 +81,13 @@ def test_get_legacy_build_wheel_path__multiple_names(caplog):
 @pytest.mark.parametrize(
     "console_scripts",
     [
-        u"pip = pip._internal.main:pip",
-        u"pip:pip = pip._internal.main:pip",
-        u"進入點 = 套件.模組:函式",
+        "pip = pip._internal.main:pip",
+        "pip:pip = pip._internal.main:pip",
+        "進入點 = 套件.模組:函式",
     ],
 )
 def test_get_entrypoints(console_scripts):
-    entry_points_text = u"""
+    entry_points_text = """
         [console_scripts]
         {}
         [section]
@@ -125,8 +125,8 @@ def test_get_entrypoints_no_entrypoints():
 
 @pytest.mark.parametrize("outrows, expected", [
     ([
-        (u'', '', 'a'),
-        (u'', '', ''),
+        ('', '', 'a'),
+        ('', '', ''),
     ], [
         ('', '', ''),
         ('', '', 'a'),
@@ -134,16 +134,16 @@ def test_get_entrypoints_no_entrypoints():
     ([
         # Include an int to check avoiding the following error:
         # > TypeError: '<' not supported between instances of 'str' and 'int'
-        (u'', '', 1),
-        (u'', '', ''),
+        ('', '', 1),
+        ('', '', ''),
     ], [
         ('', '', ''),
         ('', '', '1'),
     ]),
     ([
         # Test the normalization correctly encode everything for csv.writer().
-        (u'😉', '', 1),
-        (u'', '', ''),
+        ('😉', '', 1),
+        ('', '', ''),
     ], [
         ('', '', ''),
         ('😉', '', '1'),
@@ -160,7 +160,7 @@ def call_get_csv_rows_for_installed(tmpdir, text):
 
     # Test that an installed file appearing in RECORD has its filename
     # updated in the new RECORD file.
-    installed = {u'a': 'z'}
+    installed = {'a': 'z'}
     changed = set()
     generated = []
     lib_dir = '/lib/dir'

--- a/tools/automation/release/__init__.py
+++ b/tools/automation/release/__init__.py
@@ -76,8 +76,8 @@ def generate_authors(filename: str) -> None:
 
     # Write our authors to the AUTHORS file
     with io.open(filename, "w", encoding="utf-8") as fp:
-        fp.write(u"\n".join(authors))
-        fp.write(u"\n")
+        fp.write("\n".join(authors))
+        fp.write("\n")
 
 
 def commit_file(session: Session, filename: str, *, message: str) -> None:


### PR DESCRIPTION
Unnecessary since dropping Python 2 support.

This makes one test case from test_str_to_display a duplicate and so has
been removed.
