### PR TITLE
Mention `setup.py develop` change in 23.1 changelog

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -22,7 +22,7 @@ Deprecations and Removals
   means "don't download wheels". (`#11453 <https://github.com/pypa/pip/issues/11453>`_)
 - Deprecate ``--build-option`` and ``--global-option``. Users are invited to switch to
   ``--config-settings``. (`#11859 <https://github.com/pypa/pip/issues/11859>`_)
-- Using ``--config-settings`` with projects that don't have a ``pyproject.toml`` now print
+- Using ``--config-settings`` with projects that don't have a ``pyproject.toml`` now prints
   a deprecation warning. In the future the presence of config settings will automatically
   enable the default build backend for legacy projects and pass the setttings to it. (`#11915 <https://github.com/pypa/pip/issues/11915>`_)
 - Remove ``setup.py install`` fallback when building a wheel failed for projects without

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -28,7 +28,8 @@ Deprecations and Removals
 - Remove ``setup.py install`` fallback when building a wheel failed for projects without
   ``pyproject.toml``. (`#8368 <https://github.com/pypa/pip/issues/8368>`_)
 - When the ``wheel`` package is not installed, pip now uses the default build backend
-  instead of ``setup.py install`` for project without ``pyproject.toml``. (`#8559 <https://github.com/pypa/pip/issues/8559>`_)
+  instead of ``setup.py install`` and ``setup.py develop`` for project without
+  ``pyproject.toml``. (`#8559 <https://github.com/pypa/pip/issues/8559>`_)
 
 Features
 --------


### PR DESCRIPTION
Update changelog to mention that setup.py develop is not used anymore if `wheel` is not installed.

Tentatively assigning to 23.1 in case we have a bugfix release to do.