### PR TITLE
synthesize a traceback to get a normal exc_info from an exception

### DIFF
--- a/news/12187.bugfix.rst
+++ b/news/12187.bugfix.rst
@@ -1,1 +1,1 @@
-Fix improper handling of the new onexc argument of shutil.rmtree() in python 3.12.
+Fix improper handling of the new onexc argument of ``shutil.rmtree()`` in Python 3.12.

--- a/news/12187.bugfix.rst
+++ b/news/12187.bugfix.rst
@@ -1,0 +1,1 @@
+Fix improper handling of the new onexc argument of shutil.rmtree() in python 3.12.

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -130,7 +130,7 @@ def get_prog() -> str:
 def rmtree(
     dir: str,
     ignore_errors: bool = False,
-    onexc: Optional[OnErr] = None,
+    onexc: Optional[OnExc] = None,
 ) -> None:
     if ignore_errors:
         onexc = _onerror_ignore
@@ -158,8 +158,8 @@ def _onerror_reraise(*_args: Any) -> None:
 
 
 def rmtree_errorhandler(
-    func: Callable[..., Any],
-    path: str,
+    func: FunctionType,
+    path: Path,
     exc_info: Union[ExcInfo, BaseException],
     *,
     onexc: OnExc = _onerror_reraise,
@@ -193,6 +193,8 @@ def rmtree_errorhandler(
             except OSError:
                 pass
 
+    if not isinstance(exc_info, BaseException):
+        _, exc_info, _ = exc_info
     onexc(func, path, exc_info)
 
 

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -5,6 +5,7 @@ import os.path
 import tempfile
 import traceback
 from contextlib import ExitStack, contextmanager
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -189,7 +190,7 @@ class TempDirectory:
 
         def onerror(
             func: Callable[[str], Any],
-            path: str,
+            path: Path,
             exc_info: Tuple[Type[BaseException], BaseException, Any],
         ) -> None:
             """Log a warning for a `rmtree` error and continue"""


### PR DESCRIPTION
# Problem

`main` is currently broken on 3.12:
```bash
> nox -e test-3.12 -- -k test_tempdir_cleanup_ignore_errors
...
FAILED tests/unit/test_utils_temp_dir.py::test_tempdir_cleanup_ignore_errors - TypeError: 'PermissionError' object is not subscriptable
```

While it seems like #11394 may have been the direct trigger for the test failure, it appears the error was first introduced earlier in a hasty attempt to remove some `DeprecationWarning`s (25f4e6eabf8fb8f10ea10e4bd9c542ed30cbba5e). It turns out that while the documentation at https://docs.python.org/3.12/library/shutil.html#shutil.rmtree still uses the name "excinfo" for the third argument to `onexc`, `onexc` actually has a `BaseException` for the third argument instead of a `sys.exc_info()`, as per https://docs.python.org/3.12/whatsnew/3.12.html#shutil.

# Solution
- Since we don't use the `sys.exc_info()` parts anywhere, just convert any `sys.exc_info()` to a `BaseException` in our callback wrapper, and switch to explicitly only handling `BaseException` in our error callbacks.