### PR TITLE
🔧 Fix warning syntax to render as a warning

### DIFF
--- a/docs/html/topics/dependency-resolution.md
+++ b/docs/html/topics/dependency-resolution.md
@@ -277,10 +277,10 @@ your _dependency_ by:
 - Requesting that the package maintainers loosen _their_ dependencies
 - Forking the package and loosening the dependencies yourself
 
-:::{warning}
+```{warning}
 If you choose to fork the package yourself, you are _opting out_ of
 any support provided by the package maintainers. Proceed at your own risk!
-:::
+```
 
 #### All requirements are appropriate, but a solution does not exist
 


### PR DESCRIPTION
Fix rst syntax from `:::{warning}` to ` ```{warning}` so it can be rendered as a warning element
![image](https://user-images.githubusercontent.com/11272260/153106427-3f210a22-6b5f-42ae-a585-72f8f133d00d.png)

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
