### PR TITLE
Remove extra period in deprecation message

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -836,7 +836,7 @@ def check_invalid_constraint_type(req: InstallRequirement) -> str:
                 "undocumented. The new implementation of the resolver no "
                 "longer supports these forms."
             ),
-            replacement="replacing the constraint with a requirement.",
+            replacement="replacing the constraint with a requirement",
             # No plan yet for when the new resolver becomes default
             gone_in=None,
             issue=8210,


### PR DESCRIPTION
The `deprecate()` method automatically puts a period after `replacement`, so including one in `replacement` is redundant. Before this change, the message contains the following text:

> A possible replacement is replacing the constraint with a requirement..