### PR TITLE
Canonicalize package names before comparison for PEP658 metadata

### DIFF
--- a/news/12038.bugfix.rst
+++ b/news/12038.bugfix.rst
@@ -1,0 +1,1 @@
+Fix installation of packages with PEP658 metadata using non-canonicalized names

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -410,7 +410,7 @@ class RequirementPreparer:
         #     NB: raw_name will fall back to the name from the install requirement if
         #     the Name: field is not present, but it's noted in the raw_name docstring
         #     that that should NEVER happen anyway.
-        if metadata_dist.raw_name != req.req.name:
+        if canonicalize_name(metadata_dist.raw_name) != canonicalize_name(req.req.name):
             raise MetadataInconsistent(
                 req, "Name", req.req.name, metadata_dist.raw_name
             )

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -8,7 +8,7 @@ from enum import Enum
 from hashlib import sha256
 from pathlib import Path
 from textwrap import dedent
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import pytest
 
@@ -1267,7 +1267,7 @@ class Package:
     # This will override any dependencies specified in the actual dist's METADATA.
     requires_dist: Tuple[str, ...] = ()
     # This will override the Name specified in the actual dist's METADATA.
-    metadata_name: str = None
+    metadata_name: Optional[str] = None
 
     def metadata_filename(self) -> str:
         """This is specified by PEP 658."""
@@ -1501,6 +1501,16 @@ _simple_packages: Dict[str, List[Package]] = {
             "priority", "1.0", "priority-1.0-py2.py3-none-any.whl", MetadataKind.NoFile
         ),
     ],
+    "requires-simple-extra": [
+        # Metadata name is not canonicalized.
+        Package(
+            "requires-simple-extra",
+            "0.1",
+            "requires_simple_extra-0.1-py2.py3-none-any.whl",
+            MetadataKind.Sha256,
+            metadata_name="Requires_Simple.Extra",
+        ),
+    ],
 }
 
 
@@ -1604,5 +1614,34 @@ def test_produces_error_for_mismatched_package_name_in_metadata(
     )
     assert result.returncode != 0
     assert (
-        "simple2-3.0.tar.gz has inconsistent Name: expected 'simple2', but metadata has 'not-simple2'"
+        "simple2-3.0.tar.gz has inconsistent Name: expected 'simple2', but metadata "
+        "has 'not-simple2'"
     ) in result.stdout
+
+
+@pytest.mark.parametrize(
+    "requirement",
+    (
+        "requires-simple-extra==0.1",
+        "REQUIRES_SIMPLE-EXTRA==0.1",
+        "REQUIRES....simple-_-EXTRA==0.1",
+    ),
+)
+def test_canonicalizes_package_name_before_verifying_metadata(
+    download_generated_html_index: Callable[..., Tuple[TestPipResult, Path]],
+    requirement: str,
+) -> None:
+    """Verify that the package name from the command line and the package's
+    METADATA are both canonicalized before comparison.
+
+    Regression test for https://github.com/pypa/pip/issues/12038
+    """
+    result, download_dir = download_generated_html_index(
+        _simple_packages,
+        [requirement],
+        allow_error=True,
+    )
+    assert result.returncode == 0
+    assert os.listdir(download_dir) == [
+        "requires_simple_extra-0.1-py2.py3-none-any.whl",
+    ]

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1266,6 +1266,8 @@ class Package:
     metadata: MetadataKind
     # This will override any dependencies specified in the actual dist's METADATA.
     requires_dist: Tuple[str, ...] = ()
+    # This will override the Name specified in the actual dist's METADATA.
+    metadata_name: str = None
 
     def metadata_filename(self) -> str:
         """This is specified by PEP 658."""
@@ -1296,7 +1298,7 @@ class Package:
         return dedent(
             f"""\
         Metadata-Version: 2.1
-        Name: {self.name}
+        Name: {self.metadata_name or self.name}
         Version: {self.version}
         {self.requires_str()}
         """
@@ -1452,6 +1454,14 @@ _simple_packages: Dict[str, List[Package]] = {
         ),
         # This will raise an error when pip attempts to fetch the metadata file.
         Package("simple2", "2.0", "simple2-2.0.tar.gz", MetadataKind.NoFile),
+        # This has a METADATA file with a mismatched name.
+        Package(
+            "simple2",
+            "3.0",
+            "simple2-3.0.tar.gz",
+            MetadataKind.Sha256,
+            metadata_name="not-simple2",
+        ),
     ],
     "colander": [
         # Ensure we can read the dependencies from a metadata file within a wheel
@@ -1581,3 +1591,18 @@ def test_metadata_not_found(
         f"ERROR: 404 Client Error: FileNotFoundError for url:.*{expected_re}"
     )
     assert pattern.search(result.stderr), (pattern, result.stderr)
+
+
+def test_produces_error_for_mismatched_package_name_in_metadata(
+    download_generated_html_index: Callable[..., Tuple[TestPipResult, Path]],
+) -> None:
+    """Verify that the package name from the metadata matches the requested package."""
+    result, _ = download_generated_html_index(
+        _simple_packages,
+        ["simple2==3.0"],
+        allow_error=True,
+    )
+    assert result.returncode != 0
+    assert (
+        "simple2-3.0.tar.gz has inconsistent Name: expected 'simple2', but metadata has 'not-simple2'"
+    ) in result.stdout


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/12038

I can no longer reproduce the failure from the ticket after these changes.

I also added a regression test which fails on the `main` branch:

```
====================================== test session starts =======================================                                                             
[...]
tests/functional/test_download.py .....................................................FFF [100%]
==================================== short test summary info =====================================
FAILED tests/functional/test_download.py::test_canonicalizes_package_name_before_verifying_metadata[requires-simple-extra==0.1] - assert 1 == 0
FAILED tests/functional/test_download.py::test_canonicalizes_package_name_before_verifying_metadata[REQUIRES_SIMPLE-EXTRA==0.1] - assert 1 == 0
FAILED tests/functional/test_download.py::test_canonicalizes_package_name_before_verifying_metadata[REQUIRES....simple-_-EXTRA==0.1] - assert 1 == 0
================================= 3 failed, 53 passed in 38.56s ==================================

```

...and passes after the change:

```
====================================== test session starts =======================================
[...]
tests/functional/test_download.py ........................................................ [100%]
====================================== 56 passed in 39.37s =======================================
```