### PR TITLE
Don't exclude setuptools, distribute & wheel from freeze output on Python 3.12+

### DIFF
--- a/news/4256.removal.rst
+++ b/news/4256.removal.rst
@@ -1,0 +1,3 @@
+``freeze`` no longer excludes the ``setuptools``, ``distribute`` and ``wheel``
+packages from the output by default when running on Python 3.12 or later.
+Use ``--exclude`` if you wish to exclude any of these packages.

--- a/news/4256.removal.rst
+++ b/news/4256.removal.rst
@@ -1,3 +1,4 @@
-``freeze`` no longer excludes the ``setuptools``, ``distribute`` and ``wheel``
-packages from the output by default when running on Python 3.12 or later.
-Use ``--exclude`` if you wish to exclude any of these packages.
+``freeze`` no longer excludes the ``setuptools``, ``distribute``, and ``wheel``
+from the output when running on Python 3.12 or later, where they are not
+included in a virtual environment by default. Use ``--exclude`` if you wish to
+exclude any of these packages.

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -1,6 +1,6 @@
 import sys
 from optparse import Values
-from typing import List
+from typing import AbstractSet, List
 
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
@@ -8,10 +8,18 @@ from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.operations.freeze import freeze
 from pip._internal.utils.compat import stdlib_pkgs
 
-DEV_PKGS = {"pip"}
 
-if sys.version_info < (3, 12):
-    DEV_PKGS |= {"setuptools", "distribute", "wheel"}
+def _should_suppress_build_backends() -> bool:
+    return sys.version_info < (3, 12)
+
+
+def _dev_pkgs() -> AbstractSet[str]:
+    pkgs = {"pip"}
+
+    if _should_suppress_build_backends():
+        pkgs |= {"setuptools", "distribute", "wheel"}
+
+    return pkgs
 
 
 class FreezeCommand(Command):
@@ -64,7 +72,7 @@ class FreezeCommand(Command):
             action="store_true",
             help=(
                 "Do not skip these packages in the output:"
-                " {}".format(", ".join(DEV_PKGS))
+                " {}".format(", ".join(_dev_pkgs()))
             ),
         )
         self.cmd_opts.add_option(
@@ -80,7 +88,7 @@ class FreezeCommand(Command):
     def run(self, options: Values, args: List[str]) -> int:
         skip = set(stdlib_pkgs)
         if not options.freeze_all:
-            skip.update(DEV_PKGS)
+            skip.update(_dev_pkgs())
 
         if options.excludes:
             skip.update(options.excludes)

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -8,7 +8,10 @@ from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.operations.freeze import freeze
 from pip._internal.utils.compat import stdlib_pkgs
 
-DEV_PKGS = {"pip", "setuptools", "distribute", "wheel"}
+DEV_PKGS = {"pip"}
+
+if sys.version_info < (3, 12):
+    DEV_PKGS |= {"setuptools", "distribute", "wheel"}
 
 
 class FreezeCommand(Command):

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -88,9 +88,27 @@ def test_basic_freeze(script: PipTestEnvironment) -> None:
 
 
 def test_freeze_with_pip(script: PipTestEnvironment) -> None:
-    """Test pip shows itself"""
+    """Test that pip shows itself only when --all is used"""
+    result = script.pip("freeze")
+    assert "pip==" not in result.stdout
     result = script.pip("freeze", "--all")
     assert "pip==" in result.stdout
+
+
+def test_freeze_with_setuptools(script: PipTestEnvironment) -> None:
+    """
+    Test that pip shows setuptools only when --all is used
+    or Python version is >=3.12
+    """
+
+    result = script.pip("freeze")
+    if sys.version_info >= (3, 12):
+        assert "setuptools==" in result.stdout
+    else:
+        assert "setuptools==" not in result.stdout
+
+    result = script.pip("freeze", "--all")
+    assert "setuptools==" in result.stdout
 
 
 def test_exclude_and_normalization(script: PipTestEnvironment, tmpdir: Path) -> None:


### PR DESCRIPTION
Due to the advent of build isolation, it is no longer necessary to install setuptools and wheel in an environment just to install other packages. Moreover, on Python 3.12 both ensurepip (python/cpython#95299) and virtualenv (pypa/virtualenv#2558) are to stop installing setuptools & wheel by default. This means that when those packages are present in a Python 3.12+ environment, it is reasonable to assume that they are runtime dependencies of the user's project, and therefore should be included in freeze output.

distribute is just obsolete.

Closes #4256.
