### PR TITLE
Parse out extras when selecting from constraints

### DIFF
--- a/news/12018.bugfix.rst
+++ b/news/12018.bugfix.rst
@@ -1,0 +1,3 @@
+When looking for candidate provided via constraints, correctly parse and split
+the package name and extras from the user input, so the correct constraint can
+be picked based on the package name.


### PR DESCRIPTION
Entries in constraints do not (cannot) contain extras, so when we try to select from them we must remove the extras. Those parsed extras should be attached back to the candidates after they are selected from the constraints.

Fix #12018.

The debugging part is much more interesting than actually fixing the issue.