### PR TITLE
Add a wheel build number to pip list output.

### DIFF
--- a/news/5210.feature.rst
+++ b/news/5210.feature.rst
@@ -1,0 +1,1 @@
+Add a wheel build number to ``pip list`` output.

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -11,6 +11,7 @@ from tests.lib import (
     TestData,
     _create_test_package,
     create_test_package_with_setup,
+    make_wheel,
     wheel,
 )
 from tests.lib.direct_url import get_created_direct_url_path
@@ -758,3 +759,16 @@ def test_list_pep610_editable(script: PipTestEnvironment) -> None:
             break
     else:
         assert False, "package 'testpkg' not found in pip list result"
+
+
+def test_list_wheel_build(script: PipTestEnvironment) -> None:
+    package = make_wheel(
+        name="package",
+        version="3.0",
+        wheel_metadata_updates={"Build": "123"},
+    ).save_to_dir(script.scratch_path)
+    script.pip("install", package, "--no-index")
+
+    result = script.pip("list")
+    assert "Build" in result.stdout, str(result)
+    assert "123" in result.stdout, str(result)


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
Fix #5210 