### PR TITLE
pre-commit autoupdate except mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,13 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/psf/black
-  rev: 23.1.0
+  rev: 23.7.0
   hooks:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.0.286
+  rev: v0.0.287
   hooks:
     - id: ruff
 


### PR DESCRIPTION
* A proper subset of #11507 as discussed at https://github.com/pypa/pip/pull/12209#issuecomment-1708000373

% `pre-commit autoupdate`
% `pre-commit run --all-files`

I manually downgraded `mypy` because the current version raises too many issues.