### PR TITLE
Add `--required-by` option to `list` command

### DIFF
--- a/news/10036.feature.rst
+++ b/news/10036.feature.rst
@@ -1,0 +1,2 @@
+Add ``required-by`` option to the ``list`` command, in order to restrict the listed
+packages to some package requirements (useful for eg. with ``--outdated``)

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -95,6 +95,13 @@ class ListCommand(IndexGroupCommand):
         )
 
         self.cmd_opts.add_option(
+            '--required-by',
+            action='store',
+            dest='required_by',
+            help="List packages that are dependencies the given package.",
+        )
+
+        self.cmd_opts.add_option(
             '--exclude-editable',
             action='store_false',
             dest='include_editable',
@@ -161,6 +168,9 @@ class ListCommand(IndexGroupCommand):
         if options.not_required:
             packages = self.get_not_required(packages, options)
 
+        if options.required_by:
+            packages = self.get_required_by(packages, options)
+
         if options.outdated:
             packages = self.get_outdated(packages, options)
         elif options.uptodate:
@@ -193,6 +203,18 @@ class ListCommand(IndexGroupCommand):
         # to keep the return type consistent with get_outdated and
         # get_uptodate
         return list({pkg for pkg in packages if pkg.key not in dep_keys})
+
+    def get_required_by(self, packages, options):
+        # type: (List[Distribution], Values) -> List[Distribution]
+        dep_keys = set()  # type: Set[Distribution]
+        for dist in packages:
+            if dist.project_name == options.required_by:
+                dep_keys = set(requirement.key for requirement in dist.requires())
+
+        # Create a set to remove duplicate packages, and cast it to a list
+        # to keep the return type consistent with get_outdated and
+        # get_uptodate
+        return list({pkg for pkg in packages if pkg.key in dep_keys})
 
     def iter_packages_latest_infos(self, packages, options):
         # type: (List[Distribution], Values) -> Iterator[Distribution]

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -403,6 +403,20 @@ def test_outdated_not_required_flag(script, data):
     assert [] == json.loads(result.stdout)
 
 
+def test_required_by_flag(script, data):
+    """
+    test the behavior of --required-by flag in the list command
+    """
+    script.pip(
+        'install', '-f', data.find_links, '--no-index', 'require_simple==1.0'
+    )
+    result = script.pip(
+        'list', '-f', data.find_links, '--no-index',
+        '--required-by', 'require-simple', '--format=json',
+    )
+    assert [{'name': 'simple', 'version': '3.0'}] == json.loads(result.stdout)
+
+
 def test_outdated_pre(script, data):
     script.pip('install', '-f', data.find_links, '--no-index', 'simple==1.0')
 


### PR DESCRIPTION
This allows to do something like:

```
$ pip list --required-by mypackage
Package        Version
-------------- --------
asyncpg        0.23.0
httpx          0.18.1
Jinja2         2.11.3
minicli        0.5.0
openpyxl       3.0.7
progressist    0.1.0
PyJWT          2.1.0
roll           0.13.0
ujson          1.35
```

And yet more usesul in my workflow:

```
$ pip list --required-by mypackage --outdated
Package    Version Latest Type
---------- ------- ------ -----
Jinja2     2.11.3  3.0.1  wheel
ujson      1.35    4.0.2  wheel
```

That may be a naive approach, but I'll let you judge about that :)