### PR TITLE
Resume incomplete download

### DIFF
--- a/news/11180.feature.rst
+++ b/news/11180.feature.rst
@@ -1,0 +1,1 @@
+Add support to resume incomplete download. The behavior can be controlled using flags ``--incomplete-downloads`` and ``--incomplete-download-retries``.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -1017,6 +1017,25 @@ use_deprecated_feature: Callable[..., Option] = partial(
     help=("Enable deprecated functionality, that will be removed in the future."),
 )
 
+incomplete_downloads: Callable[..., Option] = partial(
+    Option,
+    "--incomplete-downloads",
+    dest="resume_incomplete",
+    choices=["resume", "discard"],
+    default="discard",
+    metavar="policy",
+    help="How to handle an incomplete download: resume, discard (default to %default).",
+)
+
+incomplete_download_retries: Callable[..., Option] = partial(
+    Option,
+    "--incomplete-download-retries",
+    dest="resume_attempts",
+    type="int",
+    default=5,
+    help="Maximum number of resumption retries for incomplete download "
+    "(default %default times).",
+)
 
 ##########
 # groups #
@@ -1048,6 +1067,8 @@ general_group: Dict[str, Any] = {
         no_python_version_warning,
         use_new_feature,
         use_deprecated_feature,
+        incomplete_downloads,
+        incomplete_download_retries,
     ],
 }
 

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -24,6 +24,7 @@ def _rich_progress_bar(
     *,
     bar_type: str,
     size: int,
+    initial_progress: Optional[int] = None,
 ) -> Generator[bytes, None, None]:
     assert bar_type == "on", "This should only be used in the default mode."
 
@@ -49,6 +50,8 @@ def _rich_progress_bar(
 
     progress = Progress(*columns, refresh_per_second=30)
     task_id = progress.add_task(" " * (get_indentation() + 2), total=total)
+    if initial_progress is not None:
+        progress.update(task_id, advance=initial_progress)
     with progress:
         for chunk in iterable:
             yield chunk
@@ -56,13 +59,18 @@ def _rich_progress_bar(
 
 
 def get_download_progress_renderer(
-    *, bar_type: str, size: Optional[int] = None
+    *, bar_type: str, size: Optional[int] = None, initial_progress: Optional[int] = None
 ) -> DownloadProgressRenderer:
     """Get an object that can be used to render the download progress.
 
     Returns a callable, that takes an iterable to "wrap".
     """
     if bar_type == "on":
-        return functools.partial(_rich_progress_bar, bar_type=bar_type, size=size)
+        return functools.partial(
+            _rich_progress_bar,
+            bar_type=bar_type,
+            size=size,
+            initial_progress=initial_progress,
+        )
     else:
         return iter  # no-op, when passed an iterator

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -305,6 +305,8 @@ class RequirementCommand(IndexGroupCommand):
                     "fast-deps has no effect when used with the legacy resolver."
                 )
 
+        resume_incomplete = options.resume_incomplete == "resume"
+
         return RequirementPreparer(
             build_dir=temp_build_dir_path,
             src_dir=options.src_dir,
@@ -319,6 +321,8 @@ class RequirementCommand(IndexGroupCommand):
             use_user_site=use_user_site,
             lazy_wheel=lazy_wheel,
             verbosity=verbosity,
+            resume_incomplete=resume_incomplete,
+            resume_attempts=options.resume_attempts,
         )
 
     @classmethod

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -221,6 +221,8 @@ class RequirementPreparer:
         use_user_site: bool,
         lazy_wheel: bool,
         verbosity: int,
+        resume_incomplete: bool,
+        resume_attempts: int,
     ) -> None:
         super().__init__()
 
@@ -228,8 +230,12 @@ class RequirementPreparer:
         self.build_dir = build_dir
         self.build_tracker = build_tracker
         self._session = session
-        self._download = Downloader(session, progress_bar)
-        self._batch_download = BatchDownloader(session, progress_bar)
+        self._download = Downloader(
+            session, progress_bar, resume_incomplete, resume_attempts
+        )
+        self._batch_download = BatchDownloader(
+            session, progress_bar, resume_incomplete, resume_attempts
+        )
         self.finder = finder
 
         # Where still-packed archives should be written to. If None, they are

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -1,51 +1,76 @@
 import logging
 import sys
