### PR TITLE
Add --dry-run option to pip install

### DIFF
--- a/news/11096.feature.rst
+++ b/news/11096.feature.rst
@@ -1,0 +1,2 @@
+Add ``--dry-run`` option to ``pip install``, to let it print what it would install but
+not actually change anything in the target environment.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -354,14 +354,15 @@ class InstallCommand(RequirementCommand):
             )
 
             if options.dry_run:
-                items = [
-                    f"{item.name}-{item.metadata['version']}"
-                    for item in sorted(
-                        requirement_set.all_requirements, key=lambda x: str(x.name)
+                would_install_items = sorted(
+                    (r.metadata["name"], r.metadata["version"])
+                    for r in requirement_set.all_requirements
+                )
+                if would_install_items:
+                    write_output(
+                        "Would install %s",
+                        " ".join("-".join(item) for item in would_install_items),
                     )
-                ]
-                if items:
-                    write_output("Would install %s", " ".join(items))
                 return SUCCESS
 
             try:

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -86,6 +86,17 @@ class InstallCommand(RequirementCommand):
 
         self.cmd_opts.add_option(cmdoptions.editable())
         self.cmd_opts.add_option(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help=(
+                "Don't actually install anything, just print what would be. "
+                "Can be used in combination with --ignore-installed "
+                "to 'resolve' the requirements."
+            ),
+        )
+        self.cmd_opts.add_option(
             "-t",
             "--target",
             dest="target_dir",
@@ -341,6 +352,17 @@ class InstallCommand(RequirementCommand):
             requirement_set = resolver.resolve(
                 reqs, check_supported_wheels=not options.target_dir
             )
+
+            if options.dry_run:
+                items = [
+                    f"{item.name}-{item.metadata['version']}"
+                    for item in sorted(
+                        requirement_set.all_requirements, key=lambda x: str(x.name)
+                    )
+                ]
+                if items:
+                    write_output("Would install %s", " ".join(items))
+                return SUCCESS
 
             try:
                 pip_req = requirement_set.get_requirement("pip")

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -356,9 +356,7 @@ class InstallCommand(RequirementCommand):
             if options.dry_run:
                 would_install_items = sorted(
                     (r.metadata["name"], r.metadata["version"])
-                    # Use get_installation_order because it does some important
-                    # filtering with the legacy resolver.
-                    for r in resolver.get_installation_order(requirement_set)
+                    for r in requirement_set.requirements_to_install
                 )
                 if would_install_items:
                     write_output(

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -356,7 +356,9 @@ class InstallCommand(RequirementCommand):
             if options.dry_run:
                 would_install_items = sorted(
                     (r.metadata["name"], r.metadata["version"])
-                    for r in requirement_set.all_requirements
+                    # Use get_installation_order because it does some important
+                    # filtering with the legacy resolver.
+                    for r in resolver.get_installation_order(requirement_set)
                 )
                 if would_install_items:
                     write_output(

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -67,3 +67,16 @@ class RequirementSet:
     @property
     def all_requirements(self) -> List[InstallRequirement]:
         return self.unnamed_requirements + list(self.requirements.values())
+
+    @property
+    def requirements_to_install(self) -> List[InstallRequirement]:
+        """Return the list of requirements that need to be installed.
+
+        TODO remove this property together with the legacy resolver, since the new
+             resolver only returns requirements that need to be installed.
+        """
+        return [
+            install_req
+            for install_req in self.all_requirements
+            if not install_req.constraint and not install_req.satisfied_by
+        ]

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2238,3 +2238,12 @@ def test_install_logs_pip_version_in_debug(
     result = script.pip("install", "-v", fake_package)
     pattern = "Using pip .* from .*"
     assert_re_match(pattern, result.stdout)
+
+
+def test_install_dry_run(script: PipTestEnvironment, data: TestData) -> None:
+    """Test that pip install --dry-run logs what it would install."""
+    result = script.pip(
+        "install", "--dry-run", "--find-links", data.find_links, "simple"
+    )
+    assert "Would install simple-3.0" in result.stdout
+    assert "Successfully installed" not in result.stdout


### PR DESCRIPTION
This options simply prints what pip would install instead of actually installing.

The output is human readable and mimics what an actual pip install prints.
It is not intended to be parsed by tools: that will be added by the `--report` option which will produce a rich json output.

Towards #53 and [#10771](https://github.com/pypa/pip/pull/10771#issuecomment-1114585840).
