### PR TITLE
Update unit tests for non-UTC windows environments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -659,15 +659,5 @@ def mock_server() -> Iterator[MockServer]:
 
 
 @pytest.fixture
-def utc() -> Iterator[None]:
-    # time.tzset() is not implemented on some platforms, e.g. Windows.
-    tzset = getattr(time, "tzset", lambda: None)
-    with patch.dict(os.environ, {"TZ": "UTC"}):
-        tzset()
-        yield
-    tzset()
-
-
-@pytest.fixture
 def proxy(request: pytest.FixtureRequest) -> str:
     return request.config.getoption("proxy")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ import re
 import shutil
 import subprocess
 import sys
-import time
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import (

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -16,7 +16,7 @@ from pip._internal.utils.temp_dir import TempDirectory
 
 
 @pytest.fixture
-def fixed_time(utc: None) -> Iterator[None]:
+def fixed_time() -> Iterator[None]:
     with patch("time.time", lambda: 1547704837.040001 + time.timezone):
         yield
 

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 from optparse import Values
 from pathlib import Path
 from typing import Callable, Iterator, List, NoReturn, Optional
@@ -16,7 +17,7 @@ from pip._internal.utils.temp_dir import TempDirectory
 
 @pytest.fixture
 def fixed_time(utc: None) -> Iterator[None]:
-    with patch("time.time", lambda: 1547704837.040001):
+    with patch("time.time", lambda: 1547704837.040001 + time.timezone):
         yield
 
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from threading import Thread
 from unittest.mock import patch
 
@@ -22,7 +23,7 @@ class TestIndentingFormatter:
         level_number = getattr(logging, level_name)
         attrs = dict(
             msg=msg,
-            created=1547704837.040001,
+            created=1547704837.040001 + time.timezone,
             msecs=40,
             levelname=level_name,
             levelno=level_number,

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -62,9 +62,7 @@ class TestIndentingFormatter:
             ),
         ],
     )
-    def test_format_with_timestamp(
-        self, level_name: str, expected: str
-    ) -> None:
+    def test_format_with_timestamp(self, level_name: str, expected: str) -> None:
         record = self.make_record("hello\nworld", level_name=level_name)
         f = IndentingFormatter(fmt="%(message)s", add_timestamp=True)
         assert f.format(record) == expected

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -42,7 +42,7 @@ class TestIndentingFormatter:
             ("CRITICAL", "ERROR: hello\nworld"),
         ],
     )
-    def test_format(self, level_name: str, expected: str, utc: None) -> None:
+    def test_format(self, level_name: str, expected: str) -> None:
         """
         Args:
           level_name: a logging level name (e.g. "WARNING").
@@ -63,7 +63,7 @@ class TestIndentingFormatter:
         ],
     )
     def test_format_with_timestamp(
-        self, level_name: str, expected: str, utc: None
+        self, level_name: str, expected: str
     ) -> None:
         record = self.make_record("hello\nworld", level_name=level_name)
         f = IndentingFormatter(fmt="%(message)s", add_timestamp=True)
@@ -77,7 +77,7 @@ class TestIndentingFormatter:
             ("CRITICAL", "DEPRECATION: hello\nworld"),
         ],
     )
-    def test_format_deprecated(self, level_name: str, expected: str, utc: None) -> None:
+    def test_format_deprecated(self, level_name: str, expected: str) -> None:
         """
         Test that logged deprecation warnings coming from deprecated()
         don't get another prefix.
@@ -89,7 +89,7 @@ class TestIndentingFormatter:
         f = IndentingFormatter(fmt="%(message)s")
         assert f.format(record) == expected
 
-    def test_thread_safety_base(self, utc: None) -> None:
+    def test_thread_safety_base(self) -> None:
         record = self.make_record(
             "DEPRECATION: hello\nworld",
             level_name="WARNING",
@@ -106,7 +106,7 @@ class TestIndentingFormatter:
         thread.join()
         assert results[0] == results[1]
 
-    def test_thread_safety_indent_log(self, utc: None) -> None:
+    def test_thread_safety_indent_log(self) -> None:
         record = self.make_record(
             "DEPRECATION: hello\nworld",
             level_name="WARNING",


### PR DESCRIPTION
Some of the unit tests seem to fail when run on some windows environments that are not configured with the UTC timezone. I believe this may be due to `time.tzset()` not being implemented in windows and so [this code does not get run in conftest.py](https://github.com/pypa/pip/blob/c0fb4bf1ad21d6f764085de132d25f834db1da90/tests/conftest.py#L661-L668) during the tests causing the time zone to not be updated.

I've tested this on two different machines, one running Windows 10 and the other running Windows 11. In both cases I used python 3.10, set the time zone to something other than UTC, and run the tests using nox (version 2022.1.7) with the following command: `nox -s test-3.10 -- -m unit -n auto`. This resulted the the following failing tests:
```
FAILED tests/unit/test_base_command.py::test_log_command_success - AssertionError: assert '2019-01-16T22:00:37,040 fa...
FAILED tests/unit/test_base_command.py::test_log_file_command_error - assert False
FAILED tests/unit/test_base_command.py::test_log_command_error - assert False
FAILED tests/unit/test_logging.py::TestIndentingFormatter::test_format_with_timestamp[INFO-2019-01-17T06:00:37,040 hello\n2019-01-17T06:00:37,040 world]
FAILED tests/unit/test_logging.py::TestIndentingFormatter::test_format_with_timestamp[WARNING-2019-01-17T06:00:37,040 WARNING: hello\n2019-01-17T06:00:37,040 world]
```

All tests seem to be failing due to the time stamp in the log file being wrong. For example, the error I get from `test_log_command_success` when my time zone is set to PST is:
```
>           assert f.read().rstrip() == "2019-01-17T06:00:37,040 fake"
E           AssertionError: assert '2019-01-16T22:00:37,040 fake' == '2019-01-17T06:00:37,040 fake'
E             - 2019-01-17T06:00:37,040 fake
E             ?          ^ ^^
E             + 2019-01-16T22:00:37,040 fake
E             ?          ^ ^^
```
Which is off by the 8 hour difference between PST and UTC. When I changed my system's time zone to UTC in both cases the tests then pass.

My proposed fix is to add the value `time.timezone` to the fixed time values in both `test_base_command.py` and `test_logging.py`. In the cases where the timezone was correctly set to UTC this value will be 0 and thus not change fixed time value. However, in the cases where the timezone was not correctly set to UTC this value will be non-zero and update the test's fixed time value to match the time as if it were in UTC.

fixes #10816 
closes #10834
closes #10835

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
