### PR TITLE
Exclude a known incompatible installed candidate

### DIFF
--- a/news/9841.bugfix.rst
+++ b/news/9841.bugfix.rst
@@ -1,0 +1,3 @@
+New resolver: Correctly exclude an already installed package if its version is
+known to be incompatible to stop the dependency resolution process with a clear
+error message.


### PR DESCRIPTION
The resolver collects previously known incompatibilites and sends them to the provider. But previously the provider does not correctly exclude the currently-installed candidate if it is present in that incompatibility list, causing the resolver to enter a loop trying that same candidate.

This patch correctly applies `incompat_ids` when producing an `AlreadyInstalledCandidate` to exclude it if its `id()` is in the set.

I’m hesitant to add a test since it would hang the entire test suite if it fails. Is there a way to set a timeout on a pip call instead?

Fix #9841.