### PR TITLE
Replace use of pretend library with unitest.mock in tests

### DIFF
--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -59,9 +59,9 @@ You can then invoke your local source tree pip normally.
 Running Tests
 =============
 
-pip's tests are written using the :pypi:`pytest` test framework, :pypi:`mock`
-and :pypi:`pretend`. :pypi:`tox` is used to automate the setup and execution of
-pip's tests.
+pip's tests are written using the :pypi:`pytest` test framework and
+:mod:`unittest.mock`. :pypi:`tox` is used to automate the setup and execution
+of pip's tests.
 
 It is preferable to run the tests in parallel for better experience during development,
 since the tests can take a long time to finish when run sequentially.

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -1,6 +1,6 @@
 import logging
+from unittest import mock
 
-import pretend
 import pytest
 
 from pip._internal.cli.status_codes import NO_MATCHES_FOUND, SUCCESS
@@ -156,18 +156,18 @@ def test_latest_prerelease_install_message(caplog, monkeypatch):
         }
     ]
 
-    installed_package = pretend.stub(project_name="ni")
+    installed_package = mock.Mock(project_name="ni")
     monkeypatch.setattr("pip._vendor.pkg_resources.working_set", [installed_package])
 
-    dist = pretend.stub(version="1.0.0")
-    get_dist = pretend.call_recorder(lambda x: dist)
+    get_dist = mock.Mock()
+    get_dist.return_value = mock.Mock(version="1.0.0")
     monkeypatch.setattr("pip._internal.commands.search.get_distribution", get_dist)
     with caplog.at_level(logging.INFO):
         print_results(hits)
 
     message = caplog.records[-1].getMessage()
     assert 'pre-release; install with "pip install --pre"' in message
-    assert get_dist.calls == [pretend.call("ni")]
+    assert get_dist.call_args_list == [mock.call("ni")]
 
 
 @pytest.mark.search

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -4,8 +4,8 @@ import sys
 import textwrap
 from os.path import join, normpath
 from tempfile import mkdtemp
+from unittest.mock import Mock
 
-import pretend
 import pytest
 
 from pip._internal.req.constructors import install_req_from_line
@@ -467,14 +467,13 @@ def test_uninstall_non_local_distutils(caplog, monkeypatch, tmpdir):
     with open(einfo, "wb"):
         pass
 
-    dist = pretend.stub(
+    get_dist = Mock()
+    get_dist.return_value = Mock(
         key="thing",
         project_name="thing",
         egg_info=einfo,
         location=einfo,
-        _provider=pretend.stub(),
     )
-    get_dist = pretend.call_recorder(lambda x: dist)
     monkeypatch.setattr("pip._vendor.pkg_resources.get_distribution", get_dist)
 
     req = install_req_from_line("thing")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,5 @@
 cryptography
 freezegun
-pretend
 pytest
 pytest-cov
 pytest-rerunfailures

--- a/tests/unit/test_appdirs.py
+++ b/tests/unit/test_appdirs.py
@@ -2,8 +2,8 @@ import ntpath
 import os
 import posixpath
 import sys
+from unittest import mock
 
-import pretend
 from pip._vendor import appdirs as _appdirs
 
 from pip._internal.utils import appdirs
@@ -11,9 +11,7 @@ from pip._internal.utils import appdirs
 
 class TestUserCacheDir:
     def test_user_cache_dir_win(self, monkeypatch):
-        @pretend.call_recorder
-        def _get_win_folder(base):
-            return "C:\\Users\\test\\AppData\\Local"
+        _get_win_folder = mock.Mock(return_value="C:\\Users\\test\\AppData\\Local")
 
         monkeypatch.setattr(
             _appdirs,
@@ -28,7 +26,7 @@ class TestUserCacheDir:
             appdirs.user_cache_dir("pip")
             == "C:\\Users\\test\\AppData\\Local\\pip\\Cache"
         )
-        assert _get_win_folder.calls == [pretend.call("CSIDL_LOCAL_APPDATA")]
+        assert _get_win_folder.call_args_list == [mock.call("CSIDL_LOCAL_APPDATA")]
 
     def test_user_cache_dir_osx(self, monkeypatch):
         monkeypatch.setattr(_appdirs, "system", "darwin")
@@ -89,9 +87,7 @@ class TestUserCacheDir:
 
 class TestSiteConfigDirs:
     def test_site_config_dirs_win(self, monkeypatch):
-        @pretend.call_recorder
-        def _get_win_folder(base):
-            return "C:\\ProgramData"
+        _get_win_folder = mock.Mock(return_value="C:\\ProgramData")
 
         monkeypatch.setattr(
             _appdirs,
@@ -103,7 +99,7 @@ class TestSiteConfigDirs:
         monkeypatch.setattr(os, "path", ntpath)
 
         assert appdirs.site_config_dirs("pip") == ["C:\\ProgramData\\pip"]
-        assert _get_win_folder.calls == [pretend.call("CSIDL_COMMON_APPDATA")]
+        assert _get_win_folder.call_args_list == [mock.call("CSIDL_COMMON_APPDATA")]
 
     def test_site_config_dirs_osx(self, monkeypatch):
         monkeypatch.setattr(_appdirs, "system", "darwin")
@@ -146,9 +142,7 @@ class TestSiteConfigDirs:
 
 class TestUserConfigDir:
     def test_user_config_dir_win_no_roaming(self, monkeypatch):
-        @pretend.call_recorder
-        def _get_win_folder(base):
-            return "C:\\Users\\test\\AppData\\Local"
+        _get_win_folder = mock.Mock(return_value="C:\\Users\\test\\AppData\\Local")
 
         monkeypatch.setattr(
             _appdirs,
@@ -163,12 +157,10 @@ class TestUserConfigDir:
             appdirs.user_config_dir("pip", roaming=False)
             == "C:\\Users\\test\\AppData\\Local\\pip"
         )
-        assert _get_win_folder.calls == [pretend.call("CSIDL_LOCAL_APPDATA")]
+        assert _get_win_folder.call_args_list == [mock.call("CSIDL_LOCAL_APPDATA")]
 
     def test_user_config_dir_win_yes_roaming(self, monkeypatch):
-        @pretend.call_recorder
-        def _get_win_folder(base):
-            return "C:\\Users\\test\\AppData\\Roaming"
+        _get_win_folder = mock.Mock(return_value="C:\\Users\\test\\AppData\\Roaming")
 
         monkeypatch.setattr(
             _appdirs,
@@ -182,7 +174,7 @@ class TestUserConfigDir:
         assert (
             appdirs.user_config_dir("pip") == "C:\\Users\\test\\AppData\\Roaming\\pip"
         )
-        assert _get_win_folder.calls == [pretend.call("CSIDL_APPDATA")]
+        assert _get_win_folder.call_args_list == [mock.call("CSIDL_APPDATA")]
 
     def test_user_config_dir_osx(self, monkeypatch):
         monkeypatch.setattr(_appdirs, "system", "darwin")

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -8,7 +8,6 @@ from textwrap import dedent
 from unittest import mock
 from unittest.mock import Mock, patch
 
-import pretend
 import pytest
 from pip._vendor import html5lib, requests
 
@@ -518,7 +517,7 @@ def test_request_retries(caplog):
 
 def test_make_html_page():
     headers = {"Content-Type": "text/html; charset=UTF-8"}
-    response = pretend.stub(
+    response = Mock(
         content=b"<content>",
         url="https://example.com/index.html",
         headers=headers,
@@ -604,7 +603,7 @@ def make_fake_html_response(url):
     """
     )
     content = html.encode("utf-8")
-    return pretend.stub(content=content, url=url, headers={})
+    return Mock(content=content, url=url, headers={})
 
 
 def test_get_html_page_directory_append_index(tmpdir):
@@ -636,8 +635,8 @@ def test_collect_sources__file_expand_dir(data):
     Test that a file:// dir from --find-links becomes _FlatDirectorySource
     """
     collector = LinkCollector.create(
-        session=pretend.stub(is_secure_origin=None),  # Shouldn't be used.
-        options=pretend.stub(
+        session=Mock(is_secure_origin=None),  # Shouldn't be used.
+        options=Mock(
             index_url="ignored-by-no-index",
             extra_index_urls=[],
             no_index=True,
@@ -664,8 +663,8 @@ def test_collect_sources__file_not_find_link(data):
     run
     """
     collector = LinkCollector.create(
-        session=pretend.stub(is_secure_origin=None),  # Shouldn't be used.
-        options=pretend.stub(
+        session=Mock(is_secure_origin=None),  # Shouldn't be used.
+        options=Mock(
             index_url=data.index_url("empty_with_pkg"),
             extra_index_urls=[],
             no_index=False,
@@ -688,8 +687,8 @@ def test_collect_sources__non_existing_path():
     Test that a non-existing path is ignored.
     """
     collector = LinkCollector.create(
-        session=pretend.stub(is_secure_origin=None),  # Shouldn't be used.
-        options=pretend.stub(
+        session=Mock(is_secure_origin=None),  # Shouldn't be used.
+        options=Mock(
             index_url="ignored-by-no-index",
             extra_index_urls=[],
             no_index=True,
@@ -810,7 +809,7 @@ def test_link_collector_create(
     """
     expected_find_links, expected_index_urls = expected
     session = PipSession()
-    options = pretend.stub(
+    options = Mock(
         find_links=find_links,
         index_url="default_url",
         extra_index_urls=["url1", "url2"],
@@ -846,7 +845,7 @@ def test_link_collector_create_find_links_expansion(
     mock_expanduser.side_effect = expand_path
 
     session = PipSession()
-    options = pretend.stub(
+    options = Mock(
         find_links=["~/temp1", "~/temp2"],
         index_url="default_url",
         extra_index_urls=[],

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -3,10 +3,9 @@ import logging
 import os
 import subprocess
 import textwrap
-from unittest.mock import patch
+from unittest import mock
 
 import pytest
-from pretend import stub
 
 import pip._internal.req.req_file  # this will be monkeypatched
 from pip._internal.exceptions import InstallationError, RequirementsFileParseError
@@ -39,7 +38,7 @@ def finder(session):
 
 @pytest.fixture
 def options(session):
-    return stub(
+    return mock.Mock(
         isolated_mode=False,
         index_url="default_url",
         format_control=FormatControl(set(), set()),
@@ -614,7 +613,7 @@ class TestParseRequirements:
         # Construct the session outside the monkey-patch, since it access the
         # env
         session = PipSession()
-        with patch("pip._internal.req.req_file.os.getenv") as getenv:
+        with mock.patch("pip._internal.req.req_file.os.getenv") as getenv:
             getenv.side_effect = lambda n: env_vars[n]
 
             reqs = list(
@@ -640,7 +639,7 @@ class TestParseRequirements:
         # Construct the session outside the monkey-patch, since it access the
         # env
         session = PipSession()
-        with patch("pip._internal.req.req_file.os.getenv") as getenv:
+        with mock.patch("pip._internal.req.req_file.os.getenv") as getenv:
             getenv.return_value = ""
 
             reqs = list(
@@ -761,7 +760,7 @@ class TestParseRequirements:
             )
 
         req.source_dir = os.curdir
-        with patch.object(subprocess, "Popen") as popen:
+        with mock.patch.object(subprocess, "Popen") as popen:
             popen.return_value.stdout.readline.return_value = b""
             try:
                 req.install([])


### PR DESCRIPTION
The pretend library was used by very few tests. In all cases, it is
simple enough to switch to stdlib unitest.mock.

Using stdlib means there is one fewer library to install before running
tests. It can also simplify mypy usage via typeshed.