### PR TITLE
Remove pre-commit from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,17 +55,6 @@ jobs:
               - "noxfile.py"
         if: github.event_name == 'pull_request'
 
-  pre-commit:
-    name: pre-commit
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
-        with:
-          extra_args: --all-files --hook-stage=manual
-
   packaging:
     name: packaging
     runs-on: ubuntu-latest
@@ -103,7 +92,7 @@ jobs:
     name: tests / ${{ matrix.python }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
 
-    needs: [pre-commit, packaging, determine-changes]
+    needs: [packaging, determine-changes]
     if: >-
       needs.determine-changes.outputs.tests == 'true' ||
       github.event_name != 'pull_request'
@@ -151,7 +140,7 @@ jobs:
     name: tests / ${{ matrix.python }} / ${{ matrix.os }} / ${{ matrix.group }}
     runs-on: ${{ matrix.os }}-latest
 
-    needs: [pre-commit, packaging, determine-changes]
+    needs: [packaging, determine-changes]
     if: >-
       needs.determine-changes.outputs.tests == 'true' ||
       github.event_name != 'pull_request'
@@ -225,7 +214,7 @@ jobs:
     name: tests / zipapp
     runs-on: ubuntu-latest
 
-    needs: [pre-commit, packaging, determine-changes]
+    needs: [packaging, determine-changes]
     if: >-
       needs.determine-changes.outputs.tests == 'true' ||
       github.event_name != 'pull_request'
@@ -257,7 +246,7 @@ jobs:
     env:
       _PIP_USE_IMPORTLIB_METADATA: 'true'
 
-    needs: [pre-commit, packaging, determine-changes]
+    needs: [packaging, determine-changes]
     if: >-
       needs.determine-changes.outputs.tests == 'true' ||
       github.event_name != 'pull_request'
@@ -292,7 +281,6 @@ jobs:
       - determine-changes
       - docs
       - packaging
-      - pre-commit
       - tests-unix
       - tests-windows
       - tests-zipapp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,4 +77,3 @@ repos:
   rev: '0.48'
   hooks:
   - id: check-manifest
-    stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,3 +77,8 @@ repos:
   rev: '0.48'
   hooks:
   - id: check-manifest
+
+ci:
+  autofix_prs: false
+  autoupdate_commit_msg: 'pre-commit autoupdate'
+  autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
   rev: '0.48'
   hooks:
   - id: check-manifest
+    args: [--no-build-isolation]
 
 ci:
   autofix_prs: false


### PR DESCRIPTION
This is a step in moving linting completely to pre-commit.ci, and adds some basic configuration for it.

I've just gone ahead and enabled pre-commit.ci integration on this repository. This integration will file regular pull requests to update our linters (like https://github.com/pradyunsg/furo/pull/544) while also providing a (faster) CI infrastructure to run our linters.
