### PR TITLE
Fix --target not working with --editable

### DIFF
--- a/news/4390.bugfix.rst
+++ b/news/4390.bugfix.rst
@@ -1,1 +1,1 @@
-Fix --target to work with --editable installs.
+Fixed ``--target`` to work with ``--editable`` installs.

--- a/news/4390.bugfix.rst
+++ b/news/4390.bugfix.rst
@@ -1,0 +1,1 @@
+Fix --target to work with --editable installs.

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -103,7 +103,6 @@ def make_setuptools_develop_args(
     if prefix:
         args += ["--prefix", prefix]
     if home is not None:
-        # args += ["--home", home]
         args += ["--install-dir", home]
 
     if use_user_site:

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -103,7 +103,8 @@ def make_setuptools_develop_args(
     if prefix:
         args += ["--prefix", prefix]
     if home is not None:
-        args += ["--home", home]
+        # args += ["--home", home]
+        args += ["--install-dir", home]
 
     if use_user_site:
         args += ["--user", "--prefix="]

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1059,6 +1059,28 @@ def test_install_editable_with_prefix(script):
     result.did_create(install_path)
 
 
+@pytest.mark.network
+def test_install_editable_with_target(script):
+    pkg_path = script.scratch_path / 'pkg'
+    pkg_path.mkdir()
+    pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
+        from setuptools import setup
+        setup(
+            name='pkg',
+            install_requires=['watching_testrunner']
+        )
+    """))
+
+    target = script.scratch_path / 'target'
+    target.mkdir()
+    result = script.pip(
+        'install', '--editable', pkg_path, '--target', target
+    )
+
+    result.did_create(script.scratch / 'target' / 'pkg.egg-link')
+    result.did_create(script.scratch / 'target' / 'watching_testrunner.py')
+
+
 def test_install_package_conflict_prefix_and_user(script, data):
     """
     Test installing a package using pip install --prefix --user errors out


### PR DESCRIPTION
as setup.py develop does not understand `--home` but instead requires the `--install-dir` option.

Partially fixes #4390