### PR TITLE
Fix issue with installing dependencies with extras & hashes.

### DIFF
--- a/news/9644.bugfix.rst
+++ b/news/9644.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue with installing dependencies with extras & hashes.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -318,7 +318,7 @@ class Factory:
                     self._make_candidate_from_link,
                     link=ican.link,
                     extras=extras,
-                    template=template,
+                    template=install_req_from_link_and_ireq(ican.link, template),
                     name=name,
                     version=ican.version,
                 )


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Closes #9644

I think, this https://github.com/pypa/pip/pull/10962 should be reverted, because it works without pin checks.