### PR TITLE
Prevent pip install pip install

### DIFF
--- a/news/11484.feature.rst
+++ b/news/11484.feature.rst
@@ -1,2 +1,4 @@
-Prevent users from running ``pip install pip install ...``, as this is likely
-unintentional.
+Prevent users from running ``pip install pip install package`` and
+``pip install install package``, as this is likely unintentional. Installing
+the ``install`` package is still possible by running ``pip install install``
+separately.

--- a/news/11484.feature.rst
+++ b/news/11484.feature.rst
@@ -1,0 +1,2 @@
+Prevent users from running ``pip install pip install ...``, as this is likely
+unintentional.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -281,7 +281,7 @@ class InstallCommand(RequirementCommand):
                 )
             )
         # And the same for pip install install (unless it is the only argument)
-        if args[0] == "install" and len(args) > 1:
+        if len(args) > 1 and args[0] == "install":
             raise CommandError(
                 "\n".join(
                     [

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -269,9 +269,8 @@ class InstallCommand(RequirementCommand):
 
         # Prevent users from running pip install pip install, since this likely
         # indicates a mistake with the command
-        if args[:2] == ['pip', 'install']:
-            raise CommandError(
-                "Likely incorrect command: pip install pip install ...")
+        if args[:2] == ["pip", "install"]:
+            raise CommandError("Likely incorrect command: pip install pip install ...")
 
         # Check whether the environment we're installing into is externally
         # managed, as specified in PEP 668. Specifying --root, --target, or

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -270,7 +270,7 @@ class InstallCommand(RequirementCommand):
         # Prevent users from running pip install pip install, since this likely
         # indicates a mistake with the command
         if args[:2] == ["pip", "install"]:
-            raise CommandError("Likely incorrect command: pip install pip install ...")
+            raise CommandError(f"Likely incorrect command: pip install pip install ... Did you mean \"pip install {' '.join(args[2:-1])}\".")
 
         # Check whether the environment we're installing into is externally
         # managed, as specified in PEP 668. Specifying --root, --target, or

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -270,7 +270,28 @@ class InstallCommand(RequirementCommand):
         # Prevent users from running pip install pip install, since this likely
         # indicates a mistake with the command
         if args[:2] == ["pip", "install"]:
-            raise CommandError(f"Likely incorrect command: pip install pip install ... Did you mean \"pip install {' '.join(args[2:-1])}\".")
+            raise CommandError(
+                "\n".join(
+                    [
+                        "Likely incorrect command: pip install pip install ...",
+                        f"Did you mean \"pip install {' '.join(args[2:])}\"?",
+                        'To install the "install" package, run '
+                        '"pip install install" separately',
+                    ]
+                )
+            )
+        # And the same for pip install install (unless it is the only argument)
+        if args[0] == "install" and len(args) > 1:
+            raise CommandError(
+                "\n".join(
+                    [
+                        "Likely incorrect command: pip install install ...",
+                        f"Did you mean \"pip install {' '.join(args[1:])}\"?",
+                        'To install the "install" package, run '
+                        '"pip install install" separately',
+                    ]
+                )
+            )
 
         # Check whether the environment we're installing into is externally
         # managed, as specified in PEP 668. Specifying --root, --target, or

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -267,6 +267,12 @@ class InstallCommand(RequirementCommand):
         if options.use_user_site and options.target_dir is not None:
             raise CommandError("Can not combine '--user' and '--target'")
 
+        # Prevent users from running pip install pip install, since this likely
+        # indicates a mistake with the command
+        if args[:2] == ['pip', 'install']:
+            raise CommandError(
+                "Likely incorrect command: pip install pip install ...")
+
         # Check whether the environment we're installing into is externally
         # managed, as specified in PEP 668. Specifying --root, --target, or
         # --prefix disables the check, since there's no reliable way to locate

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2575,6 +2575,4 @@ def test_prevent_pip_install_pip_install(script: PipTestEnvironment) -> None:
         expect_error=True,
     )
 
-    assert (
-        "Likely incorrect command: pip install pip install ..." in result.stderr
-    )
+    assert "Likely incorrect command: pip install pip install ..." in result.stderr

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2575,4 +2575,50 @@ def test_prevent_pip_install_pip_install(script: PipTestEnvironment) -> None:
         expect_error=True,
     )
 
-    assert "Likely incorrect command: pip install pip install ..." in result.stderr
+    assert (
+        "\n".join(
+            [
+                "Likely incorrect command: pip install pip install ...",
+                'Did you mean "pip install simple_package"?',
+                'To install the "install" package, run '
+                '"pip install install" separately',
+            ]
+        )
+        in result.stderr
+    )
+
+
+def test_prevent_pip_install_install_package(script: PipTestEnvironment) -> None:
+    """
+    Test that an error is given if a user tries to run pip install install ...,
+    as they likely made a mistake with their command
+    """
+    result = script.pip(
+        "install",
+        "install",
+        "simple_package",
+        expect_error=True,
+    )
+
+    assert (
+        "\n".join(
+            [
+                "Likely incorrect command: pip install install ...",
+                'Did you mean "pip install simple_package"?',
+                'To install the "install" package, run '
+                '"pip install install" separately',
+            ]
+        )
+        in result.stderr
+    )
+
+
+def test_allow_pip_install_install(script: PipTestEnvironment) -> None:
+    """
+    Test that users are allowed to install the "install" package explicitly
+    """
+    result = script.pip(
+        "install",
+        "install",
+    )
+    assert "Successfully installed install" in result.stdout

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2560,3 +2560,21 @@ def test_install_pip_prints_req_chain_pypi(script: PipTestEnvironment) -> None:
         f"Collecting python-openid "
         f"(from Paste[openid]==1.7.5.1->-r {req_path} (line 1))" in result.stdout
     )
+
+
+def test_prevent_pip_install_pip_install(script: PipTestEnvironment) -> None:
+    """
+    Test that an error is given if a user tries to run pip install pip install,
+    as they likely made a mistake with their command
+    """
+    result = script.pip(
+        "install",
+        "pip",
+        "install",
+        "simple_package",
+        expect_error=True,
+    )
+
+    assert (
+        "Likely incorrect command: pip install pip install ..." in result.stderr
+    )


### PR DESCRIPTION
Resolves #11484.

If a user pastes an install command into their terminal, but has already typed `pip install ` beforehand, this currently results in `pip` installing the [`install`](https://github.com/eugenekolo/pip-install) package, which is likely never their intention given that `install` is a nearly useless package to prevent typosquatting.

This appears to be a common mistake given that the `install` package has around 30000 installs on most weekdays.

This PR adds a check to prevent users from running `pip install pip install package` and `pip install install package`, which should hopefully save users some time and frustration, since there won't be a need to follow their mistaken command up with a `pip uninstall install` to rectify their mistake.

Note that it is still possible to install the `install` package using `pip install install` by itself or by specifying it as not being the first package.

* [x] Implement
* [x] Add tests
* [x] Add news entry

As far as I'm aware, this feature shouldn't require documentation, but I'm happy to write some if required (let me know where since I can't think of a good place for it).

This is my first PR to `pip`, so please let me know if there's anything I've overlooked! Thanks!