### PR TITLE
Document that using overrides disables all wheels

### DIFF
--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -205,8 +205,11 @@ Per-requirement Overrides
 -------------------------
 
 Since version 7.0 pip supports controlling the command line options given to
-``setup.py`` via requirements files. This disables the use of wheels (cached or
-otherwise) for that package, as ``setup.py`` does not exist for wheels.
+``setup.py`` via requirements files.
+
+.. warning::
+
+   This disables the use of wheels (cached or otherwise).
 
 The ``--global-option`` and ``--install-option`` options are used to pass
 options to ``setup.py``. For example:

--- a/news/9674.doc.rst
+++ b/news/9674.doc.rst
@@ -1,0 +1,1 @@
+Clarify that using per-requirement overrides disables the usage of wheels.


### PR DESCRIPTION
See #4118. Update documentation to state that using command line options on any requirements will disable all usage of wheels. Since this is unexpected behavior, move text to a warning.