### PR TITLE
Clarify --prefer-binary in cli help and docs

### DIFF
--- a/news/12122.doc.rst
+++ b/news/12122.doc.rst
@@ -1,0 +1,1 @@
+Clarify --prefer-binary in CLI and docs

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -670,7 +670,10 @@ def prefer_binary() -> Option:
         dest="prefer_binary",
         action="store_true",
         default=False,
-        help="Prefer older binary packages over newer source packages.",
+        help=(
+            "Prefer binary packages over source packages, even if the "
+            "source packages are newer."
+        ),
     )
 
 


### PR DESCRIPTION
Today I had a colleague get confused with this documentation: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-prefer-binary

The wording to them sounded like "binary packages" is the older format, and "source packages" is the newer format.

This is my attempt to remove this ambiguity, feel free to reject if you don't agree.