### PR TITLE
Bump all linters other than mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'src/pip/_vendor/'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
   - id: check-builtin-literals
   - id: check-added-large-files
@@ -17,18 +17,18 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/psf/black
-  rev: 22.6.0
+  rev: 23.1.0
   hooks:
   - id: black
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 4.0.1
+  rev: 6.0.0
   hooks:
   - id: flake8
     additional_dependencies: [
-        'flake8-bugbear==22.10.27',
-        'flake8-logging-format==0.9.0',
-        'flake8-implicit-str-concat==0.3.0',
+        'flake8-bugbear',
+        'flake8-logging-format',
+        'flake8-implicit-str-concat',
     ]
     exclude: tests/data
 
@@ -56,7 +56,7 @@ repos:
     ]
 
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.9.0
+  rev: v1.10.0
   hooks:
   - id: python-no-log-warn
   - id: python-no-eval

--- a/docs/pip_sphinxext.py
+++ b/docs/pip_sphinxext.py
@@ -254,7 +254,6 @@ class PipCLIDirective(rst.Directive):
         lines = []
         # Create a tab for each OS
         for os, variant in os_variants.items():
-
             # Unpack the values
             prompt = variant["prompt"]
             highlighter = variant["highlighter"]

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -37,7 +37,6 @@ class CacheCommand(Command):
     """
 
     def add_options(self) -> None:
-
         self.cmd_opts.add_option(
             "--format",
             action="store",

--- a/src/pip/_internal/commands/check.py
+++ b/src/pip/_internal/commands/check.py
@@ -20,7 +20,6 @@ class CheckCommand(Command):
       %prog [options]"""
 
     def run(self, options: Values, args: List[str]) -> int:
-
         package_set, parsing_probs = create_package_set_from_installed()
         missing, conflicting = check_package_set(package_set)
 

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -76,7 +76,6 @@ class DownloadCommand(RequirementCommand):
 
     @with_cleanup
     def run(self, options: Values, args: List[str]) -> int:
-
         options.ignore_installed = True
         # editable doesn't really make sense for `pip download`, but the bowels
         # of the RequirementSet code require that property.

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -43,7 +43,6 @@ class WheelCommand(RequirementCommand):
       %prog [options] <archive url/path> ..."""
 
     def add_options(self) -> None:
-
         self.cmd_opts.add_option(
             "-w",
             "--wheel-dir",

--- a/src/pip/_internal/index/sources.py
+++ b/src/pip/_internal/index/sources.py
@@ -171,7 +171,6 @@ def build_source(
     expand_dir: bool,
     cache_link_parsing: bool,
 ) -> Tuple[Optional[str], Optional[LinkSource]]:
-
     path: Optional[str] = None
     url: Optional[str] = None
     if os.path.exists(location):  # Is a local path.

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -79,7 +79,6 @@ class SearchScope:
         redacted_index_urls = []
         if self.index_urls and self.index_urls != [PyPI.simple_url]:
             for url in self.index_urls:
-
                 redacted_index_url = redact_auth_from_url(url)
 
                 # Parse the URL

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -316,7 +316,6 @@ class InsecureCacheControlAdapter(CacheControlAdapter):
 
 
 class PipSession(requests.Session):
-
     timeout: Optional[int] = None
 
     def __init__(

--- a/src/pip/_internal/operations/install/legacy.py
+++ b/src/pip/_internal/operations/install/legacy.py
@@ -69,7 +69,6 @@ def install(
     unpacked_source_directory: str,
     req_description: str,
 ) -> bool:
-
     header_dir = scheme.headers
 
     with TempDirectory(kind="record") as temp_dir:

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -209,7 +209,6 @@ def install_req_from_editable(
     permit_editable_wheels: bool = False,
     config_settings: Optional[Dict[str, str]] = None,
 ) -> InstallRequirement:
-
     parts = parse_req_from_editable(editable_req)
 
     return InstallRequirement(

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -165,7 +165,6 @@ def handle_requirement_line(
     line: ParsedLine,
     options: Optional[optparse.Values] = None,
 ) -> ParsedRequirement:
-
     # preserve for the nested code path
     line_comes_from = "{} {} (line {})".format(
         "-c" if line.constraint else "-r",
@@ -210,7 +209,6 @@ def handle_option_line(
     options: Optional[optparse.Values] = None,
     session: Optional[PipSession] = None,
 ) -> None:
-
     if options:
         # percolate options upward
         if opts.require_hashes:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -850,7 +850,6 @@ class InstallRequirement:
 
 
 def check_invalid_constraint_type(req: InstallRequirement) -> str:
-
     # Check for unsupported forms
     problem = ""
     if not req.name:

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -632,7 +632,6 @@ class Factory:
         e: "ResolutionImpossible[Requirement, Candidate]",
         constraints: Dict[str, Constraint],
     ) -> InstallationError:
-
         assert e.causes, "Installation error reported with no cause"
 
         # If one of the things we can't solve is "we need Python X.Y",

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -64,7 +64,6 @@ class SpecifierRequirement(Requirement):
         return format_name(self.project_name, self._extras)
 
     def format_for_error(self) -> str:
-
         # Convert comma-separated specifiers into "A, B, ..., F and G"
         # This makes the specifier a bit more "human readable", without
         # risking a change in meaning. (Hopefully! Not all edge cases have

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,7 +431,6 @@ def virtualenv_template(
     setuptools_install: Path,
     coverage_install: Path,
 ) -> Iterator[VirtualEnvironment]:
-
     venv_type: VirtualEnvironmentType
     if request.config.getoption("--use-venv"):
         venv_type = "venv"

--- a/tests/functional/test_build_env.py
+++ b/tests/functional/test_build_env.py
@@ -106,7 +106,6 @@ def test_build_env_allow_only_one_install(script: PipTestEnvironment) -> None:
 
 
 def test_build_env_requirements_check(script: PipTestEnvironment) -> None:
-
     create_basic_wheel_for_package(script, "foo", "2.0")
     create_basic_wheel_for_package(script, "bar", "1.0")
     create_basic_wheel_for_package(script, "bar", "3.0")
@@ -206,7 +205,6 @@ def test_build_env_overlay_prefix_has_priority(script: PipTestEnvironment) -> No
 
 @pytest.mark.usefixtures("enable_user_site")
 def test_build_env_isolation(script: PipTestEnvironment) -> None:
-
     # Create dummy `pkg` wheel.
     pkg_whl = create_basic_wheel_for_package(script, "pkg", "1.0")
 

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -107,7 +107,7 @@ def list_matches_wheel(wheel_name: str, result: TestPipResult) -> bool:
           `- foo-1.2.3-py3-none-any.whl `."""
     lines = result.stdout.splitlines()
     expected = f" - {wheel_name}-py3-none-any.whl "
