### PR TITLE
Fix broken email link in docs feedback banners

### DIFF
--- a/docs/docs_feedback_sphinxext.py
+++ b/docs/docs_feedback_sphinxext.py
@@ -141,7 +141,7 @@ def setup(app: Sphinx) -> Dict[str, Union[bool, str]]:
     )
     app.add_config_value(
         'docs_feedback_email',
-        default='Docs UX Team <docs-feedback+ux/pip.pypa.io@pypa.io>',
+        default='Docs UX Team <docs-feedback@pypa.io>',
         rebuild=rebuild_trigger,
     )
     app.add_config_value(

--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -307,7 +307,7 @@ for fname in raw_subcommands:
 # NOTE: 'important', 'note', 'tip', 'warning' or 'admonition'.
 docs_feedback_admonition_type = 'important'
 docs_feedback_big_doc_lines = 50  # bigger docs will have a banner on top
-docs_feedback_email = 'Docs UX Team <docs-feedback+ux/pip.pypa.io@pypa.io>'
+docs_feedback_email = 'Docs UX Team <docs-feedback@pypa.io>'
 docs_feedback_excluded_documents = {  # these won't have any banners
     'news', 'reference/index',
 }

--- a/news/9343.doc.rst
+++ b/news/9343.doc.rst
@@ -1,0 +1,1 @@
+Fix broken email link in docs feedback banners.


### PR DESCRIPTION
Fixes #9343.

`docs-feedback+ux/pip.pypa.io@pypa.io` isn't a valid email address, so I replaced it with the right email address according to this GitHub comment: https://github.com/pypa/pip/issues/8783#issuecomment-685823974
