### PR TITLE
Add github action to check news entries

### DIFF
--- a/.github/workflows/news-file.yaml
+++ b/.github/workflows/news-file.yaml
@@ -1,0 +1,61 @@
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+jobs:
+  check-news-file:
+    runs-on: ubuntu-20.04
+    # Prevent this job from executing when a PR is opened against a fork
+    if: ${{github.repository == 'hexagonrecursion/pip'}}
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get install -y curl grep jq jo
+      - name: Check if PR contains a news fragment or has trivial label
+        env:
+          # Pass GITHUB_TOKEN via an environment variable because the alternative is 
+          # building a shell script using string interpolation (and that would be EVIL)
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          set -euo pipefail
+          
+          # Helper function for github api
+          curl_gh() {
+            curl \
+              -L \
+              -H 'Accept: application/vnd.github.v3+json' \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              "$@"
+          }
+          
+          # Deduplicate PR status posting logic
+          post_status() {
+            local URL="$1" STATE="$2" DESCRIPTION="$3"
+            local HELP_URL='https://pip.pypa.io/en/latest/development/contributing/#news-entries'
+            local PAYLOAD="$(jo state="$STATE" description="$DESCRIPTION" context=news-file/pr target_url="$HELP_URL")"
+            echo "::group::POST the status: STATE=$2 DESCRIPTION=$3"
+              # 2>&1 >out.txt is to prevent weird mixing of stderr and stdout
+              curl_gh -X POST "$URL" -d "$PAYLOAD" 2>&1 >out.txt
+              cat out.txt
+              rm out.txt
+            echo '::endgroup::'
+          }
+          
+          echo '::group::Event payload'
+            cat "$GITHUB_EVENT_PATH"
+          echo '::endgroup::'
+          STATUSES_URL="$(jq --raw-output '.pull_request.statuses_url' "$GITHUB_EVENT_PATH")"
+          PR_URL="$(jq --raw-output '.pull_request.url' "$GITHUB_EVENT_PATH")"
+          
+          if jq --exit-status '.pull_request.labels | any(.[].name; . == "trivial")' "$GITHUB_EVENT_PATH" > /dev/null; then
+            post_status "$STATUSES_URL" success 'Change is trivial'
+          else
+            echo "::group::GET $PR_URL/files"
+              curl_gh "$PR_URL/files" 2>&1 >files.json
+              cat files.json
+            echo '::endgroup::'
+            NEWS_FRAGMENT_RE='news/[^\./]+\.(process|removal|feature|bugfix|doc|vendor|trivial)\.rst$'
+            if jq --raw-output '.[].filename' files.json | grep -E "$NEWS_FRAGMENT_RE" > /dev/null; then
+              post_status "$STATUSES_URL" success 'PR has news fragment'
+            else
+              post_status "$STATUSES_URL" failure 'Missing news fragment or trivial label'
+            fi
+          fi

--- a/.github/workflows/news-file.yaml
+++ b/.github/workflows/news-file.yaml
@@ -11,12 +11,12 @@ jobs:
         run: sudo apt-get install -y curl grep jq jo
       - name: Check if PR contains a news fragment or has trivial label
         env:
-          # Pass GITHUB_TOKEN via an environment variable because the alternative is 
+          # Pass GITHUB_TOKEN via an environment variable because the alternative is
           # building a shell script using string interpolation (and that would be EVIL)
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           set -euo pipefail
-          
+
           # Helper function for github api
           curl_gh() {
             curl \
@@ -25,7 +25,7 @@ jobs:
               -H "Authorization: Bearer $GITHUB_TOKEN" \
               "$@"
           }
-          
+
           # Deduplicate PR status posting logic
           post_status() {
             local URL="$1" STATE="$2" DESCRIPTION="$3"
@@ -38,13 +38,13 @@ jobs:
               rm out.txt
             echo '::endgroup::'
           }
-          
+
           echo '::group::Event payload'
             cat "$GITHUB_EVENT_PATH"
           echo '::endgroup::'
           STATUSES_URL="$(jq --raw-output '.pull_request.statuses_url' "$GITHUB_EVENT_PATH")"
           PR_URL="$(jq --raw-output '.pull_request.url' "$GITHUB_EVENT_PATH")"
-          
+
           if jq --exit-status '.pull_request.labels | any(.[].name; . == "trivial")' "$GITHUB_EVENT_PATH" > /dev/null; then
             post_status "$STATUSES_URL" success 'Change is trivial'
           else

--- a/.github/workflows/news-file.yaml
+++ b/.github/workflows/news-file.yaml
@@ -5,7 +5,7 @@ jobs:
   check-news-file:
     runs-on: ubuntu-20.04
     # Prevent this job from executing when a PR is opened against a fork
-    if: ${{github.repository == 'hexagonrecursion/pip'}}
+    if: ${{github.repository == 'pypa/pip'}}
     steps:
       - name: Install dependencies
         run: sudo apt-get install -y curl grep jq jo


### PR DESCRIPTION
I got tired of https://github.com/pypa/browntruck/issues/24 and wanted to fix it. I chose to reimplement the broken check as a github action. You can see the github action in action here: https://github.com/hexagonrecursion/pip/pull/1 https://github.com/hexagonrecursion/pip/pull/2 https://github.com/hexagonrecursion/pip/pull/3

The workflow uses `pull_request_target` event because workflows spawned by `pull_request` do not have sufficient permissions to create a status.

# Mandatory warning
> https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
> Warning: The pull_request_target event is granted a read/write repository token and can access secrets, even when it is triggered from a fork. Although the workflow runs in the context of the base of the pull request, you should make sure that you do not check out, build, or run untrusted code from the pull request with this event. Additionally, any caches share the same scope as the base branch, and to help prevent cache poisoning, you should not save the cache if there is a possibility that the cache contents were altered.