### PR TITLE
Deprecate --install-options

### DIFF
--- a/news/11358.removal.rst
+++ b/news/11358.removal.rst
@@ -1,0 +1,2 @@
+Deprecate ``--install-options`` which forces pip to use the deprecated ``install``
+command of ``setuptools``.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -59,31 +59,6 @@ def make_option_group(group: Dict[str, Any], parser: ConfigOptionParser) -> Opti
     return option_group
 
 
-def check_install_build_global(
-    options: Values, check_options: Optional[Values] = None
-) -> None:
-    """Disable wheels if per-setup.py call options are set.
-
-    :param options: The OptionParser options to update.
-    :param check_options: The options to check, if not supplied defaults to
-        options.
-    """
-    if check_options is None:
-        check_options = options
-
-    def getname(n: str) -> Optional[Any]:
-        return getattr(check_options, n, None)
-
-    names = ["build_options", "global_options", "install_options"]
-    if any(map(getname, names)):
-        control = options.format_control
-        control.disallow_binaries()
-        logger.warning(
-            "Disabling all use of wheels due to the use of --build-option "
-            "/ --global-option / --install-option.",
-        )
-
-
 def check_dist_restriction(options: Values, check_target: bool = False) -> None:
     """Function for determining if custom platform options are allowed.
 

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -8,6 +8,10 @@ from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.req_command import RequirementCommand, with_cleanup
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.operations.build.build_tracker import get_build_tracker
+from pip._internal.req.req_install import (
+    LegacySetupPyOptionsCheckMode,
+    check_legacy_setup_py_options,
+)
 from pip._internal.utils.misc import ensure_dir, normalize_path, write_output
 from pip._internal.utils.temp_dir import TempDirectory
 
@@ -105,6 +109,9 @@ class DownloadCommand(RequirementCommand):
         )
 
         reqs = self.get_requirements(args, options, finder, session)
+        check_legacy_setup_py_options(
+            options, reqs, LegacySetupPyOptionsCheckMode.DOWNLOAD
+        )
 
         preparer = self.make_requirement_preparer(
             temp_build_dir=directory,

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -452,7 +452,7 @@ class InstallCommand(RequirementCommand):
                 wheel_cache=wheel_cache,
                 verify=True,
                 build_options=[],
-                global_options=[],
+                global_options=global_options,
             )
 
             # If we're using PEP 517, we cannot do a legacy setup.py install

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -27,7 +27,11 @@ from pip._internal.models.installation_report import InstallationReport
 from pip._internal.operations.build.build_tracker import get_build_tracker
 from pip._internal.operations.check import ConflictDetails, check_install_conflicts
 from pip._internal.req import install_given_reqs
-from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.req_install import (
+    InstallRequirement,
+    LegacySetupPyOptionsCheckMode,
+    check_legacy_setup_py_options,
+)
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.deprecation import (
     LegacyInstallReasonFailedBdistWheel,
@@ -280,7 +284,6 @@ class InstallCommand(RequirementCommand):
         if options.use_user_site and options.target_dir is not None:
             raise CommandError("Can not combine '--user' and '--target'")
 
-        cmdoptions.check_install_build_global(options)
         upgrade_strategy = "to-satisfy-only"
         if options.upgrade:
             upgrade_strategy = options.upgrade_strategy
@@ -339,6 +342,9 @@ class InstallCommand(RequirementCommand):
 
         try:
             reqs = self.get_requirements(args, options, finder, session)
+            check_legacy_setup_py_options(
+                options, reqs, LegacySetupPyOptionsCheckMode.INSTALL
+            )
 
             if "no-binary-enable-wheel-cache" in options.features_enabled:
                 # TODO: remove format_control from WheelCache when the deprecation cycle

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -10,7 +10,11 @@ from pip._internal.cli.req_command import RequirementCommand, with_cleanup
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.exceptions import CommandError
 from pip._internal.operations.build.build_tracker import get_build_tracker
-from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.req_install import (
+    InstallRequirement,
+    LegacySetupPyOptionsCheckMode,
+    check_legacy_setup_py_options,
+)
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.misc import ensure_dir, normalize_path
 from pip._internal.utils.temp_dir import TempDirectory
@@ -101,8 +105,6 @@ class WheelCommand(RequirementCommand):
 
     @with_cleanup
     def run(self, options: Values, args: List[str]) -> int:
-        cmdoptions.check_install_build_global(options)
-
         session = self.get_default_session(options)
 
         finder = self._build_package_finder(options, session)
@@ -120,6 +122,9 @@ class WheelCommand(RequirementCommand):
         )
 
         reqs = self.get_requirements(args, options, finder, session)
+        check_legacy_setup_py_options(
+            options, reqs, LegacySetupPyOptionsCheckMode.WHEEL
+        )
 
         if "no-binary-enable-wheel-cache" in options.features_enabled:
             # TODO: remove format_control from WheelCache when the deprecation cycle

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -186,10 +186,6 @@ def handle_requirement_line(
             constraint=line.constraint,
         )
     else:
-        if options:
-            # Disable wheels if the user has specified build options
-            cmdoptions.check_install_build_global(options, line.opts)
-
         # get the options that apply to requirements
         req_options = {}
         for dest in SUPPORTED_OPTIONS_REQ_DEST:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -8,6 +8,8 @@ import shutil
 import sys
 import uuid
 import zipfile
+from enum import Enum
+from optparse import Values
 from typing import Any, Collection, Dict, Iterable, List, Optional, Sequence, Union
 
 from pip._vendor.packaging.markers import Marker
@@ -876,3 +878,51 @@ def check_invalid_constraint_type(req: InstallRequirement) -> str:
         )
 
     return problem
+
+
+def _has_option(options: Values, reqs: List[InstallRequirement], option: str) -> bool:
+    if getattr(options, option, None):
+        return True
+    for req in reqs:
+        if getattr(req, option, None):
+            return True
+    return False
+
+
+class LegacySetupPyOptionsCheckMode(Enum):
+    INSTALL = 1
+    WHEEL = 2
+    DOWNLOAD = 3
+
+
+def check_legacy_setup_py_options(
+    options: Values,
+    reqs: List[InstallRequirement],
+    mode: LegacySetupPyOptionsCheckMode,
+) -> None:
+    has_install_options = _has_option(options, reqs, "install_options")
+    has_build_options = _has_option(options, reqs, "build_options")
+    has_global_options = _has_option(options, reqs, "global_options")
+    legacy_setup_py_options_present = (
+        has_install_options or has_build_options or has_global_options
+    )
+    if not legacy_setup_py_options_present:
+        return
+
+    options.format_control.disallow_binaries()
+    logger.warning(
+        "Implying --no-binary=:all: due to the presence of "
+        "--build-option / --global-option / --install-option. "
+        "Consider using --config-settings for more flexibility.",
+    )
+    if mode == LegacySetupPyOptionsCheckMode.INSTALL and has_install_options:
+        deprecated(
+            reason=(
+                "--install-option is deprecated because "
+                "it forces pip to use the 'setup.py install' "
+                "command which is itself deprecated."
+            ),
+            issue=11358,
+            replacement="to use --config-settings",
+            gone_in="23.1",
+        )

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -842,6 +842,8 @@ def test_install_global_option(script: PipTestEnvironment) -> None:
     )
     assert "INITools==0.1\n" in result.stdout
     assert not result.files_created
+    assert "Implying --no-binary=:all:" in result.stderr
+    assert "Consider using --config-settings" in result.stderr
 
 
 def test_install_with_hacked_egg_info(

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -342,7 +342,7 @@ def test_install_option_in_requirements_file_overrides_cli(
     reqs_file = script.scratch_path.joinpath("reqs.txt")
     reqs_file.write_text("simple --install-option='-O0'")
 
-    script.pip(
+    result = script.pip(
         "install",
         "--no-index",
         "-f",
@@ -355,6 +355,9 @@ def test_install_option_in_requirements_file_overrides_cli(
     simple_args = simple_sdist.args()
     assert "install" in simple_args
     assert simple_args.index("-O1") < simple_args.index("-O0")
+    assert "Implying --no-binary=:all:" in result.stderr
+    assert "Consider using --config-settings" in result.stderr
+    assert "--install-option is deprecated" in result.stderr
 
 
 def test_constraints_not_installed_by_default(

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -881,5 +881,3 @@ class TestParseRequirements:
                 < args.index("install")
                 < args.index(install_option)
             )
-        assert options.format_control.no_binary == {":all:"}
-        assert options.format_control.only_binary == set()


### PR DESCRIPTION
Towards #8102 and #11358.

This PR does the following:

- It deprecates `--install-options`.
- It refactors `check_install_build_global` into `check_legacy_setup_py_options` that is called after parsing the requirements from CLI options and req files. This allows us to reason about these options in the context of the command for which they are used, and also avoids a side effect (`disallow_binaries`) in the req file parser
- It clarifies the WARNING message `Disabling all use of wheels due to the use of --build-option / --global-option / --install-option.` into `Implying --no-binary=:all: due to the presence of --build-option / --global-option / --install-option. Consider using --config-settings for more flexibility.`. This is clearer and will help understanding when we disentangle `--no-binary`. Fixes #8406.

TODO

- [x] tests
