### PR TITLE
Use f-strings for simple string formatting

### DIFF
--- a/docs/pip_sphinxext.py
+++ b/docs/pip_sphinxext.py
@@ -25,7 +25,7 @@ class PipCommandUsage(rst.Directive):
             cmd_prefix = cmd_prefix.strip('"')
             cmd_prefix = cmd_prefix.strip("'")
         usage = dedent(
-            cmd.usage.replace('%prog', '{} {}'.format(cmd_prefix, cmd.name))
+            cmd.usage.replace('%prog', f'{cmd_prefix} {cmd.name}')
         ).strip()
         node = nodes.literal_block(usage, usage)
         return [node]
@@ -63,7 +63,7 @@ class PipOptions(rst.Directive):
             line += option._long_opts[0]
         if option.takes_value():
             metavar = option.metavar or option.dest.lower()
-            line += " <{}>".format(metavar.lower())
+            line += f" <{metavar.lower()}>"
         # fix defaults
         opt_help = option.help.replace('%default', str(option.default))
         # fix paths with sys.prefix
@@ -123,7 +123,7 @@ class PipReqFileOptionsReference(PipOptions):
             if cmd.cmd_opts.has_option(opt_name):
                 return command
 
-        raise KeyError('Could not identify prefix of opt {}'.format(opt_name))
+        raise KeyError(f'Could not identify prefix of opt {opt_name}')
 
     def process_options(self):
         for option in SUPPORTED_OPTIONS:

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -55,7 +55,7 @@ class Command(CommandContextMixIn):
         super().__init__()
         parser_kw = {
             'usage': self.usage,
-            'prog': '{} {}'.format(get_prog(), name),
+            'prog': f'{get_prog()} {name}',
             'formatter': UpdatingDefaultsHelpFormatter(),
             'add_help_option': False,
             'name': name,
@@ -70,7 +70,7 @@ class Command(CommandContextMixIn):
         self.tempdir_registry = None  # type: Optional[TempDirRegistry]
 
         # Commands should add options to this option group
-        optgroup_name = '{} Options'.format(self.name.capitalize())
+        optgroup_name = f'{self.name.capitalize()} Options'
         self.cmd_opts = optparse.OptionGroup(self.parser, optgroup_name)
 
         # Add the general options

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -46,7 +46,7 @@ def raise_option_error(parser, option, msg):
       option: an Option instance.
       msg: the error text.
     """
-    msg = '{} error: {}'.format(option, msg)
+    msg = f'{option} error: {msg}'
     msg = textwrap.fill(' '.join(msg.split()))
     parser.error(msg)
 

--- a/src/pip/_internal/cli/main.py
+++ b/src/pip/_internal/cli/main.py
@@ -57,7 +57,7 @@ def main(args=None):
     try:
         cmd_name, cmd_args = parse_command(args)
     except PipError as exc:
-        sys.stderr.write("ERROR: {}".format(exc))
+        sys.stderr.write(f"ERROR: {exc}")
         sys.stderr.write(os.linesep)
         sys.exit(1)
 

--- a/src/pip/_internal/cli/main_parser.py
+++ b/src/pip/_internal/cli/main_parser.py
@@ -83,9 +83,9 @@ def parse_command(args):
     if cmd_name not in commands_dict:
         guess = get_similar_commands(cmd_name)
 
-        msg = ['unknown command "{}"'.format(cmd_name)]
+        msg = [f'unknown command "{cmd_name}"']
         if guess:
-            msg.append('maybe you meant "{}"'.format(guess))
+            msg.append(f'maybe you meant "{guess}"')
 
         raise CommandError(' - '.join(msg))
 

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -82,7 +82,7 @@ class PrettyHelpFormatter(optparse.IndentedHelpFormatter):
             description = description.rstrip()
             # dedent, then reindent
             description = self.indent_lines(textwrap.dedent(description), "  ")
-            description = '{}:\n{}\n'.format(label, description)
+            description = f'{label}:\n{description}\n'
             return description
         else:
             return ''
@@ -168,7 +168,7 @@ class ConfigOptionParser(CustomOptionParser):
         try:
             return option.check_value(key, val)
         except optparse.OptionValueError as exc:
-            print("An error occurred during configuration: {}".format(exc))
+            print(f"An error occurred during configuration: {exc}")
             sys.exit(3)
 
     def _get_ordered_configuration_items(self):
@@ -279,4 +279,4 @@ class ConfigOptionParser(CustomOptionParser):
 
     def error(self, msg):
         self.print_usage(sys.stderr)
-        self.exit(UNKNOWN_ERROR, "{}\n".format(msg))
+        self.exit(UNKNOWN_ERROR, f"{msg}\n")

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -152,7 +152,7 @@ class DownloadProgressMixin(object):
     def pretty_eta(self):
         # type: () -> str
         if self.eta:  # type: ignore
-            return "eta {}".format(self.eta_td)  # type: ignore
+            return f"eta {self.eta_td}"  # type: ignore
         return ""
 
     def iter(self, it):  # type: ignore

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -154,7 +154,7 @@ class CacheCommand(Command):
         for filename in files:
             wheel = os.path.basename(filename)
             size = filesystem.format_file_size(filename)
-            results.append(' - {} ({})'.format(wheel, size))
+            results.append(f' - {wheel} ({size})')
         logger.info('Cache contents:\n')
         logger.info('\n'.join(sorted(results)))
 

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -221,7 +221,7 @@ class ConfigurationCommand(Command):
         write_output("%s:", 'env_var')
         with indent_log():
             for key, value in sorted(self.configuration.get_environ_vars()):
-                env_var = 'PIP_{}'.format(key.upper())
+                env_var = f'PIP_{key.upper()}'
                 write_output("%s=%r", env_var, value)
 
     def open_in_editor(self, options, args):

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -66,7 +66,7 @@ def get_module_from_module_name(module_name):
         module_name = 'pkg_resources'
 
     __import__(
-        'pip._vendor.{}'.format(module_name),
+        f'pip._vendor.{module_name}',
         globals(),
         locals(),
         level=0
@@ -126,7 +126,7 @@ def show_tags(options):
     formatted_target = target_python.format_given()
     suffix = ''
     if formatted_target:
-        suffix = ' (target: {})'.format(formatted_target)
+        suffix = f' (target: {formatted_target})'
 
     msg = 'Compatible tags: {}{}'.format(len(tags), suffix)
     logger.info(msg)

--- a/src/pip/_internal/commands/help.py
+++ b/src/pip/_internal/commands/help.py
@@ -32,9 +32,9 @@ class HelpCommand(Command):
         if cmd_name not in commands_dict:
             guess = get_similar_commands(cmd_name)
 
-            msg = ['unknown command "{}"'.format(cmd_name)]
+            msg = [f'unknown command "{cmd_name}"']
             if guess:
-                msg.append('maybe you meant "{}"'.format(guess))
+                msg.append(f'maybe you meant "{guess}"')
 
             raise CommandError(' - '.join(msg))
 

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -164,7 +164,7 @@ class Configuration(object):
         try:
             return self._dictionary[key]
         except KeyError:
-            raise ConfigurationError("No such key - {}".format(key))
+            raise ConfigurationError(f"No such key - {key}")
 
     def set_value(self, key, value):
         # type: (str, Any) -> None
@@ -193,7 +193,7 @@ class Configuration(object):
 
         assert self.load_only
         if key not in self._config[self.load_only]:
-            raise ConfigurationError("No such key - {}".format(key))
+            raise ConfigurationError(f"No such key - {key}")
 
         fname, parser = self._get_parser_to_modify()
 
@@ -403,4 +403,4 @@ class Configuration(object):
 
     def __repr__(self):
         # type: () -> str
-        return "{}({!r})".format(self.__class__.__name__, self._dictionary)
+        return f"{self.__class__.__name__}({self._dictionary!r})"

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -52,7 +52,7 @@ class SourceDistribution(AbstractDistribution):
                 requirement=self.req,
                 conflicting_with=conflicting_with,
                 description=', '.join(
-                    '{} is incompatible with {}'.format(installed, wanted)
+                    f'{installed} is incompatible with {wanted}'
                     for installed, wanted in sorted(conflicting)
                 )
             )

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -203,11 +203,11 @@ class HashError(InstallationError):
             its link already populated by the resolver's _populate_link().
 
         """
-        return '    {}'.format(self._requirement_name())
+        return f'    {self._requirement_name()}'
 
     def __str__(self):
         # type: () -> str
-        return '{}\n{}'.format(self.head, self.body())
+        return f'{self.head}\n{self.body()}'
 
     def _requirement_name(self):
         # type: () -> str
@@ -364,8 +364,8 @@ class ConfigurationFileCouldNotBeLoaded(ConfigurationError):
     def __str__(self):
         # type: () -> str
         if self.fname is not None:
-            message_part = " in {}.".format(self.fname)
+            message_part = f" in {self.fname}."
         else:
             assert self.error is not None
-            message_part = ".\n{}\n".format(self.error)
-        return "Configuration file {}{}".format(self.reason, message_part)
+            message_part = f".\n{self.error}\n"
+        return f"Configuration file {self.reason}{message_part}"

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -448,7 +448,7 @@ def _get_html_page(link, session=None):
         reason += str(exc)
         _handle_get_page_fail(link, reason, meth=logger.info)
     except requests.ConnectionError as exc:
-        _handle_get_page_fail(link, "connection error: {}".format(exc))
+        _handle_get_page_fail(link, f"connection error: {exc}")
     except requests.Timeout:
         _handle_get_page_fail(link, "timed out")
     else:
@@ -657,7 +657,7 @@ class LinkCollector(object):
             ),
         ]
         for link in url_locations:
-            lines.append('* {}'.format(link))
+            lines.append(f'* {link}')
         logger.debug('\n'.join(lines))
 
         return CollectedLinks(

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -161,7 +161,7 @@ class LinkEvaluator(object):
         version = None
         if link.is_yanked and not self._allow_yanked:
             reason = link.yanked_reason or '<none given>'
-            return (False, 'yanked for reason: {}'.format(reason))
+            return (False, f'yanked for reason: {reason}')
 
         if link.egg_fragment:
             egg_info = link.egg_fragment
@@ -171,7 +171,7 @@ class LinkEvaluator(object):
             if not ext:
                 return (False, 'not a file')
             if ext not in SUPPORTED_EXTENSIONS:
-                return (False, 'unsupported archive format: {}'.format(ext))
+                return (False, f'unsupported archive format: {ext}')
             if "binary" not in self._formats and ext == WHEEL_EXTENSION:
                 reason = 'No binaries permitted for {}'.format(
                     self.project_name)
@@ -204,7 +204,7 @@ class LinkEvaluator(object):
 
         # This should be up by the self.ok_binary check, but see issue 2700.
         if "source" not in self._formats and ext != WHEEL_EXTENSION:
-            reason = 'No sources permitted for {}'.format(self.project_name)
+            reason = f'No sources permitted for {self.project_name}'
             return (False, reason)
 
         if not version:
@@ -212,7 +212,7 @@ class LinkEvaluator(object):
                 egg_info, self._canonical_name,
             )
         if not version:
