### PR TITLE
Don't consider dist-info in a wheel as "installed"

### DIFF
--- a/news/11217.bugfix.rst
+++ b/news/11217.bugfix.rst
@@ -1,0 +1,4 @@
+Do not consider a ``.dist-info`` directory found inside a wheel-like zip file
+as metadata for an installed distribution. A package in a wheel is (by
+definition) not installed, and is not guaranteed to work due to how a wheel is
+structured.


### PR DESCRIPTION
This applies to the new importlib.metadata backend. The legacy pkg_resources backend already does this (albeit accidentally).

A package inside a wheel is not guaranteed to "work" when directly imported, so we should not treat it as an installed distribution.

This fixes #11183 on our side. Note that this new logic slightly differs from the pkg_resources implementation, which blindly ignores all entries with a `.whl` suffix, while we only ignore files that actually look like a valid wheel. This means that something named `pip.whl` will _not_ be ignored by this logic.