### PR TITLE
Remove unnecessary str() call around str literal

### DIFF
--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -301,7 +301,7 @@ def test_pip_wheel_ext_module_with_tmpdir_inside(script, data, common_wheels):
 
     # To avoid a test dependency on a C compiler, we set the env vars to "noop"
     # The .c source is empty anyway
-    script.environ['CC'] = script.environ['LDSHARED'] = str('true')
+    script.environ['CC'] = script.environ['LDSHARED'] = 'true'
 
     result = script.pip(
         'wheel', data.src / 'extension',


### PR DESCRIPTION
Unnecessary since dropping Python 2.
