### PR TITLE
Make wheel compatibility tag preferences more important than the build tag

### DIFF
--- a/news/9565.bugfix.rst
+++ b/news/9565.bugfix.rst
@@ -1,9 +1,1 @@
 Make wheel compatibility tag preferences more important than the build tag
-
-For example: if both linux_x86_64 and linux_i386 are supported and linux_x86_64
-is preferred over linux_i386 the old behavior was to prefer
-simple-1.0-2-py3-abi3-linux_i386.whl over
-simple-1.0-1-py3-abi3-linux_x86_64.whl
-but now pip prefers
-simple-1.0-1-py3-abi3-linux_x86_64.whl over
-simple-1.0-2-py3-abi3-linux_i386.whl

--- a/news/9565.bugfix.rst
+++ b/news/9565.bugfix.rst
@@ -1,0 +1,9 @@
+Make wheel compatibility tag preferences more important than the build tag
+
+For example: if both linux_x86_64 and linux_i386 are supported and linux_x86_64
+is preferred over linux_i386 the old behavior was to prefer
+simple-1.0-2-py3-abi3-linux_i386.whl over
+simple-1.0-1-py3-abi3-linux_x86_64.whl
+but now pip prefers
+simple-1.0-1-py3-abi3-linux_x86_64.whl over
+simple-1.0-2-py3-abi3-linux_i386.whl

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 BuildTag = Union[Tuple[()], Tuple[int, str]]
 CandidateSortingKey = (
-    Tuple[int, int, int, _BaseVersion, BuildTag, Optional[int]]
+    Tuple[int, int, int, _BaseVersion, Optional[int], BuildTag]
 )
 
 
@@ -530,7 +530,7 @@ class CandidateEvaluator:
         yank_value = -1 * int(link.is_yanked)  # -1 for yanked.
         return (
             has_allowed_hash, yank_value, binary_preference, candidate.version,
-            pri, build_tag, 
+            pri, build_tag,
         )
 
     def sort_best_candidate(

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -530,7 +530,7 @@ class CandidateEvaluator:
         yank_value = -1 * int(link.is_yanked)  # -1 for yanked.
         return (
             has_allowed_hash, yank_value, binary_preference, candidate.version,
-            build_tag, pri,
+            pri, build_tag, 
         )
 
     def sort_best_candidate(

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -209,6 +209,8 @@ class TestWheel:
         with pytest.raises(BestVersionAlreadyInstalled):
             finder.find_requirement(req, True)
 
+
+class TestCandidateEvaluator:
     def test_link_sorting(self):
         """
         Test link sorting
@@ -274,6 +276,37 @@ class TestWheel:
         sort_key = candidate_evaluator._sort_key
         results = sorted(links, key=sort_key, reverse=True)
         results2 = sorted(reversed(links), key=sort_key, reverse=True)
+        assert links == results == results2, results2
+
+    def test_build_tag_is_less_important_than_other_tags(self):
+        links = [
+            InstallationCandidate(
+                "simple",
+                "1.0",
+                Link('simple-1.0-1-py3-abi3-linux_x86_64.whl'),
+            ),
+            InstallationCandidate(
+                "simple",
+                '1.0',
+                Link('simple-1.0-2-py3-abi3-linux_i386.whl'),
+            ),
+            InstallationCandidate(
+                "simple",
+                '1.0',
+                Link('simple-1.0.tar.gz'),
+            ),
+        ]
+        valid_tags = [
+            Tag('py3', 'abi3', 'linux_x86_64'),
+            Tag('py3', 'abi3', 'linux_i386'),
+        ]
+        evaluator = CandidateEvaluator(
+            'my-project', supported_tags=valid_tags, specifier = SpecifierSet(),
+        )
+        sort_key = evaluator._sort_key
+        results = sorted(links, key=sort_key, reverse=True)
+        results2 = sorted(reversed(links), key=sort_key, reverse=True)
+
         assert links == results == results2, results2
 
 

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -310,7 +310,7 @@ class TestCandidateEvaluator:
             Tag('py3', 'any', 'none'),
         ]
         evaluator = CandidateEvaluator(
-            'my-project', supported_tags=valid_tags, specifier = SpecifierSet(),
+            'my-project', supported_tags=valid_tags, specifier=SpecifierSet(),
         )
         sort_key = evaluator._sort_key
         results = sorted(links, key=sort_key, reverse=True)

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -293,12 +293,18 @@ class TestCandidateEvaluator:
             InstallationCandidate(
                 "simple",
                 '1.0',
+                Link('simple-1.0-2-py3-any-none.whl'),
+            ),
+            InstallationCandidate(
+                "simple",
+                '1.0',
                 Link('simple-1.0.tar.gz'),
             ),
         ]
         valid_tags = [
             Tag('py3', 'abi3', 'linux_x86_64'),
             Tag('py3', 'abi3', 'linux_i386'),
+            Tag('py3', 'any', 'none'),
         ]
         evaluator = CandidateEvaluator(
             'my-project', supported_tags=valid_tags, specifier = SpecifierSet(),

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -251,7 +251,8 @@ class TestCandidateEvaluator:
         results = sorted(links, key=sort_key, reverse=True)
         results2 = sorted(reversed(links), key=sort_key, reverse=True)
 
-        assert links == results == results2, results2
+        assert links == results, results
+        assert links == results2, results2
 
     def test_link_sorting_wheels_with_build_tags(self):
         """Verify build tags affect sorting."""
@@ -276,7 +277,9 @@ class TestCandidateEvaluator:
         sort_key = candidate_evaluator._sort_key
         results = sorted(links, key=sort_key, reverse=True)
         results2 = sorted(reversed(links), key=sort_key, reverse=True)
-        assert links == results == results2, results2
+
+        assert links == results, results
+        assert links == results2, results2
 
     def test_build_tag_is_less_important_than_other_tags(self):
         links = [
@@ -313,7 +316,8 @@ class TestCandidateEvaluator:
         results = sorted(links, key=sort_key, reverse=True)
         results2 = sorted(reversed(links), key=sort_key, reverse=True)
 
-        assert links == results == results2, results2
+        assert links == results, results
+        assert links == results2, results2
 
 
 def test_finder_priority_file_over_page(data):


### PR DESCRIPTION
Fixes #9565

# Example
If linux_x86_64 is preferred over linux_i386 the old behavior was to prefer
```
simple-1.0-2-py3-abi3-linux_i386.whl over
simple-1.0-1-py3-abi3-linux_x86_64.whl
```
Now pip prefers
```
simple-1.0-1-py3-abi3-linux_x86_64.whl over
simple-1.0-2-py3-abi3-linux_i386.whl
```