### PR TITLE
Experiemental trove classifiers checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,17 @@ repos:
     exclude: ^news/(.gitignore|.*\.(process|removal|feature|bugfix|vendor|doc|trivial).rst)
     files: ^news/
 
+- repo: local
+  hooks:
+  - id: check-trove-classifiers
+    name: Check Trove Classifiers
+    language: python
+    language_version: python3
+    additional_dependencies:
+      - trove-classifiers
+    entry: python tools/check_trove_classifiers.py
+    files: ^setup\.(py|cfg)
+
 - repo: https://github.com/mgedmin/check-manifest
   rev: '0.46'
   hooks:

--- a/tools/check_trove_classifiers.py
+++ b/tools/check_trove_classifiers.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+
+from trove_classifiers import classifiers
+
+
+def main() -> int:
+    ours = subprocess.check_output(
+        [sys.executable, "setup.py", "--classifiers"],
+        encoding="utf-8",
+        text=True,
+    ).splitlines(keepends=False)
+
+    wrong_lines = [line for line in ours if line not in classifiers]
+    if not wrong_lines:
+        return 0
+
+    print("Invalid trove classifiers found:")
+    for line in wrong_lines:
+        print("   ", line)
+    return len(wrong_lines)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fix #9499.

Eventually it’s probably a good idea to modify the logic to use PEP 517 instead of `setup.py` directly, and split the script into a separate repository since this is a good tool for Python projects in general. But that would depend on [pypa/build to support the `prepare_metadata_for_build_wheel`](https://github.com/pypa/build/issues/130) first.

---

How to test this:

* Make the classifier invalid (e.g. removing a trailing comma)
* `git add setup.py`
* `pre-commit run check-trove-classifiers` should fail with an error