### PR TITLE
Fix for 9505. Exclude empty drafts.

### DIFF
--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -320,6 +320,6 @@ docs_feedback_questions_list = (
 # -- Options for towncrier_draft extension -----------------------------------
 
 towncrier_draft_autoversion_mode = 'draft'  # or: 'sphinx-release', 'sphinx-version'
-towncrier_draft_include_empty = True
+towncrier_draft_include_empty = False
 towncrier_draft_working_directory = pathlib.Path(docs_dir).parent
 # Not yet supported: towncrier_draft_config_path = 'pyproject.toml'  # relative to cwd


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fix for https://github.com/pypa/pip/issues/9505