### PR TITLE
Fallback to a placeholder if a distribution's location is None

### DIFF
--- a/news/11704.bugfix.rst
+++ b/news/11704.bugfix.rst
@@ -1,0 +1,2 @@
+Fix an issue when an already existing in-memory distribution would cause
+exceptions in ``pip install``

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -1,4 +1,5 @@
 # The following comment should be removed at some point in the future.
+# mypy: strict-optional=False
 
 import functools
 import logging

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -1,5 +1,4 @@
 # The following comment should be removed at some point in the future.
-# mypy: strict-optional=False
 
 import functools
 import logging
@@ -195,7 +194,11 @@ class InstallRequirement:
         else:
             s = "<InstallRequirement>"
         if self.satisfied_by is not None:
-            s += " in {}".format(display_path(self.satisfied_by.location))
+            if self.satisfied_by.location is not None:
+                location = display_path(self.satisfied_by.location)
+            else:
+                location = 'memory'
+            s += f" in {location}"
         if self.comes_from:
             if isinstance(self.comes_from, str):
                 comes_from: Optional[str] = self.comes_from

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -198,7 +198,7 @@ class InstallRequirement:
             if self.satisfied_by.location is not None:
                 location = display_path(self.satisfied_by.location)
             else:
-                location = 'memory'
+                location = "<memory>"
             s += f" in {location}"
         if self.comes_from:
             if isinstance(self.comes_from, str):

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2357,7 +2357,7 @@ def test_install_8559_wheel_package_present(
     sys.version_info < (3, 11),
     reason="3.11 required to find distributions via importlib metadata",
 )
-def test_install_existing_memory_distribution(script: PipTestEnvironment):
+def test_install_existing_memory_distribution(script: PipTestEnvironment) -> None:
     sitecustomize_text = textwrap.dedent(
         """
         import sys

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2355,44 +2355,41 @@ def test_install_8559_wheel_package_present(
 
 @pytest.mark.skipif(
     sys.version_info < (3, 11),
-    reason="3.11 required to find distributions via importlib metadata"
+    reason="3.11 required to find distributions via importlib metadata",
 )
 def test_install_existing_memory_distribution(script: PipTestEnvironment):
     sitecustomize_text = textwrap.dedent(
         """
         import sys
         from importlib.metadata import Distribution, DistributionFinder
-        
-        
+
+
         EXAMPLE_METADATA = '''Metadata-Version: 2.1
         Name: example
         Version: 1.0.0
-        
+
         '''
 
         class ExampleDistribution(Distribution):
             def locate_file(self, path):
                 return path
-        
+
             def read_text(self, filename):
                 if filename == 'METADATA':
                     return EXAMPLE_METADATA
-        
-        
+
+
         class CustomFinder(DistributionFinder):
             def find_distributions(self, context=None):
                 return [ExampleDistribution()]
-        
-        
+
+
         sys.meta_path.append(CustomFinder())
         """
     )
-    with open(script.site_packages_path / 'sitecustomize.py', 'w') as sitecustomize_file:
-        sitecustomize_file.write(sitecustomize_text)
+    with open(script.site_packages_path / "sitecustomize.py", "w") as sitecustomize:
+        sitecustomize.write(sitecustomize_text)
 
-    result = script.pip(
-        "install",
-        "example"
-    )
+    result = script.pip("install", "example")
 
     assert "Requirement already satisfied: example in <memory>" in result.stdout


### PR DESCRIPTION
Resolves #11704

I would love to hear some thoughts on the message wording.  I feel it's not very friendly right now because it doesn't specify how pip found the package. Should we log the finder class that found the package, maybe? Not sure if it's possible though without changing the importlib API.
