### PR TITLE
PEP NNN: Always provide direct_url.json for wheel installations

### DIFF
--- a/news/9999.feature.rst
+++ b/news/9999.feature.rst
@@ -1,0 +1,2 @@
+Implement storing provenance_url.json file as specified in PEP 9999.
+This allows checking hashes of Python distributions installed from an index.

--- a/src/pip/_internal/models/direct_url.py
+++ b/src/pip/_internal/models/direct_url.py
@@ -15,6 +15,7 @@ __all__ = [
 T = TypeVar("T")
 
 DIRECT_URL_METADATA_NAME = "direct_url.json"
+PROVENANCE_URL_METADATA_NAME = "provenance_url.json"
 ENV_VAR_RE = re.compile(r"^\$\{[A-Za-z0-9-_]+\}(:\$\{[A-Za-z0-9-_]+\})?$")
 
 
@@ -144,10 +145,12 @@ class DirectUrl:
         url: str,
         info: InfoType,
         subdirectory: Optional[str] = None,
+        provenance_file: bool = False
     ) -> None:
         self.url = url
         self.info = info
         self.subdirectory = subdirectory
+        self.provenance_file = provenance_file
 
     def _remove_auth_from_netloc(self, netloc: str) -> str:
         if "@" not in netloc:

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -47,7 +47,7 @@ from pip._internal.metadata import (
     FilesystemWheel,
     get_wheel_distribution,
 )
-from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
+from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, PROVENANCE_URL_METADATA_NAME, DirectUrl
 from pip._internal.models.scheme import SCHEME_KEYS, Scheme
 from pip._internal.utils.filesystem import adjacent_tmp_file, replace
 from pip._internal.utils.misc import captured_stdout, ensure_dir, hash_file, partition
@@ -672,7 +672,11 @@ def _install_wheel(
 
     # Record the PEP 610 direct URL reference
     if direct_url is not None:
-        direct_url_path = os.path.join(dest_info_dir, DIRECT_URL_METADATA_NAME)
+        if direct_url.provenance_file:
+            direct_url_path = os.path.join(dest_info_dir, PROVENANCE_URL_METADATA_NAME)
+        else:
+            direct_url_path = os.path.join(dest_info_dir, DIRECT_URL_METADATA_NAME)
+        print(direct_url_path)
         with _generate_file(direct_url_path) as direct_url_file:
             direct_url_file.write(direct_url.to_json().encode("utf-8"))
         generated.append(direct_url_path)

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -798,6 +798,7 @@ class InstallRequirement:
                 direct_url = DirectUrl(
                     url=self.download_info.redacted_url,
                     info=ArchiveInfo("sha256=" + sha256.hexdigest()),
+                    provenance_file=True,
                 )
 
             install_wheel(

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -77,18 +77,12 @@ def direct_url_from_link(
             subdirectory=link.subdirectory_fragment,
         )
     else:
+        hash = None
         hash_name = link.hash_name
-        provenance_file = False
         if hash_name:
             hash = f"{hash_name}={link.hash}"
-        else:
-            sha256 = hash_file(link.path)[0]
-            hash = f"sha256={sha256.hexdigest()}"
-            provenance_file = True
-
         return DirectUrl(
             url=link.url_without_fragment,
             info=ArchiveInfo(hash=hash),
             subdirectory=link.subdirectory_fragment,
-            provenance_file=provenance_file,
         )

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from pip._internal.models.direct_url import ArchiveInfo, DirectUrl, DirInfo, VcsInfo
 from pip._internal.models.link import Link
-from pip._internal.utils.misc import hash_file
 from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import vcs
 

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from pip._internal.models.direct_url import ArchiveInfo, DirectUrl, DirInfo, VcsInfo
 from pip._internal.models.link import Link
+from pip._internal.utils.misc import hash_file
 from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import vcs
 
@@ -76,10 +77,13 @@ def direct_url_from_link(
             subdirectory=link.subdirectory_fragment,
         )
     else:
-        hash = None
         hash_name = link.hash_name
         if hash_name:
             hash = f"{hash_name}={link.hash}"
+        else:
+            sha256 = hash_file(link.path)[0]
+            hash = f"sha256={sha256.hexdigest()}"
+
         return DirectUrl(
             url=link.url_without_fragment,
             info=ArchiveInfo(hash=hash),

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -78,14 +78,17 @@ def direct_url_from_link(
         )
     else:
         hash_name = link.hash_name
+        provenance_file = False
         if hash_name:
             hash = f"{hash_name}={link.hash}"
         else:
             sha256 = hash_file(link.path)[0]
             hash = f"sha256={sha256.hexdigest()}"
+            provenance_file = True
 
         return DirectUrl(
             url=link.url_without_fragment,
             info=ArchiveInfo(hash=hash),
             subdirectory=link.subdirectory_fragment,
+            provenance_file=provenance_file,
         )

--- a/tests/lib/direct_url.py
+++ b/tests/lib/direct_url.py
@@ -3,13 +3,14 @@ import re
 from pathlib import Path
 from typing import Optional
 
-from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
+from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, PROVENANCE_URL_METADATA_NAME, DirectUrl
 from tests.lib import TestPipResult
 
 
-def get_created_direct_url_path(result: TestPipResult, pkg: str) -> Optional[Path]:
+def get_created_direct_url_path(result: TestPipResult, pkg: str, provenance_file: bool = False) -> Optional[Path]:
+    url_file_name = PROVENANCE_URL_METADATA_NAME if provenance_file else DIRECT_URL_METADATA_NAME
     direct_url_metadata_re = re.compile(
-        pkg + r"-[\d\.]+\.dist-info." + DIRECT_URL_METADATA_NAME + r"$"
+        pkg + r"-[\d\.]+\.dist-info." + url_file_name + r"$"
     )
     for filename in result.files_created:
         if direct_url_metadata_re.search(os.fspath(filename)):
@@ -17,8 +18,8 @@ def get_created_direct_url_path(result: TestPipResult, pkg: str) -> Optional[Pat
     return None
 
 
-def get_created_direct_url(result: TestPipResult, pkg: str) -> Optional[DirectUrl]:
-    direct_url_path = get_created_direct_url_path(result, pkg)
+def get_created_direct_url(result: TestPipResult, pkg: str, *, provenance_file: bool = False) -> Optional[DirectUrl]:
+    direct_url_path = get_created_direct_url_path(result, pkg, provenance_file=provenance_file)
     if direct_url_path:
         with open(direct_url_path) as f:
             return DirectUrl.from_json(f.read())


### PR DESCRIPTION
See https://github.com/python/peps/pull/2988 and related discussion in https://discuss.python.org/t/pip-installation-reports/12316

Signed-off-by: Fridolin Pokorny <fridolin.pokorny@datadoghq.com>

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
