### PR TITLE
Support PEP 610 editables in pip freeze and pip list

### DIFF
--- a/docs/html/cli/pip_list.rst
+++ b/docs/html/cli/pip_list.rst
@@ -139,3 +139,93 @@ Examples
          docopt==0.6.2
          idlex==1.13
          jedi==0.9.0
+
+#. List packages installed in editable mode
+
+When some packages are installed in editable mode, ``pip list`` outputs an
+additional column that shows the directory where the editable project is
+located (i.e. the directory that contains the ``pyproject.toml`` or
+``setup.py`` file).
+
+   .. tab:: Unix/macOS
+
+      .. code-block:: console
+
+         $ python -m pip list
+         Package          Version  Editable project location
+         ---------------- -------- -------------------------------------
+         pip              21.2.4
+         pip-test-package 0.1.1    /home/you/.venv/src/pip-test-package
+         setuptools       57.4.0
+         wheel            0.36.2
+
+
+   .. tab:: Windows
+
+      .. code-block:: console
+
+         C:\> py -m pip list
+         Package          Version  Editable project location
+         ---------------- -------- ----------------------------------------
+         pip              21.2.4
+         pip-test-package 0.1.1    C:\Users\You\.venv\src\pip-test-package
+         setuptools       57.4.0
+         wheel            0.36.2
+
+The json format outputs an additional ``editable_project_location`` field.
+
+   .. tab:: Unix/macOS
+
+      .. code-block:: console
+
+         $ python -m pip list --format=json | python -m json.tool
+         [
+           {
+             "name": "pip",
+             "version": "21.2.4",
+           },
+           {
+             "name": "pip-test-package",
+             "version": "0.1.1",
+             "editable_project_location": "/home/you/.venv/src/pip-test-package"
+           },
+           {
+             "name": "setuptools",
+             "version": "57.4.0"
+           },
+           {
+             "name": "wheel",
+             "version": "0.36.2"
+           }
+         ]
+
+   .. tab:: Windows
+
+      .. code-block:: console
+
+         C:\> py -m pip list --format=json | py -m json.tool
+         [
+           {
+             "name": "pip",
+             "version": "21.2.4",
+           },
+           {
+             "name": "pip-test-package",
+             "version": "0.1.1",
+             "editable_project_location": "C:\Users\You\.venv\src\pip-test-package"
+           },
+           {
+             "name": "setuptools",
+             "version": "57.4.0"
+           },
+           {
+             "name": "wheel",
+             "version": "0.36.2"
+           }
+         ]
+
+.. note::
+
+   Contrarily to the ``freeze``  comand, ``pip list --format=freeze`` will not
+   report editable install information, and will report the version of the
+   package at the time it was installed.

--- a/docs/html/cli/pip_list.rst
+++ b/docs/html/cli/pip_list.rst
@@ -226,6 +226,6 @@ The json format outputs an additional ``editable_project_location`` field.
 
 .. note::
 
-   Contrarily to the ``freeze``  comand, ``pip list --format=freeze`` will not
-   report editable install information, and will report the version of the
-   package at the time it was installed.
+   Contrary to the ``freeze``  comand, ``pip list --format=freeze`` will not
+   report editable install information, but the version of the package at the
+   time it was installed.

--- a/news/10249.feature.rst
+++ b/news/10249.feature.rst
@@ -1,0 +1,4 @@
+Support `PEP 610 <https://www.python.org/dev/peps/pep-0610/>`_ to detect
+editable installs in ``pip freeze`` and  ``pip list``. The ``pip list`` column output
+has a new ``Editable project location`` column, and  json output has a new
+``editable_project_location`` field.

--- a/news/10249.feature.rst
+++ b/news/10249.feature.rst
@@ -1,4 +1,4 @@
 Support `PEP 610 <https://www.python.org/dev/peps/pep-0610/>`_ to detect
 editable installs in ``pip freeze`` and  ``pip list``. The ``pip list`` column output
