### PR TITLE
Add filename for windows FileNotFoundError

### DIFF
--- a/news/10812.feature.rst
+++ b/news/10812.feature.rst
@@ -1,0 +1,2 @@
+Improve error message when ``pip config edit`` is provided an editor that
+doesn't exist.

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -13,6 +13,7 @@ from pip._internal.configuration import (
     kinds,
 )
 from pip._internal.exceptions import PipError
+from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import get_prog, write_output
 
@@ -225,6 +226,10 @@ class ConfigurationCommand(Command):
 
         try:
             subprocess.check_call([editor, fname])
+        except FileNotFoundError as e:
+            if WINDOWS:
+                e.filename = editor
+            raise e
         except subprocess.CalledProcessError as e:
             raise PipError(
                 "Editor Subprocess exited with exit code {}".format(e.returncode)

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -229,7 +229,7 @@ class ConfigurationCommand(Command):
         except FileNotFoundError as e:
             if WINDOWS:
                 e.filename = editor
-            raise e
+            raise
         except subprocess.CalledProcessError as e:
             raise PipError(
                 "Editor Subprocess exited with exit code {}".format(e.returncode)

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -13,7 +13,6 @@ from pip._internal.configuration import (
     kinds,
 )
 from pip._internal.exceptions import PipError
-from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import get_prog, write_output
 
@@ -227,7 +226,7 @@ class ConfigurationCommand(Command):
         try:
             subprocess.check_call([editor, fname])
         except FileNotFoundError as e:
-            if WINDOWS:
+            if not e.filename:
                 e.filename = editor
             raise
         except subprocess.CalledProcessError as e:

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -140,3 +140,10 @@ class TestBasicLoading(ConfigurationMixin):
         global_config_file = get_configuration_files()[kinds.GLOBAL][0]
         result = script.pip("config", "debug")
         assert f"{global_config_file}, exists:" in result.stdout
+
+    def test_editor_does_not_exist(self, script: PipTestEnvironment) -> None:
+        """Ensure that FileNotFoundError sets filename correctly"""
+        result = script.pip(
+            "config", "edit", "--editor", "notrealeditor", expect_error=True
+        )
+        assert "notrealeditor" in result.stderr


### PR DESCRIPTION
Fixes #10812 
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
