### PR TITLE
Use more descriptive type than _BaseVersion

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -36,7 +36,7 @@ if MYPY_CHECK_RUNNING:
     from typing import FrozenSet, Iterable, List, Optional, Set, Tuple, Union
 
     from pip._vendor.packaging.tags import Tag
-    from pip._vendor.packaging.version import _BaseVersion
+    from pip._vendor.packaging.version import LegacyVersion, Version
 
     from pip._internal.index.collector import LinkCollector
     from pip._internal.models.search_scope import SearchScope
@@ -45,7 +45,7 @@ if MYPY_CHECK_RUNNING:
 
     BuildTag = Union[Tuple[()], Tuple[int, str]]
     CandidateSortingKey = (
-        Tuple[int, int, int, _BaseVersion, BuildTag, Optional[int]]
+        Tuple[int, int, int, Union[LegacyVersion, Version], BuildTag, Optional[int]]
     )
 
 
@@ -891,7 +891,7 @@ class PackageFinder:
         )
         best_candidate = best_candidate_result.best_candidate
 
-        installed_version = None    # type: Optional[_BaseVersion]
+        installed_version = None    # type: Optional[Union[LegacyVersion, Version]]
         if req.satisfied_by is not None:
             installed_version = parse_version(req.satisfied_by.version)
 

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -2,9 +2,9 @@ from pip._internal.utils.misc import stdlib_pkgs  # TODO: Move definition here.
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Container, Iterator, List, Optional
+    from typing import Container, Iterator, List, Optional, Union
 
-    from pip._vendor.packaging.version import _BaseVersion
+    from pip._vendor.packaging.version import LegacyVersion, Version
 
 
 class BaseDistribution:
@@ -21,7 +21,7 @@ class BaseDistribution:
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> Union[LegacyVersion, Version]
         raise NotImplementedError()
 
     @property

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -11,9 +11,9 @@ from pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
 from .base import BaseDistribution, BaseEnvironment
 
 if MYPY_CHECK_RUNNING:
-    from typing import Iterator, List, Optional
+    from typing import Iterator, List, Optional, Union
 
-    from pip._vendor.packaging.version import _BaseVersion
+    from pip._vendor.packaging.version import LegacyVersion, Version
 
 
 class Distribution(BaseDistribution):
@@ -43,7 +43,7 @@ class Distribution(BaseDistribution):
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> Union[LegacyVersion, Version]
         return self._dist.parsed_version
 
     @property

--- a/src/pip/_internal/models/candidate.py
+++ b/src/pip/_internal/models/candidate.py
@@ -4,7 +4,9 @@ from pip._internal.utils.models import KeyBasedCompareMixin
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from pip._vendor.packaging.version import _BaseVersion
+    from typing import Union
+
+    from pip._vendor.packaging.version import LegacyVersion, Version
 
     from pip._internal.models.link import Link
 
@@ -18,7 +20,7 @@ class InstallationCandidate(KeyBasedCompareMixin):
     def __init__(self, name, version, link):
         # type: (str, str, Link) -> None
         self.name = name
-        self.version = parse_version(version)  # type: _BaseVersion
+        self.version = parse_version(version)  # type: Union[LegacyVersion, Version]
         self.link = link
 
         super().__init__(

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -6,9 +6,9 @@ from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import FrozenSet, Iterable, Optional, Tuple
+    from typing import FrozenSet, Iterable, Optional, Tuple, Union
 
-    from pip._vendor.packaging.version import _BaseVersion
+    from pip._vendor.packaging.version import LegacyVersion, Version
 
     from pip._internal.models.link import Link
 
@@ -125,7 +125,7 @@ class Candidate:
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> Union[LegacyVersion, Version]
         raise NotImplementedError("Override in subclass")
 
     @property

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -21,7 +21,7 @@ from .base import Candidate, format_name
 if MYPY_CHECK_RUNNING:
     from typing import Any, FrozenSet, Iterable, Optional, Tuple, Union
 
-    from pip._vendor.packaging.version import _BaseVersion
+    from pip._vendor.packaging.version import LegacyVersion
     from pip._vendor.pkg_resources import Distribution
 
     from pip._internal.models.link import Link
@@ -132,7 +132,7 @@ class _InstallRequirementBackedCandidate(Candidate):
         ireq,          # type: InstallRequirement
         factory,       # type: Factory
         name=None,     # type: Optional[str]
-        version=None,  # type: Optional[_BaseVersion]
+        version=None,  # type: Optional[Union[LegacyVersion, Version]]
     ):
         # type: (...) -> None
         self._link = link
@@ -184,7 +184,7 @@ class _InstallRequirementBackedCandidate(Candidate):
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> Union[LegacyVersion, Version]
         if self._version is None:
             self._version = self.dist.parsed_version
         return self._version
