### PR TITLE
Upgrade to vendoring 1.2

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -171,7 +171,7 @@ def lint(session: nox.Session) -> None:
 
 @nox.session
 def vendoring(session: nox.Session) -> None:
-    session.install("vendoring~=1.0.0")
+    session.install("vendoring~=1.2.0")
 
     if "--upgrade" not in session.posargs:
         session.run("vendoring", "sync", "-v")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,6 @@ distro = []
 setuptools = "pkg_resources"
 
 [tool.vendoring.license.fallback-urls]
+CacheControl = "https://raw.githubusercontent.com/ionrock/cachecontrol/v0.12.6/LICENSE.txt"
+distlib = "https://bitbucket.org/pypa/distlib/raw/master/LICENSE.txt"
 webencodings = "https://github.com/SimonSapin/python-webencodings/raw/master/LICENSE"

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -1,4 +1,4 @@
-CacheControl==0.12.6
+CacheControl==0.12.6  # Make sure to update the license in pyproject.toml for this.
 colorama==0.4.4
 distlib==0.3.3
 distro==1.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -70,10 +70,7 @@ basepython = python3
 skip_install = True
 commands_pre =
 deps =
-    vendoring~=1.0.0
-    # Required, otherwise we interpret --no-binary :all: as
-    # "do not build wheels", which fails for PEP 517 requirements
-    pip>=19.3.1
+    vendoring~=1.2.0
 whitelist_externals = git
 commands =
     # Check that the vendoring is up-to-date


### PR DESCRIPTION
Closes #10570

This enables wheel usage in vendoring's license fetching, at the cost of
requiring two more license-related fallbacks.

The additional fallbacks are due to packages which include the license
in their source distributions but not in their wheel distributions, and
the change in vendoring that prefers using wheels when possible.

This should fix the bootstrapping problem we're seeing with `flit` and
`tomli`, by allowing us to use wheels to break the loop.
