### PR TITLE
--proxy option requires scheme, does not work without it

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -84,7 +84,7 @@ in many corporate environments requires an outbound HTTP proxy server.
 pip can be configured to connect through a proxy server in various ways:
 
 * using the ``--proxy`` command-line option to specify a proxy in the form
-  ``[user:passwd@]proxy.server:port``
+  ``scheme://[user:passwd@]proxy.server:port``
 * using ``proxy`` in a :ref:`config-file`
 * by setting the standard environment-variables ``http_proxy``, ``https_proxy``
   and ``no_proxy``.

--- a/news/10951.doc.rst
+++ b/news/10951.doc.rst
@@ -1,0 +1,1 @@
+Add ``scheme://`` requirement to ``--proxy`` option's description

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -272,7 +272,7 @@ proxy: Callable[..., Option] = partial(
     dest="proxy",
     type="str",
     default="",
-    help="Specify a proxy in the form [user:passwd@]proxy.server:port.",
+    help="Specify a proxy in the form scheme://[user:passwd@]proxy.server:port.",
 )
 
 retries: Callable[..., Option] = partial(


### PR DESCRIPTION
`--proxy` option requires scheme, does not work without it.

See also: https://github.com/pypa/pip/commit/2b2ca40ccc44a3e1873f77b770b359e66349120b

Supersedes #10037

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
