### PR TITLE
Make keyring usage opt-in

### DIFF
--- a/news/8718.bugfix.rst
+++ b/news/8718.bugfix.rst
@@ -1,0 +1,1 @@
+Make keyring support opt-in.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -766,6 +766,15 @@ no_use_pep517 = partial(
     help=SUPPRESS_HELP
 )  # type: Any
 
+use_keyring = partial(
+    Option,
+    '--use-keyring',
+    dest='use_keyring',
+    action='store_true',
+    default=False,
+    help="Attempt to get credentials from the user's keyring."
+)  # type: Any
+
 install_options = partial(
     Option,
     '--install-option',

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -90,6 +90,7 @@ class SessionCommandMixin(CommandContextMixIn):
             ),
             retries=retries if retries is not None else options.retries,
             trusted_hosts=options.trusted_hosts,
+            use_keyring=options.use_keyring,
             index_urls=self._get_index_urls(options),
         )
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -87,11 +87,11 @@ class MultiDomainBasicAuth(AuthBase):
             cls._keyring = None
         return None
 
-
-    def __init__(self, prompting=True, index_urls=None):
-        # type: (bool, Optional[List[str]]) -> None
+    def __init__(self, use_keyring=True, prompting=True, index_urls=None):
+        # type: (bool, bool, Optional[List[str]]) -> None
         self.prompting = prompting
         self.index_urls = index_urls
+        self.use_keyring = use_keyring
         self.passwords = {}  # type: Dict[str, AuthInfo]
         # When the user is prompted to enter credentials and keyring is
         # available, we will offer to save them. If the user accepts,
@@ -162,7 +162,7 @@ class MultiDomainBasicAuth(AuthBase):
                 return netrc_auth
 
         # If we don't have a password and keyring is available, use it.
-        if allow_keyring:
+        if allow_keyring and self.use_keyring:
             # The index url is more specific than the netloc, so try it first
             kr_auth = (
                 self.get_keyring_auth(index_url, username) or

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -234,6 +234,7 @@ class PipSession(requests.Session):
         cache = kwargs.pop("cache", None)
         trusted_hosts = kwargs.pop("trusted_hosts", [])  # type: List[str]
         index_urls = kwargs.pop("index_urls", None)
+        use_keyring = kwargs.pop("use_keyring", False)
 
         super().__init__(*args, **kwargs)
 
@@ -245,7 +246,10 @@ class PipSession(requests.Session):
         self.headers["User-Agent"] = user_agent()
 
         # Attach our Authentication handler to the session
-        self.auth = MultiDomainBasicAuth(index_urls=index_urls)
+        self.auth = MultiDomainBasicAuth(
+            use_keyring=use_keyring,
+            index_urls=index_urls,
+        )
 
         # Create our urllib3.Retry instance which will allow us to customize
         # how we handle retries.


### PR DESCRIPTION
- [x] Made the import of `keyring` lazy
- [x] Added options in `auth.MultiDomainBasicAuth` and `session.PipSession` to disable keyring usage.
- [x] Added corresponding, user-facing knobs: a CLI flag, a config file setting, an environment variable.
- [x] Added a NEWS entry 