### PR TITLE
Remove "legacy-resolver" option, part 1

### DIFF
--- a/news/9631.removal.rst
+++ b/news/9631.removal.rst
@@ -1,0 +1,2 @@
+Usage of the old resolver via --use-deprecated=legacy-resolver is no longer
+available.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -965,7 +965,6 @@ use_deprecated_feature: Callable[..., Option] = partial(
     action="append",
     default=[],
     choices=[
-        "legacy-resolver",
         "out-of-tree-build",
         "backtrack-on-build-failures",
         "html5lib",

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -495,17 +495,14 @@ def test_vcs_url_urlquote_normalization(
     )
 
 
-@pytest.mark.parametrize("resolver", ["", "--use-deprecated=legacy-resolver"])
 @pytest.mark.usefixtures("with_wheel")
 def test_basic_install_from_local_directory(
-    script: PipTestEnvironment, data: TestData, resolver: str
+    script: PipTestEnvironment, data: TestData
 ) -> None:
     """
     Test installing from a local directory.
     """
     args = ["install"]
-    if resolver:
-        args.append(resolver)
     to_install = data.packages.joinpath("FSPkg")
     args.append(to_install)
     result = script.pip(*args)


### PR DESCRIPTION
## This is a subset of #9695 

This is the first step on the road to fully remove the legacy resolver. The aims of this PR are _strictly_ as follows:
 - Prohibit usage of `--use-deprecated=legacy-resolver`
 - Make sure the tests don't fail.
 
Edit: thanks to #9739 the yaml tests issue has been eliminated.
 