### PR TITLE
Allow prioritizing package lookup according to their source

### DIFF
--- a/news/6045.feature.rst
+++ b/news/6045.feature.rst
@@ -1,8 +1,9 @@
-Prioritize package lookup according to their source.
+Allow prioritizing package lookup according to their source.
 
-Sources now behave as fallback to each other: if a candidate is found in a
-higher priority source, it will be downloaded from that source even if a higher
-version of the package is found in another source.
+When using ``--use-feature=source-priority``, ources now behave as fallback to
+each other: if a candidate is found in a higher priority source, it will be
+downloaded from that source even if a higher version of the package is found in
+another source.
 
 Sources are ordered from highest to lowest priority as:
 

--- a/news/6045.feature.rst
+++ b/news/6045.feature.rst
@@ -1,0 +1,12 @@
+Prioritize package lookup according to their source.
+
+Sources now behave as fallback to each other: if a candidate is found in a
+higher priority source, it will be downloaded from that source even if a higher
+version of the package is found in another source.
+
+Sources are ordered from highest to lowest priority as:
+
+* ``--find-links`` archives
+* ``--find-links`` links
+* links from PEP 503 indexes: base index (pypi.org or ``--index-url``) first,
+  then other indexes in the order specified by ``--extra-index-url``

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -908,7 +908,7 @@ use_new_feature = partial(
     metavar='feature',
     action='append',
     default=[],
-    choices=['2020-resolver', 'fast-deps'],
+    choices=['2020-resolver', 'fast-deps', 'source-priority'],
     help='Enable new functionality, that may be backward incompatible.',
 )  # type: Callable[..., Option]
 

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -417,6 +417,7 @@ class RequirementCommand(IndexGroupCommand):
             allow_all_prereleases=options.pre,
             prefer_binary=options.prefer_binary,
             ignore_requires_python=ignore_requires_python,
