### PR TITLE
Surface LegacyVersion and LegacySpecifier deprecation warnings

### DIFF
--- a/news/12063.removal.rst
+++ b/news/12063.removal.rst
@@ -1,0 +1,2 @@
+Deprecate legacy version and version specifiers that don't conform to `PEP 440
+<https://peps.python.org/pep-0440/>`_

--- a/src/pip/_internal/commands/check.py
+++ b/src/pip/_internal/commands/check.py
@@ -7,6 +7,7 @@ from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.operations.check import (
     check_package_set,
     create_package_set_from_installed,
+    warn_legacy_versions_and_specifiers,
 )
 from pip._internal.utils.misc import write_output
 
@@ -21,6 +22,7 @@ class CheckCommand(Command):
 
     def run(self, options: Values, args: List[str]) -> int:
         package_set, parsing_probs = create_package_set_from_installed()
+        warn_legacy_versions_and_specifiers(package_set)
         missing, conflicting = check_package_set(package_set)
 
         for project_name in missing:

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -130,6 +130,7 @@ class DownloadCommand(RequirementCommand):
         self.trace_basic_info(finder)
 
         requirement_set = resolver.resolve(reqs, check_supported_wheels=True)
+        requirement_set.warn_legacy_versions_and_specifiers()
 
         downloaded: List[str] = []
         for req in requirement_set.requirements.values():

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -387,6 +387,9 @@ class InstallCommand(RequirementCommand):
                         json.dump(report.to_dict(), f, indent=2, ensure_ascii=False)
 
             if options.dry_run:
+                # In non dry-run mode, the legacy versions and specifiers check
+                # will be done as part of conflict detection.
+                requirement_set.warn_legacy_versions_and_specifiers()
                 would_install_items = sorted(
                     (r.metadata["name"], r.metadata["version"])
                     for r in requirement_set.requirements_to_install

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -145,6 +145,7 @@ class WheelCommand(RequirementCommand):
         self.trace_basic_info(finder)
 
         requirement_set = resolver.resolve(reqs, check_supported_wheels=True)
+        requirement_set.warn_legacy_versions_and_specifiers()
 
         reqs_to_build: List[InstallRequirement] = []
         for req in requirement_set.requirements.values():

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -5,12 +5,15 @@ import logging
 from typing import Callable, Dict, List, NamedTuple, Optional, Set, Tuple
 
 from pip._vendor.packaging.requirements import Requirement
+from pip._vendor.packaging.specifiers import LegacySpecifier
 from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from pip._vendor.packaging.version import LegacyVersion
 
 from pip._internal.distributions import make_distribution_for_install_requirement
 from pip._internal.metadata import get_default_environment
 from pip._internal.metadata.base import DistributionVersion
 from pip._internal.req.req_install import InstallRequirement
+from pip._internal.utils.deprecation import deprecated
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +59,8 @@ def check_package_set(
     If should_ignore is passed, it should be a callable that takes a
     package name and returns a boolean.
     """
+
+    warn_legacy_versions_and_specifiers(package_set)
 
     missing = {}
     conflicting = {}
@@ -147,3 +152,36 @@ def _create_whitelist(
                 break
 
     return packages_affected
+
+
+def warn_legacy_versions_and_specifiers(package_set: PackageSet) -> None:
+    for project_name, package_details in package_set.items():
+        if isinstance(package_details.version, LegacyVersion):
+            deprecated(
+                reason=(
+                    f"{project_name} {package_details.version} "
+                    f"has a non-standard version number."
+                ),
+                replacement=(
+                    f"to upgrade to a newer version of {project_name} "
+                    f"or contact the author to suggest that they "
+                    f"release a version with a conforming version number"
+                ),
+                issue=12063,
+                gone_in="23.3",
+            )
+        for dep in package_details.dependencies:
+            if any(isinstance(spec, LegacySpecifier) for spec in dep.specifier):
+                deprecated(
+                    reason=(
+                        f"{project_name} {package_details.version} "
+                        f"has a non-standard dependency specifier {dep}."
+                    ),
+                    replacement=(
+                        f"to upgrade to a newer version of {project_name} "
+                        f"or contact the author to suggest that they "
+                        f"release a version with a conforming dependency specifiers"
+                    ),
+                    issue=12063,
+                    gone_in="23.3",
+                )

--- a/src/pip/_internal/req/req_set.py
+++ b/src/pip/_internal/req/req_set.py
@@ -2,9 +2,12 @@ import logging
 from collections import OrderedDict
 from typing import Dict, List
 
+from pip._vendor.packaging.specifiers import LegacySpecifier
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import LegacyVersion
 
 from pip._internal.req.req_install import InstallRequirement
+from pip._internal.utils.deprecation import deprecated
 
 logger = logging.getLogger(__name__)
 
@@ -80,3 +83,37 @@ class RequirementSet:
             for install_req in self.all_requirements
             if not install_req.constraint and not install_req.satisfied_by
         ]
+
+    def warn_legacy_versions_and_specifiers(self) -> None:
+        for req in self.requirements_to_install:
+            version = req.get_dist().version
+            if isinstance(version, LegacyVersion):
+                deprecated(
+                    reason=(
+                        f"pip has selected the non standard version {version} "
+                        f"of {req}. In the future this version will be "
+                        f"ignored as it isn't standard compliant."
+                    ),
+                    replacement=(
+                        "set or update constraints to select another version "
+                        "or contact the package author to fix the version number"
+                    ),
+                    issue=12063,
+                    gone_in="23.3",
+                )
+            for dep in req.get_dist().iter_dependencies():
+                if any(isinstance(spec, LegacySpecifier) for spec in dep.specifier):
+                    deprecated(
+                        reason=(
+                            f"pip has selected {req} {version} which has non "
+                            f"standard dependency specifier {dep}. "
+                            f"In the future this version of {req} will be "
+                            f"ignored as it isn't standard compliant."
+                        ),
+                        replacement=(
+                            "set or update constraints to select another version "
+                            "or contact the package author to fix the version number"
+                        ),
+                        issue=12063,
+                        gone_in="23.3",
+                    )


### PR DESCRIPTION
This is a simple approach to surface `LegacyVersion` and `LegacySpecifier` deprecation warnings, by patching our vendored copy of `packaging`. I open it to support discussion only. If it ends up to be valid, it would need to be converted into a vendoring patch.

towards #12063 
refs #11715

There are two concerns with this approach
1. It is not compatible with our vendoring policy (as mentioned by @pradyunsg in https://github.com/pypa/pip/issues/11715#issuecomment-1501152834).
2. The warnings may lack context.

Regarding 1, it may be debatable, since we are "just" improving an existing deprecation warning and making it more visible?

Regarding 2, I'd need more test cases to see if there is enough context provided by surrounding messages or not. Please share them here if you have some. A simple example looks like this:

```console
❯ pip install --dry-run "pip>23.0.*"
DEPRECATION: This form of version specifier (>23.0.*) has been deprecated. pip 23.2 will enforce this behaviour change. A possible replacement is use PEP 440 compatible version specifiers.
Requirement already satisfied: pip>23.0.* in /home/sbi-local/.virtualenvs/tempenv-16fa522829ba/lib/python3.8/site-packages (23.1.dev0)
```

