### PR TITLE
Fix references in Markdown documentation files

### DIFF
--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -55,6 +55,7 @@ print("pip release:", release)
 # -- Options for myst-parser ----------------------------------------------------------
 
 myst_enable_extensions = ["deflist"]
+myst_heading_anchors = 3
 
 # -- Options for smartquotes ----------------------------------------------------------
 

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -14,7 +14,7 @@ If your Python environment does not have pip installed, there are 2 mechanisms
 to install pip supported directly by pip's maintainers:
 
 - [`ensurepip`](#ensurepip)
-- [`get-pip.py`](#get-pip-py)
+- [`get-pip.py`](#get-pippy)
 
 ### `ensurepip`
 


### PR DESCRIPTION
MyST-Parser 0.17.0 reworked the link resolution logic, which has become
stricter and caught these issues.