-            reason = 'Missing project version for {}'.format(self.project_name)
+            reason = f'Missing project version for {self.project_name}'
             return (False, reason)
 
         match = self._py_version_re.search(version)
@@ -983,7 +983,7 @@ def _find_name_version_sep(fragment, canonical_name):
             continue
         if canonicalize_name(fragment[:i]) == canonical_name:
             return i
-    raise ValueError("{} does not match {}".format(fragment, canonical_name))
+    raise ValueError(f"{fragment} does not match {canonical_name}")
 
 
 def _extract_version_from_fragment(fragment, canonical_name):

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -111,8 +111,8 @@ def distutils_scheme(
     # NOTE: setting user or home has the side-effect of creating the home dir
     # or user base for installations during finalize_options()
     # ideally, we'd prefer a scheme class that has no side-effects.
-    assert not (user and prefix), "user={} prefix={}".format(user, prefix)
-    assert not (home and prefix), "home={} prefix={}".format(home, prefix)
+    assert not (user and prefix), f"user={user} prefix={prefix}"
+    assert not (home and prefix), f"home={home} prefix={prefix}"
     i.user = user or i.user
     if user or home:
         i.prefix = ""
@@ -138,7 +138,7 @@ def distutils_scheme(
             i.prefix,
             'include',
             'site',
-            'python{}'.format(get_major_minor_version()),
+            f'python{get_major_minor_version()}',
             dist_name,
         )
 

--- a/src/pip/_internal/models/direct_url.py
+++ b/src/pip/_internal/models/direct_url.py
@@ -46,7 +46,7 @@ def _get_required(d, expected_type, key, default=None):
     # type: (Dict[str, Any], Type[T], str, Optional[T]) -> T
     value = _get(d, expected_type, key, default)
     if value is None:
-        raise DirectUrlValidationError("{} must have a value".format(key))
+        raise DirectUrlValidationError(f"{key} must have a value")
     return value
 
 

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -83,7 +83,7 @@ class Link(KeyBasedCompareMixin):
     def __str__(self):
         # type: () -> str
         if self.requires_python:
-            rp = ' (requires-python:{})'.format(self.requires_python)
+            rp = f' (requires-python:{self.requires_python})'
         else:
             rp = ''
         if self.comes_from:
@@ -94,7 +94,7 @@ class Link(KeyBasedCompareMixin):
 
     def __repr__(self):
         # type: () -> str
-        return '<Link {}>'.format(self)
+        return f'<Link {self}>'
 
     @property
     def url(self):

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -86,7 +86,7 @@ class TargetPython(object):
             ('implementation', self.implementation),
         ]
         return ' '.join(
-            '{}={!r}'.format(key, value) for key, value in key_values
+            f'{key}={value!r}' for key, value in key_values
             if value is not None
         )
 

--- a/src/pip/_internal/models/wheel.py
+++ b/src/pip/_internal/models/wheel.py
@@ -30,7 +30,7 @@ class Wheel(object):
         wheel_info = self.wheel_file_re.match(filename)
         if not wheel_info:
             raise InvalidWheelFilename(
-                "{} is not a valid wheel filename.".format(filename)
+                f"{filename} is not a valid wheel filename."
             )
         self.filename = filename
         self.name = wheel_info.group('name').replace('_', '-')

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -199,7 +199,7 @@ class MultiDomainBasicAuth(AuthBase):
             (username is not None and password is not None) or
             # Credentials were not found
             (username is None and password is None)
-        ), "Could not load credentials from url: {}".format(original_url)
+        ), f"Could not load credentials from url: {original_url}"
 
         return url, username, password
 
@@ -223,7 +223,7 @@ class MultiDomainBasicAuth(AuthBase):
     # Factored out to allow for easy patching in tests
     def _prompt_for_password(self, netloc):
         # type: (str) -> Tuple[Optional[str], Optional[str], bool]
-        username = ask_input("User for {}: ".format(netloc))
+        username = ask_input(f"User for {netloc}: ")
         if not username:
             return None, None, False
         auth = get_keyring_auth(netloc, username)

--- a/src/pip/_internal/network/lazy_wheel.py
+++ b/src/pip/_internal/network/lazy_wheel.py
@@ -190,7 +190,7 @@ class LazyZipOverHTTP(object):
         # type: (int, int, Dict[str, str]) -> Response
         """Return HTTP response to a range request from start to end."""
         headers = base_headers.copy()
