### PR TITLE
pip uses typing.NoReturn which is new in 3.6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,5 @@ setup(
         ],
     },
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.6.2",
 )


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
