### PR TITLE
Check UID unconditionally on non-Windows platforms, if os.getuid is available

### DIFF
--- a/news/10565.bugfix.rst
+++ b/news/10565.bugfix.rst
@@ -1,0 +1,1 @@
+Tweak running-as-root detection, to check ``os.getuid`` if it exists, on Unix-y and non-Linux/non-MacOS machines.

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -173,9 +173,10 @@ def warn_if_run_as_root() -> None:
     # checks: https://mypy.readthedocs.io/en/stable/common_issues.html
     if sys.platform == "win32" or sys.platform == "cygwin":
         return
-    if sys.platform == "darwin" or sys.platform == "linux":
-        if os.getuid() != 0:
-            return
+
+    if os.getuid() != 0:
+        return
+
     logger.warning(
         "Running pip as the 'root' user can result in broken permissions and "
         "conflicting behaviour with the system package manager. "


### PR DESCRIPTION
On BSD systems, pip warns about executing it as root, even though it is not being executed as root.

Fixes issue #10565.