### PR TITLE
Run `towncrier build` instead of `towncrier`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,70 @@
 
 .. towncrier release notes start
 
+21.1b1 (2022-04-30)
+===================
+
+Process
+-------
+
+- Start migration of distribution metadata implementation from ``pkg_resources``
+  to ``importlib.metadata``. The new implementation is currently not exposed in
+  any user-facing way, but included in the code base for easier development.
+
+Deprecations and Removals
+-------------------------
+
+- Drop ``--use-deprecated=out-of-tree-build``, according to deprecation message. (`#11001 <https://github.com/pypa/pip/issues/11001>`_)
+
+Features
+--------
+
+- Add option to install and uninstall commands to opt-out from running-as-root warning. (`#10556 <https://github.com/pypa/pip/issues/10556>`_)
+- Include Project-URLs in ``pip show`` output. (`#10799 <https://github.com/pypa/pip/issues/10799>`_)
+- Improve error message when ``pip config edit`` is provided an editor that
+  doesn't exist. (`#10812 <https://github.com/pypa/pip/issues/10812>`_)
+- Add a user interface for supplying config settings to build backends. (`#11059 <https://github.com/pypa/pip/issues/11059>`_)
+- Add support for Powershell autocompletion. (`#9024 <https://github.com/pypa/pip/issues/9024>`_)
+- Explains why specified version cannot be retrieved when *Requires-Python* is not satisfied. (`#9615 <https://github.com/pypa/pip/issues/9615>`_)
+- Validate build dependencies when using ``--no-build-isolation``. (`#9794 <https://github.com/pypa/pip/issues/9794>`_)
+
+Bug Fixes
+---------
+
+- Fix conditional checks to prevent ``pip.exe`` from trying to modify itself, on Windows. (`#10560 <https://github.com/pypa/pip/issues/10560>`_)
+- Fix uninstall editable from Windows junction link. (`#10696 <https://github.com/pypa/pip/issues/10696>`_)
+- Fallback to pyproject.toml-based builds if ``setup.py`` is present in a project, but ``setuptools`` cannot be imported. (`#10717 <https://github.com/pypa/pip/issues/10717>`_)
+- When checking for conflicts in the build environment, correctly skip requirements
+  containing markers that do not match the current environment. (`#10883 <https://github.com/pypa/pip/issues/10883>`_)
+- Disable brotli import in vendored urllib3 so brotli could be uninstalled/upgraded by pip. (`#10950 <https://github.com/pypa/pip/issues/10950>`_)
+- Prioritize URL credentials over netrc. (`#10979 <https://github.com/pypa/pip/issues/10979>`_)
+- Filter available distributions using hash declarations from constraints files. (`#9243 <https://github.com/pypa/pip/issues/9243>`_)
+- Fix an error when trying to uninstall packages installed as editable from a network drive. (`#9452 <https://github.com/pypa/pip/issues/9452>`_)
+- Fix pip install issues using a proxy due to an inconsistency in how Requests is currently handling variable precedence in session. (`#9691 <https://github.com/pypa/pip/issues/9691>`_)
+
+Vendored Libraries
+------------------
+
+- Upgrade CacheControl to 0.12.11
+- Upgrade distro to 1.7.0
+- Upgrade platformdirs to 2.5.2
+- Remove ``progress`` from vendored dependencies.
+- Upgrade ``pyparsing`` to 3.0.8 for startup performance improvements.
+- Upgrade rich to 12.2.0
+- Upgrade tomli to 2.0.1
+- Upgrade typing_extensions to 4.2.0
+
+Improved Documentation
+----------------------
+
+- Add more dedicated topic and reference pages to the documentation. (`#10899 <https://github.com/pypa/pip/issues/10899>`_)
+- Capitalise Y as the default for "Proceed (y/n)?" when uninstalling. (`#10936 <https://github.com/pypa/pip/issues/10936>`_)
+- Add ``scheme://`` requirement to ``--proxy`` option's description (`#10951 <https://github.com/pypa/pip/issues/10951>`_)
+- The wheel command now references the build interface section instead of stating the legacy
+  setuptools behavior as the default. (`#10972 <https://github.com/pypa/pip/issues/10972>`_)
+- Improved usefulness of ``pip config --help`` output. (`#11074 <https://github.com/pypa/pip/issues/11074>`_)
+
+
 22.0.4 (2022-03-06)
 ===================
 

