### PR TITLE
Remove support for setup.cfg only projects

### DIFF
--- a/news/10031.bugfix.rst
+++ b/news/10031.bugfix.rst
@@ -1,0 +1,1 @@
+Require ``setup.cfg``-only projects to be built via PEP 517, by requiring an explicit dependency on setuptools declared in pyproject.toml.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -509,19 +509,6 @@ class InstallRequirement:
             self.unpacked_source_directory, backend, backend_path=backend_path,
         )
 
-    def _check_setup_py_or_cfg_exists(self) -> bool:
-        """Check if the requirement actually has a setuptools build file.
-
-        If setup.py does not exist, we also check setup.cfg in the same
-        directory and allow the directory if that exists.
-        """
-        if os.path.exists(self.setup_py_path):
-            return True
-        stem, ext = os.path.splitext(self.setup_py_path)
-        if ext == ".py" and os.path.exists(f"{stem}.cfg"):
-            return True
-        return False
-
     def _generate_metadata(self):
         # type: () -> str
         """Invokes metadata generator functions, with the required arguments.
@@ -529,10 +516,9 @@ class InstallRequirement:
         if not self.use_pep517:
             assert self.unpacked_source_directory
 
-            if not self._check_setup_py_or_cfg_exists():
+            if not os.path.exists(self.setup_py_path):
                 raise InstallationError(
-                    f'File "setup.py" or "setup.cfg" not found for legacy '
-                    f'project {self}.'
+                    f'File "setup.py" not found for legacy project {self}.'
                 )
 
             return generate_metadata_legacy(


### PR DESCRIPTION
Per the discussion in #9945.

Signed-off-by: Filipe Laíns <lains@riseup.net>

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
