### PR TITLE
vcs(git): Remove redundant scheme for `git+ssh`

### DIFF
--- a/news/11208.trivial.rst
+++ b/news/11208.trivial.rst
@@ -1,0 +1,3 @@
+Remove redundant netloc schemes for ``git`` and ``git+ssh``.
+
+These have been part of cpython since `2.7 and 3.1 <https://github.com/python/cpython/commit/ead169d3114ed0f1041b5b59ca20293449608c50>`_.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -63,7 +63,6 @@ class Git(VersionControl):
     schemes = (
         "git+http",
         "git+https",
-        "git+ssh",
         "git+git",
         "git+file",
     )


### PR DESCRIPTION
This has been in cpython since 2.7 / 3.1.

See also:
- https://github.com/python/cpython/commit/ead169d3114ed0f1041b5b59ca20293449608c50
- https://bugs.python.org/issue8657 or
  https://github.com/python/cpython/issues/52903#issuecomment-1093501859

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
