### PR TITLE
Allow skips for the test jobs in branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,4 +314,18 @@ jobs:
               && 'vendoring'
               || ''
             }}
+            ,
+            ${{
+              (
+                needs.determine-changes.outputs.tests != 'true'
+                && github.event_name == 'pull_request'
+              )
+              && '
+                tests-unix,
+                tests-windows,
+                test-zipapp,
+                test-importlib-metadata,
+              '
+              || ''
+            }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This is a follow-up for https://github.com/pypa/pip/pull/11434