### PR TITLE
-v shows subprocess output

### DIFF
--- a/news/9447.feature.rst
+++ b/news/9447.feature.rst
@@ -1,0 +1,1 @@
+Require ``-vv`` for full debug-level output, ``-v`` now only enables showing subprocess output, e.g. of ``setup.py install``.

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -246,7 +246,7 @@ def setup_logging(verbosity, no_color, user_log_file):
     """
 
     # Determine the level to be logging at.
-    if verbosity >= 1:
+    if verbosity >= 2:
         level = "DEBUG"
     elif verbosity == -1:
         level = "WARNING"
@@ -256,6 +256,14 @@ def setup_logging(verbosity, no_color, user_log_file):
         level = "CRITICAL"
     else:
         level = "INFO"
+
+    if verbosity == 1:
+        # verbosity 1 means only subprocess logging is debug-level
+        # disabling capture of subprocess output
+        subprocess_level = "DEBUG"
+        subprocess_logger.setLevel(subprocess_level)
+    else:
+        subprocess_level = level
 
     level_number = getattr(logging, level)
 
@@ -334,7 +342,7 @@ def setup_logging(verbosity, no_color, user_log_file):
             # A handler responsible for logging to the console messages
             # from the "subprocessor" logger.
             "console_subprocess": {
-                "level": level,
+                "level": subprocess_level,
                 "class": handler_classes["stream"],
                 "no_color": no_color,
                 "stream": log_streams["stderr"],

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -80,7 +80,7 @@ class TestCommand:
         """
         Test raising BrokenStdoutLoggingError with debug logging enabled.
         """
-        stderr = self.call_main(capsys, ['-v'])
+        stderr = self.call_main(capsys, ['-vv'])
 
         assert 'ERROR: Pipe to stdout was broken' in stderr
         assert 'Traceback (most recent call last):' in stderr

--- a/tests/unit/test_utils_subprocess.py
+++ b/tests/unit/test_utils_subprocess.py
@@ -255,6 +255,7 @@ class TestCallSubprocess:
             command = 'print("Hello"); print("world")'
 
         caplog.set_level(log_level)
+        subprocess_logger.setLevel(log_level)
         spinner = FakeSpinner()
         args = [sys.executable, '-c', command]
 


### PR DESCRIPTION
verbosity level 1 sets subprocess log level to debug (showing subprocess output), while level 2 sets all logging to debug-level. This solves the common problem of disabling suppression of setup.py output without being buried in debug output of getting dependencies from PyPI. Closes #8856.

requires `-vv` to enable full debug-level output, which is the current behavior of `-v`.

It would map more naturally to the multi-level `-vvv` to have more than one two log levels, as `-vv` currently produces exactly the same output as `-v`, as far as I can tell. But I expect that using custom log levels (e.g. 15 for VERBOSE) is probably not preferred? The [python docs](https://docs.python.org/3/howto/logging.html#custom-levels) argue pretty strongly against custom log levels, but they are supported, if that seems better.

TODO:

- [x] assign PR number to news file (need to open PR first!)
- [ ] update any affected tests
- [ ] decide if custom log level is preferred
