### PR TITLE
Implement RFC7617-compliant multi-domain basic authentication

### DIFF
--- a/docs/html/topics/authentication.md
+++ b/docs/html/topics/authentication.md
@@ -16,6 +16,54 @@ token as the "username" and do not provide a password:
 https://0123456789abcdef@pypi.company.com/simple
 ```
 
+When you specify several indexes, each of them can come with its own
+authentication information. When the domains and schemes of multiple
+indexes partially overlap, you can specify different authentication for each of them
+For example you can have:
+
+```
+PIP_INDEX_URL=https://build:password1@pkgs.dev.azure.com/feed1
+PIP_EXTRA_INDEX_URL=https://build:password2@pkgs.dev.azure.com/feed2
+```
+
+If you specify multiple identical index URLs with different authentication information,
+authentication from the first index will be used.
+
+```{versionchanged} 22.1
+The basic authentication is now compliant with RFC 7617
+```
+
+In compliance with [RFC7617](https://datatracker.ietf.org/doc/html/rfc7617#section-2.2) if the indexes
+overlap, the authentication information from the prefix-match will be reused for the longer index if
+the longer index does not contain the authentication information. In case multiple indexes are
+prefix-matching, the authentication of the first of the longest matching prefixes is used.
+
+For example in this case, build:password authentication will be used when authenticating with the extra
+index URL.
+
+```
+PIP_INDEX_URL=https://build:password@pkgs.dev.azure.com/
+PIP_EXTRA_INDEX_URL=https://pkgs.dev.azure.com/feed1
+```
+
+```{note}
+Prior to version 22.1 reusing of basic authentication between URLs was not RFC7617 compliant.
+This could lead to the situation that custom-built indexes could receive the authentication
+provided for the index path, to download files outside fof the security domain of the path.
+
+For example if your index at https://username:password@pypi.company.com/simple served files from
+https://pypi.company.com/file.tar.gz - the username and password provided for the "/simple" path
+was also used to authenticate download of the `file.tar.gz`. This is not RFC7617 compliant and as of
+version 22.1 it will not work automatically. If you encounter a problem where your files are being
+served from different security domain than your index and authentication is not used for them, you
+should (ideally) fix it on your server side or (as temporary workaround)
+specify your file download location as extra index url:
+
+PIP_EXTRA_INDEX_URL=https://username:password@pypi.company.com/
+
+```
+
+
 ### Percent-encoding special characters
 
 ```{versionadded} 10.0

--- a/news/10904.feature.rst
+++ b/news/10904.feature.rst
@@ -1,0 +1,3 @@
+When you specify multiple indexes with common domains and schemes, basic authentication for each of
+the indexes can be different - compliant with RFC 7617. Previous versions of pip reused basic
+authentication credentials for all urls within the same domain.

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -432,7 +432,7 @@ def test_prioritize_url_credentials_over_netrc(
     server.mock.side_effect = [
         package_page(
             {
-                "simple-3.0.tar.gz": "/files/simple-3.0.tar.gz",
+                "simple-3.0.tar.gz": "/simple/files/simple-3.0.tar.gz",
             }
         ),
         authorization_response(str(data.packages / "simple-3.0.tar.gz")),


### PR DESCRIPTION
The https://datatracker.ietf.org/doc/html/rfc7617#section-2.2
defines multi-domain authentication behaviour and authentication
scopes for basic authentication. This change improves the
implementation of the multi-domain matching to be RC7617 compliant

* path matching (including longest match)
* scheme validation matching

Closes: #10902

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
