### PR TITLE
Installation/resolution report (aka pip install --dry-run --report)

### DIFF
--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -79,6 +79,18 @@ for an exception regarding pre-release versions). Where more than one source of
 the chosen version is available, it is assumed that any source is acceptable
 (as otherwise the versions would differ).
 
+Obtaining information about what was installed
+----------------------------------------------
+
+The install command has a ``--report`` option that will generate a JSON report of what
+pip has installed. In combination with the ``--dry-run`` and ``--ignore-installed`` it
+can be used to *resolve* a set of requirements without actually installing them.
+
+The report can be written to a file, or to standard output (using ``--report -`` in
+combination with ``--quiet``).
+
+The format of the JSON report is described in :doc:`../reference/installation-report`.
+
 Installation Order
 ------------------
 

--- a/docs/html/reference/index.md
+++ b/docs/html/reference/index.md
@@ -9,4 +9,5 @@ interoperability standards that pip utilises/implements.
 build-system/index
 requirement-specifiers
 requirements-file-format
+installation-report
 ```

--- a/docs/html/reference/installation-report.md
+++ b/docs/html/reference/installation-report.md
@@ -7,6 +7,7 @@ it did install (or what it would have installed, if used with the `--dry-run` op
 
 The report is a JSON object with the following properties:
 
+- `pip_version`: a string with the version of pip used to produce the report.
 - `install`: an object where the properties are the canonicalized names of the
   distribution packages (to be) installed and the values are of type
   `InstallationReportItem` (see below).
@@ -54,6 +55,7 @@ will produce an output similar to this (metadata abriged for brevity):
 
 ```json
 {
+  "pip_version": "22.2",
   "install": {
     "pydantic": {
       "download_info": {

--- a/docs/html/reference/installation-report.md
+++ b/docs/html/reference/installation-report.md
@@ -18,13 +18,16 @@ The report is a JSON object with the following properties:
   the corresponding version.
 
 - `pip_version`: a string with the version of pip used to produce the report.
-- `install`: an object where the properties are the canonicalized names of the
-  distribution packages (to be) installed and the values are of type
-  `InstallationReportItem` (see below).
+
+- `install`: an array of [InstallationReportItem](InstallationReportItem) representing
+  the distribution packages (to be) installed.
+
 - `environment`: an object describing the environment where the installation report was
   generated. See [PEP 508 environment
   markers](https://peps.python.org/pep-0508/#environment-markers) for more information.
   Values have a string type.
+
+(InstallationReportItem)=
 
 An `InstallationReportItem` is an object describing a (to be) installed distribution
 package with the following properties:
@@ -75,8 +78,8 @@ will produce an output similar to this (metadata abriged for brevity):
 {
   "version": "0",
   "pip_version": "22.2",
-  "install": {
-    "pydantic": {
+  "install": [
+    {
       "download_info": {
         "url": "https://files.pythonhosted.org/packages/a4/0c/fbaa7319dcb5eecd3484686eb5a5c5702a6445adb566f01aee6de3369bc4/pydantic-1.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
         "archive_info": {
@@ -101,7 +104,7 @@ will produce an output similar to this (metadata abriged for brevity):
         ]
       }
     },
-    "packaging": {
+    {
       "download_info": {
         "url": "https://github.com/pypa/packaging",
         "vcs_info": {
@@ -121,7 +124,7 @@ will produce an output similar to this (metadata abriged for brevity):
         "requires_python": ">=3.7"
       }
     },
-    "pyparsing": {
+    {
       "download_info": {
         "url": "https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl",
         "archive_info": {
@@ -140,7 +143,7 @@ will produce an output similar to this (metadata abriged for brevity):
         "requires_python": ">=3.6.8"
       }
     },
-    "typing-extensions": {
+    {
       "download_info": {
         "url": "https://files.pythonhosted.org/packages/75/e1/932e06004039dd670c9d5e1df0cd606bf46e29a28e65d5bb28e894ea29c9/typing_extensions-4.2.0-py3-none-any.whl",
         "archive_info": {
@@ -155,7 +158,7 @@ will produce an output similar to this (metadata abriged for brevity):
         "requires_python": ">=3.7"
       }
     }
-  },
+  ],
   "environment": {
     "implementation_name": "cpython",
     "implementation_version": "3.10.5",

--- a/docs/html/reference/installation-report.md
+++ b/docs/html/reference/installation-report.md
@@ -43,6 +43,14 @@ package with the following properties:
   structure. When `is_direct` is `true`, this field is the same as the `direct_url.json`
   metadata, otherwise it represents the URL of the artifact obtained from the index or
   `--find-links`.
+
+  ```{note}
+  For source archives, `download_info.archive_info.hash` may
+  be absent when the requirement was installed from the wheel cache
+  and the cache entry was populated by an older pip version that did not
+  record the origin URL of the downloaded artifact.
+  ```
+
 - `requested`: `true` if the requirement was explicitly provided by the user, either
   directely via a command line argument or indirectly via a requirements file. `false`
   if the requirement was installed as a dependency of another requirement.

--- a/docs/html/reference/installation-report.md
+++ b/docs/html/reference/installation-report.md
@@ -7,6 +7,16 @@ it did install (or what it would have installed, if used with the `--dry-run` op
 
 The report is a JSON object with the following properties:
 
+- `version`: the string `0`, denoting that the installation report is an experimental
+  feature. This value will change to `1`, when the feature is deemed stable after
+  gathering user feedback (likely in pip 22.3 or 23.0). Backward incompatible changes
+  may be introduced in version `1` without notice. After that, it will change only if
+  and when backward incompatible changes are introduced, such as removing mandatory
+  fields or changing the semantics or data type of existing fields. The introduction of
+  backward incompatible changes will follow the usual pip processes such as the
+  deprecation cycle or feature flags. Tools must check this field to ensure they support
+  the corresponding version.
+
 - `pip_version`: a string with the version of pip used to produce the report.
 - `install`: an object where the properties are the canonicalized names of the
   distribution packages (to be) installed and the values are of type
@@ -55,6 +65,7 @@ will produce an output similar to this (metadata abriged for brevity):
 
 ```json
 {
+  "version": "0",
   "pip_version": "22.2",
   "install": {
     "pydantic": {

--- a/docs/html/reference/installation-report.md
+++ b/docs/html/reference/installation-report.md
@@ -1,0 +1,152 @@
+# Installation Report
+
+The `--report` option of the pip install command produces a detailed JSON report of what
+it did install (or what it would have installed, if used with the `--dry-run` option).
+
+## Specification
+
+The report is a JSON object with the following properties:
+
+- `install`: an object where the properties are the canonicalized names of the
+  distribution packages (to be) installed and the values are of type
+  `InstallationReportItem` (see below).
+- `environment`: an object describing the environment where the installation report was
+  generated. See [PEP 508 environment
+  markers](https://peps.python.org/pep-0508/#environment-markers) for more information.
+  Values have a string type.
+
+An `InstallationReportItem` is an object describing a (to be) installed distribution
+package with the following properties:
+
+- `metadata`: the metadata of the distribution, converted to a JSON object according to
+  the [PEP 566
+  transformation](https://www.python.org/dev/peps/pep-0566/#json-compatible-metadata).
+
+- `is_direct`: `true` if the requirement was provided as, or constrained to, a direct
+  URL reference. `false` if the requirements was provided as a name and version
+  specifier.
+
+- `download_info`: Information about the artifact (to be) downloaded for installation,
+  using the [direct
+  URL](https://packaging.python.org/en/latest/specifications/direct-url/) data
+  structure. When `is_direct` is `true`, this field is the same as the `direct_url.json`
+  metadata, otherwise it represents the URL of the artifact obtained from the index or
+  `--find-links`.
+- `requested`: `true` if the requirement was explicitly provided by the user, either
+  directely via a command line argument or indirectly via a requirements file. `false`
+  if the requirement was installed as a dependency of another requirement.
+
+- `requested_extras`: extras requested by the user. This field is only present when the
+  `requested` field is true.
+
+## Example
+
+The following command:
+
+```console
+pip install \
+  --ignore-installed --dry-run --quiet \
+  --report - \
+  "pydantic>=1.9" git+https://github.com/pypa/packaging@main
+```
+
+will produce an output similar to this (metadata abriged for brevity):
+
+```json
+{
+  "install": {
+    "pydantic": {
+      "download_info": {
+        "url": "https://files.pythonhosted.org/packages/a4/0c/fbaa7319dcb5eecd3484686eb5a5c5702a6445adb566f01aee6de3369bc4/pydantic-1.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "archive_info": {
+          "hash": "sha256=18f3e912f9ad1bdec27fb06b8198a2ccc32f201e24174cec1b3424dda605a310"
+        }
+      },
+      "is_direct": false,
+      "requested": true,
+      "metadata": {
+        "name": "pydantic",
+        "version": "1.9.1",
+        "requires_dist": [
+          "typing-extensions (>=3.7.4.3)",
+          "dataclasses (>=0.6) ; python_version < \"3.7\"",
+          "python-dotenv (>=0.10.4) ; extra == 'dotenv'",
+          "email-validator (>=1.0.3) ; extra == 'email'"
+        ],
+        "requires_python": ">=3.6.1",
+        "provides_extra": [
+          "dotenv",
+          "email"
+        ]
+      }
+    },
+    "packaging": {
+      "download_info": {
+        "url": "https://github.com/pypa/packaging",
+        "vcs_info": {
+          "vcs": "git",
+          "requested_revision": "main",
+          "commit_id": "4f42225e91a0be634625c09e84dd29ea82b85e27"
+        }
+      },
+      "is_direct": true,
+      "requested": true,
+      "metadata": {
+        "name": "packaging",
+        "version": "21.4.dev0",
+        "requires_dist": [
+          "pyparsing (!=3.0.5,>=2.0.2)"
+        ],
+        "requires_python": ">=3.7"
+      }
+    },
+    "pyparsing": {
+      "download_info": {
+        "url": "https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl",
+        "archive_info": {
+          "hash": "sha256=5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+        }
+      },
+      "is_direct": false,
+      "requested": false,
+      "metadata": {
+        "name": "pyparsing",
+        "version": "3.0.9",
+        "requires_dist": [
+          "railroad-diagrams ; extra == \"diagrams\"",
+          "jinja2 ; extra == \"diagrams\""
+        ],
+        "requires_python": ">=3.6.8"
+      }
+    },
+    "typing-extensions": {
+      "download_info": {
+        "url": "https://files.pythonhosted.org/packages/75/e1/932e06004039dd670c9d5e1df0cd606bf46e29a28e65d5bb28e894ea29c9/typing_extensions-4.2.0-py3-none-any.whl",
+        "archive_info": {
+          "hash": "sha256=6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"
+        }
+      },
+      "is_direct": false,
+      "requested": false,
+      "metadata": {
+        "name": "typing_extensions",
+        "version": "4.2.0",
+        "requires_python": ">=3.7"
+      }
+    }
+  },
+  "environment": {
+    "implementation_name": "cpython",
+    "implementation_version": "3.10.5",
+    "os_name": "posix",
+    "platform_machine": "x86_64",
+    "platform_release": "5.13-generic",
+    "platform_system": "Linux",
+    "platform_version": "...",
+    "python_full_version": "3.10.5",
+    "platform_python_implementation": "CPython",
+    "python_version": "3.10",
+    "sys_platform": "linux"
+  }
+}
+```

--- a/news/53.feature.rst
+++ b/news/53.feature.rst
@@ -1,0 +1,3 @@
+Add ``--report`` to the install command to generate a json report of what was installed.
+In combination with ``--dry-run`` and ``--ignore-installed`` it can be used to resolve
+the requirements.

--- a/news/53.feature.rst
+++ b/news/53.feature.rst
@@ -1,3 +1,3 @@
-Add ``--report`` to the install command to generate a json report of what was installed.
-In combination with ``--dry-run`` and ``--ignore-installed`` it can be used to resolve
-the requirements.
+Add an experimental ``--report`` option to the install command to generate a JSON report
+of what was installed. In combination with ``--dry-run`` and ``--ignore-installed`` it
+can be used to resolve the requirements.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -4,11 +4,11 @@ import operator
 import os
 import shutil
 import site
-import sys
 from optparse import SUPPRESS_HELP, Values
 from typing import Iterable, List, Optional
 
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.rich import print_json
 
 from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
@@ -373,7 +373,7 @@ class InstallCommand(RequirementCommand):
             if options.json_report_file:
                 report = InstallationReport(requirement_set.requirements_to_install)
                 if options.json_report_file == "-":
-                    json.dump(report.to_dict(), sys.stdout, indent=2, ensure_ascii=True)
+                    print_json(data=report.to_dict())
                 else:
                     with open(options.json_report_file, "w", encoding="utf-8") as f:
                         json.dump(report.to_dict(), f, indent=2, ensure_ascii=False)

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -371,6 +371,12 @@ class InstallCommand(RequirementCommand):
             )
 
             if options.json_report_file:
+                logger.warning(
+                    "--report is currently an experimental option. "
+                    "The output format may change in a future release "
+                    "without prior warning."
+                )
+
                 report = InstallationReport(requirement_set.requirements_to_install)
                 if options.json_report_file == "-":
                     print_json(data=report.to_dict())

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -1,4 +1,5 @@
 import errno
+import json
 import operator
 import os
 import shutil
@@ -21,6 +22,7 @@ from pip._internal.exceptions import CommandError, InstallationError
 from pip._internal.locations import get_scheme
 from pip._internal.metadata import get_environment
 from pip._internal.models.format_control import FormatControl
+from pip._internal.models.installation_report import InstallationReport
 from pip._internal.operations.build.build_tracker import get_build_tracker
 from pip._internal.operations.check import ConflictDetails, check_install_conflicts
 from pip._internal.req import install_given_reqs
@@ -250,6 +252,19 @@ class InstallCommand(RequirementCommand):
         self.parser.insert_option_group(0, index_opts)
         self.parser.insert_option_group(0, self.cmd_opts)
 
+        self.cmd_opts.add_option(
+            "--report",
+            dest="json_report_file",
+            metavar="file",
+            default=None,
+            help=(
+                "Generate a JSON file describing what pip did to install "
+                "the provided requirements. "
+                "Can be used in combination with --dry-run and --ignore-installed "
+                "to 'resolve' the requirements."
+            ),
+        )
+
     @with_cleanup
     def run(self, options: Values, args: List[str]) -> int:
         if options.use_user_site and options.target_dir is not None:
@@ -352,6 +367,11 @@ class InstallCommand(RequirementCommand):
             requirement_set = resolver.resolve(
                 reqs, check_supported_wheels=not options.target_dir
             )
+
+            if options.json_report_file:
+                report = InstallationReport(requirement_set.requirements_to_install)
+                with open(options.json_report_file, "w", encoding="utf-8") as f:
+                    json.dump(report.to_dict(), f)
 
             if options.dry_run:
                 would_install_items = sorted(

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -4,6 +4,7 @@ import operator
 import os
 import shutil
 import site
+import sys
 from optparse import SUPPRESS_HELP, Values
 from typing import Iterable, List, Optional
 
@@ -261,7 +262,8 @@ class InstallCommand(RequirementCommand):
                 "Generate a JSON file describing what pip did to install "
                 "the provided requirements. "
                 "Can be used in combination with --dry-run and --ignore-installed "
-                "to 'resolve' the requirements."
+                "to 'resolve' the requirements. "
+                "When - is used as file name it writes to stdout."
             ),
         )
 
@@ -370,8 +372,11 @@ class InstallCommand(RequirementCommand):
 
             if options.json_report_file:
                 report = InstallationReport(requirement_set.requirements_to_install)
-                with open(options.json_report_file, "w", encoding="utf-8") as f:
-                    json.dump(report.to_dict(), f)
+                if options.json_report_file == "-":
+                    json.dump(report.to_dict(), sys.stdout, indent=2, ensure_ascii=True)
+                else:
+                    with open(options.json_report_file, "w", encoding="utf-8") as f:
+                        json.dump(report.to_dict(), f, indent=2, ensure_ascii=False)
 
             if options.dry_run:
                 would_install_items = sorted(

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -30,6 +30,9 @@ class InstallationReport:
             # https://www.python.org/dev/peps/pep-0566/#json-compatible-metadata
             "metadata": ireq.get_dist().metadata_dict,
         }
+        if ireq.user_supplied and ireq.extras:
+            # For top level requirements, the list of requested extras, if any.
+            res["requested_extras"] = list(sorted(ireq.extras))
         return res
 
     def to_dict(self) -> Dict[str, Any]:

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -39,6 +39,7 @@ class InstallationReport:
 
     def to_dict(self) -> Dict[str, Any]:
         return {
+            "version": "0",
             "pip_version": __version__,
             "install": {
                 canonicalize_name(ireq.metadata["Name"]): self._install_req_to_dict(

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -44,5 +44,11 @@ class InstallationReport:
                 )
                 for ireq in self._install_requirements
             },
+            # https://peps.python.org/pep-0508/#environment-markers
+            # TODO: currently, the resolver uses the default environment to evaluate
+            # environment markers, so that is what we report here. In the future, it
+            # should also take into account options such as --python-version or
+            # --platform, perhaps under the form of an environment_override field?
+            # https://github.com/pypa/pip/issues/11198
             "environment": default_environment(),
         }

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Sequence
 from pip._vendor.packaging.markers import default_environment
 from pip._vendor.packaging.utils import canonicalize_name
 
+from pip import __version__
 from pip._internal.req.req_install import InstallRequirement
 
 
@@ -38,6 +39,7 @@ class InstallationReport:
 
     def to_dict(self) -> Dict[str, Any]:
         return {
+            "pip_version": __version__,
             "install": {
                 canonicalize_name(ireq.metadata["Name"]): self._install_req_to_dict(
                     ireq

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, Sequence
+
+from pip._internal.req.req_install import InstallRequirement
+
+
+class InstallationReport:
+    def __init__(self, install_requirements: Sequence[InstallRequirement]):
+        self._install_requirements = install_requirements
+
+    @classmethod
+    def _install_req_to_dict(cls, ireq: InstallRequirement) -> Dict[str, Any]:
+        assert ireq.download_info, f"No download_info for {ireq}"
+        res = {
+            # PEP 610 json for the download URL. download_info.archive_info.hash may
+            # be absent when the requirement was installed from the wheel cache
+            # and the cache entry was populated by an older pip version that did not
+            # record origin.json.
+            "download_info": ireq.download_info.to_dict(),
+            # is_direct is true if the requirement was a direct URL reference (which
+            # includes editable requirements), and false if the requirement was
+            # downloaded from a PEP 503 index or --find-links.
+            "is_direct": bool(ireq.original_link),
+            # requested is true if the requirement was specified by the user (aka
+            # top level requirement), and false if it was installed as a dependency of a
+            # requirement. https://peps.python.org/pep-0376/#requested
+            "requested": ireq.user_supplied,
+            # PEP 566 json encoding for metadata
+            # https://www.python.org/dev/peps/pep-0566/#json-compatible-metadata
+            "metadata": ireq.get_dist().metadata_dict,
+        }
+        return res
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "install": {
+                ireq.get_dist().metadata["Name"]: self._install_req_to_dict(ireq)
+                for ireq in self._install_requirements
+            }
+        }

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Sequence
 
+from pip._vendor.packaging.markers import default_environment
+
 from pip._internal.req.req_install import InstallRequirement
 
 
@@ -35,5 +37,6 @@ class InstallationReport:
             "install": {
                 ireq.get_dist().metadata["Name"]: self._install_req_to_dict(ireq)
                 for ireq in self._install_requirements
-            }
+            },
+            "environment": default_environment(),
         }

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Sequence
 
 from pip._vendor.packaging.markers import default_environment
+from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.req.req_install import InstallRequirement
 
@@ -38,7 +39,9 @@ class InstallationReport:
     def to_dict(self) -> Dict[str, Any]:
         return {
             "install": {
-                ireq.get_dist().metadata["Name"]: self._install_req_to_dict(ireq)
+                canonicalize_name(ireq.metadata["Name"]): self._install_req_to_dict(
+                    ireq
+                )
                 for ireq in self._install_requirements
             },
             "environment": default_environment(),

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Sequence
 
 from pip._vendor.packaging.markers import default_environment
-from pip._vendor.packaging.utils import canonicalize_name
 
 from pip import __version__
 from pip._internal.req.req_install import InstallRequirement
@@ -41,12 +40,9 @@ class InstallationReport:
         return {
             "version": "0",
             "pip_version": __version__,
-            "install": {
-                canonicalize_name(ireq.metadata["Name"]): self._install_req_to_dict(
-                    ireq
-                )
-                for ireq in self._install_requirements
-            },
+            "install": [
+                self._install_req_to_dict(ireq) for ireq in self._install_requirements
+            ],
             # https://peps.python.org/pep-0508/#environment-markers
             # TODO: currently, the resolver uses the default environment to evaluate
             # environment markers, so that is what we report here. In the future, it

--- a/tests/functional/test_install_report.py
+++ b/tests/functional/test_install_report.py
@@ -74,9 +74,9 @@ def test_install_report_index(script: PipTestEnvironment, tmp_path: Path) -> Non
     )
     report = json.loads(report_path.read_text())
     assert len(report["install"]) == 2
-    assert report["install"]["Paste"]["requested"] is True
+    assert report["install"]["paste"]["requested"] is True
     assert report["install"]["python-openid"]["requested"] is False
-    paste_report = report["install"]["Paste"]
+    paste_report = report["install"]["paste"]
     assert paste_report["download_info"]["url"].startswith(
         "https://files.pythonhosted.org/"
     )

--- a/tests/functional/test_install_report.py
+++ b/tests/functional/test_install_report.py
@@ -1,0 +1,175 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from ..lib import PipTestEnvironment, TestData
+
+
+@pytest.mark.usefixtures("with_wheel")
+def test_install_report_basic(
+    script: PipTestEnvironment, shared_data: TestData, tmp_path: Path
+) -> None:
+    report_path = tmp_path / "report.json"
+    script.pip(
+        "install",
+        "simplewheel",
+        "--dry-run",
+        "--no-index",
+        "--find-links",
+        str(shared_data.root / "packages/"),
+        "--report",
+        str(report_path),
+    )
+    report = json.loads(report_path.read_text())
+    assert "install" in report
+    assert len(report["install"]) == 1
+    assert "simplewheel" in report["install"]
+    simplewheel_report = report["install"]["simplewheel"]
+    assert simplewheel_report["metadata"]["name"] == "simplewheel"
+    assert simplewheel_report["requested"] is True
+    assert simplewheel_report["is_direct"] is False
+    url = simplewheel_report["download_info"]["url"]
+    assert url.startswith("file://")
+    assert url.endswith("/packages/simplewheel-2.0-1-py2.py3-none-any.whl")
+    assert (
+        simplewheel_report["download_info"]["archive_info"]["hash"]
+        == "sha256=191d6520d0570b13580bf7642c97ddfbb46dd04da5dd2cf7bef9f32391dfe716"
+    )
+
+
+@pytest.mark.usefixtures("with_wheel")
+def test_install_report_dep(
+    script: PipTestEnvironment, shared_data: TestData, tmp_path: Path
+) -> None:
+    """Test dependencies are present in the install report with requested=False."""
+    report_path = tmp_path / "report.json"
+    script.pip(
+        "install",
+        "require_simple",
+        "--dry-run",
+        "--no-index",
+        "--find-links",
+        str(shared_data.root / "packages/"),
+        "--report",
+        str(report_path),
+    )
+    report = json.loads(report_path.read_text())
+    assert len(report["install"]) == 2
+    assert report["install"]["require-simple"]["requested"] is True
+    assert report["install"]["simple"]["requested"] is False
+
+
+@pytest.mark.network
+@pytest.mark.usefixtures("with_wheel")
+def test_install_report_index(script: PipTestEnvironment, tmp_path: Path) -> None:
+    """Test report for sdist obtained from index."""
+    report_path = tmp_path / "report.json"
+    script.pip(
+        "install",
+        "--dry-run",
+        "Paste[openid]==1.7.5.1",
+        "--report",
+        str(report_path),
+    )
+    report = json.loads(report_path.read_text())
+    assert len(report["install"]) == 2
+    assert report["install"]["Paste"]["requested"] is True
+    assert report["install"]["python-openid"]["requested"] is False
+    paste_report = report["install"]["Paste"]
+    assert paste_report["download_info"]["url"].startswith(
+        "https://files.pythonhosted.org/"
+    )
+    assert paste_report["download_info"]["url"].endswith("/Paste-1.7.5.1.tar.gz")
+    assert (
+        paste_report["download_info"]["archive_info"]["hash"]
+        == "sha256=11645842ba8ec986ae8cfbe4c6cacff5c35f0f4527abf4f5581ae8b4ad49c0b6"
+    )
+
+
+@pytest.mark.network
+@pytest.mark.usefixtures("with_wheel")
+def test_install_report_vcs_and_wheel_cache(
+    script: PipTestEnvironment, tmp_path: Path
+) -> None:
+    """Test report for VCS reference, and interactions with the wheel cache."""
+    cache_dir = tmp_path / "cache"
+    report_path = tmp_path / "report.json"
+    script.pip(
+        "install",
+        "git+https://github.com/pypa/pip-test-package"
+        "@5547fa909e83df8bd743d3978d6667497983a4b7",
+        "--cache-dir",
+        str(cache_dir),
+        "--report",
+        str(report_path),
+    )
+    report = json.loads(report_path.read_text())
+    assert len(report["install"]) == 1
+    pip_test_package_report = report["install"]["pip-test-package"]
+    assert pip_test_package_report["is_direct"] is True
+    assert pip_test_package_report["requested"] is True
+    assert (
+        pip_test_package_report["download_info"]["url"]
+        == "https://github.com/pypa/pip-test-package"
+    )
+    assert pip_test_package_report["download_info"]["vcs_info"]["vcs"] == "git"
+    assert (
+        pip_test_package_report["download_info"]["vcs_info"]["commit_id"]
+        == "5547fa909e83df8bd743d3978d6667497983a4b7"
+    )
+    # Now do it again to make sure the cache is used and that the report still contains
+    # the original VCS url.
+    report_path.unlink()
+    result = script.pip(
+        "install",
+        "pip-test-package @ git+https://github.com/pypa/pip-test-package"
+        "@5547fa909e83df8bd743d3978d6667497983a4b7",
+        "--ignore-installed",
+        "--cache-dir",
+        str(cache_dir),
+        "--report",
+        str(report_path),
+    )
+    assert "Using cached pip_test_package" in result.stdout
+    report = json.loads(report_path.read_text())
+    assert len(report["install"]) == 1
+    pip_test_package_report = report["install"]["pip-test-package"]
+    assert pip_test_package_report["is_direct"] is True
+    assert pip_test_package_report["requested"] is True
+    assert (
+        pip_test_package_report["download_info"]["url"]
+        == "https://github.com/pypa/pip-test-package"
+    )
+    assert pip_test_package_report["download_info"]["vcs_info"]["vcs"] == "git"
+    assert (
+        pip_test_package_report["download_info"]["vcs_info"]["commit_id"]
+        == "5547fa909e83df8bd743d3978d6667497983a4b7"
+    )
+
+
+@pytest.mark.network
+@pytest.mark.usefixtures("with_wheel")
+def test_install_report_vcs_editable(
+    script: PipTestEnvironment, tmp_path: Path
+) -> None:
+    """Test report remote editable."""
+    report_path = tmp_path / "report.json"
+    script.pip(
+        "install",
+        "--editable",
+        "git+https://github.com/pypa/pip-test-package"
+        "@5547fa909e83df8bd743d3978d6667497983a4b7"
+        "#egg=pip-test-package",
+        "--report",
+        str(report_path),
+    )
+    report = json.loads(report_path.read_text())
+    assert len(report["install"]) == 1
+    pip_test_package_report = report["install"]["pip-test-package"]
+    assert pip_test_package_report["is_direct"] is True
+    assert pip_test_package_report["download_info"]["url"].startswith("file://")
+    assert pip_test_package_report["download_info"]["url"].endswith(
+        "/src/pip-test-package"
+    )
+    assert pip_test_package_report["download_info"]["dir_info"]["editable"] is True

--- a/tests/functional/test_install_report.py
+++ b/tests/functional/test_install_report.py
@@ -85,6 +85,7 @@ def test_install_report_index(script: PipTestEnvironment, tmp_path: Path) -> Non
         paste_report["download_info"]["archive_info"]["hash"]
         == "sha256=11645842ba8ec986ae8cfbe4c6cacff5c35f0f4527abf4f5581ae8b4ad49c0b6"
     )
+    assert "requires_dist" in paste_report["metadata"]
 
 
 @pytest.mark.network

--- a/tests/functional/test_install_report.py
+++ b/tests/functional/test_install_report.py
@@ -85,6 +85,7 @@ def test_install_report_index(script: PipTestEnvironment, tmp_path: Path) -> Non
         paste_report["download_info"]["archive_info"]["hash"]
         == "sha256=11645842ba8ec986ae8cfbe4c6cacff5c35f0f4527abf4f5581ae8b4ad49c0b6"
     )
+    assert paste_report["requested_extras"] == ["openid"]
     assert "requires_dist" in paste_report["metadata"]
 
 

--- a/tests/functional/test_install_report.py
+++ b/tests/functional/test_install_report.py
@@ -26,6 +26,7 @@ def test_install_report_basic(
         str(shared_data.root / "packages/"),
         "--report",
         str(report_path),
+        allow_stderr_warning=True,
     )
     report = json.loads(report_path.read_text())
     assert "install" in report
@@ -58,6 +59,7 @@ def test_install_report_dep(
         str(shared_data.root / "packages/"),
         "--report",
         str(report_path),
+        allow_stderr_warning=True,
     )
     report = json.loads(report_path.read_text())
     assert len(report["install"]) == 2
@@ -76,6 +78,7 @@ def test_install_report_index(script: PipTestEnvironment, tmp_path: Path) -> Non
         "Paste[openid]==1.7.5.1",
         "--report",
         str(report_path),
+        allow_stderr_warning=True,
     )
     report = json.loads(report_path.read_text())
     assert len(report["install"]) == 2
@@ -111,6 +114,7 @@ def test_install_report_vcs_and_wheel_cache(
         str(cache_dir),
         "--report",
         str(report_path),
+        allow_stderr_warning=True,
     )
     report = json.loads(report_path.read_text())
     assert len(report["install"]) == 1
@@ -138,6 +142,7 @@ def test_install_report_vcs_and_wheel_cache(
         str(cache_dir),
         "--report",
         str(report_path),
+        allow_stderr_warning=True,
     )
     assert "Using cached pip_test_package" in result.stdout
     report = json.loads(report_path.read_text())
@@ -171,6 +176,7 @@ def test_install_report_vcs_editable(
         "#egg=pip-test-package",
         "--report",
         str(report_path),
+        allow_stderr_warning=True,
     )
     report = json.loads(report_path.read_text())
     assert len(report["install"]) == 1
@@ -197,8 +203,12 @@ def test_install_report_to_stdout(
         str(shared_data.root / "packages/"),
         "--report",
         "-",
+        allow_stderr_warning=True,
     )
-    assert not result.stderr
+    assert result.stderr == (
+        "WARNING: --report is currently an experimental option. "
+        "The output format may change in a future release without prior warning.\n"
+    )
     report = json.loads(result.stdout)
     assert "install" in report
     assert len(report["install"]) == 1

--- a/tests/functional/test_install_report.py
+++ b/tests/functional/test_install_report.py
@@ -175,3 +175,24 @@ def test_install_report_vcs_editable(
         "/src/pip-test-package"
     )
     assert pip_test_package_report["download_info"]["dir_info"]["editable"] is True
+
+
+@pytest.mark.usefixtures("with_wheel")
+def test_install_report_to_stdout(
+    script: PipTestEnvironment, shared_data: TestData
+) -> None:
+    result = script.pip(
+        "install",
+        "simplewheel",
+        "--quiet",
+        "--dry-run",
+        "--no-index",
+        "--find-links",
+        str(shared_data.root / "packages/"),
+        "--report",
+        "-",
+    )
+    assert not result.stderr
+    report = json.loads(result.stdout)
+    assert "install" in report
+    assert len(report["install"]) == 1


### PR DESCRIPTION
Following the conversation in https://github.com/pypa/pip/pull/10748 and @cosmicexplorer 's [request](url) that I describe more precisely what I had in mind I created this ~proof-of-concept~.

The output is conceptually very similar to #10748, but generated as part of the install command.

It enables the following use cases:

```
1. Tell me what pip installed: pip install --report
2. Tell me what pip would install: pip install --dry-run --report
3. Tell me what pip would install in an empty environment (aka resolve the requirements): pip install --dry-run --ignore-installed --report
```

It is not exactly the same as I take the opportunity to experiment a little bit on the output format.

My goal here is to have a standards based output, using PEP 610 for `download_info` and PEP 566 for `metadata`.

So far I did not need to intrude into the resolver innards as I can obtain all the information from `InstallRequirement`, by the way of a minor change to the preparer to record the downloaded artifact.

~Missing so far, compared to #10748, is dependencies and required python information, but this will be part of the metadata field obtained form the distribution metadata. TODO about metadata is convert it to PEP 566 json.~
Dependencies and required python information are part of the metadata fields in PEP 566 json format.

Here is an example:

`$ pip install "pydantic>=1.9" git+https://github.com/pypa/packaging@main --report=/tmp/report.json --ignore-installed --dry-run --no-cache`

```json
{
  "version": "0",
  "pip_version": "22.2.dev0",
  "install": [
    {
      "is_direct": false,
      "download_info": {
        "url": "https://files.pythonhosted.org/packages/78/b0/fdedac2f07344035607bfbf42217c103a6421e7845fc3cb9fd07f3fa0d2e/pydantic-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
        "archive_info": {
          "hash": "sha256=574936363cd4b9eed8acdd6b80d0143162f2eb654d96cb3a8ee91d3e64bf4cf9"
        }
      },
      "metadata": {
        "name": "pydantic",
        "version": "1.9.0"
        ...
      },
      "requested": true
    },
    {
      "is_direct": true,
      "download_info": {
        "url": "https://github.com/pypa/packaging",
        "vcs_info": {
          "vcs": "git",
          "requested_revision": "main",
          "commit_id": "ba124324e866e518ebfe0378a25b6ba4816e5880"
        }
      },
      "metadata": {
        "name": "packaging",
        "version": "21.4.dev0"
        "requires_dist": [
          "pyparsing (!=3.0.5,>=2.0.2)"
        ],
        "requires_python": ">=3.7",
        ...
      },
      "requested": true
    },
    {
      "is_direct": false,
      "download_info": {
        "url": "https://files.pythonhosted.org/packages/d9/41/d9cfb4410589805cd787f8a82cddd13142d9bf7449d12adf2d05a4a7d633/pyparsing-3.0.8-py3-none-any.whl",
        "archive_info": {
          "hash": "sha256=ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
        }
      },
      "metadata": {
        "name": "pyparsing",
        "version": "3.0.8"
        ...
      }
    },
    {
      "is_direct": false,
      "download_info": {
        "url": "https://files.pythonhosted.org/packages/75/e1/932e06004039dd670c9d5e1df0cd606bf46e29a28e65d5bb28e894ea29c9/typing_extensions-4.2.0-py3-none-any.whl",
        "archive_info": {
          "hash": "sha256=6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"
        }
      },
      "metadata": {
        "name": "typing-extensions",
        "version": "4.2.0"
        ...
      }
    }
  ],
  "environment": {
    "implementation_name": "cpython",
    "implementation_version": "3.8.10",
    "os_name": "posix",
    "platform_machine": "x86_64",
    "platform_release": "...",
    "platform_system": "Linux",
    "platform_version": "...",
    "python_full_version": "3.8.10",
    "platform_python_implementation": "CPython",
    "python_version": "3.8",
    "sys_platform": "linux"
  }
}
```

Please let me know your thoughts and if I'm missing anything.

Closes #53
Closes #6430