### PR TITLE
Fix get_preferred_scheme detection for CPython 3.10 alpha

### DIFF
--- a/news/10252.bugfix.rst
+++ b/news/10252.bugfix.rst
@@ -1,0 +1,4 @@
+Check if the sysconfig.get_preferred_scheme function
+exists in a different way. The original method relied
+on Python version but led to AttributeError on Python
+3.10.alpha as the function was added in 3.10.beta.

--- a/news/10252.bugfix.rst
+++ b/news/10252.bugfix.rst
@@ -1,4 +1,2 @@
-Check if the sysconfig.get_preferred_scheme function
-exists in a different way. The original method relied
-on Python version but led to AttributeError on Python
-3.10.alpha as the function was added in 3.10.beta.
+Modify the `sysconfig.get_preferred_scheme` function check to be
+compatible with CPython 3.10’s alphareleases.

--- a/news/10252.bugfix.rst
+++ b/news/10252.bugfix.rst
@@ -1,2 +1,2 @@
-Modify the `sysconfig.get_preferred_scheme` function check to be
+Modify the ``sysconfig.get_preferred_scheme`` function check to be
 compatible with CPython 3.10’s alphareleases.

--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 _AVAILABLE_SCHEMES = set(sysconfig.get_scheme_names())
 
-_HAS_PREFERRED_SCHEME_API = 'get_preferred_scheme' in dir(sysconfig)
+_PREFERRED_SCHEME_API = getattr(sysconfig, "get_preferred_scheme", None)
 
 
 def _infer_prefix() -> str:
@@ -41,8 +41,8 @@ def _infer_prefix() -> str:
 
     If none of the above works, fall back to ``posix_prefix``.
     """
-    if _HAS_PREFERRED_SCHEME_API:
-        return sysconfig.get_preferred_scheme("prefix")  # type: ignore
+    if _PREFERRED_SCHEME_API:
+        return _PREFERRED_SCHEME_API("prefix")  # type: ignore
     os_framework_global = is_osx_framework() and not running_under_virtualenv()
     if os_framework_global and "osx_framework_library" in _AVAILABLE_SCHEMES:
         return "osx_framework_library"
@@ -61,8 +61,8 @@ def _infer_prefix() -> str:
 
 def _infer_user() -> str:
     """Try to find a user scheme for the current platform."""
-    if _HAS_PREFERRED_SCHEME_API:
-        return sysconfig.get_preferred_scheme("user")  # type: ignore
+    if _PREFERRED_SCHEME_API:
+        return _PREFERRED_SCHEME_API("user")  # type: ignore
     if is_osx_framework() and not running_under_virtualenv():
         suffixed = "osx_framework_user"
     else:
@@ -76,8 +76,8 @@ def _infer_user() -> str:
 
 def _infer_home() -> str:
     """Try to find a home for the current platform."""
-    if _HAS_PREFERRED_SCHEME_API:
-        return sysconfig.get_preferred_scheme("home")  # type: ignore
+    if _PREFERRED_SCHEME_API:
+        return _PREFERRED_SCHEME_API("home")  # type: ignore
     suffixed = f"{os.name}_home"
     if suffixed in _AVAILABLE_SCHEMES:
         return suffixed

--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -42,7 +42,7 @@ def _infer_prefix() -> str:
     If none of the above works, fall back to ``posix_prefix``.
     """
     if _PREFERRED_SCHEME_API:
-        return _PREFERRED_SCHEME_API("prefix")  # type: ignore
+        return _PREFERRED_SCHEME_API("prefix")
     os_framework_global = is_osx_framework() and not running_under_virtualenv()
     if os_framework_global and "osx_framework_library" in _AVAILABLE_SCHEMES:
         return "osx_framework_library"
@@ -62,7 +62,7 @@ def _infer_prefix() -> str:
 def _infer_user() -> str:
     """Try to find a user scheme for the current platform."""
     if _PREFERRED_SCHEME_API:
-        return _PREFERRED_SCHEME_API("user")  # type: ignore
+        return _PREFERRED_SCHEME_API("user")
     if is_osx_framework() and not running_under_virtualenv():
         suffixed = "osx_framework_user"
     else:
@@ -77,7 +77,7 @@ def _infer_user() -> str:
 def _infer_home() -> str:
     """Try to find a home for the current platform."""
     if _PREFERRED_SCHEME_API:
-        return _PREFERRED_SCHEME_API("home")  # type: ignore
+        return _PREFERRED_SCHEME_API("home")
     suffixed = f"{os.name}_home"
     if suffixed in _AVAILABLE_SCHEMES:
         return suffixed

--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 _AVAILABLE_SCHEMES = set(sysconfig.get_scheme_names())
 
-_HAS_PREFERRED_SCHEME_API = sys.version_info >= (3, 10)
+_HAS_PREFERRED_SCHEME_API = 'get_preferred_scheme' in dir(sysconfig)
 
 
 def _infer_prefix() -> str:


### PR DESCRIPTION
Support for the feature sysconfig.get_preferred_scheme
(added on Python 3.10 - see bpo-43312) was checked based
on the Python version (see commit
ca4aa121a9f7d876b4513cadf8d9e54c8515416a
"Use Python 3.10 sysconfig.get_preferred_scheme()").

Unfortunately, this API seems to be introduced with the
3.10.beta Cpython builds and does not seem to be part of
the 3.10.alpha versions.

Hence, on these versions, pip fails with exception:
    AttributeError: module 'sysconfig' has no attribute 'get_preferred_scheme'

The solution chosen is to check if the function exists
in the sysconfig module using introspection instead of
relying on Python versions.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
