### PR TITLE
10265 - changed the description of --install-options, since the option is now deprecated

### DIFF
--- a/news/10265.bugfix.rst
+++ b/news/10265.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the description of the option "--install-options" in the documentation

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -825,8 +825,9 @@ install_options: Callable[..., Option] = partial(
     dest="install_options",
     action="append",
     metavar="options",
-    help="This option is deprecated. Using this option with location-changing options may cause unexpected behavior. "
-    "Use pip-level options like --user, --prefix, --root, and --target",
+    help="This option is deprecated. Using this option with location-changing "
+    "options may cause unexpected behavior. "
+    "Use pip-level options like --user, --prefix, --root, and --target.",
 )
 
 build_options: Callable[..., Option] = partial(

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -825,11 +825,8 @@ install_options: Callable[..., Option] = partial(
     dest="install_options",
     action="append",
     metavar="options",
-    help="Extra arguments to be supplied to the setup.py install "
-    'command (use like --install-option="--install-scripts=/usr/local/'
-    'bin"). Use multiple --install-option options to pass multiple '
-    "options to setup.py install. If you are using an option with a "
-    "directory path, be sure to use absolute path.",
+    help="This option is deprecated. Using this option with location-changing options may cause unexpected behavior. "
+    "Use pip-level options like --user, --prefix, --root, and --target",
 )
 
 build_options: Callable[..., Option] = partial(


### PR DESCRIPTION
The option --install-option is now deprecated. This has been changed in the documentation, and the recommended alternatives have been added. Fixes #10265 