-        headers['Range'] = 'bytes={}-{}'.format(start, end)
+        headers['Range'] = f'bytes={start}-{end}'
         # TODO: Get range requests to be correctly cached
         headers['Cache-Control'] = 'no-cache'
         return self._session.get(self._url, headers=headers, stream=True)

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -317,9 +317,9 @@ class PipSession(requests.Session):
             string came from.
         """
         if not suppress_logging:
-            msg = 'adding trusted host: {!r}'.format(host)
+            msg = f'adding trusted host: {host!r}'
             if source is not None:
-                msg += ' (from {})'.format(source)
+                msg += f' (from {source})'
             logger.info(msg)
 
         host_port = parse_netloc(host)

--- a/src/pip/_internal/operations/build/metadata_legacy.py
+++ b/src/pip/_internal/operations/build/metadata_legacy.py
@@ -26,7 +26,7 @@ def _find_egg_info(directory):
 
     if not filenames:
         raise InstallationError(
-            "No .egg-info directory found in {}".format(directory)
+            f"No .egg-info directory found in {directory}"
         )
 
     if len(filenames) > 1:

--- a/src/pip/_internal/operations/build/wheel.py
+++ b/src/pip/_internal/operations/build/wheel.py
@@ -34,7 +34,7 @@ def build_wheel_pep517(
         logger.debug('Destination directory: %s', tempd)
 
         runner = runner_with_spinner_message(
-            'Building wheel for {} (PEP 517)'.format(name)
+            f'Building wheel for {name} (PEP 517)'
         )
         with backend.subprocess_runner(runner):
             wheel_name = backend.build_wheel(

--- a/src/pip/_internal/operations/build/wheel_legacy.py
+++ b/src/pip/_internal/operations/build/wheel_legacy.py
@@ -23,7 +23,7 @@ def format_command_result(
     # type: (...) -> str
     """Format command information for logging."""
     command_desc = format_command_args(command_args)
-    text = 'Command arguments: {}\n'.format(command_desc)
+    text = f'Command arguments: {command_desc}\n'
 
     if not command_output:
         text += 'Command output: None'
@@ -32,7 +32,7 @@ def format_command_result(
     else:
         if not command_output.endswith('\n'):
             command_output += '\n'
-        text += 'Command output:\n{}{}'.format(command_output, LOG_DIVIDER)
+        text += f'Command output:\n{command_output}{LOG_DIVIDER}'
 
     return text
 
@@ -87,7 +87,7 @@ def build_wheel_legacy(
         destination_dir=tempd,
     )
 
-    spin_message = 'Building wheel for {} (setup.py)'.format(name)
+    spin_message = f'Building wheel for {name} (setup.py)'
     with open_spinner(spin_message) as spinner:
         logger.debug('Destination directory: %s', tempd)
 

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -56,7 +56,7 @@ def freeze(
     find_links = find_links or []
 
     for link in find_links:
-        yield '-f {}'.format(link)
+        yield f'-f {link}'
     installations = {}  # type: Dict[str, FrozenRequirement]
 
     for dist in get_installed_distributions(
@@ -195,7 +195,7 @@ def get_requirement_info(dist):
             location,
         )
         comments = [
-            '# Editable install with no version control ({})'.format(req)
+            f'# Editable install with no version control ({req})'
         ]
         return (location, True, comments)
 
@@ -270,5 +270,5 @@ class FrozenRequirement(object):
         # type: () -> str
         req = self.req
         if self.editable:
-            req = '-e {}'.format(req)
+            req = f'-e {req}'
         return '\n'.join(list(self.comments) + [str(req)]) + '\n'

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -68,7 +68,7 @@ def install(
             )
 
             runner = runner_with_spinner_message(
-                "Running setup.py install for {}".format(req_name)
+                f"Running setup.py install for {req_name}"
             )
             with indent_log(), build_env:
                 runner(

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -360,7 +360,7 @@ def get_console_script_specs(console):
             )
 
         scripts_to_generate.append(
-            'pip{} = {}'.format(get_major_minor_version(), pip_script)
+            f'pip{get_major_minor_version()} = {pip_script}'
         )
         # Delete any other versioned pip entry points
         pip_ep = [k for k in console if re.match(r'pip(\d(\.\d)?)?$', k)]

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -26,7 +26,7 @@ class InstallationResult(object):
 
     def __repr__(self):
         # type: () -> str
-        return "InstallationResult(name={!r})".format(self.name)
+        return f"InstallationResult(name={self.name!r})"
 
 
 def _validate_requirements(
@@ -34,7 +34,7 @@ def _validate_requirements(
 ):
     # type: (...) -> Iterator[Tuple[str, InstallRequirement]]
     for req in requirements:
-        assert req.name, "invalid to-be-installed requirement: {}".format(req)
+        assert req.name, f"invalid to-be-installed requirement: {req}"
         yield req.name, req
 
 

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -111,8 +111,8 @@ def parse_editable(editable_req):
             return package_name, url_no_extras, set()
 
     for version_control in vcs:
-        if url.lower().startswith('{}:'.format(version_control)):
-            url = '{}+{}'.format(version_control, url)
+        if url.lower().startswith(f'{version_control}:'):
+            url = f'{version_control}+{url}'
             break
 
     if '+' not in url:
@@ -167,7 +167,7 @@ def deduce_helpful_msg(req):
                 "Cannot parse '%s' as requirements file", req, exc_info=True
             )
     else:
-        msg += " File '{}' does not exist.".format(req)
+        msg += f" File '{req}' does not exist."
     return msg
 
 
@@ -193,7 +193,7 @@ def parse_req_from_editable(editable_req):
         try:
             req = Requirement(name)
         except InvalidRequirement:
-            raise InstallationError("Invalid requirement: '{}'".format(name))
+            raise InstallationError(f"Invalid requirement: '{name}'")
     else:
         req = None
 
@@ -342,7 +342,7 @@ def parse_req_from_line(name, line_source):
         # type: (str) -> str
         if not line_source:
             return text
-        return '{} (from {})'.format(text, line_source)
+        return f'{text} (from {line_source})'
 
     if req_as_string is not None:
         try:
@@ -357,10 +357,10 @@ def parse_req_from_line(name, line_source):
             else:
                 add_msg = ''
             msg = with_source(
-                'Invalid requirement: {!r}'.format(req_as_string)
+                f'Invalid requirement: {req_as_string!r}'
             )
             if add_msg:
-                msg += '\nHint: {}'.format(add_msg)
+                msg += f'\nHint: {add_msg}'
             raise InstallationError(msg)
         else:
             # Deprecate extras after specifiers: "name>=1.0[extras]"
@@ -370,7 +370,7 @@ def parse_req_from_line(name, line_source):
             for spec in req.specifier:
                 spec_str = str(spec)
                 if spec_str.endswith(']'):
-                    msg = "Extras after version '{}'.".format(spec_str)
+                    msg = f"Extras after version '{spec_str}'."
                     replace = "moving the extras before version specifiers"
                     deprecated(msg, replacement=replace, gone_in="21.0")
     else:
@@ -421,7 +421,7 @@ def install_req_from_req_string(
     try:
         req = Requirement(req_string)
     except InvalidRequirement:
-        raise InstallationError("Invalid requirement: '{}'".format(req_string))
+        raise InstallationError(f"Invalid requirement: '{req_string}'")
 
     domains_not_allowed = [
         PyPI.file_storage_domain,

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -201,7 +201,7 @@ def handle_requirement_line(
             if dest in line.opts.__dict__ and line.opts.__dict__[dest]:
                 req_options[dest] = line.opts.__dict__[dest]
 
-        line_source = 'line {} of {}'.format(line.lineno, line.filename)
+        line_source = f'line {line.lineno} of {line.filename}'
         return ParsedRequirement(
             requirement=line.requirement,
             is_editable=line.is_editable,
@@ -271,7 +271,7 @@ def handle_option_line(
 
         if session:
             for host in opts.trusted_hosts or []:
-                source = 'line {} of {}'.format(lineno, filename)
+                source = f'line {lineno} of {filename}'
                 session.add_trusted_host(host, source=source)
 
 
@@ -381,7 +381,7 @@ class RequirementsFileParser(object):
                 args_str, opts = self._line_parser(line)
             except OptionParsingError as e:
                 # add offending line
-                msg = 'Invalid requirement: {}\n{}'.format(line, e.msg)
+                msg = f'Invalid requirement: {line}\n{e.msg}'
                 raise RequirementsFileParseError(msg)
 
             yield ParsedLine(
@@ -559,6 +559,6 @@ def get_file_content(url, session):
             content = auto_decode(f.read())
     except IOError as exc:
         raise InstallationError(
-            'Could not open requirements file: {}'.format(exc)
+            f'Could not open requirements file: {exc}'
         )
     return url, content

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -226,7 +226,7 @@ class InstallRequirement(object):
             else:
                 comes_from = self.comes_from.from_path()
             if comes_from:
-                s += ' (from {})'.format(comes_from)
+                s += f' (from {comes_from})'
         return s
 
     def __repr__(self):
@@ -364,7 +364,7 @@ class InstallRequirement(object):
         # name so multiple builds do not interfere with each other.
         dir_name = canonicalize_name(self.name)
         if parallel_builds:
-            dir_name = "{}_{}".format(dir_name, uuid.uuid4().hex)
+            dir_name = f"{dir_name}_{uuid.uuid4().hex}"
 
         # FIXME: Is there a better place to create the build_dir? (hg and bzr
         # need this)
@@ -475,7 +475,7 @@ class InstallRequirement(object):
     @property
     def setup_py_path(self):
         # type: () -> str
-        assert self.source_dir, "No source dir for {}".format(self)
+        assert self.source_dir, f"No source dir for {self}"
         setup_py = os.path.join(self.unpacked_source_directory, 'setup.py')
 
         return setup_py
@@ -483,7 +483,7 @@ class InstallRequirement(object):
     @property
     def pyproject_toml_path(self):
         # type: () -> str
-        assert self.source_dir, "No source dir for {}".format(self)
+        assert self.source_dir, f"No source dir for {self}"
         return make_pyproject_path(self.unpacked_source_directory)
 
     def load_pyproject_toml(self):
@@ -526,7 +526,7 @@ class InstallRequirement(object):
                 setup_py_path=self.setup_py_path,
                 source_dir=self.unpacked_source_directory,
                 isolated=self.isolated,
-                details=self.name or "from {}".format(self.link)
+                details=self.name or f"from {self.link}"
             )
 
         assert self.pep517_backend is not None

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -88,9 +88,9 @@ def make_install_req_from_dist(dist, template):
     if template.req:
         line = str(template.req)
     elif template.link:
-        line = "{} @ {}".format(project_name, template.link.url)
+        line = f"{project_name} @ {template.link.url}"
     else:
-        line = "{}=={}".format(project_name, dist.parsed_version)
+        line = f"{project_name}=={dist.parsed_version}"
     ireq = install_req_from_line(
         line,
         user_supplied=template.user_supplied,
@@ -145,7 +145,7 @@ class _InstallRequirementBackedCandidate(Candidate):
 
     def __str__(self):
         # type: () -> str
-        return "{} {}".format(self.name, self.version)
+        return f"{self.name} {self.version}"
 
     def __repr__(self):
         # type: () -> str
@@ -288,7 +288,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             wheel = Wheel(ireq.link.filename)
             wheel_name = canonicalize_name(wheel.name)
             assert name == wheel_name, (
-                "{!r} != {!r} for wheel".format(name, wheel_name)
+                f"{name!r} != {wheel_name!r} for wheel"
             )
             # Version may not be present for PEP 508 direct URLs
             if version is not None:
@@ -416,7 +416,7 @@ class AlreadyInstalledCandidate(Candidate):
 
     def format_for_error(self):
         # type: () -> str
-        return "{} {} (Installed)".format(self.name, self.version)
+        return f"{self.name} {self.version} (Installed)"
 
     def iter_dependencies(self, with_requires):
         # type: (bool) -> Iterable[Optional[Requirement]]
@@ -584,7 +584,7 @@ class RequiresPythonCandidate(Candidate):
 
     def __str__(self):
         # type: () -> str
-        return "Python {}".format(self._version)
+        return f"Python {self._version}"
 
     @property
     def project_name(self):
@@ -604,7 +604,7 @@ class RequiresPythonCandidate(Candidate):
 
     def format_for_error(self):
         # type: () -> str
-        return "Python {}".format(self.version)
+        return f"Python {self.version}"
 
     def iter_dependencies(self, with_requires):
         # type: (bool) -> Iterable[Optional[Requirement]]

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -391,13 +391,13 @@ class Factory(object):
             if parent is None:
                 req_disp = str(req)
             else:
-                req_disp = '{} (from {})'.format(req, parent.name)
+                req_disp = f'{req} (from {parent.name})'
             logger.critical(
                 "Could not find a version that satisfies the requirement %s",
                 req_disp,
             )
             return DistributionNotFound(
-                'No matching distribution found for {}'.format(req)
+                f'No matching distribution found for {req}'
             )
 
         # OK, we now have a list of requirements that can't all be
@@ -415,7 +415,7 @@ class Factory(object):
             # type: (Candidate) -> str
             ireq = parent.get_install_requirement()
             if not ireq or not ireq.comes_from:
-                return "{}=={}".format(parent.name, parent.version)
+                return f"{parent.name}=={parent.version}"
             if isinstance(ireq.comes_from, InstallRequirement):
                 return str(ireq.comes_from.name)
             return str(ireq.comes_from)

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -122,7 +122,7 @@ class RequiresPythonRequirement(Requirement):
 
     def __str__(self):
         # type: () -> str
-        return "Python {}".format(self.specifier)
+        return f"Python {self.specifier}"
 
     def __repr__(self):
         # type: () -> str

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -181,7 +181,7 @@ def pip_self_version_check(session, options):
         # command context, so be pragmatic here and suggest the command
         # that's always available. This does not accommodate spaces in
         # `sys.executable`.
-        pip_cmd = "{} -m pip".format(sys.executable)
+        pip_cmd = f"{sys.executable} -m pip"
         logger.warning(
             "You are using pip version %s; however, version %s is "
             "available.\nYou should consider upgrading via the "

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -116,7 +116,7 @@ def _get_custom_interpreter(implementation=None, version=None):
         implementation = interpreter_name()
     if version is None:
         version = interpreter_version()
-    return "{}{}".format(implementation, version)
+    return f"{implementation}{version}"
 
 
 def get_supported(

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -93,7 +93,7 @@ def direct_url_from_link(link, source_dir=None, link_is_in_wheel_cache=False):
         hash = None
         hash_name = link.hash_name
         if hash_name:
-            hash = "{}={}".format(hash_name, link.hash)
+            hash = f"{hash_name}={link.hash}"
         return DirectUrl(
             url=link.url_without_fragment,
             info=ArchiveInfo(hash=hash),

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -85,7 +85,7 @@ class Hashes(object):
                 gots[hash_name] = hashlib.new(hash_name)
             except (ValueError, TypeError):
                 raise InstallationError(
-                    'Unknown hash name: {}'.format(hash_name)
+                    f'Unknown hash name: {hash_name}'
                 )
 
         for chunk in chunks:

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -116,7 +116,7 @@ def get_prog():
     try:
         prog = os.path.basename(sys.argv[0])
         if prog in ('__main__.py', '-c'):
-            return "{} -m pip".format(sys.executable)
+            return f"{sys.executable} -m pip"
         else:
             return prog
     except (AttributeError, TypeError, IndexError):
@@ -676,8 +676,8 @@ def build_netloc(host, port):
         return host
     if ':' in host:
         # Only wrap host with square brackets when it is IPv6
-        host = '[{}]'.format(host)
-    return '{}:{}'.format(host, port)
+        host = f'[{host}]'
+    return f'{host}:{port}'
 
 
 def build_url_from_netloc(netloc, scheme='https'):
@@ -687,8 +687,8 @@ def build_url_from_netloc(netloc, scheme='https'):
     """
     if netloc.count(':') >= 2 and '@' not in netloc and '[' not in netloc:
         # It must be a bare IPv6 address, so wrap it with brackets.
-        netloc = '[{}]'.format(netloc)
-    return '{}://{}'.format(scheme, netloc)
+        netloc = f'[{netloc}]'
+    return f'{scheme}://{netloc}'
 
 
 def parse_netloc(netloc):

--- a/src/pip/_internal/utils/pkg_resources.py
+++ b/src/pip/_internal/utils/pkg_resources.py
@@ -24,7 +24,7 @@ class DictMetadata(object):
             return ensure_str(self._metadata[name])
         except UnicodeDecodeError as e:
             # Mirrors handling done in pkg_resources.NullProvider.
-            e.reason += " in {} file".format(name)
+            e.reason += f" in {name} file"
             raise
 
     def get_metadata_lines(self, name):

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -151,13 +151,13 @@ class TempDirectory(object):
     def path(self):
         # type: () -> str
         assert not self._deleted, (
-            "Attempted to access deleted path: {}".format(self._path)
+            f"Attempted to access deleted path: {self._path}"
         )
         return self._path
 
     def __repr__(self):
         # type: () -> str
-        return "<{} {!r}>".format(self.__class__.__name__, self.path)
+        return f"<{self.__class__.__name__} {self.path!r}>"
 
     def __enter__(self):
         # type: (_T) -> _T
