### PR TITLE
Use a shorter timeout, to ensure that this fails more often

### DIFF
--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -5,7 +5,7 @@ import pytest
 def test_timeout(script):
     result = script.pip(
         "--timeout",
-        "0.001",
+        "0.0001",
         "install",
         "-vvv",
         "INITools",


### PR DESCRIPTION
This _may_ help out the timeout issues we're seeing in CI.