### PR TITLE
Update and provide fixes for mypy pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,20 +27,20 @@ repos:
     - id: ruff
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.961
+  rev: v1.6.1
   hooks:
   - id: mypy
     exclude: tests/data
     args: ["--pretty", "--show-error-codes"]
     additional_dependencies: [
-        'keyring==23.0.1',
-        'nox==2021.6.12',
+        'keyring==24.2.0',
+        'nox==2023.4.22',
         'pytest',
-        'types-docutils==0.18.3',
-        'types-setuptools==57.4.14',
-        'types-freezegun==1.1.9',
-        'types-six==1.16.15',
-        'types-pyyaml==6.0.12.2',
+        'types-docutils==0.20.0.3',
+        'types-setuptools==68.2.0.0',
+        'types-freezegun==1.1.10',
+        'types-six==1.16.21.9',
+        'types-pyyaml==6.0.12.12',
     ]
 
 - repo: https://github.com/pre-commit/pygrep-hooks

--- a/news/12389.bugfix.rst
+++ b/news/12389.bugfix.rst
@@ -1,1 +1,1 @@
-Update to using mypy 1.6.1 and fix/ignore types
+Update mypy to 1.6.1 and fix/ignore types

--- a/news/12389.bugfix.rst
+++ b/news/12389.bugfix.rst
@@ -1,0 +1,1 @@
+Update to using mypy 1.6.1 and fix appropriatew types

