### PR TITLE
Allow to disable warning for root user package management

### DIFF
--- a/news/10990.feature.rst
+++ b/news/10990.feature.rst
@@ -1,0 +1,1 @@
+Add option to install and uninstall commands to opt-out from root installation/uninstallation warning.

--- a/news/10990.feature.rst
+++ b/news/10990.feature.rst
@@ -1,1 +1,1 @@
-Add option to install and uninstall commands to opt-out from root installation/uninstallation warning.
+Add option to install and uninstall commands to opt-out from running-as-root warning.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -858,6 +858,15 @@ disable_pip_version_check: Callable[..., Option] = partial(
     "of pip is available for download. Implied with --no-index.",
 )
 
+warn_about_root_user: Callable[..., Option] = partial(
+    Option,
+    "--no-warn-when-using-as-a-root-user",
+    dest="warn_about_root_user",
+    default=True,
+    action="store_false",
+    help="Do not warn when used as a root user",
+)
+
 
 def _handle_merge_hash(
     option: Option, opt_str: str, value: str, parser: OptionParser

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -222,12 +222,12 @@ class InstallCommand(RequirementCommand):
             default=True,
             help="Do not warn about broken dependencies",
         )
-
         self.cmd_opts.add_option(cmdoptions.no_binary())
         self.cmd_opts.add_option(cmdoptions.only_binary())
         self.cmd_opts.add_option(cmdoptions.prefer_binary())
         self.cmd_opts.add_option(cmdoptions.require_hashes())
         self.cmd_opts.add_option(cmdoptions.progress_bar())
+        self.cmd_opts.add_option(cmdoptions.warn_about_root_user())
 
         index_opts = cmdoptions.make_option_group(
             cmdoptions.index_group,
@@ -464,8 +464,8 @@ class InstallCommand(RequirementCommand):
             self._handle_target_dir(
                 options.target_dir, target_temp_dir, options.upgrade
             )
-
-        warn_if_run_as_root()
+        if options.warn_about_root_user:
+            warn_if_run_as_root()
         return SUCCESS
 
     def _handle_target_dir(

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -4,6 +4,7 @@ from typing import List
 
 from pip._vendor.packaging.utils import canonicalize_name
 
+from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.req_command import SessionCommandMixin, warn_if_run_as_root
 from pip._internal.cli.status_codes import SUCCESS
@@ -53,7 +54,7 @@ class UninstallCommand(Command, SessionCommandMixin):
             action="store_true",
             help="Don't ask for confirmation of uninstall deletions.",
         )
-
+        self.cmd_opts.add_option(cmdoptions.warn_about_root_user())
         self.parser.insert_option_group(0, self.cmd_opts)
 
     def run(self, options: Values, args: List[str]) -> int:
@@ -100,6 +101,6 @@ class UninstallCommand(Command, SessionCommandMixin):
             )
             if uninstall_pathset:
                 uninstall_pathset.commit()
-
-        warn_if_run_as_root()
+        if options.warn_about_root_user:
+            warn_if_run_as_root()
         return SUCCESS


### PR DESCRIPTION
This PR implements the flag that allows to disable the root
warning when using `pip` to install packages. While there are
differing opinions on this, it seems that the final decision is
to lean forward to implement a long and not very easily
discoverable flag to accommodate the minority of users who know
what they are doing and using root installation to - for example
build optimized Dockerfiles.

Even approval, and eventually an adoption of PEP 668 to make the
problem largely go away is still a long time to go, so as
discussed in https://github.com/pypa/pip/issues/10556#issuecomment-1014858428
this PR adds a long and non-user friendly flag to handle the
situation.

Fixes: #10556

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
