### PR TITLE
Upgrade mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     - id: ruff
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.961
+  rev: v1.5.1
   hooks:
   - id: mypy
     exclude: tests/data

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ allow_subclassing_any = True
 allow_untyped_calls = True
 warn_return_any = False
 ignore_missing_imports = True
+explicit_package_bases = True
 
 [mypy-pip._internal.utils._jaraco_text]
 ignore_errors = True

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -56,8 +56,7 @@ def distutils_scheme(
         try:
             d.parse_config_files()
         except UnicodeDecodeError:
-            # Typeshed does not include find_config_files() for some reason.
-            paths = d.find_config_files()  # type: ignore
+            paths = d.find_config_files()
             logger.warning(
                 "Ignore distutils configs in %s due to encoding errors.",
                 ", ".join(os.path.basename(p) for p in paths),

--- a/src/pip/_internal/metadata/_json.py
+++ b/src/pip/_internal/metadata/_json.py
@@ -64,10 +64,11 @@ def msg_to_json(msg: Message) -> Dict[str, Any]:
         key = json_name(field)
         if multi:
             value: Union[str, List[str]] = [
-                sanitise_header(v) for v in msg.get_all(field)
+                sanitise_header(v)
+                for v in msg.get_all(field)  # type: ignore[union-attr]
             ]
         else:
-            value = sanitise_header(msg.get(field))
+            value = sanitise_header(msg.get(field))  # type: ignore[arg-type]
             if key == "keywords":
                 # Accept both comma-separated and space-separated
                 # forms, for better compatibility with old data.

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -33,7 +33,9 @@ class PipXmlrpcTransport(xmlrpc.client.Transport):
         self,
         host: "_HostType",
         handler: str,
-        request_body: bytes,
+        # Should ideally be typed with SizedBuffer,
+        # but that's not easily usable till Python 3.11
+        request_body: bytes,  # type: ignore[override]
         verbose: bool = False,
     ) -> Tuple["_Marshallable", ...]:
         assert isinstance(host, str)

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -69,7 +69,7 @@ ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
 VersionInfo = Tuple[int, int, int]
 NetlocTuple = Tuple[str, Tuple[Optional[str], Optional[str]]]
 OnExc = Callable[[FunctionType, Path, BaseException], Any]
-OnErr = Callable[[FunctionType, Path, ExcInfo], Any]
+OnErr = Callable[[Callable[..., Any], str, ExcInfo], Any]
 
 
 def get_pip_version() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1031,7 +1031,7 @@ def html_index_with_onetime_server(
     class InDirectoryServer(http.server.ThreadingHTTPServer):
         def finish_request(self, request: Any, client_address: Any) -> None:
             self.RequestHandlerClass(
-                request, client_address, self, directory=str(html_index_for_packages)  # type: ignore[call-arg] # noqa: E501
+                request, client_address, self, directory=str(html_index_for_packages)  # type: ignore[call-arg, arg-type] # noqa: E501
             )
 
     class Handler(OneTimeDownloadHandler):

--- a/tests/lib/configuration_helpers.py
+++ b/tests/lib/configuration_helpers.py
@@ -37,8 +37,9 @@ class ConfigurationMixin:
             )
             old()
 
-        # https://github.com/python/mypy/issues/2427
-        self.configuration._load_config_files = overridden  # type: ignore[assignment]
+        self.configuration._load_config_files = (  # type: ignore[method-assign]
+            overridden
+        )
 
     @contextlib.contextmanager
     def tmpfile(self, contents: str) -> Iterator[str]:

--- a/tests/lib/test_wheel.py
+++ b/tests/lib/test_wheel.py
@@ -19,12 +19,12 @@ from tests.lib.wheel import (
 
 def test_message_from_dict_one_value() -> None:
     message = message_from_dict({"a": "1"})
-    assert set(message.get_all("a")) == {"1"}
+    assert set(message.get_all("a")) == {"1"}  # type: ignore[arg-type]
 
 
 def test_message_from_dict_multiple_values() -> None:
     message = message_from_dict({"a": ["1", "2"]})
-    assert set(message.get_all("a")) == {"1", "2"}
+    assert set(message.get_all("a")) == {"1", "2"}  # type: ignore[arg-type]
 
 
 def message_from_bytes(contents: bytes) -> Message:
@@ -67,7 +67,7 @@ def test_make_metadata_file_custom_value_list() -> None:
     f = default_make_metadata(updates={"a": ["1", "2"]})
     assert f is not None
     message = default_metadata_checks(f)
-    assert set(message.get_all("a")) == {"1", "2"}
+    assert set(message.get_all("a")) == {"1", "2"}  # type: ignore[arg-type]
 
 
 def test_make_metadata_file_custom_value_overrides() -> None:
@@ -101,7 +101,10 @@ def default_wheel_metadata_checks(f: File) -> Message:
     assert message.get_all("Wheel-Version") == ["1.0"]
     assert message.get_all("Generator") == ["pip-test-suite"]
     assert message.get_all("Root-Is-Purelib") == ["true"]
-    assert set(message.get_all("Tag")) == {"py2-none-any", "py3-none-any"}
+    assert set(message.get_all("Tag")) == {  # type: ignore[arg-type]
+        "py2-none-any",
+        "py3-none-any",
+    }
     return message
 
 
@@ -122,7 +125,7 @@ def test_make_wheel_metadata_file_custom_value_list() -> None:
     f = default_make_wheel_metadata(updates={"a": ["1", "2"]})
     assert f is not None
     message = default_wheel_metadata_checks(f)
-    assert set(message.get_all("a")) == {"1", "2"}
+    assert set(message.get_all("a")) == {"1", "2"}  # type: ignore[arg-type]
 
 
 def test_make_wheel_metadata_file_custom_value_override() -> None:

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -23,7 +23,7 @@ def test_dist_get_direct_url_no_metadata(mock_read_text: mock.Mock) -> None:
     class FakeDistribution(BaseDistribution):
         pass
 
-    dist = FakeDistribution()
+    dist = FakeDistribution()  # type: ignore[abstract]
     assert dist.direct_url is None
     mock_read_text.assert_called_once_with(DIRECT_URL_METADATA_NAME)
 
@@ -35,7 +35,7 @@ def test_dist_get_direct_url_invalid_json(
     class FakeDistribution(BaseDistribution):
         canonical_name = cast(NormalizedName, "whatever")  # Needed for error logging.
 
-    dist = FakeDistribution()
+    dist = FakeDistribution()  # type: ignore[abstract]
     with caplog.at_level(logging.WARNING):
         assert dist.direct_url is None
 
@@ -84,7 +84,7 @@ def test_dist_get_direct_url_valid_metadata(mock_read_text: mock.Mock) -> None:
     class FakeDistribution(BaseDistribution):
         pass
 
-    dist = FakeDistribution()
+    dist = FakeDistribution()  # type: ignore[abstract]
     direct_url = dist.direct_url
     assert direct_url is not None
     mock_read_text.assert_called_once_with(DIRECT_URL_METADATA_NAME)

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="method-assign"
 import logging
 import os
 import time
@@ -150,8 +151,7 @@ def test_base_command_provides_tempdir_helpers() -> None:
         return SUCCESS
 
     c = Command("fake", "fake")
-    # https://github.com/python/mypy/issues/2427
-    c.run = Mock(side_effect=assert_helpers_set)  # type: ignore[assignment]
+    c.run = Mock(side_effect=assert_helpers_set)
     assert c.main(["fake"]) == SUCCESS
     c.run.assert_called_once()
 
@@ -175,8 +175,7 @@ def test_base_command_global_tempdir_cleanup(kind: str, exists: bool) -> None:
         return SUCCESS
 
     c = Command("fake", "fake")
-    # https://github.com/python/mypy/issues/2427
-    c.run = Mock(side_effect=create_temp_dirs)  # type: ignore[assignment]
+    c.run = Mock(side_effect=create_temp_dirs)
     assert c.main(["fake"]) == SUCCESS
     c.run.assert_called_once()
     assert os.path.exists(Holder.value) == exists
@@ -200,6 +199,6 @@ def test_base_command_local_tempdir_cleanup(kind: str, exists: bool) -> None:
 
     c = Command("fake", "fake")
     # https://github.com/python/mypy/issues/2427
-    c.run = Mock(side_effect=create_temp_dirs)  # type: ignore[assignment]
+    c.run = Mock(side_effect=create_temp_dirs)
     assert c.main(["fake"]) == SUCCESS
     c.run.assert_called_once()

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,6 +1,6 @@
 """Tests for all things related to the configuration
 """
-
+# mypy: disable-error-code="method-assign"
 import re
 from unittest.mock import MagicMock
 
@@ -214,8 +214,7 @@ class TestConfigurationModification(ConfigurationMixin):
 
         # Mock out the method
         mymock = MagicMock(spec=self.configuration._mark_as_modified)
-        # https://github.com/python/mypy/issues/2427
-        self.configuration._mark_as_modified = mymock  # type: ignore[assignment]
+        self.configuration._mark_as_modified = mymock
 
         self.configuration.set_value("test.hello", "10")
 
@@ -231,7 +230,7 @@ class TestConfigurationModification(ConfigurationMixin):
         # Mock out the method
         mymock = MagicMock(spec=self.configuration._mark_as_modified)
         # https://github.com/python/mypy/issues/2427
-        self.configuration._mark_as_modified = mymock  # type: ignore[assignment]
+        self.configuration._mark_as_modified = mymock
 
         self.configuration.set_value("test.hello", "10")
 
@@ -249,8 +248,7 @@ class TestConfigurationModification(ConfigurationMixin):
 
         # Mock out the method
         mymock = MagicMock(spec=self.configuration._mark_as_modified)
-        # https://github.com/python/mypy/issues/2427
-        self.configuration._mark_as_modified = mymock  # type: ignore[assignment]
+        self.configuration._mark_as_modified = mymock
 
         self.configuration.set_value("test.hello", "10")
 

--- a/tests/unit/test_resolution_legacy_resolver.py
+++ b/tests/unit/test_resolution_legacy_resolver.py
@@ -252,7 +252,7 @@ class TestCheckDistRequiresPython:
             def metadata(self) -> email.message.Message:
                 raise FileNotFoundError(metadata_name)
 
-        dist = make_fake_dist(klass=NotWorkingFakeDist)
+        dist = make_fake_dist(klass=NotWorkingFakeDist)  # type: ignore[type-abstract]
 
         with pytest.raises(NoneMetadataError) as exc:
             _check_dist_requires_python(


### PR DESCRIPTION
Mostly straightforward.

The new message.get_all type ignores out of fear it may return None are minorly annoying. You can see some of the extra errors on the pip codebase in the mypy_primer of the typeshed PR that made the change https://github.com/python/typeshed/pull/9620

The abstract errors are because FakeDistribution doesn't actually implement any of the Protocol it claims to implement