### PR TITLE
Requiring keyring authentication when repository returns 403

### DIFF
--- a/news/9870.bugfix.rst
+++ b/news/9870.bugfix.rst
@@ -1,0 +1,1 @@
+This fixes a keyring auth issue when internal pip repos return 403 rather than 401

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -210,7 +210,7 @@ class MultiDomainBasicAuth(AuthBase):
             # Send the basic auth with this request
             req = HTTPBasicAuth(username, password)(req)
 
-        # Attach a hook to handle 401 responses
+        # Attach a hook to handle 401, 403 responses
         req.register_hook("response", self.handle_401)
 
         return req
@@ -236,9 +236,9 @@ class MultiDomainBasicAuth(AuthBase):
 
     def handle_401(self, resp, **kwargs):
         # type: (Response, **Any) -> Response
-        # We only care about 401 responses, anything else we want to just
+        # We only care about 401 and 403 responses, anything else we want to just
         #   pass through the actual response
-        if resp.status_code != 401:
+        if resp.status_code not in [401, 403]:
             return resp
 
         # We are not able to prompt the user so simply return the response


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

This fixes #9870 