### PR TITLE
speedup Wheel.support_index_min

### DIFF
--- a/src/pip/_internal/models/wheel.py
+++ b/src/pip/_internal/models/wheel.py
@@ -58,7 +58,10 @@ class Wheel:
         :raises ValueError: If none of the wheel's file tags match one of
             the supported tags.
         """
-        return min(tags.index(tag) for tag in self.file_tags if tag in tags)
+        try:
+            return next(i for i, t in enumerate(tags) if t in self.file_tags)
+        except StopIteration:
+            raise ValueError()
 
     def find_most_preferred_tag(
         self, tags: List[Tag], tag_to_priority: Dict[Tag, int]


### PR DESCRIPTION
Given an input tag list of size `n` and wheel file tags of size `m` this
method is currently `O(n*m)` because it iterates over the set of file tags
then for each file tag it iterates over the input tags.

We can do much better and get `O(m)` time complexity by iterating the input
tags instead, and doing a cheap `O(1)` membership test among the set of file
tags. As a side benefit, this also allows early-termination of the loop.

The impact of this seemingly trivial change is surprisingly big: for a run
of `pip-compile` on macOS, which calls this method many times with large
inputs this changes gives a ~50% speedup on end-to-end `pip-compile` time,
from ~8s down to ~4s!

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
