### PR TITLE
Proposal for exposing `required-by` info in `list` command

### DIFF
--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from collections import defaultdict
 from optparse import Values
 from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple, cast
 
@@ -29,6 +30,7 @@ if TYPE_CHECKING:
 
         latest_version: DistributionVersion
         latest_filetype: str
+        required_by: Sequence[str]
 
     _ProcessedDists = Sequence[_DistWithLatestInfo]
 
@@ -172,6 +174,8 @@ class ListCommand(IndexGroupCommand):
             )
         ]
 
+        self.attach_required_by(packages)
+
         # get_not_required must be called firstly in order to find and
         # filter out all dependencies correctly. Otherwise a package
         # can't be identified as requirement because some parent packages
@@ -218,6 +222,14 @@ class ListCommand(IndexGroupCommand):
         # to keep the return type consistent with get_outdated and
         # get_uptodate
         return list({pkg for pkg in packages if pkg.canonical_name not in dep_keys})
+
+    def attach_required_by(self, packages: "_ProcessedDists"):
+        dependencies = defaultdict(set)
+        for pkg in packages:
+            for dep in pkg.iter_dependencies(extras=pkg._dist.extras):
+                dependencies[dep.key].add(pkg.canonical_name)
+        for pkg in packages:
+            pkg.required_by = dependencies[pkg.canonical_name]
 
     def iter_packages_latest_infos(
         self, packages: "_ProcessedDists", options: Values
@@ -314,8 +326,8 @@ def format_for_columns(
 
     if options.verbose >= 1:
         header.append("Location")
-    if options.verbose >= 1:
         header.append("Installer")
+        header.append("Required By")
 
     data = []
     for proj in pkgs:
@@ -332,8 +344,8 @@ def format_for_columns(
 
         if options.verbose >= 1:
             row.append(proj.location or "")
-        if options.verbose >= 1:
             row.append(proj.installer)
+            row.append(";".join(proj.required_by))
 
         data.append(row)
 
@@ -350,6 +362,7 @@ def format_for_json(packages: "_ProcessedDists", options: Values) -> str:
         if options.verbose >= 1:
             info["location"] = dist.location or ""
             info["installer"] = dist.installer
+            info["required_by"] = list(dist.required_by)
         if options.outdated:
             info["latest_version"] = str(dist.latest_version)
             info["latest_filetype"] = dist.latest_filetype


### PR DESCRIPTION
cf #10036

The new proposal is to expose the information when the command is
run with `--verbose`, as for `location` or `installer`. It is done in both `column` and `json` formats.

This allows oneliners like:

    pip list --outdated --verbose | awk '{if($7 ~ "roll") print $1}'

Or with more details and a table output:

    pip list --outdated --verbose | awk '{if($7 ~ "roll") print $1,$2,$3}' | column -t

Note: I've not adapted unit tests nor added new ones nor added a news fragment yet. Let's see if the
proposal can reach some consensus before :)