### PR TITLE
development/getting-started install nox notes

### DIFF
--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -45,6 +45,7 @@ You can then invoke your local source tree pip normally.
         python -m venv .venv
         source .venv/bin/activate
         python -m pip install -e .
+        python -m pip install nox # If planning on running tests
         python -m pip --version
 
 .. tab:: Windows


### PR DESCRIPTION
While setting up for the first time and following the install instructions in the `development/getting-started` section , I was a bit confused that running tests failed because I was required to install `nox`. 

There is a note in the very beginning about this that I missed, so to hopefully make it clearer I included an additional line in the pip install code block.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
