### PR TITLE
Simplify check_binary_allowed

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -50,8 +50,6 @@ def get_check_binary_allowed(format_control):
     # type: (FormatControl) -> BinaryAllowedPredicate
     def check_binary_allowed(req):
         # type: (InstallRequirement) -> bool
-        if req.use_pep517:
-            return True
         canonical_name = canonicalize_name(req.name)
         allowed_formats = format_control.get_allowed_formats(canonical_name)
         return "binary" in allowed_formats

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -68,6 +68,9 @@ def _should_build(
     if req.editable or not req.source_dir:
         return False
 
+    if req.use_pep517:
+        return True
+
     if not check_binary_allowed(req):
         logger.info(
             "Skipping wheel build for %s, due to binaries "
@@ -75,7 +78,7 @@ def _should_build(
         )
         return False
 
-    if not req.use_pep517 and not is_wheel_installed():
+    if not is_wheel_installed():
         # we don't build legacy requirements if wheel is not installed
         logger.info(
             "Using legacy 'setup.py install' for %s, "

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -53,17 +53,44 @@ class ReqMock:
 @pytest.mark.parametrize(
     "req, disallow_binaries, expected",
     [
-        (ReqMock(), False, True),
-        (ReqMock(), True, False),
+        # When binaries are allowed, we build.
+        (ReqMock(use_pep517=True), False, True),
+        (ReqMock(use_pep517=False), False, True),
+        # When binaries are disallowed, we don't build, unless pep517 is
+        # enabled.
+        (ReqMock(use_pep517=True), True, True),
+        (ReqMock(use_pep517=False), True, False),
+        # We don't build constraints.
         (ReqMock(constraint=True), False, False),
+        # We don't build reqs that are already wheels.
         (ReqMock(is_wheel=True), False, False),
+        # We don't build editables.
         (ReqMock(editable=True), False, False),
         (ReqMock(source_dir=None), False, False),
         # By default (i.e. when binaries are allowed), VCS requirements
         # should be built in install mode.
-        (ReqMock(link=Link("git+https://g.c/org/repo")), False, True),
+        (
+            ReqMock(link=Link("git+https://g.c/org/repo"), use_pep517=True),
+            False,
+            True,
+        ),
+        (
+            ReqMock(link=Link("git+https://g.c/org/repo"), use_pep517=False),
+            False,
+            True,
+        ),
         # Disallowing binaries, however, should cause them not to be built.
-        (ReqMock(link=Link("git+https://g.c/org/repo")), True, False),
+        # unless pep517 is enabled.
+        (
+            ReqMock(link=Link("git+https://g.c/org/repo"), use_pep517=True),
+            True,
+            True,
+        ),
+        (
+            ReqMock(link=Link("git+https://g.c/org/repo"), use_pep517=False),
+            True,
+            False,
+        ),
     ],
 )
 def test_should_build_for_install_command(req, disallow_binaries, expected):


### PR DESCRIPTION
`check_binary_allowed` is only used to check if a wheel needs to be built in 'pip install' mode.
It mixed format control and pep517 mode check.
I change it so it checks allowed formats only, which better matches the function name, and leads to better readability of `_should_build()`.

There is no behaviour change in the PR.

Towards https://github.com/pypa/pip/issues/8102#issuecomment-652818117