### PR TITLE
Add information about dev virtualenv setup

### DIFF
--- a/docs/html/development/contributing.rst
+++ b/docs/html/development/contributing.rst
@@ -8,6 +8,19 @@ Pip's internals
 We have an in-progress guide to the
 :ref:`architecture-pip-internals`. It might be helpful as you dive in.
 
+Creating development environment
+================================
+
+In order to create a development environment you should install the
+dev extra in editable mode:
+
+```
+pip install -e ".[dev]"
+```
+
+It's bet to do it while you activated a virtualenv where you
+develop `pip`.
+
 Submitting Pull Requests
 ========================
 

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,16 @@ setup(
             "w64-arm.exe",
         ],
     },
+    extras_require={
+        "dev": [
+            "freezegun",
+            "pytest",
+            "scripttest",
+            "virtualenv",
+            "werkzeug",
+            "wheel",
+        ]
+    },
     entry_points={
         "console_scripts": [
             "pip=pip._internal.cli.main:main",


### PR DESCRIPTION
In order to run unit tests of `pip`, you need to setup a
virtualenv with pip and some extra packages. Those extra
packages have not been mentioned anywhere - but when they
were missing, running unit test fails.

This PR adds documentation update and "extras" dev that
installs the missing dependencies.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
