### PR TITLE
Decrease timeout to make test less flaky

### DIFF
--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -7,7 +7,7 @@ from tests.lib import PipTestEnvironment
 def test_timeout(script: PipTestEnvironment) -> None:
     result = script.pip(
         "--timeout",
-        "0.0001",
+        "0.00001",
         "install",
         "-vvv",
         "INITools",

--- a/tests/functional/test_requests.py
+++ b/tests/functional/test_requests.py
@@ -6,6 +6,8 @@ from tests.lib import PipTestEnvironment
 @pytest.mark.network
 def test_timeout(script: PipTestEnvironment) -> None:
     result = script.pip(
+        "--retries",
+        "1",
         "--timeout",
         "0.00001",
         "install",


### PR DESCRIPTION
This has been failing a bit too often lately.