### PR TITLE
Make sphinx.ext.extlinks captions actual string templates

### DIFF
--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -74,9 +74,9 @@ intersphinx_mapping = {
 # -- Options for extlinks -------------------------------------------------------------
 
 extlinks = {
-    "issue": ("https://github.com/pypa/pip/issues/%s", "#"),
-    "pull": ("https://github.com/pypa/pip/pull/%s", "PR #"),
-    "pypi": ("https://pypi.org/project/%s/", ""),
+    "issue": ("https://github.com/pypa/pip/issues/%s", "#%s"),
+    "pull": ("https://github.com/pypa/pip/pull/%s", "PR #%s"),
+    "pypi": ("https://pypi.org/project/%s/", "%s"),
 }
 
 # -- Options for towncrier_draft extension --------------------------------------------


### PR DESCRIPTION
In Sphinx 3, this used to be a prefix, but it is the full caption since Sphinx 4:

https://github.com/sphinx-doc/sphinx/commit/fb39974486ab09320f0cf45f3c0ba0175f04d7d6

With Sphinx 6, captions without %s fail:

https://github.com/sphinx-doc/sphinx/commit/ce31e1c0c7b32f6be93186e0fef076ef65ff0b05

    Exception occurred:
    File "/usr/lib/python3.11/site-packages/sphinx/ext/extlinks.py", line 103, in role
    title = caption % part
            ~~~~~~~~^~~~~~
    TypeError: not all arguments converted during string formatting

Fixes Fedora downstream report: https://bugzilla.redhat.com/2180479

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Opening as a draft, as I've done this via the web editor, and hence there is no news fragment.