-    return any(map(lambda l: l.startswith(expected), lines))
+    return any(map(lambda line: line.startswith(expected), lines))
 
 
 def list_matches_wheel_abspath(wheel_name: str, result: TestPipResult) -> bool:
@@ -121,7 +121,9 @@ def list_matches_wheel_abspath(wheel_name: str, result: TestPipResult) -> bool:
     expected = f"{wheel_name}-py3-none-any.whl"
     return any(
         map(
-            lambda l: os.path.basename(l).startswith(expected) and os.path.exists(l),
+            lambda line: (
+                os.path.basename(line).startswith(expected) and os.path.exists(line)
+            ),
             lines,
         )
     )

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2262,7 +2262,6 @@ def test_install_skip_work_dir_pkg(script: PipTestEnvironment, data: TestData) -
 def test_install_verify_package_name_normalization(
     script: PipTestEnvironment, package_name: str
 ) -> None:
-
     """
     Test that install of a package again using a name which
     normalizes to the original package name, is a no-op

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -22,7 +22,6 @@ def fixed_time() -> Iterator[None]:
 
 
 class FakeCommand(Command):
-
     _name = "fake"
 
     def __init__(

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -1014,6 +1014,7 @@ def test_link_collector_create_find_links_expansion(
     """
     Test "~" expansion in --find-links paths.
     """
+
     # This is a mock version of expanduser() that expands "~" to the tmpdir.
     def expand_path(path: str) -> str:
         if path.startswith("~/"):

--- a/tests/unit/test_link.py
+++ b/tests/unit/test_link.py
@@ -108,7 +108,7 @@ class TestLink:
     )
     def test_invalid_egg_fragments(self, fragment: str) -> None:
         url = f"git+https://example.com/package#egg={fragment}"
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             Link(url)
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_network_cache.py
+++ b/tests/unit/test_network_cache.py
@@ -24,7 +24,6 @@ class TestSafeFileCache:
     """
 
     def test_cache_roundtrip(self, cache_tmpdir: Path) -> None:
-
         cache = SafeFileCache(os.fspath(cache_tmpdir))
         assert cache.get("test key") is None
         cache.set("test key", b"a test string")

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -454,7 +454,6 @@ class TestCountOptions(AddFakeCommandMixin):
 
 
 class TestGeneralOptions(AddFakeCommandMixin):
-
     # the reason to specifically test general options is due to the
     # extra processing they receive, and the number of bugs we've had
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -613,7 +613,6 @@ class TestBreakOptionsArgs:
 
 
 class TestOptionVariants:
-
     # this suite is really just testing optparse, but added it anyway
 
     def test_variant1(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -53,7 +53,6 @@ class Tests_EgglinkPath:
     "util.egg_link_path_from_location() tests"
 
     def setup_method(self) -> None:
-
         project = "foo"
 
         self.mock_dist = Mock(project_name=project)

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -518,7 +518,6 @@ class TestInstallUnpackedWheel:
 
 
 class TestMessageAboutScriptsNotOnPATH:
-
     tilde_warning_msg = (
         "NOTE: The current PATH contains path(s) starting with `~`, "
         "which may not be expanded by all applications."


### PR DESCRIPTION
This bumps all our linters to the latest versions, except for mypy which will require more drastic and significant changes.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
