### PR TITLE
Add cli flag --force-keyring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     additional_dependencies: [
         'keyring==23.0.1',
         'nox==2021.6.12',
-        'pytest==7.1.1',
+        'pytest',
         'types-docutils==0.18.3',
         'types-setuptools==57.4.14',
         'types-freezegun==1.1.9',

--- a/docs/html/topics/authentication.md
+++ b/docs/html/topics/authentication.md
@@ -74,6 +74,25 @@ $ echo "your-password" | keyring set pypi.company.com your-username
 $ pip install your-package --index-url https://pypi.company.com/
 ```
 
+Pip is conservative and does not query keyring at all when `--no-input` is used
+because the keyring might require user interaction such as prompting the user
+on the console. You can force keyring usage by passing `--force-keyring` or one
+of the following:
+
+```bash
+# possibly with --user, --global or --site
+$ pip config set global.force-keyring true
+# or
+$ export PIP_FORCE_KEYRING=1
+```
+
+```{warning}
+Be careful when doing this since it could cause tools such as Pipx and Pipenv
+to appear to hang. They show their own progress indicator while hiding output
+from the subprocess in which they run Pip. You won't know whether the keyring
+backend is waiting the user input or not in such situations.
+```
+
 Note that `keyring` (the Python package) needs to be installed separately from
 pip. This can create a bootstrapping issue if you need the credentials stored in
 the keyring to download and install keyring.

--- a/news/11020.feature.rst
+++ b/news/11020.feature.rst
@@ -1,0 +1,3 @@
+Add ``--force-keyring`` flag which allows ``keyring`` lookups in combination
+with ``--no-input``. See the Authentication page in the documentation for
+more info.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -244,6 +244,19 @@ no_input: Callable[..., Option] = partial(
     help="Disable prompting for input.",
 )
 
+force_keyring: Callable[..., Option] = partial(
+    Option,
+    "--force-keyring",
+    dest="force_keyring",
+    action="store_true",
+    default=False,
+    help=(
+        "Always query the keyring, regardless of pip's --no-input option. Note"
+        " that this may cause problems if the keyring expects to be able to"
+        " prompt the user interactively and no interactive user is available."
+    ),
+)
+
 proxy: Callable[..., Option] = partial(
     Option,
     "--proxy",
@@ -1019,6 +1032,7 @@ general_group: Dict[str, Any] = {
         quiet,
         log,
         no_input,
+        force_keyring,
         proxy,
         retries,
         timeout,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -151,6 +151,10 @@ class SessionCommandMixin(CommandContextMixIn):
 
         # Determine if we can prompt the user for authentication or not
         session.auth.prompting = not options.no_input
+        # We won't use keyring when --no-input is passed unless
+        # --force-keyring is passed as well because it might require
+        # user interaction
+        session.auth.use_keyring = session.auth.prompting or options.force_keyring
 
         return session
 

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -364,7 +364,7 @@ def test_do_not_prompt_for_authentication(
 
 @pytest.fixture(params=(True, False), ids=("auth_needed", "auth_not_needed"))
 def auth_needed(request: pytest.FixtureRequest) -> bool:
-    return request.param  # type: ignore[attr-defined]
+    return request.param
 
 
 @pytest.fixture(
@@ -386,7 +386,7 @@ def flags(request: pytest.FixtureRequest, auth_needed: bool) -> typing.List[str]
         no_input,
         force_keyring,
         xfail,
-    ) = request.param  # type: ignore[attr-defined]
+    ) = request.param
 
     flags = []
     if no_input:

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -369,18 +369,34 @@ def auth_needed(request: pytest.FixtureRequest) -> bool:
 
 @pytest.fixture(
     params=(
-        False,
-        True,
+        (False, False, False),
+        (False, True, False),
+        (True, True, False),
+        (True, False, True),
     ),
-    ids=("default", "no_input"),
+    ids=(
+        "default-default",
+        "default-force_keyring",
+        "no_input-force_keyring",
+        "no_input-default",
+    ),
 )
-def flags(request: pytest.FixtureRequest) -> typing.List[str]:
-    no_input = request.param  # type: ignore[attr-defined]
+def flags(request: pytest.FixtureRequest, auth_needed: bool) -> typing.List[str]:
+    (
+        no_input,
+        force_keyring,
+        xfail,
+    ) = request.param  # type: ignore[attr-defined]
 
     flags = []
     if no_input:
         flags.append("--no-input")
-
+    if force_keyring:
+        flags.append(
+            "--force-keyring",
+        )
+    if auth_needed and xfail:
+        request.applymarker(pytest.mark.xfail())
     return flags
 
 

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import sys
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -360,7 +361,7 @@ class KeyringSubprocessResult(KeyringModuleV1):
                 self.returncode = 1
             else:
                 # Passwords are returned encoded with a newline appended
-                self.stdout = password.encode("utf-8") + b"\n"
+                self.stdout = (password + os.linesep).encode("utf-8")
 
         if cmd[1] == "set":
             assert stdin is None
@@ -369,7 +370,7 @@ class KeyringSubprocessResult(KeyringModuleV1):
             assert input is not None
 
             # Input from stdin is encoded
-            self.set_password(cmd[2], cmd[3], input.decode("utf-8").strip("\n"))
+            self.set_password(cmd[2], cmd[3], input.decode("utf-8").strip(os.linesep))
 
         return self
 


### PR DESCRIPTION
Fixes #11020
Fixes #11658

Currently, Pip is conservative and does not query keyring at all when --no-input is used because the keyring might require user interaction such as prompting the user on the console.

These commits add a flag to pinky swear that the configured keyring backend does not require any user interaction. It defaults to False, making this opt-in behaviour.

Tools such as Pipx and Pipenv use Pip and have their own progress indicator that hides output from the subprocess Pip runs in. They should pass --no-input in my opinion, but Pip should provide some mechanism to still query the keyring in that case. Just not by default. So here we are.