### PR TITLE
New suggested text for note_stmt

### DIFF
--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -695,10 +695,16 @@ class ExternallyManagedEnvironment(DiagnosticPipError):
             message="This environment is externally managed",
             context=context,
             note_stmt=(
-                "If you believe this is a mistake, please contact your "
-                "Python installation or OS distribution provider. "
-                "You can override this, at the risk of breaking your Python "
-                "installation or OS, by passing --break-system-packages."
+                "You are receiving this message because this python ""
+                "installation is set up to not allow pip to alter it. This is "
+                "often because it is a system wide python managed by the OS "
+                "distribution provider, or somehow specially managed, such as "
+                "by conda or another package manager. If you think this is a "
+                "mistake, contact the provider of this Python. You may have "
+                "invoked this version of pip by mistake, but if you are sure "
+                "you want to override this check, at the risk of breaking "
+                "this python installation, you can pass the "
+                "flag --break-system-packages to the install command."
             ),
             hint_stmt=Text("See PEP 668 for the detailed specification."),
         )


### PR DESCRIPTION
More wordy, but hopefully less confusing text for the ExternallyManagedEnvironment note statement. Particually for non-linux distro use cases.

See: https://github.com/pypa/pip/issues/11855

