### PR TITLE
Refactor the freeze command

### DIFF
--- a/news/10410.feature.rst
+++ b/news/10410.feature.rst
@@ -1,0 +1,3 @@
+``pip freeze`` will now always fallback to reporting the editable project
+location when it encounters a VCS error while analyzing an editable
+requirement. Before, it sometimes reported the requirement as non-editable.

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -212,7 +212,6 @@ def _get_editable_info(dist: BaseDistribution) -> _EditableInfo:
                 f"# '{ex.url}'",
             ],
         )
-
     except BadCommand:
         logger.warning(
             "cannot determine version of editable source in %s "
@@ -220,22 +219,17 @@ def _get_editable_info(dist: BaseDistribution) -> _EditableInfo:
             location,
             vcs_backend.name,
         )
-        return _EditableInfo(requirement=None, editable=True, comments=[])
-
+        return _EditableInfo(requirement=location, editable=True, comments=[])
     except InstallationError as exc:
-        logger.warning(
-            "Error when trying to get requirement for VCS system %s, "
-            "falling back to uneditable format",
-            exc,
-        )
+        logger.warning("Error when trying to get requirement for VCS system %s", exc)
     else:
         return _EditableInfo(requirement=req, editable=True, comments=[])
 
     logger.warning("Could not determine repository location of %s", location)
 
     return _EditableInfo(
-        requirement=None,
-        editable=False,
+        requirement=location,
+        editable=True,
         comments=["## !! Could not determine repository location"],
     )
 

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -232,9 +232,6 @@ class FrozenRequirement:
 
     @classmethod
     def from_dist(cls, dist: BaseDistribution) -> "FrozenRequirement":
-        # TODO `get_requirement_info` is taking care of editable requirements.
-        # TODO This should be refactored when we will add detection of
-        #      editable that provide .dist-info metadata.
         editable = dist.editable
         if editable:
             req, comments = _get_editable_info(dist)

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -1,19 +1,8 @@
 import collections
 import logging
 import os
-from typing import (
-    Container,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Set,
-    Union,
-)
+from typing import Container, Dict, Iterable, Iterator, List, NamedTuple, Optional, Set
 
-from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 
@@ -231,7 +220,7 @@ class FrozenRequirement:
     def __init__(
         self,
         name: str,
-        req: Union[str, Requirement],
+        req: str,
         editable: bool,
         comments: Iterable[str] = (),
     ) -> None:


### PR DESCRIPTION
This is a followup to and sits on top of #10249.

This slightly changes the output of pip freeze in case the detection of the VCS reference of an editable install fails.
Before it returned a non editable requirement in some VCS error situations.
Now it always returns an editable requirement, but pointing to the local directory when the VCS could not be determined for any reason.

This is more consistent, avoids information loss, and greatly simplifies the logic.
