### PR TITLE
Reimplement the news entry check as a github workflow

### DIFF
--- a/.github/workflows/news-file.yaml
+++ b/.github/workflows/news-file.yaml
@@ -1,0 +1,13 @@
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+jobs:
+  check-news-file:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # `towncrier check` needs enough history to run `git diff --name-only origin/main...`
+          fetch-depth: 0
+      - run: pipx run towncrier check --compare-with origin/main
+        if: ${{ ! (contains(github.event.pull_request.labels.*.name, 'trivial')) }}


### PR DESCRIPTION
This is the next iteration of #9602. I got tired of browntruck news check failing for empty news entries (pypa/browntruck#24) and wanted to fix it. I chose to reimplement the broken check as a github workflow.

This time I submit just a minimal github workflow implementing only the essential features. Less code = better especially since the pip maintainers have made it clear that they prioritize maintaining pip over maintaining code written to maintain pip.

The workflow:
* Fails if there is no news entry https://github.com/hexagonrecursion/pip/pull/1/checks?check_run_id=2285952167
* Succeeds if there is a news entry https://github.com/hexagonrecursion/pip/pull/3/checks?check_run_id=2285894583
  * Even if the news entry is an empty file
* Can be overridden by adding a "trivial" label https://github.com/hexagonrecursion/pip/pull/2/checks?check_run_id=2285920792