### PR TITLE
Use keyword-only arguments

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -52,19 +52,18 @@ class Command(CommandContextMixIn):
     def __init__(self, name, summary, isolated=False):
         # type: (str, str, bool) -> None
         super().__init__()
-        parser_kw = {
-            'usage': self.usage,
-            'prog': f'{get_prog()} {name}',
-            'formatter': UpdatingDefaultsHelpFormatter(),
-            'add_help_option': False,
-            'name': name,
-            'description': self.__doc__,
-            'isolated': isolated,
-        }
 
         self.name = name
         self.summary = summary
-        self.parser = ConfigOptionParser(**parser_kw)
+        self.parser = ConfigOptionParser(
+            usage=self.usage,
+            prog=f'{get_prog()} {name}',
+            formatter=UpdatingDefaultsHelpFormatter(),
+            add_help_option=False,
+            name=name,
+            description=self.__doc__,
+            isolated=isolated,
+        )
 
         self.tempdir_registry = None  # type: Optional[TempDirRegistry]
 

--- a/src/pip/_internal/cli/main_parser.py
+++ b/src/pip/_internal/cli/main_parser.py
@@ -23,15 +23,13 @@ def create_main_parser():
     """Creates and returns the main parser for pip's CLI
     """
 
-    parser_kw = {
-        'usage': '\n%prog <command> [options]',
-        'add_help_option': False,
-        'formatter': UpdatingDefaultsHelpFormatter(),
-        'name': 'global',
-        'prog': get_prog(),
-    }
-
-    parser = ConfigOptionParser(**parser_kw)
+    parser = ConfigOptionParser(
+        usage='\n%prog <command> [options]',
+        add_help_option=False,
+        formatter=UpdatingDefaultsHelpFormatter(),
+        name='global',
+        prog=get_prog(),
+    )
     parser.disable_interspersed_args()
 
     parser.version = get_pip_version()

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -14,6 +14,10 @@ from pip._vendor.contextlib2 import suppress
 from pip._internal.cli.status_codes import UNKNOWN_ERROR
 from pip._internal.configuration import Configuration, ConfigurationError
 from pip._internal.utils.misc import redact_auth_from_url, strtobool
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -154,10 +158,15 @@ class ConfigOptionParser(CustomOptionParser):
     """Custom option parser which updates its defaults by checking the
     configuration files and environmental variables"""
 
-    def __init__(self, *args, **kwargs):
-        self.name = kwargs.pop('name')
-
-        isolated = kwargs.pop("isolated", False)
+    def __init__(
+        self,
+        *args,  # type: Any
+        name,  # type: str
+        isolated=False,  # type: bool
+        **kwargs,  # type: Any
+    ):
+        # type: (...) -> None
+        self.name = name
         self.config = Configuration(isolated)
 
         assert self.name

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -39,7 +39,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import url_to_path
 
 if MYPY_CHECK_RUNNING:
-    from typing import Iterator, List, Optional, Tuple, Union
+    from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union
 
     from pip._internal.models.link import Link
 
@@ -225,16 +225,20 @@ class PipSession(requests.Session):
 
     timeout = None  # type: Optional[int]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        *args,  # type: Any
+        retries=0,  # type: int
+        cache=None,  # type: Optional[str]
+        trusted_hosts=(),  # type: Sequence[str]
+        index_urls=None,  # type: Optional[List[str]]
+        **kwargs,  # type: Any
+    ):
+        # type: (...) -> None
         """
         :param trusted_hosts: Domains not to emit warnings for when not using
             HTTPS.
         """
-        retries = kwargs.pop("retries", 0)
-        cache = kwargs.pop("cache", None)
-        trusted_hosts = kwargs.pop("trusted_hosts", [])  # type: List[str]
-        index_urls = kwargs.pop("index_urls", None)
-
         super().__init__(*args, **kwargs)
 
         # Namespace the attribute with "pip_" just in case to prevent

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -12,6 +12,10 @@ from logging import Filter, getLogger
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
 from pip._internal.utils.misc import ensure_dir
+from pip._internal.utils.typing import MYPY_CHECK_RUNNING
+
+if MYPY_CHECK_RUNNING:
+    from typing import Any
 
 try:
     import threading
@@ -83,14 +87,20 @@ def get_indentation():
 class IndentingFormatter(logging.Formatter):
     default_time_format = "%Y-%m-%dT%H:%M:%S"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        *args,  # type: Any
+        add_timestamp=False,  # type: bool
+        **kwargs,  # type: Any
+    ):
+        # type: (...) -> None
         """
         A logging.Formatter that obeys the indent_log() context manager.
 
         :param add_timestamp: A bool indicating output lines should be prefixed
             with their record's timestamp.
         """
-        self.add_timestamp = kwargs.pop("add_timestamp", False)
+        self.add_timestamp = add_timestamp
         super().__init__(*args, **kwargs)
 
     def get_message_start(self, formatted, levelno):


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-3102/

Replaces the pattern: `self.name = kwargs.pop('name')`

Keyword-only arguments offer some advantages:

- In the event of a typo or misuse, a more informative error is   presented to the programmer.
- More self documenting and makes interfaces more explicit.
- They more easily allow explicit typing.

Adding types to `ConfigOptionParser` required changing some call sites to pass arguments without using a dict due to mypy bug:
https://github.com/python/mypy/issues/9676