### PR TITLE
Replace typing.Text with str

### DIFF
--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -7,7 +7,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 if MYPY_CHECK_RUNNING:
     import configparser
     from hashlib import _Hash
-    from typing import Any, Dict, List, Optional, Text
+    from typing import Any, Dict, List, Optional
 
     from pip._vendor.pkg_resources import Distribution
     from pip._vendor.requests.models import Request, Response
@@ -95,7 +95,7 @@ class NetworkConnectionError(PipError):
     """HTTP connection error"""
 
     def __init__(self, error_msg, response=None, request=None):
-        # type: (Text, Response, Request) -> None
+        # type: (str, Response, Request) -> None
         """
         Initialize NetworkConnectionError with  `request` and `response`
         objects.

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -33,7 +33,7 @@ from pip._internal.utils.unpacking import SUPPORTED_EXTENSIONS
 from pip._internal.utils.urls import url_to_path
 
 if MYPY_CHECK_RUNNING:
-    from typing import FrozenSet, Iterable, List, Optional, Set, Text, Tuple, Union
+    from typing import FrozenSet, Iterable, List, Optional, Set, Tuple, Union
 
     from pip._vendor.packaging.tags import Tag
     from pip._vendor.packaging.version import _BaseVersion
@@ -149,7 +149,7 @@ class LinkEvaluator(object):
         self.project_name = project_name
 
     def evaluate_link(self, link):
-        # type: (Link) -> Tuple[bool, Optional[Text]]
+        # type: (Link) -> Tuple[bool, Optional[str]]
         """
         Determine whether a link is a candidate for installation.
 
@@ -736,7 +736,7 @@ class PackageFinder(object):
         return no_eggs + eggs
 
     def _log_skipped_link(self, link, reason):
-        # type: (Link, Text) -> None
+        # type: (Link, str) -> None
         if link not in self._logged_links:
             # Mark this as a unicode string to prevent "UnicodeEncodeError:
             # 'ascii' codec can't encode character" in Python 2 when
@@ -761,9 +761,7 @@ class PackageFinder(object):
         return InstallationCandidate(
             name=link_evaluator.project_name,
             link=link,
-            # Convert the Text result to str since InstallationCandidate
-            # accepts str.
-            version=str(result),
+            version=result,
         )
 
     def evaluate_links(self, link_evaluator, links):

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -14,7 +14,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import path_to_url, url_to_path
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Text, Tuple, Union
+    from typing import Optional, Tuple, Union
 
     from pip._internal.index.collector import HTMLPage
     from pip._internal.utils.hashes import Hashes
@@ -38,7 +38,7 @@ class Link(KeyBasedCompareMixin):
         url,                   # type: str
         comes_from=None,       # type: Optional[Union[str, HTMLPage]]
         requires_python=None,  # type: Optional[str]
-        yanked_reason=None,    # type: Optional[Text]
+        yanked_reason=None,    # type: Optional[str]
         cache_link_parsing=True,  # type: bool
     ):
         # type: (...) -> None

