### PR TITLE
Feature: Allow to "All Except ...." for --only/--no-binary.

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -475,22 +475,14 @@ def _handle_no_binary(
     option: Option, opt_str: str, value: str, parser: OptionParser
 ) -> None:
     existing = _get_format_control(parser.values, option)
-    FormatControl.handle_mutual_excludes(
-        value,
-        existing.no_binary,
-        existing.only_binary,
-    )
+    FormatControl.handle_no_binary(value, existing)
 
 
 def _handle_only_binary(
     option: Option, opt_str: str, value: str, parser: OptionParser
 ) -> None:
     existing = _get_format_control(parser.values, option)
-    FormatControl.handle_mutual_excludes(
-        value,
-        existing.only_binary,
-        existing.no_binary,
-    )
+    FormatControl.handle_only_binary(value, existing)
 
 
 def no_binary() -> Option:
@@ -507,7 +499,12 @@ def no_binary() -> Option:
         'disable all binary packages, ":none:" to empty the set (notice '
         "the colons), or one or more package names with commas between "
         "them (no colons). Note that some packages are tricky to compile "
-        "and may fail to install when this option is used on them.",
+        "and may fail to install when this option is used on them. "
+        'When using ":all:", packages can be excluded from ":all:" by prefixing '
+        'their name with tilde "~", for example --no-binary=:all:~numpy '
+        "indicate to pip to install all packages using source dist with the "
+        "exception of numpy which can be installed using either a whl or tar.gz "
+        "file.",
     )
 
 
@@ -525,7 +522,12 @@ def only_binary() -> Option:
         'disable all source packages, ":none:" to empty the set, or one '
         "or more package names with commas between them. Packages "
         "without binary distributions will fail to install when this "
-        "option is used on them.",
+        "option is used on them. "
+        'When using ":all:", packages can be excluded from ":all:" by prefixing '
+        'their name with tilde "~", for example --only-binary=:all:~asciitree '
+        "indicate to pip to install all packages using wheels with the "
+        "exception of asciitree which can be installed using either a whl or "
+        "tar.gz file.",
     )
 
 

--- a/src/pip/_internal/models/format_control.py
+++ b/src/pip/_internal/models/format_control.py
@@ -37,6 +37,22 @@ class FormatControl:
             self.__class__.__name__, self.no_binary, self.only_binary
         )
 
+    @classmethod
+    def handle_no_binary(cls, value: str, existing: "FormatControl") -> None:
+        cls.handle_mutual_excludes(
+            value,
+            existing.no_binary,
+            existing.only_binary,
+        )
+
+    @classmethod
+    def handle_only_binary(cls, value: str, existing: "FormatControl") -> None:
+        cls.handle_mutual_excludes(
+            value,
+            existing.only_binary,
+            existing.no_binary,
+        )
+
     @staticmethod
     def handle_mutual_excludes(value: str, target: Set[str], other: Set[str]) -> None:
         if value.startswith("-"):
@@ -49,9 +65,6 @@ class FormatControl:
             target.clear()
             target.add(":all:")
             del new[: new.index(":all:") + 1]
-            # Without a none, we want to discard everything as :all: covers it
-            if ":none:" not in new:
-                return
         for name in new:
             if name == ":none:":
                 target.clear()
@@ -66,9 +79,12 @@ class FormatControl:
             result.discard("source")
         elif canonical_name in self.no_binary:
             result.discard("binary")
-        elif ":all:" in self.only_binary:
+        elif (
+            ":all:" in self.only_binary
+            and ("~" + canonical_name) not in self.only_binary
+        ):
             result.discard("source")
-        elif ":all:" in self.no_binary:
+        elif ":all:" in self.no_binary and ("~" + canonical_name) not in self.no_binary:
             result.discard("binary")
         return frozenset(result)
 

--- a/tests/unit/test_format_control.py
+++ b/tests/unit/test_format_control.py
@@ -64,6 +64,9 @@ def test_comma_separated_values() -> None:
         ({"fred"}, {":all:"}, "fred", frozenset(["source"])),
         (set(), {"fred"}, "fred", frozenset(["binary"])),
         ({":all:"}, {"fred"}, "fred", frozenset(["binary"])),
+        # nothing in binary except foo as binary or source
+        ({":all:", "~foo"}, set(), "bar", frozenset(["binary"])),
+        ({":all:", "~foo"}, set(), "foo", frozenset(["binary", "source"])),
     ],
 )
 def test_fmt_ctl_matches(


### PR DESCRIPTION
This is an attempt to fix #12348,

This allow to negate a package when using --only-binary, or --no-binary in addition to using `:all:` by prefixing the package with a `~`.

As noted in the issue this is not a perfect solution as we likely should maybe rethink the API, but I was hoping to achieve something useful and minimally invasive – at least to see what it entails.

With this patch doing:

pip install --only-binary=:all:,~foo --no-binary=bar  qux

Will try to install all dependencies from wheels except:
    - bar will installed only from tgz
    - foo either tgz or sdist.

At minimum, I think we can refactor FormatControl a bit to not expose the internal implementation details, which I did with 2 class methods and update to cmdoptions.py (I'm happy to pull that into a separate refactor commit/PR if you wish)

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
