### PR TITLE
Use Formatter.default_time_format after dropping PY2

### DIFF
--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -101,6 +101,7 @@ def get_indentation():
 
 
 class IndentingFormatter(logging.Formatter):
+    default_time_format = "%Y-%m-%dT%H:%M:%S"
 
     def __init__(self, *args, **kwargs):
         """
@@ -139,9 +140,7 @@ class IndentingFormatter(logging.Formatter):
 
         prefix = ''
         if self.add_timestamp:
-            # TODO: Use Formatter.default_time_format after dropping PY2.
-            t = self.formatTime(record, "%Y-%m-%dT%H:%M:%S")
-            prefix = '{t},{record.msecs:03.0f} '.format(**locals())
+            prefix = f"{self.formatTime(record)} "
         prefix += " " * get_indentation()
         formatted = "".join([
             prefix + line


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
For #8802.

Do a TODO ~and update tests to match~.
```python
# TODO: Use Formatter.default_time_format after dropping PY2.	
```