### PR TITLE
Detect indented ERROR and WARNING messages in tests and ignore own deprecation warnings

### DIFF
--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1116,9 +1116,17 @@ def test_download_file_url_existing_bad_download(
     simple_pkg_bytes = simple_pkg.read_bytes()
     url = f"{simple_pkg.as_uri()}#sha256={sha256(simple_pkg_bytes).hexdigest()}"
 
-    shared_script.pip("download", "-d", str(download_dir), url)
+    result = shared_script.pip(
+        "download",
+        "-d",
+        str(download_dir),
+        url,
+        allow_stderr_warning=True,  # bad hash
+    )
 
     assert simple_pkg_bytes == downloaded_path.read_bytes()
+    assert "WARNING: Previously-downloaded file" in result.stderr
+    assert "has bad hash. Re-downloading." in result.stderr
 
 
 def test_download_http_url_bad_hash(
@@ -1144,9 +1152,17 @@ def test_download_http_url_bad_hash(
     base_address = f"http://{mock_server.host}:{mock_server.port}"
     url = f"{base_address}/simple-1.0.tar.gz#sha256={digest}"
 
-    shared_script.pip("download", "-d", str(download_dir), url)
+    result = shared_script.pip(
+        "download",
+        "-d",
+        str(download_dir),
+        url,
+        allow_stderr_warning=True,  # bad hash
+    )
 
     assert simple_pkg_bytes == downloaded_path.read_bytes()
+    assert "WARNING: Previously-downloaded file" in result.stderr
+    assert "has bad hash. Re-downloading." in result.stderr
 
     mock_server.stop()
     requests = mock_server.get_requests()

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -94,7 +94,7 @@ def _install_version_pkg_only(
     script: PipTestEnvironment,
     path: Path,
     rev: Optional[str] = None,
-    expect_stderr: bool = False,
+    allow_stderr_warning: bool = False,
 ) -> None:
     """
     Install the version_pkg package in editable mode (without returning
@@ -106,14 +106,16 @@ def _install_version_pkg_only(
       rev: an optional revision to install like a branch name or tag.
     """
     version_pkg_url = _make_version_pkg_url(path, rev=rev)
-    script.pip("install", "-e", version_pkg_url, expect_stderr=expect_stderr)
+    script.pip(
+        "install", "-e", version_pkg_url, allow_stderr_warning=allow_stderr_warning
+    )
 
 
 def _install_version_pkg(
     script: PipTestEnvironment,
     path: Path,
     rev: Optional[str] = None,
-    expect_stderr: bool = False,
+    allow_stderr_warning: bool = False,
 ) -> str:
     """
     Install the version_pkg package in editable mode, and return the version
@@ -128,7 +130,7 @@ def _install_version_pkg(
         script,
         path,
         rev=rev,
-        expect_stderr=expect_stderr,
+        allow_stderr_warning=allow_stderr_warning,
     )
     result = script.run("version_pkg")
     version = result.stdout.strip()
@@ -227,7 +229,13 @@ def test_git_with_short_sha1_revisions(script: PipTestEnvironment) -> None:
         "HEAD~1",
         cwd=version_pkg_path,
     ).stdout.strip()[:7]
-    version = _install_version_pkg(script, version_pkg_path, rev=sha1)
+    version = _install_version_pkg(
+        script,
+        version_pkg_path,
+        rev=sha1,
+        # WARNING: Did not find branch or tag ..., assuming revision or ref.
+        allow_stderr_warning=True,
+    )
     assert "0.1" == version
 
 
@@ -273,6 +281,8 @@ def test_git_install_ref(script: PipTestEnvironment) -> None:
         script,
         version_pkg_path,
         rev="refs/foo/bar",
+        # WARNING: Did not find branch or tag ..., assuming revision or ref.
+        allow_stderr_warning=True,
     )
     assert "0.1" == version
 
@@ -294,6 +304,8 @@ def test_git_install_then_install_ref(script: PipTestEnvironment) -> None:
         script,
         version_pkg_path,
         rev="refs/foo/bar",
+        # WARNING: Did not find branch or tag ..., assuming revision or ref.
+        allow_stderr_warning=True,
     )
     assert "0.1" == version
 

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -684,7 +684,7 @@ def test_uninstall_editable_and_pip_install_easy_install_remove(
     os.remove(pip_test_fspkg_pth)
 
     # Uninstall will fail with given warning
-    uninstall = script.pip("uninstall", "FSPkg", "-y")
+    uninstall = script.pip("uninstall", "FSPkg", "-y", allow_stderr_warning=True)
     assert "Cannot remove entries from nonexistent file" in uninstall.stderr
 
     assert (

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -447,6 +447,7 @@ def _check_stderr(
 
     lines = stderr.splitlines()
     for line in lines:
+        line = line.lstrip()
         # First check for logging errors, which we don't allow during
         # tests even if allow_stderr_error=True (since a logging error
         # would signal a bug in pip's code).

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -39,7 +39,6 @@ from pip._internal.models.search_scope import SearchScope
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
-from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
 from tests.lib.venv import VirtualEnvironment
 from tests.lib.wheel import make_wheel
 
@@ -474,7 +473,7 @@ def _check_stderr(
         if allow_stderr_warning:
             continue
 
-        if line.startswith("WARNING: ") or line.startswith(DEPRECATION_MSG_PREFIX):
+        if line.startswith("WARNING: "):
             reason = (
                 "stderr has an unexpected warning "
                 "(pass allow_stderr_warning=True to permit this)"

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -150,7 +150,6 @@ class TestPipTestEnvironment:
     @pytest.mark.parametrize(
         "prefix",
         (
-            "DEPRECATION",
             "WARNING",
             "ERROR",
         ),
@@ -167,7 +166,6 @@ class TestPipTestEnvironment:
     @pytest.mark.parametrize(
         "prefix, expected_start",
         (
-            ("DEPRECATION", "stderr has an unexpected warning"),
             ("WARNING", "stderr has an unexpected warning"),
             ("ERROR", "stderr has an unexpected error"),
         ),


### PR DESCRIPTION
While trying to write a test that failed on a WARNING message, I discovered that `script.pip(allows_stderr_warning=False)` does not detect indented warnings.

So let us see what happens when we make it detect that.