### PR TITLE
Update changelog for 20.3.4

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,39 @@
 
 .. towncrier release notes start
 
+20.3.4 (2021-01-23)
+===================
+
+Features
+--------
+
+- ``pip wheel`` now verifies the built wheel contains valid metadata, and can be
+  installed by a subsequent ``pip install``. This can be disabled with
+  ``--no-verify``. (`#9206 <https://github.com/pypa/pip/issues/9206>`_)
+- Improve presentation of XMLRPC errors in pip search. (`#9315 <https://github.com/pypa/pip/issues/9315>`_)
+
+Bug Fixes
+---------
+
+- Fixed hanging VCS subprocess calls when the VCS outputs a large amount of data
+  on stderr. Restored logging of VCS errors that was inadvertently removed in pip
+  20.2. (`#8876 <https://github.com/pypa/pip/issues/8876>`_)
+- Fix error when an existing incompatibility is unable to be applied to a backtracked state. (`#9180 <https://github.com/pypa/pip/issues/9180>`_)
+- New resolver: Discard a faulty distribution, instead of quitting outright.
+  This implementation is taken from 20.2.2, with a fix that always makes the
+  resolver iterate through candidates from indexes lazily, to avoid downloading
+  candidates we do not need. (`#9203 <https://github.com/pypa/pip/issues/9203>`_)
+- New resolver: Discard a source distribution if it fails to generate metadata,
+  instead of quitting outright. This implementation is taken from 20.2.2, with a
+  fix that always makes the resolver iterate through candidates from indexes
+  lazily, to avoid downloading candidates we do not need. (`#9246 <https://github.com/pypa/pip/issues/9246>`_)
+
+Vendored Libraries
+------------------
+
+- Upgrade resolvelib to 0.5.4.
+
+
 20.3.3 (2020-12-15)
 ===================
 

--- a/news/8876.bugfix.rst
+++ b/news/8876.bugfix.rst
@@ -1,3 +1,0 @@
-Fixed hanging VCS subprocess calls when the VCS outputs a large amount of data
-on stderr. Restored logging of VCS errors that was inadvertently removed in pip
-20.2.

--- a/news/9180.bugfix.rst
+++ b/news/9180.bugfix.rst
@@ -1,1 +1,0 @@
-Fix error when an existing incompatibility is unable to be applied to a backtracked state.

--- a/news/9203.bugfix.rst
+++ b/news/9203.bugfix.rst
@@ -1,4 +1,0 @@
-New resolver: Discard a faulty distribution, instead of quitting outright.
-This implementation is taken from 20.2.2, with a fix that always makes the
-resolver iterate through candidates from indexes lazily, to avoid downloading
-candidates we do not need.

--- a/news/9206.feature.rst
+++ b/news/9206.feature.rst
@@ -1,3 +1,0 @@
-``pip wheel`` now verifies the built wheel contains valid metadata, and can be
-installed by a subsequent ``pip install``. This can be disabled with
-``--no-verify``.

--- a/news/9246.bugfix.rst
+++ b/news/9246.bugfix.rst
@@ -1,4 +1,0 @@
-New resolver: Discard a source distribution if it fails to generate metadata,
-instead of quitting outright. This implementation is taken from 20.2.2, with a
-fix that always makes the resolver iterate through candidates from indexes
-lazily, to avoid downloading candidates we do not need.

--- a/news/9315.feature.rst
+++ b/news/9315.feature.rst
@@ -1,1 +1,0 @@
-Improve presentation of XMLRPC errors in pip search.

--- a/news/resolvelib.vendor.rst
+++ b/news/resolvelib.vendor.rst
@@ -1,1 +1,0 @@
-Upgrade resolvelib to 0.5.4.


### PR DESCRIPTION
Taken out of #9494 -- because I can't be bother to make that PR mergable.

We'd want to merge this before cutting 21.0, but after making 20.3.4. :)