### PR TITLE
Add get_musl_major_minor from PEP 656.

### DIFF
--- a/news/10088.feature.rst
+++ b/news/10088.feature.rst
@@ -1,0 +1,1 @@
+Add get_musl_major_minor() from PEP 656.


### PR DESCRIPTION
Since `packaging` supports PEP 656 wheels (https://github.com/pypa/packaging/pull/411), I think all that is necessary to allow pip to install them is to have the platform check pick up the platform tag.

For example, right now `rpy2-3.4.5-cp39-cp39-musllinux_1_2_x86_64.whl` (tag `cp39-cp39-musllinux_1_2_x86_64 @ 140319066709760`) seems ready to install except for the fact that, on an actual musllinux system, `get_supported()` returns only `[<cp39-cp39-linux_x86_64 @ 140319067309696>, <cp39-abi3-linux_x86_64 @ 140319066714880>, <cp39-none-linux_x86_64 @ 140319066715456>, <cp38-abi3-linux_x86_64 @ 140319066714240>, <cp37-abi3-linux_x86_64 @ 140319066715712>, <cp36-abi3-linux_x86_64 @ 140319066715968>, <cp35-abi3-linux_x86_64 @ 140319066716224>, <cp34-abi3-linux_x86_64 @ 140319066716480>, <cp33-abi3-linux_x86_64 @ 140319066716736>, <cp32-abi3-linux_x86_64 @ 140319066716992>, <py39-none-linux_x86_64 @ 140319066714304>, <py3-none-linux_x86_64 @ 140319066714688>, <py38-none-linux_x86_64 @ 140319066717696>, <py37-none-linux_x86_64 @ 140319066717952>, <py36-none-linux_x86_64 @ 140319066726464>, <py35-none-linux_x86_64 @ 140319066726720>, <py34-none-linux_x86_64 @ 140319066726976>, <py33-none-linux_x86_64 @ 140319066727232>, <py32-none-linux_x86_64 @ 140319066727488>, <py31-none-linux_x86_64 @ 140319066727744>, <py30-none-linux_x86_64 @ 140319066728000>, <cp39-none-any @ 140319066728512>, <py39-none-any @ 140319066728256>, <py3-none-any @ 140319066728768>, <py38-none-any @ 140319066729024>, <py37-none-any @ 140319066729280>, <py36-none-any @ 140319066729536>, <py35-none-any @ 140319066729792>, <py34-none-any @ 140319066730048>, <py33-none-any @ 140319066730304>, <py32-none-any @ 140319066730624>, <py31-none-any @ 140319066730880>, <py30-none-any @ 140319066731136>]`.

By itself, this doesn't change any behavior. I haven't figured out the right place to slot into the various additions to the `supported` list. But if I'm on the right track at all, then we'll need the `get_musl_major_minor` function from PEP 656 in compatibility_tags.py, and if not, then I'm on completely the wrong track.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
