### PR TITLE
Convert type hint comments into annotations

### DIFF
--- a/news/10018.trivial.rst
+++ b/news/10018.trivial.rst
@@ -1,0 +1,1 @@
+Use annotations from the ``typing`` module on some functions.

--- a/src/pip/__init__.py
+++ b/src/pip/__init__.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 __version__ = "21.2.dev0"
 
 
-def main(args: (Optional[List[str]]) = None) -> int:
+def main(args: Optional[List[str]] = None) -> int:
     """This is an internal API only meant for use by pip's own console scripts.
 
     For additional details, see https://github.com/pypa/pip/issues/7498.

--- a/src/pip/__init__.py
+++ b/src/pip/__init__.py
@@ -3,8 +3,7 @@ from typing import List, Optional
 __version__ = "21.2.dev0"
 
 
-def main(args=None):
-    # type: (Optional[List[str]]) -> int
+def main(args: (Optional[List[str]]) = None) -> int:
     """This is an internal API only meant for use by pip's own console scripts.
 
     For additional details, see https://github.com/pypa/pip/issues/7498.

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -3,8 +3,7 @@ from typing import List, Optional
 import pip._internal.utils.inject_securetransport  # noqa
 
 
-def main(args=None):
-    # type: (Optional[List[str]]) -> int
+def main(args: (Optional[List[str]]) = None) -> int:
     """This is preserved for old console scripts that may still be referencing
     it.
 

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -13,7 +13,6 @@ from pip._internal.utils.misc import get_installed_distributions
 
 
 def autocomplete():
-    # type: () -> None
     """Entry Point for completion of main and subcommand options."""
     # Don't complete if user hasn't sourced bash_completion file.
     if "PIP_AUTO_COMPLETE" not in os.environ:
@@ -107,8 +106,7 @@ def autocomplete():
     sys.exit(1)
 
 
-def get_path_completion_type(cwords, cword, opts):
-    # type: (List[str], int, Iterable[Any]) -> Optional[str]
+def get_path_completion_type(cwords: List[str], cword: int, opts: Iterable[Any]) -> Optional[str]:
     """Get the type of path completion (``file``, ``dir``, ``path`` or None)
 
     :param cwords: same as the environmental variable ``COMP_WORDS``
@@ -130,8 +128,7 @@ def get_path_completion_type(cwords, cword, opts):
     return None
 
 
-def auto_complete_paths(current, completion_type):
-    # type: (str, str) -> Iterable[str]
+def auto_complete_paths(current: str, completion_type: str) -> Iterable[str]:
     """If ``completion_type`` is ``file`` or ``path``, list all regular files
     and directories starting with ``current``; otherwise only list directories
     starting with ``current``.

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -106,9 +106,11 @@ def autocomplete():
     sys.exit(1)
 
 
-def get_path_completion_type(cwords: List[str], 
-                             cword: int, 
-                             opts: Iterable[Any]) -> Optional[str]:
+def get_path_completion_type(
+    cwords: List[str], 
+    cword: int, 
+    opts: Iterable[Any]
+) -> Optional[str]:
     """Get the type of path completion (``file``, ``dir``, ``path`` or None)
 
     :param cwords: same as the environmental variable ``COMP_WORDS``
