### PR TITLE
Simplify vendoring configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ distro = []
 
 [tool.vendoring.license.directories]
 setuptools = "pkg_resources"
-msgpack-python = "msgpack"
 
 [tool.vendoring.license.fallback-urls]
-pytoml = "https://github.com/avakar/pytoml/raw/master/LICENSE"
-resolvelib = "https://github.com/sarugaku/resolvelib/raw/master/LICENSE"
 webencodings = "https://github.com/SimonSapin/python-webencodings/raw/master/LICENSE"


### PR DESCRIPTION
The msgpack-python was replaced by msgpack. This removes the need to
special case its directory.

The pytoml library is no longer vendored.

The resolvelib package distributes its license and so doesn't require a
license fallback URL.