### PR TITLE
Run pyupgrade

### DIFF
--- a/docs/docs_feedback_sphinxext.py
+++ b/docs/docs_feedback_sphinxext.py
@@ -19,7 +19,7 @@ EMAIL_INDENT = 6
 def _modify_rst_document_source_on_read(
         app: Sphinx,
         docname: str,
-        source: List[str],
+        source: list[str],
 ) -> None:
     """Add info block to top and bottom of each document source.
 
@@ -120,7 +120,7 @@ def _modify_rst_document_source_on_read(
     ))
 
 
-def setup(app: Sphinx) -> Dict[str, Union[bool, str]]:
+def setup(app: Sphinx) -> dict[str, bool | str]:
     """Initialize the Sphinx extension.
 
     This function adds a callback for modifying the document sources

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(rel_path):
     here = os.path.abspath(os.path.dirname(__file__))
     # intentionally *not* adding an encoding option to open, See:
     #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
-    with open(os.path.join(here, rel_path), 'r') as fp:
+    with open(os.path.join(here, rel_path)) as fp:
         return fp.read()
 
 

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -56,10 +56,10 @@ class BuildEnvironment:
             kind=tempdir_kinds.BUILD_ENV, globally_managed=True
         )
 
-        self._prefixes = OrderedDict((
+        self._prefixes = OrderedDict(
             (name, _Prefix(os.path.join(temp_dir.path, name)))
             for name in ('normal', 'overlay')
-        ))
+        )
 
         self._bin_dirs = []  # type: List[str]
         self._lib_dirs = []  # type: List[str]

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -26,10 +26,10 @@ if MYPY_CHECK_RUNNING:
     from typing import Dict, List, Optional
 
     from typing_extensions import TypedDict
-    TransformedHit = TypedDict(
-        'TransformedHit',
-        {'name': str, 'summary': str, 'versions': List[str]},
-    )
+    class TransformedHit(TypedDict):
+        name: str
+        summary: str
+        versions: List[str]
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -44,11 +44,11 @@ def raise_for_status(resp):
         reason = resp.reason
 
     if 400 <= resp.status_code < 500:
