### PR TITLE
Pass --disable-pip-version-check in tests

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -682,7 +682,7 @@ class PipTestEnvironment(TestFileEnvironment):
             kwargs["allow_stderr_warning"] = True
         if use_module:
             exe = "python"
-            args = ("-m", "pip") + args
+            args = ("-m", "pip", "--disable-pip-version-check") + args
         else:
             exe = "pip"
         return self.run(exe, *args, **kwargs)


### PR DESCRIPTION
Pass `--disable-pip-version-check` when running pip from the test suite.
In the best case, these checks are unnecessary and in the worst, they
cause tests to fail by emitting warnings.

Fixes https://github.com/pypa/pip/issues/11114