### PR TITLE
Add separator for log file, shorten timestamps, use . for msecs

### DIFF
--- a/news/9457.feature.rst
+++ b/news/9457.feature.rst
@@ -1,0 +1,1 @@
+Add separator for file log, shorten timestamps, use . for msecs

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -6,6 +6,7 @@ import optparse
 import os
 import sys
 import traceback
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from pip._internal.cli import cmdoptions
@@ -185,6 +186,9 @@ class Command(CommandContextMixIn):
             )
 
         try:
+            timestart = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+            logger.debug("--- Logging started %s ---", timestart)
+
             status = self.run(options, args)
             assert isinstance(status, int)
             return status

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -7,7 +7,6 @@ import logging
 import logging.handlers
 import os
 import sys
-from datetime import datetime
 from logging import Filter, getLogger
 from typing import TYPE_CHECKING
 
@@ -371,8 +370,5 @@ def setup_logging(verbosity, no_color, user_log_file):
             }
         },
     })
-
-    timestart = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
-    logger.debug("--- Logging started %s ---", timestart)
 
     return level_number

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -373,6 +373,6 @@ def setup_logging(verbosity, no_color, user_log_file):
     })
 
     timestart = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
-    logger.debug(f"--- Logging started {timestart} ---")
+    logger.debug("--- Logging started %s ---", timestart)
 
     return level_number

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -7,6 +7,7 @@ import logging
 import logging.handlers
 import os
 import sys
+from datetime import datetime
 from logging import Filter, getLogger
 from typing import TYPE_CHECKING
 
@@ -33,6 +34,7 @@ except Exception:
 
 _log_state = threading.local()
 subprocess_logger = getLogger('pip.subprocessor')
+logger = getLogger(__name__)
 
 
 class BrokenStdoutLoggingError(Exception):
@@ -85,7 +87,8 @@ def get_indentation():
 
 
 class IndentingFormatter(logging.Formatter):
-    default_time_format = "%Y-%m-%dT%H:%M:%S"
+    default_time_format = "%H:%M:%S"
+    default_msec_format = '%s.%03d'
 
     def __init__(
         self,
@@ -368,5 +371,8 @@ def setup_logging(verbosity, no_color, user_log_file):
             }
         },
     })
+
+    timestart = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+    logger.debug(f"--- Logging started {timestart} ---")
 
     return level_number

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -87,7 +87,7 @@ def get_indentation():
 
 class IndentingFormatter(logging.Formatter):
     default_time_format = "%H:%M:%S"
-    default_msec_format = '%s.%03d'
+    default_msec_format = "%s.%03d"
 
     def __init__(
         self,

--- a/tests/functional/test_broken_stdout.py
+++ b/tests/functional/test_broken_stdout.py
@@ -10,7 +10,7 @@ else:
     _BROKEN_STDOUT_RETURN_CODE = 120
 
 
-def setup_broken_stdout_test(args, deprecated_python):
+def setup_broken_stdout_test(args):
     proc = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     )
@@ -19,21 +19,17 @@ def setup_broken_stdout_test(args, deprecated_python):
     returncode = proc.wait()
     stderr = proc.stderr.read().decode('utf-8')
 
-    expected_msg = 'ERROR: Pipe to stdout was broken'
-    if deprecated_python:
-        assert expected_msg in stderr
-    else:
-        assert stderr.startswith(expected_msg)
+    assert 'ERROR: Pipe to stdout was broken' in stderr
 
     return stderr, returncode
 
 
-def test_broken_stdout_pipe(deprecated_python):
+def test_broken_stdout_pipe():
     """
     Test a broken pipe to stdout.
     """
     stderr, returncode = setup_broken_stdout_test(
-        ['pip', 'list'], deprecated_python=deprecated_python,
+        ['pip', 'list'],
     )
 
     # Check that no traceback occurs.
@@ -43,14 +39,13 @@ def test_broken_stdout_pipe(deprecated_python):
     assert returncode == _BROKEN_STDOUT_RETURN_CODE
 
 
-def test_broken_stdout_pipe__log_option(deprecated_python, tmpdir):
+def test_broken_stdout_pipe__log_option(tmpdir):
     """
     Test a broken pipe to stdout when --log is passed.
     """
     log_path = os.path.join(str(tmpdir), 'log.txt')
     stderr, returncode = setup_broken_stdout_test(
         ['pip', '--log', log_path, 'list'],
-        deprecated_python=deprecated_python,
     )
 
     # Check that no traceback occurs.
