### PR TITLE
Pin towncrier under 19.9.0

### DIFF
--- a/tools/requirements/docs.txt
+++ b/tools/requirements/docs.txt
@@ -1,4 +1,6 @@
 sphinx == 3.2.1
+# FIXME: Remove towncrier constraint after upgrading sphinxcontrib-towncrier.
+towncrier < 19.9.0
 furo
 myst_parser
 sphinx-copybutton


### PR DESCRIPTION
sphinxcontrib-towncrier uses towncrier internals and has not been updated to work with later versions. This is failing readthedocs runs.

See sphinx-contrib/sphinxcontrib-towncrier#44.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
