### PR TITLE
Ignore dist-info directories with invalid name

### DIFF
--- a/news/7269.bugfix.rst
+++ b/news/7269.bugfix.rst
@@ -1,0 +1,2 @@
+Ignore ``.dist-info`` directories if the stem is not a valid Python distribution
+name, so they don't show up in e.g. ``pip freeze``.

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -1,11 +1,26 @@
+import logging
+import re
 from typing import Container, Iterator, List, Optional
 
 from pip._vendor.packaging.version import _BaseVersion
 
 from pip._internal.utils.misc import stdlib_pkgs  # TODO: Move definition here.
 
+logger = logging.getLogger(__name__)
+
 
 class BaseDistribution:
+    @property
+    def location(self):
+        # type: () -> Optional[str]
+        """Where the distribution is loaded from.
+
+        A string value is not necessarily a filesystem path, since distributions
+        can be loaded from other sources, e.g. arbitrary zip archives. ``None``
+        means the distribution is created in-memory.
+        """
+        raise NotImplementedError()
+
     @property
     def metadata_version(self):
         # type: () -> Optional[str]
@@ -61,10 +76,37 @@ class BaseEnvironment:
         """Given a requirement name, return the installed distributions."""
         raise NotImplementedError()
 
+    def _iter_distributions(self):
+        # type: () -> Iterator[BaseDistribution]
+        """Iterate through installed distributions.
+
+        This function should be implemented by subclass, but never called
+        directly. Use the public ``iter_distribution()`` instead, which
+        implements additional logic to make sure the distributions are valid.
+        """
+        raise NotImplementedError()
+
     def iter_distributions(self):
         # type: () -> Iterator[BaseDistribution]
         """Iterate through installed distributions."""
-        raise NotImplementedError()
+        for dist in self._iter_distributions():
+            # Make sure the distribution actually comes from a valid Python
+            # packaging distribution. Pip's AdjacentTempDirectory leaves folders
+            # e.g. ``~atplotlib.dist-info`` if cleanup was interrupted. The
+            # valid project name pattern is taken from PEP 508.
+            project_name_valid = re.match(
+                r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$",
+                dist.canonical_name,
+                flags=re.IGNORECASE,
+            )
+            if not project_name_valid:
+                logger.warning(
+                    "Ignoring invalid distribution %s (%s)",
+                    dist.canonical_name,
+                    dist.location,
+                )
+                continue
+            yield dist
 
     def iter_installed_distributions(
         self,

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -25,6 +25,11 @@ class Distribution(BaseDistribution):
         return cls(dist)
 
     @property
+    def location(self):
+        # type: () -> Optional[str]
+        return self._dist.location
+
+    @property
     def metadata_version(self):
         # type: () -> Optional[str]
         for line in self._dist.get_metadata_lines(self._dist.PKG_INFO):
@@ -115,7 +120,7 @@ class Environment(BaseEnvironment):
             return None
         return self._search_distribution(name)
 
-    def iter_distributions(self):
+    def _iter_distributions(self):
         # type: () -> Iterator[BaseDistribution]
         for dist in self._ws:
             yield Distribution(dist)


### PR DESCRIPTION
Fix #7269. This rebases the relevant part of #9393 against the new `pip._internal.metadata` API, and adds a clearer warning when invalid directories are found (nudging users to delete them manually).