### PR TITLE
Replace `distutils.fancy_getopt` with `getopt`

### DIFF
--- a/src/pip/_internal/utils/distutils_args.py
+++ b/src/pip/_internal/utils/distutils_args.py
@@ -1,42 +1,43 @@
-from distutils.errors import DistutilsArgError
-from distutils.fancy_getopt import FancyGetopt
+from getopt import GetoptError, getopt
 from typing import Dict, List
 
 _options = [
-    ("exec-prefix=", None, ""),
-    ("home=", None, ""),
-    ("install-base=", None, ""),
-    ("install-data=", None, ""),
-    ("install-headers=", None, ""),
-    ("install-lib=", None, ""),
-    ("install-platlib=", None, ""),
-    ("install-purelib=", None, ""),
-    ("install-scripts=", None, ""),
-    ("prefix=", None, ""),
-    ("root=", None, ""),
-    ("user", None, ""),
+    "exec-prefix=",
+    "home=",
+    "install-base=",
+    "install-data=",
+    "install-headers=",
+    "install-lib=",
+    "install-platlib=",
+    "install-purelib=",
+    "install-scripts=",
+    "prefix=",
+    "root=",
+    "user",
 ]
 
 
-# typeshed doesn't permit Tuple[str, None, str], see python/typeshed#3469.
-_distutils_getopt = FancyGetopt(_options)  # type: ignore
-
-
 def parse_distutils_args(args: List[str]) -> Dict[str, str]:
-    """Parse provided arguments, returning an object that has the
-    matched arguments.
+    """Parse provided arguments, returning an object that has the matched arguments.
 
     Any unknown arguments are ignored.
     """
     result = {}
     for arg in args:
         try:
-            _, match = _distutils_getopt.getopt(args=[arg])
-        except DistutilsArgError:
+            parsed_opt, _ = getopt(args=[arg], shortopts="", longopts=_options)
+        except GetoptError:
             # We don't care about any other options, which here may be
             # considered unrecognized since our option list is not
             # exhaustive.
-            pass
-        else:
-            result.update(match.__dict__)
+            continue
+
+        if not parsed_opt:
+            continue
+
+        option = parsed_opt[0]
+        name_from_parsed = option[0][2:].replace("-", "_")
+        value_from_parsed = option[1] or "true"
+        result[name_from_parsed] = value_from_parsed
+
     return result

--- a/tests/unit/test_utils_distutils_args.py
+++ b/tests/unit/test_utils_distutils_args.py
@@ -60,4 +60,4 @@ def test_all_value_options_work(name: str, value: str) -> None:
 
 def test_user_option_works() -> None:
     result = parse_distutils_args(["--user"])
-    assert result["user"] == 1
+    assert result["user"]


### PR DESCRIPTION
This eliminates one location where distutils may be imported on
Python 3.12+, by replacing the logic with mostly equivalent logic.

Toward #11103 

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
