### PR TITLE
Harmonize return type of VersionControl.get_revision in subclasses

### DIFF
--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -96,6 +96,7 @@ class Bazaar(VersionControl):
 
     @classmethod
     def get_revision(cls, location):
+        # type: (str) -> str
         revision = cls.run_command(
             ['revno'], cwd=location,
         )

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -345,6 +345,7 @@ class Git(VersionControl):
 
     @classmethod
     def get_revision(cls, location, rev=None):
+        # type: (str, Optional[str]) -> str
         if rev is None:
             rev = 'HEAD'
         current_rev = cls.run_command(

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -97,6 +97,7 @@ class Mercurial(VersionControl):
 
     @classmethod
     def get_revision(cls, location):
+        # type: (str) -> str
         """
         Return the repository-local changeset revision number, as an integer.
         """

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -49,6 +49,7 @@ class Subversion(VersionControl):
 
     @classmethod
     def get_revision(cls, location):
+        # type: (str) -> str
         """
         Return the maximum revision for all files under a given location
         """
@@ -73,7 +74,7 @@ class Subversion(VersionControl):
                 dirs[:] = []
                 continue    # not part of the same svn tree, skip it
             revision = max(revision, localrev)
-        return revision
+        return str(revision)
 
     @classmethod
     def get_netloc_and_auth(cls, netloc, scheme):


### PR DESCRIPTION
Previously, the Subversion subclass violated the parent's type signature
by returning an int, but it is now coerced to a str to match the
expected signature.
