### PR TITLE
Restore the repeatability intersphinx reference

### DIFF
--- a/docs/html/topics/repeatable-installs.md
+++ b/docs/html/topics/repeatable-installs.md
@@ -1,3 +1,4 @@
+(repeatability)=
 # Repeatable Installs
 
 pip can be used to achieve various levels of repeatable environments. This page


### PR DESCRIPTION
This reference is used on packaging.python.org. It was removed in #10913.

/cc @henryiii 