### PR TITLE
CI: Only label merge conflicts on upstream

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   label-merge-conflicts:
+    if: github.repository_owner == 'pypa'
     runs-on: ubuntu-latest
     steps:
       - uses: pradyunsg/auto-label-merge-conflicts@v3


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Skip this action for forks because it fails:

`Error: "needs rebase or merge" label not found in your repository!`

https://github.com/hugovk/pip/runs/3504331622?check_suite_focus=true