### PR TITLE
Ignore errors in temporary directory cleanup

### DIFF
--- a/news/11394.bugfix.rst
+++ b/news/11394.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore errors in temporary directory cleanup (show a warning instead).

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -214,7 +214,7 @@ class TempDirectory:
                 rmtree(self._path, onexc=onerror)
             if errors:
                 logger.warning(
-                    "Failed to remove contents of a temporary directory '%s'.\n"
+                    "Failed to remove contents in a temporary directory '%s'.\n"
                     "You can safely remove it manually.",
                     self._path,
                 )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -257,9 +257,13 @@ def test_rmtree_errorhandler_reraises_error(tmpdir: Path) -> None:
     except RuntimeError:
         # Make sure the handler reraises an exception
         with pytest.raises(RuntimeError, match="test message"):
-            # Argument 3 to "rmtree_errorhandler" has incompatible type "None"; expected
-            # "Tuple[Type[BaseException], BaseException, TracebackType]"
-            rmtree_errorhandler(mock_func, path, None)  # type: ignore[arg-type]
+            # Argument 3 to "rmtree_errorhandler" has incompatible type
+            # "Union[Tuple[Type[BaseException], BaseException, TracebackType],
+            # Tuple[None, None, None]]"; expected "Tuple[Type[BaseException],
+            # BaseException, TracebackType]"
+            rmtree_errorhandler(
+                mock_func, path, sys.exc_info()  # type: ignore[arg-type]
+            )
 
     mock_func.assert_not_called()
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Pip frequently fails on windows with a PermissionError in temporary directory cleanup after it has already successfully installed upgraded/uninstalled a package. 

E.g if you have `import matplotlib` in one python session and run 
```
> pip install matplotlib==3.4.3
```
in another, you get
```
...
Installing collected packages: matplotlib
  Attempting uninstall: matplotlib
    Found existing installation: matplotlib 3.4.3
    Uninstalling matplotlib-3.4.3:
      Successfully uninstalled matplotlib-3.4.3
ERROR: Could not install packages due to an OSError: [WinError 5] Access is denied: 'C:\\Users\\ales\\.envs\\Lib\\site-packages\\~4tplotlib\\ft2font.cp39-win_amd64.pyd'
Check the permissions.
```
(note the '\\\\**~4**tplotlib\\\\' name) indicating this is failure to remove an temp backup; a new package is already fully installed at this point)

With this applied
```
Installing collected packages: matplotlib
  Attempting uninstall: matplotlib
    Found existing installation: matplotlib 3.4.2
    Uninstalling matplotlib-3.4.2:
      Successfully uninstalled matplotlib-3.4.2
  WARNING: Failed to remove a temporary file 'C:\Users\ales\.envs\Lib\site-packages\~-tplotlib\ft2font.cp39-win_amd64.pyd' due to PermissionError: [WinError 5] Access is denied: 'C:\\Users\\ales\\.envs\\Lib\\site-packages\\~-tplotlib\\ft2font.cp39-win_amd64.pyd'.
  You can safely remove it manually.
  WARNING: Failed to remove a temporary file 'C:\Users\ales\.envs\Lib\site-packages\~-tplotlib\_c_internal_utils.cp39-win_amd64.pyd' due to PermissionError: [WinError 5] Access is denied: 'C:\\Users\\ales\\.envs\\Lib\\site-packages\\~-tplotlib\\_c_internal_utils.cp39-win_amd64.pyd'.
  You can safely remove it manually.
  WARNING: Failed to remove a temporary file 'C:\Users\ales\.envs\Lib\site-packages\~-tplotlib\_path.cp39-win_amd64.pyd' due to PermissionError: [WinError 5] Access is denied: 'C:\\Users\\ales\\.envs\\Lib\\site-packages\\~-tplotlib\\_path.cp39-win_amd64.pyd'.
  You can safely remove it manually.
  WARNING: Failed to remove a temporary file 'C:\Users\ales\.envs\Lib\site-packages\~-tplotlib' due to OSError: [WinError 145] The directory is not empty: 'C:\\Users\\ales\\.envs\\Lib\\site-packages\\~-tplotlib'.
  You can safely remove it manually.
Successfully installed matplotlib-3.4.3
```

This also fixes https://github.com/pypa/pip/issues/6327 (similar problem on nfs)
