### PR TITLE
Add a `--strict` option to the Mypy checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
   hooks:
   - id: mypy
     exclude: tests
-    args: ["--pretty"]
+    args: ["--pretty", "--strict"]
     additional_dependencies: ['nox==2020.12.31']
 
 - repo: https://github.com/pre-commit/pygrep-hooks


### PR DESCRIPTION
It must close pypa#10076, to include all the strict flags from Mypy to be used on pypa/pip \(they are included by `--strict`\).

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
