### PR TITLE
Make new resolver process Requires-Python before other dependencies

### DIFF
--- a/news/11142.bugfix.rst
+++ b/news/11142.bugfix.rst
@@ -1,0 +1,2 @@
+New resolver: Fix a regression that prevents the ``Requires-Python`` metadata
+to be correctly checked before Python package dependencies.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -225,8 +225,8 @@ class _InstallRequirementBackedCandidate(Candidate):
                 str(dist.version),
             )
 
-    @functools.lru_cache(maxsize=1)
-    def _prepare_dist(self) -> BaseDistribution:
+    @functools.lru_cache(maxsize=None)
+    def __prepare_dist_property(self) -> BaseDistribution:
         # TODO: When we drop python 3.7 support, move this to 'dist' and use
         # functools.cached_property instead of lru_cache.
         try:
@@ -247,13 +247,13 @@ class _InstallRequirementBackedCandidate(Candidate):
 
     @property
     def dist(self) -> BaseDistribution:
-        return self._prepare_dist()
+        return self.__prepare_dist_property()
 
     def iter_dependencies(self, with_requires: bool) -> Iterable[Optional[Requirement]]:
+        yield self._factory.make_requires_python_requirement(self.dist.requires_python)
         requires = self.dist.iter_dependencies() if with_requires else ()
         for r in requires:
             yield self._factory.make_requirement_from_spec(str(r), self._ireq)
-        yield self._factory.make_requires_python_requirement(self.dist.requires_python)
 
     def get_install_requirement(self) -> Optional[InstallRequirement]:
         return self._ireq

--- a/tests/functional/test_new_resolver_errors.py
+++ b/tests/functional/test_new_resolver_errors.py
@@ -101,32 +101,32 @@ def test_new_resolver_checks_requires_python_before_dependencies(
 ) -> None:
     incompatible_python = "<{0.major}.{0.minor}".format(sys.version_info)
 
-    pkg_dep = create_basic_wheel_for_package(
+    pkgdep = create_basic_wheel_for_package(
         script,
-        name="pkg-dep",
+        name="pkgdep",
         version="1",
     )
     create_basic_wheel_for_package(
         script,
-        name="pkg-root",
+        name="pkgroot",
         version="1",
-        # Refer the dependency by URL to prioritise it as much as possible,
-        # to test that Requires-Python is *still* inspected first.
-        depends=[f"pkg-dep@{pathlib.Path(pkg_dep).as_uri()}"],
+        depends=[
+            f"pkgdep@{pathlib.Path(pkgdep).as_uri()}",
+        ],
         requires_python=incompatible_python,
     )
 
-    result = script.pip(
+    r = script.pip(
         "install",
         "--no-cache-dir",
         "--no-index",
         "--find-links",
         script.scratch_path,
-        "pkg-root",
+        "pkgroot",
         expect_error=True,
     )
 
-    # Resolution should fail because of pkg-a's Requires-Python.
-    # This check should be done before pkg-b, so pkg-b should never be pulled.
-    assert incompatible_python in result.stderr, str(result)
-    assert "pkg-b" not in result.stderr, str(result)
+    # Resolution should fail because of pkgroot's Requires-Python.
+    # This is done before dependencies so pkgdep should never be pulled.
+    assert incompatible_python in r.stderr, str(r)
+    assert "pkgdep" not in r.stderr and "pkgdep" not in r.stdout, str(r)


### PR DESCRIPTION
Fix #11142. There are actually two issues; first is that the dist object in an ExplicitRequirement was being perpared too eagerly, the second is that Requires-Python should be returned before other dependencies so it is checked first.

This broke because resolvelib added a check to ensure a candidate’s dependencies are consistent. This new check made our lazy candidate preparation logic not lazy enough.