### PR TITLE
Format project_url in pip inspect as dict

### DIFF
--- a/news/11305.feature.rst
+++ b/news/11305.feature.rst
@@ -1,0 +1,1 @@
+Format ``project_url`` in ``pip inspect`` as dict 

--- a/src/pip/_internal/commands/inspect.py
+++ b/src/pip/_internal/commands/inspect.py
@@ -94,4 +94,11 @@ class InspectCommand(Command):
         # requested
         if dist.installed_with_dist_info:
             res["requested"] = dist.requested
+        # convert project_url to dict
+        if "project_url" in res["metadata"]:
+            project_url_dict = {}
+            for i in res["metadata"]["project_url"]:
+                name, url = i.split(", ", 1)
+                project_url_dict[name] = url
+            res["metadata"]["project_url"] = project_url_dict
         return res


### PR DESCRIPTION
This makes it easier to parse. `pip inspect` currently shows a message, that the output may change, so I guess this is allowed.
