### PR TITLE
Move where show is shown in commands

### DIFF
--- a/docs/html/cli/index.md
+++ b/docs/html/cli/index.md
@@ -17,6 +17,7 @@ pip
 pip_install
 pip_uninstall
 pip_list
+pip_show
 pip_freeze
 pip_check
 ```
@@ -34,7 +35,6 @@ pip_hash
 :maxdepth: 1
 :caption: Package Index information
 
-pip_show
 pip_search
 ```
 


### PR DESCRIPTION
It is for introspecting installed packages, not on the index.

Toward #9475