### PR TITLE
Remove six import from src/pip/_internal/req/req_install.py

### DIFF
--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -3,7 +3,6 @@
 
 import logging
 import os
-import sys
 from distutils.util import change_root
 from typing import List, Optional, Sequence
 
@@ -20,8 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class LegacyInstallFailure(Exception):
-    def __init__(self) -> None:
-        self.parent = sys.exc_info()
+    pass
 
 
 def write_installed_files_from_setuptools_record(
@@ -111,9 +109,9 @@ def install(
                 # Signal to the caller that we didn't install the new package
                 return False
 
-        except Exception:
+        except Exception as e:
             # Signal to the caller that we didn't install the new package
-            raise LegacyInstallFailure
+            raise LegacyInstallFailure from e
 
         # At this point, we have successfully installed the requirement.
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -9,7 +9,7 @@ import uuid
 import zipfile
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
-from pip._vendor import pkg_resources, six
+from pip._vendor import pkg_resources
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.specifiers import SpecifierSet
@@ -795,7 +795,7 @@ class InstallRequirement:
             )
         except LegacyInstallFailure as exc:
             self.install_succeeded = False
-            six.reraise(*exc.parent)
+            raise exc.__cause__
         except Exception:
             self.install_succeeded = True
             raise


### PR DESCRIPTION
Use Python 3 `raise exc from ...` semantics to replace the use of
six.reraise.
