### PR TITLE
Speedup isolated environment creation

### DIFF
--- a/news/11257.feature.rst
+++ b/news/11257.feature.rst
@@ -1,0 +1,3 @@
+Significantly speed up isolated environment creation, by using the same
+sources for pip instead of creating a standalone installation for each
+environment.


### PR DESCRIPTION
Based on my tests, on an M1 MacBook Air, this improved `pip install ../furo --no-deps` from 12-13s to 8-9s. Both things were run interlaced, 4 times, ignoring the first run of each.

I imagine this translates to full test suite runs as well, but the numbers I have are skewed since doing a test run makes my laptop heat up, resulting in signficant-enough heat-related throttling that would skew the results.