### PR TITLE
Bump the `lock-threads` action to version 3

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -16,7 +16,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v3
         with:
-          issue-lock-inactive-days: '30'
-          pr-lock-inactive-days: '15'
+          issue-inactive-days: '30'
+          pr-inactive-days: '15'


### PR DESCRIPTION
This version of `dessant/lock-threads` has been released recently, and included a few bug fixes. Also, I had to modify the arguments passed to the action. See the [changelog](https://github.com/dessant/lock-threads/blob/master/CHANGELOG.md#changelog).

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
