### PR TITLE
Run pip in isolated env by building zip

### DIFF
--- a/news/8214.bugfix.rst
+++ b/news/8214.bugfix.rst
@@ -1,0 +1,2 @@
+Prevent packages already-installed alongside with pip to be injected into an
+isolated build environment during build-time dependency population.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -45,7 +45,7 @@ class _Prefix:
 def _create_standalone_pip() -> Iterator[str]:
     """Create a zip file containing specified pip installation."""
     source = pathlib.Path(pip_location).resolve().parent
-    with TempDirectory() as tmp_dir:
+    with TempDirectory(kind="standalone-pip") as tmp_dir:
         pip_zip = os.path.join(tmp_dir.path, "pip.zip")
         with zipfile.ZipFile(pip_zip, "w") as zf:
             for child in source.rglob("*"):

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -65,7 +65,11 @@ def _format_main_py(source: pathlib.Path) -> bytes:
 
 @contextlib.contextmanager
 def _create_standalone_pip() -> Iterator[str]:
-    """Create a zip file containing specified pip installation."""
+    """Create a "standalone pip" zip file.
+
+    The zip file contains a (modified) copy of the pip currently running.
+    It will be used to install requirements into the build environment.
+    """
     source = pathlib.Path(pip_location).resolve().parent
     with TempDirectory(kind="standalone-pip") as tmp_dir:
         pip_zip = os.path.join(tmp_dir.path, "pip.zip")

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -47,8 +47,8 @@ certifi.where = lambda: {pem!r}
 """
 
 
-def _format_main_py(source: pathlib.Path) -> bytes:
-    """Create a patched pip/__main__.py for the standalone pip.
+def _format_init_py(source: pathlib.Path) -> bytes:
+    """Create a patched pip/__init__.py for the standalone pip.
 
     The default ``certifi.where()`` relies on the certificate bundle being a
     real physical file on-disk, so we monkey-patch it to return the one used
@@ -76,8 +76,8 @@ def _create_standalone_pip() -> Iterator[str]:
         with zipfile.ZipFile(pip_zip, "w") as zf:
             for child in source.rglob("*"):
                 arcname = child.relative_to(source.parent).as_posix()
-                if arcname == "pip/__main__.py":
-                    zf.writestr(arcname, _format_main_py(child))
+                if arcname == "pip/__init__.py":
+                    zf.writestr(arcname, _format_init_py(child))
                 else:
                     zf.write(child, arcname)
         yield os.path.join(pip_zip, "pip")

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -13,6 +13,7 @@ from sysconfig import get_paths
 from types import TracebackType
 from typing import TYPE_CHECKING, Iterable, Iterator, List, Optional, Set, Tuple, Type
 
+from pip._vendor.certifi import where
 from pip._vendor.pkg_resources import Requirement, VersionConflict, WorkingSet
 
 from pip import __file__ as pip_location
@@ -63,7 +64,7 @@ def _install_requirements(
     args = [
         sys.executable, standalone_pip, 'install',
         '--ignore-installed', '--no-user', '--prefix', prefix.path,
-        '--no-warn-script-location',
+        '--cert', where(), '--no-warn-script-location',
     ]  # type: List[str]
     if logger.getEffectiveLevel() <= logging.DEBUG:
         args.append('-v')
@@ -82,7 +83,6 @@ def _install_requirements(
         args.append('--no-index')
     for link in finder.find_links:
         args.extend(['--find-links', link])
-
     for host in finder.trusted_hosts:
         args.extend(['--trusted-host', host])
     if finder.allow_all_prereleases:

--- a/tools/vendoring/patches/certifi.patch
+++ b/tools/vendoring/patches/certifi.patch
@@ -1,13 +1,41 @@
 diff --git a/src/pip/_vendor/certifi/core.py b/src/pip/_vendor/certifi/core.py
-index 5d2b8cd32..8987449f6 100644
+index 5d2b8cd32..b8140cf1a 100644
 --- a/src/pip/_vendor/certifi/core.py
 +++ b/src/pip/_vendor/certifi/core.py
-@@ -33,7 +33,7 @@ try:
+@@ -8,7 +8,21 @@ This module returns the installation location of cacert.pem or its contents.
+ """
+ import os
+ 
++
++class _PipPatchedCertificate(Exception):
++    pass
++
++
+ try:
++    # Return a certificate file on disk for a standalone pip zipapp running in
++    # an isolated build environment to use. Passing --cert to the standalone
++    # pip does not work since requests calls where() unconditionally on import.
++    _PIP_STANDALONE_CERT = os.environ.get("_PIP_STANDALONE_CERT")
++    if _PIP_STANDALONE_CERT:
++        def where():
++            return _PIP_STANDALONE_CERT
++        raise _PipPatchedCertificate()
++
+     from importlib.resources import path as get_path, read_text
+ 
+     _CACERT_CTX = None
+@@ -33,11 +47,13 @@ try:
              # We also have to hold onto the actual context manager, because
              # it will do the cleanup whenever it gets garbage collected, so
              # we will also store that at the global level as well.
 -            _CACERT_CTX = get_path("certifi", "cacert.pem")
 +            _CACERT_CTX = get_path("pip._vendor.certifi", "cacert.pem")
              _CACERT_PATH = str(_CACERT_CTX.__enter__())
-
+ 
          return _CACERT_PATH
+ 
++except _PipPatchedCertificate:
++    pass
+ 
+ except ImportError:
+     # This fallback will work for Python versions prior to 3.7 that lack the


### PR DESCRIPTION
This puts pip into a zip file, and change the isolated environment to run that instead of the pip installation in site-packages. This avoids other packages in site-packages to be injected into the isolated environment.

Fix #8214.

As discussed in https://github.com/pypa/pip/issues/8214#issuecomment-790759677, this has a ~1s overhead for each call, so an sdist build can be slowed down for up to 2s (one for `pyproject.toml` and another for `get_requires_for_build_wheel`). There are possible optimisations, e.g. creating only one pip.zip for each pip invocation, but the globally managed state would introduce much complexity, so I’m not getting into them unless we decide this is the way to go.