### PR TITLE
Fix typo in _iter_built docstring

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/found_candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/found_candidates.py
@@ -28,7 +28,7 @@ def _iter_built(infos):
     # type: (Iterator[IndexCandidateInfo]) -> Iterator[Candidate]
     """Iterator for ``FoundCandidates``.
 
-    This iterator is used the package is not already installed. Candidates
+    This iterator is used when the package is not already installed. Candidates
     from index come later in their normal ordering.
     """
     versions_found = set()  # type: Set[_BaseVersion]


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
See https://github.com/pypa/pip/pull/9522#discussion_r567143029.
