### PR TITLE
Convert more str.format() calls to f-strings

### DIFF
--- a/docs/pip_sphinxext.py
+++ b/docs/pip_sphinxext.py
@@ -50,10 +50,10 @@ class PipOptions(rst.Directive):
 
     def _format_option(self, option, cmd_name=None):
         bookmark_line = (
-            ".. _`{cmd_name}_{option._long_opts[0]}`:"
+            f".. _`{cmd_name}_{option._long_opts[0]}`:"
             if cmd_name else
-            ".. _`{option._long_opts[0]}`:"
-        ).format(**locals())
+            f".. _`{option._long_opts[0]}`:"
+        )
         line = ".. option:: "
         if option._short_opts:
             line += option._short_opts[0]

--- a/src/pip/_internal/cli/main_parser.py
+++ b/src/pip/_internal/cli/main_parser.py
@@ -45,7 +45,7 @@ def create_main_parser():
 
     # create command listing for description
     description = [''] + [
-        '{name:27} {command_info.summary}'.format(**locals())
+        f'{name:27} {command_info.summary}'
         for name, command_info in commands_dict.items()
     ]
     parser.description = '\n'.join(description)

--- a/src/pip/_internal/cli/spinners.py
+++ b/src/pip/_internal/cli/spinners.py
@@ -104,8 +104,7 @@ class NonInteractiveSpinner(SpinnerInterface):
         # type: (str) -> None
         if self._finished:
             return
-        self._update(
-            "finished with status '{final_status}'".format(**locals()))
+        self._update(f"finished with status '{final_status}'")
         self._finished = True
 
 

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -140,7 +140,7 @@ def print_results(hits, name_column_width=None, terminal_width=None):
                 summary = ('\n' + ' ' * (name_column_width + 3)).join(
                     summary_lines)
 
-        name_latest=f'{name} ({latest})'
+        name_latest = f'{name} ({latest})'
         line = f'{name_latest:{name_column_width}} - {summary}'
         try:
             write_output(line)

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -140,7 +140,8 @@ def print_results(hits, name_column_width=None, terminal_width=None):
                 summary = ('\n' + ' ' * (name_column_width + 3)).join(
                     summary_lines)
 
-        line = f'{{{name} ({latest}):{name_column_width}}} - {summary}'
+        name_latest=f'{name} ({latest})'
+        line = f'{name_latest:{name_column_width}} - {summary}'
         try:
             write_output(line)
             dist = env.get_distribution(name)

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -140,9 +140,7 @@ def print_results(hits, name_column_width=None, terminal_width=None):
                 summary = ('\n' + ' ' * (name_column_width + 3)).join(
                     summary_lines)
 
