### PR TITLE
Correct typo in 23.2 Changelog Bug Fixes

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -35,7 +35,7 @@ Features
 Bug Fixes
 ---------
 
-- Fix ``pip completion --zsh``. (`#11416 <https://github.com/pypa/pip/issues/11416>`_)
+- Fix ``pip completion --zsh``. (`#11417 <https://github.com/pypa/pip/issues/11417>`_)
 - Prevent downloading files twice when PEP 658 metadata is present (`#11847 <https://github.com/pypa/pip/issues/11847>`_)
 - Add permission check before configuration (`#11920 <https://github.com/pypa/pip/issues/11920>`_)
 - Fix deprecation warnings in Python 3.12 for usage of shutil.rmtree (`#11957 <https://github.com/pypa/pip/issues/11957>`_)


### PR DESCRIPTION
The first entry in the bug fixes section for the 23.2 release's changelog incorrectly listed the the PR/Issue for "Fix pip  completion --zsh" as #11416. However, the PR that fixed this issue was actually #11417. This commit fixes this oversight/off by one error so that the changelog points to the correct PR.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
