### PR TITLE
Update VCS support documentation

### DIFF
--- a/docs/html/topics/vcs-support.md
+++ b/docs/html/topics/vcs-support.md
@@ -130,10 +130,6 @@ VCS source will not overwrite it without an `--upgrade` flag. Further, pip
 looks at the package version, at the target revision to determine what action to
 take on the VCS requirement (not the commit itself).
 
-The {ref}`pip freeze` subcommand will record the VCS requirement specifier
-(referencing a specific commit) only if the install is done with the editable
-option.
-
 ## URL fragments
 
 pip looks at 2 fragments for VCS URLs:

--- a/news/11675.doc.rst
+++ b/news/11675.doc.rst
@@ -1,0 +1,2 @@
+Remove mention that editable installs are necessary for pip freeze to report the VCS
+URL.


### PR DESCRIPTION
Now that PEP 610 (direct_url.json) is implemented, an editable install is not required anymore for pip freeze to work correctly.
