### PR TITLE
Build using `build`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -322,7 +322,7 @@ def build_release(session: nox.Session) -> None:
         )
 
     session.log("# Install dependencies")
-    session.install("setuptools", "wheel", "twine")
+    session.install("build", "twine")
 
     with release.isolated_temporary_checkout(session, version) as build_dir:
         session.log(
@@ -358,8 +358,7 @@ def build_dists(session: nox.Session) -> List[str]:
         )
 
     session.log("# Build distributions")
-    session.install("setuptools", "wheel")
-    session.run("python", "setup.py", "sdist", "bdist_wheel", silent=True)
+    session.run("python", "-m", "build", silent=True)
     produced_dists = glob.glob("dist/*")
 
     session.log(f"# Verify distributions: {', '.join(produced_dists)}")


### PR DESCRIPTION
Update the build-release nox session to build using `build` instead of a direct setup.py call.
