### PR TITLE
Provide a better error message when uninstalling packages without dist-info/RECORD

### DIFF
--- a/news/8954.feature.rst
+++ b/news/8954.feature.rst
@@ -1,0 +1,9 @@
+When pip is asked to uninstall a project without the dist-info/RECORD file
+it will no longer traceback with FileNotFoundError,
+but it will provide a better error message instead, such as::
+
+    ERROR: Cannot uninstall foobar 0.1, RECORD file not found. You might be able to recover from this via: 'pip install --force-reinstall --no-deps foobar==0.1'.
+
+When dist-info/INSTALLER is present and contains some useful information, the info is included in the error message instead::
+
+    ERROR: Cannot uninstall foobar 0.1, RECORD file not found. Hint: The package was installed by rpm.


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/8954

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
