### PR TITLE
Added --editable-requirements option to install command

### DIFF
--- a/news/11881.feature.rst
+++ b/news/11881.feature.rst
@@ -1,0 +1,2 @@
+Implement ``--editable-requirements`` for installing requirements of editable
+packages as editable where possible (`#11881 <https://github.com/pypa/pip/issues/11881>`_)

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -443,6 +443,19 @@ def editable() -> Option:
     )
 
 
+def editable_requirements() -> Option:
+    return Option(
+        "--editable-requirements",
+        dest="editable_requirements",
+        action="store_true",
+        default=False,
+        help=(
+            "Install requirements of editable packages "
+            "in editable mode as well where possible"
+        ),
+    )
+
+
 def _handle_src(option: Option, opt_str: str, value: str, parser: OptionParser) -> None:
     value = os.path.abspath(value)
     setattr(parser.values, option.dest, value)

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -424,6 +424,7 @@ class RequirementCommand(IndexGroupCommand):
                 user_supplied=True,
                 isolated=options.isolated_mode,
                 use_pep517=options.use_pep517,
+                editable_requirements=options.editable_requirements,
                 config_settings=getattr(options, "config_settings", None),
             )
             requirements.append(req_to_add)
@@ -437,6 +438,7 @@ class RequirementCommand(IndexGroupCommand):
                     parsed_req,
                     isolated=options.isolated_mode,
                     use_pep517=options.use_pep517,
+                    editable_requirements=options.editable_requirements,
                     user_supplied=True,
                     config_settings=parsed_req.options.get("config_settings")
                     if parsed_req.options

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -80,6 +80,7 @@ class DownloadCommand(RequirementCommand):
         # editable doesn't really make sense for `pip download`, but the bowels
         # of the RequirementSet code require that property.
         options.editables = []
+        options.editable_requirements = False
 
         cmdoptions.check_dist_restriction(options)
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -76,6 +76,8 @@ class InstallCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.pre())
 
         self.cmd_opts.add_option(cmdoptions.editable())
+        self.cmd_opts.add_option(cmdoptions.editable_requirements())
+
         self.cmd_opts.add_option(
             "--dry-run",
             action="store_true",

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -62,6 +62,7 @@ class WheelCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.check_build_deps())
         self.cmd_opts.add_option(cmdoptions.constraints())
         self.cmd_opts.add_option(cmdoptions.editable())
