### PR TITLE
Fix direct usage of pip.pyz example

### DIFF
--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -87,7 +87,7 @@ then the currently active Python interpreter will be used.
 
 ````{tab} Windows
 ```doscon
-C:> .\pip.pyz
+C:\> .\pip.pyz
 ```
 
 then the currently active Python interpreter will be used.

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -67,9 +67,17 @@ $ python pip.pyz --help
 
 If run directly:
 
-```{pip-cli}
-$ pip.pyz --help
+````{tab} Unix/macOS
+```shell
+./pip.pyz
 ```
+````
+
+````{tab} Windows
+```shell
+.\pip.pyz
+```
+````
 
 then the currently active Python interpreter will be used.
 

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -61,33 +61,39 @@ also zip applications for specific pip versions, named `pip-X.Y.Z.pyz`.
 
 The zip application can be run using any supported version of Python:
 
-```{pip-cli}
+````{tab} Linux
+```console
 $ python pip.pyz --help
 ```
 
 If run directly:
-
-````{tab} Linux
 ```console
 $ chmod +x ./pip.pyz
 $ ./pip.pyz
 ```
+
+then the currently active Python interpreter will be used.
 ````
 
 ````{tab} MacOS
 ```console
+$ python pip.pyz --help
+```
+
+If run directly:
+```console
 $ chmod +x ./pip.pyz
 $ ./pip.pyz
 ```
+
+then the currently active Python interpreter will be used.
 ````
 
 ````{tab} Windows
 ```console
-C:\> .\pip.pyz
+C:> py pip.pyz --help
 ```
 ````
-
-then the currently active Python interpreter will be used.
 
 ## Alternative Methods
 

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -91,6 +91,7 @@ C:\> .\pip.pyz
 ```
 
 then the currently active Python interpreter will be used.
+
 You may need to configure your system to recognise the ``.pyz`` extension
 before this will work.
 ````

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -68,14 +68,14 @@ $ python pip.pyz --help
 If run directly:
 
 ````{tab} Unix/macOS
-```shell
-./pip.pyz
+```console
+$ ./pip.pyz
 ```
 ````
 
 ````{tab} Windows
-```shell
-.\pip.pyz
+```console
+C:\> .\pip.pyz
 ```
 ````
 

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -86,7 +86,7 @@ then the currently active Python interpreter will be used.
 ````
 
 ````{tab} Windows
-```shell
+```
 C:> .\pip.pyz
 ```
 

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -87,7 +87,7 @@ then the currently active Python interpreter will be used.
 
 ````{tab} Windows
 ```doscon
-C:\> .\pip.pyz
+C:> .\pip.pyz
 ```
 
 then the currently active Python interpreter will be used.

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -72,6 +72,8 @@ If run directly:
 $ chmod +x ./pip.pyz
 $ ./pip.pyz
 ```
+
+then the currently active Python interpreter will be used.
 ````
 
 ````{tab} MacOS
@@ -79,15 +81,19 @@ $ ./pip.pyz
 $ chmod +x ./pip.pyz
 $ ./pip.pyz
 ```
+
+then the currently active Python interpreter will be used.
 ````
 
 ````{tab} Windows
 ```console
 C:\> .\pip.pyz
 ```
-````
 
 then the currently active Python interpreter will be used.
+You may need to configure your system to recognise the ``.pyz`` extension
+before this will work.
+````
 
 ## Alternative Methods
 

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -67,8 +67,16 @@ $ python pip.pyz --help
 
 If run directly:
 
-````{tab} Unix/macOS
+````{tab} Linux
 ```console
+$ chmod +x ./pip.pyz
+$ ./pip.pyz
+```
+````
+
+````{tab} MacOS
+```console
+$ chmod +x ./pip.pyz
 $ ./pip.pyz
 ```
 ````

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -86,8 +86,8 @@ then the currently active Python interpreter will be used.
 ````
 
 ````{tab} Windows
-```console
-C:\> .\pip.pyz
+```shell
+C:> .\pip.pyz
 ```
 
 then the currently active Python interpreter will be used.

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -61,39 +61,33 @@ also zip applications for specific pip versions, named `pip-X.Y.Z.pyz`.
 
 The zip application can be run using any supported version of Python:
 
-````{tab} Linux
-```console
+```{pip-cli}
 $ python pip.pyz --help
 ```
 
 If run directly:
+
+````{tab} Linux
 ```console
 $ chmod +x ./pip.pyz
 $ ./pip.pyz
 ```
-
-then the currently active Python interpreter will be used.
 ````
 
 ````{tab} MacOS
 ```console
-$ python pip.pyz --help
-```
-
-If run directly:
-```console
 $ chmod +x ./pip.pyz
 $ ./pip.pyz
 ```
-
-then the currently active Python interpreter will be used.
 ````
 
 ````{tab} Windows
 ```console
-C:> py pip.pyz --help
+C:\> .\pip.pyz
 ```
 ````
+
+then the currently active Python interpreter will be used.
 
 ## Alternative Methods
 

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -86,7 +86,7 @@ then the currently active Python interpreter will be used.
 ````
 
 ````{tab} Windows
-```
+```doscon
 C:> .\pip.pyz
 ```
 

--- a/news/12043.doc.rst
+++ b/news/12043.doc.rst
@@ -1,0 +1,1 @@
+Fix the direct usage of zipapp showing up as ``python -m pip.pyz`` rather than ``./pip.pyz`` / ``.\pip.pyz``


### PR DESCRIPTION
Fixes the direct usage showing up as `python -m pip.pyz` rather than `./pip.pyz`/`.\pip.pyz`