### PR TITLE
Add a warning comment to the vendoring session in noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -174,7 +174,7 @@ def lint(session: nox.Session) -> None:
 
 # NOTE: This session will COMMIT upgrades to vendored libraries.
 # You should therefore not run it directly against `main`. If you
-# do (asusming you started with a clean main), you can run:
+# do (assuming you started with a clean main), you can run:
 #
 # git checkout -b vendoring-updates
 # git checkout main

--- a/noxfile.py
+++ b/noxfile.py
@@ -172,6 +172,10 @@ def lint(session: nox.Session) -> None:
     session.run("pre-commit", "run", *args)
 
 
+# NOTE: This session will COMMIT upgardes to vendored libraries.
+# You should therefore not run it directly against main, as you
+# will put your main branch out of sync with upstream. Always run
+# it on a dedicated branch
 @nox.session
 def vendoring(session: nox.Session) -> None:
     session.install("vendoring~=1.2.0")

--- a/noxfile.py
+++ b/noxfile.py
@@ -172,10 +172,13 @@ def lint(session: nox.Session) -> None:
     session.run("pre-commit", "run", *args)
 
 
-# NOTE: This session will COMMIT upgardes to vendored libraries.
-# You should therefore not run it directly against main, as you
-# will put your main branch out of sync with upstream. Always run
-# it on a dedicated branch
+# NOTE: This session will COMMIT upgrades to vendored libraries.
+# You should therefore not run it directly against `main`. If you
+# do (asusming you started with a clean main), you can run:
+#
+# git checkout -b vendoring-updates
+# git checkout main
+# git reset --hard origin/main
 @nox.session
 def vendoring(session: nox.Session) -> None:
     session.install("vendoring~=1.2.0")


### PR DESCRIPTION
I just wasted a bunch of time fixing my main branch because I assumed that `nox -s vendoring -- --upgrade` would just make changes to my working files. Instead, it committed the changes to my main branch.

I don't think there's anywhere appropriate in the docs for this note, but I want to document it so that I don't make the same mistake again 🙁