### PR TITLE
Move metadata-fetching log to VERBOSE level

### DIFF
--- a/news/12155.process.rst
+++ b/news/12155.process.rst
@@ -1,0 +1,6 @@
+The metadata-fetching log message is moved to the VERBOSE level and now hidden
+by default. The more significant information in this message to most users are
+already available in surrounding logs (the package name and version of the
+metadata being fetched), while the URL to the exact metadata file is generally
+too long and clutters the output. The message can be brought back with
+``--verbose``.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -4,7 +4,6 @@
 # The following comment should be removed at some point in the future.
 # mypy: strict-optional=False
 
-import logging
 import mimetypes
 import os
 import shutil
@@ -37,6 +36,7 @@ from pip._internal.network.lazy_wheel import (
 from pip._internal.network.session import PipSession
 from pip._internal.operations.build.build_tracker import BuildTracker
 from pip._internal.req.req_install import InstallRequirement
+from pip._internal.utils._log import getLogger
 from pip._internal.utils.direct_url_helpers import (
     direct_url_for_editable,
     direct_url_from_link,
@@ -53,7 +53,7 @@ from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.unpacking import unpack_file
 from pip._internal.vcs import vcs
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def _get_prepared_distribution(
@@ -394,7 +394,7 @@ class RequirementPreparer:
         if metadata_link is None:
             return None
         assert req.req is not None
-        logger.info(
+        logger.verbose(
             "Obtaining dependency information for %s from %s",
             req.req,
             metadata_link,


### PR DESCRIPTION
Close #12155.

After examining the logs I decided to simply move the log to VERBOSE. Due to how artifacts are named, this:

```
Collecting whitenoise[brotli]<7.0,>=6.0 (from -r requirements.txt (line 4))
  Downloading whitenoise-6.5.0-py3-none-any.whl.metadata (3.7 kB)
```

should be able to provide everything the user generally needs to know (metadata of package `whitenoise` and version `6.5.0` is being downloaded).