### PR TITLE
Use pyproject.toml-based builds in environments without wheel

### DIFF
--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -98,7 +98,9 @@ def load_pyproject_toml(
     # For more info see:
     # https://discuss.python.org/t/pip-without-setuptools-could-the-experience-be-improved/11810/9
     elif use_pep517 is None:
-        use_pep517 = has_pyproject or not importlib.util.find_spec("setuptools")
+        use_pep517 = has_pyproject or not (
+            importlib.util.find_spec("setuptools") and importlib.util.find_spec("wheel")
+        )
 
     # At this point, we know whether we're going to use PEP 517.
     assert use_pep517 is not None


### PR DESCRIPTION
This ensures that we don't fall back to `setup.py install` in such environments to install from source.

x-ref #8559 
