### PR TITLE
Add `--color=yes` for pytest to color output logs

### DIFF
--- a/news/10126.trivial.rst
+++ b/news/10126.trivial.rst
@@ -1,0 +1,1 @@
+Use ``--color=yes`` to color pytest outputs.

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ follow_imports = skip
 follow_imports = skip
 
 [tool:pytest]
-addopts = --ignore src/pip/_vendor --ignore tests/tests_cache -r aR
+addopts = --ignore src/pip/_vendor --ignore tests/tests_cache -r aR --color=yes
 markers =
     network: tests that need network
     incompatible_with_test_venv


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Add `--color=yes` for pytest to color output logs and make it easier to find errors / warnings.
