### PR TITLE
Catch + report `BadZipFile` errors in `get_wheel_distribution`

### DIFF
--- a/news/10535.feature.rst
+++ b/news/10535.feature.rst
@@ -1,2 +1,2 @@
-Catch ``BadZipFile`` errors and re-raise them as ``InvalidWheel`` which
-additionally reports wheel name and path.
+Catch exception when an invalid wheel is accessed
+and provide more information about the culprit in a new stacktrace.

--- a/news/10535.feature.rst
+++ b/news/10535.feature.rst
@@ -1,0 +1,2 @@
+Catch ``BadZipFile`` errors and re-raise them as ``InvalidWheel`` which
+additionally reports wheel name and path.

--- a/news/10535.feature.rst
+++ b/news/10535.feature.rst
@@ -1,2 +1,1 @@
-Catch exception when an invalid wheel is accessed
-and provide more information about the culprit in a new stacktrace.
+Present a better error message when an invalid wheel file is encountered, providing more context where the invalid wheel file is.

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -132,6 +132,17 @@ class UnsupportedWheel(InstallationError):
     """Unsupported wheel."""
 
 
+class InvalidWheel(InstallationError):
+    """Invalid (e.g. corrupt) wheel."""
+
+    def __init__(self, location: str, name: str):
+        self.location = location
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"Wheel '{self.name}' located at {self.location} is invalid."
+
+
 class MetadataInconsistent(InstallationError):
     """Built metadata contains inconsistent information.
 

--- a/tests/data/packages/corruptwheel-1.0-py2.py3-none-any.whl
+++ b/tests/data/packages/corruptwheel-1.0-py2.py3-none-any.whl
@@ -1,0 +1,1 @@
+This is a corrupt wheel which _clearly_ is not a zip file.

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -45,13 +45,20 @@ def test_install_from_future_wheel_version(script, tmpdir):
     result.assert_installed("futurewheel", without_egg_link=True, editable=False)
 
 
-def test_install_from_broken_wheel(script, data):
+@pytest.mark.parametrize(
+    "wheel_name",
+    [
+        "brokenwheel-1.0-py2.py3-none-any.whl",
+        "corruptwheel-1.0-py2.py3-none-any.whl",
+    ],
+)
+def test_install_from_broken_wheel(script, data, wheel_name):
     """
     Test that installing a broken wheel fails properly
     """
     from tests.lib import TestFailure
 
-    package = data.packages.joinpath("brokenwheel-1.0-py2.py3-none-any.whl")
+    package = data.packages.joinpath(wheel_name)
     result = script.pip("install", package, "--no-index", expect_error=True)
     with pytest.raises(TestFailure):
         result.assert_installed("futurewheel", without_egg_link=True, editable=False)

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -1,6 +1,6 @@
 from typing import Iterator
-from zipfile import BadZipfile
 
+from pip._internal.exceptions import InvalidWheel
 from pip._vendor.packaging.version import Version
 from pytest import fixture, mark, raises
 
@@ -62,5 +62,5 @@ def test_dist_from_wheel_url_no_range(
 @mark.network
 def test_dist_from_wheel_url_not_zip(session: PipSession) -> None:
     """Test handling with the given URL does not point to a ZIP."""
-    with raises(BadZipfile):
+    with raises(InvalidWheel):
         dist_from_wheel_url("python", "https://www.python.org/", session)

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -1,9 +1,9 @@
 from typing import Iterator
 
-from pip._internal.exceptions import InvalidWheel
 from pip._vendor.packaging.version import Version
 from pytest import fixture, mark, raises
 
+from pip._internal.exceptions import InvalidWheel
 from pip._internal.network.lazy_wheel import (
     HTTPRangeRequestUnsupported,
     dist_from_wheel_url,

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -252,9 +252,9 @@ def test_wheel_root_is_purelib(text: str, expected: bool) -> None:
     assert wheel.wheel_root_is_purelib(message_from_string(text)) == expected
 
 
-def test_dist_from_broken_wheel_fails(data) -> None:
+def test_dist_from_broken_wheel_fails(data: TestData) -> None:
     from pip._internal.exceptions import InvalidWheel
-    from pip._internal.metadata import get_wheel_distribution, FilesystemWheel
+    from pip._internal.metadata import FilesystemWheel, get_wheel_distribution
 
     package = data.packages.joinpath("corruptwheel-1.0-py2.py3-none-any.whl")
     with pytest.raises(InvalidWheel):

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -252,6 +252,15 @@ def test_wheel_root_is_purelib(text: str, expected: bool) -> None:
     assert wheel.wheel_root_is_purelib(message_from_string(text)) == expected
 
 
+def test_dist_from_broken_wheel_fails(data) -> None:
+    from pip._internal.exceptions import InvalidWheel
+    from pip._internal.metadata import get_wheel_distribution, FilesystemWheel
+
+    package = data.packages.joinpath("corruptwheel-1.0-py2.py3-none-any.whl")
+    with pytest.raises(InvalidWheel):
+        get_wheel_distribution(FilesystemWheel(package), "brokenwheel")
+
+
 class TestWheelFile:
     def test_unpack_wheel_no_flatten(self, tmpdir: Path) -> None:
         filepath = os.path.join(DATA_DIR, "packages", "meta-1.0-py2.py3-none-any.whl")


### PR DESCRIPTION
## Change
Catch `BadZipFile` errors and re-raise with some context information.
No functional change, hence no news entry.

## Motivation
I'm facing a few nasty CI bugs where the `pip install` command fails with an uncaught `BadZipFile` exception.  A stacktrace looks like this:
```
  […N similar lines…]
   Building wheel for wrapt (setup.py): started
  Building wheel for wrapt (setup.py): finished with status 'done'
  Created wheel for wrapt: filename=wrapt-1.12.1-cp39-cp39-linux_x86_64.whl size=78277 sha256=337cd2663d837fd8364f46d472964afd4b05eb1fdf68361b26245a866e714227
  Stored in directory: /opt/pycroft/.cache/pip/wheels/98/23/68/efe259aaca055e93b08e74fbe512819c69a2155c11ba3c0f10
ERROR: Exception:
Traceback (most recent call last):
  File "/opt/pycroft/venv/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 173, in _main
    status = self.run(options, args)
  File "/opt/pycroft/venv/lib/python3.9/site-packages/pip/_internal/cli/req_command.py", line 203, in wrapper
    return func(self, options, args)
  File "/opt/pycroft/venv/lib/python3.9/site-packages/pip/_internal/commands/install.py", line 342, in run
    _, build_failures = build(
  File "/opt/pycroft/venv/lib/python3.9/site-packages/pip/_internal/wheel_builder.py", line 336, in build
    wheel_file = _build_one(
  File "/opt/pycroft/venv/lib/python3.9/site-packages/pip/_internal/wheel_builder.py", line 228, in _build_one
    _verify_one(req, wheel_path)
  File "/opt/pycroft/venv/lib/python3.9/site-packages/pip/_internal/wheel_builder.py", line 177, in _verify_one
    dist = get_wheel_distribution(wheel_path, canonical_name)
  File "/opt/pycroft/venv/lib/python3.9/site-packages/pip/_internal/metadata/__init__.py", line 48, in get_wheel_distribution
    return Distribution.from_wheel(wheel_path, canonical_name)
  File "/opt/pycroft/venv/lib/python3.9/site-packages/pip/_internal/metadata/pkg_resources.py", line 43, in from_wheel
    with zipfile.ZipFile(path, allowZip64=True) as zf:
  File "/usr/local/lib/python3.9/zipfile.py", line 1257, in __init__
    self._RealGetContents()
  File "/usr/local/lib/python3.9/zipfile.py", line 1324, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file
```

Since the information which file caused the error is missing, I don't have any means to further narrow down this issue (e.g. check which files are affected, compare checksums, etc). This change should help me and anyone else facing such issues.

## NB
Please note that I have no clue about PIP internals; feel free to make any changes if e.g. the error message is factually incorrect.