### PR TITLE
Ignore failing git submodule test for now

### DIFF
--- a/news/B5BABEE8-4FFA-4D62-87AB-FE7450141ECF.trivial.rst
+++ b/news/B5BABEE8-4FFA-4D62-87AB-FE7450141ECF.trivial.rst
@@ -1,0 +1,5 @@
+Git 2.38.1 patched CVE-2022-39253 by disaling automated fetch against a
+``file:`` repository. This breaks git submodule, which is used by a pip test.
+Information on how projects relying on automated fetch should  configure git
+correctly after this change is lacking, so the test is disabled for now until
+someone can come up with a better solution.

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -544,6 +544,11 @@ def test_reinstalling_works_with_editable_non_master_branch(
 
 # TODO(pnasrat) fix all helpers to do right things with paths on windows.
 @pytest.mark.skipif("sys.platform == 'win32'")
+@pytest.mark.xfail(
+    condition=True,
+    reason="Git submodule against file: is not working; waiting for a good solution",
+    run=True,
+)
 def test_check_submodule_addition(script: PipTestEnvironment) -> None:
     """
     Submodules are pulled in on install and updated on upgrade.


### PR DESCRIPTION
Solution 3… let’s just wait until someone figures out how this is supposed to work?

Git 2.38.1 patched CVE-2022-39253 by disaling automated fetch against a file: repository. This breaks git submodule, which is used by a pip test. Information on how projects relying on automated fetch should configure git correctly after this change is lacking, so the test is disabled for now until someone can come up with a better solution.
