### PR TITLE
Convert pip._internal.configuration.kinds to enum.Enum

### DIFF
--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -7,8 +7,8 @@ import textwrap
 import pytest
 
 from pip._internal.cli.status_codes import ERROR
-from pip._internal.configuration import CONFIG_BASENAME, get_configuration_files
-from tests.lib.configuration_helpers import ConfigurationMixin, kinds
+from pip._internal.configuration import CONFIG_BASENAME, Kind, get_configuration_files
+from tests.lib.configuration_helpers import ConfigurationMixin
 
 
 def test_no_options_passed_should_error(script):
@@ -25,7 +25,7 @@ class TestBasicLoading(ConfigurationMixin):
             hello = 1
         """
 
-        with self.patched_file(kinds.USER, contents):
+        with self.patched_file(Kind.USER, contents):
             result = script.pip("config", "list")
 
         assert "test.hello=1" in result.stdout
@@ -111,7 +111,7 @@ class TestBasicLoading(ConfigurationMixin):
         """
 
         # Use new config file
-        new_config_file = get_configuration_files()[kinds.USER][1]
+        new_config_file = get_configuration_files()[Kind.USER][1]
 
         script.pip("config", "--user", "set", "global.timeout", "60")
         script.pip("config", "--user", "set", "freeze.timeout", "10")
@@ -147,6 +147,6 @@ class TestBasicLoading(ConfigurationMixin):
         # locations. Additionally we cannot patch those paths since pip config
         # commands runs inside a subprocess.
         # So we just check if the file can be identified
-        global_config_file = get_configuration_files()[kinds.GLOBAL][0]
+        global_config_file = get_configuration_files()[Kind.GLOBAL][0]
         result = script.pip("config", "debug")
         assert f"{global_config_file}, exists:" in result.stdout

--- a/tests/lib/configuration_helpers.py
+++ b/tests/lib/configuration_helpers.py
@@ -10,9 +10,6 @@ import textwrap
 import pip._internal.configuration
 from pip._internal.utils.misc import ensure_dir
 
-# This is so that tests don't need to import pip._internal.configuration.
-kinds = pip._internal.configuration.kinds
-
 
 class ConfigurationMixin:
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -4,7 +4,7 @@
 import pytest
 from mock import MagicMock
 
-from pip._internal.configuration import get_configuration_files, kinds
+from pip._internal.configuration import Kind, get_configuration_files
 from pip._internal.exceptions import ConfigurationError
 from tests.lib.configuration_helpers import ConfigurationMixin
 
@@ -12,19 +12,19 @@ from tests.lib.configuration_helpers import ConfigurationMixin
 class TestConfigurationLoading(ConfigurationMixin):
 
     def test_global_loading(self):
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "1"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "1"})
 
         self.configuration.load()
         assert self.configuration.get_value("test.hello") == "1"
 
     def test_user_loading(self):
-        self.patch_configuration(kinds.USER, {"test.hello": "2"})
+        self.patch_configuration(Kind.USER, {"test.hello": "2"})
 
         self.configuration.load()
         assert self.configuration.get_value("test.hello") == "2"
 
     def test_site_loading(self):
-        self.patch_configuration(kinds.SITE, {"test.hello": "3"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "3"})
 
         self.configuration.load()
         assert self.configuration.get_value("test.hello") == "3"
@@ -87,49 +87,49 @@ class TestConfigurationPrecedence(ConfigurationMixin):
     # configuration options
 
     def test_env_overides_site(self):
