### PR TITLE
Complete typing of noxfile.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,7 @@ repos:
   - id: mypy
     exclude: docs|tests
     args: ["--pretty"]
+    additional_dependencies: ['nox==2020.12.31']
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ per-file-ignores =
     tests/*: B011
 
 [mypy]
-follow_imports = silent
 ignore_missing_imports = True
 disallow_untyped_defs = True
 disallow_any_generics = True

--- a/tools/automation/release/__init__.py
+++ b/tools/automation/release/__init__.py
@@ -26,7 +26,8 @@ def get_version_from_arguments(session: Session) -> Optional[str]:
     # We delegate to a script here, so that it can depend on packaging.
     session.install("packaging")
     cmd = [
-        os.path.join(session.bin, "python"),
+        # https://github.com/theacodes/nox/pull/378
+        os.path.join(session.bin, "python"),  # type: ignore
         "tools/automation/release/check_version.py",
         version
     ]
@@ -153,11 +154,12 @@ def workdir(
     """Temporarily chdir when entering CM and chdir back on exit."""
     orig_dir = pathlib.Path.cwd()
 
-    nox_session.chdir(dir_path)
+    # https://github.com/theacodes/nox/pull/376
+    nox_session.chdir(dir_path)  # type: ignore
     try:
         yield dir_path
     finally:
-        nox_session.chdir(orig_dir)
+        nox_session.chdir(orig_dir)  # type: ignore
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Allows removing a `mypy: disallow-untyped-defs=False` comment.

To workaround a mypy bug, `map(os.path.basename, distribution_files)` was changed to use a generator expression. See:
https://github.com/python/mypy/issues/9864
