### PR TITLE
Change script shebang replacement to respect args

### DIFF
--- a/news/10661.feature.rst
+++ b/news/10661.feature.rst
@@ -1,0 +1,1 @@
+Script shebang "#!python" replacement now preserves all arguments after the first space (e.g. "#!python -i")


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Closes #10661 

Changes the wheel installation `fix_script` function to only replace the starting `#!python` or `#!pythonw` with the exact Python executable and to preserve any arguments after the first space on this line.

The [PEP-427 specification](https://www.python.org/dev/peps/pep-0427/#recommended-installer-features) is not specific on what should be done with arguments in the shebang line, only that lines which start with `#!python` should be rewritten to point to the correct interpreter. The current implementation replaces the whole line with the correct interpreter path and so ignores any arguments which might have been specified.
