### PR TITLE
More importlib.metadata migration preparation

### DIFF
--- a/src/pip/_internal/distributions/base.py
+++ b/src/pip/_internal/distributions/base.py
@@ -1,9 +1,7 @@
 import abc
-from typing import Optional
-
-from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.index.package_finder import PackageFinder
+from pip._internal.metadata.base import BaseDistribution
 from pip._internal.req import InstallRequirement
 
 
@@ -28,7 +26,7 @@ class AbstractDistribution(metaclass=abc.ABCMeta):
         self.req = req
 
     @abc.abstractmethod
-    def get_pkg_resources_distribution(self) -> Optional[Distribution]:
+    def get_metadata_distribution(self) -> BaseDistribution:
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/src/pip/_internal/distributions/installed.py
+++ b/src/pip/_internal/distributions/installed.py
@@ -1,9 +1,6 @@
-from typing import Optional
-
-from pip._vendor.pkg_resources import Distribution
-
 from pip._internal.distributions.base import AbstractDistribution
 from pip._internal.index.package_finder import PackageFinder
+from pip._internal.metadata import BaseDistribution
 
 
 class InstalledDistribution(AbstractDistribution):
@@ -13,7 +10,8 @@ class InstalledDistribution(AbstractDistribution):
     been computed.
     """
 
-    def get_pkg_resources_distribution(self) -> Optional[Distribution]:
+    def get_metadata_distribution(self) -> BaseDistribution:
+        assert self.req.satisfied_by is not None, "not actually installed"
         return self.req.satisfied_by
 
     def prepare_distribution_metadata(

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -1,12 +1,11 @@
 import logging
 from typing import Set, Tuple
 
-from pip._vendor.pkg_resources import Distribution
-
 from pip._internal.build_env import BuildEnvironment
 from pip._internal.distributions.base import AbstractDistribution
 from pip._internal.exceptions import InstallationError
 from pip._internal.index.package_finder import PackageFinder
+from pip._internal.metadata import BaseDistribution
 from pip._internal.utils.subprocess import runner_with_spinner_message
 
 logger = logging.getLogger(__name__)
@@ -19,8 +18,10 @@ class SourceDistribution(AbstractDistribution):
     generated, either using PEP 517 or using the legacy `setup.py egg_info`.
     """
 