-from typing import Dict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from pip._internal.models.link import Link
 from pip._internal.network.download import (
+    Downloader,
+    _get_http_response_size,
+    _http_get_download,
     _prepare_download,
     parse_content_disposition,
     sanitize_content_filename,
 )
+from pip._internal.network.session import PipSession
+from pip._internal.network.utils import HEADERS
 from tests.lib.requests_mocks import MockResponse
 
 
 @pytest.mark.parametrize(
-    "url, headers, from_cache, expected",
+    "url, headers, from_cache, range_start, expected",
     [
         (
             "http://example.com/foo.tgz",
             {},
             False,
+            None,
             "Downloading http://example.com/foo.tgz",
         ),
         (
             "http://example.com/foo.tgz",
             {"content-length": "2"},
             False,
+            None,
             "Downloading http://example.com/foo.tgz (2 bytes)",
         ),
         (
             "http://example.com/foo.tgz",
             {"content-length": "2"},
             True,
+            None,
             "Using cached http://example.com/foo.tgz (2 bytes)",
         ),
-        ("https://files.pythonhosted.org/foo.tgz", {}, False, "Downloading foo.tgz"),
+        (
+            "https://files.pythonhosted.org/foo.tgz",
+            {},
+            False,
+            None,
+            "Downloading foo.tgz",
+        ),
         (
             "https://files.pythonhosted.org/foo.tgz",
             {"content-length": "2"},
             False,
+            None,
             "Downloading foo.tgz (2 bytes)",
         ),
         (
             "https://files.pythonhosted.org/foo.tgz",
             {"content-length": "2"},
             True,
+            None,
             "Using cached foo.tgz",
+        ),
+        (
+            "http://example.com/foo.tgz",
+            {"content-length": "200"},
+            False,
+            100,
+            "Resume download http://example.com/foo.tgz (100 bytes/200 bytes)",
         ),
     ],
 )
@@ -54,6 +79,7 @@ def test_prepare_download__log(
     url: str,
     headers: Dict[str, str],
     from_cache: bool,
+    range_start: Optional[int],
     expected: str,
 ) -> None:
     caplog.set_level(logging.INFO)
