### PR TITLE
Create SECURITY.md to make the policy official

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include AUTHORS.txt
 include LICENSE.txt
 include NEWS.rst
 include README.rst
+include SECURITY.md
 include pyproject.toml
 
 include src/pip/_vendor/README.rst

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security and Vulnerability Reporting
+
+If you find any security issues, please report to [security@python.org](mailto:security@python.org)

--- a/news/11809.doc.rst
+++ b/news/11809.doc.rst
@@ -1,0 +1,1 @@
+Add SECURITY.md to make the policy offical.


### PR DESCRIPTION
This resolves https://github.com/pypa/pip/issues/11234

``pip`` has a security policy here: ``docs/html/index.md`` (https://github.com/pypa/pip/pull/11140/files), but security policies belong in a ``SECURITY.md`` file so that GitHub recognizes them as such.

``SECURITY.md`` files are typically very short and simple.
(Here's an example of one by Google: https://github.com/google/gvisor/blob/master/SECURITY.md)

CC @di 

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
