### PR TITLE
Autocancel repeated CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: 0 0 * * MON # Run every Monday at 00:00 UTC
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     name: docs


### PR DESCRIPTION
This will ensure that any specific pull request (or commit) only has a
single CI run happening at any point in time.

Spotted over at https://github.com/pyca/cryptography/blob/8a062086b31407eac92e1e92a0e6675ebfd5ff43/.github/workflows/ci.yml#L14