### PR TITLE
Remove unnecessary __ne__ definitions

### DIFF
--- a/src/pip/_internal/models/format_control.py
+++ b/src/pip/_internal/models/format_control.py
@@ -36,10 +36,6 @@ class FormatControl:
             for k in self.__slots__
         )
 
-    def __ne__(self, other):
-        # type: (object) -> bool
-        return not self.__eq__(other)
-
     def __repr__(self):
         # type: () -> str
         return "{}({}, {})".format(

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -164,11 +164,6 @@ class _InstallRequirementBackedCandidate(Candidate):
             return self._link == other._link
         return False
 
-    # Needed for Python 2, which does not implement this by default
-    def __ne__(self, other):
-        # type: (Any) -> bool
-        return not self.__eq__(other)
-
     @property
     def source_link(self):
         # type: () -> Optional[Link]
@@ -378,11 +373,6 @@ class AlreadyInstalledCandidate(Candidate):
             return self.name == other.name and self.version == other.version
         return False
 
-    # Needed for Python 2, which does not implement this by default
-    def __ne__(self, other):
-        # type: (Any) -> bool
-        return not self.__eq__(other)
-
     @property
     def project_name(self):
         # type: () -> str
@@ -474,11 +464,6 @@ class ExtrasCandidate(Candidate):
         if isinstance(other, self.__class__):
             return self.base == other.base and self.extras == other.extras
         return False
-
-    # Needed for Python 2, which does not implement this by default
-    def __ne__(self, other):
-        # type: (Any) -> bool
-        return not self.__eq__(other)
 
     @property
     def project_name(self):

--- a/src/pip/_internal/utils/models.py
+++ b/src/pip/_internal/utils/models.py
@@ -34,9 +34,6 @@ class KeyBasedCompareMixin:
     def __eq__(self, other):
         return self._compare(other, operator.__eq__)
 
-    def __ne__(self, other):
-        return self._compare(other, operator.__ne__)
-
     def _compare(self, other, method):
         if not isinstance(other, self._defining_class):
             return NotImplemented

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -847,8 +847,7 @@ class TestHiddenText:
         hidden2 = HiddenText('secret', redacted='####')
 
         assert hidden1 == hidden2
-        # Also test __ne__.  This assertion fails in Python 2 without
-        # defining HiddenText.__ne__.
+        # Also test __ne__.
         assert not hidden1 != hidden2
 
     def test_equality_different_secret(self):


### PR DESCRIPTION
Unnecessary since dropping Python 2 support. In Python 3, `__ne__`
defaults to the opposite of of `__eq__`.

https://docs.python.org/3/reference/datamodel.html#object.__ne__

> For `__ne__()`, by default it delegates to `__eq__()` and inverts the
> result unless it is `NotImplemented`.
