### PR TITLE
removed --install-scripts flag

### DIFF
--- a/news/10265.doc.rst
+++ b/news/10265.doc.rst
@@ -1,0 +1,1 @@
+removed --install-scripts flag from pip/src/pip/_internal/cli/cmdoptions.py

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -844,18 +844,6 @@ config_settings: Callable[..., Option] = partial(
     "to pass multiple keys to the backend.",
 )
 
-install_options: Callable[..., Option] = partial(
-    Option,
-    "--install-option",
-    dest="install_options",
-    action="append",
-    metavar="options",
-    help="Extra arguments to be supplied to the setup.py install "
-    'command (use like --install-option="--install-scripts=/usr/local/'
-    'bin"). Use multiple --install-option options to pass multiple '
-    "options to setup.py install. If you are using an option with a "
-    "directory path, be sure to use absolute path.",
-)
 
 build_options: Callable[..., Option] = partial(
     Option,


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
removed removed --install-scripts flag from [pip/src/pip/_internal/cli/cmdoptions.py](https://github.com/pypa/pip/blob/87aee20df2890a89f70eecbd7086262146a2e64a/src/pip/_internal/cli/cmdoptions.py#L799-L810)