### PR TITLE
Add an interface to allow calling system `keyring`

### DIFF
--- a/news/11589.feature.rst
+++ b/news/11589.feature.rst
@@ -1,0 +1,2 @@
+Enable the use of ``keyring`` found on ``PATH``. This allows ``keyring``
+installed using ``pipx`` to be used by ``pip``.

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -41,9 +41,11 @@ class KeyRingCli:
     PATH.
     """
 
-    @classmethod
-    def get_password(cls, service_name: str, username: str) -> Optional[str]:
-        cmd = ["keyring", "get", service_name, username]
+    def __init__(self, keyring: str) -> None:
+        self.keyring = keyring
+
+    def get_password(self, service_name: str, username: str) -> Optional[str]:
+        cmd = [self.keyring, "get", service_name, username]
         res = subprocess.run(
             cmd, capture_output=True, env=dict(PYTHONIOENCODING="utf-8")
         )
@@ -51,9 +53,8 @@ class KeyRingCli:
             return None
         return res.stdout.decode("utf-8").strip("\n")
 
-    @classmethod
-    def set_password(cls, service_name: str, username: str, password: str) -> None:
-        cmd = ["keyring", "set", service_name, username]
+    def set_password(self, service_name: str, username: str, password: str) -> None:
+        cmd = [self.keyring, "set", service_name, username]
         input_ = password.encode("utf-8") + b"\n"
         res = subprocess.run(cmd, input=input_, env=dict(PYTHONIOENCODING="utf-8"))
         res.check_returncode()
@@ -64,8 +65,9 @@ try:
     import keyring
 except ImportError:
     keyring = None  # type: ignore[assignment]
-    if shutil.which("keyring") is not None:
-        keyring = KeyRingCli  # type: ignore[assignment]
+    keyring_path = shutil.which("keyring")
+    if keyring_path is not None:
+        keyring = KeyRingCli(keyring_path)  # type: ignore[assignment]
 except Exception as exc:
     logger.warning(
         "Keyring is skipped due to an exception: %s",

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -154,13 +154,12 @@ def get_keyring_provider() -> KeyRingBaseProvider:
             pass
         except Exception as exc:
             # In the event of an unexpected exception
-            # we shouldn't fallback silently to the
-            # CliProvider
+            # we should warn the user
             logger.warning(
-                "Keyring is skipped due to an exception: %s",
+                "Installed copy of keyring fails with exception %s, "
+                "trying to find a keyring executable as a fallback",
                 str(exc),
             )
-            return KeyRingNullProvider()
 
         # Fallback to Cli Provider if `keyring` isn't installed
         cli = shutil.which("keyring")

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -32,11 +32,6 @@ class Credentials(NamedTuple):
     password: str
 
 
-class KeyRingCredential(NamedTuple):
-    username: Optional[str]
-    password: str
-
-
 class KeyRingCli:
     """Mirror the parts of keyring's API which pip uses
 
