### PR TITLE
Rephrase the warning printed when run as root on Unix

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -177,8 +177,9 @@ def warn_if_run_as_root():
         if os.getuid() != 0:
             return
     logger.warning(
-        "Running pip as root will break packages and permissions. "
-        "You should install packages reliably by using venv: "
+        "Running pip as the 'root' user can result in broken permissions and "
+        "conflicting behaviour with the system package manager. "
+        "It is recommended to use a virtual environment instead: "
         "https://pip.pypa.io/warnings/venv"
     )
 


### PR DESCRIPTION
The earlier warning phrasing has some awkwardness and doesn't clearly
explain why this action is potentially harmful. The change from
"you should" to "it is recommended" is also intentional, to take a
different tone.
