### PR TITLE
Don't check for `wheel` when only `build-system.requires` is present

### DIFF
--- a/news/11673.bugfix.rst
+++ b/news/11673.bugfix.rst
@@ -1,0 +1,3 @@
+Stop checking that ``wheel`` is present when ``build-system.requires``
+is provided without ``build-system.build-backend`` as ``setuptools``
+(which we still check for) will inject it anyway.

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -159,9 +159,8 @@ def load_pyproject_toml(
     if backend is None:
         # If the user didn't specify a backend, we assume they want to use
         # the setuptools backend. But we can't be sure they have included
-        # a version of setuptools which supplies the backend, or wheel
-        # (which is needed by the backend) in their requirements. So we
-        # make a note to check that those requirements are present once
+        # a version of setuptools which supplies the backend. So we
+        # make a note to check that this requirement is present once
         # we have set up the environment.
         # This is quite a lot of work to check for a very specific case. But
         # the problem is, that case is potentially quite common - projects that
@@ -170,6 +169,6 @@ def load_pyproject_toml(
         # tools themselves. The original PEP 518 code had a similar check (but
         # implemented in a different way).
         backend = "setuptools.build_meta:__legacy__"
-        check = ["setuptools>=40.8.0", "wheel"]
+        check = ["setuptools>=40.8.0"]
 
     return BuildSystemDetails(requires, backend, check, backend_path)


### PR DESCRIPTION
Fixes #11673 
