### PR TITLE
Fix  "Permission denied"/"Access refused" error when installing or updating packages (solves #9527, #9566, #9395)

### DIFF
--- a/news/10454.bugfix.rst
+++ b/news/10454.bugfix.rst
@@ -1,0 +1,1 @@
+Fix "Permission denied" error when installing or updating packages.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -666,9 +666,9 @@ def decide_user_install(
 	# Assert user installs are enabled
     if not site.ENABLE_USER_SITE:
         raise InstallationError(
-                "Can not perform a '--user' install. User site-packages "
-                "are disabled. Enable user site-packages or run "
-				"installation with privileged access."
+                "Can not perform user install because user site-packages "
+                "are disabled. Enable them or run "
+		"installation with privileged access."
             )
 	
     return True

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -652,11 +652,6 @@ def decide_user_install(
         logger.debug("Non-user install due to --prefix or --target option")
         return False
 
-    # If user installs are not enabled, choose a non-user install
-    if not site.ENABLE_USER_SITE:
-        logger.debug("Non-user install because user site-packages disabled")
-        return False
-
     # If we have permission for a non-user install, do that,
     # otherwise do a user install.
     if site_packages_writable(root=root_path, isolated=isolated_mode):
@@ -667,6 +662,15 @@ def decide_user_install(
         "Defaulting to user installation because normal site-packages "
         "is not writeable"
     )
+	
+	# Assert user installs are enabled
+    if not site.ENABLE_USER_SITE:
+        raise InstallationError(
+                "Can not perform a '--user' install. User site-packages "
+                "are disabled. Enable user site-packages or run "
+				"installation with privileged access."
+            )
+	
     return True
 
 


### PR DESCRIPTION
Add check for write permissions for non user installs.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
