### PR TITLE
Add a missing reference in the documentation

### DIFF
--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -60,6 +60,8 @@ If you face issues when using Python and pip installed using these mechanisms,
 it is recommended to request for support from the relevant provider (eg: Linux
 distro community, cloud provider support channels, etc).
 
+(compatibility-requirements)=
+
 ## Compatibility
 
 The current version of pip works on:


### PR DESCRIPTION
This was being used in another part of our documentation, to refer to
this heading.

Toward #9475
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
