### PR TITLE
Drop pytest-timeout

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -163,7 +163,6 @@ def test_pep518_with_namespace_package(script, data, common_wheels):
     )
 
 
-@pytest.mark.timeout(60)
 @pytest.mark.parametrize('command', ('install', 'wheel'))
 @pytest.mark.parametrize('package', ('pep518_forkbomb',
                                      'pep518_twin_forkbombs_first',

--- a/tools/requirements/tests.txt
+++ b/tools/requirements/tests.txt
@@ -5,7 +5,6 @@ pretend
 pytest
 pytest-cov
 pytest-rerunfailures
-pytest-timeout
 pytest-xdist
 pyyaml
 scripttest

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps = -r{toxinidir}/tools/requirements/tests.txt
 commands_pre =
     python -c 'import shutil, sys; shutil.rmtree(sys.argv[1], ignore_errors=True)' {toxinidir}/tests/data/common_wheels
     {[helpers]pip} wheel -w {toxinidir}/tests/data/common_wheels -r {toxinidir}/tools/requirements/tests-common_wheels.txt
-commands = pytest --timeout 300 []
+commands = pytest []
 install_command = {[helpers]pip} install {opts} {packages}
 list_dependencies_command = {[helpers]pip} freeze --all
 
@@ -35,7 +35,7 @@ list_dependencies_command = {[helpers]pip} freeze --all
 basepython = python3
 commands =
     {[helpers]mkdirp} {toxinidir}/.coverage-output
-    pytest --timeout 300 --cov=pip --cov-config={toxinidir}/setup.cfg []
+    pytest --cov=pip --cov-config={toxinidir}/setup.cfg []
 
 setenv =
     # Used in coverage configuration in setup.cfg.


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest-xdist/issues/204 and https://github.com/pytest-dev/pytest-timeout/issues/8

Basically, pytest-xdist and pytest-timeout don't work together, which means we should drop one of them. Parallelisation of our tests is kinda super important to us right now, so... let's drop this timeout logic.
