### PR TITLE
Patch tenacity to quote typing.NoReturn

### DIFF
--- a/src/pip/_vendor/tenacity/__init__.py
+++ b/src/pip/_vendor/tenacity/__init__.py
@@ -190,7 +190,7 @@ class RetryError(Exception):
         self.last_attempt = last_attempt
         super().__init__(last_attempt)
 
-    def reraise(self) -> t.NoReturn:
+    def reraise(self) -> "t.NoReturn":
         if self.last_attempt.failed:
             raise self.last_attempt.result()
         raise self

--- a/tools/vendoring/patches/tenacity.patch
+++ b/tools/vendoring/patches/tenacity.patch
@@ -1,5 +1,5 @@
 diff --git a/src/pip/_vendor/tenacity/__init__.py b/src/pip/_vendor/tenacity/__init__.py
-index 88c28d2d6..f984eec4e 100644
+index 88c28d2d6..086ad46e1 100644
 --- a/src/pip/_vendor/tenacity/__init__.py
 +++ b/src/pip/_vendor/tenacity/__init__.py
 @@ -76,10 +76,12 @@ from .after import after_nothing  # noqa
@@ -19,3 +19,16 @@ index 88c28d2d6..f984eec4e 100644
 
  if t.TYPE_CHECKING:
      import types
+
+--- a/src/pip/_vendor/tenacity/__init__.py
++++ b/src/pip/_vendor/tenacity/__init__.py
+@@ -190,7 +190,7 @@ class RetryError(Exception):
+         self.last_attempt = last_attempt
+         super().__init__(last_attempt)
+ 
+-    def reraise(self) -> t.NoReturn:
++    def reraise(self) -> "t.NoReturn":
+         if self.last_attempt.failed:
+             raise self.last_attempt.result()
+         raise self
+ 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fixes #10211

Everywhere else NoReturn is already quoted.