### PR TITLE
configuration: Add back load_file verbose log instead of debug one

### DIFF
--- a/news/10418.trivial.rst
+++ b/news/10418.trivial.rst
@@ -1,0 +1,1 @@
+Make _load_file log become verbose instead of debug.

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -13,7 +13,6 @@ Some terminology:
 
 import configparser
 import locale
-import logging
 import os
 import sys
 from typing import Any, Dict, Iterable, List, NewType, Optional, Tuple
@@ -24,6 +23,7 @@ from pip._internal.exceptions import (
 )
 from pip._internal.utils import appdirs
 from pip._internal.utils.compat import WINDOWS
+from pip._internal.utils.logging import getLogger
 from pip._internal.utils.misc import ensure_dir, enum
 
 RawConfigParser = configparser.RawConfigParser  # Shorthand
@@ -43,7 +43,7 @@ kinds = enum(
 OVERRIDE_ORDER = kinds.GLOBAL, kinds.USER, kinds.SITE, kinds.ENV, kinds.ENV_VAR
 VALID_LOAD_ONLY = kinds.USER, kinds.GLOBAL, kinds.SITE
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 # NOTE: Maybe use the optionx attribute to normalize keynames.
@@ -250,7 +250,7 @@ class Configuration:
                 self._parsers[variant].append((fname, parser))
 
     def _load_file(self, variant: Kind, fname: str) -> RawConfigParser:
-        logger.debug("For variant '%s', will try loading '%s'", variant, fname)
+        logger.verbose("For variant '%s', will try loading '%s'", variant, fname)
         parser = self._construct_parser(fname)
 
         for section in parser.sections():


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Closes #10268
