### PR TITLE
Use default setuptools behaviour in our tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -115,7 +115,6 @@ def test(session: nox.Session) -> None:
         *arguments,
         env={
             "LC_CTYPE": "en_US.UTF-8",
-            "SETUPTOOLS_USE_DISTUTILS": "stdlib",
         },
     )
 
@@ -245,7 +244,6 @@ def coverage(session: nox.Session) -> None:
         env={
             "COVERAGE_OUTPUT_DIR": "./.coverage-output",
             "COVERAGE_PROCESS_START": os.fsdecode(Path("setup.cfg").resolve()),
-            "SETUPTOOLS_USE_DISTUTILS": "stdlib",
         },
     )
 

--- a/src/pip/__pip-runner__.py
+++ b/src/pip/__pip-runner__.py
@@ -30,6 +30,7 @@ class PipImportRedirectingFinder:
         return spec
 
 
+# TODO https://github.com/pypa/pip/issues/11294
 sys.meta_path.insert(0, PipImportRedirectingFinder())
 
 assert __name__ == "__main__", "Cannot run __pip-runner__.py as a non-main module"


### PR DESCRIPTION
Our tests should pass without configuring setuptools in legacy mode.

Let us see if this reveals https://github.com/pypa/pip/issues/11294.

:see_no_evil: 