### PR TITLE
Fixed where compiled python files point to with prefix

### DIFF
--- a/news/11317.bugfix.rst
+++ b/news/11317.bugfix.rst
@@ -1,0 +1,3 @@
+This bug fix changes the where the compiled python files in
+a wheel to the prefix that is passed or the default prefix
+that is passed to the wheel.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -434,6 +434,7 @@ def _install_wheel(
     warn_script_location: bool = True,
     direct_url: Optional[DirectUrl] = None,
     requested: bool = False,
+    prefix: str = None,
 ) -> None:
     """Install a wheel.
 
@@ -610,7 +611,17 @@ def _install_wheel(
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore")
                 for path in pyc_source_file_paths():
-                    success = compileall.compile_file(path, force=True, quiet=True)
+                    ddir = prefix
+                    if ddir is not None:
+                        ddir = os.path.join(
+                            prefix, os.path.dirname(path[len(scheme.data) + 1 :])
+                        )
+                    success = compileall.compile_file(
+                        path,
+                        force=True,
+                        quiet=True,
+                        ddir=ddir,
+                    )
                     if success:
                         pyc_path = pyc_output_path(path)
                         assert os.path.exists(pyc_path)
@@ -721,6 +732,7 @@ def install_wheel(
     warn_script_location: bool = True,
     direct_url: Optional[DirectUrl] = None,
     requested: bool = False,
+    prefix: str = None,
 ) -> None:
     with ZipFile(wheel_path, allowZip64=True) as z:
         with req_error_context(req_description):
@@ -733,4 +745,5 @@ def install_wheel(
                 warn_script_location=warn_script_location,
                 direct_url=direct_url,
                 requested=requested,
+                prefix=prefix,
             )

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -41,10 +41,7 @@ from pip._vendor.distlib.util import get_export_entry
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import InstallationError
-from pip._internal.locations import ( 
-    get_major_minor_version,
-    get_scheme,
-)
+from pip._internal.locations import get_major_minor_version, get_scheme
 from pip._internal.metadata import (
     BaseDistribution,
     FilesystemWheel,
@@ -623,7 +620,7 @@ def _install_wheel(
                                 os.path.dirname(path[len(scheme.data) + 1 :]),
                             )
                         else:
-                            ddir = os.path.join(path[path.find(prefix):])
+                            ddir = os.path.join(path[path.find(prefix) :])
                     success = compileall.compile_file(
                         path,
                         force=True,

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -41,7 +41,7 @@ from pip._vendor.distlib.util import get_export_entry
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import InstallationError
-from pip._internal.locations import get_major_minor_version, get_scheme
+from pip._internal.locations import get_major_minor_version
 from pip._internal.metadata import (
     BaseDistribution,
     FilesystemWheel,

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -434,7 +434,7 @@ def _install_wheel(
     warn_script_location: bool = True,
     direct_url: Optional[DirectUrl] = None,
     requested: bool = False,
-    prefix: str = None,
+    prefix: Optional[str] = None,
 ) -> None:
     """Install a wheel.
 
@@ -614,7 +614,8 @@ def _install_wheel(
                     ddir = prefix
                     if ddir is not None:
                         ddir = os.path.join(
-                            prefix, os.path.dirname(path[len(scheme.data) + 1 :])
+                            cast(str, prefix),
+                            os.path.dirname(path[len(scheme.data) + 1 :]),
                         )
                     success = compileall.compile_file(
                         path,
@@ -732,7 +733,7 @@ def install_wheel(
     warn_script_location: bool = True,
     direct_url: Optional[DirectUrl] = None,
     requested: bool = False,
-    prefix: str = None,
+    prefix: Optional[str] = None,
 ) -> None:
     with ZipFile(wheel_path, allowZip64=True) as z:
         with req_error_context(req_description):

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -796,6 +796,7 @@ class InstallRequirement:
                 warn_script_location=warn_script_location,
                 direct_url=direct_url,
                 requested=self.user_supplied,
+                prefix=prefix,
             )
             self.install_succeeded = True
             return


### PR DESCRIPTION
Fixes #11317 

I have edited where compiled python files point to where the prefix is.

I am unsure about whether this is actually how things should be done. I feel if you installed an isolated wheel you could easily just install it properly.

```
pip install openqasm-pygments --isolated --root=/tmp/openqasm-pygments --prefix=/usr/local --ignore-installed --no-deps
```

So reading a `.pyc` file it points to the `.py` file in root dir. I assume this is probably the correct solution but have gone ahead and made a simple change to `wheel.py`

I am making this a draft PR to see what people think.