### PR TITLE
Document the limitations of the pip install --prefix argument

### DIFF
--- a/news/11775.doc.rst
+++ b/news/11775.doc.rst
@@ -1,0 +1,1 @@
+Cross-reference the --python flag in the docs for the --prefix flag, and mention the --prefix limitations with regards to installed console scripts.

--- a/news/11775.doc.rst
+++ b/news/11775.doc.rst
@@ -1,1 +1,2 @@
-Cross-reference the --python flag in the docs for the --prefix flag, and mention the --prefix limitations with regards to installed console scripts.
+Cross-reference the ``--python`` flag from the ``--prefix`` flag,
+and mention limitations of ``--prefix`` regarding script installation.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -156,7 +156,12 @@ class InstallCommand(RequirementCommand):
             default=None,
             help=(
                 "Installation prefix where lib, bin and other top-level "
-                "folders are placed"
+                "folders are placed. Note that the resulting installation may "
+                "contain scripts and other resources which reference the "
+                "Python interpreter of pip, and not that of ``--prefix``. "
+                "See also the ``--python`` option if the intention is to "
+                "install packages into another (possibly pip-free) "
+                "environment."
             ),
         )
 


### PR DESCRIPTION
Documents one of the limitations of the ``pip install --prefix`` argument, and cross-reference the ``--python`` flag, which can be harder to find due to it being a pip level argument.

This follows a discussion on discord with @sbidoul and @uranusjr.
