### PR TITLE
Remove direct pkg_resources usage in wheel_builder

### DIFF
--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -3,7 +3,7 @@ from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 if MYPY_CHECK_RUNNING:
     from typing import List, Optional
 
-    from .base import BaseEnvironment
+    from .base import BaseDistribution, BaseEnvironment
 
 
 def get_default_environment():
@@ -30,3 +30,17 @@ def get_environment(paths):
     from .pkg_resources import Environment
 
     return Environment.from_paths(paths)
+
+
+def get_wheel_distribution(wheel_path, canonical_name):
+    # type: (str, str) -> BaseDistribution
+    """Get the representation of the specified wheel's distribution metadata.
+
+    This returns a Distribution instance from the chosen backend based on
+    the given wheel's ``.dist-info`` directory.
+
+    :param canonical_name: Normalized project name of the given wheel.
+    """
+    from .pkg_resources import Distribution
+
+    return Distribution.from_wheel(wheel_path, canonical_name)

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -9,6 +9,12 @@ if MYPY_CHECK_RUNNING:
 
 class BaseDistribution:
     @property
+    def metadata_version(self):
+        # type: () -> Optional[str]
+        """Value of "Metadata-Version:" in the distribution, if available."""
+        raise NotImplementedError()
+
+    @property
     def canonical_name(self):
         # type: () -> str
         raise NotImplementedError()

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -5,13 +5,12 @@ import logging
 import os.path
 import re
 import shutil
-import zipfile
 
 from pip._vendor.packaging.utils import canonicalize_name, canonicalize_version
 from pip._vendor.packaging.version import InvalidVersion, Version
-from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
+from pip._internal.metadata import get_wheel_distribution
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.operations.build.wheel import build_wheel_pep517
@@ -23,7 +22,6 @@ from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 from pip._internal.utils.urls import path_to_url
-from pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
 from pip._internal.vcs import vcs
 
 if MYPY_CHECK_RUNNING:
@@ -171,19 +169,6 @@ def _always_true(_):
     return True
 
 
-def _get_metadata_version(dist):
-    # type: (Distribution) -> Optional[Version]
-    for line in dist.get_metadata_lines(dist.PKG_INFO):
-        if line.lower().startswith("metadata-version:"):
-            value = line.split(":", 1)[-1].strip()
-            try:
-                return Version(value)
-            except InvalidVersion:
-                msg = "Invalid Metadata-Version: {}".format(value)
-                raise UnsupportedWheel(msg)
-    raise UnsupportedWheel("Missing Metadata-Version")
-
-
 def _verify_one(req, wheel_path):
     # type: (InstallRequirement, str) -> None
     canonical_name = canonicalize_name(req.name)
@@ -193,20 +178,25 @@ def _verify_one(req, wheel_path):
             "Wheel has unexpected file name: expected {!r}, "
             "got {!r}".format(canonical_name, w.name),
         )
-    with zipfile.ZipFile(wheel_path, allowZip64=True) as zf:
-        dist = pkg_resources_distribution_for_wheel(
-            zf, canonical_name, wheel_path,
-        )
+    dist = get_wheel_distribution(wheel_path, canonical_name)
     if canonicalize_version(dist.version) != canonicalize_version(w.version):
         raise InvalidWheelFilename(
             "Wheel has unexpected file name: expected {!r}, "
-            "got {!r}".format(dist.version, w.version),
+            "got {!r}".format(str(dist.version), w.version),
         )
-    if (_get_metadata_version(dist) >= Version("1.2")
-            and not isinstance(dist.parsed_version, Version)):
+    metadata_version_value = dist.metadata_version
+    if metadata_version_value is None:
+        raise UnsupportedWheel("Missing Metadata-Version")
+    try:
+        metadata_version = Version(metadata_version_value)
+    except InvalidVersion:
+        msg = "Invalid Metadata-Version: {}".format(metadata_version_value)
+        raise UnsupportedWheel(msg)
+    if (metadata_version >= Version("1.2")
+            and not isinstance(dist.version, Version)):
         raise UnsupportedWheel(
             "Metadata 1.2 mandates PEP 440 version, "
-            "but {!r} is not".format(dist.version)
+            "but {!r} is not".format(str(dist.version))
         )
 
 


### PR DESCRIPTION
This needs a way to build `Distribution` from inside a zip file. `importlib.metadata` can do this natively, and pip already has `pip._internal.utils.wheel.pkg_resources_distribution_for_wheel` to extend `pkg_resources`.

Usages of `pkg_resources_distribution_for_wheel` will be gradually removed, and the function will eventually be an implementation detail of `pip._internal.metadata`.