### PR TITLE
Enable importlib.metadata backend on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,11 +219,12 @@ jobs:
         env:
           TEMP: "R:\\Temp"
 
+  # TODO: Remove this when we add Python 3.11 to CI.
   tests-importlib-metadata:
     name: tests for importlib.metadata backend
     runs-on: ubuntu-latest
     env:
-      _PIP_METADATA_BACKEND_IMPORTLIB: egg-compat
+      _PIP_USE_IMPORTLIB_METADATA: 'true'
 
     needs: [pre-commit, packaging, determine-changes]
     if: >-
@@ -241,7 +242,6 @@ jobs:
 
       - run: pip install nox 'virtualenv<20'
 
-      # Main check
       - name: Run unit tests
         run: >-
           nox -s test-3.10 --

--- a/news/11044.process.rst
+++ b/news/11044.process.rst
@@ -1,0 +1,4 @@
+Enable the ``importlib.metadata`` metadata implementation by default on
+Python 3.11 (or later). The environment variable ``_PIP_USE_IMPORTLIB_METADATA``
+can still be used to enable the implementation on 3.10 and earlier, or disable
+it on 3.11 (by setting it to ``0`` or ``false``).

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -1,6 +1,10 @@
+import contextlib
 import functools
 import os
+import sys
 from typing import TYPE_CHECKING, List, Optional, Type, cast
+
+from pip._internal.utils.misc import strtobool
 
 from .base import BaseDistribution, BaseEnvironment, FilesystemWheel, MemoryWheel, Wheel
 
@@ -22,6 +26,29 @@ __all__ = [
 ]
 
 
+def _should_use_importlib_metadata() -> bool:
+    """Whether to use the ``importlib.metadata`` or ``pkg_resources`` backend.
+
+    By default, pip uses ``importlib.metadata`` on Python 3.11+, and
+    ``pkg_resourcess`` otherwise. This can be overriden by a couple of ways:
+
+    * If environment variable ``_PIP_USE_IMPORTLIB_METADATA`` is set, it
+      dictates whether ``importlib.metadata`` is used, regardless of Python
+      version.
+    * On Python 3.11+, Python distributors can patch ``importlib.metadata``
+      to add a global constant ``_PIP_USE_IMPORTLIB_METADATA = False``. This
+      makes pip use ``pkg_resources`` (unless the user set the aforementioned
+      environment variable to *True*).
+    """
+    with contextlib.suppress(KeyError, ValueError):
+        return bool(strtobool(os.environ["_PIP_USE_IMPORTLIB_METADATA"]))
+    if sys.version_info < (3, 11):
+        return False
+    import importlib.metadata
+
+    return bool(getattr(importlib.metadata, "_PIP_USE_IMPORTLIB_METADATA", True))
+
+
 class Backend(Protocol):
     Distribution: Type[BaseDistribution]
     Environment: Type[BaseEnvironment]
@@ -29,7 +56,7 @@ class Backend(Protocol):
 
 @functools.lru_cache(maxsize=None)
 def select_backend() -> Backend:
-    if os.environ.get("_PIP_METADATA_BACKEND_IMPORTLIB"):
+    if _should_use_importlib_metadata():
         from . import importlib
 
         return cast(Backend, importlib)


### PR DESCRIPTION
With 3.11 beta coming out next month, we can get this ready for testing.

Similar to the sysconfig transition, this builds in some hidden switches for downstream distributors to use, in case they need it. (see #10647)