@@ -184,7 +184,7 @@ class TempDirectory(object):
         # scripts, so we canonicalize the path by traversing potential
         # symlinks here.
         path = os.path.realpath(
-            tempfile.mkdtemp(prefix="pip-{}-".format(kind))
+            tempfile.mkdtemp(prefix=f"pip-{kind}-")
         )
         logger.debug("Created temporary directory: %s", path)
         return path
@@ -275,7 +275,7 @@ class AdjacentTempDirectory(TempDirectory):
         else:
             # Final fallback on the default behavior.
             path = os.path.realpath(
-                tempfile.mkdtemp(prefix="pip-{}-".format(kind))
+                tempfile.mkdtemp(prefix=f"pip-{kind}-")
             )
 
         logger.debug("Created temporary directory: %s", path)

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -273,5 +273,5 @@ def unpack_file(
             filename, location, content_type,
         )
         raise InstallationError(
-            'Cannot determine archive format of {}'.format(location)
+            f'Cannot determine archive format of {location}'
         )

--- a/src/pip/_internal/utils/wheel.py
+++ b/src/pip/_internal/utils/wheel.py
@@ -57,7 +57,7 @@ def pkg_resources_distribution_for_wheel(wheel_zip, name, location):
     info_dir, _ = parse_wheel(wheel_zip, name)
 
     metadata_files = [
-        p for p in wheel_zip.namelist() if p.startswith("{}/".format(info_dir))
+        p for p in wheel_zip.namelist() if p.startswith(f"{info_dir}/")
     ]
 
     metadata_text = {}  # type: Dict[str, bytes]
@@ -152,7 +152,7 @@ def read_wheel_metadata_file(source, path):
         # and RuntimeError for password-protected files
     except (BadZipFile, KeyError, RuntimeError) as e:
         raise UnsupportedWheel(
-            "could not read {!r} file: {!r}".format(path, e)
+            f"could not read {path!r} file: {e!r}"
         )
 
 
@@ -161,14 +161,14 @@ def wheel_metadata(source, dist_info_dir):
     """Return the WHEEL metadata of an extracted wheel, if possible.
     Otherwise, raise UnsupportedWheel.
     """
-    path = "{}/WHEEL".format(dist_info_dir)
+    path = f"{dist_info_dir}/WHEEL"
     # Zip file path separators must be /
     wheel_contents = read_wheel_metadata_file(source, path)
 
     try:
         wheel_text = ensure_str(wheel_contents)
     except UnicodeDecodeError as e:
-        raise UnsupportedWheel("error decoding {!r}: {!r}".format(path, e))
+        raise UnsupportedWheel(f"error decoding {path!r}: {e!r}")
 
     # FeedParser (used by Parser) does not raise any exceptions. The returned
     # message may have .defects populated, but for backwards-compatibility we
@@ -190,7 +190,7 @@ def wheel_version(wheel_data):
     try:
         return tuple(map(int, version.split('.')))
     except ValueError:
-        raise UnsupportedWheel("invalid Wheel-Version: {!r}".format(version))
+        raise UnsupportedWheel(f"invalid Wheel-Version: {version!r}")
 
 
 def check_compatibility(version, name):

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -147,12 +147,12 @@ class Git(VersionControl):
             except ValueError:
                 # Include the offending line to simplify troubleshooting if
                 # this error ever occurs.
-                raise ValueError('unexpected show-ref line: {!r}'.format(line))
+                raise ValueError(f'unexpected show-ref line: {line!r}')
 
             refs[ref] = sha
 
-        branch_ref = 'refs/remotes/origin/{}'.format(rev)
-        tag_ref = 'refs/tags/{}'.format(rev)
+        branch_ref = f'refs/remotes/origin/{rev}'
+        tag_ref = f'refs/tags/{rev}'
 
         sha = refs.get(branch_ref)
         if sha is not None:
@@ -266,7 +266,7 @@ class Git(VersionControl):
             elif self.get_current_branch(dest) != branch_name:
                 # Then a specific branch was requested, and that branch
                 # is not yet checked out.
-                track_branch = 'origin/{}'.format(branch_name)
+                track_branch = f'origin/{branch_name}'
                 cmd_args = [
                     'checkout', '-b', branch_name, '--track', track_branch,
                 ]

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -77,9 +77,9 @@ def make_vcs_requirement_url(repo_url, rev, project_name, subdir=None):
       project_name: the (unescaped) project name.
     """
     egg_project_name = pkg_resources.to_filename(project_name)
-    req = '{}@{}#egg={}'.format(repo_url, rev, egg_project_name)
+    req = f'{repo_url}@{rev}#egg={egg_project_name}'
     if subdir:
-        req += '&subdirectory={}'.format(subdir)
+        req += f'&subdirectory={subdir}'
 
     return req
 
@@ -236,7 +236,7 @@ class RevOptions(object):
 
     def __repr__(self):
         # type: () -> str
-        return '<RevOptions {}: rev={!r}>'.format(self.vc_class.name, self.rev)
+        return f'<RevOptions {self.vc_class.name}: rev={self.rev!r}>'
 
     @property
     def arg_rev(self):
@@ -264,7 +264,7 @@ class RevOptions(object):
         if not self.rev:
             return ''
 
-        return ' (to revision {})'.format(self.rev)
+        return f' (to revision {self.rev})'
 
     def make_new(self, rev):
         # type: (str) -> RevOptions
@@ -389,7 +389,7 @@ class VersionControl(object):
         Return whether the vcs prefix (e.g. "git+") should be added to a
         repository's remote url when used in a requirement.
         """
-        return not remote_url.lower().startswith('{}:'.format(cls.name))
+        return not remote_url.lower().startswith(f'{cls.name}:')
 
     @classmethod
     def get_subdirectory(cls, location):
@@ -427,7 +427,7 @@ class VersionControl(object):
             return None
 
         if cls.should_add_vcs_url_prefix(repo_url):
-            repo_url = '{}+{}'.format(cls.name, repo_url)
+            repo_url = f'{cls.name}+{repo_url}'
 
         revision = cls.get_requirement_revision(repo_dir)
         subdir = cls.get_subdirectory(repo_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.unit)
         else:
             raise RuntimeError(
-                "Unknown test type (filename = {})".format(module_path)
+                f"Unknown test type (filename = {module_path})"
             )
 
 

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -103,7 +103,7 @@ def list_matches_wheel(wheel_name, result):
     E.g., If wheel_name is `foo-1.2.3` it searches for a line starting with
           `- foo-1.2.3-py3-none-any.whl `."""
     lines = result.stdout.splitlines()
-    expected = ' - {}-py3-none-any.whl '.format(wheel_name)
+    expected = f' - {wheel_name}-py3-none-any.whl '
     return any(map(lambda l: l.startswith(expected), lines))
 
 
@@ -115,7 +115,7 @@ def list_matches_wheel_abspath(wheel_name, result):
     E.g., If wheel_name is `foo-1.2.3` it searches for a line starting with
           `foo-1.2.3-py3-none-any.whl`."""
     lines = result.stdout.splitlines()
-    expected = '{}-py3-none-any.whl'.format(wheel_name)
+    expected = f'{wheel_name}-py3-none-any.whl'
     return any(map(lambda l: os.path.basename(l).startswith(expected)
                and os.path.exists(l), lines))
 
@@ -137,7 +137,7 @@ def remove_matches_http(http_cache_dir):
         path = os.path.join(
             http_cache_dir, 'arbitrary', 'pathname', http_filename,
         )
-        expected = 'Removed {}'.format(path)
+        expected = f'Removed {path}'
         return expected in lines
 
     return _remove_matches_http
@@ -155,14 +155,14 @@ def remove_matches_wheel(wheel_cache_dir):
     def _remove_matches_wheel(wheel_name, result):
         lines = result.stdout.splitlines()
 
-        wheel_filename = '{}-py3-none-any.whl'.format(wheel_name)
+        wheel_filename = f'{wheel_name}-py3-none-any.whl'
 
         # The "/arbitrary/pathname/" bit is an implementation detail of how
         # the `populate_wheel_cache` fixture is implemented.
         path = os.path.join(
             wheel_cache_dir, 'arbitrary', 'pathname', wheel_filename,
         )
-        expected = 'Removed {}'.format(path)
+        expected = f'Removed {path}'
         return expected in lines
 
     return _remove_matches_wheel
