### PR TITLE
fix doc building

### DIFF
--- a/docs/html/development/contributing.rst
+++ b/docs/html/development/contributing.rst
@@ -17,7 +17,7 @@ distribute any code you contribute to pip and it must be available under the
 MIT License.
 
 Provide tests that cover your changes and run the tests locally first. pip
-:ref:`supports <compatibility-requirements>` multiple Python versions and
+supports multiple Python versions and
 operating systems. Any pull request must consider and work on all these
 platforms.
 

--- a/docs/html/topics/authentication.md
+++ b/docs/html/topics/authentication.md
@@ -18,7 +18,7 @@ https://0123456789abcdef@pypi.company.com/simple
 
 ### Percent-encoding special characters
 
-```{versionaddded} 10.0
+```{versionadded} 10.0
 ```
 
 Certain special characters are not valid in the credential part of a URL.


### PR DESCRIPTION

I had errors running `tox -e docs  `
This pr fixes them.

```

Warning, treated as error:
/home/jens/workplace/pip/docs/html/topics/authentication.md:21:Unknown directive type "versionaddded".
ERROR: InvocationError for command /home/jens/workplace/pip/.tox/docs/bin/sphinx-build -W -j auto -d /home/jens/workplace/pip/.tox/docs/tmp/doctrees/html -b html docs/html docs/build/html (exited with code 2)
________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________
ERROR:   docs: commands failed

```
```
Warning, treated as error:
/home/jens/workplace/pip/docs/html/development/contributing.rst:19:undefined label: compatibility-requirements (if the link has no caption the label must precede a section header)
```