### PR TITLE
Re-implement Git version parsing with regex

### DIFF
--- a/news/10117.removal.rst
+++ b/news/10117.removal.rst
@@ -1,0 +1,2 @@
+Git version parsing is now done with regular expression to prepare for the
+pending upstream removal of non-PEP-440 version parsing logic.

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import pytest
-from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import BadCommand, InstallationError
 from pip._internal.utils.misc import hide_url, hide_value
@@ -483,7 +482,7 @@ def test_subversion__get_url_rev_options():
 
 def test_get_git_version():
     git_version = Git().get_git_version()
-    assert git_version >= parse_version('1.0.0')
+    assert git_version >= (1, 0, 0)
 
 
 @pytest.mark.parametrize('use_interactive,is_atty,expected', [


### PR DESCRIPTION
After packaging drops LegacyVersion (see pypa/packaging#407), `packaging.version.parse()` will no longer guarantee to be able to parse Git versions, so we need to invent our own parser. Since we really only care about the major and minor segments, the logic is pretty simple.
