### PR TITLE
Fix InstalledDistribution's metadata interface

### DIFF
--- a/news/10504.bugfix.rst
+++ b/news/10504.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a crash when installing an editable requirement using the legacy resolver
+due to a mismatch in internal metadata representation interfaces.

--- a/src/pip/_internal/distributions/installed.py
+++ b/src/pip/_internal/distributions/installed.py
@@ -11,8 +11,10 @@ class InstalledDistribution(AbstractDistribution):
     """
 
     def get_metadata_distribution(self) -> BaseDistribution:
+        from pip._internal.metadata.pkg_resources import Distribution as _Dist
+
         assert self.req.satisfied_by is not None, "not actually installed"
-        return self.req.satisfied_by
+        return _Dist(self.req.satisfied_by)
 
     def prepare_distribution_metadata(
         self, finder: PackageFinder, build_isolation: bool


### PR DESCRIPTION
`InstallRequirement.satisfied_by` is an old-style distribution object (`pkg_resources.Distribution`) for now, so we need to provide a shim for its access in `InstalledDistribution.get_metadata_distribution()`. Not sure why this was not picked up by the type checker :/

Fix #10504.