### PR TITLE
Include files/folders in `pip install` autocomplete

### DIFF
--- a/news/10646.feature.rst
+++ b/news/10646.feature.rst
@@ -1,0 +1,1 @@
+``pip install <tab>`` autocompletes paths.

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -138,7 +138,7 @@ def auto_complete_paths(current: str, completion_type: str) -> Iterable[str]:
     starting with ``current``.
 
     :param current: The word to be completed
-    :param completion_type: path completion type(`file`, `path` or `dir`)i
+    :param completion_type: path completion type(``file``, ``path`` or ``dir``)
     :return: A generator of regular files and/or directories
     """
     directory, filename = os.path.split(current)

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -59,6 +59,14 @@ def autocomplete() -> None:
                     print(dist)
                 sys.exit(1)
 
+        should_list_installables = (
+            not current.startswith("-") and subcommand_name == "install"
+        )
+        if should_list_installables:
+            for path in auto_complete_paths(current, "path"):
+                print(path)
+            sys.exit(1)
+
         subcommand = create_command(subcommand_name)
 
         for opt in subcommand.parser.option_list_all:

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -237,10 +237,10 @@ def test_completion_not_files_after_option(
 ) -> None:
     """
     Test not getting completion files after options which not applicable
-    (e.g. ``pip install``)
+    (e.g. ``pip wheel``)
     """
     res, env = autocomplete(
-        words=("pip install r"),
+        words=("pip wheel r"),
         cword="2",
         cwd=data.completion_paths,
     )
@@ -254,6 +254,24 @@ def test_completion_not_files_after_option(
     assert not any(
         os.path.join(out, "") in res.stdout for out in ("replay", "resources")
     ), "autocomplete function completed <dir> when it should not complete"
+
+
+def test_pip_install_complete_files(
+    autocomplete: DoAutocomplete, data: TestData
+) -> None:
+    """``pip install`` autocompletes wheel and sdist files."""
+    res, env = autocomplete(
+        words=("pip install r"),
+        cword="2",
+        cwd=data.completion_paths,
+    )
+    assert all(
+        out in res.stdout
+        for out in (
+            "requirements.txt",
+            "resources",
+        )
+    ), "autocomplete function could not complete <path>"
 
 
 @pytest.mark.parametrize("cl_opts", ["-U", "--user", "-h"])


### PR DESCRIPTION
Previously, `pip install <tab>` did not autocomplete anything. With this patch, it autocompletes paths to e.g. wheels, sdists, and directories.

Fixes #10646.