### PR TITLE
Do not pre authenticate requests

### DIFF
--- a/docs/html/topics/authentication.md
+++ b/docs/html/topics/authentication.md
@@ -2,8 +2,18 @@
 
 ## Basic HTTP authentication
 
-pip supports basic HTTP-based authentication credentials. This is done by
-providing the username (and optionally password) in the URL:
+pip supports basic HTTP-based authentication credentials. You can provide the
+credentials directly in the URLs or using {pypi}`keyring` or a `.netrc` file. When
+needed pip will search for credentials in the following order:
+
+1. package URL from requirement (if any)
+2. index URLs
+3. keyring (if available)
+4. `.netrc` file (if present)
+
+## URL credentials support
+
+You can provide the username (and optionally password) directly in the URL:
 
 ```
 https://username:password@pypi.company.com/simple
@@ -34,6 +44,15 @@ https://user:he%2F%2Fo@pypi.company.com/simple
 
 [reserved-chars]: https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_reserved_characters
 
+
+### Securely storing password in keyring
+
+It is recommended to avoid storing password in clear text. For this purpose, you can
+use {pypi}`keyring` to store the password securely while still mentioning the username
+to use in your URL. pip will then extract the username from the URL and, as it did not
+find a password, it will search for a corresponding one in your keyring. See [Keyring
+support](#keyring-support) bellow.
+
 ## netrc support
 
 pip supports loading credentials from a user's `.netrc` file. If no credentials
@@ -63,14 +82,45 @@ man pages][netrc-docs].
 [netrc-docs]: https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
 [netrc-std-lib]: https://docs.python.org/3/library/netrc.html
 
-## Keyring Support
+## Keyring support
 
-pip supports loading credentials stored in your keyring using the
-{pypi}`keyring` library, which can be enabled py passing `--keyring-provider`
-with a value of `auto`, `disabled`, `import`, or `subprocess`. The default
-value `auto` respects `--no-input` and does not query keyring at all if the option
-is used; otherwise it tries the `import`, `subprocess`, and `disabled`
-providers (in this order) and uses the first one that works.
+pip supports loading credentials stored in your keyring using the {pypi}`keyring`
+library, which can be enabled by passing `--keyring-provider` with a value of `auto`,
+`import`, or `subprocess`. The default value `auto` respects `--no-input` and does not
+query keyring at all if the option is used; otherwise it tries the `import`,
+`subprocess`, and `disabled` providers (in this order) and uses the first one that
+works.
+
+You can explicitly disable keyring support by passing `--keyring-provider=disabled`.
+
+When looking for credentials, pip will first try to find a record in your keyring for
+the corresponding URL and if none are found it will try with just the server hostname.
+
+### Storing credentials
+
+In interactive mode, when the keyring is available and the server requires the
+user to authenticate, pip will prompt you for the credentials and then save
+them in the keyring. In this case the credentials will be saved based on the server
+hostname.
+
+You can also manually store your credentials in your keyring, either for an index URL
+(note that the URL _must_ end with a `/`):
+
+```
+keyring set https://pypi.company.com/dev/simple/ user.name@company.com
+```
+
+Or for a server hostname:
+
+```
+keyring set pypi.company.com user.name@company.com
+```
+
+In both cases, `keyring` will prompt you for the password to store.
+
+Note: For server requiring a token instead of a username and password, you can still
+store it as the username with an empty password in keyring but due to the limitation of
+the `subprocess` provider, this only make sense when using the `import` provider.
 
 ### Configuring pip's keyring usage
 
@@ -103,6 +153,10 @@ $ export PIP_KEYRING_PROVIDER=disabled
 Setting `keyring-provider` to `import` makes pip communicate with `keyring` via
 its Python interface.
 
+This is slightly faster than the `subprocess` provider and it makes it possible to use
+URLs without any username as it can find it in your keyring. The downside is that you
+have to install it in every virtualenv.
+
 ```bash
 # install keyring from PyPI
 $ pip install keyring --index-url https://pypi.org/simple
@@ -115,9 +169,10 @@ $ pip install your-package --keyring-provider import --index-url https://pypi.co
 Setting `keyring-provider` to `subprocess` makes pip look for and use the
 `keyring` command found on `PATH`.
 
