### PR TITLE
Prevent pkg_resource access on Python 3.12+

### DIFF
--- a/news/11501.process.rst
+++ b/news/11501.process.rst
@@ -1,6 +1,6 @@
-Emit an error to prevent the ``pkg_resources`` metadata backend from being used
-on Python 3.12 or later. This backend exists for backward compatibility, and
-should only be used on newer Python versions by Python distributors that cannot
-correctly implement ``importlib.metadata`` support in a timely fashion. Time is
-up for transition since CPython is now removing mechanisms that ``pkg_resource``
+Prevent the ``pkg_resources`` metadata backend from being used on Python 3.12
+or later. This backend exists for backward compatibility, and should only be
+used on newer Python versions by Python distributors that cannot correctly
+implement ``importlib.metadata`` support in a timely fashion. Time is up for
+transition since CPython is now removing mechanisms that ``pkg_resource``
 relies on, and the backend will no longer work on Python 3.12 or later.

--- a/news/11501.process.rst
+++ b/news/11501.process.rst
@@ -1,0 +1,6 @@
+Emit an error to prevent the ``pkg_resources`` metadata backend from being used
+on Python 3.12 or later. This backend exists for backward compatibility, and
+should only be used on newer Python versions by Python distributors that cannot
+correctly implement ``importlib.metadata`` support in a timely fashion. Time is
+up for transition since CPython is now removing mechanisms that ``pkg_resource``
+relies on, and the backend will no longer work on Python 3.12 or later.

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -4,6 +4,7 @@ import os
 import sys
 from typing import TYPE_CHECKING, List, Optional, Type, cast
 
+from pip._internal.exceptions import PipError
 from pip._internal.utils.misc import strtobool
 
 from .base import BaseDistribution, BaseEnvironment, FilesystemWheel, MemoryWheel, Wheel
@@ -60,6 +61,11 @@ def select_backend() -> Backend:
         from . import importlib
 
         return cast(Backend, importlib)
+
+    if sys.version_info >= (3, 12):
+        message = "Cannot use pkg_resources as metadata backend on Python 3.12+"
+        raise PipError(message)
+
     from . import pkg_resources
 
     return cast(Backend, pkg_resources)


### PR DESCRIPTION
Time is up. If a downstream Python distributor hasn't implemented importlib.metadata support by now, they must expect things to break.

Close #11501.