### PR TITLE
Drop isort and flake8 settings from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,39 +1,3 @@
-[isort]
-profile = black
-skip =
-    ./build,
-    .nox,
-    .tox,
-    .scratch,
-    _vendor,
-    data
-known_third_party =
-    pip._vendor
-
-[flake8]
-max-line-length = 88
-exclude =
-    ./build,
-    .nox,
-    .tox,
-    .scratch,
-    _vendor,
-    data
-enable-extensions = G
-extend-ignore =
-    G200, G202,
-    # black adds spaces around ':'
-    E203,
-    # using a cache
-    B019,
-    # reassigning variables in a loop
-    B020,
-per-file-ignores =
-    # G: The plugin logging-format treats every .log and .error as logging.
-    noxfile.py: G
-    # B011: Do not call assert False since python -O removes these calls
-    tests/*: B011
-
 [mypy]
 mypy_path = $MYPY_CONFIG_FILE_DIR/src
 


### PR DESCRIPTION
Since we use ruff, these are not used anymore.
