### PR TITLE
Log ending round state @ during resolver debug

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -65,7 +65,7 @@ class PipDebuggingReporter(BaseReporter):
         logger.info("Reporter.starting_round(%r)", index)
 
     def ending_round(self, index: int, state: Any) -> None:
-        logger.info("Reporter.ending_round(%r, state)", index)
+        logger.info("Reporter.ending_round(%r, %r)", index, state)
 
     def ending(self, state: Any) -> None:
         logger.info("Reporter.ending(%r)", state)

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -65,7 +65,8 @@ class PipDebuggingReporter(BaseReporter):
         logger.info("Reporter.starting_round(%r)", index)
 
     def ending_round(self, index: int, state: Any) -> None:
-        logger.info("Reporter.ending_round(%r, %r)", index, state)
+        logger.info("Reporter.ending_round(%r, state)", index)
+        logger.debug("Reporter.ending_round(%r, %r)", index, state)
 
     def ending(self, state: Any) -> None:
         logger.info("Reporter.ending(%r)", state)


### PR DESCRIPTION
This change corrects a tiny-little mistake made in 9f318de7b6fc471f473069268f64dae45f7a5628 that was causing the word "state" to be printed out in the log instead of the value of the `ending_round()`'s state` argument.
