### PR TITLE
Deprecate --no-binary implying setup.py install

### DIFF
--- a/news/11452.removal.rst
+++ b/news/11452.removal.rst
@@ -1,0 +1,2 @@
+Deprecate installation with 'setup.py install' when no-binary is enabled for
+source distributions without 'pyproject.toml'.

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -124,8 +124,8 @@ class LegacyInstallReason:
     def __init__(
         self,
         reason: str,
-        replacement: Optional[str],
-        gone_in: Optional[str],
+        replacement: Optional[str] = None,
+        gone_in: Optional[str] = None,
         feature_flag: Optional[str] = None,
         issue: Optional[int] = None,
         emit_after_success: bool = False,
@@ -171,5 +171,18 @@ LegacyInstallReasonMissingWheelPackage = LegacyInstallReason(
     replacement="to enable the '--use-pep517' option",
     gone_in=None,
     issue=8559,
+    emit_before_install=True,
+)
+
+LegacyInstallReasonNoBinaryForcesSetuptoolsInstall = LegacyInstallReason(
+    reason=(
+        "{name} is being installed using the legacy "
+        "'setup.py install' method, because the '--no-binary' option was enabled "
+        "for it and this currently disables local wheel building for projects that "
+        "don't have a 'pyproject.toml' file."
+    ),
+    replacement="to enable the '--use-pep517' option",
+    gone_in="23.1",
+    issue=11451,
     emit_before_install=True,
 )

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -83,6 +83,11 @@ def _should_build(
 
     assert check_bdist_wheel is not None
     if not check_bdist_wheel(req):
+        # /!\ When we change this to unconditionally return True, we must also remove
+        # support for `--install-option`. Indeed, `--install-option` implies
+        # `--no-binary` so we can return False here and run `setup.py install`.
+        # `--global-option` and `--build-option` can remain until we drop support for
+        # building with `setup.py bdist_wheel`.
         req.legacy_install_reason = LegacyInstallReasonNoBinaryForcesSetuptoolsInstall
         return False
 

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -19,7 +19,10 @@ from pip._internal.operations.build.wheel import build_wheel_pep517
 from pip._internal.operations.build.wheel_editable import build_wheel_editable
 from pip._internal.operations.build.wheel_legacy import build_wheel_legacy
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.deprecation import LegacyInstallReasonMissingWheelPackage
+from pip._internal.utils.deprecation import (
+    LegacyInstallReasonMissingWheelPackage,
+    LegacyInstallReasonNoBinaryForcesSetuptoolsInstall,
+)
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import ensure_dir, hash_file, is_wheel_installed
 from pip._internal.utils.setuptools_build import make_setuptools_clean_args
@@ -80,10 +83,7 @@ def _should_build(
 
     assert check_bdist_wheel is not None
     if not check_bdist_wheel(req):
-        logger.info(
-            "Skipping wheel build for %s, due to binaries being disabled for it.",
-            req.name,
-        )
+        req.legacy_install_reason = LegacyInstallReasonNoBinaryForcesSetuptoolsInstall
         return False
 
     if not is_wheel_installed():


### PR DESCRIPTION
This converts an info message we already have into a deprecation.

Towards #11451 and #8102.

