### PR TITLE
Parse pkg_resources Dist versions with packaging.version

### DIFF
--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -4,6 +4,7 @@ from typing import Iterator, List, Optional
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import _BaseVersion
+from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.utils import misc  # TODO: Move definition here.
 from pip._internal.utils.packaging import get_installer
@@ -16,6 +17,7 @@ class Distribution(BaseDistribution):
     def __init__(self, dist):
         # type: (pkg_resources.Distribution) -> None
         self._dist = dist
+        self._version = None
 
     @classmethod
     def from_wheel(cls, path, name):
@@ -45,7 +47,9 @@ class Distribution(BaseDistribution):
     @property
     def version(self):
         # type: () -> _BaseVersion
-        return self._dist.parsed_version
+        if self._version is None:
+            self._version = parse_version(self._dist.version)
+        return self._version
 
     @property
     def installer(self):

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -17,7 +17,6 @@ class Distribution(BaseDistribution):
     def __init__(self, dist):
         # type: (pkg_resources.Distribution) -> None
         self._dist = dist
-        self._version = None
 
     @classmethod
     def from_wheel(cls, path, name):
@@ -47,9 +46,7 @@ class Distribution(BaseDistribution):
     @property
     def version(self):
         # type: () -> _BaseVersion
-        if self._version is None:
-            self._version = parse_version(self._dist.version)
-        return self._version
+        return parse_version(self._dist.version)
 
     @property
     def installer(self):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -347,7 +347,6 @@ class AlreadyInstalledCandidate(Candidate):
         self.dist = dist
         self._ireq = make_install_req_from_dist(dist, template)
         self._factory = factory
-        self._version = None
 
         # This is just logging some messages, so we can do it eagerly.
         # The returned dist would be exactly the same as self.dist because we
@@ -390,9 +389,7 @@ class AlreadyInstalledCandidate(Candidate):
     @property
     def version(self):
         # type: () -> _BaseVersion
-        if self._version is None:
-            self._version = parse_version(self.dist.version)
-        return self._version
+        return parse_version(self.dist.version)
 
     @property
     def is_editable(self):

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -4,6 +4,7 @@ import os
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.resolvelib import ResolutionImpossible
 from pip._vendor.resolvelib import Resolver as RLResolver
 from pip._vendor.resolvelib.resolvers import Result
@@ -139,7 +140,7 @@ class Resolver(BaseResolver):
             elif self.factory.force_reinstall:
                 # The --force-reinstall flag is set -- reinstall.
                 ireq.should_reinstall = True
-            elif installed_dist.parsed_version != candidate.version:
+            elif parse_version(installed_dist.version) != candidate.version:
                 # The installation is different in version -- reinstall.
                 ireq.should_reinstall = True
             elif candidate.is_editable or dist_is_editable(installed_dist):


### PR DESCRIPTION
Due to a mix of bundled and unbundled dependencies, pkg_resources
Version class may not be the same as packaging's Version class.

See: https://github.com/pypa/setuptools/issues/2052

As discussed in #9467