### PR TITLE
Accomodate spaces in Python executable path shown in outdated pip warning

### DIFF
--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -4,6 +4,7 @@ import json
 import logging
 import optparse
 import os.path
+import subprocess
 import sys
 from typing import Any, Dict
 
@@ -164,16 +165,17 @@ def pip_self_version_check(session: PipSession, options: optparse.Values) -> Non
 
         # We cannot tell how the current pip is available in the current
         # command context, so be pragmatic here and suggest the command
-        # that's always available. This does not accommodate spaces in
-        # `sys.executable`.
-        pip_cmd = f"{sys.executable} -m pip"
+        # that's always available.
+        pip_upgrade_cmd = subprocess.list2cmdline(
+            [sys.executable, "-m", "pip", "install", "--upgrade", "pip"]
+        )
         logger.warning(
             "You are using pip version %s; however, version %s is "
             "available.\nYou should consider upgrading via the "
-            "'%s install --upgrade pip' command.",
+            "following command:\n%s",
             pip_version,
             pypi_version,
-            pip_cmd,
+            pip_upgrade_cmd,
         )
     except Exception:
         logger.debug(


### PR DESCRIPTION
Show:

> WARNING: You are using pip version 21.2.3; however, version 21.3.1 is available.
> You should consider upgrading via the following command:
> "C:\Program Files\Python310\python.exe" -m pip install --upgrade pip

instead of:

> WARNING: You are using pip version 21.2.3; however, version 21.3.1 is available.
> You should consider upgrading via the 'C:\Program Files\Python310\python.exe -m pip install --upgrade pip' command.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
