### PR TITLE
Add deprecated description for pip search

### DIFF
--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 class SearchCommand(Command, SessionCommandMixin):
-    """Search for PyPI packages whose name or summary contains <query>."""
+    """Search for PyPI packages whose name or summary contains <query>. But it has been deprecated, so it is not recommended """
 
     usage = """
       %prog [options] <query>"""


### PR DESCRIPTION
`pip search` function is no longer available. Therefore, the description is added.
