### PR TITLE
Explicitly set permissions for label-merge-conflicts

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,5 +1,9 @@
 name: Autolabel merge conflicts
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Runs since merging #10363 have failed, since... well, they didn't have permissions. :)