### PR TITLE
Fix tests when NO_COLOR is set in the calling environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
   schedule:
     - cron: 0 0 * * MON # Run every Monday at 00:00 UTC
 
+env:
+  # The "FORCE_COLOR" variable, when set to 1,
+  # tells Nox to colorize itself.
+  FORCE_COLOR: "1"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,6 +318,10 @@ def isolate(tmpdir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Make sure tests don't share a requirements tracker.
     monkeypatch.delenv("PIP_BUILD_TRACKER", False)
 
+    # Make sure color control variables don't affect internal output.
+    monkeypatch.delenv("FORCE_COLOR", False)
+    monkeypatch.delenv("NO_COLOR", False)
+
     # FIXME: Windows...
     os.makedirs(os.path.join(home_dir, ".config", "git"))
     with open(os.path.join(home_dir, ".config", "git", "config"), "wb") as fp:

--- a/tests/functional/test_inspect.py
+++ b/tests/functional/test_inspect.py
@@ -5,7 +5,7 @@ import pytest
 from tests.lib import PipTestEnvironment, ScriptFactory, TestData
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def simple_script(
     tmpdir_factory: pytest.TempPathFactory,
     script_factory: ScriptFactory,


### PR DESCRIPTION
Add `FORCE_COLOR` and `NO_COLOR` variables to the `isolate()` fixture to ensure that these two variables do not affect internal test output. This fixes the following two test failures when pytest is called with `NO_COLOR` set:

```
FAILED tests/unit/test_exceptions.py::TestDiagnosticPipErrorPresentation_ASCII::test_complete_color - AssertionError: assert '\x1b[1merror...ing harder.\n' == '\x1b[1;31mer...ing harder.\n'
FAILED tests/unit/test_exceptions.py::TestDiagnosticPipErrorPresentation_Unicode::test_complete_color - AssertionError: assert '\x1b[1merror...ing harder.\n' == '\x1b[1;31mer...ing harder.\n'
```