### PR TITLE
Bump to vendoring 1.0.x

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -171,7 +171,7 @@ def lint(session: nox.Session) -> None:
 
 @nox.session
 def vendoring(session: nox.Session) -> None:
-    session.install("vendoring>=0.3.0")
+    session.install("vendoring~=1.0.0")
 
     if "--upgrade" not in session.posargs:
         session.run("vendoring", "sync", ".", "-v")

--- a/src/pip/_vendor/idna.pyi
+++ b/src/pip/_vendor/idna.pyi
@@ -1,1 +1,0 @@
-from idna import *

--- a/src/pip/_vendor/packaging.pyi
+++ b/src/pip/_vendor/packaging.pyi
@@ -1,1 +1,0 @@
-from packaging import *

--- a/src/pip/_vendor/resolvelib.pyi
+++ b/src/pip/_vendor/resolvelib.pyi
@@ -1,1 +1,0 @@
-from resolvelib import *

--- a/src/pip/_vendor/tenacity.pyi
+++ b/src/pip/_vendor/tenacity.pyi
@@ -1,1 +1,0 @@
-from tenacity import *

--- a/src/pip/_vendor/tomli.pyi
+++ b/src/pip/_vendor/tomli.pyi
@@ -1,1 +1,0 @@
-from tomli import *

--- a/src/pip/_vendor/urllib3/contrib/pyopenssl.py
+++ b/src/pip/_vendor/urllib3/contrib/pyopenssl.py
@@ -28,8 +28,8 @@ like this:
 .. code-block:: python
 
     try:
-        import urllib3.contrib.pyopenssl
-        urllib3.contrib.pyopenssl.inject_into_urllib3()
+        import pip._vendor.urllib3.contrib.pyopenssl as pyopenssl
+        pyopenssl.inject_into_urllib3()
     except ImportError:
         pass
 

--- a/src/pip/_vendor/urllib3/contrib/securetransport.py
+++ b/src/pip/_vendor/urllib3/contrib/securetransport.py
@@ -19,8 +19,8 @@ contrib module. So...here we are.
 
 To use this module, simply import and inject it::
 
-    import urllib3.contrib.securetransport
-    urllib3.contrib.securetransport.inject_into_urllib3()
+    import pip._vendor.urllib3.contrib.securetransport as securetransport
+    securetransport.inject_into_urllib3()
 
 Happy TLSing!
 

--- a/tools/vendoring/patches/requests.patch
+++ b/tools/vendoring/patches/requests.patch
@@ -6,7 +6,7 @@ index 0f8ae0d38..9582fa730 100644
  import sys
 
 -try:
--    from pip._vendor import chardet
+-    import chardet
 -except ImportError:
 -    import charset_normalizer as chardet
 -    import warnings
@@ -40,7 +40,7 @@ diff --git a/src/pip/_vendor/requests/__init__.py b/src/pip/_vendor/requests/__i
 index 973497f5e..4f80e28fc 100644
 --- a/src/pip/_vendor/requests/__init__.py
 +++ b/src/pip/_vendor/requests/__init__.py
-@@ -44,10 +44,7 @@ from pip._vendor import urllib3
+@@ -44,10 +44,7 @@ import urllib3
  import warnings
  from .exceptions import RequestsDependencyWarning
 
@@ -51,7 +51,7 @@ index 973497f5e..4f80e28fc 100644
 +charset_normalizer_version = None
 
  try:
-     from pip._vendor.chardet import __version__ as chardet_version
+     from chardet import __version__ as chardet_version
 @@ -107,6 +104,11 @@ except (AssertionError, ValueError):
  # if the standard library doesn't support SNI or the
  # 'ssl' library isn't available.
@@ -74,10 +74,10 @@ index 409b7b028..9e2937167 100644
  """
 
 -try:
--    from pip._vendor import chardet
+-    import chardet
 -except ImportError:
 -    import charset_normalizer as chardet
-+from pip._vendor import chardet
++import chardet
 
  import sys
 
@@ -105,7 +105,7 @@ diff --git a/src/pip/_vendor/requests/help.py b/src/pip/_vendor/requests/help.py
 index 3a843404c..745f0d7b3 100644
 --- a/src/pip/_vendor/requests/help.py
 +++ b/src/pip/_vendor/requests/help.py
-@@ -11,10 +11,7 @@ from pip._vendor import urllib3
+@@ -11,10 +11,7 @@ import urllib3
 
  from . import __version__ as requests_version
 
@@ -116,4 +116,4 @@ index 3a843404c..745f0d7b3 100644
 +charset_normalizer = None
 
  try:
-     from pip._vendor import chardet
+     import chardet

--- a/tools/vendoring/patches/urllib3.patch
+++ b/tools/vendoring/patches/urllib3.patch
@@ -1,0 +1,29 @@
+diff --git a/src/pip/_vendor/urllib3/contrib/securetransport.py b/src/pip/_vendor/urllib3/contrib/securetransport.py
+index b97555454..189132baa 100644
+--- a/src/pip/_vendor/urllib3/contrib/securetransport.py
++++ b/src/pip/_vendor/urllib3/contrib/securetransport.py
+@@ -19,8 +19,8 @@
+
+ To use this module, simply import and inject it::
+
+-    import urllib3.contrib.securetransport
+-    urllib3.contrib.securetransport.inject_into_urllib3()
++    import urllib3.contrib.securetransport as securetransport
++    securetransport.inject_into_urllib3()
+
+ Happy TLSing!
+
+diff --git a/src/pip/_vendor/urllib3/contrib/pyopenssl.py b/src/pip/_vendor/urllib3/contrib/pyopenssl.py
+index c43146279..4cded53f6 100644
+--- a/src/pip/_vendor/urllib3/contrib/pyopenssl.py
++++ b/src/pip/_vendor/urllib3/contrib/pyopenssl.py
+@@ -28,7 +28,7 @@
+ .. code-block:: python
+
+     try:
+-        import urllib3.contrib.pyopenssl
+-        urllib3.contrib.pyopenssl.inject_into_urllib3()
++        import urllib3.contrib.pyopenssl as pyopenssl
++        pyopenssl.inject_into_urllib3()
+     except ImportError:
+         pass

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ basepython = python3
 skip_install = True
 commands_pre =
 deps =
-    vendoring~=0.3.3
+    vendoring~=1.0.0
     # Required, otherwise we interpret --no-binary :all: as
     # "do not build wheels", which fails for PEP 517 requirements
     pip>=19.3.1


### PR DESCRIPTION
This now supports:

- Clearer failure mode, for imports of the format `import x.y`
- Regular expression support for dropping files (useful for when we vendor pygments)
- Patching files prior to rewriting imports, allowing generation of patches on the
  original package sources.
- Detection of py.typed files, which omits generation of unnecessary `.pyi` stubs.

Broken out of #10462