### PR TITLE
Replace Python 2 tmpdir removal workarounds

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,11 +129,8 @@ def tmpdir_factory(request, tmpdir_factory):
     """
     yield tmpdir_factory
     if not request.config.getoption("--keep-tmpdir"):
-        # py.path.remove() uses str paths on Python 2 and cannot
-        # handle non-ASCII file names. This works around the problem by
-        # passing a unicode object to rmtree().
         shutil.rmtree(
-            str(tmpdir_factory.getbasetemp()),
+            tmpdir_factory.getbasetemp(),
             ignore_errors=True,
         )
 
@@ -155,10 +152,7 @@ def tmpdir(request, tmpdir):
     # This should prevent us from needing a multiple gigabyte temporary
     # directory while running the tests.
     if not request.config.getoption("--keep-tmpdir"):
-        # py.path.remove() uses str paths on Python 2 and cannot
-        # handle non-ASCII file names. This works around the problem by
-        # passing a unicode object to rmtree().
-        shutil.rmtree(str(tmpdir), ignore_errors=True)
+        tmpdir.remove(ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

For #8802.

Follow up to https://github.com/pypa/pip/pull/9335, based on suggestions from @jdufresne and @uranusjr in  https://github.com/pypa/pip/pull/9335#discussion_r547357661.