+        self.cmd_opts.add_option(cmdoptions.editable_requirements())
         self.cmd_opts.add_option(cmdoptions.requirements())
         self.cmd_opts.add_option(cmdoptions.src())
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -203,6 +203,7 @@ def install_req_from_editable(
     comes_from: Optional[Union[InstallRequirement, str]] = None,
     *,
     use_pep517: Optional[bool] = None,
+    editable_requirements: bool = False,
     isolated: bool = False,
     global_options: Optional[List[str]] = None,
     hash_options: Optional[Dict[str, List[str]]] = None,
@@ -222,6 +223,7 @@ def install_req_from_editable(
         link=parts.link,
         constraint=constraint,
         use_pep517=use_pep517,
+        editable_requirements=editable_requirements,
         isolated=isolated,
         global_options=global_options,
         hash_options=hash_options,
@@ -439,9 +441,22 @@ def install_req_from_req_string(
             "{} depends on {} ".format(comes_from.name, req)
         )
 
+    link = None if req.url is None else Link(req.url)
+    editable = (
+        link is not None
+        and (link.scheme == "file" or link.is_vcs)
+        and comes_from is not None
+        and comes_from.editable
+        and comes_from.editable_requirements
+    )
+
     return InstallRequirement(
         req,
         comes_from,
+        editable=editable,
+        permit_editable_wheels=editable,
+        link=link,
+        editable_requirements=editable,
         isolated=isolated,
         use_pep517=use_pep517,
         user_supplied=user_supplied,
@@ -452,6 +467,7 @@ def install_req_from_parsed_requirement(
     parsed_req: ParsedRequirement,
     isolated: bool = False,
     use_pep517: Optional[bool] = None,
+    editable_requirements: bool = False,
     user_supplied: bool = False,
     config_settings: Optional[Dict[str, Union[str, List[str]]]] = None,
 ) -> InstallRequirement:
@@ -460,6 +476,7 @@ def install_req_from_parsed_requirement(
             parsed_req.requirement,
             comes_from=parsed_req.comes_from,
             use_pep517=use_pep517,
+            editable_requirements=editable_requirements,
             constraint=parsed_req.constraint,
             isolated=isolated,
             user_supplied=user_supplied,

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -58,6 +58,7 @@ SUPPORTED_OPTIONS: List[Callable[..., optparse.Option]] = [
     cmdoptions.constraints,
     cmdoptions.requirements,
     cmdoptions.editable,
+    cmdoptions.editable_requirements,
     cmdoptions.find_links,
     cmdoptions.no_binary,
     cmdoptions.only_binary,
@@ -228,6 +229,8 @@ def handle_option_line(
             options.features_enabled.extend(
                 f for f in opts.features_enabled if f not in options.features_enabled
             )
+        if opts.editable_requirements:
+            options.editable_requirements = True
 
     # set finder options
     if finder:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -78,6 +78,7 @@ class InstallRequirement:
         use_pep517: Optional[bool] = None,
         isolated: bool = False,
         *,
+        editable_requirements: bool = False,
         global_options: Optional[List[str]] = None,
         hash_options: Optional[Dict[str, List[str]]] = None,
         config_settings: Optional[Dict[str, Union[str, List[str]]]] = None,
@@ -91,6 +92,7 @@ class InstallRequirement:
         self.comes_from = comes_from
         self.constraint = constraint
         self.editable = editable
+        self.editable_requirements = editable_requirements
         self.permit_editable_wheels = permit_editable_wheels
 
         # source_dir is the local directory where the linked requirement is

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -83,6 +83,7 @@ def make_install_req_from_editable(
         link.url,
         user_supplied=template.user_supplied,
         comes_from=template.comes_from,
+        editable_requirements=template.editable_requirements,
         use_pep517=template.use_pep517,
         isolated=template.isolated,
         constraint=template.constraint,


### PR DESCRIPTION
This PR adds an `--editable-requirements` option to `pip install` to provide the functionality requested in https://github.com/pypa/pip/issues/11881

When installing a package in editable mode that depends on other packages that can be installed in editable mode (e.g. `other_package @ file:///path/to/other_package`) there are situations where it would be useful to also install `other_package` in editable mode.

This is similar to the functionality that `poetry install` offers but applies to packages using any build system.

Here are two use cases I have encountered where this functionality would be useful:

## Scenario 1
I have a set of packages for personal projects that depend on each other.
The projects will never be uploaded to a package index, therefore they depend on each other by their paths. I would like to install them all in editable mode so that I can work on them without having to re-install each time I make a change.

I manage a virtual environment for my projects with a `requirements.txt` file which lists the top-level packages to install

```
# misc packages
pytest
ipython

# my projects
-e /path/to/project1
-e /path/to/project2
```
If `project1` depends on `library1` then although `project1` and `project2` are installed in editable mode,
`library1` would not be which is confusing.

Adding `-e /path/to/library1` would not be a solution because of https://github.com/pypa/pip/issues/10216

With this PR I could add `--editable-requirements` to the top of the file to get the behaviour I want.


## Scenario 2
I have a monorepo containing multiple projects using [this approach](https://gerben-oostra.medium.com/python-poetry-mono-repo-without-limitations-dd63b47dc6b8) which has packages depend on each other using relative paths that the CI re-writes as version requirements while building the packages.

The CI itself uses some python tools developed in the monorepo to help build the packages. These tools are installed using `pip install -e` on the CI machine so that changes to the tools take immediate effect without needing to be re-installed each run. The packages are only re-installed whenever the requirements change.

Without `--editable-requirements` I am resorting to custom script that wraps pip to hack this feature in.
