### PR TITLE
Fix a typo in required CI jobs allowed to skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,8 +323,8 @@ jobs:
               && '
                 tests-unix,
                 tests-windows,
-                test-zipapp,
-                test-importlib-metadata,
+                tests-zipapp,
+                tests-importlib-metadata,
               '
               || ''
             }}


### PR DESCRIPTION
    test-zipapp -> tests-zipapp

    test-importlib-metadata -> tests-importlib-metadata

It's a follow-up to https://github.com/pypa/pip/pull/11472 and https://github.com/pypa/pip/pull/11434.
