### PR TITLE
Include rustc version in the user agent, if rustc is available

### DIFF
--- a/news/9987.feature.rst
+++ b/news/9987.feature.rst
@@ -1,0 +1,1 @@
+Include ``rustc`` version in pip's ``User-Agent``, when the system has ``rustc``.

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -169,7 +169,7 @@ def user_agent():
         # If for any reason `rustc --version` fails, silently ignore it
         try:
             rustc_output = subprocess.check_output(
-                ["rustc", "--version"], stderr=subprocess.STDOUT
+                ["rustc", "--version"], stderr=subprocess.STDOUT, timeout=.5
             )
         except Exception:
             pass

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -19,6 +19,8 @@ import logging
 import mimetypes
 import os
 import platform
+import shutil
+import subprocess
 import sys
 import urllib.parse
 import warnings
@@ -162,6 +164,21 @@ def user_agent():
     setuptools_dist = get_default_environment().get_distribution("setuptools")
     if setuptools_dist is not None:
         data["setuptools_version"] = str(setuptools_dist.version)
+
+    if shutil.which("rustc") is not None:
+        # If for any reason `rustc --version` fails, silently ignore it
+        try:
+            rustc_output = subprocess.check_output(
+                ["rustc", "--version"], stderr=subprocess.STDOUT
+            )
+        except Exception:
+            pass
+        else:
+            if rustc_output.startswith(b"rustc "):
+                # The format of `rustc --version` is:
+                # `b'rustc 1.52.1 (9bc8c42bb 2021-05-09)\n'`
+                # We extract just the middle (1.52.1) part
+                data["rustc_version"] = rustc_output.split(b" ")[1].decode()
 
     # Use None rather than False so as not to give the impression that
     # pip knows it is not being run under CI.  Rather, it is a null or

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -598,6 +598,8 @@ class TestParseRequirements:
         with open(tmpdir.joinpath('req1.txt'), 'w') as fp:
             fp.write(template.format(*map(make_var, env_vars)))
 
+        # Construct the session outside the monkey-patch, since it access the
+        # env
         session = PipSession()
         with patch('pip._internal.req.req_file.os.getenv') as getenv:
             getenv.side_effect = lambda n: env_vars[n]
@@ -624,6 +626,8 @@ class TestParseRequirements:
         with open(tmpdir.joinpath('req1.txt'), 'w') as fp:
             fp.write(req_url)
 
+        # Construct the session outside the monkey-patch, since it access the
+        # env
         session = PipSession()
         with patch('pip._internal.req.req_file.os.getenv') as getenv:
             getenv.return_value = ''

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -598,13 +598,14 @@ class TestParseRequirements:
         with open(tmpdir.joinpath('req1.txt'), 'w') as fp:
             fp.write(template.format(*map(make_var, env_vars)))
 
+        session = PipSession()
         with patch('pip._internal.req.req_file.os.getenv') as getenv:
             getenv.side_effect = lambda n: env_vars[n]
 
             reqs = list(parse_reqfile(
                 tmpdir.joinpath('req1.txt'),
                 finder=finder,
-                session=PipSession()
+                session=session
             ))
 
         assert len(reqs) == 1, \
@@ -623,13 +624,14 @@ class TestParseRequirements:
         with open(tmpdir.joinpath('req1.txt'), 'w') as fp:
             fp.write(req_url)
 
+        session = PipSession()
         with patch('pip._internal.req.req_file.os.getenv') as getenv:
             getenv.return_value = ''
 
             reqs = list(parse_reqfile(
                 tmpdir.joinpath('req1.txt'),
                 finder=finder,
-                session=PipSession()
+                session=session
             ))
 
             assert len(reqs) == 1, \


### PR DESCRIPTION
Rust is becoming more popular for writing Python extension modules in, this information would be valuable for package maintainers to assess the ecosystem, in the same way glibc or openssl version is.

Does this requires a newsfragment for pip? I'm not sure whether this is considered a user-facing change or not.