### PR TITLE
Remove unnecessary type override NamedTemporaryFileResult

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -46,6 +46,7 @@ else:
     from typing import (
         IO,
         Any,
+        BinaryIO,
         Callable,
         Dict,
         Iterable,
@@ -65,7 +66,6 @@ else:
     from pip._vendor.pkg_resources import Distribution
 
     from pip._internal.models.scheme import Scheme
-    from pip._internal.utils.filesystem import NamedTemporaryFileResult
 
     RecordPath = NewType('RecordPath', str)
     InstalledCSVRow = Tuple[RecordPath, str, Union[int, str]]
@@ -742,7 +742,7 @@ def _install_wheel(
 
     @contextlib.contextmanager
     def _generate_file(path, **kwargs):
-        # type: (str, **Any) -> Iterator[NamedTemporaryFileResult]
+        # type: (str, **Any) -> Iterator[BinaryIO]
         with adjacent_tmp_file(path, **kwargs) as f:
             yield f
         os.chmod(f.name, generated_file_mode)

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -19,12 +19,6 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING, cast
 if MYPY_CHECK_RUNNING:
     from typing import Any, BinaryIO, Iterator, List, Union
 
-    class NamedTemporaryFileResult(BinaryIO):
-        @property
-        def file(self):
-            # type: () -> BinaryIO
-            pass
-
 
 def check_path_owner(path):
     # type: (str) -> bool
@@ -86,7 +80,7 @@ def is_socket(path):
 
 @contextmanager
 def adjacent_tmp_file(path, **kwargs):
-    # type: (str, **Any) -> Iterator[NamedTemporaryFileResult]
+    # type: (str, **Any) -> Iterator[BinaryIO]
     """Return a file-like object pointing to a tmp file next to path.
 
     The file is created securely and is ensured to be written to disk
@@ -102,12 +96,12 @@ def adjacent_tmp_file(path, **kwargs):
         suffix='.tmp',
         **kwargs
     ) as f:
-        result = cast('NamedTemporaryFileResult', f)
+        result = cast('BinaryIO', f)
         try:
             yield result
         finally:
-            result.file.flush()
-            os.fsync(result.file.fileno())
+            result.flush()
+            os.fsync(result.fileno())
 
 
 _replace_retry = retry(stop_max_delay=1000, wait_fixed=250)


### PR DESCRIPTION
The object returned by NamedTemporaryFile delegates all functions calls
to the underlying file so can avoid the type override by relying on IO
methods.
