### PR TITLE
Remove the setuptools-provided distutils hack, if using distutils

### DIFF
--- a/news/11298.bugfix.rst
+++ b/news/11298.bugfix.rst
@@ -1,0 +1,4 @@
+Ensure that things work correctly in environments where setuptools-injected
+``distutils`` is available by default. This is done by cooperating with
+setuptools' injection logic to ensure that pip uses the ``distutils`` from the
+Python standard library instead.

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -3,6 +3,17 @@
 # The following comment should be removed at some point in the future.
 # mypy: strict-optional=False
 
+# If pip's going to use distutils, it should not be using the copy that setuptools
+# might have injected into the environment. This is done by removing the injected
+# shim, if it's injected.
+#
+# See https://github.com/pypa/pip/issues/8761 for the original discussion and
+# rationale for why this is done within pip.
+try:
+    __import__("_distutils_hack").remove_shim()
+except ImportError:
+    pass
+
 import logging
 import os
 import sys


### PR DESCRIPTION
This ensures that pip's imported copy of distutils comes from the
standard library, if/when the hack needs to be used.

Closes #11294 
Closes #8761