### PR TITLE
Configure a redirect to recommend venv

### DIFF
--- a/docs/html/warnings/venv.rst
+++ b/docs/html/warnings/venv.rst
@@ -1,0 +1,5 @@
+.. raw:: html
+
+    <script type="text/javascript">
+        window.location.replace('https://docs.python.org/3/tutorial/venv.html');
+    </script>

--- a/docs/html/warnings/venv.rst
+++ b/docs/html/warnings/venv.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. raw:: html
 
     <script type="text/javascript">

--- a/news/9680.doc.rst
+++ b/news/9680.doc.rst
@@ -1,0 +1,1 @@
+This change configures a redirect for venv usage.


### PR DESCRIPTION
This PR configures a redirect from https://pip.pypa.io/en/latest/warnings/venv to https://docs.python.org/3/tutorial/venv.html.

As part of #9394, users who run pip as root will be warned with the former URL. The redirected link will guide users towards installing venv to avoid root usage.

A redirect is preferred since the destination URL may change, and this decouples documentation from the code.