### PR TITLE
_vendor/README.rst: link to pypi.org/project/vendoring 

### DIFF
--- a/src/pip/_vendor/README.rst
+++ b/src/pip/_vendor/README.rst
@@ -116,7 +116,7 @@ Modifications
 Automatic Vendoring
 ===================
 
-Vendoring is automated via the ``vendoring`` tool from the content of
+Vendoring is automated via the `vendoring <https://pypi.org/project/vendoring/>`_ tool from the content of
 ``pip/_vendor/vendor.txt`` and the different patches in
 ``tools/automation/vendoring/patches``.
 Launch it via ``vendoring sync . -v`` (requires ``vendoring>=0.2.2``).


### PR DESCRIPTION
I got confused and searched for a tool called "vendoring" in this repository. Hopefully this will save some time to the next person trying to figure out how to run the vendoring tool.
