### PR TITLE
Enforce utf-8 encoding for origin.json in wheel cache

### DIFF
--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -286,4 +286,4 @@ class WheelCache(Cache):
                     cache_dir,
                     download_info.url,
                 )
-        origin_path.write_text(download_info.to_json())
+        origin_path.write_text(download_info.to_json(), encoding="utf-8")


### PR DESCRIPTION
A small followup to #11137