### PR TITLE
Remove support for extras after specifier in requirements

### DIFF
--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -23,7 +23,6 @@ from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.pyproject import make_pyproject_path
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filetypes import is_archive_file
 from pip._internal.utils.misc import is_installable_dir
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -365,8 +364,7 @@ def parse_req_from_line(name, line_source):
                 spec_str = str(spec)
                 if spec_str.endswith(']'):
                     msg = f"Extras after version '{spec_str}'."
-                    replace = "moving the extras before version specifiers"
-                    deprecated(msg, replacement=replace, gone_in="21.0")
+                    raise InstallationError(msg)
     else:
         req = None
 

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -104,9 +104,9 @@ def test_nonexistent_options_listed_in_order(script, data):
     assert matches == ['nonexistent', 'nope']
 
 
-def test_install_deprecated_extra(script, data):
+def test_install_fails_if_extra_at_end(script, data):
     """
-    Warn about deprecated order of specifiers and extras.
+    Fail if order of specifiers and extras is incorrect.
 
     Test uses a requirements file to avoid a testing issue where
     the specifier gets interpreted as shell redirect.
@@ -114,15 +114,12 @@ def test_install_deprecated_extra(script, data):
     script.scratch_path.joinpath("requirements.txt").write_text(
         "requires_simple_extra>=0.1[extra]"
     )
-    simple = script.site_packages / 'simple'
 
     result = script.pip(
         'install', '--no-index', '--find-links=' + data.find_links,
-        '-r', script.scratch_path / 'requirements.txt', expect_stderr=True,
+        '-r', script.scratch_path / 'requirements.txt', expect_error=True,
     )
-
-    result.did_create(simple)
-    assert ("DEPRECATION: Extras after version" in result.stderr)
+    assert "Extras after version" in result.stderr
 
 
 def test_install_special_extra(script):

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -226,32 +226,6 @@ def test_new_resolver_installs_extras(tmpdir, script, root_dep):
     assert_installed(script, base="0.1.0", dep="0.1.0")
 
 
-def test_new_resolver_installs_extras_deprecated(tmpdir, script):
-    req_file = tmpdir.joinpath("requirements.txt")
-    req_file.write_text("base >= 0.1.0[add]")
-
-    create_basic_wheel_for_package(
-        script,
-        "base",
-        "0.1.0",
-        extras={"add": ["dep"]},
-    )
-    create_basic_wheel_for_package(
-        script,
-        "dep",
-        "0.1.0",
-    )
-    result = script.pip(
-        "install",
-        "--no-cache-dir", "--no-index",
-        "--find-links", script.scratch_path,
-        "-r", req_file,
-        expect_stderr=True
-    )
-    assert "DEPRECATION: Extras after version" in result.stderr
-    assert_installed(script, base="0.1.0", dep="0.1.0")
-
-
 def test_new_resolver_installs_extras_warn_missing(script):
     create_basic_wheel_for_package(
         script,


### PR DESCRIPTION
Deprecated and due for removal in 21.0. Implementing the removal.