### PR TITLE
Add alias support for `install` and `uninstall`

### DIFF
--- a/news/8130.feature.rst
+++ b/news/8130.feature.rst
@@ -1,0 +1,2 @@
+Add 'add' and 'i' aliases for 'install', 'remove' and 'u' aliases for 
+'uninstall'.

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -8,7 +8,7 @@ from itertools import chain
 from typing import Any, Iterable, List, Optional
 
 from pip._internal.cli.main_parser import create_main_parser
-from pip._internal.commands import commands_dict, create_command
+from pip._internal.commands import create_command, subcommands_set
 from pip._internal.metadata import get_default_environment
 
 
@@ -25,7 +25,7 @@ def autocomplete() -> None:
         current = ""
 
     parser = create_main_parser()
-    subcommands = list(commands_dict)
+    subcommands = list(subcommands_set)
     options = []
 
     # subcommand

--- a/src/pip/_internal/cli/main_parser.py
+++ b/src/pip/_internal/cli/main_parser.py
@@ -7,8 +7,7 @@ from typing import List, Tuple
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.parser import ConfigOptionParser, UpdatingDefaultsHelpFormatter
-from pip._internal.commands import commands_dict, get_similar_commands
-from pip._internal.exceptions import CommandError
+from pip._internal.commands import aliases_of_commands, check_subcommand, commands_dict
 from pip._internal.utils.misc import get_pip_version, get_prog
 
 __all__ = ["create_main_parser", "parse_command"]
@@ -36,10 +35,10 @@ def create_main_parser() -> ConfigOptionParser:
     parser.main = True  # type: ignore
 
     # create command listing for description
-    description = [""] + [
-        f"{name:27} {command_info.summary}"
-        for name, command_info in commands_dict.items()
-    ]
+    description = ['']
+    for name, info in commands_dict.items():
+        names = ', '.join(aliases_of_commands[name])
+        description.append('{:27} {.summary}'.format(names, info))
     parser.description = "\n".join(description)
 
     return parser
@@ -70,15 +69,7 @@ def parse_command(args: List[str]) -> Tuple[str, List[str]]:
 
     # the subcommand name
     cmd_name = args_else[0]
-
-    if cmd_name not in commands_dict:
-        guess = get_similar_commands(cmd_name)
-
-        msg = [f'unknown command "{cmd_name}"']
-        if guess:
-            msg.append(f'maybe you meant "{guess}"')
-
-        raise CommandError(" - ".join(msg))
+    check_subcommand(cmd_name)
 
     # all the args without the subcommand
     cmd_args = args[:]

--- a/src/pip/_internal/commands/__init__.py
+++ b/src/pip/_internal/commands/__init__.py
@@ -4,9 +4,10 @@ Package containing all pip commands
 
 import importlib
 from collections import namedtuple
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from pip._internal.cli.base_command import Command
+from pip._internal.exceptions import CommandError
 
 CommandInfo = namedtuple("CommandInfo", "module_path, class_name, summary")
 
@@ -101,11 +102,30 @@ commands_dict: Dict[str, CommandInfo] = {
 }
 
 
+aliases_dict = {
+    'add': 'install',
+    'i': 'install',
+    'remove': 'uninstall',
+    'u': 'uninstall'
+}  # type: Dict[str, str]
+
+aliases_of_commands = {
+    name: [name] for name in commands_dict}  # type: Dict[str, List[str]]
+for alias, name in aliases_dict.items():
+    aliases_of_commands[name].append(alias)
+
+subcommands_set = {cmd for aliases in aliases_of_commands.values()
+                   for cmd in aliases}  # type: Set[str]
+
+
 def create_command(name: str, **kwargs: Any) -> Command:
     """
     Create an instance of the Command class with the given name.
     """
-    module_path, class_name, summary = commands_dict[name]
+    try:
+        module_path, class_name, summary = commands_dict[name]
+    except KeyError:
+        module_path, class_name, summary = commands_dict[aliases_dict[name]]
     module = importlib.import_module(module_path)
     command_class = getattr(module, class_name)
     command = command_class(name=name, summary=summary, **kwargs)
@@ -119,9 +139,20 @@ def get_similar_commands(name: str) -> Optional[str]:
 
     name = name.lower()
 
-    close_commands = get_close_matches(name, commands_dict.keys())
+    close_commands = get_close_matches(name, subcommands_set)
 
     if close_commands:
         return close_commands[0]
     else:
         return None
+
+
+def check_subcommand(name):
+    # type: (str) -> None
+    """Raise CommandError if the given subcommand not found."""
+    if name not in aliases_dict and name not in commands_dict:
+        guess = get_similar_commands(name)
+        msg = 'unknown command "{}"'.format(name)
+        if guess:
+            msg += ' - maybe you meant "{}"'.format(guess)
+        raise CommandError(msg)

