### PR TITLE
[docs] the --keyring-provider default isn't auto

### DIFF
--- a/docs/html/topics/authentication.md
+++ b/docs/html/topics/authentication.md
@@ -67,7 +67,7 @@ man pages][netrc-docs].
 
 pip supports loading credentials stored in your keyring using the
 {pypi}`keyring` library, which can be enabled py passing `--keyring-provider`
-with a value of `auto`, `disabled`, `import`, or `subprocess`. The default
+with a value of `auto`, `disabled`, `import`, or `subprocess`. The
 value `auto` respects `--no-input` and not query keyring at all if the option
 is used; otherwise it tries the `import`, `subprocess`, and `disabled`
 providers (in this order) and uses the first one that works.


### PR DESCRIPTION
The documentation said pip defaulted to `--keyring-provider auto`, but
it actually defaults to `--keyring-provider disabled`.