### PR TITLE
Add a version check to __pip-runner__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,5 +81,7 @@ setup(
         ],
     },
     zip_safe=False,
+    # NOTE: python_requires is duplicated in __pip-runner__.py.
+    # When changing this value, please change the other copy as well.
     python_requires=">=3.7",
 )

--- a/src/pip/__pip-runner__.py
+++ b/src/pip/__pip-runner__.py
@@ -4,24 +4,38 @@ This file is named as it is, to ensure that this module can't be imported via
 an import statement.
 """
 
-import runpy
+# /!\ This version compatibility check section must be Python 2 compatible. /!\
+
 import sys
-import types
-from importlib.machinery import ModuleSpec, PathFinder
-from os.path import dirname
-from typing import Optional, Sequence, Union
+
+# Copied from setup.py
+PYTHON_REQUIRES = (3, 7)
+
+
+def version_str(version):  # type: ignore
+    return ".".join(str(v) for v in version)
+
+
+if sys.version_info[:2] < PYTHON_REQUIRES:
+    raise SystemExit(
+        "This version of pip does not support python {} (requires >={}).".format(
+            version_str(sys.version_info[:2]), version_str(PYTHON_REQUIRES)
+        )
+    )
+
+# From here on, we can use Python 3 features, but the syntax must remain
+# Python 2 compatible.
+
+import runpy  # noqa: E402
+from importlib.machinery import PathFinder  # noqa: E402
+from os.path import dirname  # noqa: E402
 
 PIP_SOURCES_ROOT = dirname(dirname(__file__))
 
 
 class PipImportRedirectingFinder:
     @classmethod
-    def find_spec(
-        self,
-        fullname: str,
-        path: Optional[Sequence[Union[bytes, str]]] = None,
-        target: Optional[types.ModuleType] = None,
-    ) -> Optional[ModuleSpec]:
+    def find_spec(self, fullname, path=None, target=None):  # type: ignore
         if fullname != "pip":
             return None
 


### PR DESCRIPTION
This adds a check to the "pip runner" script to ensure that it is being run by a supported version of Python. This is not needed for the "isolated build" use case, as we always know which Python version is running the script in that case. But now that the script is also being used for the `--python` option, this makes the error handling a bit more robust if an unsupported python version is supplied.

Note that in order to avoid an ugly backtrace, this change now requires `__pip-runner__.py` to conform to Python 2 compatible syntax (although Python 3 features may be used once the version check is complete).

I'm not sure if it's worth adding tests (we don't currently have tests that explicitly target this file).