### PR TITLE
Order resolution preference by command ordering

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -5,7 +5,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from .base import Constraint
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any, Dict, Iterable, Optional, Sequence, Set, Tuple, Union
+    from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, Union
 
     from .base import Candidate, Requirement
     from .factory import Factory
@@ -46,7 +46,7 @@ class PipProvider(AbstractProvider):
         constraints,  # type: Dict[str, Constraint]
         ignore_dependencies,  # type: bool
         upgrade_strategy,  # type: str
-        user_requested,  # type: Set[str]
+        user_requested,  # type: Dict[str, int]
     ):
         # type: (...) -> None
         self._factory = factory
@@ -77,7 +77,8 @@ class PipProvider(AbstractProvider):
         * If equal, prefer if any requirements contain ``===`` and ``==``.
         * If equal, prefer if requirements include version constraints, e.g.
           ``>=`` and ``<``.
-        * If equal, prefer user-specified (non-transitive) requirements.
+        * If equal, prefer user-specified (non-transitive) requirements, and
+          order user-specified requirements by the order they are specified.
         * If equal, order alphabetically for consistency (helps debuggability).
         """
 
@@ -115,8 +116,8 @@ class PipProvider(AbstractProvider):
             return 3
 
         restrictive = _get_restrictive_rating(req for req, _ in information)
-        transitive = all(parent is not None for _, parent in information)
         key = next(iter(candidates)).name if candidates else ""
+        order = self._user_requested.get(key, float("inf"))
 
         # HACK: Setuptools have a very long and solid backward compatibility
         # track record, and extremely few projects would request a narrow,
@@ -128,7 +129,7 @@ class PipProvider(AbstractProvider):
         # while we work on "proper" branch pruning techniques.
         delay_this = (key == "setuptools")
 
-        return (delay_this, restrictive, transitive, key)
+        return (delay_this, restrictive, order, key)
 
     def find_matches(self, requirements):
         # type: (Sequence[Requirement]) -> Iterable[Candidate]

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -79,9 +79,9 @@ class Resolver(BaseResolver):
         # type: (List[InstallRequirement], bool) -> RequirementSet
 
         constraints = {}  # type: Dict[str, Constraint]
-        user_requested = set()  # type: Set[str]
+        user_requested = {}  # type: Dict[str, int]
         requirements = []
-        for req in root_reqs:
+        for i, req in enumerate(root_reqs):
             if req.constraint:
                 # Ensure we only accept valid constraints
                 problem = check_invalid_constraint_type(req)
@@ -96,7 +96,9 @@ class Resolver(BaseResolver):
                     constraints[name] = Constraint.from_ireq(req)
             else:
                 if req.user_supplied and req.name:
-                    user_requested.add(canonicalize_name(req.name))
+                    canonical_name = canonicalize_name(req.name)
+                    if canonical_name not in user_requested:
+                        user_requested[canonical_name] = i
                 r = self.factory.make_requirement_from_install_req(
                     req, requested_extras=(),
                 )

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -69,5 +69,5 @@ def provider(factory):
         constraints={},
         ignore_dependencies=False,
         upgrade_strategy="to-satisfy-only",
-        user_requested=set(),
+        user_requested={},
     )


### PR DESCRIPTION
Fix #9316. The order requirements are specified from the command line (and requirements files) are now carried into the provider, and used to determine preferences. Non-user-specified requirements have `float('inf')`, i.e. always resolved after user-specified requiremenets.

I’m intentionally omitting a news fragment so this change does not show up in the release notes. Otherwise users may (incorrectly) assume this is actually a guarenteed behaviour.