### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'src/pip/_vendor/'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: 8fe62d14e0b4d7d845a7022c5c2c3ae41bdd3f26  # frozen: v4.1.0
   hooks:
   - id: check-builtin-literals
   - id: check-added-large-files
@@ -17,12 +17,12 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/psf/black
-  rev: 21.7b0
+  rev: fc0be6eb1e2a96091e6f64009ee5e9081bf8b6c6  # frozen: 22.1.0
   hooks:
   - id: black
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
+- repo: https://github.com/PyCQA/flake8
+  rev: cbeb4c9c4137cff1568659fcc48e8b85cddd0c8d  # frozen: 4.0.1
   hooks:
   - id: flake8
     additional_dependencies: [
@@ -33,13 +33,13 @@ repos:
     exclude: tests/data
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.7.0
+  rev: c5e8fa75dda5f764d20f66a215d71c21cfa198e1  # frozen: 5.10.1
   hooks:
   - id: isort
     files: \.py$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910
+  rev: f6f816c65d285f8a4a15e0e9965b3dd66ecddd79  # frozen: v0.931
   hooks:
   - id: mypy
     exclude: tests/data
@@ -54,7 +54,7 @@ repos:
     ]
 
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.7.0
+  rev: 6f51a66bba59954917140ec2eeeaa4d5e630e6ce  # frozen: v1.9.0
   hooks:
   - id: python-no-log-warn
   - id: python-no-eval
@@ -73,7 +73,7 @@ repos:
     files: ^news/
 
 - repo: https://github.com/mgedmin/check-manifest
-  rev: '0.46'
+  rev: 'f98aa338b772b37972c0077016e75c23ac7c63e8'  # frozen: 0.47
   hooks:
   - id: check-manifest
     stages: [manual]

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -86,7 +86,7 @@ class InterruptibleMixin:
         Save the original SIGINT handler for later.
         """
         # https://github.com/python/mypy/issues/5887
-        super().__init__(*args, **kwargs)  # type: ignore
+        super().__init__(*args, **kwargs)
 
         self.original_handler = signal(SIGINT, self.handle_sigint)
 
@@ -96,7 +96,7 @@ class InterruptibleMixin:
         # The least bad option should be Python's default SIGINT handler, which
         # just raises KeyboardInterrupt.
         if self.original_handler is None:
-            self.original_handler = default_int_handler
+            self.original_handler = default_int_handler  # type: ignore[assignment]
 
     def finish(self) -> None:
         """
@@ -134,8 +134,7 @@ class BlueEmojiBar(IncrementalBar):
 
 class DownloadProgressMixin:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        # https://github.com/python/mypy/issues/5887
-        super().__init__(*args, **kwargs)  # type: ignore
+        super().__init__(*args, **kwargs)
         self.message: str = (" " * (get_indentation() + 2)) + self.message
 
     @property
@@ -176,8 +175,7 @@ class WindowsMixin:
         if WINDOWS and self.hide_cursor:  # type: ignore
             self.hide_cursor = False
 
-        # https://github.com/python/mypy/issues/5887
-        super().__init__(*args, **kwargs)  # type: ignore
+        super().__init__(*args, **kwargs)
 
         # Check if we are running on Windows and we have the colorama module,
         # if we do then wrap our file with it.

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -47,7 +47,7 @@ def create_vendor_txt_map() -> Dict[str, str]:
         ]
 
     # Transform into "module" -> version dict.
-    return dict(line.split("==", 1) for line in lines)  # type: ignore
+    return dict(line.split("==", 1) for line in lines)
 
 
 def get_module_from_module_name(module_name: str) -> ModuleType:
@@ -67,7 +67,7 @@ def get_vendor_version_from_module(module_name: str) -> Optional[str]:
 
     if not version:
         # Try to find version in debundled module info.
-        env = get_environment([os.path.dirname(module.__file__)])
+        env = get_environment([os.path.dirname(module.__file__)])  # type: ignore
         dist = env.get_distribution(module_name)
         if dist:
             version = str(dist.version)

--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -73,7 +73,7 @@ def _looks_like_bpo_44860() -> bool:
 
     See <https://bugs.python.org/issue44860>.
     """
-    from distutils.command.install import INSTALL_SCHEMES  # type: ignore
+    from distutils.command.install import INSTALL_SCHEMES
 
     try:
         unix_user_platlib = INSTALL_SCHEMES["unix_user"]["platlib"]
@@ -98,7 +98,7 @@ def _looks_like_red_hat_lib() -> bool:
 
     This is the only way I can see to tell a Red Hat-patched Python.
     """
