### PR TITLE
Remove outdated `noqa` comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ select = [
     "PLE",
     "PLR0",
     "W",
+    "RUF100",
 ]
 
 [tool.ruff.isort]

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -826,7 +826,7 @@ def _handle_config_settings(
 ) -> None:
     key, sep, val = value.partition("=")
     if sep != "=":
-        parser.error(f"Arguments to {opt_str} must be of the form KEY=VAL")  # noqa
+        parser.error(f"Arguments to {opt_str} must be of the form KEY=VAL")
     dest = getattr(parser.values, option.dest)
     if dest is None:
         dest = {}
@@ -921,13 +921,13 @@ def _handle_merge_hash(
         algo, digest = value.split(":", 1)
     except ValueError:
         parser.error(
-            "Arguments to {} must be a hash name "  # noqa
+            "Arguments to {} must be a hash name "
             "followed by a value, like --hash=sha256:"
             "abcde...".format(opt_str)
         )
     if algo not in STRONG_HASHES:
         parser.error(
-            "Allowed hash algorithms for {} are {}.".format(  # noqa
+            "Allowed hash algorithms for {} are {}.".format(
                 opt_str, ", ".join(STRONG_HASHES)
             )
         )

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -229,7 +229,7 @@ class ConfigOptionParser(CustomOptionParser):
                     val = strtobool(val)
                 except ValueError:
                     self.error(
-                        "{} is not a valid value for {} option, "  # noqa
+                        "{} is not a valid value for {} option, "
                         "please specify a boolean value like yes/no, "
                         "true/false or 1/0 instead.".format(val, key)
                     )
@@ -240,7 +240,7 @@ class ConfigOptionParser(CustomOptionParser):
                     val = int(val)
                 if not isinstance(val, int) or val < 0:
                     self.error(
-                        "{} is not a valid value for {} option, "  # noqa
+                        "{} is not a valid value for {} option, "
                         "please instead specify either a non-negative integer "
                         "or a boolean value like yes/no or false/true "
                         "which is equivalent to 1/0.".format(val, key)

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -134,9 +134,7 @@ def show_tags(options: Values) -> None:
 
 
 def ca_bundle_info(config: Configuration) -> str:
-    # Ruff misidentifies config as a dict.
-    # Configuration does not have support the mapping interface.
-    levels = {key.split(".", 1)[0] for key, _ in config.items()}  # noqa: PERF102
+    levels = {key.split(".", 1)[0] for key, _ in config.items()}
     if not levels:
         return "Not specified"
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -501,7 +501,7 @@ class InstallCommand(RequirementCommand):
                 show_traceback,
                 options.use_user_site,
             )
-            logger.error(message, exc_info=show_traceback)  # noqa
+            logger.error(message, exc_info=show_traceback)
 
             return ERROR
 

--- a/tests/functional/test_install_compat.py
+++ b/tests/functional/test_install_compat.py
@@ -11,7 +11,7 @@ from tests.lib import (
     PipTestEnvironment,
     TestData,
     assert_all_changes,
-    pyversion,  # noqa: F401
+    pyversion,
 )
 
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -10,7 +10,7 @@ from pip._internal.cli.status_codes import ERROR
 from tests.lib import (
     PipTestEnvironment,
     TestData,
-    pyversion,  # noqa: F401
+    pyversion,
 )
 
 


### PR DESCRIPTION
This removes unnecessary `noqa` which are intended to hide linter errors and adds a ruff rule to prevent unnecessary `noqa` comments in the future.