### PR TITLE
Set Mypy follow_imports = silent and fix (some) typing issues found

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,14 +31,28 @@ per-file-ignores =
     tests/*: B011
 
 [mypy]
+follow_imports = silent
 ignore_missing_imports = True
 disallow_untyped_defs = True
 disallow_any_generics = True
 warn_unused_ignores = True
 
-[mypy-pip/_vendor/*]
-follow_imports = skip
+[mypy-pip._vendor.*]
 ignore_errors = True
+
+# These vendored libraries use runtime magic to populate things and don't sit
+# well with static typing out of the box. Eventually we should provide correct
+# typing information for their public interface and remove these configs.
+[mypy-pip._vendor.colorama]
+follow_imports = skip
+[mypy-pip._vendor.pkg_resources]
+follow_imports = skip
+[mypy-pip._vendor.progress.*]
+follow_imports = skip
+[mypy-pip._vendor.requests.*]
+follow_imports = skip
+[mypy-pip._vendor.retrying]
+follow_imports = skip
 
 [tool:pytest]
 addopts = --ignore src/pip/_vendor --ignore tests/tests_cache -r aR

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ per-file-ignores =
     tests/*: B011
 
 [mypy]
-follow_imports = silent
 ignore_missing_imports = True
 disallow_untyped_defs = True
 disallow_any_generics = True

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -4,7 +4,7 @@ import os
 import sys
 from optparse import Values
 from types import ModuleType
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import pip._vendor
 from pip._vendor.certifi import where
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 def show_value(name, value):
-    # type: (str, Optional[str]) -> None
+    # type: (str, Any) -> None
     logger.info('%s: %s', name, value)
 
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import site
 from optparse import SUPPRESS_HELP, Values
-from typing import TYPE_CHECKING, Iterable, List, Optional
+from typing import Iterable, List, Optional
 
 from pip._vendor.packaging.utils import canonicalize_name
 
@@ -22,7 +22,7 @@ from pip._internal.exceptions import CommandError, InstallationError
 from pip._internal.locations import get_scheme
 from pip._internal.metadata import get_environment
 from pip._internal.models.format_control import FormatControl
-from pip._internal.operations.check import check_install_conflicts
+from pip._internal.operations.check import ConflictDetails, check_install_conflicts
 from pip._internal.req import install_given_reqs
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.req.req_tracker import get_requirement_tracker
@@ -41,9 +41,6 @@ from pip._internal.wheel_builder import (
     build,
     should_build_for_install_command,
 )
-
-if TYPE_CHECKING:
-    from pip._internal.operations.check import ConflictDetails
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import site
 from optparse import SUPPRESS_HELP, Values
-from typing import Iterable, List, Optional
+from typing import TYPE_CHECKING, Iterable, List, Optional
 
 from pip._vendor.packaging.utils import canonicalize_name
 
@@ -22,7 +22,7 @@ from pip._internal.exceptions import CommandError, InstallationError
 from pip._internal.locations import get_scheme
 from pip._internal.metadata import get_environment
 from pip._internal.models.format_control import FormatControl
-from pip._internal.operations.check import ConflictDetails, check_install_conflicts
+from pip._internal.operations.check import check_install_conflicts
 from pip._internal.req import install_given_reqs
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.req.req_tracker import get_requirement_tracker
@@ -42,6 +42,9 @@ from pip._internal.wheel_builder import (
     should_build_for_install_command,
 )
 
+if TYPE_CHECKING:
+    from pip._internal.operations.check import ConflictDetails
+
 logger = logging.getLogger(__name__)
 
 
@@ -49,7 +52,7 @@ def get_check_binary_allowed(format_control):
     # type: (FormatControl) -> BinaryAllowedPredicate
     def check_binary_allowed(req):
         # type: (InstallRequirement) -> bool
-        canonical_name = canonicalize_name(req.name)
+        canonical_name = canonicalize_name(req.name or "")
         allowed_formats = format_control.get_allowed_formats(canonical_name)
         return "binary" in allowed_formats
 

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -1,10 +1,12 @@
 import logging
 import re
-from typing import Container, Iterator, List, Optional
+from typing import Container, Iterator, List, Optional, Union
 
-from pip._vendor.packaging.version import _BaseVersion
+from pip._vendor.packaging.version import LegacyVersion, Version
 
 from pip._internal.utils.misc import stdlib_pkgs  # TODO: Move definition here.
+
+DistributionVersion = Union[LegacyVersion, Version]
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +36,7 @@ class BaseDistribution:
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> DistributionVersion
         raise NotImplementedError()
 
     @property

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -3,14 +3,13 @@ from typing import Iterator, List, Optional
 
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import _BaseVersion
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.utils import misc  # TODO: Move definition here.
 from pip._internal.utils.packaging import get_installer
 from pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
 
-from .base import BaseDistribution, BaseEnvironment
+from .base import BaseDistribution, BaseEnvironment, DistributionVersion
 
 
 class Distribution(BaseDistribution):
@@ -45,7 +44,7 @@ class Distribution(BaseDistribution):
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> DistributionVersion
         return parse_version(self._dist.version)
 
     @property

--- a/src/pip/_internal/models/candidate.py
+++ b/src/pip/_internal/models/candidate.py
@@ -1,4 +1,3 @@
-from pip._vendor.packaging.version import _BaseVersion
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.models.link import Link
@@ -14,7 +13,7 @@ class InstallationCandidate(KeyBasedCompareMixin):
     def __init__(self, name, version, link):
         # type: (str, str, Link) -> None
         self.name = name
-        self.version = parse_version(version)  # type: _BaseVersion
+        self.version = parse_version(version)
         self.link = link
 
         super().__init__(

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -295,7 +295,7 @@ class PipSession(requests.Session):
             # Add a small amount of back off between failed requests in
             # order to prevent hammering the service.
             backoff_factor=0.25,
-        )
+        )  # type: ignore
 
         # Our Insecure HTTPAdapter disables HTTPS validation. It does not
         # support caching so we'll use it for all http:// URLs.

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -15,18 +15,17 @@ from pip._internal.utils.misc import get_installed_distributions
 if TYPE_CHECKING:
     from pip._vendor.packaging.utils import NormalizedName
 
-    # Shorthands
-    PackageSet = Dict[NormalizedName, 'PackageDetails']
-    Missing = Tuple[str, Any]
-    Conflicting = Tuple[str, str, Any]
-
-    MissingDict = Dict[NormalizedName, List[Missing]]
-    ConflictingDict = Dict[NormalizedName, List[Conflicting]]
-    CheckResult = Tuple[MissingDict, ConflictingDict]
-    ConflictDetails = Tuple[PackageSet, CheckResult]
-
-
 logger = logging.getLogger(__name__)
+
+# Shorthands
+PackageSet = Dict['NormalizedName', 'PackageDetails']
+Missing = Tuple[str, Any]
+Conflicting = Tuple[str, str, Any]
+
+MissingDict = Dict['NormalizedName', List[Missing]]
+ConflictingDict = Dict['NormalizedName', List[Conflicting]]
+CheckResult = Tuple[MissingDict, ConflictingDict]
+ConflictDetails = Tuple[PackageSet, CheckResult]
 
 PackageDetails = namedtuple('PackageDetails', ['version', 'requires'])
 

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -3,7 +3,7 @@
 
 import logging
 from collections import namedtuple
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.pkg_resources import RequirementParseError
@@ -12,23 +12,26 @@ from pip._internal.distributions import make_distribution_for_install_requiremen
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.misc import get_installed_distributions
 
+if TYPE_CHECKING:
+    from pip._vendor.packaging.utils import NormalizedName
+
+    # Shorthands
+    PackageSet = Dict[NormalizedName, 'PackageDetails']
+    Missing = Tuple[str, Any]
+    Conflicting = Tuple[str, str, Any]
+
+    MissingDict = Dict[NormalizedName, List[Missing]]
+    ConflictingDict = Dict[NormalizedName, List[Conflicting]]
+    CheckResult = Tuple[MissingDict, ConflictingDict]
+    ConflictDetails = Tuple[PackageSet, CheckResult]
+
+
 logger = logging.getLogger(__name__)
-
-# Shorthands
-PackageSet = Dict[str, 'PackageDetails']
-Missing = Tuple[str, Any]
-Conflicting = Tuple[str, str, Any]
-
-MissingDict = Dict[str, List[Missing]]
-ConflictingDict = Dict[str, List[Conflicting]]
-CheckResult = Tuple[MissingDict, ConflictingDict]
-ConflictDetails = Tuple[PackageSet, CheckResult]
 
 PackageDetails = namedtuple('PackageDetails', ['version', 'requires'])
 
 
-def create_package_set_from_installed(**kwargs):
-    # type: (**Any) -> Tuple[PackageSet, bool]
+def create_package_set_from_installed(**kwargs: Any) -> Tuple["PackageSet", bool]:
     """Converts a list of distributions into a PackageSet.
     """
     # Default to using all packages installed on the system
@@ -59,7 +62,7 @@ def check_package_set(package_set, should_ignore=None):
     missing = {}
     conflicting = {}
 
-    for package_name in package_set:
+    for package_name, package_detail in package_set.items():
         # Info about dependencies of package_name
         missing_deps = set()  # type: Set[Missing]
         conflicting_deps = set()  # type: Set[Conflicting]
@@ -67,8 +70,8 @@ def check_package_set(package_set, should_ignore=None):
         if should_ignore and should_ignore(package_name):
             continue
 
-        for req in package_set[package_name].requires:
-            name = canonicalize_name(req.project_name)  # type: str
+        for req in package_detail.requires:
+            name = canonicalize_name(req.project_name)
 
             # Check if it's missing
             if name not in package_set:
@@ -114,7 +117,7 @@ def check_install_conflicts(to_install):
 
 
 def _simulate_installation_of(to_install, package_set):
-    # type: (List[InstallRequirement], PackageSet) -> Set[str]
+    # type: (List[InstallRequirement], PackageSet) -> Set[NormalizedName]
     """Computes the version of packages after installing to_install.
     """
 
@@ -136,7 +139,7 @@ def _simulate_installation_of(to_install, package_set):
 
 
 def _create_whitelist(would_be_installed, package_set):
-    # type: (Set[str], PackageSet) -> Set[str]
+    # type: (Set[NormalizedName], PackageSet) -> Set[NormalizedName]
     packages_affected = set(would_be_installed)
 
     for package_name in package_set:

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -182,7 +182,7 @@ def parse_req_from_editable(editable_req):
 
     if name is not None:
         try:
-            req = Requirement(name)
+            req = Requirement(name)  # type: Optional[Requirement]
         except InvalidRequirement:
             raise InstallationError(f"Invalid requirement: '{name}'")
     else:
@@ -335,7 +335,7 @@ def parse_req_from_line(name, line_source):
             return text
         return f'{text} (from {line_source})'
 
-    if req_as_string is not None:
+    def _parse_req_string(req_as_string: str) -> Requirement:
         try:
             req = Requirement(req_as_string)
         except InvalidRequirement:
@@ -363,6 +363,10 @@ def parse_req_from_line(name, line_source):
                 if spec_str.endswith(']'):
                     msg = f"Extras after version '{spec_str}'."
                     raise InstallationError(msg)
+        return req
+
+    if req_as_string is not None:
+        req = _parse_req_string(req_as_string)  # type: Optional[Requirement]
     else:
         req = None
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -349,7 +349,7 @@ class InstallRequirement:
 
         # When parallel builds are enabled, add a UUID to the build directory
         # name so multiple builds do not interfere with each other.
-        dir_name = canonicalize_name(self.name)
+        dir_name = canonicalize_name(self.name)  # type: str
         if parallel_builds:
             dir_name = f"{dir_name}_{uuid.uuid4().hex}"
 

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -28,7 +28,7 @@ class RequirementSet:
         # type: () -> str
         requirements = sorted(
             (req for req in self.requirements.values() if not req.comes_from),
-            key=lambda req: canonicalize_name(req.name),
+            key=lambda req: canonicalize_name(req.name or ""),
         )
         return ' '.join(str(req.req) for req in requirements)
 
@@ -36,7 +36,7 @@ class RequirementSet:
         # type: () -> str
         requirements = sorted(
             self.requirements.values(),
-            key=lambda req: canonicalize_name(req.name),
+            key=lambda req: canonicalize_name(req.name or ""),
         )
 
         format_string = '<{classname} object; {count} requirement(s): {reqs}>'
@@ -122,6 +122,8 @@ class RequirementSet:
             existing_req and
             not existing_req.constraint and
             existing_req.extras == install_req.extras and
+            existing_req.req and
+            install_req.req and
             existing_req.req.specifier != install_req.req.specifier
         )
         if has_conflicting_requirement:

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -1,14 +1,15 @@
-from typing import FrozenSet, Iterable, Optional, Tuple
+from typing import FrozenSet, Iterable, Optional, Tuple, Union
 
 from pip._vendor.packaging.specifiers import SpecifierSet
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import _BaseVersion
+from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from pip._vendor.packaging.version import LegacyVersion, Version
 
 from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.hashes import Hashes
 
 CandidateLookup = Tuple[Optional["Candidate"], Optional[InstallRequirement]]
+CandidateVersion = Union[LegacyVersion, Version]
 
 
 def format_name(project, extras):
@@ -62,7 +63,7 @@ class Constraint:
 class Requirement:
     @property
     def project_name(self):
-        # type: () -> str
+        # type: () -> NormalizedName
         """The "project name" of a requirement.
 
         This is different from ``name`` if this requirement contains extras,
@@ -97,7 +98,7 @@ class Requirement:
 class Candidate:
     @property
     def project_name(self):
-        # type: () -> str
+        # type: () -> NormalizedName
         """The "project name" of the candidate.
 
         This is different from ``name`` if this candidate contains extras,
@@ -118,7 +119,7 @@ class Candidate:
 
     @property
     def version(self):
-        # type: () -> _BaseVersion
+        # type: () -> CandidateVersion
         raise NotImplementedError("Override in subclass")
 
     @property

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -167,7 +167,7 @@ def _always_true(_):
 
 def _verify_one(req, wheel_path):
     # type: (InstallRequirement, str) -> None
-    canonical_name = canonicalize_name(req.name)
+    canonical_name = canonicalize_name(req.name or "")
     w = Wheel(os.path.basename(wheel_path))
     if canonicalize_name(w.name) != canonical_name:
         raise InvalidWheelFilename(
@@ -175,10 +175,11 @@ def _verify_one(req, wheel_path):
             "got {!r}".format(canonical_name, w.name),
         )
     dist = get_wheel_distribution(wheel_path, canonical_name)
-    if canonicalize_version(dist.version) != canonicalize_version(w.version):
+    dist_verstr = str(dist.version)
+    if canonicalize_version(dist_verstr) != canonicalize_version(w.version):
         raise InvalidWheelFilename(
             "Wheel has unexpected file name: expected {!r}, "
-            "got {!r}".format(str(dist.version), w.version),
+            "got {!r}".format(dist_verstr, w.version),
         )
     metadata_version_value = dist.metadata_version
     if metadata_version_value is None:
@@ -192,7 +193,7 @@ def _verify_one(req, wheel_path):
             and not isinstance(dist.version, Version)):
         raise UnsupportedWheel(
             "Metadata 1.2 mandates PEP 440 version, "
-            "but {!r} is not".format(str(dist.version))
+            "but {!r} is not".format(dist_verstr)
         )
 
 
@@ -242,6 +243,7 @@ def _build_one_inside_env(
         assert req.name
         if req.use_pep517:
             assert req.metadata_directory
+            assert req.pep517_backend
             wheel_path = build_wheel_pep517(
                 name=req.name,
                 backend=req.pep517_backend,


### PR DESCRIPTION
Close #9502. Most fixes are just boilerplates (I just configure away the difficult ones), but there are a few legistimate bugs found. The two most significant classes of bugs are found by converting all `canonicalize_name` recipients to use `NormalizedName` (@pfmoore I think you’ll be happy about this one), and convert `_BaseVersion` references to `Union[LegacyVersion, Version]`.