@@ -47,17 +42,14 @@ class KeyRingCli:
     """
 
     @classmethod
-    def get_credential(
-        cls, service_name: str, username: Optional[str]
-    ) -> Optional[KeyRingCredential]:
-        cmd = ["keyring", "get", service_name, str(username)]
+    def get_password(cls, service_name: str, username: str) -> Optional[str]:
+        cmd = ["keyring", "get", service_name, username]
         res = subprocess.run(
             cmd, capture_output=True, env=dict(PYTHONIOENCODING="utf-8")
         )
         if res.returncode:
             return None
-        password = res.stdout.decode("utf-8").strip("\n")
-        return KeyRingCredential(username=username, password=password)
+        return res.stdout.decode("utf-8").strip("\n")
 
     @classmethod
     def set_password(cls, service_name: str, username: str, password: str) -> None:

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -63,9 +63,9 @@ class KeyRingCli:
 try:
     import keyring
 except ImportError:
+    keyring = None  # type: ignore[assignment]
     if shutil.which("keyring") is not None:
         keyring = KeyRingCli  # type: ignore[assignment]
-    keyring = None  # type: ignore[assignment]
 except Exception as exc:
     logger.warning(
         "Keyring is skipped due to an exception: %s",

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -47,7 +47,10 @@ class KeyRingCli:
     def get_password(self, service_name: str, username: str) -> Optional[str]:
         cmd = [self.keyring, "get", service_name, username]
         res = subprocess.run(
-            cmd, capture_output=True, env=dict(PYTHONIOENCODING="utf-8")
+            cmd,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            env=dict(PYTHONIOENCODING="utf-8"),
         )
         if res.returncode:
             return None

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -61,8 +61,7 @@ class KeyRingCli:
     def set_password(cls, service_name: str, username: str, password: str) -> None:
         cmd = ["keyring", "set", service_name, username]
         res = subprocess.run(cmd, input=password.encode() + b"\n", capture_output=True)
-        if res.returncode:
-            raise RuntimeError(res.stderr)
+        res.check_returncode()
         return None
 
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -147,13 +147,26 @@ class KeyRingCliProvider(KeyRingBaseProvider):
 def get_keyring_provider() -> KeyRingBaseProvider:
     # keyring has previously failed and been disabled
     if not KEYRING_DISABLED:
+        # Default to trying to use Python provider
         try:
             return KeyRingPythonProvider()
         except ImportError:
             pass
+        except Exception as exc:
+            # In the event of an unexpected exception
+            # we shouldn't fallback silently to the
+            # CliProvider
+            logger.warning(
+                "Keyring is skipped due to an exception: %s",
+                str(exc),
+            )
+            return KeyRingNullProvider()
+
+        # Fallback to Cli Provider if `keyring` isn't installed
         cli = shutil.which("keyring")
         if cli:
             return KeyRingCliProvider(cli)
+
     return KeyRingNullProvider()
 
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -9,7 +9,6 @@ import shutil
 import subprocess
 import urllib.parse
 from abc import ABC, abstractmethod
-from types import ModuleType
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
@@ -62,8 +61,10 @@ class KeyRingNullProvider(KeyRingBaseProvider):
 class KeyRingPythonProvider(KeyRingBaseProvider):
     """Keyring interface which uses locally imported `keyring`"""
 
-    def __init__(self, module: ModuleType) -> None:
-        self.keyring = module
+    def __init__(self) -> None:
+        import keyring
+
+        self.keyring = keyring
 
     def get_auth_info(self, url: str, username: Optional[str]) -> Optional[AuthInfo]:
         # Support keyring's get_credential interface which supports getting
@@ -147,9 +148,7 @@ def get_keyring_provider() -> KeyRingBaseProvider:
     # keyring has previously failed and been disabled
     if not KEYRING_DISABLED:
         try:
-            import keyring
-
-            return KeyRingPythonProvider(keyring)
+            return KeyRingPythonProvider()
         except ImportError:
             pass
         cli = shutil.which("keyring")

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -51,17 +51,19 @@ class KeyRingCli:
         cls, service_name: str, username: Optional[str]
     ) -> Optional[KeyRingCredential]:
         cmd = ["keyring", "get", service_name, str(username)]
-        res = subprocess.run(cmd, capture_output=True)
+        res = subprocess.run(
+            cmd, capture_output=True, env=dict(PYTHONIOENCODING="utf-8")
+        )
         if res.returncode:
             return None
-        password = res.stdout.decode().strip("\n")
+        password = res.stdout.decode("utf-8").strip("\n")
         return KeyRingCredential(username=username, password=password)
 
     @classmethod
     def set_password(cls, service_name: str, username: str, password: str) -> None:
         cmd = ["keyring", "set", service_name, username]
-        input_ = password.encode() + b"\n"
-        res = subprocess.run(cmd, input=input_)
+        input_ = password.encode("utf-8") + b"\n"
+        res = subprocess.run(cmd, input=input_, env=dict(PYTHONIOENCODING="utf-8"))
         res.check_returncode()
         return None
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -60,7 +60,8 @@ class KeyRingCli:
     @classmethod
     def set_password(cls, service_name: str, username: str, password: str) -> None:
         cmd = ["keyring", "set", service_name, username]
-        res = subprocess.run(cmd, input=password.encode() + b"\n", capture_output=True)
+        input_ = password.encode() + b"\n"
+        res = subprocess.run(cmd, input=input_)
         res.check_returncode()
         return None
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -133,7 +133,7 @@ class KeyRingCliProvider(KeyRingBaseProvider):
             return None
 
         cmd = [cls.keyring, "get", service_name, username]
-        env = os.environ
+        env = os.environ.copy()
         env["PYTHONIOENCODING"] = "utf-8"
         res = subprocess.run(
             cmd,
@@ -153,7 +153,7 @@ class KeyRingCliProvider(KeyRingBaseProvider):
 
         cmd = [cls.keyring, "set", service_name, username]
         input_ = password.encode("utf-8") + b"\n"
-        env = os.environ
+        env = os.environ.copy()
         env["PYTHONIOENCODING"] = "utf-8"
         res = subprocess.run(cmd, input=input_, env=env)
         res.check_returncode()

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -1,6 +1,6 @@
 import functools
 import sys
-from typing import Any, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import pytest
 
@@ -334,3 +334,143 @@ def test_broken_keyring_disables_keyring(monkeypatch: pytest.MonkeyPatch) -> Non
             url, allow_netrc=False, allow_keyring=True
         ) == (None, None)
         assert keyring_broken._call_count == 1
+
+
+class KeyringSubprocessResult(KeyringModuleV1):
+    """Represents the subprocess call to keyring"""
+
+    returncode = 0  # Default to zero retcode
+
+    def __call__(
+        self,
+        cmd: List[str],
+        *,
+        env: Dict[str, str],
+        stdin: Optional[Any] = None,
+        capture_output: Optional[bool] = None,
+        input: Optional[bytes] = None,
+    ) -> Any:
+        if cmd[1] == "get":
+            assert stdin == -3  # subprocess.DEVNULL
+            assert capture_output is True
+            assert env["PYTHONIOENCODING"] == "utf-8"
+
+            password = self.get_password(*cmd[2:])
+            if password is None:
+                # Expect non-zero returncode if no password present
+                self.returncode = 1
+            else:
+                # Passwords are returned encoded with a newline appended
+                self.stdout = password.encode("utf-8") + b"\n"
+
+        if cmd[1] == "set":
+            assert stdin is None
+            assert capture_output is None
+            assert env["PYTHONIOENCODING"] == "utf-8"
+            assert input is not None
+
+            # Input from stdin is encoded
+            self.set_password(cmd[2], cmd[3], input.decode("utf-8").strip("\n"))
+
+        return self
+
+    def check_returncode(self) -> None:
+        if self.returncode:
+            raise Exception()
+
+
+@pytest.mark.parametrize(
+    "url, expect",
+    (
+        ("http://example.com/path1", (None, None)),
+        # path1 URLs will be resolved by netloc
+        ("http://user@example.com/path1", ("user", "user!netloc")),
+        ("http://user2@example.com/path1", ("user2", "user2!netloc")),
+        # path2 URLs will be resolved by index URL
+        ("http://example.com/path2/path3", (None, None)),
+        ("http://foo@example.com/path2/path3", ("foo", "foo!url")),
+    ),
+)
+def test_keyring_cli_get_password(
+    monkeypatch: pytest.MonkeyPatch,
+    url: str,
+    expect: Tuple[Optional[str], Optional[str]],
+) -> None:
+    monkeypatch.setattr(pip._internal.network.auth.shutil, "which", lambda x: "keyring")
+    monkeypatch.setattr(
+        pip._internal.network.auth.subprocess, "run", KeyringSubprocessResult()
+    )
+    auth = MultiDomainBasicAuth(index_urls=["http://example.com/path2"])
+
+    actual = auth._get_new_credentials(url, allow_netrc=False, allow_keyring=True)
+    assert actual == expect
+
+
+@pytest.mark.parametrize(
+    "response_status, creds, expect_save",
+    (
+        (403, ("user", "pass", True), False),
+        (
+            200,
+            ("user", "pass", True),
+            True,
+        ),
+        (
+            200,
+            ("user", "pass", False),
+            False,
+        ),
+    ),
+)
+def test_keyring_cli_set_password(
+    monkeypatch: pytest.MonkeyPatch,
+    response_status: int,
+    creds: Tuple[str, str, bool],
+    expect_save: bool,
+) -> None:
+    monkeypatch.setattr(pip._internal.network.auth.shutil, "which", lambda x: "keyring")
+    keyring = KeyringSubprocessResult()
+    monkeypatch.setattr(pip._internal.network.auth.subprocess, "run", keyring)
+    auth = MultiDomainBasicAuth(prompting=True)
+    monkeypatch.setattr(auth, "_get_url_and_credentials", lambda u: (u, None, None))
+    monkeypatch.setattr(auth, "_prompt_for_password", lambda *a: creds)
+    if creds[2]:
+        # when _prompt_for_password indicates to save, we should save
+        def should_save_password_to_keyring(*a: Any) -> bool:
+            return True
+
+    else:
+        # when _prompt_for_password indicates not to save, we should
+        # never call this function
+        def should_save_password_to_keyring(*a: Any) -> bool:
+            assert False, "_should_save_password_to_keyring should not be called"
+
+    monkeypatch.setattr(
+        auth, "_should_save_password_to_keyring", should_save_password_to_keyring
+    )
+
+    req = MockRequest("https://example.com")
+    resp = MockResponse(b"")
+    resp.url = req.url
+    connection = MockConnection()
+
+    def _send(sent_req: MockRequest, **kwargs: Any) -> MockResponse:
+        assert sent_req is req
+        assert "Authorization" in sent_req.headers
+        r = MockResponse(b"")
+        r.status_code = response_status
+        return r
+
+    # https://github.com/python/mypy/issues/2427
+    connection._send = _send  # type: ignore[assignment]
+
+    resp.request = req
+    resp.status_code = 401
+    resp.connection = connection
+
+    auth.handle_401(resp)
+
+    if expect_save:
+        assert keyring.saved_passwords == [("example.com", creds[0], creds[1])]
+    else:
+        assert keyring.saved_passwords == []

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -14,7 +14,6 @@ def reset_keyring() -> Iterable[None]:
     yield None
     # Reset the state of the module between tests
     pip._internal.network.auth.KEYRING_DISABLED = False
-    pip._internal.network.auth.get_keyring_provider.cache_clear()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #11588 

This PR allows `pip` to use system wide `keyring` installations which appear on `PATH`.

In order to avoid breaking peoples current systems this will still default to using `keyring` imported from
the local environment. A different `keyring` installation will only be used if no local `keyring` is found.

Edit: this may also partially address #8485 as it delays the import of `keyring`

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
