### PR TITLE
Fix crashes with higher logging levels

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -37,7 +37,6 @@ from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import build_netloc
 from pip._internal.utils.packaging import check_requires_python
 from pip._internal.utils.unpacking import SUPPORTED_EXTENSIONS
-from pip._internal.utils.urls import url_to_path
 
 __all__ = ["FormatControl", "BestCandidateResult", "PackageFinder"]
 
@@ -816,7 +815,14 @@ class PackageFinder:
         )
 
         if logger.isEnabledFor(logging.DEBUG) and file_candidates:
-            paths = [url_to_path(c.link.url) for c in file_candidates]
+            paths = []
+            for candidate in file_candidates:
+                assert candidate.link.url  # we need to have a URL
+                try:
+                    paths.append(candidate.link.file_path)
+                except Exception:
+                    paths.append(candidate.link.url)  # it's not a local file
+
             logger.debug("Local files found: %s", ", ".join(paths))
 
         # This is an intentional priority ordering


### PR DESCRIPTION
This can be reproduced just by running the test suite locally, for me -- though I haven't been able to identify what in my new setup is different. 🤷🏽

```
_________________________________________ test_finder_installs_pre_releases_with_version_spec _________________________________________
[gw6] darwin -- Python 3.9.6 /Users/pradyunsg/Developer/pip/.nox/test-3-9/bin/python

    def test_finder_installs_pre_releases_with_version_spec() -> None:
        """
        Test PackageFinder only accepts stable versioned releases by default.
        """
        req = install_req_from_line("bar>=0.0.dev0", None)
        links = ["https://foo/bar-1.0.tar.gz", "https://foo/bar-2.0b1.tar.gz"]
    
        finder = make_test_finder(links)
>       found = finder.find_requirement(req, False)

tests/unit/test_finder.py:461: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.nox/test-3-9/lib/python3.9/site-packages/pip/_internal/index/package_finder.py:875: in find_requirement
    best_candidate_result = self.find_best_candidate(
.nox/test-3-9/lib/python3.9/site-packages/pip/_internal/index/package_finder.py:857: in find_best_candidate
    candidates = self.find_all_candidates(project_name)
.nox/test-3-9/lib/python3.9/site-packages/pip/_internal/index/package_finder.py:819: in find_all_candidates
    paths = [url_to_path(c.link.url) for c in file_candidates]
.nox/test-3-9/lib/python3.9/site-packages/pip/_internal/index/package_finder.py:819: in <listcomp>
    paths = [url_to_path(c.link.url) for c in file_candidates]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

url = 'https://foo/bar-2.0b1.tar.gz'

    def url_to_path(url: str) -> str:
        """
        Convert a file: URL to a path.
        """
>       assert url.startswith(
            "file:"
        ), f"You can only turn file: urls into filenames (not {url!r})"
E       AssertionError: You can only turn file: urls into filenames (not 'https://foo/bar-2.0b1.tar.gz')

.nox/test-3-9/lib/python3.9/site-packages/pip/_internal/utils/urls.py:30: AssertionError
```

Anyway, this fixes my test runs locally on `nox -s test-3.9 -- -n auto`, which... it would be nice to have that. :)