### PR TITLE
Kill location warning on Debian and Red Hat system Python

### DIFF
--- a/src/pip/_internal/locations/base.py
+++ b/src/pip/_internal/locations/base.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import site
 import sys
@@ -46,5 +47,6 @@ except AttributeError:
     user_site = site.USER_SITE
 
 
+@functools.lru_cache(maxsize=None)
 def is_osx_framework() -> bool:
     return bool(sysconfig.get_config_var("PYTHONFRAMEWORK"))


### PR DESCRIPTION
This accounts for the `sudo pip install` (for both Red Hat and Debian patches) and pymalloc parts of #10208.