### PR TITLE
Ignore leading whitespace when checking for HTML doctype

### DIFF
--- a/news/10855.bugfix.rst
+++ b/news/10855.bugfix.rst
@@ -1,0 +1,1 @@
+Accept HTML files with whitespace before the doctype declaration.

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -350,7 +350,16 @@ def parse_links(page: "HTMLPage", use_deprecated_html5lib: bool) -> Iterable[Lin
     # requested to use html5lib.
     if not use_deprecated_html5lib:
         expected_doctype = "<!doctype html>".encode(encoding)
-        actual_start = page.content.lstrip()[: len(expected_doctype)]
+
+        char: int
+        offset: int = 0
+        for char in page.content:
+            if chr(char).isspace():
+                offset += 1
+            else:
+                break
+
+        actual_start = page.content[offset : offset + len(expected_doctype)]
         if actual_start.decode(encoding).lower() != "<!doctype html>":
             deprecated(
                 reason=(

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -350,7 +350,7 @@ def parse_links(page: "HTMLPage", use_deprecated_html5lib: bool) -> Iterable[Lin
     # requested to use html5lib.
     if not use_deprecated_html5lib:
         expected_doctype = "<!doctype html>".encode(encoding)
-        actual_start = page.content[: len(expected_doctype)]
+        actual_start = page.content.lstrip()[: len(expected_doctype)]
         if actual_start.decode(encoding).lower() != "<!doctype html>":
             deprecated(
                 reason=(

--- a/tests/data/indexes/README.txt
+++ b/tests/data/indexes/README.txt
@@ -13,3 +13,7 @@ for testing url quoting with indexes
 simple
 ------
 contains index page for "simple" pkg
+
+indent
+------
+For testing indented HTML pages

--- a/tests/data/indexes/indent/simple/index.html
+++ b/tests/data/indexes/indent/simple/index.html
@@ -1,0 +1,6 @@
+    <!DOCTYPE html>
+    <html>
+      <body>
+        <a href="../../../packages/simple-1.0.tar.gz#md5=4bdf78ebb7911f215c1972cf71b378f0">simple-1.0.tar.gz</a>
+      </body>
+    </html>

--- a/tests/functional/test_install_index.py
+++ b/tests/functional/test_install_index.py
@@ -74,3 +74,14 @@ def test_file_index_url_quoting(script: PipTestEnvironment, data: TestData) -> N
     result = script.pip("install", "-vvv", "--index-url", index_url, "simple")
     result.did_create(script.site_packages / "simple")
     result.did_create(script.site_packages / "simple-1.0.dist-info")
+
+
+@pytest.mark.usefixtures("with_wheel")
+def test_file_index_indent(script: PipTestEnvironment, data: TestData) -> None:
+    """
+    Test url quoting of file index url with a space
+    """
+    index_url = data.index_url(urllib.parse.quote("indent"))
+    result = script.pip("install", "-vvv", "--index-url", index_url, "simple")
+    result.did_create(script.site_packages / "simple")
+    result.did_create(script.site_packages / "simple-1.0.dist-info")


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Ref https://github.com/pypa/pip/issues/10825#issuecomment-1025534650