### PR TITLE
Allow pre-release to satisfy build requirements

### DIFF
--- a/news/11123.bugfix.rst
+++ b/news/11123.bugfix.rst
@@ -1,0 +1,3 @@
+Allow using a pre-release version to satisfy a build requirement. This helps
+manually populated build environments to more accurately detect build-time
+requirement conflicts.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -185,7 +185,7 @@ class BuildEnvironment:
                     installed_req_str = f"{req.name}=={dist.version}"
                 else:
                     installed_req_str = f"{req.name}==={dist.version}"
-                if dist.version not in req.specifier:
+                if not req.specifier.contains(dist.version, prereleases=True):
                     conflicting.add((installed_req_str, req_str))
                 # FIXME: Consider direct URL?
         return conflicting, missing


### PR DESCRIPTION
This bug has been there fore since forever, but only exposed when we actually trying to enforce it to manually populated environments.

Fix #11123.