### PR TITLE
Remove unconditionally skipped test (fails if skip removed)

### DIFF
--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -4,8 +4,6 @@
 import re
 import textwrap
 
-import pytest
-
 from pip._internal.cli.status_codes import ERROR
 from pip._internal.configuration import CONFIG_BASENAME, get_configuration_files
 from tests.lib.configuration_helpers import ConfigurationMixin, kinds
@@ -17,18 +15,6 @@ def test_no_options_passed_should_error(script):
 
 
 class TestBasicLoading(ConfigurationMixin):
-    @pytest.mark.skip("Can't modify underlying file for any mode")
-    def test_reads_file_appropriately(self, script):
-        contents = """
-            [test]
-            hello = 1
-        """
-
-        with self.patched_file(kinds.USER, contents):
-            result = script.pip("config", "list")
-
-        assert "test.hello=1" in result.stdout
-
     def test_basic_modification_pipeline(self, script):
         script.pip("config", "get", "test.blah", expect_error=True)
         script.pip("config", "set", "test.blah", "1")


### PR DESCRIPTION
The test was introduced in f9990605dc580ad775a1d40852442040bdfb0ba1 (May
2017) and was unconditionally skipped in
6cf5d7db54ee272fa9af66d45a504d5994693ae4. It remains skipped to this
day.

In commit bd850c079851d5458e4af82921739666545b6170, the patched_file
method was removed/renamed. So even if the skip were removed, it would
fail on the undefined attribute.

This was caught via mypy which emits an error due to the missing method.