### PR TITLE
Present found conflicts when discarding some criterion

### DIFF
--- a/news/10937.feature.rst
+++ b/news/10937.feature.rst
@@ -1,0 +1,1 @@
+Present conflict information during installation after each choice that is rejected (pass ``-vv`` to ``pip install`` to show it)

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -42,6 +42,18 @@ class PipReporter(BaseReporter):
         message = self._messages_at_reject_count[count]
         logger.info("INFO: %s", message.format(package_name=candidate.name))
 
+        msg = "Will try a different candidate, due to conflict:"
+        for req_info in criterion.information:
+            req, parent = req_info.requirement, req_info.parent
+            # Inspired by Factory.get_installation_error
+            msg += "\n    "
+            if parent:
+                msg += f"{parent.name} {parent.version} depends on "
+            else:
+                msg += "The user requested "
+            msg += req.format_for_error()
+        logger.debug(msg)
+
 
 class PipDebuggingReporter(BaseReporter):
     """A reporter that does an info log for every event it sees."""


### PR DESCRIPTION
Fixes gh-9254.
Closes gh-10258.
See https://github.com/pypa/pip/pull/10258#issuecomment-999060298 for inspiration.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

This is a proof of concept of an alternative approach to gh-10258, hoping that it will (1) provide a better UX when "backtracking" (in quotes, see below) happens, and (2) do it in a way that is acceptable for the pip maintainers. It doesn't have tests or a news entry yet, hoping that I can get maintainer approval & community consensus first.

First of all, I did all of this in a hurry, so forgive me if I'm overloading the terms "requirement", "candidate", "round", "resolve", and such. I only spent 3 hours looking at the pip codebase, and I didn't find high-level docs on "how the new resolver works". By the way, the code comments are _great_ 💯 

