### PR TITLE
Avoid importing a non-vendored version of Tornado

### DIFF
--- a/news/10020.bugfix.rst
+++ b/news/10020.bugfix.rst
@@ -1,0 +1,1 @@
+Remove unused optional ``tornado`` import in vendored ``tenacity`` to prevent old versions of Tornado from breaking pip.

--- a/src/pip/_vendor/tenacity/__init__.py
+++ b/src/pip/_vendor/tenacity/__init__.py
@@ -22,10 +22,12 @@ try:
 except ImportError:
     iscoroutinefunction = None
 
-try:
-    import tornado
-except ImportError:
-    tornado = None
+# Replace a conditional import with a hard-coded None so that pip does
+# not attempt to use tornado even if it is present in the environment.
+# If tornado is non-None, tenacity will attempt to execute some code
+# that is sensitive to the version of tornado, which could break pip
+# if an old version is found.
+tornado = None
 
 import sys
 import threading

--- a/tools/vendoring/patches/tenacity.patch
+++ b/tools/vendoring/patches/tenacity.patch
@@ -1,0 +1,21 @@
+﻿diff --git a/src/pip/_vendor/tenacity/__init__.py b/src/pip/_vendor/tenacity/__init__.py
+index 5f8cb5058..42e9d8940 100644
+--- a/src/pip/_vendor/tenacity/__init__.py
++++ b/src/pip/_vendor/tenacity/__init__.py
+@@ -22,10 +22,12 @@ try:
+ except ImportError:
+     iscoroutinefunction = None
+ 
+-try:
+-    import tornado
+-except ImportError:
+-    tornado = None
++# Replace a conditional import with a hard-coded None so that pip does
++# not attempt to use tornado even if it is present in the environment.
++# If tornado is non-None, tenacity will attempt to execute some code
++# that is sensitive to the version of tornado, which could break pip
++# if an old version is found.
++tornado = None
+ 
+ import sys
+ import threading


### PR DESCRIPTION
Code depending on this conditional import could break if an old
version of Tornado is present in the environment, rendering pip
unusable.

Fixes #10020
