### PR TITLE
Simplify str_to_display() and its uses

### DIFF
--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -9,7 +9,7 @@ import locale
 import logging
 import os
 import sys
-from typing import Optional, Union
+from typing import Optional
 
 __all__ = ["console_to_str", "get_path_uid", "stdlib_pkgs", "WINDOWS"]
 
@@ -30,7 +30,7 @@ def has_tls():
 
 
 def str_to_display(data, desc=None):
-    # type: (Union[bytes, str], Optional[str]) -> str
+    # type: (bytes, Optional[str]) -> str
     """
     For display or logging purposes, convert a bytes object (or text) to
     text (e.g. unicode in Python 2) safe for output.
@@ -48,10 +48,7 @@ def str_to_display(data, desc=None):
     We also ensure that the output can be safely written to standard output
     without encoding errors.
     """
-    if isinstance(data, str):
-        return data
 
-    # Otherwise, data is a bytes object (str in Python 2).
     # First, get the encoding we assume. This is the preferred
     # encoding for the locale, unless that is not found, or
     # it is ASCII, in which case assume UTF-8

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
 
 from pip._internal.cli.spinners import SpinnerInterface, open_spinner
 from pip._internal.exceptions import InstallationSubprocessError
-from pip._internal.utils.compat import console_to_str, str_to_display
+from pip._internal.utils.compat import console_to_str
 from pip._internal.utils.logging import subprocess_logger
 from pip._internal.utils.misc import HiddenText
 
