### PR TITLE
pip download: make sure that --use-pep517 is propagated to the dependencies

### DIFF
--- a/news/9523.bugfix.rst
+++ b/news/9523.bugfix.rst
@@ -1,0 +1,3 @@
+Make the ``--use-pep517`` option of the ``download`` command apply not just
+to the requirements specified on the command line, but to their dependencies,
+as well.

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -122,6 +122,7 @@ class DownloadCommand(RequirementCommand):
             finder=finder,
             options=options,
             ignore_requires_python=options.ignore_requires_python,
+            use_pep517=options.use_pep517,
             py_version_info=options.python_version,
         )
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -9,7 +9,12 @@ import pytest
 
 from pip._internal.cli.status_codes import ERROR
 from tests.conftest import MockServer, ScriptFactory
-from tests.lib import PipTestEnvironment, TestData, create_really_basic_wheel
+from tests.lib import (
+    PipTestEnvironment,
+    TestData,
+    create_basic_sdist_for_package,
+    create_really_basic_wheel,
+)
 from tests.lib.server import file_response
 
 
@@ -1166,3 +1171,33 @@ def test_download_editable(
     downloads = os.listdir(download_dir)
     assert len(downloads) == 1
     assert downloads[0].endswith(".zip")
+
+
+def test_download_use_pep517_propagation(
+    script: PipTestEnvironment, tmpdir: Path, common_wheels: Path
+) -> None:
+    """
+    Check that --use-pep517 applies not just to the requirements specified
+    on the command line, but to their dependencies too.
+    """
+
+    # Remove setuptools to ensure that metadata retrieval fails unless PEP 517
+    # is used.
+    script.pip("uninstall", "-y", "setuptools")
+
+    create_basic_sdist_for_package(script, "fake_proj", "1.0", depends=["fake_dep"])
+    create_basic_sdist_for_package(script, "fake_dep", "1.0")
+
+    download_dir = tmpdir / "download_dir"
+    script.pip(
+        "download",
+        f"--dest={download_dir}",
+        "--no-index",
+        f"--find-links={common_wheels}",
+        f"--find-links={script.scratch_path}",
+        "--use-pep517",
+        "fake_proj",
+    )
+
+    downloads = os.listdir(download_dir)
+    assert len(downloads) == 2

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1211,6 +1211,7 @@ def create_basic_sdist_for_package(
     *,
     fails_egg_info: bool = False,
     fails_bdist_wheel: bool = False,
+    depends: Optional[List[str]] = None,
 ) -> pathlib.Path:
     files = {
         "setup.py": f"""\
@@ -1226,7 +1227,8 @@ def create_basic_sdist_for_package(
             if fails_bdist_wheel and "bdist_wheel" in sys.argv:
                 raise Exception("Simulated failure for building a wheel.")
 
-            setup(name={name!r}, version={version!r})
+            setup(name={name!r}, version={version!r},
+                install_requires={depends or []!r})
         """,
     }
 


### PR DESCRIPTION
Fixes #9523

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
