### PR TITLE
fix: correct the way to decide if keyring is available

### DIFF
--- a/news/11774.bugfix.rst
+++ b/news/11774.bugfix.rst
@@ -1,0 +1,1 @@
+Correct the way to decide if keyring is available.

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -359,7 +359,7 @@ class MultiDomainBasicAuth(AuthBase):
 
     # Factored out to allow for easy patching in tests
     def _should_save_password_to_keyring(self) -> bool:
-        if get_keyring_provider() is None:
+        if isinstance(get_keyring_provider(), KeyRingNullProvider):
             return False
         return ask("Save credentials to keyring [y/N]: ", ["y", "n"]) == "y"
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -39,6 +39,8 @@ class Credentials(NamedTuple):
 class KeyRingBaseProvider(ABC):
     """Keyring base provider interface"""
 
+    has_keyring: bool
+
     @abstractmethod
     def get_auth_info(self, url: str, username: Optional[str]) -> Optional[AuthInfo]:
         ...
@@ -51,6 +53,8 @@ class KeyRingBaseProvider(ABC):
 class KeyRingNullProvider(KeyRingBaseProvider):
     """Keyring null provider"""
 
+    has_keyring = False
+
     def get_auth_info(self, url: str, username: Optional[str]) -> Optional[AuthInfo]:
         return None
 
@@ -60,6 +64,8 @@ class KeyRingNullProvider(KeyRingBaseProvider):
 
 class KeyRingPythonProvider(KeyRingBaseProvider):
     """Keyring interface which uses locally imported `keyring`"""
+
+    has_keyring = True
 
     def __init__(self) -> None:
         import keyring
@@ -96,6 +102,8 @@ class KeyRingCliProvider(KeyRingBaseProvider):
     use which ever installation of keyring is available first in
     PATH.
     """
+
+    has_keyring = True
 
     def __init__(self, cmd: str) -> None:
         self.keyring = cmd
@@ -359,7 +367,7 @@ class MultiDomainBasicAuth(AuthBase):
 
     # Factored out to allow for easy patching in tests
     def _should_save_password_to_keyring(self) -> bool:
-        if isinstance(get_keyring_provider(), KeyRingNullProvider):
+        if not get_keyring_provider().has_keyring:
             return False
         return ask("Save credentials to keyring [y/N]: ", ["y", "n"]) == "y"
 
@@ -432,9 +440,7 @@ class MultiDomainBasicAuth(AuthBase):
     def save_credentials(self, resp: Response, **kwargs: Any) -> None:
         """Response callback to save credentials on success."""
         keyring = get_keyring_provider()
-        assert not isinstance(
-            keyring, KeyRingNullProvider
-        ), "should never reach here without keyring"
+        assert keyring.has_keyring, "should never reach here without keyring"
 
         creds = self._credentials_to_save
         self._credentials_to_save = None


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

`get_keyring_provider()` will never return `None`, correct it to use the right check. This also goes along with: 
```python
        assert not isinstance(
            keyring, KeyRingNullProvider
        ), "should never reach here without keyring"
```