### PR TITLE
Run mypy on parts of the tests/ directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
   rev: v0.800
   hooks:
   - id: mypy
-    exclude: docs|tests
+    exclude: ^(docs|tests/(data|functional|unit|yaml))
     args: ["--pretty"]
     additional_dependencies: ['nox==2020.12.31']
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,9 @@ warn_unused_ignores = True
 follow_imports = skip
 ignore_errors = True
 
+[mypy-tests/*]
+allow_untyped_defs = True
+
 [tool:pytest]
 addopts = --ignore src/pip/_vendor --ignore tests/tests_cache -r aR
 markers =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import time
 from contextlib import ExitStack, contextmanager
-from typing import Dict, Iterable
+from typing import TYPE_CHECKING, Iterable, List
 from unittest.mock import patch
 
 import pytest
@@ -20,10 +20,13 @@ from tests.lib import DATA_DIR, SRC_DIR, PipTestEnvironment, TestData
 from tests.lib.certs import make_tls_cert, serialize_cert, serialize_key
 from tests.lib.path import Path
 from tests.lib.server import MockServer as _MockServer
-from tests.lib.server import Responder, make_mock_server, server_running
+from tests.lib.server import make_mock_server, server_running
 from tests.lib.venv import VirtualEnvironment
 
 from .lib.compat import nullcontext
+
+if TYPE_CHECKING:
+    from _typeshed.wsgi import WSGIApplication
 
 
 def pytest_addoption(parser):
@@ -512,7 +515,7 @@ class MockServer:
         return self._server.host
 
     def set_responses(self, responses):
-        # type: (Iterable[Responder]) -> None
+        # type: (Iterable[WSGIApplication]) -> None
         assert not self._running, "responses cannot be set on running server"
         self._server.mock.side_effect = responses
 
@@ -536,7 +539,7 @@ class MockServer:
         self.context.close()
 
     def get_requests(self):
-        # type: () -> Dict[str, str]
+        # type: () -> List[str]
         """Get environ for each received request.
         """
         assert not self._running, "cannot get mock from running server"

--- a/tests/lib/certs.py
+++ b/tests/lib/certs.py
@@ -9,7 +9,7 @@ from cryptography.x509.oid import NameOID
 
 
 def make_tls_cert(hostname):
-    # type: (str) -> Tuple[x509.Certificate, rsa.RSAPrivateKey]
+    # type: (str) -> Tuple[x509.Certificate, rsa.RSAPrivateKeyWithSerialization]
     key = rsa.generate_private_key(
         public_exponent=65537,
         key_size=2048,
@@ -36,7 +36,7 @@ def make_tls_cert(hostname):
 
 
 def serialize_key(key):
-    # type: (rsa.RSAPrivateKey) -> bytes
+    # type: (rsa.RSAPrivateKeyWithSerialization) -> bytes
     return key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,

--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -55,6 +55,7 @@ def local_checkout(
         repo_url_path = os.path.join(repo_url_path, 'trunk')
     else:
         vcs_backend = vcs.get_backend(vcs_name)
+        assert vcs_backend is not None
         vcs_backend.obtain(repo_url_path, url=hide_url(remote_repo))
 
     return '{}+{}'.format(vcs_name, path_to_url(repo_url_path))

--- a/tests/lib/path.py
+++ b/tests/lib/path.py
@@ -26,6 +26,7 @@ class Path(str):
         return super().__new__(cls)
 
     def __div__(self, path):
+        # type: (str) -> Path
         """
         Joins this path with another path.
 

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -5,8 +5,7 @@ import threading
 from base64 import b64encode
 from contextlib import contextmanager
 from textwrap import dedent
-from types import TracebackType
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator
 from unittest.mock import Mock
 
 from werkzeug.serving import BaseWSGIServer, WSGIRequestHandler
@@ -14,14 +13,10 @@ from werkzeug.serving import make_server as _make_server
 
 from .compat import nullcontext
 
-Environ = Dict[str, str]
-Status = str
-Headers = Iterable[Tuple[str, str]]
-ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
-Write = Callable[[bytes], None]
-StartResponse = Callable[[Status, Headers, Optional[ExcInfo]], Write]
-Body = List[bytes]
-Responder = Callable[[Environ, StartResponse], Body]
+if TYPE_CHECKING:
+    from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+
+Body = Iterable[bytes]
 
 
 class MockServer(BaseWSGIServer):
@@ -77,13 +72,15 @@ class _RequestHandler(WSGIRequestHandler):
         return environ
 
 
-def _mock_wsgi_adapter(mock):
-    # type: (Callable[[Environ, StartResponse], Responder]) -> Responder
+def _mock_wsgi_adapter(
+        mock  # type: Callable[[WSGIEnvironment, StartResponse], WSGIApplication]
+):
+    # type: (...) -> WSGIApplication
     """Uses a mock to record function arguments and provide
     the actual function that should respond.
     """
     def adapter(environ, start_response):
-        # type: (Environ, StartResponse) -> Body
+        # type: (WSGIEnvironment, StartResponse) -> Body
         try:
             responder = mock(environ, start_response)
         except StopIteration:
@@ -135,7 +132,7 @@ def make_mock_server(**kwargs):
 
 @contextmanager
 def server_running(server):
-    # type: (BaseWSGIServer) -> None
+    # type: (BaseWSGIServer) -> Iterator[None]
     """Context manager for running the provided server in a separate thread.
     """
     thread = threading.Thread(target=server.serve_forever)
@@ -153,9 +150,9 @@ def server_running(server):
 
 
 def text_html_response(text):
-    # type: (str) -> Responder
+    # type: (str) -> WSGIApplication
     def responder(environ, start_response):
-        # type: (Environ, StartResponse) -> Body
+        # type: (WSGIEnvironment, StartResponse) -> Body
         start_response("200 OK", [
             ("Content-Type", "text/html; charset=UTF-8"),
         ])
@@ -177,7 +174,7 @@ def html5_page(text):
 
 
 def index_page(spec):
-    # type: (Dict[str, str]) -> Responder
+    # type: (Dict[str, str]) -> WSGIApplication
     def link(name, value):
         return '<a href="{}">{}</a>'.format(
             value, name
@@ -188,7 +185,7 @@ def index_page(spec):
 
 
 def package_page(spec):
-    # type: (Dict[str, str]) -> Responder
+    # type: (Dict[str, str]) -> WSGIApplication
     def link(name, value):
         return '<a href="{}">{}</a>'.format(
             value, name
@@ -199,9 +196,9 @@ def package_page(spec):
 
 
 def file_response(path):
-    # type: (str) -> Responder
+    # type: (str) -> WSGIApplication
     def responder(environ, start_response):
-        # type: (Environ, StartResponse) -> Body
+        # type: (WSGIEnvironment, StartResponse) -> Body
         size = os.stat(path).st_size
         start_response(
             "200 OK", [
@@ -217,11 +214,11 @@ def file_response(path):
 
 
 def authorization_response(path):
-    # type: (str) -> Responder
+    # type: (str) -> WSGIApplication
     correct_auth = "Basic " + b64encode(b"USERNAME:PASSWORD").decode("ascii")
 
     def responder(environ, start_response):
-        # type: (Environ, StartResponse) -> Body
+        # type: (WSGIEnvironment, StartResponse) -> Body
 
         if environ.get('HTTP_AUTHORIZATION') == correct_auth:
             size = os.stat(path).st_size

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -28,11 +28,7 @@ from pip._vendor.requests.structures import CaseInsensitiveDict
 
 from tests.lib.path import Path
 
-# path, digest, size
-RecordLike = Tuple[str, str, str]
-RecordCallback = Callable[
-    [List["Record"]], Union[str, bytes, List[RecordLike]]
-]
+RecordCallback = Callable[[List["Record"]], List["Record"]]
 # As would be used in metadata
 HeaderValue = Union[str, List[str]]
 
@@ -88,7 +84,7 @@ def make_metadata_file(
     updates,  # type: Defaulted[Dict[str, HeaderValue]]
     body,  # type: Defaulted[AnyStr]
 ):
-    # type: () -> File
+    # type: (...) -> Optional[File]
     if value is None:
         return None
 
@@ -211,7 +207,7 @@ def digest(contents):
 def record_file_maker_wrapper(
     name,  # type: str
     version,  # type: str
-    files,  # type: List[File]
+    files,  # type: Iterable[File]
     record,  # type: Defaulted[Optional[AnyStr]]
     record_callback,  # type: Defaulted[RecordCallback]
 ):
@@ -241,15 +237,15 @@ def record_file_maker_wrapper(
 
     with StringIO(newline="") as buf:
         writer = csv.writer(buf)
-        for record in records:
-            writer.writerow(record)
+        for r in records:
+            writer.writerow(r)
         contents = buf.getvalue().encode("utf-8")
 
     yield File(record_path, contents)
 
 
 def wheel_name(name, version, pythons, abis, platforms):
-    # type: (str, str, str, str, str) -> str
+    # type: (str, str, Iterable[str], Iterable[str], Iterable[str]) -> str
     stem = "-".join([
         name,
         version,
@@ -265,7 +261,7 @@ class WheelBuilder:
     """
 
     def __init__(self, name, files):
-        # type: (str, List[File]) -> None
+        # type: (str, Iterable[File]) -> None
         self._name = name
         self._files = files
 


### PR DESCRIPTION
Some of the test code already has type annotations, so might as well
verify them. Running mypy caught some mislabled types in the tests/lib/
directory.

The tests are a consumer of the pip functions and API. By running mypy
on tests, it helps ensure that tests are representative and that typing
is consistent with the expectations represented by tests.

As time goes on, the project can expand the mypy coverage of tests.

For the tests directory, untyped defs are allowed so as not to require
all tests functions be annotated.
