### PR TITLE
Replace six.moves.xmlrpc_client with stdlib

### DIFF
--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -3,20 +3,20 @@
 
 import logging
 import urllib.parse
-from typing import Dict
-
-# NOTE: XMLRPC Client is not annotated in typeshed as on 2017-07-17, which is
-#       why we ignore the type on this import
-from pip._vendor.six.moves import xmlrpc_client  # type: ignore
+import xmlrpc.client
+from typing import TYPE_CHECKING, Tuple
 
 from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.network.session import PipSession
 from pip._internal.network.utils import raise_for_status
 
+if TYPE_CHECKING:
+    from xmlrpc.client import _HostType, _Marshallable
+
 logger = logging.getLogger(__name__)
 
 
-class PipXmlrpcTransport(xmlrpc_client.Transport):
+class PipXmlrpcTransport(xmlrpc.client.Transport):
     """Provide a `xmlrpclib.Transport` implementation via a `PipSession`
     object.
     """
@@ -29,7 +29,8 @@ class PipXmlrpcTransport(xmlrpc_client.Transport):
         self._session = session
 
     def request(self, host, handler, request_body, verbose=False):
-        # type: (str, str, Dict[str, str], bool) -> None
+        # type: (_HostType, str, bytes, bool) -> Tuple[_Marshallable, ...]
+        assert isinstance(host, str)
         parts = (self._scheme, host, handler, None, None, None)
         url = urllib.parse.urlunparse(parts)
         try:


### PR DESCRIPTION
Updated type signatures for compatibility with the stdlib class.
