### PR TITLE
Remove typing.TYPE_CHECKING guards

### DIFF
--- a/docs/docs_feedback_sphinxext.py
+++ b/docs/docs_feedback_sphinxext.py
@@ -3,13 +3,9 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import Dict, List, Union
 
-if TYPE_CHECKING:
-    from typing import Dict, List, Union
-
-    from sphinx.application import Sphinx
-
+from sphinx.application import Sphinx
 
 DEFAULT_DOC_LINES_THRESHOLD = 250
 RST_INDENT = 4

--- a/src/pip/__init__.py
+++ b/src/pip/__init__.py
@@ -1,8 +1,4 @@
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import List, Optional
-
+from typing import List, Optional
 
 __version__ = "21.1.dev0"
 

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -1,9 +1,6 @@
-from typing import TYPE_CHECKING
+from typing import List, Optional
 
 import pip._internal.utils.inject_securetransport  # noqa
-
-if TYPE_CHECKING:
-    from typing import List, Optional
 
 
 def main(args=None):

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -8,7 +8,8 @@ import textwrap
 from collections import OrderedDict
 from distutils.sysconfig import get_python_lib
 from sysconfig import get_paths
-from typing import TYPE_CHECKING
+from types import TracebackType
+from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple, Type
 
 from pip._vendor.pkg_resources import Requirement, VersionConflict, WorkingSet
 
@@ -18,9 +19,6 @@ from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 
 if TYPE_CHECKING:
-    from types import TracebackType
-    from typing import Iterable, List, Optional, Set, Tuple, Type
-
     from pip._internal.index.package_finder import PackageFinder
 
 logger = logging.getLogger(__name__)

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -5,23 +5,17 @@ import hashlib
 import json
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Set
 
-from pip._vendor.packaging.tags import interpreter_name, interpreter_version
+from pip._vendor.packaging.tags import Tag, interpreter_name, interpreter_version
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import InvalidWheelFilename
+from pip._internal.models.format_control import FormatControl
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 from pip._internal.utils.urls import path_to_url
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Set
-
-    from pip._vendor.packaging.tags import Tag
-
-    from pip._internal.models.format_control import FormatControl
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -5,14 +5,11 @@ import optparse
 import os
 import sys
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import Any, Iterable, List, Optional
 
 from pip._internal.cli.main_parser import create_main_parser
 from pip._internal.commands import commands_dict, create_command
 from pip._internal.utils.misc import get_installed_distributions
-
-if TYPE_CHECKING:
-    from typing import Any, Iterable, List, Optional
 
 
 def autocomplete():

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -6,7 +6,8 @@ import optparse
 import os
 import sys
 import traceback
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import Any, List, Optional, Tuple
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.command_context import CommandContextMixIn
@@ -29,16 +30,9 @@ from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
 from pip._internal.utils.misc import get_prog, normalize_path
+from pip._internal.utils.temp_dir import TempDirectoryTypeRegistry as TempDirRegistry
 from pip._internal.utils.temp_dir import global_tempdir_manager, tempdir_registry
 from pip._internal.utils.virtualenv import running_under_virtualenv
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import Any, List, Optional, Tuple
-
-    from pip._internal.utils.temp_dir import (
-        TempDirectoryTypeRegistry as TempDirRegistry,
-    )
 
 __all__ = ['Command']
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -14,12 +14,13 @@ import os
 import textwrap
 import warnings
 from functools import partial
-from optparse import SUPPRESS_HELP, Option, OptionGroup
+from optparse import SUPPRESS_HELP, Option, OptionGroup, OptionParser, Values
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from pip._vendor.packaging.utils import canonicalize_name
 
+from pip._internal.cli.parser import ConfigOptionParser
 from pip._internal.cli.progress_bars import BAR_TYPES
 from pip._internal.exceptions import CommandError
 from pip._internal.locations import USER_CACHE_DIR, get_src_prefix
@@ -28,12 +29,6 @@ from pip._internal.models.index import PyPI
 from pip._internal.models.target_python import TargetPython
 from pip._internal.utils.hashes import STRONG_HASHES
 from pip._internal.utils.misc import strtobool
-
-if TYPE_CHECKING:
-    from optparse import OptionParser, Values
-    from typing import Any, Callable, Dict, Optional, Tuple
-
-    from pip._internal.cli.parser import ConfigOptionParser
 
 
 def raise_option_error(parser, option, msg):

--- a/src/pip/_internal/cli/command_context.py
+++ b/src/pip/_internal/cli/command_context.py
@@ -1,10 +1,7 @@
 from contextlib import ExitStack, contextmanager
-from typing import TYPE_CHECKING
+from typing import ContextManager, Iterator, TypeVar
 
-if TYPE_CHECKING:
-    from typing import ContextManager, Iterator, TypeVar
-
-    _T = TypeVar('_T', covariant=True)
+_T = TypeVar('_T', covariant=True)
 
 
 class CommandContextMixIn:

--- a/src/pip/_internal/cli/main.py
+++ b/src/pip/_internal/cli/main.py
@@ -4,16 +4,13 @@ import locale
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING
+from typing import List, Optional
 
 from pip._internal.cli.autocompletion import autocomplete
 from pip._internal.cli.main_parser import parse_command
 from pip._internal.commands import create_command
 from pip._internal.exceptions import PipError
 from pip._internal.utils import deprecation
-
-if TYPE_CHECKING:
-    from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/cli/main_parser.py
+++ b/src/pip/_internal/cli/main_parser.py
@@ -3,17 +3,13 @@
 
 import os
 import sys
-from typing import TYPE_CHECKING
+from typing import List, Tuple
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.parser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
 from pip._internal.commands import commands_dict, get_similar_commands
 from pip._internal.exceptions import CommandError
 from pip._internal.utils.misc import get_pip_version, get_prog
-
-if TYPE_CHECKING:
-    from typing import List, Tuple
-
 
 __all__ = ["create_main_parser", "parse_command"]
 

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -9,14 +9,11 @@ import shutil
 import sys
 import textwrap
 from contextlib import suppress
-from typing import TYPE_CHECKING
+from typing import Any
 
 from pip._internal.cli.status_codes import UNKNOWN_ERROR
 from pip._internal.configuration import Configuration, ConfigurationError
 from pip._internal.utils.misc import redact_auth_from_url, strtobool
-
-if TYPE_CHECKING:
-    from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -1,7 +1,7 @@
 import itertools
 import sys
 from signal import SIGINT, default_int_handler, signal
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List
 
 from pip._vendor.progress.bar import Bar, FillingCirclesBar, IncrementalBar
 from pip._vendor.progress.spinner import Spinner
@@ -9,9 +9,6 @@ from pip._vendor.progress.spinner import Spinner
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.logging import get_indentation
 from pip._internal.utils.misc import format_size
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, List
 
 try:
     from pip._vendor import colorama

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -8,8 +8,10 @@ PackageFinder machinery and all its vendored dependencies, etc.
 import logging
 import os
 from functools import partial
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import Any, List, Optional, Tuple
 
