### PR TITLE
Hotfix for CI due to borked setuptools release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         if: matrix.os == 'MacOS'
         run: brew install bzr
 
-      - run: pip install nox 'virtualenv<20'
+      - run: pip install nox 'virtualenv<20' 'setuptools != 60.6.0'
 
       # Main check
       - name: Run unit tests

--- a/tests/requirements-common_wheels.txt
+++ b/tests/requirements-common_wheels.txt
@@ -5,7 +5,7 @@
 # 4. Replacing the `setuptools` entry below with a `file:///...` URL
 # (Adjust artifact directory used based on preference and operating system)
 
-setuptools >= 40.8.0
+setuptools >= 40.8.0, != 60.6.0
 wheel
 # As required by pytest-cov.
 coverage >= 4.4


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