@@ -267,7 +267,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
         template,        # type: InstallRequirement
         factory,       # type: Factory
         name=None,     # type: Optional[str]
-        version=None,  # type: Optional[_BaseVersion]
+        version=None,  # type: Optional[Union[LegacyVersion, Version]]
     ):
         # type: (...) -> None
         source_link = link
@@ -322,7 +322,7 @@ class EditableCandidate(_InstallRequirementBackedCandidate):
         template,        # type: InstallRequirement
         factory,       # type: Factory
         name=None,     # type: Optional[str]
-        version=None,  # type: Optional[_BaseVersion]
+        version=None,  # type: Optional[Union[LegacyVersion, Version]]
     ):
         # type: (...) -> None
         super().__init__(
@@ -394,7 +394,7 @@ class AlreadyInstalledCandidate(Candidate):
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> Union[LegacyVersion, Version]
         return self.dist.parsed_version
 
     @property
@@ -487,7 +487,7 @@ class ExtrasCandidate(Candidate):
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> Union[LegacyVersion, Version]
         return self.base.version
 
     def format_for_error(self):
@@ -582,7 +582,7 @@ class RequiresPythonCandidate(Candidate):
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> Union[LegacyVersion, Version]
         return self._version
 
     def format_for_error(self):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -51,10 +51,11 @@ if MYPY_CHECK_RUNNING:
         Set,
         Tuple,
         TypeVar,
+        Union,
     )
 
     from pip._vendor.packaging.specifiers import SpecifierSet
-    from pip._vendor.packaging.version import _BaseVersion
+    from pip._vendor.packaging.version import LegacyVersion, Version
     from pip._vendor.pkg_resources import Distribution
     from pip._vendor.resolvelib import ResolutionImpossible
 
@@ -138,7 +139,7 @@ class Factory:
         extras,  # type: FrozenSet[str]
         template,  # type: InstallRequirement
         name,  # type: Optional[str]
-        version,  # type: Optional[_BaseVersion]
+        version,  # type: Optional[Union[LegacyVersion, Version]]
     ):
         # type: (...) -> Optional[Candidate]
         # TODO: Check already installed candidate, and use it if the link and

--- a/src/pip/_internal/resolution/resolvelib/found_candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/found_candidates.py
@@ -15,13 +15,15 @@ from pip._vendor.six.moves import collections_abc  # type: ignore
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Callable, Iterator, Optional, Set, Tuple
+    from typing import Callable, Iterator, Optional, Set, Tuple, Union
 
-    from pip._vendor.packaging.version import _BaseVersion
+    from pip._vendor.packaging.version import LegacyVersion, Version
 
     from .base import Candidate
 
-    IndexCandidateInfo = Tuple[_BaseVersion, Callable[[], Optional[Candidate]]]
+    IndexCandidateInfo = Tuple[
+        Union[LegacyVersion, Version], Callable[[], Optional[Candidate]]
+    ]
 
 
 def _iter_built(infos):
@@ -31,7 +33,7 @@ def _iter_built(infos):
     This iterator is used when the package is not already installed. Candidates
     from index come later in their normal ordering.
     """
-    versions_found = set()  # type: Set[_BaseVersion]
+    versions_found = set()  # type: Set[Union[LegacyVersion, Version]]
     for version, func in infos:
         if version in versions_found:
             continue
@@ -52,7 +54,7 @@ def _iter_built_with_prepended(installed, infos):
     normal ordering, except skipped when the version is already installed.
     """
     yield installed
-    versions_found = {installed.version}  # type: Set[_BaseVersion]
+    versions_found = {installed.version}  # type: Set[Union[LegacyVersion, Version]]
     for version, func in infos:
         if version in versions_found:
             continue
@@ -75,7 +77,7 @@ def _iter_built_with_inserted(installed, infos):
     the installed candidate exactly once before we start yielding older or
     equivalent candidates, or after all other candidates if they are all newer.
     """
-    versions_found = set()  # type: Set[_BaseVersion]
+    versions_found = set()  # type: Set[Union[LegacyVersion, Version]]
     for version, func in infos:
         if version in versions_found:
             continue


### PR DESCRIPTION
Using _BaseVersion does not allow mypy to know about the Version methods
and properties. For example: .is_prerelease. By using the more
descriptive type, mypy is able to know about these and use them to
verify types.

This is the approach taken by the upstream packaging project. See:
https://github.com/pypa/packaging/blob/20.9/packaging/version.py

Beyond the internal benefit, this will help downstream projects such as
pip-tools which use pip with mypy:
https://github.com/jazzband/pip-tools/blob/5.5.0/piptools/exceptions.py#L20

Currently, the above fails mypy checks with the error:

    "_BaseVersion" has no attribute "is_prerelease"
