### PR TITLE
The purpose of this change is to avoid useless HTTP(S) requests

### DIFF
--- a/news/12398.feature.rst
+++ b/news/12398.feature.rst
@@ -1,0 +1,1 @@
+Allow ``pip install`` to avoid useless HTTPS requests in case the file is in cache and corresponds to the provided hash.

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -136,7 +136,7 @@ class Downloader:
             if data:
                 resp = adapter.controller.serializer.loads(None, data)
                 filepath = os.path.join(location, link.filename)
-                with open(filepath, 'wb') as content_file:
+                with open(filepath, "wb") as content_file:
                     content_file.write(resp.data)
                 return filepath
         except Exception:

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -128,6 +128,21 @@ class Downloader:
         self._session = session
         self._progress_bar = progress_bar
 
+    def check_cache(self, link: Link, location: str) -> Optional[str]:
+        target_url = link.url.split("#", 1)[0]
+        adapter = self._session.get_adapter(target_url)
+        try:
+            data = adapter.cache.get(target_url)
+            if data:
+                resp = adapter.controller.serializer.loads(None, data)
+                filepath = os.path.join(location, link.filename)
+                with open(filepath, 'wb') as content_file:
+                    content_file.write(resp.data)
+                return filepath
+        except Exception:
+            pass
+        return None
+
     def __call__(self, link: Link, location: str) -> Tuple[str, str]:
         """Download the file given by link into location."""
         try:

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -105,10 +105,22 @@ def get_http_url(
         from_path = already_downloaded_path
         content_type = None
     else:
-        # let's download to a tmp dir
-        from_path, content_type = download(link, temp_dir.path)
-        if hashes:
-            hashes.check_against_path(from_path)
+        if hashes:  # bypass http headers only in case we have a hash
+            content_type = None
+            from_path = download.check_cache(link, temp_dir.path)
+            if from_path:
+                try:
+                    hashes.check_against_path(from_path)
+                except HashMismatch:
+                    from_path = None
+        else:
+            from_path = None
+
+        if from_path is None:
+            # let's download to a tmp dir
+            from_path, content_type = download(link, temp_dir.path)
+            if hashes:
+                hashes.check_against_path(from_path)
 
     return File(from_path, content_type)
 


### PR DESCRIPTION
In essence, if the cache already contains the file we want to get over HTTPS *and* it matches the hash that we have at hand, there is no use checking for different/newer versions over the network.

A use case for this is if you have a requirements.txt that contains packages with urls and hashes, if you reinstall packages, you do not need to go over the network.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
