### PR TITLE
 Fixed the return value of uninstall

### DIFF
--- a/news/5073.bugfix.rst
+++ b/news/5073.bugfix.rst
@@ -1,0 +1,1 @@
+Return error when trying to uninstall package that exist but not uninstallable.

--- a/src/pip/_internal/commands/uninstall.py
+++ b/src/pip/_internal/commands/uninstall.py
@@ -7,7 +7,7 @@ from pip._vendor.packaging.utils import canonicalize_name
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.req_command import SessionCommandMixin, warn_if_run_as_root
-from pip._internal.cli.status_codes import SUCCESS
+from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.exceptions import InstallationError
 from pip._internal.req import parse_requirements
 from pip._internal.req.constructors import (
@@ -94,6 +94,7 @@ class UninstallCommand(Command, SessionCommandMixin):
             modifying_pip="pip" in reqs_to_uninstall
         )
 
+        everything_okay = True
         for req in reqs_to_uninstall.values():
             uninstall_pathset = req.uninstall(
                 auto_confirm=options.yes,
@@ -101,6 +102,11 @@ class UninstallCommand(Command, SessionCommandMixin):
             )
             if uninstall_pathset:
                 uninstall_pathset.commit()
+            else:
+                everything_okay = False
         if options.root_user_action == "warn":
             warn_if_run_as_root()
-        return SUCCESS
+        if everything_okay:
+            return SUCCESS
+        else:
+            return ERROR


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
This PR Fixes #5073 
Currently clones changes from PR #10176 - Need inputs on specific modifications to fix this.

Requirement - [pip should not fail if there is a name that's not currently installed (e.g. pip uninstall asddfjkg should return SUCCESS), it should only fail if asddfjkg actually exists but is not uninstallable.](https://github.com/pypa/pip/pull/10176#pullrequestreview-713376922)

