### PR TITLE
Don't trust link hash in direct URL dependencies

### DIFF
--- a/news/11938.bugfix.rst
+++ b/news/11938.bugfix.rst
@@ -1,0 +1,3 @@
+When package A depends on package B provided as a direct URL dependency including a hash
+embedded in the link, the ``--require-hashes`` option did not warn when user supplied hashes
+were missing for package B.

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -287,7 +287,12 @@ class InstallRequirement:
 
         """
         good_hashes = self.hash_options.copy()
-        link = self.link if trust_internet else self.original_link
+        if trust_internet:
+            link = self.link
+        elif self.original_link and self.user_supplied:
+            link = self.original_link
+        else:
+            link = None
         if link and link.hash:
             good_hashes.setdefault(link.hash_name, []).append(link.hash)
         return Hashes(good_hashes)

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -634,11 +634,27 @@ def test_link_hash_pass_require_hashes(
 def test_bad_link_hash_install_failure(
     script: PipTestEnvironment, shared_data: TestData
 ) -> None:
-    """Test that wrong hash in direct URL stop installation."""
+    """Test that wrong hash in direct URL stops installation."""
     url = path_to_url(str(shared_data.packages.joinpath("simple-1.0.tar.gz")))
     url = f"{url}#sha256=invalidhash"
     result = script.pip_install_local("--no-deps", url, expect_error=True)
     assert "THESE PACKAGES DO NOT MATCH THE HASHES" in result.stderr
+
+
+def test_bad_link_hash_good_user_hash_install_success(
+    script: PipTestEnvironment, shared_data: TestData, tmp_path: Path
+) -> None:
+    """Test that wrong hash in direct URL ignored when good --hash provided.
+
+    This behaviour may be accidental?
+    """
+    url = path_to_url(str(shared_data.packages.joinpath("simple-1.0.tar.gz")))
+    url = f"{url}#sha256=invalidhash"
+    digest = "393043e672415891885c9a2a0929b1af95fb866d6ca016b42d2e6ce53619b653"
+    with requirements_file(
+        f"simple @ {url} --hash sha256:{digest}", tmp_path
+    ) as reqs_file:
+        script.pip_install_local("--no-deps", "--require-hashes", "-r", reqs_file)
 
 
 def test_link_hash_in_dep_fails_require_hashes(


### PR DESCRIPTION
When package A depends on package B provided as a direct URL dependency including a hash embedded in the link, the `--require-hashes` option did not warn when user supplied hashes were missing for package B.

Also add a some more test coverage for link hash validation.