### PR TITLE
Replace `pyproject.toml` with backend string in logs

### DIFF
--- a/src/pip/_internal/operations/build/metadata.py
+++ b/src/pip/_internal/operations/build/metadata.py
@@ -29,7 +29,9 @@ def generate_metadata(
         # Note that BuildBackendHookCaller implements a fallback for
         # prepare_metadata_for_build_wheel, so we don't have to
         # consider the possibility that this hook doesn't exist.
-        runner = runner_with_spinner_message("Preparing metadata (pyproject.toml)")
+        runner = runner_with_spinner_message(
+            f"Preparing metadata ({backend.build_backend})"
+        )
         with backend.subprocess_runner(runner):
             try:
                 distinfo_dir = backend.prepare_metadata_for_build_wheel(metadata_dir)

--- a/src/pip/_internal/operations/build/metadata_editable.py
+++ b/src/pip/_internal/operations/build/metadata_editable.py
@@ -30,7 +30,7 @@ def generate_editable_metadata(
         # prepare_metadata_for_build_wheel/editable, so we don't have to
         # consider the possibility that this hook doesn't exist.
         runner = runner_with_spinner_message(
-            "Preparing editable metadata (pyproject.toml)"
+            f"Preparing editable metadata ({backend.build_backend})"
         )
         with backend.subprocess_runner(runner):
             try:

--- a/src/pip/_internal/operations/build/wheel.py
+++ b/src/pip/_internal/operations/build/wheel.py
@@ -24,7 +24,7 @@ def build_wheel_pep517(
         logger.debug("Destination directory: %s", tempd)
 
         runner = runner_with_spinner_message(
-            f"Building wheel for {name} (pyproject.toml)"
+            f"Building wheel for {name} ({backend.build_backend})"
         )
         with backend.subprocess_runner(runner):
             wheel_name = backend.build_wheel(

--- a/src/pip/_internal/operations/build/wheel_editable.py
+++ b/src/pip/_internal/operations/build/wheel_editable.py
@@ -24,7 +24,7 @@ def build_wheel_editable(
         logger.debug("Destination directory: %s", tempd)
 
         runner = runner_with_spinner_message(
-            f"Building editable for {name} (pyproject.toml)"
+            f"Building editable for {name} ({backend.build_backend})"
         )
         with backend.subprocess_runner(runner):
             try:


### PR DESCRIPTION
In #12339, it was pointed out that displaying logs like:

```
Preparing editable metadata (pyproject.toml): started
Preparing editable metadata (pyproject.toml): finished with status 'done'
Building editable for X (pyproject.toml): started
Building editable for X (pyproject.toml): finished with status 'done'
```

can be a source of confusion for users, when the package does not contain any `pyproject.toml`.

Since the API-based build process (described in PEP 517/660) does not actually need a `pyproject.toml`, I propose that a better way to communicate to the end-user this is the kind of process being used would be to show the "backend string".

If we take the logs above as example, this change would mean printing the following:

```
Preparing editable metadata (setuptools.build_meta:__legacy__): started
Preparing editable metadata (setuptools.build_meta:__legacy__): finished with status 'done'
Building editable for X (setuptools.build_meta:__legacy__): started
Building editable for X (setuptools.build_meta:__legacy__): finished with status 'done'
```

This should leave less margin of confusion, and communicate clearly for anyone trying to debug a problem what is the direction to look for.

Resolves #12339.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
