### PR TITLE
Clarify pip cache output

### DIFF
--- a/news/11300.bugfix.rst
+++ b/news/11300.bugfix.rst
@@ -1,0 +1,1 @@
+Clarify that ``pip cache``'s wheels-related output is about locally built wheels only.

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -105,9 +105,9 @@ class CacheCommand(Command):
                     Package index page cache location: {http_cache_location}
                     Package index page cache size: {http_cache_size}
                     Number of HTTP files: {num_http_files}
-                    Wheels location: {wheels_cache_location}
-                    Wheels size: {wheels_cache_size}
-                    Number of wheels: {package_count}
+                    Built wheels location: {wheels_cache_location}
+                    Built wheels size: {wheels_cache_size}
+                    Number of built wheels: {package_count}
                 """
             )
             .format(
@@ -140,7 +140,7 @@ class CacheCommand(Command):
 
     def format_for_human(self, files: List[str]) -> None:
         if not files:
-            logger.info("Nothing cached.")
+            logger.info("No locally built wheels cached.")
             return
 
         results = []

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -105,9 +105,9 @@ class CacheCommand(Command):
                     Package index page cache location: {http_cache_location}
                     Package index page cache size: {http_cache_size}
                     Number of HTTP files: {num_http_files}
-                    Built wheels location: {wheels_cache_location}
-                    Built wheels size: {wheels_cache_size}
-                    Number of built wheels: {package_count}
+                    Locally built wheels location: {wheels_cache_location}
+                    Locally built wheels size: {wheels_cache_size}
+                    Number of locally built wheels: {package_count}
                 """
             )
             .format(

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -210,9 +210,9 @@ def test_cache_info(
     result = script.pip("cache", "info")
 
     assert f"Package index page cache location: {http_cache_dir}" in result.stdout
-    assert f"Wheels location: {wheel_cache_dir}" in result.stdout
+    assert f"Built wheels location: {wheel_cache_dir}" in result.stdout
     num_wheels = len(wheel_cache_files)
-    assert f"Number of wheels: {num_wheels}" in result.stdout
+    assert f"Number of built wheels: {num_wheels}" in result.stdout
 
 
 @pytest.mark.usefixtures("populate_wheel_cache")
@@ -242,9 +242,9 @@ def test_cache_list_abspath(script: PipTestEnvironment) -> None:
 @pytest.mark.usefixtures("empty_wheel_cache")
 def test_cache_list_with_empty_cache(script: PipTestEnvironment) -> None:
     """Running `pip cache list` with an empty cache should print
-    "Nothing cached." and exit."""
+    "No locally built wheels cached." and exit."""
     result = script.pip("cache", "list")
-    assert result.stdout == "Nothing cached.\n"
+    assert result.stdout == "No locally built wheels cached.\n"
 
 
 @pytest.mark.usefixtures("empty_wheel_cache")

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -210,9 +210,9 @@ def test_cache_info(
     result = script.pip("cache", "info")
 
     assert f"Package index page cache location: {http_cache_dir}" in result.stdout
-    assert f"Built wheels location: {wheel_cache_dir}" in result.stdout
+    assert f"Locally built wheels location: {wheel_cache_dir}" in result.stdout
     num_wheels = len(wheel_cache_files)
-    assert f"Number of built wheels: {num_wheels}" in result.stdout
+    assert f"Number of locally built wheels: {num_wheels}" in result.stdout
 
 
 @pytest.mark.usefixtures("populate_wheel_cache")


### PR DESCRIPTION
pip cache reported 'Nothing cached' and 'Number of wheels: 0' even when things were
obviously cached. The reason, as per @uranusjr's comment is

1. If a wheel is downloaded (from a secure source), pip uses the network layer
   cache (provided by a requests extension implemented with cachecontrol) in
   ${CACHE_DIR}/http.
2. If a wheel is built from source, pip caches it separately in ${CACHE_DIR}/wheels.
3. The pip cache list command is currently only capable of showing entries in
   the wheel cache, not the network cache.

The solution is to clarify what `pip cache` is reporting about.

Fixes #11300