### PR TITLE
Specify the encoding and enable warnings in tests when unspecified.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -116,6 +116,7 @@ def test(session: nox.Session) -> None:
         *arguments,
         env={
             "LC_CTYPE": "en_US.UTF-8",
+            "PYTHON_WARN_DEFAULT_ENCODING": "1",
         },
     )
 

--- a/src/pip/_internal/utils/subprocess.py
+++ b/src/pip/_internal/utils/subprocess.py
@@ -146,6 +146,7 @@ def call_subprocess(
             stderr=subprocess.STDOUT if not stdout_only else subprocess.PIPE,
             cwd=cwd,
             env=env,
+            encoding='utf-8',
             errors="backslashreplace",
         )
     except Exception as exc:


### PR DESCRIPTION
- Enable PYTHON_WARN_DEFAULT_ENCODING to catch EncodingWarnings. Ref #12070.
- Specify encoding in Popen. Fixes #12070.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
