### PR TITLE
Use `-r=...` instead of `-r ...` for VCS CLI

### DIFF
--- a/news/12306.bugfix.rst
+++ b/news/12306.bugfix.rst
@@ -1,0 +1,1 @@
+Use ``-r=...`` instead of ``-r ...`` to specify references with Mercurial.

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -31,7 +31,7 @@ class Mercurial(VersionControl):
 
     @staticmethod
     def get_base_rev_args(rev: str) -> List[str]:
-        return ["-r", rev]
+        return [f"-r={rev}"]
 
     def fetch_new(
         self, dest: str, url: HiddenText, rev_options: RevOptions, verbosity: int

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -66,7 +66,7 @@ def test_rev_options_repr() -> None:
         # First check VCS-specific RevOptions behavior.
         (Bazaar, [], ["-r", "123"], {}),
         (Git, ["HEAD"], ["123"], {}),
-        (Mercurial, [], ["-r", "123"], {}),
+        (Mercurial, [], ["-r=123"], {}),
         (Subversion, [], ["-r", "123"], {}),
         # Test extra_args.  For this, test using a single VersionControl class.
         (


### PR DESCRIPTION
This ensures that the resulting revision can not be misinterpreted as an option.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
