### PR TITLE
Warn when doing a PEP 517 build in presence of --global-option

### DIFF
--- a/news/9774.feature.rst
+++ b/news/9774.feature.rst
@@ -1,2 +1,3 @@
 Warn instead of erroring out when doing a PEP 517 build in presence of
-``--build-option``.
+``--build-option``. Warn when doing a PEP 517 build in presence of
+``--global-option``.

--- a/news/9774.feature.rst
+++ b/news/9774.feature.rst
@@ -1,0 +1,2 @@
+Warn instead of erroring out when doing a PEP 517 build in presence of
+``--build-option``.

--- a/src/pip/_internal/operations/build/wheel.py
+++ b/src/pip/_internal/operations/build/wheel.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import List, Optional
+from typing import Optional
 
 from pip._vendor.pep517.wrappers import Pep517HookCaller
 
@@ -13,7 +13,6 @@ def build_wheel_pep517(
     name,  # type: str
     backend,  # type: Pep517HookCaller
     metadata_directory,  # type: str
-    build_options,  # type: List[str]
     tempd,  # type: str
 ):
     # type: (...) -> Optional[str]
@@ -22,11 +21,6 @@ def build_wheel_pep517(
     Returns path to wheel if successfully built. Otherwise, returns None.
     """
     assert metadata_directory is not None
-    if build_options:
-        # PEP 517 does not support --build-options
-        logger.error('Cannot build wheel for %s using PEP 517 when '
-                     '--build-option is present', name)
-        return None
     try:
         logger.debug('Destination directory: %s', tempd)
 

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -244,11 +244,14 @@ def _build_one_inside_env(
         if req.use_pep517:
             assert req.metadata_directory
             assert req.pep517_backend
+            if build_options:
+                logger.warning(
+                    'Ignoring --build-option when building %s using PEP 517', req.name
+                )
             wheel_path = build_wheel_pep517(
                 name=req.name,
                 backend=req.pep517_backend,
                 metadata_directory=req.metadata_directory,
-                build_options=build_options,
                 tempd=temp_dir.path,
             )
         else:

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -244,6 +244,10 @@ def _build_one_inside_env(
         if req.use_pep517:
             assert req.metadata_directory
             assert req.pep517_backend
+            if global_options:
+                logger.warning(
+                    'Ignoring --global-option when building %s using PEP 517', req.name
+                )
             if build_options:
                 logger.warning(
                     'Ignoring --build-option when building %s using PEP 517', req.name

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -266,3 +266,17 @@ def test_pep517_and_build_options(script, tmpdir, data, common_wheels):
     )
     assert 'Ignoring --build-option when building' in result.stderr
     assert 'using PEP 517' in result.stderr
+
+
+@pytest.mark.network
+def test_pep517_and_global_options(script, tmpdir, data, common_wheels):
+    """Backend generated requirements are installed in the build env"""
+    project_dir, name = make_pyproject_with_setup(tmpdir)
+    result = script.pip(
+        'wheel', '--wheel-dir', tmpdir,
+        '--global-option', 'foo',
+        '-f', common_wheels,
+        project_dir,
+    )
+    assert 'Ignoring --global-option when building' in result.stderr
+    assert 'using PEP 517' in result.stderr

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -263,7 +263,6 @@ def test_pep517_and_build_options(script, tmpdir, data, common_wheels):
         '--build-option', 'foo',
         '-f', common_wheels,
         project_dir,
-        expect_error=True
     )
-    assert 'Cannot build wheel' in result.stderr
-    assert 'when --build-option is present' in result.stderr
+    assert 'Ignoring --build-option when building' in result.stderr
+    assert 'using PEP 517' in result.stderr


### PR DESCRIPTION
- Warn when doing a PEP 517 build in presence of --global-option
- Warn instead of erroring out when doing a PEP 517 build in presence of --build-option

--build-option and --global-option are not supported by PEP 517.
Before, --global-option was silently ignored and --build-option caused an error.

We now warn if any of the two is present, in order to be more explicit about ignored options, and to avoid any backward compatibility issues when we start passing --build-option in the install command.

This is a first step towards #9769. I'll see if I can split #9422 in small PRs to facilitate review.