### PR TITLE
Replace utils.compat.lru_cache with stdlib functools.lru_cache

### DIFF
--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -21,7 +21,6 @@ from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.models.link import Link
 from pip._internal.models.search_scope import SearchScope
 from pip._internal.network.utils import raise_for_status
-from pip._internal.utils.compat import lru_cache
 from pip._internal.utils.filetypes import is_archive_file
 from pip._internal.utils.misc import pairwise, redact_auth_from_url
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -311,7 +310,7 @@ def with_cached_html_pages(
     `page` has `page.cache_link_parsing == False`.
     """
 
-    @lru_cache(maxsize=None)
+    @functools.lru_cache(maxsize=None)
     def wrapper(cacheable_page):
         # type: (CacheablePageContent) -> List[Link]
         return list(fn(cacheable_page.page))

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -3,6 +3,7 @@
 # The following comment should be removed at some point in the future.
 # mypy: strict-optional=False
 
+import functools
 import logging
 import re
 
@@ -23,7 +24,6 @@ from pip._internal.models.link import Link
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.models.wheel import Wheel
-from pip._internal.utils.compat import lru_cache
 from pip._internal.utils.filetypes import WHEEL_EXTENSION
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import build_netloc
@@ -796,7 +796,7 @@ class PackageFinder(object):
 
         return package_links
 
-    @lru_cache(maxsize=None)
+    @functools.lru_cache(maxsize=None)
     def find_all_candidates(self, project_name):
         # type: (str) -> List[InstallationCandidate]
         """Find all available InstallationCandidate for project_name
@@ -859,7 +859,7 @@ class PackageFinder(object):
             hashes=hashes,
         )
 
-    @lru_cache(maxsize=None)
+    @functools.lru_cache(maxsize=None)
     def find_best_candidate(
         self,
         project_name,       # type: str

--- a/src/pip/_internal/resolution/resolvelib/found_candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/found_candidates.py
@@ -1,9 +1,9 @@
+import functools
 import itertools
 import operator
 
 from pip._vendor.six.moves import collections_abc  # type: ignore
 
-from pip._internal.utils.compat import lru_cache
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
@@ -88,7 +88,7 @@ class FoundCandidates(collections_abc.Sequence):
         # performance reasons).
         raise NotImplementedError("don't do this")
 
-    @lru_cache(maxsize=1)
+    @functools.lru_cache(maxsize=1)
     def __bool__(self):
         # type: () -> bool
         if self._prefers_installed and self._installed:

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -5,7 +5,6 @@ distributions."""
 # mypy: disallow-untyped-defs=False
 
 import codecs
-import functools
 import locale
 import logging
 import os
@@ -14,15 +13,7 @@ import sys
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Callable, Optional, Protocol, TypeVar, Union
-
-    # Used in the @lru_cache polyfill.
-    F = TypeVar('F')
-
-    class LruCache(Protocol):
-        def __call__(self, maxsize=None):
-            # type: (Optional[int]) -> Callable[[F], F]
-            raise NotImplementedError
+    from typing import Optional, Union
 
 try:
     import ipaddress
@@ -185,16 +176,3 @@ stdlib_pkgs = {"python", "wsgiref", "argparse"}
 # windows detection, covers cpython and ironpython
 WINDOWS = (sys.platform.startswith("win") or
            (sys.platform == 'cli' and os.name == 'nt'))
-
-
-# Fallback to noop_lru_cache in Python 2
-# TODO: this can be removed when python 2 support is dropped!
-def noop_lru_cache(maxsize=None):
-    # type: (Optional[int]) -> Callable[[F], F]
-    def _wrapper(f):
-        # type: (F) -> F
-        return f
-    return _wrapper
-
-
-lru_cache = getattr(functools, "lru_cache", noop_lru_cache)  # type: LruCache


### PR DESCRIPTION
The stdlib version has been available since Python 3.2.