@@ -191,12 +191,12 @@ def test_cache_info(
     result = script.pip('cache', 'info')
 
     assert (
-        'Package index page cache location: {}'.format(http_cache_dir)
+        f'Package index page cache location: {http_cache_dir}'
         in result.stdout
     )
-    assert 'Wheels location: {}'.format(wheel_cache_dir) in result.stdout
+    assert f'Wheels location: {wheel_cache_dir}' in result.stdout
     num_wheels = len(wheel_cache_files)
-    assert 'Number of wheels: {}'.format(num_wheels) in result.stdout
+    assert f'Number of wheels: {num_wheels}' in result.stdout
 
 
 @pytest.mark.usefixtures("populate_wheel_cache")

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -98,7 +98,7 @@ class TestBasicLoading(ConfigurationMixin):
             """))
 
         result = script.pip("config", "debug")
-        assert "{}, exists: True".format(config_file) in result.stdout
+        assert f"{config_file}, exists: True" in result.stdout
         assert "global.timeout: 60" in result.stdout
         assert "freeze.timeout: 10" in result.stdout
         assert re.search(r"env:\n(  .+\n)+", result.stdout)
@@ -117,7 +117,7 @@ class TestBasicLoading(ConfigurationMixin):
         script.pip("config", "--user", "set", "freeze.timeout", "10")
 
         result = script.pip("config", "debug")
-        assert "{}, exists: True".format(new_config_file) in result.stdout
+        assert f"{new_config_file}, exists: True" in result.stdout
         assert "global.timeout: 60" in result.stdout
         assert "freeze.timeout: 10" in result.stdout
         assert re.search(r"user:\n(  .+\n)+", result.stdout)
@@ -134,7 +134,7 @@ class TestBasicLoading(ConfigurationMixin):
         script.pip("config", "--site", "set", "freeze.timeout", "10")
 
         result = script.pip("config", "debug")
-        assert "{}, exists: True".format(site_config_file) in result.stdout
+        assert f"{site_config_file}, exists: True" in result.stdout
         assert "global.timeout: 60" in result.stdout
         assert "freeze.timeout: 10" in result.stdout
         assert re.search(r"site:\n(  .+\n)+", result.stdout)
@@ -149,4 +149,4 @@ class TestBasicLoading(ConfigurationMixin):
         # So we just check if the file can be identified
         global_config_file = get_configuration_files()[kinds.GLOBAL][0]
         result = script.pip("config", "debug")
-        assert "{}, exists:".format(global_config_file) in result.stdout
+        assert f"{global_config_file}, exists:" in result.stdout

--- a/tests/functional/test_debug.py
+++ b/tests/functional/test_debug.py
@@ -40,7 +40,7 @@ def test_debug__library_versions(script):
 
     vendored_versions = create_vendor_txt_map()
     for name, value in vendored_versions.items():
-        assert '{}=={}'.format(name, value) in result.stdout
+        assert f'{name}=={value}' in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -364,7 +364,7 @@ class TestDownloadPlatformManylinuxes(object):
         """
         Earlier manylinuxes are compatible with later manylinuxes.
         """
-        wheel = 'fake-1.0-py2.py3-none-{}.whl'.format(wheel_abi)
+        wheel = f'fake-1.0-py2.py3-none-{wheel_abi}.whl'
         fake_wheel(data, wheel)
         result = script.pip(
             'download', '--no-index', '--find-links', data.find_links,
@@ -491,7 +491,7 @@ def make_wheel_with_python_requires(script, package_name, python_requires):
         'python', 'setup.py', 'bdist_wheel', '--universal', cwd=package_dir,
     )
 
-    file_name = '{}-1.0-py2.py3-none-any.whl'.format(package_name)
+    file_name = f'{package_name}-1.0-py2.py3-none-any.whl'
     return package_dir / 'dist' / file_name
 
 
@@ -521,7 +521,7 @@ def test_download__python_version_used_for_python_requires(
         "ERROR: Package 'mypackage' requires a different Python: "
         "3.3.0 not in '==3.2'"
     )
-    assert expected_err in result.stderr, 'stderr: {}'.format(result.stderr)
+    assert expected_err in result.stderr, f'stderr: {result.stderr}'
 
     # Now try with a --python-version that satisfies the Requires-Python.
     args = make_args('32')
@@ -863,8 +863,8 @@ def test_download_http_url_bad_hash(
         file_response(simple_pkg)
     ])
     mock_server.start()
-    base_address = 'http://{}:{}'.format(mock_server.host, mock_server.port)
-    url = "{}/simple-1.0.tar.gz#sha256={}".format(base_address, digest)
+    base_address = f'http://{mock_server.host}:{mock_server.port}'
+    url = f"{base_address}/simple-1.0.tar.gz#sha256={digest}"
 
     shared_script.pip('download', '-d', str(download_dir), url)
 

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -495,7 +495,7 @@ def test_freeze_bazaar_clone(script, tmpdir):
     try:
         checkout_path = _create_test_package(script, vcs='bazaar')
     except OSError as e:
-        pytest.fail('Invoking `bzr` failed: {e}'.format(e=e))
+        pytest.fail(f'Invoking `bzr` failed: {e}')
 
     result = script.run(
         'bzr', 'checkout', checkout_path, 'bzr-package'
@@ -552,7 +552,7 @@ def test_freeze_nested_vcs(script, outer_vcs, inner_vcs):
     result = script.pip("freeze", expect_stderr=True)
     _check_output(
         result.stdout,
-        "...-e {}+...#egg=version_pkg\n...".format(inner_vcs),
+        f"...-e {inner_vcs}+...#egg=version_pkg\n...",
     )
 
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -530,7 +530,7 @@ def test_hashed_install_failure(script, tmpdir):
 
 def assert_re_match(pattern, text):
     assert re.search(pattern, text), (
-        "Could not find {!r} in {!r}".format(pattern, text)
+        f"Could not find {pattern!r} in {text!r}"
     )
 
 
@@ -1023,7 +1023,7 @@ def test_install_package_with_prefix(script, data):
     install_path = (
         distutils.sysconfig.get_python_lib(prefix=rel_prefix_path) /
         # we still test for egg-info because no-binary implies setup.py install
-        'simple-1.0-py{}.egg-info'.format(pyversion)
+        f'simple-1.0-py{pyversion}.egg-info'
     )
     result.did_create(install_path)
 
@@ -1040,7 +1040,7 @@ def test_install_editable_with_prefix(script):
 
     if hasattr(sys, "pypy_version_info"):
         site_packages = os.path.join(
-            'prefix', 'lib', 'python{}'.format(pyversion), 'site-packages')
+            'prefix', 'lib', f'python{pyversion}', 'site-packages')
     else:
         site_packages = distutils.sysconfig.get_python_lib(prefix='prefix')
 
@@ -1086,7 +1086,7 @@ def test_install_package_that_emits_unicode(script, data):
     )
     assert (
         'FakeError: this package designed to fail on install' in result.stderr
-    ), 'stderr: {}'.format(result.stderr)
+    ), f'stderr: {result.stderr}'
     assert 'UnicodeDecodeError' not in result.stderr
     assert 'UnicodeDecodeError' not in result.stdout
 
@@ -1838,7 +1838,7 @@ def test_install_sends_client_cert(install_args, script, cert_factory, data):
         file_response(str(data.packages / "simple-3.0.tar.gz")),
     ]
 
-    url = "https://{}:{}/simple".format(server.host, server.port)
+    url = f"https://{server.host}:{server.port}/simple"
 
     args = ["install", "-vvv", "--cert", cert_path, "--client-cert", cert_path]
     args.extend(["--index-url", url])

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -14,7 +14,7 @@ def test_no_clean_option_blocks_cleaning_after_install(script, data):
     build = script.base_path / 'pip-build'
     script.pip(
         'install', '--no-clean', '--no-index', '--build', build,
-        '--find-links={}'.format(data.find_links), 'simple',
+        f'--find-links={data.find_links}', 'simple',
         expect_temp=True,
         # TODO: allow_stderr_warning is used for the --build deprecation,
         #       remove it when removing support for --build

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -100,9 +100,9 @@ def test_command_line_append_flags(script, virtualenv, data):
         in result.stdout
     )
     assert (
-        'Skipping link: not a file: {}'.format(data.find_links) in
+        f'Skipping link: not a file: {data.find_links}' in
         result.stdout
-    ), 'stdout: {}'.format(result.stdout)
+    ), f'stdout: {result.stdout}'
 
 
 @pytest.mark.network
@@ -124,9 +124,9 @@ def test_command_line_appends_correctly(script, data):
         in result.stdout
     ), result.stdout
     assert (
-        'Skipping link: not a file: {}'.format(data.find_links) in
+        f'Skipping link: not a file: {data.find_links}' in
         result.stdout
-    ), 'stdout: {}'.format(result.stdout)
+    ), f'stdout: {result.stdout}'
 
 
 def test_config_file_override_stack(
@@ -143,7 +143,7 @@ def test_config_file_override_stack(
         file_response(shared_data.packages.joinpath("INITools-0.2.tar.gz")),
     ])
     mock_server.start()
-    base_address = "http://{}:{}".format(mock_server.host, mock_server.port)
+    base_address = f"http://{mock_server.host}:{mock_server.port}"
 
     config_file = script.scratch_path / "test-pip.cfg"
 
@@ -166,7 +166,7 @@ def test_config_file_override_stack(
     )
     script.pip('install', '-vvv', 'INITools', expect_error=True)
     script.pip(
-        'install', '-vvv', '--index-url', "{}/simple3".format(base_address),
+        'install', '-vvv', '--index-url', f"{base_address}/simple3",
         'INITools',
     )
 
@@ -236,14 +236,14 @@ def test_prompt_for_authentication(script, data, cert_factory):
         authorization_response(str(data.packages / "simple-3.0.tar.gz")),
     ]
 
-    url = "https://{}:{}/simple".format(server.host, server.port)
+    url = f"https://{server.host}:{server.port}/simple"
 
     with server_running(server):
         result = script.pip('install', "--index-url", url,
                             "--cert", cert_path, "--client-cert", cert_path,
                             'simple', expect_error=True)
 
-    assert 'User for {}:{}'.format(server.host, server.port) in \
+    assert f'User for {server.host}:{server.port}' in \
            result.stdout, str(result)
 
 
@@ -266,7 +266,7 @@ def test_do_not_prompt_for_authentication(script, data, cert_factory):
         authorization_response(str(data.packages / "simple-3.0.tar.gz")),
     ]
 
-    url = "https://{}:{}/simple".format(server.host, server.port)
+    url = f"https://{server.host}:{server.port}/simple"
 
     with server_running(server):
         result = script.pip('install', "--index-url", url,

--- a/tests/functional/test_install_direct_url.py
+++ b/tests/functional/test_install_direct_url.py
@@ -33,7 +33,7 @@ def test_install_vcs_editable_no_direct_url(script, with_wheel):
 def test_install_vcs_non_editable_direct_url(script, with_wheel):
     pkg_path = _create_test_package(script, name="testpkg")
     url = path_to_url(pkg_path)
-    args = ["install", "git+{}#egg=testpkg".format(url)]
+    args = ["install", f"git+{url}#egg=testpkg"]
     result = script.pip(*args)
     direct_url = _get_created_direct_url(result, "testpkg")
     assert direct_url

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -171,5 +171,4 @@ def test_install_extra_merging(script, data, extra_to_install, simple_version):
         '{pkga_path}{extra_to_install}'.format(**locals()),
     )
 
-    assert ('Successfully installed pkga-0.1 simple-{}'.format(simple_version)
-            ) in result.stdout
+    assert f'Successfully installed pkga-0.1 simple-{simple_version}' in result.stdout

--- a/tests/functional/test_install_force_reinstall.py
+++ b/tests/functional/test_install_force_reinstall.py
@@ -11,7 +11,7 @@ def check_installed_version(script, package, expected):
         if line.startswith('Version: '):
             version = line.split()[-1]
             break
-    assert version == expected, 'version {} != {}'.format(version, expected)
+    assert version == expected, f'version {version} != {expected}'
 
 
 def check_force_reinstall(script, specifier, expected):

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -55,7 +55,7 @@ def arg_recording_sdist_maker(script):
         sdist_path = create_basic_sdist_for_package(
             script, name, "0.1.0", extra_files
         )
-        args_path = output_dir / "{}.json".format(name)
+        args_path = output_dir / f"{name}.json"
         return ArgRecordingSdist(sdist_path, args_path)
 
     return _arg_recording_sdist_maker

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -470,5 +470,5 @@ def test_install_find_existing_package_canonicalize(script, req1, req2):
     result = script.pip(
         "install", "--no-index", "--find-links", pkg_container, "pkg",
     )
-    satisfied_message = "Requirement already satisfied: {}".format(req2)
+    satisfied_message = f"Requirement already satisfied: {req2}"
     assert satisfied_message in result.stdout, str(result)

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -38,7 +38,7 @@ def _get_branch_remote(script, package_name, branch):
     """
     repo_dir = _get_editable_repo_dir(script, package_name)
     result = script.run(
-        'git', 'config', 'branch.{}.remote'.format(branch), cwd=repo_dir
+        'git', 'config', f'branch.{branch}.remote', cwd=repo_dir
     )
     return result.stdout.strip()
 
@@ -57,12 +57,12 @@ def _github_checkout(url_path, temp_dir, rev=None, egg=None, scheme=None):
     """
     if scheme is None:
         scheme = 'https'
-    url = 'git+{}://github.com/{}'.format(scheme, url_path)
+    url = f'git+{scheme}://github.com/{url_path}'
     local_url = local_checkout(url, temp_dir)
     if rev is not None:
-        local_url += '@{}'.format(rev)
+        local_url += f'@{rev}'
     if egg is not None:
-        local_url += '#egg={}'.format(egg)
+        local_url += f'#egg={egg}'
 
     return local_url
 
@@ -77,8 +77,8 @@ def _make_version_pkg_url(path, rev=None, name="version_pkg"):
       rev: an optional revision to install like a branch name, tag, or SHA.
     """
     file_url = _test_path_to_file_url(path)
-    url_rev = '' if rev is None else '@{}'.format(rev)
-    url = 'git+{}{}#egg={}'.format(file_url, url_rev, name)
+    url_rev = '' if rev is None else f'@{rev}'
+    url = f'git+{file_url}{url_rev}#egg={name}'
 
     return url
 
@@ -278,11 +278,11 @@ def test_git_with_tag_name_and_update(script, tmpdir):
     url_path = 'pypa/pip-test-package.git'
     base_local_url = _github_checkout(url_path, tmpdir)
 
-    local_url = '{}#egg=pip-test-package'.format(base_local_url)
+    local_url = f'{base_local_url}#egg=pip-test-package'
     result = script.pip('install', '-e', local_url)
     result.assert_installed('pip-test-package', with_files=['.git'])
 
-    new_local_url = '{}@0.1.2#egg=pip-test-package'.format(base_local_url)
+    new_local_url = f'{base_local_url}@0.1.2#egg=pip-test-package'
     result = script.pip(
         'install', '--global-option=--version', '-e', new_local_url,
     )
@@ -484,12 +484,12 @@ def test_install_git_branch_not_cached(script, with_wheel):
     repo_dir = _create_test_package(script, name=PKG)
     url = _make_version_pkg_url(repo_dir, rev="master", name=PKG)
     result = script.pip("install", url, "--only-binary=:all:")
-    assert "Successfully built {}".format(PKG) in result.stdout, result.stdout
+    assert f"Successfully built {PKG}" in result.stdout, result.stdout
     script.pip("uninstall", "-y", PKG)
     # build occurs on the second install too because it is not cached
     result = script.pip("install", url)
     assert (
-        "Successfully built {}".format(PKG) in result.stdout
+        f"Successfully built {PKG}" in result.stdout
     ), result.stdout
 
 
@@ -504,10 +504,10 @@ def test_install_git_sha_cached(script, with_wheel):
     ).stdout.strip()
     url = _make_version_pkg_url(repo_dir, rev=commit, name=PKG)
     result = script.pip("install", url)
