### PR TITLE
Push deprecated sdist reinstall feature removal from 21.2 to 21.3

### DIFF
--- a/news/8711.process.rst
+++ b/news/8711.process.rst
@@ -1,0 +1,1 @@
+The source distribution re-installation feature removal has been delayed to 21.3.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -151,7 +151,7 @@ class Resolver(BaseResolver):
                     deprecated(
                         reason=reason,
                         replacement=replacement,
-                        gone_in="21.2",
+                        gone_in="21.3",
                         issue=8711,
                     )
 


### PR DESCRIPTION
See https://github.com/pypa/pip/pull/10198#issuecomment-886060404 and #9147.