The tricky thing was summarized, if I understood correctly, in [this comment by @pradyunsg](https://github.com/pypa/pip/pull/10258#issuecomment-999060298):

> I'm also pretty sure I wrote that code, and arguably, doing what I'm suggesting here would have been a better match for what people consider "backtracking" than what is implemented there. 😅 
>
> I don't think using resolvelib's "round" as a unit of backtracking is particularly useful for deciding when to present conflicts -- we can have conflicts that cause a package to be rejected within a single "round" as well, and I think presenting those cases is much more useful/informative.

Indeed, what users call "backtracking" might be two things:

- Actual backtracking messages, as defined in the codebase: `INFO: pip is looking at multiple versions of pyjwt to determine which version is compatible with other requirements. This could take a while.`.
- Retrial of older and older versions of a given requirement while pip is trying to satisfy some constraints, which comes _before_ the backtracking phase, but it _looks_ like "backtracking".

In this implementation I'm trying to hook into "the right place" so that conflict information is presented immediately when discarding a certain candidate.

Example of output with direct, impossible resolution example [from the documentation](https://pip.pypa.io/en/stable/topics/dependency-resolution/?highlight=backtracking#understanding-your-error-message):

```
$ python -m pip install "pytest < 4.6" "pytest-cov==2.12.1" --no-cache-dir
Collecting pytest<4.6
  Downloading pytest-4.5.0-py2.py3-none-any.whl (227 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 227.5/227.5 KB 4.8 MB/s eta 0:00:00
Collecting pytest-cov==2.12.1
  Downloading pytest_cov-2.12.1-py2.py3-none-any.whl (20 kB)
Will try a different candidate, due to conflict:
    The user requested pytest<4.6
    pytest-cov 2.12.1 depends on pytest>=4.6
ERROR: Cannot install pytest-cov==2.12.1 and pytest<4.6 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested pytest<4.6
    pytest-cov 2.12.1 depends on pytest>=4.6

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

Example of so-called "backtracking" but-not-quite, when pip is reaching out to older versions of an unpinned dependency to try to satisfy the constraints (and which _doesn't_ produce a "this will take a while" message):

```
$ pip install "botocore~=1.10.0" boto3 --no-cache-dir
Collecting botocore~=1.10.0
  Downloading botocore-1.10.84-py2.py3-none-any.whl (4.5 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.5/4.5 MB 6.6 MB/s eta 0:00:00
Collecting boto3
  Downloading boto3-1.21.11-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.2/132.2 KB 6.9 MB/s eta 0:00:00
Collecting jmespath<1.0.0,>=0.7.1
  Downloading jmespath-0.10.0-py2.py3-none-any.whl (24 kB)
Collecting docutils>=0.10
  Downloading docutils-0.18.1-py2.py3-none-any.whl (570 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 570.0/570.0 KB 7.9 MB/s eta 0:00:00
Collecting python-dateutil<3.0.0,>=2.1
  Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 KB 7.8 MB/s eta 0:00:00
Collecting s3transfer<0.6.0,>=0.5.0
  Downloading s3transfer-0.5.2-py3-none-any.whl (79 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 79.5/79.5 KB 12.9 MB/s eta 0:00:00
Will try a different candidate, due to conflict:
    The user requested botocore~=1.10.0
    boto3 1.21.11 depends on botocore<1.25.0 and >=1.24.11
Collecting boto3
  Downloading boto3-1.21.10-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.2/132.2 KB 7.8 MB/s eta 0:00:00
Will try a different candidate, due to conflict:
    The user requested botocore~=1.10.0
    boto3 1.21.10 depends on botocore<1.25.0 and >=1.24.10
  Downloading boto3-1.21.9-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.2/132.2 KB 7.5 MB/s eta 0:00:00
Will try a different candidate, due to conflict:
    The user requested botocore~=1.10.0
    boto3 1.21.9 depends on botocore<1.25.0 and >=1.24.9
  Downloading boto3-1.21.8-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.2/132.2 KB 8.7 MB/s eta 0:00:00
Will try a different candidate, due to conflict:
    The user requested botocore~=1.10.0
    boto3 1.21.8 depends on botocore<1.25.0 and >=1.24.8
  Downloading boto3-1.21.7-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.2/132.2 KB 9.2 MB/s eta 0:00:00
Will try a different candidate, due to conflict:
    The user requested botocore~=1.10.0
    boto3 1.21.7 depends on botocore<1.25.0 and >=1.24.7
  Downloading boto3-1.21.6-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.2/132.2 KB 9.9 MB/s eta 0:00:00
Will try a different candidate, due to conflict:
    The user requested botocore~=1.10.0
    boto3 1.21.6 depends on botocore<1.25.0 and >=1.24.6
  Downloading boto3-1.21.5-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.1/132.1 KB 9.7 MB/s eta 0:00:00
Will try a different candidate, due to conflict:
    The user requested botocore~=1.10.0
    boto3 1.21.5 depends on botocore<1.25.0 and >=1.24.5
  Downloading boto3-1.21.4-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.1/132.1 KB 7.2 MB/s eta 0:00:00
^CERROR: Operation cancelled by user
```

Example with super long backtracking as officially defined in the pip codebase ([full output](https://gist.github.com/astrojuanlu/dce96fe4f5a27abcc07945fa094681c6), too long for GitHub):

```
root@f4372a0219b2:/opt/airflow# pip install ".[devel_all]" --upgrade --upgrade-strategy eager "dill<0.3.3" "certifi<2021.0.0" "google-ads<14.0.1"
Processing /opt/airflow
  Preparing metadata (setup.py) ... done
...
Requirement already satisfied: ipython-genutils in /usr/local/lib/python3.7/site-packages (from nbformat>=5.1.2->papermill[all]>=1.2.1->apache-airflow==2.3.0.dev0) (0.2.0)
Requirement already satisfied: jupyter-core in /usr/local/lib/python3.7/site-packages (from nbformat>=5.1.2->papermill[all]>=1.2.1->apache-airflow==2.3.0.dev0) (4.9.2)
Requirement already satisfied: locket in /usr/local/lib/python3.7/site-packages (from partd>=0.3.10->dask<2021.6.1,>=2.9.0->apache-airflow==2.3.0.dev0) (0.2.1)
Will try a different candidate, due to conflict:
    flask-appbuilder 3.4.4 depends on PyJWT<2.0.0 and >=1.7.1
    snowflake-connector-python 2.7.1 depends on pyjwt<3.0.0
    yandexcloud 0.146.0 depends on pyjwt>=1.7.1
    pygithub 1.54.1 depends on pyjwt<2.0
    adal 1.2.7 depends on PyJWT<3 and >=1.0.0
    flask-jwt-extended 3.25.1 depends on PyJWT<2.0 and >=1.6.4
    pyjwt[crypto] 2.3.0 depends on pyjwt 2.3.0 (from https://files.pythonhosted.org/packages/2a/4d/67cc66a0c49003dc216fc73db2d05a3b80c7193167fd113da1f2c678ac2a/PyJWT-2.3.0-py3-none-any.whl#sha256=e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f (from https://pypi.org/simple/pyjwt/) (requires-python:>=3.6))
INFO: pip is looking at multiple versions of pyjwt to determine which version is compatible with other requirements. This could take a while.
Collecting PyJWT<2.0.0,>=1.7.1
  Downloading PyJWT-1.7.1-py2.py3-none-any.whl (18 kB)
Will try a different candidate, due to conflict:
    flask-appbuilder 3.4.4 depends on PyJWT<2.0.0 and >=1.7.1
    snowflake-connector-python 2.7.1 depends on pyjwt<3.0.0
    yandexcloud 0.146.0 depends on pyjwt>=1.7.1
    pygithub 1.54.1 depends on pyjwt<2.0
    adal 1.2.7 depends on PyJWT<3 and >=1.0.0
    flask-jwt-extended 3.25.1 depends on PyJWT<2.0 and >=1.6.4
    pyjwt[crypto] 2.3.0 depends on pyjwt 2.3.0 (from https://files.pythonhosted.org/packages/2a/4d/67cc66a0c49003dc216fc73db2d05a3b80c7193167fd113da1f2c678ac2a/PyJWT-2.3.0-py3-none-any.whl#sha256=e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f (from https://pypi.org/simple/pyjwt/) (requires-python:>=3.6))
INFO: pip is looking at multiple versions of pyflakes to determine which version is compatible with other requirements. This could take a while.
Collecting pyflakes<2.4.0,>=2.3.0
  Downloading pyflakes-2.3.1-py2.py3-none-any.whl (68 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 68.8/68.8 KB 6.0 MB/s eta 0:00:00
Will try a different candidate, due to conflict:
    flask-appbuilder 3.4.4 depends on PyJWT<2.0.0 and >=1.7.1
    snowflake-connector-python 2.7.1 depends on pyjwt<3.0.0
    yandexcloud 0.146.0 depends on pyjwt>=1.7.1
    pygithub 1.54.1 depends on pyjwt<2.0
    adal 1.2.7 depends on PyJWT<3 and >=1.0.0
    flask-jwt-extended 3.25.1 depends on PyJWT<2.0 and >=1.6.4
    pyjwt[crypto] 2.3.0 depends on pyjwt 2.3.0 (from https://files.pythonhosted.org/packages/2a/4d/67cc66a0c49003dc216fc73db2d05a3b80c7193167fd113da1f2c678ac2a/PyJWT-2.3.0-py3-none-any.whl#sha256=e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f (from https://pypi.org/simple/pyjwt/) (requires-python:>=3.6))
...
```