### PR TITLE
Enable mypy's strict equality checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,11 +36,14 @@ per-file-ignores =
 
 [mypy]
 mypy_path = $MYPY_CONFIG_FILE_DIR/src
+
+strict = True
+
+no_implicit_reexport = False
+allow_subclassing_any = True
+allow_untyped_calls = True
+warn_return_any = False
 ignore_missing_imports = True
-disallow_untyped_defs = True
-disallow_any_generics = True
-warn_unused_ignores = True
-no_implicit_optional = True
 
 [mypy-pip._internal.utils._jaraco_text]
 ignore_errors = True

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -6,9 +6,9 @@ import tempfile
 import traceback
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from types import FunctionType
 from typing import (
     Any,
+    Callable,
     Dict,
     Generator,
     List,
@@ -187,7 +187,7 @@ class TempDirectory:
         errors: List[BaseException] = []
 
         def onerror(
-            func: FunctionType,
+            func: Callable[..., Any],
             path: Path,
             exc_val: BaseException,
         ) -> None:
@@ -196,11 +196,7 @@ class TempDirectory:
                 traceback.format_exception_only(type(exc_val), exc_val)
             )
             formatted_exc = formatted_exc.rstrip()  # remove trailing new line
-            if func in (
-                os.unlink,
-                os.remove,
-                os.rmdir,
-            ):  # type: ignore[comparison-overlap]
+            if func in (os.unlink, os.remove, os.rmdir):
                 logger.debug(
                     "Failed to remove a temporary file '%s' due to %s.\n",
                     path,

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -196,7 +196,11 @@ class TempDirectory:
                 traceback.format_exception_only(type(exc_val), exc_val)
             )
             formatted_exc = formatted_exc.rstrip()  # remove trailing new line
-            if func in (os.unlink, os.remove, os.rmdir):
+            if func in (
+                os.unlink,
+                os.remove,
+                os.rmdir,
+            ):  # type: ignore[comparison-overlap]
                 logger.debug(
                     "Failed to remove a temporary file '%s' due to %s.\n",
                     path,

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -601,8 +601,7 @@ def test_outdated_formats(script: PipTestEnvironment, data: TestData) -> None:
         "--outdated",
         "--format=json",
     )
-    data = json.loads(result.stdout)
-    assert data == [
+    assert json.loads(result.stdout) == [
         {
             "name": "simple",
             "version": "1.0",

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -46,7 +46,9 @@ if TYPE_CHECKING:
     # Literal was introduced in Python 3.8.
     from typing import Literal
 
-    ResolverVariant = Literal["resolvelib", "legacy"]
+    ResolverVariant = Literal[
+        "resolvelib", "legacy", "2020-resolver", "legacy-resolver"
+    ]
 else:
     ResolverVariant = str
 

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -352,7 +352,7 @@ class KeyringModuleV2:
     ),
 )
 def test_keyring_get_credential(
-    monkeypatch: pytest.MonkeyPatch, url: str, expect: str
+    monkeypatch: pytest.MonkeyPatch, url: str, expect: Tuple[str, str]
 ) -> None:
     monkeypatch.setitem(sys.modules, "keyring", KeyringModuleV2())
     auth = MultiDomainBasicAuth(

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -2,7 +2,7 @@ import os
 from contextlib import contextmanager
 from optparse import Values
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Iterator, List, Tuple, Union, cast
+from typing import Any, Dict, Iterator, List, Tuple, Type, Union, cast
 
 import pytest
 
@@ -605,7 +605,7 @@ class TestOptionsConfigFiles:
         self,
         monkeypatch: pytest.MonkeyPatch,
         args: List[str],
-        expect: Union[None, str, PipError],
+        expect: Union[None, str, Type[PipError]],
     ) -> None:
         cmd = cast(ConfigurationCommand, create_command("config"))
         # Replace a handler with a no-op to avoid side effects

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -99,17 +99,17 @@ class TestTargetPython:
         py_version_info: Optional[Tuple[int, ...]],
         expected_version: Optional[str],
     ) -> None:
-        mock_get_supported.return_value = ["tag-1", "tag-2"]
+        dummy_tags = [Tag("py4", "none", "any"), Tag("py5", "none", "any")]
+        mock_get_supported.return_value = dummy_tags
 
         target_python = TargetPython(py_version_info=py_version_info)
         actual = target_python.get_sorted_tags()
-        assert actual == ["tag-1", "tag-2"]
+        assert actual == dummy_tags
 
-        actual = mock_get_supported.call_args[1]["version"]
-        assert actual == expected_version
+        assert mock_get_supported.call_args[1]["version"] == expected_version
 
         # Check that the value was cached.
-        assert target_python._valid_tags == ["tag-1", "tag-2"]
+        assert target_python._valid_tags == dummy_tags
 
     def test_get_unsorted_tags__uses_cached_value(self) -> None:
         """


### PR DESCRIPTION
This would have caught an issue I had when writing https://github.com/pypa/pip/pull/12204. In that PR I changed something from a list to a set, which caused comparisons to other lists that previously held true to no longer hold. With this option enabled, mypy will complain about comparing something that's always a set to something that's always a list