### PR TITLE
2020 resolver: list out helpful info on basic resolution failures

### DIFF
--- a/news/9139.feature.rst
+++ b/news/9139.feature.rst
@@ -1,0 +1,1 @@
+Bring back the "(from versions: ...)" message, that was shown on resolution failures.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -412,7 +412,7 @@ class Factory:
             req_disp = f"{req} (from {parent.name})"
 
         cands = self._finder.find_all_candidates(req.project_name)
-        versions = [str(v) for v in sorted(set(c.version for c in cands))]
+        versions = [str(v) for v in sorted({c.version for c in cands})]
 
         logger.critical(
             "Could not find a version that satisfies the requirement %s "

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -410,10 +410,17 @@ class Factory:
             req_disp = str(req)
         else:
             req_disp = f"{req} (from {parent.name})"
+
+        cands = self._finder.find_all_candidates(req.project_name)
+        versions = [str(v) for v in sorted(set(c.version for c in cands))]
+
         logger.critical(
-            "Could not find a version that satisfies the requirement %s",
+            "Could not find a version that satisfies the requirement %s "
+            "(from versions: %s)",
             req_disp,
+            ", ".join(versions) or "none",
         )
+
         return DistributionNotFound(f"No matching distribution found for {req}")
 
     def get_installation_error(


### PR DESCRIPTION
Fixes #9139 

Adds the old diagnostic information ("from versions:") to the new resolver.

---

If there was a failure in resolution of a requirement that stemmed from
a simple fact of there being no candidate found that could possibly
satisfy it, make pip output diagnostic information about which versions 
of the package are available to pip (outputs "(none)" if there weren't any).

---

Note: since `finder.find_all_candidates()` uses `lru_cache`, this avoids performing additional API calls to PyPI.
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
