### PR TITLE
Add note to divert away from adding content to user guide

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -2,6 +2,15 @@
 User Guide
 ==========
 
+.. Hello there!
+
+   If you're thinking of adding content to this page... please take a moment
+   to consider if this content can live on its own, within a topic guide or a
+   reference page.
+
+   There is active effort being put toward *reducing* the amount of content on
+   this specific page (https://github.com/pypa/pip/issues/9475) and moving it
+   into more focused single-page documents that cover that specific topic.
 
 Running pip
 ===========


### PR DESCRIPTION
This guide is being broken up, and multiple folks have now tried to add content to it instead of adding dedicated pages for it.

This note should help direct contributors away from adding more content on this page, to stop the bleeding and avoid regressing on the amount of content we'll have to move out of this page later.

Related to #9475, in that it is meant to stop the bleeding since we're adding new contents to the pages that we're also trying to remove content from. :)