### PR TITLE
Fix renamed author

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -34,6 +34,7 @@ Ludovic Gasc        <gmludo@gmail.com>                      <git@gmludo.eu>
 Markus Hametner                                             <fin+github@xbhd.org>
 Masklinn                                                    <bitbucket.org@masklinn.net>
 Matthew Iversen     <teh.ivo@gmail.com>                     <teh.ivo@gmail.com>
+Ofek Lev                                                    <ofekmeister@gmail.com>
 Pi Delport                                                  <pjdelport@gmail.com>
                     <pnasrat@gmail.com>                     <pnasrat@googlemail.com>
 Pradyun Gedam       <pradyunsg@gmail.com>                   <pradyunsg@users.noreply.github.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -443,7 +443,7 @@ Nowell Strite
 NtaleGrey
 nvdv
 OBITORASU
-Ofekmeister
+Ofek Lev
 ofrinevo
 Oliver Jeeves
 Oliver Mannion


### PR DESCRIPTION
That was from my email and old GitHub name before renaming the account, I'll just use my name now instead