### PR TITLE
Allow overriding constraints with '-o' in constraints file.

### DIFF
--- a/news/8076.feature.rst
+++ b/news/8076.feature.rst
@@ -1,0 +1,1 @@
+Allow overriding constraints with ``-o`` in constraints file.

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -208,6 +208,7 @@ def install_req_from_editable(
     user_supplied: bool = False,
     permit_editable_wheels: bool = False,
     config_settings: Optional[Dict[str, str]] = None,
+    is_override: Optional[bool] = False,
 ) -> InstallRequirement:
 
     parts = parse_req_from_editable(editable_req)
@@ -227,6 +228,7 @@ def install_req_from_editable(
         hash_options=options.get("hashes", {}) if options else {},
         config_settings=config_settings,
         extras=parts.extras,
+        is_override=is_override,
     )
 
 
@@ -383,6 +385,7 @@ def install_req_from_line(
     line_source: Optional[str] = None,
     user_supplied: bool = False,
     config_settings: Optional[Dict[str, str]] = None,
+    is_override: Optional[bool] = False,
 ) -> InstallRequirement:
     """Creates an InstallRequirement from a name, which might be a
     requirement, directory containing 'setup.py', filename, or URL.
@@ -406,6 +409,7 @@ def install_req_from_line(
         constraint=constraint,
         extras=parts.extras,
         user_supplied=user_supplied,
+        is_override=is_override,
     )
 
 
@@ -465,6 +469,7 @@ def install_req_from_parsed_requirement(
             isolated=isolated,
             user_supplied=user_supplied,
             config_settings=config_settings,
+            is_override=parsed_req.is_override,
         )
 
     else:
@@ -478,6 +483,7 @@ def install_req_from_parsed_requirement(
             line_source=parsed_req.line_source,
             user_supplied=user_supplied,
             config_settings=config_settings,
+            is_override=parsed_req.is_override,
         )
     return req
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -91,6 +91,7 @@ class InstallRequirement:
         extras: Collection[str] = (),
         user_supplied: bool = False,
         permit_editable_wheels: bool = False,
+        is_override: Optional[bool] = False,
     ) -> None:
         assert req is None or isinstance(req, Requirement), req
         self.req = req
@@ -99,6 +100,7 @@ class InstallRequirement:
         self.editable = editable
         self.permit_editable_wheels = permit_editable_wheels
         self.legacy_install_reason: Optional[LegacyInstallReason] = None
+        self.is_override = is_override
 
         # source_dir is the local directory where the linked requirement is
         # located, or unpacked. In case unpacking is needed, creating and

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -483,7 +483,7 @@ class Factory:
                     continue
                 assert ireq.name, "Constraint must be named"
                 name = canonicalize_name(ireq.name)
-                if name in collected.constraints:
+                if name in collected.constraints and not ireq.is_override:
                     collected.constraints[name] &= ireq
                 else:
                     collected.constraints[name] = Constraint.from_ireq(ireq)


### PR DESCRIPTION
This is one approach of solving issue #8076, you know, the one with over one hundred comments. I had basically the same idea as @PiotrDabkowski expressed in one of the [most recent comments](https://github.com/pypa/pip/issues/8076#issuecomment-1217850316): extend the syntax of what you can say in a constraints file.

Let's show what it can do with a [simple package](https://github.com/plone/plone.intelligenttext) without any dependencies.

```
$ cat constraints.txt
plone.intelligenttext == 3.1.0
-o plone.intelligenttext == 3.0.0
$ bin/pip install plone.intelligenttext -c constraints.txt 
...
Successfully installed plone.intelligenttext-3.0.0
```

So I requested version 3.1.0, then overrode this with version 3.0.0, and the override was installed.

The package is used in Plone, or at least included in the Plone constraints file. Installing an editable version of a package that is pinned in a constraints file, is not possible, see issue #8307. But with this PR we can override it without a version pin:

```
$ cat constraints.txt
# The next file contains plone.intelligenttext==3.1.0
-c https://dist.plone.org/release/6.0.0b3/constraints.txt
-o plone.intelligenttext
$ bin/pip install -e git+https://github.com/plone/plone.intelligenttext.git#egg=plone.intelligenttext -c constraints.txt 
...
Successfully installed plone.intelligenttext-3.1.1.dev0
```

The implementation is rather easy: a few lines of (perhaps too manual) parsing of a line starting with `-o` or --override`, adding `is_override` to the `InstallRequirement` class and several functions, and then checking `is_override` when getting the constraints of the root requirements.

Obviously this needs tests and documentation, which I won't (or shouldn't) have time for soon. But what do you think: would this solve most problems, without giving people a too powerful gun to shoot in their own foot?