### PR TITLE
Replace deprecated setup/teardown usage

### DIFF
--- a/tests/lib/configuration_helpers.py
+++ b/tests/lib/configuration_helpers.py
@@ -17,7 +17,7 @@ kinds = pip._internal.configuration.kinds
 
 
 class ConfigurationMixin:
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.configuration = pip._internal.configuration.Configuration(
             isolated=False,
         )

--- a/tests/lib/options_helpers.py
+++ b/tests/lib/options_helpers.py
@@ -22,12 +22,12 @@ class FakeCommand(Command):
 
 
 class AddFakeCommandMixin:
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         commands_dict["fake"] = CommandInfo(
             "tests.lib.options_helpers",
             "FakeCommand",
             "fake summary",
         )
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         commands_dict.pop("fake")

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -28,13 +28,13 @@ def _get_scheme_dict(*args: Any, **kwargs: Any) -> Dict[str, str]:
 
 
 class TestLocations:
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.tempdir = tempfile.mkdtemp()
         self.st_uid = 9999
         self.username = "example"
         self.patch()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         self.revert_patch()
         shutil.rmtree(self.tempdir, ignore_errors=True)
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -71,10 +71,10 @@ def get_processed_req_from_line(
 class TestRequirementSet:
     """RequirementSet tests"""
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.tempdir = tempfile.mkdtemp()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
     @contextlib.contextmanager
@@ -507,10 +507,10 @@ class TestRequirementSet:
 
 
 class TestInstallRequirement:
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.tempdir = tempfile.mkdtemp()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def test_url_with_query(self) -> None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -52,7 +52,7 @@ from pip._internal.utils.setuptools_build import make_setuptools_shim_args
 class Tests_EgglinkPath:
     "util.egg_link_path_from_location() tests"
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
 
         project = "foo"
 
@@ -81,7 +81,7 @@ class Tests_EgglinkPath:
         self.old_isfile = path.isfile
         self.mock_isfile = path.isfile = Mock()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         from pip._internal.utils import egg_link as utils
 
         utils.site_packages = self.old_site_packages

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -37,12 +37,12 @@ class TestUnpackArchives:
 
     """
 
-    def setup(self) -> None:
+    def setup_method(self) -> None:
         self.tempdir = tempfile.mkdtemp()
         self.old_mask = os.umask(0o022)
         self.symlink_expected_mode = None
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         os.umask(self.old_mask)
         shutil.rmtree(self.tempdir, ignore_errors=True)
 


### PR DESCRIPTION
As explained in <https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose>, `setup`/`teardown` are a part of nose compatibility, which is deprecated. You're supposed to use `setup_method` and `teardown_method` instead.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
