### PR TITLE
Try to make distutils not emit relative paths

### DIFF
--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -90,15 +90,6 @@ def _fix_abiflags(parts: Tuple[str]) -> Iterator[str]:
         yield part
 
 
-def _default_base(*, user: bool) -> str:
-    if user:
-        base = sysconfig.get_config_var("userbase")
-    else:
-        base = sysconfig.get_config_var("base")
-    assert base is not None
-    return base
-
-
 @functools.lru_cache(maxsize=None)
 def _warn_mismatched(old: pathlib.Path, new: pathlib.Path, *, key: str) -> None:
     issue_url = "https://github.com/pypa/pip/issues/10151"
@@ -161,11 +152,9 @@ def get_scheme(
         prefix=prefix,
     )
 
-    base = prefix or home or _default_base(user=user)
     warning_contexts = []
     for k in SCHEME_KEYS:
-        # Extra join because distutils can return relative paths.
-        old_v = pathlib.Path(base, getattr(old, k))
+        old_v = pathlib.Path(getattr(old, k))
         new_v = pathlib.Path(getattr(new, k))
 
         if old_v == new_v:

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -138,17 +138,20 @@ def get_scheme(
 
 
 def get_bin_prefix() -> str:
+    # XXX: In old virtualenv versions, sys.prefix can contain '..' components,
+    # so we need to call normpath to eliminate them.
+    prefix = os.path.normpath(sys.prefix)
     if WINDOWS:
-        bin_py = os.path.join(sys.prefix, "Scripts")
+        bin_py = os.path.join(prefix, "Scripts")
         # buildout uses 'bin' on Windows too?
         if not os.path.exists(bin_py):
-            bin_py = os.path.join(sys.prefix, "bin")
+            bin_py = os.path.join(prefix, "bin")
         return bin_py
     # Forcing to use /usr/local/bin for standard macOS framework installs
     # Also log to ~/Library/Logs/ for use with the Console.app log viewer
-    if sys.platform[:6] == "darwin" and sys.prefix[:16] == "/System/Library/":
+    if sys.platform[:6] == "darwin" and prefix[:16] == "/System/Library/":
         return "/usr/local/bin"
-    return os.path.join(sys.prefix, "bin")
+    return os.path.join(prefix, "bin")
 
 
 def get_purelib() -> str:

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -81,8 +81,14 @@ def distutils_scheme(
         scheme.update(dict(purelib=i.install_lib, platlib=i.install_lib))
 
     if running_under_virtualenv():
+        if home:
+            prefix = home
+        elif user:
+            prefix = i.install_userbase  # type: ignore
+        else:
+            prefix = i.prefix
         scheme["headers"] = os.path.join(
-            i.prefix,
+            prefix,
             "include",
             "site",
             f"python{get_major_minor_version()}",
@@ -91,10 +97,7 @@ def distutils_scheme(
 
         if root is not None:
             path_no_drive = os.path.splitdrive(os.path.abspath(scheme["headers"]))[1]
-            scheme["headers"] = os.path.join(
-                root,
-                path_no_drive[1:],
-            )
+            scheme["headers"] = os.path.join(root, path_no_drive[1:])
 
     return scheme
 


### PR DESCRIPTION
https://github.com/pypa/pip/issues/10151#issuecomment-888765045
https://github.com/pypa/pip/issues/10151#issuecomment-889568500

~~To prevent distutils from returning weird paths, try to normalise the target prefix before passing it into distutils.~~

~~Not sure how well this would work, so not pinging people for testing yet…~~

Turns out the original implementation simply had a bug… This should fix the relative path issue (but not the normalisation part).