### PR TITLE
Fix slowness on Python 3.11 when updating an existing large environment.

### DIFF
--- a/news/12079.bugfix.rst
+++ b/news/12079.bugfix.rst
@@ -1,1 +1,1 @@
-Fix slowness on Python 3.11 when updating an existing large environment.
+Fix slowness when using ``importlib.metadata`` and there is a large overlap between already installed and to-be-installed packages.

--- a/news/12079.bugfix.rst
+++ b/news/12079.bugfix.rst
@@ -1,1 +1,1 @@
-Fix slowness when using ``importlib.metadata`` and there is a large overlap between already installed and to-be-installed packages.  This is the default in Python 3.11, though it can be overridden with the ``_PIP_USE_IMPORTLIB_METADATA`` environment variable.
+Fix slowness when using ``importlib.metadata`` (the default way for pip to read metadata in Python 3.11+) and there is a large overlap between already installed and to-be-installed packages.

--- a/news/12079.bugfix.rst
+++ b/news/12079.bugfix.rst
@@ -1,0 +1,1 @@
+Fix slowness on Python 3.11 when updating an existing large environment.

--- a/news/12079.bugfix.rst
+++ b/news/12079.bugfix.rst
@@ -1,1 +1,1 @@
-Fix slowness when using ``importlib.metadata`` and there is a large overlap between already installed and to-be-installed packages.
+Fix slowness when using ``importlib.metadata`` and there is a large overlap between already installed and to-be-installed packages.  This is the default in Python 3.11, though it can be overridden with the ``_PIP_USE_IMPORTLIB_METADATA`` environment variable.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -341,6 +341,7 @@ class AlreadyInstalledCandidate(Candidate):
         self.dist = dist
         self._ireq = _make_install_req_from_dist(dist, template)
         self._factory = factory
+        self._version = None
 
         # This is just logging some messages, so we can do it eagerly.
         # The returned dist would be exactly the same as self.dist because we
@@ -376,7 +377,9 @@ class AlreadyInstalledCandidate(Candidate):
 
     @property
     def version(self) -> CandidateVersion:
-        return self.dist.version
+        if self._version is None:
+            self._version = self.dist.version
+        return self._version
 
     @property
     def is_editable(self) -> bool:


### PR DESCRIPTION
Fixes issue #12079 by adding a simple cache on `AlreadyInstalledCandidate.version`.