### PR TITLE
Include the package name in the error reason

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -706,8 +706,8 @@ class PackageFinder:
 
     def requires_python_skipped_reasons(self) -> List[str]:
         reasons = {
-            detail
-            for _, result, detail in self._logged_links
+            "{} {}".format(link.filename, detail)
+            for link, result, detail in self._logged_links
             if result == LinkType.requires_python_mismatch
         }
         return sorted(reasons)


### PR DESCRIPTION
Add a bit more info to the error message when package resolution fails.

This is useful when `pip` is invoked from `pip-compile` tool. Here's an example of an error message one would receive from `pip-compile` before and after this change:

### Before

```
ERROR: Ignored the following versions that require a different python version: 5.2.0 Requires-Python >=3.9; 2023.5.1 Requires-Python >=3.9
  ERROR: Could not find a version that satisfies the requirement baz==0.6.0 (from versions: none)
```

### After

```
ERROR: Ignored the following versions that require a different python version: foo-5.2.0-py3-none-any.whl 5.2.0 Requires-Python >=3.9; foobar-2023.5.1-py3-none-any.whl 2023.5.1 Requires-Python >=3.9
  ERROR: Could not find a version that satisfies the requirement baz==0.6.0 (from versions: none)
```