### PR TITLE
Metadata backend with importlib.metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,6 @@ jobs:
           python-version: '3.10'
 
       - name: Install Ubuntu dependencies
-        if: matrix.os == 'Ubuntu'
         run: sudo apt-get install bzr
 
       - run: pip install nox 'virtualenv<20'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
     name: tests for importlib.metadata backend
     runs-on: ubuntu-latest
     env:
-      _PIP_METADATA_BACKEND_IMPORTLIB: '1'
+      _PIP_METADATA_BACKEND_IMPORTLIB: egg-compat
 
     needs: [pre-commit, packaging, determine-changes]
     if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,3 +218,39 @@ jobs:
           --verbose --numprocesses auto --showlocals
         env:
           TEMP: "R:\\Temp"
+
+  tests-importlib-metadata:
+    name: tests for importlib.metadata backend
+    runs-on: ubuntu-latest
+    env:
+      _PIP_METADATA_BACKEND_IMPORTLIB: '1'
+
+    needs: [pre-commit, packaging, determine-changes]
+    if: >-
+      needs.determine-changes.outputs.tests == 'true' ||
+      github.event_name != 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install Ubuntu dependencies
+        if: matrix.os == 'Ubuntu'
+        run: sudo apt-get install bzr
+
+      - run: pip install nox 'virtualenv<20'
+
+      # Main check
+      - name: Run unit tests
+        run: >-
+          nox -s test-3.10 --
+          -m unit
+          --verbose --numprocesses auto --showlocals
+      - name: Run integration tests
+        run: >-
+          nox -s test-3.10 --
+          -m integration
+          --verbose --numprocesses auto --showlocals
+          --durations=5

--- a/news/10709.process.rst
+++ b/news/10709.process.rst
@@ -1,0 +1,3 @@
+Start migration of distribution metadata implementation from ``pkg_resources``
+to ``importlib.metadata``. The new implementation is currently not exposed in
+any user-facing way, but included in the code base for easier development.

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -76,7 +76,7 @@ def search_packages_info(query: List[str]) -> Generator[_PackageInfo, None, None
     """
     env = get_default_environment()
 
-    installed = {dist.canonical_name: dist for dist in env.iter_distributions()}
+    installed = {dist.canonical_name: dist for dist in env.iter_all_distributions()}
     query_names = [canonicalize_name(name) for name in query]
     missing = sorted(
         [name for name, pkg in zip(query, query_names) if pkg not in installed]

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -1,6 +1,13 @@
-from typing import List, Optional
+import functools
+import os
+from typing import TYPE_CHECKING, List, Optional, Type, cast
 
 from .base import BaseDistribution, BaseEnvironment, FilesystemWheel, MemoryWheel, Wheel
+
+if TYPE_CHECKING:
+    from typing import Protocol
+else:
+    Protocol = object
 
 __all__ = [
     "BaseDistribution",
@@ -14,6 +21,22 @@ __all__ = [
 ]
 
 
+class _Backend(Protocol):
+    Distribution: Type[BaseDistribution]
+    Environment: Type[BaseEnvironment]
+
+
+@functools.lru_cache(maxsize=None)
+def _select_backend() -> _Backend:
+    if os.environ.get("_PIP_METADATA_BACKEND_USE_IMPORTLIB"):
+        from . import importlib
+
+        return cast(_Backend, importlib)
+    from . import pkg_resources
+
+    return cast(_Backend, pkg_resources)
+
+
 def get_default_environment() -> BaseEnvironment:
     """Get the default representation for the current environment.
 
@@ -21,9 +44,7 @@ def get_default_environment() -> BaseEnvironment:
     Environment instance should be built from ``sys.path`` and may use caching
     to share instance state accorss calls.
     """
-    from .pkg_resources import Environment
-
-    return Environment.default()
+    return _select_backend().Environment.default()
 
 
 def get_environment(paths: Optional[List[str]]) -> BaseEnvironment:
@@ -33,9 +54,7 @@ def get_environment(paths: Optional[List[str]]) -> BaseEnvironment:
     given import paths. The backend must build a fresh instance representing
     the state of installed distributions when this function is called.
     """
-    from .pkg_resources import Environment
-
-    return Environment.from_paths(paths)
+    return _select_backend().Environment.from_paths(paths)
 
 
 def get_directory_distribution(directory: str) -> BaseDistribution:
@@ -44,9 +63,7 @@ def get_directory_distribution(directory: str) -> BaseDistribution:
     This returns a Distribution instance from the chosen backend based on
     the given on-disk ``.dist-info`` directory.
     """
-    from .pkg_resources import Distribution
-
-    return Distribution.from_directory(directory)
+    return _select_backend().Distribution.from_directory(directory)
 
 
 def get_wheel_distribution(wheel: Wheel, canonical_name: str) -> BaseDistribution:
@@ -57,6 +74,4 @@ def get_wheel_distribution(wheel: Wheel, canonical_name: str) -> BaseDistributio
 
     :param canonical_name: Normalized project name of the given wheel.
     """
-    from .pkg_resources import Distribution
-
-    return Distribution.from_wheel(wheel, canonical_name)
+    return _select_backend().Distribution.from_wheel(wheel, canonical_name)

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -18,23 +18,24 @@ __all__ = [
     "get_default_environment",
     "get_environment",
     "get_wheel_distribution",
+    "select_backend",
 ]
 
 
-class _Backend(Protocol):
+class Backend(Protocol):
     Distribution: Type[BaseDistribution]
     Environment: Type[BaseEnvironment]
 
 
 @functools.lru_cache(maxsize=None)
-def _select_backend() -> _Backend:
+def select_backend() -> Backend:
     if os.environ.get("_PIP_METADATA_BACKEND_IMPORTLIB"):
         from . import importlib
 
-        return cast(_Backend, importlib)
+        return cast(Backend, importlib)
     from . import pkg_resources
 
-    return cast(_Backend, pkg_resources)
+    return cast(Backend, pkg_resources)
 
 
 def get_default_environment() -> BaseEnvironment:
@@ -44,7 +45,7 @@ def get_default_environment() -> BaseEnvironment:
     Environment instance should be built from ``sys.path`` and may use caching
     to share instance state accorss calls.
     """
-    return _select_backend().Environment.default()
+    return select_backend().Environment.default()
 
 
 def get_environment(paths: Optional[List[str]]) -> BaseEnvironment:
@@ -54,7 +55,7 @@ def get_environment(paths: Optional[List[str]]) -> BaseEnvironment:
     given import paths. The backend must build a fresh instance representing
     the state of installed distributions when this function is called.
     """
-    return _select_backend().Environment.from_paths(paths)
+    return select_backend().Environment.from_paths(paths)
 
 
 def get_directory_distribution(directory: str) -> BaseDistribution:
@@ -63,7 +64,7 @@ def get_directory_distribution(directory: str) -> BaseDistribution:
     This returns a Distribution instance from the chosen backend based on
     the given on-disk ``.dist-info`` directory.
     """
-    return _select_backend().Distribution.from_directory(directory)
+    return select_backend().Distribution.from_directory(directory)
 
 
 def get_wheel_distribution(wheel: Wheel, canonical_name: str) -> BaseDistribution:
@@ -74,4 +75,4 @@ def get_wheel_distribution(wheel: Wheel, canonical_name: str) -> BaseDistributio
 
     :param canonical_name: Normalized project name of the given wheel.
     """
-    return _select_backend().Distribution.from_wheel(wheel, canonical_name)
+    return select_backend().Distribution.from_wheel(wheel, canonical_name)

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -28,7 +28,7 @@ class _Backend(Protocol):
 
 @functools.lru_cache(maxsize=None)
 def _select_backend() -> _Backend:
-    if os.environ.get("_PIP_METADATA_BACKEND_USE_IMPORTLIB"):
+    if os.environ.get("_PIP_METADATA_BACKEND_IMPORTLIB"):
         from . import importlib
 
         return cast(_Backend, importlib)

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -511,10 +511,10 @@ class BaseEnvironment:
     ) -> Iterator[BaseDistribution]:
         """Return a list of installed distributions.
 
-        This is based on ``iter_all_distributions()``, but applies some
-        configurabilities. Note that ``iter_installed_distributions()`` without
-        arguments is *not* equal to ``iter_all_distributions()``, since some of
-        the configurations exclude packages by default.
+        This is based on ``iter_all_distributions()`` with additional filtering
+        options. Note that ``iter_installed_distributions()`` without arguments
+        is *not* equal to ``iter_all_distributions()``, since some of the
+        configurations exclude packages by default.
 
         :param local_only: If True (default), only return installations
         local to the current virtualenv, if in a virtualenv.

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -10,7 +10,6 @@ from typing import (
     TYPE_CHECKING,
     Collection,
     Container,
-    Generator,
     Iterable,
     Iterator,
     List,
@@ -491,8 +490,8 @@ class BaseEnvironment:
         """
         raise NotImplementedError()
 
