### PR TITLE
use .metadata distribution info when possible

### DIFF
--- a/news/11512.bugfix.rst
+++ b/news/11512.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid downloading wheels when performing a ``--dry-run`` install when .metadata files are used.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -398,7 +398,9 @@ class InstallCommand(RequirementCommand):
             self.trace_basic_info(finder)
 
             requirement_set = resolver.resolve(
-                reqs, check_supported_wheels=not options.target_dir
+                reqs,
+                check_supported_wheels=not options.target_dir,
+                dry_run=options.dry_run,
             )
 
             if options.json_report_file:

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -493,7 +493,7 @@ class RequirementPreparer:
             return self._prepare_linked_requirement(req, parallel_builds)
 
     def prepare_download_info(self, reqs: Iterable[InstallRequirement]) -> None:
-        """ Prepare linked requirements with download_info, if needed. """
+        """Prepare linked requirements with download_info, if needed."""
         # During install --dry-run, .metadata files or lazy wheels may be used when determining
         # distribution dependencies. The associated wheel does not need to be downloaded so the
         # download_info need to be derived from the link. If the link does not contain a hash no

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -185,6 +185,10 @@ class InstallRequirement:
         # This requirement needs more preparation before it can be built
         self.needs_more_preparation = False
 
+        # Distribution from the .metadata file referenced by the PEP 658
+        # data-dist-info-metadata attribute.
+        self.dist_from_metadata: Optional[BaseDistribution] = None
+
     def __str__(self) -> str:
         if self.req:
             s = str(self.req)
@@ -568,6 +572,8 @@ class InstallRequirement:
             return get_wheel_distribution(
                 FilesystemWheel(self.local_file_path), canonicalize_name(self.name)
             )
+        elif self.is_wheel and self.dist_from_metadata:
+            return self.dist_from_metadata
         raise AssertionError(
             f"InstallRequirement {self} has no metadata directory and no wheel: "
             f"can't make a distribution."

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -68,7 +68,10 @@ class Resolver(BaseResolver):
         self._result: Optional[Result] = None
 
     def resolve(
-        self, root_reqs: List[InstallRequirement], check_supported_wheels: bool, dry_run: bool = False,
+        self,
+        root_reqs: List[InstallRequirement],
+        check_supported_wheels: bool,
+        dry_run: bool = False,
     ) -> RequirementSet:
         collected = self.factory.collect_root_requirements(root_reqs)
         provider = PipProvider(

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -68,7 +68,7 @@ class Resolver(BaseResolver):
         self._result: Optional[Result] = None
 
     def resolve(
-        self, root_reqs: List[InstallRequirement], check_supported_wheels: bool
+        self, root_reqs: List[InstallRequirement], check_supported_wheels: bool, dry_run: bool = False,
     ) -> RequirementSet:
         collected = self.factory.collect_root_requirements(root_reqs)
         provider = PipProvider(
@@ -158,7 +158,10 @@ class Resolver(BaseResolver):
             req_set.add_named_requirement(ireq)
 
         reqs = req_set.all_requirements
-        self.factory.preparer.prepare_linked_requirements_more(reqs)
+        if dry_run:
+            self.factory.preparer.prepare_download_info(reqs)
+        else:
+            self.factory.preparer.prepare_linked_requirements_more(reqs)
         return req_set
 
     def get_installation_order(


### PR DESCRIPTION
When performing `install --dry-run` and PEP 658 .metadata files are available to guide the resolve, do not download the associated wheels.

Rather use the distribution information directly from the .metadata files when reporting the results on the CLI and in the --report file.