### PR TITLE
Ignore invalid or unreadable ``origin.json`` files in wheel cache

### DIFF
--- a/news/11985.bugfix.rst
+++ b/news/11985.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore invalid or unreadable ``origin.json`` files in the cache of locally built wheels.


### PR DESCRIPTION
fixes #11985 

Also, make sure to read them as utf-8.