### PR TITLE
Rework resolution ordering to consider "depth"

### DIFF
--- a/news/9455.feature.rst
+++ b/news/9455.feature.rst
@@ -1,0 +1,2 @@
+New resolver: The order of dependencies resolution has been tweaked to traverse
+the dependency graph in a more breadth-first approach.

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -1,3 +1,5 @@
+import collections
+import math
 from typing import TYPE_CHECKING, Dict, Iterable, Iterator, Mapping, Sequence, Union
 
 from pip._vendor.resolvelib.providers import AbstractProvider
@@ -60,6 +62,7 @@ class PipProvider(_ProviderBase):
         self._ignore_dependencies = ignore_dependencies
         self._upgrade_strategy = upgrade_strategy
         self._user_requested = user_requested
+        self._known_depths: Dict[str, float] = collections.defaultdict(lambda: math.inf)
 
     def identify(self, requirement_or_candidate):
         # type: (Union[Requirement, Candidate]) -> str
@@ -79,48 +82,43 @@ class PipProvider(_ProviderBase):
 
         Currently pip considers the followings in order:
 
-        * Prefer if any of the known requirements points to an explicit URL.
-        * If equal, prefer if any requirements contain ``===`` and ``==``.
-        * If equal, prefer if requirements include version constraints, e.g.
-          ``>=`` and ``<``.
-        * If equal, prefer user-specified (non-transitive) requirements, and
-          order user-specified requirements by the order they are specified.
+        * Prefer if any of the known requirements is "direct", e.g. points to an
+          explicit URL.
+        * If equal, prefer if any requirement is "pinned", i.e. contains
+          operator ``===`` or ``==``.
+        * If equal, calculate an approximate "depth" and resolve requirements
+          closer to the user-specified requirements first.
+        * Order user-specified requirements by the order they are specified.
+        * If equal, prefers "non-free" requirements, i.e. contains at least one
+          operator, such as ``>=`` or ``<``.
         * If equal, order alphabetically for consistency (helps debuggability).
         """
+        lookups = (r.get_candidate_lookup() for r, _ in information[identifier])
+        candidate, ireqs = zip(*lookups)
+        operators = [
+            specifier.operator
+            for specifier_set in (ireq.specifier for ireq in ireqs if ireq)
+            for specifier in specifier_set
+        ]
 
-        def _get_restrictive_rating(requirements):
-            # type: (Iterable[Requirement]) -> int
-            """Rate how restrictive a set of requirements are.
+        direct = candidate is not None
+        pinned = any(op[:2] == "==" for op in operators)
+        unfree = bool(operators)
 
-            ``Requirement.get_candidate_lookup()`` returns a 2-tuple for
-            lookup. The first element is ``Optional[Candidate]`` and the
-            second ``Optional[InstallRequirement]``.
+        try:
+            requested_order: Union[int, float] = self._user_requested[identifier]
+        except KeyError:
+            requested_order = math.inf
+            parent_depths = (
+                self._known_depths[parent.name] if parent is not None else 0.0
+                for _, parent in information[identifier]
+            )
+            inferred_depth = min(d for d in parent_depths) + 1.0
+            self._known_depths[identifier] = inferred_depth
+        else:
+            inferred_depth = 1.0
 
-            * If the requirement is an explicit one, the explicitly-required
-              candidate is returned as the first element.
-            * If the requirement is based on a PEP 508 specifier, the backing
-              ``InstallRequirement`` is returned as the second element.
-
-            We use the first element to check whether there is an explicit
-            requirement, and the second for equality operator.
-            """
-            lookups = (r.get_candidate_lookup() for r in requirements)
-            cands, ireqs = zip(*lookups)
-            if any(cand is not None for cand in cands):
-                return 0
-            spec_sets = (ireq.specifier for ireq in ireqs if ireq)
-            operators = [
-                specifier.operator for spec_set in spec_sets for specifier in spec_set
-            ]
-            if any(op in ("==", "===") for op in operators):
-                return 1
-            if operators:
-                return 2
-            # A "bare" requirement without any version requirements.
-            return 3
-
-        rating = _get_restrictive_rating(r for r, _ in information[identifier])
-        order = self._user_requested.get(identifier, float("inf"))
+        requested_order = self._user_requested.get(identifier, math.inf)
 
         # Requires-Python has only one candidate and the check is basically
         # free, so we always do it first to avoid needless work if it fails.
@@ -136,7 +134,16 @@ class PipProvider(_ProviderBase):
         # while we work on "proper" branch pruning techniques.
         delay_this = identifier == "setuptools"
 
-        return (not requires_python, delay_this, rating, order, identifier)
+        return (
+            not requires_python,
+            delay_this,
+            not direct,
+            not pinned,
+            inferred_depth,
+            requested_order,
+            not unfree,
+            identifier,
+        )
 
     def find_matches(
         self,


### PR DESCRIPTION
End goal is to resolve #9455.

This modifies `Provider.get_preference()` to try to calculate a package’s “depth” in the dependency graph, and resolve packages closer to the root first. This works pretty well for #9455.

I also tweaked the preference logic a little to prioritise “shallow” dependencies over those with non-pinning operators. This means that previously `foo>2` would be preferred over `bar` even if the latter is user-specified, but now `bar` is resolved first. This is from a few examples I tried that had the same priority logic issue (the one in #9455, `apache-airflow[all]`, and https://github.com/pypa/pip/issues/9187#issuecomment-756652530); in a reasonably maintained and mature project, almost all dependencies would have some kind of version constraints, but those generally are so wide they are really not meaningfully better than bare requirements, so I de-prioritised that part.

I’m not quite sure how we can know if this is indeed a better implementation in the big picture, however. We probably should roll this out with a feature flag (i.e. keep the current implement behind `--use-deprecated`), but even with that we can’t be sure about tradeoffs if some people report negative impact, because those being impacted positively won’t report anything 😟 