### PR TITLE
Replace io.open() and codecs.open() with builtin open()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: disallow-untyped-defs=False
 
-import codecs
 import os
 import sys
 
@@ -12,7 +11,7 @@ def read(rel_path):
     here = os.path.abspath(os.path.dirname(__file__))
     # intentionally *not* adding an encoding option to open, See:
     #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
-    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+    with open(os.path.join(here, rel_path), 'r') as fp:
         return fp.read()
 
 

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -1,4 +1,3 @@
-import io
 import os
 from collections import namedtuple
 
@@ -62,7 +61,7 @@ def load_pyproject_toml(
     has_setup = os.path.isfile(setup_py)
 
     if has_pyproject:
-        with io.open(pyproject_toml, encoding="utf-8") as f:
+        with open(pyproject_toml, encoding="utf-8") as f:
             pp_toml = toml.load(f)
         build_system = pp_toml.get("build-system")
     else:

--- a/src/pip/_internal/utils/virtualenv.py
+++ b/src/pip/_internal/utils/virtualenv.py
@@ -1,4 +1,3 @@
-import io
 import logging
 import os
 import re
@@ -52,7 +51,7 @@ def _get_pyvenv_cfg_lines():
     try:
         # Although PEP 405 does not specify, the built-in venv module always
         # writes with UTF-8. (pypa/pip#8717)
-        with io.open(pyvenv_cfg_file, encoding='utf-8') as f:
+        with open(pyvenv_cfg_file, encoding='utf-8') as f:
             return f.read().splitlines()  # avoids trailing newlines
     except IOError:
         return None

--- a/tools/automation/release/__init__.py
+++ b/tools/automation/release/__init__.py
@@ -4,7 +4,6 @@ These are written according to the order they are called in.
 """
 
 import contextlib
-import io
 import os
 import pathlib
 import subprocess
@@ -75,7 +74,7 @@ def generate_authors(filename: str) -> None:
     authors = get_author_list()
 
     # Write our authors to the AUTHORS file
-    with io.open(filename, "w", encoding="utf-8") as fp:
+    with open(filename, "w", encoding="utf-8") as fp:
         fp.write("\n".join(authors))
         fp.write("\n")
 


### PR DESCRIPTION
In Python 3, these are functionally equivalent and share the same
feature set.