### PR TITLE
Error handling upon `uninstall` invalid parameter

### DIFF
--- a/news/4958.feature.rst
+++ b/news/4958.feature.rst
@@ -1,0 +1,1 @@
+Add a warning when passing an invalid requirement to ``pip uninstall``.

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -1,3 +1,4 @@
+import logging
 from optparse import Values
 from typing import List
 
@@ -13,6 +14,9 @@ from pip._internal.req.constructors import (
     install_req_from_parsed_requirement,
 )
 from pip._internal.utils.misc import protect_pip_from_modification_on_windows
+
+
+logger = logging.getLogger(__name__)
 
 
 class UninstallCommand(Command, SessionCommandMixin):
@@ -60,6 +64,13 @@ class UninstallCommand(Command, SessionCommandMixin):
             )
             if req.name:
                 reqs_to_uninstall[canonicalize_name(req.name)] = req
+            else:
+                logger.warning(
+                    "Invalid requirement: %r ignored -"
+                    " the uninstall command expects named"
+                    " requirements.",
+                    name,
+                )
         for filename in options.requirements:
             for parsed_req in parse_requirements(
                     filename,

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -15,7 +15,6 @@ from pip._internal.req.constructors import (
 )
 from pip._internal.utils.misc import protect_pip_from_modification_on_windows
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -76,6 +76,18 @@ def test_basic_uninstall_with_scripts(script):
     )
 
 
+@pytest.mark.parametrize("name",
+                         ["GTrolls.tar.gz",
+                          "https://guyto.com/archives/"])
+def test_uninstall_invalid_parameter(script, caplog, name):
+    result = script.pip("uninstall", name, "-y", expect_error=True)
+    expected_message = (
+        f"Invalid requirement: '{name}' ignored -"
+        f" the uninstall command expects named requirements."
+    )
+    assert expected_message in result.stderr
+
+
 @pytest.mark.network
 def test_uninstall_easy_install_after_import(script):
     """


### PR DESCRIPTION
Implemented error handling when passing an invalid paramer to `pip uninstall`