@@ -130,8 +132,7 @@ def get_path_completion_type(cwords: List[str],
     return None
 
 
-def auto_complete_paths(current: str, 
-                        completion_type: str) -> Iterable[str]:
+def auto_complete_paths(current: str, completion_type: str) -> Iterable[str]:
     """If ``completion_type`` is ``file`` or ``path``, list all regular files
     and directories starting with ``current``; otherwise only list directories
     starting with ``current``.

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -107,9 +107,7 @@ def autocomplete():
 
 
 def get_path_completion_type(
-    cwords: List[str], 
-    cword: int, 
-    opts: Iterable[Any]
+    cwords: List[str], cword: int, opts: Iterable[Any]
 ) -> Optional[str]:
     """Get the type of path completion (``file``, ``dir``, ``path`` or None)
 

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -12,7 +12,7 @@ from pip._internal.commands import commands_dict, create_command
 from pip._internal.utils.misc import get_installed_distributions
 
 
-def autocomplete():
+def autocomplete() -> None:
     """Entry Point for completion of main and subcommand options."""
     # Don't complete if user hasn't sourced bash_completion file.
     if "PIP_AUTO_COMPLETE" not in os.environ:

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -106,7 +106,9 @@ def autocomplete():
     sys.exit(1)
 
 
-def get_path_completion_type(cwords: List[str], cword: int, opts: Iterable[Any]) -> Optional[str]:
+def get_path_completion_type(cwords: List[str], 
+                             cword: int, 
+                             opts: Iterable[Any]) -> Optional[str]:
     """Get the type of path completion (``file``, ``dir``, ``path`` or None)
 
     :param cwords: same as the environmental variable ``COMP_WORDS``
@@ -128,7 +130,8 @@ def get_path_completion_type(cwords: List[str], cword: int, opts: Iterable[Any])
     return None
 
 
-def auto_complete_paths(current: str, completion_type: str) -> Iterable[str]:
+def auto_complete_paths(current: str, 
+                        completion_type: str) -> Iterable[str]:
     """If ``completion_type`` is ``file`` or ``path``, list all regular files
     and directories starting with ``current``; otherwise only list directories
     starting with ``current``.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -43,8 +43,7 @@ class Command(CommandContextMixIn):
     usage = None  # type: str
     ignore_require_venv = False  # type: bool
 
-    def __init__(self, name, summary, isolated=False):
-        # type: (str, str, bool) -> None
+    def __init__(self, name: str, summary: str, isolated: bool = False) -> None:
         super().__init__()
 
         self.name = name
@@ -75,11 +74,9 @@ class Command(CommandContextMixIn):
         self.add_options()
 
     def add_options(self):
-        # type: () -> None
         pass
 
-    def handle_pip_version_check(self, options):
-        # type: (Values) -> None
+    def handle_pip_version_check(self, options: Values) -> None:
         """
         This is a no-op so that commands by default do not do the pip version
         check.
@@ -88,25 +85,21 @@ class Command(CommandContextMixIn):
         # are present.
         assert not hasattr(options, "no_index")
 
-    def run(self, options, args):
-        # type: (Values, List[Any]) -> int
+    def run(self, options: Values, args: List(Any)) -> int:
         raise NotImplementedError
 
-    def parse_args(self, args):
-        # type: (List[str]) -> Tuple[Any, Any]
+    def parse_args(self, args: List[str]) -> Tuple[Any, Any]:
         # factored out for testability
         return self.parser.parse_args(args)
 
-    def main(self, args):
-        # type: (List[str]) -> int
+    def main(self, args: List[str]) -> int:
         try:
             with self.main_context():
                 return self._main(args)
         finally:
             logging.shutdown()
 
-    def _main(self, args):
-        # type: (List[str]) -> int
+    def _main(self, args: List[str]) -> int:
         # We must initialize this before the tempdir manager, otherwise the
         # configuration would not be accessible by the time we clean up the
         # tempdir manager.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -73,10 +73,10 @@ class Command(CommandContextMixIn):
 
         self.add_options()
 
-    def add_options(self):
+    def add_options(self) -> None:
         pass
 
-    def handle_pip_version_check(self, options: Values):
+    def handle_pip_version_check(self, options: Values) -> None:
         """
         This is a no-op so that commands by default do not do the pip version
         check.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -85,7 +85,7 @@ class Command(CommandContextMixIn):
         # are present.
         assert not hasattr(options, "no_index")
 
-    def run(self, options: Values, args: List(Any)) -> int:
+    def run(self, options: Values, args: List[Any]) -> int:
         raise NotImplementedError
 
     def parse_args(self, args: List[str]) -> Tuple[Any, Any]:

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -43,7 +43,7 @@ class Command(CommandContextMixIn):
     usage = None  # type: str
     ignore_require_venv = False  # type: bool
 
-    def __init__(self, name: str, summary: str, isolated: bool = False) -> None:
+    def __init__(self, name: str, summary: str, isolated: bool = False):
         super().__init__()
 
         self.name = name
@@ -76,7 +76,7 @@ class Command(CommandContextMixIn):
     def add_options(self):
         pass
 
-    def handle_pip_version_check(self, options: Values) -> None:
+    def handle_pip_version_check(self, options: Values):
         """
         This is a no-op so that commands by default do not do the pip version
         check.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -43,7 +43,7 @@ class Command(CommandContextMixIn):
     usage = None  # type: str
     ignore_require_venv = False  # type: bool
 
-    def __init__(self, name: str, summary: str, isolated: bool = False):
+    def __init__(self, name: str, summary: str, isolated: bool = False) -> None:
         super().__init__()
 
         self.name = name

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -31,7 +31,7 @@ from pip._internal.utils.hashes import STRONG_HASHES
 from pip._internal.utils.misc import strtobool
 
 
-def raise_option_error(parser: OptionParser, option: Option, msg: str):
+def raise_option_error(parser: OptionParser, option: Option, msg: str) -> None:
     """
     Raise an option parsing error using parser.error().
 
@@ -57,7 +57,7 @@ def make_option_group(group: Dict[str, Any], parser: ConfigOptionParser) -> Opti
     return option_group
 
 
-def check_install_build_global(options: Values, check_options: Optional[Values] = None):
+def check_install_build_global(options: Values, check_options: Optional[Values] = None) -> None:
     """Disable wheels if per-setup.py call options are set.
 
     :param options: The OptionParser options to update.
@@ -81,7 +81,7 @@ def check_install_build_global(options: Values, check_options: Optional[Values] 
         )
 
 
-def check_dist_restriction(options: Values, check_target: bool = False):
+def check_dist_restriction(options: Values, check_target: bool = False) -> None:
     """Function for determining if custom platform options are allowed.
 
     :param options: The OptionParser options.
@@ -427,7 +427,7 @@ def editable() -> Option:
     )
 
 
-def _handle_src(option: Option, opt_str: str, value: str, parser: OptionParser):
+def _handle_src(option: Option, opt_str: str, value: str, parser: OptionParser) -> None:
     value = os.path.abspath(value)
     setattr(parser.values, option.dest, value)
 
@@ -455,7 +455,7 @@ def _get_format_control(values: Values, option: Option) -> Any:
     return getattr(values, option.dest)
 
 