-    from distutils.command.install import INSTALL_SCHEMES  # type: ignore
+    from distutils.command.install import INSTALL_SCHEMES
 
     return all(
         k in INSTALL_SCHEMES
@@ -110,7 +110,7 @@ def _looks_like_red_hat_lib() -> bool:
 @functools.lru_cache(maxsize=None)
 def _looks_like_debian_scheme() -> bool:
     """Debian adds two additional schemes."""
-    from distutils.command.install import INSTALL_SCHEMES  # type: ignore
+    from distutils.command.install import INSTALL_SCHEMES
 
     return "deb_system" in INSTALL_SCHEMES and "unix_local" in INSTALL_SCHEMES
 
@@ -171,7 +171,9 @@ def _looks_like_msys2_mingw_scheme() -> bool:
 
 def _fix_abiflags(parts: Tuple[str]) -> Iterator[str]:
     ldversion = sysconfig.get_config_var("LDVERSION")
-    abiflags: str = getattr(sys, "abiflags", None)
+    _abiflags = getattr(sys, "abiflags", None)
+    assert isinstance(_abiflags, str)
+    abiflags = _abiflags
 
     # LDVERSION does not end with sys.abiflags. Just return the path unchanged.
     if not ldversion or not abiflags or not ldversion.endswith(abiflags):

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -84,7 +84,7 @@ def distutils_scheme(
         if home:
             prefix = home
         elif user:
-            prefix = i.install_userbase  # type: ignore
+            prefix = i.install_userbase
         else:
             prefix = i.prefix
         scheme["headers"] = os.path.join(

--- a/src/pip/_internal/utils/encoding.py
+++ b/src/pip/_internal/utils/encoding.py
@@ -14,7 +14,7 @@ BOMS: List[Tuple[bytes, str]] = [
     (codecs.BOM_UTF32_LE, "utf-32-le"),
 ]
 
-ENCODING_RE = re.compile(br"coding[:=]\s*([-\w.]+)")
+ENCODING_RE = re.compile(rb"coding[:=]\s*([-\w.]+)")
 
 
 def auto_decode(data: bytes) -> str:

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -152,8 +152,9 @@ class RichPipStreamHandler(RichHandler):
         style: Optional[Style] = None
 
         # If we are given a diagnostic error to present, present it with indentation.
-        if record.msg == "[present-diagnostic] %s" and len(record.args) == 1:
-            diagnostic_error: DiagnosticPipError = record.args[0]  # type: ignore[index]
+        msg = "[present-diagnostic] %s"
+        if record.msg == msg and len(record.args) == 1:  # type: ignore[arg-type]
+            diagnostic_error: DiagnosticPipError = record.args[0]  # type: ignore
             assert isinstance(diagnostic_error, DiagnosticPipError)
 
             renderable: ConsoleRenderable = IndentedRenderable(
@@ -193,7 +194,7 @@ class RichPipStreamHandler(RichHandler):
 
 
 class BetterRotatingFileHandler(logging.handlers.RotatingFileHandler):
-    def _open(self) -> IO[Any]:
+    def _open(self) -> IO[Any]:  # type: ignore[override]
         ensure_dir(os.path.dirname(self.baseFilename))
         return super()._open()
 

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -121,7 +121,7 @@ def call_subprocess(
     else:
         # Then log the subprocess output using VERBOSE.  This also ensures
         # it will be logged to the log file (aka user_log), if enabled.
-        log_subprocess = subprocess_logger.verbose
+        log_subprocess = subprocess_logger.verbose  # type: ignore[assignment]
         used_level = VERBOSE
 
     # Whether the subprocess will be visible in the console.

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -188,8 +188,7 @@ def untar_file(filename: str, location: str) -> None:
                 ensure_dir(path)
             elif member.issym():
                 try:
-                    # https://github.com/python/typeshed/issues/2673
-                    tar._extract_member(member, path)  # type: ignore
+                    tar._extract_member(member, path)
                 except Exception as exc:
                     # Some corrupt tar files seem to produce this
                     # (specifically bad symlinks)

--- a/tests/data/packages/SetupPyLatin1/setup.py
+++ b/tests/data/packages/SetupPyLatin1/setup.py
@@ -4,5 +4,5 @@ from distutils.core import setup
 
 setup(
     name="SetupPyUTF8",
-    author=u"Saúl Ibarra Corretgé",
+    author="Saúl Ibarra Corretgé",
 )


### PR DESCRIPTION
Hooks were updated with `pre-commit autoupdate --freeze` and
flake8 had its repository moved to Github, which has newer versions.

The newer mypy version had some fixes where `# type ignores` were
added. The new type issues it caught which were less obvious, were
`# type ignored`, for the time being.