### PR TITLE
Do not parse JSON content with HTML parser

### DIFF
--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -345,6 +345,7 @@ def parse_links(page: "IndexContent") -> Iterable[Link]:
                 yanked_reason=yanked_reason,
                 hashes=file.get("hashes", {}),
             )
+        return
 
     parser = HTMLLinkParser(page.url)
     encoding = page.encoding or "utf-8"


### PR DESCRIPTION
PEP 691 support

I do think that parsing JSON content with the HTMLParser is slowing down for no reason.

(My gut feeling is that this would not need a towncrier news item.)