### PR TITLE
Upgrade doc requirements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ build:
     python: "3.11"
 
 sphinx:
-  builder: htmldir
+  builder: dirhtml
   configuration: docs/html/conf.py
 
 python:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx ~= 6.0
+sphinx ~= 7.0
 towncrier
 furo
 myst_parser


### PR DESCRIPTION
Documentation builds have been failing. Not sure what the reason is but everything seems to build cleanly for me locally with Sphinx 7, so I upgraded to that.