### PR TITLE
Add parallel download support to BatchDownloader

### DIFF
--- a/news/12388.feature.rst
+++ b/news/12388.feature.rst
@@ -1,0 +1,1 @@
+Add parallel download support to BatchDownloader

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -764,6 +764,19 @@ check_build_deps: Callable[..., Option] = partial(
     help="Check the build dependencies when PEP517 is used.",
 )
 
+parallel_downloads: Callable[..., Option] = partial(
+    Option,
+    "--parallel-downloads",
+    dest="parallel_downloads",
+    type="int",
+    metavar="n",
+    default=None,
+    help=(
+        "Use upto <n> threads to download packages in parallel."
+        "<n> must be greater than 0"
+    ),
+)
+
 
 def _handle_no_use_pep517(
     option: Option, opt: str, value: str, parser: OptionParser

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -770,7 +770,7 @@ parallel_downloads: Callable[..., Option] = partial(
     dest="parallel_downloads",
     type="int",
     metavar="n",
-    default=None,
+    default=1,
     help=(
         "Use upto <n> threads to download packages in parallel."
         "<n> must be greater than 0"

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -118,6 +118,10 @@ class SessionCommandMixin(CommandContextMixIn):
                 ssl_context = None
         else:
             ssl_context = None
+        if "parallel_downloads" in options.__dict__:
+            parallel_downloads = options.parallel_downloads
+        else:
+            parallel_downloads = None
 
         session = PipSession(
             cache=os.path.join(cache_dir, "http-v2") if cache_dir else None,
@@ -125,6 +129,7 @@ class SessionCommandMixin(CommandContextMixIn):
             trusted_hosts=options.trusted_hosts,
             index_urls=self._get_index_urls(options),
             ssl_context=ssl_context,
+            parallel_downloads=parallel_downloads,
         )
 
         # Handle custom ca-bundles from the user

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -118,10 +118,6 @@ class SessionCommandMixin(CommandContextMixIn):
                 ssl_context = None
         else:
             ssl_context = None
-        if "parallel_downloads" in options.__dict__:
-            parallel_downloads = options.parallel_downloads
-        else:
-            parallel_downloads = None
 
         session = PipSession(
             cache=os.path.join(cache_dir, "http-v2") if cache_dir else None,
@@ -129,7 +125,7 @@ class SessionCommandMixin(CommandContextMixIn):
             trusted_hosts=options.trusted_hosts,
             index_urls=self._get_index_urls(options),
             ssl_context=ssl_context,
-            parallel_downloads=parallel_downloads,
+            parallel_downloads=options.parallel_downloads,
         )
 
         # Handle custom ca-bundles from the user

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -119,13 +119,17 @@ class SessionCommandMixin(CommandContextMixIn):
         else:
             ssl_context = None
 
+        if "parallel_downloads" in options.__dict__:
+            parallel_downloads = options.parallel_downloads
+        else:
+            parallel_downloads = 1
         session = PipSession(
             cache=os.path.join(cache_dir, "http-v2") if cache_dir else None,
             retries=retries if retries is not None else options.retries,
             trusted_hosts=options.trusted_hosts,
             index_urls=self._get_index_urls(options),
             ssl_context=ssl_context,
-            parallel_downloads=options.parallel_downloads,
+            parallel_downloads=parallel_downloads,
         )
 
         # Handle custom ca-bundles from the user

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -52,6 +52,7 @@ class DownloadCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.no_use_pep517())
         self.cmd_opts.add_option(cmdoptions.check_build_deps())
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
+        self.cmd_opts.add_option(cmdoptions.parallel_downloads())
 
         self.cmd_opts.add_option(
             "-d",

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -78,9 +78,7 @@ class DownloadCommand(RequirementCommand):
 
     @with_cleanup
     def run(self, options: Values, args: List[str]) -> int:
-        if (options.parallel_downloads is not None) and (
-            options.parallel_downloads < 1
-        ):
+        if options.parallel_downloads < 1:
             raise CommandError("Value of '--parallel-downloads' must be greater than 0")
 
         options.ignore_installed = True

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -7,6 +7,7 @@ from pip._internal.cli import cmdoptions
 from pip._internal.cli.cmdoptions import make_target_python
 from pip._internal.cli.req_command import RequirementCommand, with_cleanup
 from pip._internal.cli.status_codes import SUCCESS
+from pip._internal.exceptions import CommandError
 from pip._internal.operations.build.build_tracker import get_build_tracker
 from pip._internal.req.req_install import check_legacy_setup_py_options
 from pip._internal.utils.misc import ensure_dir, normalize_path, write_output
@@ -77,6 +78,11 @@ class DownloadCommand(RequirementCommand):
 
     @with_cleanup
     def run(self, options: Values, args: List[str]) -> int:
+        if (options.parallel_downloads is not None) and (
+            options.parallel_downloads < 1
+        ):
+            raise CommandError("Value of '--parallel-downloads' must be greater than 0")
+
         options.ignore_installed = True
         # editable doesn't really make sense for `pip download`, but the bowels
         # of the RequirementSet code require that property.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -74,6 +74,7 @@ class InstallCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.constraints())
         self.cmd_opts.add_option(cmdoptions.no_deps())
         self.cmd_opts.add_option(cmdoptions.pre())
+        self.cmd_opts.add_option(cmdoptions.parallel_downloads())
 
         self.cmd_opts.add_option(cmdoptions.editable())
         self.cmd_opts.add_option(

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -268,9 +268,7 @@ class InstallCommand(RequirementCommand):
         if options.use_user_site and options.target_dir is not None:
             raise CommandError("Can not combine '--user' and '--target'")
 
-        if (options.parallel_downloads is not None) and (
-            options.parallel_downloads < 1
-        ):
+        if options.parallel_downloads < 1:
             raise CommandError("Value of '--parallel-downloads' must be greater than 0")
         # Check whether the environment we're installing into is externally
         # managed, as specified in PEP 668. Specifying --root, --target, or

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -268,6 +268,10 @@ class InstallCommand(RequirementCommand):
         if options.use_user_site and options.target_dir is not None:
             raise CommandError("Can not combine '--user' and '--target'")
 
+        if (options.parallel_downloads is not None) and (
+            options.parallel_downloads < 1
+        ):
+            raise CommandError("Value of '--parallel-downloads' must be greater than 0")
         # Check whether the environment we're installing into is externally
         # managed, as specified in PEP 668. Specifying --root, --target, or
         # --prefix disables the check, since there's no reliable way to locate

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -183,10 +183,9 @@ class BatchDownloader:
     def _download_parallel(
         self, links: Iterable[Link], location: str, max_workers: int
     ) -> Iterable[Tuple[Link, Tuple[str, str]]]:
-
         """
         Wraps the _sequential_download method in a ThreadPoolExecutor. `rich`
-        progress bar doesn't support naive parallelism, hence the progress bar 
+        progress bar doesn't support naive parallelism, hence the progress bar
         is disabled for parallel downloads. For more info see PR #12388
         """
         with ThreadPoolExecutor(max_workers=max_workers) as pool:

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -326,7 +326,7 @@ class PipSession(requests.Session):
         trusted_hosts: Sequence[str] = (),
         index_urls: Optional[List[str]] = None,
         ssl_context: Optional["SSLContext"] = None,
-        parallel_downloads: Optional[int] = None,
+        parallel_downloads: int = 1,
         **kwargs: Any,
     ) -> None:
         """
@@ -367,9 +367,7 @@ class PipSession(requests.Session):
         # pip._internal.network.BatchDownloader and to set pool_connection in
         # the HTTPAdapter to prevent connection pool from hitting the default(10)
         # limit and throwing 'Connection pool is full' warnings
-        self.parallel_downloads = (
-            parallel_downloads if (parallel_downloads is not None) else 1
-        )
+        self.parallel_downloads = parallel_downloads
         pool_maxsize = max(self.parallel_downloads, 10)
         # Our Insecure HTTPAdapter disables HTTPS validation. It does not
         # support caching so we'll use it for all http:// URLs.


### PR DESCRIPTION
This PR adds parallel download support to `BatchDownloader` and adds a cli option `--parallel-downloads <n>` to the install and download commands. If the option is not specified, or if set to 1, it doesn't change pip's behaviour or UI.

`BatchDownloader` is only called by [`_complete_partial_requirements`](https://github.com/pypa/pip/blob/fd77ebfc742de4d76ff976de22e86d116e0faad3/src/pip/_internal/operations/prepare.py#L445) after resolution is completed, so it wouldn't affect the resolution process as far as I can tell. It is used to download wheels where only metadata access was available for resolution. So as more packages adopt PEP 658 the number of wheels we would be able to download in parallel would also increase :)

### Note
Importantly, this PR does not add UI/progress bars for parallel downloads, it just logs the `Downloading <wheel-file-name>` message and disables the progress bar. ~I am working on a separate PR that adds a progress bar for parallel downloads. These 2 PR's can then be combined. I don't expect this PR to be merged until that PR is opened.~ I have opened a [separate PR](https://github.com/pypa/pip/pull/12404) to add UI support for parallel  downloads

I've done it this way because the UI requires some discussion, due to limitations of how rich and even tqdm render parallel progress bars in Jupyter notebooks (see [this issue](https://github.com/Textualize/rich/issues/3183)). Currently the best way I can think to circumvent this issue is to add a flag (something like --jupyter) to be used when downloading in parallel in jupyter notebooks that will disable the progress bar only for the parallel downloads. But this isn't ideal.

Also, if someone could tell me where I should ideally initiate this sort of discussion(discourse/IRC/discord etc.) I would appreciate it :)