### PR TITLE
Added `--scoped-index-url` command line option

### DIFF
--- a/news/8606.feature.rst
+++ b/news/8606.feature.rst
@@ -1,0 +1,5 @@
+Added ``--scoped-index-url`` command line option
+
+It allows pip users to ensure that the specified package names (or prefixes of package names) are downloaded exclusively from the specified indexes.
+
+Example syntax: ``pip install companyname-package-name==1.0.0 --scoped-index-url companyname:http://url/of/private/index``

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -371,6 +371,18 @@ no_index: Callable[..., Option] = partial(
 )
 
 
+def scoped_index_url() -> Option:
+    return Option(
+        "--scoped-index-url",
+        dest="scoped_index_urls",
+        metavar="URL",
+        action="append",
+        default=[],
+        help="Index URLs for specific package name prefixes, eg 'company-name-:URL'"
+        "URL follows the same rules as --index-url.",
+    )
+
+
 def find_links() -> Option:
     return Option(
         "-f",
@@ -1059,6 +1071,7 @@ index_group: Dict[str, Any] = {
         index_url,
         extra_index_url,
         no_index,
+        scoped_index_url,
         find_links,
     ],
 }

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -546,10 +546,12 @@ class LinkCollector:
 
         # Make sure find_links is a list before passing to create().
         find_links = options.find_links or []
+        scoped_index_urls = options.scoped_index_urls or []
 
         search_scope = SearchScope.create(
             find_links=find_links,
             index_urls=index_urls,
+            scoped_index_urls=scoped_index_urls,
         )
         link_collector = LinkCollector(
             session=session,


### PR DESCRIPTION
It allows pip users to ensure that the specified package names (or prefixes of package names) are downloaded exclusively from the specified indexes.
Example syntax: `pip install companyname-package-name==1.0.0 --scoped-index-url companyname:http://url/of/private/index`

See #8606