### PR TITLE
delete “good first issue” in doc

### DIFF
--- a/docs/html/development/issue-triage.md
+++ b/docs/html/development/issue-triage.md
@@ -58,10 +58,6 @@ seen on the [Labels](https://github.com/pypa/pip/labels) page.
 
 In addition, there are several standalone labels:
 
-**good first issue**
-: this label marks an issue as beginner-friendly and shows up in banners that
-GitHub displays for first-time visitors to the repository
-
 **triage**
 : default label given to issues when they are created
 


### PR DESCRIPTION
someone delete the "good first issue" template, so delete “good first issue” in doc

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
