### PR TITLE
Optimize provider's is_backtrack_cause by caching resolved names

### DIFF
--- a/news/10621.feature.rst
+++ b/news/10621.feature.rst
@@ -1,1 +1,1 @@
-Optimize performance of conflict cause resolution while backtracking.
+Optimize performance of conflict cause resolution while the dependency resolver backtracks.

--- a/news/10621.feature.rst
+++ b/news/10621.feature.rst
@@ -1,0 +1,1 @@
+Optimize performance of conflict cause resolution while backtracking.


### PR DESCRIPTION
`is_backtrack_cause` is called for every requirement on every step of resolution. As it's implemented currently if an identifier is not the backtrack cause, the entire list is scanned, invoking the `.name` property on every element of the list (and possibly parents). Since all the provider needs to know is presence or absence of the identifier in the backtrack causes list stash the resolved names in a set on first invocation and check for presence/absence in that set.

[Profile on branch](https://gist.githubusercontent.com/jbylund/875aa775b93732fad6470da10e5caafc/raw/d8c50029607ea524e0219384656578e81b3ee3d7/branch.svg) `is_backtrack_cause` is down to ~1% (from 43% on main), note that this isn't a scientific experiment as I let resolution run for 10-20 minutes and then cancel the process.