### PR TITLE
Raise RequirementsFileParseError when missing closing quotation

### DIFF
--- a/news/11491.bugfix.rst
+++ b/news/11491.bugfix.rst
@@ -1,0 +1,1 @@
+Raise RequirementsFileParseError when parsing malformed requirements options that can't be sucessfully parsed by shlex.

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -397,7 +397,12 @@ def get_line_parser(finder: Optional["PackageFinder"]) -> LineParser:
 
         args_str, options_str = break_args_options(line)
 
-        opts, _ = parser.parse_args(shlex.split(options_str), defaults)
+        try:
+            options = shlex.split(options_str)
+        except ValueError as e:
+            raise OptionParsingError(f"Could not split options: {options_str}") from e
+
+        opts, _ = parser.parse_args(options, defaults)
 
         return args_str, opts
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -786,6 +786,20 @@ class TestParseRequirements:
 
         assert not reqs
 
+    def test_invalid_options(self, tmpdir: Path, finder: PackageFinder) -> None:
+        """
+        Test parsing invalid options such as missing closing quotation
+        """
+        with open(tmpdir.joinpath("req1.txt"), "w") as fp:
+            fp.write("--'data\n")
+
+        with pytest.raises(RequirementsFileParseError):
+            list(
+                parse_reqfile(
+                    tmpdir.joinpath("req1.txt"), finder=finder, session=PipSession()
+                )
+            )
+
     def test_req_file_parse_comment_end_of_line_with_url(
         self, tmpdir: Path, finder: PackageFinder
     ) -> None:


### PR DESCRIPTION
shlex.split, used to split options in requirements.txt files, might raise a ValueError when the input string is not well formed. Catch the ValueError and re-raise it as a RequirementsFileParseError instead.

Fix https://github.com/pypa/pip/issues/11491 .