### PR TITLE
Remove tenacity/tests from vendoring configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,6 @@ drop = [
   "setuptools",
   "pkg_resources/_vendor/",
   "pkg_resources/extern/",
-  # unneeded part for tenacity
-  "tenacity/tests",
 ]
 
 [tool.vendoring.typing-stubs]


### PR DESCRIPTION
Since upstream release 8.0.0 and change:

https://github.com/jd/tenacity/commit/d442271252b90d15a56f3fd1c622e3902fc4d3cd

the tenacity package does not include tests.
