### PR TITLE
Resolves junction links when deleting packages installed as editable

### DIFF
--- a/news/10696.bugfix.rst
+++ b/news/10696.bugfix.rst
@@ -1,0 +1,1 @@
+Fix uninstall editable from Windows junction link

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -526,10 +526,8 @@ class UninstallPathSet:
             # PEP 660 modern editable is handled in the ``.dist-info`` case
             # above, so this only covers the setuptools-style editable.
             with open(develop_egg_link) as fh:
-                link_pointer = os.path.normcase(
-                    os.path.realpath(fh.readline().strip())
-                )
-            assert link_pointer == dist_location, (
+                link_pointer = os.path.normcase(fh.readline().strip())
+            assert os.path.samefile(link_pointer, dist_location), (
                 f"Egg-link {link_pointer} does not match installed location of "
                 f"{dist.raw_name} (at {dist_location})"
             )

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -526,7 +526,9 @@ class UninstallPathSet:
             # PEP 660 modern editable is handled in the ``.dist-info`` case
             # above, so this only covers the setuptools-style editable.
             with open(develop_egg_link) as fh:
-                link_pointer = os.path.normcase(fh.readline().strip())
+                link_pointer = os.path.normcase(
+                    os.path.realpath(fh.readline().strip())
+                )
             assert link_pointer == dist_location, (
                 f"Egg-link {link_pointer} does not match installed location of "
                 f"{dist.raw_name} (at {dist_location})"


### PR DESCRIPTION
Resolve #10696 

Or would it be better to use `pathlib.Path`?