### PR TITLE
Support wheel cache when using --require-hashes

### DIFF
--- a/news/5037.feature.rst
+++ b/news/5037.feature.rst
@@ -1,1 +1,1 @@
-Support wheel cache when using --require-hashes.
+Support wheel cache when using ``--require-hashes``.

--- a/news/5037.feature.rst
+++ b/news/5037.feature.rst
@@ -1,0 +1,1 @@
+Support wheel cache when using --require-hashes.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -575,10 +575,7 @@ class RequirementPreparer:
                     "don't match, ignoring cached built wheel "
                     "and re-downloading source."
                 )
-                # For some reason req.original_link is not set here, even though
-                # req.is_wheel_from_cache is True. So we get the original
-                # link from download_info.
-                req.link = Link(req.download_info.url)  # TODO comes_from?
+                req.link = req.cached_wheel_source_link
                 link = req.link
 
         self._ensure_link_req_src_dir(req, parallel_builds)

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -553,13 +553,10 @@ class RequirementPreparer:
 
         hashes = self._get_linked_req_hashes(req)
 
-        if (
-            hashes
-            and link.is_wheel
-            and link.is_file
-            and req.original_link_is_in_wheel_cache
-        ):
+        if hashes and req.original_link_is_in_wheel_cache:
             assert req.download_info is not None
+            assert link.is_wheel
+            assert link.is_file
             # We need to verify hashes, and we have found the requirement in the cache
             # of locally built wheels.
             if (

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -267,7 +267,7 @@ class RequirementPreparer:
 
     def _log_preparing_link(self, req: InstallRequirement) -> None:
         """Provide context for the requirement being prepared."""
-        if req.link.is_file and not req.original_link_is_in_wheel_cache:
+        if req.link.is_file and not req.is_wheel_from_cache:
             message = "Processing %s"
             information = str(display_path(req.link.file_path))
         else:
@@ -288,7 +288,7 @@ class RequirementPreparer:
             self._previous_requirement_header = (message, information)
             logger.info(message, information)
 
-        if req.original_link_is_in_wheel_cache:
+        if req.is_wheel_from_cache:
             with indent_log():
                 logger.info("Using cached %s", req.link.filename)
 
@@ -499,7 +499,7 @@ class RequirementPreparer:
                     # original link, not the cached link. It that case the already
                     # downloaded file will be removed and re-fetched from cache (which
                     # implies a hash check against the cache entry's origin.json).
-                    warn_on_hash_mismatch=not req.original_link_is_in_wheel_cache,
+                    warn_on_hash_mismatch=not req.is_wheel_from_cache,
                 )
 
             if file_path is not None:
@@ -553,7 +553,7 @@ class RequirementPreparer:
 
         hashes = self._get_linked_req_hashes(req)
 
-        if hashes and req.original_link_is_in_wheel_cache:
+        if hashes and req.is_wheel_from_cache:
             assert req.download_info is not None
             assert link.is_wheel
             assert link.is_file
@@ -576,7 +576,7 @@ class RequirementPreparer:
                     "and re-downloading source."
                 )
                 # For some reason req.original_link is not set here, even though
-                # req.original_link_is_in_wheel_cache is True. So we get the original
+                # req.is_wheel_from_cache is True. So we get the original
                 # link from download_info.
                 req.link = Link(req.download_info.url)  # TODO comes_from?
                 link = req.link

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -108,7 +108,10 @@ class InstallRequirement:
             # PEP 508 URL requirement
             link = Link(req.url)
         self.link = self.original_link = link
-        self.original_link_is_in_wheel_cache = False
+
+        # When is_wheel_from_cache is True, it means that this InstallRequirement
+        # is a local wheel file in the cache of locally built wheels.
+        self.is_wheel_from_cache = False
 
         # Information about the location of the artifact that was downloaded . This
         # property is guaranteed to be set in resolver results.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -109,11 +109,9 @@ class InstallRequirement:
             link = Link(req.url)
         self.link = self.original_link = link
 
-        # When is_wheel_from_cache is True, it means that this InstallRequirement
-        # is a local wheel file in the cache of locally built wheels.
-        self.is_wheel_from_cache = False
-        # When is_wheel_from_cache is True, this is the source link corresponding
-        # to the cache entry, which was used to download and build the cached wheel.
+        # When this InstallRequirement is a wheel obtained from the cache of locally
+        # built wheels, this is the source link corresponding to the cache entry, which
+        # was used to download and build the cached wheel.
         self.cached_wheel_source_link: Optional[Link] = None
 
         # Information about the location of the artifact that was downloaded . This
@@ -442,6 +440,12 @@ class InstallRequirement:
         if not self.link:
             return False
         return self.link.is_wheel
