### PR TITLE
Add section clarifying pip version support

### DIFF
--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -72,7 +72,7 @@ Supported Versions
 
 The latest major version of the pip is the only supported version, previous
 major versions should be considered unsupported. Folks are encouraged to make
-regular updates to their version of pip for best performance.
+regular updates to their version of pip in order to remain supported.
 
 .. _`Python 2 Support`:
 

--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -71,7 +71,7 @@ Supported Versions
 ==================
 
 The latest version of the pip is the only supported version, previous
-major versions should be considered unsupported. Folks are encouraged to make
+versions should be considered unsupported. Users are encouraged to make
 regular updates to their version of pip in order to remain supported.
 
 .. _`Python 2 Support`:

--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -65,6 +65,15 @@ their merits.
   ``pip._internal.utils.deprecation.deprecated``. The function is not a part of
   pip's public API.
 
+.. _`Supported Versions`:
+
+Supported Versions
+==================
+
+The latest major version of the pip is the only supported version, previous
+major versions should be considered unsupported. Folks are encouraged to make
+regular updates to their version of pip for best performance.
+
 .. _`Python 2 Support`:
 
 Python 2 Support

--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -65,8 +65,6 @@ their merits.
   ``pip._internal.utils.deprecation.deprecated``. The function is not a part of
   pip's public API.
 
-.. _`Supported Versions`:
-
 Supported Versions
 ==================
 

--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -70,7 +70,7 @@ their merits.
 Supported Versions
 ==================
 
-The latest major version of the pip is the only supported version, previous
+The latest version of the pip is the only supported version, previous
 major versions should be considered unsupported. Folks are encouraged to make
 regular updates to their version of pip in order to remain supported.
 


### PR DESCRIPTION
## Why
Since pip is a widely used library by the python community, it would be nice to have some formal documentation out there making clear what versions are supported.

## What these changes do
Adds a section to the release-process page titled Supported Versions, along with language making clear that the latest major version of pip is the only supported version. It also encourages folks make regular updates.

## Other considerations:
Since this is a documentation update, I wasn't sure if this warrants a news file. If folks feel its warranted please let me know and I'll add that to this PR!

## See also:
GH issue [11549](https://github.com/pypa/pip/issues/11549)


