### PR TITLE
parallelize coverage as much as possible, by default

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -243,11 +243,15 @@ def coverage(session: nox.Session) -> None:
 
     if not os.path.exists(".coverage-output"):
         os.mkdir(".coverage-output")
+    
+    # parallelize coverage as much as possible, by default.
+    arguments = session.posargs or ["-n", "auto"]
+    
     session.run(
         "pytest",
         "--cov=pip",
         "--cov-config=./setup.cfg",
-        *session.posargs,
+        *arguments,
         env={
             "COVERAGE_OUTPUT_DIR": "./.coverage-output",
             "COVERAGE_PROCESS_START": os.fsdecode(Path("setup.cfg").resolve()),


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
