### PR TITLE
Validate build deps when `--no-build-isolation` is passed

### DIFF
--- a/news/9794.feature.rst
+++ b/news/9794.feature.rst
@@ -1,1 +1,1 @@
-Validate build dependencies when using --no-build-isolation.
+Validate build dependencies when using ``--no-build-isolation``.

--- a/news/9794.feature.rst
+++ b/news/9794.feature.rst
@@ -1,0 +1,1 @@
+Validate build dependencies when using --no-build-isolation.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -20,7 +20,7 @@ from pip._vendor.packaging.version import Version
 from pip import __file__ as pip_location
 from pip._internal.cli.spinners import open_spinner
 from pip._internal.locations import get_platlib, get_prefixed_libs, get_purelib
-from pip._internal.metadata import get_environment
+from pip._internal.metadata import get_default_environment, get_environment
 from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 
@@ -168,7 +168,11 @@ class BuildEnvironment:
         missing = set()
         conflicting = set()
         if reqs:
-            env = get_environment(self._lib_dirs)
+            env = (
+                get_environment(self._lib_dirs)
+                if hasattr(self, "_lib_dirs")
+                else get_default_environment()
+            )
             for req_str in reqs:
                 req = Requirement(req_str)
                 dist = env.get_distribution(req.name)

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -140,6 +140,6 @@ class SourceDistribution(AbstractDistribution):
             "Some build dependencies for {requirement} are missing: {missing}."
         )
         error_message = format_string.format(
-            requirement=self.req, missing=", ".join(missing)
+            requirement=self.req, missing=", ".join(map(repr, sorted(missing)))
         )
         raise InstallationError(error_message)

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -43,7 +43,7 @@ class SourceDistribution(AbstractDistribution):
             self.req.isolated_editable_sanity_check()
             # Install the dynamic build requirements.
             self._install_build_reqs(finder)
-        else:
+        elif self.req.use_pep517:
             pyproject_requires = self.req.pyproject_requires
             assert pyproject_requires is not None
             conflicting, missing = self.req.build_env.check_requirements(

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -43,7 +43,16 @@ class SourceDistribution(AbstractDistribution):
             self.req.isolated_editable_sanity_check()
             # Install the dynamic build requirements.
             self._install_build_reqs(finder)
-
+        else:
+            pyproject_requires = self.req.pyproject_requires
+            assert pyproject_requires is not None
+            conflicting, missing = self.req.build_env.check_requirements(
+                pyproject_requires
+            )
+            if conflicting:
+                self._raise_conflicts("the backend dependencies", conflicting)
+            if missing:
+                self._raise_missing_reqs(missing)
         self.req.prepare_metadata()
 
     def _prepare_build_backend(self, finder: PackageFinder) -> None:
@@ -123,5 +132,14 @@ class SourceDistribution(AbstractDistribution):
                 f"{installed} is incompatible with {wanted}"
                 for installed, wanted in sorted(conflicting_reqs)
             ),
+        )
+        raise InstallationError(error_message)
+
+    def _raise_missing_reqs(self, missing: Set[str]) -> None:
+        format_string = (
+            "Some build dependencies for {requirement} are missing: {missing}."
+        )
+        error_message = format_string.format(
+            requirement=self.req, missing=", ".join(missing)
         )
         raise InstallationError(error_message)

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -5,13 +5,7 @@ import tomli_w
 
 from pip._internal.build_env import BuildEnvironment
 from pip._internal.req import InstallRequirement
-from tests.lib import (
-    PipTestEnvironment,
-    TestData,
-    create_test_package_with_setup,
-    make_test_finder,
-    path_to_url,
-)
+from tests.lib import PipTestEnvironment, TestData, make_test_finder, path_to_url
 from tests.lib.path import Path
 
 
@@ -196,8 +190,7 @@ def test_validate_conflicting_pep517_backend_requirements(
     project_dir = make_project(
         tmpdir, requires=["simplewheel==1.0"], backend="test_backend"
     )
-    pkg_path = create_test_package_with_setup(script, name="simplewheel", version="2.0")
-    script.pip("install", "--no-index", pkg_path)
+    script.pip("install", "simplewheel==2.0", "--no-index", "-f", data.packages)
     result = script.pip(
         "install",
         "--no-index",


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Closes #9794