@@ -63,7 +89,14 @@ def test_prepare_download__log(
     if from_cache:
         resp.from_cache = from_cache
     link = Link(url)
-    _prepare_download(resp, link, progress_bar="on")
+    total_length = _get_http_response_size(resp)
+    _prepare_download(
+        resp,
+        link,
+        progress_bar="on",
+        total_length=total_length,
+        range_start=range_start,
+    )
 
     assert len(caplog.records) == 1
     record = caplog.records[0]
@@ -114,6 +147,29 @@ def test_sanitize_content_filename__platform_dependent(
 
 
 @pytest.mark.parametrize(
+    "range_start, if_range, expected_headers",
+    [
+        (None, None, HEADERS),
+        (1234, None, {**HEADERS, "Range": "bytes=1234-"}),
+        (1234, '"etag"', {**HEADERS, "Range": "bytes=1234-", "If-Range": '"etag"'}),
+    ],
+)
+def test_http_get_download(
+    range_start: Optional[int],
+    if_range: Optional[str],
+    expected_headers: Dict[str, str],
+) -> None:
+    session = PipSession()
+    session.get = MagicMock()
+    link = Link("http://example.com/foo.tgz")
+    with patch("pip._internal.network.download.raise_for_status"):
+        _http_get_download(session, link, range_start, if_range)
+    session.get.assert_called_once_with(
+        "http://example.com/foo.tgz", headers=expected_headers, stream=True
+    )
+
+
+@pytest.mark.parametrize(
     "content_disposition, default_filename, expected",
     [
         ('attachment;filename="../file"', "df", "file"),
@@ -124,3 +180,188 @@ def test_parse_content_disposition(
 ) -> None:
     actual = parse_content_disposition(content_disposition, default_filename)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "resume_incomplete,"
+    "resume_attempts,"
+    "mock_responses,"
+    "expected_resume_args,"
+    "expected_bytes",
+    [
+        # If content-length is not provided, the download will
+        # always "succeed" since we don't have a way to check if
+        # the download is complete.
+        (
+            False,
+            5,
+            [({}, 200, b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89")],
+            [],
+            b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+        ),
+        # Complete download (content-length matches body)
+        (
+            False,
+            5,
+            [({"content-length": "36"}, 200, b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89")],
+            [],
+            b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+        ),
+        # Incomplete download with auto resume disabled
+        (
+            False,
+            5,
+            [({"content-length": "36"}, 200, b"0cfa7e9d-1868-4dd7-9fb3-")],
+            [],
+            None,
+        ),
+        # Incomplete download with auto resume enabled
+        (
+            True,
+            5,
+            [
+                ({"content-length": "36"}, 200, b"0cfa7e9d-1868-4dd7-9fb3-"),
+                ({"content-length": "12"}, 206, b"f2561d5dfd89"),
+            ],
+            [(24, None)],
+            b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+        ),
+        # If the server responds with 200 (e.g. no range header support or the file
+        # has changed between the requests) the downloader should restart instead of
+        # resume. The downloaded file should not be affected.
+        (
+            True,
+            5,
+            [
+                ({"content-length": "36"}, 200, b"0cfa7e9d-1868-4dd7-9fb3-"),
+                ({"content-length": "36"}, 200, b"0cfa7e9d-1868-"),
+                (
+                    {"content-length": "36"},
+                    200,
+                    b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+                ),
+            ],
+            [(24, None), (14, None)],
+            b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+        ),
+        # File size could change between requests. Make sure this is handled correctly.
+        (
+            True,
+            5,
+            [
+                ({"content-length": "36"}, 200, b"0cfa7e9d-1868-4dd7-9fb3-"),
+                (
+                    {"content-length": "40"},
+                    200,
+                    b"new-0cfa7e9d-1868-4dd7-9fb3-f2561d5d",
+                ),
+                ({"content-length": "4"}, 206, b"fd89"),
+            ],
+            [(24, None), (36, None)],
+            b"new-0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+        ),
+        # The downloader should fail after resume_attempts attempts.
+        # This prevents the downloader from getting stuck if the connection
+        # is unstable and the server doesn't not support range requests.
+        (
+            True,
+            1,
+            [
+                ({"content-length": "36"}, 200, b"0cfa7e9d-1868-4dd7-9fb3-"),
+                ({"content-length": "36"}, 200, b"0cfa7e9d-1868-"),
+            ],
+            [(24, None)],
+            None,
+        ),
+        # The downloader should use If-Range header to make the range
+        # request conditional if it is possible to check for modifications
+        # (e.g. if we know the creation time of the initial response).
+        (
+            True,
+            5,
+            [
+                (
+                    {"content-length": "36", "date": "Wed, 21 Oct 2015 07:28:00 GMT"},
+                    200,
+                    b"0cfa7e9d-1868-4dd7-9fb3-",
+                ),
+                (
+                    {"content-length": "12", "date": "Wed, 21 Oct 2015 07:54:00 GMT"},
+                    206,
+                    b"f2561d5dfd89",
+                ),
+            ],
+            [(24, "Wed, 21 Oct 2015 07:28:00 GMT")],
+            b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+        ),
+        # ETag is preferred over Date for the If-Range condition.
+        (
+            True,
+            5,
+            [
+                (
+                    {
+                        "content-length": "36",
+                        "date": "Wed, 21 Oct 2015 07:28:00 GMT",
+                        "etag": '"33a64df551425fcc55e4d42a148795d9f25f89d4"',
+                    },
+                    200,
+                    b"0cfa7e9d-1868-4dd7-9fb3-",
+                ),
+                (
+                    {
+                        "content-length": "12",
+                        "date": "Wed, 21 Oct 2015 07:54:00 GMT",
+                        "etag": '"33a64df551425fcc55e4d42a148795d9f25f89d4"',
+                    },
+                    206,
+                    b"f2561d5dfd89",
+                ),
+            ],
+            [(24, '"33a64df551425fcc55e4d42a148795d9f25f89d4"')],
+            b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+        ),
+    ],
+)
+def test_downloader(
+    resume_incomplete: bool,
+    resume_attempts: int,
+    mock_responses: List[Tuple[Dict[str, str], int, bytes]],
+    # list of (range_start, if_range)
+    expected_resume_args: List[Tuple[Optional[int], Optional[int]]],
+    # expected_bytes is None means the download should fail
+    expected_bytes: Optional[bytes],
+    tmpdir: Path,
+) -> None:
+    session = PipSession()
+    link = Link("http://example.com/foo.tgz")
+    downloader = Downloader(session, "on", resume_incomplete, resume_attempts)
+
+    responses = []
+    for headers, status_code, body in mock_responses:
+        resp = MockResponse(body)
+        resp.headers = headers
+        resp.status_code = status_code
+        responses.append(resp)
+    _http_get_download = MagicMock(side_effect=responses)
+
+    with patch("pip._internal.network.download._http_get_download", _http_get_download):
+        if expected_bytes is None:
+            remove = MagicMock(return_value=None)
+            with patch("os.remove", remove):
+                with pytest.raises(RuntimeError):
+                    downloader(link, str(tmpdir))
+            # Make sure the incomplete file is removed
+            remove.assert_called_once()
+        else:
+            filepath, _ = downloader(link, str(tmpdir))
+            with open(filepath, "rb") as downloaded_file:
+                downloaded_bytes = downloaded_file.read()
+                assert downloaded_bytes == expected_bytes
+
+    calls = [call(session, link)]  # the initial request
+    for range_start, if_range in expected_resume_args:
+        calls.append(call(session, link, range_start=range_start, if_range=if_range))
+
+    # Make sure that the download makes additional requests for resumption
+    _http_get_download.assert_has_calls(calls)

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from pip._internal.exceptions import IncompleteDownloadError
 from pip._internal.models.link import Link
 from pip._internal.network.download import (
     Downloader,
@@ -349,7 +350,7 @@ def test_downloader(
         if expected_bytes is None:
             remove = MagicMock(return_value=None)
             with patch("os.remove", remove):
-                with pytest.raises(RuntimeError):
+                with pytest.raises(IncompleteDownloadError):
                     downloader(link, str(tmpdir))
             # Make sure the incomplete file is removed
             remove.assert_called_once()

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -31,7 +31,9 @@ def test_unpack_url_with_urllib_response_without_content_type(data: TestData) ->
 
     session = Mock()
     session.get = _fake_session_get
-    download = Downloader(session, progress_bar="on")
+    download = Downloader(
+        session, progress_bar="on", resume_incomplete=False, resume_attempts=5
+    )
 
     uri = data.packages.joinpath("simple-1.0.tar.gz").as_uri()
     link = Link(uri)
@@ -77,7 +79,9 @@ def test_download_http_url__no_directory_traversal(
         "content-disposition": 'attachment;filename="../out_dir_file"',
     }
     session.get.return_value = resp
-    download = Downloader(session, progress_bar="on")
+    download = Downloader(
+        session, progress_bar="on", resume_incomplete=False, resume_attempts=5
+    )
 
     download_dir = os.fspath(tmpdir.joinpath("download"))
     os.mkdir(download_dir)

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -106,6 +106,8 @@ class TestRequirementSet:
                 use_user_site=False,
                 lazy_wheel=False,
                 verbosity=0,
+                resume_incomplete=False,
+                resume_attempts=5,
             )
             yield Resolver(
                 preparer=preparer,


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

## Overview

This PR adds a feature that resumes download if the downloaded file is incomplete (e.g. when the Internet connection is poor). More specifically, if :

1. The initial response includes a `Content-Length` header,
2. The server sends fewer bytes than indicated in the `Content-Length` header,
3. The user enables the auto resumption feature using `--incomplete-downloads=resume`,

the downloader will make new requests and attempt to resume download using a `Range` header. If the initial response includes an `ETag` (preferred) or `Date` header, the downloader will ask the server to resume download only when it is safe (i.e., the file hasn't changed since the initial request) using an `If-Range` header.

If the server responds with a 200 (e.g. if the server doesn't support partial content or can't check if the file has changed), the downloader will restart the download (i.e. start from the very first byte); if the server responds with a 206 Partial Content, the downloader will resume the download from the partially downloaded file.

Note if the server always responds with 200, the downloader can potentially get stuck and waste unreasonable amounts of bandwidth downloading the first few bytes over and over again. Therefore, a retry limit is introduced to avoid this case.

If not enough bytes are received and auto resumption is disabled or the retry limit is exceeded, the downloader will clean up the incomplete file and fail with an exception.

## Flags

To control the auto resumption behavior, two new flags are added:
- `--incomplete-downloads=resume,/discard` controls whether the auto resumption feature is enabled (defaults to `discard`);
- `--incomplete-download-retries` limits the maximum number of retries (defaults to `5`).

---

Towards https://github.com/pypa/pip/issues/4796