### PR TITLE
Remove `--use-deprecated=backtrack-on-build-failures`

### DIFF
--- a/news/11241.removal.rst
+++ b/news/11241.removal.rst
@@ -1,0 +1,1 @@
+Remove ``--use-deprecated=backtrack-on-build-failures``.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -1013,7 +1013,6 @@ use_deprecated_feature: Callable[..., Option] = partial(
     default=[],
     choices=[
         "legacy-resolver",
-        "backtrack-on-build-failures",
         "html5lib",
     ],
     help=("Enable deprecated functionality, that will be removed in the future."),

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -34,7 +34,6 @@ from pip._internal.req.req_file import parse_requirements
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.resolution.base import BaseResolver
 from pip._internal.self_outdated_check import pip_self_version_check
-from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.temp_dir import (
     TempDirectory,
     TempDirectoryTypeRegistry,
@@ -270,31 +269,6 @@ class RequirementCommand(IndexGroupCommand):
 
         return "2020-resolver"
 
-    @staticmethod
-    def determine_build_failure_suppression(options: Values) -> bool:
-        """Determines whether build failures should be suppressed and backtracked on."""
-        if "backtrack-on-build-failures" not in options.deprecated_features_enabled:
-            return False
-
-        if "legacy-resolver" in options.deprecated_features_enabled:
-            raise CommandError("Cannot backtrack with legacy resolver.")
-
-        deprecated(
-            reason=(
-                "Backtracking on build failures can mask issues related to how "
-                "a package generates metadata or builds a wheel. This flag will "
-                "be removed in pip 22.2."
-            ),
-            gone_in=None,
-            replacement=(
-                "avoiding known-bad versions by explicitly telling pip to ignore them "
-                "(either directly as requirements, or via a constraints file)"
-            ),
-            feature_flag=None,
-            issue=10655,
-        )
-        return True
-
     @classmethod
     def make_requirement_preparer(
         cls,
@@ -371,7 +345,6 @@ class RequirementCommand(IndexGroupCommand):
             use_pep517=use_pep517,
             config_settings=getattr(options, "config_settings", None),
         )
-        suppress_build_failures = cls.determine_build_failure_suppression(options)
         resolver_variant = cls.determine_resolver_variant(options)
         # The long import name and duplicated invocation is needed to convince
         # Mypy into correctly typechecking. Otherwise it would complain the
@@ -391,7 +364,6 @@ class RequirementCommand(IndexGroupCommand):
                 force_reinstall=force_reinstall,
                 upgrade_strategy=upgrade_strategy,
                 py_version_info=py_version_info,
-                suppress_build_failures=suppress_build_failures,
             )
         import pip._internal.resolution.legacy.resolver
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -27,7 +27,6 @@ from pip._internal.cache import CacheEntry, WheelCache
 from pip._internal.exceptions import (
     DistributionNotFound,
     InstallationError,
-    InstallationSubprocessError,
     MetadataInconsistent,
     UnsupportedPythonVersion,
     UnsupportedWheel,
@@ -97,7 +96,6 @@ class Factory:
         force_reinstall: bool,
         ignore_installed: bool,
         ignore_requires_python: bool,
-        suppress_build_failures: bool,
         py_version_info: Optional[Tuple[int, ...]] = None,
     ) -> None:
         self._finder = finder
@@ -108,7 +106,6 @@ class Factory:
         self._use_user_site = use_user_site
         self._force_reinstall = force_reinstall
         self._ignore_requires_python = ignore_requires_python
-        self._suppress_build_failures = suppress_build_failures
 
         self._build_failures: Cache[InstallationError] = {}
         self._link_candidate_cache: Cache[LinkCandidate] = {}
@@ -201,12 +198,6 @@ class Factory:
                     )
                     self._build_failures[link] = e
                     return None
-                except InstallationSubprocessError as e:
-                    if not self._suppress_build_failures:
-                        raise
-                    logger.warning("Discarding %s due to build failure: %s", link, e)
-                    self._build_failures[link] = e
-                    return None
 
             base: BaseCandidate = self._editable_candidate_cache[link]
         else:
@@ -226,12 +217,6 @@ class Factory:
                         e,
                         extra={"markup": True},
                     )
-                    self._build_failures[link] = e
-                    return None
-                except InstallationSubprocessError as e:
-                    if not self._suppress_build_failures:
-                        raise
-                    logger.warning("Discarding %s due to build failure: %s", link, e)
                     self._build_failures[link] = e
                     return None
             base = self._link_candidate_cache[link]

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -47,7 +47,6 @@ class Resolver(BaseResolver):
         ignore_requires_python: bool,
         force_reinstall: bool,
         upgrade_strategy: str,
-        suppress_build_failures: bool,
         py_version_info: Optional[Tuple[int, ...]] = None,
     ):
         super().__init__()
@@ -62,7 +61,6 @@ class Resolver(BaseResolver):
             force_reinstall=force_reinstall,
             ignore_installed=ignore_installed,
             ignore_requires_python=ignore_requires_python,
-            suppress_build_failures=suppress_build_failures,
             py_version_info=py_version_info,
         )
         self.ignore_dependencies = ignore_dependencies

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -2326,26 +2326,6 @@ def test_new_resolver_do_not_backtrack_on_build_failure(
     assert "egg_info" in result.stderr
 
 
-def test_new_resolver_flag_permits_backtracking_on_build_failure(
-    script: PipTestEnvironment,
-) -> None:
-    create_basic_sdist_for_package(script, "pkg1", "2.0", fails_egg_info=True)
-    create_basic_wheel_for_package(script, "pkg1", "1.0")
-
-    script.pip(
-        "install",
-        "--use-deprecated=backtrack-on-build-failures",
-        "--no-cache-dir",
-        "--no-index",
-        "--find-links",
-        script.scratch_path,
-        "pkg1",
-        allow_stderr_warning=True,
-    )
-
-    script.assert_installed(pkg1="1.0")
-
-
 def test_new_resolver_works_when_failing_package_builds_are_disallowed(
     script: PipTestEnvironment,
 ) -> None:

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -63,7 +63,6 @@ def factory(finder: PackageFinder, preparer: RequirementPreparer) -> Iterator[Fa
         force_reinstall=False,
         ignore_installed=False,
         ignore_requires_python=False,
-        suppress_build_failures=False,
         py_version_info=None,
     )
 

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -29,7 +29,6 @@ def resolver(preparer: RequirementPreparer, finder: PackageFinder) -> Resolver:
         ignore_requires_python=False,
         force_reinstall=False,
         upgrade_strategy="to-satisfy-only",
-        suppress_build_failures=False,
     )
     return resolver
 


### PR DESCRIPTION
This flag is due for removal in 22.2.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
