### PR TITLE
Make pip work with warnings converted to errors

### DIFF
--- a/news/9779.bugfix.rst
+++ b/news/9779.bugfix.rst
@@ -1,0 +1,1 @@
+Fix pip to work with warnings converted to errors.

--- a/src/pip/__main__.py
+++ b/src/pip/__main__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import warnings
 
 # Remove '' and current working directory from the first entry
 # of sys.path, if present to avoid using current directory
@@ -18,7 +19,13 @@ if __package__ == "":
     path = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(0, path)
 
-from pip._internal.cli.main import main as _main
-
 if __name__ == "__main__":
+    # Work around the error reported in #9540, pending a proper fix.
+    # Note: It is essential the warning filter is set *before* importing
+    #       pip, as the deprecation happens at import time, not runtime.
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, module=".*packaging\\.version"
+    )
+    from pip._internal.cli.main import main as _main
+
     sys.exit(_main())

--- a/tests/functional/test_warning.py
+++ b/tests/functional/test_warning.py
@@ -42,3 +42,8 @@ def test_version_warning_is_not_shown_if_python_version_is_not_2(script):
 
 def test_flag_does_nothing_if_python_version_is_not_2(script):
     script.pip("list", "--no-python-version-warning")
+
+
+def test_pip_works_with_warnings_as_errors(script):
+    script.environ['PYTHONWARNINGS'] = 'error'
+    script.pip("--version")


### PR DESCRIPTION
Fixes #9540. This is the workaround noted in that issue (ignoring the warning) and should be considered a temporary fix until setuptools gets fixed.

The new test should remain, though, as it ensures pip will work in the cpython ensurepip tests.