--- a/news/10556.feature.rst
+++ b/news/10556.feature.rst
@@ -1,1 +1,0 @@
-Add option to install and uninstall commands to opt-out from running-as-root warning.

--- a/news/10560.bugfix.rst
+++ b/news/10560.bugfix.rst
@@ -1,1 +1,0 @@
-Fix conditional checks to prevent ``pip.exe`` from trying to modify itself, on Windows.

--- a/news/10630.trivial.rst
+++ b/news/10630.trivial.rst
@@ -1,1 +1,0 @@
-Replace the git protocol with https in tests.

--- a/news/10696.bugfix.rst
+++ b/news/10696.bugfix.rst
@@ -1,1 +1,0 @@
-Fix uninstall editable from Windows junction link.

--- a/news/10709.process.rst
+++ b/news/10709.process.rst
@@ -1,3 +1,0 @@
-Start migration of distribution metadata implementation from ``pkg_resources``
-to ``importlib.metadata``. The new implementation is currently not exposed in
-any user-facing way, but included in the code base for easier development.

--- a/news/10717.bugfix.rst
+++ b/news/10717.bugfix.rst
@@ -1,1 +1,0 @@
-Fallback to pyproject.toml-based builds if ``setup.py`` is present in a project, but ``setuptools`` cannot be imported.

--- a/news/10799.feature.rst
+++ b/news/10799.feature.rst
@@ -1,1 +1,0 @@
-Include Project-URLs in ``pip show`` output.

--- a/news/10812.feature.rst
+++ b/news/10812.feature.rst
@@ -1,2 +1,0 @@
-Improve error message when ``pip config edit`` is provided an editor that
-doesn't exist.

--- a/news/10883.bugfix.rst
+++ b/news/10883.bugfix.rst
@@ -1,2 +1,0 @@
-When checking for conflicts in the build environment, correctly skip requirements
-containing markers that do not match the current environment.

--- a/news/10899.doc.rst
+++ b/news/10899.doc.rst
@@ -1,1 +1,0 @@
-Add more dedicated topic and reference pages to the documentation.

--- a/news/10936.doc.rst
+++ b/news/10936.doc.rst
@@ -1,1 +1,0 @@
-Capitalise Y as the default for "Proceed (y/n)?" when uninstalling.

--- a/news/10950.bugfix.rst
+++ b/news/10950.bugfix.rst
@@ -1,1 +1,0 @@
-Disable brotli import in vendored urllib3 so brotli could be uninstalled/upgraded by pip.

--- a/news/10951.doc.rst
+++ b/news/10951.doc.rst
@@ -1,1 +1,0 @@
-Add ``scheme://`` requirement to ``--proxy`` option's description

--- a/news/10972.doc.rst
+++ b/news/10972.doc.rst
@@ -1,2 +1,0 @@
-The wheel command now references the build interface section instead of stating the legacy
-setuptools behavior as the default.

--- a/news/10979.bugfix.rst
+++ b/news/10979.bugfix.rst
@@ -1,1 +1,0 @@
-Prioritize URL credentials over netrc.

--- a/news/11001.removal.rst
+++ b/news/11001.removal.rst
@@ -1,1 +1,0 @@
-Drop ``--use-deprecated=out-of-tree-build``, according to deprecation message.

--- a/news/11059.feature.rst
+++ b/news/11059.feature.rst
@@ -1,1 +1,0 @@
-Add a user interface for supplying config settings to build backends.

--- a/news/11074.doc.rst
+++ b/news/11074.doc.rst
@@ -1,1 +1,0 @@
-Improved usefulness of ``pip config --help`` output.

