### PR TITLE
Load user config with existing `PIP_CONFIG_FILE`

### DIFF
--- a/news/10643.bugfix.rst
+++ b/news/10643.bugfix.rst
@@ -1,0 +1,1 @@
+Load user config file even with existing `PIP_CONFIG_FILE` (breaking).

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -337,9 +337,7 @@ class Configuration:
         yield kinds.GLOBAL, config_files[kinds.GLOBAL]
 
         # per-user configuration next
-        should_load_user_config = not self.isolated and not (
-            config_file and os.path.exists(config_file)
-        )
+        should_load_user_config = not self.isolated
         if should_load_user_config:
             # The legacy config file is overridden by the new config file
             yield kinds.USER, config_files[kinds.USER]


### PR DESCRIPTION
If `PIP_CONFIG_FILE` is set to an existing file, the user configuration
is currently not loaded. This commit changes this behavior, so that the
user configuration will be loaded either way.

This adheres to the [documentation](https://github.com/pypa/pip/blame/f66b3e8d0168990e35f981e77b6abe6a6974c4ee/docs/html/topics/configuration.md#L84-L105) and fixes #10643.

Implementing tests for this is currently not possible without more
monkey patching methods, which would have to allow us to load temporary
files for config files with fixed paths.

This is a breaking change if a user depends on the existence of
`PIP_CONFIG_FILE` leading to the user configuration file being skipped.