### PR TITLE
Try to suggest python/python3/pythonX.Y/pylauncher command in pip warning

### DIFF
--- a/news/11057.feature.rst
+++ b/news/11057.feature.rst
@@ -1,0 +1,2 @@
+Try to suggest python/python3/pythonX.Y/pylauncher command in pip warning
+before falling back to sys.executable


### PR DESCRIPTION
The pip warning that shows up when pip is running on an older version, gives users a command that invokes python via `sys.executable`. While this is less error-prone, it can potentially give a rather verbose command, and does not handle the case where there could be spaces in `sys.executable` (which I've seen, tends to confuse a lot of newbies new to pip and working with shells, when the command recommended in the warning does not work for them due to having spaces)

This PR tries to make this warning use `python`/`python3`/`pythonX.Y` if available on path, falling back to trying to use a py launcher version of the command (with some sanity checking) and finally falling back to old behaviour of using `sys.executable` if the above methods did not work.

This PR is not very robust either... since it involves running an arbitrary command `py`, which could potentially point to some random executable on the users setup (could this be a security risk?) although I imagine this would be super rare. Either way, I'd be happy to hear if there's another way of doing what I want to implement.