-    def get_pkg_resources_distribution(self) -> Distribution:
-        return self.req.get_dist()
+    def get_metadata_distribution(self) -> BaseDistribution:
+        from pip._internal.metadata.pkg_resources import Distribution as _Dist
+
+        return _Dist(self.req.get_dist())
 
     def prepare_distribution_metadata(
         self, finder: PackageFinder, build_isolation: bool

--- a/src/pip/_internal/distributions/wheel.py
+++ b/src/pip/_internal/distributions/wheel.py
@@ -1,10 +1,12 @@
-from zipfile import ZipFile
-
-from pip._vendor.pkg_resources import Distribution
+from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.distributions.base import AbstractDistribution
 from pip._internal.index.package_finder import PackageFinder
-from pip._internal.utils.wheel import pkg_resources_distribution_for_wheel
+from pip._internal.metadata import (
+    BaseDistribution,
+    FilesystemWheel,
+    get_wheel_distribution,
+)
 
 
 class WheelDistribution(AbstractDistribution):
@@ -13,20 +15,15 @@ class WheelDistribution(AbstractDistribution):
     This does not need any preparation as wheels can be directly unpacked.
     """
 
-    def get_pkg_resources_distribution(self) -> Distribution:
+    def get_metadata_distribution(self) -> BaseDistribution:
         """Loads the metadata from the wheel file into memory and returns a
         Distribution that uses it, not relying on the wheel file or
         requirement.
         """
-        # Set as part of preparation during download.
-        assert self.req.local_file_path
-        # Wheels are never unnamed.
-        assert self.req.name
-
-        with ZipFile(self.req.local_file_path, allowZip64=True) as z:
-            return pkg_resources_distribution_for_wheel(
-                z, self.req.name, self.req.local_file_path
-            )
+        assert self.req.local_file_path, "Set as part of preparation during download"
+        assert self.req.name, "Wheels are never unnamed"
+        wheel = FilesystemWheel(self.req.local_file_path)
+        return get_wheel_distribution(wheel, canonicalize_name(self.req.name))
 
     def prepare_distribution_metadata(
         self, finder: PackageFinder, build_isolation: bool

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -2,7 +2,7 @@
 
 import configparser
 from itertools import chain, groupby, repeat
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from pip._vendor.pkg_resources import Distribution
 from pip._vendor.requests.models import Request, Response
@@ -10,6 +10,7 @@ from pip._vendor.requests.models import Request, Response
 if TYPE_CHECKING:
     from hashlib import _Hash
 
+    from pip._internal.metadata import BaseDistribution
     from pip._internal.req.req_install import InstallRequirement
 
 
@@ -38,7 +39,11 @@ class NoneMetadataError(PipError):
     "PKG-INFO").
     """
 
-    def __init__(self, dist: Distribution, metadata_name: str) -> None:
+    def __init__(
+        self,
+        dist: Union[Distribution, "BaseDistribution"],
+        metadata_name: str,
+    ) -> None:
         """
         :param dist: A Distribution object.
         :param metadata_name: The name of the metadata being accessed

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -1,10 +1,13 @@
 from typing import List, Optional
 
-from .base import BaseDistribution, BaseEnvironment
+from .base import BaseDistribution, BaseEnvironment, FilesystemWheel, MemoryWheel, Wheel
 
 __all__ = [
     "BaseDistribution",
     "BaseEnvironment",
+    "FilesystemWheel",
+    "MemoryWheel",
+    "Wheel",
     "get_default_environment",
     "get_environment",
     "get_wheel_distribution",
@@ -35,7 +38,7 @@ def get_environment(paths: Optional[List[str]]) -> BaseEnvironment:
     return Environment.from_paths(paths)
 
 
-def get_wheel_distribution(wheel_path: str, canonical_name: str) -> BaseDistribution:
+def get_wheel_distribution(wheel: Wheel, canonical_name: str) -> BaseDistribution:
     """Get the representation of the specified wheel's distribution metadata.
 
     This returns a Distribution instance from the chosen backend based on
@@ -45,4 +48,4 @@ def get_wheel_distribution(wheel_path: str, canonical_name: str) -> BaseDistribu
     """
     from .pkg_resources import Distribution
 
-    return Distribution.from_wheel(wheel_path, canonical_name)
+    return Distribution.from_wheel(wheel, canonical_name)

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from pip._vendor.packaging.requirements import Requirement
+from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.version import LegacyVersion, Version
 
 from pip._internal.models.direct_url import (
@@ -159,10 +160,32 @@ class BaseDistribution(Protocol):
     def raw_name(self) -> str:
         """Value of "Name:" in distribution metadata."""
         # The metadata should NEVER be missing the Name: key, but if it somehow
-        # does not, fall back to the known canonical name.
+        # does, fall back to the known canonical name.
         return self.metadata.get("Name", self.canonical_name)
 
+    @property
+    def requires_python(self) -> SpecifierSet:
+        """Value of "Requires-Python:" in distribution metadata.
+
+        If the key does not exist or contains an invalid value, an empty
+        SpecifierSet should be returned.
+        """
+        raise NotImplementedError()
+
     def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
+        """Dependencies of this distribution.
+
+        For modern .dist-info distributions, this is the collection of
+        "Requires-Dist:" entries in distribution metadata.
+        """
+        raise NotImplementedError()
+
+    def iter_provided_extras(self) -> Iterable[str]:
+        """Extras provided by this distribution.
+
+        For modern .dist-info distributions, this is the collection of
+        "Provides-Extra:" entries in distribution metadata.
+        """
         raise NotImplementedError()
 
 

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -126,11 +126,9 @@ def _simulate_installation_of(
     # Modify it as installing requirement_set would (assuming no errors)
     for inst_req in to_install:
         abstract_dist = make_distribution_for_install_requirement(inst_req)
-        dist = abstract_dist.get_pkg_resources_distribution()
-
-        assert dist is not None
-        name = canonicalize_name(dist.project_name)
-        package_set[name] = PackageDetails(dist.parsed_version, dist.requires())
+        dist = abstract_dist.get_metadata_distribution()
+        name = dist.canonical_name
+        package_set[name] = PackageDetails(dist.version, list(dist.iter_dependencies()))
 
         installed.add(name)
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -42,7 +42,11 @@ from pip._vendor.six import ensure_str, ensure_text, reraise
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.locations import get_major_minor_version
-from pip._internal.metadata import BaseDistribution, get_wheel_distribution
+from pip._internal.metadata import (
+    BaseDistribution,
+    FilesystemWheel,
+    get_wheel_distribution,
+)
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
 from pip._internal.models.scheme import SCHEME_KEYS, Scheme
 from pip._internal.utils.filesystem import adjacent_tmp_file, replace
@@ -575,7 +579,10 @@ def _install_wheel(
     files = chain(files, other_scheme_files)
 
     # Get the defined entry points
-    distribution = get_wheel_distribution(wheel_path, canonicalize_name(name))
+    distribution = get_wheel_distribution(
+        FilesystemWheel(wheel_path),
+        canonicalize_name(name),
+    )
     console, gui = get_entrypoints(distribution)
 
     def is_entrypoint_wrapper(file: "File") -> bool:

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -20,7 +20,7 @@ from itertools import chain
 from typing import DefaultDict, Iterable, List, Optional, Set, Tuple
 
 from pip._vendor.packaging import specifiers
-from pip._vendor.pkg_resources import Distribution
+from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.cache import WheelCache
 from pip._internal.exceptions import (
@@ -28,9 +28,11 @@ from pip._internal.exceptions import (
     DistributionNotFound,
     HashError,
     HashErrors,
+    NoneMetadataError,
     UnsupportedPythonVersion,
 )
 from pip._internal.index.package_finder import PackageFinder
+from pip._internal.metadata import BaseDistribution
 from pip._internal.models.link import Link
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req.req_install import (
@@ -42,7 +44,7 @@ from pip._internal.resolution.base import BaseResolver, InstallRequirementProvid
 from pip._internal.utils.compatibility_tags import get_supported
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import dist_in_usersite, normalize_version_info
-from pip._internal.utils.packaging import check_requires_python, get_requires_python
+from pip._internal.utils.packaging import check_requires_python
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +52,7 @@ DiscoveredDependencies = DefaultDict[str, List[InstallRequirement]]
 
 
 def _check_dist_requires_python(
-    dist: Distribution,
+    dist: BaseDistribution,
     version_info: Tuple[int, int, int],
     ignore_requires_python: bool = False,
 ) -> None:
@@ -66,14 +68,21 @@ def _check_dist_requires_python(
     :raises UnsupportedPythonVersion: When the given Python version isn't
         compatible.
     """
-    requires_python = get_requires_python(dist)
     try:
+        requires_python = str(dist.requires_python)
+    except FileNotFoundError as e:
+        raise NoneMetadataError(dist, str(e))
+    try:
+        # This idiosyncratically converts the SpecifierSet to str and let
+        # check_requires_python then parse it again into SpecifierSet. But this
+        # is the legacy resolver so I'm just not going to bother refactoring.
         is_compatible = check_requires_python(
-            requires_python, version_info=version_info
+            requires_python,
+            version_info=version_info,
         )
     except specifiers.InvalidSpecifier as exc:
         logger.warning(
-            "Package %r has an invalid Requires-Python: %s", dist.project_name, exc
+            "Package %r has an invalid Requires-Python: %s", dist.raw_name, exc
         )
         return
 
@@ -84,7 +93,7 @@ def _check_dist_requires_python(
     if ignore_requires_python:
         logger.debug(
             "Ignoring failed Requires-Python check for package %r: %s not in %r",
-            dist.project_name,
+            dist.raw_name,
             version,
             requires_python,
         )
@@ -92,7 +101,7 @@ def _check_dist_requires_python(
 
     raise UnsupportedPythonVersion(
         "Package {!r} requires a different Python: {} not in {!r}".format(
-            dist.project_name, version, requires_python
+            dist.raw_name, version, requires_python
         )
     )
 
@@ -303,7 +312,7 @@ class Resolver(BaseResolver):
                 req.original_link_is_in_wheel_cache = True
             req.link = cache_entry.link
 
-    def _get_dist_for(self, req: InstallRequirement) -> Distribution:
+    def _get_dist_for(self, req: InstallRequirement) -> BaseDistribution:
         """Takes a InstallRequirement and returns a single AbstractDist \
         representing a prepared variant of the same.
         """
@@ -378,7 +387,10 @@ class Resolver(BaseResolver):
 
         more_reqs: List[InstallRequirement] = []
 
-        def add_req(subreq: Distribution, extras_requested: Iterable[str]) -> None:
+        def add_req(subreq: Requirement, extras_requested: Iterable[str]) -> None:
+            # This idiosyncratically converts the Requirement to str and let
+            # make_install_req then parse it again into Requirement. But this is
+            # the legacy resolver so I'm just not going to bother refactoring.
             sub_install_req = self._make_install_req(
                 str(subreq),
                 req_to_install,
@@ -410,15 +422,20 @@ class Resolver(BaseResolver):
                         ",".join(req_to_install.extras),
                     )
                 missing_requested = sorted(
-                    set(req_to_install.extras) - set(dist.extras)
+                    set(req_to_install.extras) - set(dist.iter_provided_extras())
                 )
                 for missing in missing_requested:
-                    logger.warning("%s does not provide the extra '%s'", dist, missing)
+                    logger.warning(
+                        "%s %s does not provide the extra '%s'",
+                        dist.raw_name,
+                        dist.version,
+                        missing,
+                    )
 
                 available_requested = sorted(
-                    set(dist.extras) & set(req_to_install.extras)
+                    set(dist.iter_provided_extras()) & set(req_to_install.extras)
                 )
-                for subreq in dist.requires(available_requested):
+                for subreq in dist.iter_dependencies(available_requested):
                     add_req(subreq, extras_requested=available_requested)
 
         return more_reqs

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -68,14 +68,14 @@ def _check_dist_requires_python(
     :raises UnsupportedPythonVersion: When the given Python version isn't
         compatible.
     """
+    # This idiosyncratically converts the SpecifierSet to str and let
+    # check_requires_python then parse it again into SpecifierSet. But this
+    # is the legacy resolver so I'm just not going to bother refactoring.
     try:
         requires_python = str(dist.requires_python)
     except FileNotFoundError as e:
         raise NoneMetadataError(dist, str(e))
     try:
-        # This idiosyncratically converts the SpecifierSet to str and let
-        # check_requires_python then parse it again into SpecifierSet. But this
-        # is the legacy resolver so I'm just not going to bother refactoring.
         is_compatible = check_requires_python(
             requires_python,
             version_info=version_info,
@@ -391,10 +391,7 @@ class Resolver(BaseResolver):
             # This idiosyncratically converts the Requirement to str and let
             # make_install_req then parse it again into Requirement. But this is
             # the legacy resolver so I'm just not going to bother refactoring.
-            sub_install_req = self._make_install_req(
-                str(subreq),
-                req_to_install,
-            )
+            sub_install_req = self._make_install_req(str(subreq), req_to_install)
             parent_req_name = req_to_install.name
             to_scan_again, add_to_parent = requirement_set.add_requirement(
                 sub_install_req,

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -287,12 +287,8 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
         )
 
     def _prepare_distribution(self) -> BaseDistribution:
-        from pip._internal.metadata.pkg_resources import Distribution as _CompatDist
-
-        dist = self._factory.preparer.prepare_linked_requirement(
-            self._ireq, parallel_builds=True
-        )
-        return _CompatDist(dist)
+        preparer = self._factory.preparer
+        return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
 
 
 class EditableCandidate(_InstallRequirementBackedCandidate):
@@ -316,10 +312,7 @@ class EditableCandidate(_InstallRequirementBackedCandidate):
         )
 
     def _prepare_distribution(self) -> BaseDistribution:
-        from pip._internal.metadata.pkg_resources import Distribution as _CompatDist
-
-        dist = self._factory.preparer.prepare_editable_requirement(self._ireq)
-        return _CompatDist(dist)
+        return self._factory.preparer.prepare_editable_requirement(self._ireq)
 
 
 class AlreadyInstalledCandidate(Candidate):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -2,13 +2,11 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, Optional, Tuple, Union, cast
 
-from pip._vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import Version
-from pip._vendor.packaging.version import parse as parse_version
-from pip._vendor.pkg_resources import Distribution
 
 from pip._internal.exceptions import HashError, MetadataInconsistent
+from pip._internal.metadata import BaseDistribution
 from pip._internal.models.link import Link, links_equivalent
 from pip._internal.models.wheel import Wheel
 from pip._internal.req.constructors import (
@@ -16,8 +14,7 @@ from pip._internal.req.constructors import (
     install_req_from_line,
 )
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.misc import dist_is_editable, normalize_version_info
-from pip._internal.utils.packaging import get_requires_python
+from pip._internal.utils.misc import normalize_version_info
 
 from .base import Candidate, CandidateVersion, Requirement, format_name
 
@@ -93,16 +90,17 @@ def make_install_req_from_editable(
     )
 
 
-def make_install_req_from_dist(
-    dist: Distribution, template: InstallRequirement
+def _make_install_req_from_dist(
+    dist: BaseDistribution, template: InstallRequirement
 ) -> InstallRequirement:
-    project_name = canonicalize_name(dist.project_name)
+    from pip._internal.metadata.pkg_resources import Distribution as _CompatDist
+
     if template.req:
         line = str(template.req)
     elif template.link:
-        line = f"{project_name} @ {template.link.url}"
+        line = f"{dist.canonical_name} @ {template.link.url}"
     else:
-        line = f"{project_name}=={dist.parsed_version}"
+        line = f"{dist.canonical_name}=={dist.version}"
     ireq = install_req_from_line(
         line,
         user_supplied=template.user_supplied,
@@ -116,7 +114,7 @@ def make_install_req_from_dist(
             hashes=template.hash_options,
         ),
     )
-    ireq.satisfied_by = dist
+    ireq.satisfied_by = cast(_CompatDist, dist)._dist
     return ireq
 
 
@@ -136,6 +134,7 @@ class _InstallRequirementBackedCandidate(Candidate):
         found remote link (e.g. from pypi.org).
     """
 
+    dist: BaseDistribution
     is_installed = False
 
     def __init__(
@@ -180,7 +179,7 @@ class _InstallRequirementBackedCandidate(Candidate):
     def project_name(self) -> NormalizedName:
         """The normalised name of the project the candidate refers to"""
         if self._name is None:
-            self._name = canonicalize_name(self.dist.project_name)
+            self._name = self.dist.canonical_name
         return self._name
 
     @property
@@ -190,7 +189,7 @@ class _InstallRequirementBackedCandidate(Candidate):
     @property
     def version(self) -> CandidateVersion:
         if self._version is None:
-            self._version = parse_version(self.dist.version)
+            self._version = self.dist.version
         return self._version
 
     def format_for_error(self) -> str:
@@ -200,29 +199,27 @@ class _InstallRequirementBackedCandidate(Candidate):
             self._link.file_path if self._link.is_file else self._link,
         )
 
-    def _prepare_distribution(self) -> Distribution:
+    def _prepare_distribution(self) -> BaseDistribution:
         raise NotImplementedError("Override in subclass")
 
-    def _check_metadata_consistency(self, dist: Distribution) -> None:
+    def _check_metadata_consistency(self, dist: BaseDistribution) -> None:
         """Check for consistency of project name and version of dist."""
-        canonical_name = canonicalize_name(dist.project_name)
-        if self._name is not None and self._name != canonical_name:
+        if self._name is not None and self._name != dist.canonical_name:
             raise MetadataInconsistent(
                 self._ireq,
                 "name",
                 self._name,
-                dist.project_name,
+                dist.canonical_name,
             )
-        parsed_version = parse_version(dist.version)
-        if self._version is not None and self._version != parsed_version:
+        if self._version is not None and self._version != dist.version:
             raise MetadataInconsistent(
                 self._ireq,
                 "version",
                 str(self._version),
-                dist.version,
+                str(dist.version),
             )
 
-    def _prepare(self) -> Distribution:
+    def _prepare(self) -> BaseDistribution:
         try:
             dist = self._prepare_distribution()
         except HashError as e:
@@ -234,23 +231,11 @@ class _InstallRequirementBackedCandidate(Candidate):
         self._check_metadata_consistency(dist)
         return dist
 
-    def _get_requires_python_dependency(self) -> Optional[Requirement]:
-        requires_python = get_requires_python(self.dist)
-        if requires_python is None:
-            return None
-        try:
-            spec = SpecifierSet(requires_python)
-        except InvalidSpecifier as e:
-            message = "Package %r has an invalid Requires-Python: %s"
-            logger.warning(message, self.name, e)
-            return None
-        return self._factory.make_requires_python_requirement(spec)
-
     def iter_dependencies(self, with_requires: bool) -> Iterable[Optional[Requirement]]:
-        requires = self.dist.requires() if with_requires else ()
+        requires = self.dist.iter_dependencies() if with_requires else ()
         for r in requires:
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
-        yield self._get_requires_python_dependency()
+        yield self._factory.make_requires_python_requirement(self.dist.requires_python)
 
     def get_install_requirement(self) -> Optional[InstallRequirement]:
         return self._ireq
@@ -301,10 +286,13 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             version=version,
         )
 
-    def _prepare_distribution(self) -> Distribution:
-        return self._factory.preparer.prepare_linked_requirement(
+    def _prepare_distribution(self) -> BaseDistribution:
+        from pip._internal.metadata.pkg_resources import Distribution as _CompatDist
+
+        dist = self._factory.preparer.prepare_linked_requirement(
             self._ireq, parallel_builds=True
         )
+        return _CompatDist(dist)
 
 
 class EditableCandidate(_InstallRequirementBackedCandidate):
@@ -327,8 +315,11 @@ class EditableCandidate(_InstallRequirementBackedCandidate):
             version=version,
         )
 
-    def _prepare_distribution(self) -> Distribution:
-        return self._factory.preparer.prepare_editable_requirement(self._ireq)
+    def _prepare_distribution(self) -> BaseDistribution:
+        from pip._internal.metadata.pkg_resources import Distribution as _CompatDist
+
+        dist = self._factory.preparer.prepare_editable_requirement(self._ireq)
+        return _CompatDist(dist)
 
 
 class AlreadyInstalledCandidate(Candidate):
@@ -337,17 +328,17 @@ class AlreadyInstalledCandidate(Candidate):
 
     def __init__(
         self,
-        dist: Distribution,
+        dist: BaseDistribution,
         template: InstallRequirement,
         factory: "Factory",
     ) -> None:
         self.dist = dist
-        self._ireq = make_install_req_from_dist(dist, template)
+        self._ireq = _make_install_req_from_dist(dist, template)
         self._factory = factory
 
         # This is just logging some messages, so we can do it eagerly.
         # The returned dist would be exactly the same as self.dist because we
-        # set satisfied_by in make_install_req_from_dist.
+        # set satisfied_by in _make_install_req_from_dist.
         # TODO: Supply reason based on force_reinstall and upgrade_strategy.
         skip_reason = "already satisfied"
         factory.preparer.prepare_installed_requirement(self._ireq, skip_reason)
@@ -371,7 +362,7 @@ class AlreadyInstalledCandidate(Candidate):
 
     @property
     def project_name(self) -> NormalizedName:
-        return canonicalize_name(self.dist.project_name)
+        return self.dist.canonical_name
 
     @property
     def name(self) -> str:
@@ -379,11 +370,11 @@ class AlreadyInstalledCandidate(Candidate):
 
     @property
     def version(self) -> CandidateVersion:
-        return parse_version(self.dist.version)
+        return self.dist.version
 
     @property
     def is_editable(self) -> bool:
-        return dist_is_editable(self.dist)
+        return self.dist.editable
 
     def format_for_error(self) -> str:
         return f"{self.name} {self.version} (Installed)"
@@ -391,7 +382,7 @@ class AlreadyInstalledCandidate(Candidate):
     def iter_dependencies(self, with_requires: bool) -> Iterable[Optional[Requirement]]:
         if not with_requires:
             return
-        for r in self.dist.requires():
+        for r in self.dist.iter_dependencies():
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
 
     def get_install_requirement(self) -> Optional[InstallRequirement]:
@@ -491,8 +482,8 @@ class ExtrasCandidate(Candidate):
 
         # The user may have specified extras that the candidate doesn't
         # support. We ignore any unsupported extras here.
-        valid_extras = self.extras.intersection(self.base.dist.extras)
-        invalid_extras = self.extras.difference(self.base.dist.extras)
+        valid_extras = self.extras.intersection(self.base.dist.iter_provided_extras())
+        invalid_extras = self.extras.difference(self.base.dist.iter_provided_extras())
         for extra in sorted(invalid_extras):
             logger.warning(
                 "%s %s does not provide the extra '%s'",
@@ -501,7 +492,7 @@ class ExtrasCandidate(Candidate):
                 extra,
             )
 
-        for r in self.base.dist.requires(valid_extras):
+        for r in self.base.dist.iter_dependencies(valid_extras):
             requirement = factory.make_requirement_from_spec(
                 str(r), self.base._ireq, valid_extras
             )

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -93,7 +93,7 @@ def make_install_req_from_editable(
 def _make_install_req_from_dist(
     dist: BaseDistribution, template: InstallRequirement
 ) -> InstallRequirement:
-    from pip._internal.metadata.pkg_resources import Distribution as _CompatDist
+    from pip._internal.metadata.pkg_resources import Distribution as _Dist
 
     if template.req:
         line = str(template.req)
@@ -114,7 +114,7 @@ def _make_install_req_from_dist(
             hashes=template.hash_options,
         ),
     )
-    ireq.satisfied_by = cast(_CompatDist, dist)._dist
+    ireq.satisfied_by = cast(_Dist, dist)._dist
     return ireq
 
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -158,10 +158,7 @@ class Factory:
         try:
             base = self._installed_candidate_cache[dist.canonical_name]
         except KeyError:
-            from pip._internal.metadata.pkg_resources import Distribution as _Dist
-
-            compat_dist = cast(_Dist, dist)._dist
-            base = AlreadyInstalledCandidate(compat_dist, template, factory=self)
+            base = AlreadyInstalledCandidate(dist, template, factory=self)
             self._installed_candidate_cache[dist.canonical_name] = base
         if not extras:
             return base
@@ -494,9 +491,13 @@ class Factory:
         return self._make_requirement_from_install_req(ireq, requested_extras)
 
     def make_requires_python_requirement(
-        self, specifier: Optional[SpecifierSet]
+        self,
+        specifier: SpecifierSet,
     ) -> Optional[Requirement]:
-        if self._ignore_requires_python or specifier is None:
+        if self._ignore_requires_python:
+            return None
+        # Don't bother creating a dependency for an empty Requires-Python.
+        if not str(specifier):
             return None
         return RequiresPythonRequirement(specifier, self._python_candidate)
 

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -63,22 +63,6 @@ def get_metadata(dist: Distribution) -> Message:
     return feed_parser.close()
 
 
-def get_requires_python(dist: pkg_resources.Distribution) -> Optional[str]:
-    """
-    Return the "Requires-Python" metadata for a distribution, or None
-    if not present.
-    """
-    pkg_info_dict = get_metadata(dist)
-    requires_python = pkg_info_dict.get("Requires-Python")
-
-    if requires_python is not None:
-        # Convert to a str to satisfy the type checker, since requires_python
-        # can be a Header object.
-        requires_python = str(requires_python)
-
-    return requires_python
-
-
 def get_installer(dist: Distribution) -> str:
     if dist.has_metadata("INSTALLER"):
         for line in dist.get_metadata_lines("INSTALLER"):

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -12,7 +12,7 @@ from pip._vendor.packaging.version import InvalidVersion, Version
 
 from pip._internal.cache import WheelCache
 from pip._internal.exceptions import InvalidWheelFilename, UnsupportedWheel
-from pip._internal.metadata import get_wheel_distribution
+from pip._internal.metadata import FilesystemWheel, get_wheel_distribution
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.operations.build.wheel import build_wheel_pep517
@@ -166,7 +166,7 @@ def _verify_one(req: InstallRequirement, wheel_path: str) -> None:
             "Wheel has unexpected file name: expected {!r}, "
             "got {!r}".format(canonical_name, w.name),
         )
-    dist = get_wheel_distribution(wheel_path, canonical_name)
+    dist = get_wheel_distribution(FilesystemWheel(wheel_path), canonical_name)
     dist_verstr = str(dist.version)
     if canonicalize_version(dist_verstr) != canonicalize_version(w.version):
         raise InvalidWheelFilename(

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -26,6 +26,7 @@ from zipfile import ZipFile
 
 from pip._vendor.requests.structures import CaseInsensitiveDict
 
+from pip._internal.metadata import BaseDistribution, MemoryWheel, get_wheel_distribution
 from tests.lib.path import Path
 
 # path, digest, size
@@ -282,6 +283,10 @@ class WheelBuilder:
 
     def as_zipfile(self) -> ZipFile:
         return ZipFile(BytesIO(self.as_bytes()))
+
+    def as_distribution(self, name: str) -> BaseDistribution:
+        stream = BytesIO(self.as_bytes())
+        return get_wheel_distribution(MemoryWheel(self._name, stream), name)
 
 
 def make_wheel(

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -1,6 +1,6 @@
 from zipfile import BadZipfile
 
-from pip._vendor.pkg_resources import Requirement
+from pip._vendor.packaging.version import Version
 from pytest import fixture, mark, raises
 
 from pip._internal.network.lazy_wheel import (
@@ -16,10 +16,10 @@ MYPY_0_782_WHL = (
     "mypy-0.782-py3-none-any.whl"
 )
 MYPY_0_782_REQS = {
-    Requirement("typed-ast (<1.5.0,>=1.4.0)"),
-    Requirement("typing-extensions (>=3.7.4)"),
-    Requirement("mypy-extensions (<0.5.0,>=0.4.3)"),
-    Requirement('psutil (>=4.0); extra == "dmypy"'),
+    "typed-ast<1.5.0,>=1.4.0",
+    "typing-extensions>=3.7.4",
+    "mypy-extensions<0.5.0,>=0.4.3",
+    'psutil>=4.0; extra == "dmypy"',
 }
 
 
@@ -42,10 +42,11 @@ def mypy_whl_no_range(mock_server, shared_data):
 def test_dist_from_wheel_url(session):
     """Test if the acquired distribution contain correct information."""
     dist = dist_from_wheel_url("mypy", MYPY_0_782_WHL, session)
-    assert dist.key == "mypy"
-    assert dist.version == "0.782"
-    assert dist.extras == ["dmypy"]
-    assert set(dist.requires(dist.extras)) == MYPY_0_782_REQS
+    assert dist.canonical_name == "mypy"
+    assert dist.version == Version("0.782")
+    extras = list(dist.iter_provided_extras())
+    assert extras == ["dmypy"]
+    assert {str(d) for d in dist.iter_dependencies(extras)} == MYPY_0_782_REQS
 
 
 def test_dist_from_wheel_url_no_range(session, mypy_whl_no_range):

--- a/tests/unit/test_utils_pkg_resources.py
+++ b/tests/unit/test_utils_pkg_resources.py
@@ -1,9 +1,13 @@
 from email.message import Message
 
 import pytest
-from pip._vendor.pkg_resources import DistInfoDistribution, Requirement
+from pip._vendor.packaging.specifiers import SpecifierSet
+from pip._vendor.packaging.version import parse as parse_version
+from pip._vendor.pkg_resources import DistInfoDistribution
 
-from pip._internal.utils.packaging import get_metadata, get_requires_python
+from pip._internal.metadata.pkg_resources import (
+    Distribution as PkgResourcesDistribution,
+)
 from pip._internal.utils.pkg_resources import DictMetadata
 
 
@@ -11,8 +15,8 @@ def test_dict_metadata_works():
     name = "simple"
     version = "0.1.0"
     require_a = "a==1.0"
-    require_b = "b==1.1; extra == 'also_b'"
-    requires = [require_a, require_b, "c==1.2; extra == 'also_c'"]
+    require_b = 'b==1.1; extra == "also_b"'
+    requires = [require_a, require_b, 'c==1.2; extra == "also_c"']
     extras = ["also_b", "also_c"]
     requires_python = ">=3"
 
@@ -25,21 +29,23 @@ def test_dict_metadata_works():
         metadata["Provides-Extra"] = extra
     metadata["Requires-Python"] = requires_python
 
-    inner_metadata = DictMetadata({"METADATA": metadata.as_bytes()})
-    dist = DistInfoDistribution(
-        location="<in-memory>", metadata=inner_metadata, project_name=name
+    dist = PkgResourcesDistribution(
+        DistInfoDistribution(
+            location="<in-memory>",
+            metadata=DictMetadata({"METADATA": metadata.as_bytes()}),
+            project_name=name,
+        ),
     )
 
-    assert name == dist.project_name
-    assert version == dist.version
-    assert set(extras) == set(dist.extras)
-    assert [Requirement.parse(require_a)] == dist.requires([])
-    assert [
-        Requirement.parse(require_a),
-        Requirement.parse(require_b),
-    ] == dist.requires(["also_b"])
-    assert metadata.as_string() == get_metadata(dist).as_string()
-    assert requires_python == get_requires_python(dist)
+    assert name == dist.canonical_name == dist.raw_name
+    assert parse_version(version) == dist.version
+    assert set(extras) == set(dist.iter_provided_extras())
+    assert [require_a] == [str(r) for r in dist.iter_dependencies()]
+    assert [require_a, require_b] == [
+        str(r) for r in dist.iter_dependencies(["also_b"])
+    ]
+    assert metadata.as_string() == dist.metadata.as_string()
+    assert SpecifierSet(requires_python) == dist.requires_python
 
 
 def test_dict_metadata_throws_on_bad_unicode():

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -11,7 +11,6 @@ from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.locations import get_scheme
-from pip._internal.metadata import get_wheel_distribution
 from pip._internal.models.direct_url import (
     DIRECT_URL_METADATA_NAME,
     ArchiveInfo,
@@ -96,14 +95,13 @@ def test_get_entrypoints(tmp_path, console_scripts):
         console_scripts
     )
 
-    wheel_zip = make_wheel(
+    distribution = make_wheel(
         "simple",
         "0.1.0",
         extra_metadata_files={
             "entry_points.txt": entry_points_text,
         },
-    ).save_to_dir(tmp_path)
-    distribution = get_wheel_distribution(wheel_zip, "simple")
+    ).as_distribution("simple")
 
     assert wheel.get_entrypoints(distribution) == (
         dict([console_scripts.split(" = ")]),
@@ -112,8 +110,7 @@ def test_get_entrypoints(tmp_path, console_scripts):
 
 
 def test_get_entrypoints_no_entrypoints(tmp_path):
-    wheel_zip = make_wheel("simple", "0.1.0").save_to_dir(tmp_path)
-    distribution = get_wheel_distribution(wheel_zip, "simple")
+    distribution = make_wheel("simple", "0.1.0").as_distribution("simple")
 
     console, gui = wheel.get_entrypoints(distribution)
     assert console == {}


### PR DESCRIPTION
Some compatibility hacks are needed at the boundary between resolver and preparer. The preparer's internals are pretty tangled with pkg_resources and we need to do this carefully.
