### PR TITLE
Upgrade resolvelib to 0.7.1

### DIFF
--- a/news/resolvelib.vendor.rst
+++ b/news/resolvelib.vendor.rst
@@ -1,0 +1,1 @@
+Upgrade resolvelib to 0.7.1.

--- a/src/pip/_vendor/resolvelib/__init__.py
+++ b/src/pip/_vendor/resolvelib/__init__.py
@@ -11,7 +11,7 @@ __all__ = [
     "ResolutionTooDeep",
 ]
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 
 from .providers import AbstractProvider, AbstractResolver

--- a/src/pip/_vendor/resolvelib/structs.py
+++ b/src/pip/_vendor/resolvelib/structs.py
@@ -75,6 +75,18 @@ class IteratorMapping(collections_abc.Mapping):
         self._accessor = accessor
         self._appends = appends or {}
 
+    def __repr__(self):
+        return "IteratorMapping({!r}, {!r}, {!r})".format(
+            self._mapping,
+            self._accessor,
+            self._appends,
+        )
+
+    def __bool__(self):
+        return bool(self._mapping or self._appends)
+
+    __nonzero__ = __bool__  # XXX: Python 2.
+
     def __contains__(self, key):
         return key in self._mapping or key in self._appends
 
@@ -90,7 +102,7 @@ class IteratorMapping(collections_abc.Mapping):
         return itertools.chain(self._mapping, more)
 
     def __len__(self):
-        more = len(k for k in self._appends if k not in self._mapping)
+        more = sum(1 for k in self._appends if k not in self._mapping)
         return len(self._mapping) + more
 
 

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -14,7 +14,7 @@ requests==2.25.1
     chardet==4.0.0
     idna==3.1
     urllib3==1.26.5
-resolvelib==0.7.0
+resolvelib==0.7.1
 setuptools==44.0.0
 six==1.16.0
 tenacity==7.0.0


### PR DESCRIPTION
~~Should fix #10081. This needs a proper resolvelib release and vendoring upgrade, but I want to put this out first for testing (both automatic and manual).~~

Fix #10081. This does not include a test since the failure is unfortunately not deterministic, as described in the linked issue. A regression test has been added to resolvelib, we’ll depend on that instead.