### PR TITLE
Update our RTD redirects to use `latest` for dev, `stable` for errors

### DIFF
--- a/.readthedocs-custom-redirects.yml
+++ b/.readthedocs-custom-redirects.yml
@@ -2,9 +2,9 @@
 # It is related to Read the Docs, but is not a file processed by the platform.
 
 /dev/news-entry-failure: >-
-  https://pip.pypa.io/en/stable/development/contributing/#news-entries
+  https://pip.pypa.io/en/latest/development/contributing/#news-entries
 /errors/resolution-impossible: >-
-  https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
+  https://pip.pypa.io/en/stable/topics/dependency-resolution/#dealing-with-dependency-conflicts
 /surveys/backtracking: >-
   https://forms.gle/LkZP95S4CfqBAU1N6
 /warnings/backtracking: >-


### PR DESCRIPTION
x-ref https://github.com/pypa/pip/pull/11652

/cc @uranusjr 
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
