### PR TITLE
create_basic_sdist_for_package: simplify parameters

### DIFF
--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -2307,10 +2307,19 @@ def test_new_resolver_respect_user_requested_if_extra_is_installed(
     script.assert_installed(pkg3="1.0", pkg2="2.0", pkg1="1.0")
 
 
+FAIL_EGG_INFO = """\
+import sys
+if "egg_info" in sys.argv:
+    raise Exception("Simulated failure for generating metadata.")
+"""
+
+
 def test_new_resolver_do_not_backtrack_on_build_failure(
     script: PipTestEnvironment,
 ) -> None:
-    create_basic_sdist_for_package(script, "pkg1", "2.0", fails_egg_info=True)
+    create_basic_sdist_for_package(
+        script, "pkg1", "2.0", setup_py_prelude=FAIL_EGG_INFO
+    )
     create_basic_wheel_for_package(script, "pkg1", "1.0")
 
     result = script.pip(
@@ -2330,7 +2339,9 @@ def test_new_resolver_works_when_failing_package_builds_are_disallowed(
     script: PipTestEnvironment,
 ) -> None:
     create_basic_wheel_for_package(script, "pkg2", "1.0", depends=["pkg1"])
-    create_basic_sdist_for_package(script, "pkg1", "2.0", fails_egg_info=True)
+    create_basic_sdist_for_package(
+        script, "pkg1", "2.0", setup_py_prelude=FAIL_EGG_INFO
+    )
     create_basic_wheel_for_package(script, "pkg1", "1.0")
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text("pkg1 != 2.0")

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1218,27 +1218,15 @@ def create_basic_sdist_for_package(
     version: str,
     extra_files: Optional[Dict[str, str]] = None,
     *,
-    fails_egg_info: bool = False,
-    fails_bdist_wheel: bool = False,
     depends: Optional[List[str]] = None,
     setup_py_prelude: str = "",
 ) -> pathlib.Path:
     files = {
         "setup.py": textwrap.dedent(
             """\
-            import sys
             from setuptools import find_packages, setup
 
             {setup_py_prelude}
-
-            fails_bdist_wheel = {fails_bdist_wheel!r}
-            fails_egg_info = {fails_egg_info!r}
-
-            if fails_egg_info and "egg_info" in sys.argv:
-                raise Exception("Simulated failure for generating metadata.")
-
-            if fails_bdist_wheel and "bdist_wheel" in sys.argv:
-                raise Exception("Simulated failure for building a wheel.")
 
             setup(name={name!r}, version={version!r},
                 install_requires={depends!r})
@@ -1248,8 +1236,6 @@ def create_basic_sdist_for_package(
             version=version,
             depends=depends or [],
             setup_py_prelude=setup_py_prelude,
-            fails_bdist_wheel=fails_bdist_wheel,
-            fails_egg_info=fails_egg_info,
         ),
     }
 


### PR DESCRIPTION
`fails_egg_info` and `fails_bdist_wheel` are just more specific versions of `setup_py_prelude`, and `fails_bdist_wheel` isn't even used anywhere. Remove them, and replace the usages of `fails_egg_info` with `setup_py_prelude` and an equivalent prelude.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
