### PR TITLE
Added an explicit warning on parsing git version failure

### DIFF
--- a/news/10361.trivial.rst
+++ b/news/10361.trivial.rst
@@ -1,0 +1,1 @@
+Added an explicit warning when pip is unable to parse git version.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -94,6 +94,7 @@ class Git(VersionControl):
         version = self.run_command(["version"], show_stdout=False, stdout_only=True)
         match = GIT_VERSION_REGEX.match(version)
         if not match:
+            logger.warning("Can't parse git version: %s", version)
             return ()
         return tuple(int(c) for c in match.groups())
 


### PR DESCRIPTION
There is not enough visibility in case we fail to parse a git version. Adding an explicit logging here to facilitate debug should the parsing fail.

This addresses #10361