### PR TITLE
Disable location warning for Python < 3.10

### DIFF
--- a/news/10840.removal.rst
+++ b/news/10840.removal.rst
@@ -1,0 +1,3 @@
+Disable location mismatch warnings on Python versions prior to 3.10 since we
+have completed the transition and no longer need to rely on reports from older
+Python versions.


### PR DESCRIPTION
Judging from #10151, there are probably not more incompatibilities to report; all we’re getting at this point are duplicates. And since we’ve enabled sysconfig for 3.10, we’ll be getting “real” bugs when people actually try to install things on newer Python versions, so we don’t need 3.9 (and lower) users to help out anymore.