### PR TITLE
Remove Python 2 compat shim path_to_display()

### DIFF
--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -32,7 +32,7 @@ from pip._internal.network.lazy_wheel import (
 from pip._internal.utils.filesystem import copy2_fixed
 from pip._internal.utils.hashes import MissingHashes
 from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import display_path, hide_url, path_to_display, rmtree
+from pip._internal.utils.misc import display_path, hide_url, rmtree
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.unpacking import unpack_file
 from pip._internal.vcs import vcs
@@ -128,8 +128,8 @@ def _copy2_ignoring_special_files(src, dest):
         logger.warning(
             "Ignoring special file error '%s' encountered copying %s to %s.",
             str(e),
-            path_to_display(src),
-            path_to_display(dest),
+            src,
+            dest,
         )
 
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -147,30 +147,6 @@ def rmtree_errorhandler(func, path, exc_info):
         raise
 
 
-def path_to_display(path):
-    # type: (Optional[str]) -> Optional[str]
-    """
-    Convert a bytes (or text) path to text (unicode in Python 2) for display
-    and logging purposes.
-
-    This function should never error out. Also, this function is mainly needed
-    for Python 2 since in Python 3 str paths are already text.
-    """
-    if path is None:
-        return None
-    if isinstance(path, str):
-        return path
-    # Otherwise, path is a bytes object (str in Python 2).
-    try:
-        display_path = path.decode(sys.getfilesystemencoding(), 'strict')
-    except UnicodeDecodeError:
-        # Include the full bytes to make troubleshooting easier, even though
-        # it may not be very human readable.
-        display_path = ascii(path)
-
-    return display_path
-
-
 def display_path(path):
     # type: (str) -> str
     """Gives the display value for a given path, making it relative to cwd

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -8,7 +8,7 @@ from pip._internal.cli.spinners import SpinnerInterface, open_spinner
 from pip._internal.exceptions import InstallationSubprocessError
 from pip._internal.utils.compat import console_to_str, str_to_display
 from pip._internal.utils.logging import subprocess_logger
-from pip._internal.utils.misc import HiddenText, path_to_display
+from pip._internal.utils.misc import HiddenText
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
@@ -82,7 +82,6 @@ def make_subprocess_output_error(
     # "UnicodeDecodeError: 'ascii' codec can't decode byte ..." in Python 2
     # if either contains a non-ascii character.
     command_display = str_to_display(command, desc='command bytes')
-    cwd_display = path_to_display(cwd)
 
     # We know the joined output value ends in a newline.
     output = ''.join(lines)
@@ -97,7 +96,7 @@ def make_subprocess_output_error(
     ).format(
         exit_status=exit_status,
         command_display=command_display,
-        cwd_display=cwd_display,
+        cwd_display=cwd,
         line_count=len(lines),
         output=output,
         divider=LOG_DIVIDER,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -38,7 +38,6 @@ from pip._internal.utils.misc import (
     normalize_path,
     normalize_version_info,
     parse_netloc,
-    path_to_display,
     redact_auth_from_url,
     redact_netloc,
     remove_auth_from_url,
@@ -429,22 +428,6 @@ elif sys.byteorder == "big":
         "b'\\xfe\\xff\\x00/\\x00p\\x00a\\x00t\\x00h\\"
         "x00/\\x00d\\x00\\xe9\\x00f'"
     )
-
-
-@pytest.mark.parametrize('path, fs_encoding, expected', [
-    (None, None, None),
-    # Test passing a text (unicode) string.
-    ('/path/déf', None, '/path/déf'),
-    # Test a bytes object with a non-ascii character.
-    ('/path/déf'.encode('utf-8'), 'utf-8', '/path/déf'),
-    # Test a bytes object with a character that can't be decoded.
-    ('/path/déf'.encode('utf-8'), 'ascii', "b'/path/d\\xc3\\xa9f'"),
-    ('/path/déf'.encode('utf-16'), 'utf-8', expected_byte_string),
-])
-def test_path_to_display(monkeypatch, path, fs_encoding, expected):
-    monkeypatch.setattr(sys, 'getfilesystemencoding', lambda: fs_encoding)
-    actual = path_to_display(path)
-    assert actual == expected, f'actual: {actual!r}'
 
 
 class Test_normalize_path:


### PR DESCRIPTION
Per the function's type signature, this accepted either a str or None.
In both cases, the value was returned unaltered. Since dropping Python
2, it has been unnecessary.
