### PR TITLE
Refactor `BaseDistribution.metadata` property to make sure it has `Requires-Dist` and `Provides-Extra`

### DIFF
--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -171,8 +171,7 @@ class Distribution(BaseDistribution):
                 name, _, value = str(entry_point).partition("=")
                 yield EntryPoint(name=name.strip(), value=value.strip(), group=group)
 
-    @property
-    def metadata(self) -> email.message.Message:
+    def _metadata_impl(self) -> email.message.Message:
         """
         :raises NoneMetadataError: if the distribution reports `has_metadata()`
             True but `get_metadata()` returns None.


### PR DESCRIPTION
`egg-info` distribution may not have the `Requires-Dist` and `Provides-Extra` fields in their metadata. For consistency, and to provide an unsurprising `BaseDistribution.metadata` property, we emulate it by reading `requires.txt`.

The logic was already present in the `importlib.metadata.Distribution` adapter, so we reuse it by moving the corresponding methods up to `BaseDistribution`.

I noticed this while working on #10771 where the installation report was missing requires_dist for older setup.py projects.