### PR TITLE
Fix RST formatting for 22.0.1 changelog

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -25,7 +25,7 @@ Bug Fixes
 ---------
 
 - Accept lowercase ``<!doctype html>`` on index pages. (`#10844 <https://github.com/pypa/pip/issues/10844>`_)
-- Properly handle links parsed by html5lib, when using ```--use-deprecated=html5lib``. (`#10846 <https://github.com/pypa/pip/issues/10846>`_)
+- Properly handle links parsed by html5lib, when using ``--use-deprecated=html5lib``. (`#10846 <https://github.com/pypa/pip/issues/10846>`_)
 
 
 22.0 (2022-01-29)


### PR DESCRIPTION
There is an extra ` in a news entry released yesterday.

This should probably be marked as "trivial", but I made the change from my web browser and don't have an easy way to add the trivial news file to this commit.