### PR TITLE
Postpone removal of --global-option and --build-option

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -905,7 +905,7 @@ def check_legacy_setup_py_options(
             reason="--build-option and --global-option are deprecated.",
             issue=11859,
             replacement="to use --config-settings",
-            gone_in="24.0",
+            gone_in="24.2",
         )
         logger.warning(
             "Implying --no-binary=:all: due to the presence of "


### PR DESCRIPTION
Following feedback in #11859, postpone removal of these deprecated options.