### PR TITLE
vendor: packaging: Redact auth from url in str repr

### DIFF
--- a/news/9730.bugfix.rst
+++ b/news/9730.bugfix.rst
@@ -1,0 +1,1 @@
+Redact auth from URL in requirement info logs.

--- a/src/pip/_vendor/packaging/requirements.py
+++ b/src/pip/_vendor/packaging/requirements.py
@@ -146,7 +146,8 @@ class Requirement(object):
             parts.append(str(self.specifier))
 
         if self.url:
-            parts.append("@ {0}".format(self.url))
+            from pip._internal.utils.misc import redact_auth_from_url
+            parts.append("@ {0}".format(redact_auth_from_url(self.url)))
             if self.marker:
                 parts.append(" ")
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -37,6 +37,7 @@ from pip._internal.req.req_file import (
 )
 from pip._internal.req.req_tracker import get_requirement_tracker
 from pip._internal.resolution.legacy.resolver import Resolver
+from pip._internal.utils.misc import redact_auth_from_url
 from pip._internal.utils.urls import path_to_url
 from tests.lib import assert_raises_regexp, make_test_finder, requirements_file
 
@@ -348,7 +349,9 @@ class TestInstallRequirement:
         parts = str(req.req).split('@', 1)
         assert len(parts) == 2
         assert parts[0].strip() == 'foo'
-        assert parts[1].strip() == url
+        # Requirements should be redacted
+        assert parts[1].strip() == redact_auth_from_url(url)
+        assert req.link.url == url
 
     def test_url_with_authentication_link_requirement(self):
         url = 'https://what@whatever.com/test-0.4-py2.py3-bogus-any.whl'


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Closes #9709

Usually I think we should not touch any vendored code, but it seems to me that redacting the URL in the
requirement class fixes the root cause of the problem.

Let me know what you guys think :smile:
