### PR TITLE
Set TestData.__test__ to False to avoid pytest discovery

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -150,6 +150,8 @@ class TestData:
     data into a directory and operating on the copied data.
     """
 
+    __test__ = False
+
     def __init__(self, root, source=None):
         self.source = source or DATA_DIR
         self.root = Path(root).resolve()


### PR DESCRIPTION
As the class name starts with "Test", pytest interprets it as a test
case, but it is not one. Further, due to its `__init__` method, pytest
emits the following warning:

    .../pip/tests/lib/__init__.py:141: PytestCollectionWarning: cannot
    collect test class 'TestData' because it has a __init__ constructor

For additional information on pytest discovery, see:
https://docs.pytest.org/en/latest/example/pythoncollection.html