### PR TITLE
Fix error reporting on Requires-Python conflicts

### DIFF
--- a/news/9541.bugfix.rst
+++ b/news/9541.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect reporting on ``Requires-Python`` conflicts.

--- a/tests/functional/test_new_resolver_errors.py
+++ b/tests/functional/test_new_resolver_errors.py
@@ -1,4 +1,6 @@
-from tests.lib import create_basic_wheel_for_package
+import sys
+
+from tests.lib import create_basic_wheel_for_package, create_test_package_with_setup
 
 
 def test_new_resolver_conflict_requirements_file(tmpdir, script):
@@ -45,3 +47,29 @@ def test_new_resolver_conflict_constraints_file(tmpdir, script):
 
     message = "The user requested (constraint) pkg!=1.0"
     assert message in result.stdout, str(result)
+
+
+def test_new_resolver_requires_python_error(script):
+    compatible_python = ">={0.major}.{0.minor}".format(sys.version_info)
+    incompatible_python = "<{0.major}.{0.minor}".format(sys.version_info)
+
+    pkga = create_test_package_with_setup(
+        script,
+        name="pkga",
+        version="1.0",
+        python_requires=compatible_python,
+    )
+    pkgb = create_test_package_with_setup(
+        script,
+        name="pkgb",
+        version="1.0",
+        python_requires=incompatible_python,
+    )
+
+    # This always fails because pkgb can never be satisfied.
+    result = script.pip("install", "--no-index", pkga, pkgb, expect_error=True)
+
+    # The error message should mention the Requires-Python: value causing the
+    # conflict, not the compatible one.
+    assert incompatible_python in result.stderr, str(result)
+    assert compatible_python not in result.stderr, str(result)


### PR DESCRIPTION
Fix #9541.

Currently, when resolution fails, the error message only shows a `Requires-Python` line if there is any in the graph. However, the `RequiresPythonRequirement` is not necessarily the actual cause to the failure.

A check is added to make sure the `RequiresPythonRequirement` objects are actually not satisfying, and only report a `Requires-Python` error if any is. Some extra logic is also added when there are more than one unsatisfying `RequiresPythonRequirement` objects, to show all of them instead of just the first one.