### PR TITLE
Ensure newline after literal block in NEWS.rst

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -59,7 +59,9 @@ Features
 
   When dist-info/INSTALLER is present and contains some useful information, the info is included in the error message instead::
 
-      ERROR: Cannot uninstall foobar 0.1, RECORD file not found. Hint: The package was installed by rpm. (`#8954 <https://github.com/pypa/pip/issues/8954>`_)
+      ERROR: Cannot uninstall foobar 0.1, RECORD file not found. Hint: The package was installed by rpm.
+
+  (`#8954 <https://github.com/pypa/pip/issues/8954>`_)
 - Add an additional level of verbosity. ``--verbose`` (and the shorthand ``-v``) now
   contains significantly less output, and users that need complete full debug-level output
   should pass it twice (``--verbose --verbose`` or ``-vv``). (`#9450 <https://github.com/pypa/pip/issues/9450>`_)


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Without the newline the link to the pull request becomes part of the literal block, which I don't think was the intention.
