### PR TITLE
Drop released news fragments

### DIFF
--- a/news/9841.bugfix.rst
+++ b/news/9841.bugfix.rst
@@ -1,3 +1,0 @@
-New resolver: Correctly exclude an already installed package if its version is
-known to be incompatible to stop the dependency resolution process with a clear
-error message.

--- a/news/9910.bugfix.rst
+++ b/news/9910.bugfix.rst
@@ -1,1 +1,0 @@
-Allow ZIP to archive files with timestamps earlier than 1980.

--- a/news/9944.bugfix.rst
+++ b/news/9944.bugfix.rst
@@ -1,2 +1,0 @@
-Emit clearer error message when a project root does not contain either
-``pyproject.toml``, ``setup.py`` or ``setup.cfg``.

--- a/news/9953.bugfix.rst
+++ b/news/9953.bugfix.rst
@@ -1,1 +1,0 @@
-Fix detection of existing standalone pip instance for PEP 517 builds.


### PR DESCRIPTION
I'm surprised `git merge` did not do this, as this was part of 8737f903eaa9475e1b7693e436d9bdf17e46e43a.