### PR TITLE
Update vendored resolvelib to 0.7.0

### DIFF
--- a/news/resolvelib.vendor.rst
+++ b/news/resolvelib.vendor.rst
@@ -1,1 +1,1 @@
-Upgrade vendored resolvelib to 0.6.0.
+Upgrade vendored resolvelib to 0.7.0.

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -1,13 +1,4 @@
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    Iterable,
-    Iterator,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator, Mapping, Sequence, Union
 
 from pip._vendor.resolvelib.providers import AbstractProvider
 
@@ -75,11 +66,11 @@ class PipProvider(_ProviderBase):
 
     def get_preference(
         self,
-        resolution,  # type: Optional[Candidate]
-        candidates,  # type: Iterable[Candidate]
-        information,  # type: Iterable[PreferenceInformation]
-    ):
-        # type: (...) -> Preference
+        identifier: str,
+        resolutions: Mapping[str, Candidate],
+        candidates: Mapping[str, Iterator[Candidate]],
+        information: Mapping[str, Iterator["PreferenceInformation"]],
+    ) -> "Preference":
         """Produce a sort key for given requirement based on preference.
 
         The lower the return value is, the more preferred this group of
@@ -127,9 +118,8 @@ class PipProvider(_ProviderBase):
             # A "bare" requirement without any version requirements.
             return 3
 
-        restrictive = _get_restrictive_rating(req for req, _ in information)
-        key = next(iter(candidates)).name if candidates else ""
-        order = self._user_requested.get(key, float("inf"))
+        rating = _get_restrictive_rating(r for r, _ in information[identifier])
+        order = self._user_requested.get(identifier, float("inf"))
 
         # HACK: Setuptools have a very long and solid backward compatibility
         # track record, and extremely few projects would request a narrow,
@@ -139,9 +129,9 @@ class PipProvider(_ProviderBase):
         # delaying Setuptools helps reduce branches the resolver has to check.
         # This serves as a temporary fix for issues like "apache-airlfow[all]"
         # while we work on "proper" branch pruning techniques.
-        delay_this = key == "setuptools"
+        delay_this = identifier == "setuptools"
 
-        return (delay_this, restrictive, order, key)
+        return (delay_this, rating, order, identifier)
 
     def find_matches(
         self,

--- a/src/pip/_vendor/resolvelib/__init__.py
+++ b/src/pip/_vendor/resolvelib/__init__.py
@@ -11,7 +11,7 @@ __all__ = [
     "ResolutionTooDeep",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 
 from .providers import AbstractProvider, AbstractResolver

--- a/src/pip/_vendor/resolvelib/providers.py
+++ b/src/pip/_vendor/resolvelib/providers.py
@@ -9,28 +9,29 @@ class AbstractProvider(object):
         """
         raise NotImplementedError
 
-    def get_preference(self, resolution, candidates, information):
+    def get_preference(self, identifier, resolutions, candidates, information):
         """Produce a sort key for given requirement based on preference.
 
         The preference is defined as "I think this requirement should be
         resolved first". The lower the return value is, the more preferred
         this group of arguments is.
 
-        :param resolution: Currently pinned candidate, or `None`.
-        :param candidates: An iterable of possible candidates.
-        :param information: A list of requirement information.
+        :param identifier: An identifier as returned by ``identify()``. This
+            identifies the dependency matches of which should be returned.
+        :param resolutions: Mapping of candidates currently pinned by the
+            resolver. Each key is an identifier, and the value a candidate.
+            The candidate may conflict with requirements from ``information``.
+        :param candidates: Mapping of each dependency's possible candidates.
+            Each value is an iterator of candidates.
+        :param information: Mapping of requirement information of each package.
+            Each value is an iterator of *requirement information*.
 
-        The `candidates` iterable's exact type depends on the return type of
-        `find_matches()`. A sequence is passed-in as-is if possible. If it
-        returns a callble, the iterator returned by that callable is passed
-        in here.
+        A *requirement information* instance is a named tuple with two members:
 
-        Each element in `information` is a named tuple with two entries:
-
-        * `requirement` specifies a requirement contributing to the current
-          candidate list.
-        * `parent` specifies the candidate that provides (dependend on) the
-          requirement, or `None` to indicate a root requirement.
+        * ``requirement`` specifies a requirement contributing to the current
+          list of candidates.
+        * ``parent`` specifies the candidate that provides (dependend on) the
+          requirement, or ``None`` to indicate a root requirement.
 
         The preference could depend on a various of issues, including (not
         necessarily in this order):
@@ -43,10 +44,10 @@ class AbstractProvider(object):
         * Are there any known conflicts for this requirement? We should
           probably work on those with the most known conflicts.
 
-        A sortable value should be returned (this will be used as the `key`
+        A sortable value should be returned (this will be used as the ``key``
         parameter of the built-in sorting function). The smaller the value is,
         the more preferred this requirement is (i.e. the sorting function
-        is called with `reverse=False`).
+        is called with ``reverse=False``).
         """
         raise NotImplementedError
 
