### PR TITLE
Optional truststore support

### DIFF
--- a/news/11082.feature.rst
+++ b/news/11082.feature.rst
@@ -1,0 +1,3 @@
+Add support to use `truststore <https://pypi.org/project/truststore/>`_ as an alternative SSL certificate verification backend. The backend can be enabled on Python 3.10 and later by installing ``truststore`` into the environment, and adding the ``--use-feature=truststore`` flag to various pip commands.
+
+``truststore`` differs from the current default verification backend (provided by ``certifi``) in it uses the operating system’s trust store, which can be better controlled and augmented to better support non-standard certificates. Depending on feedback, pip may switch to this as the default certificate verification backend in the future.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -991,7 +991,7 @@ use_new_feature: Callable[..., Option] = partial(
     metavar="feature",
     action="append",
     default=[],
-    choices=["2020-resolver", "fast-deps"],
+    choices=["2020-resolver", "fast-deps", "truststore"],
     help="Enable new functionality, that may be backward incompatible.",
 )
 

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -15,11 +15,23 @@ import subprocess
 import sys
 import urllib.parse
 import warnings
-from typing import Any, Dict, Generator, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from pip._vendor import requests, urllib3
-from pip._vendor.cachecontrol import CacheControlAdapter
-from pip._vendor.requests.adapters import BaseAdapter, HTTPAdapter
+from pip._vendor.cachecontrol import CacheControlAdapter as _BaseCacheControlAdapter
+from pip._vendor.requests.adapters import DEFAULT_POOLBLOCK, BaseAdapter
+from pip._vendor.requests.adapters import HTTPAdapter as _BaseHTTPAdapter
 from pip._vendor.requests.models import PreparedRequest, Response
 from pip._vendor.requests.structures import CaseInsensitiveDict
 from pip._vendor.urllib3.connectionpool import ConnectionPool
@@ -36,6 +48,12 @@ from pip._internal.utils.compat import has_tls
 from pip._internal.utils.glibc import libc_ver
 from pip._internal.utils.misc import build_url_from_netloc, parse_netloc
 from pip._internal.utils.urls import url_to_path
+
+if TYPE_CHECKING:
+    from ssl import SSLContext
+
+    from pip._vendor.urllib3.poolmanager import PoolManager
+
 
 logger = logging.getLogger(__name__)
 
@@ -233,6 +251,48 @@ class LocalFSAdapter(BaseAdapter):
         pass
 
 
+class _SSLContextAdapterMixin:
+    """Mixin to add the ``ssl_context`` contructor argument to HTTP adapters.
+
+    The additional argument is forwarded directly to the pool manager. This allows us
+    to dynamically decide what SSL store to use at runtime, which is used to implement
+    the optional ``truststore`` backend.
+    """
+
+    def __init__(
+        self,
+        *,
+        ssl_context: Optional["SSLContext"] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(
+        self,
+        connections: int,
+        maxsize: int,
+        block: bool = DEFAULT_POOLBLOCK,
+        **pool_kwargs: Any,
+    ) -> "PoolManager":
+        if self._ssl_context is not None:
+            pool_kwargs.setdefault("ssl_context", self._ssl_context)
+        return super().init_poolmanager(  # type: ignore[misc]
+            connections=connections,
+            maxsize=maxsize,
+            block=block,
+            **pool_kwargs,
+        )
+
+
+class HTTPAdapter(_SSLContextAdapterMixin, _BaseHTTPAdapter):
+    pass
+
+
+class CacheControlAdapter(_SSLContextAdapterMixin, _BaseCacheControlAdapter):
+    pass
+
+
 class InsecureHTTPAdapter(HTTPAdapter):
     def cert_verify(
         self,
@@ -266,6 +326,7 @@ class PipSession(requests.Session):
         cache: Optional[str] = None,
         trusted_hosts: Sequence[str] = (),
         index_urls: Optional[List[str]] = None,
+        ssl_context: Optional["SSLContext"] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -318,13 +379,14 @@ class PipSession(requests.Session):
             secure_adapter = CacheControlAdapter(
                 cache=SafeFileCache(cache),
                 max_retries=retries,
+                ssl_context=ssl_context,
             )
             self._trusted_host_adapter = InsecureCacheControlAdapter(
                 cache=SafeFileCache(cache),
                 max_retries=retries,
             )
         else:
-            secure_adapter = HTTPAdapter(max_retries=retries)
+            secure_adapter = HTTPAdapter(max_retries=retries, ssl_context=ssl_context)
             self._trusted_host_adapter = insecure_adapter
 
         self.mount("https://", secure_adapter)

--- a/tests/functional/test_truststore.py
+++ b/tests/functional/test_truststore.py
@@ -1,0 +1,61 @@
+import sys
+from typing import Any, Callable
+
+import pytest
+
+from tests.lib import PipTestEnvironment, TestPipResult
+
+PipRunner = Callable[..., TestPipResult]
+
+
+@pytest.fixture()
+def pip(script: PipTestEnvironment) -> PipRunner:
+    def pip(*args: str, **kwargs: Any) -> TestPipResult:
+        return script.pip(*args, "--use-feature=truststore", **kwargs)
+
+    return pip
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 10), reason="3.10 can run truststore")
+def test_truststore_error_on_old_python(pip: PipRunner) -> None:
+    result = pip(
+        "install",
+        "--no-index",
+        "does-not-matter",
+        expect_error=True,
+    )
+    assert "The truststore feature is only available for Python 3.10+" in result.stderr
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="3.10+ required for truststore")
+def test_truststore_error_without_preinstalled(pip: PipRunner) -> None:
+    result = pip(
+        "install",
+        "--no-index",
+        "does-not-matter",
+        expect_error=True,
+    )
+    assert (
+        "To use the truststore feature, 'truststore' must be installed into "
+        "pip's current environment."
+    ) in result.stderr
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="3.10+ required for truststore")
+@pytest.mark.network
+@pytest.mark.parametrize(
+    "package",
+    [
+        "INITools",
+        "https://github.com/pypa/pip-test-package/archive/refs/heads/master.zip",
+    ],
+    ids=["PyPI", "GitHub"],
+)
+def test_trustore_can_install(
+    script: PipTestEnvironment,
+    pip: PipRunner,
+    package: str,
+) -> None:
+    script.pip("install", "truststore")
+    result = pip("install", package)
+    assert "Successfully installed" in result.stdout


### PR DESCRIPTION
This adds a --use-feature=truststore flag that, when specified on Python 3.10+ with `truststore` installed, switches pip to use truststore to provide HTTPS certificate validation, instead of certifi. This allows pip to verify certificates against custom certificates in the system store.

`truststore` is deliberately NOT vendored because it is expected the library to be under active development in the short term, and this prevents users having to wait for a pip release to get potentially vital bug fixes needed to be made in truststore.

Supplying the use-feature flag without installing truststore beforehand, or on Python versions prior to 3.10, results in a command error.

See #11038 (and other issues linked there).