### PR TITLE
Improve ``pip config --help`` text

### DIFF
--- a/news/11074.doc.rst
+++ b/news/11074.doc.rst
@@ -1,0 +1,1 @@
+Improved usefulness of ``pip config --help`` output.

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -27,10 +27,16 @@ class ConfigurationCommand(Command):
 
     - list: List the active configuration (or from the file specified)
     - edit: Edit the configuration file in an editor
-    - get: Get the value associated with name
-    - set: Set the name=value
-    - unset: Unset the value associated with name
+    - get: Get the value associated with command.option
+    - set: Set the command.option=value
+    - unset: Unset the value associated with command.option
     - debug: List the configuration files and values defined under them
+
+    Configuration keys should be dot separated command and option name,
+    with the special prefix "global" affecting any command. For example,
+    "pip config set global.index-url https://example.org/" would configure
+    the index url for all commands, but "pip config set download.timeout 10"
+    would configure a 10 second timeout only for "pip download" commands.
 
     If none of --user, --global and --site are passed, a virtual
     environment configuration file is used if one is active and the file
@@ -43,9 +49,9 @@ class ConfigurationCommand(Command):
         %prog [<file-option>] list
         %prog [<file-option>] [--editor <editor-path>] edit
 
-        %prog [<file-option>] get name
-        %prog [<file-option>] set name value
-        %prog [<file-option>] unset name
+        %prog [<file-option>] get command.option
+        %prog [<file-option>] set command.option value
+        %prog [<file-option>] unset command.option
         %prog [<file-option>] debug
     """
 


### PR DESCRIPTION
The https://pip.pypa.io/en/stable/cli/pip_config/ page and corresponding `pip config --help` output is not very useful, I've lost count of the number of times I've seen this kind of error message:

```
$ pip config set index-url http://localhost:8080/
ERROR: Key does not contain dot separated section and key. Perhaps you wanted to use 'global.index-url' instead?
```

It's also pretty confusing that there is a `--global` option for the command and a `global.option` prefix for config keys with the word "global" here meaning quite different things, unless you've visit [another section of the documentation](https://pip.pypa.io/en/stable/topics/configuration/#per-command-section) which explains that the prefix is for per-command configuration.

Today I saw a [user](https://stackoverflow.com/questions/72051807/how-to-set-pip-config-for-virtual-environments/72051858#comment127312254_72051858) struggling to configure pip in a venv and reported:

> Ah! I kept using `site.extra-index-url` thinking I was meant to replace global with site rather than adding it as an option.

This change hopefully makes the `pip config --help` clearer.