### PR TITLE
Display dependency chain on each Collecting line

### DIFF
--- a/news/11169.feature.rst
+++ b/news/11169.feature.rst
@@ -1,0 +1,1 @@
+Display dependency chain on each Collecting/Processing log line.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -270,6 +270,16 @@ class RequirementPreparer:
             message = "Collecting %s"
             information = str(req.req or req)
 
+        # If we used req.req, inject requirement source if available (this
+        # would already be included if we used req directly)
+        if req.req and req.comes_from:
+            if isinstance(req.comes_from, str):
+                comes_from: Optional[str] = req.comes_from
+            else:
+                comes_from = req.comes_from.from_path()
+            if comes_from:
+                information += f" (from {comes_from})"
+
         if (message, information) != self._previous_requirement_header:
             self._previous_requirement_header = (message, information)
             logger.info(message, information)


### PR DESCRIPTION
This tremendously helps understand why a package is being fetched and
can help investigate and fix dependency resolver backtracking issues
when incoherent constraints/package sets are provided or when new
versions of a package trigger a completely different backtracking
strategy, leading to very hard to debug situations.