### PR TITLE
Force strict xfail on pytest, and update/remove tests accordingly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ allow_untyped_defs = True
 
 [tool:pytest]
 addopts = --ignore src/pip/_vendor --ignore tests/tests_cache -r aR --color=yes
+xfail_strict = True
 markers =
     network: tests that need network
     incompatible_with_sysconfig

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -213,7 +213,7 @@ def test_multiple_constraints_files(script, data):
     assert "installed Upper-1.0" in result.stdout
 
 
-@pytest.mark.xfail(reason="Unclear what this guarantee is for.")
+# FIXME: Unclear what this guarantee is for.
 def test_respect_order_in_requirements_file(script, data):
     script.scratch_path.joinpath("frameworks-req.txt").write_text(
         textwrap.dedent(

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -240,7 +240,6 @@ def test_pip_wheel_fail(script, data):
     assert result.returncode != 0
 
 
-@pytest.mark.xfail(reason="The --build option was removed")
 def test_no_clean_option_blocks_cleaning_after_wheel(
     script,
     data,

--- a/tests/unit/test_models_wheel.py
+++ b/tests/unit/test_models_wheel.py
@@ -92,14 +92,6 @@ class TestWheelFile:
         w = Wheel("simple-0.1-cp27-none-macosx_10_9_intel.whl")
         assert not w.supported(tags=tags)
 
-    @pytest.mark.xfail(
-        reason=(
-            "packaging.tags changed behaviour in this area, and @pradyunsg "
-            "decided as the release manager that this behaviour change is less "
-            "critical than Big Sur support for pip 20.3. See "
-            "https://github.com/pypa/packaging/pull/361 for further discussion."
-        )
-    )
     def test_supported_multiarch_darwin(self) -> None:
         """
         Multi-arch wheels (intel) are supported on components (i386, x86_64)


### PR DESCRIPTION
These should not fail with the new resolver, so don't skip them.