### PR TITLE
Update egg deprecation message

### DIFF
--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -151,7 +151,8 @@ def _emit_egg_deprecation(location: Optional[str]) -> None:
     deprecated(
         reason=f"Loading egg at {location} is deprecated.",
         replacement="to use pip for package installation.",
-        gone_in="23.3",
+        gone_in="24.3",
+        issue=12330,
     )
 
 


### PR DESCRIPTION
Postponed the deprecation of installed eggs discovery for one year, as discussed in https://github.com/pypa/pip/pull/12308.

Add a tracking issue to collect user feedback (#12330).