### PR TITLE
Update the RECORD entry when rewriting the shebang line in a script

### DIFF
--- a/news/10744.bugfix.rst
+++ b/news/10744.bugfix.rst
@@ -1,0 +1,2 @@
+When pip rewrites the shebang line in a script during wheel installation,
+update the hash and size in the corresponding ``RECORD`` file entry.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -224,19 +224,16 @@ def _normalized_outrows(
     )
 
 
-def _record_to_fs_path(record_path: RecordPath) -> str:
-    return record_path
+def _record_to_fs_path(record_path: RecordPath, lib_dir: str) -> str:
+    return os.path.join(lib_dir, record_path)
 
 
-def _fs_to_record_path(path: str, relative_to: Optional[str] = None) -> RecordPath:
-    if relative_to is not None:
-        # On Windows, do not handle relative paths if they belong to different
-        # logical disks
-        if (
-            os.path.splitdrive(path)[0].lower()
-            == os.path.splitdrive(relative_to)[0].lower()
-        ):
-            path = os.path.relpath(path, relative_to)
+def _fs_to_record_path(path: str, lib_dir: str) -> RecordPath:
+    # On Windows, do not handle relative paths if they belong to different
+    # logical disks
+    if os.path.splitdrive(path)[0].lower() == os.path.splitdrive(lib_dir)[0].lower():
+        path = os.path.relpath(path, lib_dir)
+
     path = path.replace(os.path.sep, "/")
     return cast("RecordPath", path)
 
@@ -259,7 +256,7 @@ def get_csv_rows_for_installed(
         old_record_path = cast("RecordPath", row[0])
         new_record_path = installed.pop(old_record_path, old_record_path)
         if new_record_path in changed:
-            digest, length = rehash(_record_to_fs_path(new_record_path))
+            digest, length = rehash(_record_to_fs_path(new_record_path, lib_dir))
         else:
             digest = row[1] if len(row) > 1 else ""
             length = row[2] if len(row) > 2 else ""
@@ -475,7 +472,7 @@ def _install_wheel(
         newpath = _fs_to_record_path(destfile, lib_dir)
         installed[srcfile] = newpath
         if modified:
-            changed.add(_fs_to_record_path(destfile))
+            changed.add(newpath)
 
     def is_dir_path(path: RecordPath) -> bool:
         return path.endswith("/")


### PR DESCRIPTION
The code to do this already exists in `get_csv_rows_for_installed`, but it's broken due to inconsistent usage of the `_fs_to_record_path` function. When we build the dictionary of installed files, we call it with a base directory, while when build the set of modified files, we call it without a base directory. As a result, the values of `installed` do not match the elements of `changed`, and `get_csv_rows_for_installed` fails to identify the rows that should be updated.

Fix this by ensuring that `_fs_to_record_path` is always called with a base directory. `_record_to_fs_path` also needs a a base directory parameter to be able to transform the path back into an absolute path, so add one.

Fixes #10744 

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
