### PR TITLE
Add maintainers-only link to file blank issues, to "New Issue" selector

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,5 @@ contact_links:
   - name: "💬 IRC: #pypa"
     url: https://kiwiirc.com/nextclient/#ircs://irc.libera.chat:+6697/pypa
     about: Chat with devs
+  - name: "(maintainers only) Blank issue"
+    url: https://github.com/pypa/pip/issues/new


### PR DESCRIPTION
This link is only accessible for users who have the "Write" or "Admin"
permissions on the repository. Everyone else will get redirected to
the same URL as the selector, which I imagine to be an amusing
experience.

Closes #10496.
