### PR TITLE
Fix git submodule usage in the testsuite

### DIFF
--- a/news/11540.bugfix.rst
+++ b/news/11540.bugfix.rst
@@ -1,0 +1,2 @@
+Fix pip's submodule usage in the test suite to accomodate Git updates
+for CVE-2022-39253.

--- a/tests/lib/git_submodule_helpers.py
+++ b/tests/lib/git_submodule_helpers.py
@@ -72,6 +72,8 @@ def _create_test_package_with_submodule(
 
     env.run(
         "git",
+        "-c",
+        "protocol.file.allow=always",
         "submodule",
         "add",
         os.fspath(submodule_path),


### PR DESCRIPTION
Git patched a security issue (CVE-2022-39253) which prevents the use of local file pathed submodules by default. The reason for this is that untrusted submodules could be abused to expose file system contents.

The pip test suite tests handling of git submodules and to do so creates a git repo which it then uses as a submodule. This was failing due to git's stricter rules on acceptable submodules. Thankfully, pip creates and controls the content of this git repo which means pip can trust it. To express that to git we pass `-c protocol.file.allow=always` to the git submodule add command which overrides the default behavior.

This fixes https://github.com/pypa/pip/issues/11540

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
