### PR TITLE
Hook reporter to emit a resolution progress file

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -110,10 +110,13 @@ class Resolver(BaseResolver):
             upgrade_strategy=self.upgrade_strategy,
             user_requested=user_requested,
         )
+
+        resolver_progress_path = os.environ.get("PIP_RESOLVER_PROGRESS", "")
         if "PIP_RESOLVER_DEBUG" in os.environ:
-            reporter = PipDebuggingReporter()
+            reporter = PipDebuggingReporter(resolver_progress_path)
         else:
-            reporter = PipReporter()
+            reporter = PipReporter(resolver_progress_path)
+
         resolver = RLResolver(provider, reporter)
 
         try:


### PR DESCRIPTION
This adds an environment variable `PIP_RESOLVER_PROGRESS` that, when set, should be a path to emit a “resolution progress file”. This can be `tail -f`-ed to get an idea what is going on during resolution.

The format looks something like this:

```
Pin  coverage 5.3
 Pin  Python 3.6.12
  Pin  pytest-mock 3.5.0
   Pin  pytest-sugar 0.9.4
   Back pytest-sugar 0.9.4
  Back pytest-mock 3.5.0
  Pin  pytest-mock 3.2.0
   Pin  pytest-sugar 0.9.4
    Pin  pytest-testmon 0.9.13
     Pin  packaging 20.8
      Pin  pyparsing 2.4.7
       Pin  pytest 3.10.1
        Pin  atomicwrites 1.4.0
         Pin  attrs 20.3.0
          Pin  more-itertools 8.6.0
           Pin  pluggy 0.13.1
            Pin  importlib-metadata 3.3.0
             Pin  py 1.10.0
              Pin  six 1.15.0
               Pin  termcolor 1.1.0
                Pin  typing-extensions 3.7.4.3
                 Pin  zipp 3.4.0
                  Pin  setuptools 51.0.0
```

I’ve been using the same approach in resolvelib’s test case to get a quick idea what’s going on when something does not work as expected.