### PR TITLE
Gracefully fallback to html5lib for parsing non-compliant index pages

### DIFF
--- a/news/10847.removal.rst
+++ b/news/10847.removal.rst
@@ -1,0 +1,1 @@
+Instead of failing on index pages that use non-compliant HTML 5, print a deprecation warning and fall back to ``html5lib``-based parsing for now. This simplifies the migration for non-compliant index pages, by letting such indexes function with a warning.

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -16,6 +16,8 @@ from tests.lib.server import (
 )
 from tests.lib.venv import VirtualEnvironment
 
+TEST_PYPI_INITOOLS = "https://test.pypi.org/simple/initools/"
+
 
 def test_options_from_env_vars(script: PipTestEnvironment) -> None:
     """
@@ -94,7 +96,7 @@ def test_command_line_append_flags(
     variables.
 
     """
-    script.environ["PIP_FIND_LINKS"] = "https://test.pypi.org"
+    script.environ["PIP_FIND_LINKS"] = TEST_PYPI_INITOOLS
     result = script.pip(
         "install",
         "-vvv",
@@ -133,7 +135,7 @@ def test_command_line_appends_correctly(
     Test multiple appending options set by environmental variables.
 
     """
-    script.environ["PIP_FIND_LINKS"] = f"https://test.pypi.org {data.find_links}"
+    script.environ["PIP_FIND_LINKS"] = f"{TEST_PYPI_INITOOLS} {data.find_links}"
     result = script.pip(
         "install",
         "-vvv",

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -36,7 +36,7 @@ def _create_find_links(script: PipTestEnvironment) -> _FindLinks:
             wheel_url=path_to_url(wheel_path),
             wheel_hash=wheel_hash,
             wheel_path=wheel_path,
-        )
+        ).strip()
     )
 
     return _FindLinks(index_html, sdist_hash, wheel_hash)


### PR DESCRIPTION
Builds upon https://github.com/pypa/pip/pull/10846

Toward #10825, since it looks like using non-compliant HTML 5 documents is really common across the entire ecosystem outside of PyPI.