### PR TITLE
Work around Debian bug in get_python_lib()

### DIFF
--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -277,10 +277,29 @@ def get_bin_user() -> str:
     return _sysconfig.get_scheme("", user=True).scripts
 
 
+def _looks_like_deb_system_dist_packages(value: str) -> bool:
+    """Check if the value is Debian's APT-controlled dist-packages.
+
+    Debian's ``distutils.sysconfig.get_python_lib()`` implementation returns the
+    default package path controlled by APT, but does not patch ``sysconfig`` to
+    do the same. This is similar to the bug worked around in ``get_scheme()``,
+    but here the default is ``deb_system`` instead of ``unix_local``. Ultimately
+    we can't do anything about this Debian bug, and this detection allows us to
+    skip the warning when needed.
+    """
+    if not _looks_like_debian_patched():
+        return False
+    if value == "/usr/lib/python3/dist-packages":
+        return True
+    return False
+
+
 def get_purelib() -> str:
     """Return the default pure-Python lib location."""
     old = _distutils.get_purelib()
     new = _sysconfig.get_purelib()
+    if _looks_like_deb_system_dist_packages(old):
+        return old
     if _warn_if_mismatch(pathlib.Path(old), pathlib.Path(new), key="purelib"):
         _log_context()
     return old
@@ -290,6 +309,8 @@ def get_platlib() -> str:
     """Return the default platform-shared lib location."""
     old = _distutils.get_platlib()
     new = _sysconfig.get_platlib()
+    if _looks_like_deb_system_dist_packages(old):
+        return old
     if _warn_if_mismatch(pathlib.Path(old), pathlib.Path(new), key="platlib"):
         _log_context()
     return old


### PR DESCRIPTION
https://github.com/pypa/pip/issues/10151#issuecomment-888165609
https://github.com/pypa/pip/issues/10151#issuecomment-886957554
https://github.com/pypa/pip/issues/10151#issuecomment-889358122
https://github.com/pypa/pip/issues/10151#issuecomment-889189881
https://github.com/pypa/pip/pull/10217#issuecomment-890401414

@siddhpant @Molkree @pdxjohnny @KanTakahiro

It turns out this is a bug in Debian’s `distutils.sysconfig.get_python_lib()` implementation. This function is called when pip builds a package from source (to create a build-time isolated environment), so it does not happen when you install a wheel (or when installing a package from source for a second time, because pip would cache the previously-built wheel). This patch basically just tries to detect that bug and pretend nothing happens when it triggers the warning.

Please give this a try and tell me if it can correctly suppress the warning.