### PR TITLE
Add Proxy Integration Test

### DIFF
--- a/tests/functional/test_proxy.py
+++ b/tests/functional/test_proxy.py
@@ -1,0 +1,35 @@
+import contextlib
+import subprocess
+import sys
+from typing import Iterator
+
+import pytest
+
+from tests.lib import PipTestEnvironment
+from tests.lib.path import Path
+
+
+@contextlib.contextmanager
+def run_proxy_server() -> Iterator[None]:
+    proc = subprocess.Popen([sys.executable, "-m", "proxy"])
+    yield
+    proc.kill()
+
+
+@pytest.mark.network
+def test_download_over_http_proxy(script: PipTestEnvironment) -> None:
+    """
+    It should download (in the scratch path) and not install if requested.
+    """
+    with run_proxy_server():
+        result = script.pip(
+            "download",
+            "--proxy",
+            "http://127.0.0.1:8899",
+            "--trusted-host",
+            "127.0.0.1",
+            "-d",
+            "pip_downloads",
+            "INITools==0.1",
+            )
+        result.did_create(Path("scratch") / "pip_downloads" / "INITools-0.1.tar.gz")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,3 +10,4 @@ virtualenv < 20.0
 werkzeug
 wheel
 tomli-w
+proxy.py


### PR DESCRIPTION
Initial proxy Integration test.

Uses [proxy.py](https://github.com/abhinavsingh/proxy.py) which seems to be a very fast well maintained Python proxy server. Seems it could be expanded to test lots of other possible proxy configurations (e.g. TLS interception for self signed certificates).