### PR TITLE
Smarter (and looser) link equivalency logic

### DIFF
--- a/news/10002.feature.rst
+++ b/news/10002.feature.rst
@@ -1,0 +1,7 @@
+New resolver: Loosen URL comparison logic when checking for direct URL reference
+equivalency. The logic includes the following notable characteristics:
+
+* The authentication part of the URL is explicitly ignored.
+* Most of the fragment part, including ``egg=``, is explicitly ignored. Only
+  ``subdirectory=`` and hash values (e.g. ``sha256=``) are kept.
+* The query part of the URL is parsed to allow ordering differences.

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -423,7 +423,7 @@ def test_constraints_constrain_to_local(script, data, resolver_variant):
     assert 'Running setup.py install for singlemodule' in result.stdout
 
 
-def test_constrained_to_url_install_same_url(script, data, resolver_variant):
+def test_constrained_to_url_install_same_url(script, data):
     to_install = data.src.joinpath("singlemodule")
     constraints = path_to_url(to_install) + "#egg=singlemodule"
     script.scratch_path.joinpath("constraints.txt").write_text(constraints)
@@ -431,17 +431,8 @@ def test_constrained_to_url_install_same_url(script, data, resolver_variant):
         'install', '--no-index', '-f', data.find_links, '-c',
         script.scratch_path / 'constraints.txt', to_install,
         allow_stderr_warning=True,
-        expect_error=(resolver_variant == "2020-resolver"),
     )
-    if resolver_variant == "2020-resolver":
-        assert 'Cannot install singlemodule 0.0.1' in result.stderr, str(result)
-        assert (
-            'because these package versions have conflicting dependencies.'
-            in result.stderr
-        ), str(result)
-    else:
-        assert ('Running setup.py install for singlemodule'
-                in result.stdout), str(result)
+    assert 'Running setup.py install for singlemodule' in result.stdout, str(result)
 
 
 def test_double_install_spurious_hash_mismatch(


### PR DESCRIPTION
Fix #10002 (eventually).

Todo:

* [x] Add unit tests around `links_equivalent`.
* [x] Add integration tests for the resolver’s behaviour.
* ~~Add a `--use-deprecated` flag to enable the current (stricter) behaviour in case this does not work for some cases.~~
  Decided to not do this since I don’t see how users would find this flag useful.
* ~~Add a deprecation warning when `egg=` is used. (How can we only show this once?)~~
  Not doing this for now, see https://github.com/pypa/pip/issues/10002#issuecomment-865504625
* ~~Dig out previous issues on this and close them (IIRC there are a couple).~~
  #1289 is the other issue about this, but that one is wider in scope and cannot be closed by this alone.
* [x] Add a news fragment.