### PR TITLE
Use warnings module for running as root message

### DIFF
--- a/news/10792.bugfix.rst
+++ b/news/10792.bugfix.rst
@@ -1,0 +1,2 @@
+Use warnings module for producing warning when run as root and outside a
+virtual environment.

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -8,6 +8,7 @@ PackageFinder machinery and all its vendored dependencies, etc.
 import logging
 import os
 import sys
+import warnings
 from functools import partial
 from optparse import Values
 from typing import Any, List, Optional, Tuple
@@ -177,7 +178,7 @@ def warn_if_run_as_root() -> None:
     if os.getuid() != 0:
         return
 
-    logger.warning(
+    warnings.warn(
         "Running pip as the 'root' user can result in broken permissions and "
         "conflicting behaviour with the system package manager. "
         "It is recommended to use a virtual environment instead: "


### PR DESCRIPTION
Allows use of warnings module for runtime warning as this allows fine tuning using `PYTHONWARNINGS` variable, providing a workaround for #10556

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Related: #10772
Closes: #10556