### PR TITLE
Fix the protect-pip-on-windows logic

### DIFF
--- a/news/10560.bugfix.rst
+++ b/news/10560.bugfix.rst
@@ -1,0 +1,1 @@
+Fix conditional checks to prevent ``pip.exe`` from trying to modify itself, on Windows.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -557,8 +557,8 @@ def protect_pip_from_modification_on_windows(modifying_pip: bool) -> None:
     """
     pip_names = [
         "pip",
-        "pip{}".format(sys.version_info[0]),
-        "pip{}.{}".format(*sys.version_info[:2]),
+        f"pip{sys.version_info.major}",
+        f"pip{sys.version_info.major}.{sys.version_info.minor}",
     ]
 
     # See https://github.com/pypa/pip/issues/1299 for more discussion

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -556,9 +556,9 @@ def protect_pip_from_modification_on_windows(modifying_pip: bool) -> None:
         python -m pip ...
     """
     pip_names = [
-        "pip.exe",
-        "pip{}.exe".format(sys.version_info[0]),
-        "pip{}.{}.exe".format(*sys.version_info[:2]),
+        "pip",
+        "pip{}".format(sys.version_info[0]),
+        "pip{}.{}".format(*sys.version_info[:2]),
     ]
 
     # See https://github.com/pypa/pip/issues/1299 for more discussion

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import sys
 import textwrap
 
 import pytest
@@ -411,3 +412,14 @@ def test_install_find_existing_package_canonicalize(
     )
     satisfied_message = f"Requirement already satisfied: {req2}"
     assert satisfied_message in result.stdout, str(result)
+
+
+@pytest.mark.network
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+def test_modifying_pip_presents_error(script: PipTestEnvironment) -> None:
+    result = script.pip(
+        "install", "pip", "--force-reinstall", use_module=False, expect_error=True
+    )
+
+    assert "python.exe" in result.stderr or "python.EXE" in result.stderr, str(result)
+    assert " -m " in result.stderr, str(result)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -666,7 +666,7 @@ class PipTestEnvironment(TestFileEnvironment):
         if expect_error and not allow_error:
             if result.returncode == 0:
                 __tracebackhide__ = True
-                raise AssertionError("Script passed unexpectedly.")
+                raise AssertionError(f"Script passed unexpectedly:\n{result}")
 
         _check_stderr(
             result.stderr,


### PR DESCRIPTION
No idea how we missed this, but this conditional was flipped and, thus, wrong. >.<

Closes #7280
Closes #8247
Closes #8274
Closes #8450
Closes #9395
Closes #9527
Closes #9566
Closes #10014
Closes #10454
Closes #10505
Closes #10848
