### PR TITLE
Check if sys.stdin is closed for interactive check

### DIFF
--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -583,7 +583,11 @@ def protect_pip_from_modification_on_windows(modifying_pip: bool) -> None:
 
 def is_console_interactive() -> bool:
     """Is this console interactive?"""
-    return sys.stdin is not None and not sys.stdin.closed and sys.stdin.isatty()
+    return (
+        sys.stdin is not None
+        and (not hasattr(sys.stdin, "closed") or not sys.stdin.closed)
+        and sys.stdin.isatty()
+    )
 
 
 def hash_file(path: str, blocksize: int = 1 << 20) -> Tuple[Any, int]:

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -583,7 +583,7 @@ def protect_pip_from_modification_on_windows(modifying_pip: bool) -> None:
 
 def is_console_interactive() -> bool:
     """Is this console interactive?"""
-    return sys.stdin is not None and sys.stdin.isatty()
+    return sys.stdin is not None and not sys.stdin.closed and sys.stdin.isatty()
 
 
 def hash_file(path: str, blocksize: int = 1 << 20) -> Tuple[Any, int]:


### PR DESCRIPTION
I'm seeing an issue with some benchmarking code that runs pip in a subprocess. The traceback has:

```
                 File "/home/msarahan/code/benchmarks/env/76391772e92136ec87b9940d70226329/lib/python3.8/site-packages/pip/_internal/utils/misc.py", line 586, in is_console_interactive
                   return sys.stdin is not None and sys.stdin.isatty()
               ValueError: I/O operation on closed file
```

With the proposed additional check, is_console_interactive returns the expected False value.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