+            use_source_priority='source-priority' in options.features_enabled,
         )
 
         return PackageFinder.create(

--- a/src/pip/_internal/models/candidate.py
+++ b/src/pip/_internal/models/candidate.py
@@ -13,23 +13,24 @@ class InstallationCandidate(KeyBasedCompareMixin):
     """Represents a potential "candidate" for installation.
     """
 
-    __slots__ = ["name", "version", "link"]
+    __slots__ = ["name", "version", "link", "source_priority"]
 
-    def __init__(self, name, version, link):
-        # type: (str, str, Link) -> None
+    def __init__(self, name, version, link, source_priority=0):
+        # type: (str, str, Link, int) -> None
         self.name = name
         self.version = parse_version(version)  # type: _BaseVersion
         self.link = link
+        self.source_priority = source_priority
 
         super().__init__(
-            key=(self.name, self.version, self.link),
+            key=(self.name, self.source_priority, self.version, self.link),
             defining_class=InstallationCandidate
         )
 
     def __repr__(self):
         # type: () -> str
-        return "<InstallationCandidate({!r}, {!r}, {!r})>".format(
-            self.name, self.version, self.link,
+        return "<InstallationCandidate({!r}, {!r}, {!r}, {!r})>".format(
+            self.name, self.version, self.link, self.source_priority
         )
 
     def __str__(self):

--- a/src/pip/_internal/models/selection_prefs.py
+++ b/src/pip/_internal/models/selection_prefs.py
@@ -13,7 +13,8 @@ class SelectionPreferences:
     """
 
     __slots__ = ['allow_yanked', 'allow_all_prereleases', 'format_control',
-                 'prefer_binary', 'ignore_requires_python']
+                 'prefer_binary', 'ignore_requires_python',
+                 'use_source_priority']
 
     # Don't include an allow_yanked default value to make sure each call
     # site considers whether yanked releases are allowed. This also causes
@@ -26,6 +27,7 @@ class SelectionPreferences:
         format_control=None,          # type: Optional[FormatControl]
         prefer_binary=False,          # type: bool
         ignore_requires_python=None,  # type: Optional[bool]
+        use_source_priority=False,    # type: bool
     ):
         # type: (...) -> None
         """Create a SelectionPreferences object.
@@ -39,6 +41,8 @@ class SelectionPreferences:
             dist over a new source dist.
         :param ignore_requires_python: Whether to ignore incompatible
             "Requires-Python" values in links. Defaults to False.
+        :param use_source_priority: Whether to sort candidates using their source
+            priority.
         """
         if ignore_requires_python is None:
             ignore_requires_python = False
@@ -48,3 +52,4 @@ class SelectionPreferences:
         self.format_control = format_control
         self.prefer_binary = prefer_binary
         self.ignore_requires_python = ignore_requires_python
+        self.use_source_priority = use_source_priority

--- a/tests/data/indexes/README.txt
+++ b/tests/data/indexes/README.txt
@@ -13,3 +13,7 @@ for testing url quoting with indexes
 simple
 ------
 contains index page for "simple" pkg
+
+simplev2
+--------
+contains index page for "simple" pkg at version 1 and 2

--- a/tests/data/indexes/simplev2/simple/index.html
+++ b/tests/data/indexes/simplev2/simple/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <a href="../../../packages/simple-1.0.tar.gz#md5=4bdf78ebb7911f215c1972cf71b378f0">simple-1.0.tar.gz</a>
+    <a href="../../../packages/simple-2.0.tar.gz#md5=ca1e43f96df91226a6e0d8f9ce4dcada">simple-2.0.tar.gz</a>
+  </body>
+</html>

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -124,6 +124,7 @@ def make_test_finder(
     allow_all_prereleases=False,  # type: bool
     session=None,                 # type: Optional[PipSession]
     target_python=None,           # type: Optional[TargetPython]
+    use_source_priority=False,    # type: bool
 ):
     # type: (...) -> PackageFinder
     """
@@ -137,6 +138,7 @@ def make_test_finder(
     selection_prefs = SelectionPreferences(
         allow_yanked=True,
         allow_all_prereleases=allow_all_prereleases,
+        use_source_priority=use_source_priority,
     )
 
     return PackageFinder.create(

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -414,6 +414,24 @@ def test_finder_installs_dev_releases(data):
     assert found.link.url.endswith("bar-2.0.dev1.tar.gz"), found.link.url
 
 
+def test_finder_prioritize_first_index(data):
+    """
+    Test PackageFinder prioritizes the first index before the second one.
+    """
+    req = install_req_from_line("simple")
+    index_urls = [data.index_url("simple"), data.index_url("simplev2")]
+
+    finder = make_test_finder(index_urls=index_urls)
+    found = finder.find_requirement(req, False)
+    assert "simple-1.0.tar.gz" in found.link.url
+
+    index_urls.reverse()
+
+    finder = make_test_finder(index_urls=index_urls)
+    found = finder.find_requirement(req, False)
+    assert "simple-2.0.tar.gz" in found.link.url
+
+
 def test_finder_installs_pre_releases_with_version_spec():
     """
     Test PackageFinder only accepts stable versioned releases by default.
@@ -478,7 +496,7 @@ def test_process_project_url(data):
     finder = make_test_finder(index_urls=[index_url])
     link_evaluator = finder.make_link_evaluator(project_name)
     actual = finder.process_project_url(
-        project_url, link_evaluator=link_evaluator,
+        project_url, link_evaluator=link_evaluator, source_priority=0,
     )
 
     assert len(actual) == 1

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -414,20 +414,20 @@ def test_finder_installs_dev_releases(data):
     assert found.link.url.endswith("bar-2.0.dev1.tar.gz"), found.link.url
 
 
-def test_finder_prioritize_first_index(data):
+def test_finder_with_source_priority_prioritize_first_index(data):
     """
     Test PackageFinder prioritizes the first index before the second one.
     """
     req = install_req_from_line("simple")
     index_urls = [data.index_url("simple"), data.index_url("simplev2")]
 
-    finder = make_test_finder(index_urls=index_urls)
+    finder = make_test_finder(index_urls=index_urls, use_source_priority=True)
     found = finder.find_requirement(req, False)
     assert "simple-1.0.tar.gz" in found.link.url
 
     index_urls.reverse()
 
-    finder = make_test_finder(index_urls=index_urls)
+    finder = make_test_finder(index_urls=index_urls, use_source_priority=True)
     found = finder.find_requirement(req, False)
     assert "simple-2.0.tar.gz" in found.link.url
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -58,4 +58,6 @@ class TestInstallationCandidate:
         obj = candidate.InstallationCandidate(
             "A", "1.0.0", "https://somewhere.com/path/A-1.0.0.tar.gz", 1
         )
-        assert obj._compare_key == (obj.name, obj.source_priority, obj.version, obj.link)
+        assert obj._compare_key == (
+            obj.name, obj.source_priority, obj.version, obj.link
+        )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -45,16 +45,17 @@ class TestInstallationCandidate:
 
     def test_sets_correct_variables(self):
         obj = candidate.InstallationCandidate(
-            "A", "1.0.0", "https://somewhere.com/path/A-1.0.0.tar.gz"
+            "A", "1.0.0", "https://somewhere.com/path/A-1.0.0.tar.gz", 1
         )
         assert obj.name == "A"
         assert obj.version == parse_version("1.0.0")
         assert obj.link == "https://somewhere.com/path/A-1.0.0.tar.gz"
+        assert obj.source_priority == 1
 
     # NOTE: This isn't checking the ordering logic; only the data provided to
     #       it is correct.
     def test_sets_the_right_key(self):
         obj = candidate.InstallationCandidate(
-            "A", "1.0.0", "https://somewhere.com/path/A-1.0.0.tar.gz"
+            "A", "1.0.0", "https://somewhere.com/path/A-1.0.0.tar.gz", 1
         )
-        assert obj._compare_key == (obj.name, obj.version, obj.link)
+        assert obj._compare_key == (obj.name, obj.source_priority, obj.version, obj.link)


### PR DESCRIPTION
This is a first try for  #6045.

Previously, installation candidates would (roughly) be ordered by version only.
With this change, a source priority is introduced, making sources behave as fallbacks to each other: if a candidate is found in a higher priority source, it will be downloaded from that source even if a higher version of the package is found in another source.
Sources are ordered from highest to lowest priority as: find_links archives, find_links links, index urls in order.
At least that's what I believe is happening based on how ``--find-links`` and ``--extra-index-url`` are documented, but ``LinkCollector.collect_links`` seems to be slightly different. 

I'm aware that this changes the behavior of package resolution as decribed in [Satisfying Requirements](https://pip.pypa.io/en/latest/reference/pip_install/#satisfying-requirements), so I don't know if this should be hidden behind a feature flag or something like that.
