### PR TITLE
Add extra markers empty as default

### DIFF
--- a/news/b1bcc768-00c6-4864-8adb-790eb8f1aad6.trivial.rst
+++ b/news/b1bcc768-00c6-4864-8adb-790eb8f1aad6.trivial.rst
@@ -1,0 +1,1 @@
+Fix error while checking for conflicts when calling evaluate function

--- a/news/b1bcc768-00c6-4864-8adb-790eb8f1aad6.trivial.rst
+++ b/news/b1bcc768-00c6-4864-8adb-790eb8f1aad6.trivial.rst
@@ -1,1 +1,1 @@
-Fix error while checking for conflicts when calling evaluate function
+Fix error while checking for conflicts when calling evaluate function.

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -76,7 +76,7 @@ def check_package_set(package_set, should_ignore=None):
             if name not in package_set:
                 missed = True
                 if req.marker is not None:
-                    missed = req.marker.evaluate()
+                    missed = req.marker.evaluate({"extra": ""})
                 if missed:
                     missing_deps.add((name, req))
                 continue


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Change `req.marker.evaluate()` to `req.marker.evaluate({"extra": ""})` in `operations/check.py`

Closes #9643