### PR TITLE
Handle standalone pip creation from pip wheel

### DIFF
--- a/news/9953.bugfix.rst
+++ b/news/9953.bugfix.rst
@@ -1,0 +1,1 @@
+Fix detection of existing standalone pip instance for PEP 517 builds.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -50,9 +50,9 @@ def _create_standalone_pip() -> Iterator[str]:
     """
     source = pathlib.Path(pip_location).resolve().parent
 
-    # Return the current instance if it is already a zip file. This can happen
-    # if a PEP 517 requirement is an sdist itself.
-    if not source.is_dir() and source.parent.name == "__env_pip__.zip":
+    # Return the current instance if `source` is not a directory. We can't build
+    # a zip from this, and it likely means the instance is already standalone.
+    if not source.is_dir():
         yield str(source)
         return
 


### PR DESCRIPTION
This change ensures that when pip is executed from a wheel/zip, 
standalone pip creation for build environment reuses the source.

Resolves: #9953
