### PR TITLE
Sort `Requires` and `Required-By` fields for `pip show`

### DIFF
--- a/news/10422.feature.rst
+++ b/news/10422.feature.rst
@@ -1,0 +1,1 @@
+``pip show`` now sorts ``Requires`` and ``Required-By`` alphabetically.

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -113,13 +113,13 @@ def search_packages_info(query: List[str]) -> Iterator[_PackageInfo]:
     if missing:
         logger.warning("Package(s) not found: %s", ", ".join(missing))
 
-    def _get_requiring_packages(current_dist: BaseDistribution) -> List[str]:
-        return [
+    def _get_requiring_packages(current_dist: BaseDistribution) -> Iterator[str]:
+        return (
             dist.metadata["Name"] or "UNKNOWN"
             for dist in installed.values()
             if current_dist.canonical_name
             in {canonicalize_name(d.name) for d in dist.iter_dependencies()}
-        ]
+        )
 
     def _files_from_record(dist: BaseDistribution) -> Optional[Iterator[str]]:
         try:

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -155,10 +155,8 @@ def search_packages_info(query: List[str]) -> Iterator[_PackageInfo]:
         except KeyError:
             continue
 
-        requires = sorted(
-            (req.name for req in dist.iter_dependencies()), key=lambda pkg: pkg.lower()
-        )
-        required_by = sorted(_get_requiring_packages(dist), key=lambda pkg: pkg.lower())
+        requires = sorted((req.name for req in dist.iter_dependencies()), key=str.lower)
+        required_by = sorted(_get_requiring_packages(dist), key=str.lower)
 
         try:
             entry_points_text = dist.read_text("entry_points.txt")

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -155,6 +155,11 @@ def search_packages_info(query: List[str]) -> Iterator[_PackageInfo]:
         except KeyError:
             continue
 
+        requires = sorted(
+            (req.name for req in dist.iter_dependencies()), key=lambda pkg: pkg.lower()
+        )
+        required_by = sorted(_get_requiring_packages(dist), key=lambda pkg: pkg.lower())
+
         try:
             entry_points_text = dist.read_text("entry_points.txt")
             entry_points = entry_points_text.splitlines(keepends=False)
@@ -173,8 +178,8 @@ def search_packages_info(query: List[str]) -> Iterator[_PackageInfo]:
             name=dist.raw_name,
             version=str(dist.version),
             location=dist.location or "",
-            requires=[req.name for req in dist.iter_dependencies()],
-            required_by=_get_requiring_packages(dist),
+            requires=requires,
+            required_by=required_by,
             installer=dist.installer,
             metadata_version=dist.metadata_version or "",
             classifiers=metadata.get_all("Classifier", []),


### PR DESCRIPTION
I have noticed that when running `pip show`, `Requires` has a non-deterministic order across runs and `Required-By` has deterministic order but without any clear logic behind the order. I propose that we change this to improve readability. This was first a problem for me when it made comparing the results of `pip show` across environments more difficult than a simple diff.

Of the three other `List` fields, one (`Files`) is already being sorted, so this change does not seem out-of-place. The remaining other fields (`Classfiers` and `Entry-points`) are not sorted in `pip show`, but they might be sorted elsewhere or are intentionally left unsorted, so I did not touch them.

I sort the packages case-insensitively to match the logic in `pip list` and `pip freeze`.

This seems like a `trivial` change to me, but if you think this requires further discussion, I can make an issue for it.
