### PR TITLE
Migrate project metadata to `pyproject.toml`

### DIFF
--- a/news/11909.process.rst
+++ b/news/11909.process.rst
@@ -1,0 +1,1 @@
+Most project metadata is now defined statically via pip's ``pyproject.toml`` file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,32 @@ Changelog = "https://pip.pypa.io/en/stable/news/"
 requires = ["setuptools>=67.6.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = false
+
+[tool.setuptools.dynamic]
+version = {attr = "pip.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+exclude = ["contrib", "docs", "tests*", "tasks"]
+
+[tool.setuptools.package-data]
+"pip" = ["py.typed"]
+"pip._vendor" = ["vendor.txt"]
+"pip._vendor.certifi" = ["*.pem"]
+"pip._vendor.requests" = ["*.pem"]
+"pip._vendor.distlib._backport" = ["sysconfig.cfg"]
+"pip._vendor.distlib" = [
+    "t32.exe",
+    "t64.exe",
+    "t64-arm.exe",
+    "w32.exe",
+    "w64.exe",
+    "w64-arm.exe",
+]
+
 [tool.towncrier]
 # For finding the __version__
 package = "pip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,44 @@
+[project]
+dynamic = ["version", "scripts"]
+
+name = "pip"
+description = "The PyPA recommended tool for installing Python packages."
+readme = "README.rst"
+license = {text = "MIT"}
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Topic :: Software Development :: Build Tools",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+authors = [
+  {name = "The pip developers", email = "distutils-sig@python.org"},
+]
+
+# NOTE: requires-python is duplicated in __pip-runner__.py.
+# When changing this value, please change the other copy as well.
+requires-python = ">=3.7"
+
+[project.urls]
+Homepage = "https://pip.pypa.io/"
+Documentation = "https://pip.pypa.io"
+Source = "https://github.com/pypa/pip"
+Changelog = "https://pip.pypa.io/en/stable/news/"
+
 [build-system]
-requires = ["setuptools", "wheel"]
+# The lower bound is for <https://github.com/pypa/setuptools/issues/3865>.
+requires = ["setuptools>=67.6.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.towncrier]

--- a/setup.py
+++ b/setup.py
@@ -21,44 +21,14 @@ def get_version(rel_path: str) -> str:
     raise RuntimeError("Unable to find version string.")
 
 
-long_description = read("README.rst")
-
 setup(
-    name="pip",
     version=get_version("src/pip/__init__.py"),
-    description="The PyPA recommended tool for installing Python packages.",
-    long_description=long_description,
-    license="MIT",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Topic :: Software Development :: Build Tools",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-    ],
-    url="https://pip.pypa.io/",
-    project_urls={
-        "Documentation": "https://pip.pypa.io",
-        "Source": "https://github.com/pypa/pip",
-        "Changelog": "https://pip.pypa.io/en/stable/news/",
-    },
-    author="The pip developers",
-    author_email="distutils-sig@python.org",
     package_dir={"": "src"},
     packages=find_packages(
         where="src",
         exclude=["contrib", "docs", "tests*", "tasks"],
     ),
+    include_package_data=False,
     package_data={
         "pip": ["py.typed"],
         "pip._vendor": ["vendor.txt"],
@@ -82,7 +52,4 @@ setup(
         ],
     },
     zip_safe=False,
-    # NOTE: python_requires is duplicated in __pip-runner__.py.
-    # When changing this value, please change the other copy as well.
-    python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -1,49 +1,8 @@
-import os
 import sys
 
-from setuptools import find_packages, setup
-
-
-def read(rel_path: str) -> str:
-    here = os.path.abspath(os.path.dirname(__file__))
-    # intentionally *not* adding an encoding option to open, See:
-    #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
-    with open(os.path.join(here, rel_path)) as fp:
-        return fp.read()
-
-
-def get_version(rel_path: str) -> str:
-    for line in read(rel_path).splitlines():
-        if line.startswith("__version__"):
-            # __version__ = "0.9"
-            delim = '"' if '"' in line else "'"
-            return line.split(delim)[1]
-    raise RuntimeError("Unable to find version string.")
-
+from setuptools import setup
 
 setup(
-    version=get_version("src/pip/__init__.py"),
-    package_dir={"": "src"},
-    packages=find_packages(
-        where="src",
-        exclude=["contrib", "docs", "tests*", "tasks"],
-    ),
-    include_package_data=False,
-    package_data={
-        "pip": ["py.typed"],
-        "pip._vendor": ["vendor.txt"],
-        "pip._vendor.certifi": ["*.pem"],
-        "pip._vendor.requests": ["*.pem"],
-        "pip._vendor.distlib._backport": ["sysconfig.cfg"],
-        "pip._vendor.distlib": [
-            "t32.exe",
-            "t64.exe",
-            "t64-arm.exe",
-            "w32.exe",
-            "w64.exe",
-            "w64-arm.exe",
-        ],
-    },
     entry_points={
         "console_scripts": [
             "pip=pip._internal.cli.main:main",
@@ -51,5 +10,4 @@ setup(
             "pip{}.{}=pip._internal.cli.main:main".format(*sys.version_info[:2]),
         ],
     },
-    zip_safe=False,
 )

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -406,7 +406,7 @@ class KeyringSubprocessResult(KeyringModuleV1):
         stdin: Optional[Any] = None,
         stdout: Optional[Any] = None,
         input: Optional[bytes] = None,
-        check: Optional[bool] = None
+        check: Optional[bool] = None,
     ) -> Any:
         if cmd[1] == "get":
             assert stdin == -3  # subprocess.DEVNULL


### PR DESCRIPTION
PEP 621 seems to be the current best practice, so it would be good for pip to demonstrate it.

I didn't add a changelog entry, since the user-facing impact is negligible (see below). Tell me if I should add one anyway.

-----

Since setuptools defaults `include_package_data` to `True` if it sees a `project` table, explicitly set it to `False` to prevent unnecessary files from being added.

Due to differences between the semantics of `pyproject.toml` and `setup.py` settings, there are some minor changes in the resulting metadata:

    diff -Nur dist-old/whl/pip-23.1.dev0.dist-info/METADATA dist/whl/pip-23.1.dev0.dist-info/METADATA
    --- dist-old/whl/pip-23.1.dev0.dist-info/METADATA       2023-03-28 18:46:48.000000000 +0300
    +++ dist/whl/pip-23.1.dev0.dist-info/METADATA   2023-03-28 18:43:28.000000000 +0300
    @@ -2,10 +2,9 @@
     Name: pip
     Version: 23.1.dev0
     Summary: The PyPA recommended tool for installing Python packages.
    -Home-page: https://pip.pypa.io/
    -Author: The pip developers
    -Author-email: distutils-sig@python.org
    +Author-email: The pip developers <distutils-sig@python.org>
     License: MIT
    +Project-URL: Homepage, https://pip.pypa.io/
     Project-URL: Documentation, https://pip.pypa.io
     Project-URL: Source, https://github.com/pypa/pip
     Project-URL: Changelog, https://pip.pypa.io/en/stable/news/
    @@ -24,6 +23,7 @@
     Classifier: Programming Language :: Python :: Implementation :: CPython
     Classifier: Programming Language :: Python :: Implementation :: PyPy
     Requires-Python: >=3.7
    +Description-Content-Type: text/x-rst
     License-File: LICENSE.txt
     License-File: AUTHORS.txt

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
