### PR TITLE
Switch install scheme backend to sysconfig

### DIFF
--- a/news/10358.removal.rst
+++ b/news/10358.removal.rst
@@ -1,0 +1,4 @@
+On Python 3.10 or later, the installation scheme backend has been changed to use
+``sysconfig``. This is to anticipate the deprecation of ``distutils`` in Python
+3.10, and its scheduled removal in 3.12. For compatibility considerations, pip
+installations running on Python 3.9 or lower will continue to use ``distutils``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ follow_imports = skip
 addopts = --ignore src/pip/_vendor --ignore tests/tests_cache -r aR --color=yes
 markers =
     network: tests that need network
+    incompatible_with_sysconfig
     incompatible_with_test_venv
     incompatible_with_venv
     no_auto_tempdir_manager

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -628,10 +628,7 @@ def _install_wheel(
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore")
                 for path in pyc_source_file_paths():
-                    # Python 2's `compileall.compile_file` requires a str in
-                    # error cases, so we must convert to the native type.
-                    path_arg = ensure_str(path, encoding=sys.getfilesystemencoding())
-                    success = compileall.compile_file(path_arg, force=True, quiet=True)
+                    success = compileall.compile_file(path, force=True, quiet=True)
                     if success:
                         pyc_path = pyc_output_path(path)
                         assert os.path.exists(pyc_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import pytest
 from setuptools.wheel import Wheel
 
 from pip._internal.cli.main import main as pip_entry_point
+from pip._internal.locations import _USE_SYSCONFIG
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from tests.lib import DATA_DIR, SRC_DIR, PipTestEnvironment, TestData
 from tests.lib.certs import make_tls_cert, serialize_cert, serialize_key
@@ -76,6 +77,9 @@ def pytest_collection_modifyitems(config, items):
             and sys.prefix != sys.base_prefix
         ):
             item.add_marker(pytest.mark.skip("Incompatible with venv"))
+
+        if item.get_closest_marker("incompatible_with_sysconfig") and _USE_SYSCONFIG:
+            item.add_marker(pytest.mark.skip("Incompatible with sysconfig"))
 
         module_path = os.path.relpath(
             item.module.__file__,

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -96,6 +96,7 @@ class TestDistutilsScheme:
             expected = os.path.join(root, path[1:])
             assert os.path.abspath(root_scheme[key]) == expected
 
+    @pytest.mark.incompatible_with_sysconfig
     @pytest.mark.incompatible_with_venv
     def test_distutils_config_file_read(self, tmpdir, monkeypatch):
         # This deals with nt/posix path differences
@@ -116,10 +117,11 @@ class TestDistutilsScheme:
         scheme = _get_scheme_dict("example")
         assert scheme["scripts"] == install_scripts
 
+    @pytest.mark.incompatible_with_sysconfig
     @pytest.mark.incompatible_with_venv
     # when we request install-lib, we should install everything (.py &
     # .so) into that path; i.e. ensure platlib & purelib are set to
-    # this path
+    # this path. sysconfig does not support this.
     def test_install_lib_takes_precedence(self, tmpdir, monkeypatch):
         # This deals with nt/posix path differences
         install_lib = os.path.normcase(

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -422,7 +422,7 @@ class TestInstallUnpackedWheel:
             self.name,
             user=False,
             home=None,
-            root=tmpdir,
+            root=str(tmpdir),  # Casting needed for CPython 3.10+. See GH-10358.
             isolated=False,
             prefix=prefix,
         )


### PR DESCRIPTION
Now we’ve weeded out (almost) all the known distutils-sysconfig inompatibilities, let’s make the switch? Installations running on Python 3.9 or lower are not affected. Only Python 3.10 and up will use sysconfig.

Right now I’m targeting 21.3 although this is a bit awkward since CPython 3.10 is scheduled to be released slightly before that. But that’s probably a good thing since we can at least be sure the pip bundled in 3.10.0 is “guaranteed” to work? We can always bundle this switch in the first 3.10.x patch release anyway.