### PR TITLE
Replace usage of `distutils.utils.change_root` with copied-over logic

### DIFF
--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -1,4 +1,3 @@
-import distutils.util  # FIXME: For change_root.
 import logging
 import os
 import sys
@@ -9,7 +8,7 @@ from pip._internal.exceptions import InvalidSchemeCombination, UserInstallationI
 from pip._internal.models.scheme import SCHEME_KEYS, Scheme
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
-from .base import get_major_minor_version, is_osx_framework
+from .base import change_root, get_major_minor_version, is_osx_framework
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +193,7 @@ def get_scheme(
     )
     if root is not None:
         for key in SCHEME_KEYS:
-            value = distutils.util.change_root(root, getattr(scheme, key))
+            value = change_root(root, getattr(scheme, key))
             setattr(scheme, key, value)
     return scheme
 

--- a/src/pip/_internal/locations/base.py
+++ b/src/pip/_internal/locations/base.py
@@ -5,6 +5,7 @@ import sys
 import sysconfig
 import typing
 
+from pip._internal.exceptions import InstallationError
 from pip._internal.utils import appdirs
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
@@ -21,6 +22,34 @@ def get_major_minor_version() -> str:
     "3.7" or "3.10".
     """
     return "{}.{}".format(*sys.version_info)
+
+
+def change_root(new_root: str, pathname: str) -> str:
+    """Return 'pathname' with 'new_root' prepended.
+
+    If 'pathname' is relative, this is equivalent to os.path.join(new_root, pathname).
+    Otherwise, it requires making 'pathname' relative and then joining the
+    two, which is tricky on DOS/Windows and Mac OS.
+
+    This is borrowed from Python's standard library's distutils module.
+    """
+    if os.name == "posix":
+        if not os.path.isabs(pathname):
+            return os.path.join(new_root, pathname)
+        else:
+            return os.path.join(new_root, pathname[1:])
+
+    elif os.name == "nt":
+        (drive, path) = os.path.splitdrive(pathname)
+        if path[0] == "\\":
+            path = path[1:]
+        return os.path.join(new_root, path)
+
+    else:
+        raise InstallationError(
+            f"Unknown platform: {os.name}\n"
+            "Can not change root path prefix on unknown platform."
+        )
 
 
 def get_src_prefix() -> str:

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -3,11 +3,11 @@
 
 import logging
 import os
-from distutils.util import change_root
 from typing import List, Optional, Sequence
 
 from pip._internal.build_env import BuildEnvironment
 from pip._internal.exceptions import InstallationError, LegacyInstallFailure
+from pip._internal.locations.base import change_root
 from pip._internal.models.scheme import Scheme
 from pip._internal.utils.misc import ensure_dir
 from pip._internal.utils.setuptools_build import make_setuptools_install_args


### PR DESCRIPTION
This eliminates an import from distutils, by pulling in the relevant code
into pip itself.

Related to #11103 
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
