### PR TITLE
Test suite support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           - "3.10"
           - "3.11"
           - key: "3.12"
-            full: "3.12.0-dev"
+            full: "3.12-dev"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           - "3.10"
           - "3.11"
           - key: "3.12"
-            full: "3.12.0-beta.3"
+            full: "3.12.0-dev"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - run: git diff --exit-code
 
   tests-unix:
-    name: tests / ${{ matrix.python }} / ${{ matrix.os }}
+    name: tests / ${{ matrix.python.key || matrix.python }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
 
     needs: [packaging, determine-changes]
@@ -109,12 +109,14 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - key: "3.12"
+            full: "3.12.0-beta.3"
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python.full || matrix.python }}
 
       - name: Install Ubuntu dependencies
         if: matrix.os == 'Ubuntu'
@@ -129,12 +131,12 @@ jobs:
       # Main check
       - name: Run unit tests
         run: >-
-          nox -s test-${{ matrix.python }} --
+          nox -s test-${{ matrix.python.key || matrix.python }} --
           -m unit
           --verbose --numprocesses auto --showlocals
       - name: Run integration tests
         run: >-
-          nox -s test-${{ matrix.python }} --
+          nox -s test-${{ matrix.python.key || matrix.python }} --
           -m integration
           --verbose --numprocesses auto --showlocals
           --durations=5

--- a/docs/html/installation.md
+++ b/docs/html/installation.md
@@ -103,7 +103,7 @@ $ pip install --upgrade pip
 The current version of pip works on:
 
 - Windows, Linux and MacOS.
-- CPython 3.7, 3.8, 3.9, 3.10 and latest PyPy3.
+- CPython 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, and latest PyPy3.
 
 pip is tested to work on the latest patch version of the Python interpreter,
 for each of the minor versions listed above. Previous patch versions are

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,7 +67,7 @@ def should_update_common_wheels() -> bool:
 # -----------------------------------------------------------------------------
 # Development Commands
 # -----------------------------------------------------------------------------
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3"])
 def test(session: nox.Session) -> None:
     # Get the common wheels.
     if should_update_common_wheels():

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,6 +89,7 @@ def test(session: nox.Session) -> None:
         shutil.rmtree(sdist_dir, ignore_errors=True)
 
     # fmt: off
+    session.install("setuptools")
     session.run(
         "python", "setup.py", "sdist", "--formats=zip", "--dist-dir", sdist_dir,
         silent=True,
@@ -351,6 +352,7 @@ def build_dists(session: nox.Session) -> List[str]:
         )
 
     session.log("# Build distributions")
+    session.install("setuptools", "wheel")
     session.run("python", "setup.py", "sdist", "bdist_wheel", silent=True)
     produced_dists = glob.glob("dist/*")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ from .lib.compat import nullcontext
 if TYPE_CHECKING:
     from typing import Protocol
 
-    from wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIApplication
 else:
     # TODO: Protocol was introduced in Python 3.8. Remove this branch when
     # dropping support for Python 3.7.
@@ -645,7 +645,12 @@ class InMemoryPip:
         try:
             returncode = pip_entry_point([os.fspath(a) for a in args])
         except SystemExit as e:
-            returncode = e.code or 0
+            if isinstance(e.code, int):
+                returncode = e.code
+            elif e.code:
+                returncode = 1
+            else:
+                returncode = 0
         finally:
             sys.stdout = orig_stdout
         return InMemoryPipResult(returncode, stdout.getvalue())

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -848,14 +848,18 @@ def test_editable_install__local_dir_no_setup_py(
     )
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Setuptools<64 does not support Python 3.12+",
+)
 @pytest.mark.network
-def test_editable_install__local_dir_no_setup_py_with_pyproject(
+def test_editable_install_legacy__local_dir_no_setup_py_with_pyproject(
     script: PipTestEnvironment,
 ) -> None:
     """
-    Test installing in editable mode from a local directory with no setup.py
-    but that does have pyproject.toml with a build backend that does not support
-    the build_editable hook.
+    Test installing in legacy editable mode from a local directory with no
+    setup.py but that does have pyproject.toml with a build backend that does
+    not support the build_editable hook.
     """
     local_dir = script.scratch_path.joinpath("temp")
     local_dir.mkdir()
@@ -1383,8 +1387,14 @@ setup(name='pkga', version='0.1')
     _test_install_editable_with_prefix(script, {"setup.py": setup_py})
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Setuptools<64 does not support Python 3.12+",
+)
 @pytest.mark.network
-def test_install_editable_with_prefix_setup_cfg(script: PipTestEnvironment) -> None:
+def test_install_editable_legacy_with_prefix_setup_cfg(
+    script: PipTestEnvironment,
+) -> None:
     setup_cfg = """[metadata]
 name = pkga
 version = 0.1

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -37,6 +37,10 @@ def test_basic_uninstall(script: PipTestEnvironment) -> None:
     assert_all_changes(result, result2, [script.venv / "build", "cache"])
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="distutils is no longer available in Python 3.12+",
+)
 def test_basic_uninstall_distutils(script: PipTestEnvironment) -> None:
     """
     Test basic install and uninstall.
@@ -68,6 +72,10 @@ def test_basic_uninstall_distutils(script: PipTestEnvironment) -> None:
     ) in result.stderr
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Setuptools<64 does not support Python 3.12+",
+)
 @pytest.mark.network
 def test_basic_uninstall_with_scripts(script: PipTestEnvironment) -> None:
     """
@@ -101,6 +109,10 @@ def test_uninstall_invalid_parameter(
     assert expected_message in result.stderr
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Setuptools<64 does not support Python 3.12+",
+)
 @pytest.mark.network
 def test_uninstall_easy_install_after_import(script: PipTestEnvironment) -> None:
     """
@@ -126,6 +138,10 @@ def test_uninstall_easy_install_after_import(script: PipTestEnvironment) -> None
     )
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Setuptools<64 does not support Python 3.12+",
+)
 @pytest.mark.network
 def test_uninstall_trailing_newline(script: PipTestEnvironment) -> None:
     """
@@ -337,6 +353,10 @@ def test_uninstall_console_scripts_uppercase_name(script: PipTestEnvironment) ->
     assert not script_name.exists()
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason="Setuptools<64 does not support Python 3.12+",
+)
 @pytest.mark.network
 def test_uninstall_easy_installed_console_scripts(script: PipTestEnvironment) -> None:
     """

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -124,7 +124,7 @@ class VirtualEnvironment:
                 )
             elif self._venv_type == "venv":
                 builder = _venv.EnvBuilder()
-                context = builder.ensure_directories(self.location)
+                context = builder.ensure_directories(os.fspath(self.location))
                 builder.create_configuration(context)
                 builder.setup_python(context)
                 self.site.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This makes the test suite run on 3.12. Also fix #12121 since the same fixes in noxfile apply for virtualenv configured to not populate setuptools.