### PR TITLE
Fix fish completion when commandline contains multiple commands

### DIFF
--- a/news/9727.bugfix.rst
+++ b/news/9727.bugfix.rst
@@ -1,0 +1,1 @@
+Fix fish shell completion when commandline contains multiple commands.

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -38,12 +38,18 @@ COMPLETION_SCRIPTS = {
     """,
     "fish": """
         function __fish_complete_pip
-            set -lx COMP_WORDS (commandline -o) ""
-            set -lx COMP_CWORD ( \\
-                math (contains -i -- (commandline -t) $COMP_WORDS)-1 \\
-            )
+            set -lx COMP_WORDS \\
+                (commandline --current-process --tokenize --cut-at-cursor) \\
+                (commandline --current-token --cut-at-cursor)
+            set -lx COMP_CWORD (math (count $COMP_WORDS) - 1)
             set -lx PIP_AUTO_COMPLETE 1
-            string split \\  -- (eval $COMP_WORDS[1])
+            set -l completions
+            if string match -q '2.*' $version
+                set completions (eval $COMP_WORDS[1])
+            else
+                set completions ($COMP_WORDS[1])
+            end
+            string split \\  -- $completions
         end
         complete -fa "(__fish_complete_pip)" -c {prog}
     """,

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -23,12 +23,18 @@ complete -o default -F _pip_completion pip""",
         "fish",
         """\
 function __fish_complete_pip
-    set -lx COMP_WORDS (commandline -o) ""
-    set -lx COMP_CWORD ( \\
-        math (contains -i -- (commandline -t) $COMP_WORDS)-1 \\
-    )
+    set -lx COMP_WORDS \\
+        (commandline --current-process --tokenize --cut-at-cursor) \\
+        (commandline --current-token --cut-at-cursor)
+    set -lx COMP_CWORD (math (count $COMP_WORDS) - 1)
     set -lx PIP_AUTO_COMPLETE 1
-    string split \\  -- (eval $COMP_WORDS[1])
+    set -l completions
+    if string match -q '2.*' $version
+        set completions (eval $COMP_WORDS[1])
+    else
+        set completions ($COMP_WORDS[1])
+    end
+    string split \\  -- $completions
 end
 complete -fa "(__fish_complete_pip)" -c pip""",
     ),


### PR DESCRIPTION
This changes some of the options passed to "complete", see also
https://fishshell.com/docs/current/cmds/complete.html

The flag --current-process means to only include tokens of the current command,
as delimited by shell metacharacters like ;, & and |, and newlines.

This fixes completion of a command line like
"python && pip <TAB>". Previously we'd run "eval python" (!)

Also, avoid using "eval" if possible since it's usually not necessary in
fish 3.0.0 and later.

Flag --cut-at-cursor means to only include tokens left of the cursor.
It's extremely unusual in fish that completions use anything right of the
cursor to complete. I didn't check pip sources but I doubt it's an exception.

I also used --cut-at-cursor for the current token because it potentially
offers more completions, and fish will filter them anyway.
for example, now it's possible to get completions on a commandline like

	pip uninstall urllb3
			 ^ cursor is here, so "commmandline -tc" is "url"

This correctly completes to "urllib3", because fish uses fuzzy matching.

Fixes https://github.com/fish-shell/fish-shell/issues/7850
