### PR TITLE
Accomodate spaces in Python executable path shown in outdated pip warning

### DIFF
--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -4,6 +4,7 @@ import json
 import logging
 import optparse
 import os.path
+import subprocess
 import sys
 from typing import Any, Dict
 
@@ -164,9 +165,8 @@ def pip_self_version_check(session: PipSession, options: optparse.Values) -> Non
 
         # We cannot tell how the current pip is available in the current
         # command context, so be pragmatic here and suggest the command
-        # that's always available. This does not accommodate spaces in
-        # `sys.executable`.
-        pip_cmd = f"{sys.executable} -m pip"
+        # that's always available.
+        pip_cmd = f"{subprocess.list2cmdline([sys.executable])} -m pip"
         logger.warning(
             "You are using pip version %s; however, version %s is "
             "available.\nYou should consider upgrading via the "


### PR DESCRIPTION
Show
```
WARNING: You are using pip version 21.2.3; however, version 21.3.1 is available.
You should consider upgrading via the '"C:\Program Files\Python310\python.exe" -m pip install --upgrade pip' command.
```
instead of
```
WARNING: You are using pip version 21.2.3; however, version 21.3.1 is available.
You should consider upgrading via the 'C:\Program Files\Python310\python.exe -m pip install --upgrade pip' command.
```