### PR TITLE
Avoid deprecation warning from Tomli

### DIFF
--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -60,7 +60,7 @@ def load_pyproject_toml(
 
     if has_pyproject:
         with open(pyproject_toml, encoding="utf-8") as f:
-            pp_toml = tomli.load(f)
+            pp_toml = tomli.loads(f.read())
         build_system = pp_toml.get("build-system")
     else:
         build_system = None


### PR DESCRIPTION
~~Universal newlines are not TOML compatible.~~

~~See e.g. https://github.com/toml-lang/toml/issues/837 for context.~~ EDIT: this is no longer relevant to this PR given the new title and current changes.