### PR TITLE
Run CI on main not master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags:
       # Tags for all potential release numbers till 2030.
       - "2[0-9].[0-3]" # 20.0 -> 29.3


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

For https://github.com/pypa/pip/issues/8948.

GitHub Actions is set to run on pushes to `master`, but it's recently been renamed to `main`.

---

Note: having _any_ branch restriction means contributors cannot test their feature branches on CI, without first creating a PR. I recommend removing it to allow better quality PRs when they're first opened, to reduce noise and iterations.
