### PR TITLE
Add a "Topic Guide" section to the documentation

### DIFF
--- a/docs/html/index.md
+++ b/docs/html/index.md
@@ -13,6 +13,7 @@ install packages from the [Python Package Index][pypi] and other indexes.
 getting-started
 installation
 user_guide
+topics/index
 cli/index
 ```
 

--- a/docs/html/topics/index.md
+++ b/docs/html/topics/index.md
@@ -1,0 +1,12 @@
+# Topic Guides
+
+These pages provide detailed information on individual topics.
+
+```{note}
+This section of the documentation is currently being fleshed out. See
+{issue}`9475` for more details.
+```
+
+```{toctree}
+:maxdepth: 1
+```


### PR DESCRIPTION
This section will contain pages that describe a single topic (like
"Authentication", "Caching", etc).

Toward #9475