### PR TITLE
Avoid use of 2020-resolver and legacy-resolver

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -268,7 +268,7 @@ class RequirementCommand(IndexGroupCommand):
         if "legacy-resolver" in options.deprecated_features_enabled:
             return "legacy"
 
-        return "2020-resolver"
+        return "resolvelib"
 
     @classmethod
     def make_requirement_preparer(
@@ -290,7 +290,7 @@ class RequirementCommand(IndexGroupCommand):
         legacy_resolver = False
 
         resolver_variant = cls.determine_resolver_variant(options)
-        if resolver_variant == "2020-resolver":
+        if resolver_variant == "resolvelib":
             lazy_wheel = "fast-deps" in options.features_enabled
             if lazy_wheel:
                 logger.warning(
@@ -352,7 +352,7 @@ class RequirementCommand(IndexGroupCommand):
         # The long import name and duplicated invocation is needed to convince
         # Mypy into correctly typechecking. Otherwise it would complain the
         # "Resolver" class being redefined.
-        if resolver_variant == "2020-resolver":
+        if resolver_variant == "resolvelib":
             import pip._internal.resolution.resolvelib.resolver
 
             return pip._internal.resolution.resolvelib.resolver.Resolver(

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -595,7 +595,7 @@ class InstallCommand(RequirementCommand):
                 "source of the following dependency conflicts."
             )
         else:
-            assert resolver_variant == "2020-resolver"
+            assert resolver_variant == "resolvelib"
             parts.append(
                 "pip's dependency resolver does not currently take into account "
                 "all the packages that are installed. This behaviour is the "
@@ -628,7 +628,7 @@ class InstallCommand(RequirementCommand):
                     requirement=req,
                     dep_name=dep_name,
                     dep_version=dep_version,
-                    you=("you" if resolver_variant == "2020-resolver" else "you'll"),
+                    you=("you" if resolver_variant == "resolvelib" else "you'll"),
                 )
                 parts.append(message)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,8 +76,8 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addoption(
         "--resolver",
         action="store",
-        default="2020-resolver",
-        choices=["2020-resolver", "legacy"],
+        default="resolvelib",
+        choices=["resolvelib", "legacy"],
         help="use given resolver in tests",
     )
     parser.addoption(

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -629,7 +629,7 @@ _freeze_req_opts = textwrap.dedent(
     --extra-index-url http://ignore
     --find-links http://ignore
     --index-url http://ignore
-    --use-feature 2020-resolver
+    --use-feature resolvelib
 """
 )
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1209,9 +1209,9 @@ def test_install_nonlocal_compatible_wheel_path(
         "--no-index",
         "--only-binary=:all:",
         Path(data.packages) / "simplewheel-2.0-py3-fakeabi-fakeplat.whl",
-        expect_error=(resolver_variant == "2020-resolver"),
+        expect_error=(resolver_variant == "resolvelib"),
     )
-    if resolver_variant == "2020-resolver":
+    if resolver_variant == "resolvelib":
         assert result.returncode == ERROR
     else:
         assert result.returncode == SUCCESS
@@ -1825,14 +1825,14 @@ def test_install_editable_with_wrong_egg_name(
         "install",
         "--editable",
         f"file://{pkga_path}#egg=pkgb",
-        expect_error=(resolver_variant == "2020-resolver"),
+        expect_error=(resolver_variant == "resolvelib"),
     )
     assert (
         "Generating metadata for package pkgb produced metadata "
         "for project name pkga. Fix your #egg=pkgb "
         "fragments."
     ) in result.stderr
-    if resolver_variant == "2020-resolver":
+    if resolver_variant == "resolvelib":
         assert "has inconsistent" in result.stdout, str(result)
     else:
         assert "Successfully installed pkga" in str(result), str(result)

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -242,7 +242,7 @@ def test_install_extra_merging(
         expect_error=(fails_on_legacy and resolver_variant == "legacy"),
     )
 
-    if not fails_on_legacy or resolver_variant == "2020-resolver":
+    if not fails_on_legacy or resolver_variant == "resolvelib":
         expected = f"Successfully installed pkga-0.1 simple-{simple_version}"
         assert expected in result.stdout
 

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -392,11 +392,8 @@ def test_constraints_local_editable_install_causes_error(
         to_install,
         expect_error=True,
     )
-    if resolver_variant == "legacy-resolver":
-        assert "Could not satisfy constraints" in result.stderr, str(result)
-    else:
-        # Because singlemodule only has 0.0.1 available.
-        assert "Cannot install singlemodule 0.0.1" in result.stderr, str(result)
+    # Because singlemodule only has 0.0.1 available.
+    assert "Cannot install singlemodule 0.0.1" in result.stderr, str(result)
 
 
 @pytest.mark.network
@@ -426,11 +423,8 @@ def test_constraints_local_install_causes_error(
         to_install,
         expect_error=True,
     )
-    if resolver_variant == "legacy-resolver":
-        assert "Could not satisfy constraints" in result.stderr, str(result)
-    else:
-        # Because singlemodule only has 0.0.1 available.
-        assert "Cannot install singlemodule 0.0.1" in result.stderr, str(result)
+    # Because singlemodule only has 0.0.1 available.
+    assert "Cannot install singlemodule 0.0.1" in result.stderr, str(result)
 
 
 def test_constraints_constrain_to_local_editable(
@@ -451,9 +445,9 @@ def test_constraints_constrain_to_local_editable(
         script.scratch_path / "constraints.txt",
         "singlemodule",
         allow_stderr_warning=True,
-        expect_error=(resolver_variant == "2020-resolver"),
+        expect_error=(resolver_variant == "resolvelib"),
     )
-    if resolver_variant == "2020-resolver":
+    if resolver_variant == "resolvelib":
         assert "Editable requirements are not allowed as constraints" in result.stderr
     else:
         assert "Running setup.py develop for singlemodule" in result.stdout
@@ -551,9 +545,9 @@ def test_install_with_extras_from_constraints(
         script.scratch_path / "constraints.txt",
         "LocalExtras",
         allow_stderr_warning=True,
-        expect_error=(resolver_variant == "2020-resolver"),
+        expect_error=(resolver_variant == "resolvelib"),
     )
-    if resolver_variant == "2020-resolver":
+    if resolver_variant == "resolvelib":
         assert "Constraints cannot have extras" in result.stderr
     else:
         result.did_create(script.site_packages / "simple")
@@ -589,9 +583,9 @@ def test_install_with_extras_joined(
         script.scratch_path / "constraints.txt",
         "LocalExtras[baz]",
         allow_stderr_warning=True,
-        expect_error=(resolver_variant == "2020-resolver"),
+        expect_error=(resolver_variant == "resolvelib"),
     )
-    if resolver_variant == "2020-resolver":
+    if resolver_variant == "resolvelib":
         assert "Constraints cannot have extras" in result.stderr
     else:
         result.did_create(script.site_packages / "simple")
@@ -610,9 +604,9 @@ def test_install_with_extras_editable_joined(
         script.scratch_path / "constraints.txt",
         "LocalExtras[baz]",
         allow_stderr_warning=True,
-        expect_error=(resolver_variant == "2020-resolver"),
+        expect_error=(resolver_variant == "resolvelib"),
     )
-    if resolver_variant == "2020-resolver":
+    if resolver_variant == "resolvelib":
         assert "Editable requirements are not allowed as constraints" in result.stderr
     else:
         result.did_create(script.site_packages / "simple")
@@ -654,9 +648,9 @@ def test_install_distribution_union_with_constraints(
         script.scratch_path / "constraints.txt",
         f"{to_install}[baz]",
         allow_stderr_warning=True,
-        expect_error=(resolver_variant == "2020-resolver"),
+        expect_error=(resolver_variant == "resolvelib"),
     )
-    if resolver_variant == "2020-resolver":
+    if resolver_variant == "resolvelib":
         msg = "Unnamed requirements are not allowed as constraints"
         assert msg in result.stderr
     else:
@@ -674,9 +668,9 @@ def test_install_distribution_union_with_versions(
     result = script.pip_install_local(
         f"{to_install_001}[bar]",
         f"{to_install_002}[baz]",
-        expect_error=(resolver_variant == "2020-resolver"),
+        expect_error=(resolver_variant == "resolvelib"),
     )
-    if resolver_variant == "2020-resolver":
+    if resolver_variant == "resolvelib":
         assert "Cannot install localextras[bar]" in result.stderr
         assert ("localextras[bar] 0.0.1 depends on localextras 0.0.1") in result.stdout
         assert ("localextras[baz] 0.0.2 depends on localextras 0.0.2") in result.stdout

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -172,7 +172,7 @@ def test_upgrade_with_newest_already_installed(
         "install", "--upgrade", "-f", data.find_links, "--no-index", "simple"
     )
     assert not result.files_created, "simple upgraded when it should not have"
-    if resolver_variant == "2020-resolver":
+    if resolver_variant == "resolvelib":
         msg = "Requirement already satisfied"
     else:
         msg = "already up-to-date"

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -46,9 +46,7 @@ if TYPE_CHECKING:
     # Literal was introduced in Python 3.8.
     from typing import Literal
 
-    ResolverVariant = Literal[
-        "resolvelib", "legacy", "2020-resolver", "legacy-resolver"
-    ]
+    ResolverVariant = Literal["resolvelib", "legacy"]
 else:
     ResolverVariant = str
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -471,9 +471,7 @@ class TestProcessLine:
     ) -> None:
         """--use-feature triggers error when parsing requirements files."""
         with pytest.raises(RequirementsFileParseError):
-            line_processor(
-                "--use-feature=2020-resolver", "filename", 1, options=options
-            )
+            line_processor("--use-feature=resolvelib", "filename", 1, options=options)
 
     def test_relative_local_find_links(
         self,


### PR DESCRIPTION
This is a followup I promised to @pradyunsg in https://github.com/pypa/pip/pull/12209/files/2fcca557724da564a35e2df34b881a675b48f3ea#r1287885953