### PR TITLE
fix hg: parse error at 0: not a prefix: (use --rev instead -r=)

### DIFF
--- a/news/370392cf-52cd-402c-b402-06d2ff398f89.bugfix.rst
+++ b/news/370392cf-52cd-402c-b402-06d2ff398f89.bugfix.rst
@@ -1,0 +1,1 @@
+fix mercurial revision parse error: use two hypen argument --rev= instead of -r=

--- a/src/pip/_internal/vcs/mercurial.py
+++ b/src/pip/_internal/vcs/mercurial.py
@@ -31,7 +31,7 @@ class Mercurial(VersionControl):
 
     @staticmethod
     def get_base_rev_args(rev: str) -> List[str]:
-        return [f"-r={rev}"]
+        return [f"--rev={rev}"]
 
     def fetch_new(
         self, dest: str, url: HiddenText, rev_options: RevOptions, verbosity: int

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -66,7 +66,7 @@ def test_rev_options_repr() -> None:
         # First check VCS-specific RevOptions behavior.
         (Bazaar, [], ["-r", "123"], {}),
         (Git, ["HEAD"], ["123"], {}),
-        (Mercurial, [], ["-r=123"], {}),
+        (Mercurial, [], ["--rev=123"], {}),
         (Subversion, [], ["-r", "123"], {}),
         # Test extra_args.  For this, test using a single VersionControl class.
         (


### PR DESCRIPTION
fix mercurial revision parse error (https://github.com/pypa/pip/issues/12371)