+from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.command_context import CommandContextMixIn
@@ -17,6 +19,7 @@ from pip._internal.exceptions import CommandError, PreviousBuildDirError
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
+from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req.constructors import (
@@ -26,20 +29,15 @@ from pip._internal.req.constructors import (
     install_req_from_req_string,
 )
 from pip._internal.req.req_file import parse_requirements
+from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.req_tracker import RequirementTracker
+from pip._internal.resolution.base import BaseResolver
 from pip._internal.self_outdated_check import pip_self_version_check
-from pip._internal.utils.temp_dir import tempdir_kinds
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import Any, List, Optional, Tuple
-
-    from pip._internal.cache import WheelCache
-    from pip._internal.models.target_python import TargetPython
-    from pip._internal.req.req_install import InstallRequirement
-    from pip._internal.req.req_tracker import RequirementTracker
-    from pip._internal.resolution.base import BaseResolver
-    from pip._internal.utils.temp_dir import TempDirectory, TempDirectoryTypeRegistry
-
+from pip._internal.utils.temp_dir import (
+    TempDirectory,
+    TempDirectoryTypeRegistry,
+    tempdir_kinds,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/cli/spinners.py
+++ b/src/pip/_internal/cli/spinners.py
@@ -3,15 +3,12 @@ import itertools
 import logging
 import sys
 import time
-from typing import TYPE_CHECKING
+from typing import IO, Iterator
 
 from pip._vendor.progress import HIDE_CURSOR, SHOW_CURSOR
 
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.logging import get_indentation
-
-if TYPE_CHECKING:
-    from typing import IO, Iterator
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/__init__.py
+++ b/src/pip/_internal/commands/__init__.py
@@ -4,13 +4,9 @@ Package containing all pip commands
 
 import importlib
 from collections import OrderedDict, namedtuple
-from typing import TYPE_CHECKING
+from typing import Any, Optional
 
-if TYPE_CHECKING:
-    from typing import Any, Optional
-
-    from pip._internal.cli.base_command import Command
-
+from pip._internal.cli.base_command import Command
 
 CommandInfo = namedtuple('CommandInfo', 'module_path, class_name, summary')
 

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -1,17 +1,13 @@
 import logging
 import os
 import textwrap
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import Any, List
 
 import pip._internal.utils.filesystem as filesystem
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.exceptions import CommandError, PipError
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import Any, List
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/check.py
+++ b/src/pip/_internal/commands/check.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import Any, List
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import ERROR, SUCCESS
@@ -10,10 +11,6 @@ from pip._internal.operations.check import (
 from pip._internal.utils.misc import write_output
 
 logger = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import Any, List
 
 
 class CheckCommand(Command):

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -1,14 +1,11 @@
 import sys
 import textwrap
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import List
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.utils.misc import get_prog
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import List
 
 BASE_COMPLETION = """
 # pip {shell} completion start{script}# pip {shell} completion end

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -1,20 +1,20 @@
 import logging
 import os
 import subprocess
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import Any, List, Optional
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.configuration import Configuration, get_configuration_files, kinds
+from pip._internal.configuration import (
+    Configuration,
+    Kind,
+    get_configuration_files,
+    kinds,
+)
 from pip._internal.exceptions import PipError
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import get_prog, write_output
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import Any, List, Optional
-
-    from pip._internal.configuration import Kind
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -2,7 +2,9 @@ import locale
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING
+from optparse import Values
+from types import ModuleType
+from typing import Dict, List, Optional
 
 import pip._vendor
 from pip._vendor.certifi import where
@@ -13,16 +15,10 @@ from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.status_codes import SUCCESS
+from pip._internal.configuration import Configuration
 from pip._internal.metadata import get_environment
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import get_pip_version
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from types import ModuleType
-    from typing import Dict, List, Optional
-
-    from pip._internal.configuration import Configuration
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -1,6 +1,7 @@
 import logging
 import os
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import List
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.cmdoptions import make_target_python
@@ -9,10 +10,6 @@ from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.misc import ensure_dir, normalize_path, write_output
 from pip._internal.utils.temp_dir import TempDirectory
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import List
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -1,5 +1,6 @@
 import sys
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import List
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
@@ -9,10 +10,6 @@ from pip._internal.utils.compat import stdlib_pkgs
 from pip._internal.utils.deprecation import deprecated
 
 DEV_PKGS = {'pip', 'setuptools', 'distribute', 'wheel'}
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import List
 
 
 class FreezeCommand(Command):

--- a/src/pip/_internal/commands/hash.py
+++ b/src/pip/_internal/commands/hash.py
@@ -1,16 +1,13 @@
 import hashlib
 import logging
 import sys
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import List
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.utils.hashes import FAVORITE_HASH, STRONG_HASHES
 from pip._internal.utils.misc import read_chunks, write_output
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import List
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/help.py
+++ b/src/pip/_internal/commands/help.py
@@ -1,12 +1,9 @@
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import List
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.exceptions import CommandError
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import List
 
 
 class HelpCommand(Command):

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -4,8 +4,8 @@ import operator
 import os
 import shutil
 import site
-from optparse import SUPPRESS_HELP
-from typing import TYPE_CHECKING
+from optparse import SUPPRESS_HELP, Values
+from typing import Iterable, List, Optional
 
 from pip._vendor.packaging.utils import canonicalize_name
 
@@ -17,8 +17,10 @@ from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.exceptions import CommandError, InstallationError
 from pip._internal.locations import distutils_scheme
 from pip._internal.metadata import get_environment
-from pip._internal.operations.check import check_install_conflicts
+from pip._internal.models.format_control import FormatControl
+from pip._internal.operations.check import ConflictDetails, check_install_conflicts
 from pip._internal.req import install_given_reqs
+from pip._internal.req.req_install import InstallRequirement
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.distutils_args import parse_distutils_args
 from pip._internal.utils.filesystem import test_writable_dir
@@ -30,17 +32,11 @@ from pip._internal.utils.misc import (
 )
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.virtualenv import virtualenv_no_global
-from pip._internal.wheel_builder import build, should_build_for_install_command
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import Iterable, List, Optional
-
-    from pip._internal.models.format_control import FormatControl
-    from pip._internal.operations.check import ConflictDetails
-    from pip._internal.req.req_install import InstallRequirement
-    from pip._internal.wheel_builder import BinaryAllowedPredicate
-
+from pip._internal.wheel_builder import (
+    BinaryAllowedPredicate,
+    build,
+    should_build_for_install_command,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -1,6 +1,9 @@
 import json
 import logging
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import Iterator, List, Set, Tuple
+
+from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.req_command import IndexGroupCommand
@@ -9,6 +12,7 @@ from pip._internal.exceptions import CommandError
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
+from pip._internal.network.session import PipSession
 from pip._internal.utils.compat import stdlib_pkgs
 from pip._internal.utils.misc import (
     dist_is_editable,
@@ -18,14 +22,6 @@ from pip._internal.utils.misc import (
 )
 from pip._internal.utils.packaging import get_installer
 from pip._internal.utils.parallel import map_multithread
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import Iterator, List, Set, Tuple
-
-    from pip._vendor.pkg_resources import Distribution
-
-    from pip._internal.network.session import PipSession
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -3,7 +3,8 @@ import shutil
 import sys
 import textwrap
 from collections import OrderedDict
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from pip._vendor.packaging.version import parse as parse_version
 
@@ -22,10 +23,8 @@ from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import write_output
 
 if TYPE_CHECKING:
-    from optparse import Values
-    from typing import Dict, List, Optional
+    from typing import TypedDict
 
-    from typing_extensions import TypedDict
     TransformedHit = TypedDict(
         'TransformedHit',
         {'name': str, 'summary': str, 'versions': List[str]},

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -1,7 +1,8 @@
 import logging
 import os
 from email.parser import FeedParser
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import Dict, Iterator, List
 
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.utils import canonicalize_name
@@ -9,10 +10,6 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.utils.misc import write_output
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import Dict, Iterator, List
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import List
 
 from pip._vendor.packaging.utils import canonicalize_name
 
@@ -12,10 +13,6 @@ from pip._internal.req.constructors import (
     install_req_from_parsed_requirement,
 )
 from pip._internal.utils.misc import protect_pip_from_modification_on_windows
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import List
 
 
 class UninstallCommand(Command, SessionCommandMixin):

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -1,23 +1,19 @@
 import logging
 import os
 import shutil
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import List
 
 from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.req_command import RequirementCommand, with_cleanup
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.exceptions import CommandError
+from pip._internal.req.req_install import InstallRequirement
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.utils.misc import ensure_dir, normalize_path
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.wheel_builder import build, should_build_for_wheel_command
-
-if TYPE_CHECKING:
-    from optparse import Values
-    from typing import List
-
-    from pip._internal.req.req_install import InstallRequirement
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -16,7 +16,7 @@ import locale
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING
+from typing import Any, Dict, Iterable, List, NewType, Optional, Tuple
 
 from pip._internal.exceptions import (
     ConfigurationError,
@@ -26,11 +26,8 @@ from pip._internal.utils import appdirs
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.misc import ensure_dir, enum
 
-if TYPE_CHECKING:
-    from typing import Any, Dict, Iterable, List, NewType, Optional, Tuple
-
-    RawConfigParser = configparser.RawConfigParser  # Shorthand
-    Kind = NewType("Kind", str)
+RawConfigParser = configparser.RawConfigParser  # Shorthand
+Kind = NewType("Kind", str)
 
 CONFIG_BASENAME = 'pip.ini' if WINDOWS else 'pip.conf'
 ENV_NAMES_IGNORED = "version", "help"

--- a/src/pip/_internal/distributions/__init__.py
+++ b/src/pip/_internal/distributions/__init__.py
@@ -1,11 +1,7 @@
-from typing import TYPE_CHECKING
-
+from pip._internal.distributions.base import AbstractDistribution
 from pip._internal.distributions.sdist import SourceDistribution
 from pip._internal.distributions.wheel import WheelDistribution
-
-if TYPE_CHECKING:
-    from pip._internal.distributions.base import AbstractDistribution
-    from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.req_install import InstallRequirement
 
 
 def make_distribution_for_install_requirement(install_req):

--- a/src/pip/_internal/distributions/base.py
+++ b/src/pip/_internal/distributions/base.py
@@ -1,13 +1,10 @@
 import abc
-from typing import TYPE_CHECKING
+from typing import Optional
 
-if TYPE_CHECKING:
-    from typing import Optional
+from pip._vendor.pkg_resources import Distribution
 
-    from pip._vendor.pkg_resources import Distribution
-
-    from pip._internal.index.package_finder import PackageFinder
-    from pip._internal.req import InstallRequirement
+from pip._internal.index.package_finder import PackageFinder
+from pip._internal.req import InstallRequirement
 
 
 class AbstractDistribution(metaclass=abc.ABCMeta):

--- a/src/pip/_internal/distributions/installed.py
+++ b/src/pip/_internal/distributions/installed.py
@@ -1,13 +1,9 @@
-from typing import TYPE_CHECKING
+from typing import Optional
+
+from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.distributions.base import AbstractDistribution
-
-if TYPE_CHECKING:
-    from typing import Optional
-
-    from pip._vendor.pkg_resources import Distribution
-
-    from pip._internal.index.package_finder import PackageFinder
+from pip._internal.index.package_finder import PackageFinder
 
 
 class InstalledDistribution(AbstractDistribution):

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -1,18 +1,13 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import Set, Tuple
+
+from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.build_env import BuildEnvironment
 from pip._internal.distributions.base import AbstractDistribution
 from pip._internal.exceptions import InstallationError
+from pip._internal.index.package_finder import PackageFinder
 from pip._internal.utils.subprocess import runner_with_spinner_message
-
-if TYPE_CHECKING:
-    from typing import Set, Tuple
-
-    from pip._vendor.pkg_resources import Distribution
-
-    from pip._internal.index.package_finder import PackageFinder
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/distributions/wheel.py
+++ b/src/pip/_internal/distributions/wheel.py
@@ -1,13 +1,10 @@
-from typing import TYPE_CHECKING
 from zipfile import ZipFile
 
+from pip._vendor.pkg_resources import Distribution
+
 from pip._internal.distributions.base import AbstractDistribution
+from pip._internal.index.package_finder import PackageFinder
 from pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
-
-if TYPE_CHECKING:
-    from pip._vendor.pkg_resources import Distribution
-
-    from pip._internal.index.package_finder import PackageFinder
 
 
 class WheelDistribution(AbstractDistribution):

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -1,15 +1,14 @@
 """Exceptions used throughout package"""
 
+import configparser
 from itertools import chain, groupby, repeat
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+from pip._vendor.pkg_resources import Distribution
+from pip._vendor.requests.models import Request, Response
 
 if TYPE_CHECKING:
-    import configparser
     from hashlib import _Hash
-    from typing import Dict, List, Optional
-
-    from pip._vendor.pkg_resources import Distribution
-    from pip._vendor.requests.models import Request, Response
 
     from pip._internal.req.req_install import InstallRequirement
 

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -11,45 +11,39 @@ import os
 import re
 import urllib.parse
 import urllib.request
+import xml.etree.ElementTree
 from collections import OrderedDict
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import (
+    Callable,
+    Iterable,
+    List,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from pip._vendor import html5lib, requests
 from pip._vendor.distlib.compat import unescape
+from pip._vendor.requests import Response
 from pip._vendor.requests.exceptions import RetryError, SSLError
 
 from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.models.link import Link
 from pip._internal.models.search_scope import SearchScope
+from pip._internal.network.session import PipSession
 from pip._internal.network.utils import raise_for_status
 from pip._internal.utils.filetypes import is_archive_file
 from pip._internal.utils.misc import pairwise, redact_auth_from_url
 from pip._internal.utils.urls import path_to_url, url_to_path
 from pip._internal.vcs import is_url, vcs
 
-if TYPE_CHECKING:
-    import xml.etree.ElementTree
-    from optparse import Values
-    from typing import (
-        Callable,
-        Iterable,
-        List,
-        MutableMapping,
-        Optional,
-        Sequence,
-        Tuple,
-        Union,
-    )
-
-    from pip._vendor.requests import Response
-
-    from pip._internal.network.session import PipSession
-
-    HTMLElement = xml.etree.ElementTree.Element
-    ResponseHeaders = MutableMapping[str, str]
-
-
 logger = logging.getLogger(__name__)
+
+HTMLElement = xml.etree.ElementTree.Element
+ResponseHeaders = MutableMapping[str, str]
 
 
 def _match_vcs_scheme(url):

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -6,10 +6,12 @@
 import functools
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import FrozenSet, Iterable, List, Optional, Set, Tuple, Union
 
 from pip._vendor.packaging import specifiers
+from pip._vendor.packaging.tags import Tag
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import _BaseVersion
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import (
@@ -18,41 +20,32 @@ from pip._internal.exceptions import (
     InvalidWheelFilename,
     UnsupportedWheel,
 )
-from pip._internal.index.collector import parse_links
+from pip._internal.index.collector import LinkCollector, parse_links
 from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.models.format_control import FormatControl
 from pip._internal.models.link import Link
+from pip._internal.models.search_scope import SearchScope
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.models.wheel import Wheel
+from pip._internal.req import InstallRequirement
 from pip._internal.utils.filetypes import WHEEL_EXTENSION
+from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import build_netloc
 from pip._internal.utils.packaging import check_requires_python
 from pip._internal.utils.unpacking import SUPPORTED_EXTENSIONS
 from pip._internal.utils.urls import url_to_path
 
-if TYPE_CHECKING:
-    from typing import FrozenSet, Iterable, List, Optional, Set, Tuple, Union
-
-    from pip._vendor.packaging.tags import Tag
-    from pip._vendor.packaging.version import _BaseVersion
-
-    from pip._internal.index.collector import LinkCollector
-    from pip._internal.models.search_scope import SearchScope
-    from pip._internal.req import InstallRequirement
-    from pip._internal.utils.hashes import Hashes
-
-    BuildTag = Union[Tuple[()], Tuple[int, str]]
-    CandidateSortingKey = (
-        Tuple[int, int, int, _BaseVersion, BuildTag, Optional[int]]
-    )
-
-
 __all__ = ['FormatControl', 'BestCandidateResult', 'PackageFinder']
 
 
 logger = logging.getLogger(__name__)
+
+BuildTag = Union[Tuple[()], Tuple[int, str]]
+CandidateSortingKey = (
+    Tuple[int, int, int, _BaseVersion, BuildTag, Optional[int]]
+)
 
 
 def _check_link_requires_python(

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -8,19 +8,15 @@ import os.path
 import site
 import sys
 import sysconfig
+from distutils.cmd import Command as DistutilsCommand
 from distutils.command.install import SCHEME_KEYS
 from distutils.command.install import install as distutils_install_command
-from typing import TYPE_CHECKING, cast
+from typing import Dict, List, Optional, Union, cast
 
 from pip._internal.models.scheme import Scheme
 from pip._internal.utils import appdirs
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.virtualenv import running_under_virtualenv
-
-if TYPE_CHECKING:
-    from distutils.cmd import Command as DistutilsCommand
-    from typing import Dict, List, Optional, Union
-
 
 # Application Directories
 USER_CACHE_DIR = appdirs.user_cache_dir("pip")

--- a/src/pip/_internal/main.py
+++ b/src/pip/_internal/main.py
@@ -1,7 +1,4 @@
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import List, Optional
+from typing import List, Optional
 
 
 def main(args=None):

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -1,9 +1,6 @@
-from typing import TYPE_CHECKING
+from typing import List, Optional
 
-if TYPE_CHECKING:
-    from typing import List, Optional
-
-    from .base import BaseDistribution, BaseEnvironment
+from .base import BaseDistribution, BaseEnvironment
 
 
 def get_default_environment():

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -1,11 +1,8 @@
-from typing import TYPE_CHECKING
+from typing import Container, Iterator, List, Optional
+
+from pip._vendor.packaging.version import _BaseVersion
 
 from pip._internal.utils.misc import stdlib_pkgs  # TODO: Move definition here.
-
-if TYPE_CHECKING:
-    from typing import Container, Iterator, List, Optional
-
-    from pip._vendor.packaging.version import _BaseVersion
 
 
 class BaseDistribution:

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -1,19 +1,15 @@
 import zipfile
-from typing import TYPE_CHECKING
+from typing import Iterator, List, Optional
 
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import _BaseVersion
 
 from pip._internal.utils import misc  # TODO: Move definition here.
 from pip._internal.utils.packaging import get_installer
 from pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
 
 from .base import BaseDistribution, BaseEnvironment
-
-if TYPE_CHECKING:
-    from typing import Iterator, List, Optional
-
-    from pip._vendor.packaging.version import _BaseVersion
 
 
 class Distribution(BaseDistribution):

--- a/src/pip/_internal/models/candidate.py
+++ b/src/pip/_internal/models/candidate.py
@@ -1,13 +1,8 @@
-from typing import TYPE_CHECKING
-
+from pip._vendor.packaging.version import _BaseVersion
 from pip._vendor.packaging.version import parse as parse_version
 
+from pip._internal.models.link import Link
 from pip._internal.utils.models import KeyBasedCompareMixin
-
-if TYPE_CHECKING:
-    from pip._vendor.packaging.version import _BaseVersion
-
-    from pip._internal.models.link import Link
 
 
 class InstallationCandidate(KeyBasedCompareMixin):

--- a/src/pip/_internal/models/direct_url.py
+++ b/src/pip/_internal/models/direct_url.py
@@ -2,16 +2,7 @@
 import json
 import re
 import urllib.parse
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, Iterable, Optional, Type, TypeVar, Union
-
-    T = TypeVar("T")
-
-
-DIRECT_URL_METADATA_NAME = "direct_url.json"
-ENV_VAR_RE = re.compile(r"^\$\{[A-Za-z0-9-_]+\}(:\$\{[A-Za-z0-9-_]+\})?$")
+from typing import Any, Dict, Iterable, Optional, Type, TypeVar, Union
 
 __all__ = [
     "DirectUrl",
@@ -20,6 +11,11 @@ __all__ = [
     "ArchiveInfo",
     "VcsInfo",
 ]
+
+T = TypeVar("T")
+
+DIRECT_URL_METADATA_NAME = "direct_url.json"
+ENV_VAR_RE = re.compile(r"^\$\{[A-Za-z0-9-_]+\}(:\$\{[A-Za-z0-9-_]+\})?$")
 
 
 class DirectUrlValidationError(Exception):
@@ -155,8 +151,7 @@ class DirInfo:
         return _filter_none(editable=self.editable or None)
 
 
-if TYPE_CHECKING:
-    InfoType = Union[ArchiveInfo, DirInfo, VcsInfo]
+InfoType = Union[ArchiveInfo, DirInfo, VcsInfo]
 
 
 class DirectUrl:

--- a/src/pip/_internal/models/format_control.py
+++ b/src/pip/_internal/models/format_control.py
@@ -1,11 +1,8 @@
-from typing import TYPE_CHECKING
+from typing import FrozenSet, Optional, Set
 
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import CommandError
-
-if TYPE_CHECKING:
-    from typing import FrozenSet, Optional, Set
 
 
 class FormatControl:

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -2,9 +2,10 @@ import os
 import posixpath
 import re
 import urllib.parse
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 from pip._internal.utils.filetypes import WHEEL_EXTENSION
+from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.misc import (
     redact_auth_from_url,
     split_auth_from_netloc,
@@ -14,10 +15,7 @@ from pip._internal.utils.models import KeyBasedCompareMixin
 from pip._internal.utils.urls import path_to_url, url_to_path
 
 if TYPE_CHECKING:
-    from typing import Optional, Tuple, Union
-
     from pip._internal.index.collector import HTMLPage
-    from pip._internal.utils.hashes import Hashes
 
 
 class Link(KeyBasedCompareMixin):

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -3,17 +3,13 @@ import logging
 import os
 import posixpath
 import urllib.parse
-from typing import TYPE_CHECKING
+from typing import List
 
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.models.index import PyPI
 from pip._internal.utils.compat import has_tls
 from pip._internal.utils.misc import normalize_path, redact_auth_from_url
-
-if TYPE_CHECKING:
-    from typing import List
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/models/selection_prefs.py
+++ b/src/pip/_internal/models/selection_prefs.py
@@ -1,9 +1,6 @@
-from typing import TYPE_CHECKING
+from typing import Optional
 
-if TYPE_CHECKING:
-    from typing import Optional
-
-    from pip._internal.models.format_control import FormatControl
+from pip._internal.models.format_control import FormatControl
 
 
 class SelectionPreferences:

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -1,13 +1,10 @@
 import sys
-from typing import TYPE_CHECKING
+from typing import List, Optional, Tuple
+
+from pip._vendor.packaging.tags import Tag
 
 from pip._internal.utils.compatibility_tags import get_supported, version_info_to_nodot
 from pip._internal.utils.misc import normalize_version_info
-
-if TYPE_CHECKING:
-    from typing import List, Optional, Tuple
-
-    from pip._vendor.packaging.tags import Tag
 
 
 class TargetPython:

--- a/src/pip/_internal/models/wheel.py
+++ b/src/pip/_internal/models/wheel.py
@@ -2,14 +2,11 @@
 name that have meaning.
 """
 import re
-from typing import TYPE_CHECKING
+from typing import List
 
 from pip._vendor.packaging.tags import Tag
 
 from pip._internal.exceptions import InvalidWheelFilename
-
-if TYPE_CHECKING:
-    from typing import List
 
 
 class Wheel:

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -6,9 +6,10 @@ providing credentials in the context of network requests.
 
 import logging
 import urllib.parse
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple
 
 from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
+from pip._vendor.requests.models import Request, Response
 from pip._vendor.requests.utils import get_netrc_auth
 
 from pip._internal.utils.misc import (
@@ -18,17 +19,11 @@ from pip._internal.utils.misc import (
     remove_auth_from_url,
     split_auth_netloc_from_url,
 )
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Tuple
-
-    from pip._vendor.requests.models import Request, Response
-
-    from pip._internal.vcs.versioncontrol import AuthInfo
-
-    Credentials = Tuple[str, str, str]
+from pip._internal.vcs.versioncontrol import AuthInfo
 
 logger = logging.getLogger(__name__)
+
+Credentials = Tuple[str, str, str]
 
 try:
     import keyring

--- a/src/pip/_internal/network/cache.py
+++ b/src/pip/_internal/network/cache.py
@@ -3,7 +3,7 @@
 
 import os
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
+from typing import Iterator, Optional
 
 from pip._vendor.cachecontrol.cache import BaseCache
 from pip._vendor.cachecontrol.caches import FileCache
@@ -11,9 +11,6 @@ from pip._vendor.requests.models import Response
 
 from pip._internal.utils.filesystem import adjacent_tmp_file, replace
 from pip._internal.utils.misc import ensure_dir
-
-if TYPE_CHECKING:
-    from typing import Iterator, Optional
 
 
 def is_from_cache(response):

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -4,24 +4,18 @@ import cgi
 import logging
 import mimetypes
 import os
-from typing import TYPE_CHECKING
+from typing import Iterable, Optional, Tuple
 
-from pip._vendor.requests.models import CONTENT_CHUNK_SIZE
+from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
 
 from pip._internal.cli.progress_bars import DownloadProgressProvider
 from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.models.index import PyPI
+from pip._internal.models.link import Link
 from pip._internal.network.cache import is_from_cache
+from pip._internal.network.session import PipSession
 from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
 from pip._internal.utils.misc import format_size, redact_auth_from_url, splitext
-
-if TYPE_CHECKING:
-    from typing import Iterable, Optional, Tuple
-
-    from pip._vendor.requests.models import Response
-
-    from pip._internal.models.link import Link
-    from pip._internal.network.session import PipSession
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/network/lazy_wheel.py
+++ b/src/pip/_internal/network/lazy_wheel.py
@@ -5,21 +5,15 @@ __all__ = ['HTTPRangeRequestUnsupported', 'dist_from_wheel_url']
 from bisect import bisect_left, bisect_right
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
-from typing import TYPE_CHECKING
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 from zipfile import BadZipfile, ZipFile
 
-from pip._vendor.requests.models import CONTENT_CHUNK_SIZE
+from pip._vendor.pkg_resources import Distribution
+from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
 
+from pip._internal.network.session import PipSession
 from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
 from pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, Iterator, List, Optional, Tuple
-
-    from pip._vendor.pkg_resources import Distribution
-    from pip._vendor.requests.models import Response
-
-    from pip._internal.network.session import PipSession
 
 
 class HTTPRangeRequestUnsupported(Exception):

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -15,7 +15,7 @@ import platform
 import sys
 import urllib.parse
 import warnings
-from typing import TYPE_CHECKING
+from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union
 
 from pip._vendor import requests, urllib3
 from pip._vendor.cachecontrol import CacheControlAdapter
@@ -26,6 +26,7 @@ from pip._vendor.urllib3.exceptions import InsecureRequestWarning
 
 from pip import __version__
 from pip._internal.metadata import get_default_environment
+from pip._internal.models.link import Link
 from pip._internal.network.auth import MultiDomainBasicAuth
 from pip._internal.network.cache import SafeFileCache
 
@@ -35,15 +36,9 @@ from pip._internal.utils.glibc import libc_ver
 from pip._internal.utils.misc import build_url_from_netloc, parse_netloc
 from pip._internal.utils.urls import url_to_path
 
-if TYPE_CHECKING:
-    from typing import Any, Iterator, List, Optional, Sequence, Tuple, Union
-
-    from pip._internal.models.link import Link
-
-    SecureOrigin = Tuple[str, str, Optional[Union[int, str]]]
-
-
 logger = logging.getLogger(__name__)
+
+SecureOrigin = Tuple[str, str, Optional[Union[int, str]]]
 
 
 # Ignore warning raised when using --trusted-host.

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -1,11 +1,8 @@
-from typing import TYPE_CHECKING
+from typing import Dict, Iterator
 
 from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
 
 from pip._internal.exceptions import NetworkConnectionError
-
-if TYPE_CHECKING:
-    from typing import Dict, Iterator
 
 # The following comments and HTTP headers were originally added by
 # Donald Stufft in git commit 22c562429a61bb77172039e480873fb239dd8c03.

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -3,20 +3,15 @@
 
 import logging
 import urllib.parse
-from typing import TYPE_CHECKING
+from typing import Dict
 
 # NOTE: XMLRPC Client is not annotated in typeshed as on 2017-07-17, which is
 #       why we ignore the type on this import
 from pip._vendor.six.moves import xmlrpc_client  # type: ignore
 
 from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.network.session import PipSession
 from pip._internal.network.utils import raise_for_status
-
-if TYPE_CHECKING:
-    from typing import Dict
-
-    from pip._internal.network.session import PipSession
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/operations/build/metadata.py
+++ b/src/pip/_internal/operations/build/metadata.py
@@ -2,15 +2,12 @@
 """
 
 import os
-from typing import TYPE_CHECKING
 
+from pip._vendor.pep517.wrappers import Pep517HookCaller
+
+from pip._internal.build_env import BuildEnvironment
 from pip._internal.utils.subprocess import runner_with_spinner_message
 from pip._internal.utils.temp_dir import TempDirectory
-
-if TYPE_CHECKING:
-    from pip._vendor.pep517.wrappers import Pep517HookCaller
-
-    from pip._internal.build_env import BuildEnvironment
 
 
 def generate_metadata(build_env, backend):

--- a/src/pip/_internal/operations/build/metadata_legacy.py
+++ b/src/pip/_internal/operations/build/metadata_legacy.py
@@ -3,15 +3,12 @@
 
 import logging
 import os
-from typing import TYPE_CHECKING
 
+from pip._internal.build_env import BuildEnvironment
 from pip._internal.exceptions import InstallationError
 from pip._internal.utils.setuptools_build import make_setuptools_egg_info_args
 from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory
-
-if TYPE_CHECKING:
-    from pip._internal.build_env import BuildEnvironment
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/operations/build/wheel.py
+++ b/src/pip/_internal/operations/build/wheel.py
@@ -1,13 +1,10 @@
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import List, Optional
+
+from pip._vendor.pep517.wrappers import Pep517HookCaller
 
 from pip._internal.utils.subprocess import runner_with_spinner_message
-
-if TYPE_CHECKING:
-    from typing import List, Optional
-
-    from pip._vendor.pep517.wrappers import Pep517HookCaller
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/operations/build/wheel_legacy.py
+++ b/src/pip/_internal/operations/build/wheel_legacy.py
@@ -1,6 +1,6 @@
 import logging
 import os.path
-from typing import TYPE_CHECKING
+from typing import List, Optional
 
 from pip._internal.cli.spinners import open_spinner
 from pip._internal.utils.setuptools_build import make_setuptools_bdist_wheel_args
@@ -9,9 +9,6 @@ from pip._internal.utils.subprocess import (
     call_subprocess,
     format_command_args,
 )
-
-if TYPE_CHECKING:
-    from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -3,30 +3,26 @@
 
 import logging
 from collections import namedtuple
-from typing import TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.pkg_resources import RequirementParseError
 
 from pip._internal.distributions import make_distribution_for_install_requirement
+from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.misc import get_installed_distributions
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+# Shorthands
+PackageSet = Dict[str, 'PackageDetails']
+Missing = Tuple[str, Any]
+Conflicting = Tuple[str, str, Any]
 
-    from pip._internal.req.req_install import InstallRequirement
-
-    # Shorthands
-    PackageSet = Dict[str, 'PackageDetails']
-    Missing = Tuple[str, Any]
-    Conflicting = Tuple[str, str, Any]
-
-    MissingDict = Dict[str, List[Missing]]
-    ConflictingDict = Dict[str, List[Conflicting]]
-    CheckResult = Tuple[MissingDict, ConflictingDict]
-    ConflictDetails = Tuple[PackageSet, CheckResult]
+MissingDict = Dict[str, List[Missing]]
+ConflictingDict = Dict[str, List[Conflicting]]
+CheckResult = Tuple[MissingDict, ConflictingDict]
+ConflictDetails = Tuple[PackageSet, CheckResult]
 
 PackageDetails = namedtuple('PackageDetails', ['version', 'requires'])
 

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -1,10 +1,20 @@
 import collections
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import (
+    Container,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.pkg_resources import RequirementParseError
+from pip._vendor.pkg_resources import Distribution, Requirement, RequirementParseError
 
 from pip._internal.exceptions import BadCommand, InstallationError
 from pip._internal.req.constructors import (
@@ -18,25 +28,9 @@ from pip._internal.utils.direct_url_helpers import (
 )
 from pip._internal.utils.misc import dist_is_editable, get_installed_distributions
 
-if TYPE_CHECKING:
-    from typing import (
-        Container,
-        Dict,
-        Iterable,
-        Iterator,
-        List,
-        Optional,
-        Set,
-        Tuple,
-        Union,
-    )
-
-    from pip._vendor.pkg_resources import Distribution, Requirement
-
-    RequirementInfo = Tuple[Optional[Union[str, Requirement]], bool, List[str]]
-
-
 logger = logging.getLogger(__name__)
+
+RequirementInfo = Tuple[Optional[Union[str, Requirement]], bool, List[str]]
 
 
 def freeze(

--- a/src/pip/_internal/operations/install/editable_legacy.py
+++ b/src/pip/_internal/operations/install/editable_legacy.py
@@ -1,17 +1,12 @@
 """Legacy editable installation process, i.e. `setup.py develop`.
 """
 import logging
-from typing import TYPE_CHECKING
+from typing import List, Optional, Sequence
 
+from pip._internal.build_env import BuildEnvironment
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.setuptools_build import make_setuptools_develop_args
 from pip._internal.utils.subprocess import call_subprocess
-
-if TYPE_CHECKING:
-    from typing import List, Optional, Sequence
-
-    from pip._internal.build_env import BuildEnvironment
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -5,21 +5,16 @@ import logging
 import os
 import sys
 from distutils.util import change_root
-from typing import TYPE_CHECKING
+from typing import List, Optional, Sequence
 
+from pip._internal.build_env import BuildEnvironment
 from pip._internal.exceptions import InstallationError
+from pip._internal.models.scheme import Scheme
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import ensure_dir
 from pip._internal.utils.setuptools_build import make_setuptools_install_args
 from pip._internal.utils.subprocess import runner_with_spinner_message
 from pip._internal.utils.temp_dir import TempDirectory
-
-if TYPE_CHECKING:
-    from typing import List, Optional, Sequence
-
-    from pip._internal.build_env import BuildEnvironment
-    from pip._internal.models.scheme import Scheme
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -8,9 +8,10 @@ import logging
 import mimetypes
 import os
 import shutil
-from typing import TYPE_CHECKING
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.distributions import make_distribution_for_install_requirement
 from pip._internal.distributions.installed import InstalledDistribution
@@ -23,32 +24,24 @@ from pip._internal.exceptions import (
     PreviousBuildDirError,
     VcsHashUnsupported,
 )
+from pip._internal.index.package_finder import PackageFinder
+from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.network.download import BatchDownloader, Downloader
 from pip._internal.network.lazy_wheel import (
     HTTPRangeRequestUnsupported,
     dist_from_wheel_url,
 )
+from pip._internal.network.session import PipSession
+from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.req_tracker import RequirementTracker
 from pip._internal.utils.filesystem import copy2_fixed
-from pip._internal.utils.hashes import MissingHashes
+from pip._internal.utils.hashes import Hashes, MissingHashes
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import display_path, hide_url, path_to_display, rmtree
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.unpacking import unpack_file
 from pip._internal.vcs import vcs
-
-if TYPE_CHECKING:
-    from typing import Dict, Iterable, List, Optional, Tuple
-
-    from pip._vendor.pkg_resources import Distribution
-
-    from pip._internal.index.package_finder import PackageFinder
-    from pip._internal.models.link import Link
-    from pip._internal.network.session import PipSession
-    from pip._internal.req.req_install import InstallRequirement
-    from pip._internal.req.req_tracker import RequirementTracker
-    from pip._internal.utils.hashes import Hashes
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -1,14 +1,11 @@
 import os
 from collections import namedtuple
-from typing import TYPE_CHECKING
+from typing import Any, List, Optional
 
 from pip._vendor import toml
 from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
 
 from pip._internal.exceptions import InstallationError
-
-if TYPE_CHECKING:
-    from typing import Any, List, Optional
 
 
 def _is_list_of_str(obj):

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -1,15 +1,12 @@
 import collections
 import logging
-from typing import TYPE_CHECKING
+from typing import Iterator, List, Optional, Sequence, Tuple
 
 from pip._internal.utils.logging import indent_log
 
 from .req_file import parse_requirements
 from .req_install import InstallRequirement
 from .req_set import RequirementSet
-
-if TYPE_CHECKING:
-    from typing import Iterator, List, Optional, Sequence, Tuple
 
 __all__ = [
     "RequirementSet", "InstallRequirement",

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -11,7 +11,7 @@ InstallRequirement.
 import logging
 import os
 import re
-from typing import TYPE_CHECKING
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
@@ -23,17 +23,12 @@ from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.pyproject import make_pyproject_path
+from pip._internal.req.req_file import ParsedRequirement
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.filetypes import is_archive_file
 from pip._internal.utils.misc import is_installable_dir
 from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import is_url, vcs
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, Optional, Set, Tuple, Union
-
-    from pip._internal.req.req_file import ParsedRequirement
-
 
 __all__ = [
     "install_req_from_editable", "install_req_from_line",

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -7,38 +7,36 @@ import os
 import re
 import shlex
 import urllib.parse
-from typing import TYPE_CHECKING
+from optparse import Values
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    NoReturn,
+    Optional,
+    Text,
+    Tuple,
+)
 
 from pip._internal.cli import cmdoptions
 from pip._internal.exceptions import InstallationError, RequirementsFileParseError
 from pip._internal.models.search_scope import SearchScope
+from pip._internal.network.session import PipSession
 from pip._internal.network.utils import raise_for_status
 from pip._internal.utils.encoding import auto_decode
 from pip._internal.utils.urls import get_url_scheme, url_to_path
 
 if TYPE_CHECKING:
-    from optparse import Values
-    from typing import (
-        Any,
-        Callable,
-        Dict,
-        Iterator,
-        List,
-        NoReturn,
-        Optional,
-        Text,
-        Tuple,
-    )
-
     from pip._internal.index.package_finder import PackageFinder
-    from pip._internal.network.session import PipSession
-
-    ReqFileLines = Iterator[Tuple[int, Text]]
-
-    LineParser = Callable[[Text], Tuple[str, Values]]
-
 
 __all__ = ['parse_requirements']
+
+ReqFileLines = Iterator[Tuple[int, Text]]
+
+LineParser = Callable[[Text], Tuple[str, Values]]
 
 SCHEME_RE = re.compile(r'^(http|https|file):', re.I)
 COMMENT_RE = re.compile(r'(^|\s+)#.*$')

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -7,16 +7,19 @@ import shutil
 import sys
 import uuid
 import zipfile
-from typing import TYPE_CHECKING
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
 from pip._vendor import pkg_resources, six
+from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
+from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.pep517.wrappers import Pep517HookCaller
+from pip._vendor.pkg_resources import Distribution
 
-from pip._internal.build_env import NoOpBuildEnvironment
+from pip._internal.build_env import BuildEnvironment, NoOpBuildEnvironment
 from pip._internal.exceptions import InstallationError
 from pip._internal.locations import get_scheme
 from pip._internal.models.link import Link
@@ -50,16 +53,6 @@ from pip._internal.utils.packaging import get_metadata
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 from pip._internal.utils.virtualenv import running_under_virtualenv
 from pip._internal.vcs import vcs
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
-
-    from pip._vendor.packaging.markers import Marker
-    from pip._vendor.packaging.specifiers import SpecifierSet
-    from pip._vendor.pkg_resources import Distribution
-
-    from pip._internal.build_env import BuildEnvironment
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -1,18 +1,13 @@
 import logging
 from collections import OrderedDict
-from typing import TYPE_CHECKING
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.models.wheel import Wheel
+from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils import compatibility_tags
-
-if TYPE_CHECKING:
-    from typing import Dict, Iterable, List, Optional, Tuple
-
-    from pip._internal.req.req_install import InstallRequirement
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/req/req_tracker.py
+++ b/src/pip/_internal/req/req_tracker.py
@@ -2,16 +2,12 @@ import contextlib
 import hashlib
 import logging
 import os
-from typing import TYPE_CHECKING
+from types import TracebackType
+from typing import Dict, Iterator, Optional, Set, Type, Union
 
+from pip._internal.models.link import Link
+from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.temp_dir import TempDirectory
-
-if TYPE_CHECKING:
-    from types import TracebackType
-    from typing import Dict, Iterator, Optional, Set, Type, Union
-
-    from pip._internal.models.link import Link
-    from pip._internal.req.req_install import InstallRequirement
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -5,9 +5,10 @@ import os
 import sys
 import sysconfig
 from importlib.util import cache_from_source
-from typing import TYPE_CHECKING
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple
 
 from pip._vendor import pkg_resources
+from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.exceptions import UninstallationError
 from pip._internal.locations import bin_py, bin_user
@@ -24,21 +25,6 @@ from pip._internal.utils.misc import (
     rmtree,
 )
 from pip._internal.utils.temp_dir import AdjacentTempDirectory, TempDirectory
-
-if TYPE_CHECKING:
-    from typing import (
-        Any,
-        Callable,
-        Dict,
-        Iterable,
-        Iterator,
-        List,
-        Optional,
-        Set,
-        Tuple,
-    )
-
-    from pip._vendor.pkg_resources import Distribution
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/resolution/base.py
+++ b/src/pip/_internal/resolution/base.py
@@ -1,14 +1,11 @@
-from typing import TYPE_CHECKING
+from typing import Callable, List
 
-if TYPE_CHECKING:
-    from typing import Callable, List
+from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.req_set import RequirementSet
 
-    from pip._internal.req.req_install import InstallRequirement
-    from pip._internal.req.req_set import RequirementSet
-
-    InstallRequirementProvider = Callable[
-        [str, InstallRequirement], InstallRequirement
-    ]
+InstallRequirementProvider = Callable[
+    [str, InstallRequirement], InstallRequirement
+]
 
 
 class BaseResolver:

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -1,22 +1,14 @@
-from typing import TYPE_CHECKING
+from typing import FrozenSet, Iterable, Optional, Tuple
 
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import _BaseVersion
 
+from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.hashes import Hashes
 
-if TYPE_CHECKING:
-    from typing import FrozenSet, Iterable, Optional, Tuple
-
-    from pip._vendor.packaging.version import _BaseVersion
-
-    from pip._internal.models.link import Link
-
-    CandidateLookup = Tuple[
-        Optional["Candidate"],
-        Optional[InstallRequirement],
-    ]
+CandidateLookup = Tuple[Optional["Candidate"], Optional[InstallRequirement]]
 
 
 def format_name(project, extras):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -1,12 +1,14 @@
 import logging
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, Optional, Tuple, Union
 
 from pip._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import Version
+from pip._vendor.packaging.version import Version, _BaseVersion
+from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.exceptions import HashError, MetadataInconsistent
+from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.req.constructors import (
     install_req_from_editable,
@@ -16,27 +18,18 @@ from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.misc import dist_is_editable, normalize_version_info
 from pip._internal.utils.packaging import get_requires_python
 
-from .base import Candidate, format_name
+from .base import Candidate, Requirement, format_name
 
 if TYPE_CHECKING:
-    from typing import Any, FrozenSet, Iterable, Optional, Tuple, Union
-
-    from pip._vendor.packaging.version import _BaseVersion
-    from pip._vendor.pkg_resources import Distribution
-
-    from pip._internal.models.link import Link
-
-    from .base import Requirement
     from .factory import Factory
 
-    BaseCandidate = Union[
-        "AlreadyInstalledCandidate",
-        "EditableCandidate",
-        "LinkCandidate",
-    ]
-
-
 logger = logging.getLogger(__name__)
+
+BaseCandidate = Union[
+    "AlreadyInstalledCandidate",
+    "EditableCandidate",
+    "LinkCandidate",
+]
 
 
 def make_install_req_from_link(link, template):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -1,9 +1,25 @@
 import functools
 import logging
-from typing import TYPE_CHECKING
+from typing import (
+    Dict,
+    FrozenSet,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypeVar,
+)
 
+from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import _BaseVersion
+from pip._vendor.pkg_resources import Distribution
+from pip._vendor.resolvelib import ResolutionImpossible
 
+from pip._internal.cache import CacheEntry, WheelCache
 from pip._internal.exceptions import (
     DistributionNotFound,
     InstallationError,
@@ -12,8 +28,12 @@ from pip._internal.exceptions import (
     UnsupportedPythonVersion,
     UnsupportedWheel,
 )
+from pip._internal.index.package_finder import PackageFinder
+from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
+from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req.req_install import InstallRequirement
+from pip._internal.resolution.base import InstallRequirementProvider
 from pip._internal.utils.compatibility_tags import get_supported
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.misc import (
@@ -23,15 +43,16 @@ from pip._internal.utils.misc import (
 )
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
-from .base import Constraint
+from .base import Candidate, Constraint, Requirement
 from .candidates import (
     AlreadyInstalledCandidate,
+    BaseCandidate,
     EditableCandidate,
     ExtrasCandidate,
     LinkCandidate,
     RequiresPythonCandidate,
 )
-from .found_candidates import FoundCandidates
+from .found_candidates import FoundCandidates, IndexCandidateInfo
 from .requirements import (
     ExplicitRequirement,
     RequiresPythonRequirement,
@@ -39,39 +60,10 @@ from .requirements import (
     UnsatisfiableRequirement,
 )
 
-if TYPE_CHECKING:
-    from typing import (
-        Dict,
-        FrozenSet,
-        Iterable,
-        Iterator,
-        List,
-        Optional,
-        Sequence,
-        Set,
-        Tuple,
-        TypeVar,
-    )
-
-    from pip._vendor.packaging.specifiers import SpecifierSet
-    from pip._vendor.packaging.version import _BaseVersion
-    from pip._vendor.pkg_resources import Distribution
-    from pip._vendor.resolvelib import ResolutionImpossible
-
-    from pip._internal.cache import CacheEntry, WheelCache
-    from pip._internal.index.package_finder import PackageFinder
-    from pip._internal.models.link import Link
-    from pip._internal.operations.prepare import RequirementPreparer
-    from pip._internal.resolution.base import InstallRequirementProvider
-
-    from .base import Candidate, Requirement
-    from .candidates import BaseCandidate
-    from .found_candidates import IndexCandidateInfo
-
-    C = TypeVar("C")
-    Cache = Dict[Link, C]
-
 logger = logging.getLogger(__name__)
+
+C = TypeVar("C")
+Cache = Dict[Link, C]
 
 
 class Factory:

--- a/src/pip/_internal/resolution/resolvelib/found_candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/found_candidates.py
@@ -9,18 +9,14 @@ something.
 """
 
 import functools
-from typing import TYPE_CHECKING
+from typing import Callable, Iterator, Optional, Set, Tuple
 
+from pip._vendor.packaging.version import _BaseVersion
 from pip._vendor.six.moves import collections_abc  # type: ignore
 
-if TYPE_CHECKING:
-    from typing import Callable, Iterator, Optional, Set, Tuple
+from .base import Candidate
 
-    from pip._vendor.packaging.version import _BaseVersion
-
-    from .base import Candidate
-
-    IndexCandidateInfo = Tuple[_BaseVersion, Callable[[], Optional[Candidate]]]
+IndexCandidateInfo = Tuple[_BaseVersion, Callable[[], Optional[Candidate]]]
 
 
 def _iter_built(infos):

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -1,14 +1,9 @@
-from typing import TYPE_CHECKING
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, Union
 
 from pip._vendor.resolvelib.providers import AbstractProvider
 
-from .base import Constraint
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, Union
-
-    from .base import Candidate, Requirement
-    from .factory import Factory
+from .base import Candidate, Constraint, Requirement
+from .factory import Factory
 
 # Notes on the relationship between the provider, the factory, and the
 # candidate and requirement classes.

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -1,14 +1,10 @@
 from collections import defaultdict
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import Any, DefaultDict
 
 from pip._vendor.resolvelib.reporters import BaseReporter
 
-if TYPE_CHECKING:
-    from typing import Any, DefaultDict
-
-    from .base import Candidate, Requirement
-
+from .base import Candidate, Requirement
 
 logger = getLogger(__name__)
 

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -1,15 +1,9 @@
-from typing import TYPE_CHECKING
-
+from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
 
-from .base import Requirement, format_name
+from pip._internal.req.req_install import InstallRequirement
 
-if TYPE_CHECKING:
-    from pip._vendor.packaging.specifiers import SpecifierSet
-
-    from pip._internal.req.req_install import InstallRequirement
-
-    from .base import Candidate, CandidateLookup
+from .base import Candidate, CandidateLookup, Requirement, format_name
 
 
 class ExplicitRequirement(Requirement):

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -1,17 +1,24 @@
 import functools
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 from pip._vendor import six
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.resolvelib import ResolutionImpossible
 from pip._vendor.resolvelib import Resolver as RLResolver
+from pip._vendor.resolvelib.resolvers import Result
 
+from pip._internal.cache import WheelCache
 from pip._internal.exceptions import InstallationError
-from pip._internal.req.req_install import check_invalid_constraint_type
+from pip._internal.index.package_finder import PackageFinder
+from pip._internal.operations.prepare import RequirementPreparer
+from pip._internal.req.req_install import (
+    InstallRequirement,
+    check_invalid_constraint_type,
+)
 from pip._internal.req.req_set import RequirementSet
-from pip._internal.resolution.base import BaseResolver
+from pip._internal.resolution.base import BaseResolver, InstallRequirementProvider
 from pip._internal.resolution.resolvelib.provider import PipProvider
 from pip._internal.resolution.resolvelib.reporter import (
     PipDebuggingReporter,
@@ -25,17 +32,7 @@ from .base import Constraint
 from .factory import Factory
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Optional, Set, Tuple
-
-    from pip._vendor.resolvelib.resolvers import Result
     from pip._vendor.resolvelib.structs import Graph
-
-    from pip._internal.cache import WheelCache
-    from pip._internal.index.package_finder import PackageFinder
-    from pip._internal.operations.prepare import RequirementPreparer
-    from pip._internal.req.req_install import InstallRequirement
-    from pip._internal.resolution.base import InstallRequirementProvider
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -2,9 +2,10 @@ import datetime
 import hashlib
 import json
 import logging
+import optparse
 import os.path
 import sys
-from typing import TYPE_CHECKING
+from typing import Any, Dict
 
 from pip._vendor.packaging.version import parse as parse_version
 
@@ -12,15 +13,9 @@ from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import get_default_environment
 from pip._internal.models.selection_prefs import SelectionPreferences
+from pip._internal.network.session import PipSession
 from pip._internal.utils.filesystem import adjacent_tmp_file, check_path_owner, replace
 from pip._internal.utils.misc import ensure_dir
-
-if TYPE_CHECKING:
-    import optparse
-    from typing import Any, Dict
-
-    from pip._internal.network.session import PipSession
-
 
 SELFCHECK_DATE_FMT = "%Y-%m-%dT%H:%M:%SZ"
 

--- a/src/pip/_internal/utils/appdirs.py
+++ b/src/pip/_internal/utils/appdirs.py
@@ -7,12 +7,9 @@ and eventually drop this after all usages are changed.
 """
 
 import os
-from typing import TYPE_CHECKING
+from typing import List
 
 from pip._vendor import appdirs as _appdirs
-
-if TYPE_CHECKING:
-    from typing import List
 
 
 def user_cache_dir(appname):

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -9,11 +9,7 @@ import locale
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Optional, Union
-
+from typing import Optional, Union
 
 __all__ = ["console_to_str", "get_path_uid", "stdlib_pkgs", "WINDOWS"]
 

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -2,7 +2,7 @@
 """
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from pip._vendor.packaging.tags import (
     Tag,
@@ -15,9 +15,8 @@ from pip._vendor.packaging.tags import (
 )
 
 if TYPE_CHECKING:
-    from typing import List, Optional, Tuple
-
     from pip._vendor.packaging.tags import PythonVersion
+
 
 _osx_arch_pat = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
 

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -7,15 +7,11 @@ A module that implements tooling to enable easy warnings about deprecations.
 
 import logging
 import warnings
-from typing import TYPE_CHECKING
+from typing import Any, Optional
 
 from pip._vendor.packaging.version import parse
 
 from pip import __version__ as current_version
-
-if TYPE_CHECKING:
-    from typing import Any, Optional
-
 
 DEPRECATION_MSG_PREFIX = "DEPRECATION: "
 

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -1,6 +1,8 @@
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import Optional
+
+from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.models.direct_url import (
     DIRECT_URL_METADATA_NAME,
@@ -10,14 +12,8 @@ from pip._internal.models.direct_url import (
     DirInfo,
     VcsInfo,
 )
+from pip._internal.models.link import Link
 from pip._internal.vcs import vcs
-
-if TYPE_CHECKING:
-    from typing import Optional
-
-    from pip._vendor.pkg_resources import Distribution
-
-    from pip._internal.models.link import Link
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/utils/distutils_args.py
+++ b/src/pip/_internal/utils/distutils_args.py
@@ -1,10 +1,6 @@
 from distutils.errors import DistutilsArgError
 from distutils.fancy_getopt import FancyGetopt
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Dict, List
-
+from typing import Dict, List
 
 _options = [
     ("exec-prefix=", None, ""),

--- a/src/pip/_internal/utils/encoding.py
+++ b/src/pip/_internal/utils/encoding.py
@@ -2,10 +2,7 @@ import codecs
 import locale
 import re
 import sys
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import List, Tuple
+from typing import List, Tuple
 
 BOMS = [
     (codecs.BOM_UTF8, 'utf-8'),

--- a/src/pip/_internal/utils/entrypoints.py
+++ b/src/pip/_internal/utils/entrypoints.py
@@ -1,10 +1,7 @@
 import sys
-from typing import TYPE_CHECKING
+from typing import List, Optional
 
 from pip._internal.cli.main import main
-
-if TYPE_CHECKING:
-    from typing import List, Optional
 
 
 def _wrapper(args=None):

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -7,7 +7,7 @@ import stat
 import sys
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
-from typing import TYPE_CHECKING, cast
+from typing import Any, BinaryIO, Iterator, List, Union, cast
 
 # NOTE: retrying is not annotated in typeshed as on 2017-07-17, which is
 #       why we ignore the type on this import.
@@ -15,9 +15,6 @@ from pip._vendor.retrying import retry  # type: ignore
 
 from pip._internal.utils.compat import get_path_uid
 from pip._internal.utils.misc import format_size
-
-if TYPE_CHECKING:
-    from typing import Any, BinaryIO, Iterator, List, Union
 
 
 def check_path_owner(path):
@@ -96,7 +93,7 @@ def adjacent_tmp_file(path, **kwargs):
         suffix='.tmp',
         **kwargs
     ) as f:
-        result = cast('BinaryIO', f)
+        result = cast(BinaryIO, f)
         try:
             yield result
         finally:

--- a/src/pip/_internal/utils/filetypes.py
+++ b/src/pip/_internal/utils/filetypes.py
@@ -1,11 +1,9 @@
 """Filetype information.
 """
-from typing import TYPE_CHECKING
+
+from typing import Tuple
 
 from pip._internal.utils.misc import splitext
-
-if TYPE_CHECKING:
-    from typing import Tuple
 
 WHEEL_EXTENSION = '.whl'
 BZ2_EXTENSIONS = ('.tar.bz2', '.tbz')  # type: Tuple[str, ...]

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -3,10 +3,7 @@
 
 import os
 import sys
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Optional, Tuple
+from typing import Optional, Tuple
 
 
 def glibc_version_string():

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -1,12 +1,11 @@
 import hashlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, BinaryIO, Dict, Iterator, List, NoReturn
 
 from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError
 from pip._internal.utils.misc import read_chunks
 
 if TYPE_CHECKING:
     from hashlib import _Hash
-    from typing import BinaryIO, Dict, Iterator, List, NoReturn
 
 
 # The recommended hash algo of the moment. Change this whenever the state of

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -8,14 +8,11 @@ import logging.handlers
 import os
 import sys
 from logging import Filter, getLogger
-from typing import TYPE_CHECKING
+from typing import Any
 
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
 from pip._internal.utils.misc import ensure_dir
-
-if TYPE_CHECKING:
-    from typing import Any
 
 try:
     import threading

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -16,7 +16,21 @@ import sys
 import urllib.parse
 from io import StringIO
 from itertools import filterfalse, tee, zip_longest
-from typing import TYPE_CHECKING, cast
+from typing import (
+    Any,
+    AnyStr,
+    Callable,
+    Container,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    cast,
+)
+
+from pip._vendor.pkg_resources import Distribution
 
 # NOTE: retrying is not annotated in typeshed as on 2017-07-17, which is
 #       why we ignore the type on this import.
@@ -31,26 +45,6 @@ from pip._internal.utils.virtualenv import (
     virtualenv_no_global,
 )
 
-if TYPE_CHECKING:
-    from typing import (
-        Any,
-        AnyStr,
-        Callable,
-        Container,
-        Iterable,
-        Iterator,
-        List,
-        Optional,
-        Tuple,
-        TypeVar,
-    )
-
-    from pip._vendor.pkg_resources import Distribution
-
-    VersionInfo = Tuple[int, int, int]
-    T = TypeVar("T")
-
-
 __all__ = ['rmtree', 'display_path', 'backup_dir',
            'ask', 'splitext',
            'format_size', 'is_installable_dir',
@@ -61,6 +55,9 @@ __all__ = ['rmtree', 'display_path', 'backup_dir',
 
 
 logger = logging.getLogger(__name__)
+
+VersionInfo = Tuple[int, int, int]
+T = TypeVar("T")
 
 
 def get_pip_version():

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -1,19 +1,14 @@
 import logging
+from email.message import Message
 from email.parser import FeedParser
-from typing import TYPE_CHECKING
+from typing import Optional, Tuple
 
 from pip._vendor import pkg_resources
 from pip._vendor.packaging import specifiers, version
+from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.exceptions import NoneMetadataError
 from pip._internal.utils.misc import display_path
-
-if TYPE_CHECKING:
-    from email.message import Message
-    from typing import Optional, Tuple
-
-    from pip._vendor.pkg_resources import Distribution
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/utils/parallel.py
+++ b/src/pip/_internal/utils/parallel.py
@@ -20,18 +20,15 @@ __all__ = ['map_multiprocess', 'map_multithread']
 
 from contextlib import contextmanager
 from multiprocessing import Pool as ProcessPool
+from multiprocessing import pool
 from multiprocessing.dummy import Pool as ThreadPool
-from typing import TYPE_CHECKING
+from typing import Callable, Iterable, Iterator, TypeVar, Union
 
 from pip._vendor.requests.adapters import DEFAULT_POOLSIZE
 
-if TYPE_CHECKING:
-    from multiprocessing import pool
-    from typing import Callable, Iterable, Iterator, TypeVar, Union
-
-    Pool = Union[pool.Pool, pool.ThreadPool]
-    S = TypeVar('S')
-    T = TypeVar('T')
+Pool = Union[pool.Pool, pool.ThreadPool]
+S = TypeVar('S')
+T = TypeVar('T')
 
 # On platforms without sem_open, multiprocessing[.dummy] Pool
 # cannot be created.

--- a/src/pip/_internal/utils/pkg_resources.py
+++ b/src/pip/_internal/utils/pkg_resources.py
@@ -1,9 +1,6 @@
-from typing import TYPE_CHECKING
+from typing import Dict, Iterable, List
 
 from pip._vendor.pkg_resources import yield_lines
-
-if TYPE_CHECKING:
-    from typing import Dict, Iterable, List
 
 
 class DictMetadata:

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -1,8 +1,5 @@
 import sys
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence
 
 # Shim to wrap setup.py invocation with setuptools
 #

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -2,7 +2,7 @@ import logging
 import os
 import shlex
 import subprocess
-from typing import TYPE_CHECKING
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
 
 from pip._internal.cli.spinners import SpinnerInterface, open_spinner
 from pip._internal.exceptions import InstallationSubprocessError
@@ -10,10 +10,7 @@ from pip._internal.utils.compat import console_to_str, str_to_display
 from pip._internal.utils.logging import subprocess_logger
 from pip._internal.utils.misc import HiddenText, path_to_display
 
-if TYPE_CHECKING:
-    from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
-
-    CommandArgs = List[Union[str, HiddenText]]
+CommandArgs = List[Union[str, HiddenText]]
 
 
 LOG_DIVIDER = '----------------------------------------'

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -4,17 +4,13 @@ import logging
 import os.path
 import tempfile
 from contextlib import ExitStack, contextmanager
-from typing import TYPE_CHECKING
+from typing import Any, Dict, Iterator, Optional, TypeVar, Union
 
 from pip._internal.utils.misc import enum, rmtree
 
-if TYPE_CHECKING:
-    from typing import Any, Dict, Iterator, Optional, TypeVar, Union
-
-    _T = TypeVar('_T', bound='TempDirectory')
-
-
 logger = logging.getLogger(__name__)
+
+_T = TypeVar('_T', bound='TempDirectory')
 
 
 # Kinds of temporary directories. Only needed for ones that are

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -7,7 +7,8 @@ import shutil
 import stat
 import tarfile
 import zipfile
-from typing import TYPE_CHECKING
+from typing import Iterable, List, Optional
+from zipfile import ZipInfo
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.utils.filetypes import (
@@ -17,11 +18,6 @@ from pip._internal.utils.filetypes import (
     ZIP_EXTENSIONS,
 )
 from pip._internal.utils.misc import ensure_dir
-
-if TYPE_CHECKING:
-    from typing import Iterable, List, Optional
-    from zipfile import ZipInfo
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/utils/urls.py
+++ b/src/pip/_internal/utils/urls.py
@@ -2,10 +2,7 @@ import os
 import sys
 import urllib.parse
 import urllib.request
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Optional
+from typing import Optional
 
 
 def get_url_scheme(url):

--- a/src/pip/_internal/utils/virtualenv.py
+++ b/src/pip/_internal/utils/virtualenv.py
@@ -3,10 +3,7 @@ import os
 import re
 import site
 import sys
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import List, Optional
+from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 _INCLUDE_SYSTEM_SITE_PACKAGES_REGEX = re.compile(

--- a/src/pip/_internal/utils/wheel.py
+++ b/src/pip/_internal/utils/wheel.py
@@ -2,22 +2,16 @@
 """
 
 import logging
+from email.message import Message
 from email.parser import Parser
-from typing import TYPE_CHECKING
+from typing import Dict, Tuple
 from zipfile import BadZipFile, ZipFile
 
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.pkg_resources import DistInfoDistribution
+from pip._vendor.pkg_resources import DistInfoDistribution, Distribution
 
 from pip._internal.exceptions import UnsupportedWheel
 from pip._internal.utils.pkg_resources import DictMetadata
-
-if TYPE_CHECKING:
-    from email.message import Message
-    from typing import Dict, Tuple
-
-    from pip._vendor.pkg_resources import Distribution
-
 
 VERSION_COMPATIBLE = (1, 0)
 

--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -1,7 +1,6 @@
 # Expose a limited set of classes and functions so callers outside of
 # the vcs package don't need to import deeper than `pip._internal.vcs`.
-# (The test directory and imports protected by TYPE_CHECKING may
-# still need to import from a vcs sub-package.)
+# (The test directory may still need to import from a vcs sub-package.)
 # Import all vcs modules to register each VCS in the VcsSupport object.
 import pip._internal.vcs.bazaar
 import pip._internal.vcs.git

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -1,18 +1,17 @@
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import List, Optional, Tuple
 
-from pip._internal.utils.misc import display_path, rmtree
+from pip._internal.utils.misc import HiddenText, display_path, rmtree
 from pip._internal.utils.subprocess import make_command
 from pip._internal.utils.urls import path_to_url
-from pip._internal.vcs.versioncontrol import RemoteNotFoundError, VersionControl, vcs
-
-if TYPE_CHECKING:
-    from typing import List, Optional, Tuple
-
-    from pip._internal.utils.misc import HiddenText
-    from pip._internal.vcs.versioncontrol import AuthInfo, RevOptions
-
+from pip._internal.vcs.versioncontrol import (
+    AuthInfo,
+    RemoteNotFoundError,
+    RevOptions,
+    VersionControl,
+    vcs,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -3,29 +3,23 @@ import os.path
 import re
 import urllib.parse
 import urllib.request
-from typing import TYPE_CHECKING
+from typing import List, Optional, Tuple
 
+from pip._vendor.packaging.version import _BaseVersion
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import BadCommand, InstallationError
-from pip._internal.utils.misc import display_path, hide_url
+from pip._internal.utils.misc import HiddenText, display_path, hide_url
 from pip._internal.utils.subprocess import make_command
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.vcs.versioncontrol import (
+    AuthInfo,
     RemoteNotFoundError,
+    RevOptions,
     VersionControl,
     find_path_to_setup_from_repo_root,
     vcs,
 )
-
-if TYPE_CHECKING:
-    from typing import List, Optional, Tuple
-
-    from pip._vendor.packaging.version import _BaseVersion
-
-    from pip._internal.utils.misc import HiddenText
-    from pip._internal.vcs.versioncontrol import AuthInfo, RevOptions
-
 
 urlsplit = urllib.parse.urlsplit
 urlunsplit = urllib.parse.urlunsplit

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -1,25 +1,19 @@
 import configparser
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import List, Optional
 
 from pip._internal.exceptions import BadCommand, InstallationError
-from pip._internal.utils.misc import display_path
+from pip._internal.utils.misc import HiddenText, display_path
 from pip._internal.utils.subprocess import make_command
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs.versioncontrol import (
+    RevOptions,
     VersionControl,
     find_path_to_setup_from_repo_root,
     vcs,
 )
-
-if TYPE_CHECKING:
-    from typing import List, Optional
-
-    from pip._internal.utils.misc import HiddenText
-    from pip._internal.vcs.versioncontrol import RevOptions
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -1,33 +1,31 @@
 import logging
 import os
 import re
-from typing import TYPE_CHECKING
+from typing import List, Optional, Tuple
 
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import (
+    HiddenText,
     display_path,
     is_console_interactive,
     rmtree,
     split_auth_from_netloc,
 )
-from pip._internal.utils.subprocess import make_command
-from pip._internal.vcs.versioncontrol import RemoteNotFoundError, VersionControl, vcs
+from pip._internal.utils.subprocess import CommandArgs, make_command
+from pip._internal.vcs.versioncontrol import (
+    AuthInfo,
+    RemoteNotFoundError,
+    RevOptions,
+    VersionControl,
+    vcs,
+)
+
+logger = logging.getLogger(__name__)
 
 _svn_xml_url_re = re.compile('url="([^"]+)"')
 _svn_rev_re = re.compile(r'committed-rev="(\d+)"')
 _svn_info_xml_rev_re = re.compile(r'\s*revision="(\d+)"')
 _svn_info_xml_url_re = re.compile(r'<url>(.*)</url>')
-
-
-if TYPE_CHECKING:
-    from typing import List, Optional, Tuple
-
-    from pip._internal.utils.misc import HiddenText
-    from pip._internal.utils.subprocess import CommandArgs
-    from pip._internal.vcs.versioncontrol import AuthInfo, RevOptions
-
-
-logger = logging.getLogger(__name__)
 
 
 class Subversion(VersionControl):

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -5,12 +5,25 @@ import os
 import shutil
 import sys
 import urllib.parse
-from typing import TYPE_CHECKING
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 from pip._vendor import pkg_resources
 
+from pip._internal.cli.spinners import SpinnerInterface
 from pip._internal.exceptions import BadCommand, InstallationError
 from pip._internal.utils.misc import (
+    HiddenText,
     ask_path_exists,
     backup_dir,
     display_path,
@@ -18,34 +31,15 @@ from pip._internal.utils.misc import (
     hide_value,
     rmtree,
 )
-from pip._internal.utils.subprocess import call_subprocess, make_command
+from pip._internal.utils.subprocess import CommandArgs, call_subprocess, make_command
 from pip._internal.utils.urls import get_url_scheme
-
-if TYPE_CHECKING:
-    from typing import (
-        Any,
-        Dict,
-        Iterable,
-        Iterator,
-        List,
-        Mapping,
-        Optional,
-        Tuple,
-        Type,
-        Union,
-    )
-
-    from pip._internal.cli.spinners import SpinnerInterface
-    from pip._internal.utils.misc import HiddenText
-    from pip._internal.utils.subprocess import CommandArgs
-
-    AuthInfo = Tuple[Optional[str], Optional[str]]
-
 
 __all__ = ['vcs']
 
 
 logger = logging.getLogger(__name__)
+
+AuthInfo = Tuple[Optional[str], Optional[str]]
 
 
 def is_url(name):

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -5,17 +5,19 @@ import logging
 import os.path
 import re
 import shutil
-from typing import TYPE_CHECKING
+from typing import Any, Callable, Iterable, List, Optional, Tuple
 
 from pip._vendor.packaging.utils import canonicalize_name, canonicalize_version
 from pip._vendor.packaging.version import InvalidVersion, Version
 
+from pip._internal.cache import WheelCache
 from pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
 from pip._internal.metadata import get_wheel_distribution
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.operations.build.wheel import build_wheel_pep517
 from pip._internal.operations.build.wheel_legacy import build_wheel_legacy
+from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import ensure_dir, hash_file, is_wheel_installed
 from pip._internal.utils.setuptools_build import make_setuptools_clean_args
@@ -24,18 +26,12 @@ from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import vcs
 
-if TYPE_CHECKING:
-    from typing import Any, Callable, Iterable, List, Optional, Tuple
-
-    from pip._internal.cache import WheelCache
-    from pip._internal.req.req_install import InstallRequirement
-
-    BinaryAllowedPredicate = Callable[[InstallRequirement], bool]
-    BuildResult = Tuple[List[InstallRequirement], List[InstallRequirement]]
-
 logger = logging.getLogger(__name__)
 
 _egg_info_re = re.compile(r'([a-z0-9_.]+)-([a-z0-9_.!+-]+)', re.IGNORECASE)
+
+BinaryAllowedPredicate = Callable[[InstallRequirement], bool]
+BuildResult = Tuple[List[InstallRequirement], List[InstallRequirement]]
 
 
 def _contains_egg_info(s):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import time
 from contextlib import ExitStack, contextmanager
-from typing import TYPE_CHECKING
+from typing import Dict, Iterable
 from unittest.mock import patch
 
 import pytest
@@ -19,16 +19,11 @@ from pip._internal.utils.temp_dir import global_tempdir_manager
 from tests.lib import DATA_DIR, SRC_DIR, PipTestEnvironment, TestData
 from tests.lib.certs import make_tls_cert, serialize_cert, serialize_key
 from tests.lib.path import Path
-from tests.lib.server import make_mock_server, server_running
+from tests.lib.server import MockServer as _MockServer
+from tests.lib.server import Responder, make_mock_server, server_running
 from tests.lib.venv import VirtualEnvironment
 
 from .lib.compat import nullcontext
-
-if TYPE_CHECKING:
-    from typing import Dict, Iterable
-
-    from tests.lib.server import MockServer as _MockServer
-    from tests.lib.server import Responder
 
 
 def pytest_addoption(parser):

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from hashlib import sha256
 from io import BytesIO
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import List, Optional
 from zipfile import ZipFile
 
 import pytest
@@ -21,16 +21,11 @@ from pip._internal.index.package_finder import PackageFinder
 from pip._internal.locations import get_major_minor_version
 from pip._internal.models.search_scope import SearchScope
 from pip._internal.models.selection_prefs import SelectionPreferences
+from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
 from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
 from tests.lib.path import Path, curdir
 from tests.lib.wheel import make_wheel
-
-if TYPE_CHECKING:
-    from typing import List, Optional
-
-    from pip._internal.models.target_python import TargetPython
-
 
 DATA_DIR = Path(__file__).parent.parent.joinpath("data").resolve()
 SRC_DIR = Path(__file__).resolve().parent.parent.parent

--- a/tests/lib/certs.py
+++ b/tests/lib/certs.py
@@ -1,14 +1,11 @@
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import Tuple
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
-
-if TYPE_CHECKING:
-    from typing import Tuple
 
 
 def make_tls_cert(hostname):

--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -1,14 +1,11 @@
 import os
 import subprocess
 import urllib.request
-from typing import TYPE_CHECKING
 
 from pip._internal.utils.misc import hide_url
 from pip._internal.vcs import vcs
 from tests.lib import path_to_url
-
-if TYPE_CHECKING:
-    from tests.lib.path import Path
+from tests.lib.path import Path
 
 
 def _create_svn_initools_repo(initools_dir):

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -5,31 +5,28 @@ import threading
 from base64 import b64encode
 from contextlib import contextmanager
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from types import TracebackType
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 from unittest.mock import Mock
 
-from werkzeug.serving import WSGIRequestHandler
+from werkzeug.serving import BaseWSGIServer, WSGIRequestHandler
 from werkzeug.serving import make_server as _make_server
 
 from .compat import nullcontext
 
-if TYPE_CHECKING:
-    from types import TracebackType
-    from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
+Environ = Dict[str, str]
+Status = str
+Headers = Iterable[Tuple[str, str]]
+ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
+Write = Callable[[bytes], None]
+StartResponse = Callable[[Status, Headers, Optional[ExcInfo]], Write]
+Body = List[bytes]
+Responder = Callable[[Environ, StartResponse], Body]
 
-    from werkzeug.serving import BaseWSGIServer
 
-    Environ = Dict[str, str]
-    Status = str
-    Headers = Iterable[Tuple[str, str]]
-    ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
-    Write = Callable[[bytes], None]
-    StartResponse = Callable[[Status, Headers, Optional[ExcInfo]], Write]
-    Body = List[bytes]
-    Responder = Callable[[Environ, StartResponse], Body]
+class MockServer(BaseWSGIServer):
+    mock = Mock()  # type: Mock
 
-    class MockServer(BaseWSGIServer):
-        mock = Mock()  # type: Mock
 
 # Applies on Python 2 and Windows.
 if not hasattr(signal, "pthread_sigmask"):

--- a/tests/lib/test_wheel.py
+++ b/tests/lib/test_wheel.py
@@ -2,8 +2,8 @@
 """
 import csv
 from email import message_from_string
+from email.message import Message
 from functools import partial
-from typing import TYPE_CHECKING
 from zipfile import ZipFile
 
 from tests.lib.wheel import (
@@ -13,9 +13,6 @@ from tests.lib.wheel import (
     make_wheel_metadata_file,
     message_from_dict,
 )
-
-if TYPE_CHECKING:
-    from email import Message
 
 
 def test_message_from_dict_one_value():

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -10,34 +10,31 @@ from enum import Enum
 from functools import partial
 from hashlib import sha256
 from io import BytesIO, StringIO
-from typing import TYPE_CHECKING
+from typing import (
+    AnyStr,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 from zipfile import ZipFile
 
 from pip._vendor.requests.structures import CaseInsensitiveDict
 
 from tests.lib.path import Path
 
-if TYPE_CHECKING:
-    from typing import (
-        AnyStr,
-        Callable,
-        Dict,
-        Iterable,
-        List,
-        Optional,
-        Sequence,
-        Tuple,
-        TypeVar,
-        Union,
-    )
-
-    # path, digest, size
-    RecordLike = Tuple[str, str, str]
-    RecordCallback = Callable[
-        [List["Record"]], Union[str, bytes, List[RecordLike]]
-    ]
-    # As would be used in metadata
-    HeaderValue = Union[str, List[str]]
+# path, digest, size
+RecordLike = Tuple[str, str, str]
+RecordCallback = Callable[
+    [List["Record"]], Union[str, bytes, List[RecordLike]]
+]
+# As would be used in metadata
+HeaderValue = Union[str, List[str]]
 
 
 File = namedtuple("File", ["name", "contents"])
@@ -50,14 +47,10 @@ class Default(Enum):
 
 _default = Default.token
 
+T = TypeVar("T")
 
-if TYPE_CHECKING:
-    T = TypeVar("T")
-
-    class Defaulted(Union[Default, T]):
-        """A type which may be defaulted.
-        """
-        pass
+# A type which may be defaulted.
+Defaulted = Union[Default, T]
 
 
 def ensure_binary(value):

--- a/tests/unit/test_utils_wheel.py
+++ b/tests/unit/test_utils_wheel.py
@@ -2,16 +2,13 @@ import os
 from contextlib import ExitStack
 from email import message_from_string
 from io import BytesIO
-from typing import TYPE_CHECKING
 from zipfile import ZipFile
 
 import pytest
 
 from pip._internal.exceptions import UnsupportedWheel
 from pip._internal.utils import wheel
-
-if TYPE_CHECKING:
-    from tests.lib.path import Path
+from tests.lib.path import Path
 
 
 @pytest.fixture


### PR DESCRIPTION
The typing module has been available since Python 3.5. Guarding the
import has been unnecessary since dropping Python 2.

Some guards remain to either:

- Avoid circular imports
- Importing objects that are also guarded by typing.TYPE_CHECKING
- Avoid mypy_extensions dependency