### PR TITLE
Fix build isolation on Pythons where purelib/platlib aren't enough

### DIFF
--- a/news/6264.bugfix.rst
+++ b/news/6264.bugfix.rst
@@ -1,0 +1,1 @@
+Fix build environment isolation on some system Pythons.


### PR DESCRIPTION
use `site.getsitepackages()` where available instead of just purelib/platlib, which is sometimes insufficient on e.g. System Pythons for Debian/macOS.

handle `virtualenv < 20` overwriting site.py without getsitepackages() by preserving current behavior. I _think_ the cases where this fix is needed and site.py is overwritten are mutually exclusive, so this should be okay. At the very least, it should be an improvement in all cases where behavior is changed.

I don't know how to write a great test, since it needs to actually run against system Python on Mac or Debian outside a virtualenv in order to directly test this. As it is, the added test only assumes that `site.getsitepackages()` is right to remove and then removed, which is a bit tautological.

closes #6264