-def _handle_no_binary(option: Option, opt_str: str, value: str, parser: OptionParser):
+def _handle_no_binary(option: Option, opt_str: str, value: str, parser: OptionParser) -> None:
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,
@@ -464,7 +464,7 @@ def _handle_no_binary(option: Option, opt_str: str, value: str, parser: OptionPa
     )
 
 
-def _handle_only_binary(option: Option, opt_str: str, value: str, parser: OptionParser):
+def _handle_only_binary(option: Option, opt_str: str, value: str, parser: OptionParser) -> None:
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,
@@ -556,7 +556,7 @@ def _convert_python_version(value: str) -> Tuple[Tuple[int, ...], Optional[str]]
 
 def _handle_python_version(
     option: Option, opt_str: str, value: str, parser: OptionParser
-):
+) -> None:
     """
     Handle a provided --python-version value.
     """
@@ -626,7 +626,7 @@ abis = partial(
 )  # type: Callable[..., Option]
 
 
-def add_target_python_options(cmd_opts: OptionGroup):
+def add_target_python_options(cmd_opts: OptionGroup) -> None:
     cmd_opts.add_option(platforms())
     cmd_opts.add_option(python_version())
     cmd_opts.add_option(implementation())
@@ -665,7 +665,9 @@ cache_dir = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_no_cache_dir(option: Option, opt: str, value: str, parser: OptionParser):
+def _handle_no_cache_dir(
+    option: Option, opt: str, value: str, parser: OptionParser
+) -> None:
     """
     Process a value provided for the --no-cache-dir option.
 
@@ -743,7 +745,9 @@ no_build_isolation = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_no_use_pep517(option: Option, opt: str, value: str, parser: OptionParser):
+def _handle_no_use_pep517(
+    option: Option, opt: str, value: str, parser: OptionParser
+) -> None:
     """
     Process a value provided for the --no-use-pep517 option.
 
@@ -846,7 +850,9 @@ disable_pip_version_check = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_merge_hash(option: Option, opt_str: str, value: str, parser: OptionParser):
+def _handle_merge_hash(
+    option: Option, opt_str: str, value: str, parser: OptionParser
+) -> None:
     """Given a value spelled "algo:digest", append the digest to a list
     pointed to in a dict by the algo name."""
     if not parser.values.hashes:
@@ -905,7 +911,7 @@ list_path = partial(
 )  # type: Callable[..., Option]
 
 
-def check_list_path_option(options: Values):
+def check_list_path_option(options: Values) -> None:
     if options.path and (options.user or options.local):
         raise CommandError("Cannot combine '--path' with '--user' or '--local'")
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -31,7 +31,10 @@ from pip._internal.utils.hashes import STRONG_HASHES
 from pip._internal.utils.misc import strtobool
 
 
-def raise_option_error(parser: OptionParser, option: Option, msg: str):
+def raise_option_error(
+    parser: OptionParser, 
+    option: Option, 
+    msg: str):
     """
     Raise an option parsing error using parser.error().
 
@@ -45,7 +48,10 @@ def raise_option_error(parser: OptionParser, option: Option, msg: str):
     parser.error(msg)
 
 
-def make_option_group(group: Dict[str, Any], parser: ConfigOptionParser) -> OptionGroup:
+def make_option_group(
+    group: Dict[str, Any], 
+    parser: ConfigOptionParser
+) -> OptionGroup:
     """
     Return an OptionGroup object
     group  -- assumed to be dict with 'name' and 'options' keys
@@ -57,7 +63,9 @@ def make_option_group(group: Dict[str, Any], parser: ConfigOptionParser) -> Opti
     return option_group
 
 
-def check_install_build_global(options: Values, check_options: Optional[Values] = None):
+def check_install_build_global(
+    options: Values, 
+    check_options: Optional[Values] = None):
     """Disable wheels if per-setup.py call options are set.
 
     :param options: The OptionParser options to update.
@@ -427,7 +435,11 @@ def editable() -> Option:
     )
 
 
-def _handle_src(option: Option, opt_str: str, value: str, parser: OptionParser):
+def _handle_src(
+    option: Option, 
+    opt_str: str, 
+    value: str, 
+    parser: OptionParser):
     value = os.path.abspath(value)
     setattr(parser.values, option.dest, value)
 
@@ -455,7 +467,11 @@ def _get_format_control(values: Values, option: Option) -> Any:
     return getattr(values, option.dest)
 
 
-def _handle_no_binary(option: Option, opt_str: str, value: str, parser: OptionParser):
+def _handle_no_binary(
+    option: Option, 
+    opt_str: str, 
+    value: str, 
+    parser: OptionParser):
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,
@@ -464,7 +480,11 @@ def _handle_no_binary(option: Option, opt_str: str, value: str, parser: OptionPa
     )
 
 
-def _handle_only_binary(option: Option, opt_str: str, value: str, parser: OptionParser):
+def _handle_only_binary(
+    option: Option, 
+    opt_str: str, 
+    value: str, 
+    parser: OptionParser):
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,
@@ -554,7 +574,12 @@ def _convert_python_version(value: str) -> Tuple[Tuple[int, ...], Optional[str]]
     return (version_info, None)
 
 
-def _handle_python_version(option: Option, opt_str: str, value: str, parser: OptionParser):
+def _handle_python_version(
+    option: Option, 
+    opt_str: str, 
+    value: str, 
+    parser: OptionParser
+):
     """
     Handle a provided --python-version value.
     """
@@ -663,7 +688,12 @@ cache_dir = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_no_cache_dir(option: Option, opt: str, value: str, parser: OptionParser):
+def _handle_no_cache_dir(
+    option: Option, 
+    opt: str, 
+    value: str, 
+    parser: OptionParser
+):
     """
     Process a value provided for the --no-cache-dir option.
 
