### PR TITLE
Add '--ignore-constraint' option

### DIFF
--- a/news/7839.feature.rst
+++ b/news/7839.feature.rst
@@ -1,0 +1,3 @@
+Add the ``--ignore-constraint`` option to ``pip install``, ``pip download``
+and ``pip wheel`` commands to ignore an individual constraint from a
+constraints file.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -415,6 +415,19 @@ def constraints() -> Option:
     )
 
 
+def ignored_constraints() -> Option:
+    return Option(
+        "--ignore-constraint",
+        dest="ignored_constraints",
+        action="append",
+        default=[],
+        metavar="package",
+        help="Ignore constraints for given package. This is commonly used "
+        "during development of a package when using a common constraints "
+        "file. This option be used multiple times.",
+    )
+
+
 def requirements() -> Option:
     return Option(
         "-r",

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -363,10 +363,13 @@ class RequirementCommand(IndexGroupCommand):
                 ignore_requires_python=ignore_requires_python,
                 force_reinstall=force_reinstall,
                 upgrade_strategy=upgrade_strategy,
+                ignored_constraints=options.ignored_constraints,
                 py_version_info=py_version_info,
             )
         import pip._internal.resolution.legacy.resolver
 
+        # we intentionally don't pass ignored_constraints to this since the
+        # resolver is deprecated
         return pip._internal.resolution.legacy.resolver.Resolver(
             preparer=preparer,
             finder=finder,

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -37,6 +37,7 @@ class DownloadCommand(RequirementCommand):
 
     def add_options(self) -> None:
         self.cmd_opts.add_option(cmdoptions.constraints())
+        self.cmd_opts.add_option(cmdoptions.ignored_constraints())
         self.cmd_opts.add_option(cmdoptions.requirements())
         self.cmd_opts.add_option(cmdoptions.no_deps())
         self.cmd_opts.add_option(cmdoptions.global_options())

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -72,6 +72,7 @@ class InstallCommand(RequirementCommand):
     def add_options(self) -> None:
         self.cmd_opts.add_option(cmdoptions.requirements())
         self.cmd_opts.add_option(cmdoptions.constraints())
+        self.cmd_opts.add_option(cmdoptions.ignored_constraints())
         self.cmd_opts.add_option(cmdoptions.no_deps())
         self.cmd_opts.add_option(cmdoptions.pre())
 

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -61,6 +61,7 @@ class WheelCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.no_use_pep517())
         self.cmd_opts.add_option(cmdoptions.check_build_deps())
         self.cmd_opts.add_option(cmdoptions.constraints())
+        self.cmd_opts.add_option(cmdoptions.ignored_constraints())
         self.cmd_opts.add_option(cmdoptions.editable())
         self.cmd_opts.add_option(cmdoptions.requirements())
         self.cmd_opts.add_option(cmdoptions.src())

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -2,7 +2,7 @@ import contextlib
 import functools
 import logging
 import os
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Set, Tuple, cast
 
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible
@@ -50,6 +50,7 @@ class Resolver(BaseResolver):
         ignore_requires_python: bool,
         force_reinstall: bool,
         upgrade_strategy: str,
+        ignored_constraints: Sequence[str],
         py_version_info: Optional[Tuple[int, ...]] = None,
     ):
         super().__init__()
@@ -68,6 +69,7 @@ class Resolver(BaseResolver):
         )
         self.ignore_dependencies = ignore_dependencies
         self.upgrade_strategy = upgrade_strategy
+        self.ignored_constraints = ignored_constraints
         self._result: Optional[Result] = None
 
     def resolve(
@@ -80,6 +82,7 @@ class Resolver(BaseResolver):
             ignore_dependencies=self.ignore_dependencies,
             upgrade_strategy=self.upgrade_strategy,
             user_requested=collected.user_requested,
+            ignored_constraints=self.ignored_constraints,
         )
         if "PIP_RESOLVER_DEBUG" in os.environ:
             reporter: BaseReporter = PipDebuggingReporter()

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -681,6 +681,26 @@ def test_new_resolver_constraints(
     script.assert_not_installed("constraint_only")
 
 
+def test_new_resolver_constraint_ignored(script: PipTestEnvironment) -> None:
+    "We can ignore constraints. Useful when hacking on a constrained package."
+    create_basic_wheel_for_package(script, "pkg", "1.1.dev1")
+    constraints_file = script.scratch_path / "constraints.txt"
+    constraints_file.write_text("pkg==1.0")
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "-c",
+        constraints_file,
+        "--ignore-constraint",
+        "pkg",
+        "pkg",
+    )
+    script.assert_installed(pkg="1.1.dev1")
+
+
 def test_new_resolver_constraint_no_specifier(script: PipTestEnvironment) -> None:
     "It's allowed (but useless...) for a constraint to have no specifier"
     create_basic_wheel_for_package(script, "pkg", "1.0")

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -75,4 +75,5 @@ def provider(factory: Factory) -> Iterator[PipProvider]:
         ignore_dependencies=False,
         upgrade_strategy="to-satisfy-only",
         user_requested={},
+        ignored_constraints=[],
     )

--- a/tests/unit/resolution_resolvelib/test_provider.py
+++ b/tests/unit/resolution_resolvelib/test_provider.py
@@ -36,6 +36,7 @@ def test_provider_known_depths(factory: Factory) -> None:
         ignore_dependencies=False,
         upgrade_strategy="to-satisfy-only",
         user_requested={root_requirement_name: 0},
+        ignored_constraints=[],
     )
 
     root_requirement_information = build_requirement_information(

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -29,6 +29,7 @@ def resolver(preparer: RequirementPreparer, finder: PackageFinder) -> Resolver:
         ignore_requires_python=False,
         force_reinstall=False,
         upgrade_strategy="to-satisfy-only",
+        ignored_constraints=[],
     )
     return resolver
 


### PR DESCRIPTION
Constraint files are often shared across an organization. When developing a package included in such a constraint file, it is not possible to install the package with constraints since the constraint on the package prevents us installing a development version.

```console
❯ cd my-amazing-package
❯ cat constraints.txt
my-amazing-package==1.2.3
Jinja2==3.1.2
iso8601==1.1.0
msgpack==1.0.4
❯ pip install -c constraints.txt .
Processing /dev/my-amazing-package
  Preparing metadata (setup.py) ... done
ERROR: Cannot install my-amazing-package 1.2.4.dev1 (from /dev/my-amazing-package) because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested my-amazing-package 1.2.4.dev1 (from /dev/my-amazing-package)
    The user requested (constraint) my-amazing-package===1.2.4.dev1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

Resolve this by allowing users to opt out of individual constraints to the `install`, `wheel`, and `download` subcommands. This is rather manual but it's expected that tools like tox could automatically generate a value for this option when invoking `pip install` command.

```console
❯ pip install -c constraints.txt --ignore-constraint my-amazing-package .
❯ pip wheel -c constraints.txt --ignore-constraint my-amazing-package .
❯ pip download -c constraints.txt --ignore-constraint my-amazing-package .
```

This is only added for the `2020-resolver` resolver, not the `legacy-resolver` resolver, given the latter is deprecated for removal.

Fixes: #7839

## Open questions

- [ ] Are we happy to make this a flag that the user should pass manually? I wasn't able to think of a foolproof way to detect that the we're installing a package and wanted to ignore constraints for that specific package. I also wasn't sure we wanted to do this.
- [ ] Should we validate the package name provided by the user? Currently it's free-form, in line with most other options that I could see. We might want to validate (a) it's a valid package name and (b) it's actually going to be installed (to prevent typos). Not sure this is needed though.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
