### PR TITLE
Special case warning for requirements.txt install

### DIFF
--- a/news/9915.feature.rst
+++ b/news/9915.feature.rst
@@ -1,0 +1,1 @@
+Add a special error message when users forget the -r flag when installing.

--- a/news/9915.feature.rst
+++ b/news/9915.feature.rst
@@ -1,1 +1,1 @@
-Add a special error message when users forget the -r flag when installing.
+Add a special error message when users forget the ``-r`` flag when installing.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -540,6 +540,13 @@ class Factory:
             req_disp,
             ", ".join(versions) or "none",
         )
+        if str(req) == "requirements.txt":
+            logger.critical(
+                "HINT: You are attempting to install a package literally "
+                'named "requirements.txt" (which cannot exist). Consider '
+                "using the '-r' flag to install the packages listed in "
+                "requirements.txt"
+            )
 
         return DistributionNotFound(f"No matching distribution found for {req}")
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -541,7 +541,7 @@ class Factory:
             ", ".join(versions) or "none",
         )
         if str(req) == "requirements.txt":
-            logger.critical(
+            logger.info(
                 "HINT: You are attempting to install a package literally "
                 'named "requirements.txt" (which cannot exist). Consider '
                 "using the '-r' flag to install the packages listed in "

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -146,7 +146,7 @@ def test_install_special_extra(script):
 def test_install_requirements_no_r_flag(script):
     '''Beginners sometimes forget the -r and this leads to confusion'''
     result = script.pip('install', 'requirements.txt', expect_error=True)
-    assert 'literally named "requirements.txt"' in result.stderr
+    assert 'literally named "requirements.txt"' in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -143,6 +143,12 @@ def test_install_special_extra(script):
     ) in result.stderr, str(result)
 
 
+def test_install_requirements_no_r_flag(script):
+    '''Beginners sometimes forget the -r and this leads to confusion'''
+    result = script.pip('install', 'requirements.txt', expect_error=True)
+    assert 'literally named "requirements.txt"' in result.stderr
+
+
 @pytest.mark.parametrize(
     "extra_to_install, simple_version", [
         ['', '3.0'],


### PR DESCRIPTION
Added a special warning for users who accidentally do
`pip install requirements.txt` and forget the `-r` flag.
Issue #9908

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
