### PR TITLE
Use installer instead of setuptools in test suite

### DIFF
--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -109,7 +109,7 @@ def test_local_columns_flag(simple_script: PipTestEnvironment) -> None:
     assert "Package" in result.stdout
     assert "Version" in result.stdout
     assert "simple (1.0)" not in result.stdout
-    assert "simple     1.0" in result.stdout, str(result)
+    assert "simple  1.0" in result.stdout, str(result)
 
 
 def test_multiple_exclude_and_normalization(

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 cryptography
 freezegun
+installer
 pytest
 pytest-cov
 pytest-rerunfailures


### PR DESCRIPTION
In the test suite, instead of using a private setuptools api to install common wheels in "editable" mode, use `installer` together with a `.pth`.

closes #11256