### PR TITLE
Restore pre 22.3 wheel cache pathing

### DIFF
--- a/news/11527.bugfix.rst
+++ b/news/11527.bugfix.rst
@@ -1,0 +1,2 @@
+This change restores 22.2.x wheel cache behavior to pip allowing the
+cache to find existing entries.

--- a/news/11527.bugfix.rst
+++ b/news/11527.bugfix.rst
@@ -1,2 +1,2 @@
-This change restores 22.2.x wheel cache behavior to pip allowing the
+Wheel cache behavior is restored to match previous versions, allowing the
 cache to find existing entries.

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -253,6 +253,7 @@ class Link(KeyBasedCompareMixin):
             for hash_name in _SUPPORTED_HASHES:
                 if hash_name in hashes:
                     link_hash = LinkHash(name=hash_name, value=hashes[hash_name])
+                    break
 
         # The Link.yanked_reason expects an empty string instead of a boolean.
         if yanked_reason and not isinstance(yanked_reason, str):

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -248,6 +248,11 @@ class Link(KeyBasedCompareMixin):
         yanked_reason = file_data.get("yanked")
         dist_info_metadata = file_data.get("dist-info-metadata")
         hashes = file_data.get("hashes", {})
+        link_hash = None
+        if hashes:
+            for hash_name in _SUPPORTED_HASHES:
+                if hash_name in hashes:
+                    link_hash = LinkHash(name=hash_name, value=hashes[hash_name])
 
         # The Link.yanked_reason expects an empty string instead of a boolean.
         if yanked_reason and not isinstance(yanked_reason, str):
@@ -262,6 +267,7 @@ class Link(KeyBasedCompareMixin):
             requires_python=pyrequire,
             yanked_reason=yanked_reason,
             hashes=hashes,
+            link_hash=link_hash,
             dist_info_metadata=dist_info_metadata,
         )
 


### PR DESCRIPTION
Prior to bad03ef931d9b3ff4f9e75f35f9c41f45839e2a1 wheel cache paths incorporated source material hashes in their paths. This commit which ended up in 22.3 stopped including that information. This is problematic for two reasons. First our cache is no longer encoding data integrity information that was previously intentionally included. Second it means anyone upgrading from < 22.3 to 22.3 will have orphaned wheel cache entries.

The fix here is to update the Link object to set Link.link_hash in the Link.from_json method. Otherwise the hash information is simply missing.

This will cause anyone upgrading from 22.3 to newer to have orphaned wheels, but that seems worthwhile considering 22.3 hasn't been around as long as the previous implementation and we get stronger data integrity controls out of it.

This fixes https://github.com/pypa/pip/issues/11527

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
