### PR TITLE
Remove unused method ConfigurationMixin.get_file_contents()

### DIFF
--- a/tests/lib/configuration_helpers.py
+++ b/tests/lib/configuration_helpers.py
@@ -46,8 +46,3 @@ class ConfigurationMixin:
         yield path
 
         os.remove(path)
-
-    @staticmethod
-    def get_file_contents(path):
-        with open(path) as f:
-            return f.read()


### PR DESCRIPTION
Unused since its introduction in
f9990605dc580ad775a1d40852442040bdfb0ba1.
