### PR TITLE
Correctly handle keyring auth subprocess newlines on Windows

### DIFF
--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -128,7 +128,7 @@ class KeyRingCliProvider(KeyRingBaseProvider):
         )
         if res.returncode:
             return None
-        return res.stdout.decode("utf-8").strip("\n")
+        return res.stdout.decode("utf-8").strip(os.linesep)
 
     def _set_password(self, service_name: str, username: str, password: str) -> None:
         """Mirror the implementation of keyring.set_password using cli"""
@@ -136,7 +136,7 @@ class KeyRingCliProvider(KeyRingBaseProvider):
             return None
 
         cmd = [self.keyring, "set", service_name, username]
-        input_ = password.encode("utf-8") + b"\n"
+        input_ = (password + os.linesep).encode("utf-8")
         env = os.environ.copy()
         env["PYTHONIOENCODING"] = "utf-8"
         res = subprocess.run(cmd, input=input_, env=env)

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import sys
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -360,7 +361,7 @@ class KeyringSubprocessResult(KeyringModuleV1):
                 self.returncode = 1
             else:
                 # Passwords are returned encoded with a newline appended
-                self.stdout = password.encode("utf-8") + b"\n"
+                self.stdout = (password + os.linesep).encode("utf-8")
 
         if cmd[1] == "set":
             assert stdin is None
@@ -369,7 +370,7 @@ class KeyringSubprocessResult(KeyringModuleV1):
             assert input is not None
 
             # Input from stdin is encoded
-            self.set_password(cmd[2], cmd[3], input.decode("utf-8").strip("\n"))
+            self.set_password(cmd[2], cmd[3], input.decode("utf-8").strip(os.linesep))
 
         return self
 


### PR DESCRIPTION
Closes #11658