### PR TITLE
Drop the SCHEMES['nt_user']['scripts'] shim

### DIFF
--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -136,13 +136,6 @@ def get_scheme(
         python_xy = f"python{get_major_minor_version()}"
         paths["include"] = os.path.join(base, "include", "site", python_xy)
 
-    # Special user scripts path on Windows for compatibility to distutils.
-    # See ``distutils.commands.install.INSTALL_SCHEMES["nt_user"]["scripts"]``.
-    if scheme_name == "nt_user":
-        base = variables.get("userbase", sys.prefix)
-        python_xy = f"Python{sys.version_info.major}{sys.version_info.minor}"
-        paths["scripts"] = os.path.join(base, python_xy, "Scripts")
-
     scheme = Scheme(
         platlib=paths["platlib"],
         purelib=paths["purelib"],


### PR DESCRIPTION
I dug into CPython commit history and this was fixed in 3.5, so we shouldn't need this? Let's find out...

News fragment skipped since this code has never been released yet.