### PR TITLE
Record download of completed partial requirements

### DIFF
--- a/news/11847.bugfix.rst
+++ b/news/11847.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent downloading files twice when PEP 658 metadata is present

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -476,7 +476,7 @@ class RequirementPreparer:
             # distributions get downloaded twice when metadata is loaded
             # from a PEP 658 standalone metadata file. Setting _downloaded
             # fixes this for wheels, but breaks the sdist case (tests
-            # test_download_metadata). As PyPI is currently not serving
+            # test_download_metadata). As PyPI is currently only serving
             # metadata for wheels, this is not an immediate issue.
             # Fixing the problem properly looks like it will require a
             # complete refactoring of the `prepare_linked_requirements_more`

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -471,7 +471,19 @@ class RequirementPreparer:
             logger.debug("Downloading link %s to %s", link, filepath)
             req = links_to_fully_download[link]
             req.local_file_path = filepath
-            self._downloaded[req.link.url] = filepath
+            # TODO: This needs fixing for sdists
+            # This is an emergency fix for #11847, which reports that
+            # distributions get downloaded twice when metadata is loaded
+            # from a PEP 658 standalone metadata file. Setting _downloaded
+            # fixes this for wheels, but breaks the sdist case (tests
+            # test_download_metadata). As PyPI is currently not serving
+            # metadata for wheels, this is not an immediate issue.
+            # Fixing the problem properly looks like it will require a
+            # complete refactoring of the `prepare_linked_requirements_more`
+            # logic, and I haven't a clue where to start on that, so for now
+            # I have fixed the issue *just* for wheels.
+            if req.is_wheel:
+                self._downloaded[req.link.url] = filepath
 
         # This step is necessary to ensure all lazy wheels are processed
         # successfully by the 'download', 'wheel', and 'install' commands.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -471,6 +471,7 @@ class RequirementPreparer:
             logger.debug("Downloading link %s to %s", link, filepath)
             req = links_to_fully_download[link]
             req.local_file_path = filepath
+            self._downloaded[req.link.url] = filepath
 
         # This step is necessary to ensure all lazy wheels are processed
         # successfully by the 'download', 'wheel', and 'install' commands.


### PR DESCRIPTION
**Does not fix** #11847 (it's a partial fix, but see that issue for further discussion).

When a requirement's metadata is downloaded from a PEP 658 metadata file, the requirement is marked as needing more preparation (because we didn't download the distribution). When we come to do that preparation, we failed to record the fact that the file was now downloaded in the `_downloaded` dictionary, causing the file to be downloaded a second time.