### PR TITLE
Remove unused wheel_cache argument in freeze operation

### DIFF
--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -1,10 +1,8 @@
 import sys
 
-from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.models.format_control import FormatControl
 from pip._internal.operations.freeze import freeze
 from pip._internal.utils.compat import stdlib_pkgs
 from pip._internal.utils.deprecation import deprecated
@@ -78,8 +76,6 @@ class FreezeCommand(Command):
 
     def run(self, options, args):
         # type: (Values, List[str]) -> int
-        format_control = FormatControl(set(), set())
-        wheel_cache = WheelCache(options.cache_dir, format_control)
         skip = set(stdlib_pkgs)
         if not options.freeze_all:
             skip.update(DEV_PKGS)
@@ -104,7 +100,6 @@ class FreezeCommand(Command):
             user_only=options.user,
             paths=options.path,
             isolated=options.isolated_mode,
-            wheel_cache=wheel_cache,
             skip=skip,
             exclude_editable=options.exclude_editable,
         )

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -93,7 +93,7 @@ class FreezeCommand(Command):
                 issue=9069,
             )
 
-        freeze_kwargs = dict(
+        for line in freeze(
             requirement=options.requirements,
             find_links=options.find_links,
             local_only=options.local,
@@ -102,8 +102,6 @@ class FreezeCommand(Command):
             isolated=options.isolated_mode,
             skip=skip,
             exclude_editable=options.exclude_editable,
-        )
-
-        for line in freeze(**freeze_kwargs):
+        ):
             sys.stdout.write(line + '\n')
         return SUCCESS

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -33,8 +33,6 @@ if MYPY_CHECK_RUNNING:
 
     from pip._vendor.pkg_resources import Distribution, Requirement
 
-    from pip._internal.cache import WheelCache
-
     RequirementInfo = Tuple[Optional[Union[str, Requirement]], bool, List[str]]
 
 
@@ -48,7 +46,6 @@ def freeze(
     user_only=False,  # type: bool
     paths=None,  # type: Optional[List[str]]
     isolated=False,  # type: bool
-    wheel_cache=None,  # type: Optional[WheelCache]
     exclude_editable=False,  # type: bool
     skip=()  # type: Container[str]
 ):


### PR DESCRIPTION
There is no reason why the `freeze` operation would use a `WheelCache`, and indeed this argument is unused. So I remove it.