### PR TITLE
Codespell: config, action, pre-commit + few typos fixed 

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+# ignore-words-list = 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,10 @@
 [codespell]
 skip = .git,*.pdf,*.svg,_vendor,AUTHORS.txt
+# case sensitive matching of a class name or a string in tests
+ignore-regex = Failer|Building wheel for requir"
 # Wil - is a name
 # falsy - terminology used to describe bool eval to False values
 # uptodate - used as a word in options etc
 # lousily - as in a bad manner
-ignore-words-list = wil,falsy,uptodate,lousily
+# afile - common variable
+ignore-words-list = wil,falsy,uptodate,lousily,afile

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,5 @@ skip = .git,*.pdf,*.svg,_vendor,AUTHORS.txt
 # Wil - is a name
 # falsy - terminology used to describe bool eval to False values
 # uptodate - used as a word in options etc
-ignore-words-list = wil,falsy,uptodate
+# lousily - as in a bad manner
+ignore-words-list = wil,falsy,uptodate,lousily

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,6 @@
 [codespell]
-skip = .git,*.pdf,*.svg
-# ignore-words-list = 
+skip = .git,*.pdf,*.svg,_vendor,AUTHORS.txt
+# Wil - is a name
+# falsy - terminology used to describe bool eval to False values
+# uptodate - used as a word in options etc
+ignore-words-list = wil,falsy,uptodate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,11 @@ repos:
     types: [file]
     exclude: NEWS.rst  # The errors flagged in NEWS.rst are old.
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.4
+  hooks:
+    - id: codespell
+
 - repo: local
   hooks:
   - id: news-fragment-filenames

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,7 @@ include docs/docutils.conf
 include docs/requirements.txt
 
 exclude .git-blame-ignore-revs
+exclude .codespellrc
 exclude .coveragerc
 exclude .mailmap
 exclude .appveyor.yml

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -186,7 +186,7 @@ Improved Documentation
 
 - Cross-reference the ``--python`` flag from the ``--prefix`` flag,
   and mention limitations of ``--prefix`` regarding script installation. (`#11775 <https://github.com/pypa/pip/issues/11775>`_)
-- Add SECURITY.md to make the policy offical. (`#11809 <https://github.com/pypa/pip/issues/11809>`_)
+- Add SECURITY.md to make the policy official. (`#11809 <https://github.com/pypa/pip/issues/11809>`_)
 - Add username to Git over SSH example. (`#11838 <https://github.com/pypa/pip/issues/11838>`_)
 - Quote extras in the pip install docs to guard shells with default glob
   qualifiers, like zsh. (`#11842 <https://github.com/pypa/pip/issues/11842>`_)

--- a/news/11893.trivial.rst
+++ b/news/11893.trivial.rst
@@ -1,0 +1,3 @@
+Add `codespell <https://github.com/codespell-project/codespell>`_ support:
+configuration and github action to ensure that no new typos sneak in. A few
+typos were found and fixed throughout the codebase.

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -44,7 +44,7 @@ class Cache:
         """Get parts of part that must be os.path.joined with cache_dir"""
 
         # We want to generate an url to use as our cache key, we don't want to
-        # just re-use the URL because it might have other items in the fragment
+        # just reuse the URL because it might have other items in the fragment
         # and we don't care about those.
         key_parts = {"url": link.url_without_fragment}
         if link.hash_name is not None and link.hash is not None:

--- a/src/pip/_internal/utils/_jaraco_text.py
+++ b/src/pip/_internal/utils/_jaraco_text.py
@@ -88,7 +88,7 @@ def join_continuation(lines):
     ['foobarbaz']
 
     Not sure why, but...
-    The character preceeding the backslash is also elided.
+    The character preceding the backslash is also elided.
 
     >>> list(join_continuation(['goo\\', 'dly']))
     ['godly']

--- a/tests/functional/test_new_resolver_user.py
+++ b/tests/functional/test_new_resolver_user.py
@@ -27,7 +27,7 @@ def test_new_resolver_install_user_satisfied_by_global_site(
     script: PipTestEnvironment,
 ) -> None:
     """
-    An install a matching version to user site should re-use a global site
+    An install a matching version to user site should reuse a global site
     installation if it satisfies.
     """
     create_basic_wheel_for_package(script, "base", "1.0.0")

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -911,7 +911,7 @@ def test_collect_sources__non_existing_path() -> None:
             index_url="ignored-by-no-index",
             extra_index_urls=[],
             no_index=True,
-            find_links=[os.path.join("this", "doesnt", "exist")],
+            find_links=[os.path.join("this", "does", "not", "exist")],
         ),
     )
     sources = collector.collect_sources(


### PR DESCRIPTION
There were codespell fixes submitted in the past but no action or pre-commit was configured, so new typos seems to penetrate.  So I decided to propose action/config and pre-commit to ensure that in the future `pip` would remain typos free

