### PR TITLE
Use the "venv" scheme if available to obtain prefixed lib paths

### DIFF
--- a/news/11598.bugfix.rst
+++ b/news/11598.bugfix.rst
@@ -1,0 +1,1 @@
+Use the "venv" scheme if available to obtain prefixed lib paths.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -18,7 +18,11 @@ from pip._vendor.packaging.version import Version
 
 from pip import __file__ as pip_location
 from pip._internal.cli.spinners import open_spinner
-from pip._internal.locations import get_platlib, get_prefixed_libs, get_purelib
+from pip._internal.locations import (
+    get_isolated_environment_lib_paths,
+    get_platlib,
+    get_purelib,
+)
 from pip._internal.metadata import get_default_environment, get_environment
 from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
@@ -37,7 +41,7 @@ class _Prefix:
             "nt" if os.name == "nt" else "posix_prefix",
             vars={"base": path, "platbase": path},
         )["scripts"]
-        self.lib_dirs = get_prefixed_libs(path)
+        self.lib_dirs = get_isolated_environment_lib_paths(path)
 
 
 def get_runnable_pip() -> str:

--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -27,7 +27,7 @@ __all__ = [
     "get_bin_user",
     "get_major_minor_version",
     "get_platlib",
-    "get_prefixed_libs",
+    "get_isolated_environment_lib_paths",
     "get_purelib",
     "get_scheme",
     "get_src_prefix",
@@ -482,13 +482,13 @@ def _looks_like_apple_library(path: str) -> bool:
     return path == f"/Library/Python/{get_major_minor_version()}/site-packages"
 
 
-def get_prefixed_libs(prefix: str) -> List[str]:
+def get_isolated_environment_lib_paths(prefix: str) -> List[str]:
     """Return the lib locations under ``prefix``."""
-    new_pure, new_plat = _sysconfig.get_prefixed_libs(prefix)
+    new_pure, new_plat = _sysconfig.get_isolated_environment_lib_paths(prefix)
     if _USE_SYSCONFIG:
         return _deduplicated(new_pure, new_plat)
 
-    old_pure, old_plat = _distutils.get_prefixed_libs(prefix)
+    old_pure, old_plat = _distutils.get_isolated_environment_lib_paths(prefix)
     old_lib_paths = _deduplicated(old_pure, old_plat)
 
     # Apple's Python (shipped with Xcode and Command Line Tools) hard-code

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -173,7 +173,7 @@ def get_platlib() -> str:
     return get_python_lib(plat_specific=True)
 
 
-def get_prefixed_libs(prefix: str) -> Tuple[str, str]:
+def get_isolated_environment_lib_paths(prefix: str) -> Tuple[str, str]:
     return (
         get_python_lib(plat_specific=False, prefix=prefix),
         get_python_lib(plat_specific=True, prefix=prefix),

--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -213,7 +213,7 @@ def get_platlib() -> str:
     return sysconfig.get_paths()["platlib"]
 
 
-def get_prefixed_libs(prefix: str) -> typing.Tuple[str, str]:
+def get_isolated_environment_lib_paths(prefix: str) -> typing.Tuple[str, str]:
     vars = {"base": prefix, "platbase": prefix}
     if "venv" in sysconfig.get_scheme_names():
         paths = sysconfig.get_paths(vars=vars, scheme="venv")

--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -214,5 +214,9 @@ def get_platlib() -> str:
 
 
 def get_prefixed_libs(prefix: str) -> typing.Tuple[str, str]:
-    paths = sysconfig.get_paths(vars={"base": prefix, "platbase": prefix})
+    vars = {"base": prefix, "platbase": prefix}
+    if "venv" in sysconfig.get_scheme_names():
+        paths = sysconfig.get_paths(vars=vars, scheme="venv")
+    else:
+        paths = sysconfig.get_paths(vars=vars)
     return (paths["purelib"], paths["platlib"])


### PR DESCRIPTION
get_prefixed_libs() computes the Python path for libraries in a pip isolation environment. Python 3.11 introduced the "venv" path scheme to be used in these cases. Use it if available.

This solves a bug on Homebrew's Python 3.10 and later where the default paths scheme when Python is invoked outside a virtual environment is "osx_framework_library" and does not relative to the "{base}" or "{platbase}" variables.

Fixes #11539.