@@ -85,7 +86,7 @@ class AbstractProvider(object):
         The candidate is guarenteed to have been generated from the
         requirement.
 
-        A boolean should be returned to indicate whether `candidate` is a
+        A boolean should be returned to indicate whether ``candidate`` is a
         viable solution to the requirement.
         """
         raise NotImplementedError

--- a/src/pip/_vendor/resolvelib/providers.pyi
+++ b/src/pip/_vendor/resolvelib/providers.pyi
@@ -12,13 +12,7 @@ from typing import (
 
 from .reporters import BaseReporter
 from .resolvers import RequirementInformation
-from .structs import (
-    KT,
-    RT,
-    CT,
-    IterableView,
-    Matches,
-)
+from .structs import KT, RT, CT, Matches
 
 class Preference(Protocol):
     def __lt__(self, __other: Any) -> bool: ...
@@ -27,9 +21,10 @@ class AbstractProvider(Generic[RT, CT, KT]):
     def identify(self, requirement_or_candidate: Union[RT, CT]) -> KT: ...
     def get_preference(
         self,
-        resolution: Optional[CT],
-        candidates: IterableView[CT],
-        information: Collection[RequirementInformation[RT, CT]],
+        identifier: KT,
+        resolutions: Mapping[KT, CT],
+        candidates: Mapping[KT, Iterator[CT]],
+        information: Mapping[KT, Iterator[RequirementInformation[RT, CT]]],
     ) -> Preference: ...
     def find_matches(
         self,

--- a/src/pip/_vendor/resolvelib/structs.py
+++ b/src/pip/_vendor/resolvelib/structs.py
@@ -1,4 +1,5 @@
 import itertools
+
 from .compat import collections_abc
 
 
@@ -120,18 +121,6 @@ class _FactoryIterableView(object):
     def __iter__(self):
         return self._factory()
 
-    def for_preference(self):
-        """Provide an candidate iterable for `get_preference()`"""
-        return self._factory()
-
-    def excluding(self, candidates):
-        """Create a new instance excluding specified candidates."""
-
-        def factory():
-            return (c for c in self._factory() if c not in candidates)
-
-        return type(self)(factory)
-
 
 class _SequenceIterableView(object):
     """Wrap an iterable returned by find_matches().
@@ -153,17 +142,6 @@ class _SequenceIterableView(object):
 
     def __iter__(self):
         return iter(self._sequence)
-
-    def __len__(self):
-        return len(self._sequence)
-
-    def for_preference(self):
-        """Provide an candidate iterable for `get_preference()`"""
-        return self._sequence
-
-    def excluding(self, candidates):
-        """Create a new instance excluding specified candidates."""
-        return type(self)([c for c in self._sequence if c not in candidates])
 
 
 def build_iter_view(matches):

--- a/src/pip/_vendor/resolvelib/structs.pyi
+++ b/src/pip/_vendor/resolvelib/structs.pyi
@@ -17,7 +17,7 @@ _T = TypeVar("_T")
 Matches = Union[Iterable[CT], Callable[[], Iterator[CT]]]
 
 class IterableView(Container[CT], Iterable[CT], metaclass=ABCMeta):
-    def excluding(self: _T, candidates: Container[CT]) -> _T: ...
+    pass
 
 class DirectedGraph(Generic[KT]):
     def __iter__(self) -> Iterator[KT]: ...

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -14,7 +14,7 @@ requests==2.25.1
     chardet==4.0.0
     idna==2.10
     urllib3==1.26.4
-resolvelib==0.6.0
+resolvelib==0.7.0
 setuptools==44.0.0
 six==1.15.0
 tenacity==6.3.1


### PR DESCRIPTION
This does not need to be in 21.1; the associated issue (how to best order the dependencies for the resolver to try) needs a lot more real-world testing, probably even need to be introduced via a feature flag.

---

Edit: To clarify, this *can* go into 21.1, since the vendor version update should be no behavioural change visible to pip. The real behavioural change that depends on resolvelib 0.7.0 is yet to happen.