### PR TITLE
Move NameTuple method out of class

### DIFF
--- a/news/10280.bugfix.rst
+++ b/news/10280.bugfix.rst
@@ -1,0 +1,1 @@
+Fix 3.6.0 compatibility in link comparison logic.


### PR DESCRIPTION
Suppport for defining methods on a typing.NameTuple was added in 3.6.1, so this fixes compatibility to 3.6.0.

Fix #10280.