### PR TITLE
Bump pre-commit isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     exclude: tests/data
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
     files: \.py$


### PR DESCRIPTION
This release contains a critical fix for newer Poetry versions that crashes due to "invalid" pyproject.toml syntax. See PyCQA/isort#2078.

This should fix CI errors in recent PRs.