### PR TITLE
Document the new issue choice (`new/choose`)

### DIFF
--- a/docs/html/development/issue-triage.rst
+++ b/docs/html/development/issue-triage.rst
@@ -99,6 +99,24 @@ After an issue has been closed for 30 days, the
 issues, but unfortunately prevents and references to issues from showing up as
 links on the closed issue.
 
+Issue forms
+-----------
+
+We are using `issue forms
+<https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/>`_
+to create structured issues, and disable
+blank issues. We have 3 issue forms:
+
+**Bug report**
+  Something is not working correctly.
+
+**Feature request**
+  Suggest an idea for this project
+
+**Good first issue**
+  This is for maintainers-only.
+  Create a "good first issue" for new contributors.
+
 
 Triage Issues
 =============

--- a/docs/html/development/issue-triage.rst
+++ b/docs/html/development/issue-triage.rst
@@ -109,7 +109,7 @@ blank issues. After that, the link to create
 issues becomes https://github.com/pypa/pip/issues/new/choose
 (note the ``new/choose`` part), where you have to choose
 one of our forms. Only the maintainers of the repository
-can override that choice (going just to ``new/``).
+can override that choice (going just to https://github.com/pypa/pip/issues/new/).
 
 
 Triage Issues

--- a/docs/html/development/issue-triage.rst
+++ b/docs/html/development/issue-triage.rst
@@ -105,17 +105,11 @@ Issue forms
 We are using `issue forms
 <https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/>`_
 to create structured issues, and disable
-blank issues. We have 3 issue forms:
-
-**Bug report**
-  Something is not working correctly.
-
-**Feature request**
-  Suggest an idea for this project
-
-**Good first issue**
-  This is for maintainers-only.
-  Create a "good first issue" for new contributors.
+blank issues. After that, the link to create
+issues becomes https://github.com/pypa/pip/issues/new/choose
+(note the ``new/choose`` part), where you have to choose
+one of our forms. Only the maintainers of the repository
+can override that choice (going just to ``new/``).
 
 
 Triage Issues


### PR DESCRIPTION
Since #10406 was merged, we are using the new GitHub issue forms. This pull request is to document the changes.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