-        line = '{name_latest:{name_column_width}} - {summary}'.format(
-            name_latest='{name} ({latest})'.format(**locals()),
-            **locals())
+        line = f'{{{name} ({latest}):{name_column_width}}} - {summary}'
         try:
             write_output(line)
             dist = env.get_distribution(name)

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -75,8 +75,8 @@ class UninstallCommand(Command, SessionCommandMixin):
                     reqs_to_uninstall[canonicalize_name(req.name)] = req
         if not reqs_to_uninstall:
             raise InstallationError(
-                'You must give at least one requirement to {self.name} (see '
-                '"pip help {self.name}")'.format(**locals())
+                f'You must give at least one requirement to {self.name} (see '
+                f'"pip help {self.name}")'
             )
 
         protect_pip_from_modification_on_windows(

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -113,8 +113,7 @@ class Link(KeyBasedCompareMixin):
             return netloc
 
         name = urllib.parse.unquote(name)
-        assert name, (
-            'URL {self._url!r} produced no filename'.format(**locals()))
+        assert name, f'URL {self._url!r} produced no filename'
         return name
 
     @property

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -261,8 +261,8 @@ def _get_url_from_path(path, name):
         if is_installable_dir(path):
             return path_to_url(path)
         raise InstallationError(
-            "Directory {name!r} is not installable. Neither 'setup.py' "
-            "nor 'pyproject.toml' found.".format(**locals())
+            f"Directory {name!r} is not installable. Neither 'setup.py' "
+            "nor 'pyproject.toml' found."
         )
     if not is_archive_file(path):
         return None
@@ -319,7 +319,7 @@ def parse_req_from_line(name, line_source):
         # wheel file
         if link.is_wheel:
             wheel = Wheel(link.filename)  # can raise InvalidWheelFilename
-            req_as_string = "{wheel.name}=={wheel.version}".format(**locals())
+            req_as_string = f"{wheel.name}=={wheel.version}"
         else:
             # set the req to the egg fragment.  when it's not there, this
             # will become an 'unnamed' requirement

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -664,8 +664,7 @@ class InstallRequirement:
         def _clean_zip_name(name, prefix):
             # type: (str, str) -> str
             assert name.startswith(prefix + os.path.sep), (
-                "name {name!r} doesn't start with prefix {prefix!r}"
-                .format(**locals())
+                f"name {name!r} doesn't start with prefix {prefix!r}"
             )
             name = name[len(prefix) + 1:]
             name = name.replace(os.path.sep, '/')

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -194,7 +194,7 @@ class RequirementSet:
         if project_name in self.requirements:
             return self.requirements[project_name]
 
-        raise KeyError("No project with the name {name!r}".format(**locals()))
+        raise KeyError(f"No project with the name {name!r}")
 
     @property
     def all_requirements(self):

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -67,8 +67,7 @@ def copy2_fixed(src, dest):
                 pass
             else:
                 if is_socket_file:
-                    raise shutil.SpecialFileError(
-                        "`{f}` is a socket".format(**locals()))
+                    raise shutil.SpecialFileError(f"`{f}` is a socket")
 
         raise
 

--- a/src/pip/_internal/utils/urls.py
+++ b/src/pip/_internal/utils/urls.py
@@ -33,8 +33,7 @@ def url_to_path(url):
     Convert a file: URL to a path.
     """
     assert url.startswith('file:'), (
-        "You can only turn file: urls into filenames (not {url!r})"
-        .format(**locals()))
+        f"You can only turn file: urls into filenames (not {url!r})")
 
     _, netloc, path, _, _ = urllib.parse.urlsplit(url)
 
@@ -46,8 +45,7 @@ def url_to_path(url):
         netloc = '\\\\' + netloc
     else:
         raise ValueError(
-            'non-local file URIs are not supported on this platform: {url!r}'
-            .format(**locals())
+            f'non-local file URIs are not supported on this platform: {url!r}'
         )
 
     path = urllib.request.url2pathname(netloc + path)

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -158,8 +158,7 @@ class Subversion(VersionControl):
         elif data.startswith('<?xml'):
             match = _svn_xml_url_re.search(data)
             if not match:
-                raise ValueError(
-                    'Badly formatted data: {data!r}'.format(**locals()))
+                raise ValueError(f'Badly formatted data: {data!r}')
             url = match.group(1)    # get repository URL
             revs = [int(m.group(1)) for m in _svn_rev_re.finditer(data)] + [0]
         else:

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -690,9 +690,8 @@ class VersionControl:
             # errno.ENOENT = no such file or directory
             # In other words, the VCS executable isn't available
             raise BadCommand(
-                'Cannot find command {cls.name!r} - do you have '
-                '{cls.name!r} installed and in your '
-                'PATH?'.format(**locals()))
+                f'Cannot find command {cls.name!r} - do you have '
+                f'{cls.name!r} installed and in your PATH?')
 
     @classmethod
     def is_repository_directory(cls, path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,12 +287,12 @@ def pip_src(tmpdir_factory):
 
 def _common_wheel_editable_install(tmpdir_factory, common_wheels, package):
     wheel_candidates = list(
-        common_wheels.glob('{package}-*.whl'.format(**locals())))
+        common_wheels.glob(f'{package}-*.whl'))
     assert len(wheel_candidates) == 1, wheel_candidates
     install_dir = Path(str(tmpdir_factory.mktemp(package))) / 'install'
     Wheel(wheel_candidates[0]).install_as_egg(install_dir)
     (install_dir / 'EGG-INFO').rename(
-        install_dir / '{package}.egg-info'.format(**locals()))
+        install_dir / f'{package}.egg-info')
     assert compileall.compile_dir(str(install_dir), quiet=1)
     return install_dir
 

--- a/tests/data/src/chattymodule/setup.py
+++ b/tests/data/src/chattymodule/setup.py
@@ -5,7 +5,7 @@ import sys
 
 from setuptools import setup
 
-print("HELLO FROM CHATTYMODULE {sys.argv[1]}".format(**locals()))
+print(f"HELLO FROM CHATTYMODULE {sys.argv[1]}")
 print(os.environ)
 print(sys.argv)
 if "--fail" in sys.argv:

--- a/tests/functional/test_build_env.py
+++ b/tests/functional/test_build_env.py
@@ -79,15 +79,15 @@ def test_build_env_allow_only_one_install(script):
     for prefix in ('normal', 'overlay'):
         build_env.install_requirements(
             finder, ['foo'], prefix,
-            'installing foo in {prefix}'.format(**locals()))
+            f'installing foo in {prefix}')
         with pytest.raises(AssertionError):
             build_env.install_requirements(
                 finder, ['bar'], prefix,
-                'installing bar in {prefix}'.format(**locals()))
+                f'installing bar in {prefix}')
         with pytest.raises(AssertionError):
             build_env.install_requirements(
                 finder, [], prefix,
-                'installing in {prefix}'.format(**locals()))
+                f'installing in {prefix}')
 
 
 def test_build_env_requirements_check(script):
@@ -201,7 +201,7 @@ def test_build_env_isolation(script):
             pass
         else:
             print(
-                'imported `pkg` from `{pkg.__file__}`'.format(**locals()),
+                f'imported `pkg` from `{pkg.__file__}`',
                 file=sys.stderr)
             print('system sites:\n  ' + '\n  '.join(sorted({
                           get_python_lib(plat_specific=0),

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -230,7 +230,7 @@ def test_completion_not_files_after_nonexpecting_option(
     (e.g. ``pip install``)
     """
     res, env = autocomplete(
-        words=('pip install {cl_opts} r'.format(**locals())),
+        words=(f'pip install {cl_opts} r'),
         cword='2',
         cwd=data.completion_paths,
     )

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -42,7 +42,7 @@ def _check_output(result, expected):
     actual = distribute_re.sub('', actual)
 
     def banner(msg):
-        return '\n========== {msg} ==========\n'.format(**locals())
+        return f'\n========== {msg} ==========\n'
 
     assert checker.check_output(expected, actual, ELLIPSIS), (
         banner('EXPECTED') + expected + banner('ACTUAL') + actual +
@@ -272,7 +272,7 @@ def test_freeze_git_clone(script, tmpdir):
     _check_output(result.stdout, expected)
 
     result = script.pip(
-        'freeze', '-f', '{repo_dir}#egg=pip_test_package'.format(**locals()),
+        'freeze', '-f', f'{repo_dir}#egg=pip_test_package',
         expect_stderr=True,
     )
     expected = textwrap.dedent(
@@ -337,7 +337,7 @@ def test_freeze_git_clone_srcdir(script, tmpdir):
     _check_output(result.stdout, expected)
 
     result = script.pip(
-        'freeze', '-f', '{repo_dir}#egg=pip_test_package'.format(**locals()),
+        'freeze', '-f', f'{repo_dir}#egg=pip_test_package',
         expect_stderr=True,
     )
     expected = textwrap.dedent(
@@ -378,7 +378,7 @@ def test_freeze_mercurial_clone_srcdir(script, tmpdir):
     _check_output(result.stdout, expected)
 
     result = script.pip(
-        'freeze', '-f', '{repo_dir}#egg=pip_test_package'.format(**locals()),
+        'freeze', '-f', f'{repo_dir}#egg=pip_test_package',
         expect_stderr=True,
     )
     expected = textwrap.dedent(
@@ -473,7 +473,7 @@ def test_freeze_mercurial_clone(script, tmpdir):
     _check_output(result.stdout, expected)
 
     result = script.pip(
-        'freeze', '-f', '{repo_dir}#egg=pip_test_package'.format(**locals()),
+        'freeze', '-f', f'{repo_dir}#egg=pip_test_package',
         expect_stderr=True,
     )
     expected = textwrap.dedent(
@@ -513,7 +513,7 @@ def test_freeze_bazaar_clone(script, tmpdir):
 
     result = script.pip(
         'freeze', '-f',
-        '{checkout_path}/#egg=django-wikiapp'.format(**locals()),
+        f'{checkout_path}/#egg=django-wikiapp',
         expect_stderr=True,
     )
     expected = textwrap.dedent("""\

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -199,7 +199,7 @@ def test_pip_second_command_line_interface_works(
     if pyversion_tuple < (2, 7, 9):
         kwargs['expect_stderr'] = True
 
-    args = ['pip{pyversion}'.format(**globals())]
+    args = [f'pip{pyversion}']
     args.extend(['install', 'INITools==0.2'])
     args.extend(['-f', data.packages])
     result = script.run(*args, **kwargs)
@@ -727,11 +727,10 @@ def test_install_using_install_option_and_editable(script, tmpdir):
     """
     folder = 'script_folder'
     script.scratch_path.joinpath(folder).mkdir()
-    url = 'git+git://github.com/pypa/pip-test-package'
+    url = local_checkout('git+git://github.com/pypa/pip-test-package', tmpdir)
     result = script.pip(
-        'install', '-e', '{url}#egg=pip-test-package'
-        .format(url=local_checkout(url, tmpdir)),
-        '--install-option=--script-dir={folder}'.format(**locals()),
+        'install', '-e', f'{url}#egg=pip-test-package',
+        f'--install-option=--script-dir={folder}',
         expect_stderr=True)
     script_file = (
         script.venv / 'src' / 'pip-test-package' /
@@ -799,10 +798,7 @@ def test_install_folder_using_slash_in_the_end(script, with_wheel):
     pkg_path = script.scratch_path / 'mock'
     pkg_path.joinpath("setup.py").write_text(mock100_setup_py)
     result = script.pip('install', 'mock' + os.path.sep)
-    dist_info_folder = (
-        script.site_packages /
-        'mock-100.1.dist-info'
-    )
+    dist_info_folder = script.site_packages / 'mock-100.1.dist-info'
     result.did_create(dist_info_folder)
 
 
@@ -815,10 +811,7 @@ def test_install_folder_using_relative_path(script, with_wheel):
     pkg_path = script.scratch_path / 'initools' / 'mock'
     pkg_path.joinpath("setup.py").write_text(mock100_setup_py)
     result = script.pip('install', Path('initools') / 'mock')
-    dist_info_folder = (
-        script.site_packages /
-        'mock-100.1.dist-info'.format(**globals())
-    )
+    dist_info_folder = script.site_packages / 'mock-100.1.dist-info'
     result.did_create(dist_info_folder)
 
 
@@ -1294,7 +1287,7 @@ def test_install_subprocess_output_handling(script, data):
 def test_install_log(script, data, tmpdir):
     # test that verbose logs go to "--log" file
     f = tmpdir.joinpath("log.txt")
-    args = ['--log={f}'.format(**locals()),
+    args = [f'--log={f}',
             'install', data.src.joinpath('chattymodule')]
     result = script.pip(*args)
     assert 0 == result.stdout.count("HELLO FROM CHATTYMODULE")
@@ -1448,7 +1441,7 @@ def test_install_editable_with_wrong_egg_name(script, resolver_variant):
     """))
     result = script.pip(
         'install', '--editable',
-        'file://{pkga_path}#egg=pkgb'.format(**locals()),
+        f'file://{pkga_path}#egg=pkgb',
         expect_error=(resolver_variant == "2020-resolver"),
     )
     assert ("Generating metadata for package pkgb produced metadata "
@@ -1534,7 +1527,7 @@ def test_install_incompatible_python_requires_editable(script):
     """))
     result = script.pip(
         'install',
-        '--editable={pkga_path}'.format(**locals()),
+        f'--editable={pkga_path}',
         expect_error=True)
     assert _get_expected_error_text() in result.stderr, str(result)
 
@@ -1651,7 +1644,7 @@ def test_installed_files_recorded_in_deterministic_order(script, data):
     to_install = data.packages.joinpath("FSPkg")
     result = script.pip('install', to_install)
     fspkg_folder = script.site_packages / 'fspkg'
-    egg_info = 'FSPkg-0.1.dev0-py{pyversion}.egg-info'.format(**globals())
+    egg_info = f'FSPkg-0.1.dev0-py{pyversion}.egg-info'
     installed_files_path = (
         script.site_packages / egg_info / 'installed-files.txt'
     )
@@ -1714,10 +1707,10 @@ def test_target_install_ignores_distutils_config_install_prefix(script):
                             'pydistutils.cfg' if sys.platform == 'win32'
                             else '.pydistutils.cfg')
     distutils_config.write_text(textwrap.dedent(
-        '''
+        f'''
         [install]
         prefix={prefix}
-        '''.format(**locals())))
+        '''))
     target = script.scratch_path / 'target'
     result = script.pip_install_local('simplewheel', '-t', target)
 

--- a/tests/functional/test_install_compat.py
+++ b/tests/functional/test_install_compat.py
@@ -26,7 +26,7 @@ def test_debian_egg_name_workaround(script):
 
     egg_info = os.path.join(
         script.site_packages,
-        "INITools-0.2-py{pyversion}.egg-info".format(**globals()))
+        f"INITools-0.2-py{pyversion}.egg-info")
 
     # Debian only removes pyversion for global installs, not inside a venv
     # so even if this test runs on a Debian/Ubuntu system with broken
@@ -34,14 +34,14 @@ def test_debian_egg_name_workaround(script):
     # .egg-info
     result.did_create(
         egg_info,
-        message="Couldn't find {egg_info}".format(**locals())
+        message=f"Couldn't find {egg_info}"
     )
 
     # The Debian no-pyversion version of the .egg-info
     mangled = os.path.join(script.site_packages, "INITools-0.2.egg-info")
     result.did_not_create(
         mangled,
-        message="Found unexpected {mangled}".format(**locals())
+        message=f"Found unexpected {mangled}"
     )
 
     # Simulate a Debian install by copying the .egg-info to their name for it

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -112,7 +112,7 @@ def test_command_line_appends_correctly(script, data):
 
     """
     script.environ['PIP_FIND_LINKS'] = (
-        'https://test.pypi.org {data.find_links}'.format(**locals())
+        f'https://test.pypi.org {data.find_links}'
     )
     result = script.pip(
         'install', '-vvv', 'INITools', '--trusted-host',

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -136,7 +136,7 @@ def test_install_special_extra(script):
     """))
 
     result = script.pip(
-        'install', '--no-index', '{pkga_path}[Hop_hOp-hoP]'.format(**locals()),
+        'install', '--no-index', f'{pkga_path}[Hop_hOp-hoP]',
         expect_error=True)
     assert (
         "Could not find a version that satisfies the requirement missing_pkg"
@@ -165,7 +165,7 @@ def test_install_extra_merging(script, data, extra_to_install, simple_version):
     """))
 
     result = script.pip_install_local(
-        '{pkga_path}{extra_to_install}'.format(**locals()),
+        f'{pkga_path}{extra_to_install}',
     )
 
     assert f'Successfully installed pkga-0.1 simple-{simple_version}' in result.stdout

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -645,7 +645,7 @@ def test_install_unsupported_wheel_file(script, data):
     # Trying to install a local wheel with an incompatible version/type
     # should fail.
     path = data.packages.joinpath("simple.dist-0.1-py1-none-invalid.whl")
-    script.scratch_path.joinpath("wheel-file.txt").write_text(path + '\n'))
+    script.scratch_path.joinpath("wheel-file.txt").write_text(path + '\n')
     result = script.pip(
         'install', '-r', script.scratch_path / 'wheel-file.txt',
         expect_error=True,

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -68,11 +68,11 @@ def test_requirements_file(script, with_wheel):
 
     """
     other_lib_name, other_lib_version = 'anyjson', '0.3'
-    script.scratch_path.joinpath("initools-req.txt").write_text(textwrap.dedent("""\
+    script.scratch_path.joinpath("initools-req.txt").write_text(textwrap.dedent(f"""\
         INITools==0.2
         # and something else to test out:
         {other_lib_name}<={other_lib_version}
-        """.format(**locals())))
+        """))
     result = script.pip(
         'install', '-r', script.scratch_path / 'initools-req.txt'
     )
@@ -178,15 +178,14 @@ def test_multiple_requirements_files(script, tmpdir, with_wheel):
             other_lib_name
         ),
     )
-    script.scratch_path.joinpath(
-        "{other_lib_name}-req.txt".format(**locals())).write_text(
-            "{other_lib_name}<={other_lib_version}".format(**locals())
+    script.scratch_path.joinpath(f"{other_lib_name}-req.txt").write_text(
+            f"{other_lib_name}<={other_lib_version}"
     )
     result = script.pip(
         'install', '-r', script.scratch_path / 'initools-req.txt'
     )
     assert result.files_created[script.site_packages / other_lib_name].dir
-    fn = '{other_lib_name}-{other_lib_version}.dist-info'.format(**locals())
+    fn = f'{other_lib_name}-{other_lib_version}.dist-info'
     assert result.files_created[script.site_packages / fn].dir
     result.did_create(script.venv / 'src' / 'initools')
 
@@ -295,9 +294,9 @@ def test_wheel_user_with_prefix_in_pydistutils_cfg(
     user_cfg = os.path.join(os.path.expanduser('~'), user_filename)
     script.scratch_path.joinpath("bin").mkdir()
     with open(user_cfg, "w") as cfg:
-        cfg.write(textwrap.dedent("""
+        cfg.write(textwrap.dedent(f"""
             [install]
-            prefix={script.scratch_path}""".format(**locals())))
+            prefix={script.scratch_path}"""))
 
     result = script.pip(
         'install', '--user', '--no-index',
@@ -559,8 +558,7 @@ def test_install_distribution_duplicate_extras(script, data):
     package_name = to_install + "[bar]"
     with pytest.raises(AssertionError):
         result = script.pip_install_local(package_name, package_name)
-        expected = (
-            'Double requirement given: {package_name}'.format(**locals()))
+        expected = (f'Double requirement given: {package_name}')
         assert expected in result.stderr
 
 
@@ -571,7 +569,7 @@ def test_install_distribution_union_with_constraints(
 ):
     to_install = data.packages.joinpath("LocalExtras")
     script.scratch_path.joinpath("constraints.txt").write_text(
-        "{to_install}[bar]".format(**locals()))
+        f"{to_install}[bar]")
     result = script.pip_install_local(
         '-c', script.scratch_path / 'constraints.txt', to_install + '[baz]',
         allow_stderr_warning=True,
@@ -647,9 +645,9 @@ def test_install_unsupported_wheel_file(script, data):
     # Trying to install a local wheel with an incompatible version/type
     # should fail.
     path = data.packages.joinpath("simple.dist-0.1-py1-none-invalid.whl")
-    script.scratch_path.joinpath("wheel-file.txt").write_text(textwrap.dedent("""\
+    script.scratch_path.joinpath("wheel-file.txt").write_text(textwrap.dedent(f"""\
         {path}
-        """.format(**locals())))
+        """))
     result = script.pip(
         'install', '-r', script.scratch_path / 'wheel-file.txt',
         expect_error=True,

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -645,9 +645,7 @@ def test_install_unsupported_wheel_file(script, data):
     # Trying to install a local wheel with an incompatible version/type
     # should fail.
     path = data.packages.joinpath("simple.dist-0.1-py1-none-invalid.whl")
-    script.scratch_path.joinpath("wheel-file.txt").write_text(textwrap.dedent(f"""\
-        {path}
-        """))
+    script.scratch_path.joinpath("wheel-file.txt").write_text(path + '\n'))
     result = script.pip(
         'install', '-r', script.scratch_path / 'wheel-file.txt',
         expect_error=True,

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -421,8 +421,7 @@ class TestUpgradeDistributeToSetuptools:
 
     def prep_ve(self, script, version, pip_src, distribute=False):
         self.script = script
-        self.script.pip_install_local(
-            'virtualenv=={version}'.format(**locals()))
+        self.script.pip_install_local(f'virtualenv=={version}')
         args = ['virtualenv', self.script.scratch_path / 'VE']
         if distribute:
             args.insert(1, '--distribute')

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -118,8 +118,7 @@ class Tests_UserSite:
         # usersite has 0.1
         # we still test for egg-info because no-binary implies setup.py install
         egg_info_folder = (
-            script.user_site /
-            'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
+            script.user_site / f'INITools-0.1-py{pyversion}.egg-info'
         )
         initools_v3_file = (
             # file only in 0.3
@@ -146,8 +145,7 @@ class Tests_UserSite:
         # usersite has 0.1
         # we still test for egg-info because no-binary implies setup.py install
         egg_info_folder = (
-            script.user_site /
-            'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
+            script.user_site / f'INITools-0.1-py{pyversion}.egg-info'
         )
         initools_folder = script.user_site / 'initools'
         result2.did_create(egg_info_folder)
@@ -156,7 +154,7 @@ class Tests_UserSite:
         # site still has 0.2 (can't look in result1; have to check)
         egg_info_folder = (
             script.base_path / script.site_packages /
-            'INITools-0.2-py{pyversion}.egg-info'.format(**globals())
+            f'INITools-0.2-py{pyversion}.egg-info'
         )
         initools_folder = script.base_path / script.site_packages / 'initools'
         assert isdir(egg_info_folder)
@@ -178,8 +176,7 @@ class Tests_UserSite:
         # usersite has 0.3.1
         # we still test for egg-info because no-binary implies setup.py install
         egg_info_folder = (
-            script.user_site /
-            'INITools-0.3.1-py{pyversion}.egg-info'.format(**globals())
+            script.user_site / f'INITools-0.3.1-py{pyversion}.egg-info'
         )
         initools_folder = script.user_site / 'initools'
         result2.did_create(egg_info_folder)
@@ -188,7 +185,7 @@ class Tests_UserSite:
         # site still has 0.2 (can't look in result1; have to check)
         egg_info_folder = (
             script.base_path / script.site_packages /
-            'INITools-0.2-py{pyversion}.egg-info'.format(**globals())
+            f'INITools-0.2-py{pyversion}.egg-info'
         )
         initools_folder = script.base_path / script.site_packages / 'initools'
         assert isdir(egg_info_folder), result2.stdout
@@ -213,8 +210,7 @@ class Tests_UserSite:
         # usersite has 0.1
         # we still test for egg-info because no-binary implies setup.py install
         egg_info_folder = (
-            script.user_site /
-            'INITools-0.1-py{pyversion}.egg-info'.format(**globals())
+            script.user_site / f'INITools-0.1-py{pyversion}.egg-info'
         )
         initools_v3_file = (
             # file only in 0.3
@@ -227,7 +223,7 @@ class Tests_UserSite:
         # site still has 0.2 (can't just look in result1; have to check)
         egg_info_folder = (
             script.base_path / script.site_packages /
-            'INITools-0.2-py{pyversion}.egg-info'.format(**globals())
+            f'INITools-0.2-py{pyversion}.egg-info'
         )
         initools_folder = script.base_path / script.site_packages / 'initools'
         assert isdir(egg_info_folder)

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -46,7 +46,7 @@ class Tests_UninstallUserSite:
         # keep checking for egg-info because no-binary implies setup.py install
         egg_info_folder = (
             script.base_path / script.site_packages /
-            'pip_test_package-0.1-py{pyversion}.egg-info'.format(**globals())
+            f'pip_test_package-0.1-py{pyversion}.egg-info'
         )
         assert isdir(egg_info_folder)
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -49,8 +49,7 @@ def test_pip_wheel_success(script, data):
         'wheel', '--no-index', '-f', data.find_links,
         'simple==3.0',
     )
-    wheel_file_name = 'simple-3.0-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'simple-3.0-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     assert re.search(
         r"Created wheel for simple: "
@@ -70,8 +69,7 @@ def test_pip_wheel_build_cache(script, data):
         'wheel', '--no-index', '-f', data.find_links,
         'simple==3.0',
     )
-    wheel_file_name = 'simple-3.0-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'simple-3.0-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     result.did_create(wheel_file_path)
     assert "Successfully built simple" in result.stdout, result.stdout
@@ -148,8 +146,7 @@ def test_pip_wheel_builds_editable_deps(script, data):
         'wheel', '--no-index', '-f', data.find_links,
         '-e', editable_path
     )
-    wheel_file_name = 'simple-1.0-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'simple-1.0-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     result.did_create(wheel_file_path)
 
@@ -163,8 +160,7 @@ def test_pip_wheel_builds_editable(script, data):
         'wheel', '--no-index', '-f', data.find_links,
         '-e', editable_path
     )
-    wheel_file_name = 'simplewheel-1.0-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'simplewheel-1.0-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     result.did_create(wheel_file_path)
 
@@ -213,8 +209,7 @@ def test_pip_wheel_fail(script, data):
         'wheelbroken==0.1',
         expect_error=True,
     )
-    wheel_file_name = 'wheelbroken-0.1-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'wheelbroken-0.1-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     result.did_not_create(wheel_file_path)
     assert "FakeError" in result.stderr, result.stderr
@@ -236,7 +231,7 @@ def test_no_clean_option_blocks_cleaning_after_wheel(
     build = script.venv_path / 'build'
     result = script.pip(
         'wheel', '--no-clean', '--no-index', '--build', build,
-        '--find-links={data.find_links}'.format(**locals()),
+        f'--find-links={data.find_links}',
         'simple',
         expect_temp=True,
         # TODO: allow_stderr_warning is used for the --build deprecation,
@@ -260,8 +255,7 @@ def test_pip_wheel_source_deps(script, data):
         'wheel', '--no-index', '-f', data.find_links,
         'requires_source',
     )
-    wheel_file_name = 'source-1.0-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'source-1.0-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     result.did_create(wheel_file_path)
     assert "Successfully built source" in result.stdout, result.stdout
@@ -278,8 +272,7 @@ def test_wheel_package_with_latin1_setup(script, data):
 def test_pip_wheel_with_pep518_build_reqs(script, data, common_wheels):
     result = script.pip('wheel', '--no-index', '-f', data.find_links,
                         '-f', common_wheels, 'pep518==3.0',)
-    wheel_file_name = 'pep518-3.0-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'pep518-3.0-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     result.did_create(wheel_file_path)
     assert "Successfully built pep518" in result.stdout, result.stdout
@@ -292,8 +285,7 @@ def test_pip_wheel_with_pep518_build_reqs_no_isolation(script, data):
         'wheel', '--no-index', '-f', data.find_links,
         '--no-build-isolation', 'pep518==3.0',
     )
-    wheel_file_name = 'pep518-3.0-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'pep518-3.0-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     result.did_create(wheel_file_path)
     assert "Successfully built pep518" in result.stdout, result.stdout
@@ -339,8 +331,7 @@ def test_pep517_wheels_are_not_confused_with_other_files(script, tmpdir, data):
     result = script.pip('wheel', pkg_to_wheel, '-w', script.scratch_path)
     assert "Installing build dependencies" in result.stdout, result.stdout
 
-    wheel_file_name = 'withpyproject-0.0.1-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'withpyproject-0.0.1-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     result.did_create(wheel_file_path)
 
@@ -354,7 +345,6 @@ def test_legacy_wheels_are_not_confused_with_other_files(script, tmpdir, data):
     result = script.pip('wheel', pkg_to_wheel, '-w', script.scratch_path)
     assert "Installing build dependencies" not in result.stdout, result.stdout
 
-    wheel_file_name = 'simplewheel-1.0-py{pyversion[0]}-none-any.whl' \
-        .format(**globals())
+    wheel_file_name = f'simplewheel-1.0-py{pyversion[0]}-none-any.whl'
     wheel_file_path = script.scratch / wheel_file_name
     result.did_create(wheel_file_path)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -288,15 +288,13 @@ class TestPipResult:
             if egg_link_path in self.files_created:
                 raise TestFailure(
                     'unexpected egg link file created: '
-                    '{egg_link_path!r}\n{self}'
-                    .format(**locals())
+                    f'{egg_link_path!r}\n{self}'
                 )
         else:
             if egg_link_path not in self.files_created:
                 raise TestFailure(
                     'expected egg link file missing: '
-                    '{egg_link_path!r}\n{self}'
-                    .format(**locals())
+                    f'{egg_link_path!r}\n{self}'
                 )
 
             egg_link_file = self.files_created[egg_link_path]
@@ -305,15 +303,14 @@ class TestPipResult:
             # FIXME: I don't understand why there's a trailing . here
             if not (egg_link_contents.endswith('\n.') and
                     egg_link_contents[:-2].endswith(pkg_dir)):
+                expected_ending = pkg_dir + '\n.'
                 raise TestFailure(textwrap.dedent(
-                    '''\
+                    f'''\
                     Incorrect egg_link file {egg_link_file!r}
                     Expected ending: {expected_ending!r}
                     ------- Actual contents -------
                     {egg_link_contents!r}
-                    -------------------------------'''.format(
-                        expected_ending=pkg_dir + '\n.',
-                        **locals())
+                    -------------------------------'''
                 ))
 
         if use_user_site:
@@ -322,36 +319,33 @@ class TestPipResult:
             pth_file = e.site_packages / 'easy-install.pth'
 
         if (pth_file in self.files_updated) == without_egg_link:
+            maybe = '' if without_egg_link else 'not '
             raise TestFailure(
-                '{pth_file} unexpectedly {maybe}updated by install'.format(
-                    maybe=not without_egg_link and 'not ' or '',
-                    **locals()))
+                f'{pth_file} unexpectedly {maybe}updated by install'
+            )
 
         if (pkg_dir in self.files_created) == (curdir in without_files):
-            raise TestFailure(textwrap.dedent('''\
+            maybe = 'not ' if curdir in without_files else ''
+            files = sorted(self.files_created.keys())
+            raise TestFailure(textwrap.dedent(f'''\
             expected package directory {pkg_dir!r} {maybe}to be created
             actually created:
             {files}
-            ''').format(
-                pkg_dir=pkg_dir,
-                maybe=curdir in without_files and 'not ' or '',
-                files=sorted(self.files_created.keys()),
-            ))
+            '''))
 
         for f in with_files:
             normalized_path = os.path.normpath(pkg_dir / f)
             if normalized_path not in self.files_created:
                 raise TestFailure(
-                    'Package directory {pkg_dir!r} missing '
-                    'expected content {f!r}'.format(**locals())
+                    f'Package directory {pkg_dir!r} missing '
+                    f'expected content {f!r}'
                 )
 
         for f in without_files:
             normalized_path = os.path.normpath(pkg_dir / f)
             if normalized_path in self.files_created:
                 raise TestFailure(
-                    'Package directory {pkg_dir!r} has unexpected content {f}'
-                    .format(**locals())
+                    f'Package directory {pkg_dir!r} has unexpected content {f}'
                 )
 
     def did_create(self, path, message=None):
@@ -511,7 +505,7 @@ class PipTestEnvironment(TestFileEnvironment):
         # Expand our absolute path directories into relative
         for name in ["base", "venv", "bin", "lib", "site_packages",
                      "user_base", "user_site", "user_bin", "scratch"]:
-            real_name = "{name}_path".format(**locals())
+            real_name = f"{name}_path"
             relative_path = Path(os.path.relpath(
                 getattr(self, real_name), self.base_path
             ))
@@ -565,7 +559,7 @@ class PipTestEnvironment(TestFileEnvironment):
             compatibility.
         """
         if self.verbose:
-            print('>> running {args} {kw}'.format(**locals()))
+            print(f'>> running {args} {kw}')
 
         cwd = kw.pop('cwd', None)
         run_from = kw.pop('run_from', None)
@@ -823,7 +817,7 @@ def _vcs_add(script, version_pkg_path, vcs='git'):
             '-m', 'initial version', cwd=version_pkg_path,
         )
     else:
-        raise ValueError('Unknown vcs: {vcs}'.format(**locals()))
+        raise ValueError(f'Unknown vcs: {vcs}')
     return version_pkg_path
 
 
@@ -932,7 +926,7 @@ def assert_raises_regexp(exception, reg, run, *args, **kwargs):
 
     try:
         run(*args, **kwargs)
-        assert False, "{exception} should have been thrown".format(**locals())
+        assert False, f"{exception} should have been thrown"
     except exception:
         e = sys.exc_info()[1]
         p = re.compile(reg)
@@ -958,11 +952,11 @@ def create_test_package_with_setup(script, **setup_kwargs):
     assert 'name' in setup_kwargs, setup_kwargs
     pkg_path = script.scratch_path / setup_kwargs['name']
     pkg_path.mkdir()
-    pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
+    pkg_path.joinpath("setup.py").write_text(textwrap.dedent(f"""
         from setuptools import setup
         kwargs = {setup_kwargs!r}
         setup(**kwargs)
-    """).format(**locals()))
+    """))
     return pkg_path
 
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -326,7 +326,7 @@ class TestPipResult:
 
         if (pkg_dir in self.files_created) == (curdir in without_files):
             maybe = 'not ' if curdir in without_files else ''
-            files = sorted(self.files_created.keys())
+            files = sorted(self.files_created)
             raise TestFailure(textwrap.dedent(f'''\
             expected package directory {pkg_dir!r} {maybe}to be created
             actually created:

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -63,8 +63,8 @@ def test_correct_pip_version(script):
         if x.endswith('.py')
     ]
     assert not mismatch_py, (
-        'mismatched source files in {pip_folder!r} '
-        'and {pip_folder_outputed!r}: {mismatch_py!r}'.format(**locals())
+        f'mismatched source files in {pip_folder!r} '
+        f'and {pip_folder_outputed!r}: {mismatch_py!r}'
     )
 
 

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -608,7 +608,7 @@ def test_group_locations__file_expand_dir(data):
     files, urls = group_locations([data.find_links], expand_dir=True)
     assert files and not urls, (
         "files and not urls should have been found "
-        "at find-links url: {data.find_links}".format(**locals())
+        f"at find-links url: {data.find_links}"
     )
 
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -511,7 +511,7 @@ class TestInstallRequirement:
     def test_extras_for_line_path_requirement(self):
         line = 'SomeProject[ex1,ex2]'
         filename = 'filename'
-        comes_from = f'-r {filename} (line {1})'
+        comes_from = f'-r {filename} (line 1)'
         req = install_req_from_line(line, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}
@@ -519,7 +519,7 @@ class TestInstallRequirement:
     def test_extras_for_line_url_requirement(self):
         line = 'git+https://url#egg=SomeProject[ex1,ex2]'
         filename = 'filename'
-        comes_from = f'-r {filename} (line {1})'
+        comes_from = f'-r {filename} (line 1)'
         req = install_req_from_line(line, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}
@@ -527,7 +527,7 @@ class TestInstallRequirement:
     def test_extras_for_editable_path_requirement(self):
         url = '.[ex1,ex2]'
         filename = 'filename'
-        comes_from = f'-r {filename} (line {1})'
+        comes_from = f'-r {filename} (line 1)'
         req = install_req_from_editable(url, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}
@@ -535,7 +535,7 @@ class TestInstallRequirement:
     def test_extras_for_editable_url_requirement(self):
         url = 'git+https://url#egg=SomeProject[ex1,ex2]'
         filename = 'filename'
-        comes_from = f'-r {filename} (line {1})'
+        comes_from = f'-r {filename} (line 1)'
         req = install_req_from_editable(url, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -194,7 +194,7 @@ class TestRequirementSet:
         ))
         dir_path = data.packages.joinpath('FSPkg')
         reqset.add_requirement(get_processed_req_from_line(
-            'file://{dir_path}'.format(**locals()),
+            f'file://{dir_path}',
             lineno=2,
         ))
         finder = make_test_finder(find_links=[data.find_links])
@@ -254,7 +254,7 @@ class TestRequirementSet:
             (data.packages / 'simple-1.0.tar.gz').resolve())
         reqset = RequirementSet()
         reqset.add_requirement(get_processed_req_from_line(
-            '{file_url} --hash=sha256:badbad'.format(**locals()), lineno=1,
+            f'{file_url} --hash=sha256:badbad', lineno=1,
         ))
         finder = make_test_finder(find_links=[data.find_links])
         with self._basic_resolver(finder, require_hashes=True) as resolver:
@@ -470,7 +470,7 @@ class TestInstallRequirement:
         # match
         for markers in (
             'python_version >= "1.0"',
-            'sys_platform == {sys.platform!r}'.format(**globals()),
+            f'sys_platform == {sys.platform!r}',
         ):
             line = 'name; ' + markers
             req = install_req_from_line(line)
@@ -480,7 +480,7 @@ class TestInstallRequirement:
         # don't match
         for markers in (
             'python_version >= "5.0"',
-            'sys_platform != {sys.platform!r}'.format(**globals()),
+            f'sys_platform != {sys.platform!r}',
         ):
             line = 'name; ' + markers
             req = install_req_from_line(line)
@@ -491,7 +491,7 @@ class TestInstallRequirement:
         # match
         for markers in (
             'python_version >= "1.0"',
-            'sys_platform == {sys.platform!r}'.format(**globals()),
+            f'sys_platform == {sys.platform!r}',
         ):
             line = 'name; ' + markers
             req = install_req_from_line(line, comes_from='')
@@ -501,7 +501,7 @@ class TestInstallRequirement:
         # don't match
         for markers in (
             'python_version >= "5.0"',
-            'sys_platform != {sys.platform!r}'.format(**globals()),
+            f'sys_platform != {sys.platform!r}',
         ):
             line = 'name; ' + markers
             req = install_req_from_line(line, comes_from='')
@@ -511,7 +511,7 @@ class TestInstallRequirement:
     def test_extras_for_line_path_requirement(self):
         line = 'SomeProject[ex1,ex2]'
         filename = 'filename'
-        comes_from = '-r {} (line {})'.format(filename, 1)
+        comes_from = f'-r {filename} (line {1})'
         req = install_req_from_line(line, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}
@@ -519,7 +519,7 @@ class TestInstallRequirement:
     def test_extras_for_line_url_requirement(self):
         line = 'git+https://url#egg=SomeProject[ex1,ex2]'
         filename = 'filename'
-        comes_from = '-r {} (line {})'.format(filename, 1)
+        comes_from = f'-r {filename} (line {1})'
         req = install_req_from_line(line, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}
@@ -527,7 +527,7 @@ class TestInstallRequirement:
     def test_extras_for_editable_path_requirement(self):
         url = '.[ex1,ex2]'
         filename = 'filename'
-        comes_from = '-r {} (line {})'.format(filename, 1)
+        comes_from = f'-r {filename} (line {1})'
         req = install_req_from_editable(url, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}
@@ -535,7 +535,7 @@ class TestInstallRequirement:
     def test_extras_for_editable_url_requirement(self):
         url = 'git+https://url#egg=SomeProject[ex1,ex2]'
         filename = 'filename'
-        comes_from = '-r {} (line {})'.format(filename, 1)
+        comes_from = f'-r {filename} (line {1})'
         req = install_req_from_editable(url, comes_from=comes_from)
         assert len(req.extras) == 2
         assert req.extras == {'ex1', 'ex2'}

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -229,14 +229,14 @@ class TestProcessLine:
     def test_yield_line_requirement(self, line_processor):
         line = 'SomeProject'
         filename = 'filename'
-        comes_from = f'-r {filename} (line {1})'
+        comes_from = f'-r {filename} (line 1)'
         req = install_req_from_line(line, comes_from=comes_from)
         assert repr(line_processor(line, filename, 1)[0]) == repr(req)
 
     def test_yield_pep440_line_requirement(self, line_processor):
         line = 'SomeProject @ https://url/SomeProject-py2-py3-none-any.whl'
         filename = 'filename'
-        comes_from = f'-r {filename} (line {1})'
+        comes_from = f'-r {filename} (line 1)'
         req = install_req_from_line(line, comes_from=comes_from)
         assert repr(line_processor(line, filename, 1)[0]) == repr(req)
 
@@ -255,7 +255,7 @@ class TestProcessLine:
     ):
         line = 'SomeProject >= 2'
         filename = 'filename'
-        comes_from = f'-r {filename} (line {1})'
+        comes_from = f'-r {filename} (line 1)'
         req = install_req_from_line(line, comes_from=comes_from)
         assert repr(line_processor(line, filename, 1)[0]) == repr(req)
         assert str(req.req.specifier) == '>=2'
@@ -264,7 +264,7 @@ class TestProcessLine:
         url = 'git+https://url#egg=SomeProject'
         line = f'-e {url}'
         filename = 'filename'
-        comes_from = f'-r {filename} (line {1})'
+        comes_from = f'-r {filename} (line 1)'
         req = install_req_from_editable(url, comes_from=comes_from)
         assert repr(line_processor(line, filename, 1)[0]) == repr(req)
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -229,14 +229,14 @@ class TestProcessLine:
     def test_yield_line_requirement(self, line_processor):
         line = 'SomeProject'
         filename = 'filename'
-        comes_from = '-r {} (line {})'.format(filename, 1)
+        comes_from = f'-r {filename} (line {1})'
         req = install_req_from_line(line, comes_from=comes_from)
         assert repr(line_processor(line, filename, 1)[0]) == repr(req)
 
     def test_yield_pep440_line_requirement(self, line_processor):
         line = 'SomeProject @ https://url/SomeProject-py2-py3-none-any.whl'
         filename = 'filename'
-        comes_from = '-r {} (line {})'.format(filename, 1)
+        comes_from = f'-r {filename} (line {1})'
         req = install_req_from_line(line, comes_from=comes_from)
         assert repr(line_processor(line, filename, 1)[0]) == repr(req)
 
@@ -255,16 +255,16 @@ class TestProcessLine:
     ):
         line = 'SomeProject >= 2'
         filename = 'filename'
-        comes_from = '-r {} (line {})'.format(filename, 1)
+        comes_from = f'-r {filename} (line {1})'
         req = install_req_from_line(line, comes_from=comes_from)
         assert repr(line_processor(line, filename, 1)[0]) == repr(req)
         assert str(req.req.specifier) == '>=2'
 
     def test_yield_editable_requirement(self, line_processor):
         url = 'git+https://url#egg=SomeProject'
-        line = '-e {url}'.format(**locals())
+        line = f'-e {url}'
         filename = 'filename'
-        comes_from = '-r {} (line {})'.format(filename, 1)
+        comes_from = f'-r {filename} (line {1})'
         req = install_req_from_editable(url, comes_from=comes_from)
         assert repr(line_processor(line, filename, 1)[0]) == repr(req)
 
@@ -588,7 +588,7 @@ class TestParseRequirements:
         )
 
         def make_var(name):
-            return '${{{name}}}'.format(**locals())
+            return f'${{{name}}}'
 
         env_vars = collections.OrderedDict([
             ('GITHUB_TOKEN', 'notarealtoken'),


### PR DESCRIPTION
Using grep I have found all code like `str.format(**locals())` and `str.format(**globals())`. I then manually refactored it all to use f-strings. While I was at it I noticed and refactored a couple of calls to format that don't follow the pattern.