### PR TITLE
Fix RST admonition & add missing inline code formatting

### DIFF
--- a/docs/html/topics/dependency-resolution.md
+++ b/docs/html/topics/dependency-resolution.md
@@ -277,10 +277,10 @@ your _dependency_ by:
 - Requesting that the package maintainers loosen _their_ dependencies
 - Forking the package and loosening the dependencies yourself
 
-:::{warning}
+```{warning}
 If you choose to fork the package yourself, you are _opting out_ of
 any support provided by the package maintainers. Proceed at your own risk!
-:::
+```
 
 #### All requirements are appropriate, but a solution does not exist
 

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -17,7 +17,7 @@ to your system, which can be run from the command prompt as follows:
 
    ``python -m pip`` executes pip using the Python interpreter you
    specified as python. So ``/usr/bin/python3.7 -m pip`` means
-   you are executing pip for your interpreter located at /usr/bin/python3.7.
+   you are executing pip for your interpreter located at ``/usr/bin/python3.7``.
 
 .. tab:: Windows
 
@@ -629,7 +629,7 @@ Moreover, the "user scheme" can be customized by setting the
 ``PYTHONUSERBASE`` environment variable, which updates the value of
 ``site.USER_BASE``.
 
-To install "SomePackage" into an environment with site.USER_BASE customized to
+To install "SomePackage" into an environment with ``site.USER_BASE`` customized to
 '/myappenv', do the following:
 
 .. tab:: Unix/macOS


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
