### PR TITLE
Better way to run slow linters in CI only

### DIFF
--- a/.pre-commit-config-slow.yaml
+++ b/.pre-commit-config-slow.yaml
@@ -1,7 +1,0 @@
-# Slow pre-commit checks we don't want to run locally with each commit.
-
-repos:
-- repo: https://github.com/mgedmin/check-manifest
-  rev: '0.43'
-  hooks:
-  - id: check-manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'src/pip/_vendor/'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.4.0
   hooks:
   - id: check-builtin-literals
   - id: check-added-large-files
@@ -53,7 +53,7 @@ repos:
 
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
+  rev: 3.8.4
   hooks:
   - id: flake8
     additional_dependencies: [
@@ -63,20 +63,20 @@ repos:
     exclude: tests/data
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.5.3
+  rev: 5.7.0
   hooks:
   - id: isort
     files: \.py$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.790
+  rev: v0.800
   hooks:
   - id: mypy
     exclude: docs|tests
     args: ["--pretty"]
 
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.6.0
+  rev: v1.7.0
   hooks:
   - id: python-no-log-warn
   - id: python-no-eval

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,3 +93,9 @@ repos:
     entry: NEWS fragment files must be named *.(process|removal|feature|bugfix|vendor|doc|trivial).rst
     exclude: ^news/(.gitignore|.*\.(process|removal|feature|bugfix|vendor|doc|trivial).rst)
     files: ^news/
+
+- repo: https://github.com/mgedmin/check-manifest
+  rev: '0.46'
+  hooks:
+  - id: check-manifest
+    stages: [manual]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,7 +17,6 @@ exclude .appveyor.yml
 exclude .travis.yml
 exclude .readthedocs.yml
 exclude .pre-commit-config.yaml
-exclude .pre-commit-config-slow.yaml
 exclude tox.ini
 exclude noxfile.py
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -147,11 +147,9 @@ def lint(session):
         args = session.posargs + ["--all-files"]
     else:
         args = ["--all-files", "--show-diff-on-failure"]
+    args.append("--hook-stage=manual")
 
     session.run("pre-commit", "run", *args)
-    session.run(
-        "pre-commit", "run", "-c", ".pre-commit-config-slow.yaml", *args
-    )
 
 
 @nox.session

--- a/src/pip/_internal/locations.py
+++ b/src/pip/_internal/locations.py
@@ -8,7 +8,7 @@ import os.path
 import site
 import sys
 import sysconfig
-from distutils.command.install import SCHEME_KEYS  # type: ignore
+from distutils.command.install import SCHEME_KEYS
 from distutils.command.install import install as distutils_install_command
 
 from pip._internal.models.scheme import Scheme

--- a/tox.ini
+++ b/tox.ini
@@ -63,8 +63,7 @@ skip_install = True
 commands_pre =
 deps = pre-commit
 commands =
-   pre-commit run [] --all-files --show-diff-on-failure
-   pre-commit run [] -c .pre-commit-config-slow.yaml --all-files --show-diff-on-failure
+   pre-commit run [] --all-files --show-diff-on-failure --hook-stage=manual
 
 [testenv:vendoring]
 basepython = python3


### PR DESCRIPTION
- update pre-commit hooks
- a better implementation of https://github.com/pypa/pip/pull/9333, taking advantage of pre-commit manual hook stages