### PR TITLE
Add an environment containing the secret token

### DIFF
--- a/.github/workflows/update-rtd-redirects.yml
+++ b/.github/workflows/update-rtd-redirects.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   update-rtd-redirects:
     runs-on: ubuntu-latest
+    environment: RTD Deploys
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
This ensures that we only expose the token to this one job on `main`.

Follow up to #11680 