### PR TITLE
Remove Python 2 compatibility shim for urlparse.uses_fragment

### DIFF
--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-from urllib import parse as urllib_parse
 
 from pip._internal.utils.misc import display_path, rmtree
 from pip._internal.utils.subprocess import make_command
@@ -29,13 +28,6 @@ class Bazaar(VersionControl):
         'bzr', 'bzr+http', 'bzr+https', 'bzr+ssh', 'bzr+sftp', 'bzr+ftp',
         'bzr+lp',
     )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # This is only needed for python <2.7.5
-        # Register lp but do not expose as a scheme to support bzr+lp.
-        if getattr(urllib_parse, 'uses_fragment', None):
-            urllib_parse.uses_fragment.extend(['lp'])
 
     @staticmethod
     def get_base_rev_args(rev):

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -286,7 +286,6 @@ class VcsSupport(object):
         # Register more schemes with urlparse for various version control
         # systems
         urllib_parse.uses_netloc.extend(self.schemes)
-        urllib_parse.uses_fragment.extend(self.schemes)
         super().__init__()
 
     def __iter__(self):


### PR DESCRIPTION
This attribute (now urllib.parse.uses_fragment) is unused by the stdlib
and remains only for backwards compatibility. See the comment:

https://github.com/python/cpython/blob/v3.6.0/Lib/urllib/parse.py#L55-L63


