### PR TITLE
Drop news files from 21.3.1 release

### DIFF
--- a/news/10531.bugfix.rst
+++ b/news/10531.bugfix.rst
@@ -1,2 +1,0 @@
-Always refuse installing or building projects that have no ``pyproject.toml`` nor
-``setup.py``.

--- a/news/10565.bugfix.rst
+++ b/news/10565.bugfix.rst
@@ -1,1 +1,0 @@
-Tweak running-as-root detection, to check ``os.getuid`` if it exists, on Unix-y and non-Linux/non-MacOS machines.

--- a/news/10573.bugfix.rst
+++ b/news/10573.bugfix.rst
@@ -1,5 +1,0 @@
-When installing projects with a ``pyproject.toml`` in editable mode, and the build
-backend does not support :pep:`660`, prepare metadata using
-``prepare_metadata_for_build_wheel`` instead of ``setup.py egg_info``. Also, refuse
-installing projects that only have a ``setup.cfg`` and no ``setup.py`` nor
-``pyproject.toml``. These restore the pre-21.3 behaviour.

--- a/news/10585.bugfix.rst
+++ b/news/10585.bugfix.rst
@@ -1,1 +1,0 @@
-Restore compatibility of where configuration files are loaded from on MacOS (back to ``Library/Application Support/pip``, instead of ``Preferences/pip``).

--- a/news/pep517.vendor.rst
+++ b/news/pep517.vendor.rst
@@ -1,1 +1,0 @@
-Upgrade pep517 to 0.12.0


### PR DESCRIPTION
I didn't merge back in #10609, so... this is the obvious follow up.