### PR TITLE
Use str.encode() instead of str.encode('utf-8')

### DIFF
--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -63,11 +63,11 @@ def test_str_to_display(data, expected):
     # Test str input with non-ascii characters.
     ('déf', 'utf-8', 'déf'),
     # Test bytes input with non-ascii characters:
-    ('déf'.encode('utf-8'), 'utf-8', 'déf'),
+    ('déf'.encode(), 'utf-8', 'déf'),
     # Test a Windows encoding.
     ('déf'.encode('cp1252'), 'cp1252', 'déf'),
     # Test a Windows encoding with incompatibly encoded text.
-    ('déf'.encode('utf-8'), 'cp1252', 'dÃ©f'),
+    ('déf'.encode(), 'cp1252', 'dÃ©f'),
 ])
 def test_str_to_display__encoding(monkeypatch, data, encoding, expected):
     monkeypatch.setattr(locale, 'getpreferredencoding', lambda: encoding)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -436,9 +436,9 @@ elif sys.byteorder == "big":
     # Test passing a text (unicode) string.
     ('/path/déf', None, '/path/déf'),
     # Test a bytes object with a non-ascii character.
-    ('/path/déf'.encode('utf-8'), 'utf-8', '/path/déf'),
+    ('/path/déf'.encode(), 'utf-8', '/path/déf'),
     # Test a bytes object with a character that can't be decoded.
-    ('/path/déf'.encode('utf-8'), 'ascii', "b'/path/d\\xc3\\xa9f'"),
+    ('/path/déf'.encode(), 'ascii', "b'/path/d\\xc3\\xa9f'"),
     ('/path/déf'.encode('utf-16'), 'utf-8', expected_byte_string),
 ])
 def test_path_to_display(monkeypatch, path, fs_encoding, expected):


### PR DESCRIPTION
Suggested by `pyupgrade --py3-plus`