### PR TITLE
Fix types for logging Rich objects

### DIFF
--- a/news/11136.bugfix.rst
+++ b/news/11136.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an incorrect assertion in the logging logic, that prevented the upgrade prompt from being presented.

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -14,7 +14,9 @@ from pip._vendor.rich.console import (
     Console,
     ConsoleOptions,
     ConsoleRenderable,
+    RenderableType,
     RenderResult,
+    RichCast,
 )
 from pip._vendor.rich.highlighter import NullHighlighter
 from pip._vendor.rich.logging import RichHandler
@@ -121,7 +123,7 @@ class IndentingFormatter(logging.Formatter):
 
 @dataclass
 class IndentedRenderable:
-    renderable: ConsoleRenderable
+    renderable: RenderableType
     indent: int
 
     def __rich_console__(
@@ -156,10 +158,10 @@ class RichPipStreamHandler(RichHandler):
         if record.msg == "[present-rich] %s" and len(record.args) == 1:
             rich_renderable = record.args[0]
             assert isinstance(
-                rich_renderable, ConsoleRenderable
+                rich_renderable, (ConsoleRenderable, RichCast, str)
             ), f"{rich_renderable} is not rich-console-renderable"
 
-            renderable: ConsoleRenderable = IndentedRenderable(
+            renderable: RenderableType = IndentedRenderable(
                 rich_renderable, indent=get_indentation()
             )
         else:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/pradyunsg/Developer/github/pip/.venv/lib/python3.10/site-packages/pip/_internal/self_outdated_check.py", line 237, in pip_self_version_check
    logger.info("[present-rich] %s", upgrade_prompt)
  File "/Users/pradyunsg/.asdf/installs/python/3.10.1/lib/python3.10/logging/__init__.py", line 1468, in info
    self._log(INFO, msg, args, **kwargs)
  File "/Users/pradyunsg/.asdf/installs/python/3.10.1/lib/python3.10/logging/__init__.py", line 1615, in _log
    self.handle(record)
  File "/Users/pradyunsg/.asdf/installs/python/3.10.1/lib/python3.10/logging/__init__.py", line 1625, in handle
    self.callHandlers(record)
  File "/Users/pradyunsg/.asdf/installs/python/3.10.1/lib/python3.10/logging/__init__.py", line 1687, in callHandlers
    hdlr.handle(record)
  File "/Users/pradyunsg/.asdf/installs/python/3.10.1/lib/python3.10/logging/__init__.py", line 967, in handle
    self.emit(record)
  File "/Users/pradyunsg/Developer/github/pip/.venv/lib/python3.10/site-packages/pip/_internal/utils/logging.py", line 158, in emit
    assert isinstance(
AssertionError: UpgradePrompt(old='22.1', new='22.1.1') is not rich-console-renderable
```

Turns out, my attempt at defensive coding was overly defensive and the pretty upgrade prompts do not work in 21.1 or 21.1.1. :(