### PR TITLE
fix: Less noisy conflict message

### DIFF
--- a/news/11596.bugfix.rst
+++ b/news/11596.bugfix.rst
@@ -1,0 +1,1 @@
+Make conflict messages less noisy during install command.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -655,7 +655,7 @@ class Factory:
 
         # The simplest case is when we have *one* cause that can't be
         # satisfied. We just report that case.
-        if len(e.causes) == 1:
+        if not e.req_conflict and len(e.causes) == 1:
             req, parent = e.causes[0]
             if req.name not in constraints:
                 return self._report_single_requirement_conflict(req, parent)

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -64,7 +64,6 @@ class SpecifierRequirement(Requirement):
         return format_name(self.project_name, self._extras)
 
     def format_for_error(self) -> str:
-
         # Convert comma-separated specifiers into "A, B, ..., F and G"
         # This makes the specifier a bit more "human readable", without
         # risking a change in meaning. (Hopefully! Not all edge cases have

--- a/src/pip/_vendor/resolvelib/resolvers.py
+++ b/src/pip/_vendor/resolvelib/resolvers.py
@@ -85,10 +85,11 @@ class ResolutionError(ResolverException):
 
 
 class ResolutionImpossible(ResolutionError):
-    def __init__(self, causes):
+    def __init__(self, causes, req_conflict=False):
         super(ResolutionImpossible, self).__init__(causes)
         # causes is a list of RequirementInformation objects
         self.causes = causes
+        self.req_conflict = req_conflict
 
 
 class ResolutionTooDeep(ResolutionError):
@@ -382,7 +383,7 @@ class Resolution(object):
 
                 # Dead ends everywhere. Give up.
                 if not success:
-                    raise ResolutionImpossible(self.state.backtrack_causes)
+                    raise ResolutionImpossible(self.state.backtrack_causes[-1:], req_conflict=True)
             else:
                 # Pinning was successful. Push a new state to do another pin.
                 self._push_new_state()

--- a/src/pip/_vendor/resolvelib/resolvers.pyi
+++ b/src/pip/_vendor/resolvelib/resolvers.pyi
@@ -51,6 +51,7 @@ class InconsistentCandidate(ResolverException, Generic[RT, CT, KT]):
 
 class ResolutionImpossible(ResolutionError, Generic[RT, CT]):
     causes: List[RequirementInformation[RT, CT]]
+    req_conflict: bool
 
 class ResolutionTooDeep(ResolutionError):
     round_count: int


### PR DESCRIPTION
### Before

```python
(env) ➜  pip git:(main) ✗ pip install --no-cache-dir -r reqs11596.txt
Collecting flake8==5.0.4
  Downloading flake8-5.0.4-py2.py3-none-any.whl (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.9/61.9 kB 4.5 MB/s eta 0:00:00
Requirement already satisfied: flake8-typing-imports==1.12.0 in ./env/lib/python3.12/site-packages (from -r reqs11596.txt (line 2)) (1.12.0)
...
Collecting flake8-typing-imports==1.12.0
  Downloading flake8_typing_imports-1.12.0-py2.py3-none-any.whl (8.1 kB)
INFO: pip is looking at multiple versions of flake8-bugbear to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of <Python from Requires-Python> to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of flake8 to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r reqs11596.txt (line 2), -r reqs11596.txt (line 3), -r reqs11596.txt (line 4), flake8-isort==4.1.1 and flake8==5.0.4 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested flake8==5.0.4
    flake8-typing-imports 1.12.0 depends on flake8>=3.8
    flake8-builtins 1.5.3 depends on flake8
    flake8-bugbear 22.1.11 depends on flake8>=3.0.0
    flake8-isort 4.1.1 depends on flake8<5 and >=3.2.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

### After

```python
(env) ➜  pip git:(resolution-conflicts) ✗ pip install --no-cache-dir -r reqs11596.txt
Collecting flake8==5.0.4
  Downloading flake8-5.0.4-py2.py3-none-any.whl (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.9/61.9 kB 2.8 MB/s eta 0:00:00
...
INFO: pip is looking at multiple versions of flake8-typing-imports to determine which version is compatible with other requirements. This could take a while.
Collecting flake8-typing-imports==1.12.0
  Downloading flake8_typing_imports-1.12.0-py2.py3-none-any.whl (8.1 kB)
INFO: pip is looking at multiple versions of flake8-bugbear to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of <Python from Requires-Python> to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of flake8 to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install flake8-isort==4.1.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    flake8-isort 4.1.1 depends on flake8<5 and >=3.2.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

---

Contents of the `reqs11596.txt` file:

```txt
flake8==5.0.4
flake8-typing-imports==1.12.0
flake8-builtins==1.5.3
flake8-bugbear==22.1.11
flake8-isort==4.1.1
```

Closes https://github.com/pypa/pip/issues/11596