-has a new ``Editable project location`` column, and  json output has a new
+has a new ``Editable project location`` column, and the JSON output has a new
 ``editable_project_location`` field.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -14,7 +14,8 @@ from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import BaseDistribution, get_environment
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.network.session import PipSession
-from pip._internal.utils.misc import stdlib_pkgs, tabulate, write_output
+from pip._internal.utils.compat import stdlib_pkgs
+from pip._internal.utils.misc import tabulate, write_output
 from pip._internal.utils.parallel import map_multithread
 
 if TYPE_CHECKING:

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -303,12 +303,11 @@ def format_for_columns(
     Convert the package data into something usable
     by output_package_listing_columns.
     """
+    header = ["Package", "Version"]
+
     running_outdated = options.outdated
-    # Adjust the header for the `pip list --outdated` case.
     if running_outdated:
-        header = ["Package", "Version", "Latest", "Type"]
-    else:
-        header = ["Package", "Version"]
+        header.extend(["Latest", "Type"])
 
     has_editables = any(x.editable for x in pkgs)
     if has_editables:

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -309,12 +309,16 @@ def format_for_columns(
     else:
         header = ["Package", "Version"]
 
-    data = []
-    if options.verbose >= 1 or any(x.editable for x in pkgs):
+    has_editables = any(x.editable for x in pkgs)
+    if has_editables:
+        header.append("Editable project location")
+
+    if options.verbose >= 1:
         header.append("Location")
     if options.verbose >= 1:
         header.append("Installer")
 
+    data = []
     for proj in pkgs:
         # if we're working on the 'outdated' list, separate out the
         # latest_version and type
@@ -324,7 +328,10 @@ def format_for_columns(
             row.append(str(proj.latest_version))
             row.append(proj.latest_filetype)
 
-        if options.verbose >= 1 or proj.editable:
+        if has_editables:
+            row.append(proj.editable_project_location or "")
+
+        if options.verbose >= 1:
             row.append(proj.location or "")
         if options.verbose >= 1:
             row.append(proj.installer)
@@ -347,5 +354,8 @@ def format_for_json(packages: "_ProcessedDists", options: Values) -> str:
         if options.outdated:
             info["latest_version"] = str(dist.latest_version)
             info["latest_filetype"] = dist.latest_filetype
+        editable_project_location = dist.editable_project_location
+        if editable_project_location:
+            info["editable_project_location"] = editable_project_location
         data.append(info)
     return json.dumps(data)

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -26,7 +26,7 @@ from pip._internal.models.direct_url import (
     DirInfo,
 )
 from pip._internal.utils.compat import stdlib_pkgs  # TODO: Move definition here.
-from pip._internal.utils.misc import egg_link_path_from_sys_path
+from pip._internal.utils.egg_link import egg_link_path_from_sys_path
 from pip._internal.utils.urls import url_to_path
 
 if TYPE_CHECKING:

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -23,8 +23,11 @@ from pip._internal.models.direct_url import (
     DIRECT_URL_METADATA_NAME,
     DirectUrl,
     DirectUrlValidationError,
+    DirInfo,
 )
 from pip._internal.utils.misc import stdlib_pkgs  # TODO: Move definition here.
+from pip._internal.utils.misc import egg_link_path_from_sys_path
+from pip._internal.utils.urls import url_to_path
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -72,6 +75,28 @@ class BaseDistribution(Protocol):
         it and files in the distribution.
         """
         raise NotImplementedError()
+
+    @property
+    def editable_project_location(self) -> Optional[str]:
+        """The project location for editable distributions.
+
+        This is the directory where pyproject.toml or setup.py is located.
+        None if the distribution is not installed in editable mode.
+        """
+        # TODO: this property is relatively costly to compute, memoize it ?
+        direct_url = self.direct_url
+        if direct_url:
+            if isinstance(direct_url.info, DirInfo) and direct_url.info.editable:
+                return url_to_path(direct_url.url)
+        else:
+            # Search for an .egg-link file by walking sys.path, as it was
+            # done before by dist_is_editable().
+            egg_link_path = egg_link_path_from_sys_path(self.raw_name)
+            if egg_link_path:
+                # TODO: get project location from second line of egg_link file
+                #       (https://github.com/pypa/pip/issues/10243)
+                return self.location
+        return None
 
     @property
     def info_directory(self) -> Optional[str]:
@@ -129,7 +154,7 @@ class BaseDistribution(Protocol):
 
     @property
     def editable(self) -> bool:
-        raise NotImplementedError()
+        return bool(self.editable_project_location)
 
     @property
     def local(self) -> bool:

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -25,7 +25,7 @@ from pip._internal.models.direct_url import (
     DirectUrlValidationError,
     DirInfo,
 )
-from pip._internal.utils.misc import stdlib_pkgs  # TODO: Move definition here.
+from pip._internal.utils.compat import stdlib_pkgs  # TODO: Move definition here.
 from pip._internal.utils.misc import egg_link_path_from_sys_path
 from pip._internal.utils.urls import url_to_path
 

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -23,7 +23,6 @@ from pip._internal.models.direct_url import (
     DIRECT_URL_METADATA_NAME,
     DirectUrl,
     DirectUrlValidationError,
-    DirInfo,
 )
 from pip._internal.utils.compat import stdlib_pkgs  # TODO: Move definition here.
 from pip._internal.utils.egg_link import egg_link_path_from_sys_path
@@ -86,7 +85,7 @@ class BaseDistribution(Protocol):
         # TODO: this property is relatively costly to compute, memoize it ?
         direct_url = self.direct_url
         if direct_url:
-            if isinstance(direct_url.info, DirInfo) and direct_url.info.editable:
+            if direct_url.is_local_editable():
                 return url_to_path(direct_url.url)
         else:
             # Search for an .egg-link file by walking sys.path, as it was

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -70,10 +70,6 @@ class Distribution(BaseDistribution):
         return get_installer(self._dist)
 
     @property
-    def editable(self) -> bool:
-        return misc.dist_is_editable(self._dist)
-
-    @property
     def local(self) -> bool:
         return misc.dist_is_local(self._dist)
 

--- a/src/pip/_internal/models/direct_url.py
+++ b/src/pip/_internal/models/direct_url.py
@@ -215,3 +215,6 @@ class DirectUrl:
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict(), sort_keys=True)
+
+    def is_local_editable(self) -> bool:
+        return isinstance(self.info, DirInfo) and self.info.editable

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -169,7 +169,8 @@ def _get_editable_info(dist: BaseDistribution) -> _EditableInfo:
     """
     if not dist.editable:
         return _EditableInfo(requirement=None, editable=False, comments=[])
-    if dist.location is None:
+    editable_project_location = dist.editable_project_location
+    if editable_project_location is None:
         display = _format_as_name_version(dist)
         logger.warning("Editable requirement not found on disk: %s", display)
         return _EditableInfo(
@@ -178,7 +179,7 @@ def _get_editable_info(dist: BaseDistribution) -> _EditableInfo:
             comments=[f"# Editable install not found ({display})"],
         )
 
-    location = os.path.normcase(os.path.abspath(dist.location))
+    location = os.path.normcase(os.path.abspath(editable_project_location))
 
     from pip._internal.vcs import RemoteNotFoundError, RemoteNotValidError, vcs
 

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -170,15 +170,7 @@ def _get_editable_info(dist: BaseDistribution) -> _EditableInfo:
     if not dist.editable:
         return _EditableInfo(requirement=None, editable=False, comments=[])
     editable_project_location = dist.editable_project_location
-    if editable_project_location is None:
-        display = _format_as_name_version(dist)
-        logger.warning("Editable requirement not found on disk: %s", display)
-        return _EditableInfo(
-            requirement=None,
-            editable=True,
-            comments=[f"# Editable install not found ({display})"],
-        )
-
+    assert editable_project_location
     location = os.path.normcase(os.path.abspath(editable_project_location))
 
     from pip._internal.vcs import RemoteNotFoundError, RemoteNotValidError, vcs

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -12,12 +12,12 @@ from pip._vendor.pkg_resources import Distribution
 from pip._internal.exceptions import UninstallationError
 from pip._internal.locations import get_bin_prefix, get_bin_user
 from pip._internal.utils.compat import WINDOWS
+from pip._internal.utils.egg_link import egg_link_path_from_location
 from pip._internal.utils.logging import getLogger, indent_log
 from pip._internal.utils.misc import (
     ask,
     dist_in_usersite,
     dist_is_local,
-    egg_link_path,
     is_local,
     normalize_path,
     renames,
@@ -459,7 +459,7 @@ class UninstallPathSet:
             return cls(dist)
 
         paths_to_remove = cls(dist)
-        develop_egg_link = egg_link_path(dist)
+        develop_egg_link = egg_link_path_from_location(dist.project_name)
         develop_egg_link_egg_info = "{}.egg-info".format(
             pkg_resources.to_filename(dist.project_name)
         )

--- a/src/pip/_internal/utils/egg_link.py
+++ b/src/pip/_internal/utils/egg_link.py
@@ -1,0 +1,83 @@
+# The following comment should be removed at some point in the future.
+# mypy: strict-optional=False
+
+import os
+import re
+import sys
+from typing import Optional
+
+from pip._vendor.pkg_resources import Distribution
+
+from pip._internal.locations import site_packages, user_site
+from pip._internal.utils.virtualenv import (
+    running_under_virtualenv,
+    virtualenv_no_global,
+)
+
+__all__ = [
+    "egg_link_path_from_sys_path",
+    "egg_link_path_from_location",
+    "egg_link_path",
+]
+
+
+def _egg_link_name(raw_name: str) -> str:
+    """
+    Convert a Name metadata value to a .egg-link name, by applying
+    the same substitution as pkg_resources's safe_name function.
+    Note: we cannot use canonicalize_name because it has a different logic.
+    """
+    return re.sub("[^A-Za-z0-9.]+", "-", raw_name) + ".egg-link"
+
+
+def egg_link_path_from_sys_path(raw_name: str) -> Optional[str]:
+    """
+    Look for a .egg-link file for project name, by walking sys.path.
+    """
+    egg_link_name = _egg_link_name(raw_name)
+    for path_item in sys.path:
+        egg_link = os.path.join(path_item, egg_link_name)
+        if os.path.isfile(egg_link):
+            return egg_link
+    return None
+
+
+def egg_link_path_from_location(raw_name: str) -> Optional[str]:
+    """
+    Return the path for the .egg-link file if it exists, otherwise, None.
+
+    There's 3 scenarios:
+    1) not in a virtualenv
+       try to find in site.USER_SITE, then site_packages
+    2) in a no-global virtualenv
+       try to find in site_packages
+    3) in a yes-global virtualenv
+       try to find in site_packages, then site.USER_SITE
+       (don't look in global location)
+
+    For #1 and #3, there could be odd cases, where there's an egg-link in 2
+    locations.
+
+    This method will just return the first one found.
+    """
+    sites = []
+    if running_under_virtualenv():
+        sites.append(site_packages)
+        if not virtualenv_no_global() and user_site:
+            sites.append(user_site)
+    else:
+        if user_site:
+            sites.append(user_site)
+        sites.append(site_packages)
+
+    egg_link_name = _egg_link_name(raw_name)
+    for site in sites:
+        egglink = os.path.join(site, egg_link_name)
+        if os.path.isfile(egglink):
+            return egglink
+    return None
+
+
+def egg_link_path(dist):
+    # type: (Distribution) -> Optional[str]
+    return egg_link_path_from_location(dist.project_name)

--- a/src/pip/_internal/utils/egg_link.py
+++ b/src/pip/_internal/utils/egg_link.py
@@ -6,8 +6,6 @@ import re
 import sys
 from typing import Optional
 
-from pip._vendor.pkg_resources import Distribution
-
 from pip._internal.locations import site_packages, user_site
 from pip._internal.utils.virtualenv import (
     running_under_virtualenv,
@@ -17,7 +15,6 @@ from pip._internal.utils.virtualenv import (
 __all__ = [
     "egg_link_path_from_sys_path",
     "egg_link_path_from_location",
-    "egg_link_path",
 ]
 
 
@@ -76,8 +73,3 @@ def egg_link_path_from_location(raw_name: str) -> Optional[str]:
         if os.path.isfile(egglink):
             return egglink
     return None
-
-
-def egg_link_path(dist):
-    # type: (Distribution) -> Optional[str]
-    return egg_link_path_from_location(dist.project_name)

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -9,7 +9,6 @@ import io
 import logging
 import os
 import posixpath
-import re
 import shutil
 import stat
 import sys
@@ -40,10 +39,8 @@ from pip import __version__
 from pip._internal.exceptions import CommandError
 from pip._internal.locations import get_major_minor_version, site_packages, user_site
 from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.virtualenv import (
-    running_under_virtualenv,
-    virtualenv_no_global,
-)
+from pip._internal.utils.egg_link import egg_link_path
+from pip._internal.utils.virtualenv import running_under_virtualenv
 
 __all__ = [
     "rmtree",
@@ -357,18 +354,6 @@ def dist_in_site_packages(dist: Distribution) -> bool:
     return dist_location(dist).startswith(normalize_path(site_packages))
 
 
-def egg_link_path_from_sys_path(raw_name: str) -> Optional[str]:
-    """
-    Look for a .egg-link file for project name, by walking sys.path.
-    """
-    egg_link_name = _egg_link_name(raw_name)
-    for path_item in sys.path:
-        egg_link = os.path.join(path_item, egg_link_name)
-        if os.path.isfile(egg_link):
-            return egg_link
-    return None
-
-
 def get_distribution(req_name: str) -> Optional[Distribution]:
     """Given a requirement name, return the installed Distribution object.
 
@@ -384,55 +369,6 @@ def get_distribution(req_name: str) -> Optional[Distribution]:
     if dist is None:
         return None
     return cast(_Dist, dist)._dist
-
-
-def _egg_link_name(raw_name: str) -> str:
-    """
-    Convert a Name metadata value to a .egg-link name, by applying
-    the same substitution as pkg_resources's safe_name function.
-    Note: we cannot use canonicalize_name because it has a different logic.
-    """
-    return re.sub("[^A-Za-z0-9.]+", "-", raw_name) + ".egg-link"
-
-
-def egg_link_path_from_location(raw_name: str) -> Optional[str]:
-    """
-    Return the path for the .egg-link file if it exists, otherwise, None.
-
-    There's 3 scenarios:
-    1) not in a virtualenv
-       try to find in site.USER_SITE, then site_packages
-    2) in a no-global virtualenv
-       try to find in site_packages
-    3) in a yes-global virtualenv
-       try to find in site_packages, then site.USER_SITE
-       (don't look in global location)
-
-    For #1 and #3, there could be odd cases, where there's an egg-link in 2
-    locations.
-
-    This method will just return the first one found.
-    """
-    sites = []
-    if running_under_virtualenv():
-        sites.append(site_packages)
-        if not virtualenv_no_global() and user_site:
-            sites.append(user_site)
-    else:
-        if user_site:
-            sites.append(user_site)
-        sites.append(site_packages)
-
-    egg_link_name = _egg_link_name(raw_name)
-    for site in sites:
-        egglink = os.path.join(site, egg_link_name)
-        if os.path.isfile(egglink):
-            return egglink
-    return None
-
-
-def egg_link_path(dist: Distribution) -> Optional[str]:
-    return egg_link_path_from_location(dist.project_name)
 
 
 def dist_location(dist: Distribution) -> str:

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -21,7 +21,6 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
-    Container,
     ContextManager,
     Iterable,
     Iterator,
@@ -40,7 +39,7 @@ from pip._vendor.tenacity import retry, stop_after_delay, wait_fixed
 from pip import __version__
 from pip._internal.exceptions import CommandError
 from pip._internal.locations import get_major_minor_version, site_packages, user_site
-from pip._internal.utils.compat import WINDOWS, stdlib_pkgs
+from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.virtualenv import (
     running_under_virtualenv,
     virtualenv_no_global,
@@ -368,35 +367,6 @@ def egg_link_path_from_sys_path(raw_name: str) -> Optional[str]:
         if os.path.isfile(egg_link):
             return egg_link
     return None
-
-
-def get_installed_distributions(
-    local_only: bool = True,
-    skip: Container[str] = stdlib_pkgs,
-    include_editables: bool = True,
-    editables_only: bool = False,
-    user_only: bool = False,
-    paths: Optional[List[str]] = None,
-) -> List[Distribution]:
-    """Return a list of installed Distribution objects.
-
-    Left for compatibility until direct pkg_resources uses are refactored out.
-    """
-    from pip._internal.metadata import get_default_environment, get_environment
-    from pip._internal.metadata.pkg_resources import Distribution as _Dist
-
-    if paths is None:
-        env = get_default_environment()
-    else:
-        env = get_environment(paths)
-    dists = env.iter_installed_distributions(
-        local_only=local_only,
-        skip=skip,
-        include_editables=include_editables,
-        editables_only=editables_only,
-        user_only=user_only,
-    )
-    return [cast(_Dist, dist)._dist for dist in dists]
 
 
 def get_distribution(req_name: str) -> Optional[Distribution]:

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -39,7 +39,7 @@ from pip import __version__
 from pip._internal.exceptions import CommandError
 from pip._internal.locations import get_major_minor_version, site_packages, user_site
 from pip._internal.utils.compat import WINDOWS
-from pip._internal.utils.egg_link import egg_link_path
+from pip._internal.utils.egg_link import egg_link_path_from_location
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
 __all__ = [
@@ -380,7 +380,7 @@ def dist_location(dist: Distribution) -> str:
 
     The returned location is normalized (in particular, with symlinks removed).
     """
-    egg_link = egg_link_path(dist)
+    egg_link = egg_link_path_from_location(dist.project_name)
     if egg_link:
         return normalize_path(egg_link)
     return normalize_path(dist.location)

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -370,13 +370,6 @@ def egg_link_path_from_sys_path(raw_name: str) -> Optional[str]:
     return None
 
 
-def dist_is_editable(dist: Distribution) -> bool:
-    """
-    Return True if given Distribution is an editable install.
-    """
-    return bool(egg_link_path_from_sys_path(dist.project_name))
-
-
 def get_installed_distributions(
     local_only: bool = True,
     skip: Container[str] = stdlib_pkgs,

--- a/tests/lib/direct_url.py
+++ b/tests/lib/direct_url.py
@@ -3,15 +3,22 @@ from typing import Optional
 
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
 from tests.lib import TestPipResult
+from tests.lib.path import Path
 
 
-def get_created_direct_url(result: TestPipResult, pkg: str) -> Optional[DirectUrl]:
+def get_created_direct_url_path(result: TestPipResult, pkg: str) -> Optional[Path]:
     direct_url_metadata_re = re.compile(
         pkg + r"-[\d\.]+\.dist-info." + DIRECT_URL_METADATA_NAME + r"$"
     )
     for filename in result.files_created:
         if direct_url_metadata_re.search(filename):
-            direct_url_path = result.test_env.base_path / filename
-            with open(direct_url_path) as f:
-                return DirectUrl.from_json(f.read())
+            return result.test_env.base_path / filename
+    return None
+
+
+def get_created_direct_url(result: TestPipResult, pkg: str) -> Optional[DirectUrl]:
+    direct_url_path = get_created_direct_url_path(result, pkg)
+    if direct_url_path:
+        with open(direct_url_path) as f:
+            return DirectUrl.from_json(f.read())
     return None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,6 +17,7 @@ import pytest
 
 from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError
 from pip._internal.utils.deprecation import PipDeprecationWarning, deprecated
+from pip._internal.utils.egg_link import egg_link_path_from_location
 from pip._internal.utils.encoding import BOMS, auto_decode
 from pip._internal.utils.glibc import (
     glibc_version_string,
@@ -28,7 +29,6 @@ from pip._internal.utils.misc import (
     HiddenText,
     build_netloc,
     build_url_from_netloc,
-    egg_link_path,
     format_size,
     get_distribution,
     get_prog,
@@ -51,7 +51,7 @@ from pip._internal.utils.setuptools_build import make_setuptools_shim_args
 
 
 class Tests_EgglinkPath:
-    "util.egg_link_path() tests"
+    "util.egg_link_path_from_location() tests"
 
     def setup(self):
 
@@ -106,19 +106,25 @@ class Tests_EgglinkPath:
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = False
         self.mock_isfile.side_effect = self.eggLinkInUserSite
-        assert egg_link_path(self.mock_dist) == self.user_site_egglink
+        assert (
+            egg_link_path_from_location(self.mock_dist.project_name)
+            == self.user_site_egglink
+        )
 
     def test_egglink_in_usersite_venv_noglobal(self):
         self.mock_virtualenv_no_global.return_value = True
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.side_effect = self.eggLinkInUserSite
-        assert egg_link_path(self.mock_dist) is None
+        assert egg_link_path_from_location(self.mock_dist.project_name) is None
 
     def test_egglink_in_usersite_venv_global(self):
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.side_effect = self.eggLinkInUserSite
-        assert egg_link_path(self.mock_dist) == self.user_site_egglink
+        assert (
+            egg_link_path_from_location(self.mock_dist.project_name)
+            == self.user_site_egglink
+        )
 
     # ####################### #
     # # egglink in sitepkgs # #
@@ -127,19 +133,28 @@ class Tests_EgglinkPath:
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = False
         self.mock_isfile.side_effect = self.eggLinkInSitePackages
-        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
+        assert (
+            egg_link_path_from_location(self.mock_dist.project_name)
+            == self.site_packages_egglink
+        )
 
     def test_egglink_in_sitepkgs_venv_noglobal(self):
         self.mock_virtualenv_no_global.return_value = True
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.side_effect = self.eggLinkInSitePackages
-        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
+        assert (
+            egg_link_path_from_location(self.mock_dist.project_name)
+            == self.site_packages_egglink
+        )
 
     def test_egglink_in_sitepkgs_venv_global(self):
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.side_effect = self.eggLinkInSitePackages
-        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
+        assert (
+            egg_link_path_from_location(self.mock_dist.project_name)
+            == self.site_packages_egglink
+        )
 
     # ################################## #
     # # egglink in usersite & sitepkgs # #
@@ -148,19 +163,28 @@ class Tests_EgglinkPath:
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = False
         self.mock_isfile.return_value = True
-        assert egg_link_path(self.mock_dist) == self.user_site_egglink
+        assert (
+            egg_link_path_from_location(self.mock_dist.project_name)
+            == self.user_site_egglink
+        )
 
     def test_egglink_in_both_venv_noglobal(self):
         self.mock_virtualenv_no_global.return_value = True
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.return_value = True
-        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
+        assert (
+            egg_link_path_from_location(self.mock_dist.project_name)
+            == self.site_packages_egglink
+        )
 
     def test_egglink_in_both_venv_global(self):
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.return_value = True
-        assert egg_link_path(self.mock_dist) == self.site_packages_egglink
+        assert (
+            egg_link_path_from_location(self.mock_dist.project_name)
+            == self.site_packages_egglink
+        )
 
     # ############## #
     # # no egglink # #
@@ -169,19 +193,19 @@ class Tests_EgglinkPath:
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = False
         self.mock_isfile.return_value = False
-        assert egg_link_path(self.mock_dist) is None
+        assert egg_link_path_from_location(self.mock_dist.project_name) is None
 
     def test_noegglink_in_sitepkgs_venv_noglobal(self):
         self.mock_virtualenv_no_global.return_value = True
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.return_value = False
-        assert egg_link_path(self.mock_dist) is None
+        assert egg_link_path_from_location(self.mock_dist.project_name) is None
 
     def test_noegglink_in_sitepkgs_venv_global(self):
         self.mock_virtualenv_no_global.return_value = False
         self.mock_running_under_virtualenv.return_value = True
         self.mock_isfile.return_value = False
-        assert egg_link_path(self.mock_dist) is None
+        assert egg_link_path_from_location(self.mock_dist.project_name) is None
 
 
 @patch("pip._internal.utils.misc.dist_in_usersite")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -67,7 +67,7 @@ class Tests_EgglinkPath:
         )
 
         # patches
-        from pip._internal.utils import misc as utils
+        from pip._internal.utils import egg_link as utils
 
         self.old_site_packages = utils.site_packages
         self.mock_site_packages = utils.site_packages = "SITE_PACKAGES"


### PR DESCRIPTION
This makes pip list and freeze support PEP 610 editables (from direct_url.json), in preparation for PEP 660.

This should be fully backward compatible. The new column in pip list column format is not a breaking change because it is meant for human consumption (the json format is there for machines, and in the semantics of existing field did not change in the json output).

- Detect editable installs from `direct_url.json`, fallback on the legacy `.egg-link` search.
- Add an `Editable project location` column in pip list default output. This column appears only when there is and editable project in the list. The `Location` column appears in verbose mode only and shows the same value as before (i.e. the parent of the metadata directory). Closes #10245.
- Add `editable_project_location` field to pip list json output (closes #7664, supersedes #7670).
- Use `editable_project_location` in pip freeze.
- Remove unused `get_installed_distributions` function.

This may be tested by installing a flit project with `flit install --pth` or `flit install --symlink` and noticing that pip list and pip freeze correctly detect it as editable.