### PR TITLE
Stop injecting `wheel` as a build dep fallback

### DIFF
--- a/docs/html/reference/build-system/pyproject-toml.md
+++ b/docs/html/reference/build-system/pyproject-toml.md
@@ -135,7 +135,7 @@ section, it will be assumed to have the following backend settings:
 
 ```toml
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel"]
+requires = ["setuptools>=40.8.0"]
 build-backend = "setuptools.build_meta:__legacy__"
 ```
 

--- a/docs/html/reference/build-system/pyproject-toml.md
+++ b/docs/html/reference/build-system/pyproject-toml.md
@@ -141,7 +141,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 
 If a project has a `build-system` section but no `build-backend`, then:
 
-- It is expected to include `setuptools` and `wheel` as build requirements. An
+- It is expected to include `setuptools` as a build requirement. An
   error is reported if the available version of `setuptools` is not recent
   enough.
 

--- a/news/12449.bugfix.rst
+++ b/news/12449.bugfix.rst
@@ -1,0 +1,2 @@
+Removed ``wheel`` from the ``[build-system].requires`` list fallback
+that is used when ``pyproject.toml`` is absent.

--- a/news/12449.doc.rst
+++ b/news/12449.doc.rst
@@ -1,0 +1,2 @@
+Updated the ``pyproject.toml`` document to stop suggesting
+to depend on ``wheel`` as a build dependency directly.

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -123,7 +123,7 @@ def load_pyproject_toml(
         # a version of setuptools that supports that backend.
 
         build_system = {
-            "requires": ["setuptools>=40.8.0", "wheel"],
+            "requires": ["setuptools>=40.8.0"],
             "build-backend": "setuptools.build_meta:__legacy__",
         }
 


### PR DESCRIPTION
PEP 517 doesn't mandate depending on `wheel` when a `__legacy__` setuptools fallback is used. Historically, it used to be assumed as necessary, but later it turned out to be wrong. The reason is that `setuptools`' `get_requires_for_build_wheel()` hook already injects this dependency when building wheels is requested [[1]]. It also used to have this hint in the docs, but it was corrected earlier [[2]].

It could be argued that this is an optimization as `pip` will request building wheels anyway. However, it also shows up in the docs, giving the readers a wrong impression of what to put into `[build-system].requires` when they start a new project using setuptools.

This patch removes `wheel` from said `requires` list fallback in the docs and the actual runtime.

[1]: https://github.com/pypa/setuptools/blob/v40.8.0/setuptools/build_meta.py#L130
[2]: https://github.com/pypa/setuptools/pull/3056