### PR TITLE
Deprecate legacy setup.py install when --no-binary is used

### DIFF
--- a/news/9769.feature.rst
+++ b/news/9769.feature.rst
@@ -1,0 +1,9 @@
+Deprecate legacy setup.py install when --no-binary is used:
+
+- add a new feature flag ``--use-feature=always-install-via-wheel``, that is intended to become the default and only mechanism in the future
+- when ``--no-binary`` is used without the feature flag, emit a deprecation warning about the fallback to ``setup.py install``
+- when ``--no-binary`` is used with the feature flag, build a wheel from the sdist (via PEP 517 or ``setup.py bdist_wheel``) then install it
+- when ``--no-binary`` is used with the feature flag, the wheel that was built locally is cached (unless the cache is disabled)
+- since ``--install-option``, ``--build-option`` and ``--global-option`` imply ``--no-binary``, the deprecation warning will be emitted when these options are used without the feature flag
+- deprecate ``--install-option``
+- allow using ``--build-option`` in the ``install`` command, as well as in ``requirement.txt`` lines, as a transitory mechanism until the ecosystem supports PEP 517 config settings, which are meant to replace both ``--build-options`` and ``--global-options``

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -221,7 +221,11 @@ class WheelCache(Cache):
     when a certain link is not found in the simple wheel cache first.
     """
 
-    def __init__(self, cache_dir: str, format_control: FormatControl) -> None:
+    def __init__(
+        self, cache_dir: str, format_control: Optional[FormatControl] = None
+    ) -> None:
+        if format_control is None:
+            format_control = FormatControl()
         super().__init__(cache_dir, format_control, {"binary"})
         self._wheel_cache = SimpleWheelCache(cache_dir, format_control)
         self._ephem_cache = EphemWheelCache(format_control)

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -68,6 +68,12 @@ def check_install_build_global(
     :param check_options: The options to check, if not supplied defaults to
         options.
     """
+    if "always-install-via-wheel" in options.features_enabled:
+        # In this mode, we accept --global-option and --build-option that are
+        # passed to setup.py bdist_wheel. --install-option is not allowed at
+        # all in this mode, since setup.py install will not be used.
+        return
+
     if check_options is None:
         check_options = options
 
