### PR TITLE
Fix `pip completion --zsh`

### DIFF
--- a/news/11416.bugfix.rst
+++ b/news/11416.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``pip completion --zsh``.

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -22,15 +22,10 @@ COMPLETION_SCRIPTS = {
         complete -o default -F _pip_completion {prog}
     """,
     "zsh": """
-        function _pip_completion {{
-          local words cword
-          read -Ac words
-          read -cn cword
-          reply=( $( COMP_WORDS="$words[*]" \\
-                     COMP_CWORD=$(( cword-1 )) \\
-                     PIP_AUTO_COMPLETE=1 $words[1] 2>/dev/null ))
-        }}
-        compctl -K _pip_completion {prog}
+        #compdef -P pip[0-9.]#
+        compadd $( COMP_WORDS="$words[*]" \\
+                   COMP_CWORD=$((CURRENT-1)) \\
+                   PIP_AUTO_COMPLETE=1 $words[1] 2>/dev/null )
     """,
     "fish": """
         function __fish_complete_pip

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -44,15 +44,10 @@ complete -fa "(__fish_complete_pip)" -c pip""",
     (
         "zsh",
         """\
-function _pip_completion {
-  local words cword
-  read -Ac words
-  read -cn cword
-  reply=( $( COMP_WORDS="$words[*]" \\
-             COMP_CWORD=$(( cword-1 )) \\
-             PIP_AUTO_COMPLETE=1 $words[1] 2>/dev/null ))
-}
-compctl -K _pip_completion pip""",
+#compdef -P pip[0-9.]#
+compadd $( COMP_WORDS="$words[*]" \\
+           COMP_CWORD=$((CURRENT-1)) \\
+           PIP_AUTO_COMPLETE=1 $words[1] 2>/dev/null )""",
     ),
     (
         "powershell",
@@ -392,7 +387,8 @@ def test_completion_path_after_option(
     )
 
 
-@pytest.mark.parametrize("flag", ["--bash", "--zsh", "--fish", "--powershell"])
+# zsh completion script doesn't contain pip3
+@pytest.mark.parametrize("flag", ["--bash", "--fish", "--powershell"])
 def test_completion_uses_same_executable_name(
     autocomplete_script: PipTestEnvironment, flag: str, deprecated_python: bool
 ) -> None:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Fix `pip completion --zsh`

Fix #4955 #5364 #11409