-    assert "Successfully built {}".format(PKG) in result.stdout, result.stdout
+    assert f"Successfully built {PKG}" in result.stdout, result.stdout
     script.pip("uninstall", "-y", PKG)
     # build does not occur on the second install because it is cached
     result = script.pip("install", url)
     assert (
-        "Successfully built {}".format(PKG) not in result.stdout
+        f"Successfully built {PKG}" not in result.stdout
     ), result.stdout

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -14,7 +14,7 @@ from tests.lib.wheel import make_wheel
 # assert_installed expects a package subdirectory, so give it to them
 def make_wheel_with_file(name, version, **kwargs):
     extra_files = kwargs.setdefault("extra_files", {})
-    extra_files["{}/__init__.py".format(name)] = "# example"
+    extra_files[f"{name}/__init__.py"] = "# example"
     return make_wheel(name=name, version=version, **kwargs)
 
 
@@ -691,7 +691,7 @@ def test_wheel_with_file_in_data_dir_has_reasonable_error(
     result = script.pip(
         "install", "--no-index", str(wheel_path), expect_error=True
     )
-    assert "simple-0.1.0.data/{}".format(name) in result.stderr
+    assert f"simple-0.1.0.data/{name}" in result.stderr
 
 
 def test_wheel_with_unknown_subdir_in_data_dir_has_reasonable_error(

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -21,8 +21,7 @@ def assert_installed(script, **kwargs):
         for val in json.loads(ret.stdout)
     )
     expected = set((canonicalize_name(k), v) for k, v in kwargs.items())
-    assert expected <= installed, \
-        "{!r} not all in {!r}".format(expected, installed)
+    assert expected <= installed, f"{expected!r} not all in {installed!r}"
 
 
 def assert_not_installed(script, *args):
@@ -34,17 +33,16 @@ def assert_not_installed(script, *args):
     # None of the given names should be listed as installed, i.e. their
     # intersection should be empty.
     expected = set(canonicalize_name(k) for k in args)
-    assert not (expected & installed), \
-        "{!r} contained in {!r}".format(expected, installed)
+    assert not (expected & installed), f"{expected!r} contained in {installed!r}"
 
 
 def assert_editable(script, *args):
     # This simply checks whether all of the listed packages have a
     # corresponding .egg-link file installed.
     # TODO: Implement a more rigorous way to test for editable installations.
-    egg_links = set("{}.egg-link".format(arg) for arg in args)
+    egg_links = set(f"{arg}.egg-link" for arg in args)
     assert egg_links <= set(os.listdir(script.site_packages_path)), \
-        "{!r} not all found in {!r}".format(args, script.site_packages_path)
+        f"{args!r} not all found in {script.site_packages_path!r}"
 
 
 def test_new_resolver_can_install(script):
@@ -732,7 +730,7 @@ def test_new_resolver_constraint_on_path_empty(
     setup_py.write_text(text)
 
     constraints_txt = script.scratch_path / "constraints.txt"
-    constraints_txt.write_text("foo=={}".format(constraint_version))
+    constraints_txt.write_text(f"foo=={constraint_version}")
 
     result = script.pip(
         "install",
@@ -1067,8 +1065,8 @@ def test_new_resolver_prefers_installed_in_upgrade_if_latest(script):
 def test_new_resolver_presents_messages_when_backtracking_a_lot(script, N):
     # Generate a set of wheels that will definitely cause backtracking.
     for index in range(1, N+1):
-        A_version = "{index}.0.0".format(index=index)
-        B_version = "{index}.0.0".format(index=index)
+        A_version = f"{index}.0.0"
+        B_version = f"{index}.0.0"
         C_version = "{index_minus_one}.0.0".format(index_minus_one=index - 1)
 
         depends = ["B == " + B_version]
@@ -1079,15 +1077,15 @@ def test_new_resolver_presents_messages_when_backtracking_a_lot(script, N):
         create_basic_wheel_for_package(script, "A", A_version, depends=depends)
 
     for index in range(1, N+1):
-        B_version = "{index}.0.0".format(index=index)
-        C_version = "{index}.0.0".format(index=index)
+        B_version = f"{index}.0.0"
+        C_version = f"{index}.0.0"
         depends = ["C == " + C_version]
 
         print("B", B_version, "C", C_version)
         create_basic_wheel_for_package(script, "B", B_version, depends=depends)
 
     for index in range(1, N+1):
-        C_version = "{index}.0.0".format(index=index)
+        C_version = f"{index}.0.0"
         print("C", C_version)
         create_basic_wheel_for_package(script, "C", C_version)
 
@@ -1138,7 +1136,7 @@ def test_new_resolver_check_wheel_version_normalized(
     metadata_version,
     filename_version,
 ):
-    filename = "simple-{}-py2.py3-none-any.whl".format(filename_version)
+    filename = f"simple-{filename_version}-py2.py3-none-any.whl"
 
     wheel_builder = make_wheel(name="simple", version=metadata_version)
     wheel_builder.save_to(script.scratch_path / filename)

--- a/tests/functional/test_new_resolver_target.py
+++ b/tests/functional/test_new_resolver_target.py
@@ -16,7 +16,7 @@ def make_fake_wheel(script):
             version="1.0",
             wheel_metadata_updates={"Tag": []},
         )
-        wheel_path = wheel_house.joinpath("fake-1.0-{}.whl".format(wheel_tag))
+        wheel_path = wheel_house.joinpath(f"fake-1.0-{wheel_tag}.whl")
         wheel_builder.save_to(wheel_path)
         return wheel_path
 

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -16,7 +16,7 @@ def test_basic_show(script):
     lines = result.stdout.splitlines()
     assert len(lines) == 10
     assert 'Name: pip' in lines
-    assert 'Version: {}'.format(__version__) in lines
+    assert f'Version: {__version__}' in lines
     assert any(line.startswith('Location: ') for line in lines)
     assert 'Requires: ' in lines
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -227,7 +227,7 @@ def test_no_clean_option_blocks_cleaning_after_wheel(
 
     if resolver_variant == "legacy":
         build = build / 'simple'
-        message = "build/simple should still exist {}".format(result)
+        message = f"build/simple should still exist {result}"
         assert exists(build), message
 
 

--- a/tests/functional/test_yaml.py
+++ b/tests/functional/test_yaml.py
@@ -77,7 +77,7 @@ def convert_to_dict(string):
 
     for part in parts[1:]:
         verb, args_str = stripping_split(part, " ", 1)
-        assert verb in ["depends"], "Unknown verb {!r}".format(verb)
+        assert verb in ["depends"], f"Unknown verb {verb!r}"
 
         retval[verb] = stripping_split(args_str, ",")
 
@@ -94,14 +94,14 @@ def handle_request(script, action, requirement, options, resolver_variant):
     elif action == 'uninstall':
         args = ['uninstall', '--yes']
     else:
-        raise "Did not excpet action: {!r}".format(action)
+        raise f"Did not excpet action: {action!r}"
 
     if isinstance(requirement, str):
         args.append(requirement)
     elif isinstance(requirement, list):
         args.extend(requirement)
     else:
-        raise "requirement neither str nor list {!r}".format(requirement)
+        raise f"requirement neither str nor list {requirement!r}"
 
     args.extend(options)
     args.append("--verbose")
@@ -177,7 +177,7 @@ def test_yaml_based(script, case):
             if action in request:
                 break
         else:
-            raise "Unsupported request {!r}".format(request)
+            raise f"Unsupported request {request!r}"
 
         # Perform the requested action
         effect = handle_request(script, action,

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -373,7 +373,7 @@ def _one_or_both(a, b):
     if not a:
         return str(b)
 
-    return "{a}\n{b}".format(a=a, b=b)
+    return f"{a}\n{b}"
 
 
 def make_check_stderr_message(stderr, line, reason):
@@ -748,7 +748,7 @@ def _create_main_file(dir_path, name=None, output=None):
     def main():
         print({!r})
     """.format(output))
-    filename = '{}.py'.format(name)
+    filename = f'{name}.py'
     dir_path.joinpath(filename).write_text(text)
 
 
@@ -983,14 +983,14 @@ def create_really_basic_wheel(name, version):
         z.writestr(path, contents)
         records.append((path, digest(contents), str(len(contents))))
 
-    dist_info = "{}-{}.dist-info".format(name, version)
-    record_path = "{}/RECORD".format(dist_info)
+    dist_info = f"{name}-{version}.dist-info"
+    record_path = f"{dist_info}/RECORD"
     records = [(record_path, "", "")]
     buf = BytesIO()
     with ZipFile(buf, "w") as z:
-        add_file("{}/WHEEL".format(dist_info), "Wheel-Version: 1.0")
+        add_file(f"{dist_info}/WHEEL", "Wheel-Version: 1.0")
         add_file(
-            "{}/METADATA".format(dist_info),
+            f"{dist_info}/METADATA",
             dedent(
                 """\
                 Metadata-Version: 2.1
@@ -1023,10 +1023,10 @@ def create_basic_wheel_for_package(
     # Fix wheel distribution name by replacing runs of non-alphanumeric
     # characters with an underscore _ as per PEP 491
     name = re.sub(r"[^\w\d.]+", "_", name, re.UNICODE)
-    archive_name = "{}-{}-py2.py3-none-any.whl".format(name, version)
+    archive_name = f"{name}-{version}-py2.py3-none-any.whl"
     archive_path = script.scratch_path / archive_name
 
-    package_init_py = "{name}/__init__.py".format(name=name)
+    package_init_py = f"{name}/__init__.py"
     assert package_init_py not in extra_files
     extra_files[package_init_py] = textwrap.dedent(
         """
@@ -1037,7 +1037,7 @@ def create_basic_wheel_for_package(
     ).format(version=version, name=name)
 
     requires_dist = depends + [
-        '{package}; extra == "{extra}"'.format(package=package, extra=extra)
+        f'{package}; extra == "{extra}"'
         for extra, packages in extras.items()
         for package in packages
     ]
@@ -1118,7 +1118,7 @@ def need_executable(name, check_cmd):
             subprocess.check_output(check_cmd)
         except (OSError, subprocess.CalledProcessError):
             return pytest.mark.skip(
-                reason='{name} is not available'.format(name=name))(fn)
+                reason=f'{name} is not available')(fn)
         return fn
     return wrapper
 

--- a/tests/lib/index.py
+++ b/tests/lib/index.py
@@ -3,10 +3,10 @@ from pip._internal.models.link import Link
 
 
 def make_mock_candidate(version, yanked_reason=None, hex_digest=None):
-    url = 'https://example.com/pkg-{}.tar.gz'.format(version)
+    url = f'https://example.com/pkg-{version}.tar.gz'
     if hex_digest is not None:
         assert len(hex_digest) == 64
-        url += '#sha256={}'.format(hex_digest)
+        url += f'#sha256={hex_digest}'
 
     link = Link(url, yanked_reason=yanked_reason)
     candidate = InstallationCandidate('mypackage', version, link)

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -19,7 +19,7 @@ def assert_error_startswith(exc_type, expected_start):
         yield
 
     assert str(err.value).startswith(expected_start), (
-        'full message: {}'.format(err.value)
+        f'full message: {err.value}'
     )
 
 
@@ -82,8 +82,8 @@ class TestPipTestEnvironment:
         """
         Call run() that prints stderr with the given prefix.
         """
-        text = '{}: hello, world\\n'.format(prefix)
-        command = 'import sys; sys.stderr.write("{}")'.format(text)
+        text = f'{prefix}: hello, world\\n'
+        command = f'import sys; sys.stderr.write("{text}")'
         args = [sys.executable, '-c', command]
         script.run(*args, **kwargs)
 

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -38,7 +38,7 @@ class VirtualEnvironment(object):
             self.lib = Path(lib)
 
     def __repr__(self):
-        return "<VirtualEnvironment {}>".format(self.location)
+        return f"<VirtualEnvironment {self.location}>"
 
     def _create(self, clear=False):
         if clear:

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -79,7 +79,7 @@ def message_from_dict(headers):
 
 def dist_info_path(name, version, path):
     # type: (str, str, str) -> str
-    return "{}-{}.dist-info/{}".format(name, version, path)
+    return f"{name}-{version}.dist-info/{path}"
 
 
 def make_metadata_file(
@@ -162,7 +162,7 @@ def make_entry_points_file(
 
     lines = []
     for section, values in entry_points_data.items():
-        lines.append("[{}]".format(section))
+        lines.append(f"[{section}]")
         lines.extend(values)
 
     return File(
@@ -190,9 +190,9 @@ def make_metadata_files(name, version, files):
 
 def make_data_files(name, version, files):
     # type: (str, str, Dict[str, AnyStr]) -> List[File]
-    data_dir = "{}-{}.data".format(name, version)
+    data_dir = f"{name}-{version}.data"
     return [
-        File("{}/{}".format(data_dir, name), ensure_binary(contents))
+        File(f"{data_dir}/{name}", ensure_binary(contents))
         for name, contents in files.items()
     ]
 
@@ -258,7 +258,7 @@ def wheel_name(name, version, pythons, abis, platforms):
         ".".join(abis),
         ".".join(platforms),
     ])
-    return "{}.whl".format(stem)
+    return f"{stem}.whl"
 
 
 class WheelBuilder(object):

--- a/tests/unit/test_cmdoptions.py
+++ b/tests/unit/test_cmdoptions.py
@@ -21,4 +21,4 @@ from pip._internal.cli.cmdoptions import _convert_python_version
 ])
 def test_convert_python_version(value, expected):
     actual = _convert_python_version(value)
-    assert actual == expected, 'actual: {!r}'.format(actual)
+    assert actual == expected, f'actual: {actual!r}'

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -398,7 +398,7 @@ def test_parse_links__yanked_reason(anchor_html, expected):
         encoding=None,
         # parse_links() is cached by url, so we inject a random uuid to ensure
         # the page content isn't cached.
-        url='https://example.com/simple-{}/'.format(uuid.uuid4()),
+        url=f'https://example.com/simple-{uuid.uuid4()}/',
     )
     links = list(parse_links(page))
     link, = links
@@ -580,7 +580,7 @@ def test_get_html_page_directory_append_index(tmpdir):
         actual = _get_html_page(Link(dir_url), session=session)
         assert mock_func.mock_calls == [
             mock.call(expected_url, session=session),
-        ], 'actual calls: {}'.format(mock_func.mock_calls)
+        ], f'actual calls: {mock_func.mock_calls}'
 
         assert actual.content == fake_response.content
         assert actual.encoding is None
@@ -636,7 +636,7 @@ def check_links_include(links, names):
     """
     for name in names:
         assert any(link.url.endswith(name) for link in links), (
-            'name {!r} not among links: {}'.format(name, links)
+            f'name {name!r} not among links: {links}'
         )
 
 

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -19,7 +19,7 @@ def check_commands(pred, expected):
     """
     commands = [create_command(name) for name in sorted(commands_dict)]
     actual = [command.name for command in commands if pred(command)]
-    assert actual == expected, 'actual: {}'.format(actual)
+    assert actual == expected, f'actual: {actual}'
 
 
 def test_commands_dict__order():

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -60,7 +60,7 @@ def test_str_to_display(data, expected):
     actual = str_to_display(data)
     assert actual == expected, (
         # Show the encoding for easier troubleshooting.
-        'encoding: {!r}'.format(locale.getpreferredencoding())
+        f'encoding: {locale.getpreferredencoding()!r}'
     )
 
 
@@ -79,7 +79,7 @@ def test_str_to_display__encoding(monkeypatch, data, encoding, expected):
     actual = str_to_display(data)
     assert actual == expected, (
         # Show the encoding for easier troubleshooting.
-        'encoding: {!r}'.format(locale.getpreferredencoding())
+        f'encoding: {locale.getpreferredencoding()!r}'
     )
 
 
@@ -96,7 +96,7 @@ def test_str_to_display__decode_error(monkeypatch, caplog):
 
     assert actual == expected, (
         # Show the encoding for easier troubleshooting.
-        'encoding: {!r}'.format(locale.getpreferredencoding())
+        f'encoding: {locale.getpreferredencoding()!r}'
     )
     assert len(caplog.records) == 1
     record = caplog.records[0]

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -474,7 +474,7 @@ class TestLinkEvaluator(object):
 def test_process_project_url(data):
     project_name = 'simple'
     index_url = data.index_url('simple')
-    project_url = Link('{}/{}'.format(index_url, project_name))
+    project_url = Link(f'{index_url}/{project_name}')
     finder = make_test_finder(index_urls=[index_url])
     link_evaluator = finder.make_link_evaluator(project_name)
     actual = finder.process_project_url(

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -763,7 +763,7 @@ def test_find_name_version_sep(fragment, canonical_name, expected):
 def test_find_name_version_sep_failure(fragment, canonical_name):
     with pytest.raises(ValueError) as ctx:
         _find_name_version_sep(fragment, canonical_name)
-    message = "{} does not match {}".format(fragment, canonical_name)
+    message = f"{fragment} does not match {canonical_name}"
     assert str(ctx.value) == message
 
 

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -33,7 +33,7 @@ def mypy_whl_no_range(mock_server, shared_data):
     mypy_whl = shared_data.packages / 'mypy-0.782-py3-none-any.whl'
     mock_server.set_responses([file_response(mypy_whl)])
     mock_server.start()
-    base_address = 'http://{}:{}'.format(mock_server.host, mock_server.port)
+    base_address = f'http://{mock_server.host}:{mock_server.port}'
     yield "{}/{}".format(base_address, 'mypy-0.782-py3-none-any.whl')
     mock_server.stop()
 

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -13,7 +13,7 @@ def get_user_agent():
 def test_user_agent():
     user_agent = get_user_agent()
 
-    assert user_agent.startswith("pip/{}".format(__version__))
+    assert user_agent.startswith(f"pip/{__version__}")
 
 
 @pytest.mark.parametrize('name, expected_like_ci', [
@@ -115,7 +115,7 @@ class TestPipSession:
         session.add_trusted_host('host3')
         assert session.pip_trusted_origins == [
             ('host1', None), ('host3', None), ('host2', None)
-        ], 'actual: {}'.format(session.pip_trusted_origins)
+        ], f'actual: {session.pip_trusted_origins}'
 
         session.add_trusted_host('host4:8080')
         prefix4 = 'https://host4:8080/'

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -189,7 +189,7 @@ class Test_unpack_url(object):
         Test when the file url hash fragment is wrong
         """
         self.prep(tmpdir, data)
-        url = '{}#md5=bogus'.format(self.dist_url.url)
+        url = f'{self.dist_url.url}#md5=bogus'
         dist_url = Link(url)
         with pytest.raises(HashMismatch):
             unpack_url(dist_url,

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -262,7 +262,7 @@ class TestOptionsInterspersed(AddFakeCommandMixin):
 @contextmanager
 def tmpconfig(option, value, section='global'):
     with NamedTemporaryFile(mode='w', delete=False) as f:
-        f.write('[{}]\n{}={}\n'.format(section, option, value))
+        f.write(f'[{section}]\n{option}={value}\n')
         name = f.name
     try:
         yield name
@@ -275,7 +275,7 @@ class TestCountOptions(AddFakeCommandMixin):
     @pytest.mark.parametrize('option', ('verbose', 'quiet'))
     @pytest.mark.parametrize('value', range(4))
     def test_cli_long(self, option, value):
-        flags = ['--{}'.format(option)] * value
+        flags = [f'--{option}'] * value
         opt1, args1 = main(flags+['fake'])
         opt2, args2 = main(['fake']+flags)
         assert getattr(opt1, option) == getattr(opt2, option) == value

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -454,14 +454,14 @@ class TestInstallRequirement(object):
     def test_markers_url(self):
         # test "URL; markers" syntax
         url = 'http://foo.com/?p=bar.git;a=snapshot;h=v0.1;sf=tgz'
-        line = '{}; python_version >= "3"'.format(url)
+        line = f'{url}; python_version >= "3"'
         req = install_req_from_line(line)
         assert req.link.url == url, req.url
         assert str(req.markers) == 'python_version >= "3"'
 
         # without space, markers are part of the URL
         url = 'http://foo.com/?p=bar.git;a=snapshot;h=v0.1;sf=tgz'
-        line = '{};python_version >= "3"'.format(url)
+        line = f'{url};python_version >= "3"'
         req = install_req_from_line(line)
         assert req.link.url == line, req.url
         assert req.markers is None
@@ -560,7 +560,7 @@ class TestInstallRequirement(object):
         with pytest.raises(InstallationError) as e:
             install_req_from_line(test_name)
         err_msg = e.value.args[0]
-        assert "Invalid requirement: '{}'".format(test_name) == err_msg
+        assert f"Invalid requirement: '{test_name}'" == err_msg
 
     def test_requirement_file(self):
         req_file_path = os.path.join(self.tempdir, 'test.txt')

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -270,7 +270,7 @@ class TestProcessLine(object):
 
     def test_yield_editable_constraint(self, line_processor):
         url = 'git+https://url#egg=SomeProject'
-        line = '-e {}'.format(url)
+        line = f'-e {url}'
         filename = 'filename'
         comes_from = '-c {} (line {})'.format(filename, 1)
         req = install_req_from_editable(
@@ -432,7 +432,7 @@ class TestProcessLine(object):
                 return None, '-r reqs.txt'
             elif filename == 'http://me.com/me/reqs.txt':
                 return None, req_name
-            assert False, 'Unexpected file requested {}'.format(filename)
+            assert False, f'Unexpected file requested {filename}'
 
         monkeypatch.setattr(
             pip._internal.req.req_file, 'get_file_content', get_file_content
@@ -478,7 +478,7 @@ class TestProcessLine(object):
         # POSIX-ify the path, since Windows backslashes aren't supported.
         other_req_file_str = str(other_req_file).replace('\\', '/')
 
-        req_file.write_text('-r {}'.format(other_req_file_str))
+        req_file.write_text(f'-r {other_req_file_str}')
         other_req_file.write_text(req_name)
 
         reqs = list(parse_reqfile(str(req_file), session=session))
@@ -498,10 +498,10 @@ class TestProcessLine(object):
 
         def get_file_content(filename, *args, **kwargs):
             if filename == str(req_file):
-                return None, '-r {}'.format(nested_req_file)
+                return None, f'-r {nested_req_file}'
             elif filename == nested_req_file:
                 return None, req_name
-            assert False, 'Unexpected file requested {}'.format(filename)
+            assert False, f'Unexpected file requested {filename}'
 
         monkeypatch.setattr(
             pip._internal.req.req_file, 'get_file_content', get_file_content

--- a/tests/unit/test_resolution_legacy_resolver.py
+++ b/tests/unit/test_resolution_legacy_resolver.py
@@ -34,7 +34,7 @@ class FakeDist(pkg_resources.DistInfoDistribution):
         self.metadata = metadata
 
     def __str__(self):
-        return '<distribution {!r}>'.format(self.project_name)
+        return f'<distribution {self.project_name!r}>'
 
     def has_metadata(self, name):
         return (name == self.metadata_name)
@@ -47,7 +47,7 @@ class FakeDist(pkg_resources.DistInfoDistribution):
 def make_fake_dist(requires_python=None, metadata_name=None):
     metadata = 'Name: test\n'
     if requires_python is not None:
-        metadata += 'Requires-Python:{}'.format(requires_python)
+        metadata += f'Requires-Python:{requires_python}'
 
     return FakeDist(metadata, metadata_name=metadata_name)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -63,11 +63,11 @@ class Tests_EgglinkPath:
         self.user_site = 'USER_SITE'
         self.user_site_egglink = os.path.join(
             self.user_site,
-            '{}.egg-link'.format(project)
+            f'{project}.egg-link'
         )
         self.site_packages_egglink = os.path.join(
             self.site_packages,
-            '{}.egg-link'.format(project),
+            f'{project}.egg-link',
         )
 
         # patches
@@ -440,7 +440,7 @@ elif sys.byteorder == "big":
 def test_path_to_display(monkeypatch, path, fs_encoding, expected):
     monkeypatch.setattr(sys, 'getfilesystemencoding', lambda: fs_encoding)
     actual = path_to_display(path)
-    assert actual == expected, 'actual: {!r}'.format(actual)
+    assert actual == expected, f'actual: {actual!r}'
 
 
 class Test_normalize_path(object):

--- a/tests/unit/test_utils_distutils_args.py
+++ b/tests/unit/test_utils_distutils_args.py
@@ -50,7 +50,7 @@ def test_multiple_invocations_do_not_keep_options():
     ("root", "11"),
 ])
 def test_all_value_options_work(name, value):
-    result = parse_distutils_args(["--{}={}".format(name, value)])
+    result = parse_distutils_args([f"--{name}={value}"])
     key_name = name.replace("-", "_")
     assert result[key_name] == value
 

--- a/tests/unit/test_utils_parallel.py
+++ b/tests/unit/test_utils_parallel.py
@@ -62,7 +62,7 @@ def test_have_sem_open(name, monkeypatch):
     """Test fallback when sem_open is available."""
     monkeypatch.setattr(DUNDER_IMPORT, have_sem_open)
     with tmp_import_parallel() as parallel:
-        assert getattr(parallel, name) is getattr(parallel, '_{}'.format(name))
+        assert getattr(parallel, name) is getattr(parallel, f'_{name}')
 
 
 @mark.parametrize('name', MAPS)

--- a/tests/unit/test_utils_subprocess.py
+++ b/tests/unit/test_utils_subprocess.py
@@ -48,7 +48,7 @@ def test_make_subprocess_output_error():
     line2
     line3
     ----------------------------------------""")
-    assert actual == expected, 'actual: {}'.format(actual)
+    assert actual == expected, f'actual: {actual}'
 
 
 def test_make_subprocess_output_error__non_ascii_command_arg(monkeypatch):
@@ -76,7 +76,7 @@ def test_make_subprocess_output_error__non_ascii_command_arg(monkeypatch):
          cwd: /path/to/cwd
     Complete output (0 lines):
     ----------------------------------------""")
-    assert actual == expected, 'actual: {}'.format(actual)
+    assert actual == expected, f'actual: {actual}'
 
 
 @pytest.mark.skipif("sys.version_info < (3,)")
@@ -98,7 +98,7 @@ def test_make_subprocess_output_error__non_ascii_cwd_python_3(monkeypatch):
          cwd: /path/to/cwd/déf
     Complete output (0 lines):
     ----------------------------------------""")
-    assert actual == expected, 'actual: {}'.format(actual)
+    assert actual == expected, f'actual: {actual}'
 
 
 @pytest.mark.parametrize('encoding', [
@@ -128,7 +128,7 @@ def test_make_subprocess_output_error__non_ascii_cwd_python_2(
          cwd: /path/to/cwd/déf
     Complete output (0 lines):
     ----------------------------------------""")
-    assert actual == expected, 'actual: {}'.format(actual)
+    assert actual == expected, f'actual: {actual}'
 
 
 # This test is mainly important for checking unicode in Python 2.
@@ -150,7 +150,7 @@ def test_make_subprocess_output_error__non_ascii_line():
     Complete output (1 lines):
     curly-quote: \u2018
     ----------------------------------------""")
-    assert actual == expected, 'actual: {}'.format(actual)
+    assert actual == expected, f'actual: {actual}'
 
 
 class FakeSpinner(SpinnerInterface):
@@ -205,7 +205,7 @@ class TestCallSubprocess(object):
 
         records = caplog.record_tuples
         if len(records) != len(expected_records):
-            raise RuntimeError('{} != {}'.format(records, expected_records))
+            raise RuntimeError(f'{records} != {expected_records}')
 
         for record, expected_record in zip(records, expected_records):
             # Check the logger_name and log level parts exactly.
@@ -316,7 +316,7 @@ class TestCallSubprocess(object):
             'Hello',
             'fail',
             'world',
-        ], 'lines: {}'.format(actual)  # Show the full output on failure.
+        ], f'lines: {actual}'  # Show the full output on failure.
 
         assert command_line.startswith(' command: ')
         assert command_line.endswith('print("world"); exit("fail")\'')
@@ -375,7 +375,7 @@ class TestCallSubprocess(object):
         expected_spin_count = expected[2]
 
         command = (
-            'print("Hello"); print("world"); exit({})'.format(exit_status)
+            f'print("Hello"); print("world"); exit({exit_status})'
         )
         args, spinner = self.prepare_call(caplog, log_level, command=command)
         try:

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -66,14 +66,14 @@ class TestUnpackArchives(object):
             if expected_contents is not None:
                 with open(path, mode='rb') as f:
                     contents = f.read()
-                assert contents == expected_contents, 'fname: {}'.format(fname)
+                assert contents == expected_contents, f'fname: {fname}'
             if sys.platform == 'win32':
                 # the permissions tests below don't apply in windows
                 # due to os.chmod being a noop
                 continue
             mode = self.mode(path)
             assert mode == expected_mode, (
-                "mode: {}, expected mode: {}".format(mode, expected_mode)
+                f"mode: {mode}, expected mode: {expected_mode}"
             )
 
     def make_zip_file(self, filename, file_list):

--- a/tests/unit/test_utils_wheel.py
+++ b/tests/unit/test_utils_wheel.py
@@ -112,7 +112,7 @@ def test_wheel_version_fails_on_no_wheel_version():
 def test_wheel_version_fails_on_bad_wheel_version(version):
     with pytest.raises(UnsupportedWheel) as e:
         wheel.wheel_version(
-            message_from_string("Wheel-Version: {}".format(version))
+            message_from_string(f"Wheel-Version: {version}")
         )
     assert "invalid Wheel-Version" in str(e.value)
 

--- a/tools/automation/release/__init__.py
+++ b/tools/automation/release/__init__.py
@@ -98,13 +98,13 @@ def update_version_file(version: str, filepath: str) -> None:
     with open(filepath, "w", encoding="utf-8") as f:
         for line in content:
             if line.startswith("__version__ ="):
-                f.write('__version__ = "{}"\n'.format(version))
+                f.write(f'__version__ = "{version}"\n')
                 file_modified = True
             else:
                 f.write(line)
 
     assert file_modified, \
-        "Version file {} did not get modified".format(filepath)
+        f"Version file {filepath} did not get modified"
 
 
 def create_git_tag(session: Session, tag_name: str, *, message: str) -> None:


### PR DESCRIPTION
Use pyupgrade to convert simple string formatting to use f-string
syntax. pyupgrade is intentionally timid and will not create an f-string
if it would make the expression longer or if the substitution parameters
are anything but simple names or dotted names.
