### PR TITLE
Remove unnecessary class FakeFile

### DIFF
--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -13,7 +13,6 @@ from pip._internal.locations import bin_py, bin_user
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
-    FakeFile,
     ask,
     dist_in_usersite,
     dist_is_local,
@@ -90,7 +89,7 @@ def uninstallation_paths(dist):
 
     UninstallPathSet.add() takes care of the __pycache__ .py[co].
     """
-    r = csv.reader(FakeFile(dist.get_metadata_lines('RECORD')))
+    r = csv.reader(dist.get_metadata_lines('RECORD'))
     for row in r:
         path = os.path.join(dist.location, row[0])
         yield path

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -572,22 +572,6 @@ def write_output(msg, *args):
     logger.info(msg, *args)
 
 
-class FakeFile:
-    """Wrap a list of lines in an object with readline() to make
-    ConfigParser happy."""
-    def __init__(self, lines):
-        self._gen = iter(lines)
-
-    def readline(self):
-        try:
-            return next(self._gen)
-        except StopIteration:
-            return ''
-
-    def __iter__(self):
-        return self._gen
-
-
 class StreamWrapper(StringIO):
 
     @classmethod


### PR DESCRIPTION
The class was being used in a single place, passed to csv.reader().
However, per the docs, csv.reader() can handle a list of str objects.

https://docs.python.org/3/library/csv.html#csv.reader

> csvfile can be any object which supports the iterator protocol and
> returns a string each time its `__next__()` method is called — file
> objects and list objects are both suitable.