### PR TITLE
Replace `cgi` module with `email.message`

### DIFF
--- a/news/11099.process.rst
+++ b/news/11099.process.rst
@@ -1,0 +1,1 @@
+Remove reliance on the stdlib cgi module, which is deprecated in Python 3.11.

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -2,8 +2,8 @@
 The main purpose of this module is to expose LinkCollector.collect_sources().
 """
 
-import cgi
 import collections
+import email.message
 import functools
 import itertools
 import logging
@@ -155,9 +155,11 @@ def _get_html_response(url: str, session: PipSession) -> Response:
 def _get_encoding_from_headers(headers: ResponseHeaders) -> Optional[str]:
     """Determine if we have any encoding information in our headers."""
     if headers and "Content-Type" in headers:
-        content_type, params = cgi.parse_header(headers["Content-Type"])
-        if "charset" in params:
-            return params["charset"]
+        m = email.message.Message()
+        m["content-type"] = headers["Content-Type"]
+        charset = m.get_param("charset")
+        if charset:
+            return str(charset)
     return None
 
 

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -1,6 +1,6 @@
 """Download files with progress indicators.
 """
-import cgi
+import email.message
 import logging
 import mimetypes
 import os
@@ -81,12 +81,13 @@ def parse_content_disposition(content_disposition: str, default_filename: str) -
     Parse the "filename" value from a Content-Disposition header, and
     return the default filename if the result is empty.
     """
-    _type, params = cgi.parse_header(content_disposition)
-    filename = params.get("filename")
+    m = email.message.Message()
+    m["content-type"] = content_disposition
+    filename = m.get_param("filename")
     if filename:
         # We need to sanitize the filename to prevent directory traversal
         # in case the filename contains ".." path parts.
-        filename = sanitize_content_filename(filename)
+        filename = sanitize_content_filename(str(filename))
     return filename or default_filename
 
 


### PR DESCRIPTION
As of Python 3.11.0b1, the cgi module is deprecated per PEP 594
(Removing dead batteries from the standard library), and raises
DeprecationWarning when imported. The only places pip relies on this
are pip._internal.index.collector._get_encoding_from_headers() and
pip._internal.network.download.parse_content_disposition() calling
parse_headers(), so replace that with the solution recommended in an
old PEP 594 thread from 2019: https://discuss.python.org/t/1704/14

Fixes: #11099