### PR TITLE
Update ruff and config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,10 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.292
+  rev: v0.1.4
   hooks:
     - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.961

--- a/news/12390.trivial.rst
+++ b/news/12390.trivial.rst
@@ -1,0 +1,1 @@
+Update ruff versions and config for dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,8 @@ ignore = [
     "B020",
     "B904", # Ruff enables opinionated warnings by default
     "B905", # Ruff enables opinionated warnings by default
-    "G202",
 ]
+target-version = "py37"
 line-length = 88
 select = [
     "ASYNC",


### PR DESCRIPTION
* Update ruff to the latest version
* Set target-version to Python 3.7, this acts as a minimum Python version to support (https://docs.astral.sh/ruff/settings/#target-version), and I don't think it can automatically pick it up via setup.py
* Remove G202 from exluded rules, seems it was added in https://github.com/pypa/pip/pull/8423 and looks no longer needed
* Add "--fix" to pre-commit now that Ruff respects safe fixes: https://astral.sh/blog/ruff-v0.1.0#respecting-fix-safety. Meaning for a lot of rule violations running `nox -s lint` should fix it for you automatically (much like it fixes formatting with black)