### PR TITLE
Install pytest in mypy environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
     additional_dependencies: [
         'keyring==23.0.1',
         'nox==2021.6.12',
+        'pytest==6.2.5',
         'types-docutils==0.1.8',
         'types-setuptools==57.0.2',
         'types-six==0.1.9',

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -1,18 +1,18 @@
 import pytest
 
 
-@pytest.mark.skipif
+@pytest.mark.network
 def test_timeout(script):
     result = script.pip(
         "--timeout",
-        "0.01",
+        "0.001",
         "install",
         "-vvv",
         "INITools",
         expect_error=True,
     )
     assert (
-        "Could not fetch URL https://pypi.org/simple/INITools/: "
-        "timed out" in result.stdout
-    )
-    assert "Could not fetch URL https://pypi.org/simple/: timed out" in result.stdout
+        "Could not fetch URL https://pypi.org/simple/initools/: "
+        "connection error: HTTPSConnectionPool(host='pypi.org', port=443): "
+        "Max retries exceeded with url: /simple/initools/ "
+    ) in result.stdout


### PR DESCRIPTION
pytest includes type annotations and is PEP-561 compliant. This helps
ensure correct pytest API usage.

This caught a misuse of pytest.mark.skipif which did not include a
boolean argument. The test is now marked "network" and no longer
skipped.