### PR TITLE
Remove duplicate news entry for #11547

### DIFF
--- a/news/11547.bugfix.rst
+++ b/news/11547.bugfix.rst
@@ -1,3 +1,0 @@
-Fix entry point generation of ``pip.X``, ``pipX.Y``, and ``easy_install-X.Y``
-to correctly account for multi-digit Python version segments (e.g. the "11"
-part of 3.11).


### PR DESCRIPTION
#11547 was backported to pip 22.3.1, so has already been released and already has a news entry:
https://pip.pypa.io/en/latest/news/#v22-3-1

As such, one shouldn't be included for it, for the next pip release:
https://pip.pypa.io/en/latest/news/#not-yet-released-2022-12-19
