### PR TITLE
Ignore optional (`extra`) dependencies in `pip check`

### DIFF
--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -75,7 +75,7 @@ def check_package_set(
             if name not in package_set:
                 missed = True
                 if req.marker is not None:
-                    missed = req.marker.evaluate()
+                    missed = req.marker.evaluate({"extra": ""})
                 if missed:
                     missing_deps.add((name, req))
                 continue


### PR DESCRIPTION
Closes #11191