### PR TITLE
Use str to pass versions to avoid debundling issue

### DIFF
--- a/news/9348.bugfix.rst
+++ b/news/9348.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid parsing version to make the version check more robust against lousily
+debundled downstream distributions.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -432,8 +432,16 @@ class InstallRequirement:
         if not existing_dist:
             return
 
-        existing_version = existing_dist.parsed_version
-        if not self.req.specifier.contains(existing_version, prereleases=True):
+        # pkg_resouces may contain a different copy of packaging.version from
+        # pip in if the downstream distributor does a poor job debundling pip.
+        # We avoid existing_dist.parsed_version and let SpecifierSet.contains
+        # parses the version instead.
+        existing_version = existing_dist.version
+        version_compatible = (
+            existing_version is not None and
+            self.req.specifier.contains(existing_version, prereleases=True)
+        )
+        if not version_compatible:
             self.satisfied_by = None
             if use_user_site:
                 if dist_in_usersite(existing_dist):


### PR DESCRIPTION
Fix #9348. `SpecifierSet.contains` automatically parses a string into `Version`, so we can just avoid using `parsed_version` here to avoid issues from a poorly-debundled downstream. The change is pretty cheap and straightforward, and I feel it’s easier to include the workaround so we can avoid the need to explain things when users inevitably report the issue here.