### PR TITLE
Bump mypy to 0.910

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,12 +51,17 @@ repos:
     files: \.py$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.800
+  rev: v0.910
   hooks:
   - id: mypy
     exclude: tests
-    args: ["--pretty"]
-    additional_dependencies: ['nox==2020.12.31']
+    args: ["--pretty", "--show-error-codes"]
+    additional_dependencies: [
+        'keyring==23.0.1',
+        'nox==2020.12.31',
+        'types-docutils==0.1.8',
+        'types-six==0.1.9',
+    ]
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.7.0

--- a/docs/pip_sphinxext.py
+++ b/docs/pip_sphinxext.py
@@ -127,8 +127,7 @@ class PipOptions(rst.Directive):
             line += f" <{metavar.lower()}>"
         # fix defaults
         assert option.help is not None
-        # https://github.com/python/typeshed/pull/5080
-        opt_help = option.help.replace("%default", str(option.default))  # type: ignore
+        opt_help = option.help.replace("%default", str(option.default))
         # fix paths with sys.prefix
         opt_help = opt_help.replace(sys.prefix, "<sys.prefix>")
         return [bookmark_line, "", line, "", "    " + opt_help, ""]

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -28,13 +28,13 @@ Credentials = Tuple[str, str, str]
 try:
     import keyring
 except ImportError:
-    keyring = None
+    keyring = None  # type: ignore[assignment]
 except Exception as exc:
     logger.warning(
         "Keyring is skipped due to an exception: %s",
         str(exc),
     )
-    keyring = None
+    keyring = None  # type: ignore[assignment]
 
 
 def get_keyring_auth(url: Optional[str], username: Optional[str]) -> Optional[AuthInfo]:
@@ -66,7 +66,7 @@ def get_keyring_auth(url: Optional[str], username: Optional[str]) -> Optional[Au
             "Keyring is skipped due to an exception: %s",
             str(exc),
         )
-        keyring = None
+        keyring = None  # type: ignore[assignment]
     return None
 
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -566,7 +566,7 @@ def _install_wheel(
         wheel_zip,
         ensure_text(lib_dir, encoding=sys.getfilesystemencoding()),
     )
-    files = map(make_root_scheme_file, root_scheme_paths)
+    files: Iterator[File] = map(make_root_scheme_file, root_scheme_paths)
 
     def is_script_scheme_path(path: RecordPath) -> bool:
         parts = path.split("/", 2)
@@ -604,7 +604,9 @@ def _install_wheel(
         # Ignore setuptools-generated scripts
         return (matchname in console or matchname in gui)
 
-    script_scheme_files = map(make_data_scheme_file, script_scheme_paths)
+    script_scheme_files: Iterator[File] = map(
+        make_data_scheme_file, script_scheme_paths
+    )
     script_scheme_files = filterfalse(
         is_entrypoint_wrapper, script_scheme_files
     )


### PR DESCRIPTION
This notably gets us on a version of mypy that uses modular typeshed:
https://mypy-lang.blogspot.com/2021/05/the-upcoming-switch-to-modular-typeshed.html
which allows us to have finer control over what version of stubs we pull
in from typeshed. Also contains other routine improvements to mypy.

Required a few minor typing changes.

Add flag --show-error-code so errors look like this

```
src/pip/_internal/network/auth.py:70: error: Incompatible types in assignment
(expression has type "None", variable has type Module)  [assignment]
```

rather than

```
src/pip/_internal/network/auth.py:70: error: Incompatible types in assignment
(expression has type "None", variable has type Module)
```

