### PR TITLE
Correctly ignore osx_framework_user mismatches

### DIFF
--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -137,8 +137,8 @@ def get_scheme(
             user
             and is_osx_framework()
             and k == "headers"
-            and old_v.parent == new_v
-            and old_v.name.startswith("python")
+            and old_v.parent.parent == new_v.parent
+            and old_v.parent.name.startswith("python")
         )
         if skip_osx_framework_user_special_case:
             continue


### PR DESCRIPTION
This is the macOS `--user` part of #10208.

The expected 'headers' path is generally:

* distutils (old): `$PREFIX/include/python3.8/$PROJECT`
* sysconfig (new): `$PREFIX/include/$PROJECT`

So we should check whether the old value's parent is a pythonX.Y, and the new value's parent matches the old's second-level parent.