### PR TITLE
entrypoints.py: check if expected_executable exists

### DIFF
--- a/src/pip/_internal/utils/entrypoints.py
+++ b/src/pip/_internal/utils/entrypoints.py
@@ -55,9 +55,13 @@ def get_best_invocation_for_this_pip() -> str:
     if exe_are_in_PATH:
         for exe_name in _EXECUTABLE_NAMES:
             found_executable = shutil.which(exe_name)
-            if found_executable and os.path.samefile(
-                found_executable,
-                os.path.join(binary_prefix, exe_name),
+            # os.path.samefile can throw FileNotFoundError
+            # so we need os.path.exists
+            expected_executable = os.path.join(binary_prefix, exe_name)
+            if (
+                found_executable and
+                os.path.exists(expected_executable) and
+                os.path.samefile(found_executable, expected_executable)
             ):
                 return exe_name
 


### PR DESCRIPTION
in rare cases, python cannot call pip, and prints a stack trace.
not a fatal error

problem:
os.path.samefile can throw FileNotFoundError, when expected_executable does not exist

example debug output:

```
debug: exe_are_in_PATH = True
debug: binary_prefix = /nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/bin
debug: exe_name = pip
debug: found_executable = /nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/bin/pip
debug: expected_executable = /nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/bin/pip
debug: return: exe_name = pip
```

relevant call stack:

* pip/_internal/self_outdated_check.py
* pip/_internal/utils/entrypoints.py

<details>
<summary>
Traceback
</summary>


```
Traceback (most recent call last):
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/utils/logging.py", line 177, in emit
    self.console.print(renderable, overflow="ignore", crop=False, style=style)
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_vendor/rich/console.py", line 1752, in print
    extend(render(renderable, render_options))
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_vendor/rich/console.py", line 1390, in render
    for render_output in iter_render:
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/utils/logging.py", line 134, in __rich_console__
    for line in lines:
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_vendor/rich/segment.py", line 245, in split_lines
    for segment in segments:
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_vendor/rich/console.py", line 1368, in render
    renderable = rich_cast(renderable)
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_vendor/rich/protocol.py", line 36, in rich_cast
    renderable = cast_method()
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/self_outdated_check.py", line 130, in __rich__
    pip_cmd = get_best_invocation_for_this_pip()
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/utils/entrypoints.py", line 63, in get_best_invocation_for_this_pip
    if found_executable and os.path.samefile(
  File "/nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/lib/python3.9/genericpath.py", line 101, in samefile
    s2 = os.stat(f2)
FileNotFoundError: [Errno 2] No such file or directory: '/nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/bin/pip'
Call stack:
  File "/nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/__main__.py", line 31, in <module>
    sys.exit(_main())
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/cli/main.py", line 70, in main
    return command.main(cmd_args)
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 101, in main
    return self._main(args)
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 223, in _main
    self.handle_pip_version_check(options)
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/cli/req_command.py", line 148, in handle_pip_version_check
    pip_self_version_check(session, options)
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/self_outdated_check.py", line 237, in pip_self_version_check
    logger.info("[present-rich] %s", upgrade_prompt)
  File "/nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/lib/python3.9/logging/__init__.py", line 1446, in info
    self._log(INFO, msg, args, **kwargs)
  File "/nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/lib/python3.9/logging/__init__.py", line 1589, in _log
    self.handle(record)
  File "/nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/lib/python3.9/logging/__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "/nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/lib/python3.9/logging/__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "/nix/store/6v602p5l3c05iiq7jx8y0rjwiv2n8hhj-python3-3.9.13/lib/python3.9/logging/__init__.py", line 952, in handle
    self.emit(record)
  File "/nix/store/bn2i33wra8x54ax33l5dnrsfghx46ky7-python3-3.9.13-env/lib/python3.9/site-packages/pip/_internal/utils/logging.py", line 179, in emit
    self.handleError(record)
Message: '[present-rich] %s'
Arguments: (UpgradePrompt(old='22.1.2', new='22.2.2'),)
```

</details>



<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
