### PR TITLE
Fix: #9973. Don't disclose empty passwords.

### DIFF
--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -629,12 +629,13 @@ def redact_netloc(netloc):
 
     For example:
         - "user:pass@example.com" returns "user:****@example.com"
+        - "user:@example.com" returns "****@example.com"
         - "accesstoken@example.com" returns "****@example.com"
     """
     netloc, (user, password) = split_auth_from_netloc(netloc)
     if user is None:
         return netloc
-    if password is None:
+    if not password:
         user = "****"
         password = ""
     else:


### PR DESCRIPTION
Empty passwords can be associated with access tokens.
Avoid disclosing them.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