--- a/news/1631cd96-53bb-4f35-9f20-c52daf607a72.trivial.rst
+++ b/news/1631cd96-53bb-4f35-9f20-c52daf607a72.trivial.rst
@@ -1,1 +1,0 @@
-Update pre-commit hooks.

--- a/news/20ef81f6-dfa6-453a-a23a-74b0de4c2f88.trivial.rst
+++ b/news/20ef81f6-dfa6-453a-a23a-74b0de4c2f88.trivial.rst
@@ -1,1 +1,0 @@
-Replace ``Iterator[T]`` with ``Generator[T, None, None]``.

--- a/news/40015744-0875-4d5b-b323-ae1bae280614.trivial.rst
+++ b/news/40015744-0875-4d5b-b323-ae1bae280614.trivial.rst
@@ -1,1 +1,0 @@
-Update black==22.3.0.

--- a/news/9024.feature.rst
+++ b/news/9024.feature.rst
@@ -1,1 +1,0 @@
-Add support for Powershell autocompletion.

--- a/news/9243.bugfix.rst
+++ b/news/9243.bugfix.rst
@@ -1,1 +1,0 @@
-Filter available distributions using hash declarations from constraints files.

--- a/news/9452.bugfix.rst
+++ b/news/9452.bugfix.rst
@@ -1,1 +1,0 @@
-Fix an error when trying to uninstall packages installed as editable from a network drive.

--- a/news/9615.feature.rst
+++ b/news/9615.feature.rst
@@ -1,1 +1,0 @@
-Explains why specified version cannot be retrieved when *Requires-Python* is not satisfied.

--- a/news/9691.bugfix.rst
+++ b/news/9691.bugfix.rst
@@ -1,1 +1,0 @@
-Fix pip install issues using a proxy due to an inconsistency in how Requests is currently handling variable precedence in session.

--- a/news/9794.feature.rst
+++ b/news/9794.feature.rst
@@ -1,1 +1,0 @@
-Validate build dependencies when using ``--no-build-isolation``.

--- a/news/CacheControl.vendor.rst
+++ b/news/CacheControl.vendor.rst
@@ -1,1 +1,0 @@
-Upgrade CacheControl to 0.12.11

--- a/news/distro.vendor.rst
+++ b/news/distro.vendor.rst
@@ -1,1 +1,0 @@
-Upgrade distro to 1.7.0

--- a/news/platformdirs.vendor.rst
+++ b/news/platformdirs.vendor.rst
@@ -1,1 +1,0 @@
-Upgrade platformdirs to 2.5.2

--- a/news/progress.vendor.rst
+++ b/news/progress.vendor.rst
@@ -1,1 +1,0 @@
-Remove ``progress`` from vendored dependencies.

--- a/news/pyparsing.vendor.rst
+++ b/news/pyparsing.vendor.rst
@@ -1,1 +1,0 @@
-Upgrade ``pyparsing`` to 3.0.8 for startup performance improvements.

--- a/news/rich.vendor.rst
+++ b/news/rich.vendor.rst
@@ -1,1 +1,0 @@
-Upgrade rich to 12.2.0

--- a/news/tomli.vendor.rst
+++ b/news/tomli.vendor.rst
@@ -1,1 +1,0 @@
-Upgrade tomli to 2.0.1

--- a/news/typing_extensions.vendor.rst
+++ b/news/typing_extensions.vendor.rst
@@ -1,1 +1,0 @@
-Upgrade typing_extensions to 4.2.0

--- a/tools/release/__init__.py
+++ b/tools/release/__init__.py
@@ -85,7 +85,7 @@ def commit_file(session: Session, filename: str, *, message: str) -> None:
 
 def generate_news(session: Session, version: str) -> None:
     session.install("towncrier")
-    session.run("towncrier", "--yes", "--version", version, silent=True)
+    session.run("towncrier", "build", "--yes", "--version", version, silent=True)
 
 
 def update_version_file(version: str, filepath: str) -> None:


### PR DESCRIPTION
Newer versions of towncrier exit eagerly, when `towncrier --version` is
run only printing the version and not actually doing any news file
generation.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
