### PR TITLE
Fix ill-formatted link to pip-tools

### DIFF
--- a/docs/html/topics/dependency-resolution.md
+++ b/docs/html/topics/dependency-resolution.md
@@ -156,7 +156,7 @@ how to inspect:
 
 During deployment, you can create a lockfile stating the exact package and
 version number for for each dependency of that package. You can create this
-with `pip-tools <https://github.com/jazzband/pip-tools/>`\_\_.
+with [pip-tools](https://github.com/jazzband/pip-tools/).
 
 This means the "work" is done once during development process, and thus
 will avoid performing dependency resolution during deployment.


### PR DESCRIPTION
This link seems to have gone through a transform on the way out of reStructuredText and was rendering as raw markup in the docs seen [here](https://pip.pypa.io/en/latest/topics/dependency-resolution/#use-constraint-files-or-lockfiles).
