### PR TITLE
locations: Add ignore directive to mypy for sys.platlibdir

### DIFF
--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -65,7 +65,9 @@ def _looks_like_bpo_44860() -> bool:
 def _looks_like_red_hat_patched_platlib_purelib(scheme: Dict[str, str]) -> bool:
     platlib = scheme["platlib"]
     if "/$platlibdir/" in platlib and hasattr(sys, "platlibdir"):
-        platlib = platlib.replace("/$platlibdir/", f"/{sys.platlibdir}/")
+        platlib = platlib.replace(
+            "/$platlibdir/", f"/{sys.platlibdir}/"  # type: ignore
+        )
     if "/lib64/" not in platlib:
         return False
     unpatched = platlib.replace("/lib64/", "/lib/")


### PR DESCRIPTION
This line has caused mypy to fail for me locally for the last few days..
Seems like mypy does not understand that ``sys.platlibdir`` will never be called unless this attribute exists

This does not warrant a news fragment IMO
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
