### PR TITLE
add ability to override script python executable for pip install

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -141,6 +141,16 @@ class InstallCommand(RequirementCommand):
                 "environment."
             ),
         )
+        self.cmd_opts.add_option(
+            "--override-python-executable",
+            dest="override_python_executable",
+            default=None,
+            help=(
+                "When installing scripts, overrides the python executable "
+                "in the shebang. Can be used when installing and relocating "
+                "to another environment."
+            ),
+        )
 
         self.cmd_opts.add_option(cmdoptions.src())
 
@@ -458,6 +468,7 @@ class InstallCommand(RequirementCommand):
                 warn_script_location=warn_script_location,
                 use_user_site=options.use_user_site,
                 pycompile=options.compile,
+                override_python_executable=options.override_python_executable,
             )
 
             lib_locations = get_lib_location_guesses(

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -416,9 +416,9 @@ def _raise_for_invalid_entrypoint(specification: str) -> None:
 
 
 class PipScriptMaker(ScriptMaker):
-    def __init__(self, source_dir, target_dir, python_executable=None):
+    def __init__(self, source_dir, target_dir, override_python_executable=None):
         super().__init__(source_dir, target_dir)
-        self.executable = python_executable
+        self.executable = override_python_executable
 
     def make(
         self, specification: str, options: Optional[Dict[str, Any]] = None
@@ -436,7 +436,7 @@ def _install_wheel(
     warn_script_location: bool = True,
     direct_url: Optional[DirectUrl] = None,
     requested: bool = False,
-    python_executable: Optional[str] = None,
+    override_python_executable: Optional[str] = None,
 ) -> None:
     """Install a wheel.
 
@@ -623,7 +623,11 @@ def _install_wheel(
                         record_installed(pyc_record_path, pyc_path)
         logger.debug(stdout.getvalue())
 
-    maker = PipScriptMaker(None, scheme.scripts, python_executable=python_executable)
+    maker = PipScriptMaker(
+        None,
+        scheme.scripts,
+        override_python_executable=override_python_executable,
+    )
 
     # Ensure old scripts are overwritten.
     # See https://github.com/pypa/pip/issues/1800
@@ -724,7 +728,7 @@ def install_wheel(
     warn_script_location: bool = True,
     direct_url: Optional[DirectUrl] = None,
     requested: bool = False,
-    python_executable: Optional[str] = None,
+    override_python_executable: Optional[str] = None,
 ) -> None:
     with ZipFile(wheel_path, allowZip64=True) as z:
         with req_error_context(req_description):
@@ -737,5 +741,5 @@ def install_wheel(
                 warn_script_location=warn_script_location,
                 direct_url=direct_url,
                 requested=requested,
-                python_executable=python_executable,
+                override_python_executable=override_python_executable,
             )

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -416,6 +416,10 @@ def _raise_for_invalid_entrypoint(specification: str) -> None:
 
 
 class PipScriptMaker(ScriptMaker):
+    def __init__(self, source_dir, target_dir, python_executable=None):
+        super().__init__(source_dir, target_dir)
+        self.executable = python_executable
+
     def make(
         self, specification: str, options: Optional[Dict[str, Any]] = None
     ) -> List[str]:
@@ -619,7 +623,7 @@ def _install_wheel(
                         record_installed(pyc_record_path, pyc_path)
         logger.debug(stdout.getvalue())
 
-    maker = PipScriptMaker(None, scheme.scripts)
+    maker = PipScriptMaker(None, scheme.scripts, python_executable=python_executable)
 
     # Ensure old scripts are overwritten.
     # See https://github.com/pypa/pip/issues/1800
@@ -634,9 +638,6 @@ def _install_wheel(
     # executable.
     # See https://bitbucket.org/pypa/distlib/issue/32/
     maker.set_mode = True
-
-    if python_executable is not None:
-        maker.executable = python_executable
 
     # Generate the console and GUI entry points specified in the wheel
     scripts_to_generate = get_console_script_specs(console)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -432,6 +432,7 @@ def _install_wheel(
     warn_script_location: bool = True,
     direct_url: Optional[DirectUrl] = None,
     requested: bool = False,
+    python_executable: Optional[str] = None,
 ) -> None:
     """Install a wheel.
 
@@ -634,6 +635,9 @@ def _install_wheel(
     # See https://bitbucket.org/pypa/distlib/issue/32/
     maker.set_mode = True
 
+    if python_executable is not None:
+        maker.executable = python_executable
+
     # Generate the console and GUI entry points specified in the wheel
     scripts_to_generate = get_console_script_specs(console)
 
@@ -719,6 +723,7 @@ def install_wheel(
     warn_script_location: bool = True,
     direct_url: Optional[DirectUrl] = None,
     requested: bool = False,
+    python_executable: Optional[str] = None,
 ) -> None:
     with ZipFile(wheel_path, allowZip64=True) as z:
         with req_error_context(req_description):
@@ -731,4 +736,5 @@ def install_wheel(
                 warn_script_location=warn_script_location,
                 direct_url=direct_url,
                 requested=requested,
+                python_executable=python_executable,
             )

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -416,9 +416,14 @@ def _raise_for_invalid_entrypoint(specification: str) -> None:
 
 
 class PipScriptMaker(ScriptMaker):
-    def __init__(self, source_dir, target_dir, override_python_executable=None):
+    def __init__(
+        self,
+        source_dir: Optional[str],
+        target_dir: str,
+        override_python_executable: Optional[str] = None,
+    ) -> None:
         super().__init__(source_dir, target_dir)
-        self.executable = override_python_executable
+        self.executable = override_python_executable  # type: ignore
 
     def make(
         self, specification: str, options: Optional[Dict[str, Any]] = None

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -43,6 +43,7 @@ def install_given_reqs(
     warn_script_location: bool,
     use_user_site: bool,
     pycompile: bool,
+    override_python_executable: Optional[str],
 ) -> List[InstallationResult]:
     """
     Install everything in the given list.
@@ -77,6 +78,7 @@ def install_given_reqs(
                     warn_script_location=warn_script_location,
                     use_user_site=use_user_site,
                     pycompile=pycompile,
+                    override_python_executable=override_python_executable,
                 )
             except Exception:
                 # if install did not succeed, rollback previous uninstall

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -148,7 +148,7 @@ class InstallRequirement:
         # Supplied options
         self.global_options = global_options if global_options else []
         self.hash_options = hash_options if hash_options else {}
-        self.config_settings = config_settings if config_settings else {}
+        self.config_settings = config_settings
         # Set to True after successful preparation of this requirement
         self.prepared = False
         # User supplied requirement are explicitly requested for installation
@@ -815,6 +815,7 @@ class InstallRequirement:
         warn_script_location: bool = True,
         use_user_site: bool = False,
         pycompile: bool = True,
+        override_python_executable: Optional[str] = None,
     ) -> None:
         assert self.req is not None
         scheme = get_scheme(
@@ -844,9 +845,6 @@ class InstallRequirement:
         assert self.is_wheel
         assert self.local_file_path
 
-        python_executable = self.config_settings.get("python_executable")
-        assert python_executable is None or isinstance(python_executable, str)
-
         install_wheel(
             self.req.name,
             self.local_file_path,
@@ -856,7 +854,7 @@ class InstallRequirement:
             warn_script_location=warn_script_location,
             direct_url=self.download_info if self.is_direct else None,
             requested=self.user_supplied,
-            python_executable=python_executable,
+            override_python_executable=override_python_executable,
         )
         self.install_succeeded = True
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -148,7 +148,7 @@ class InstallRequirement:
         # Supplied options
         self.global_options = global_options if global_options else []
         self.hash_options = hash_options if hash_options else {}
-        self.config_settings = config_settings
+        self.config_settings = config_settings if config_settings else {}
         # Set to True after successful preparation of this requirement
         self.prepared = False
         # User supplied requirement are explicitly requested for installation
@@ -844,6 +844,9 @@ class InstallRequirement:
         assert self.is_wheel
         assert self.local_file_path
 
+        python_executable = self.config_settings.get("python_executable")
+        assert python_executable is None or isinstance(python_executable, str)
+
         install_wheel(
             self.req.name,
             self.local_file_path,
@@ -853,6 +856,7 @@ class InstallRequirement:
             warn_script_location=warn_script_location,
             direct_url=self.download_info if self.is_direct else None,
             requested=self.user_supplied,
+            python_executable=python_executable,
         )
         self.install_succeeded = True
 

--- a/src/pip/_vendor/distlib/scripts.py
+++ b/src/pip/_vendor/distlib/scripts.py
@@ -75,8 +75,6 @@ class ScriptMaker(object):
     """
     script_template = SCRIPT_TEMPLATE
 
-    executable = None  # for shebangs
-
     def __init__(self, source_dir, target_dir, add_launchers=True,
                  dry_run=False, fileop=None):
         self.source_dir = source_dir
@@ -93,6 +91,8 @@ class ScriptMaker(object):
         self._is_nt = os.name == 'nt' or (
             os.name == 'java' and os._name == 'nt')
         self.version_info = sys.version_info
+
+        self.executable = None  # for shebangs
 
     def _get_alternate_executable(self, executable, options):
         if options.get('gui', False) and self._is_nt:  # pragma: no cover

--- a/src/pip/_vendor/distlib/scripts.py
+++ b/src/pip/_vendor/distlib/scripts.py
@@ -75,6 +75,8 @@ class ScriptMaker(object):
     """
     script_template = SCRIPT_TEMPLATE
 
+    executable = None  # for shebangs
+
     def __init__(self, source_dir, target_dir, add_launchers=True,
                  dry_run=False, fileop=None):
         self.source_dir = source_dir
@@ -91,8 +93,6 @@ class ScriptMaker(object):
         self._is_nt = os.name == 'nt' or (
             os.name == 'java' and os._name == 'nt')
         self.version_info = sys.version_info
-
-        self.executable = None  # for shebangs
 
     def _get_alternate_executable(self, executable, options):
         if options.get('gui', False) and self._is_nt:  # pragma: no cover

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -807,7 +807,7 @@ def test_install_wheel_with_python_executable(
 ) -> None:
     """
     Test installing a wheel using:
-    pip install --config-settings=python_executable=/foo/bar/python
+    pip install --override_python_executable=/foo/bar/python
     """
     shutil.copy(
         shared_data.packages / "console_scripts_uppercase-1.0-py2.py3-none-any.whl",
@@ -817,9 +817,9 @@ def test_install_wheel_with_python_executable(
         "install",
         "console_scripts_uppercase==1.0",
         "--no-index",
+        "--override-python-executable=/foo/bar/python",
         "--find-links",
         tmpdir,
-        "--config-settings=python_executable=/foo/bar/python",
     )
     dist_info_folder = script.site_packages / "console_scripts_uppercase-1.0.dist-info"
     result.did_create(dist_info_folder)


### PR DESCRIPTION
This PR adds support for overriding the python executable (shebang) in installed scripts. Here is some demand for such a feature:
- https://github.com/pypa/pip/issues/11483
- https://github.com/pypa/pip/issues/6278

One use-case is installing packages to a tmp directory and then moving them. Another use-case is installing with one version of python but using a different, system version during execution (or vice-versa). It's not always the case that the interpreter used to install the package should be used at execution time.

There are a number of ways this could be implemented, so this is more of a proposal. There was an encouragement for a PR [here](https://github.com/pypa/pip/issues/11483#issuecomment-1265955503) so I figured I'd give it a shot. I'd be happy to alter approach. I did test it and wrote a test.

Some open questions:
- I noticed `executable` is [pinned](https://github.com/pypa/pip/blob/92dd5532533fe1c42e62b58b1ff66b85ba4de6b4/src/pip/_vendor/distlib/scripts.py#L78) in `distlib`, but the logic _does_ indicate that it [can/should be overridden](https://github.com/pypa/pip/blob/92dd5532533fe1c42e62b58b1ff66b85ba4de6b4/src/pip/_vendor/distlib/scripts.py#L162-L163) in some cases.
    
    We could open a PR against `distutils` to see if they're open to this change
    
    Another option is to do this in `PipScriptMaker`, as pip already extends `ScriptMaker`.
- I used `config_settings` to configure the executable. This seemed convenient because it is already smuggled through to the wheel install. We can also use a different interface if desirable.