### PR TITLE
Use UTF-8 encoding for log file.

### DIFF
--- a/news/10071.feature.rst
+++ b/news/10071.feature.rst
@@ -1,0 +1,1 @@
+Change the encoding of log file from default text encoding to UTF-8.

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -375,6 +375,7 @@ def setup_logging(verbosity, no_color, user_log_file):
                     "level": "DEBUG",
                     "class": handler_classes["file"],
                     "filename": additional_log_file,
+                    "encoding": "utf-8",
                     "delay": True,
                     "formatter": "indent_with_timestamp",
                 },


### PR DESCRIPTION
Fixes #10071.