### PR TITLE
Add a warning to "Fallback behavior" doc snippet

### DIFF
--- a/docs/html/reference/build-system/pyproject-toml.md
+++ b/docs/html/reference/build-system/pyproject-toml.md
@@ -130,6 +130,13 @@ dealing with [the same challenges as pip has for legacy builds](build-output).
 
 ## Fallback Behaviour
 
+```{warning}
+The following snippet merely describes the fallback behavior. For valid
+examples of `pyproject.toml` to use with setuptools, please refer to
+[the setuptools documentation](
+https://setuptools.pypa.io/en/stable/userguide/quickstart.html#basic-use).
+```
+
 If a project does not have a `pyproject.toml` file containing a `build-system`
 section, it will be assumed to have the following backend settings:
 

--- a/news/12122.doc.rst
+++ b/news/12122.doc.rst
@@ -1,0 +1,3 @@
+Add a warning explaining that the snippet in "Fallback behavior" is not a valid
+``pyproject.toml`` snippet for projects, and link to setuptools documentation
+instead.


### PR DESCRIPTION
Add a warning noting that the "Fallback behavior" doc snippet does not provide a good example of what projects put in `pyproject.toml` and instead link to the respective setuptools documentation.

In my experience, more than one project has either copied the snippets verbatim, or incorrectly included `wheel` in their `requires` based on it.
