### PR TITLE
Don't use virtualenv internals in tests

### DIFF
--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -1,5 +1,6 @@
 import compileall
 import shutil
+import subprocess
 import sys
 import textwrap
 import venv as _venv
@@ -55,11 +56,16 @@ class VirtualEnvironment:
         else:
             # Create a new virtual environment.
             if self._venv_type == "virtualenv":
-                _virtualenv.create_environment(
-                    self.location,
-                    no_pip=True,
-                    no_wheel=True,
-                    no_setuptools=True,
+                subprocess.check_call(
+                    [
+                        sys.executable,
+                        "-m",
+                        "virtualenv",
+                        "--no-pip",
+                        "--no-wheel",
+                        "--no-setuptools",
+                        str(self.location),
+                    ]
                 )
                 self._fix_virtualenv_site_module()
             elif self._venv_type == "venv":


### PR DESCRIPTION
The test suite has been intermittently failing on one of my PCs, with a nasty "virtualenv isn't supported on your system" error.

Looking into it, the root cause seems to be the fact that we're doing some really horrible stuff - running an old virtualenv version from a virtual environment built with the new virtualenv, and even worse, using internal APIs from the old virtualenv. Frankly, I'm impressed that it ever worked...

In practice, there is no reason I can see to use the internal API, we should run virtualenv as a command line application like good citizens. And indeed, if we do that, my "not supported" errors go away.

This will probably make no difference to anyone who wasn't getting that error - but it is essential on some systems (well, mine, at least) to get a working test suite.