### PR TITLE
Add new --with-blanklines option to pip freeze command

### DIFF
--- a/news/12479.feature.rst
+++ b/news/12479.feature.rst
@@ -1,0 +1,1 @@
+Add --with-blanklines option to `pip freeze` command. If the given requirements file contains multiple blank lines, they will be preserved.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -980,7 +980,7 @@ list_exclude: Callable[..., Option] = partial(
     action="append",
     metavar="package",
     type="package_name",
-    help="Exclude specified package from the output",
+    help="Exclude specified package from the output.",
 )
 
 

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -82,6 +82,16 @@ class FreezeCommand(Command):
             help="Exclude editable package from output.",
         )
         self.cmd_opts.add_option(cmdoptions.list_exclude())
+        self.cmd_opts.add_option(
+            "--with-blanklines",
+            dest="preserve_blanklines",
+            action="store_true",
+            default=False,
+            help=(
+                "If the given requirements file contains multiple blank lines, they "
+                "will be preserved."
+            ),
+        )
 
         self.parser.insert_option_group(0, self.cmd_opts)
 
@@ -103,6 +113,7 @@ class FreezeCommand(Command):
             isolated=options.isolated_mode,
             skip=skip,
             exclude_editable=options.exclude_editable,
+            preserve_blanklines=options.preserve_blanklines,
         ):
             sys.stdout.write(line + "\n")
         return SUCCESS

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -25,6 +25,7 @@ class _EditableInfo(NamedTuple):
 
 def freeze(
     requirement: Optional[List[str]] = None,
+    preserve_blanklines: bool = False,
     local_only: bool = False,
     user_only: bool = False,
     paths: Optional[List[str]] = None,
@@ -57,6 +58,9 @@ def freeze(
         for req_file_path in requirement:
             with open(req_file_path) as req_file:
                 for line in req_file:
+                    if preserve_blanklines and not line.strip():
+                        yield line.rstrip()
+                        continue
                     if (
                         not line.strip()
                         or line.strip().startswith("#")


### PR DESCRIPTION
This pull request (PR) introduces a new option to the pip freeze command.  New `--with-blanklines` option allows you to preserve blank lines in final output when using the `--requirement` option, which can be convenient and useful in certain scenarios.

For example, when updating dependencies, it will be based on `requirements.txt`:
```txt
# databases
alembic==1.13.1
asyncpg==0.29.0
SQLAlchemy==2.0.25
psycopg2==2.9.9

# network
aiohttp==3.9.1
requests==2.31.0

# parsing
bs4==0.0.1
Scrapy==2.11.0
```

The `requirements.txt` format will be preserved without violations, including the retention of empty lines in final result.
```txt
# databases
alembic==1.13.1
asyncpg==0.29.0
SQLAlchemy==2.0.25
psycopg2==2.9.9

# network
aiohttp==3.9.1
requests==2.31.0

# parsing
bs4==0.0.1
Scrapy==2.11.0
## The following requirements were added by pip freeze:
...other packages...
```
