### PR TITLE
add typehints to MultiDomainBasicAuth.handle_401._get_new_credentials

### DIFF
--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -259,9 +259,9 @@ class MultiDomainBasicAuth(AuthBase):
 
         # Query the keyring for credentials:
         username, password = self._get_new_credentials(
-            resp.url,
-            allow_netrc=False,
-            allow_keyring=True,
+            resp.url: str,
+            allow_netrc: bool = False,
+            allow_keyring bool = True,
         )
 
         # Prompt the user for a new username and password


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
