### PR TITLE
Add a detection for Red Hat's variable replacement

### DIFF
--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -64,6 +64,8 @@ def _looks_like_bpo_44860() -> bool:
 
 def _looks_like_red_hat_patched_platlib_purelib(scheme: Dict[str, str]) -> bool:
     platlib = scheme["platlib"]
+    if "/$platlibdir/" in platlib and hasattr(sys, "platlibdir"):
+        platlib = platlib.replace("/$platlibdir/", f"/{sys.platlibdir}/")
     if "/lib64/" not in platlib:
         return False
     unpatched = platlib.replace("/lib64/", "/lib/")


### PR DESCRIPTION
To silence warning caused by [bpo-45035](https://bugs.python.org/issue45035) in 3.9.

Warning message generated: https://github.com/pypa/pip/issues/10151#issuecomment-906433374