### PR TITLE
Reorder vcs imports, to try more popular VCS systems sooner

### DIFF
--- a/src/pip/_internal/vcs/__init__.py
+++ b/src/pip/_internal/vcs/__init__.py
@@ -1,11 +1,17 @@
+# Import all vcs modules to register each VCS in the VcsSupport object.
+#
+# These imports are ordered based on rough "popularity" as judged by
+# @pradyunsg in July 2021. This ordering determines the order that
+# directories are checked for "is this in a vcs backend" and thus
+# ordering by priority here makes things a few ms faster.
+import pip._internal.vcs.git  # isort: skip
+import pip._internal.vcs.subversion  # isort: skip
+import pip._internal.vcs.mercurial  # isort: skip
+import pip._internal.vcs.bazaar  # isort: skip  # noqa: F401
+
 # Expose a limited set of classes and functions so callers outside of
 # the vcs package don't need to import deeper than `pip._internal.vcs`.
 # (The test directory may still need to import from a vcs sub-package.)
-# Import all vcs modules to register each VCS in the VcsSupport object.
-import pip._internal.vcs.bazaar
-import pip._internal.vcs.git
-import pip._internal.vcs.mercurial
-import pip._internal.vcs.subversion  # noqa: F401
 from pip._internal.vcs.versioncontrol import (  # noqa: F401
     RemoteNotFoundError,
     RemoteNotValidError,


### PR DESCRIPTION
Closes #7162, but using the check-order optimisation suggested there rather than via adding additional checks.

I don't think this is worth calling out in the changelog though.

---

This changes the order of `vcs_backend` in https://github.com/pypa/pip/blob/72e38ca3df4d1690a972eef9a27e20f154aa0b63/src/pip/_internal/vcs/versioncontrol.py#L237

```sh-session
$ # before
$ pip freeze
<pip._internal.vcs.bazaar.Bazaar object at 0x7f1a34c8cac0>
<pip._internal.vcs.git.Git object at 0x7f1a34c950a0>
<pip._internal.vcs.mercurial.Mercurial object at 0x7f1a34c954c0>
<pip._internal.vcs.subversion.Subversion object at 0x7f1a34c959a0>
$ # after
$ pip freeze
<pip._internal.vcs.git.Git object at 0x7f04ceceefa0>
<pip._internal.vcs.subversion.Subversion object at 0x7f04cecf4400>
<pip._internal.vcs.mercurial.Mercurial object at 0x7f04cecf48b0>
<pip._internal.vcs.bazaar.Bazaar object at 0x7f04cecf4c40>
```