### PR TITLE
Add missing rich as vendored()

### DIFF
--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -106,6 +106,7 @@ if DEBUNDLED:
     vendored("requests.packages.urllib3.util.timeout")
     vendored("requests.packages.urllib3.util.url")
     vendored("resolvelib")
+    vendored("rich")
     vendored("tenacity")
     vendored("tomli")
     vendored("urllib3")


### PR DESCRIPTION
In debundled setup, `rich` is missing from the vendored() list.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
