### PR TITLE
Fix tests broken by Setuptools 69.0.3 which now preserves underscores in egg_info

### DIFF
--- a/tests/functional/test_check.py
+++ b/tests/functional/test_check.py
@@ -119,7 +119,7 @@ def test_check_complicated_name_missing(script: PipTestEnvironment) -> None:
 
     # Without dependency
     result = script.pip("install", "--no-index", package_a_path, "--no-deps")
-    assert "Successfully installed package-A-1.0" in result.stdout, str(result)
+    assert "Successfully installed package_A-1.0" in result.stdout, str(result)
 
     result = script.pip("check", expect_error=True)
     expected_lines = ("package-a 1.0 requires dependency-b, which is not installed.",)
@@ -142,7 +142,7 @@ def test_check_complicated_name_broken(script: PipTestEnvironment) -> None:
 
     # With broken dependency
     result = script.pip("install", "--no-index", package_a_path, "--no-deps")
-    assert "Successfully installed package-A-1.0" in result.stdout, str(result)
+    assert "Successfully installed package_A-1.0" in result.stdout, str(result)
 
     result = script.pip(
         "install",
@@ -175,7 +175,7 @@ def test_check_complicated_name_clean(script: PipTestEnvironment) -> None:
     )
 
     result = script.pip("install", "--no-index", package_a_path, "--no-deps")
-    assert "Successfully installed package-A-1.0" in result.stdout, str(result)
+    assert "Successfully installed package_A-1.0" in result.stdout, str(result)
 
     result = script.pip(
         "install",
@@ -203,7 +203,7 @@ def test_check_considers_conditional_reqs(script: PipTestEnvironment) -> None:
     )
 
     result = script.pip("install", "--no-index", package_a_path, "--no-deps")
-    assert "Successfully installed package-A-1.0" in result.stdout, str(result)
+    assert "Successfully installed package_A-1.0" in result.stdout, str(result)
 
     result = script.pip("check", expect_error=True)
     expected_lines = ("package-a 1.0 requires dependency-b, which is not installed.",)

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -449,7 +449,7 @@ def test_git_with_ambiguous_revs(script: PipTestEnvironment) -> None:
     assert "Could not find a tag or branch" not in result.stdout
     # it is 'version-pkg' instead of 'version_pkg' because
     # egg-link name is version-pkg.egg-link because it is a single .py module
-    result.assert_installed("version-pkg", with_files=[".git"])
+    result.assert_installed("version_pkg", with_files=[".git"])
 
 
 def test_editable__no_revision(script: PipTestEnvironment) -> None:

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -1847,7 +1847,7 @@ def test_new_resolver_succeeds_on_matching_constraint_and_requirement(
 
     script.assert_installed(test_pkg="0.1.0")
     if editable:
-        assert_editable(script, "test-pkg")
+        assert_editable(script, "test_pkg")
 
 
 def test_new_resolver_applies_url_constraint_to_dep(script: PipTestEnvironment) -> None:

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -277,7 +277,7 @@ def test_show_required_by_packages_basic(
     lines = result.stdout.splitlines()
 
     assert "Name: simple" in lines
-    assert "Required-by: requires-simple" in lines
+    assert "Required-by: requires_simple" in lines
 
 
 def test_show_required_by_packages_capitalized(
@@ -294,7 +294,7 @@ def test_show_required_by_packages_capitalized(
     lines = result.stdout.splitlines()
 
     assert "Name: simple" in lines
-    assert "Required-by: Requires-Capitalized" in lines
+    assert "Required-by: Requires_Capitalized" in lines
 
 
 def test_show_required_by_packages_requiring_capitalized(
@@ -314,8 +314,8 @@ def test_show_required_by_packages_requiring_capitalized(
     lines = result.stdout.splitlines()
     print(lines)
 
-    assert "Name: Requires-Capitalized" in lines
-    assert "Required-by: requires-requires-capitalized" in lines
+    assert "Name: Requires_Capitalized" in lines
+    assert "Required-by: requires_requires_capitalized" in lines
 
 
 def test_show_skip_work_dir_pkg(script: PipTestEnvironment) -> None:

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -320,7 +320,7 @@ class TestPipResult:
         e = self.test_env
 
         if editable:
-            pkg_dir = e.venv / "src" / pkg_name.lower()
+            pkg_dir = e.venv / "src" / canonicalize_name(pkg_name)
             # If package was installed in a sub directory
             if sub_dir:
                 pkg_dir = pkg_dir / sub_dir


### PR DESCRIPTION
Let's see if this works...

Some tests are still broken due to https://github.com/pypa/setuptools/issues/4167.