### PR TITLE
Add root path to sys.path in build env for embedded Python

### DIFF
--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -102,9 +102,10 @@ class BuildEnvironment:
         # If interpreter is embedded Python, its build-in pyd files are in the same directory as python.exe rather
         # than DLLs folder. Add it in sys.path to make sure packages like pyexpat can be imported.
         extra_path = []
-        import pyexpat
-        if os.path.dirname(pyexpat.__file__) == os.path.dirname(sys.executable):
-            extra_path.append(os.path.dirname(sys.executable))
+        if os.name == "nt":
+            import pyexpat
+            if os.path.dirname(pyexpat.__file__) == os.path.dirname(sys.executable):
+                extra_path.append(os.path.dirname(sys.executable))
 
         self._site_dir = os.path.join(temp_dir.path, "site")
         if not os.path.exists(self._site_dir):


### PR DESCRIPTION
Fix https://github.com/pypa/pip/issues/11670, related issue: https://github.com/python/cpython/issues/100399, https://github.com/Azure/azure-cli/issues/24781

In embedded python, the pyd files are put in root folder.
In standard python, they are put into DLLs folder.

``` 
  Directory: C:\Users\kk\AppData\Local\Programs\Python\Python310\DLLs

-a----        10/11/2022     16:59        1121152 unicodedata.pyd
-a----        10/11/2022     16:59          29560 winsound.pyd
-a----        10/11/2022     16:59          64384 _asyncio.pyd
-a----        10/11/2022     16:59          83320 _bz2.pyd
-a----        10/11/2022     16:59         123264 _ctypes.pyd
```
```
  Directory: C:\Users\kk\Downloads\python_emb

-a----        12/21/2022     14:38        1113976 unicodedata.pyd
-a----        12/21/2022     14:38          90440 vcruntime140.dll
-a----        12/21/2022     14:38          26488 winsound.pyd
-a----        12/21/2022     14:38          55680 _asyncio.pyd
-a----        12/21/2022     14:38          79736 _bz2.pyd
-a----        12/21/2022     14:38         106368 _ctypes.pyd
```

In `build_env.py`, the root folder is excluded by this logic, as root folder is in `system_paths`/`system_sites`.
https://github.com/pypa/pip/blob/07a360dfe8fcad8c34d7bb70c77362cc3ec8a374/src/pip/_internal/build_env.py#L122-L126

If these pyd files need to be imported when install new package, `ModuleNotFoundError` is raised.
Currently, I find `pwinput` and `pendulum` can't be installed in embedded Python.

I'm not sure whether this change brings some side effect. Let me know if you have any concern.

### Repro step
1. Download https://www.python.org/ftp/python/3.10.9/python-3.10.9-embed-win32.zip and extract it
2. curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
3. .\python.exe get-pip.py
4. .\python.exe -m pip install pwinput
5. `ModuleNotFoundError: No module named 'pyexpat'` raises

It can be installed successfully with this PR. 