-    def iter_distributions(self) -> Generator["BaseDistribution", None, None]:
-        """Iterate through installed distributions."""
+    def iter_all_distributions(self) -> Iterator[BaseDistribution]:
+        """Iterate through all installed distributions without any filtering."""
         for dist in self._iter_distributions():
             # Make sure the distribution actually comes from a valid Python
             # packaging distribution. Pip's AdjacentTempDirectory leaves folders
@@ -522,6 +521,11 @@ class BaseEnvironment:
     ) -> Iterator[BaseDistribution]:
         """Return a list of installed distributions.
 
+        This is based on ``iter_all_distributions()``, but applies some
+        configurabilities. Note that ``iter_installed_distributions()`` without
+        arguments is *not* equal to ``iter_all_distributions()``, since some of
+        the configurations exclude packages by default.
+
         :param local_only: If True (default), only return installations
         local to the current virtualenv, if in a virtualenv.
         :param skip: An iterable of canonicalized project names to ignore;
@@ -531,7 +535,7 @@ class BaseEnvironment:
         :param user_only: If True, only report installations in the user
         site directory.
         """
-        it = self.iter_distributions()
+        it = self.iter_all_distributions()
         if local_only:
             it = (d for d in it if d.local)
         if not include_editables:

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -46,7 +46,7 @@ else:
 
 DistributionVersion = Union[LegacyVersion, Version]
 
-InfoPath = Union[str, pathlib.PurePosixPath]
+InfoPath = Union[str, pathlib.PurePath]
 
 logger = logging.getLogger(__name__)
 
@@ -344,16 +344,16 @@ class BaseDistribution(Protocol):
 
         Each item yielded would be a path relative to the info directory.
 
-        :raise FileNotFoundError: If ``name`` does not exist in the directory.
-        :raise NotADirectoryError: If ``name`` does not point to a directory.
+        :raise FileNotFoundError: If ``path`` does not exist in the directory.
+        :raise NotADirectoryError: If ``path`` does not point to a directory.
         """
         raise NotImplementedError()
 
     def read_text(self, path: InfoPath) -> str:
         """Read a file in the info directory.
 
