### PR TITLE
Skip problematic test in MacOS

### DIFF
--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -342,6 +342,10 @@ def test_pip_wheel_with_user_set_in_config(
     sys.platform.startswith("win"),
     reason="The empty extension module does not work on Win",
 )
+@pytest.mark.skipif(
+    sys.platform.startswith("darwin"),
+    reason="The empty extension module does not work on MacOS",
+)
 def test_pip_wheel_ext_module_with_tmpdir_inside(
     script: PipTestEnvironment, data: TestData, common_wheels: Path
 ) -> None:


### PR DESCRIPTION
This test is being flaky on MacOS, and it's unclear what the fix is. Instead of blocking the entire project on this, we're skipping this test to be respectful of the time of contributors and mindful that there's limited contributor bandwidth to investigate this right now.
