### PR TITLE
Use --no-implicit-optional for type checking

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ ignore_missing_imports = True
 disallow_untyped_defs = True
 disallow_any_generics = True
 warn_unused_ignores = True
+no_implicit_optional = True
 
 [mypy-pip._vendor.*]
 ignore_errors = True

--- a/src/pip/_internal/cli/spinners.py
+++ b/src/pip/_internal/cli/spinners.py
@@ -3,7 +3,7 @@ import itertools
 import logging
 import sys
 import time
-from typing import IO, Generator
+from typing import IO, Generator, Optional
 
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.logging import get_indentation
@@ -23,7 +23,7 @@ class InteractiveSpinner(SpinnerInterface):
     def __init__(
         self,
         message: str,
-        file: IO[str] = None,
+        file: Optional[IO[str]] = None,
         spin_chars: str = "-\\|/",
         # Empirically, 8 updates/second looks nice
         min_update_interval_seconds: float = 0.125,

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -288,7 +288,10 @@ class NetworkConnectionError(PipError):
     """HTTP connection error"""
 
     def __init__(
-        self, error_msg: str, response: Response = None, request: Request = None
+        self,
+        error_msg: str,
+        response: Optional[Response] = None,
+        request: Optional[Request] = None,
     ) -> None:
         """
         Initialize NetworkConnectionError with  `request` and `response`

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -35,10 +35,10 @@ logger = logging.getLogger(__name__)
 def distutils_scheme(
     dist_name: str,
     user: bool = False,
-    home: str = None,
-    root: str = None,
+    home: Optional[str] = None,
+    root: Optional[str] = None,
     isolated: bool = False,
-    prefix: str = None,
+    prefix: Optional[str] = None,
     *,
     ignore_config_files: bool = False,
 ) -> Dict[str, str]:

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -420,7 +420,9 @@ def _raise_for_invalid_entrypoint(specification: str) -> None:
 
 
 class PipScriptMaker(ScriptMaker):
-    def make(self, specification: str, options: Dict[str, Any] = None) -> List[str]:
+    def make(
+        self, specification: str, options: Optional[Dict[str, Any]] = None
+    ) -> List[str]:
         _raise_for_invalid_entrypoint(specification)
         return super().make(specification, options)
 

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -28,7 +28,7 @@ class Hashes:
 
     """
 
-    def __init__(self, hashes: Dict[str, List[str]] = None) -> None:
+    def __init__(self, hashes: Optional[Dict[str, List[str]]] = None) -> None:
         """
         :param hashes: A dict of algorithm names pointing to lists of allowed
             hex digests

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import TYPE_CHECKING, BinaryIO, Dict, Iterable, List
+from typing import TYPE_CHECKING, BinaryIO, Dict, Iterable, List, Optional
 
 from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError
 from pip._internal.utils.misc import read_chunks

--- a/src/pip/_internal/utils/setuptools_build.py
+++ b/src/pip/_internal/utils/setuptools_build.py
@@ -48,7 +48,7 @@ _SETUPTOOLS_SHIM = textwrap.dedent(
 
 def make_setuptools_shim_args(
     setup_py_path: str,
-    global_options: Sequence[str] = None,
+    global_options: Optional[Sequence[str]] = None,
     no_user_config: bool = False,
     unbuffered_output: bool = False,
 ) -> List[str]:

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -184,7 +184,7 @@ class Subversion(VersionControl):
         """Always assume the versions don't match"""
         return False
 
-    def __init__(self, use_interactive: bool = None) -> None:
+    def __init__(self, use_interactive: Optional[bool] = None) -> None:
         if use_interactive is None:
             use_interactive = is_console_interactive()
         self.use_interactive = use_interactive

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1168,7 +1168,7 @@ def create_basic_wheel_for_package(
     name: str,
     version: str,
     depends: Optional[List[str]] = None,
-    extras: Dict[str, List[str]] = None,
+    extras: Optional[Dict[str, List[str]]] = None,
     requires_python: Optional[str] = None,
     extra_files: Optional[Dict[str, Union[bytes, str]]] = None,
 ) -> pathlib.Path:

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -60,8 +60,8 @@ def options(session: PipSession) -> mock.Mock:
 def parse_reqfile(
     filename: Union[Path, str],
     session: PipSession,
-    finder: PackageFinder = None,
-    options: Values = None,
+    finder: Optional[PackageFinder] = None,
+    options: Optional[Values] = None,
     constraint: bool = False,
     isolated: bool = False,
 ) -> Iterator[InstallRequirement]:


### PR DESCRIPTION
This makes type checking PEP 484 compliant (as of 2018).
mypy will change its defaults soon.

See:
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401