### PR TITLE
Cache is_satisfied_by

### DIFF
--- a/news/12453.feature.rst
+++ b/news/12453.feature.rst
@@ -1,0 +1,1 @@
+Improve performance of resolution of large dependency trees, with more caching.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -20,7 +20,6 @@ from pip._internal.req.constructors import (
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.direct_url_helpers import direct_url_from_link
 from pip._internal.utils.misc import normalize_version_info
-from pip._internal.utils.models import KeyBasedCompareMixin
 
 from .base import Candidate, CandidateVersion, Requirement, format_name
 
@@ -325,7 +324,7 @@ class EditableCandidate(_InstallRequirementBackedCandidate):
         return self._factory.preparer.prepare_editable_requirement(self._ireq)
 
 
-class AlreadyInstalledCandidate(Candidate, KeyBasedCompareMixin):
+class AlreadyInstalledCandidate(Candidate):
     is_installed = True
     source_link = None
 
@@ -347,15 +346,19 @@ class AlreadyInstalledCandidate(Candidate, KeyBasedCompareMixin):
         skip_reason = "already satisfied"
         factory.preparer.prepare_installed_requirement(self._ireq, skip_reason)
 
-        KeyBasedCompareMixin.__init__(
-            self, key=(self.name, self.version), defining_class=self.__class__
-        )
-
     def __str__(self) -> str:
         return str(self.dist)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.dist!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AlreadyInstalledCandidate):
+            return NotImplemented
+        return self.name == other.name and self.version == other.version
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.version))
 
     @property
     def project_name(self) -> NormalizedName:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -20,6 +20,7 @@ from pip._internal.req.constructors import (
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.direct_url_helpers import direct_url_from_link
 from pip._internal.utils.misc import normalize_version_info
+from pip._internal.utils.models import KeyBasedCompareMixin
 
 from .base import Candidate, CandidateVersion, Requirement, format_name
 
@@ -324,7 +325,7 @@ class EditableCandidate(_InstallRequirementBackedCandidate):
         return self._factory.preparer.prepare_editable_requirement(self._ireq)
 
 
-class AlreadyInstalledCandidate(Candidate):
+class AlreadyInstalledCandidate(Candidate, KeyBasedCompareMixin):
     is_installed = True
     source_link = None
 
@@ -346,19 +347,15 @@ class AlreadyInstalledCandidate(Candidate):
         skip_reason = "already satisfied"
         factory.preparer.prepare_installed_requirement(self._ireq, skip_reason)
 
+        KeyBasedCompareMixin.__init__(
+            self, key=(self.name, self.version), defining_class=self.__class__
+        )
+
     def __str__(self) -> str:
         return str(self.dist)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.dist!r})"
-
-    def __hash__(self) -> int:
-        return hash((self.__class__, self.name, self.version))
-
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, self.__class__):
-            return self.name == other.name and self.version == other.version
-        return False
 
     @property
     def project_name(self) -> NormalizedName:

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -3,6 +3,7 @@ import functools
 import logging
 from typing import (
     TYPE_CHECKING,
+    Callable,
     Dict,
     FrozenSet,
     Iterable,
@@ -391,6 +392,7 @@ class Factory:
         incompatibilities: Mapping[str, Iterator[Candidate]],
         constraint: Constraint,
         prefers_installed: bool,
+        is_satisfied_by: Callable[[Requirement, Candidate], bool],
     ) -> Iterable[Candidate]:
         # Collect basic lookup information from the requirements.
         explicit_candidates: Set[Candidate] = set()
@@ -456,7 +458,7 @@ class Factory:
             for c in explicit_candidates
             if id(c) not in incompat_ids
             and constraint.is_satisfied_by(c)
-            and all(req.is_satisfied_by(c) for req in requirements[identifier])
+            and all(is_satisfied_by(req, c) for req in requirements[identifier])
         )
 
     def _make_requirements_from_install_req(

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -1,5 +1,6 @@
 import collections
 import math
+from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -236,6 +237,7 @@ class PipProvider(_ProviderBase):
             incompatibilities=incompatibilities,
         )
 
+    @lru_cache(maxsize=None)
     def is_satisfied_by(self, requirement: Requirement, candidate: Candidate) -> bool:
         return requirement.is_satisfied_by(candidate)
 

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -235,6 +235,7 @@ class PipProvider(_ProviderBase):
             constraint=constraint,
             prefers_installed=(not _eligible_for_upgrade(identifier)),
             incompatibilities=incompatibilities,
+            is_satisfied_by=self.is_satisfied_by,
         )
 
     @lru_cache(maxsize=None)

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -5,7 +5,6 @@ from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 
 from pip._internal.req.constructors import install_req_drop_extras
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.models import KeyBasedCompareMixin
 
 from .base import Candidate, CandidateLookup, Requirement, format_name
 
