### PR TITLE
Refactor checking of hashes embedded in user-provided URLs

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -404,6 +404,7 @@ class RequirementCommand(IndexGroupCommand):
                     parsed_req,
                     isolated=options.isolated_mode,
                     user_supplied=False,
+                    trust_link_hash=True,
                 )
                 requirements.append(req_to_add)
 
@@ -415,6 +416,7 @@ class RequirementCommand(IndexGroupCommand):
                 use_pep517=options.use_pep517,
                 user_supplied=True,
                 config_settings=getattr(options, "config_settings", None),
+                trust_link_hash=True,
             )
             requirements.append(req_to_add)
 
@@ -441,6 +443,7 @@ class RequirementCommand(IndexGroupCommand):
                     config_settings=parsed_req.options.get("config_settings")
                     if parsed_req.options
                     else None,
+                    trust_link_hash=True,
                 )
                 requirements.append(req_to_add)
 

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -904,7 +904,7 @@ class PackageFinder:
         Returns a InstallationCandidate if found,
         Raises DistributionNotFound or BestVersionAlreadyInstalled otherwise
         """
-        hashes = req.hashes(trust_internet=False)
+        hashes = req.hashes()
         best_candidate_result = self.find_best_candidate(
             req.name,
             specifier=req.specifier,

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -336,7 +336,7 @@ class RequirementPreparer:
         # (For example, we can raise VcsHashUnsupported for a VCS URL
         # rather than HashMissing.)
         if not self.require_hashes:
-            return req.hashes(trust_internet=True)
+            return req.hashes()
 
         # We could check these first 2 conditions inside unpack_url
         # and save repetition of conditions, but then we would
@@ -359,7 +359,7 @@ class RequirementPreparer:
         # shim it with a facade object that will provoke hash
         # computation and then raise a HashMissing exception
         # showing the user what the hash should be.
-        return req.hashes(trust_internet=False) or MissingHashes()
+        return req.hashes() or MissingHashes()
 
     def _fetch_metadata_only(
         self,

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -206,7 +206,7 @@ def install_req_from_editable(
     use_pep517: Optional[bool] = None,
     isolated: bool = False,
     global_options: Optional[List[str]] = None,
-    hash_options: Optional[Dict[str, List[str]]] = None,
+    trusted_hashes: Optional[Dict[str, List[str]]] = None,
     constraint: bool = False,
     user_supplied: bool = False,
     permit_editable_wheels: bool = False,
@@ -225,7 +225,7 @@ def install_req_from_editable(
         use_pep517=use_pep517,
         isolated=isolated,
         global_options=global_options,
-        hash_options=hash_options,
+        trusted_hashes=trusted_hashes,
         config_settings=config_settings,
         extras=parts.extras,
     )
@@ -381,7 +381,7 @@ def install_req_from_line(
     use_pep517: Optional[bool] = None,
     isolated: bool = False,
     global_options: Optional[List[str]] = None,
-    hash_options: Optional[Dict[str, List[str]]] = None,
+    trusted_hashes: Optional[Dict[str, List[str]]] = None,
     constraint: bool = False,
     line_source: Optional[str] = None,
     user_supplied: bool = False,
@@ -401,8 +401,8 @@ def install_req_from_line(
     #
     if parts.link and parts.link.hash and trust_link_hash:
         assert parts.link.hash_name
-        hash_options = copy.deepcopy(hash_options) or {}
-        hash_options.setdefault(parts.link.hash_name, []).append(parts.link.hash)
+        trusted_hashes = copy.deepcopy(trusted_hashes) or {}
+        trusted_hashes.setdefault(parts.link.hash_name, []).append(parts.link.hash)
 
     return InstallRequirement(
         parts.requirement,
@@ -412,7 +412,7 @@ def install_req_from_line(
         use_pep517=use_pep517,
         isolated=isolated,
         global_options=global_options,
-        hash_options=hash_options,
+        trusted_hashes=trusted_hashes,
         config_settings=config_settings,
         constraint=constraint,
         extras=parts.extras,
@@ -488,7 +488,7 @@ def install_req_from_parsed_requirement(
                 if parsed_req.options
                 else []
             ),
-            hash_options=(
+            trusted_hashes=(
                 parsed_req.options.get("hashes", {}) if parsed_req.options else {}
             ),
             constraint=parsed_req.constraint,
@@ -512,7 +512,7 @@ def install_req_from_link_and_ireq(
         use_pep517=ireq.use_pep517,
         isolated=ireq.isolated,
         global_options=ireq.global_options,
-        hash_options=ireq.hash_options,
+        trusted_hashes=ireq.trusted_hashes,
         config_settings=ireq.config_settings,
         user_supplied=ireq.user_supplied,
     )

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -275,31 +275,9 @@ class InstallRequirement:
         """
         return bool(self.hash_options)
 
