### PR TITLE
Include all resolution conflict fix info on stderr.

### DIFF
--- a/news/9420.feature.rst
+++ b/news/9420.feature.rst
@@ -1,0 +1,1 @@
+Include all resolution conflict fix info on stderr.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -469,9 +469,8 @@ class Factory:
             info = "the requested packages"
 
         msg = "Cannot install {} because these package versions " \
-            "have conflicting dependencies.".format(info)
-        logger.critical(msg)
-        msg = "\nThe conflict is caused by:"
+            "have conflicting dependencies.\n".format(info)
+        msg = msg + "\nThe conflict is caused by:"
         for req, parent in e.causes:
             msg = msg + "\n    "
             if parent:
@@ -489,7 +488,7 @@ class Factory:
             "2. remove package versions to allow pip attempt to solve " + \
             "the dependency conflict\n"
 
-        logger.info(msg)
+        logger.critical(msg)
 
         return DistributionNotFound(
             "ResolutionImpossible: for help visit "

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -601,10 +601,10 @@ def test_install_distribution_union_with_versions(
         assert "Cannot install localextras[bar]" in result.stderr
         assert (
             "localextras[bar] 0.0.1 depends on localextras 0.0.1"
-        ) in result.stdout
+        ) in result.stderr
         assert (
             "localextras[baz] 0.0.2 depends on localextras 0.0.2"
-        ) in result.stdout
+        ) in result.stderr
     else:
         assert (
             "Successfully installed LocalExtras-0.0.1 simple-3.0 "


### PR DESCRIPTION
This allows resolution conflict errors to be triaged completely from
stderr which generally aids non-interactive use.

Closes #9420