### PR TITLE
Improve warning message for using pip as root

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -179,9 +179,13 @@ def warn_if_run_as_root() -> None:
 
     logger.warning(
         "Running pip as the 'root' user can result in broken permissions and "
-        "conflicting behaviour with the system package manager. "
+        "conflicting behaviour with the system package manager.")
+    logger.warning(
         "It is recommended to use a virtual environment instead: "
-        "https://pip.pypa.io/warnings/venv"
+        "https://pip.pypa.io/warnings/venv in most cases as it is considered best practice.")
+    logger.warning(
+        "You might also consider using --user flag with non-root user, "
+        "especially if you use PIP to build containers, where virtualenv use is considered an anti-pattern."
     )
 
 


### PR DESCRIPTION
Using PIP as rot is not recommended, however the recommendation
given by PIP in the warning message when someone usess PIP as root
contains recommendeation that might be misleading.

The message only mentiones recommendation of using virtualenv,
however this recommendation does not apply to building containers.

This has been extensively discussed with varying opinions in
the #10556. There are a number of users who use PIP to build
containers who consider using virtualenv as an antipattern,
however there are also PIP maintainers who claim that the
warning message is ok, even if there were attempts to
implement the recommended approach as documented in
https://github.com/apache/airflow/pull/19189 where attempts
to follow the recommendation failed.

This PR attempts to modify the message in a minimal way to still
keep the original recommendation but also provides the container
developers with more appropriate option of switching to another
user and using --user flag instead.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
