### PR TITLE
CI: Only lock threads on upstream

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   action:
+    if: github.repository_owner == 'pypa'
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Like `.github/workflows/label-merge-conflicts.yml` (https://github.com/pypa/pip/pull/10424), there's no need to run `.github/workflows/lock-threads.yml` on forks.

Let's save some resources and electricity.