@@ -741,7 +771,12 @@ no_build_isolation = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_no_use_pep517(option: Option, opt: str, value: str, parser: OptionParser):
+def _handle_no_use_pep517(
+    option: Option, 
+    opt: str, 
+    value: str, 
+    parser: OptionParser
+):
     """
     Process a value provided for the --no-use-pep517 option.
 
@@ -844,7 +879,12 @@ disable_pip_version_check = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_merge_hash(option: Option, opt_str: str, value: str, parser: OptionParser):
+def _handle_merge_hash(
+    option: Option, 
+    opt_str: str, 
+    value: str, 
+    parser: OptionParser
+):
     """Given a value spelled "algo:digest", append the digest to a list
     pointed to in a dict by the algo name."""
     if not parser.values.hashes:

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -31,10 +31,7 @@ from pip._internal.utils.hashes import STRONG_HASHES
 from pip._internal.utils.misc import strtobool
 
 
-def raise_option_error(
-    parser: OptionParser, 
-    option: Option, 
-    msg: str):
+def raise_option_error(parser: OptionParser, option: Option, msg: str):
     """
     Raise an option parsing error using parser.error().
 
@@ -48,10 +45,7 @@ def raise_option_error(
     parser.error(msg)
 
 
-def make_option_group(
-    group: Dict[str, Any], 
-    parser: ConfigOptionParser
-) -> OptionGroup:
+def make_option_group(group: Dict[str, Any], parser: ConfigOptionParser) -> OptionGroup:
     """
     Return an OptionGroup object
     group  -- assumed to be dict with 'name' and 'options' keys
@@ -63,9 +57,7 @@ def make_option_group(
     return option_group
 
 
-def check_install_build_global(
-    options: Values, 
-    check_options: Optional[Values] = None):
+def check_install_build_global(options: Values, check_options: Optional[Values] = None):
     """Disable wheels if per-setup.py call options are set.
 
     :param options: The OptionParser options to update.
@@ -435,11 +427,7 @@ def editable() -> Option:
     )
 
 
-def _handle_src(
-    option: Option, 
-    opt_str: str, 
-    value: str, 
-    parser: OptionParser):
+def _handle_src(option: Option, opt_str: str, value: str, parser: OptionParser):
     value = os.path.abspath(value)
     setattr(parser.values, option.dest, value)
 
@@ -467,11 +455,7 @@ def _get_format_control(values: Values, option: Option) -> Any:
     return getattr(values, option.dest)
 
 
-def _handle_no_binary(
-    option: Option, 
-    opt_str: str, 
-    value: str, 
-    parser: OptionParser):
+def _handle_no_binary(option: Option, opt_str: str, value: str, parser: OptionParser):
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,
@@ -480,11 +464,7 @@ def _handle_no_binary(
     )
 
 
-def _handle_only_binary(
-    option: Option, 
-    opt_str: str, 
-    value: str, 
-    parser: OptionParser):
+def _handle_only_binary(option: Option, opt_str: str, value: str, parser: OptionParser):
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,
@@ -574,11 +554,7 @@ def _convert_python_version(value: str) -> Tuple[Tuple[int, ...], Optional[str]]
     return (version_info, None)
 
 
-def _handle_python_version(
-    option: Option, 
-    opt_str: str, 
-    value: str, 
-    parser: OptionParser
+def _handle_python_version(option: Option, opt_str: str, value: str, parser: OptionParser
 ):
     """
     Handle a provided --python-version value.
@@ -688,12 +664,7 @@ cache_dir = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_no_cache_dir(
-    option: Option, 
-    opt: str, 
-    value: str, 
-    parser: OptionParser
-):
+def _handle_no_cache_dir(option: Option, opt: str, value: str, parser: OptionParser):
     """
     Process a value provided for the --no-cache-dir option.
 
@@ -771,12 +742,7 @@ no_build_isolation = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_no_use_pep517(
-    option: Option, 
-    opt: str, 
-    value: str, 
-    parser: OptionParser
-):
+def _handle_no_use_pep517(option: Option, opt: str, value: str, parser: OptionParser):
     """
     Process a value provided for the --no-use-pep517 option.
 
@@ -879,12 +845,7 @@ disable_pip_version_check = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_merge_hash(
-    option: Option, 
-    opt_str: str, 
-    value: str, 
-    parser: OptionParser
-):
+def _handle_merge_hash(option: Option, opt_str: str, value: str, parser: OptionParser):
     """Given a value spelled "algo:digest", append the digest to a list
     pointed to in a dict by the algo name."""
     if not parser.values.hashes:

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -31,8 +31,7 @@ from pip._internal.utils.hashes import STRONG_HASHES
 from pip._internal.utils.misc import strtobool
 
 
-def raise_option_error(parser, option, msg):
-    # type: (OptionParser, Option, str) -> None
+def raise_option_error(parser: OptionParser, option: Option, msg: str):
     """
     Raise an option parsing error using parser.error().
 
@@ -46,8 +45,7 @@ def raise_option_error(parser, option, msg):
     parser.error(msg)
 
 
-def make_option_group(group, parser):
-    # type: (Dict[str, Any], ConfigOptionParser) -> OptionGroup
+def make_option_group(group: Dict[str, Any], parser: ConfigOptionParser) -> OptionGroup:
     """
     Return an OptionGroup object
     group  -- assumed to be dict with 'name' and 'options' keys
@@ -59,8 +57,7 @@ def make_option_group(group, parser):
     return option_group
 
 
-def check_install_build_global(options, check_options=None):
-    # type: (Values, Optional[Values]) -> None
+def check_install_build_global(options: Values, check_options: Optional[Values] = None):
     """Disable wheels if per-setup.py call options are set.
 
     :param options: The OptionParser options to update.
@@ -70,8 +67,7 @@ def check_install_build_global(options, check_options=None):
     if check_options is None:
         check_options = options
 
-    def getname(n):
-        # type: (str) -> Optional[Any]
+    def getname(n: str) -> Optional[Any]:
         return getattr(check_options, n, None)
 
     names = ["build_options", "global_options", "install_options"]
@@ -85,8 +81,7 @@ def check_install_build_global(options, check_options=None):
         )
 
 
