### PR TITLE
Point user to `pip debug --verbose` to debug incompatible wheel

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -194,7 +194,7 @@ class LinkEvaluator:
                     # simplify troubleshooting compatibility issues.
                     file_tags = wheel.get_formatted_file_tags()
                     reason = (
-                        "none of the wheel's tags match: {}".format(
+                        "none of the wheel's tags ({}) are compatible (run pip debug --verbose to show compatible tags)".format(
                             ', '.join(file_tags)
                         )
                     )

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -194,7 +194,8 @@ class LinkEvaluator:
                     # simplify troubleshooting compatibility issues.
                     file_tags = wheel.get_formatted_file_tags()
                     reason = (
-                        "none of the wheel's tags ({}) are compatible (run pip debug --verbose to show compatible tags)".format(
+                        "none of the wheel's tags ({}) are compatible "
+                        "(run pip debug --verbose to show compatible tags)".format(
                             ', '.join(file_tags)
                         )
                     )

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -170,7 +170,9 @@ class TestLinkEvaluator:
         link = Link('https://example.com/sample-1.0-py2.py3-none-any.whl')
         actual = evaluator.evaluate_link(link)
         expected = (
-            False, "none of the wheel's tags match: py2-none-any, py3-none-any"
+            False,
+            "none of the wheel's tags (py2-none-any, py3-none-any) are compatible "
+            "(run pip debug --verbose to show compatible tags)"
         )
         assert actual == expected
 


### PR DESCRIPTION
Resolves https://github.com/pypa/pip/issues/9621

(Does not require news file fragment - not newsworthy)