### PR TITLE
Set strict_timestamps=False when zip is called for isolated environment

### DIFF
--- a/news/9910.bugfix.rst
+++ b/news/9910.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for ValueError('ZIP does not support timestamps before 1980') on GitHub package install.

--- a/news/9910.bugfix.rst
+++ b/news/9910.bugfix.rst
@@ -1,1 +1,1 @@
-Fix for ValueError('ZIP does not support timestamps before 1980') on GitHub package install.
+Allow ZIP to archive files with timestamps earlier than 1980.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -58,7 +58,7 @@ def _create_standalone_pip() -> Iterator[str]:
 
     with TempDirectory(kind="standalone-pip") as tmp_dir:
         pip_zip = os.path.join(tmp_dir.path, "__env_pip__.zip")
-        with zipfile.ZipFile(pip_zip, "w") as zf:
+        with zipfile.ZipFile(pip_zip, "w", strict_timestamps=False) as zf:
             for child in source.rglob("*"):
                 zf.write(child, child.relative_to(source.parent).as_posix())
         yield os.path.join(pip_zip, "pip")

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -58,7 +58,10 @@ def _create_standalone_pip() -> Iterator[str]:
 
     with TempDirectory(kind="standalone-pip") as tmp_dir:
         pip_zip = os.path.join(tmp_dir.path, "__env_pip__.zip")
-        with zipfile.ZipFile(pip_zip, "w", strict_timestamps=False) as zf:
+        kwargs = {}
+        if sys.version_info >= (3, 8):
+            kwargs["strict_timestamps"] = False
+        with zipfile.ZipFile(pip_zip, "w", **kwargs) as zf:
             for child in source.rglob("*"):
                 zf.write(child, child.relative_to(source.parent).as_posix())
         yield os.path.join(pip_zip, "pip")


### PR DESCRIPTION
Fixes #9910

Set strict_timestamps=False when using ZipFile for new isolated environment installs. Was triggering an inconsistent ValueError('ZIP does not support timestamps before 1980') on GitHub package installs.

https://docs.python.org/3/library/zipfile.html#zipfile-objects