### PR TITLE
Rename trivial label to skip news

### DIFF
--- a/.github/workflows/news-file.yml
+++ b/.github/workflows/news-file.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check news entry
-        if: "!contains(github.event.pull_request.labels.*.name, 'trivial')"
+        if: "!contains(github.event.pull_request.labels.*.name, 'skip news')"
         run: |
           if ! pipx run towncrier check --compare-with origin/${{ github.base_ref }}; then
             echo "Please see https://pip.pypa.io/dev/news-entry-failure for guidance."


### PR DESCRIPTION
The actual label rename will be manual -- this is mostly the automation getting updated to do the right thing once the label is renamed.

When this merges, please rename the `trivial` label to `skip news`.

Closes #10853

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
