### PR TITLE
Add a dependabot config to update CI actions monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This change introduces a Dependabot configuration that will submit PRs when new action versions are released.

I noticed this need while browsing recent workflow runs in GitHub. In particular, the "Lock Closed Threads" workflow has warnings that Node 12 is deprecated, and that various components the `dessant/lock-threads@3` action uses will be removed soon ([recent example](https://github.com/pypa/pip/actions/runs/6428545292)).

Rather than update that one action this one time, I think that this Dependabot configuration will ensure _all actions get updated continuously moving forward_.

Please let me know if I missed anything, or if this PR needs changes to meet project requirements. Thanks for all of your work on pip!