### PR TITLE
Prefer subprocess.DEVNULL over open(os.devnull, 'w')

### DIFF
--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -22,15 +22,12 @@ def _create_svn_initools_repo(initools_dir):
         'http://bitbucket.org/hltbra/pip-initools-dump/raw/8b55c908a320/'
         'INITools_modified.dump'
     )
-    devnull = open(os.devnull, 'w')
-    dump = open(filename)
-    subprocess.check_call(
-        ['svnadmin', 'load', initools_dir],
-        stdin=dump,
-        stdout=devnull,
-    )
-    dump.close()
-    devnull.close()
+    with open(filename) as dump:
+        subprocess.check_call(
+            ['svnadmin', 'load', initools_dir],
+            stdin=dump,
+            stdout=subprocess.DEVNULL,
+        )
     os.remove(filename)
 
 


### PR DESCRIPTION
Available since Python 3.3.

https://docs.python.org/3/library/subprocess.html#subprocess.DEVNULL