### PR TITLE
Fail if _distutils is imported on later Pythons

### DIFF
--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -21,6 +21,10 @@ from .base import get_major_minor_version
 logger = logging.getLogger(__name__)
 
 
+# This module should never be invoked on Python 3.10 or later
+assert sys.version_info < (3, 10)
+
+
 def distutils_scheme(
     dist_name: str,
     user: bool = False,

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 # This module should never be invoked on Python 3.10 or later
-assert sys.version_info < (3, 10)
+assert sys.version_info < (3, 10) or __import__("typing").TYPE_CHECKING
 
 
 def distutils_scheme(


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
