### PR TITLE
show: show editable location instead if package is editable (#11638)

### DIFF
--- a/news/11638.bugfix.rst
+++ b/news/11638.bugfix.rst
@@ -1,0 +1,1 @@
+Make ``pip show`` show the editable location if package is editable

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -53,6 +53,7 @@ class _PackageInfo(NamedTuple):
     name: str
     version: str
     location: str
+    editable_project_location: Optional[str]
     requires: List[str]
     required_by: List[str]
     installer: str
@@ -120,6 +121,7 @@ def search_packages_info(query: List[str]) -> Generator[_PackageInfo, None, None
             name=dist.raw_name,
             version=str(dist.version),
             location=dist.location or "",
+            editable_project_location=dist.editable_project_location,
             requires=requires,
             required_by=required_by,
             installer=dist.installer,
@@ -158,6 +160,10 @@ def print_results(
         write_output("Author-email: %s", dist.author_email)
         write_output("License: %s", dist.license)
         write_output("Location: %s", dist.location)
+        if dist.editable_project_location is not None:
+            write_output(
+                "Editable project location: %s", dist.editable_project_location
+            )
         write_output("Requires: %s", ", ".join(dist.requires))
         write_output("Required-by: %s", ", ".join(dist.required_by))
 

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -17,7 +17,7 @@ def test_basic_show(script: PipTestEnvironment) -> None:
     """
     result = script.pip("show", "pip")
     lines = result.stdout.splitlines()
-    assert len(lines) == 10
+    assert len(lines) == 11
     assert "Name: pip" in lines
     assert f"Version: {__version__}" in lines
     assert any(line.startswith("Location: ") for line in lines)
@@ -33,7 +33,7 @@ def test_show_with_files_not_found(script: PipTestEnvironment, data: TestData) -
     script.pip("install", "-e", editable)
     result = script.pip("show", "-f", "SetupPyUTF8")
     lines = result.stdout.splitlines()
-    assert len(lines) == 12
+    assert len(lines) == 13
     assert "Name: SetupPyUTF8" in lines
     assert "Version: 0.0.0" in lines
     assert any(line.startswith("Location: ") for line in lines)
@@ -128,7 +128,7 @@ def test_report_mixed_not_found(script: PipTestEnvironment) -> None:
     result = script.pip("show", "Abcd3", "A-B-C", "pip", allow_stderr_warning=True)
     assert "WARNING: Package(s) not found: A-B-C, Abcd3" in result.stderr
     lines = result.stdout.splitlines()
-    assert len(lines) == 10
+    assert len(lines) == 11
     assert "Name: pip" in lines
 
 
@@ -213,6 +213,7 @@ def test_all_fields(script: PipTestEnvironment) -> None:
         "Author-email",
         "License",
         "Location",
+        "Editable project location",
         "Requires",
         "Required-by",
     }
@@ -226,7 +227,7 @@ def test_pip_show_is_short(script: PipTestEnvironment) -> None:
     """
     result = script.pip("show", "pip")
     lines = result.stdout.splitlines()
-    assert len(lines) <= 10
+    assert len(lines) <= 11
 
 
 def test_pip_show_divider(script: PipTestEnvironment, data: TestData) -> None:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
