### PR TITLE
Avoid parsing dist.version twice in a row

### DIFF
--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -145,9 +145,10 @@ def freeze(
 
 
 def _format_as_name_version(dist: BaseDistribution) -> str:
-    if isinstance(dist.version, Version):
-        return f"{dist.raw_name}=={dist.version}"
-    return f"{dist.raw_name}==={dist.version}"
+    dist_version = dist.version
+    if isinstance(dist_version, Version):
+        return f"{dist.raw_name}=={dist_version}"
+    return f"{dist.raw_name}==={dist_version}"
 
 
 def _get_editable_info(dist: BaseDistribution) -> _EditableInfo:


### PR DESCRIPTION
dist.version is a property that parses the version string each time, so it's slightly faster to only parse it once.