-        http_error_msg = '%s Client Error: %s for url: %s' % (
+        http_error_msg = '{} Client Error: {} for url: {}'.format(
             resp.status_code, reason, resp.url)
 
     elif 500 <= resp.status_code < 600:
-        http_error_msg = '%s Server Error: %s for url: %s' % (
+        http_error_msg = '{} Server Error: {} for url: {}'.format(
             resp.status_code, reason, resp.url)
 
     if http_error_msg:

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -145,7 +145,7 @@ def deduce_helpful_msg(req):
         msg = " The path does exist. "
         # Try to parse and check if it is a requirements file.
         try:
-            with open(req, 'r') as fp:
+            with open(req) as fp:
                 # parse first line only
                 next(parse_requirements(fp.read()))
                 msg += (

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -33,9 +33,9 @@ if MYPY_CHECK_RUNNING:
     from pip._internal.index.package_finder import PackageFinder
     from pip._internal.network.session import PipSession
 
-    ReqFileLines = Iterator[Tuple[int, Text]]
+    ReqFileLines = Iterator[Tuple[int, str]]
 
-    LineParser = Callable[[Text], Tuple[str, Values]]
+    LineParser = Callable[[str], Tuple[str, Values]]
 
 
 __all__ = ['parse_requirements']

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -543,7 +543,7 @@ class UninstallPathSet:
 
         elif develop_egg_link:
             # develop egg
-            with open(develop_egg_link, 'r') as fh:
+            with open(develop_egg_link) as fh:
                 link_pointer = os.path.normcase(fh.readline().strip())
             assert (link_pointer == dist.location), (
                 'Egg-link {} does not match installed location of {} '

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -169,7 +169,7 @@ class UnsatisfiableRequirement(Requirement):
 
     def __str__(self):
         # type: () -> str
-        return "{} (unavailable)".format(self._name)
+        return f"{self._name} (unavailable)"
 
     def __repr__(self):
         # type: () -> str

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -124,7 +124,7 @@ class Resolver(BaseResolver):
 
         except ResolutionImpossible as e:
             error = self.factory.get_installation_error(e)
-            six.raise_from(error, e)
+            raise error from e
 
         req_set = RequirementSet(check_supported_wheels=check_supported_wheels)
         for candidate in self._result.mapping.values():

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -257,7 +257,7 @@ def strtobool(val):
     elif val in ('n', 'no', 'f', 'false', 'off', '0'):
         return 0
     else:
-        raise ValueError("invalid truth value {!r}".format(val))
+        raise ValueError(f"invalid truth value {val!r}")
 
 
 def format_size(bytes):

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -257,7 +257,7 @@ def strtobool(val):
     elif val in ('n', 'no', 'f', 'false', 'off', '0'):
         return 0
     else:
-        raise ValueError("invalid truth value %r" % (val,))
+        raise ValueError("invalid truth value {!r}".format(val))
 
 
 def format_size(bytes):

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -190,7 +190,7 @@ def _verify_one(req, wheel_path):
     try:
         metadata_version = Version(metadata_version_value)
     except InvalidVersion:
-        msg = "Invalid Metadata-Version: {}".format(metadata_version_value)
+        msg = f"Invalid Metadata-Version: {metadata_version_value}"
         raise UnsupportedWheel(msg)
     if (metadata_version >= Version("1.2")
             and not isinstance(dist.version, Version)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import time
 from contextlib import contextmanager
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 from pip._vendor.contextlib2 import ExitStack, nullcontext
 from setuptools.wheel import Wheel
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ import subprocess
 import sys
 import time
 from contextlib import contextmanager
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 from pip._vendor.contextlib2 import ExitStack, nullcontext
 from setuptools.wheel import Wheel
 

--- a/tests/data/packages/HackedEggInfo/setup.py
+++ b/tests/data/packages/HackedEggInfo/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from setuptools import setup
 from setuptools.command import egg_info as orig_egg_info
 

--- a/tests/data/packages/SetupPyUTF8/setup.py
+++ b/tests/data/packages/SetupPyUTF8/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from distutils.core import setup
 
 setup(name="SetupPyUTF8",

--- a/tests/data/src/prjwithdatafile/setup.py
+++ b/tests/data/src/prjwithdatafile/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import setup
 
 setup(

--- a/tests/functional/test_help.py
+++ b/tests/functional/test_help.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.commands import commands_dict, create_command

--- a/tests/functional/test_help.py
+++ b/tests/functional/test_help.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.commands import commands_dict, create_command

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1298,7 +1298,7 @@ def test_install_log(script, data, tmpdir):
             'install', data.src.joinpath('chattymodule')]
     result = script.pip(*args)
     assert 0 == result.stdout.count("HELLO FROM CHATTYMODULE")
-    with open(f, 'r') as fp:
+    with open(f) as fp:
         # one from egg_info, one from install
         assert 2 == fp.read().count("HELLO FROM CHATTYMODULE")
 
@@ -1321,7 +1321,7 @@ def test_cleanup_after_failed_wheel(script, with_wheel):
     # One of the effects of not cleaning up is broken scripts:
     script_py = script.bin_path / "script.py"
     assert script_py.exists(), script_py
-    shebang = open(script_py, 'r').readline().strip()
+    shebang = open(script_py).readline().strip()
     assert shebang != '#!python', shebang
     # OK, assert that we *said* we were cleaning up:
     # /!\ if in need to change this, also change test_pep517_no_legacy_cleanup

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -16,23 +16,23 @@ from tests.lib.wheel import make_wheel
 
 def assert_installed(script, **kwargs):
     ret = script.pip('list', '--format=json')
-    installed = set(
+    installed = {
         (canonicalize_name(val['name']), val['version'])
         for val in json.loads(ret.stdout)
-    )
-    expected = set((canonicalize_name(k), v) for k, v in kwargs.items())
+    }
+    expected = {(canonicalize_name(k), v) for k, v in kwargs.items()}
     assert expected <= installed, f"{expected!r} not all in {installed!r}"
 
 
 def assert_not_installed(script, *args):
     ret = script.pip("list", "--format=json")
-    installed = set(
+    installed = {
         canonicalize_name(val["name"])
         for val in json.loads(ret.stdout)
-    )
+    }
     # None of the given names should be listed as installed, i.e. their
     # intersection should be empty.
-    expected = set(canonicalize_name(k) for k in args)
+    expected = {canonicalize_name(k) for k in args}
     assert not (expected & installed), f"{expected!r} contained in {installed!r}"
 
 
@@ -40,7 +40,7 @@ def assert_editable(script, *args):
     # This simply checks whether all of the listed packages have a
     # corresponding .egg-link file installed.
     # TODO: Implement a more rigorous way to test for editable installations.
-    egg_links = set(f"{arg}.egg-link" for arg in args)
+    egg_links = {f"{arg}.egg-link" for arg in args}
     assert egg_links <= set(os.listdir(script.site_packages_path)), \
         f"{args!r} not all found in {script.site_packages_path!r}"
 

--- a/tests/functional/test_no_color.py
+++ b/tests/functional/test_no_color.py
@@ -33,7 +33,7 @@ def test_no_color(script):
             pytest.skip("Unable to capture output using script: " + cmd)
 
         try:
-            with open("/tmp/pip-test-no-color.txt", "r") as output_file:
+            with open("/tmp/pip-test-no-color.txt") as output_file:
                 retval = output_file.read()
             return retval
         finally:

--- a/tests/functional/test_vcs_bazaar.py
+++ b/tests/functional/test_vcs_bazaar.py
@@ -64,7 +64,7 @@ def test_export_rev(script, tmpdir):
     url = hide_url('bzr+' + _test_path_to_file_url(source_dir) + '@1')
     Bazaar().export(str(export_dir), url=url)
 
-    with open(export_dir / 'test_file', 'r') as f:
+    with open(export_dir / 'test_file') as f:
         assert f.read() == 'something initial'
 
 

--- a/tests/functional/test_yaml.py
+++ b/tests/functional/test_yaml.py
@@ -142,7 +142,7 @@ def check_error(error, result):
 
     for patter in patters:
         match = re.search(patter, result.stderr, re.I)
-        assert match, 'regex %r not found in stderr: %r' % (
+        assert match, 'regex {!r} not found in stderr: {!r}'.format(
             stderr, result.stderr)
 
 

--- a/tests/lib/path.py
+++ b/tests/lib/path.py
@@ -173,7 +173,7 @@ class Path(str):
             f.write(content)
 
     def read_text(self):
-        with open(self, "r") as fp:
+        with open(self) as fp:
             return fp.read()
 
     def write_text(self, content):

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -5,7 +5,7 @@ import threading
 from contextlib import contextmanager
 from textwrap import dedent
 
-from mock import Mock
+from unittest.mock import Mock
 from pip._vendor.contextlib2 import nullcontext
 from werkzeug.serving import WSGIRequestHandler
 from werkzeug.serving import make_server as _make_server

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -4,8 +4,8 @@ import ssl
 import threading
 from contextlib import contextmanager
 from textwrap import dedent
-
 from unittest.mock import Mock
+
 from pip._vendor.contextlib2 import nullcontext
 from werkzeug.serving import WSGIRequestHandler
 from werkzeug.serving import make_server as _make_server

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -32,7 +32,7 @@ class VirtualEnvironment:
         self.site = Path(lib) / 'site-packages'
         # Workaround for https://github.com/pypa/virtualenv/issues/306
         if hasattr(sys, "pypy_version_info"):
-            version_dir = '{0}'.format(*sys.version_info)
+            version_dir = '{}'.format(*sys.version_info)
             self.lib = Path(home, 'lib-python', version_dir)
         else:
             self.lib = Path(lib)

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.resolvelib.resolvers import Result

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 import pytest
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.resolvelib.resolvers import Result

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -1,8 +1,8 @@
 import logging
 import os
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import Mock, patch
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS

--- a/tests/unit/test_check.py
+++ b/tests/unit/test_check.py
@@ -1,7 +1,7 @@
 """Unit Tests for pip's dependency checking logic
 """
 
-import mock
+from unittest import mock
 
 from pip._internal.operations import check
 

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -4,11 +4,11 @@ import re
 import urllib.request
 import uuid
 from textwrap import dedent
-
 from unittest import mock
+from unittest.mock import Mock, patch
+
 import pretend
 import pytest
-from unittest.mock import Mock, patch
 from pip._vendor import html5lib, requests
 
 from pip._internal.exceptions import NetworkConnectionError

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -5,10 +5,10 @@ import urllib.request
 import uuid
 from textwrap import dedent
 
-import mock
+from unittest import mock
 import pretend
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from pip._vendor import html5lib, requests
 
 from pip._internal.exceptions import NetworkConnectionError

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -1,7 +1,7 @@
 import errno
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.commands.install import (

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -1,7 +1,7 @@
 import errno
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.commands.install import (

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from pip._internal.cli.req_command import (
     IndexGroupCommand,

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from pip._internal.cli.req_command import (
     IndexGroupCommand,

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -63,11 +63,11 @@ def test_str_to_display(data, expected):
     # Test str input with non-ascii characters.
     ('déf', 'utf-8', 'déf'),
     # Test bytes input with non-ascii characters:
-    ('déf'.encode('utf-8'), 'utf-8', 'déf'),
+    ('déf'.encode(), 'utf-8', 'déf'),
     # Test a Windows encoding.
     ('déf'.encode('cp1252'), 'cp1252', 'déf'),
     # Test a Windows encoding with incompatibly encoded text.
-    ('déf'.encode('utf-8'), 'cp1252', 'dÃ©f'),
+    ('déf'.encode(), 'cp1252', 'dÃ©f'),
 ])
 def test_str_to_display__encoding(monkeypatch, data, encoding, expected):
     monkeypatch.setattr(locale, 'getpreferredencoding', lambda: encoding)

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -2,7 +2,7 @@
 """
 
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from pip._internal.configuration import get_configuration_files, kinds
 from pip._internal.exceptions import ConfigurationError

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,8 +1,9 @@
 """Tests for all things related to the configuration
 """
 
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from pip._internal.configuration import get_configuration_files, kinds
 from pip._internal.exceptions import ConfigurationError

--- a/tests/unit/test_direct_url_helpers.py
+++ b/tests/unit/test_direct_url_helpers.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from pip._internal.models.direct_url import (
     DIRECT_URL_METADATA_NAME,

--- a/tests/unit/test_direct_url_helpers.py
+++ b/tests/unit/test_direct_url_helpers.py
@@ -1,5 +1,4 @@
 from functools import partial
-
 from unittest.mock import MagicMock, patch
 
 from pip._internal.models.direct_url import (

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.tags import Tag
 from pkg_resources import parse_version

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -1,8 +1,8 @@
 import logging
 import sys
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import Mock, patch
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.tags import Tag
 from pkg_resources import parse_version

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from pip._internal.locations import distutils_scheme
 

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -7,9 +7,9 @@ import os
 import shutil
 import sys
 import tempfile
+from unittest.mock import Mock
 
 import pytest
-from unittest.mock import Mock
 
 from pip._internal.locations import distutils_scheme
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,8 +1,8 @@
 import logging
 from threading import Thread
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 
 from pip._internal.utils.logging import (
     BrokenStdoutLoggingError,

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -2,7 +2,7 @@ import logging
 from threading import Thread
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from pip._internal.utils.logging import (
     BrokenStdoutLoggingError,

--- a/tests/unit/test_network_cache.py
+++ b/tests/unit/test_network_cache.py
@@ -1,7 +1,7 @@
 import os
+from unittest.mock import Mock
 
 import pytest
-from unittest.mock import Mock
 from pip._vendor.cachecontrol.caches import FileCache
 
 from pip._internal.network.cache import SafeFileCache

--- a/tests/unit/test_network_cache.py
+++ b/tests/unit/test_network_cache.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 from pip._vendor.cachecontrol.caches import FileCache
 
 from pip._internal.network.cache import SafeFileCache

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -2,9 +2,9 @@ import os
 import shutil
 from shutil import rmtree
 from tempfile import mkdtemp
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import Mock, patch
 
 from pip._internal.exceptions import HashMismatch
 from pip._internal.models.link import Link

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -4,7 +4,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from pip._internal.exceptions import HashMismatch
 from pip._internal.models.link import Link

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -6,7 +6,7 @@ import tempfile
 from functools import partial
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -4,9 +4,9 @@ import shutil
 import sys
 import tempfile
 from functools import partial
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -5,7 +5,7 @@ import subprocess
 import textwrap
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 from pretend import stub
 
 import pip._internal.req.req_file  # this will be monkeypatched

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -3,9 +3,9 @@ import logging
 import os
 import subprocess
 import textwrap
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 from pretend import stub
 
 import pip._internal.req.req_file  # this will be monkeypatched

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -162,9 +162,9 @@ class TestUninstallPathSet:
             pth.add(share_com)
         # Check that the paths were added to entries
         if on_windows:
-            check = set([tmpdir, relative, share, share_com])
+            check = {tmpdir, relative, share, share_com}
         else:
-            check = set([tmpdir, relative])
+            check = {tmpdir, relative}
         assert pth.entries == check
 
     @pytest.mark.skipif("sys.platform == 'win32'")

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 import pip._internal.req.req_uninstall
 from pip._internal.req.req_uninstall import (

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -1,8 +1,8 @@
 import os
 import sys
+from unittest.mock import Mock
 
 import pytest
-from unittest.mock import Mock
 
 import pip._internal.req.req_uninstall
 from pip._internal.req.req_uninstall import (

--- a/tests/unit/test_resolution_legacy_resolver.py
+++ b/tests/unit/test_resolution_legacy_resolver.py
@@ -1,6 +1,6 @@
 import logging
 
-import mock
+from unittest import mock
 import pytest
 from pip._vendor import pkg_resources
 

--- a/tests/unit/test_resolution_legacy_resolver.py
+++ b/tests/unit/test_resolution_legacy_resolver.py
@@ -1,6 +1,6 @@
 import logging
-
 from unittest import mock
+
 import pytest
 from pip._vendor import pkg_resources
 

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -57,7 +57,7 @@ class MockDistribution:
             raise NotImplementedError('nope')
 
 
-class MockEnvironment(object):
+class MockEnvironment:
     def __init__(self, installer):
         self.installer = installer
 

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from pip._internal.models.target_python import TargetPython
 from tests.lib import CURRENT_PY_VERSION_INFO, pyversion

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from pip._internal.models.target_python import TargetPython
 from tests.lib import CURRENT_PY_VERSION_INFO, pyversion

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,9 +10,9 @@ import stat
 import sys
 import time
 from io import BytesIO
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import Mock, patch
 
 from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError
 from pip._internal.utils.deprecation import PipDeprecationWarning, deprecated

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -12,7 +12,7 @@ import time
 from io import BytesIO
 
 import pytest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError
 from pip._internal.utils.deprecation import PipDeprecationWarning, deprecated
@@ -436,9 +436,9 @@ elif sys.byteorder == "big":
     # Test passing a text (unicode) string.
     ('/path/déf', None, '/path/déf'),
     # Test a bytes object with a non-ascii character.
-    ('/path/déf'.encode('utf-8'), 'utf-8', '/path/déf'),
+    ('/path/déf'.encode(), 'utf-8', '/path/déf'),
     # Test a bytes object with a character that can't be decoded.
-    ('/path/déf'.encode('utf-8'), 'ascii', "b'/path/d\\xc3\\xa9f'"),
+    ('/path/déf'.encode(), 'ascii', "b'/path/d\\xc3\\xa9f'"),
     ('/path/déf'.encode('utf-16'), 'utf-8', expected_byte_string),
 ])
 def test_path_to_display(monkeypatch, path, fs_encoding, expected):

--- a/tests/unit/test_utils_compatibility_tags.py
+++ b/tests/unit/test_utils_compatibility_tags.py
@@ -1,7 +1,7 @@
 import sysconfig
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from pip._internal.utils import compatibility_tags
 

--- a/tests/unit/test_utils_compatibility_tags.py
+++ b/tests/unit/test_utils_compatibility_tags.py
@@ -1,7 +1,7 @@
 import sysconfig
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 
 from pip._internal.utils import compatibility_tags
 

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -2,7 +2,7 @@ import os
 from unittest import TestCase
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import BadCommand, InstallationError

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -1,8 +1,8 @@
 import os
 from unittest import TestCase
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import BadCommand, InstallationError

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -6,7 +6,7 @@ import textwrap
 from email import message_from_string
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.exceptions import InstallationError

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -4,9 +4,9 @@ import logging
 import os
 import textwrap
 from email import message_from_string
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.exceptions import InstallationError

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -1,7 +1,7 @@
 import logging
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 
 from pip._internal import wheel_builder
 from pip._internal.models.link import Link

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from pip._internal import wheel_builder
 from pip._internal.models.link import Link

--- a/tools/automation/release/__init__.py
+++ b/tools/automation/release/__init__.py
@@ -90,7 +90,7 @@ def generate_news(session: Session, version: str) -> None:
 
 
 def update_version_file(version: str, filepath: str) -> None:
-    with open(filepath, "r", encoding="utf-8") as f:
+    with open(filepath, encoding="utf-8") as f:
         content = list(f)
 
     file_modified = False


### PR DESCRIPTION
pip 21.0 dropped support for Python 2 and Python 3.5. I figured this is a good time to run https://github.com/asottile/pyupgrade and see what fixes it suggests.