### PR TITLE
Simplify graph in get_topological_weights.

### DIFF
--- a/news/10557.bugfix.rst
+++ b/news/10557.bugfix.rst
@@ -1,1 +1,1 @@
-Simplify the graph when calculating weights for the installation order.
+Optimize installation order calculation to improve performance when installing requirements that form a complex depedency graph with a large amount of edges.

--- a/news/10557.bugfix.rst
+++ b/news/10557.bugfix.rst
@@ -1,1 +1,1 @@
-Optimize installation order calculation to improve performance when installing requirements that form a complex depedency graph with a large amount of edges.
+Optimize installation order calculation to improve performance when installing requirements that form a complex dependency graph with a large amount of edges.

--- a/news/10557.bugfix.rst
+++ b/news/10557.bugfix.rst
@@ -1,0 +1,1 @@
+Simplify the graph when calculating weights for the installation order.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -222,7 +222,11 @@ def get_topological_weights(
         for key in graph:
             if key is None:
                 continue
-            if next(graph.iter_children(key), None) is None:
+            for _child in graph.iter_children(key):
+                # This means we have at least one child
+                break
+            else:
+                # No child.
                 leaves.add(key)
         if not leaves:
             # We are done simplifying.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -222,7 +222,7 @@ def get_topological_weights(
         for key in graph:
             if key is None:
                 continue
-            if next(graph.iter_children(key), None) is not None:
+            if next(graph.iter_children(key), None) is None:
                 leaves.add(key)
         if not leaves:
             # We are done simplifying.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -217,25 +217,23 @@ def get_topological_weights(
     path: Set[Optional[str]] = set()
     weights: Dict[Optional[str], int] = {}
 
-    # Make a copy of the graph and edit the copy,
-    # instead of changing the original.
-    cgraph: "DirectedGraph[Optional[str]]" = graph.copy()
-
     def simplify_graph() -> None:
         leaves = set()
-        for key in cgraph:
-            if not list(cgraph.iter_children(key)) and key is not None:
+        for key in graph:
+            if key is None:
+                continue
+            if next(graph.iter_children(key), None) is not None:
                 leaves.add(key)
         if not leaves:
             # We are done simplifying.
             return
         # Calculate the weight for the leaves.
-        weight = len(cgraph) - 1
-        for leave in leaves:
-            weights[leave] = weight
+        weight = len(graph) - 1
+        for leaf in leaves:
+            weights[leaf] = weight
         # Remove the leaves from the copy of the graph, making the copy simpler.
-        for leave in leaves:
-            cgraph.remove(leave)
+        for leaf in leaves:
+            graph.remove(leaf)
         # Now that we have a simpler graph, try to simplify it again.
         simplify_graph()
 
@@ -246,7 +244,7 @@ def get_topological_weights(
 
         # Time to visit the children!
         path.add(node)
-        for child in cgraph.iter_children(node):
+        for child in graph.iter_children(node):
             visit(child)
         path.remove(node)
 

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -173,9 +173,8 @@ class Resolver(BaseResolver):
         The current implementation creates a topological ordering of the
         dependency graph, giving more weight to packages with less
         or no dependencies, while breaking any cycles in the graph at
-        arbitrary points.
-        We make no guarantees about where the cycle would be broken,
-        other than it *would* be broken.
+        arbitrary points. We make no guarantees about where the cycle
+        would be broken, other than it *would* be broken.
         """
         assert self._result is not None, "must call resolve() first"
 
@@ -205,22 +204,19 @@ def get_topological_weights(
     This implementation may change at any point in the future without prior
     notice.
 
-    We first simplify the dependency graph by pruning any leaves
-    and giving them the highest weight: a package without any dependencies
-    should be installed first.
-    We simplify again and again in the same way, giving ever less weight
-    to the newly found leaves.
-    This stops when no leaves are left: all remaining packages have at least
-    one dependency left in the graph.
+    We first simplify the dependency graph by pruning any leaves and giving them
+    the highest weight: a package without any dependencies should be installed
+    first. This is done again and again in the same way, giving ever less weight
+    to the newly found leaves. The loop stops when no leaves are left: all
+    remaining packages have at least one dependency left in the graph.
 
-    Then we continue with the remaining graph.
-    We take the length for the longest path to any node from root, ignoring any
-    paths that contain a single node twice (i.e. cycles). This is done through
-    a depth-first search through the graph, while keeping track of the path to
-    the node.
+    Then we continue with the remaining graph, by taking the length for the
+    longest path to any node from root, ignoring any paths that contain a single
+    node twice (i.e. cycles). This is done through a depth-first search through
+    the graph, while keeping track of the path to the node.
 
     Cycles in the graph result would result in node being revisited while also
-    being on it's own path. In this case, take no action. This helps ensure we
+    being on its own path. In this case, take no action. This helps ensure we
     don't get stuck in a cycle.
 
     When assigning weight, the longer path (i.e. larger length) is preferred.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -254,7 +254,7 @@ def get_topological_weights(
         weight = len(graph) - 1
         for leaf in leaves:
             weights[leaf] = weight
-        # Remove the leaves from the copy of the graph, making the copy simpler.
+        # Remove the leaves from the graph, making it simpler.
         for leaf in leaves:
             graph.remove(leaf)
 

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -222,10 +222,6 @@ def get_topological_weights(
     cgraph: "DirectedGraph[Optional[str]]" = graph.copy()
 
     def simplify_graph() -> None:
-        # In the first pass, we iterate over the original graph,
-        # looking for any keys that have no dependencies themselves.
-        # Use a large weight for them.
-        # Actually, maybe not.
         leaves = set()
         for key in cgraph:
             if not cgraph._forwards[key] and key is not None:
@@ -235,9 +231,6 @@ def get_topological_weights(
             return
         # Calculate the weight for the leaves.
         weight = len(cgraph) - 1
-        if weight == 0:
-            # Precaution against dividing by zero.  We are done.
-            return
         for leave in leaves:
             weights[leave] = weight
         # Remove the leaves from the copy of the graph, making the copy simpler.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -224,7 +224,7 @@ def get_topological_weights(
     def simplify_graph() -> None:
         leaves = set()
         for key in cgraph:
-            if not cgraph._forwards[key] and key is not None:
+            if not list(cgraph.iter_children(key)) and key is not None:
                 leaves.add(key)
         if not leaves:
             # We are done simplifying.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -221,7 +221,7 @@ def get_topological_weights(
     # instead of changing the original.
     cgraph: "DirectedGraph[Optional[str]]" = graph.copy()
 
-    def simplify_graph():
+    def simplify_graph() -> None:
         # In the first pass, we iterate over the original graph,
         # looking for any keys that have no dependencies themselves.
         # Use a large weight for them.

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -115,7 +115,7 @@ def test_new_resolver_get_installation_order(
                 ("three", "four"),
                 ("four", "five"),
             ],
-            {None: 0, "one": 1, "two": 1, "three": 2, "four": 3, "five": 4},
+            {None: 0, "five": 5, "four": 4, "one": 4, "three": 2, "two": 1},
         ),
         (
             "linear",


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/10557 where the resolver spends too much time calculating the weights.

Also, do not let `get_installation_order` calculate these weights at all when there is nothing left to install.

I had to change one test in `test_resolver.py` because some weights have changed. The test was meant to address [this comment](https://github.com/pypa/pip/pull/8127#discussion_r414564664) and I think the new weights with new order are okay. Translated to that comment, the new order is that B is installed before D, but that should not matter, because A is still installed first, before C, which is the point of the comment.

This is my first PR for `pip`.
I wonder: should this PR be done in https://github.com/sarugaku/resolvelib first?

Meanwhile, let me share the output of a few runs with extra print statements.

Installing `Zope`:

```
$ bin/python -m pip install Zope -c https://dist.plone.org/release/pip-resolver-test/constraints.txt
...
Expected node count: 80
simplified graph to 66
simplified graph to 46
simplified graph to 32
simplified graph to 25
simplified graph to 23
simplified graph to 19
simplified graph to 17
simplified graph to 14
simplified graph to 8
simplified graph to 3
simplified graph to 2
simplified graph to 1
```

Same with `Products.CMFPlone` (a much larger superset of Zope):

```
Expected node count: 238
simplified graph to 209
simplified graph to 169
simplified graph to 151
simplified graph to 144
simplified graph to 140
simplified graph to 127
simplified graph to 116
simplified graph to 110
simplified graph to 103
simplified graph to 95
simplified graph to 91
simplified graph to 89
simplified graph to 79
simplified graph to 70
simplified graph to 65
simplified graph to 49
simplified graph to 40
simplified graph to 36
simplified graph to 35
```

So 35 packages in the graph is the maximum simplification. The original `visit` function is called on the remaining graph.

Same with `Plone` (a slightly larger superset of `Products.CMFPlone`):

```
Expected node count: 253
simplified graph to 221
simplified graph to 178
simplified graph to 159
simplified graph to 152
simplified graph to 148
simplified graph to 135
simplified graph to 124
simplified graph to 118
simplified graph to 111
simplified graph to 103
simplified graph to 99
simplified graph to 97
simplified graph to 87
simplified graph to 77
simplified graph to 72
simplified graph to 55
simplified graph to 46
simplified graph to 42
simplified graph to 41
```

In the last case, extra packages needed to be installed, and this order was calculated:

```
Installing collected packages: PyJWT, certifi, urllib3, idna, chardet, requests, plone.cachepurging,
plone.rest, Products.CMFPlacefulWorkflow, plone.app.iterate, plone.restapi, plone.app.upgrade,
plone.app.caching, Plone
```

That seems right. For example `certify` is installed before `requests`, and `Plone` is installed last.
