### PR TITLE
Set project name to UNKNOWN when empty

### DIFF
--- a/news/9838.bugfix.rst
+++ b/news/9838.bugfix.rst
@@ -1,0 +1,1 @@
+Fix compatibility between distutils and sysconfig when the project name is unknown outside of a virtual environment.

--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -127,8 +127,11 @@ def get_scheme(
 
     paths = sysconfig.get_paths(scheme=scheme_name, vars=variables)
 
-    # Pip historically uses a special header path in virtual environments.
     # Logic here is very arbitrary, we're doing it for compatibility, don't ask.
+    # 1. Pip historically uses a special header path in virtual environments.
+    # 2. If the distribution name is not known, distutils uses 'UNKNOWN'. We
+    #    only do the same when not running in a virtual environment because
+    #    pip's historical header path logic (see point 1) did not do this.
     if running_under_virtualenv():
         if user:
             base = variables.get("userbase", sys.prefix)

--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -128,6 +128,7 @@ def get_scheme(
     paths = sysconfig.get_paths(scheme=scheme_name, vars=variables)
 
     # Pip historically uses a special header path in virtual environments.
+    # Logic here is very arbitrary, we're doing it for compatibility, don't ask.
     if running_under_virtualenv():
         if user:
             base = variables.get("userbase", sys.prefix)
@@ -135,6 +136,8 @@ def get_scheme(
             base = variables.get("base", sys.prefix)
         python_xy = f"python{get_major_minor_version()}"
         paths["include"] = os.path.join(base, "include", "site", python_xy)
+    elif not dist_name:
+        dist_name = "UNKNOWN"
 
     scheme = Scheme(
         platlib=paths["platlib"],


### PR DESCRIPTION
For compatibility with distutils. This should fix the flood of incoming reports in #9617.
