### PR TITLE
Break up ignores for black+tests/functional/ files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,23 @@ repos:
         # Tests
         ^tests/data|
         ^tests/unit|
-        ^tests/functional/(?!test_install)|
-        ^tests/functional/test_install|
+        ^tests/functional/test_b|
+        ^tests/functional/test_c|
+        ^tests/functional/test_d|
+        ^tests/functional/test_f|
+        ^tests/functional/test_h|
+        ^tests/functional/test_index|
+        ^tests/functional/test_install_c|
+        ^tests/functional/test_install_[^c]|
+        ^tests/functional/test_install.py|
+        ^tests/functional/test_l|
+        ^tests/functional/test_n|
+        ^tests/functional/test_p|
+        ^tests/functional/test_r|
+        ^tests/functional/test_s|
+        ^tests/functional/test_u|
+        ^tests/functional/test_v|
+        ^tests/functional/test_w|
         # A blank ignore, to avoid merge conflicts later.
         ^$
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         ^src/pip/_internal/\w+\.py$|
         # Tests
         ^tests/data|
-        ^tests/unit|
+        ^tests/unit|  # TODO: we need to break this up in smaller chunks
         ^tests/functional/test_b|
         ^tests/functional/test_c|
         ^tests/functional/test_d|


### PR DESCRIPTION
The original proposal had too many files being formatted in a single go.

This should help with #10299 -- by making it possible for us to enable linting while also reformatting the files.