### PR TITLE
Make get_similar_command() return None for no value

### DIFF
--- a/src/pip/_internal/commands/__init__.py
+++ b/src/pip/_internal/commands/__init__.py
@@ -2,20 +2,13 @@
 Package containing all pip commands
 """
 
-# The following comment should be removed at some point in the future.
-# mypy: disallow-untyped-defs=False
-# There is currently a bug in python/typeshed mentioned at
-# https://github.com/python/typeshed/issues/3906 which causes the
-# return type of difflib.get_close_matches to be reported
-# as List[Sequence[str]] whereas it should have been List[str]
-
 import importlib
 from collections import OrderedDict, namedtuple
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any
+    from typing import Any, Optional
 
     from pip._internal.cli.base_command import Command
 
@@ -108,6 +101,7 @@ def create_command(name, **kwargs):
 
 
 def get_similar_commands(name):
+    # type: (str) -> Optional[str]
     """Command name auto-correct."""
     from difflib import get_close_matches
 
@@ -118,4 +112,4 @@ def get_similar_commands(name):
     if close_commands:
         return close_commands[0]
     else:
-        return False
+        return None


### PR DESCRIPTION
Follows the more conventional pattern of using `None`, instead of `False`, when no value can be returned. This simplifies typing a bit by using `Optional` instead of `Union[bool, ...]`.