### PR TITLE
try-except distutils config parsing

### DIFF
--- a/news/8931.bugfix.rst
+++ b/news/8931.bugfix.rst
@@ -1,0 +1,1 @@
+Skip distutils configuration parsing on encoding errors.


### PR DESCRIPTION
If we’re lucky, nobody is going to care about this message, and we can just remove distutils legacy once the importlib.metadata migration is finished.

Close #8931.