### PR TITLE
Fix import error introduced in 21.1

### DIFF
--- a/news/9831.bugfix.rst
+++ b/news/9831.bugfix.rst
@@ -1,0 +1,1 @@
+This change fixes a bug on Python <=3.6.1 with a Typing feature added in 3.6.2

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -8,17 +8,7 @@ import re
 import shlex
 import urllib.parse
 from optparse import Values
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    NoReturn,
-    Optional,
-    Tuple,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Tuple
 
 from pip._internal.cli import cmdoptions
 from pip._internal.exceptions import InstallationError, RequirementsFileParseError
@@ -29,6 +19,10 @@ from pip._internal.utils.encoding import auto_decode
 from pip._internal.utils.urls import get_url_scheme, url_to_path
 
 if TYPE_CHECKING:
+    # NoReturn introduced in 3.6.2; imported only for type checking to maintain
+    # pip compatibility with older patch versions of Python 3.6
+    from typing import NoReturn
+
     from pip._internal.index.package_finder import PackageFinder
 
 __all__ = ['parse_requirements']

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -1,11 +1,15 @@
 import hashlib
-from typing import TYPE_CHECKING, BinaryIO, Dict, Iterator, List, NoReturn
+from typing import TYPE_CHECKING, BinaryIO, Dict, Iterator, List
 
 from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError
 from pip._internal.utils.misc import read_chunks
 
 if TYPE_CHECKING:
     from hashlib import _Hash
+
+    # NoReturn introduced in 3.6.2; imported only for type checking to maintain
+    # pip compatibility with older patch versions of Python 3.6
+    from typing import NoReturn
 
 
 # The recommended hash algo of the moment. Change this whenever the state of


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fixes #9831 by guarding the import of `NoReturn` in a `if TYPE_CHECKING:` block because this type was only introduced in Python 3.6.2, but `pip` is compatible with Python >=`3.6.0`
