### PR TITLE
Standardise link repr in logs

### DIFF
--- a/news/7390.trivial.rst
+++ b/news/7390.trivial.rst
@@ -1,0 +1,1 @@
+Standardize ``Link`` representation in logs.

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -424,7 +424,10 @@ def _handle_get_page_fail(
 ) -> None:
     if meth is None:
         meth = logger.debug
-    meth("Could not fetch URL %s: %s - skipping", link, reason)
+    url = str(link)
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        url = link.show_url
+    meth("Could not fetch URL %s: %s - skipping", url, reason)
 
 
 def _make_html_page(response: Response, cache_link_parsing: bool = True) -> HTMLPage:

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -10,7 +10,6 @@ from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
 
 from pip._internal.cli.progress_bars import get_download_progress_renderer
 from pip._internal.exceptions import NetworkConnectionError
-from pip._internal.models.index import PyPI
 from pip._internal.models.link import Link
 from pip._internal.network.cache import is_from_cache
 from pip._internal.network.session import PipSession
@@ -34,11 +33,7 @@ def _prepare_download(
 ) -> Iterable[bytes]:
     total_length = _get_http_response_size(resp)
 
-    if link.netloc == PyPI.file_storage_domain:
-        url = link.show_url
-    else:
-        url = link.url_without_fragment
-
+    url = link.show_url
     logged_url = redact_auth_from_url(url)
 
     if total_length:
@@ -170,7 +165,7 @@ class BatchDownloader:
                 logger.critical(
                     "HTTP error %s while getting %s",
                     e.response.status_code,
-                    link,
+                    link.show_url,
                 )
                 raise
 

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -20,19 +20,19 @@ from tests.lib.requests_mocks import MockResponse
             "http://example.com/foo.tgz",
             {},
             False,
-            "Downloading http://example.com/foo.tgz",
+            "Downloading foo.tgz",
         ),
         (
             "http://example.com/foo.tgz",
             {"content-length": "2"},
             False,
-            "Downloading http://example.com/foo.tgz (2 bytes)",
+            "Downloading foo.tgz (2 bytes)",
         ),
         (
             "http://example.com/foo.tgz",
             {"content-length": "2"},
             True,
-            "Using cached http://example.com/foo.tgz (2 bytes)",
+            "Using cached foo.tgz (2 bytes)",
         ),
         ("https://files.pythonhosted.org/foo.tgz", {}, False, "Downloading foo.tgz"),
         (


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Closes #7390
ref: https://github.com/pypa/pip/pull/10276#issuecomment-922245044