### PR TITLE
Cache location calculation functions

### DIFF
--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import pathlib
 import sys
@@ -42,6 +43,7 @@ def _default_base(*, user: bool) -> str:
     return base
 
 
+@functools.lru_cache(maxsize=None)
 def _warn_if_mismatch(old: pathlib.Path, new: pathlib.Path, *, key: str) -> bool:
     if old == new:
         return False
@@ -55,6 +57,7 @@ def _warn_if_mismatch(old: pathlib.Path, new: pathlib.Path, *, key: str) -> bool
     return True
 
 
+@functools.lru_cache(maxsize=None)
 def _log_context(
     *,
     user: bool = False,


### PR DESCRIPTION
The practical difference is the mismatch detection is not performed at most once for every invocation, thus only warned once if there are any mismatches.
