### PR TITLE
Fix package permissions

### DIFF
--- a/news/4692.bugfix.rst
+++ b/news/4692.bugfix.rst
@@ -1,0 +1,1 @@
+This change adds a warning for situations where pip is run with sudo.

--- a/news/4727.bugfix.rst
+++ b/news/4727.bugfix.rst
@@ -1,0 +1,1 @@
+This change adds a warning for situations where pip is run with sudo.

--- a/news/7269.bugfix.rst
+++ b/news/7269.bugfix.rst
@@ -1,0 +1,1 @@
+This change fixes pip freeze by suppressing warnings for invalid packages.

--- a/news/7307.bugfix.rst
+++ b/news/7307.bugfix.rst
@@ -1,0 +1,1 @@
+This change prevents the unintended creation of temporary package directories.

--- a/news/7450.bugfix.rst
+++ b/news/7450.bugfix.rst
@@ -1,0 +1,1 @@
+This change prevents the unintended creation of temporary package directories.

--- a/news/7763.bugfix.rst
+++ b/news/7763.bugfix.rst
@@ -1,0 +1,1 @@
+This change prevents the unintended creation of temporary package directories.

--- a/news/7940.bugfix.rst
+++ b/news/7940.bugfix.rst
@@ -1,0 +1,1 @@
+This change adds a warning for situations where pip is run with sudo.

