### PR TITLE
Cache construction of name and version strings

### DIFF
--- a/news/12316.bugfix.rst
+++ b/news/12316.bugfix.rst
@@ -1,0 +1,1 @@
+Significantly improve performance when installing hundreds of packages

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -102,6 +102,7 @@ class Distribution(BaseDistribution):
         self._dist = dist
         self._info_location = info_location
         self._installed_location = installed_location
+        self._cached_canonical_name: Optional[NormalizedName] = None
 
     @classmethod
     def from_directory(cls, directory: str) -> BaseDistribution:
@@ -169,8 +170,10 @@ class Distribution(BaseDistribution):
 
     @property
     def canonical_name(self) -> NormalizedName:
-        name = self._get_dist_name_from_location() or get_dist_name(self._dist)
-        return canonicalize_name(name)
+        if self._cached_canonical_name is None:
+            name = self._get_dist_name_from_location() or get_dist_name(self._dist)
+            self._cached_canonical_name = canonicalize_name(name)
+        return self._cached_canonical_name
 
     @property
     def version(self) -> DistributionVersion:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -349,6 +349,7 @@ class AlreadyInstalledCandidate(Candidate):
         # TODO: Supply reason based on force_reinstall and upgrade_strategy.
         skip_reason = "already satisfied"
         factory.preparer.prepare_installed_requirement(self._ireq, skip_reason)
+        self._name: Optional[NormalizedName] = None
 
     def __str__(self) -> str:
         return str(self.dist)
@@ -369,7 +370,9 @@ class AlreadyInstalledCandidate(Candidate):
 
     @property
     def project_name(self) -> NormalizedName:
-        return self.dist.canonical_name
+        if self._name is None:
+            self._name = self.dist.canonical_name
+        return self._name
 
     @property
     def name(self) -> str:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -3,7 +3,7 @@ import sys
 from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, Optional, Tuple, Union, cast
 
 from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
-from pip._vendor.packaging.version import Version
+from pip._vendor.packaging.version import parse_version
 
 from pip._internal.exceptions import (
     HashError,
@@ -271,7 +271,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             assert name == wheel_name, f"{name!r} != {wheel_name!r} for wheel"
             # Version may not be present for PEP 508 direct URLs
             if version is not None:
-                wheel_version = Version(wheel.version)
+                wheel_version = parse_version(wheel.version)
                 assert version == wheel_version, "{!r} != {!r} for wheel {}".format(
                     version, wheel_version, name
                 )
@@ -565,7 +565,7 @@ class RequiresPythonCandidate(Candidate):
             version_info = normalize_version_info(py_version_info)
         else:
             version_info = sys.version_info[:3]
-        self._version = Version(".".join(str(c) for c in version_info))
+        self._version = parse_version(".".join(str(c) for c in version_info))
 
     # We don't need to implement __eq__() and __ne__() since there is always
     # only one RequiresPythonCandidate in a resolution, i.e. the host Python.

--- a/src/pip/_vendor/packaging/specifiers.py
+++ b/src/pip/_vendor/packaging/specifiers.py
@@ -180,7 +180,7 @@ class _IndividualSpecifier(BaseSpecifier):
         # Determine if we should be supporting prereleases in this specifier
         # or not, if we do not support prereleases than we can short circuit
         # logic if this version is a prereleases.
-        if normalized_item.is_prerelease and not prereleases:
+        if not prereleases and normalized_item.is_prerelease:
             return False
 
         # Actually do the comparison to determine if this item is contained

--- a/src/pip/_vendor/packaging/specifiers.py
+++ b/src/pip/_vendor/packaging/specifiers.py
@@ -486,7 +486,7 @@ class Specifier(_IndividualSpecifier):
         # NB: Local version identifiers are NOT permitted in the version
         # specifier, so local version labels can be universally removed from
         # the prospective version.
-        return Version(prospective.public) >= Version(spec)
+        return parse_version(prospective.public) >= parse_version(spec)
 
     @_require_version_compare
     def _compare_less_than(self, prospective: ParsedVersion, spec_str: str) -> bool:

--- a/src/pip/_vendor/packaging/specifiers.py
+++ b/src/pip/_vendor/packaging/specifiers.py
@@ -143,7 +143,7 @@ class _IndividualSpecifier(BaseSpecifier):
 
     def _coerce_version(self, version: UnparsedVersion) -> ParsedVersion:
         if not isinstance(version, (LegacyVersion, Version)):
-            version = parse(version)
+            return parse(version)
         return version
 
     @property

--- a/src/pip/_vendor/packaging/utils.py
+++ b/src/pip/_vendor/packaging/utils.py
@@ -7,7 +7,7 @@ import re
 from typing import FrozenSet, NewType, Tuple, Union, cast
 
 from .tags import Tag, parse_tag
-from .version import InvalidVersion, Version
+from .version import parse_version, InvalidVersion, Version
 
 BuildTag = Union[Tuple[()], Tuple[int, str]]
 NormalizedName = NewType("NormalizedName", str)
@@ -30,6 +30,7 @@ _canonicalize_regex = re.compile(r"[-_.]+")
 _build_tag_regex = re.compile(r"(\d+)(.*)")
 
 
+@functools.lru_cache(maxsize=4096)
 def canonicalize_name(name: str) -> NormalizedName:
     # This is taken from PEP 503.
     value = _canonicalize_regex.sub("-", name).lower()
@@ -44,7 +45,7 @@ def canonicalize_version(version: Union[Version, str]) -> str:
     """
     if isinstance(version, str):
         try:
-            parsed = Version(version)
+            parsed = parse_version(version)
         except InvalidVersion:
             # Legacy versions cannot be normalized
             return version

--- a/src/pip/_vendor/packaging/utils.py
+++ b/src/pip/_vendor/packaging/utils.py
@@ -2,6 +2,7 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+import functools
 import re
 from typing import FrozenSet, NewType, Tuple, Union, cast
 
@@ -35,6 +36,7 @@ def canonicalize_name(name: str) -> NormalizedName:
     return cast(NormalizedName, value)
 
 
+@functools.lru_cache(maxsize=4096)
 def canonicalize_version(version: Union[Version, str]) -> str:
     """
     This is very similar to Version.__str__, but has one subtle difference

--- a/src/pip/_vendor/packaging/version.py
+++ b/src/pip/_vendor/packaging/version.py
@@ -391,15 +391,15 @@ class Version(_BaseVersion):
 
     @property
     def is_prerelease(self) -> bool:
-        return self.dev is not None or self.pre is not None
+        return self._version.dev is not None or self._version.pre is not None
 
     @property
     def is_postrelease(self) -> bool:
-        return self.post is not None
+        return self._version.post is not None
 
     @property
     def is_devrelease(self) -> bool:
-        return self.dev is not None
+        return self._version.dev is not None
 
     @property
     def major(self) -> int:


### PR DESCRIPTION
fixes #12314

The install finishes in minutes instead of hours after this change.

~~I'm not sure if `packaging` should be patched, or if I should open a PR to https://github.com/pypa/packaging so I'm looking for a bit of guidance on that.~~
needs https://github.com/pypa/packaging/pull/726