### PR TITLE
Update release process to use PR workflow

### DIFF
--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -116,15 +116,17 @@ Release Process
 Creating a new release
 ----------------------
 
-#. Checkout the current pip ``main`` branch.
 #. Ensure you have the latest ``nox`` installed.
+#. Create a new ``release/YY.N`` branch off ``main`` and switch to it.
 #. Prepare for release using ``nox -s prepare-release -- YY.N``.
    This will update the relevant files and tag the correct commit.
+#. Submit the ``release/YY.N`` branch as a pull request and ensure CI passes.
+   Merge the changes back into ``main`` and pull them back locally.
 #. Build the release artifacts using ``nox -s build-release -- YY.N``.
    This will checkout the tag, generate the distribution files to be
    uploaded and checkout the main branch again.
 #. Upload the release to PyPI using ``nox -s upload-release -- YY.N``.
-#. Push all of the changes including the tag.
+#. Push the tag created by ``prepare-release``.
 #. Regenerate the ``get-pip.py`` script in the `get-pip repository`_ (as
    documented there) and commit the results.
 #. Submit a Pull Request to `CPython`_ adding the new version of pip (and upgrading
@@ -168,7 +170,7 @@ order to create one of these the changes should already be merged into the
 #. Push the ``release/YY.N.Z+1`` branch to github and submit a PR for it against
    the ``main`` branch and wait for the tests to run.
 #. Once tests run, merge the ``release/YY.N.Z+1`` branch into ``main``, and
-   follow the above release process starting with step 4.
+   follow the above release process starting with step 5.
 
 .. _`get-pip repository`: https://github.com/pypa/get-pip
 .. _`psf-salt repository`: https://github.com/python/psf-salt

--- a/tools/release/__init__.py
+++ b/tools/release/__init__.py
@@ -175,23 +175,18 @@ def isolated_temporary_checkout(
         git_checkout_dir = tmp_dir / f"pip-build-{target_ref}"
         nox_session.run(
             # fmt: off
-            "git", "worktree", "add", "--force", "--checkout",
-            str(git_checkout_dir), str(target_ref),
+            "git", "clone",
+            "--depth", "1",
+            "--config", "core.autocrlf=false",
+            "--branch", str(target_ref),
+            "--",
+            ".", str(git_checkout_dir),
             # fmt: on
             external=True,
             silent=True,
         )
 
-        try:
-            yield git_checkout_dir
-        finally:
-            nox_session.run(
-                # fmt: off
-                "git", "worktree", "remove", "--force", str(git_checkout_dir),
-                # fmt: on
-                external=True,
-                silent=True,
-            )
+        yield git_checkout_dir
 
 
 def get_git_untracked_files() -> Iterator[str]:


### PR DESCRIPTION
Based on the discussion in https://github.com/pypa/pip/pull/10198#issuecomment-886058694

I also changed the release script to use `git clone --depth 1` instead of `git worktree` to make the release. This is a bit slower, but allows checking out the repository with `core.autocrlf=false` so the checked out tree (thus the packaged distributions) use LF everywhere, even on Windows.