### PR TITLE
Add metadata field to pip list json output

### DIFF
--- a/docs/html/cli/pip_list.rst
+++ b/docs/html/cli/pip_list.rst
@@ -104,19 +104,31 @@ Examples
 
 #. Use json formatting
 
+   The ``metadata`` field is the distribution metadata, converted to JSON using the
+   transformation described in `PEP 566
+   <https://peps.python.org/pep-0566/#json-compatible-metadata>`_.
+
    .. tab:: Unix/macOS
 
       .. code-block:: console
 
          $ python -m pip list --format=json
-         [{'name': 'colorama', 'version': '0.3.7'}, {'name': 'docopt', 'version': '0.6.2'}, ...
+         [
+            {'name': 'colorama', 'version': '0.3.7', 'metadata': {...}},
+            {'name': 'docopt', 'version': '0.6.2', 'metadata': {...}},
+            ...
+         ]
 
    .. tab:: Windows
 
       .. code-block:: console
 
          C:\> py -m pip list --format=json
-         [{'name': 'colorama', 'version': '0.3.7'}, {'name': 'docopt', 'version': '0.6.2'}, ...
+         [
+            {'name': 'colorama', 'version': '0.3.7', 'metadata': {...}},
+            {'name': 'docopt', 'version': '0.6.2', 'metadata': {...}},
+            ...
+         ]
 
 #. Use freeze formatting
 

--- a/news/11097.feature.rst
+++ b/news/11097.feature.rst
@@ -1,0 +1,1 @@
+Add a ``metadata`` field to the ``pip list`` JSON output.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -1,7 +1,17 @@
 import json
 import logging
 from optparse import Values
-from typing import TYPE_CHECKING, Generator, List, Optional, Sequence, Tuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    cast,
+)
 
 from pip._vendor.packaging.utils import canonicalize_name
 
@@ -344,7 +354,7 @@ def format_for_columns(
 def format_for_json(packages: "_ProcessedDists", options: Values) -> str:
     data = []
     for dist in packages:
-        info = {
+        info: Dict[str, Any] = {
             "name": dist.raw_name,
             "version": str(dist.version),
         }
@@ -357,5 +367,6 @@ def format_for_json(packages: "_ProcessedDists", options: Values) -> str:
         editable_project_location = dist.editable_project_location
         if editable_project_location:
             info["editable_project_location"] = editable_project_location
+        info["metadata"] = dist.metadata_dict
         data.append(info)
     return json.dumps(data)

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -682,6 +682,9 @@ def test_list_json(simple_script: PipTestEnvironment) -> None:
     data = json.loads(result.stdout)
     assert subdict_in_list({"name": "simple", "version": "1.0"}, data)
     assert subdict_in_list({"name": "simple2", "version": "3.0"}, data)
+    for item in data:
+        assert item["metadata"]["name"] == item["name"]
+        assert item["metadata"]["version"] == item["version"]
 
 
 def test_list_path(tmpdir: Path, script: PipTestEnvironment, data: TestData) -> None:


### PR DESCRIPTION
Such a metadata field in pip list json output is useful for tools that need to explore the content of a python environment without being installed in it (or are written in other languages than python).

This also helps answering feature requests about extending pip list query options. With a rich output we can ask users to use `jq` or a similar tool to process their queries.

This PR sits on top of #11095 