--- a/news/12389.bugfix.rst
+++ b/news/12389.bugfix.rst
@@ -1,1 +1,1 @@
-Update to using mypy 1.6.1 and fix appropriatew types
+Update to using mypy 1.6.1 and fix/ignore types

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -56,7 +56,6 @@ def distutils_scheme(
         try:
             d.parse_config_files()
         except UnicodeDecodeError:
-            # Typeshed does not include find_config_files() for some reason.
             paths = d.find_config_files()
             logger.warning(
                 "Ignore distutils configs in %s due to encoding errors.",

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -57,7 +57,7 @@ def distutils_scheme(
             d.parse_config_files()
         except UnicodeDecodeError:
             # Typeshed does not include find_config_files() for some reason.
-            paths = d.find_config_files()  # type: ignore
+            paths = d.find_config_files()
             logger.warning(
                 "Ignore distutils configs in %s due to encoding errors.",
                 ", ".join(os.path.basename(p) for p in paths),

--- a/src/pip/_internal/metadata/_json.py
+++ b/src/pip/_internal/metadata/_json.py
@@ -64,10 +64,10 @@ def msg_to_json(msg: Message) -> Dict[str, Any]:
         key = json_name(field)
         if multi:
             value: Union[str, List[str]] = [
-                sanitise_header(v) for v in msg.get_all(field)
+                sanitise_header(v) for v in msg.get_all(field)  # type: ignore
             ]
         else:
-            value = sanitise_header(msg.get(field))
+            value = sanitise_header(msg.get(field))  # type: ignore
             if key == "keywords":
                 # Accept both comma-separated and space-separated
                 # forms, for better compatibility with old data.

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -13,6 +13,8 @@ from pip._internal.network.utils import raise_for_status
 if TYPE_CHECKING:
     from xmlrpc.client import _HostType, _Marshallable
 
+    from _typeshed import SizedBuffer
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,7 +35,7 @@ class PipXmlrpcTransport(xmlrpc.client.Transport):
         self,
         host: "_HostType",
         handler: str,
-        request_body: bytes,
+        request_body: SizedBuffer,
         verbose: bool = False,
     ) -> Tuple["_Marshallable", ...]:
         assert isinstance(host, str)

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -35,7 +35,7 @@ class PipXmlrpcTransport(xmlrpc.client.Transport):
         self,
         host: "_HostType",
         handler: str,
-        request_body: SizedBuffer,
+        request_body: "SizedBuffer",
         verbose: bool = False,
     ) -> Tuple["_Marshallable", ...]:
         assert isinstance(host, str)

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -145,7 +145,7 @@ def rmtree(
     )
     if sys.version_info >= (3, 12):
         # See https://docs.python.org/3.12/whatsnew/3.12.html#shutil.
-        shutil.rmtree(dir, onexc=handler)
+        shutil.rmtree(dir, onexc=handler)  # type: ignore
     else:
         shutil.rmtree(dir, onerror=handler)
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -147,7 +147,7 @@ def rmtree(
         # See https://docs.python.org/3.12/whatsnew/3.12.html#shutil.
         shutil.rmtree(dir, onexc=handler)  # type: ignore
     else:
-        shutil.rmtree(dir, onerror=handler)
+        shutil.rmtree(dir, onerror=handler)  # type: ignore
 
 
 def _onerror_ignore(*_args: Any) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ from tests.lib.server import MockServer, make_mock_server
 from tests.lib.venv import VirtualEnvironment, VirtualEnvironmentType
 
 if TYPE_CHECKING:
-    from typing import Self
+    from pip._vendor.typing_extensions import Self
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -945,7 +945,7 @@ def html_index_with_onetime_server(
     """
 
     class InDirectoryServer(http.server.ThreadingHTTPServer):
-        def finish_request(self: Self, request: Any, client_address: Any) -> None:
+        def finish_request(self: "Self", request: Any, client_address: Any) -> None:
             self.RequestHandlerClass(
                 request,
                 client_address,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from hashlib import sha256
 from pathlib import Path
 from textwrap import dedent
 from typing import (
+    TYPE_CHECKING,
     Any,
     AnyStr,
     Callable,
@@ -57,6 +58,9 @@ from tests.lib import (
 )
 from tests.lib.server import MockServer, make_mock_server
 from tests.lib.venv import VirtualEnvironment, VirtualEnvironmentType
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -941,7 +945,7 @@ def html_index_with_onetime_server(
     """
 
     class InDirectoryServer(http.server.ThreadingHTTPServer):
-        def finish_request(self, request: Any, client_address: Any) -> None:
+        def finish_request(self: Self, request: Any, client_address: Any) -> None:
             self.RequestHandlerClass(
                 request,
                 client_address,

--- a/tests/lib/configuration_helpers.py
+++ b/tests/lib/configuration_helpers.py
@@ -38,7 +38,7 @@ class ConfigurationMixin:
             old()
 
         # https://github.com/python/mypy/issues/2427
-        self.configuration._load_config_files = overridden  # type: ignore[assignment]
+        self.configuration._load_config_files = overridden  # type: ignore[method-assign]
 
     @contextlib.contextmanager
     def tmpfile(self, contents: str) -> Iterator[str]:

--- a/tests/lib/test_wheel.py
+++ b/tests/lib/test_wheel.py
@@ -19,12 +19,12 @@ from tests.lib.wheel import (
 
 def test_message_from_dict_one_value() -> None:
     message = message_from_dict({"a": "1"})
-    assert set(message.get_all("a")) == {"1"}
+    assert set(message.get_all("a")) == {"1"}  # type: ignore
 
 
 def test_message_from_dict_multiple_values() -> None:
     message = message_from_dict({"a": ["1", "2"]})
-    assert set(message.get_all("a")) == {"1", "2"}
+    assert set(message.get_all("a")) == {"1", "2"}  # type: ignore
 
 
 def message_from_bytes(contents: bytes) -> Message:
@@ -67,7 +67,7 @@ def test_make_metadata_file_custom_value_list() -> None:
     f = default_make_metadata(updates={"a": ["1", "2"]})
     assert f is not None
     message = default_metadata_checks(f)
-    assert set(message.get_all("a")) == {"1", "2"}
+    assert set(message.get_all("a")) == {"1", "2"}  # type: ignore
 
 
 def test_make_metadata_file_custom_value_overrides() -> None:
@@ -101,7 +101,7 @@ def default_wheel_metadata_checks(f: File) -> Message:
     assert message.get_all("Wheel-Version") == ["1.0"]
     assert message.get_all("Generator") == ["pip-test-suite"]
     assert message.get_all("Root-Is-Purelib") == ["true"]
-    assert set(message.get_all("Tag")) == {"py2-none-any", "py3-none-any"}
+    assert set(message.get_all("Tag")) == {"py2-none-any", "py3-none-any"}  # type: ignore
     return message
 
 
@@ -122,7 +122,7 @@ def test_make_wheel_metadata_file_custom_value_list() -> None:
     f = default_make_wheel_metadata(updates={"a": ["1", "2"]})
     assert f is not None
     message = default_wheel_metadata_checks(f)
-    assert set(message.get_all("a")) == {"1", "2"}
+    assert set(message.get_all("a")) == {"1", "2"}  # type: ignore
 
 
 def test_make_wheel_metadata_file_custom_value_override() -> None:

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -23,7 +23,7 @@ def test_dist_get_direct_url_no_metadata(mock_read_text: mock.Mock) -> None:
     class FakeDistribution(BaseDistribution):
         pass
 
-    dist = FakeDistribution()
+    dist = FakeDistribution()  # type: ignore
     assert dist.direct_url is None
     mock_read_text.assert_called_once_with(DIRECT_URL_METADATA_NAME)
 
@@ -35,7 +35,7 @@ def test_dist_get_direct_url_invalid_json(
     class FakeDistribution(BaseDistribution):
         canonical_name = cast(NormalizedName, "whatever")  # Needed for error logging.
 
-    dist = FakeDistribution()
+    dist = FakeDistribution()  # type: ignore
     with caplog.at_level(logging.WARNING):
         assert dist.direct_url is None
 
@@ -84,7 +84,7 @@ def test_dist_get_direct_url_valid_metadata(mock_read_text: mock.Mock) -> None:
     class FakeDistribution(BaseDistribution):
         pass
 
-    dist = FakeDistribution()
+    dist = FakeDistribution()  # type: ignore
     direct_url = dist.direct_url
     assert direct_url is not None
     mock_read_text.assert_called_once_with(DIRECT_URL_METADATA_NAME)

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -151,7 +151,7 @@ def test_base_command_provides_tempdir_helpers() -> None:
 
     c = Command("fake", "fake")
     # https://github.com/python/mypy/issues/2427
-    c.run = Mock(side_effect=assert_helpers_set)  # type: ignore[assignment]
+    c.run = Mock(side_effect=assert_helpers_set)  # type: ignore[method-assign]
     assert c.main(["fake"]) == SUCCESS
     c.run.assert_called_once()
 
@@ -176,7 +176,7 @@ def test_base_command_global_tempdir_cleanup(kind: str, exists: bool) -> None:
 
     c = Command("fake", "fake")
     # https://github.com/python/mypy/issues/2427
-    c.run = Mock(side_effect=create_temp_dirs)  # type: ignore[assignment]
+    c.run = Mock(side_effect=create_temp_dirs)  # type: ignore[method-assign]
     assert c.main(["fake"]) == SUCCESS
     c.run.assert_called_once()
     assert os.path.exists(Holder.value) == exists
@@ -200,6 +200,6 @@ def test_base_command_local_tempdir_cleanup(kind: str, exists: bool) -> None:
 
     c = Command("fake", "fake")
     # https://github.com/python/mypy/issues/2427
-    c.run = Mock(side_effect=create_temp_dirs)  # type: ignore[assignment]
+    c.run = Mock(side_effect=create_temp_dirs)  # type: ignore[method-assign]
     assert c.main(["fake"]) == SUCCESS
     c.run.assert_called_once()

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -215,7 +215,7 @@ class TestConfigurationModification(ConfigurationMixin):
         # Mock out the method
         mymock = MagicMock(spec=self.configuration._mark_as_modified)
         # https://github.com/python/mypy/issues/2427
-        self.configuration._mark_as_modified = mymock  # type: ignore[assignment]
+        self.configuration._mark_as_modified = mymock  # type: ignore[method-assign]
 
         self.configuration.set_value("test.hello", "10")
 
@@ -231,7 +231,7 @@ class TestConfigurationModification(ConfigurationMixin):
         # Mock out the method
         mymock = MagicMock(spec=self.configuration._mark_as_modified)
         # https://github.com/python/mypy/issues/2427
-        self.configuration._mark_as_modified = mymock  # type: ignore[assignment]
+        self.configuration._mark_as_modified = mymock  # type: ignore[method-assign]
 
         self.configuration.set_value("test.hello", "10")
 
@@ -250,7 +250,7 @@ class TestConfigurationModification(ConfigurationMixin):
         # Mock out the method
         mymock = MagicMock(spec=self.configuration._mark_as_modified)
         # https://github.com/python/mypy/issues/2427
-        self.configuration._mark_as_modified = mymock  # type: ignore[assignment]
+        self.configuration._mark_as_modified = mymock  # type: ignore[method-assign]
 
         self.configuration.set_value("test.hello", "10")
 

--- a/tests/unit/test_resolution_legacy_resolver.py
+++ b/tests/unit/test_resolution_legacy_resolver.py
@@ -252,7 +252,7 @@ class TestCheckDistRequiresPython:
             def metadata(self) -> email.message.Message:
                 raise FileNotFoundError(metadata_name)
 
-        dist = make_fake_dist(klass=NotWorkingFakeDist)
+        dist = make_fake_dist(klass=NotWorkingFakeDist)  # type: ignore
 
         with pytest.raises(NoneMetadataError) as exc:
             _check_dist_requires_python(


### PR DESCRIPTION
Update and provide fixes for mypy pre-commit

When running pre-commit locally with Python 3.12 on Pip main I am getting the error:

```
src/pip/_internal/utils/misc.py:148: error: Unexpected keyword argument "onexc"
for "rmtree"  [call-arg]
            shutil.rmtree(dir, onexc=handler)
            ^
/home/damian/.cache/pre-commit/repozzcb1fld/py_env-python3.12/lib/python3.12/site-packages/mypy/typeshed/stdlib/shutil.pyi:85: note: "rmtree" defined here
Found 1 error in 1 file (checked 293 source files)
```

I assume this is because the version of MyPy in the pre-commit is quite old. I updated it and then went through all the new errors it produced trying to fix them as seemed most appropriate.

I ended up having to add a type-ignore on this line regardless as although it now recognizes onexc it can not translate the type:

```
Argument "onexc" to "__call__" of "_RmtreeType" has incompatible type "Callable[[FunctionType, Path, tuple[type[BaseException], BaseException, TracebackType]], Any]"; expected "Callable[[Callable[..., Any], str, Exception], object]"
```