### PR TITLE
Enable strict optionals in egg_link code

### DIFF
--- a/src/pip/_internal/locations/base.py
+++ b/src/pip/_internal/locations/base.py
@@ -13,7 +13,7 @@ from pip._internal.utils.virtualenv import running_under_virtualenv
 USER_CACHE_DIR = appdirs.user_cache_dir("pip")
 
 # FIXME doesn't account for venv linked to global site-packages
-site_packages: typing.Optional[str] = sysconfig.get_path("purelib")
+site_packages: str = sysconfig.get_path("purelib")
 
 
 def get_major_minor_version() -> str:

--- a/src/pip/_internal/utils/egg_link.py
+++ b/src/pip/_internal/utils/egg_link.py
@@ -1,10 +1,7 @@
-# The following comment should be removed at some point in the future.
-# mypy: strict-optional=False
-
 import os
 import re
 import sys
-from typing import Optional
+from typing import List, Optional
 
 from pip._internal.locations import site_packages, user_site
 from pip._internal.utils.virtualenv import (
@@ -57,7 +54,7 @@ def egg_link_path_from_location(raw_name: str) -> Optional[str]:
 
     This method will just return the first one found.
     """
-    sites = []
+    sites: List[str] = []
     if running_under_virtualenv():
         sites.append(site_packages)
         if not virtualenv_no_global() and user_site:


### PR DESCRIPTION
Newer typeshed correctly annotates `sysconfig.get_path()` to return str so this just works now.