### PR TITLE
Test PyPy only on Ubuntu, macOS has limited workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+        include:
+          # Test PyPy only on Ubuntu, macOS has limited workers
+          - { os: Ubuntu, python: pypy-3.6 }
+          - { os: Ubuntu, python: pypy-3.7 }
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fixes https://github.com/pypa/pip/issues/9651.

PyPy has already been removed from Travis CI, add PyPy 3.6 and 3.7 to GitHub Actions.

Does this need a news file or trivial label?