### PR TITLE
Update flake8 additional_dependencies via 'upadup'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,8 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [
-        'flake8-bugbear==22.3.23',
-        'flake8-logging-format==0.6.0',
+        'flake8-bugbear==22.10.27',
+        'flake8-logging-format==0.9.0',
         'flake8-implicit-str-concat==0.3.0',
     ]
     exclude: tests/data


### PR DESCRIPTION
👋 Hi there!

I've recently been tinkering on [a tool to complement `pre-commit autoupdate` and take care of `flake8-bugbear`](https://pypi.org/project/upadup/) and related `additional_dependencies` problems.

`pipx run upadup` is sufficient to see how it behaves on the `pip` config.

The tool is brand new, so it might have some rough edges, but I figured it would be nice to introduce it by means of PRs on projects to show that it works on their config.

I've made a change (not yet released) to add `flake8-logging-format` and `flake8-implicit-str-concat` to the defaults which are checked, so those are included here but wouldn't be visible.