### PR TITLE
Use @pytest.mark.usefixture("with_wheel") in tests

### DIFF
--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -622,11 +622,8 @@ def make_wheel_with_python_requires(script, package_name, python_requires):
     return package_dir / "dist" / file_name
 
 
-def test_download__python_version_used_for_python_requires(
-    script,
-    data,
-    with_wheel,
-):
+@pytest.mark.usefixtures("with_wheel")
+def test_download__python_version_used_for_python_requires(script, data):
     """
     Test that --python-version is used for the Requires-Python check.
     """
@@ -664,10 +661,8 @@ def test_download__python_version_used_for_python_requires(
     script.pip(*args)  # no exception
 
 
-def test_download_ignore_requires_python_dont_fail_with_wrong_python(
-    script,
-    with_wheel,
-):
+@pytest.mark.usefixtures("with_wheel")
+def test_download_ignore_requires_python_dont_fail_with_wrong_python(script):
     """
     Test that --ignore-requires-python ignores Requires-Python check.
     """

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -99,7 +99,8 @@ def test_exclude_and_normalization(script, tmpdir):
     assert "Normalizable_Name" not in result.stdout
 
 
-def test_freeze_multiple_exclude_with_all(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_freeze_multiple_exclude_with_all(script):
     result = script.pip("freeze", "--all")
     assert "pip==" in result.stdout
     assert "wheel==" in result.stdout
@@ -936,7 +937,8 @@ def test_freeze_path_multiple(tmpdir, script, data):
     _check_output(result.stdout, expected)
 
 
-def test_freeze_direct_url_archive(script, shared_data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_freeze_direct_url_archive(script, shared_data):
     req = "simple @ " + path_to_url(shared_data.packages / "simple-2.0.tar.gz")
     assert req.startswith("simple @ file://")
     script.pip("install", req)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -222,8 +222,9 @@ def test_pep518_forkbombs(script, data, common_wheels, command, package):
 
 
 @pytest.mark.network
+@pytest.mark.usefixtures("with_wheel")
 def test_pip_second_command_line_interface_works(
-    script, pip_src, data, common_wheels, deprecated_python, with_wheel
+    script, pip_src, data, common_wheels, deprecated_python
 ):
     """
     Check if ``pip<PYVERSION>`` commands behaves equally
@@ -258,7 +259,8 @@ def test_install_exit_status_code_when_blank_requirements_file(script):
 
 
 @pytest.mark.network
-def test_basic_install_from_pypi(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_basic_install_from_pypi(script):
     """
     Test installing a package from PyPI.
     """
@@ -316,7 +318,8 @@ def test_basic_install_editable_from_git(script):
     _test_install_editable_from_git(script)
 
 
-def test_install_editable_from_git_autobuild_wheel(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_editable_from_git_autobuild_wheel(script):
     _test_install_editable_from_git(script)
 
 
@@ -434,7 +437,8 @@ def test_vcs_url_urlquote_normalization(script, tmpdir):
 
 
 @pytest.mark.parametrize("resolver", ["", "--use-deprecated=legacy-resolver"])
-def test_basic_install_from_local_directory(script, data, resolver, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_basic_install_from_local_directory(script, data, resolver):
     """
     Test installing from a local directory.
     """
@@ -461,9 +465,8 @@ def test_basic_install_from_local_directory(script, data, resolver, with_wheel):
         ("embedded_rel_path", True),
     ],
 )
-def test_basic_install_relative_directory(
-    script, data, test_type, editable, with_wheel
-):
+@pytest.mark.usefixtures("with_wheel")
+def test_basic_install_relative_directory(script, data, test_type, editable):
     """
     Test installing a requirement using a relative path.
     """
@@ -578,9 +581,8 @@ def test_hashed_install_failure_later_flag(script, tmpdir):
     )
 
 
-def test_install_from_local_directory_with_symlinks_to_directories(
-    script, data, with_wheel
-):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_from_local_directory_with_symlinks_to_directories(script, data):
     """
     Test installing from a local directory containing symlinks to directories.
     """
@@ -592,7 +594,8 @@ def test_install_from_local_directory_with_symlinks_to_directories(
     result.did_create(dist_info_folder)
 
 
-def test_install_from_local_directory_with_in_tree_build(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_from_local_directory_with_in_tree_build(script, data):
     """
     Test installing from a local directory with --use-feature=in-tree-build.
     """
@@ -610,9 +613,8 @@ def test_install_from_local_directory_with_in_tree_build(script, data, with_whee
 
 
 @pytest.mark.skipif("sys.platform == 'win32'")
-def test_install_from_local_directory_with_socket_file(
-    script, data, tmpdir, with_wheel
-):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_from_local_directory_with_socket_file(script, data, tmpdir):
     """
     Test installing from a local directory containing a socket file.
     """
@@ -689,7 +691,8 @@ def test_upgrade_argparse_shadowed(script):
     assert "Not uninstalling argparse" not in result.stdout
 
 
-def test_install_curdir(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_curdir(script, data):
     """
     Test installing current directory ('.').
     """
@@ -705,7 +708,8 @@ def test_install_curdir(script, data, with_wheel):
     result.did_create(dist_info_folder)
 
 
-def test_install_pardir(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_pardir(script, data):
     """
     Test installing parent directory ('..').
     """
@@ -780,7 +784,8 @@ def test_install_global_option_using_editable(script, tmpdir):
 
 
 @pytest.mark.network
-def test_install_package_with_same_name_in_curdir(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_package_with_same_name_in_curdir(script):
     """
     Test installing a package with the same name of a local folder
     """
@@ -798,7 +803,8 @@ mock100_setup_py = textwrap.dedent(
 )
 
 
-def test_install_folder_using_dot_slash(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_folder_using_dot_slash(script):
     """
     Test installing a folder using pip install ./foldername
     """
@@ -810,7 +816,8 @@ def test_install_folder_using_dot_slash(script, with_wheel):
     result.did_create(dist_info_folder)
 
 
-def test_install_folder_using_slash_in_the_end(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_folder_using_slash_in_the_end(script):
     r"""
     Test installing a folder using pip install foldername/ or foldername\
     """
@@ -822,7 +829,8 @@ def test_install_folder_using_slash_in_the_end(script, with_wheel):
     result.did_create(dist_info_folder)
 
 
-def test_install_folder_using_relative_path(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_folder_using_relative_path(script):
     """
     Test installing a folder using pip install folder1/folder2
     """
@@ -836,7 +844,8 @@ def test_install_folder_using_relative_path(script, with_wheel):
 
 
 @pytest.mark.network
-def test_install_package_which_contains_dev_in_name(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_package_which_contains_dev_in_name(script):
     """
     Test installing package from PyPI which contains 'dev' in name
     """
@@ -847,7 +856,8 @@ def test_install_package_which_contains_dev_in_name(script, with_wheel):
     result.did_create(dist_info_folder)
 
 
-def test_install_package_with_target(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_package_with_target(script):
     """
     Test installing a package using pip install --target
     """
@@ -975,7 +985,8 @@ def test_install_nonlocal_compatible_wheel_path(
 
 
 @pytest.mark.parametrize("opt", ("--target", "--prefix"))
-def test_install_with_target_or_prefix_and_scripts_no_warning(opt, script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_with_target_or_prefix_and_scripts_no_warning(opt, script):
     """
     Test that installing with --target does not trigger the "script not
     in PATH" warning (issue #5201)
@@ -1011,7 +1022,8 @@ def test_install_with_target_or_prefix_and_scripts_no_warning(opt, script, with_
     assert "--no-warn-script-location" not in result.stderr, str(result)
 
 
-def test_install_package_with_root(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_package_with_root(script, data):
     """
     Test installing a package using pip install --root
     """
@@ -1194,7 +1206,8 @@ def test_install_package_with_latin1_setup(script, data):
     script.pip("install", to_install)
 
 
-def test_url_req_case_mismatch_no_index(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_url_req_case_mismatch_no_index(script, data):
     """
     tar ball url requirements (with no egg fragment), that happen to have upper
     case project names, should be considered equal to later requirements that
@@ -1215,7 +1228,8 @@ def test_url_req_case_mismatch_no_index(script, data, with_wheel):
     result.did_not_create(dist_info_folder)
 
 
-def test_url_req_case_mismatch_file_index(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_url_req_case_mismatch_file_index(script, data):
     """
     tar ball url requirements (with no egg fragment), that happen to have upper
     case project names, should be considered equal to later requirements that
@@ -1242,7 +1256,8 @@ def test_url_req_case_mismatch_file_index(script, data, with_wheel):
     result.did_not_create(dist_info_folder)
 
 
-def test_url_incorrect_case_no_index(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_url_incorrect_case_no_index(script, data):
     """
     Same as test_url_req_case_mismatch_no_index, except testing for the case
     where the incorrect case is given in the name of the package to install
@@ -1263,7 +1278,8 @@ def test_url_incorrect_case_no_index(script, data, with_wheel):
     result.did_create(dist_info_folder)
 
 
-def test_url_incorrect_case_file_index(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_url_incorrect_case_file_index(script, data):
     """
     Same as test_url_req_case_mismatch_file_index, except testing for the case
     where the incorrect case is given in the name of the package to install
@@ -1408,12 +1424,14 @@ def test_install_topological_sort(script, data):
     assert order1 in res or order2 in res, res
 
 
-def test_install_wheel_broken(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_wheel_broken(script):
     res = script.pip_install_local("wheelbroken", expect_stderr=True)
     assert "Successfully installed wheelbroken-0.1" in str(res), str(res)
 
 
-def test_cleanup_after_failed_wheel(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_cleanup_after_failed_wheel(script):
     res = script.pip_install_local("wheelbrokenafter", expect_stderr=True)
     # One of the effects of not cleaning up is broken scripts:
     script_py = script.bin_path / "script.py"
@@ -1426,7 +1444,8 @@ def test_cleanup_after_failed_wheel(script, with_wheel):
     assert "Running setup.py clean for wheelbrokenafter" in str(res), str(res)
 
 
-def test_install_builds_wheels(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_builds_wheels(script, data):
     # We need to use a subprocess to get the right value on Windows.
     res = script.run(
         "python",
@@ -1473,7 +1492,8 @@ def test_install_builds_wheels(script, data, with_wheel):
     ]
 
 
-def test_install_no_binary_disables_building_wheels(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_no_binary_disables_building_wheels(script, data):
     to_install = data.packages.joinpath("requires_wheelbroken_upper")
     res = script.pip(
         "install",
@@ -1504,7 +1524,8 @@ def test_install_no_binary_disables_building_wheels(script, data, with_wheel):
 
 
 @pytest.mark.network
-def test_install_no_binary_builds_pep_517_wheel(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_no_binary_builds_pep_517_wheel(script, data):
     to_install = data.packages.joinpath("pep517_setup_and_pyproject")
     res = script.pip("install", "--no-binary=:all:", "-f", data.find_links, to_install)
     expected = "Successfully installed pep517-setup-and-pyproject"
@@ -1516,7 +1537,8 @@ def test_install_no_binary_builds_pep_517_wheel(script, data, with_wheel):
 
 
 @pytest.mark.network
-def test_install_no_binary_uses_local_backend(script, data, with_wheel, tmpdir):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_no_binary_uses_local_backend(script, data, tmpdir):
     to_install = data.packages.joinpath("pep517_wrapper_buildsys")
     script.environ["PIP_TEST_MARKER_FILE"] = marker = str(tmpdir / "marker")
     res = script.pip("install", "--no-binary=:all:", "-f", data.find_links, to_install)
@@ -1527,7 +1549,8 @@ def test_install_no_binary_uses_local_backend(script, data, with_wheel, tmpdir):
     assert os.path.isfile(marker), "Local PEP 517 backend not used"
 
 
-def test_install_no_binary_disables_cached_wheels(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_no_binary_disables_cached_wheels(script, data):
     # Seed the cache
     script.pip("install", "--no-index", "-f", data.find_links, "upper")
     script.pip("uninstall", "upper", "-y")
@@ -1659,7 +1682,8 @@ def test_install_incompatible_python_requires_editable(script):
     assert _get_expected_error_text() in result.stderr, str(result)
 
 
-def test_install_incompatible_python_requires_wheel(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_incompatible_python_requires_wheel(script):
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
     pkga_path.joinpath("setup.py").write_text(

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -27,7 +27,8 @@ def test_no_clean_option_blocks_cleaning_after_install(script, data):
 
 
 @pytest.mark.network
-def test_pep517_no_legacy_cleanup(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_pep517_no_legacy_cleanup(script, data):
     """Test a PEP 517 failed build does not attempt a legacy cleanup"""
     to_install = data.packages.joinpath("pep517_wrapper_buildsys")
     script.environ["PIP_TEST_FAIL_BUILD_WHEEL"] = "1"

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -222,7 +222,8 @@ def test_options_from_venv_config(script, virtualenv):
     assert msg.lower() in result.stdout.lower(), str(result)
 
 
-def test_install_no_binary_via_config_disables_cached_wheels(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_no_binary_via_config_disables_cached_wheels(script, data):
     config_file = tempfile.NamedTemporaryFile(mode="wt", delete=False)
     try:
         script.environ["PIP_CONFIG_FILE"] = config_file.name

--- a/tests/functional/test_install_direct_url.py
+++ b/tests/functional/test_install_direct_url.py
@@ -4,12 +4,14 @@ from tests.lib import _create_test_package, path_to_url
 from tests.lib.direct_url import get_created_direct_url
 
 
-def test_install_find_links_no_direct_url(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_find_links_no_direct_url(script):
     result = script.pip_install_local("simple")
     assert not get_created_direct_url(result, "simple")
 
 
-def test_install_vcs_editable_no_direct_url(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_vcs_editable_no_direct_url(script):
     pkg_path = _create_test_package(script, name="testpkg")
     args = ["install", "-e", "git+%s#egg=testpkg" % path_to_url(pkg_path)]
     result = script.pip(*args)
@@ -18,7 +20,8 @@ def test_install_vcs_editable_no_direct_url(script, with_wheel):
     assert not get_created_direct_url(result, "testpkg")
 
 
-def test_install_vcs_non_editable_direct_url(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_vcs_non_editable_direct_url(script):
     pkg_path = _create_test_package(script, name="testpkg")
     url = path_to_url(pkg_path)
     args = ["install", f"git+{url}#egg=testpkg"]
@@ -29,7 +32,8 @@ def test_install_vcs_non_editable_direct_url(script, with_wheel):
     assert direct_url.info.vcs == "git"
 
 
-def test_install_archive_direct_url(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_archive_direct_url(script, data):
     req = "simple @ " + path_to_url(data.packages / "simple-2.0.tar.gz")
     assert req.startswith("simple @ file://")
     result = script.pip("install", req)
@@ -37,7 +41,8 @@ def test_install_archive_direct_url(script, data, with_wheel):
 
 
 @pytest.mark.network
-def test_install_vcs_constraint_direct_url(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_vcs_constraint_direct_url(script):
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text(
         "git+https://github.com/pypa/pip-test-package"
@@ -48,7 +53,8 @@ def test_install_vcs_constraint_direct_url(script, with_wheel):
     assert get_created_direct_url(result, "pip_test_package")
 
 
-def test_install_vcs_constraint_direct_file_url(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_vcs_constraint_direct_file_url(script):
     pkg_path = _create_test_package(script, name="testpkg")
     url = path_to_url(pkg_path)
     constraints_file = script.scratch_path / "constraints.txt"

--- a/tests/functional/test_install_index.py
+++ b/tests/functional/test_install_index.py
@@ -2,8 +2,11 @@ import os
 import textwrap
 import urllib.parse
 
+import pytest
 
-def test_find_links_relative_path(script, data, with_wheel):
+
+@pytest.mark.usefixtures("with_wheel")
+def test_find_links_relative_path(script, data):
     """Test find-links as a relative path."""
     result = script.pip(
         "install",
@@ -19,7 +22,8 @@ def test_find_links_relative_path(script, data, with_wheel):
     result.did_create(initools_folder)
 
 
-def test_find_links_requirements_file_relative_path(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_find_links_requirements_file_relative_path(script, data):
     """Test find-links as a relative path to a reqs file."""
     script.scratch_path.joinpath("test-req.txt").write_text(
         textwrap.dedent(
@@ -44,7 +48,8 @@ def test_find_links_requirements_file_relative_path(script, data, with_wheel):
     result.did_create(initools_folder)
 
 
-def test_install_from_file_index_hash_link(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_from_file_index_hash_link(script, data):
     """
     Test that a pkg can be installed from a file:// index using a link with a
     hash
@@ -54,7 +59,8 @@ def test_install_from_file_index_hash_link(script, data, with_wheel):
     result.did_create(dist_info_folder)
 
 
-def test_file_index_url_quoting(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_file_index_url_quoting(script, data):
     """
     Test url quoting of file index url with a space
     """

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -57,7 +57,8 @@ def arg_recording_sdist_maker(script):
 
 
 @pytest.mark.network
-def test_requirements_file(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_requirements_file(script):
     """
     Test installing from a requirements file.
 
@@ -107,7 +108,8 @@ def test_schema_check_in_requirements_file(script):
         ("embedded_rel_path", True),
     ],
 )
-def test_relative_requirements_file(script, data, test_type, editable, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_relative_requirements_file(script, data, test_type, editable):
     """
     Test installing from a requirements file with a relative path. For path
     URLs, use an egg= definition.
@@ -152,7 +154,8 @@ def test_relative_requirements_file(script, data, test_type, editable, with_whee
 @pytest.mark.xfail
 @pytest.mark.network
 @need_svn
-def test_multiple_requirements_files(script, tmpdir, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_multiple_requirements_files(script, tmpdir):
     """
     Test installing from multiple nested requirements files.
 
@@ -290,7 +293,8 @@ def test_install_local_with_subdirectory(script):
 
 
 @pytest.mark.incompatible_with_test_venv
-def test_wheel_user_with_prefix_in_pydistutils_cfg(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_wheel_user_with_prefix_in_pydistutils_cfg(script, data):
     if os.name == "posix":
         user_filename = ".pydistutils.cfg"
     else:
@@ -482,7 +486,8 @@ def test_constrained_to_url_install_same_url(script, data):
     assert "Running setup.py install for singlemodule" in result.stdout, str(result)
 
 
-def test_double_install_spurious_hash_mismatch(script, tmpdir, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_double_install_spurious_hash_mismatch(script, tmpdir, data):
     """Make sure installing the same hashed sdist twice doesn't throw hash
     mismatch errors.
 

--- a/tests/functional/test_install_requested.py
+++ b/tests/functional/test_install_requested.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def _assert_requested_present(script, result, name, version):
     dist_info = script.site_packages / name + "-" + version + ".dist-info"
     requested = dist_info / "REQUESTED"
@@ -12,7 +15,8 @@ def _assert_requested_absent(script, result, name, version):
     assert requested not in result.files_created
 
 
-def test_install_requested_basic(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_requested_basic(script, data):
     result = script.pip(
         "install", "--no-index", "-f", data.find_links, "require_simple"
     )
@@ -21,7 +25,8 @@ def test_install_requested_basic(script, data, with_wheel):
     _assert_requested_absent(script, result, "simple", "3.0")
 
 
-def test_install_requested_requirements(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_requested_requirements(script, data):
     script.scratch_path.joinpath("requirements.txt").write_text("require_simple\n")
     result = script.pip(
         "install",
@@ -35,7 +40,8 @@ def test_install_requested_requirements(script, data, with_wheel):
     _assert_requested_absent(script, result, "simple", "3.0")
 
 
-def test_install_requested_dep_in_requirements(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_requested_dep_in_requirements(script, data):
     script.scratch_path.joinpath("requirements.txt").write_text(
         "require_simple\nsimple<3\n"
     )
@@ -52,7 +58,8 @@ def test_install_requested_dep_in_requirements(script, data, with_wheel):
     _assert_requested_present(script, result, "simple", "2.0")
 
 
-def test_install_requested_reqs_and_constraints(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_requested_reqs_and_constraints(script, data):
     script.scratch_path.joinpath("requirements.txt").write_text("require_simple\n")
     script.scratch_path.joinpath("constraints.txt").write_text("simple<3\n")
     result = script.pip(
@@ -70,7 +77,8 @@ def test_install_requested_reqs_and_constraints(script, data, with_wheel):
     _assert_requested_absent(script, result, "simple", "2.0")
 
 
-def test_install_requested_in_reqs_and_constraints(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_requested_in_reqs_and_constraints(script, data):
     script.scratch_path.joinpath("requirements.txt").write_text(
         "require_simple\nsimple\n"
     )

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -36,9 +36,8 @@ def test_invalid_upgrade_strategy_causes_error(script):
     assert "invalid choice" in result.stderr
 
 
-def test_only_if_needed_does_not_upgrade_deps_when_satisfied(
-    script, resolver_variant, with_wheel
-):
+@pytest.mark.usefixtures("with_wheel")
+def test_only_if_needed_does_not_upgrade_deps_when_satisfied(script, resolver_variant):
     """
     It doesn't upgrade a dependency if it already satisfies the requirements.
 
@@ -63,7 +62,8 @@ def test_only_if_needed_does_not_upgrade_deps_when_satisfied(
     ), "did not print correct message for not-upgraded requirement"
 
 
-def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(script):
     """
     It does upgrade a dependency if it no longer satisfies the requirements.
 
@@ -82,7 +82,8 @@ def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(script, with_
     assert expected in result.files_deleted, "should have uninstalled simple==1.0"
 
 
-def test_eager_does_upgrade_dependecies_when_currently_satisfied(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_eager_does_upgrade_dependecies_when_currently_satisfied(script):
     """
     It does upgrade a dependency even if it already satisfies the requirements.
 
@@ -100,7 +101,8 @@ def test_eager_does_upgrade_dependecies_when_currently_satisfied(script, with_wh
     ) in result.files_deleted, "should have uninstalled simple==2.0"
 
 
-def test_eager_does_upgrade_dependecies_when_no_longer_satisfied(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_eager_does_upgrade_dependecies_when_no_longer_satisfied(script):
     """
     It does upgrade a dependency if it no longer satisfies the requirements.
 
@@ -123,7 +125,8 @@ def test_eager_does_upgrade_dependecies_when_no_longer_satisfied(script, with_wh
 
 
 @pytest.mark.network
-def test_upgrade_to_specific_version(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_upgrade_to_specific_version(script):
     """
     It does upgrade to specific version requested.
 
@@ -136,7 +139,8 @@ def test_upgrade_to_specific_version(script, with_wheel):
 
 
 @pytest.mark.network
-def test_upgrade_if_requested(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_upgrade_if_requested(script):
     """
     And it does upgrade if requested.
 
@@ -296,7 +300,8 @@ def test_uninstall_rollback(script, data):
 
 
 @pytest.mark.network
-def test_should_not_install_always_from_cache(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_should_not_install_always_from_cache(script):
     """
     If there is an old cached package, pip should download the newer version
     Related to issue #175
@@ -309,7 +314,8 @@ def test_should_not_install_always_from_cache(script, with_wheel):
 
 
 @pytest.mark.network
-def test_install_with_ignoreinstalled_requested(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_with_ignoreinstalled_requested(script):
     """
     Test old conflicting package is completely ignored
     """

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -69,9 +69,8 @@ class Tests_UserSite:
         result.assert_installed("INITools", use_user_site=True)
 
     @pytest.mark.incompatible_with_test_venv
-    def test_install_from_current_directory_into_usersite(
-        self, script, data, with_wheel
-    ):
+    @pytest.mark.usefixtures("with_wheel")
+    def test_install_from_current_directory_into_usersite(self, script, data):
         """
         Test installing current directory ('.') into usersite
         """

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -158,7 +158,8 @@ def test_install_editable_from_git_with_https(script, tmpdir):
 
 
 @pytest.mark.network
-def test_install_noneditable_git(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_noneditable_git(script):
     """
     Test installing from a non-editable git URL with a given tag.
     """
@@ -516,7 +517,8 @@ def test_check_submodule_addition(script):
     update_result.did_create(script.venv / "src/version-pkg/testpkg/static/testfile2")
 
 
-def test_install_git_branch_not_cached(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_git_branch_not_cached(script):
     """
     Installing git urls with a branch revision does not cause wheel caching.
     """
@@ -531,7 +533,8 @@ def test_install_git_branch_not_cached(script, with_wheel):
     assert f"Successfully built {PKG}" in result.stdout, result.stdout
 
 
-def test_install_git_sha_cached(script, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_git_sha_cached(script):
     """
     Installing git urls with a sha revision does cause wheel caching.
     """

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -172,7 +172,8 @@ def test_install_from_wheel_with_headers(script):
     assert header_path.read_text() == header_text
 
 
-def test_install_wheel_with_target(script, shared_data, with_wheel, tmpdir):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_wheel_with_target(script, shared_data, tmpdir):
     """
     Test installing a wheel using pip install --target
     """
@@ -190,7 +191,8 @@ def test_install_wheel_with_target(script, shared_data, with_wheel, tmpdir):
     result.did_create(Path("scratch") / "target" / "simpledist")
 
 
-def test_install_wheel_with_target_and_data_files(script, data, with_wheel):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_wheel_with_target_and_data_files(script, data):
     """
     Test for issue #4092. It will be checked that a data_files specification in
     setup.py is handled correctly when a wheel is installed with the --target
@@ -326,7 +328,8 @@ def test_wheel_record_lines_have_hash_for_data_files(script):
 
 
 @pytest.mark.incompatible_with_test_venv
-def test_install_user_wheel(script, shared_data, with_wheel, tmpdir):
+@pytest.mark.usefixtures("with_wheel")
+def test_install_user_wheel(script, shared_data, tmpdir):
     """
     Test user install from wheel (that has a script)
     """

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -9,10 +9,7 @@ import pytest
 from pip._internal.cli.status_codes import ERROR
 from tests.lib import pyversion  # noqa: F401
 
-
-@pytest.fixture(autouse=True)
-def auto_with_wheel(with_wheel):
-    pass
+pytestmark = pytest.mark.usefixtures("with_wheel")
 
 
 def add_files_to_dist_directory(folder):


### PR DESCRIPTION
The with_wheel fixture doesn't have a value and isn't ever referenced
within a test function.

To avoid typing it every test function, change tests to use
pytest.mark.usefixture. It will no longer appear as an argument.

https://docs.pytest.org/en/latest/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures
