### PR TITLE
Fix `22.1b1` version in changelog

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,7 +9,7 @@
 
 .. towncrier release notes start
 
-21.1b1 (2022-04-30)
+22.1b1 (2022-04-30)
 ===================
 
 Process


### PR DESCRIPTION
A really tiny fix to use the correct version name in the changelog.