### PR TITLE
Improve docs for --root-user-action option

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -903,8 +903,7 @@ root_user_action: Callable[..., Option] = partial(
     dest="root_user_action",
     default="warn",
     choices=["warn", "ignore"],
-    help="Action if pip is run as a root user ('warn' or 'ignore'). "
-    "By default, a warning message is shown.",
+    help="Action if pip is run as a root user [warn, ignore] (default: warn)",
 )
 
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -903,7 +903,8 @@ root_user_action: Callable[..., Option] = partial(
     dest="root_user_action",
     default="warn",
     choices=["warn", "ignore"],
-    help="Action if pip is run as a root user. By default, a warning message is shown.",
+    help="Action if pip is run as a root user ('warn' or 'ignore'). "
+    "By default, a warning message is shown.",
 )
 
 

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -221,7 +221,9 @@ def warn_if_run_as_root() -> None:
         "Running pip as the 'root' user can result in broken permissions and "
         "conflicting behaviour with the system package manager. "
         "It is recommended to use a virtual environment instead: "
-        "https://pip.pypa.io/warnings/venv"
+        "https://pip.pypa.io/warnings/venv. "
+        "Use the --root-user-action option if you know what you are doing and "
+        "want to suppress this warning."
     )
 
 

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -219,7 +219,8 @@ def warn_if_run_as_root() -> None:
 
     logger.warning(
         "Running pip as the 'root' user can result in broken permissions and "
-        "conflicting behaviour with the system package manager. "
+        "conflicting behaviour with the system package manager, possibly "
+        "rendering your system unusable."
         "It is recommended to use a virtual environment instead: "
         "https://pip.pypa.io/warnings/venv. "
         "Use the --root-user-action option if you know what you are doing and "


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

https://github.com/pypa/pip/pull/11201 was too verbose, so this change just adds a note to the warning message itself and shows allowed values for the option when using `pip install --help`. The warning message now contains all information from the proposed alternative in the rejected PR but is easier to discover.

Closes #11179.
