### PR TITLE
Correct keyring provider default

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -257,7 +257,7 @@ keyring_provider: Callable[..., Option] = partial(
     "--keyring-provider",
     dest="keyring_provider",
     choices=["auto", "disabled", "import", "subprocess"],
-    default="disabled",
+    default="auto",
     help=(
         "Enable the credential lookup via the keyring library if user input is allowed."
         " Specify which mechanism to use [disabled, import, subprocess]."


### PR DESCRIPTION
Correct the default for `--keyring-provider` from `disabled` to `auto`. See #11939.