### PR TITLE
Allow pip to pick up the config from the sys.base_prefix.

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -499,8 +499,8 @@ pip allows you to set all command line option defaults in a standard ini
 style config file.
 
 The names and locations of the configuration files vary slightly across
-platforms. You may have per-user, per-virtualenv or global (shared amongst
-all users) configuration:
+platforms. You may have per-user, per-site (e.g per virtualenv) or global
+(shared amongst all users) configuration:
 
 **Per-user**:
 
@@ -521,10 +521,12 @@ To find its location:
 You can set a custom path location for this config file using the environment
 variable ``PIP_CONFIG_FILE``.
 
-**Inside a virtualenv**:
+**Site (e.g inside a virtualenv)**
 
 * On Unix and macOS the file is :file:`$VIRTUAL_ENV/pip.conf`
 * On Windows the file is: :file:`%VIRTUAL_ENV%\\pip.ini`
+
+Additionally ``sys.base_prefix`` is searched for a pip config of the same name.
 
 **Global**:
 
@@ -546,7 +548,7 @@ the following order:
 
 1. The global file is read
 2. The per-user file is read
-3. The virtualenv-specific file is read
+3. The site file is read
 
 Each file read overrides any values read from previous files, so if the
 global timeout is specified in both the global file and the per-user file

--- a/news/9752.feature.rst
+++ b/news/9752.feature.rst
@@ -1,0 +1,1 @@
+Virtual environments may now inherit their pip config from the base environment.

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -75,7 +75,14 @@ def get_configuration_files():
         for path in appdirs.site_config_dirs('pip')
     ]
 
-    site_config_file = os.path.join(sys.prefix, CONFIG_BASENAME)
+    site_config_files = [
+        os.path.join(sys.prefix, CONFIG_BASENAME)
+    ]
+    if getattr(sys, 'base_prefix', sys.prefix) != sys.prefix:
+        site_config_files.append(
+            os.path.join(sys.base_prefix, CONFIG_BASENAME),
+        )
+
     legacy_config_file = os.path.join(
         os.path.expanduser('~'),
         'pip' if WINDOWS else '.pip',
@@ -86,7 +93,7 @@ def get_configuration_files():
     )
     return {
         kinds.GLOBAL: global_config_files,
-        kinds.SITE: [site_config_file],
+        kinds.SITE: site_config_files,
         kinds.USER: [legacy_config_file, new_config_file],
     }
 

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -75,13 +75,13 @@ def get_configuration_files():
         for path in appdirs.site_config_dirs('pip')
     ]
 
-    site_config_files = [
-        os.path.join(sys.prefix, CONFIG_BASENAME)
-    ]
+    site_config_files = []
     if getattr(sys, 'base_prefix', sys.prefix) != sys.prefix:
         site_config_files.append(
             os.path.join(sys.base_prefix, CONFIG_BASENAME),
         )
+    # A virtual environment config takes precedence over a base_prefix config.
+    site_config_files.append(os.path.join(sys.prefix, CONFIG_BASENAME))
 
     legacy_config_file = os.path.join(
         os.path.expanduser('~'),

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -189,10 +189,11 @@ class TestConfigurationModification(ConfigurationMixin):
 
         self.configuration.set_value("test.hello", "10")
 
-        # get the path to site config file
+        # get the path to site config file, mirroring the behaviour
+        # in _get_parser_to_modify.
         assert mymock.call_count == 1
         assert mymock.call_args[0][0] == (
-            get_configuration_files()[kinds.SITE][0]
+            get_configuration_files()[kinds.SITE][-1]
         )
 
     def test_user_modification(self):


### PR DESCRIPTION
Closes #9752.

I have tried to update the docs appropriately, but wasn't sure if there are more places that need addressing.
I didn't add tests for this, as I wasn't sure how to proceed with requiring a non-virtual environment for testing purposed. 