### PR TITLE
Remove test for deprecated behaviour that's gone in 21.0

### DIFF
--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -226,32 +226,6 @@ def test_new_resolver_installs_extras(tmpdir, script, root_dep):
     assert_installed(script, base="0.1.0", dep="0.1.0")
 
 
-def test_new_resolver_installs_extras_deprecated(tmpdir, script):
-    req_file = tmpdir.joinpath("requirements.txt")
-    req_file.write_text("base >= 0.1.0[add]")
-
-    create_basic_wheel_for_package(
-        script,
-        "base",
-        "0.1.0",
-        extras={"add": ["dep"]},
-    )
-    create_basic_wheel_for_package(
-        script,
-        "dep",
-        "0.1.0",
-    )
-    result = script.pip(
-        "install",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
-        "-r", req_file,
-        expect_stderr=True
-    )
-    assert "DEPRECATION: Extras after version" in result.stderr
-    assert_installed(script, base="0.1.0", dep="0.1.0")
-
-
 def test_new_resolver_installs_extras_warn_missing(script):
     create_basic_wheel_for_package(
         script,


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