-def check_dist_restriction(options, check_target=False):
-    # type: (Values, bool) -> None
+def check_dist_restriction(options: Values, check_target: bool = False):
     """Function for determining if custom platform options are allowed.
 
     :param options: The OptionParser options.
@@ -126,13 +121,11 @@ def check_dist_restriction(options, check_target=False):
             )
 
 
-def _path_option_check(option, opt, value):
-    # type: (Option, str, str) -> str
+def _path_option_check(option: Option, opt: str, value: str) -> str:
     return os.path.expanduser(value)
 
 
-def _package_name_option_check(option, opt, value):
-    # type: (Option, str, str) -> str
+def _package_name_option_check(option: Option, opt: str, value: str) -> str:
     return canonicalize_name(value)
 
 
@@ -287,8 +280,7 @@ timeout = partial(
 )  # type: Callable[..., Option]
 
 
-def exists_action():
-    # type: () -> Option
+def exists_action() -> Option:
     return Option(
         # Option when path already exist
         "--exists-action",
@@ -343,8 +335,7 @@ index_url = partial(
 )  # type: Callable[..., Option]
 
 
-def extra_index_url():
-    # type: () -> Option
+def extra_index_url() -> Option:
     return Option(
         "--extra-index-url",
         dest="extra_index_urls",
@@ -367,8 +358,7 @@ no_index = partial(
 )  # type: Callable[..., Option]
 
 
-def find_links():
-    # type: () -> Option
+def find_links() -> Option:
     return Option(
         "-f",
         "--find-links",
@@ -384,8 +374,7 @@ def find_links():
     )
 
 
-def trusted_host():
-    # type: () -> Option
+def trusted_host() -> Option:
     return Option(
         "--trusted-host",
         dest="trusted_hosts",
@@ -397,8 +386,7 @@ def trusted_host():
     )
 
 
-def constraints():
-    # type: () -> Option
+def constraints() -> Option:
     return Option(
         "-c",
         "--constraint",
@@ -411,8 +399,7 @@ def constraints():
     )
 
 
-def requirements():
-    # type: () -> Option
+def requirements() -> Option:
     return Option(
         "-r",
         "--requirement",
@@ -425,8 +412,7 @@ def requirements():
     )
 
 
-def editable():
-    # type: () -> Option
+def editable() -> Option:
     return Option(
         "-e",
         "--editable",
@@ -441,8 +427,7 @@ def editable():
     )
 
 
-def _handle_src(option, opt_str, value, parser):
-    # type: (Option, str, str, OptionParser) -> None
+def _handle_src(option: Option, opt_str: str, value: str, parser: OptionParser):
     value = os.path.abspath(value)
     setattr(parser.values, option.dest, value)
 
@@ -465,14 +450,12 @@ src = partial(
 )  # type: Callable[..., Option]
 
 
-def _get_format_control(values, option):
-    # type: (Values, Option) -> Any
+def _get_format_control(values: Values, option: Option) -> Any:
     """Get a format_control object."""
     return getattr(values, option.dest)
 
 
-def _handle_no_binary(option, opt_str, value, parser):
-    # type: (Option, str, str, OptionParser) -> None
+def _handle_no_binary(option: Option, opt_str: str, value: str, parser: OptionParser):
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,
@@ -481,8 +464,7 @@ def _handle_no_binary(option, opt_str, value, parser):
     )
 
 
-def _handle_only_binary(option, opt_str, value, parser):
-    # type: (Option, str, str, OptionParser) -> None
+def _handle_only_binary(option: Option, opt_str: str, value: str, parser: OptionParser):
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,
@@ -491,8 +473,7 @@ def _handle_only_binary(option, opt_str, value, parser):
     )
 
 
-def no_binary():
-    # type: () -> Option
+def no_binary() -> Option:
     format_control = FormatControl(set(), set())
     return Option(
         "--no-binary",
@@ -510,8 +491,7 @@ def no_binary():
     )
 
 
-def only_binary():
-    # type: () -> Option
+def only_binary() -> Option:
     format_control = FormatControl(set(), set())
     return Option(
         "--only-binary",
@@ -545,8 +525,7 @@ platforms = partial(
 
 
 # This was made a separate function for unit-testing purposes.
-def _convert_python_version(value):
-    # type: (str) -> Tuple[Tuple[int, ...], Optional[str]]
+def _convert_python_version(value: str) -> Tuple[Tuple[int, ...], Optional[str]]:
     """
     Convert a version string like "3", "37", or "3.7.3" into a tuple of ints.
 
