### PR TITLE
GitHub Actions: Allow testing of feature branches

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,8 +2,6 @@ name: MacOS
 
 on:
   push:
-    branches:
-    - master
   pull_request:
   schedule:
   # Run every Friday at 18:02 UTC


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

The macOS CI tests on GitHub Actions are currently limited to only the `master` branch, which means I cannot test my work on CI before creating a PR (or otherwise develop in `master`...).

The Travis CI config does not have this limitation, nor (as far as I can see) does Azure Pipelines.

And because AP is a bit of a pain to enable for forks, and because Travis is, well, let's say not exactly prioritising OSS at the moment, GHA is the easiest CI to test on before creating PRs.
