### PR TITLE
Update the docs URL shown for `ResolutionImpossible` errors

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -696,6 +696,6 @@ class Factory:
 
         return DistributionNotFound(
             "ResolutionImpossible: for help visit "
-            "https://pip.pypa.io/en/latest/user_guide/"
-            "#fixing-conflicting-dependencies"
+            "https://pip.pypa.io/en/latest/topics/dependency-resolution/"
+            "#dealing-with-dependency-conflicts"
         )


### PR DESCRIPTION
Previously the `ResolutionImpossible` error message referenced:
https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies

However, that section was moved in #10279, to:
https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts

Updating the URL not only saves a click, but also saves having to find the related content halfway-down the dependency resolution page, since the forwarding link was to the top of the page rather than the specific section.