--- a/src/pip/_internal/operations/build/wheel_legacy.py
+++ b/src/pip/_internal/operations/build/wheel_legacy.py
@@ -11,14 +11,14 @@ from pip._internal.utils.subprocess import (
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import List, Optional, Text
+    from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
 
 def format_command_result(
     command_args,  # type: List[str]
-    command_output,  # type: Text
+    command_output,  # type: str
 ):
     # type: (...) -> str
     """Format command information for logging."""
@@ -42,7 +42,7 @@ def get_legacy_build_wheel_path(
     temp_dir,  # type: str
     name,  # type: str
     command_args,  # type: List[str]
-    command_output,  # type: Text
+    command_output,  # type: str
 ):
     # type: (...) -> Optional[str]
     """Return the path to the wheel in the temporary build directory."""

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -156,7 +156,7 @@ def parse_requirements(
 
 
 def preprocess(content):
-    # type: (Text) -> ReqFileLines
+    # type: (str) -> ReqFileLines
     """Split, filter, and join lines, and return a line iterator
 
     :param content: the content of the requirements file
@@ -396,7 +396,7 @@ class RequirementsFileParser(object):
 def get_line_parser(finder):
     # type: (Optional[PackageFinder]) -> LineParser
     def parse_line(line):
-        # type: (Text) -> Tuple[str, Values]
+        # type: (str) -> Tuple[str, Values]
         # Build new parser for each line since it accumulates appendable
         # options.
         parser = build_parser()
@@ -415,7 +415,7 @@ def get_line_parser(finder):
 
 
 def break_args_options(line):
-    # type: (Text) -> Tuple[str, Text]
+    # type: (str) -> Tuple[str, str]
     """Break up the line into an args and options string.  We only want to shlex
     (and then optparse) the options, not the args.  args can contain markers
     which are corrupted by shlex.
@@ -468,7 +468,7 @@ def join_lines(lines_enum):
     comments).  The joined line takes on the index of the first line.
     """
     primary_line_number = None
-    new_line = []  # type: List[Text]
+    new_line = []  # type: List[str]
     for line_number, line in lines_enum:
         if not line.endswith('\\') or COMMENT_RE.match(line):
             if COMMENT_RE.match(line):
@@ -535,7 +535,7 @@ def expand_env_variables(lines_enum):
 
 
 def get_file_content(url, session):
-    # type: (str, PipSession) -> Tuple[str, Text]
+    # type: (str, PipSession) -> Tuple[str, str]
     """Gets the content of a file; it may be a filename, file: URL, or
     http: URL.  Returns (location, content).  Content is unicode.
     Respects # -*- coding: declarations on the retrieved files.

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -18,7 +18,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     import optparse
-    from typing import Any, Dict, Text, Union
+    from typing import Any, Dict
 
     from pip._internal.network.session import PipSession
 
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_statefile_name(key):
-    # type: (Union[str, Text]) -> str
+    # type: (str) -> str
     key_bytes = ensure_binary(key)
     name = hashlib.sha224(key_bytes).hexdigest()
     return name

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -14,7 +14,7 @@ import sys
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Callable, Optional, Protocol, Text, TypeVar, Union
+    from typing import Callable, Optional, Protocol, TypeVar, Union
 
     # Used in the @lru_cache polyfill.
     F = TypeVar('F')
@@ -57,7 +57,7 @@ def has_tls():
 
 
 def str_to_display(data, desc=None):
-    # type: (Union[bytes, Text], Optional[str]) -> Text
+    # type: (Union[bytes, str], Optional[str]) -> str
     """
     For display or logging purposes, convert a bytes object (or text) to
     text (e.g. unicode in Python 2) safe for output.
@@ -124,7 +124,7 @@ def str_to_display(data, desc=None):
 
 
 def console_to_str(data):
-    # type: (bytes) -> Text
+    # type: (bytes) -> str
     """Return a string, safe for output, of subprocess output.
     """
     return str_to_display(data, desc='Subprocess output')

--- a/src/pip/_internal/utils/encoding.py
+++ b/src/pip/_internal/utils/encoding.py
@@ -6,7 +6,7 @@ import sys
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import List, Text, Tuple
+    from typing import List, Tuple
 
 BOMS = [
     (codecs.BOM_UTF8, 'utf-8'),
@@ -16,13 +16,13 @@ BOMS = [
     (codecs.BOM_UTF32, 'utf-32'),
     (codecs.BOM_UTF32_BE, 'utf-32-be'),
     (codecs.BOM_UTF32_LE, 'utf-32-le'),
-]  # type: List[Tuple[bytes, Text]]
+]  # type: List[Tuple[bytes, str]]
 
 ENCODING_RE = re.compile(br'coding[:=]\s*([-\w.]+)')
 
 
 def auto_decode(data):
-    # type: (bytes) -> Text
+    # type: (bytes) -> str
     """Check a bytes string for a BOM to correctly detect the encoding
 
     Fallback to locale.getpreferredencoding(False) like open() on Python3"""

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -46,10 +46,8 @@ if MYPY_CHECK_RUNNING:
         Iterator,
         List,
         Optional,
-        Text,
         Tuple,
         TypeVar,
-        Union,
     )
 
     from pip._vendor.pkg_resources import Distribution
@@ -155,7 +153,7 @@ def rmtree_errorhandler(func, path, exc_info):
 
 
 def path_to_display(path):
-    # type: (Optional[Union[str, Text]]) -> Optional[Text]
+    # type: (Optional[str]) -> Optional[str]
     """
     Convert a bytes (or text) path to text (unicode in Python 2) for display
     and logging purposes.
@@ -181,7 +179,7 @@ def path_to_display(path):
 
 
 def display_path(path):
-    # type: (Union[str, Text]) -> str
+    # type: (str) -> str
     """Gives the display value for a given path, making it relative to cwd
     if possible."""
     path = os.path.normcase(os.path.abspath(path))
@@ -885,7 +883,7 @@ def is_console_interactive():
 
 
 def hash_file(path, blocksize=1 << 20):
-    # type: (Text, int) -> Tuple[Any, int]
+    # type: (str, int) -> Tuple[Any, int]
     """Return (hash, length) for path using hashlib.sha256()
     """
 

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -11,7 +11,7 @@ from pip._internal.utils.misc import HiddenText, path_to_display
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any, Callable, Iterable, List, Mapping, Optional, Text, Union
+    from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
 
     CommandArgs = List[Union[str, HiddenText]]
 
@@ -66,10 +66,10 @@ def reveal_command_args(args):
 def make_subprocess_output_error(
     cmd_args,     # type: Union[List[str], CommandArgs]
     cwd,          # type: Optional[str]
-    lines,        # type: List[Text]
+    lines,        # type: List[str]
     exit_status,  # type: int
 ):
-    # type: (...) -> Text
+    # type: (...) -> str
     """
     Create and return the error message to use to log a subprocess error
     with command output.
@@ -117,7 +117,7 @@ def call_subprocess(
     spinner=None,  # type: Optional[SpinnerInterface]
     log_failed_cmd=True  # type: Optional[bool]
 ):
-    # type: (...) -> Text
+    # type: (...) -> str
     """
     Args:
       show_stdout: if true, use INFO to log the subprocess's stderr and

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -19,7 +19,7 @@ from pip._internal.utils.misc import ensure_dir
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Iterable, List, Optional, Text, Union
+    from typing import Iterable, List, Optional
     from zipfile import ZipInfo
 
 
@@ -51,7 +51,7 @@ def current_umask():
 
 
 def split_leading_dir(path):
-    # type: (Union[str, Text]) -> List[Union[str, Text]]
+    # type: (str) -> List[str]
     path = path.lstrip('/').lstrip('\\')
     if (
         '/' in path and (
@@ -67,7 +67,7 @@ def split_leading_dir(path):
 
 
 def has_leading_dir(paths):
-    # type: (Iterable[Union[str, Text]]) -> bool
+    # type: (Iterable[str]) -> bool
     """Returns true if all the paths have the same leading path name
     (i.e., everything is in one subdirectory in an archive)"""
     common_prefix = None
@@ -83,7 +83,7 @@ def has_leading_dir(paths):
 
 
 def is_within_directory(directory, target):
-    # type: ((Union[str, Text]), (Union[str, Text])) -> bool
+    # type: (str, str) -> bool
     """
     Return true if the absolute path of target is within the directory
     """
@@ -95,7 +95,7 @@ def is_within_directory(directory, target):
 
 
 def set_extracted_file_to_default_mode_plus_executable(path):
-    # type: (Union[str, Text]) -> None
+    # type: (str) -> None
     """
     Make file present at path have execute for user/group/world
     (chmod +x) is no-op on windows per python docs

--- a/src/pip/_internal/utils/urls.py
+++ b/src/pip/_internal/utils/urls.py
@@ -6,18 +6,18 @@ from urllib import request as urllib_request
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Optional, Text, Union
+    from typing import Optional
 
 
 def get_url_scheme(url):
-    # type: (Union[str, Text]) -> Optional[Text]
+    # type: (str) -> Optional[str]
     if ':' not in url:
         return None
     return url.split(':', 1)[0].lower()
 
 
 def path_to_url(path):
-    # type: (Union[str, Text]) -> str
+    # type: (str) -> str
     """
     Convert a path to a file: URL.  The path will be made absolute and have
     quoted path parts.

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -39,7 +39,6 @@ if MYPY_CHECK_RUNNING:
         List,
         Mapping,
         Optional,
-        Text,
         Tuple,
         Type,
         Union,
@@ -58,7 +57,7 @@ logger = logging.getLogger(__name__)
 
 
 def is_url(name):
-    # type: (Union[str, Text]) -> bool
+    # type: (str) -> bool
     """
     Return true if the name looks like a URL.
     """
@@ -92,7 +91,7 @@ def call_subprocess(
     extra_ok_returncodes=None,  # type: Optional[Iterable[int]]
     log_failed_cmd=True  # type: Optional[bool]
 ):
-    # type: (...) -> Text
+    # type: (...) -> str
     """
     Args:
       extra_ok_returncodes: an iterable of integer return codes that are
@@ -764,7 +763,7 @@ class VersionControl(object):
         extra_ok_returncodes=None,  # type: Optional[Iterable[int]]
         log_failed_cmd=True  # type: bool
     ):
-        # type: (...) -> Text
+        # type: (...) -> str
         """
         Run a VCS subcommand
         This is simply a wrapper around call_subprocess that adds the VCS

--- a/tests/lib/certs.py
+++ b/tests/lib/certs.py
@@ -9,11 +9,11 @@ from cryptography.x509.oid import NameOID
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Text, Tuple
+    from typing import Tuple
 
 
 def make_tls_cert(hostname):
-    # type: (Text) -> Tuple[x509.Certificate, rsa.RSAPrivateKey]
+    # type: (str) -> Tuple[x509.Certificate, rsa.RSAPrivateKey]
     key = rsa.generate_private_key(
         public_exponent=65537,
         key_size=2048,

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -14,18 +14,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
     from types import TracebackType
-    from typing import (
-        Any,
-        Callable,
-        Dict,
-        Iterable,
-        List,
-        Optional,
-        Text,
-        Tuple,
-        Type,
-        Union,
-    )
+    from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 
     from werkzeug.serving import BaseWSGIServer
 
@@ -166,7 +155,7 @@ def server_running(server):
 
 
 def text_html_response(text):
-    # type: (Text) -> Responder
+    # type: (str) -> Responder
     def responder(environ, start_response):
         # type: (Environ, StartResponse) -> Body
         start_response("200 OK", [
@@ -178,7 +167,7 @@ def text_html_response(text):
 
 
 def html5_page(text):
-    # type: (Union[Text, str]) -> Text
+    # type: (str) -> str
     return dedent(u"""
     <!DOCTYPE html>
     <html>


### PR DESCRIPTION
Using typing.Text is unnecessary since dropping Python 2 support.

In Python 3, typing.Text is a simple alias of str. It exists as a
backward compatibility shim for Python 2.
