### PR TITLE
Use strict optional checking in legacy resolver

### DIFF
--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -49,7 +49,7 @@ from pip._internal.utils.packaging import check_requires_python
 
 logger = logging.getLogger(__name__)
 
-DiscoveredDependencies = DefaultDict[str, List[InstallRequirement]]
+DiscoveredDependencies = DefaultDict[Optional[str], List[InstallRequirement]]
 
 
 def _check_dist_requires_python(
@@ -592,7 +592,7 @@ class Resolver(BaseResolver):
             if req.constraint:
                 return
             ordered_reqs.add(req)
-            for dep in self._discovered_dependencies[req.name]:  # type: ignore[index]
+            for dep in self._discovered_dependencies[req.name]:
                 schedule(dep)
             order.append(req)
 

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -10,8 +10,6 @@ for sub-dependencies
     a. "first found, wins" (where the order is breadth first)
 """
 
-# The following comment should be removed at some point in the future.
-
 import logging
 import sys
 from collections import defaultdict

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -11,7 +11,6 @@ for sub-dependencies
 """
 
 # The following comment should be removed at some point in the future.
-# mypy: strict-optional=False
 
 import logging
 import sys
@@ -325,6 +324,7 @@ class Resolver(BaseResolver):
         """
         # Don't uninstall the conflict if doing a user install and the
         # conflict is not a user install.
+        assert req.satisfied_by is not None
         if not self.use_user_site or req.satisfied_by.in_usersite:
             req.should_reinstall = True
         req.satisfied_by = None
@@ -423,6 +423,8 @@ class Resolver(BaseResolver):
 
         if self.wheel_cache is None or self.preparer.require_hashes:
             return
+
+        assert req.link is not None, "_find_requirement_link unexpectedly returned None"
         cache_entry = self.wheel_cache.get_cache_entry(
             link=req.link,
             package_name=req.name,
@@ -536,6 +538,7 @@ class Resolver(BaseResolver):
         with indent_log():
             # We add req_to_install before its dependencies, so that we
             # can refer to it when adding dependencies.
+            assert req_to_install.name is not None
             if not requirement_set.has_requirement(req_to_install.name):
                 # 'unnamed' requirements will get added here
                 # 'unnamed' requirements can only come from being directly
@@ -591,7 +594,7 @@ class Resolver(BaseResolver):
             if req.constraint:
                 return
             ordered_reqs.add(req)
-            for dep in self._discovered_dependencies[req.name]:
+            for dep in self._discovered_dependencies[req.name]:  # type: ignore[index]
                 schedule(dep)
             order.append(req)
 


### PR DESCRIPTION
The assert in _set_req_to_reinstall is definitely correct, the three call sites have guards

The assert in _populate_link is a little trickier. It's not obvious to me how to prove it will never trigger. But do note that if link were ever None, it could potentially cause AttributeError in Cache._get_cache_path_parts and direct_url_from_link

The assert in _resolve_one is safe, if req_to_install.name was None it would raise TypeError in canonicalize_name

I can't prove that req.name is not None in get_installation_order and the code would work fine if that were the case (since it's a defaultdict), so I opted to just ignore