@@ -74,11 +74,6 @@ def make_subprocess_output_error(
     :param lines: A list of lines, each ending with a newline.
     """
     command = format_command_args(cmd_args)
-    # Convert `command` and `cwd` to text (unicode in Python 2) so we can use
-    # them as arguments in the unicode format string below. This avoids
-    # "UnicodeDecodeError: 'ascii' codec can't decode byte ..." in Python 2
-    # if either contains a non-ascii character.
-    command_display = str_to_display(command, desc='command bytes')
 
     # We know the joined output value ends in a newline.
     output = ''.join(lines)
@@ -92,7 +87,7 @@ def make_subprocess_output_error(
         'Complete output ({line_count} lines):\n{output}{divider}'
     ).format(
         exit_status=exit_status,
-        command_display=command_display,
+        command_display=command,
         cwd_display=cwd,
         line_count=len(lines),
         output=output,

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -191,7 +191,7 @@ def call_subprocess(
         proc.stdin.close()
         # In this mode, stdout and stderr are in the same pipe.
         while True:
-            line = proc.stdout.readline()
+            line = proc.stdout.readline()  # type: str
             if not line:
                 break
             line = line.rstrip()

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,11 +1,8 @@
-import locale
 import os
-import sys
 
 import pytest
 
-import pip._internal.utils.compat as pip_compat
-from pip._internal.utils.compat import console_to_str, get_path_uid, str_to_display
+from pip._internal.utils.compat import get_path_uid
 
 
 def test_get_path_uid():
@@ -44,66 +41,3 @@ def test_get_path_uid_symlink_without_NOFOLLOW(tmpdir, monkeypatch):
     os.symlink(f, fs)
     with pytest.raises(OSError):
         get_path_uid(fs)
-
-
-@pytest.mark.parametrize('data, encoding, expected', [
-    # Test bytes input with non-ascii characters:
-    ('déf'.encode('utf-8'), 'utf-8', 'déf'),
-    # Test a Windows encoding.
-    ('déf'.encode('cp1252'), 'cp1252', 'déf'),
-    # Test a Windows encoding with incompatibly encoded text.
-    ('déf'.encode('utf-8'), 'cp1252', 'dÃ©f'),
-])
-def test_str_to_display__encoding(monkeypatch, data, encoding, expected):
-    monkeypatch.setattr(locale, 'getpreferredencoding', lambda: encoding)
-    actual = str_to_display(data)
-    assert actual == expected, (
-        # Show the encoding for easier troubleshooting.
-        f'encoding: {locale.getpreferredencoding()!r}'
-    )
-
-
-def test_str_to_display__decode_error(monkeypatch, caplog):
-    monkeypatch.setattr(locale, 'getpreferredencoding', lambda: 'utf-8')
-    # Encode with an incompatible encoding.
-    data = 'ab'.encode('utf-16')
-    actual = str_to_display(data)
-    # Keep the expected value endian safe
-    if sys.byteorder == "little":
-        expected = "\\xff\\xfea\x00b\x00"
-    elif sys.byteorder == "big":
-        expected = "\\xfe\\xff\x00a\x00b"
-
-    assert actual == expected, (
-        # Show the encoding for easier troubleshooting.
-        f'encoding: {locale.getpreferredencoding()!r}'
-    )
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
-    assert record.levelname == 'WARNING'
-    assert record.message == (
-        'Bytes object does not appear to be encoded as utf-8'
-    )
-
-
-def test_console_to_str(monkeypatch):
-    some_bytes = b"a\xE9\xC3\xE9b"
-    encodings = ('ascii', 'utf-8', 'iso-8859-1', 'iso-8859-5',
-                 'koi8_r', 'cp850')
-    for e in encodings:
-        monkeypatch.setattr(locale, 'getpreferredencoding', lambda: e)
-        result = console_to_str(some_bytes)
-        assert result.startswith("a")
-        assert result.endswith("b")
-
-
-def test_console_to_str_warning(monkeypatch):
-    some_bytes = b"a\xE9b"
-
-    def check_warning(msg, *args, **kwargs):
-        assert 'does not appear to be encoded as' in msg
-        assert args[0] == 'Subprocess output'
-
-    monkeypatch.setattr(locale, 'getpreferredencoding', lambda: 'utf-8')
-    monkeypatch.setattr(pip_compat.logger, 'warning', check_warning)
-    console_to_str(some_bytes)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -46,22 +46,7 @@ def test_get_path_uid_symlink_without_NOFOLLOW(tmpdir, monkeypatch):
         get_path_uid(fs)
 
 
-@pytest.mark.parametrize('data, expected', [
-    ('abc', 'abc'),
-    # Test text input with non-ascii characters.
-    ('déf', 'déf'),
-])
-def test_str_to_display(data, expected):
-    actual = str_to_display(data)
-    assert actual == expected, (
-        # Show the encoding for easier troubleshooting.
-        f'encoding: {locale.getpreferredencoding()!r}'
-    )
-
-
 @pytest.mark.parametrize('data, encoding, expected', [
-    # Test str input with non-ascii characters.
-    ('déf', 'utf-8', 'déf'),
     # Test bytes input with non-ascii characters:
     ('déf'.encode('utf-8'), 'utf-8', 'déf'),
     # Test a Windows encoding.

--- a/tests/unit/test_utils_subprocess.py
+++ b/tests/unit/test_utils_subprocess.py
@@ -445,13 +445,6 @@ def test_unicode_decode_error(caplog):
         show_stdout=True
     )
 
-    assert len(caplog.records) == 3
+    assert len(caplog.records) == 2
     # First log record is "Running command ..."
-    assert caplog.record_tuples[1:] == [
-        (
-            "pip._internal.utils.compat",
-            WARNING,
-            "Subprocess output does not appear to be encoded as UTF-8",
-        ),
-        ("pip.subprocessor", INFO, "\\xff"),
-    ]
+    assert caplog.record_tuples[1] == ("pip.subprocessor", INFO, "\\xff")


### PR DESCRIPTION
With Python 2 dropped, only bytes need to be handled. Passing str was a
nop. These bytes/str boundaries are much clearer now.

There remains one use of str_to_display(): constole_to_str(). It
converts subprocess bytes output to str while handling decoding errors.
