### PR TITLE
Stop relying on undocumented duck typing by `urlunsplit()`

### DIFF
--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -150,7 +150,7 @@ class Link(KeyBasedCompareMixin):
     def url_without_fragment(self):
         # type: () -> str
         scheme, netloc, path, query, fragment = self._parsed_url
-        return urllib.parse.urlunsplit((scheme, netloc, path, query, None))
+        return urllib.parse.urlunsplit((scheme, netloc, path, query, ''))
 
     _egg_fragment_re = re.compile(r'[#&]egg=([^&]*)')
 


### PR DESCRIPTION
There are proposals in CPython to enforce correct types (str, bytes, bytearray) in urllib.parse: bpo-19094 and bpo-22234. `None` is not valid (and not returned by `urlsplit()`, which is how `urlunsplit()` is documented).

https://bugs.python.org/issue19094
https://bugs.python.org/issue22234

This point of this PR is to get ahead of those potential changes.


<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