--- a/news/9235.bugfix.rst
+++ b/news/9235.bugfix.rst
@@ -1,0 +1,1 @@
+This change fixes pip freeze by suppressing warnings for invalid packages.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -722,9 +722,9 @@ def create_os_error_message(error, show_traceback, using_user_site):
         user_option_part = "Consider using the `--user` option"
         permissions_part = "Check the permissions"
         chown_part = ("Oftentimes packages are unnecessarily installed with "
-            "`sudo pip`, which sets the folder owner to root. In this case, "
-            "consider changing the owner to $USER: "
-            "`$ sudo chown -R $USER [package folder]`")
+                "`sudo pip`, which sets the folder owner to root. In this case, "
+                "consider changing the owner to $USER: "
+                "`$ sudo chown -R $USER [package folder]`")
 
         if not using_user_site:
             parts.extend([

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -721,10 +721,10 @@ def create_os_error_message(error, show_traceback, using_user_site):
     if error.errno == errno.EACCES:
         user_option_part = "Consider using the `--user` option"
         permissions_part = "Check the permissions"
-        chown_part = "Oftentimes packages are unnecessarily installed with "\
-        "`sudo pip`, which sets the folder owner to root. In this case, "\
-        "consider changing the owner to $USER: "\
-        "`$ sudo chown -R $USER [package folder]`"
+        chown_part = ("Oftentimes packages are unnecessarily installed with "
+            "`sudo pip`, which sets the folder owner to root. In this case, "
+            "consider changing the owner to $USER: "
+            "`$ sudo chown -R $USER [package folder]`")
 
         if not using_user_site:
             parts.extend([

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -721,11 +721,16 @@ def create_os_error_message(error, show_traceback, using_user_site):
     if error.errno == errno.EACCES:
         user_option_part = "Consider using the `--user` option"
         permissions_part = "Check the permissions"
+        chown_part = "Oftentimes packages are unnecessarily installed with "
+        "`sudo pip`, which sets the folder owner to root. In this case, "
+        "consider changing the owner to $USER: "
+        "`$ sudo chown -R $USER [package folder]`"
 
         if not using_user_site:
             parts.extend([
                 user_option_part, " or ",
-                permissions_part.lower(),
+                permissions_part.lower(), ". ",
+                chown_part
             ])
         else:
             parts.append(permissions_part)

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -721,15 +721,15 @@ def create_os_error_message(error, show_traceback, using_user_site):
     if error.errno == errno.EACCES:
         user_option_part = "Consider using the `--user` option"
         permissions_part = "Check the permissions"
-        chown_part = "Oftentimes packages are unnecessarily installed with "
-        "`sudo pip`, which sets the folder owner to root. In this case, "
-        "consider changing the owner to $USER: "
+        chown_part = "Oftentimes packages are unnecessarily installed with "\
+        "`sudo pip`, which sets the folder owner to root. In this case, "\
+        "consider changing the owner to $USER: "\
         "`$ sudo chown -R $USER [package folder]`"
 
         if not using_user_site:
             parts.extend([
                 user_option_part, " or ",
-                permissions_part.lower(), ". ",
+                permissions_part.lower(), ".\n",
                 chown_part
             ])
         else:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -722,9 +722,9 @@ def create_os_error_message(error, show_traceback, using_user_site):
         user_option_part = "Consider using the `--user` option"
         permissions_part = "Check the permissions"
         chown_part = ("Oftentimes packages are unnecessarily installed with "
-                "`sudo pip`, which sets the folder owner to root. In this case, "
-                "consider changing the owner to $USER: "
-                "`$ sudo chown -R $USER [package folder]`")
+                      "`sudo pip`, which sets the folder owner to root. "
+                      "In this case, consider changing the owner to $USER: "
+                      "`$ sudo chown -R $USER [package folder]`")
 
         if not using_user_site:
             parts.extend([

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -398,8 +398,21 @@ class UninstallPathSet:
                 for_rename = compress_for_rename(self.paths)
 
                 for path in sorted(compact(for_rename)):
-                    moved.stash(path)
                     logger.debug('Removing file or directory %s', path)
+                    try:
+                        moved.stash(path)
+                    except PermissionError as ex:
+                        raise UninstallationError(
+                            "{!r}\nFailed to uninstall {!r} because "
+                            "this user lacks permissions to the package "
+                            "folder. Consider using the `--user` option or "
+                            "check the permissions.\nOftentimes packages "
+                            "are unnecessarily installed with `sudo pip`, "
+                            "which sets the folder owner to root. In this "
+                            "case, consider changing the owner to $USER: "
+                            "`$ sudo chown -R $USER [package folder]`"
+                            .format(str(ex), dist_name_version)
+                        )
 
                 for pth in self.pth.values():
                     pth.remove()

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -463,7 +463,7 @@ def get_installed_distributions(
     return [d for d in working_set
             if local_test(d) and
             d.key not in skip and
-            d.key[0].isalnum() and
+            '-' not in d.key[0] and
             editable_test(d) and
             editables_only_test(d) and
             user_test(d)

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -327,6 +327,11 @@ def renames(old, new):
     """Like os.renames(), but handles renaming across devices."""
     # Implementation borrowed from os.renames().
     head, tail = os.path.split(new)
+    if not os.access(old, os.W_OK):
+        raise PermissionError(
+            'Rename aborted. User does not have write access to ' + old
+        )
+
     if head and tail and not os.path.exists(head):
         os.makedirs(head)
 
@@ -458,6 +463,7 @@ def get_installed_distributions(
     return [d for d in working_set
             if local_test(d) and
             d.key not in skip and
+            d.key[0].isalnum() and
             editable_test(d) and
             editables_only_test(d) and
             user_test(d)

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -123,7 +123,7 @@ def test_freeze_with_invalid_names(script):
 
     valid_pkgnames = ('middle-dash', 'middle_underscore', 'middle.dot')
     invalid_pkgnames = (
-        '-leadingdash', '_leadingunderscore', '.leadingdot',
+        '_leadingunderscore', '.leadingdot',
         'trailingdash-', 'trailingunderscore_', 'trailingdot.'
     )
     for pkgname in valid_pkgnames + invalid_pkgnames:

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -123,9 +123,12 @@ def test_freeze_with_invalid_names(script):
 
     valid_pkgnames = ('middle-dash', 'middle_underscore', 'middle.dot')
     invalid_pkgnames = (
-        '_leadingunderscore', '.leadingdot',
         'trailingdash-', 'trailingunderscore_', 'trailingdot.'
     )
+    ignored_pkgnames = )
+        '-leadingdash', '_leadingunderscore', '.leadingdot'
+    )
+
     for pkgname in valid_pkgnames + invalid_pkgnames:
         fake_install(pkgname, script.site_packages_path)
     result = script.pip('freeze', expect_stderr=True)
@@ -142,6 +145,9 @@ def test_freeze_with_invalid_names(script):
             'distribution {}...'.format(dist_repr)
         )
         _check_output(result.stderr, expected)
+    for pkgname in ignored_pkgnames:
+        assert(pkgname not in result.stdout)
+        assert(pkgname not in result.stderr)
 
     # Also check that the parse error details occur at least once.
     # We only need to find one occurrence to know that exception details

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -125,7 +125,7 @@ def test_freeze_with_invalid_names(script):
     invalid_pkgnames = (
         'trailingdash-', 'trailingunderscore_', 'trailingdot.'
     )
-    ignored_pkgnames = )
+    ignored_pkgnames = (
         '-leadingdash', '_leadingunderscore', '.leadingdot'
     )
 

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -89,9 +89,13 @@ def test_rejection_for_location_requirement_options():
     # show_traceback = True, using_user_site = False
     (OSError("Illegal byte sequence"), True, False, 'Could not'
         ' install packages due to an OSError.\n'),
-    (OSError(errno.EACCES, "No file permission"), True, False, 'Could'
-        ' not install packages due to an OSError.\nConsider using the'
-        ' `--user` option or check the permissions.\n'),
+    (OSError(errno.EACCES, "No file permission"), True, False,
+        'Could not install packages due to an OSError.'
+        '\nConsider using the `--user` option or check the permissions.'
+        '\nOftentimes packages are unnecessarily installed with `sudo pip`, '
+        'which sets the folder owner to root. In this '
+        'case, consider changing the owner to $USER: '
+        '`$ sudo chown -R $USER [package folder]`.\n'),
     # show_traceback = False, using_user_site = True
     (OSError("Illegal byte sequence"), False, True, 'Could not'
         ' install packages due to an OSError: Illegal byte'
@@ -104,9 +108,13 @@ def test_rejection_for_location_requirement_options():
         ' install packages due to an OSError: Illegal byte sequence'
         '\n'),
     (OSError(errno.EACCES, "No file permission"), False, False,
-        'Could not install packages due to an OSError: [Errno 13] No'
-        ' file permission\nConsider using the `--user` option or check the'
-        ' permissions.\n'),
+        'Could not install packages due to an OSError: '
+        '[Errno 13] No file permission\nConsider using the `--user` '
+        'option or check the permissions.'
+        '\nOftentimes packages are unnecessarily installed with `sudo pip`, '
+        'which sets the folder owner to root. In this '
+        'case, consider changing the owner to $USER: '
+        '`$ sudo chown -R $USER [package folder]`.\n')
 ])
 def test_create_os_error_message(
     error, show_traceback, using_user_site, expected


### PR DESCRIPTION
This PR addresses issues that arise when packages in `site-packages` are not owned by the same user running `pip`.

Reproduce:
```
$ sudo pip install package        # installs into site-packages/package-1.0.dist-info with owner=root
$ pip install --upgrade package   # fails since $USER doesnt have permission to rename package-1.0.dist-info...
                                  #  ...but still generates site-packages/~ackage-1.0.dist-info with owner=$USER
$ pip freeze                      # WARNING when parsing site-packages/~ackage-1.0.dist-info
```

Changes:
- **Fail fast when upgrading packages:** Currently, if a user tries to upgrade a package that they don't own, a temporary folder is created before pip fails, resulting in an orphaned temp folder within `site-packages` every time this command is run. This change adds a `UninstallationError` that is raised *before* the temporary folder is created, through a `PermissionError` exception at the `utils::misc::renames` level.
-  **Add chown warning:** Installing, upgrading, and uninstalling with pip fails if users don't have access to the package folder. This often happens most often when the package is owned by `root` from a previous `sudo pip install`. This change warns the user and offers potential solutions.
- **Fix pip freeze for temp folders:** When orphaned temp directories are left in `site-packages`, `pip freeze` warns with a parsing error. This change makes pip ignore temp directories when running `pip freeze`.

Issues addressed:
- Failing fast will prevent temporary directories from being created when users run pip with the wrong user: #7763
- The new chown warning will address this user's concerns about a permissions error: #4692 #4727 #7940
- User concerns about `~`-prefixed temp directories in `pip freeze` will be addressed when the warning is removed. #7269 #9235

Fixes #7269 
Fixes #9235 