### PR TITLE
fix the dir `/usr/local/bin` is deleted

### DIFF
--- a/news/12242.bugfix.rst
+++ b/news/12242.bugfix.rst
@@ -1,0 +1,1 @@
+If there is only one package in the ``/usr/local/bin`` directory, the ``/usr/local/bin`` directory is deleted when the package is uninstalled.

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -141,7 +141,7 @@ def compress_for_rename(paths: Iterable[str]) -> Set[str]:
         # If all the files we found are in our remaining set of files to
         # remove, then remove them from the latter set and add a wildcard
         # for the directory.
-        if not (all_files - remaining):
+        if not (all_files - remaining) and root != "/usr/local/bin":
             remaining.difference_update(all_files)
             wildcards.add(root + os.sep)
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -361,7 +361,7 @@ def renames(old: str, new: str) -> None:
     shutil.move(old, new)
 
     head, tail = os.path.split(old)
-    if head and tail:
+    if head and tail and head != "/usr/local/bin":
         try:
             os.removedirs(head)
         except OSError:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

https://github.com/pypa/pip/issues/12237
