### PR TITLE
Fix failing test due to removed setuptools feature, use_2to3

### DIFF
--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -62,7 +62,7 @@ def test_requirements_file(script, with_wheel):
     Test installing from a requirements file.
 
     """
-    other_lib_name, other_lib_version = "anyjson", "0.3"
+    other_lib_name, other_lib_version = "peppercorn", "0.6"
     script.scratch_path.joinpath("initools-req.txt").write_text(
         textwrap.dedent(
             f"""\
@@ -157,7 +157,7 @@ def test_multiple_requirements_files(script, tmpdir, with_wheel):
     Test installing from multiple nested requirements files.
 
     """
-    other_lib_name, other_lib_version = "anyjson", "0.3"
+    other_lib_name, other_lib_version = "six", "1.16.0"
     script.scratch_path.joinpath("initools-req.txt").write_text(
         textwrap.dedent(
             """


### PR DESCRIPTION
setuptools removed use_2to3 in version v58.0.1 (2021-09-06). Some tests
install the anyjson package which uses this feature and so those tests
result in a command failure. The failure appeared as:

    error in anyjson setup command: use_2to3 is invalid.

As anyjson package is no longer maintained (last release was 2012),
change the tests to use a package that is healthy.

For details on the setuptools change, see the history at:

https://setuptools.readthedocs.io/en/latest/history.html#v58-0-2