### PR TITLE
Remove get_installed_version() for Environment equivalent

### DIFF
--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -25,17 +25,14 @@ from pip._vendor.requests.structures import CaseInsensitiveDict
 from pip._vendor.urllib3.exceptions import InsecureRequestWarning
 
 from pip import __version__
+from pip._internal.metadata import get_default_environment
 from pip._internal.network.auth import MultiDomainBasicAuth
 from pip._internal.network.cache import SafeFileCache
 
 # Import ssl from compat so the initial import occurs in only one place.
 from pip._internal.utils.compat import has_tls
 from pip._internal.utils.glibc import libc_ver
-from pip._internal.utils.misc import (
-    build_url_from_netloc,
-    get_installed_version,
-    parse_netloc,
-)
+from pip._internal.utils.misc import build_url_from_netloc, parse_netloc
 from pip._internal.utils.urls import url_to_path
 
 if TYPE_CHECKING:
@@ -156,9 +153,9 @@ def user_agent():
         import _ssl as ssl
         data["openssl_version"] = ssl.OPENSSL_VERSION
 
-    setuptools_version = get_installed_version("setuptools")
-    if setuptools_version is not None:
-        data["setuptools_version"] = setuptools_version
+    setuptools_dist = get_default_environment().get_distribution("setuptools")
+    if setuptools_dist is not None:
+        data["setuptools_version"] = str(setuptools_dist.version)
 
     # Use None rather than False so as not to give the impression that
     # pip knows it is not being run under CI.  Rather, it is a null or

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -43,7 +43,6 @@ from pip._internal.utils.misc import (
     dist_in_site_packages,
     dist_in_usersite,
     get_distribution,
-    get_installed_version,
     hide_url,
     redact_auth_from_url,
 )
@@ -272,11 +271,6 @@ class InstallRequirement:
         specifiers = self.specifier
         return (len(specifiers) == 1 and
                 next(iter(specifiers)).operator in {'==', '==='})
-
-    @property
-    def installed_version(self):
-        # type: () -> Optional[str]
-        return get_installed_version(self.name)
 
     def match_markers(self, extras_requested=None):
         # type: (Optional[Iterable[str]]) -> bool

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -6,14 +6,14 @@ import os.path
 import sys
 from typing import TYPE_CHECKING
 
-from pip._vendor.packaging import version as packaging_version
+from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import get_default_environment
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.utils.filesystem import adjacent_tmp_file, check_path_owner, replace
-from pip._internal.utils.misc import ensure_dir, get_installed_version
+from pip._internal.utils.misc import ensure_dir
 
 if TYPE_CHECKING:
     import optparse
@@ -114,11 +114,11 @@ def pip_self_version_check(session, options):
     the active virtualenv or in the user's USER_CACHE_DIR keyed off the prefix
     of the pip script path.
     """
-    installed_version = get_installed_version("pip")
-    if not installed_version:
+    installed_dist = get_default_environment().get_distribution("pip")
+    if not installed_dist:
         return
 
-    pip_version = packaging_version.parse(installed_version)
+    pip_version = installed_dist.version
     pypi_version = None
 
     try:
@@ -162,7 +162,7 @@ def pip_self_version_check(session, options):
             # save that we've performed a check
             state.save(pypi_version, current_time)
 
-        remote_version = packaging_version.parse(pypi_version)
+        remote_version = parse_version(pypi_version)
 
         local_version_is_older = (
             pip_version < remote_version and

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -18,8 +18,6 @@ from io import StringIO
 from itertools import filterfalse, tee, zip_longest
 from typing import TYPE_CHECKING, cast
 
-from pip._vendor import pkg_resources
-
 # NOTE: retrying is not annotated in typeshed as on 2017-07-17, which is
 #       why we ignore the type on this import.
 from pip._vendor.retrying import retry  # type: ignore
@@ -59,7 +57,7 @@ __all__ = ['rmtree', 'display_path', 'backup_dir',
            'normalize_path',
            'renames', 'get_prog',
            'captured_stdout', 'ensure_dir',
-           'get_installed_version', 'remove_auth_from_url']
+           'remove_auth_from_url']
 
 
 logger = logging.getLogger(__name__)
@@ -558,24 +556,6 @@ def captured_stderr():
     See captured_stdout().
     """
     return captured_output('stderr')
