### PR TITLE
Remove the location warnings for now

### DIFF
--- a/news/9912.removal.rst
+++ b/news/9912.removal.rst
@@ -1,0 +1,4 @@
+Temporarily set the new "Value for ... does not match" location warnings level
+to *DEBUG*, to hide them from casual users. This prepares pip 21.1 for CPython
+inclusion, while pip maintainers digest the first intake of location mismatch
+issues for the ``distutils``-``sysconfig`` trasition.

--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -51,7 +51,7 @@ def _warn_if_mismatch(old: pathlib.Path, new: pathlib.Path, *, key: str) -> bool
         "\ndistutils: %s"
         "\nsysconfig: %s"
     )
-    logger.warning(message, key, issue_url, old, new)
+    logger.debug(message, key, issue_url, old, new)
     return True
 
 
@@ -65,7 +65,7 @@ def _log_context(
     message = (
         "Additional context:" "\nuser = %r" "\nhome = %r" "\nroot = %r" "\nprefix = %r"
     )
-    logger.warning(message, user, home, root, prefix)
+    logger.debug(message, user, home, root, prefix)
 
 
 def get_scheme(


### PR DESCRIPTION
We can revert and discuss how we want to present the message better once Python 3.8.10 is out.

Not sure what kind of news this should use.