### PR TITLE
Always use pep 517 when the 'wheel' package is absent

### DIFF
--- a/news/8559.removal.rst
+++ b/news/8559.removal.rst
@@ -1,0 +1,2 @@
+When the ``wheel`` package is not installed, pip now uses the default build backend
+instead of ``setup.py install`` for project without ``pyproject.toml``.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -783,11 +783,15 @@ def _handle_no_use_pep517(
         """
         raise_option_error(parser, option=option, msg=msg)
 
-    # If user doesn't wish to use pep517, we check if setuptools is installed
+    # If user doesn't wish to use pep517, we check if setuptools and wheel are installed
     # and raise error if it is not.
-    if not importlib.util.find_spec("setuptools"):
-        msg = "It is not possible to use --no-use-pep517 without setuptools installed."
-        raise_option_error(parser, option=option, msg=msg)
+    for package in ("setuptools", "wheel"):
+        if not importlib.util.find_spec(package):
+            msg = (
+                f"It is not possible to use --no-use-pep517 "
+                f"without {package} installed."
+            )
+            raise_option_error(parser, option=option, msg=msg)
 
     # Otherwise, --no-use-pep517 was passed via the command-line.
     parser.values.use_pep517 = False

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -785,13 +785,13 @@ def _handle_no_use_pep517(
 
     # If user doesn't wish to use pep517, we check if setuptools and wheel are installed
     # and raise error if it is not.
-    for package in ("setuptools", "wheel"):
-        if not importlib.util.find_spec(package):
-            msg = (
-                f"It is not possible to use --no-use-pep517 "
-                f"without {package} installed."
-            )
-            raise_option_error(parser, option=option, msg=msg)
+    packages = ("setuptools", "wheel")
+    if not all(importlib.util.find_spec(package) for package in packages):
+        msg = (
+            f"It is not possible to use --no-use-pep517 "
+            f"without {' and '.join(packages)} installed."
+        )
+        raise_option_error(parser, option=option, msg=msg)
 
     # Otherwise, --no-use-pep517 was passed via the command-line.
     parser.values.use_pep517 = False

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -93,12 +93,17 @@ def load_pyproject_toml(
     # we do so if the project has a pyproject.toml file
     # or if we cannot import setuptools.
 
-    # We fallback to PEP 517 when without setuptools,
+    # We fallback to PEP 517 when without setuptools or without the wheel package,
     # so setuptools can be installed as a default build backend.
     # For more info see:
     # https://discuss.python.org/t/pip-without-setuptools-could-the-experience-be-improved/11810/9
+    # https://github.com/pypa/pip/issues/8559
     elif use_pep517 is None:
-        use_pep517 = has_pyproject or not importlib.util.find_spec("setuptools")
+        use_pep517 = (
+            has_pyproject
+            or not importlib.util.find_spec("setuptools")
+            or not importlib.util.find_spec("wheel")
+        )
 
     # At this point, we know whether we're going to use PEP 517.
     assert use_pep517 is not None

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -159,17 +159,3 @@ LegacyInstallReasonFailedBdistWheel = LegacyInstallReason(
     issue=8368,
     emit_after_success=True,
 )
-
-
-LegacyInstallReasonMissingWheelPackage = LegacyInstallReason(
-    reason=(
-        "{name} is being installed using the legacy "
-        "'setup.py install' method, because it does not have a "
-        "'pyproject.toml' and the 'wheel' package "
-        "is not installed."
-    ),
-    replacement="to enable the '--use-pep517' option",
-    gone_in="23.1",
-    issue=8559,
-    emit_before_install=True,
-)

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -614,18 +614,6 @@ def hash_file(path: str, blocksize: int = 1 << 20) -> Tuple[Any, int]:
     return h, length
 
 
-def is_wheel_installed() -> bool:
-    """
-    Return whether the wheel package is installed.
-    """
-    try:
-        import wheel  # noqa: F401
-    except ImportError:
-        return False
-
-    return True
-
-
 def pairwise(iterable: Iterable[Any]) -> Iterator[Tuple[Any, Any]]:
     """
     Return paired elements.

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -19,9 +19,8 @@ from pip._internal.operations.build.wheel import build_wheel_pep517
 from pip._internal.operations.build.wheel_editable import build_wheel_editable
 from pip._internal.operations.build.wheel_legacy import build_wheel_legacy
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.deprecation import LegacyInstallReasonMissingWheelPackage
 from pip._internal.utils.logging import indent_log
-from pip._internal.utils.misc import ensure_dir, hash_file, is_wheel_installed
+from pip._internal.utils.misc import ensure_dir, hash_file
 from pip._internal.utils.setuptools_build import make_setuptools_clean_args
 from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory
@@ -72,14 +71,6 @@ def _should_build(
     if req.editable:
         # we only build PEP 660 editable requirements
         return req.supports_pyproject_editable()
-
-    if req.use_pep517:
-        return True
-
-    if not is_wheel_installed():
-        # we don't build legacy requirements if wheel is not installed
-        req.legacy_install_reason = LegacyInstallReasonMissingWheelPackage
-        return False
 
     return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -429,6 +429,7 @@ def virtualenv_template(
     tmpdir_factory: pytest.TempPathFactory,
     pip_src: Path,
     setuptools_install: Path,
+    wheel_install: Path,
     coverage_install: Path,
 ) -> Iterator[VirtualEnvironment]:
 
@@ -442,8 +443,9 @@ def virtualenv_template(
     tmpdir = tmpdir_factory.mktemp("virtualenv")
     venv = VirtualEnvironment(tmpdir.joinpath("venv_orig"), venv_type=venv_type)
 
-    # Install setuptools and pip.
+    # Install setuptools, wheel and pip.
     install_pth_link(venv, "setuptools", setuptools_install)
+    install_pth_link(venv, "wheel", wheel_install)
     pip_editable = tmpdir_factory.mktemp("pip") / "pip"
     shutil.copytree(pip_src, pip_editable, symlinks=True)
     # noxfile.py is Python 3 only
@@ -503,7 +505,7 @@ def virtualenv(
 
 @pytest.fixture
 def with_wheel(virtualenv: VirtualEnvironment, wheel_install: Path) -> None:
-    install_pth_link(virtualenv, "wheel", wheel_install)
+    pass
 
 
 class ScriptFactory(Protocol):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -503,11 +503,6 @@ def virtualenv(
     yield virtualenv_factory(tmpdir.joinpath("workspace", "venv"))
 
 
-@pytest.fixture
-def with_wheel(virtualenv: VirtualEnvironment, wheel_install: Path) -> None:
-    pass
-
-
 class ScriptFactory(Protocol):
     def __call__(
         self,

--- a/tests/data/packages/BrokenEmitsUTF8/setup.py
+++ b/tests/data/packages/BrokenEmitsUTF8/setup.py
@@ -8,7 +8,7 @@ class FakeError(Exception):
     pass
 
 
-if sys.argv[1] == "install":
+if sys.argv[1] in ("install", "bdist_wheel"):
     if hasattr(sys.stdout, "buffer"):
         sys.stdout.buffer.write(
             "\nThis package prints out UTF-8 stuff like:\n".encode("utf-8")

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -659,7 +659,6 @@ def make_wheel_with_python_requires(
     return package_dir / "dist" / file_name
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_download__python_version_used_for_python_requires(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -700,7 +699,6 @@ def test_download__python_version_used_for_python_requires(
     script.pip(*args)  # no exception
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_download_ignore_requires_python_dont_fail_with_wrong_python(
     script: PipTestEnvironment,
 ) -> None:

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -104,7 +104,6 @@ def test_exclude_and_normalization(script: PipTestEnvironment, tmpdir: Path) -> 
     assert "Normalizable_Name" not in result.stdout
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_freeze_multiple_exclude_with_all(script: PipTestEnvironment) -> None:
     result = script.pip("freeze", "--all")
     assert "pip==" in result.stdout
@@ -962,7 +961,6 @@ def test_freeze_path_multiple(
     _check_output(result.stdout, expected)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_freeze_direct_url_archive(
     script: PipTestEnvironment, shared_data: TestData
 ) -> None:
@@ -1005,7 +1003,6 @@ def test_freeze_include_work_dir_pkg(script: PipTestEnvironment) -> None:
     assert "simple==1.0" in result.stdout
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_freeze_pep610_editable(script: PipTestEnvironment) -> None:
     """
     Test that a package installed with a direct_url.json with editable=true

--- a/tests/functional/test_inspect.py
+++ b/tests/functional/test_inspect.py
@@ -31,11 +31,12 @@ def test_inspect_basic(simple_script: PipTestEnvironment) -> None:
     result = simple_script.pip("inspect")
     report = json.loads(result.stdout)
     installed = report["installed"]
-    assert len(installed) == 4
+    assert len(installed) == 5
     installed_by_name = {i["metadata"]["name"]: i for i in installed}
     assert installed_by_name.keys() == {
         "pip",
         "setuptools",
+        "wheel",
         "coverage",
         "simplewheel",
     }

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1174,7 +1174,7 @@ def test_install_package_with_prefix(
     install_path = join(
         sysconfig.get_path("purelib", vars={"base": rel_prefix_path}),
         # we still test for egg-info because no-binary implies setup.py install
-        f"simple-1.0-py{pyversion}.egg-info",
+        "simple-1.0.dist-info",
     )
     result.did_create(install_path)
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -272,7 +272,6 @@ def test_pep518_forkbombs(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_pip_second_command_line_interface_works(
     script: PipTestEnvironment,
     pip_src: Path,
@@ -317,7 +316,6 @@ def test_install_exit_status_code_when_blank_requirements_file(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_basic_install_from_pypi(script: PipTestEnvironment) -> None:
     """
     Test installing a package from PyPI.
@@ -376,7 +374,6 @@ def test_basic_install_editable_from_git(script: PipTestEnvironment) -> None:
     _test_install_editable_from_git(script)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_editable_from_git_autobuild_wheel(script: PipTestEnvironment) -> None:
     _test_install_editable_from_git(script)
 
@@ -503,7 +500,6 @@ def test_vcs_url_urlquote_normalization(
 
 
 @pytest.mark.parametrize("resolver", ["", "--use-deprecated=legacy-resolver"])
-@pytest.mark.usefixtures("with_wheel")
 def test_basic_install_from_local_directory(
     script: PipTestEnvironment, data: TestData, resolver: str
 ) -> None:
@@ -533,7 +529,6 @@ def test_basic_install_from_local_directory(
         ("embedded_rel_path", True),
     ],
 )
-@pytest.mark.usefixtures("with_wheel")
 def test_basic_install_relative_directory(
     script: PipTestEnvironment, data: TestData, test_type: str, editable: bool
 ) -> None:
@@ -655,7 +650,6 @@ def test_hashed_install_failure_later_flag(
     )
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_from_local_directory_with_in_tree_build(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -800,7 +794,6 @@ def test_upgrade_argparse_shadowed(script: PipTestEnvironment) -> None:
     assert "Not uninstalling argparse" not in result.stdout
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_curdir(script: PipTestEnvironment, data: TestData) -> None:
     """
     Test installing current directory ('.').
@@ -817,7 +810,6 @@ def test_install_curdir(script: PipTestEnvironment, data: TestData) -> None:
     result.did_create(dist_info_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_pardir(script: PipTestEnvironment, data: TestData) -> None:
     """
     Test installing parent directory ('..').
@@ -877,7 +869,6 @@ def test_install_global_option_using_editable(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_package_with_same_name_in_curdir(script: PipTestEnvironment) -> None:
     """
     Test installing a package with the same name of a local folder
@@ -896,7 +887,6 @@ mock100_setup_py = textwrap.dedent(
 )
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_folder_using_dot_slash(script: PipTestEnvironment) -> None:
     """
     Test installing a folder using pip install ./foldername
@@ -909,7 +899,6 @@ def test_install_folder_using_dot_slash(script: PipTestEnvironment) -> None:
     result.did_create(dist_info_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_folder_using_slash_in_the_end(script: PipTestEnvironment) -> None:
     r"""
     Test installing a folder using pip install foldername/ or foldername\
@@ -922,7 +911,6 @@ def test_install_folder_using_slash_in_the_end(script: PipTestEnvironment) -> No
     result.did_create(dist_info_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_folder_using_relative_path(script: PipTestEnvironment) -> None:
     """
     Test installing a folder using pip install folder1/folder2
@@ -937,7 +925,6 @@ def test_install_folder_using_relative_path(script: PipTestEnvironment) -> None:
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_package_which_contains_dev_in_name(script: PipTestEnvironment) -> None:
     """
     Test installing package from PyPI which contains 'dev' in name
@@ -949,7 +936,6 @@ def test_install_package_which_contains_dev_in_name(script: PipTestEnvironment) 
     result.did_create(dist_info_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_package_with_target(script: PipTestEnvironment) -> None:
     """
     Test installing a package using pip install --target
@@ -1082,7 +1068,6 @@ def test_install_nonlocal_compatible_wheel_path(
 
 
 @pytest.mark.parametrize("opt", ("--target", "--prefix"))
-@pytest.mark.usefixtures("with_wheel")
 def test_install_with_target_or_prefix_and_scripts_no_warning(
     opt: str, script: PipTestEnvironment
 ) -> None:
@@ -1121,7 +1106,6 @@ def test_install_with_target_or_prefix_and_scripts_no_warning(
     assert "--no-warn-script-location" not in result.stderr, str(result)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_package_with_root(script: PipTestEnvironment, data: TestData) -> None:
     """
     Test installing a package using pip install --root
@@ -1318,7 +1302,6 @@ def test_install_package_with_latin1_setup(
     script.pip("install", to_install)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_url_req_case_mismatch_no_index(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -1342,7 +1325,6 @@ def test_url_req_case_mismatch_no_index(
     result.did_not_create(dist_info_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_url_req_case_mismatch_file_index(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -1372,7 +1354,6 @@ def test_url_req_case_mismatch_file_index(
     result.did_not_create(dist_info_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_url_incorrect_case_no_index(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -1396,7 +1377,6 @@ def test_url_incorrect_case_no_index(
     result.did_create(dist_info_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_url_incorrect_case_file_index(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -1546,7 +1526,6 @@ def test_install_topological_sort(script: PipTestEnvironment, data: TestData) ->
     assert order1 in res or order2 in res, res
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_wheel_broken(script: PipTestEnvironment) -> None:
     res = script.pip_install_local("wheelbroken", allow_stderr_error=True)
     assert "ERROR: Failed building wheel for wheelbroken" in res.stderr
@@ -1554,7 +1533,6 @@ def test_install_wheel_broken(script: PipTestEnvironment) -> None:
     assert "Successfully installed wheelbroken-0.1" in str(res), str(res)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_cleanup_after_failed_wheel(script: PipTestEnvironment) -> None:
     res = script.pip_install_local("wheelbrokenafter", allow_stderr_error=True)
     assert "ERROR: Failed building wheel for wheelbrokenafter" in res.stderr
@@ -1569,7 +1547,6 @@ def test_cleanup_after_failed_wheel(script: PipTestEnvironment) -> None:
     assert "Running setup.py clean for wheelbrokenafter" in str(res), str(res)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_builds_wheels(script: PipTestEnvironment, data: TestData) -> None:
     # We need to use a subprocess to get the right value on Windows.
     res = script.run(
@@ -1622,7 +1599,6 @@ def test_install_builds_wheels(script: PipTestEnvironment, data: TestData) -> No
     ]
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_no_binary_disables_building_wheels(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -1653,7 +1629,6 @@ def test_install_no_binary_disables_building_wheels(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_no_binary_builds_pep_517_wheel(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -1668,7 +1643,6 @@ def test_install_no_binary_builds_pep_517_wheel(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_no_binary_uses_local_backend(
     script: PipTestEnvironment, data: TestData, tmpdir: Path
 ) -> None:
@@ -1682,7 +1656,6 @@ def test_install_no_binary_uses_local_backend(
     assert os.path.isfile(marker), "Local PEP 517 backend not used"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_no_binary_disables_cached_wheels(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -1821,7 +1794,6 @@ def test_install_incompatible_python_requires_editable(
     assert _get_expected_error_text() in result.stderr, str(result)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_incompatible_python_requires_wheel(script: PipTestEnvironment) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1945,28 +1945,6 @@ def test_installing_scripts_on_path_does_not_print_warning(
     assert "--no-warn-script-location" not in result.stderr
 
 
-def test_installed_files_recorded_in_deterministic_order(
-    script: PipTestEnvironment, data: TestData
-) -> None:
-    """
-    Ensure that we record the files installed by a package in a deterministic
-    order, to make installs reproducible.
-    """
-    to_install = data.packages.joinpath("FSPkg")
-    result = script.pip("install", to_install)
-    fspkg_folder = script.site_packages / "fspkg"
-    egg_info = f"FSPkg-0.1.dev0-py{pyversion}.egg-info"
-    installed_files_path = script.site_packages / egg_info / "installed-files.txt"
-    result.did_create(fspkg_folder)
-    result.did_create(installed_files_path)
-
-    installed_files_path = result.files_created[installed_files_path].full
-    installed_files_lines = [
-        p for p in Path(installed_files_path).read_text().split("\n") if p
-    ]
-    assert installed_files_lines == sorted(installed_files_lines)
-
-
 def test_install_conflict_results_in_warning(
     script: PipTestEnvironment, data: TestData
 ) -> None:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1515,12 +1515,18 @@ def test_install_subprocess_output_handling(
     # If the install fails, then we *should* show the output... but only once,
     # even if --verbose is given.
     result = script.pip(*(args + ["--global-option=--fail"]), expect_error=True)
-    assert 1 == result.stderr.count("I DIE, I DIE")
+    # This error is emitted 3 times:
+    # - by setup.py bdist_wheel
+    # - by setup.py clean
+    # - by setup.py install which is used as fallback when setup.py bdist_wheel failed
+    # Before, it failed only once because it attempted only setup.py install.
+    # TODO update this when we remove the last setup.py install code path.
+    assert 3 == result.stderr.count("I DIE, I DIE")
 
     result = script.pip(
         *(args + ["--global-option=--fail", "--verbose"]), expect_error=True
     )
-    assert 1 == result.stderr.count("I DIE, I DIE")
+    assert 3 == result.stderr.count("I DIE, I DIE")
 
 
 def test_install_log(script: PipTestEnvironment, data: TestData, tmpdir: Path) -> None:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -12,7 +12,6 @@ import pytest
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.models.index import PyPI, TestPyPI
-from pip._internal.utils.deprecation import DEPRECATION_MSG_PREFIX
 from pip._internal.utils.misc import rmtree
 from tests.conftest import CertFactory
 from tests.lib import (
@@ -2294,35 +2293,6 @@ def test_install_dry_run(script: PipTestEnvironment, data: TestData) -> None:
     )
     assert "Would install simple-3.0" in result.stdout
     assert "Successfully installed" not in result.stdout
-
-
-def test_install_8559_missing_wheel_package(
-    script: PipTestEnvironment, shared_data: TestData
-) -> None:
-    result = script.pip(
-        "install",
-        "--find-links",
-        shared_data.find_links,
-        "simple",
-        allow_stderr_warning=True,
-    )
-    assert DEPRECATION_MSG_PREFIX in result.stderr
-    assert "'wheel' package is not installed" in result.stderr
-    assert "using the legacy 'setup.py install' method" in result.stderr
-
-
-@pytest.mark.usefixtures("with_wheel")
-def test_install_8559_wheel_package_present(
-    script: PipTestEnvironment, shared_data: TestData
-) -> None:
-    result = script.pip(
-        "install",
-        "--find-links",
-        shared_data.find_links,
-        "simple",
-        allow_stderr_warning=False,
-    )
-    assert DEPRECATION_MSG_PREFIX not in result.stderr
 
 
 @pytest.mark.skipif(

--- a/tests/functional/test_install_cleanup.py
+++ b/tests/functional/test_install_cleanup.py
@@ -31,7 +31,6 @@ def test_no_clean_option_blocks_cleaning_after_install(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_pep517_no_legacy_cleanup(script: PipTestEnvironment, data: TestData) -> None:
     """Test a PEP 517 failed build does not attempt a legacy cleanup"""
     to_install = data.packages.joinpath("pep517_wrapper_buildsys")

--- a/tests/functional/test_install_compat.py
+++ b/tests/functional/test_install_compat.py
@@ -3,6 +3,7 @@ Tests for compatibility workarounds.
 
 """
 import os
+from pathlib import Path
 
 import pytest
 
@@ -11,7 +12,11 @@ from tests.lib import PipTestEnvironment, TestData, assert_all_changes
 
 
 @pytest.mark.network
-def test_debian_egg_name_workaround(script: PipTestEnvironment) -> None:
+def test_debian_egg_name_workaround(
+    script: PipTestEnvironment,
+    shared_data: TestData,
+    tmp_path: Path,
+) -> None:
     """
     We can uninstall packages installed with the pyversion removed from the
     egg-info metadata directory name.
@@ -22,10 +27,17 @@ def test_debian_egg_name_workaround(script: PipTestEnvironment) -> None:
     https://bitbucket.org/ianb/pip/issue/104/pip-uninstall-on-ubuntu-linux
 
     """
-    result = script.pip("install", "INITools==0.2")
+    result = script.run(
+        "python",
+        "setup.py",
+        "install",
+        "--single-version-externally-managed",
+        f"--record={tmp_path / 'record'}",
+        cwd=shared_data.src / "simplewheel-2.0",
+    )
 
     egg_info = os.path.join(
-        script.site_packages, f"INITools-0.2-py{pyversion}.egg-info"
+        script.site_packages, f"simplewheel-2.0-py{pyversion}.egg-info"
     )
 
     # Debian only removes pyversion for global installs, not inside a venv
@@ -35,7 +47,7 @@ def test_debian_egg_name_workaround(script: PipTestEnvironment) -> None:
     result.did_create(egg_info, message=f"Couldn't find {egg_info}")
 
     # The Debian no-pyversion version of the .egg-info
-    mangled = os.path.join(script.site_packages, "INITools-0.2.egg-info")
+    mangled = os.path.join(script.site_packages, "simplewheel-2.0.egg-info")
     result.did_not_create(mangled, message=f"Found unexpected {mangled}")
 
     # Simulate a Debian install by copying the .egg-info to their name for it
@@ -46,7 +58,7 @@ def test_debian_egg_name_workaround(script: PipTestEnvironment) -> None:
     assert os.path.isdir(full_mangled)
 
     # Try the uninstall and verify that everything is removed.
-    result2 = script.pip("uninstall", "INITools", "-y")
+    result2 = script.pip("uninstall", "simplewheel", "-y")
     assert_all_changes(result, result2, [script.venv / "build", "cache"])
 
 

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -245,7 +245,6 @@ def test_options_from_venv_config(
     assert msg.lower() in result.stdout.lower(), str(result)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_no_binary_via_config_disables_cached_wheels(
     script: PipTestEnvironment, data: TestData
 ) -> None:

--- a/tests/functional/test_install_direct_url.py
+++ b/tests/functional/test_install_direct_url.py
@@ -5,13 +5,11 @@ from tests.lib import PipTestEnvironment, TestData, _create_test_package
 from tests.lib.direct_url import get_created_direct_url
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_find_links_no_direct_url(script: PipTestEnvironment) -> None:
     result = script.pip_install_local("simple")
     assert not get_created_direct_url(result, "simple")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_vcs_editable_no_direct_url(script: PipTestEnvironment) -> None:
     pkg_path = _create_test_package(script.scratch_path, name="testpkg")
     args = ["install", "-e", f"git+{pkg_path.as_uri()}#egg=testpkg"]
@@ -21,7 +19,6 @@ def test_install_vcs_editable_no_direct_url(script: PipTestEnvironment) -> None:
     assert not get_created_direct_url(result, "testpkg")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_vcs_non_editable_direct_url(script: PipTestEnvironment) -> None:
     pkg_path = _create_test_package(script.scratch_path, name="testpkg")
     url = pkg_path.as_uri()
@@ -34,7 +31,6 @@ def test_install_vcs_non_editable_direct_url(script: PipTestEnvironment) -> None
     assert direct_url.info.vcs == "git"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_archive_direct_url(script: PipTestEnvironment, data: TestData) -> None:
     req = "simple @ " + data.packages.joinpath("simple-2.0.tar.gz").as_uri()
     assert req.startswith("simple @ file://")
@@ -43,7 +39,6 @@ def test_install_archive_direct_url(script: PipTestEnvironment, data: TestData) 
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_vcs_constraint_direct_url(script: PipTestEnvironment) -> None:
     constraints_file = script.scratch_path / "constraints.txt"
     constraints_file.write_text(
@@ -55,7 +50,6 @@ def test_install_vcs_constraint_direct_url(script: PipTestEnvironment) -> None:
     assert get_created_direct_url(result, "pip_test_package")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_vcs_constraint_direct_file_url(script: PipTestEnvironment) -> None:
     pkg_path = _create_test_package(script.scratch_path, name="testpkg")
     url = pkg_path.as_uri()

--- a/tests/functional/test_install_index.py
+++ b/tests/functional/test_install_index.py
@@ -1,12 +1,9 @@
 import shutil
 import textwrap
 
-import pytest
-
 from tests.lib import PipTestEnvironment, TestData
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_find_links_relative_path(script: PipTestEnvironment, data: TestData) -> None:
     """Test find-links as a relative path."""
     result = script.pip(
@@ -23,7 +20,6 @@ def test_find_links_relative_path(script: PipTestEnvironment, data: TestData) ->
     result.did_create(initools_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_find_links_no_doctype(script: PipTestEnvironment, data: TestData) -> None:
     shutil.copy(data.packages / "simple-1.0.tar.gz", script.scratch_path)
     html = script.scratch_path.joinpath("index.html")
@@ -39,7 +35,6 @@ def test_find_links_no_doctype(script: PipTestEnvironment, data: TestData) -> No
     assert not result.stderr
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_find_links_requirements_file_relative_path(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -67,7 +62,6 @@ def test_find_links_requirements_file_relative_path(
     result.did_create(initools_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_from_file_index_hash_link(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -80,7 +74,6 @@ def test_install_from_file_index_hash_link(
     result.did_create(dist_info_folder)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_file_index_url_quoting(script: PipTestEnvironment, data: TestData) -> None:
     """
     Test url quoting of file index url with a space

--- a/tests/functional/test_install_report.py
+++ b/tests/functional/test_install_report.py
@@ -12,7 +12,6 @@ def _install_dict(report: Dict[str, Any]) -> Dict[str, Any]:
     return {canonicalize_name(i["metadata"]["name"]): i for i in report["install"]}
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_report_basic(
     script: PipTestEnvironment, shared_data: TestData, tmp_path: Path
 ) -> None:
@@ -43,7 +42,6 @@ def test_install_report_basic(
     )
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_report_dep(
     script: PipTestEnvironment, shared_data: TestData, tmp_path: Path
 ) -> None:
@@ -66,7 +64,6 @@ def test_install_report_dep(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_report_index(script: PipTestEnvironment, tmp_path: Path) -> None:
     """Test report for sdist obtained from index."""
     report_path = tmp_path / "report.json"
@@ -96,7 +93,6 @@ def test_install_report_index(script: PipTestEnvironment, tmp_path: Path) -> Non
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_report_vcs_and_wheel_cache(
     script: PipTestEnvironment, tmp_path: Path
 ) -> None:
@@ -157,7 +153,6 @@ def test_install_report_vcs_and_wheel_cache(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_report_vcs_editable(
     script: PipTestEnvironment, tmp_path: Path
 ) -> None:
@@ -183,7 +178,6 @@ def test_install_report_vcs_editable(
     assert pip_test_package_report["download_info"]["dir_info"]["editable"] is True
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_report_to_stdout(
     script: PipTestEnvironment, shared_data: TestData
 ) -> None:

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -62,7 +62,6 @@ def arg_recording_sdist_maker(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_requirements_file(script: PipTestEnvironment) -> None:
     """
     Test installing from a requirements file.
@@ -113,7 +112,6 @@ def test_schema_check_in_requirements_file(script: PipTestEnvironment) -> None:
         ("embedded_rel_path", True),
     ],
 )
-@pytest.mark.usefixtures("with_wheel")
 def test_relative_requirements_file(
     script: PipTestEnvironment, data: TestData, test_type: str, editable: bool
 ) -> None:
@@ -161,7 +159,6 @@ def test_relative_requirements_file(
 @pytest.mark.xfail
 @pytest.mark.network
 @need_svn
-@pytest.mark.usefixtures("with_wheel")
 def test_multiple_requirements_files(script: PipTestEnvironment, tmpdir: Path) -> None:
     """
     Test installing from multiple nested requirements files.
@@ -305,7 +302,7 @@ def test_install_local_with_subdirectory(script: PipTestEnvironment) -> None:
     result.assert_installed("version_subpkg.py", editable=False)
 
 
-@pytest.mark.usefixtures("enable_user_site", "with_wheel")
+@pytest.mark.usefixtures("enable_user_site")
 def test_wheel_user_with_prefix_in_pydistutils_cfg(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -488,7 +485,6 @@ def test_constrained_to_url_install_same_url(
     assert "Building wheel for singlemodule" in result.stdout, str(result)
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_double_install_spurious_hash_mismatch(
     script: PipTestEnvironment, tmpdir: Path, data: TestData
 ) -> None:

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -466,7 +466,7 @@ def test_constraints_constrain_to_local(
         "singlemodule",
         allow_stderr_warning=True,
     )
-    assert "Running setup.py install for singlemodule" in result.stdout
+    assert "Building wheel for singlemodule" in result.stdout
 
 
 def test_constrained_to_url_install_same_url(
@@ -485,7 +485,7 @@ def test_constrained_to_url_install_same_url(
         to_install,
         allow_stderr_warning=True,
     )
-    assert "Running setup.py install for singlemodule" in result.stdout, str(result)
+    assert "Building wheel for singlemodule" in result.stdout, str(result)
 
 
 @pytest.mark.usefixtures("with_wheel")
@@ -617,7 +617,7 @@ def test_install_distribution_full_union(
     result = script.pip_install_local(
         to_install, f"{to_install}[bar]", f"{to_install}[baz]"
     )
-    assert "Running setup.py install for LocalExtras" in result.stdout
+    assert "Building wheel for LocalExtras" in result.stdout
     result.did_create(script.site_packages / "simple")
     result.did_create(script.site_packages / "singlemodule.py")
 

--- a/tests/functional/test_install_requested.py
+++ b/tests/functional/test_install_requested.py
@@ -21,7 +21,6 @@ def _assert_requested_absent(
     assert requested not in result.files_created
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_requested_basic(script: PipTestEnvironment, data: TestData) -> None:
     result = script.pip(
         "install", "--no-index", "-f", data.find_links, "require_simple"
@@ -31,7 +30,6 @@ def test_install_requested_basic(script: PipTestEnvironment, data: TestData) -> 
     _assert_requested_absent(script, result, "simple", "3.0")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_requested_requirements(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -48,7 +46,6 @@ def test_install_requested_requirements(
     _assert_requested_absent(script, result, "simple", "3.0")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_requested_dep_in_requirements(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -68,7 +65,6 @@ def test_install_requested_dep_in_requirements(
     _assert_requested_present(script, result, "simple", "2.0")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_requested_reqs_and_constraints(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -89,7 +85,6 @@ def test_install_requested_reqs_and_constraints(
     _assert_requested_absent(script, result, "simple", "2.0")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_requested_in_reqs_and_constraints(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -112,7 +107,6 @@ def test_install_requested_in_reqs_and_constraints(
     _assert_requested_present(script, result, "simple", "2.0")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_requested_from_cli_with_constraint(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -130,7 +124,6 @@ def test_install_requested_from_cli_with_constraint(
     _assert_requested_present(script, result, "simple", "2.0")
 
 
-@pytest.mark.usefixtures("with_wheel")
 @pytest.mark.network
 def test_install_requested_from_cli_with_url_constraint(
     script: PipTestEnvironment, data: TestData

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -38,7 +38,6 @@ def test_invalid_upgrade_strategy_causes_error(script: PipTestEnvironment) -> No
     assert "invalid choice" in result.stderr
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_only_if_needed_does_not_upgrade_deps_when_satisfied(
     script: PipTestEnvironment, resolver_variant: ResolverVariant
 ) -> None:
@@ -66,7 +65,6 @@ def test_only_if_needed_does_not_upgrade_deps_when_satisfied(
     ), "did not print correct message for not-upgraded requirement"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(
     script: PipTestEnvironment,
 ) -> None:
@@ -88,7 +86,6 @@ def test_only_if_needed_does_upgrade_deps_when_no_longer_satisfied(
     assert expected in result.files_deleted, "should have uninstalled simple==1.0"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_eager_does_upgrade_dependencies_when_currently_satisfied(
     script: PipTestEnvironment,
 ) -> None:
@@ -109,7 +106,6 @@ def test_eager_does_upgrade_dependencies_when_currently_satisfied(
     ) in result.files_deleted, "should have uninstalled simple==2.0"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_eager_does_upgrade_dependencies_when_no_longer_satisfied(
     script: PipTestEnvironment,
 ) -> None:
@@ -135,7 +131,6 @@ def test_eager_does_upgrade_dependencies_when_no_longer_satisfied(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_upgrade_to_specific_version(script: PipTestEnvironment) -> None:
     """
     It does upgrade to specific version requested.
@@ -149,7 +144,6 @@ def test_upgrade_to_specific_version(script: PipTestEnvironment) -> None:
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_upgrade_if_requested(script: PipTestEnvironment) -> None:
     """
     And it does upgrade if requested.
@@ -312,7 +306,6 @@ def test_uninstall_rollback(script: PipTestEnvironment, data: TestData) -> None:
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_should_not_install_always_from_cache(script: PipTestEnvironment) -> None:
     """
     If there is an old cached package, pip should download the newer version
@@ -326,7 +319,6 @@ def test_should_not_install_always_from_cache(script: PipTestEnvironment) -> Non
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_with_ignoreinstalled_requested(script: PipTestEnvironment) -> None:
     """
     Test old conflicting package is completely ignored

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -133,8 +133,7 @@ class Tests_UserSite:
         result2 = script.pip("install", "--user", "INITools==0.1", "--no-binary=:all:")
 
         # usersite has 0.1
-        # we still test for egg-info because no-binary implies setup.py install
-        egg_info_folder = script.user_site / f"INITools-0.1-py{pyversion}.egg-info"
+        dist_info_folder = script.user_site / "INITools-0.1.dist-info"
         initools_v3_file = (
             # file only in 0.3
             script.base_path
@@ -142,7 +141,7 @@ class Tests_UserSite:
             / "initools"
             / "configparser.py"
         )
-        result2.did_create(egg_info_folder)
+        result2.did_create(dist_info_folder)
         assert not isfile(initools_v3_file), initools_v3_file
 
     def test_install_user_conflict_in_globalsite(

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -76,7 +76,6 @@ class Tests_UserSite:
         )
         result.assert_installed("INITools", use_user_site=True)
 
-    @pytest.mark.usefixtures("with_wheel")
     def test_install_from_current_directory_into_usersite(
         self, script: PipTestEnvironment, data: TestData
     ) -> None:

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -186,7 +186,6 @@ def test_install_editable_from_git_with_https(
 
 
 @pytest.mark.network
-@pytest.mark.usefixtures("with_wheel")
 def test_install_noneditable_git(script: PipTestEnvironment) -> None:
     """
     Test installing from a non-editable git URL with a given tag.
@@ -580,7 +579,6 @@ def test_check_submodule_addition(script: PipTestEnvironment) -> None:
     update_result.did_create(script.venv / "src/version-pkg/testpkg/static/testfile2")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_git_branch_not_cached(script: PipTestEnvironment) -> None:
     """
     Installing git urls with a branch revision does not cause wheel caching.
@@ -596,7 +594,6 @@ def test_install_git_branch_not_cached(script: PipTestEnvironment) -> None:
     assert f"Successfully built {PKG}" in result.stdout, result.stdout
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_git_sha_cached(script: PipTestEnvironment) -> None:
     """
     Installing git urls with a sha revision does cause wheel caching.

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -195,7 +195,6 @@ def test_install_from_wheel_with_headers(script: PipTestEnvironment) -> None:
     assert header_path.read_text() == header_text
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_wheel_with_target(
     script: PipTestEnvironment, shared_data: TestData, tmpdir: Path
 ) -> None:
@@ -216,7 +215,6 @@ def test_install_wheel_with_target(
     result.did_create(Path("scratch") / "target" / "simpledist")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_wheel_with_target_and_data_files(
     script: PipTestEnvironment, data: TestData
 ) -> None:
@@ -406,7 +404,7 @@ def test_wheel_record_lines_have_updated_hash_for_scripts(
     ]
 
 
-@pytest.mark.usefixtures("enable_user_site", "with_wheel")
+@pytest.mark.usefixtures("enable_user_site")
 def test_install_user_wheel(
     script: PipTestEnvironment, shared_data: TestData, tmpdir: Path
 ) -> None:

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -734,7 +734,6 @@ def test_list_include_work_dir_pkg(script: PipTestEnvironment) -> None:
     assert {"name": "simple", "version": "1.0"} in json_result
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_list_pep610_editable(script: PipTestEnvironment) -> None:
     """
     Test that a package installed with a direct_url.json with editable=true

--- a/tests/functional/test_pep660.py
+++ b/tests/functional/test_pep660.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
-import pytest
 import tomli_w
 
 from tests.lib import PipTestEnvironment
@@ -94,7 +93,6 @@ def _assert_hook_not_called(project_dir: Path, hook: str) -> None:
     assert f":{hook} called" not in log, f"{hook} should not have been called"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_pep517_basic(tmpdir: Path, script: PipTestEnvironment) -> None:
     """
     Check that the test harness we have in this file is sane.
@@ -110,7 +108,6 @@ def test_install_pep517_basic(tmpdir: Path, script: PipTestEnvironment) -> None:
     _assert_hook_called(project_dir, "build_wheel")
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_pep660_basic(tmpdir: Path, script: PipTestEnvironment) -> None:
     """
     Test with backend that supports build_editable.
@@ -131,7 +128,6 @@ def test_install_pep660_basic(tmpdir: Path, script: PipTestEnvironment) -> None:
     ), "a .egg-link file should not have been created"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_no_pep660_setup_py_fallback(
     tmpdir: Path, script: PipTestEnvironment
 ) -> None:
@@ -156,7 +152,6 @@ def test_install_no_pep660_setup_py_fallback(
     ), "a .egg-link file should have been created"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_install_no_pep660_setup_cfg_fallback(
     tmpdir: Path, script: PipTestEnvironment
 ) -> None:
@@ -182,7 +177,6 @@ def test_install_no_pep660_setup_cfg_fallback(
     ), ".egg-link file should have been created"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_wheel_editable_pep660_basic(tmpdir: Path, script: PipTestEnvironment) -> None:
     """
     Test 'pip wheel' of an editable pep 660 project.
@@ -206,7 +200,6 @@ def test_wheel_editable_pep660_basic(tmpdir: Path, script: PipTestEnvironment) -
     assert len(os.listdir(str(wheel_dir))) == 1, "a wheel should have been created"
 
 
-@pytest.mark.usefixtures("with_wheel")
 def test_download_editable_pep660_basic(
     tmpdir: Path, script: PipTestEnvironment
 ) -> None:

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -219,7 +219,11 @@ def test_uninstall_overlapping_package(
 
 
 @pytest.mark.parametrize(
-    "console_scripts", ["test_ = distutils_install", "test_:test_ = distutils_install"]
+    "console_scripts",
+    [
+        "test_ = distutils_install:test",
+        "test_:test_ = distutils_install:test_test",
+    ],
 )
 def test_uninstall_entry_point_colon_in_name(
     script: PipTestEnvironment, console_scripts: str
@@ -266,7 +270,7 @@ def test_uninstall_gui_scripts(script: PipTestEnvironment) -> None:
         version="0.1",
         entry_points={
             "gui_scripts": [
-                "test_ = distutils_install",
+                "test_ = distutils_install:test",
             ],
         },
     )
@@ -300,6 +304,7 @@ def test_uninstall_console_scripts(script: PipTestEnvironment) -> None:
             os.path.join(script.venv, "build"),
             "cache",
             os.path.join("scratch", "discover", "discover.egg-info"),
+            os.path.join("scratch", "discover", "build"),
         ],
     )
 
@@ -314,7 +319,7 @@ def test_uninstall_console_scripts_uppercase_name(script: PipTestEnvironment) ->
         version="0.1",
         entry_points={
             "console_scripts": [
-                "Test = distutils_install",
+                "Test = distutils_install:Test",
             ],
         },
     )

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -222,7 +222,12 @@ def test_uninstall_overlapping_package(
     "console_scripts",
     [
         "test_ = distutils_install:test",
-        "test_:test_ = distutils_install:test_test",
+        pytest.param(
+            "test_:test_ = distutils_install:test_test",
+            marks=pytest.mark.xfail(
+                reason="colon not supported in wheel entry point name?"
+            ),
+        ),
     ],
 )
 def test_uninstall_entry_point_colon_in_name(

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -10,8 +10,6 @@ from pip._internal.cli.status_codes import ERROR
 from tests.lib import pyversion  # noqa: F401
 from tests.lib import PipTestEnvironment, TestData
 
-pytestmark = pytest.mark.usefixtures("with_wheel")
-
 
 def add_files_to_dist_directory(folder: Path) -> None:
     (folder / "dist").mkdir(parents=True)

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -2,7 +2,6 @@ import logging
 import os
 from pathlib import Path
 from typing import Optional, cast
-from unittest import mock
 
 import pytest
 
@@ -115,26 +114,6 @@ def test_should_build_for_wheel_command(req: ReqMock, expected: bool) -> None:
         cast(InstallRequirement, req)
     )
     assert should_build is expected
-
-
-@mock.patch("pip._internal.wheel_builder.is_wheel_installed")
-def test_should_build_legacy_wheel_not_installed(is_wheel_installed: mock.Mock) -> None:
-    is_wheel_installed.return_value = False
-    legacy_req = ReqMock(use_pep517=False)
-    should_build = wheel_builder.should_build_for_install_command(
-        cast(InstallRequirement, legacy_req),
-    )
-    assert not should_build
-
-
-@mock.patch("pip._internal.wheel_builder.is_wheel_installed")
-def test_should_build_legacy_wheel_installed(is_wheel_installed: mock.Mock) -> None:
-    is_wheel_installed.return_value = True
-    legacy_req = ReqMock(use_pep517=False)
-    should_build = wheel_builder.should_build_for_install_command(
-        cast(InstallRequirement, legacy_req),
-    )
-    assert should_build
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #8559

TODO
- [x] remove `with_wheel` fixture
- [x] check this test with colons in console scripts
- [x] check what to do with `test_debian_egg_name_workaround`