### PR TITLE
Add `.venv` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ tests/data/common_wheels/
 *~
 .*.sw?
 .env/
+.venv/
 
 # For IntelliJ IDEs (basically PyCharm)
 .idea/


### PR DESCRIPTION
This directory is a fairly common virtual environment name, and,
more importantly, is used by GitHub Codespaces as their default virtual
environment path without adding it to a global gitignore.

(Yes, I'm using GitHub Codespaces now)
