### PR TITLE
Fixes win/git-bash `pip uninstall mypackage` crash when in virtual environment "input(): lost sys.stderr"

### DIFF
--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -364,19 +364,28 @@ class UninstallPathSet:
         logger.info("Uninstalling %s:", dist_name_version)
 
         with indent_log():
-            if auto_confirm or self._allowed_to_proceed(verbose):
-                moved = self._moved_paths
+            try:
+                if auto_confirm or self._allowed_to_proceed(verbose):
+                    moved = self._moved_paths
 
-                for_rename = compress_for_rename(self._paths)
+                    for_rename = compress_for_rename(self._paths)
 
-                for path in sorted(compact(for_rename)):
-                    moved.stash(path)
-                    logger.verbose("Removing file or directory %s", path)
+                    for path in sorted(compact(for_rename)):
+                        moved.stash(path)
+                        logger.verbose("Removing file or directory %s", path)
 
-                for pth in self._pth.values():
-                    pth.remove()
+                    for pth in self._pth.values():
+                        pth.remove()
 
-                logger.info("Successfully uninstalled %s", dist_name_version)
+                    logger.info("Successfully uninstalled %s", dist_name_version)
+            except RuntimeError as runerror:
+                if "lost sys.stderr" in runerror.args[0]:
+                    logger.error(
+                        "A crash was detected while prompting for user input. Rerun `pip uninstall`\n"
+                        "with -y to suppress, see https://github.com/pypa/pip/issues/11632"
+                    )
+                raise
+
 
     def _allowed_to_proceed(self, verbose: bool) -> bool:
         """Display which files would be deleted and prompt for confirmation"""

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -398,6 +398,10 @@ class UninstallPathSet:
             will_remove = set(self._paths)
             will_skip = set()
 
+        # git-bash breaks the stdin pipe, so assume confirmation.
+        if os.name == "nt" and os.getenv("MSYSTEM") == "MINGW64":
+            logger.warning("git bash can not prompt input, skipping.")
+            return True  # fixes crash on git-bash win32.
         _display("Would remove:", will_remove)
         _display("Would not remove (might be manually added):", will_skip)
         _display("Would not remove (outside of prefix):", self._refuse)


### PR DESCRIPTION
Workaround for: https://github.com/pypa/pip/issues/11632

On win32/gitbash, this currently crashes while in a virtual environment:

```bash
pip uninstall mypackage
```

It does not happen while in the global environment, or if in a virtual environment and using `cmd` or `powershell`

To reproduce the issue, simply run the pip uninstall -y mypackage command in Git Bash on a win32 system. The command should crash, but with this fix applied, it should uninstall mypackage without crashing.

This is done by checking that the current system platform is both windows and MINGW64. This fix will apply to git-bash and also cygwin. No other platforms are affected.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->