### PR TITLE
Install headers to UNKNOWN on missing dist name

### DIFF
--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -143,10 +143,13 @@ def get_scheme(
         python_xy = f"Python{sys.version_info.major}{sys.version_info.minor}"
         paths["scripts"] = os.path.join(base, python_xy, "Scripts")
 
+    # Substitute an empty name with "UNKNOWN" for distutils compatibility.
+    headers = os.path.join(paths["include"], dist_name or "UNKNOWN")
+
     scheme = Scheme(
         platlib=paths["platlib"],
         purelib=paths["purelib"],
-        headers=os.path.join(paths["include"], dist_name),
+        headers=headers,
         scripts=paths["scripts"],
         data=paths["data"],
     )


### PR DESCRIPTION
Resolves issue raised in https://github.com/pypa/pip/issues/9617#issuecomment-803566242.

News fragment skipped since the sysconfig migration has not been released yet.