-For this use case, a username *must* be included in the URL, since it is
-required by `keyring`'s command line interface. See the example below or the
-basic HTTP authentication section at the top of this page.
+The advantage is that you only need to install it once (and it can even be installed
+system-wide for all users).
+The disadvantage is that, a username *must* be included in the URL, since it is required
+by `keyring`'s command line interface. See the example below.
 
 ```bash
 # Install keyring from PyPI using pipx, which we assume is installed properly
@@ -154,25 +209,6 @@ You can force keyring usage by requesting a keyring provider other than `auto`
 $ pip config set global.keyring-provider subprocess
 # or via environment variable
 $ export PIP_KEYRING_PROVIDER=import
-```
-
-```{warning}
-Be careful when doing this since it could cause tools such as pipx and Pipenv
-to appear to hang. They show their own progress indicator while hiding output
-from the subprocess in which they run Pip. You won't know whether the keyring
-backend is waiting the user input or not in such situations.
-```
-
-pip is conservative and does not query keyring at all when `--no-input` is used
-because the keyring might require user interaction such as prompting the user
-on the console. You can force keyring usage by passing `--force-keyring` or one
-of the following:
-
-```bash
-# possibly with --user, --global or --site
-$ pip config set global.force-keyring true
-# or
-$ export PIP_FORCE_KEYRING=1
 ```
 
 ```{warning}

--- a/news/11721.bugfix.rst
+++ b/news/11721.bugfix.rst
@@ -1,0 +1,2 @@
+Wait until the index server tells us that authentication is required before trying
+to make sense of the userinfo section of the URLs and potentially query ``keyring``.

--- a/news/11721.doc.rst
+++ b/news/11721.doc.rst
@@ -1,0 +1,2 @@
+- Removed mention of un-implemented ``--force-keyring`` option.
+- Detailed the pros and cons of using the ``import`` and ``subprocess`` keyring providers.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -260,8 +260,8 @@ keyring_provider: Callable[..., Option] = partial(
     default="auto",
     help=(
         "Enable the credential lookup via the keyring library if user input is allowed."
-        " Specify which mechanism to use [disabled, import, subprocess]."
-        " (default: disabled)"
+        " Specify which mechanism to use [auto, disabled, import, subprocess]."
+        " (default: %default)"
     ),
 )
 

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -129,11 +129,11 @@ def test_prioritize_longest_path_prefix_match_organization() -> None:
     )
 
     # Inspired by Azure DevOps URL structure, GitLab should look similar
-    assert get("http://example.com/org-name-alpha/repo-guid/dowbload/") == (
+    assert get("http://example.com/org-name-alpha/repo-guid/download/") == (
         "foo",
         "bar",
     )
-    assert get("http://example.com/org-name-beta/repo-guid/dowbload/") == ("bar", "foo")
+    assert get("http://example.com/org-name-beta/repo-guid/download/") == ("bar", "foo")
 
 
 def test_prioritize_longest_path_prefix_match_project() -> None:
@@ -149,10 +149,10 @@ def test_prioritize_longest_path_prefix_match_project() -> None:
 
     # Inspired by Azure DevOps URL structure, GitLab should look similar
     assert get(
-        "http://example.com/org-alpha/project-name-alpha/repo-guid/dowbload/"
+        "http://example.com/org-alpha/project-name-alpha/repo-guid/download/"
     ) == ("foo", "bar")
     assert get(
-        "http://example.com/org-alpha/project-name-beta/repo-guid/dowbload/"
+        "http://example.com/org-alpha/project-name-beta/repo-guid/download/"
     ) == ("bar", "foo")
 
 

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -108,13 +108,17 @@ def test_get_index_url_credentials() -> None:
             "http://foo:bar@example.com/path",
         ]
     )
-    get = functools.partial(
-        auth._get_new_credentials, allow_netrc=False, allow_keyring=False
-    )
+    get = functools.partial(auth._get_new_credentials)
 
     # Check resolution of indexes
-    assert get("http://example.com/path/path2") == ("foo", "bar")
-    assert get("http://example.com/path3/path2") == (None, None)
+    assert get("http://example.com/path/path2") == (
+        "http://example.com/path/",
+        ("foo", "bar"),
+    )
+    assert get("http://example.com/path3/path2") == (
+        "http://example.com/",
+        (None, None),
+    )
 
 
 def test_prioritize_longest_path_prefix_match_organization() -> None:
@@ -124,16 +128,17 @@ def test_prioritize_longest_path_prefix_match_organization() -> None:
             "http://bar:foo@example.com/org-name-beta/repo-alias/simple",
         ]
     )
-    get = functools.partial(
-        auth._get_new_credentials, allow_netrc=False, allow_keyring=False
-    )
+    get = functools.partial(auth._get_new_credentials)
 
     # Inspired by Azure DevOps URL structure, GitLab should look similar
     assert get("http://example.com/org-name-alpha/repo-guid/download/") == (
-        "foo",
-        "bar",
+        "http://example.com/org-name-alpha/",
+        ("foo", "bar"),
     )
-    assert get("http://example.com/org-name-beta/repo-guid/download/") == ("bar", "foo")
+    assert get("http://example.com/org-name-beta/repo-guid/download/") == (
+        "http://example.com/org-name-beta/",
+        ("bar", "foo"),
+    )
 
 
 def test_prioritize_longest_path_prefix_match_project() -> None:
@@ -143,17 +148,15 @@ def test_prioritize_longest_path_prefix_match_project() -> None:
             "http://bar:foo@example.com/org-alpha/project-name-beta/repo-alias/simple",
         ]
     )
-    get = functools.partial(
-        auth._get_new_credentials, allow_netrc=False, allow_keyring=False
-    )
+    get = functools.partial(auth._get_new_credentials)
 
     # Inspired by Azure DevOps URL structure, GitLab should look similar
     assert get(
         "http://example.com/org-alpha/project-name-alpha/repo-guid/download/"
-    ) == ("foo", "bar")
+    ) == ("http://example.com/org-alpha/project-name-alpha/", ("foo", "bar"))
     assert get(
         "http://example.com/org-alpha/project-name-beta/repo-guid/download/"
-    ) == ("bar", "foo")
+    ) == ("http://example.com/org-alpha/project-name-beta/", ("bar", "foo"))
 
 
 class KeyringModuleV1:
@@ -178,19 +181,28 @@ class KeyringModuleV1:
 @pytest.mark.parametrize(
     "url, expect",
     (
-        ("http://example.com/path1", (None, None)),
+        ("http://example.com/path1", ("http://example.com/", (None, None))),
         # path1 URLs will be resolved by netloc
-        ("http://user@example.com/path3", ("user", "user!netloc")),
-        ("http://user2@example.com/path3", ("user2", "user2!netloc")),
+        (
+            "http://user@example.com/path3",
+            ("http://example.com/", ("user", "user!netloc")),
+        ),
+        (
+            "http://user2@example.com/path3",
+            ("http://example.com/", ("user2", "user2!netloc")),
+        ),
         # path2 URLs will be resolved by index URL
-        ("http://example.com/path2/path3", (None, None)),
-        ("http://foo@example.com/path2/path3", ("foo", "foo!url")),
+        ("http://example.com/path2/path3", ("http://example.com/", (None, None))),
+        (
+            "http://foo@example.com/path2/path3",
+            ("http://example.com/path2/", ("foo", "foo!url")),
+        ),
     ),
 )
 def test_keyring_get_password(
     monkeypatch: pytest.MonkeyPatch,
     url: str,
-    expect: Tuple[Optional[str], Optional[str]],
+    expect: Tuple[str, Tuple[Optional[str], Optional[str]]],
 ) -> None:
     keyring = KeyringModuleV1()
     monkeypatch.setitem(sys.modules, "keyring", keyring)
@@ -199,7 +211,7 @@ def test_keyring_get_password(
         keyring_provider="import",
     )
 
-    actual = auth._get_new_credentials(url, allow_netrc=False, allow_keyring=True)
+    actual = auth._get_new_credentials(url)
     assert actual == expect
 
 
@@ -247,12 +259,16 @@ def test_keyring_get_password_username_in_index(
         index_urls=["http://user@example.com/path2", "http://example.com/path4"],
         keyring_provider="import",
     )
-    get = functools.partial(
-        auth._get_new_credentials, allow_netrc=False, allow_keyring=True
-    )
+    get = functools.partial(auth._get_new_credentials)
 
-    assert get("http://example.com/path2/path3") == ("user", "user!url")
-    assert get("http://example.com/path4/path1") == (None, None)
+    assert get("http://example.com/path2/path3") == (
+        "http://example.com/path2/",
+        ("user", "user!url"),
+    )
+    assert get("http://example.com/path4/path1") == (
+        "http://example.com/",
+        (None, None),
+    )
 
 
 @pytest.mark.parametrize(
@@ -346,13 +362,22 @@ class KeyringModuleV2:
 @pytest.mark.parametrize(
     "url, expect",
     (
-        ("http://example.com/path1", ("username", "netloc")),
-        ("http://example.com/path2/path3", ("username", "url")),
-        ("http://user2@example.com/path2/path3", ("username", "url")),
+        (
+            "http://example.com/",
+            ("http://example.com/", ("username", "netloc")),
+        ),
+        (
+            "http://example.com/path2/path3",
+            ("http://example.com/path2/", ("username", "url")),
+        ),
+        (
+            "http://user2@example.com/path2/path3",
+            ("http://example.com/", ("user2", None)),
+        ),
     ),
 )
 def test_keyring_get_credential(
-    monkeypatch: pytest.MonkeyPatch, url: str, expect: Tuple[str, str]
+    monkeypatch: pytest.MonkeyPatch, url: str, expect: Tuple[str, Tuple[str, str]]
 ) -> None:
     monkeypatch.setitem(sys.modules, "keyring", KeyringModuleV2())
     auth = MultiDomainBasicAuth(
@@ -360,9 +385,7 @@ def test_keyring_get_credential(
         keyring_provider="import",
     )
 
-    assert (
-        auth._get_new_credentials(url, allow_netrc=False, allow_keyring=True) == expect
-    )
+    assert auth._get_new_credentials(url) == expect
 
 
 class KeyringModuleBroken:
@@ -387,9 +410,7 @@ def test_broken_keyring_disables_keyring(monkeypatch: pytest.MonkeyPatch) -> Non
     assert keyring_broken._call_count == 0
     for i in range(5):
         url = "http://example.com/path" + str(i)
-        assert auth._get_new_credentials(
-            url, allow_netrc=False, allow_keyring=True
-        ) == (None, None)
+        assert auth._get_new_credentials(url) == ("http://example.com/", (None, None))
         assert keyring_broken._call_count == 1
 
 
@@ -443,19 +464,28 @@ class KeyringSubprocessResult(KeyringModuleV1):
 @pytest.mark.parametrize(
     "url, expect",
     (
-        ("http://example.com/path1", (None, None)),
+        ("http://example.com/path1", ("http://example.com/", (None, None))),
         # path1 URLs will be resolved by netloc
-        ("http://user@example.com/path3", ("user", "user!netloc")),
-        ("http://user2@example.com/path3", ("user2", "user2!netloc")),
+        (
+            "http://user@example.com/path3/",
+            ("http://example.com/", ("user", "user!netloc")),
+        ),
+        (
+            "http://user2@example.com/path3",
+            ("http://example.com/", ("user2", "user2!netloc")),
+        ),
         # path2 URLs will be resolved by index URL
-        ("http://example.com/path2/path3", (None, None)),
-        ("http://foo@example.com/path2/path3", ("foo", "foo!url")),
+        ("http://example.com/path2/path3", ("http://example.com/", (None, None))),
+        (
+            "http://foo@example.com/path2/path3",
+            ("http://example.com/path2/", ("foo", "foo!url")),
+        ),
     ),
 )
 def test_keyring_cli_get_password(
     monkeypatch: pytest.MonkeyPatch,
     url: str,
-    expect: Tuple[Optional[str], Optional[str]],
+    expect: Tuple[str, Tuple[Optional[str], Optional[str]]],
 ) -> None:
     monkeypatch.setattr(pip._internal.network.auth.shutil, "which", lambda x: "keyring")
     monkeypatch.setattr(
@@ -466,7 +496,7 @@ def test_keyring_cli_get_password(
         keyring_provider="subprocess",
     )
 
-    actual = auth._get_new_credentials(url, allow_netrc=False, allow_keyring=True)
+    actual = auth._get_new_credentials(url)
     assert actual == expect
 
 

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -513,6 +513,16 @@ class TestGeneralOptions(AddFakeCommandMixin):
         assert options1.no_input
         assert options2.no_input
 
+    def test_keyring_provider(self) -> None:
+        # FakeCommand intentionally returns the wrong type.
+        options1, args1 = cast(
+            Tuple[Values, List[str]], main(["--keyring-provider", "import", "fake"])
+        )
+        options2, args2 = cast(
+            Tuple[Values, List[str]], main(["fake", "--keyring-provider", "import"])
+        )
+        assert options1.keyring_provider == options2.keyring_provider == "import"
+
     def test_proxy(self) -> None:
         # FakeCommand intentionally returns the wrong type.
         options1, args1 = cast(


### PR DESCRIPTION
This PR addresses the issue raised in #11721 and specifically the problems with Artifactory temporarily suspending users due to an initial request with an `Autentication` header being constructed with only the username provided in the (index-)url and without attempting to find a password in keyring. It supersedes #12473.

The problem stem from #6818 that solve #6796 requesting support for token in URL. The semantic of the [userinfo](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1) part of the URL is not well specified. We cannot distinguish the case of a token and a username without password only from the URL. A token can be identified as such only after searching for a password corresponding to what could be a username has failed. To avoid the potentially costly / blocking request to keyring, pip considered the userinfo without password to be a token and sends an authenticated requests to the server. If the server accepts this as a token, all is fine. Otherwise, as is the case with Artifactory, this is seen as a failed authentication attempt and subjected to throttling. That's what happens with Artifactory (which can be seen as being overly protective) that temporarily suspend the user named in the `Authentication` header for 1s (initially). While short, this is still enough to block the second attempt made while handling the 401 during which pip would have found a complete set of credentials.

This PR is based on the reasoning that only the server actually knows whether authentication is required or not and as such pip should first attempt to access the resource without any `Authentication` header. This obviously prevent the server from temporarily suspending the user because it no longer have enough information to identify the relevant user.

If the server requires authentication, it will let us know by returning a 401 Unauthorized response with a `WWW-Authenticate` header which is meant to tell us what kind of [challenge](https://datatracker.ietf.org/doc/html/rfc9110#name-challenge-and-response) to use. The code is not changed with respect to the challenge supported and still assumes blindly that the server want us to use [Basic](https://datatracker.ietf.org/doc/html/rfc7617#section-2) authentication. (The proposed code could be extended to store the kind of authentication challenge to use alongside the credentials. As I've still to see a server advertising something other than Basic, I've considered this out of scope.)

Once we know that credentials are actually required, attempts are made to obtain them from (in order):
- the resource URL
- the closest index-url
- the `keyring` if available (depends on `--keyring-provider` and `--no-input`)
- `netrc`

The credentials are then cached in order to be reused for subsequent requests to the server.

Things to note compared to the current implementation:
- `netrc` is now the last resort because it is the least specific. Keyring allows to store credentials per service, which can be an URL but `netrc` only support `netloc`. Of course, the difference only matters when configuring credentials in both `keyring` and `netrc`.
- Credentials are no longer cached per `netloc` with some logic to check the usernames are the same. Instead the caching is per url-prefix which allows for multiple entries for the same `netloc` but with different common path. As such, caching will work for server hosting multiple indexes with different user per path unlike the current implementation.
- Unlike the current implementation where having both username and password set in the (index-)url leads to a first request being successfully authenticated, we will now get a 401 and then cache the credentials and retry. Subsequent requests will hit the cache as before.

The PR consist of:
- 3 boyscout commits addressing minor unrelated issues encountered along the way.
- the credentials lookup logic is updated as described above.
- the existing tests are first adapted to the changed signature of `_get_new_credentials` and `_get_index_url` which now return the url_prefix to use for caching the credentials too
- the tests for the now removed `_get_url_and_credentials` are removed too
- new tests are added for the new `_cache_required_credentials` and `_get_required_credentials`
- finally the authentication topic of the documentation is updated to give more details about how pip and keyring work together