### PR TITLE
Pin setuptools under 52 for easy_install tests

### DIFF
--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -63,6 +63,9 @@ def test_basic_uninstall_with_scripts(script):
     Uninstall an easy_installed package with scripts.
 
     """
+    # setuptools 52 removed easy_install.
+    script.pip("install", "setuptools==51.3.3", use_module=True)
+
     result = script.easy_install('PyLogo', expect_stderr=True)
     easy_install_pth = script.site_packages / 'easy-install.pth'
     pylogo = sys.platform == 'win32' and 'pylogo' or 'PyLogo'
@@ -81,6 +84,9 @@ def test_uninstall_easy_install_after_import(script):
     Uninstall an easy_installed package after it's been imported
 
     """
+    # setuptools 52 removed easy_install.
+    script.pip("install", "setuptools==51.3.3", use_module=True)
+
     result = script.easy_install('INITools==0.2', expect_stderr=True)
     # the import forces the generation of __pycache__ if the version of python
     # supports it
@@ -104,6 +110,9 @@ def test_uninstall_trailing_newline(script):
     lacks a trailing newline
 
     """
+    # setuptools 52 removed easy_install.
+    script.pip("install", "setuptools==51.3.3", use_module=True)
+
     script.easy_install('INITools==0.2', expect_stderr=True)
     script.easy_install('PyLogo', expect_stderr=True)
     easy_install_pth = script.site_packages_path / 'easy-install.pth'
@@ -285,8 +294,10 @@ def test_uninstall_easy_installed_console_scripts(script):
     """
     Test uninstalling package with console_scripts that is easy_installed.
     """
-    # setuptools >= 42.0.0 deprecates easy_install and prints a warning when
-    # used
+    # setuptools 52 removed easy_install and prints a warning after 42 when
+    # the command is used.
+    script.pip("install", "setuptools==51.3.3", use_module=True)
+
     result = script.easy_install('discover', allow_stderr_warning=True)
     result.did_create(script.bin / 'discover' + script.exe)
     result2 = script.pip('uninstall', 'discover', '-y')


### PR DESCRIPTION
setuptools 52.0.0 (released yesterday) removed `easy_install`, and some tests need to be tweaked to continue to work. These tests ensure `pip uninstall` work as well as it could against `easy_install`-ed packages.