### PR TITLE
Allow to decide whether to use distutils or sysconfig with sysconfig._PIP_USE_SYSCONFIG

### DIFF
--- a/news/10647.feature.rst
+++ b/news/10647.feature.rst
@@ -1,0 +1,3 @@
+Allow Python distributors to opt-out from or opt-in to the ``sysconfig``
+installation scheme backend by setting ``sysconfig._PIP_USE_SYSCONFIG``
+to ``True`` or ``False``.

--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -45,7 +45,22 @@ else:
 
 _PLATLIBDIR: str = getattr(sys, "platlibdir", "lib")
 
-_USE_SYSCONFIG = sys.version_info >= (3, 10)
+
+def _should_use_sysconfig() -> bool:
+    """
+    This function determines the value of _USE_SYSCONFIG.
+    By default, pip uses sysconfig on Python 3.10+.
+    But Python distributors can override this decision by setting:
+        sysconfig._PIP_USE_SYSCONFIG = True / False
+    Rationale in https://github.com/pypa/pip/issues/10647
+    """
+    if hasattr(sysconfig, "_PIP_USE_SYSCONFIG"):
+        return bool(sysconfig._PIP_USE_SYSCONFIG)  # type: ignore [attr-defined]
+    return sys.version_info >= (3, 10)
+
+
+# This is a function for testability, but should be constant during any one run.
+_USE_SYSCONFIG = _should_use_sysconfig()
 
 
 def _looks_like_bpo_44860() -> bool:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

(description of the change, taken from 63b50517653adf8bc02faa16e524d05e4dabcd64)

> Allow Python distributors to opt-out from or opt-in to the ``sysconfig`` installation scheme backend. By default, the installation scheme backend is ``sysconfig`` on Python 3.10 or later, but by setting the ``sysconfig._PIP_USE_SYSCONFIG`` the distributors can override this default: The boolean value of this private ``sysconfig`` attribute will take precedence over the default if set. This can be used for compatibility considerations as well as for opting in for more leading-edge technology if so desired. Distributors who set ``sysconfig._PIP_USE_SYSCONFIG = False`` are strongly encouraged to ensure ``distutils`` is present, e.g. it is not recommended to set this when ``distutils`` was removed from the standard library, as it will result in failures.

Fixes https://github.com/pypa/pip/issues/10647