### PR TITLE
Minify `origin.json` and `direct_url.json` files:

### DIFF
--- a/src/pip/_internal/models/direct_url.py
+++ b/src/pip/_internal/models/direct_url.py
@@ -231,7 +231,7 @@ class DirectUrl:
         return cls.from_dict(json.loads(s))
 
     def to_json(self) -> str:
-        return json.dumps(self.to_dict(), sort_keys=True)
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
 
     def is_local_editable(self) -> bool:
         return isinstance(self.info, DirInfo) and self.info.editable

--- a/tests/unit/test_direct_url.py
+++ b/tests/unit/test_direct_url.py
@@ -24,7 +24,7 @@ def test_to_json() -> None:
     )
     direct_url.validate()
     assert direct_url.to_json() == (
-        '{"archive_info": {}, "url": "file:///home/user/archive.tgz"}'
+        '{"archive_info":{},"url":"file:///home/user/archive.tgz"}'
     )
 
 


### PR DESCRIPTION
I noticed that the `origin.json` and `direct_url.json` files have some extra whitespace which can be removed by setting the `separators` kwarg.