### PR TITLE
Filter available distributions using hash declarations from constraints files

### DIFF
--- a/news/9243.bugfix.rst
+++ b/news/9243.bugfix.rst
@@ -1,0 +1,2 @@
+New resolver: Pick up hash declarations in constraints files and use them to
+filter available distributions.

--- a/news/9243.bugfix.rst
+++ b/news/9243.bugfix.rst
@@ -1,2 +1,1 @@
-New resolver: Pick up hash declarations in constraints files and use them to
-filter available distributions.
+Filter available distributions using hash declarations from constraints files.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -52,7 +52,7 @@ from pip._internal.utils.misc import (
     hide_url,
     redact_auth_from_url,
 )
-from pip._internal.utils.packaging import safe_extra
+from pip._internal.utils.packaging import is_pinned, safe_extra
 from pip._internal.utils.subprocess import runner_with_spinner_message
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 from pip._internal.utils.virtualenv import running_under_virtualenv
@@ -238,8 +238,7 @@ class InstallRequirement:
 
         For example, some-package==1.2 is pinned; some-package>1.2 is not.
         """
-        specifiers = self.specifier
-        return len(specifiers) == 1 and next(iter(specifiers)).operator in {"==", "==="}
+        return is_pinned(self.specifier)
 
     def match_markers(self, extras_requested: Optional[Iterable[str]] = None) -> bool:
         if not extras_requested:

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -45,7 +45,7 @@ from pip._internal.req.req_install import (
 from pip._internal.resolution.base import InstallRequirementProvider
 from pip._internal.utils.compatibility_tags import get_supported
 from pip._internal.utils.hashes import Hashes
-from pip._internal.utils.packaging import get_requirement
+from pip._internal.utils.packaging import get_requirement, is_pinned
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
 from .base import Candidate, CandidateVersion, Constraint, Requirement
@@ -303,18 +303,11 @@ class Factory:
             # solely satisfied by a yanked release.
             all_yanked = all(ican.link.is_yanked for ican in icans)
 
-            def is_pinned(specifier: SpecifierSet) -> bool:
-                for sp in specifier:
-                    if sp.operator == "===":
-                        return True
-                    if sp.operator != "==":
-                        continue
-                    if sp.version.endswith(".*"):
-                        continue
-                    return True
-                return False
-
             pinned = is_pinned(specifier)
+
+            assert template.req, "Candidates found on index must be PEP 508"
+            template.req.specifier = specifier
+            template.hash_options = hashes.allowed
 
             # PackageFinder returns earlier versions first, so we reverse.
             for ican in reversed(icans):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -305,9 +305,10 @@ class Factory:
 
             pinned = is_pinned(specifier)
 
-            assert template.req, "Candidates found on index must be PEP 508"
-            template.req.specifier = specifier
-            template.hash_options = hashes.allowed
+            if not template.is_pinned:
+                assert template.req, "Candidates found on index must be PEP 508"
+                template.req.specifier = specifier
+                template.hash_options = hashes.allowed
 
             # PackageFinder returns earlier versions first, so we reverse.
             for ican in reversed(icans):

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -63,6 +63,10 @@ class Hashes:
     def digest_count(self) -> int:
         return sum(len(digests) for digests in self._allowed.values())
 
+    @property
+    def allowed(self) -> Dict[str, List[str]]:
+        return self._allowed
+
     def is_hash_allowed(self, hash_name: str, hex_digest: str) -> bool:
         """Return whether the given hex digest is allowed."""
         return hex_digest in self._allowed.get(hash_name, [])

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -5,6 +5,7 @@ from typing import NewType, Optional, Tuple, cast
 
 from pip._vendor.packaging import specifiers, version
 from pip._vendor.packaging.requirements import Requirement
+from pip._vendor.packaging.specifiers import SpecifierSet
 
 NormalizedExtra = NewType("NormalizedExtra", str)
 
@@ -55,3 +56,15 @@ def safe_extra(extra: str) -> NormalizedExtra:
     the same to either ``canonicalize_name`` or ``_egg_link_name``.
     """
     return cast(NormalizedExtra, re.sub("[^A-Za-z0-9.-]+", "_", extra).lower())
+
+
+def is_pinned(specifier: SpecifierSet) -> bool:
+    for sp in specifier:
+        if sp.operator == "===":
+            return True
+        if sp.operator != "==":
+            continue
+        if sp.version.endswith(".*"):
+            continue
+        return True
+    return False

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -223,9 +223,11 @@ def test_new_resolver_hash_intersect_empty_from_constraint(
         expect_error=True,
     )
 
-    assert (
-        "THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE."
-    ) in result.stderr, str(result)
+    message = (
+        "Hashes are required in --require-hashes mode, but they are missing "
+        "from some requirements."
+    )
+    assert message in result.stderr, str(result)
 
 
 @pytest.mark.parametrize("constrain_by_hash", [False, True])

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -223,11 +223,9 @@ def test_new_resolver_hash_intersect_empty_from_constraint(
         expect_error=True,
     )
 
-    message = (
-        "Hashes are required in --require-hashes mode, but they are missing "
-        "from some requirements."
-    )
-    assert message in result.stderr, str(result)
+    assert (
+        "THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE."
+    ) in result.stderr, str(result)
 
 
 @pytest.mark.parametrize("constrain_by_hash", [False, True])
@@ -373,3 +371,34 @@ def test_new_resolver_hash_with_extras(script: PipTestEnvironment) -> None:
         child="0.1.0",
         extra="0.1.0",
     )
+
+
+def test_new_resolver_hash_with_pin(script: PipTestEnvironment) -> None:
+    find_links = _create_find_links(script)
+
+    requirements_txt = script.scratch_path / "requirements.txt"
+    requirements_txt.write_text("base")
+
+    constraints_txt = script.scratch_path / "constraints.txt"
+    constraints_txt.write_text(
+        """
+        base==0.1.0 --hash=sha256:{sdist_hash} --hash=sha256:{wheel_hash}
+        """.format(
+            sdist_hash=find_links.sdist_hash,
+            wheel_hash=find_links.wheel_hash,
+        )
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        find_links.index_html,
+        "--requirement",
+        requirements_txt,
+        "--constraint",
+        constraints_txt,
+    )
+
+    script.assert_installed(base="0.1.0")


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Closes #9243
 
`is_pinned` implementation is fixed according to https://github.com/pypa/pip/pull/10625#discussion_r749088550.