### PR TITLE
Drop --build-dir from the CLI

### DIFF
--- a/news/10485.removal.rst
+++ b/news/10485.removal.rst
@@ -1,0 +1,1 @@
+Remove the ``--build-dir`` option and aliases, one last time.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -27,7 +27,6 @@ from pip._internal.exceptions import (
     PreviousBuildDirError,
     UninstallationError,
 )
-from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
 from pip._internal.utils.misc import get_prog, normalize_path
@@ -148,20 +147,6 @@ class Command(CommandContextMixIn):
                     options.cache_dir,
                 )
                 options.cache_dir = None
-
-        if getattr(options, "build_dir", None):
-            deprecated(
-                reason=(
-                    "The -b/--build/--build-dir/--build-directory "
-                    "option is deprecated and has no effect anymore."
-                ),
-                replacement=(
-                    "use the TMPDIR/TEMP/TMP environment variable, "
-                    "possibly combined with --no-clean"
-                ),
-                gone_in="21.3",
-                issue=8333,
-            )
 
         if "2020-resolver" in options.features_enabled:
             logger.warning(

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -731,18 +731,6 @@ no_deps: Callable[..., Option] = partial(
     help="Don't install package dependencies.",
 )
 
-build_dir: Callable[..., Option] = partial(
-    PipOption,
-    "-b",
-    "--build",
-    "--build-dir",
-    "--build-directory",
-    dest="build_dir",
-    type="path",
-    metavar="dir",
-    help=SUPPRESS_HELP,
-)
-
 ignore_requires_python: Callable[..., Option] = partial(
     Option,
     "--ignore-requires-python",

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -37,7 +37,6 @@ class DownloadCommand(RequirementCommand):
     def add_options(self) -> None:
         self.cmd_opts.add_option(cmdoptions.constraints())
         self.cmd_opts.add_option(cmdoptions.requirements())
-        self.cmd_opts.add_option(cmdoptions.build_dir())
         self.cmd_opts.add_option(cmdoptions.no_deps())
         self.cmd_opts.add_option(cmdoptions.global_options())
         self.cmd_opts.add_option(cmdoptions.no_binary())

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -135,8 +135,6 @@ class InstallCommand(RequirementCommand):
             ),
         )
 
-        self.cmd_opts.add_option(cmdoptions.build_dir())
-
         self.cmd_opts.add_option(cmdoptions.src())
 
         self.cmd_opts.add_option(

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -65,7 +65,6 @@ class WheelCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.src())
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
         self.cmd_opts.add_option(cmdoptions.no_deps())
-        self.cmd_opts.add_option(cmdoptions.build_dir())
         self.cmd_opts.add_option(cmdoptions.progress_bar())
 
         self.cmd_opts.add_option(

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -2,7 +2,6 @@
 import os
 import re
 import sys
-from os.path import exists
 
 import pytest
 
@@ -238,35 +237,6 @@ def test_pip_wheel_fail(script, data):
     assert "FakeError" in result.stderr, result.stderr
     assert "Failed to build wheelbroken" in result.stdout, result.stdout
     assert result.returncode != 0
-
-
-def test_no_clean_option_blocks_cleaning_after_wheel(
-    script,
-    data,
-    resolver_variant,
-):
-    """
-    Test --no-clean option blocks cleaning after wheel build
-    """
-    build = script.venv_path / "build"
-    result = script.pip(
-        "wheel",
-        "--no-clean",
-        "--no-index",
-        "--build",
-        build,
-        f"--find-links={data.find_links}",
-        "simple",
-        expect_temp=True,
-        # TODO: allow_stderr_warning is used for the --build deprecation,
-        #       remove it when removing support for --build
-        allow_stderr_warning=True,
-    )
-
-    if resolver_variant == "legacy":
-        build = build / "simple"
-        message = f"build/simple should still exist {result}"
-        assert exists(build), message
 
 
 def test_pip_wheel_source_deps(script, data):


### PR DESCRIPTION
This was restored as a no-op for PyCharm, as a way to soften the
migration for them. It is no longer necessary, since the migration has
completed.

Closes out #9193. Not sure if we care about calling this out in our news file.