### PR TITLE
Remove deprecated support for VCS pseudo URLs

### DIFF
--- a/news/7554.removal.rst
+++ b/news/7554.removal.rst
@@ -1,0 +1,2 @@
+Remove support for VCS pseudo URLs editable requirements. It was emitting
+deprecation warning since version 20.0.

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -118,7 +118,7 @@ def parse_editable(editable_req):
     link = Link(url)
 
     if not link.is_vcs:
-        backends = ", ".join([backend.name + '+' for backend in vcs.backends])
+        backends = ", ".join(f"{backend.name}+" for backend in vcs.backends)
         raise InstallationError(
             f'{editable_req} is not a valid editable requirement. '
             f'It should either be a path to a local project or a VCS URL '

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -115,7 +115,9 @@ def parse_editable(editable_req):
             url = f'{version_control}+{url}'
             break
 
-    if '+' not in url:
+    link = Link(url)
+
+    if not link.is_vcs:
         backends = ", ".join([backend.name + '+' for backend in vcs.backends])
         raise InstallationError(
             f'{editable_req} is not a valid editable requirement. '
@@ -123,16 +125,7 @@ def parse_editable(editable_req):
             f'(beginning with {backends}).'
         )
 
-    vc_type = url.split('+', 1)[0].lower()
-
-    if not vcs.get_backend(vc_type):
-        backends = ", ".join([bends.name + '+URL' for bends in vcs.backends])
-        error_message = "For --editable={}, " \
-                        "only {} are currently supported".format(
-                            editable_req, backends)
-        raise InstallationError(error_message)
-
-    package_name = Link(url).egg_fragment
+    package_name = link.egg_fragment
     if not package_name:
         raise InstallationError(
             "Could not detect requirement name for '{}', please specify one "

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -118,7 +118,7 @@ def parse_editable(editable_req):
     link = Link(url)
 
     if not link.is_vcs:
-        backends = ", ".join(f"{backend.name}+" for backend in vcs.backends)
+        backends = ", ".join(vcs.all_schemes)
         raise InstallationError(
             f'{editable_req} is not a valid editable requirement. '
             f'It should either be a path to a local project or a VCS URL '

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -116,10 +116,11 @@ def parse_editable(editable_req):
             break
 
     if '+' not in url:
+        backends = ", ".join([backend.name + '+' for backend in vcs.backends])
         raise InstallationError(
-            '{} is not a valid editable requirement. '
-            'It should either be a path to a local project or a VCS URL '
-            '(beginning with svn+, git+, hg+, or bzr+).'.format(editable_req)
+            f'{editable_req} is not a valid editable requirement. '
+            f'It should either be a path to a local project or a VCS URL '
+            f'(beginning with {backends}).'
         )
 
     vc_type = url.split('+', 1)[0].lower()

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -26,7 +26,7 @@ class Bazaar(VersionControl):
     repo_name = 'branch'
     schemes = (
         'bzr', 'bzr+http', 'bzr+https', 'bzr+ssh', 'bzr+sftp', 'bzr+ftp',
-        'bzr+lp',
+        'bzr+lp', 'bzr+file'
     )
 
     @staticmethod

--- a/src/pip/_internal/vcs/bazaar.py
+++ b/src/pip/_internal/vcs/bazaar.py
@@ -25,7 +25,7 @@ class Bazaar(VersionControl):
     dirname = '.bzr'
     repo_name = 'branch'
     schemes = (
-        'bzr', 'bzr+http', 'bzr+https', 'bzr+ssh', 'bzr+sftp', 'bzr+ftp',
+        'bzr+http', 'bzr+https', 'bzr+ssh', 'bzr+sftp', 'bzr+ftp',
         'bzr+lp', 'bzr+file'
     )
 

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -47,7 +47,7 @@ class Git(VersionControl):
     dirname = '.git'
     repo_name = 'clone'
     schemes = (
-        'git', 'git+http', 'git+https', 'git+ssh', 'git+git', 'git+file',
+        'git+http', 'git+https', 'git+ssh', 'git+git', 'git+file',
     )
     # Prevent the user's environment variables from interfering with pip:
     # https://github.com/pypa/pip/issues/1130

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -30,7 +30,7 @@ class Mercurial(VersionControl):
     dirname = '.hg'
     repo_name = 'clone'
     schemes = (
-        'hg', 'hg+file', 'hg+http', 'hg+https', 'hg+ssh', 'hg+static-http',
+        'hg+file', 'hg+http', 'hg+https', 'hg+ssh', 'hg+static-http',
     )
 
     @staticmethod

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -38,7 +38,7 @@ class Subversion(VersionControl):
     dirname = '.svn'
     repo_name = 'checkout'
     schemes = (
-        'svn', 'svn+ssh', 'svn+http', 'svn+https', 'svn+svn', 'svn+file'
+        'svn+ssh', 'svn+http', 'svn+https', 'svn+svn', 'svn+file'
     )
 
     @classmethod

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -37,7 +37,9 @@ class Subversion(VersionControl):
     name = 'svn'
     dirname = '.svn'
     repo_name = 'checkout'
-    schemes = ('svn', 'svn+ssh', 'svn+http', 'svn+https', 'svn+svn')
+    schemes = (
+        'svn', 'svn+ssh', 'svn+http', 'svn+https', 'svn+svn', 'svn+file'
+    )
 
     @classmethod
     def should_add_vcs_url_prefix(cls, remote_url):

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pip._internal.utils.urls import path_to_url
 from tests.lib import pyversion  # noqa: F401
 from tests.lib import (
     _change_test_package_version,
@@ -454,7 +455,7 @@ def test_check_submodule_addition(script):
     )
 
     install_result = script.pip(
-        'install', '-e', 'git+' + module_path + '#egg=version_pkg'
+        'install', '-e', 'git+' + path_to_url(module_path) + '#egg=version_pkg'
     )
     install_result.did_create(
         script.venv / 'src/version-pkg/testpkg/static/testfile'
@@ -467,7 +468,7 @@ def test_check_submodule_addition(script):
 
     # expect error because git may write to stderr
     update_result = script.pip(
-        'install', '-e', 'git+' + module_path + '#egg=version_pkg',
+        'install', '-e', 'git+' + path_to_url(module_path) + '#egg=version_pkg',
         '--upgrade',
     )
 


### PR DESCRIPTION
This transforms the deprecation introduced in pip 20.0 into an error, simplifying the code and enabling easier reasoning about editable requirements (which are now guaranteed to be URLs or local directories).

In #7554, there was [one user comment](https://github.com/pypa/pip/issues/7554#issuecomment-674147501) about the `git+locadir#egg=...` syntax which found a satisfactory alternative.

Closes #7554 