### PR TITLE
Make download speed disappear after progress bar finished

### DIFF
--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -132,7 +132,9 @@ class DownloadProgressMixin:
         # Avoid zero division errors...
         if self.avg == 0.0:  # type: ignore
             return "..."
-        return format_size(1 / self.avg) + "/s"  # type: ignore
+        if self.eta:  # type: ignore
+            return format_size(1 / self.avg) + "/s"  # type: ignore
+        return ""
 
     @property
     def pretty_eta(self) -> str:

--- a/tests/unit/test_progress_bars.py
+++ b/tests/unit/test_progress_bars.py
@@ -1,0 +1,32 @@
+from typing import Dict
+
+import pytest
+
+from pip._internal.cli.progress_bars import DefaultDownloadProgressBar
+
+
+@pytest.mark.parametrize(
+    "value, downloaded, download_speed, pretty_eta",
+    [
+        (
+            {"avg": 5, "index": 10, "max": 100},
+            "10 bytes",
+            "0 bytes/s",
+            "eta 0:07:30",
+        ),
+        (
+            {"avg": 5, "index": 100, "max": 100},
+            "100 bytes",
+            "",
+            "",
+        ),
+    ],
+)
+def test_display_infos(
+    value: Dict[str, int], downloaded: str, download_speed: str, pretty_eta: str
+) -> None:
+    bar = DefaultDownloadProgressBar(**value)
+
+    assert bar.downloaded == downloaded, f"actual: {bar.downloaded}"
+    assert bar.download_speed == download_speed, f"actual: {bar.download_speed}"
+    assert bar.pretty_eta == pretty_eta, f"actual: {bar.pretty_eta}"


### PR DESCRIPTION

Closes https://github.com/pypa/pip/issues/10633

Hi, I am new to code base. I tried to find progress bar tests location but I couldn't find any. So I opened new test file to test my addings.

Before
```
Collecting torch==1.9.0
  Downloading torch-1.9.0-cp39-none-macosx_11_0_arm64.whl (41.5 MB)
     |████████████████████████████████| 41.5 MB 494 kB/s 
Collecting typing-extensions
  Downloading typing_extensions-4.0.0-py3-none-any.whl (22 kB)
Saved ./torch-1.9.0-cp39-none-macosx_11_0_arm64.whl
Saved ./typing_extensions-4.0.0-py3-none-any.whl
```

After
```
Collecting torch==1.9.0
  Downloading torch-1.9.0-cp39-none-macosx_11_0_arm64.whl (41.5 MB)
     |████████████████████████████████| 41.5 MB                     
Collecting typing-extensions
  Downloading typing_extensions-4.0.0-py3-none-any.whl (22 kB)
Saved ./torch-1.9.0-cp39-none-macosx_11_0_arm64.whl
Saved ./typing_extensions-4.0.0-py3-none-any.whl
```