### PR TITLE
Don't split git references on unicode separators

### DIFF
--- a/news/9827.bugfix.rst
+++ b/news/9827.bugfix.rst
@@ -1,0 +1,3 @@
+**SECURITY**: Stop splitting on unicode separators in git references,
+which could be maliciously used to install a different revision on the
+repository.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -131,9 +131,15 @@ class Git(VersionControl):
             on_returncode='ignore',
         )
         refs = {}
-        for line in output.strip().splitlines():
+        # NOTE: We do not use splitlines here since that would split on other
+        #       unicode separators, which can be maliciously used to install a
+        #       different revision.
+        for line in output.strip().split("\n"):
+            line = line.rstrip("\r")
+            if not line:
+                continue
             try:
-                ref_sha, ref_name = line.split()
+                ref_sha, ref_name = line.split(" ", maxsplit=2)
             except ValueError:
                 # Include the offending line to simplify troubleshooting if
                 # this error ever occurs.


### PR DESCRIPTION
Previously, maliciously formatted tags could be used to hijack a
commit-based pin. Using the fact that the split here allowed for
all of unicode's whitespace characters as separators -- which git allows
as a part of a tag name -- it is possible to force a different revision
to be installed; if an attacker gains access to the repository.

This change stops splitting the string on unicode characters, by forcing
the splits to happen on newlines and ASCII spaces.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
