### PR TITLE
Fix unreachable code in tests/unit/test_network_utils.py

### DIFF
--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -18,12 +18,12 @@ def test_raise_for_status_raises_exception(status_code, error_type):
     resp.status_code = status_code
     resp.url = "http://www.example.com/whatever.tgz"
     resp.reason = "Network Error"
-    with pytest.raises(NetworkConnectionError) as exc:
+    with pytest.raises(NetworkConnectionError) as excinfo:
         raise_for_status(resp)
-        assert str(exc.info) == (
-            "{} {}: Network Error for url:"
-            " http://www.example.com/whatever.tgz".format(status_code, error_type)
-        )
+    assert str(excinfo.value) == (
+        "{} {}: Network Error for url:"
+        " http://www.example.com/whatever.tgz".format(status_code, error_type)
+    )
 
 
 def test_raise_for_status_does_not_raises_exception():


### PR DESCRIPTION
Examining the pytest.raises excinfo object should be done outside the
with statement block. Previously, the raised exception prevented the
assert from being executed.

Per the docs:
https://docs.pytest.org/en/latest/how-to/assert.html#assertions-about-expected-exceptions

The exception is the "value" attribute, not "info".

mypy also caught this mistake:

    tests/unit/test_network_utils.py:23: error:
    "ExceptionInfo[NetworkConnectionError]" has no attribute "info"  [attr-defined]
                assert str(exc.info) == (

