### PR TITLE
Fix typos in HTML docs

### DIFF
--- a/docs/html/reference/inspect-report.md
+++ b/docs/html/reference/inspect-report.md
@@ -44,7 +44,7 @@ the following properties:
   `.egg-info` directory.
 
   ```{warning}
-  This field may not necessary point to a directory, for instance, in the case of older
+  This field may not necessarily point to a directory, for instance, in the case of older
   `.egg` installs.
   ```
 

--- a/docs/html/topics/caching.md
+++ b/docs/html/topics/caching.md
@@ -96,7 +96,7 @@ In some cases, pip's caching behaviour can be undesirable. As an example, if you
 have package with optional C extensions, that generates a pure Python wheel
 when the C extension can’t be built, pip will use that cached wheel even when
 you later invoke it from an environment that could have built those optional C
-extensions. This is because pip is seeing a cached wheel for that matches the
+extensions. This is because pip is seeing a cached wheel that matches the
 package being built, and pip assumes that the result of building a package from
 a package index is deterministic.
 

--- a/docs/html/topics/repeatable-installs.md
+++ b/docs/html/topics/repeatable-installs.md
@@ -20,7 +20,7 @@ specific version.
 ```
 
 A requirements file, containing pinned package versions can be generated using
-{ref}`pip freeze`. This would not only the top-level packages, but also all of
+{ref}`pip freeze`. This would pin not only the top-level packages, but also all of
 their transitive dependencies. Performing the installation using
 {ref}`--no-deps <install_--no-deps>` would provide an extra dose of insurance
 against installing anything not explicitly listed.


### PR DESCRIPTION
This PR fixes some trivial typos in the HTML documentation.