### PR TITLE
Add a nox session to build a zipapp version of pip

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -266,11 +266,11 @@ def coverage(session: nox.Session) -> None:
 
 
 @nox.session(name="make-zipapp")
-def make_zipapp(session: nox.Session):
+def make_zipapp(session: nox.Session) -> None:
 
-    with TemporaryDirectory() as tmp:
+    with TemporaryDirectory() as tmpdir:
         session.log("# Creating application code")
-        tmp = Path(tmp)
+        tmp = Path(tmpdir)
         (tmp / "__main__.py").write_text(ZIPAPP_MAIN, encoding="utf-8")
         lib = tmp / "lib"
         lib.mkdir()
@@ -278,11 +278,11 @@ def make_zipapp(session: nox.Session):
         session.log("# Installing pip into application")
         session.run("python", "-m", "pip", "install", "--target", str(lib), ".")
 
-        distinfo = list(lib.glob("*.dist-info"))
-        if len(distinfo) != 1:
+        distinfo_l = list(lib.glob("*.dist-info"))
+        if len(distinfo_l) != 1:
             session.error("Failed to install pip, no dist-info directory")
 
-        distinfo = distinfo[0]
+        distinfo = distinfo_l[0]
         distinfo_name = distinfo.name
         if not distinfo_name.startswith("pip-"):
             session.error(


### PR DESCRIPTION
Adds a simple nox session that builds a zipapp version of the current pip sources.

Things to do to make this into an actual zipapp distribution format:

- [ ] Add documentation, including a news entry.
- [ ] Integrate building the zipapp into the release process.
- [ ] Decide where we will distribute the zipapp and document how to upload it as part of a release.
- [ ] Publicise the new approach, noting that it's currently experimental and asking for feedback.