### PR TITLE
Follow imports for more vendored dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,11 +54,7 @@ ignore_errors = True
 # These vendored libraries use runtime magic to populate things and don't sit
 # well with static typing out of the box. Eventually we should provide correct
 # typing information for their public interface and remove these configs.
-[mypy-pip._vendor.colorama]
-follow_imports = skip
 [mypy-pip._vendor.pkg_resources]
-follow_imports = skip
-[mypy-pip._vendor.progress.*]
 follow_imports = skip
 [mypy-pip._vendor.requests.*]
 follow_imports = skip


### PR DESCRIPTION
This will allow mypy to notice if you e.g. try to call a colorama function that does not exist. Note we won't report any errors in vendored code due to the ignore_errors config above.

It would also be quite easy to let mypy look at pkg_resources code, but this would involve the addition of like three type ignores.