### PR TITLE
Add option for global installation warning

### DIFF
--- a/news/11752.feature.rst
+++ b/news/11752.feature.rst
@@ -1,0 +1,2 @@
+Add option to enable a warning if a virtual environment could not be detected,
+preventing accidental installation of global packages.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -32,7 +32,7 @@ from pip._internal.exceptions import (
 )
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
-from pip._internal.utils.misc import get_prog, normalize_path
+from pip._internal.utils.misc import ask, get_prog, normalize_path
 from pip._internal.utils.temp_dir import TempDirectoryTypeRegistry as TempDirRegistry
 from pip._internal.utils.temp_dir import global_tempdir_manager, tempdir_registry
 from pip._internal.utils.virtualenv import running_under_virtualenv
@@ -137,6 +137,16 @@ class Command(CommandContextMixIn):
             if not running_under_virtualenv():
                 logger.critical("Could not find an activated virtualenv (required).")
                 sys.exit(VIRTUALENV_NOT_FOUND)
+
+        # if both require_venv and global_install_warning options are set
+        # then global_install_warning should not run
+        if options.global_install_warning and not (
+            options.require_venv or self.ignore_require_venv
+        ):
+            if not running_under_virtualenv():
+                logger.warning("Could not find an activated virtualenv.")
+                if ask("Proceed (y/N)? ", ("y", "n", "")) != "y":
+                    sys.exit(VIRTUALENV_NOT_FOUND)
 
         if options.cache_dir:
             options.cache_dir = normalize_path(options.cache_dir)

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -164,6 +164,15 @@ require_virtualenv: Callable[..., Option] = partial(
     ),
 )
 
+global_install_warning: Callable[..., Option] = partial(
+    Option,
+    "--global-install-warning",
+    dest="global_install_warning",
+    action="store_true",
+    default=False,
+    help=("Warn if pip is not running in a virtual environment."),
+)
+
 python: Callable[..., Option] = partial(
     Option,
     "--python",
@@ -1013,6 +1022,7 @@ general_group: Dict[str, Any] = {
         debug_mode,
         isolated_mode,
         require_virtualenv,
+        global_install_warning,
         python,
         verbose,
         version,


### PR DESCRIPTION
This PR implements a new (opt-in) option `--global-install-warning` to warn the user if they're installing without a virtual environment activated, this does not conflict with the existing option `--require-virtualenv` which gives an error when enabled and a virtualenv is not detected. If both `--require-virtualenv` and `--global-install-warning` are given then it will behave as if only `--require-virtualenv` was passed.

Example:
```
$ pip config set install.require-virtualenv true
Writing to /home/<user>/.config/pip/pip.conf

$ pip config set install.global-install-warning true
Writing to /home/<user>/.config/pip/pip.conf

$ pip install -r requirements.txt
ERROR: Could not find an activated virtualenv (required).

$ pip config unset install.require-virtualenv
Writing to /home/<user>/.config/pip/pip.conf

$ pip install -r requirements.txt
WARNING: Could not find an activated virtualenv.
Proceed (y/N)? 

```

fixes #11752.