### PR TITLE
Only error about missing `--target` is missing `--dry-run`.

### DIFF
--- a/news/12215.bugfix.rst
+++ b/news/12215.bugfix.rst
@@ -1,0 +1,1 @@
+Fix unnecessary error when using ``--dry-run`` and ``--python-version`` without ``--target``

--- a/news/12215.bugfix.rst
+++ b/news/12215.bugfix.rst
@@ -1,1 +1,0 @@
-Fix unnecessary error when using ``--dry-run`` and ``--python-version`` without ``--target``

--- a/news/12215.feature.rst
+++ b/news/12215.feature.rst
@@ -1,0 +1,1 @@
+Allow ``pip install --dry-run`` to use platform and ABI overriding options similar to ``--target``.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -92,10 +92,10 @@ def check_dist_restriction(options: Values, check_target: bool = False) -> None:
         )
 
     if check_target:
-        if dist_restriction_set and not options.target_dir:
+        if not options.dry_run and dist_restriction_set and not options.target_dir:
             raise CommandError(
                 "Can not use any platform or abi specific options unless "
-                "installing via '--target'"
+                "installing via '--target' or using '--dry-run'"
             )
 
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2459,6 +2459,40 @@ def test_install_pip_prints_req_chain_local(script: PipTestEnvironment) -> None:
     )
 
 
+def test_install_dist_restriction_without_target(script: PipTestEnvironment) -> None:
+    result = script.pip(
+        "install", "--python-version=3.1", "--only-binary=:all:", expect_error=True
+    )
+    assert (
+        "Can not use any platform or abi specific options unless installing "
+        "via '--target'" in result.stderr
+    ), str(result)
+
+
+def test_install_dist_restriction_dry_run_doesnt_require_target(
+    script: PipTestEnvironment,
+) -> None:
+    create_basic_wheel_for_package(
+        script,
+        "base",
+        "0.1.0",
+    )
+
+    result = script.pip(
+        "install",
+        "--python-version=3.1",
+        "--only-binary=:all:",
+        "--dry-run",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "base",
+    )
+
+    assert not result.stderr, str(result)
+
+
 @pytest.mark.network
 def test_install_pip_prints_req_chain_pypi(script: PipTestEnvironment) -> None:
     """


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fixes #12215