### PR TITLE
Ignore require-virtualenv in `pip index`

### DIFF
--- a/news/10657.feature.rst
+++ b/news/10657.feature.rst
@@ -1,0 +1,1 @@
+Allow ``pip index`` to be run outside of a virtual environment with ``requires-virtualenv`` set.

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -24,6 +24,7 @@ class IndexCommand(IndexGroupCommand):
     Inspect information available from package indexes.
     """
 
+    ignore_require_venv = True
     usage = """
         %prog versions <package>
     """


### PR DESCRIPTION
resolves #10657 

extremely similar to #8603 and follows same conventions