### PR TITLE
Add forced progress bar option

### DIFF
--- a/news/11171 .feature.rst
+++ b/news/11171 .feature.rst
@@ -1,0 +1,1 @@
+Add ability to force progress bars to be used, for allowing progress bars to be shown in subprocesses.

--- a/news/11171 .feature.rst
+++ b/news/11171 .feature.rst
@@ -1,1 +1,0 @@
-Add ability to force progress bars to be used, for allowing progress bars to be shown in subprocesses.

--- a/news/11171.feature.rst
+++ b/news/11171.feature.rst
@@ -1,0 +1,1 @@
+Add ability to force progress bars to be used, for allowing progress bars to be shown in subprocesses.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -238,7 +238,10 @@ progress_bar: Callable[..., Option] = partial(
     type="choice",
     choices=["on", "off", "forced"],
     default="on",
-    help="Specify whether the progress bar should be used [on, off, forced] (default: on)",
+    help=(
+        "Specify whether the progress bar should be used [on, off, forced]"
+        " (default: on)"
+    ),
 )
 
 log: Callable[..., Option] = partial(

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -236,9 +236,9 @@ progress_bar: Callable[..., Option] = partial(
     "--progress-bar",
     dest="progress_bar",
     type="choice",
-    choices=["on", "off"],
+    choices=["on", "off", "forced"],
     default="on",
-    help="Specify whether the progress bar should be used [on, off] (default: on)",
+    help="Specify whether the progress bar should be used [on, off, forced] (default: on)",
 )
 
 log: Callable[..., Option] = partial(

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -71,7 +71,7 @@ def get_download_progress_renderer(
 
     Returns a callable, that takes an iterable to "wrap".
     """
-    if bar_type == "on":
+    if bar_type == "on" or bar_type == "forced":
         return functools.partial(_rich_progress_bar, bar_type=bar_type, size=size)
     else:
         return iter  # no-op, when passed an iterator

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -1,6 +1,7 @@
 import functools
 from typing import Callable, Generator, Iterable, Iterator, Optional, Tuple
 
+from pip._vendor.rich.console import Console
 from pip._vendor.rich.progress import (
     BarColumn,
     DownloadColumn,
@@ -25,7 +26,9 @@ def _rich_progress_bar(
     bar_type: str,
     size: int,
 ) -> Generator[bytes, None, None]:
-    assert bar_type == "on", "This should only be used in the default mode."
+    assert (
+        bar_type == "on" or bar_type == "forced"
+    ), "This should only be used in the default mode or if forced."
 
     if not size:
         total = float("inf")
@@ -47,7 +50,13 @@ def _rich_progress_bar(
             TimeRemainingColumn(),
         )
 
-    progress = Progress(*columns, refresh_per_second=30)
+    progress = Progress(
+        *columns,
+        refresh_per_second=30,
+        console=Console(
+            force_terminal=bar_type == "forced",
+        ),
+    )
     task_id = progress.add_task(" " * (get_indentation() + 2), total=total)
     with progress:
         for chunk in iterable:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

This PR adds the ability to force progress bars on. This allows progress bars to be fully shown in subprocesses, which allows their data to be piped. See #11171 for more details.

Closes #11171 