+
+    @property
+    def is_wheel_from_cache(self) -> bool:
+        # When True, it means that this InstallRequirement is a local wheel file in the
+        # cache of locally built wheels.
+        return self.cached_wheel_source_link is not None
 
     # Things valid for sdists
     @property

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -112,6 +112,9 @@ class InstallRequirement:
         # When is_wheel_from_cache is True, it means that this InstallRequirement
         # is a local wheel file in the cache of locally built wheels.
         self.is_wheel_from_cache = False
+        # When is_wheel_from_cache is True, this is the source link corresponding
+        # to the cache entry, which was used to download and build the cached wheel.
+        self.cached_wheel_source_link: Optional[Link] = None
 
         # Information about the location of the artifact that was downloaded . This
         # property is guaranteed to be set in resolver results.

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -431,7 +431,7 @@ class Resolver(BaseResolver):
         if cache_entry is not None:
             logger.debug("Using cached wheel link: %s", cache_entry.link)
             if req.link is req.original_link and cache_entry.persistent:
-                req.original_link_is_in_wheel_cache = True
+                req.is_wheel_from_cache = True
             if cache_entry.origin is not None:
                 req.download_info = cache_entry.origin
             else:

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -431,6 +431,7 @@ class Resolver(BaseResolver):
         if cache_entry is not None:
             logger.debug("Using cached wheel link: %s", cache_entry.link)
             if req.link is req.original_link and cache_entry.persistent:
+                req.cached_wheel_source_link = req.link
                 req.is_wheel_from_cache = True
             if cache_entry.origin is not None:
                 req.download_info = cache_entry.origin

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -432,7 +432,6 @@ class Resolver(BaseResolver):
             logger.debug("Using cached wheel link: %s", cache_entry.link)
             if req.link is req.original_link and cache_entry.persistent:
                 req.cached_wheel_source_link = req.link
-                req.is_wheel_from_cache = True
             if cache_entry.origin is not None:
                 req.download_info = cache_entry.origin
             else:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -280,6 +280,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             assert ireq.link.is_wheel
             assert ireq.link.is_file
             if cache_entry.persistent and template.link is template.original_link:
+                ireq.cached_wheel_source_link = source_link
                 ireq.is_wheel_from_cache = True
             if cache_entry.origin is not None:
                 ireq.download_info = cache_entry.origin

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -281,7 +281,6 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             assert ireq.link.is_file
             if cache_entry.persistent and template.link is template.original_link:
                 ireq.cached_wheel_source_link = source_link
-                ireq.is_wheel_from_cache = True
             if cache_entry.origin is not None:
                 ireq.download_info = cache_entry.origin
             else:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -259,7 +259,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
         version: Optional[CandidateVersion] = None,
     ) -> None:
         source_link = link
-        cache_entry = factory.get_wheel_cache_entry(link, name)
+        cache_entry = factory.get_wheel_cache_entry(source_link, name)
         if cache_entry is not None:
             logger.debug("Using cached wheel link: %s", cache_entry.link)
             link = cache_entry.link

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -277,6 +277,8 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
                 )
 
         if cache_entry is not None:
+            assert ireq.link.is_wheel
+            assert ireq.link.is_file
             if cache_entry.persistent and template.link is template.original_link:
                 ireq.is_wheel_from_cache = True
             if cache_entry.origin is not None:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -278,7 +278,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
 
         if cache_entry is not None:
             if cache_entry.persistent and template.link is template.original_link:
