### PR TITLE
Handle ._get_svn_url_rev() returning None in .get_remote_url()

### DIFF
--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -128,7 +128,11 @@ class Subversion(VersionControl):
                 )
                 raise RemoteNotFoundError
 
-        return cls._get_svn_url_rev(location)[0]
+        url, _rev = cls._get_svn_url_rev(location)
+        if url is None:
+            raise RemoteNotFoundError
+
+        return url
 
     @classmethod
     def _get_svn_url_rev(cls, location):

--- a/tests/functional/test_vcs_subversion.py
+++ b/tests/functional/test_vcs_subversion.py
@@ -15,3 +15,17 @@ def test_get_remote_url__no_remote(script, tmpdir):
 
     with pytest.raises(RemoteNotFoundError):
         Subversion().get_remote_url(repo_dir)
+
+
+@need_svn
+def test_get_remote_url__no_remote_with_setup(script, tmpdir):
+    repo_dir = tmpdir / 'temp-repo'
+    repo_dir.mkdir()
+    setup = repo_dir / "setup.py"
+    setup.touch()
+    repo_dir = str(repo_dir)
+
+    _create_svn_repo(script, repo_dir)
+
+    with pytest.raises(RemoteNotFoundError):
+        Subversion().get_remote_url(repo_dir)


### PR DESCRIPTION
The method Subversion._get_svn_url_rev() will sometimes return None for
a remote URL. The calling code should handle this. If it is None, raise
a RemoteNotFoundError as prescribed by the parent class docstring.

Followup to 0b761a164c6429db4a6b0e0e173c3f7dba2546a0.