-        self.patch_configuration(kinds.SITE, {"test.hello": "1"})
-        self.patch_configuration(kinds.ENV, {"test.hello": "0"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "1"})
+        self.patch_configuration(Kind.ENV, {"test.hello": "0"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "0"
 
     def test_env_overides_user(self):
-        self.patch_configuration(kinds.USER, {"test.hello": "2"})
-        self.patch_configuration(kinds.ENV, {"test.hello": "0"})
+        self.patch_configuration(Kind.USER, {"test.hello": "2"})
+        self.patch_configuration(Kind.ENV, {"test.hello": "0"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "0"
 
     def test_env_overides_global(self):
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "3"})
-        self.patch_configuration(kinds.ENV, {"test.hello": "0"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "3"})
+        self.patch_configuration(Kind.ENV, {"test.hello": "0"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "0"
 
     def test_site_overides_user(self):
-        self.patch_configuration(kinds.USER, {"test.hello": "2"})
-        self.patch_configuration(kinds.SITE, {"test.hello": "1"})
+        self.patch_configuration(Kind.USER, {"test.hello": "2"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "1"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "1"
 
     def test_site_overides_global(self):
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "3"})
-        self.patch_configuration(kinds.SITE, {"test.hello": "1"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "3"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "1"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "1"
 
     def test_user_overides_global(self):
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "3"})
-        self.patch_configuration(kinds.USER, {"test.hello": "2"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "3"})
+        self.patch_configuration(Kind.USER, {"test.hello": "2"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "2"
 
     def test_env_not_overriden_by_environment_var(self, monkeypatch):
-        self.patch_configuration(kinds.ENV, {"test.hello": "1"})
+        self.patch_configuration(Kind.ENV, {"test.hello": "1"})
         monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
@@ -138,7 +138,7 @@ class TestConfigurationPrecedence(ConfigurationMixin):
         assert self.configuration.get_value(":env:.hello") == "5"
 
     def test_site_not_overriden_by_environment_var(self, monkeypatch):
-        self.patch_configuration(kinds.SITE, {"test.hello": "2"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "2"})
         monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
@@ -147,7 +147,7 @@ class TestConfigurationPrecedence(ConfigurationMixin):
         assert self.configuration.get_value(":env:.hello") == "5"
 
     def test_user_not_overriden_by_environment_var(self, monkeypatch):
-        self.patch_configuration(kinds.USER, {"test.hello": "3"})
+        self.patch_configuration(Kind.USER, {"test.hello": "3"})
         monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
@@ -156,7 +156,7 @@ class TestConfigurationPrecedence(ConfigurationMixin):
         assert self.configuration.get_value(":env:.hello") == "5"
 
     def test_global_not_overriden_by_environment_var(self, monkeypatch):
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "4"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "4"})
         monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
@@ -179,7 +179,7 @@ class TestConfigurationModification(ConfigurationMixin):
             assert False, "Should have raised an error."
 
     def test_site_modification(self):
-        self.configuration.load_only = kinds.SITE
+        self.configuration.load_only = Kind.SITE
         self.configuration.load()
 
         # Mock out the method
@@ -191,12 +191,12 @@ class TestConfigurationModification(ConfigurationMixin):
         # get the path to site config file
         assert mymock.call_count == 1
         assert mymock.call_args[0][0] == (
-            get_configuration_files()[kinds.SITE][0]
+            get_configuration_files()[Kind.SITE][0]
         )
 
     def test_user_modification(self):
         # get the path to local config file
-        self.configuration.load_only = kinds.USER
+        self.configuration.load_only = Kind.USER
         self.configuration.load()
 
         # Mock out the method
@@ -209,12 +209,12 @@ class TestConfigurationModification(ConfigurationMixin):
         assert mymock.call_count == 1
         assert mymock.call_args[0][0] == (
             # Use new config file
-            get_configuration_files()[kinds.USER][1]
+            get_configuration_files()[Kind.USER][1]
         )
 
     def test_global_modification(self):
         # get the path to local config file
-        self.configuration.load_only = kinds.GLOBAL
+        self.configuration.load_only = Kind.GLOBAL
         self.configuration.load()
 
         # Mock out the method
@@ -226,5 +226,5 @@ class TestConfigurationModification(ConfigurationMixin):
         # get the path to user config file
         assert mymock.call_count == 1
         assert mymock.call_args[0][0] == (
-            get_configuration_files()[kinds.GLOBAL][-1]
+            get_configuration_files()[Kind.GLOBAL][-1]
         )

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -452,9 +452,9 @@ class TestOptionsConfigFiles:
         "args, expect",
         (
             ([], None),
-            (["--global"], "global"),
-            (["--site"], "site"),
-            (["--user"], "user"),
+            (["--global"], pip._internal.configuration.Kind.GLOBAL),
+            (["--site"], pip._internal.configuration.Kind.SITE),
+            (["--user"], pip._internal.configuration.Kind.USER),
             (["--global", "--user"], PipError),
             (["--global", "--site"], PipError),
             (["--global", "--site", "--user"], PipError),


### PR DESCRIPTION
We have real enums in 3.4+ and don’t need to simulate anymore.