-                ireq.original_link_is_in_wheel_cache = True
+                ireq.is_wheel_from_cache = True
             if cache_entry.origin is not None:
                 ireq.download_info = cache_entry.origin
             else:

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -535,7 +535,7 @@ class Factory:
         hash mismatches. Furthermore, cached wheels at present have
         nondeterministic contents due to file modification times.
         """
-        if self._wheel_cache is None or self.preparer.require_hashes:
+        if self._wheel_cache is None:
             return None
         return self._wheel_cache.get_cache_entry(
             link=link,

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -105,6 +105,13 @@ class Hashes:
         with open(path, "rb") as file:
             return self.check_against_file(file)
 
+    def has_one_of(self, hashes: Dict[str, str]) -> bool:
+        """Return whether any of the given hashes are allowed."""
+        for hash_name, hex_digest in hashes.items():
+            if self.is_hash_allowed(hash_name, hex_digest):
+                return True
+        return False
+
     def __bool__(self) -> bool:
         """Return whether I know any known-good hashes."""
         return bool(self._allowed)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -763,6 +763,10 @@ def test_hashed_install_from_cache(
             reqs_file.resolve(),
             expect_error=True,
         )
+        assert (
+            "WARNING: The hashes of the source archive found in cache entry "
+            "don't match, ignoring cached built wheel and re-downloading source."
+        ) in result.stderr
         assert "Using cached simple2" in result.stdout
         assert "ERROR: THESE PACKAGES DO NOT MATCH THE HASHES" in result.stderr
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -729,6 +729,44 @@ def test_bad_link_hash_in_dep_install_failure(
     assert "THESE PACKAGES DO NOT MATCH THE HASHES" in result.stderr, result.stderr
 
 
+def test_hashed_install_from_cache(
+    script: PipTestEnvironment, data: TestData, tmpdir: Path
+) -> None:
+    """
+    Test that installing from a cached built wheel works and that the hash is verified
+    against the hash of the original source archived stored in the cache entry.
+    """
+    with requirements_file(
+        "simple2==1.0 --hash=sha256:"
+        "9336af72ca661e6336eb87bc7de3e8844d853e3848c2b9bbd2e8bf01db88c2c7\n",
+        tmpdir,
+    ) as reqs_file:
+        result = script.pip_install_local(
+            "--use-pep517", "--no-build-isolation", "-r", reqs_file.resolve()
+        )
+        assert "Created wheel for simple2" in result.stdout
+        script.pip("uninstall", "simple2", "-y")
+        result = script.pip_install_local(
+            "--use-pep517", "--no-build-isolation", "-r", reqs_file.resolve()
+        )
+        assert "Using cached simple2" in result.stdout
+    # now try with an invalid hash
+    with requirements_file(
+        "simple2==1.0 --hash=sha256:invalid\n",
+        tmpdir,
+    ) as reqs_file:
+        script.pip("uninstall", "simple2", "-y")
+        result = script.pip_install_local(
+            "--use-pep517",
+            "--no-build-isolation",
+            "-r",
+            reqs_file.resolve(),
+            expect_error=True,
+        )
+        assert "Using cached simple2" in result.stdout
+        assert "ERROR: THESE PACKAGES DO NOT MATCH THE HASHES" in result.stderr
+
+
 def assert_re_match(pattern: str, text: str) -> None:
     assert re.search(pattern, text), f"Could not find {pattern!r} in {text!r}"
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -412,6 +412,7 @@ class TestRequirementSet:
             assert len(reqset.all_requirements) == 1
             req = reqset.all_requirements[0]
             assert req.is_wheel_from_cache
+            assert req.cached_wheel_source_link
             assert req.download_info
             assert req.download_info.url == url
             assert isinstance(req.download_info.info, ArchiveInfo)
@@ -438,6 +439,7 @@ class TestRequirementSet:
             assert len(reqset.all_requirements) == 1
             req = reqset.all_requirements[0]
             assert req.is_wheel_from_cache
+            assert req.cached_wheel_source_link
             assert req.download_info
             assert req.download_info.url == url
             assert isinstance(req.download_info.info, ArchiveInfo)

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -411,7 +411,7 @@ class TestRequirementSet:
             reqset = resolver.resolve([ireq], True)
             assert len(reqset.all_requirements) == 1
             req = reqset.all_requirements[0]
-            assert req.original_link_is_in_wheel_cache
+            assert req.is_wheel_from_cache
             assert req.download_info
             assert req.download_info.url == url
             assert isinstance(req.download_info.info, ArchiveInfo)
@@ -437,7 +437,7 @@ class TestRequirementSet:
             reqset = resolver.resolve([ireq], True)
             assert len(reqset.all_requirements) == 1
             req = reqset.all_requirements[0]
-            assert req.original_link_is_in_wheel_cache
+            assert req.is_wheel_from_cache
             assert req.download_info
             assert req.download_info.url == url
             assert isinstance(req.download_info.info, ArchiveInfo)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -425,6 +425,14 @@ class TestHashes:
         cache[Hashes({"sha256": ["ab", "cd"]})] = 42
         assert cache[Hashes({"sha256": ["ab", "cd"]})] == 42
 
+    def test_has_one_of(self) -> None:
+        hashes = Hashes({"sha256": ["abcd", "efgh"], "sha384": ["ijkl"]})
+        assert hashes.has_one_of({"sha256": "abcd"})
+        assert hashes.has_one_of({"sha256": "efgh"})
+        assert not hashes.has_one_of({"sha256": "xyzt"})
+        empty_hashes = Hashes()
+        assert not empty_hashes.has_one_of({"sha256": "xyzt"})
+
 
 class TestEncoding:
     """Tests for pip._internal.utils.encoding"""


### PR DESCRIPTION
closes #5037

@ewdurbin would you like to test this and try to break it?

I'm not doing it for the bounty, as this is also one of the things in my way of actually using hashes. So hopefully we'll share a :beer: if our paths cross one day.

TODO

- [x] investigate how this impacts `pip wheel` (I think it works but the warning should be silenced)