### PR TITLE
Tweak the news-file workflow

### DIFF
--- a/.github/workflows/news-file.yml
+++ b/.github/workflows/news-file.yml
@@ -20,6 +20,6 @@ jobs:
         if: "!contains(github.event.pull_request.labels.*.name, 'trivial')"
         run: |
           if ! pipx run towncrier check --compare-with origin/${{ github.base_ref }}; then
-            echo "Please https://pip.pypa.io/dev/news-entry-failure for guidance."
+            echo "Please see https://pip.pypa.io/dev/news-entry-failure for guidance."
             false
           fi

--- a/.github/workflows/news-file.yml
+++ b/.github/workflows/news-file.yml
@@ -15,5 +15,11 @@ jobs:
           # `towncrier check` runs `git diff --name-only origin/main...`, which
           # needs a non-shallow clone.
           fetch-depth: 0
-      - run: pipx run towncrier check --compare-with origin/${{ github.event.pull_request.base.ref }}
-        if: ${{ ! (contains(github.event.pull_request.labels.*.name, 'trivial')) }}
+
+      - name: Check news entry
+        if: "!contains(github.event.pull_request.labels.*.name, 'trivial')"
+        run: |
+          if ! pipx run towncrier check --compare-with origin/${{ github.base_ref }}; then
+            echo "Please https://pip.pypa.io/dev/news-entry-failure for guidance."
+            false
+          fi

--- a/.github/workflows/news-file.yml
+++ b/.github/workflows/news-file.yml
@@ -1,13 +1,19 @@
+name: Check
+
 on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, synchronize]
+
 jobs:
-  check-news-file:
+  check-news-entry:
+    name: news entry
     runs-on: ubuntu-20.04
+
     steps:
       - uses: actions/checkout@v2
         with:
-          # `towncrier check` needs enough history to run `git diff --name-only origin/main...`
+          # `towncrier check` runs `git diff --name-only origin/main...`, which
+          # needs a non-shallow clone.
           fetch-depth: 0
-      - run: pipx run towncrier check --compare-with origin/main
+      - run: pipx run towncrier check --compare-with origin/${{ github.event.pull_request.base.ref }}
         if: ${{ ! (contains(github.event.pull_request.labels.*.name, 'trivial')) }}


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
