### PR TITLE
Ensure that removing shim in older setuptools does not error

### DIFF
--- a/news/11314.bugfix.rst
+++ b/news/11314.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid  ``AttributeError`` when removing the setuptools-provided ``_distutils_hack`` and it is missing its implementation.

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -11,7 +11,7 @@
 # rationale for why this is done within pip.
 try:
     __import__("_distutils_hack").remove_shim()
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 import logging


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Addresses https://github.com/pypa/pip/issues/11314