### PR TITLE
Include Project-URLs in `pip show -v` output

### DIFF
--- a/news/10799.feature.rst
+++ b/news/10799.feature.rst
@@ -1,0 +1,1 @@
+Include Project-URLs in ``pip show`` output.

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -60,6 +60,7 @@ class _PackageInfo(NamedTuple):
     classifiers: List[str]
     summary: str
     homepage: str
+    project_urls: List[str]
     author: str
     author_email: str
     license: str
@@ -126,6 +127,7 @@ def search_packages_info(query: List[str]) -> Iterator[_PackageInfo]:
             classifiers=metadata.get_all("Classifier", []),
             summary=metadata.get("Summary", ""),
             homepage=metadata.get("Home-page", ""),
+            project_urls=metadata.get_all("Project-URL", []),
             author=metadata.get("Author", ""),
             author_email=metadata.get("Author-email", ""),
             license=metadata.get("License", ""),
@@ -168,6 +170,9 @@ def print_results(
             write_output("Entry-points:")
             for entry in dist.entry_points:
                 write_output("  %s", entry.strip())
+            write_output("Project-URLs:")
+            for project_url in dist.project_urls:
+                write_output("  %s", project_url)
         if list_files:
             write_output("Files:")
             if dist.files is None:

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -175,6 +175,9 @@ def test_show_verbose_installer(script: PipTestEnvironment, data: TestData) -> N
 
 
 def test_show_verbose_project_urls(script: PipTestEnvironment) -> None:
+    """
+    Test that project urls can be listed
+    """
     result = script.pip("show", "pip", "--verbose")
     lines = result.stdout.splitlines()
     assert "Name: pip" in lines

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -174,6 +174,14 @@ def test_show_verbose_installer(script: PipTestEnvironment, data: TestData) -> N
     assert "Installer: pip" in lines
 
 
+def test_show_verbose_project_urls(script: PipTestEnvironment) -> None:
+    result = script.pip("show", "pip", "--verbose")
+    lines = result.stdout.splitlines()
+    assert "Name: pip" in lines
+    assert re.search(r"Project-URLs:\n(  .+\n)+", result.stdout)
+    assert "Source, https://github.com/pypa/pip" in result.stdout
+
+
 def test_show_verbose(script: PipTestEnvironment) -> None:
     """
     Test end to end test for verbose show command.
@@ -184,6 +192,7 @@ def test_show_verbose(script: PipTestEnvironment) -> None:
     assert any(line.startswith("Installer: ") for line in lines)
     assert "Entry-points:" in lines
     assert "Classifiers:" in lines
+    assert "Project-URLs:" in lines
 
 
 def test_all_fields(script: PipTestEnvironment) -> None:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Fixes #10799 