@@ -78,6 +84,7 @@ def check_install_build_global(
     if any(map(getname, names)):
         control = options.format_control
         control.disallow_binaries()
+        # TODO this should be a deprecation
         logger.warning(
             "Disabling all use of wheels due to the use of --build-option "
             "/ --global-option / --install-option.",
@@ -1000,7 +1007,7 @@ use_new_feature: Callable[..., Option] = partial(
     metavar="feature",
     action="append",
     default=[],
-    choices=["2020-resolver", "fast-deps", "truststore"],
+    choices=["2020-resolver", "fast-deps", "truststore", "always-install-via-wheel"],
     help="Enable new functionality, that may be backward incompatible.",
 )
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -325,7 +325,12 @@ class InstallCommand(RequirementCommand):
             target_python=target_python,
             ignore_requires_python=options.ignore_requires_python,
         )
-        wheel_cache = WheelCache(options.cache_dir, options.format_control)
+        if "always-install-via-wheel" in options.features_enabled:
+            wheel_cache = WheelCache(options.cache_dir)
+        else:
+            # TODO when removing this, also remove format control support
+            #      in WheelCache.
+            wheel_cache = WheelCache(options.cache_dir, options.format_control)
 
         build_tracker = self.enter_context(get_build_tracker())
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -52,8 +52,12 @@ from pip._internal.wheel_builder import (
 logger = getLogger(__name__)
 
 
-def get_check_binary_allowed(format_control: FormatControl) -> BinaryAllowedPredicate:
+def get_check_binary_allowed(
+    format_control: FormatControl, features_enabled: List[str]
+) -> BinaryAllowedPredicate:
     def check_binary_allowed(req: InstallRequirement) -> bool:
+        if "always-install-via-wheel" in features_enabled:
+            return True
         canonical_name = canonicalize_name(req.name or "")
         allowed_formats = format_control.get_allowed_formats(canonical_name)
         return "binary" in allowed_formats
@@ -406,7 +410,9 @@ class InstallCommand(RequirementCommand):
                 modifying_pip = pip_req.satisfied_by is None
             protect_pip_from_modification_on_windows(modifying_pip=modifying_pip)
 
-            check_binary_allowed = get_check_binary_allowed(finder.format_control)
+            check_binary_allowed = get_check_binary_allowed(
+                finder.format_control, options.features_enabled
+            )
 
             reqs_to_build = [
                 r

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -105,7 +105,10 @@ class WheelCommand(RequirementCommand):
         session = self.get_default_session(options)
 
         finder = self._build_package_finder(options, session)
-        wheel_cache = WheelCache(options.cache_dir, options.format_control)
+        if "always-install-via-wheel" in options.features_enabled:
+            wheel_cache = WheelCache(options.cache_dir)
+        else:
+            wheel_cache = WheelCache(options.cache_dir, options.format_control)
 
         options.wheel_dir = normalize_path(options.wheel_dir)
         ensure_dir(options.wheel_dir)

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -800,6 +800,17 @@ class InstallRequirement:
             self.install_succeeded = True
             return
 
+        if self.legacy_install_reason == 9769:
+            deprecated(
+                reason=(
+                    "Installing {} using the legacy 'setup.py install' "
+                    "method, due to binaries being disabled for it.".format(self.name)
+                ),
+                replacement="--use-feature=always-install-via-wheel",
+                gone_in=None,
+                issue=9769,
+            )
+
         # TODO: Why don't we do this for editable installs?
 
         # Extend the list of global and install options passed on to

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -79,8 +79,8 @@ def _should_build(
 
     if not check_binary_allowed(req):
         logger.info(
-            "Skipping wheel build for %s, due to binaries being disabled for it.",
-            req.name,
+            "Using legacy 'setup.py install' for %s, due to binaries "
+            "being disabled for it.", req.name,
         )
         return False
 

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -78,10 +78,7 @@ def _should_build(
         return True
 
     if not check_binary_allowed(req):
-        logger.info(
-            "Using legacy 'setup.py install' for %s, due to binaries "
-            "being disabled for it.", req.name,
-        )
+        req.legacy_install_reason = 9769
         return False
 
     if not is_wheel_installed():


### PR DESCRIPTION
Towards #8102 
Closes #9769 

This is the first (and most difficult) leg of https://github.com/pypa/pip/issues/8102#issuecomment-632718595, still with the goal of capturing user feedback about why the `setup.py install` code path would still be necessary, and nudging the ecosystem towards installing via wheel building.

This is still draft, but I'd appreciate feedback from @pypa/pip-committers, to get confirmation that people are on board with the general approach before going further. Individual commits should be easy to grasp.

It basically implements what was discussed around https://github.com/pypa/pip/issues/2677#issuecomment-640034838 and https://github.com/pypa/pip/issues/8102#issuecomment-640214691.

- ~support `--build-option` in the install command in addition to the wheel command (as a transitory phase until the ecosystem supports PEP 517 config settings)~
- ~accept `--build-option` in requirement lines (as a transitory phase until the ecosystem supports PEP 517 config settings)~
- ~deprecate `--install-option`~
- [x] deprecate `--no-binary` implying `setup.py install` (i.e. build wheel even if --no-binary is used)
- [x] add a new feature flag (`always-install-via-wheel`) that, when active:

  - [x] lets a wheel build occur, even when `--no-binary` is used (and therefore silence the corresponding deprecation)
  - [ ] ignore and warn when `--install-option` is used with `always-install-via-wheel`
  - [ ] ignore and warn when `--build-option` is used without `always-install-via-wheel`
  - [x] does not disable the wheel cache when `--no-binary` is used (https://github.com/pypa/pip/issues/9162)
  - [ ] errors if `setup.py install` is attempted for any reason
