### PR TITLE
Flag for 'pip index versions' to output only latest version

### DIFF
--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -42,6 +42,14 @@ class IndexCommand(IndexGroupCommand):
             default=False,
             help="Print only the latest version of the given package.",
         )
+        self.cmd_opts.add_option(
+            "--format",
+            action="store",
+            dest="list_format",
+            default="human",
+            choices=("human", "json"),
+            help="Select the output format among: human (default) or json",
+        )
 
         index_opts = cmdoptions.make_option_group(
             cmdoptions.index_group,
@@ -143,9 +151,16 @@ class IndexCommand(IndexGroupCommand):
                 write_output(str(max(versions)))
                 return
 
+        if options.list_format == 'human':
             formatted_versions = [str(ver) for ver in sorted(versions, reverse=True)]
             latest = formatted_versions[0]
 
-        write_output("{} ({})".format(query, latest))
-        write_output("Available versions: {}".format(", ".join(formatted_versions)))
-        print_dist_installation_info(query, latest)
+            write_output("{} ({})".format(query, latest))
+            write_output("Available versions: {}".format(", ".join(formatted_versions)))
+            print_dist_installation_info(query, latest)
+        elif options.list_format == 'json':
+            json_output = {
+                'name': query,
+                'versions': [str(version) for version in sorted(versions)]
+            }
+            write_output(json_output)

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -35,6 +35,13 @@ class IndexCommand(IndexGroupCommand):
         self.cmd_opts.add_option(cmdoptions.pre())
         self.cmd_opts.add_option(cmdoptions.no_binary())
         self.cmd_opts.add_option(cmdoptions.only_binary())
+        self.cmd_opts.add_option(
+            "--latest",
+            dest="latest",
+            action="store_true",
+            default=False,
+            help="Print only the latest version of the given package.",
+        )
 
         index_opts = cmdoptions.make_option_group(
             cmdoptions.index_group,
@@ -130,6 +137,11 @@ class IndexCommand(IndexGroupCommand):
                 raise DistributionNotFound(
                     "No matching distribution found for {}".format(query)
                 )
+
+            if options.latest:
+                # Print only the last version in the list.
+                write_output(str(max(versions)))
+                return
 
             formatted_versions = [str(ver) for ver in sorted(versions, reverse=True)]
             latest = formatted_versions[0]


### PR DESCRIPTION
### Description
This flag prints the latest available version of package in a pypi index.

I used `pip index versions` command to obtain the latest version of a package.
The problem is that I had to parse the command and wanted a simple solution like this flag.
