### PR TITLE
Disallow freeze format with pip list --outdated

### DIFF
--- a/news/9789.removal.rst
+++ b/news/9789.removal.rst
@@ -1,0 +1,1 @@
+Remove the ability to use 'pip list --outdated' in combination with "--format=freeze".

--- a/news/9789.removal.rst
+++ b/news/9789.removal.rst
@@ -1,1 +1,1 @@
-Remove the ability to use 'pip list --outdated' in combination with "--format=freeze".
+Remove the ability to use ``pip list --outdated`` in combination with ``--format=freeze``.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -155,6 +155,11 @@ class ListCommand(IndexGroupCommand):
         if options.outdated and options.uptodate:
             raise CommandError("Options --outdated and --uptodate cannot be combined.")
 
+        if options.outdated and options.list_format == "freeze":
+            raise CommandError(
+                "List format 'freeze' can not be used with the --outdated option."
+            )
+
         cmdoptions.check_list_path_option(options)
 
         skip = set(stdlib_pkgs)

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -577,7 +577,7 @@ def test_outdated_formats(script: PipTestEnvironment, data: TestData) -> None:
     assert "Package Version Latest Type" in result.stdout
     assert "simple  1.0     1.1    wheel" in result.stdout
 
-    # Check freeze
+    # Check that freeze is not allowed
     result = script.pip(
         "list",
         "--no-index",
@@ -585,8 +585,12 @@ def test_outdated_formats(script: PipTestEnvironment, data: TestData) -> None:
         wheelhouse_path,
         "--outdated",
         "--format=freeze",
+        expect_error=True,
     )
-    assert "simple==1.0" in result.stdout
+    assert (
+        "List format 'freeze' can not be used with the --outdated option."
+        in result.stderr
+    )
 
     # Check json
     result = script.pip(


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Resolves #9789 by raising an error if `pip list --outdated` is used in combination with `--format=freeze`