-
-
-def get_installed_version(dist_name, working_set=None):
-    """Get the installed version of dist_name avoiding pkg_resources cache"""
-    # Create a requirement that we'll look for inside of setuptools.
-    req = pkg_resources.Requirement.parse(dist_name)
-
-    if working_set is None:
-        # We want to avoid having this cached, so we need to construct a new
-        # working set each time.
-        working_set = pkg_resources.WorkingSet()
-
-    # Get the installed distribution from our working set
-    dist = working_set.find(req)
-
-    # Check to see if we got an installed distribution or not, if we did
-    # we want to return it's version.
-    return dist.version if dist else None
 
 
 # Simulates an enum

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -382,10 +382,6 @@ class TestInstallRequirement:
         with pytest.raises(InstallationError):
             reqset.add_requirement(req)
 
-    def test_installed_version_not_installed(self):
-        req = install_req_from_line('simple-0.1-py2.py3-none-any.whl')
-        assert req.installed_version is None
-
     def test_str(self):
         req = install_req_from_line('simple==0.1')
         assert str(req) == 'simple==0.1'

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import json
 import os
 import sys
@@ -6,6 +7,7 @@ import sys
 import freezegun
 import pretend
 import pytest
+from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal import self_outdated_check
 from pip._internal.models.candidate import InstallationCandidate
@@ -44,25 +46,20 @@ class MockPackageFinder:
 
 
 class MockDistribution:
-    def __init__(self, installer):
+    def __init__(self, installer, version):
         self.installer = installer
-
-    def has_metadata(self, name):
-        return name == 'INSTALLER'
-
-    def get_metadata_lines(self, name):
-        if self.has_metadata(name):
-            yield self.installer
-        else:
-            raise NotImplementedError('nope')
+        self.version = parse_version(version)
 
 
 class MockEnvironment(object):
-    def __init__(self, installer):
+    def __init__(self, installer, installed_version):
         self.installer = installer
+        self.installed_version = installed_version
 
     def get_distribution(self, name):
-        return MockDistribution(self.installer)
+        if self.installed_version is None:
+            return None
+        return MockDistribution(self.installer, self.installed_version)
 
 
 def _options():
@@ -97,16 +94,26 @@ def _options():
 def test_pip_self_version_check(monkeypatch, stored_time, installed_ver,
                                 new_ver, installer,
                                 check_if_upgrade_required, check_warn_logs):
-    monkeypatch.setattr(self_outdated_check, 'get_installed_version',
-                        lambda name: installed_ver)
-    monkeypatch.setattr(self_outdated_check, 'PackageFinder',
-                        MockPackageFinder)
-    monkeypatch.setattr(logger, 'warning',
-                        pretend.call_recorder(lambda *a, **kw: None))
-    monkeypatch.setattr(logger, 'debug',
-                        pretend.call_recorder(lambda s, exc_info=None: None))
-    monkeypatch.setattr(self_outdated_check, 'get_default_environment',
-                        lambda: MockEnvironment(installer))
+    monkeypatch.setattr(
+        self_outdated_check,
+        "get_default_environment",
+        functools.partial(MockEnvironment, installer, installed_ver),
+    )
+    monkeypatch.setattr(
+        self_outdated_check,
+        "PackageFinder",
+        MockPackageFinder,
+    )
+    monkeypatch.setattr(
+        logger,
+        "warning",
+        pretend.call_recorder(lambda *a, **kw: None),
+    )
+    monkeypatch.setattr(
+        logger,
+        "debug",
+        pretend.call_recorder(lambda s, exc_info=None: None),
+    )
 
     fake_state = pretend.stub(
         state={"last_check": stored_time, 'pypi_version': installed_ver},


### PR DESCRIPTION
All usages of it now use `Environment.get_distribution()` instead.

`InstallRequirement.installed_version` is also removed since it is no longer used anywhere in the code base.