### PR TITLE
Docs: update to past tense now pip 21.0 is out

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ We release updates regularly, with a new version every 3 months. Find more detai
 
 In pip 20.3, we've `made a big improvement to the heart of pip`_; `learn more`_. We want your input, so `sign up for our user experience research studies`_ to help us do it right.
 
-**Note**: pip 21.0, in January 2021, will remove Python 2 support, per pip's `Python 2 support policy`_. Please migrate to Python 3.
+**Note**: pip 21.0, in January 2021, removed Python 2 support, per pip's `Python 2 support policy`_. Please migrate to Python 3.
 
 If you find bugs, need help, or want to talk to the developers, please use our mailing lists or chat rooms:
 

--- a/docs/html/index.rst
+++ b/docs/html/index.rst
@@ -25,7 +25,7 @@ Please take a look at our documentation for how to install and use pip:
 
 .. warning::
 
-   pip 21.0, in January 2021, will remove Python 2 support, per pip's
+   pip 21.0, in January 2021, removed Python 2 support, per pip's
    :ref:`Python 2 Support` policy. Please migrate to Python 3.
 
 If you find bugs, need help, or want to talk to the developers, please use our mailing lists or chat rooms:

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -1699,7 +1699,7 @@ errors. Specifically:
 Per our :ref:`Python 2 Support` policy, pip 20.3 users who are using
 Python 2 will use the legacy resolver by default. Python 2 users
 should upgrade to Python 3 as soon as possible, since in pip 21.0 in
-January 2021, pip will drop support for Python 2 altogether.
+January 2021, pip dropped support for Python 2 altogether.
 
 
 How to upgrade and migrate


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

pip 21.0 has been released, dropping support for Python 2.7 🚀 

Update the docs to past tense, for example:
```diff
-pip 21.0, in January 2021, will remove Python 2 support
+pip 21.0, in January 2021, removed Python 2 support
```