### PR TITLE
Remove old documentation pages

### DIFF
--- a/docs/html/cookbook.rst
+++ b/docs/html/cookbook.rst
@@ -1,7 +1,0 @@
-:orphan:
-
-========
-Cookbook
-========
-
-This content is now covered in the :doc:`User Guide <user_guide>`

--- a/docs/html/logic.rst
+++ b/docs/html/logic.rst
@@ -1,7 +1,0 @@
-:orphan:
-
-================
-Internal Details
-================
-
-This content is now covered in the :doc:`Architecture section <development/architecture/index>`.

--- a/docs/html/usage.rst
+++ b/docs/html/usage.rst
@@ -1,7 +1,0 @@
-:orphan:
-
-=====
-Usage
-=====
-
-The "Usage" section is now covered in the :doc:`Reference Guide <reference/index>`


### PR DESCRIPTION
These pages were redirecting users from really old versions of pip.
Breaking those links now should be fine, since these pages do not get
much traffic.
