### PR TITLE
Don't maintain 2 copies of change_root

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1145,39 +1145,6 @@ def test_install_with_target_or_prefix_and_scripts_no_warning(
     assert "--no-warn-script-location" not in result.stderr, str(result)
 
 
-def _change_root(new_root: str, pathname: str) -> str:
-    """
-    Adapted from distutils.
-
-    Return 'pathname' with 'new_root' prepended.  If 'pathname' is
-    relative, this is equivalent to "os.path.join(new_root,pathname)".
-    Otherwise, it requires making 'pathname' relative and then joining the
-    two, which is tricky on DOS/Windows and Mac OS.
-    """
-    try:
-        from distutils.util import change_root
-    except ImportError:
-        pass
-    else:
-        return change_root(new_root, pathname)
-
-    if os.name == "posix":
-        if not os.path.isabs(pathname):
-            return os.path.join(new_root, pathname)
-        else:
-            return os.path.join(new_root, pathname[1:])
-
-    elif os.name == "nt":
-        drive, path = os.path.splitdrive(pathname)
-        if path[0] == "\\":
-            path = path[1:]
-        return os.path.join(new_root, path)
-
-    else:
-        # distutils raise DistutilsPlatformError here
-        raise RuntimeError(f"nothing known about platform '{os.name}'")
-
-
 @pytest.mark.usefixtures("with_wheel")
 def test_install_package_with_root(script: PipTestEnvironment, data: TestData) -> None:
     """
@@ -1196,8 +1163,11 @@ def test_install_package_with_root(script: PipTestEnvironment, data: TestData) -
     normal_install_path = os.fspath(
         script.base_path / script.site_packages / "simple-1.0.dist-info"
     )
+    # use a function borrowed from distutils
+    # to change the root exactly how the --root option does it
+    from pip._internal.locations.base import change_root
 
-    root_path = _change_root(os.path.join(script.scratch, "root"), normal_install_path)
+    root_path = change_root(os.path.join(script.scratch, "root"), normal_install_path)
     result.did_create(root_path)
 
     # Should show find-links location in output


### PR DESCRIPTION
The change_root function was added twice:

In ae324d17033253626725330c6635c0089927fbf5 and in 36a9b365234a0e6608e9304f560d68df7bf85038

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
