### PR TITLE
Remove RIGHT-TO-LEFT OVERRIDE from AUTHORS.txt

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -473,7 +473,7 @@ Miro Hrončok
 Monica Baluna
 montefra
 Monty Taylor
-Muha Ajjan‮
+Muha Ajjan
 Nadav Wexler
 Nahuel Ambrosini
 Nate Coraor
@@ -725,4 +725,4 @@ Zvezdan Petkovic
 Łukasz Langa
 Роман Донченко
 Семён Марьясин
-‮rekcäH nitraM‮
+Martin Häcker


### PR DESCRIPTION
The names don't seem to be right-to-left anyway.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
