### PR TITLE
Check Requires-Python before other dependencies

### DIFF
--- a/news/9925.feature.rst
+++ b/news/9925.feature.rst
@@ -1,0 +1,3 @@
+New resolver: A distribution's ``Requires-Python`` metadata is now checked
+before its Python dependencies. This makes the resolver fail quicker when
+there's an interpreter version conflict.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -32,6 +32,9 @@ BaseCandidate = Union[
     "LinkCandidate",
 ]
 
+# Avoid conflicting with the PyPI package "Python".
+REQUIRES_PYTHON_IDENTIFIER = cast(NormalizedName, "<Python from Requires-Python>")
+
 
 def as_base_candidate(candidate: Candidate) -> Optional[BaseCandidate]:
     """The runtime version of BaseCandidate."""
@@ -578,13 +581,12 @@ class RequiresPythonCandidate(Candidate):
     @property
     def project_name(self):
         # type: () -> NormalizedName
-        # Avoid conflicting with the PyPI package "Python".
-        return cast(NormalizedName, "<Python from Requires-Python>")
+        return REQUIRES_PYTHON_IDENTIFIER
 
     @property
     def name(self):
         # type: () -> str
-        return self.project_name
+        return REQUIRES_PYTHON_IDENTIFIER
 
     @property
     def version(self):


### PR DESCRIPTION
This makes the resolver fail quicker when there's a interpreter version conflict, and avoid additional (useless) downloads.

Fix #9925.