### PR TITLE
Remove unnecessary import

### DIFF
--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -1,6 +1,5 @@
 import sys
 import textwrap
-from optparse import Values
 from typing import List
 
 from pip._internal.cli.base_command import Command


### PR DESCRIPTION
`Values` is never used, pretty trivial to me.