### PR TITLE
Add is_yanked to installation report

### DIFF
--- a/docs/html/reference/installation-report.md
+++ b/docs/html/reference/installation-report.md
@@ -56,6 +56,9 @@ package with the following properties:
   URL reference. `false` if the requirements was provided as a name and version
   specifier.
 
+- `is_yanked`: `true` if the requirement was yanked from the index, but was still
+  selected by pip conform to [PEP 592](https://peps.python.org/pep-0592/#installers).
+
 - `download_info`: Information about the artifact (to be) downloaded for installation,
   using the [direct URL data
   structure](https://packaging.python.org/en/latest/specifications/direct-url-data-structure/).
@@ -106,6 +109,7 @@ will produce an output similar to this (metadata abriged for brevity):
         }
       },
       "is_direct": false,
+      "is_yanked": false,
       "requested": true,
       "metadata": {
         "name": "pydantic",
@@ -133,6 +137,7 @@ will produce an output similar to this (metadata abriged for brevity):
         }
       },
       "is_direct": true,
+      "is_yanked": false,
       "requested": true,
       "metadata": {
         "name": "packaging",

--- a/news/12224.feature.rst
+++ b/news/12224.feature.rst
@@ -1,0 +1,1 @@
+Add ``is_yanked`` boolean entry to the installation report (``--report``) to indicate whether the requirement was yanked from the index, but still was selected by pip conform PEP 592.

--- a/news/12224.feature.rst
+++ b/news/12224.feature.rst
@@ -1,1 +1,1 @@
-Add ``is_yanked`` boolean entry to the installation report (``--report``) to indicate whether the requirement was yanked from the index, but still was selected by pip conform PEP 592.
+Add ``is_yanked`` boolean entry to the installation report (``--report``) to indicate whether the requirement was yanked from the index, but was still selected by pip conform to PEP 592.

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -23,6 +23,9 @@ class InstallationReport:
             # includes editable requirements), and false if the requirement was
             # downloaded from a PEP 503 index or --find-links.
             "is_direct": ireq.is_direct,
+            # is_yanked is true if the requirement was yanked from the index, but
+            # still was selected by pip conform PEP 592
+            "is_yanked": ireq.link.is_yanked if ireq.link else False,
             # requested is true if the requirement was specified by the user (aka
             # top level requirement), and false if it was installed as a dependency of a
             # requirement. https://peps.python.org/pep-0376/#requested

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -24,7 +24,7 @@ class InstallationReport:
             # downloaded from a PEP 503 index or --find-links.
             "is_direct": ireq.is_direct,
             # is_yanked is true if the requirement was yanked from the index, but
-            # still was selected by pip conform PEP 592
+            # still was selected by pip conform PEP 592.
             "is_yanked": ireq.link.is_yanked if ireq.link else False,
             # requested is true if the requirement was specified by the user (aka
             # top level requirement), and false if it was installed as a dependency of a

--- a/src/pip/_internal/models/installation_report.py
+++ b/src/pip/_internal/models/installation_report.py
@@ -24,7 +24,7 @@ class InstallationReport:
             # downloaded from a PEP 503 index or --find-links.
             "is_direct": ireq.is_direct,
             # is_yanked is true if the requirement was yanked from the index, but
-            # still was selected by pip conform PEP 592.
+            # was still selected by pip to conform to PEP 592.
             "is_yanked": ireq.link.is_yanked if ireq.link else False,
             # requested is true if the requirement was specified by the user (aka
             # top level requirement), and false if it was installed as a dependency of a


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

This PR adds `is_yanked` to the installation report as a machine-readable alternative to https://github.com/pypa/pip/pull/12225
