### PR TITLE
Fix the coverage tracking nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -229,15 +229,23 @@ def vendoring(session: nox.Session) -> None:
 
 @nox.session
 def coverage(session: nox.Session) -> None:
-    if not os.path.exists("./.coverage-output"):
-        os.mkdir("./.coverage-output")
+    # Install source distribution
+    run_with_protected_pip(session, "install", ".")
+
+    # Install test dependencies
+    run_with_protected_pip(session, "install", "-r", REQUIREMENTS["tests"])
+
+    if not os.path.exists(".coverage-output"):
+        os.mkdir(".coverage-output")
     session.run(
         "pytest",
         "--cov=pip",
         "--cov-config=./setup.cfg",
+        *session.posargs,
         env={
             "COVERAGE_OUTPUT_DIR": "./.coverage-output",
-            "COVERAGE_PROCESS_START": "./setup.cfg",
+            "COVERAGE_PROCESS_START": os.fsdecode(Path("setup.cfg").resolve()),
+            "SETUPTOOLS_USE_DISTUTILS": "stdlib",
         },
     )
 


### PR DESCRIPTION
This session now correctly handles tracking coverage and running tests.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
