### PR TITLE
Bump up to Sphinx 4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx == 3.2.1
+sphinx ~= 4.1.0
 towncrier
 furo
 myst_parser


### PR DESCRIPTION
Using the newer versions of Sphinx enables using newer versions of the
Sphinx theme we use.

Notably, this allows us to provide dark mode toggles to our users -- https://pradyunsg.me/furo/changelog/#beta39.

I could see nothing concerning with the upgrade, that the docs built fine locally.
