### PR TITLE
Josev814 invocation for pip patch

### DIFF
--- a/news/11387.bugfix.rst
+++ b/news/11387.bugfix.rst
@@ -1,0 +1,1 @@
+Adding a check to verify that pip exists in th binary_prefix path prior to checking if it matches the pip found using shutil

--- a/src/pip/_internal/utils/entrypoints.py
+++ b/src/pip/_internal/utils/entrypoints.py
@@ -55,9 +55,10 @@ def get_best_invocation_for_this_pip() -> str:
     if exe_are_in_PATH:
         for exe_name in _EXECUTABLE_NAMES:
             found_executable = shutil.which(exe_name)
-            if found_executable and os.path.samefile(
+            bin_exe_path = os.path.join(binary_prefix, exe_name)
+            if found_executable and os.path.isfile(bin_path) and os.path.samefile(
                 found_executable,
-                os.path.join(binary_prefix, exe_name),
+                bin_exe_path,
             ):
                 return exe_name
 


### PR DESCRIPTION
On Linux, when pip is installed in /usr/local/bin/pip, shutil.which detects this.  The binary_prefix is defaulting to /usr/bin/.  If the file isn't symlinked to /usr/bin it will error out.  Adding in a check to verify that the (binary_prefix, exe_name) exists should be done before passing to samefile to prevent errors from being thrown and for the -m invocation to then be used.

Bug: #11387 


<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
