### PR TITLE
Update the macos tag in `pip download` docs

### DIFF
--- a/docs/html/cli/pip_download.rst
+++ b/docs/html/cli/pip_download.rst
@@ -81,7 +81,7 @@ Examples
 
 #. Download a package and all of its dependencies with OSX specific interpreter constraints.
    This forces OSX 10.10 or lower compatibility. Since OSX deps are forward compatible,
-   this will also match ``macosx-10_9_x86_64``, ``macosx-10_8_x86_64``, ``macosx-10_8_intel``,
+   this will also match ``macosx_10_9_x86_64``, ``macosx_10_8_x86_64``, ``macosx_10_8_intel``,
    etc.
    It will also match deps with platform ``any``. Also force the interpreter version to ``27``
    (or more generic, i.e. ``2``) and implementation to ``cp`` (or more generic, i.e. ``py``).
@@ -92,7 +92,7 @@ Examples
 
          python -m pip download \
             --only-binary=:all: \
-            --platform macosx-10_10_x86_64 \
+            --platform macosx_10_10_x86_64 \
             --python-version 27 \
             --implementation cp \
             SomePackage
@@ -103,7 +103,7 @@ Examples
 
          py -m pip download ^
             --only-binary=:all: ^
-            --platform macosx-10_10_x86_64 ^
+            --platform macosx_10_10_x86_64 ^
             --python-version 27 ^
             --implementation cp ^
             SomePackage


### PR DESCRIPTION
Correct platform tag for macosx.