@@ -60,12 +55,12 @@ def test_broken_stdout_pipe__log_option(deprecated_python, tmpdir):
     assert returncode == _BROKEN_STDOUT_RETURN_CODE
 
 
-def test_broken_stdout_pipe__verbose(deprecated_python):
+def test_broken_stdout_pipe__verbose():
     """
     Test a broken pipe to stdout with verbose logging enabled.
     """
     stderr, returncode = setup_broken_stdout_test(
-        ['pip', '-v', 'list'], deprecated_python=deprecated_python,
+        ['pip', '-v', 'list'],
     )
 
     # Check that a traceback occurs and that it occurs at most once.

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -355,7 +355,11 @@ def test_cache_purge_too_many_args(
     cached http files or wheels."""
     result = script.pip('cache', 'purge', 'aaa', '--verbose',
                         expect_error=True)
-    assert result.stdout == ''
+
+    output = result.stdout.splitlines()
+    assert len(output) == 1
+    assert output[0].startswith('--- Logging started')
+    assert output[0].endswith('---')
 
     # This would be `result.stderr == ...`, but pip prints deprecation
     # warnings on Python 2.7, so we check if the _line_ is in stderr.

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -102,7 +102,9 @@ def test_log_command_success(fixed_time, tmpdir):
     log_path = tmpdir.joinpath('log')
     cmd.main(['fake', '--log', log_path])
     with open(log_path) as f:
-        assert f.read().rstrip() == '2019-01-17T06:00:37,040 fake'
+        c = f.read().splitlines()
+        assert c[0].startswith('06:00:37.040 --- Logging started')
+        assert c[1].startswith('06:00:37.040 fake')
 
 
 def test_log_command_error(fixed_time, tmpdir):
@@ -111,7 +113,9 @@ def test_log_command_error(fixed_time, tmpdir):
     log_path = tmpdir.joinpath('log')
     cmd.main(['fake', '--log', log_path])
     with open(log_path) as f:
-        assert f.read().startswith('2019-01-17T06:00:37,040 fake')
+        c = f.read().splitlines()
+        assert c[0].startswith('06:00:37.040 ---')
+        assert c[1].startswith('06:00:37.040 fake')
 
 
 def test_log_file_command_error(fixed_time, tmpdir):
@@ -120,7 +124,9 @@ def test_log_file_command_error(fixed_time, tmpdir):
     log_file_path = tmpdir.joinpath('log_file')
     cmd.main(['fake', '--log-file', log_file_path])
     with open(log_file_path) as f:
-        assert f.read().startswith('2019-01-17T06:00:37,040 fake')
+        c = f.read().splitlines()
+        assert c[0].startswith('06:00:37.040 ---')
+        assert c[1].startswith('06:00:37.040 fake')
 
 
 def test_log_unicode_messages(fixed_time, tmpdir):

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -49,11 +49,11 @@ class TestIndentingFormatter:
 
     @pytest.mark.parametrize('level_name, expected', [
         ('INFO',
-         '2019-01-17T06:00:37,040 hello\n'
-         '2019-01-17T06:00:37,040 world'),
+         '06:00:37.040 hello\n'
+         '06:00:37.040 world'),
         ('WARNING',
-         '2019-01-17T06:00:37,040 WARNING: hello\n'
-         '2019-01-17T06:00:37,040 world'),
+         '06:00:37.040 WARNING: hello\n'
+         '06:00:37.040 world'),
     ])
     def test_format_with_timestamp(self, level_name, expected, utc):
         record = self.make_record('hello\nworld', level_name=level_name)


### PR DESCRIPTION
After this change, the log file looks like this.

    23:59:51.143 --- Logging started 2021-01-14 20:59:51.143 ---
    23:59:51.163 Created temporary directory: /tmp/pip-ephem-wheel-cache-jjwj2b28

Because the file log is constantly appended, the separator line
allows to quickly find the next run. Date info is moved into the
separator line to free more horizonal space for each line. The
`msec` format was modified, because the default in Python 3 is
using comma.

https://github.com/python/cpython/blob/ddc0fa3a1c1da32359f2019d14cbcfc8eb73498b/Lib/logging/__init__.py#L576

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
