### PR TITLE
docs: fix outdated setuptools links in user guide and reference guide

### DIFF
--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -540,7 +540,7 @@ Finding Packages
 
 pip searches for packages on `PyPI`_ using the
 `HTTP simple interface <https://pypi.org/simple/>`_,
-which is documented `here <https://setuptools.readthedocs.io/en/latest/easy_install.html#package-index-api>`_
+which is documented `here <https://setuptools.readthedocs.io/en/latest/deprecated/easy_install.html#package-index-api>`_
 and `there <https://www.python.org/dev/peps/pep-0503/>`_.
 
 pip offers a number of package index options for modifying how packages are
@@ -825,7 +825,7 @@ option in pip's command line.
 ^^^^^^^^^^^^^^^^^^^
 
 "Editable" installs are fundamentally `"setuptools develop mode"
-<https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode>`_
+<https://setuptools.readthedocs.io/en/latest/userguide/development_mode.html>`_
 installs.
 
 You can install local projects or VCS projects in "editable" mode:
@@ -858,7 +858,7 @@ Controlling setup_requires
 --------------------------
 
 Setuptools offers the ``setup_requires`` `setup() keyword
-<https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords>`_
+<https://setuptools.readthedocs.io/en/latest/userguide/keywords.html>`_
 for specifying dependencies that need to be present in order for the
 ``setup.py`` script to run.  Internally, Setuptools uses ``easy_install``
 to fulfill these dependencies.
@@ -898,7 +898,7 @@ the following commands::
 
 The ``egg_info`` command should create egg metadata for the package, as
 described in the setuptools documentation at
-https://setuptools.readthedocs.io/en/latest/setuptools.html#egg-info-create-egg-metadata-and-set-build-tags
+https://setuptools.readthedocs.io/en/latest/userguide/commands.html#egg-info-create-egg-metadata-and-set-build-tags
 
 The ``install`` command should implement the complete process of installing the
 package to the target directory XXX.
@@ -927,7 +927,7 @@ No other build system commands are invoked by the ``pip install`` command.
 Installing a package from a wheel does not invoke the build system at all.
 
 .. _PyPI: https://pypi.org/
-.. _setuptools extras: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
+.. _setuptools extras: https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies
 
 
 

--- a/docs/html/reference/pip_install.rst
+++ b/docs/html/reference/pip_install.rst
@@ -540,8 +540,7 @@ Finding Packages
 
 pip searches for packages on `PyPI`_ using the
 `HTTP simple interface <https://pypi.org/simple/>`_,
-which is documented `here <https://setuptools.readthedocs.io/en/latest/deprecated/easy_install.html#package-index-api>`_
-and `there <https://www.python.org/dev/peps/pep-0503/>`_.
+which is documented `here <https://packaging.python.org/specifications/simple-repository-api>`_.
 
 pip offers a number of package index options for modifying how packages are
 found.

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -235,7 +235,7 @@ In practice, there are 4 common uses of Requirements files:
 
 It's important to be clear that pip determines package dependencies using
 `install_requires metadata
-<https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies>`_,
+<https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#declaring-required-dependency>`_,
 not by discovering ``requirements.txt`` files embedded in projects.
 
 See also:

--- a/news/9660.doc.rst
+++ b/news/9660.doc.rst
@@ -1,0 +1,1 @@
+Fix outdated setuptools links in user and reference guide.


### PR DESCRIPTION
Fixes #9660.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
