### PR TITLE
Add /src explicitly to MYPY_PATH

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ per-file-ignores =
     tests/*: B011
 
 [mypy]
+mypy_path = $MYPY_CONFIG_FILE_DIR/src
 ignore_missing_imports = True
 disallow_untyped_defs = True
 disallow_any_generics = True


### PR DESCRIPTION
Newer versions of Mypy seems to prefer packages in the site-packages directory over those found in the project directory. This causes issues if Mypy is installed in an environment that has an older pip version present, e.g. pre-commit. Adding our pip into MYPY_PATH seems to fix
the issue.