### PR TITLE
Move check-manifest to GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
       - run: pip install nox
       - run: nox -s prepare-release -- 99.9
       - run: nox -s build-release -- 99.9
+      - run: pipx run check-manifest
 
   vendoring:
     name: vendoring

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,12 +73,6 @@ repos:
     exclude: ^news/(.gitignore|.*\.(process|removal|feature|bugfix|vendor|doc|trivial).rst)
     files: ^news/
 
-- repo: https://github.com/mgedmin/check-manifest
-  rev: '0.48'
-  hooks:
-  - id: check-manifest
-    args: [--no-build-isolation]
-
 ci:
   autofix_prs: false
   autoupdate_commit_msg: 'pre-commit autoupdate'


### PR DESCRIPTION
This makes local runs of `nox -s lint` quicker while still providing the relevant protections for checking the MANIFEST file.
