### PR TITLE
Fix docstring to match reality

### DIFF
--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -79,7 +79,7 @@ def _make_version_pkg_url(
     Return a "git+file://" URL to the version_pkg test package.
 
     Args:
-      path: a tests.lib.path.Path object pointing to a Git repository
+      path: a pathlib.Path object pointing to a Git repository
         containing the version_pkg package.
       rev: an optional revision to install like a branch name, tag, or SHA.
     """
@@ -101,7 +101,7 @@ def _install_version_pkg_only(
     the version).
 
     Args:
-      path: a tests.lib.path.Path object pointing to a Git repository
+      path: a pathlib.Path object pointing to a Git repository
         containing the package.
       rev: an optional revision to install like a branch name or tag.
     """
@@ -122,7 +122,7 @@ def _install_version_pkg(
     installed.
 
     Args:
-      path: a tests.lib.path.Path object pointing to a Git repository
+      path: a pathlib.Path object pointing to a Git repository
         containing the package.
       rev: an optional revision to install like a branch name or tag.
     """


### PR DESCRIPTION
We've moved to pathlib a while ago, the docstring still references tests.lib.path, which no longer exists.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