-    def hashes(self, trust_internet: bool = True) -> Hashes:
-        """Return a hash-comparer that considers my option- and URL-based
-        hashes to be known-good.
-
-        Hashes in URLs--ones embedded in the requirements file, not ones
-        downloaded from an index server--are almost peers with ones from
-        flags. They satisfy --require-hashes (whether it was implicitly or
-        explicitly activated) but do not activate it. md5 and sha224 are not
-        allowed in flags, which should nudge people toward good algos. We
-        always OR all hashes together, even ones from URLs.
-
-        :param trust_internet: Whether to trust URL-based (#md5=...) hashes
-            downloaded from the internet, as by populate_link()
-
-        """
-        good_hashes = self.hash_options.copy()
-        if trust_internet:
-            link = self.link
-        elif self.original_link and self.user_supplied:
-            link = self.original_link
-        else:
-            link = None
-        if link and link.hash:
-            good_hashes.setdefault(link.hash_name, []).append(link.hash)
-        return Hashes(good_hashes)
+    def hashes(self) -> Hashes:
+        """Return a hash-comparer that considers my option-hashes to be known-good."""
+        return Hashes(self.hash_options)
 
     def from_path(self) -> Optional[str]:
         """Format a nice indicator to show where this "comes from" """

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -79,7 +79,7 @@ class InstallRequirement:
         isolated: bool = False,
         *,
         global_options: Optional[List[str]] = None,
-        hash_options: Optional[Dict[str, List[str]]] = None,
+        trusted_hashes: Optional[Dict[str, List[str]]] = None,
         config_settings: Optional[Dict[str, Union[str, List[str]]]] = None,
         constraint: bool = False,
         extras: Collection[str] = (),
@@ -144,7 +144,7 @@ class InstallRequirement:
         self.install_succeeded: Optional[bool] = None
         # Supplied options
         self.global_options = global_options if global_options else []
-        self.hash_options = hash_options if hash_options else {}
+        self.trusted_hashes = trusted_hashes if trusted_hashes else {}
         self.config_settings = config_settings
         # Set to True after successful preparation of this requirement
         self.prepared = False
@@ -273,11 +273,11 @@ class InstallRequirement:
         URL do not.
 
         """
-        return bool(self.hash_options)
+        return bool(self.trusted_hashes)
 
     def hashes(self) -> Hashes:
         """Return a hash-comparer that considers my option-hashes to be known-good."""
-        return Hashes(self.hash_options)
+        return Hashes(self.trusted_hashes)
 
     def from_path(self) -> Optional[str]:
         """Format a nice indicator to show where this "comes from" """

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -34,7 +34,7 @@ class Constraint:
     @classmethod
     def from_ireq(cls, ireq: InstallRequirement) -> "Constraint":
         links = frozenset([ireq.link]) if ireq.link else frozenset()
-        return Constraint(ireq.specifier, ireq.hashes(trust_internet=False), links)
+        return Constraint(ireq.specifier, ireq.hashes(), links)
 
     def __bool__(self) -> bool:
         return bool(self.specifier) or bool(self.hashes) or bool(self.links)
@@ -43,7 +43,7 @@ class Constraint:
         if not isinstance(other, InstallRequirement):
             return NotImplemented
         specifier = self.specifier & other.specifier
-        hashes = self.hashes & other.hashes(trust_internet=False)
+        hashes = self.hashes & other.hashes()
         links = self.links
         if other.link:
             links = links.union([other.link])

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -66,7 +66,7 @@ def make_install_req_from_link(
         isolated=template.isolated,
         constraint=template.constraint,
         global_options=template.global_options,
-        hash_options=template.hash_options,
+        trusted_hashes=template.trusted_hashes,
         config_settings=template.config_settings,
     )
     ireq.original_link = template.original_link
@@ -88,7 +88,7 @@ def make_install_req_from_editable(
         constraint=template.constraint,
         permit_editable_wheels=template.permit_editable_wheels,
         global_options=template.global_options,
-        hash_options=template.hash_options,
+        trusted_hashes=template.trusted_hashes,
         config_settings=template.config_settings,
     )
     ireq.extras = template.extras
@@ -112,7 +112,7 @@ def _make_install_req_from_dist(
         isolated=template.isolated,
         constraint=template.constraint,
         global_options=template.global_options,
-        hash_options=template.hash_options,
+        trusted_hashes=template.trusted_hashes,
         config_settings=template.config_settings,
     )
     ireq.satisfied_by = dist

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -248,7 +248,7 @@ class Factory:
         for ireq in ireqs:
             assert ireq.req, "Candidates found on index must be PEP 508"
             specifier &= ireq.req.specifier
-            hashes &= ireq.hashes(trust_internet=False)
+            hashes &= ireq.hashes()
             extras |= frozenset(ireq.extras)
 
         def _get_installed_candidate() -> Optional[Candidate]:

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -374,7 +374,7 @@ class TestProcessLine:
         )
         filename = "filename"
         req = line_processor(line, filename, 1)[0]
-        assert req.hash_options == {
+        assert req.trusted_hashes == {
             "sha256": [
                 "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
                 "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",


### PR DESCRIPTION
Some URLs can contain hashes, like so: https://example.com/archive-1.0.tar.gz#sha256=abcdef...
Such URLs can be provided by the user, in which case the hash must be considered good, and the dowloaded resource verified against that hash.
Such URLs can also be obtained from indexes, in which case the hash must be verified, but not trusted.

The `hashes()` method of `InstallRequirements` is extremely sensitive to whether original_link is set or not.
It is also very hard (to me) to understand when and why `trust_internet` must be True or False.
While working on https://github.com/pypa/pip/pull/11897 I found  that it was very easy to break hash checking just by trying to preserve `req.original_link` after obtaining a cache entry.

So I propose this refactoring that achieves the same behaviour in a more robust way, by extending hash_options with the hash passed in the link URL when we are certain that such a link is user provided.

Creating as draft to check tests pass and I'm still sane of mind... Not ready to review.