### PR TITLE
Complete type annotations in `pip/_internal/metadata`

### DIFF
--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -66,8 +66,7 @@ class BaseDistribution(Protocol):
     def in_usersite(self) -> bool:
         raise NotImplementedError()
 
-    def iter_dependencies(self, extras=()):
-        # type: (Collection[str]) -> Iterable[Requirement]
+    def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
         raise NotImplementedError()
 
 

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -61,8 +61,7 @@ class Distribution(BaseDistribution):
     def in_usersite(self) -> bool:
         return misc.dist_in_usersite(self._dist)
 
-    def iter_dependencies(self, extras=()):
-        # type: (Collection[str]) -> Iterable[Requirement]
+    def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
         # pkg_resources raises on invalid extras, so we sanitize.
         requested_extras = set(extras)
         valid_extras = requested_extras & set(self._dist.extras)


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

- A follow-up for https://github.com/pypa/pip/pull/10124.
- Convert type comments on `iter_dependencies` to type annotations.

