### PR TITLE
Add the ability to exclude selected packages from vendoring upgrades

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -193,8 +193,8 @@ def vendoring(session: nox.Session) -> None:
     # complex than is warranted.
     exclude = {pkg for pkg in session.posargs if pkg != "--upgrade"}
 
-    # Always exclude setuptools.
-    # See https://github.com/pypa/pip/pull/9170/commits/1466e7c49ac90cf11f4990a5cb0793aa1a42a3a7
+    # Always exclude setuptools. See
+    # https://github.com/pypa/pip/commit/1466e7c49ac90cf11f4990a5cb0793aa1a42a3a7
     # which was part of https://github.com/pypa/pip/pull/9170
     exclude.add("setuptools")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -187,6 +187,8 @@ def vendoring(session: nox.Session) -> None:
         session.run("vendoring", "sync", "-v")
         return
 
+    selected = [pkg for pkg in session.posargs if pkg != "--upgrade"]
+
     def pinned_requirements(path: Path) -> Iterator[Tuple[str, str]]:
         for line in path.read_text().splitlines(keepends=False):
             one, sep, two = line.partition("==")
@@ -200,6 +202,9 @@ def vendoring(session: nox.Session) -> None:
     vendor_txt = Path("src/pip/_vendor/vendor.txt")
     for name, old_version in pinned_requirements(vendor_txt):
         if name == "setuptools":
+            continue
+
+        if selected and name not in selected:
             continue
 
         # update requirements.txt


### PR DESCRIPTION
This allows us to deliberately exclude certain packages from our `nox -s vendoring -- --upgrade` script.

The UI is deliberately kept simple, you just add a list of packages to be excluded after `--upgrade`, like `nox -s vendoring -- --upgrade certifi`. Yes, this reads very badly (it looks like you're only going to upgrade certifi) but I wanted to avoid having to add an actual parser for `posargs`.

We always add setuptools to the exclusions - see https://github.com/pypa/pip/pull/9170/commits/1466e7c49ac90cf11f4990a5cb0793aa1a42a3a7 which was included in #9170.