### PR TITLE
Suppress "not on PATH" warning when `--prefix` is given

### DIFF
--- a/news/9931.feature.rst
+++ b/news/9931.feature.rst
@@ -1,0 +1,1 @@
+Suppress "not on PATH" warning when ``--prefix`` is given.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -385,9 +385,9 @@ class InstallCommand(RequirementCommand):
                 conflicts = self._determine_conflicts(to_install)
 
             # Don't warn about script install locations if
-            # --target has been specified
+            # --target or --prefix has been specified
             warn_script_location = options.warn_script_location
-            if options.target_dir:
+            if options.target_dir or options.prefix_path:
                 warn_script_location = False
 
             installed = install_given_reqs(

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -960,7 +960,8 @@ def test_install_nonlocal_compatible_wheel_path(
     assert result.returncode == ERROR
 
 
-def test_install_with_target_and_scripts_no_warning(script, with_wheel):
+@pytest.mark.parametrize('opt', ('--target', '--prefix'))
+def test_install_with_target_or_prefix_and_scripts_no_warning(opt, script, with_wheel):
     """
     Test that installing with --target does not trigger the "script not
     in PATH" warning (issue #5201)
@@ -981,7 +982,7 @@ def test_install_with_target_and_scripts_no_warning(script, with_wheel):
     pkga_path.joinpath("pkga.py").write_text(textwrap.dedent("""
         def main(): pass
     """))
-    result = script.pip('install', '--target', target_dir, pkga_path)
+    result = script.pip('install', opt, target_dir, pkga_path)
     # This assertion isn't actually needed, if we get the script warning
     # the script.pip() call will fail with "stderr not expected". But we
     # leave the assertion to make the intention of the code clearer.
@@ -1666,6 +1667,9 @@ def test_install_from_test_pypi_with_ext_url_dep_is_blocked(script, index):
     assert error_cause in res.stderr, str(res)
 
 
+@pytest.mark.xfail(
+    reason="No longer possible to trigger the warning with either --prefix or --target"
+)
 def test_installing_scripts_outside_path_prints_warning(script):
     result = script.pip_install_local(
         "--prefix", script.scratch_path, "script_wheel1"


### PR DESCRIPTION
Closes: #9821

Similar to how it works with `--target`, avoid printing the
warning since it's clear from the context that the final
destionation of the executables is unlikely to be in the PATH.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
