### PR TITLE
Check keylog_filename existence

### DIFF
--- a/src/pip/_vendor/urllib3/util/ssl_.py
+++ b/src/pip/_vendor/urllib3/util/ssl_.py
@@ -346,7 +346,7 @@ def create_urllib3_context(
     # 'SSLKEYLOGFILE', if the feature is available (Python 3.8+). Skip empty values.
     if hasattr(context, "keylog_filename"):
         sslkeylogfile = os.environ.get("SSLKEYLOGFILE")
-        if sslkeylogfile:
+        if sslkeylogfile and os.path.isfile(sslkeylogfile):
             context.keylog_filename = sslkeylogfile
 
     return context


### PR DESCRIPTION
If the file path doesn't exist it throw following exception:
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ProtocolError('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))'

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
