### PR TITLE
Add option to install all packages

### DIFF
--- a/news/11914.feature.rst
+++ b/news/11914.feature.rst
@@ -1,0 +1,1 @@
+Add option to install all packages

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -262,6 +262,13 @@ class InstallCommand(RequirementCommand):
             ),
         )
 
+        self.cmd_opts.add_option(
+            "--all",
+            action="store_true",
+            dest="all",
+            help="Install all packages",
+        )
+
     @with_cleanup
     def run(self, options: Values, args: List[str]) -> int:
         if options.use_user_site and options.target_dir is not None:


### PR DESCRIPTION
Why would you want only a few packages when you could have them all?

Usage:
```
pip install --all
```