@@ -575,8 +554,7 @@ def _convert_python_version(value):
     return (version_info, None)
 
 
-def _handle_python_version(option, opt_str, value, parser):
-    # type: (Option, str, str, OptionParser) -> None
+def _handle_python_version(option: Option, opt_str: str, value: str, parser: OptionParser):
     """
     Handle a provided --python-version value.
     """
@@ -646,16 +624,14 @@ abis = partial(
 )  # type: Callable[..., Option]
 
 
-def add_target_python_options(cmd_opts):
-    # type: (OptionGroup) -> None
+def add_target_python_options(cmd_opts: OptionGroup):
     cmd_opts.add_option(platforms())
     cmd_opts.add_option(python_version())
     cmd_opts.add_option(implementation())
     cmd_opts.add_option(abis())
 
 
-def make_target_python(options):
-    # type: (Values) -> TargetPython
+def make_target_python(options: Values) -> TargetPython:
     target_python = TargetPython(
         platforms=options.platforms,
         py_version_info=options.python_version,
@@ -666,8 +642,7 @@ def make_target_python(options):
     return target_python
 
 
-def prefer_binary():
-    # type: () -> Option
+def prefer_binary() -> Option:
     return Option(
         "--prefer-binary",
         dest="prefer_binary",
@@ -688,8 +663,7 @@ cache_dir = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_no_cache_dir(option, opt, value, parser):
-    # type: (Option, str, str, OptionParser) -> None
+def _handle_no_cache_dir(option: Option, opt: str, value: str, parser: OptionParser):
     """
     Process a value provided for the --no-cache-dir option.
 
@@ -767,8 +741,7 @@ no_build_isolation = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_no_use_pep517(option, opt, value, parser):
-    # type: (Option, str, str, OptionParser) -> None
+def _handle_no_use_pep517(option: Option, opt: str, value: str, parser: OptionParser):
     """
     Process a value provided for the --no-use-pep517 option.
 
@@ -871,8 +844,7 @@ disable_pip_version_check = partial(
 )  # type: Callable[..., Option]
 
 
-def _handle_merge_hash(option, opt_str, value, parser):
-    # type: (Option, str, str, OptionParser) -> None
+def _handle_merge_hash(option: Option, opt_str: str, value: str, parser: OptionParser):
     """Given a value spelled "algo:digest", append the digest to a list
     pointed to in a dict by the algo name."""
     if not parser.values.hashes:
@@ -931,8 +903,7 @@ list_path = partial(
 )  # type: Callable[..., Option]
 
 
-def check_list_path_option(options):
-    # type: (Values) -> None
+def check_list_path_option(options: Values):
     if options.path and (options.user or options.local):
         raise CommandError("Cannot combine '--path' with '--user' or '--local'")
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -554,7 +554,8 @@ def _convert_python_version(value: str) -> Tuple[Tuple[int, ...], Optional[str]]
     return (version_info, None)
 
 
-def _handle_python_version(option: Option, opt_str: str, value: str, parser: OptionParser
+def _handle_python_version(
+    option: Option, opt_str: str, value: str, parser: OptionParser
 ):
     """
     Handle a provided --python-version value.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -57,7 +57,9 @@ def make_option_group(group: Dict[str, Any], parser: ConfigOptionParser) -> Opti
     return option_group
 
 
-def check_install_build_global(options: Values, check_options: Optional[Values] = None) -> None:
+def check_install_build_global(
+    options: Values, check_options: Optional[Values] = None
+) -> None:
     """Disable wheels if per-setup.py call options are set.
 
     :param options: The OptionParser options to update.
@@ -455,7 +457,9 @@ def _get_format_control(values: Values, option: Option) -> Any:
     return getattr(values, option.dest)
 
 
-def _handle_no_binary(option: Option, opt_str: str, value: str, parser: OptionParser) -> None:
+def _handle_no_binary(
+    option: Option, opt_str: str, value: str, parser: OptionParser
+) -> None:
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,
@@ -464,7 +468,9 @@ def _handle_no_binary(option: Option, opt_str: str, value: str, parser: OptionPa
     )
 
 
-def _handle_only_binary(option: Option, opt_str: str, value: str, parser: OptionParser) -> None:
+def _handle_only_binary(
+    option: Option, opt_str: str, value: str, parser: OptionParser
+) -> None:
     existing = _get_format_control(parser.values, option)
     FormatControl.handle_mutual_excludes(
         value,

--- a/src/pip/_internal/cli/command_context.py
+++ b/src/pip/_internal/cli/command_context.py
@@ -5,15 +5,13 @@ _T = TypeVar("_T", covariant=True)
 
 
 class CommandContextMixIn:
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         super().__init__()
         self._in_main_context = False
         self._main_context = ExitStack()
 
     @contextmanager
-    def main_context(self):
-        # type: () -> Iterator[None]
+    def main_context(self) -> Iterator[None]:
         assert not self._in_main_context
 
         self._in_main_context = True
@@ -23,8 +21,7 @@ class CommandContextMixIn:
         finally:
             self._in_main_context = False
 
-    def enter_context(self, context_provider):
-        # type: (ContextManager[_T]) -> _T
+    def enter_context(self, context_provider: ContextManager[_T]) -> _T:
         assert self._in_main_context
 
         return self._main_context.enter_context(context_provider)

--- a/src/pip/_internal/cli/main.py
+++ b/src/pip/_internal/cli/main.py
@@ -42,8 +42,7 @@ logger = logging.getLogger(__name__)
 # main, this should not be an issue in practice.
 
 
-def main(args=None):
-    # type: (Optional[List[str]]) -> int
+def main(args: Optional[List[str]] = None) -> int:
     if args is None:
         args = sys.argv[1:]
 

--- a/src/pip/_internal/cli/main_parser.py
+++ b/src/pip/_internal/cli/main_parser.py
@@ -14,8 +14,7 @@ from pip._internal.utils.misc import get_pip_version, get_prog
 __all__ = ["create_main_parser", "parse_command"]
 
 
-def create_main_parser():
-    # type: () -> ConfigOptionParser
+def create_main_parser() -> ConfigOptionParser:
     """Creates and returns the main parser for pip's CLI"""
 
     parser = ConfigOptionParser(
@@ -46,8 +45,7 @@ def create_main_parser():
     return parser
 
 
-def parse_command(args):
-    # type: (List[str]) -> Tuple[str, List[str]]
+def parse_command(args: List[str]) -> Tuple[str, List[str]]:
     parser = create_main_parser()
 
     # Note: parser calls disable_interspersed_args(), so the result of this

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -130,7 +130,9 @@ class UpdatingDefaultsHelpFormatter(PrettyHelpFormatter):
 
 
 class CustomOptionParser(optparse.OptionParser):
-    def insert_option_group(self, idx: int, *args: Any, **kwargs: Any) -> optparse.OptionGroup:
+    def insert_option_group(
+        self, idx: int, *args: Any, **kwargs: Any
+    ) -> optparse.OptionGroup:
         """Insert an OptionGroup at a given position."""
         group = self.add_option_group(*args, **kwargs)
 

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -18,20 +18,19 @@ logger = logging.getLogger(__name__)
 class PrettyHelpFormatter(optparse.IndentedHelpFormatter):
     """A prettier/less verbose help formatter for optparse."""
 
-    def __init__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def __init__(self, *args: *Any, **kwargs: **Any) -> None:
         # help position must be aligned with __init__.parseopts.description
         kwargs["max_help_position"] = 30
         kwargs["indent_increment"] = 1
         kwargs["width"] = shutil.get_terminal_size()[0] - 2
         super().__init__(*args, **kwargs)
 
-    def format_option_strings(self, option):
-        # type: (optparse.Option) -> str
+    def format_option_strings(self, option: optparse.Option) -> str:
         return self._format_option_strings(option)
 
-    def _format_option_strings(self, option, mvarfmt=" <{}>", optsep=", "):
-        # type: (optparse.Option, str, str) -> str
+    def _format_option_strings(
+        self, option: optparse.Option, mvarfmt: str = " <{}>", optsep: str = ", "
+    ) -> str:
         """
         Return a comma-separated list of option strings and metavars.
 
@@ -55,14 +54,12 @@ class PrettyHelpFormatter(optparse.IndentedHelpFormatter):
 
         return "".join(opts)
 
-    def format_heading(self, heading):
-        # type: (str) -> str
+    def format_heading(self, heading: str) -> str:
         if heading == "Options":
             return ""
         return heading + ":\n"
 
-    def format_usage(self, usage):
-        # type: (str) -> str
+    def format_usage(self, usage: str) -> str:
         """
         Ensure there is only one newline between usage and the first heading
         if there is no description.
@@ -70,8 +67,7 @@ class PrettyHelpFormatter(optparse.IndentedHelpFormatter):
         msg = "\nUsage: {}\n".format(self.indent_lines(textwrap.dedent(usage), "  "))
         return msg
 
-    def format_description(self, description):
-        # type: (str) -> str
+    def format_description(self, description: str) -> str:
         # leave full control over description to us
         if description:
             if hasattr(self.parser, "main"):
@@ -89,16 +85,14 @@ class PrettyHelpFormatter(optparse.IndentedHelpFormatter):
         else:
             return ""
 
-    def format_epilog(self, epilog):
-        # type: (str) -> str
+    def format_epilog(self, epilog: str) -> str:
         # leave full control over epilog to us
         if epilog:
             return epilog
         else:
             return ""
 
-    def indent_lines(self, text, indent):
-        # type: (str, str) -> str
+    def indent_lines(self, text: str, indent: str) -> str:
         new_lines = [indent + line for line in text.split("\n")]
         return "\n".join(new_lines)
 
@@ -112,8 +106,7 @@ class UpdatingDefaultsHelpFormatter(PrettyHelpFormatter):
     Also redact auth from url type options
     """
 
-    def expand_default(self, option):
-        # type: (optparse.Option) -> str
+    def expand_default(self, option: optparse.Option) -> str:
         default_values = None
         if self.parser is not None:
             assert isinstance(self.parser, ConfigOptionParser)
@@ -137,7 +130,7 @@ class UpdatingDefaultsHelpFormatter(PrettyHelpFormatter):
 
 
 class CustomOptionParser(optparse.OptionParser):
-    def insert_option_group(self, idx, *args, **kwargs):
+    def insert_option_group(self, idx: int, *args: *Any, **kwargs: **Any) -> optparse.OptionGroup:
         # type: (int, Any, Any) -> optparse.OptionGroup
         """Insert an OptionGroup at a given position."""
         group = self.add_option_group(*args, **kwargs)
@@ -148,8 +141,7 @@ class CustomOptionParser(optparse.OptionParser):
         return group
 
     @property
-    def option_list_all(self):
-        # type: () -> List[optparse.Option]
+    def option_list_all(self) -> List[optparse.Option]:
         """Get a list of all options, including those in option groups."""
         res = self.option_list[:]
         for i in self.option_groups:
@@ -164,28 +156,25 @@ class ConfigOptionParser(CustomOptionParser):
 
     def __init__(
         self,
-        *args,  # type: Any
-        name,  # type: str
-        isolated=False,  # type: bool
-        **kwargs,  # type: Any
-    ):
-        # type: (...) -> None
+        *args: *Any,
+        name: str,
+        isolated: bool = False,
+        **kwargs: **Any,
+    ) -> None:
         self.name = name
         self.config = Configuration(isolated)
 
         assert self.name
         super().__init__(*args, **kwargs)
 
-    def check_default(self, option, key, val):
-        # type: (optparse.Option, str, Any) -> Any
+    def check_default(self, option: optparse.Option, key: str, val: Any) -> Any:
         try:
             return option.check_value(key, val)
         except optparse.OptionValueError as exc:
             print(f"An error occurred during configuration: {exc}")
             sys.exit(3)
 
-    def _get_ordered_configuration_items(self):
-        # type: () -> Iterator[Tuple[str, Any]]
+    def _get_ordered_configuration_items(self) -> Iterator[Tuple[str, Any]]:
         # Configuration gives keys in an unordered manner. Order them.
         override_order = ["global", self.name, ":env:"]
 
@@ -211,8 +200,7 @@ class ConfigOptionParser(CustomOptionParser):
             for key, val in section_items[section]:
                 yield key, val
 
-    def _update_defaults(self, defaults):
-        # type: (Dict[str, Any]) -> Dict[str, Any]
+    def _update_defaults(self, defaults: Dict[str, Any]) -> Dict[str, Any]:
         """Updates the given defaults with values from the config files and
         the environ. Does a little special handling for certain types of
         options (lists)."""
@@ -276,8 +264,7 @@ class ConfigOptionParser(CustomOptionParser):
         self.values = None
         return defaults
 
-    def get_default_values(self):
-        # type: () -> optparse.Values
+    def get_default_values(self) -> optparse.Values:
         """Overriding to make updating the defaults after instantiation of
         the option parser possible, _update_defaults() does the dirty work."""
         if not self.process_default_values:
@@ -299,7 +286,6 @@ class ConfigOptionParser(CustomOptionParser):
                 defaults[option.dest] = option.check_value(opt_str, default)
         return optparse.Values(defaults)
 
-    def error(self, msg):
-        # type: (str) -> None
+    def error(self, msg: str) -> None:
         self.print_usage(sys.stderr)
         self.exit(UNKNOWN_ERROR, f"{msg}\n")

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class PrettyHelpFormatter(optparse.IndentedHelpFormatter):
     """A prettier/less verbose help formatter for optparse."""
 
-    def __init__(self, *args: *Any, **kwargs: **Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         # help position must be aligned with __init__.parseopts.description
         kwargs["max_help_position"] = 30
         kwargs["indent_increment"] = 1
@@ -130,8 +130,7 @@ class UpdatingDefaultsHelpFormatter(PrettyHelpFormatter):
 
 
 class CustomOptionParser(optparse.OptionParser):
-    def insert_option_group(self, idx: int, *args: *Any, **kwargs: **Any) -> optparse.OptionGroup:
-        # type: (int, Any, Any) -> optparse.OptionGroup
+    def insert_option_group(self, idx: int, *args: Any, **kwargs: Any) -> optparse.OptionGroup:
         """Insert an OptionGroup at a given position."""
         group = self.add_option_group(*args, **kwargs)
 

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -155,10 +155,10 @@ class ConfigOptionParser(CustomOptionParser):
 
     def __init__(
         self,
-        *args: *Any,
+        *args: Any,
         name: str,
         isolated: bool = False,
-        **kwargs: **Any,
+        **kwargs: Any,
     ) -> None:
         self.name = name
         self.config = Configuration(isolated)


### PR DESCRIPTION
As I said on the pypa/pip PR #10004, it is necessary to remove the comments and use the `typing` annotations instead.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
