### PR TITLE
Docs: Link directly to the new Configuration location

### DIFF
--- a/docs/html/cli/pip.rst
+++ b/docs/html/cli/pip.rst
@@ -47,7 +47,7 @@ verbosity log will be kept.  This option is empty by default. This log appends
 to previous logging.
 
 Like all pip options, ``--log`` can also be set as an environment variable, or
-placed into the pip config file.  See the :ref:`Configuration` section.
+placed into the pip config file.  See the :doc:`topics/configuration` section.
 
 .. _`exists-action`:
 

--- a/docs/html/development/configuration.rst
+++ b/docs/html/development/configuration.rst
@@ -4,4 +4,4 @@
 Configuration
 =============
 
-This content is now covered in the :ref:`Configuration` section of the :doc:`User Guide </user_guide>`.
+This content is now covered in the :doc:`topics/configuration` section of the :doc:`User Guide </user_guide>`.


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

At https://pip.pypa.io/en/latest/cli/pip/#file-logging, the link in "See the Configuration section." goes to https://pip.pypa.io/en/latest/user_guide/#configuration:

![image](https://user-images.githubusercontent.com/1324225/128155912-d9ebea0a-dd30-4f26-afc2-040a745bff04.png)

Likewise for "This content is now covered in the Configuration section of the User Guide." in https://pip.pypa.io/en/latest/development/configuration/

Instead, update these two to link _directly_ to https://pip.pypa.io/en/latest/topics/configuration/ to avoid the need for an extra click and new page load.




