### PR TITLE
fix forgotten rename

### DIFF
--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -448,7 +448,7 @@ def _get_index_content(
 ) -> Optional["IndexContent"]:
     if session is None:
         raise TypeError(
-            "_get_html_page() missing 1 required keyword argument: 'session'"
+            "_get_index_content() missing 1 required keyword argument: 'session'"
         )
 
     url = link.url.split("#", 1)[0]


### PR DESCRIPTION
Forgotten when renamed from ``_get_html_page`` to ``_get_index_content``

@sbidoul Would you add the ``skip news`` label ?
