### PR TITLE
Release process now (as of 21.0) produces py3-only wheels

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -324,7 +324,7 @@ def upload_release(session):
     # Sanity check: Make sure the files are correctly named.
     distfile_names = map(os.path.basename, distribution_files)
     expected_distribution_files = [
-        f"pip-{version}-py2.py3-none-any.whl",
+        f"pip-{version}-py3-none-any.whl",
         f"pip-{version}.tar.gz",
     ]
     if sorted(distfile_names) != sorted(expected_distribution_files):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
