### PR TITLE
Always open tar files with UTF-8 

### DIFF
--- a/news/7667.bugfix.rst
+++ b/news/7667.bugfix.rst
@@ -1,0 +1,1 @@
+Fix extraction of files with utf-8 encoded paths from tars.

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -178,7 +178,7 @@ def untar_file(filename, location):
             filename,
         )
         mode = "r:*"
-    tar = tarfile.open(filename, mode)
+    tar = tarfile.open(filename, mode, encoding="utf-8")
     try:
         leading = has_leading_dir([member.name for member in tar.getmembers()])
         for member in tar.getmembers():

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -168,6 +168,25 @@ class TestUnpackArchives:
         untar_file(test_tar, self.tempdir)
 
 
+def test_unpack_tar_unicode(tmpdir):
+    test_tar = tmpdir / "test.tar"
+    # tarfile tries to decode incoming
+    with tarfile.open(
+        test_tar, "w", format=tarfile.PAX_FORMAT, encoding="utf-8"
+    ) as f:
+        metadata = tarfile.TarInfo("dir/åäö_日本語.py")
+        f.addfile(metadata, "hello world")
+
+    output_dir = tmpdir / "output"
+    output_dir.mkdir()
+
+    untar_file(test_tar, str(output_dir))
+
+    output_dir_name = str(output_dir)
+    contents = os.listdir(output_dir_name)
+    assert u"åäö_日本語.py" in contents
+
+
 @pytest.mark.parametrize('args, expected', [
     # Test the second containing the first.
     (('parent/sub', 'parent/'), False),


### PR DESCRIPTION
[This is a re-filing of #7668, but with Python 2 things removed.

Close #7668, fix #7667.]