### PR TITLE
Reduce resolver rounds by an order of magnitude

### DIFF
--- a/news/11908.feature.rst
+++ b/news/11908.feature.rst
@@ -1,0 +1,1 @@
+Reduce the number of resolver rounds, since backjumping makes the resolver more efficient in finding solutions. This also makes pathological cases fail quicker.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -88,9 +88,9 @@ class Resolver(BaseResolver):
         )
 
         try:
-            try_to_avoid_resolution_too_deep = 2000000
+            limit_how_complex_resolution_can_be = 200000
             result = self._result = resolver.resolve(
-                collected.requirements, max_rounds=try_to_avoid_resolution_too_deep
+                collected.requirements, max_rounds=limit_how_complex_resolution_can_be
             )
 
         except ResolutionImpossible as e:


### PR DESCRIPTION
This ensures that we're not trying "too hard" to resolve a dependency graph. Combined with the recent improvements to resolvelib, this should ensure that the resolution process takes a limited amount of wall clock time for complex graphs.

Toward https://github.com/pypa/pip/issues/11480

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