--- a/src/pip/_internal/commands/help.py
+++ b/src/pip/_internal/commands/help.py
@@ -3,7 +3,6 @@ from typing import List
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.exceptions import CommandError
 
 
 class HelpCommand(Command):
@@ -14,11 +13,7 @@ class HelpCommand(Command):
     ignore_require_venv = True
 
     def run(self, options: Values, args: List[str]) -> int:
-        from pip._internal.commands import (
-            commands_dict,
-            create_command,
-            get_similar_commands,
-        )
+        from pip._internal.commands import check_subcommand, create_command
 
         try:
             # 'pip help' with no args is handled by pip.__init__.parseopt()
@@ -26,15 +21,7 @@ class HelpCommand(Command):
         except IndexError:
             return SUCCESS
 
-        if cmd_name not in commands_dict:
-            guess = get_similar_commands(cmd_name)
-
-            msg = [f'unknown command "{cmd_name}"']
-            if guess:
-                msg.append(f'maybe you meant "{guess}"')
-
-            raise CommandError(" - ".join(msg))
-
+        check_subcommand(cmd_name)
         command = create_command(cmd_name)
         command.parser.print_help()
 

--- a/tests/functional/test_help.py
+++ b/tests/functional/test_help.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.commands import commands_dict, create_command
+from pip._internal.commands import create_command, subcommands_set
 from pip._internal.exceptions import CommandError
 from tests.conftest import InMemoryPip
 from tests.lib import PipTestEnvironment
@@ -110,7 +110,7 @@ def test_help_commands_equally_functional(in_memory_pip: InMemoryPip) -> None:
     assert sum(ret) == 0, "exit codes of: " + msg
     assert all(len(o) > 0 for o in out)
 
-    for name in commands_dict:
+    for name in subcommands_set:
         assert (
             in_memory_pip.pip("help", name).stdout
             == in_memory_pip.pip(name, "--help").stdout

--- a/tests/lib/options_helpers.py
+++ b/tests/lib/options_helpers.py
@@ -6,7 +6,12 @@ from typing import List, Tuple
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
-from pip._internal.commands import CommandInfo, commands_dict
+from pip._internal.commands import (
+    CommandInfo,
+    aliases_of_commands,
+    commands_dict,
+    subcommands_set,
+)
 
 
 class FakeCommand(Command):
@@ -29,5 +34,10 @@ class AddFakeCommandMixin:
             "fake summary",
         )
 
+    aliases_of_commands['fake'] = ['fake']
+    subcommands_set.add('fake')
+
     def teardown(self) -> None:
         commands_dict.pop("fake")
+        aliases_of_commands.pop('fake')
+        subcommands_set.remove('fake')

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -9,7 +9,12 @@ from pip._internal.cli.req_command import (
     RequirementCommand,
     SessionCommandMixin,
 )
-from pip._internal.commands import commands_dict, create_command
+from pip._internal.commands import (
+    aliases_dict,
+    commands_dict,
+    create_command,
+    subcommands_set,
+)
 
 # These are the expected names of the commands whose classes inherit from
 # IndexGroupCommand.
@@ -36,12 +41,16 @@ def test_commands_dict__order() -> None:
     assert names[-1] == "help"
 
 
-@pytest.mark.parametrize("name", list(commands_dict))
+@pytest.mark.parametrize('name', subcommands_set)
 def test_create_command(name: str) -> None:
     """Test creating an instance of each available command."""
     command = create_command(name)
     assert command.name == name
-    assert command.summary == commands_dict[name].summary
+    try:
+        summary = commands_dict[name].summary
+    except KeyError:
+        summary = commands_dict[aliases_dict[name]].summary
+    assert command.summary == summary
 
 
 def test_session_commands() -> None:


### PR DESCRIPTION
As per pradyunsg's [comment](https://github.com/pypa/pip/issues/8130#issuecomment-1044947983), I have added the `i` and `u` aliases based off of McSinyx's implementation at [#8137](https://github.com/pypa/pip/pull/8137). 

In summary, this fixes issue [#8130](https://github.com/pypa/pip/issues/8130) and allows users to install packages with `i` and `add`, and uninstall packages with `u` and `remove`.

```
$ pip help
Usage:
  pip <command> [options]

Commands:
  install, add, i             Install packages.
  download                    Download packages.
  uninstall, remove, u        Uninstall packages.
...

$ pip i numpy      # or pip add numpy
Collecting numpy
  Using cached numpy-1.22.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.8 MB)
Installing collected packages: numpy
Successfully installed numpy-1.22.3

$ pip u numpy      # or pip remove numpy
Found existing installation: numpy 1.22.3
Uninstalling numpy-1.22.3:
  Would remove:
...
```

Credits to McSinyx for implementing the alias mechanism.