### PR TITLE
Bump ReadTheDocs Python version to 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,6 @@ sphinx:
   configuration: docs/html/conf.py
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: tools/requirements/docs.txt


### PR DESCRIPTION
Required for compatibility with the latest sphinx-inline-tabs release.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
