### PR TITLE
Make pip --verbose report which platform it thinks it's on in the event of an installation failure.

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -25,6 +25,7 @@ from pip._internal.exceptions import (
     NetworkConnectionError,
     PreviousBuildDirError,
     UninstallationError,
+    WheelSupportedByPipButNotByPlatform,
 )
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filesystem import check_path_owner
@@ -201,6 +202,10 @@ class Command(CommandContextMixIn):
                 traceback.print_exc(file=sys.stderr)
 
             return ERROR
+        except WheelSupportedByPipButNotByPlatform as e:
+            logger.debug("Compatible tags for this platform:"
+                         f"{e.supported_tags}")
+            raise
         except KeyboardInterrupt:
             logger.critical("Operation cancelled by user")
             logger.debug("Exception information:", exc_info=True)

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -129,6 +129,25 @@ class UnsupportedWheel(InstallationError):
     """Unsupported wheel."""
 
 
+class WheelSupportedByPipButNotByPlatform(UnsupportedWheel):
+    """Wheel is incompatible with the host that pip is running on.
+
+    This is raised when a wheel is compatible and fully recognized by this
+    version of pip, and pip's examination of the wheel determines that the
+    wheel cannot be used on the host pip is running on.
+    """
+    def __init__(self, wheel, supported_tags):
+        # type: (Wheel, List[Tag]) -> None
+        super().__init__()
+        self.wheel = wheel
+        self.supported_tags = supported_tags
+
+    def __str__(self):
+        return (
+            f"{self.wheel.filename} (tags {self.wheel.file_tags}) is "
+            f"not a supported wheel on this platform."
+        )
+
 class MetadataInconsistent(InstallationError):
     """Built metadata contains inconsistent information.
 

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -19,7 +19,7 @@ from pip._internal.exceptions import (
     BestVersionAlreadyInstalled,
     DistributionNotFound,
     InvalidWheelFilename,
-    UnsupportedWheel,
+    WheelSupportedByPipButNotByPlatform,
 )
 from pip._internal.index.collector import LinkCollector, parse_links
 from pip._internal.models.candidate import InstallationCandidate
@@ -524,10 +524,7 @@ class CandidateEvaluator:
                     valid_tags, self._wheel_tag_preferences
                 ))
             except ValueError:
-                raise UnsupportedWheel(
-                    "{} is not a supported wheel for this platform. It "
-                    "can't be sorted.".format(wheel.filename)
-                )
+                raise WheelSupportedByPipButNotByPlatform(wheel, valid_tags)
             if self._prefer_binary:
                 binary_preference = 1
             if wheel.build_tag is not None:

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -136,7 +136,9 @@ class Factory:
         msg = (f"{link.filename} (tags {wheel.file_tags}) is not a supported "
                 "wheel on the platform "
                f"{self._finder.target_python.get_tags()}.")
-        raise UnsupportedWheel(msg)
+        logger.debug(msg)
+        raise UnsupportedWheel(f"{link.filename} (tags {wheel.file_tags}) is "
+                                "not a supported wheel on this platform.")
 
     def _make_extras_candidate(self, base, extras):
         # type: (BaseCandidate, FrozenSet[str]) -> ExtrasCandidate

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -133,7 +133,8 @@ class Factory:
         wheel = Wheel(link.filename)
         if wheel.supported(self._finder.target_python.get_tags()):
             return
-        msg = (f"{link.filename} is not a supported wheel on the platform "
+        msg = (f"{link.filename} (tags {wheel.file_tags}) is not a supported "
+                "wheel on the platform "
                f"{self._finder.target_python.get_tags()}.")
         raise UnsupportedWheel(msg)
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -133,12 +133,9 @@ class Factory:
         wheel = Wheel(link.filename)
         if wheel.supported(self._finder.target_python.get_tags()):
             return
-        msg = (f"{link.filename} (tags {wheel.file_tags}) is not a supported "
-                "wheel on the platform "
-               f"{self._finder.target_python.get_tags()}.")
-        logger.debug(msg)
-        raise UnsupportedWheel(f"{link.filename} (tags {wheel.file_tags}) is "
-                                "not a supported wheel on this platform.")
+        raise WheelSupportedByPipButNotByPlatform(
+            wheel, self._finder.target_python.get_tags()
+        )
 
     def _make_extras_candidate(self, base, extras):
         # type: (BaseCandidate, FrozenSet[str]) -> ExtrasCandidate

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -133,7 +133,8 @@ class Factory:
         wheel = Wheel(link.filename)
         if wheel.supported(self._finder.target_python.get_tags()):
             return
-        msg = f"{link.filename} is not a supported wheel on this platform."
+        msg = (f"{link.filename} is not a supported wheel on the platform "
+               f"{self._finder.target_python.get_tags()}.")
         raise UnsupportedWheel(msg)
 
     def _make_extras_candidate(self, base, extras):


### PR DESCRIPTION
This makes `pip install --verbose` report the tags of the `TargetPython` if installation fails.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
