### PR TITLE
Describe how to avoid dependency confusion in "secure installs" topic

### DIFF
--- a/docs/html/topics/secure-installs.md
+++ b/docs/html/topics/secure-installs.md
@@ -98,3 +98,27 @@ Instead of `python setup.py develop`, use:
 ```{pip-cli}
 $ pip install --no-deps -e .
 ```
+
+## Avoiding dependency confusion
+
+When dealing with private packages on your project you need to be careful to [dependency confusion](https://azure.microsoft.com/mediahandler/files/resourcefiles/3-ways-to-mitigate-risk-using-private-package-feeds/3%20Ways%20to%20Mitigate%20Risk%20When%20Using%20Private%20Package%20Feeds%20-%20v1.0.pdf), where an attacker can claim the package on the public repository in a way that will ensure it gets chosen over the private package.
+
+To avoid that risk you shouldn't install your private packages using {any}`--extra-index-url` like below:
+
+```{pip-cli}
+$ pip install --extra-index-url http://my.package.repo/simple SomePackage
+```
+
+Instead use {any}`--index-url`:
+
+```{pip-cli}
+$ pip install --index-url http://my.package.repo/simple/ SomePackage
+```
+
+Or, use {any}`--find-links` with {any}`--no-index`:
+
+```{pip-cli}
+$ pip install --no-index --find-links=file:///local/dir/ SomePackage
+```
+
+For more examples see the {ref}`pip install examples <pip install Examples>`.

--- a/news/11722.doc.rst
+++ b/news/11722.doc.rst
@@ -1,0 +1,1 @@
+describe how to avoid dependency confusion in ``Secure installs`` topic


### PR DESCRIPTION
added to secure-installs topic how to avoid dependency confusion, where is better use --index-url or --find-links with --no-index instead --extra-index-url.

resolve: #11722

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
