### PR TITLE
Remove deprecation deadline for #8368

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -864,7 +864,7 @@ class InstallRequirement:
                     format(self.name)
                 ),
                 replacement="to fix the wheel build issue reported above",
-                gone_in="21.0",
+                gone_in=None,
                 issue=8368,
             )
 


### PR DESCRIPTION
There is no urgency to remove this, and if we ever remove it, it might be better to coordinate it with the other legs of #8102.

That said, so far I've not noticed good reasons to keep it in the feedback we got in #8368.