### PR TITLE
Make the reference to packaging docs compatible with MyST-Parser 0.19+

### DIFF
--- a/docs/html/getting-started.md
+++ b/docs/html/getting-started.md
@@ -98,5 +98,5 @@ Successfully uninstalled sampleproject
 ## Next Steps
 
 It is recommended to learn about what virtual environments are and how to use
-them. This is covered in the ["Installing Packages"](pypug:tutorials/installing-packages)
+them. This is covered in the ["Installing Packages"](inv:pypug:std:doc#tutorials/installing-packages)
 tutorial on packaging.python.org.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx ~= 4.2, != 4.4.0
+sphinx ~= 6.1
 towncrier
 furo
 myst_parser


### PR DESCRIPTION
This change is needed to build the documentation with Sphinx 6+, which currently pulls in MyST-Parser 1.0.0. 

The previous definition causes an error when run with MyST-Parser 0.19+:
'myst' cross-reference target not found: 'pypug:tutorials/installing-packages'
Source: https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html#cross-project-intersphinx-links
