### PR TITLE
Sign tags on release

### DIFF
--- a/tools/release/__init__.py
+++ b/tools/release/__init__.py
@@ -105,9 +105,12 @@ def update_version_file(version: str, filepath: str) -> None:
 
 
 def create_git_tag(session: Session, tag_name: str, *, message: str) -> None:
+    # Check if the user has configured a signing key
+    no_sign = subprocess.run(["git", "config", "--get", "user.signingkey"]).returncode
+
     session.run(
         # fmt: off
-        "git", "tag", "-s", "-m", message, tag_name,
+        "git", "tag", "-m", message, tag_name, "--no-sign" if no_sign else "--sign",
         # fmt: on
         external=True,
         silent=True,

--- a/tools/release/__init__.py
+++ b/tools/release/__init__.py
@@ -107,7 +107,7 @@ def update_version_file(version: str, filepath: str) -> None:
 def create_git_tag(session: Session, tag_name: str, *, message: str) -> None:
     session.run(
         # fmt: off
-        "git", "tag", "-m", message, tag_name,
+        "git", "tag", "-s", "-m", message, tag_name,
         # fmt: on
         external=True,
         silent=True,


### PR DESCRIPTION
This updates the release process to sign tags when creating a release.

ref: https://discuss.python.org/t/unverified-tags-for-recent-pip-releases/13206