### PR TITLE
Docs: Rename Unix to Linux

### DIFF
--- a/docs/html/topics/caching.md
+++ b/docs/html/topics/caching.md
@@ -67,7 +67,7 @@ You can use `pip cache dir` to get the cache directory that pip is currently con
 
 ### Default paths
 
-````{tab} Unix
+````{tab} Linux
 ```
 ~/.cache/pip
 ```


### PR DESCRIPTION
this keeps the tabs under "Default paths" and "Avoiding caching" in sync

to reproduce the issue this commit solves, go to this page: https://pip.pypa.io/en/stable/topics/caching/
then change the tabs under one of the sections, notice how changing to Unix / Linux breaks sync due to PipCLIDirective using the name [Linux](https://github.com/pypa/pip/blob/95a58e7ba58e769af882502f7436559f61ecca8a/docs/pip_sphinxext.py#L231) for Unix based OS's

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
