### PR TITLE
Introduce a `check` CI job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,3 +284,34 @@ jobs:
           -m integration
           --verbose --numprocesses auto --showlocals
           --durations=5
+
+  check:  # This job does nothing and is only used for the branch protection
+    if: always()
+
+    needs:
+      - determine-changes
+      - docs
+      - packaging
+      - pre-commit
+      - tests-unix
+      - tests-windows
+      - tests-zipapp
+      - tests-importlib-metadata
+      - vendoring
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: >-
+            ${{
+              (
+                needs.determine-changes.outputs.vendoring != 'true'
+                && github.event_name == 'pull_request'
+              )
+              && 'vendoring'
+              || ''
+            }}
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This patch adds a special check-job that produces a clear failure or
success status based on how the dependent jobs are doing. It is
possible to use it in GitHub's branch protection instead of having to
manually add and remove individual job names via the repo settings.

https://github.com/marketplace/actions/alls-green#why

This action has been battle-tested in the projects of aio-libs, Ansible, attrs, CherryPy, PyCA, PyCQA, pytest, setuptools and Towncrier (off the top of my head but there's more).