### PR TITLE
Norm path before compare

### DIFF
--- a/news/11719.bugfix.rst
+++ b/news/11719.bugfix.rst
@@ -1,0 +1,1 @@
+Normalize paths before checking if installed scripts are on PATH.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -143,16 +143,18 @@ def message_about_scripts_not_on_PATH(scripts: Sequence[str]) -> Optional[str]:
 
     # We don't want to warn for directories that are on PATH.
     not_warn_dirs = [
-        os.path.normcase(i).rstrip(os.sep)
+        os.path.normcase(os.path.normpath(i)).rstrip(os.sep)
         for i in os.environ.get("PATH", "").split(os.pathsep)
     ]
     # If an executable sits with sys.executable, we don't warn for it.
     #     This covers the case of venv invocations without activating the venv.
-    not_warn_dirs.append(os.path.normcase(os.path.dirname(sys.executable)))
+    not_warn_dirs.append(
+        os.path.normcase(os.path.normpath(os.path.dirname(sys.executable)))
+    )
     warn_for: Dict[str, Set[str]] = {
         parent_dir: scripts
         for parent_dir, scripts in grouped_by_dir.items()
-        if os.path.normcase(parent_dir) not in not_warn_dirs
+        if os.path.normcase(os.path.normpath(parent_dir)) not in not_warn_dirs
     }
     if not warn_for:
         return None

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -589,6 +589,12 @@ class TestMessageAboutScriptsNotOnPATH:
         )
         assert retval is None
 
+    def test_PATH_check_path_normalization(self) -> None:
+        retval = self._template(
+            paths=["/a/./b/../b//c/", "/d/e/bin"], scripts=["/a/b/c/foo"]
+        )
+        assert retval is None
+
     def test_single_script__single_dir_on_PATH(self) -> None:
         retval = self._template(paths=["/a/b", "/c/d/bin"], scripts=["/a/b/foo"])
         assert retval is None


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

This PR norms the paths before checking, if the installed scripts are on `PATH`. I got wrong warnings, when the  PATH contains something like `/a/./bin` instead of `/a/bin`.

I also add a small test for this, contains all the cases from the [os.path.normpath() docs](https://docs.python.org/3/library/os.path.html#os.path.normpath). I am not sure, if this works also on windows ~~and I am also not sure, if I should add a news fragment, as this is just a small change~~.