### PR TITLE
PipDeprecationWarning subclass DeprecationWarning

### DIFF
--- a/news/11225.feature.rst
+++ b/news/11225.feature.rst
@@ -1,0 +1,3 @@
+pip's deprecation warnings now suclass the built-in ``DeprecationWarning``, and
+can be suppressed by running the Python interpreter with
+``-W ignore::DeprecationWarning``.

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -13,7 +13,7 @@ from pip import __version__ as current_version  # NOTE: tests patch this name.
 DEPRECATION_MSG_PREFIX = "DEPRECATION: "
 
 
-class PipDeprecationWarning(Warning):
+class PipDeprecationWarning(DeprecationWarning):
     pass
 
 


### PR DESCRIPTION
This makes it easier for users to use Python’s -W flag to suppress deprecation warnings emitted by pip.

Close #11225. I’m not sure why this was not done in the first place—perhaps there were considerations I did not know.