### PR TITLE
Decouple logs output color from the logging level

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -722,7 +722,7 @@ class Factory:
             + "the dependency conflict\n"
         )
 
-        logger.info(msg)
+        logger.critical(msg, extra={"color": "black"})
 
         return DistributionNotFound(
             "ResolutionImpossible: for help visit "

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -167,7 +167,11 @@ class RichPipStreamHandler(RichHandler):
         else:
             message = self.format(record)
             renderable = self.render_message(record, message)
-            if record.levelno is not None:
+            # If a custom color is passed use it, otherwise use default colors.
+            color_attribute = "color"
+            if hasattr(record, color_attribute):
+                style = Style(color=getattr(record, color_attribute))
+            elif record.levelno is not None:
                 if record.levelno >= logging.ERROR:
                     style = Style(color="red")
                 elif record.levelno >= logging.WARNING:

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -696,8 +696,8 @@ def test_install_distribution_union_with_versions(
     )
     if resolver_variant == "2020-resolver":
         assert "Cannot install localextras[bar]" in result.stderr
-        assert ("localextras[bar] 0.0.1 depends on localextras 0.0.1") in result.stdout
-        assert ("localextras[baz] 0.0.2 depends on localextras 0.0.2") in result.stdout
+        assert ("localextras[bar] 0.0.1 depends on localextras 0.0.1") in result.stderr
+        assert ("localextras[baz] 0.0.2 depends on localextras 0.0.2") in result.stderr
     else:
         assert (
             "Successfully installed LocalExtras-0.0.1 simple-3.0 singlemodule-0.0.1"

--- a/tests/functional/test_new_resolver_errors.py
+++ b/tests/functional/test_new_resolver_errors.py
@@ -67,7 +67,7 @@ def test_new_resolver_conflict_constraints_file(
     assert "ResolutionImpossible" in result.stderr, str(result)
 
     message = "The user requested (constraint) pkg!=1.0"
-    assert message in result.stdout, str(result)
+    assert message in result.stderr, str(result)
 
 
 def test_new_resolver_requires_python_error(script: PipTestEnvironment) -> None:


### PR DESCRIPTION
Previously, each logging level was coupled with a specific
output color. This isn't always ideal because we might need
to log at a certain level but use a custom color (based on
user feedback / see linked issue).

This patch decouples the logs output color from the logging
level.

Fixes #10519

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
