### PR TITLE
Change the development docs to suggest .venv instead of venv

### DIFF
--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -42,7 +42,7 @@ You can then invoke your local source tree pip normally.
 
     .. code-block:: shell
 
-        virtualenv .venv # You can also use "python -m venv .venv" from python3.3+
+        virtualenv .venv # You can also use "python -m venv .venv"
         source .venv/bin/activate
         python -m pip install -e .
         python -m pip --version
@@ -51,7 +51,7 @@ You can then invoke your local source tree pip normally.
 
     .. code-block:: shell
 
-        virtualenv .venv # You can also use "py -m venv .venv" from python3.3+
+        virtualenv .venv # You can also use "py -m venv .venv"
         .venv\Scripts\activate
         py -m pip install -e .
         py -m pip --version

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -42,8 +42,8 @@ You can then invoke your local source tree pip normally.
 
     .. code-block:: shell
 
-        virtualenv venv # You can also use "python -m venv venv" from python3.3+
-        source venv/bin/activate
+        virtualenv .venv # You can also use "python -m venv .venv" from python3.3+
+        source .venv/bin/activate
         python -m pip install -e .
         python -m pip --version
 
@@ -51,8 +51,8 @@ You can then invoke your local source tree pip normally.
 
     .. code-block:: shell
 
-        virtualenv venv # You can also use "py -m venv venv" from python3.3+
-        venv\Scripts\activate
+        virtualenv .venv # You can also use "py -m venv .venv" from python3.3+
+        .venv\Scripts\activate
         py -m pip install -e .
         py -m pip --version
 


### PR DESCRIPTION
Searched through `docs/*` and the [Running pip From Source Tree](https://pip.pypa.io/en/latest/development/getting-started/#running-pip-from-source-tree) section in [Development](https://pip.pypa.io/en/latest/development/) was the only place where `venv` was used instead of `.venv` regarding instructions for new contributors.

I didn't add a news entry since I don't think the change is significant enough.

Closes #10518.