-        :raise FileNotFoundError: If ``name`` does not exist in the directory.
-        :raise NoneMetadataError: If ``name`` exists in the info directory, but
+        :raise FileNotFoundError: If ``path`` does not exist in the directory.
+        :raise NoneMetadataError: If ``path`` exists in the info directory, but
             cannot be read.
         """
         raise NotImplementedError()

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -339,13 +339,11 @@ class BaseDistribution(Protocol):
         """Check whether an entry in the info directory is a file."""
         raise NotImplementedError()
 
-    def iterdir(self, path: InfoPath) -> Iterator[pathlib.PurePosixPath]:
-        """Iterate through a directory in the info directory.
+    def iter_distutils_script_names(self) -> Iterator[str]:
+        """Find distutils 'scripts' entries metadata.
 
-        Each item yielded would be a path relative to the info directory.
-
-        :raise FileNotFoundError: If ``path`` does not exist in the directory.
-        :raise NotADirectoryError: If ``path`` does not point to a directory.
+        If 'scripts' is supplied in ``setup.py``, distutils records those in the
+        installed distribution's ``scripts`` directory, a file for each script.
         """
         raise NotImplementedError()
 

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -96,6 +96,28 @@ def _convert_installed_files_path(
 
 
 class BaseDistribution(Protocol):
+    @classmethod
+    def from_directory(cls, directory: str) -> "BaseDistribution":
+        """Load the distribution from a metadata directory.
+
+        :param directory: Path to a metadata directory, e.g. ``.dist-info``.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def from_wheel(cls, wheel: "Wheel", name: str) -> "BaseDistribution":
+        """Load the distribution from a given wheel.
+
+        :param wheel: A concrete wheel definition.
+        :param name: File name of the wheel.
+
+        :raises InvalidWheel: Whenever loading of the wheel causes a
+            :py:exc:`zipfile.BadZipFile` exception to be thrown.
+        :raises UnsupportedWheel: If the wheel is a valid zip, but malformed
+            internally.
+        """
+        raise NotImplementedError()
+
     def __repr__(self) -> str:
         return f"{self.raw_name} {self.version} ({self.location})"
 

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -31,10 +31,7 @@ from pip._internal.models.direct_url import (
     DirectUrlValidationError,
 )
 from pip._internal.utils.compat import stdlib_pkgs  # TODO: Move definition here.
-from pip._internal.utils.egg_link import (
-    egg_link_path_from_location,
-    egg_link_path_from_sys_path,
-)
+from pip._internal.utils.egg_link import egg_link_path_from_sys_path
 from pip._internal.utils.misc import is_local, normalize_path
 from pip._internal.utils.urls import url_to_path
 
@@ -170,14 +167,7 @@ class BaseDistribution(Protocol):
 
         The returned location is normalized (in particular, with symlinks removed).
         """
-        egg_link = egg_link_path_from_location(self.raw_name)
-        if egg_link:
-            location = egg_link
-        elif self.location:
-            location = self.location
-        else:
-            return None
-        return normalize_path(location)
+        raise NotImplementedError()
 
     @property
     def info_location(self) -> Optional[str]:

--- a/src/pip/_internal/metadata/importlib.py
+++ b/src/pip/_internal/metadata/importlib.py
@@ -258,7 +258,7 @@ class Environment(BaseEnvironment):
     def get_distribution(self, name: str) -> Optional[BaseDistribution]:
         matches = (
             distribution
-            for distribution in self._iter_distributions()
+            for distribution in self.iter_all_distributions()
             if distribution.canonical_name == canonicalize_name(name)
         )
         return next(matches, None)

--- a/src/pip/_internal/metadata/importlib.py
+++ b/src/pip/_internal/metadata/importlib.py
@@ -198,6 +198,8 @@ class Distribution(BaseDistribution):
             req = Requirement(r)
             if not req.marker:
                 yield req
+            elif not extras and req.marker.evaluate({"extra": ""}):
+                yield req
             elif any(req.marker.evaluate({"extra": extra}) for extra in extras):
                 yield req
 

--- a/src/pip/_internal/metadata/importlib.py
+++ b/src/pip/_internal/metadata/importlib.py
@@ -1,0 +1,249 @@
+import contextlib
+import email.message
+import importlib.metadata
+import pathlib
+import sys
+import zipfile
+from typing import Collection, Iterable, Iterator, List, Mapping, Optional, Sequence
+
+from pip._vendor.packaging.requirements import Requirement
+from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from pip._vendor.packaging.version import parse as parse_version
+
+from pip._internal.exceptions import InvalidWheel, UnsupportedWheel
+from pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
+
+from .base import (
+    BaseDistribution,
+    BaseEntryPoint,
+    BaseEnvironment,
+    DistributionVersion,
+    InfoPath,
+    Wheel,
+)
+
+
+class _WheelDistribution(importlib.metadata.Distribution):
+    """Distribution read from a wheel.
+
+    Although ``importlib.metadata.PathDistribution`` accepts ``zipfile.Path``,
+    its implementation is too "lazy" for pip's needs (we can't keep the ZipFile
+    handle open for the entire lifetime of the distribution object).
+
+    This implementation eagerly reads the entire metadata directory into the
+    memory instead, and operates from that.
+    """
+
+    def __init__(
+        self,
+        files: Mapping[pathlib.PurePosixPath, bytes],
+        info_location: pathlib.PurePosixPath,
+    ) -> None:
+        self._files = files
+        self.info_location = info_location
+
+    @classmethod
+    def from_zipfile(
+        cls,
+        zf: zipfile.ZipFile,
+        name: str,
+        location: str,
+    ) -> "_WheelDistribution":
+        info_dir, _ = parse_wheel(zf, name)
+        paths = (
+            (name, pathlib.PurePosixPath(name.split("/", 1)[-1]))
+            for name in zf.namelist()
+            if name.startswith(f"{info_dir}/")
+        )
+        files = {
+            relpath: read_wheel_metadata_file(zf, fullpath)
+            for fullpath, relpath in paths
+        }
+        info_location = pathlib.PurePosixPath(location, info_dir)
+        return cls(files, info_location)
+
+    def iterdir(self, path: InfoPath) -> Iterator[pathlib.PurePosixPath]:
+        # Only allow iterating through the metadata directory.
+        if pathlib.PurePosixPath(str(path)) in self._files:
+            return iter(self._files)
+        raise FileNotFoundError(path)
+
+    def read_text(self, filename: str) -> Optional[str]:
+        try:
+            data = self._files[pathlib.PurePosixPath(filename)]
+        except KeyError:
+            return None
+        return data.decode("utf-8")
+
+
+class Distribution(BaseDistribution):
+    def __init__(
+        self,
+        dist: importlib.metadata.Distribution,
+        location: pathlib.PurePath,
+        info_location: Optional[pathlib.PurePath],
+    ) -> None:
+        self._dist = dist
+        self._location = location
+        self._info_location = info_location
+
+    @classmethod
+    def from_directory(cls, directory: str) -> BaseDistribution:
+        info_location = pathlib.Path(directory)
+        dist = importlib.metadata.Distribution.at(info_location)
+        location = info_location.parent
+        return cls(dist, location, info_location)
+
+    @classmethod
+    def from_wheel(cls, wheel: Wheel, name: str) -> BaseDistribution:
+        try:
+            with wheel.as_zipfile() as zf:
+                dist = _WheelDistribution.from_zipfile(zf, name, wheel.location)
+        except zipfile.BadZipFile as e:
+            raise InvalidWheel(wheel.location, name) from e
+        except UnsupportedWheel as e:
+            raise UnsupportedWheel(f"{name} has an invalid wheel, {e}")
+        return cls(dist, pathlib.PurePosixPath(wheel.location), dist.info_location)
+
+    @property
+    def location(self) -> Optional[str]:
+        return str(self._location)
+
+    @property
+    def info_location(self) -> Optional[str]:
+        if self._info_location is None:
+            return None
+        return str(self._info_location)
+
+    def _get_dist_name(self) -> str:
+        # The 'name' attribute is only available in Python 3.10 or later. We are
+        # only targeting that, but Mypy does not know this.
+        return self._dist.name  # type: ignore[attr-defined]
+
+    @property
+    def canonical_name(self) -> NormalizedName:
+        # Try to get the name from the metadata directory name. This is much
+        # faster than reading metadata.
+        if self._info_location is None:
+            name = self._get_dist_name()
+        elif self._info_location.suffix in (".dist-info", ".egg-info"):
+            name, _, _ = self._info_location.stem.partition("-")
+        else:
+            name = self._get_dist_name()
+        return canonicalize_name(name)
+
+    @property
+    def version(self) -> DistributionVersion:
+        return parse_version(self._dist.version)
+
+    def is_file(self, path: InfoPath) -> bool:
+        return self._dist.read_text(str(path)) is not None
+
+    def iterdir(self, path: InfoPath) -> Iterator[pathlib.PurePosixPath]:
+        # We have an optimized implementation for wheels.
+        with contextlib.suppress(AttributeError):
+            return self._dist.iterdir(path)  # type: ignore [attr-defined]
+
+        # This is not actually based on anything concrete to iterate on.
+        if self._info_location is None:
+            raise FileNotFoundError(path)
+
+        # Just use pathlib if this is actually on the filesystem.
+        info_root = self._info_location
+        full_path = info_root.joinpath(path)
+        if isinstance(full_path, pathlib.Path):
+            return (
+                pathlib.PurePosixPath(p.relative_to(info_root).as_posix())
+                for p in full_path.iterdir()
+            )
+
+        raise FileNotFoundError(path)  # Nothing else is implemetned for now.
+
+    def read_text(self, path: InfoPath) -> str:
+        content = self._dist.read_text(str(path))
+        if content is None:
+            raise FileNotFoundError(path)
+        return content
+
+    def iter_entry_points(self) -> Iterable[BaseEntryPoint]:
+        # importlib.metadata's EntryPoint structure sasitfies BaseEntryPoint.
+        return self._dist.entry_points
+
+    @property
+    def metadata(self) -> email.message.Message:
+        return self._dist.metadata
+
+    def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
+        requires = self._dist.requires
+        if requires is None:
+            return
+        for r in requires:
+            req = Requirement(r)
+            if not req.marker:
+                yield req
+            elif any(req.marker.evaluate({"extra": extra}) for extra in extras):
+                yield req
+
+    def _iter_egg_info_extras(self) -> Iterable[str]:
+        """Parse extras from an .egg-info directory.
+
+        An .egg-info directory stores dependencies in an INI-like file named
+        ``requires.txt``, with extras being a part of the section names.
+        """
+        requires_txt = self._dist.read_text("requires.txt")
+        if requires_txt is None:
+            return
+        for line in requires_txt.splitlines():
+            line = line.strip()
+            if line.startswith("[") and line.endswith("]"):
+                yield line.strip("[]").partition(":")[0]
+
+    def iter_provided_extras(self) -> Iterable[str]:
+        return (
+            self._dist.metadata.get_all("Provides-Extra")
+            or self._iter_egg_info_extras()
+        )
+
+
+def _get_info_location(d: importlib.metadata.Distribution) -> Optional[pathlib.Path]:
+    """Find the path to the distribution's metadata directory.
+
+    HACK: This relies on importlib.metadata's private ``_path`` attribute. Not
+    all distributions exist on disk, so importlib.metadata is correct to not
+    expose the attribute as public. But pip's code base is old and not as clean,
+    so we do this to avoid having to rewrite too many things. Hopefully we can
+    eliminate this some day.
+    """
+    return getattr(d, "_path", None)
+
+
+class Environment(BaseEnvironment):
+    def __init__(self, paths: Sequence[str]) -> None:
+        self._paths = paths
+
+    @classmethod
+    def default(cls) -> BaseEnvironment:
+        return cls(sys.path)
+
+    @classmethod
+    def from_paths(cls, paths: Optional[List[str]]) -> BaseEnvironment:
+        if paths is None:
+            return cls(sys.path)
+        return cls(paths)
+
+    def _iter_distributions(self) -> Iterator[BaseDistribution]:
+        # To know exact where we found a distribution, we have to feed the paths
+        # in one by one, instead of dumping entire list to importlib.metadata.
+        for path in self._paths:
+            for dist in importlib.metadata.distributions(path=[path]):
+                location = pathlib.Path(path)
+                info_location = _get_info_location(dist)
+                yield Distribution(dist, location, info_location)
+
+    def get_distribution(self, name: str) -> Optional[BaseDistribution]:
+        matches = (
+            distribution
+            for distribution in self._iter_distributions()
+            if distribution.canonical_name == canonicalize_name(name)
+        )
+        return next(matches, None)

--- a/src/pip/_internal/metadata/importlib.py
+++ b/src/pip/_internal/metadata/importlib.py
@@ -96,7 +96,13 @@ class WheelDistribution(importlib.metadata.Distribution):
             data = self._files[pathlib.PurePosixPath(filename)]
         except KeyError:
             return None
-        return data.decode("utf-8")
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as e:
+            wheel = self.info_location.parent
+            error = f"Error decoding metadata for {wheel}: {e} in {filename} file"
+            raise UnsupportedWheel(error)
+        return text
 
 
 class Distribution(BaseDistribution):

--- a/src/pip/_internal/metadata/importlib/__init__.py
+++ b/src/pip/_internal/metadata/importlib/__init__.py
@@ -1,0 +1,4 @@
+from ._dists import Distribution
+from ._envs import Environment
+
+__all__ = ["Distribution", "Environment"]

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -1,8 +1,6 @@
 import importlib.metadata
 from typing import Optional, Protocol
 
-from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
-
 
 class BasePath(Protocol):
     """A protocol that various path objects conform.
@@ -34,10 +32,10 @@ def get_info_location(d: importlib.metadata.Distribution) -> Optional[BasePath]:
     return getattr(d, "_path", None)
 
 
-def get_dist_normalized_name(dist: importlib.metadata.Distribution) -> NormalizedName:
+def get_dist_name(dist: importlib.metadata.Distribution) -> str:
     """Get the distribution's project name.
 
     The ``name`` attribute is only available in Python 3.10 or later. We are
     targeting exactly that, but Mypy does not know this.
     """
-    return canonicalize_name(dist.name)  # type: ignore[attr-defined]
+    return dist.name  # type: ignore[attr-defined]

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -16,6 +16,7 @@ class BasePath(Protocol):
     """
 
     name: str
+    parent: "BasePath"
 
 
 def get_info_location(d: importlib.metadata.Distribution) -> Optional[BasePath]:

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -1,5 +1,5 @@
 import importlib.metadata
-from typing import Optional, Protocol
+from typing import Any, Optional, Protocol, cast
 
 
 class BasePath(Protocol):
@@ -38,4 +38,4 @@ def get_dist_name(dist: importlib.metadata.Distribution) -> str:
     The ``name`` attribute is only available in Python 3.10 or later. We are
     targeting exactly that, but Mypy does not know this.
     """
-    return dist.name  # type: ignore[attr-defined]
+    return cast(Any, dist).name

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -1,0 +1,39 @@
+import importlib.metadata
+from typing import Optional, Protocol
+
+from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+
+
+class BasePath(Protocol):
+    """A protocol that various path objects conform.
+
+    This exists because importlib.metadata uses both ``pathlib.Path`` and
+    ``zipfile.Path``, and we need a common base for type hints (Union does not
+    work well since ``zipfile.Path`` is too new for our linter setup).
+
+    This does not mean to be exhaustive, but only contains things that present
+    in both classes *that we need*.
+    """
+
+    name: str
+
+
+def get_info_location(d: importlib.metadata.Distribution) -> Optional[BasePath]:
+    """Find the path to the distribution's metadata directory.
+
+    HACK: This relies on importlib.metadata's private ``_path`` attribute. Not
+    all distributions exist on disk, so importlib.metadata is correct to not
+    expose the attribute as public. But pip's code base is old and not as clean,
+    so we do this to avoid having to rewrite too many things. Hopefully we can
+    eliminate this some day.
+    """
+    return getattr(d, "_path", None)
+
+
+def get_dist_normalized_name(dist: importlib.metadata.Distribution) -> NormalizedName:
+    """Get the distribution's project name.
+
+    The ``name`` attribute is only available in Python 3.10 or later. We are
+    targeting exactly that, but Mypy does not know this.
+    """
+    return canonicalize_name(dist.name)  # type: ignore[attr-defined]

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -16,7 +16,10 @@ class BasePath(Protocol):
     """
 
     name: str
-    parent: "BasePath"
+
+    @property
+    def parent(self) -> "BasePath":
+        raise NotImplementedError()
 
 
 def get_info_location(d: importlib.metadata.Distribution) -> Optional[BasePath]:

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -26,6 +26,7 @@ from pip._internal.metadata.base import (
     InfoPath,
     Wheel,
 )
+from pip._internal.utils.misc import normalize_path
 from pip._internal.utils.packaging import safe_extra
 from pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
 
@@ -141,7 +142,7 @@ class Distribution(BaseDistribution):
     def installed_location(self) -> Optional[str]:
         if self._installed_location is None:
             return None
-        return str(self._installed_location)
+        return normalize_path(str(self._installed_location))
 
     def _get_dist_name_from_location(self) -> Optional[str]:
         """Try to get the name from the metadata directory name.

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -169,6 +169,9 @@ class Distribution(BaseDistribution):
         return self._dist.read_text(str(path)) is not None
 
     def iter_distutils_script_names(self) -> Iterator[str]:
+        # A distutils installation is always "flat" (not in e.g. egg form), so
+        # if this distribution's info location is NOT a pathlib.Path (but e.g.
+        # zipfile.Path), it can never contain any distutils scripts.
         if not isinstance(self._info_location, pathlib.Path):
             return
         for child in self._info_location.joinpath("scripts").iterdir():

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -101,12 +101,10 @@ class Distribution(BaseDistribution):
     def __init__(
         self,
         dist: importlib.metadata.Distribution,
-        location: BasePath,
         info_location: Optional[BasePath],
         installed_location: Optional[BasePath],
     ) -> None:
         self._dist = dist
-        self._location = location
         self._info_location = info_location
         self._installed_location = installed_location
 
@@ -130,7 +128,9 @@ class Distribution(BaseDistribution):
 
     @property
     def location(self) -> Optional[str]:
-        return str(self._location)
+        if self._info_location is None:
+            return None
+        return str(self._info_location.parent)
 
     @property
     def info_location(self) -> Optional[str]:

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -151,10 +151,11 @@ class Environment(BaseEnvironment):
         finder = _DistributionFinder()
         for location in self._paths:
             yield from finder.find(location)
-            yield from finder.find_linked(location)
             for dist in finder.find_eggs(location):
                 # _emit_egg_deprecation(dist.location)  # TODO: Enable this.
                 yield dist
+            # This must go last because that's how pkg_resources tie-breaks.
+            yield from finder.find_linked(location)
 
     def get_distribution(self, name: str) -> Optional[BaseDistribution]:
         matches = (

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -26,10 +26,10 @@ class _DistributionFinder:
 
     FoundResult = Tuple[importlib.metadata.Distribution, Optional[BasePath]]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._found_names: Set[NormalizedName] = set()
 
-    def _find_impl(self, location: str) -> FoundResult:
+    def _find_impl(self, location: str) -> Iterator[FoundResult]:
         """Find distributions in a location.
 
         The extra *source* argument is used by the egg-link finder to specify
@@ -77,7 +77,8 @@ class _DistributionFinder:
                 target_rel = next((line for line in lines if line), "")
             if not target_rel:
                 continue
-            for dist, info_location in self._find_impl(path.joinpath(target_rel)):
+            target_location = str(path.joinpath(target_rel))
+            for dist, info_location in self._find_impl(target_location):
                 yield Distribution(dist, info_location, path)
 
 

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -7,7 +7,7 @@ from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 
 from pip._internal.metadata.base import BaseDistribution, BaseEnvironment
 
-from ._compat import BasePath, get_dist_normalized_name, get_info_location
+from ._compat import BasePath, get_dist_name, get_info_location
 from ._dists import Distribution
 
 
@@ -38,7 +38,7 @@ class _DistributionFinder:
         # To know exact where we found a distribution, we have to feed the paths
         # in one by one, instead of dumping entire list to importlib.metadata.
         for dist in importlib.metadata.distributions(path=[location]):
-            normalized_name = get_dist_normalized_name(dist)
+            normalized_name = canonicalize_name(get_dist_name(dist))
             if normalized_name in self._found_names:
                 continue
             self._found_names.add(normalized_name)

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -35,13 +35,9 @@ class _DistributionFinder:
         self._found_names: Set[NormalizedName] = set()
 
     def _find_impl(self, location: str) -> Iterator[FoundResult]:
-        """Find distributions in a location.
-
-        The extra *source* argument is used by the egg-link finder to specify
-        where the egg-link file is found.
-        """
-        # To know exact where we found a distribution, we have to feed the paths
-        # in one by one, instead of dumping entire list to importlib.metadata.
+        """Find distributions in a location."""
+        # To know exactly where we find a distribution, we have to feed in the
+        # paths one by one, instead of dumping the list to importlib.metadata.
         for dist in importlib.metadata.distributions(path=[location]):
             normalized_name = canonicalize_name(get_dist_name(dist))
             if normalized_name in self._found_names:
@@ -115,8 +111,9 @@ class _DistributionFinder:
 
         This actually uses the old *pkg_resources* backend. We likely want to
         deprecate this so we can eventually remove the *pkg_resources*
-        dependency entirely. Before that, this be behind a flag because
-        importing *pkg_resources* is slow for those who don't need it.
+        dependency entirely. Before that, this should first emit a deprecation
+        warning for some versions when using the fallback since importing
+        *pkg_resources* is slow for those who don't need it.
         """
         if os.path.isdir(location):
             yield from self._find_eggs_in_dir(location)

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -1,0 +1,77 @@
+import importlib.metadata
+import pathlib
+import sys
+from typing import Iterator, List, Optional, Sequence, Set
+
+from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+
+from pip._internal.metadata.base import BaseDistribution, BaseEnvironment
+
+from ._compat import BasePath, get_dist_normalized_name, get_info_location
+from ._dists import Distribution
+
+
+class _DistributionFinder:
+    """Finder to locate distributions.
+
+    The main purpose of this class is to memoize found distributions' names, so
+    only one distribution is returned for each package name. At lot of pip code
+    assumes this (because it is setuptools's behavior), and not doing the same
+    can potentially cause a distribution in lower precedence path to override a
+    higher precedence one if the caller is not careful.
+
+    Eventually we probably want to make it possible to see lower precedence
+    installations as well. It's useful feature, after all.
+    """
+
+    Distributions = Iterator[BaseDistribution]
+
+    def __init__(self):
+        self._found_names: Set[NormalizedName] = set()
+
+    def _find_impl(self, path: pathlib.Path, source: BasePath) -> Distributions:
+        """Find distributions in a location."""
+        # To know exact where we found a distribution, we have to feed the paths
+        # in one by one, instead of dumping entire list to importlib.metadata.
+        for dist in importlib.metadata.distributions(path=[str(path)]):
+            normalized_name = get_dist_normalized_name(dist)
+            if normalized_name in self._found_names:
+                continue
+            self._found_names.add(normalized_name)
+            info_location = get_info_location(dist)
+            yield Distribution(dist, path, info_location, source)
+
+    def find_in(self, path: pathlib.Path) -> Distributions:
+        """Find distributions in a location.
+
+        The path can be either a directory, or a ZIP archive.
+        """
+        yield from self._find_impl(path, source=path)
+
+
+class Environment(BaseEnvironment):
+    def __init__(self, paths: Sequence[str]) -> None:
+        self._paths = paths
+
+    @classmethod
+    def default(cls) -> BaseEnvironment:
+        return cls(sys.path)
+
+    @classmethod
+    def from_paths(cls, paths: Optional[List[str]]) -> BaseEnvironment:
+        if paths is None:
+            return cls(sys.path)
+        return cls(paths)
+
+    def _iter_distributions(self) -> Iterator[BaseDistribution]:
+        finder = _DistributionFinder()
+        for location in self._paths:
+            yield from finder.find_in(pathlib.Path(location))
+
+    def get_distribution(self, name: str) -> Optional[BaseDistribution]:
+        matches = (
+            distribution
+            for distribution in self.iter_all_distributions()
+            if distribution.canonical_name == canonicalize_name(name)
+        )
+        return next(matches, None)

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -2,9 +2,8 @@ import email.message
 import email.parser
 import logging
 import os
-import pathlib
 import zipfile
-from typing import Collection, Generator, Iterable, List, Mapping, NamedTuple, Optional
+from typing import Collection, Iterable, Iterator, List, Mapping, NamedTuple, Optional
 
 from pip._vendor import pkg_resources
 from pip._vendor.packaging.requirements import Requirement
@@ -142,14 +141,8 @@ class Distribution(BaseDistribution):
     def is_file(self, path: InfoPath) -> bool:
         return self._dist.has_metadata(str(path))
 
-    def iterdir(self, path: InfoPath) -> Generator[pathlib.PurePosixPath, None, None]:
-        name = str(path)
-        if not self._dist.has_metadata(name):
-            raise FileNotFoundError(name)
-        if not self._dist.isdir(name):
-            raise NotADirectoryError(name)
-        for child in self._dist.metadata_listdir(name):
-            yield pathlib.PurePosixPath(path, child)
+    def iter_distutils_script_names(self) -> Iterator[str]:
+        yield from self._dist.metadata_listdir("scripts")
 
     def read_text(self, path: InfoPath) -> str:
         name = str(path)
@@ -244,6 +237,6 @@ class Environment(BaseEnvironment):
             return None
         return self._search_distribution(name)
 
-    def _iter_distributions(self) -> Generator[BaseDistribution, None, None]:
+    def _iter_distributions(self) -> Iterator[BaseDistribution]:
         for dist in self._ws:
             yield Distribution(dist)

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -11,7 +11,8 @@ from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import InvalidWheel, NoneMetadataError, UnsupportedWheel
-from pip._internal.utils.misc import display_path
+from pip._internal.utils.egg_link import egg_link_path_from_location
+from pip._internal.utils.misc import display_path, normalize_path
 from pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
 
 from .base import (
@@ -115,6 +116,17 @@ class Distribution(BaseDistribution):
     @property
     def location(self) -> Optional[str]:
         return self._dist.location
+
+    @property
+    def installed_location(self) -> Optional[str]:
+        egg_link = egg_link_path_from_location(self.raw_name)
+        if egg_link:
+            location = egg_link
+        elif self.location:
+            location = self.location
+        else:
+            return None
+        return normalize_path(location)
 
     @property
     def info_location(self) -> Optional[str]:

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -203,6 +203,10 @@ class Environment(BaseEnvironment):
     def from_paths(cls, paths: Optional[List[str]]) -> BaseEnvironment:
         return cls(pkg_resources.WorkingSet(paths))
 
+    def _iter_distributions(self) -> Iterator[BaseDistribution]:
+        for dist in self._ws:
+            yield Distribution(dist)
+
     def _search_distribution(self, name: str) -> Optional[BaseDistribution]:
         """Find a distribution matching the ``name`` in the environment.
 
@@ -210,7 +214,7 @@ class Environment(BaseEnvironment):
         match the behavior of ``pkg_resources.get_distribution()``.
         """
         canonical_name = canonicalize_name(name)
-        for dist in self.iter_distributions():
+        for dist in self.iter_all_distributions():
             if dist.canonical_name == canonical_name:
                 return dist
         return None
@@ -236,7 +240,3 @@ class Environment(BaseEnvironment):
         except pkg_resources.DistributionNotFound:
             return None
         return self._search_distribution(name)
-
-    def _iter_distributions(self) -> Iterator[BaseDistribution]:
-        for dist in self._ws:
-            yield Distribution(dist)

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -73,7 +73,7 @@ class Distribution(BaseDistribution):
         self._dist = dist
 
     @classmethod
-    def from_directory(cls, directory: str) -> "Distribution":
+    def from_directory(cls, directory: str) -> BaseDistribution:
         dist_dir = directory.rstrip(os.sep)
 
         # Build a PathMetadata object, from path to metadata. :wink:
@@ -93,14 +93,7 @@ class Distribution(BaseDistribution):
         return cls(dist)
 
     @classmethod
-    def from_wheel(cls, wheel: Wheel, name: str) -> "Distribution":
-        """Load the distribution from a given wheel.
-
-        :raises InvalidWheel: Whenever loading of the wheel causes a
-            :py:exc:`zipfile.BadZipFile` exception to be thrown.
-        :raises UnsupportedWheel: If the wheel is a valid zip, but malformed
-            internally.
-        """
+    def from_wheel(cls, wheel: Wheel, name: str) -> BaseDistribution:
         try:
             with wheel.as_zipfile() as zf:
                 info_dir, _ = parse_wheel(zf, name)

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -558,10 +558,10 @@ class UninstallPathSet:
 
         # find distutils scripts= scripts
         try:
-            for script in dist.iterdir("scripts"):
-                paths_to_remove.add(os.path.join(bin_dir, script.name))
+            for script in dist.iter_distutils_script_names():
+                paths_to_remove.add(os.path.join(bin_dir, script))
                 if WINDOWS:
-                    paths_to_remove.add(os.path.join(bin_dir, f"{script.name}.bat"))
+                    paths_to_remove.add(os.path.join(bin_dir, f"{script}.bat"))
         except (FileNotFoundError, NotADirectoryError):
             pass
 

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -1233,7 +1233,7 @@ def test_new_resolver_presents_messages_when_backtracking_a_lot(
         # cannot handle it correctly. Nobody is complaining about it right now,
         # we're probably dropping it for importlib.metadata soon(tm), so let's
         # ignore it for the time being.
-        pytest.param("0.1.0+local-1", marks=pytest.mark.xfail),
+        pytest.param("0.1.0+local-1", marks=pytest.mark.xfail(strict=False)),
     ],
     ids=["meta_dot", "meta_underscore", "meta_dash"],
 )

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -615,11 +615,13 @@ def test_uninstall_setuptools_develop_install(
     script.assert_installed(FSPkg="0.1.dev0")
     # Uninstall both develop and install
     uninstall = script.pip("uninstall", "FSPkg", "-y")
-    assert any(filename.endswith(".egg") for filename in uninstall.files_deleted.keys())
+    assert any(filename.endswith(".egg") for filename in uninstall.files_deleted), str(
+        uninstall
+    )
     uninstall2 = script.pip("uninstall", "FSPkg", "-y")
     assert (
         join(script.site_packages, "FSPkg.egg-link") in uninstall2.files_deleted
-    ), list(uninstall2.files_deleted.keys())
+    ), str(uninstall2)
     script.assert_not_installed("FSPkg")
 
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -21,7 +21,7 @@ from pip._internal.exceptions import (
     PreviousBuildDirError,
 )
 from pip._internal.index.package_finder import PackageFinder
-from pip._internal.metadata.pkg_resources import Distribution
+from pip._internal.metadata import select_backend
 from pip._internal.network.session import PipSession
 from pip._internal.operations.build.build_tracker import get_build_tracker
 from pip._internal.operations.prepare import RequirementPreparer
@@ -451,7 +451,7 @@ class TestInstallRequirement:
         req = install_req_from_line("foo")
         req.metadata_directory = path
         dist = req.get_dist()
-        assert isinstance(dist, Distribution)
+        assert isinstance(dist, select_backend().Distribution)
         assert dist.raw_name == dist.canonical_name == "foo"
         assert dist.location == "/path/to".replace("/", os.path.sep)
 


### PR DESCRIPTION
This doesn’t take a lot of code because we’ve done most work upfront. There are definitely optimisations available since importlib.metadata has a pretty different implementation, but this should make the most common cases “work”.

~Likely far from perfect, I’m only submitting this as draft to run a new workflow against it to see how things currently stand.~ Better now.

Currently the backend is only accessible via a private environment variable. Eventually I want to target the implementation to only 3.10 or later (because importlib.metadata API is quite unstable before that), expose behind the feature flag first, and slowly rolling it out to maybe 3.11 the earliest.