### PR TITLE
Fix a small typo in the docs

### DIFF
--- a/docs/html/cli/pip.rst
+++ b/docs/html/cli/pip.rst
@@ -71,7 +71,7 @@ when decision is needed.
     Rename the file or checkout to ``{name}{'.bak' * n}``, where n is some number
     of ``.bak`` extensions, such that the file didn't exist at some point.
     So the most recent backup will be the one with the largest number after ``.bak``.
-*(a)abort*
+*(a)bort*
     Abort pip and return non-zero exit status.
 
 


### PR DESCRIPTION
I consider `(a)abort` should be `(a)bort` [here](https://pip.pypa.io/en/latest/cli/pip/?highlight=cert#exists-action-option), like the other options (`(w)ipe`, `(b)ackup`, etc.). However, maybe it's just me, so please tell me your thoughts.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
