### PR TITLE
Better diagnose when setup.py/cfg cannot be found

### DIFF
--- a/news/9944.bugfix.rst
+++ b/news/9944.bugfix.rst
@@ -1,0 +1,2 @@
+Emit clearer error message when a project root does not contain either
+``pyproject.toml``, ``setup.py`` or ``setup.cfg``.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -269,18 +269,14 @@ def tabulate(rows):
     return table, sizes
 
 
-def is_installable_dir(path):
-    # type: (str) -> bool
-    """Is path is a directory containing setup.py or pyproject.toml?"""
+def is_installable_dir(path: str) -> bool:
+    """Is path is a directory containing pyproject.toml, setup.cfg or setup.py?"""
     if not os.path.isdir(path):
         return False
-    setup_py = os.path.join(path, "setup.py")
-    if os.path.isfile(setup_py):
-        return True
-    pyproject_toml = os.path.join(path, "pyproject.toml")
-    if os.path.isfile(pyproject_toml):
-        return True
-    return False
+    return any(
+        os.path.isfile(os.path.join(path, signifier))
+        for signifier in ("pyproject.toml", "setup.cfg", "setup.py")
+    )
 
 
 def read_chunks(file, size=io.DEFAULT_BUFFER_SIZE):


### PR DESCRIPTION
This adds a check before invoking `egg_info` to make sure either setup.py or setup.cfg actually exists, and emit a clearer error message when neither can be found.

Fix #9944.