### PR TITLE
Remove --install-options flag from documentation

### DIFF
--- a/news/10265.doc.rst
+++ b/news/10265.doc.rst
@@ -1,0 +1,1 @@
+remove --install-scripts from doc as is now an invalid option

--- a/news/10265.doc.rst
+++ b/news/10265.doc.rst
@@ -1,1 +1,1 @@
-Remove --install-scripts from doc as is now an invalid option.
+Remove ``--install-scripts`` from doc as is now an invalid option.

--- a/news/10265.doc.rst
+++ b/news/10265.doc.rst
@@ -1,1 +1,1 @@
-remove --install-scripts from doc as is now an invalid option
+Remove --install-scripts from doc as is now an invalid option.

--- a/news/10265.doc.rst
+++ b/news/10265.doc.rst
@@ -1,1 +1,1 @@
-Remove ``--install-scripts`` from doc as is now an invalid option.
+Remove ``--install-scripts`` from documentation as it is now an invalid option.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -799,19 +799,6 @@ no_use_pep517: Any = partial(
     help=SUPPRESS_HELP,
 )
 
-install_options: Callable[..., Option] = partial(
-    Option,
-    "--install-option",
-    dest="install_options",
-    action="append",
-    metavar="options",
-    help="Extra arguments to be supplied to the setup.py install "
-    'command (use like --install-option="--install-scripts=/usr/local/'
-    'bin"). Use multiple --install-option options to pass multiple '
-    "options to setup.py install. If you are using an option with a "
-    "directory path, be sure to use absolute path.",
-)
-
 build_options: Callable[..., Option] = partial(
     Option,
     "--build-option",


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Removed the flag `--install-options` from the docs as is no longer a valid option  
per issue #10265 and  #7309