### PR TITLE
Correctly normalize relative paths for 'pip show'

### DIFF
--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -109,10 +109,10 @@ def search_packages_info(query: List[str]) -> Iterator[_PackageInfo]:
             return None
         paths = (p for p in text.splitlines(keepends=False) if p)
         root = dist.location
-        info = dist.metadata_directory
+        info = dist.info_directory
         if root is None or info is None:
             return paths
-        return (str(pathlib.Path(info, p).resolve().relative_to(root)) for p in paths)
+        return (str(pathlib.Path(info, p).relative_to(root)) for p in paths)
 
     for query_name in query_names:
         try:

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -61,6 +61,18 @@ class BaseDistribution(Protocol):
         raise NotImplementedError()
 
     @property
+    def metadata_directory(self) -> Optional[str]:
+        """Location of the metadata directory.
+
+        Similarly to ``location``, a string value is not necessarily a
+        filesystem path. ``None`` means the distribution is created in-memory.
+
+        For a modern .dist-info installation on disk, this should be something
+        like ``{location}/{raw_name}-{version}.dist-info``.
+        """
+        raise NotImplementedError()
+
+    @property
     def canonical_name(self) -> "NormalizedName":
         raise NotImplementedError()
 

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -57,18 +57,26 @@ class BaseDistribution(Protocol):
         A string value is not necessarily a filesystem path, since distributions
         can be loaded from other sources, e.g. arbitrary zip archives. ``None``
         means the distribution is created in-memory.
+
+        Do not canonicalize this value with e.g. ``pathlib.Path.resolve()``. If
+        this is a symbolic link, we want to preserve the relative path between
+        it and files in the distribution.
         """
         raise NotImplementedError()
 
     @property
-    def metadata_directory(self) -> Optional[str]:
-        """Location of the metadata directory.
+    def info_directory(self) -> Optional[str]:
+        """Location of the .[egg|dist]-info directory.
 
         Similarly to ``location``, a string value is not necessarily a
         filesystem path. ``None`` means the distribution is created in-memory.
 
         For a modern .dist-info installation on disk, this should be something
         like ``{location}/{raw_name}-{version}.dist-info``.
+
+        Do not canonicalize this value with e.g. ``pathlib.Path.resolve()``. If
+        this is a symbolic link, we want to preserve the relative path between
+        it and other files in the distribution.
         """
         raise NotImplementedError()
 

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -49,7 +49,7 @@ class Distribution(BaseDistribution):
         return self._dist.location
 
     @property
-    def metadata_directory(self) -> Optional[str]:
+    def info_directory(self) -> Optional[str]:
         return self._dist.egg_info
 
     @property

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -49,6 +49,10 @@ class Distribution(BaseDistribution):
         return self._dist.location
 
     @property
+    def metadata_directory(self) -> Optional[str]:
+        return self._dist.egg_info
+
+    @property
     def canonical_name(self) -> "NormalizedName":
         return canonicalize_name(self._dist.project_name)
 

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -25,6 +25,46 @@ class LegacyInstallFailure(Exception):
         self.parent = sys.exc_info()
 
 
+def write_installed_files_from_setuptools_record(
+    record_lines: List[str],
+    root: Optional[str],
+    req_description: str,
+) -> None:
+    def prepend_root(path):
+        # type: (str) -> str
+        if root is None or not os.path.isabs(path):
+            return path
+        else:
+            return change_root(root, path)
+
+    for line in record_lines:
+        directory = os.path.dirname(line)
+        if directory.endswith('.egg-info'):
+            egg_info_dir = prepend_root(directory)
+            break
+    else:
+        message = (
+            "{} did not indicate that it installed an "
+            ".egg-info directory. Only setup.py projects "
+            "generating .egg-info directories are supported."
+        ).format(req_description)
+        raise InstallationError(message)
+
+    new_lines = []
+    for line in record_lines:
+        filename = line.strip()
+        if os.path.isdir(filename):
+            filename += os.path.sep
+        new_lines.append(
+            os.path.relpath(prepend_root(filename), egg_info_dir)
+        )
+    new_lines.sort()
+    ensure_dir(egg_info_dir)
+    inst_files_path = os.path.join(egg_info_dir, 'installed-files.txt')
+    with open(inst_files_path, 'w') as f:
+        f.write('\n'.join(new_lines) + '\n')
+
+
 def install(
     install_options,  # type: List[str]
     global_options,  # type: Sequence[str]
@@ -88,38 +128,5 @@ def install(
         with open(record_filename) as f:
             record_lines = f.read().splitlines()
 
-    def prepend_root(path):
-        # type: (str) -> str
-        if root is None or not os.path.isabs(path):
-            return path
-        else:
-            return change_root(root, path)
-
-    for line in record_lines:
-        directory = os.path.dirname(line)
-        if directory.endswith('.egg-info'):
-            egg_info_dir = prepend_root(directory)
-            break
-    else:
-        message = (
-            "{} did not indicate that it installed an "
-            ".egg-info directory. Only setup.py projects "
-            "generating .egg-info directories are supported."
-        ).format(req_description)
-        raise InstallationError(message)
-
-    new_lines = []
-    for line in record_lines:
-        filename = line.strip()
-        if os.path.isdir(filename):
-            filename += os.path.sep
-        new_lines.append(
-            os.path.relpath(prepend_root(filename), egg_info_dir)
-        )
-    new_lines.sort()
-    ensure_dir(egg_info_dir)
-    inst_files_path = os.path.join(egg_info_dir, 'installed-files.txt')
-    with open(inst_files_path, 'w') as f:
-        f.write('\n'.join(new_lines) + '\n')
-
+    write_installed_files_from_setuptools_record(record_lines, root, req_description)
     return True


### PR DESCRIPTION
Fix #10204. Fix #10231.

Since the legacy `installed-files.txt` writes paths relatively to the egg-info directory, we need to introduce a new property on `BaseDistribution` to return that directory's path (analoguous to `pkg_resources.Distribution.egg_info`).

Entries in RECORD are normalized with pathlib.Path so they have the correct path component separator depending on the platform (e.g. `/` on Windows), to match the previous behavior.