### PR TITLE
fix: Allow extra-index-url to precede index-url

### DIFF
--- a/news/11511.bugfix.rst
+++ b/news/11511.bugfix.rst
@@ -1,0 +1,2 @@
+Fix the error that may be caused when the order of "index-url" and 
+"extra-index-url" in the requirements.txt file alternates.

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -22,6 +22,7 @@ from typing import (
 
 from pip._internal.cli import cmdoptions
 from pip._internal.exceptions import InstallationError, RequirementsFileParseError
+from pip._internal.models.index import PyPI
 from pip._internal.models.search_scope import SearchScope
 from pip._internal.network.session import PipSession
 from pip._internal.network.utils import raise_for_status
@@ -230,7 +231,9 @@ def handle_option_line(
             no_index = True
             index_urls = []
         if opts.index_url and not no_index:
-            index_urls = [opts.index_url]
+            if PyPI.simple_url in index_urls:
+                index_urls.remove(PyPI.simple_url)
+            index_urls.append(opts.index_url)
         if opts.extra_index_urls and not no_index:
             index_urls.extend(opts.extra_index_urls)
         if opts.find_links:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

fix #11511 

fix https://github.com/python-poetry/poetry-plugin-export/issues/149