### PR TITLE
 Suggest disabling pip cache in containers

### DIFF
--- a/docs/html/topics/caching.md
+++ b/docs/html/topics/caching.md
@@ -140,6 +140,6 @@ The {ref}`pip cache` command can be used to manage pip's cache.
 
 pip's caching behaviour is disabled by passing the `--no-cache-dir` option.
 
-It is, however, recommended to **NOT** disable pip's caching. Doing so can
+It is, however, recommended to **NOT** disable pip's caching (except for building containerized appplications). Doing so can
 significantly slow down pip (due to repeated operations and package builds)
 and result in significantly more network usage.

--- a/docs/html/topics/caching.md
+++ b/docs/html/topics/caching.md
@@ -140,6 +140,6 @@ The {ref}`pip cache` command can be used to manage pip's cache.
 
 pip's caching behaviour is disabled by passing the `--no-cache-dir` option.
 
-It is, however, recommended to **NOT** disable pip's caching (except for building containerized appplications). Doing so can
+It is, however, recommended to **NOT** disable pip's caching unless you have caching at a higher level (eg: layered caches in container builds). Doing so can
 significantly slow down pip (due to repeated operations and package builds)
 and result in significantly more network usage.


### PR DESCRIPTION
When building containers (like docker or podman) the layer system already handles the caching.
Not disabling pip's cache could result in the duplication of the size of the images.

I know this sujbject is not specially relevant to the documentation, so the comment is fairly small.
Duplication of pip's cache is a recurrent problem in many Python images.