@@ -48,20 +47,25 @@ class ExplicitRequirement(Requirement):
         return candidate == self.candidate
 
 
-class SpecifierRequirement(Requirement, KeyBasedCompareMixin):
+class SpecifierRequirement(Requirement):
     def __init__(self, ireq: InstallRequirement) -> None:
         assert ireq.link is None, "This is a link, not a specifier"
         self._ireq = ireq
         self._extras = frozenset(canonicalize_name(e) for e in self._ireq.extras)
-        KeyBasedCompareMixin.__init__(
-            self, key=str(ireq), defining_class=SpecifierRequirement
-        )
 
     def __str__(self) -> str:
         return str(self._ireq.req)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({str(self._ireq.req)!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SpecifierRequirement):
+            return NotImplemented
+        return str(self._ireq) == str(other._ireq)
+
+    def __hash__(self) -> int:
+        return hash(str(self._ireq))
 
     @property
     def project_name(self) -> NormalizedName:
@@ -111,9 +115,14 @@ class SpecifierWithoutExtrasRequirement(SpecifierRequirement):
         assert ireq.link is None, "This is a link, not a specifier"
         self._ireq = install_req_drop_extras(ireq)
         self._extras = frozenset(canonicalize_name(e) for e in self._ireq.extras)
-        KeyBasedCompareMixin.__init__(
-            self, key=str(ireq), defining_class=SpecifierRequirement
-        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SpecifierWithoutExtrasRequirement):
+            return NotImplemented
+        return str(self._ireq) == str(other._ireq)
+
+    def __hash__(self) -> int:
+        return hash(str(self._ireq))
 
 
 class RequiresPythonRequirement(Requirement):
@@ -165,20 +174,25 @@ class RequiresPythonRequirement(Requirement):
         return self.specifier.contains(candidate.version, prereleases=True)
 
 
-class UnsatisfiableRequirement(Requirement, KeyBasedCompareMixin):
+class UnsatisfiableRequirement(Requirement):
     """A requirement that cannot be satisfied."""
 
     def __init__(self, name: NormalizedName) -> None:
         self._name = name
-        KeyBasedCompareMixin.__init__(
-            self, key=str(name), defining_class=UnsatisfiableRequirement
-        )
 
     def __str__(self) -> str:
         return f"{self._name} (unavailable)"
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({str(self._name)!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, UnsatisfiableRequirement):
+            return NotImplemented
+        return self._name == other._name
+
+    def __hash__(self) -> int:
+        return hash(self._name)
 
     @property
     def project_name(self) -> NormalizedName:

--- a/tests/unit/resolution_resolvelib/test_requirement.py
+++ b/tests/unit/resolution_resolvelib/test_requirement.py
@@ -23,6 +23,14 @@ from tests.lib import TestData
 #   Editables
 
 
+def _is_satisfied_by(requirement: Requirement, candidate: Candidate) -> bool:
+    """A helper function to check if a requirement is satisfied by a candidate.
+
+    Used for mocking PipProvider.is_satified_by.
+    """
+    return requirement.is_satisfied_by(candidate)
+
+
 @pytest.fixture
 def test_cases(data: TestData) -> Iterator[List[Tuple[str, str, int]]]:
     def _data_file(name: str) -> Path:
@@ -80,6 +88,7 @@ def test_new_resolver_correct_number_of_matches(
             {},
             Constraint.empty(),
             prefers_installed=False,
+            is_satisfied_by=_is_satisfied_by,
         )
         assert sum(1 for _ in matches) == match_count
 
@@ -98,6 +107,7 @@ def test_new_resolver_candidates_match_requirement(
             {},
             Constraint.empty(),
             prefers_installed=False,
+            is_satisfied_by=_is_satisfied_by,
         )
         for c in candidates:
             assert isinstance(c, Candidate)


### PR DESCRIPTION
This is a performance improvement for a presumably common use case, namely the installation of a project with locked dependencies using `pip install -c requirements.txt -e .`, in an environment where most dependencies are already installed.

More precisely the case I'm testing is a ~500 lines `requirements.txt`, and running the above command in an environment where all dependencies are already installed. This is typically done by developers when pulling a new version of the project, to ensure their environment is up-to-date.

When running this under py-spy, it appears that `PipProvider.is_satisfied_by` largely dominates the 50 seconds running `resolve()` (out of a total 55 sec execution time).

![image](https://github.com/pypa/pip/assets/692075/534fcc51-3133-4213-9083-7c69a1fecec9)

Some tracing showed that `is_satisfied_by` is repeatedly called for the same requirement and candidate.

So I experimented with some caching. 

The result of this PR is a 40 seconds saving on the 50 sec `resolve()`. The total execution time went down to 15 sec from 55.

![image](https://github.com/pypa/pip/assets/692075/eb032eed-a604-4321-a05f-4fd5efe1c1b4)

I'm opening as draft as there are some possible improvements, but it's ready for comments on the general approach already.