### PR TITLE
Remove the opt-in for `2020-resolver`

### DIFF
--- a/news/11493.removal.rst
+++ b/news/11493.removal.rst
@@ -1,0 +1,1 @@
+Remove ``--use-feature=2020-resolver`` opt-in flag. This was supposed to be removed in 21.0, but missed during that release cycle.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -151,13 +151,6 @@ class Command(CommandContextMixIn):
                 )
                 options.cache_dir = None
 
-        if "2020-resolver" in options.features_enabled:
-            logger.warning(
-                "--use-feature=2020-resolver no longer has any effect, "
-                "since it is now the default dependency resolver in pip. "
-                "This will become an error in pip 21.0."
-            )
-
         def intercepts_unhandled_exc(
             run_func: Callable[..., int]
         ) -> Callable[..., int]:

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -983,7 +983,6 @@ use_new_feature: Callable[..., Option] = partial(
     action="append",
     default=[],
     choices=[
-        "2020-resolver",
         "fast-deps",
         "truststore",
         "no-binary-enable-wheel-cache",

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -459,8 +459,16 @@ class TestProcessLine:
         self, line_processor: LineProcessor, options: mock.Mock
     ) -> None:
         """--use-feature can be set in requirements files."""
-        line_processor("--use-feature=2020-resolver", "filename", 1, options=options)
-        assert "2020-resolver" in options.features_enabled
+        line_processor("--use-feature=fast-deps", "filename", 1, options=options)
+
+    def test_use_feature_with_error(
+        self, line_processor: LineProcessor, options: mock.Mock
+    ) -> None:
+        """--use-feature triggers error when parsing requirements files."""
+        with pytest.raises(RequirementsFileParseError):
+            line_processor(
+                "--use-feature=2020-resolver", "filename", 1, options=options
+            )
 
     def test_relative_local_find_links(
         self,


### PR DESCRIPTION
This has been the default for quite some time now.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
