### PR TITLE
Make proxy parameter override environment proxy

### DIFF
--- a/news/10685.bugfix.rst
+++ b/news/10685.bugfix.rst
@@ -1,1 +1,1 @@
-Make the '--proxy' parameter take precedence over proxies defined in environment variables.
+Make the ``--proxy`` parameter take precedence over environment variables.

--- a/news/10685.bugfix.rst
+++ b/news/10685.bugfix.rst
@@ -1,0 +1,1 @@
+Make the '--proxy' parameter take precedence over proxies defined in environment variables.

--- a/src/pip/_vendor/requests/sessions.py
+++ b/src/pip/_vendor/requests/sessions.py
@@ -527,7 +527,7 @@ class Session(SessionRedirectMixin):
         )
         prep = self.prepare_request(req)
 
-        proxies = proxies or {}
+        proxies = proxies or self.proxies or {}
 
         settings = self.merge_environment_settings(
             prep.url, proxies, stream, verify, cert


### PR DESCRIPTION
This PR addresses #10685. It makes the "--proxy" parameter take precedence over environment variables. 
