### PR TITLE
Prefer direct conflicting causes when backtracking

### DIFF
--- a/news/12459.feature.rst
+++ b/news/12459.feature.rst
@@ -1,0 +1,1 @@
+When there are complex conflicting requirements use much faster backtracking choices

--- a/src/pip/_vendor/resolvelib/providers.py
+++ b/src/pip/_vendor/resolvelib/providers.py
@@ -131,3 +131,55 @@ class AbstractResolver(object):
         :raises: ``self.base_exception`` or its subclass.
         """
         raise NotImplementedError
+
+    def narrow_requirement_selection(
+        self, identifiers, resolutions, candidates, information, backtrack_causes
+    ):
+        """
+        Narrows the selection of requirements being considered during
+        resolution.
+
+        The requirement selection is defined as "The possible requirements
+        that will be resolved next." If a requirement isn't part of the returned
+        iterable, it will not be considered during the next step of resolution.
+
+        :param identifiers: An iterable of `identifier` as returned by
+            ``identify()``. These identify all requirements currently being
+            considered.
+        :param resolutions: Mapping of candidates currently pinned by the
+            resolver. Each key is an identifier, and the value is a candidate.
+            The candidate may conflict with requirements from ``information``.
+        :param candidates: Mapping of each dependency's possible candidates.
+            Each value is an iterator of candidates.
+        :param information: Mapping of requirement information of each package.
+            Each value is an iterator of *requirement information*.
+        :param backtrack_causes: Sequence of *requirement information* that are
+            the requirements that caused the resolver to most recently
+            backtrack.
+
+        A *requirement information* instance is a named tuple with two members:
+
+        * ``requirement`` specifies a requirement contributing to the current
+          list of candidates.
+        * ``parent`` specifies the candidate that provides (depended on) the
+          requirement, or ``None`` to indicate a root requirement.
+
+        Must return a non-empty subset of `identifiers`, with the simplest
+        implementation being to return `identifiers` unchanged.
+
+        Can be used by the provider to optimize the dependency resolution
+        process. `get_preference` will only be called on the identifiers
+        returned. If there is only one identifier returned, then `get_preference`
+        won't be called at all.
+
+        Serving a similar purpose as `get_preference`, this method allows the
+        provider to guide resolvelib through the resolution process. It should
+        be used instead of `get_preference` when the provider needs to consider
+        multiple identifiers simultaneously, or when the provider wants to skip
+        checking all identifiers, e.g., because the checks are prohibitively
+        expensive.
+
+        Returns:
+            Iterable[KT]: A non-empty subset of `identifiers`.
+        """
+        return identifiers

--- a/src/pip/_vendor/resolvelib/resolvers.py
+++ b/src/pip/_vendor/resolvelib/resolvers.py
@@ -378,6 +378,12 @@ class Resolution(object):
         # No way to backtrack anymore.
         return False
 
+    def _extract_causes(self, criteron):
+        """Extract causes from list of criterion and deduplicate"""
+        return list(
+            {id(i): i for c in criteron for i in c.information}.values()
+        )
+
     def resolve(self, requirements, max_rounds):
         if self._states:
             raise RuntimeError("already resolved")
@@ -422,12 +428,38 @@ class Resolution(object):
                 unsatisfied_names
             )
 
-            # Choose the most preferred unpinned criterion to try.
-            name = min(unsatisfied_names, key=self._get_preference)
-            failure_causes = self._attempt_to_pin_criterion(name)
+            if len(unsatisfied_names) > 1:
+                narrowed_unstatisfied_names = list(
+                    self._p.narrow_requirement_selection(
+                        identifiers=unsatisfied_names,
+                        resolutions=self.state.mapping,
+                        candidates=IteratorMapping(
+                            self.state.criteria,
+                            operator.attrgetter("candidates"),
+                        ),
+                        information=IteratorMapping(
+                            self.state.criteria,
+                            operator.attrgetter("information"),
+                        ),
+                        backtrack_causes=self.state.backtrack_causes,
+                    )
+                )
+            else:
+                narrowed_unstatisfied_names = unsatisfied_names
 
-            if failure_causes:
-                causes = [i for c in failure_causes for i in c.information]
+            # If there is only 1 unsatisfied name skip calling self._get_preference
+            if len(narrowed_unstatisfied_names) > 1:
+                # Choose the most preferred unpinned criterion to try.
+                name = min(
+                    narrowed_unstatisfied_names, key=self._get_preference
+                )
+            else:
+                name = narrowed_unstatisfied_names[0]
+
+            failure_criterion = self._attempt_to_pin_criterion(name)
+
+            if failure_criterion:
+                causes = self._extract_causes(failure_criterion)
                 # Backjump if pinning fails. The backjump process puts us in
                 # an unpinned state, so we can work on it in the next round.
                 self._r.resolving_conflicts(causes=causes)


### PR DESCRIPTION
Fixes: https://github.com/pypa/pip/issues/12498

This PR introduces enhancements to Pip's dependency resolution logic. Below is a description of the three main functions implemented in this PR:

* `_causes_with_conflicting_parent`
   - This function identifies causes of conflict where a cause's parent requirement conflicts with another cause, or is not satisfied by them. It helps pinpoint critical conflicts, allowing the resolver to focus on significant barriers in the dependency graph.

*  `_first_causes_with_no_candidates`
   - This function finds at least one pair of causes whose combined specifiers have no possible candidates. It groups causes by name to minimize comparisons, then evaluates if combined specifiers lead to a scenario where no candidates are available. Due to the complexity of statically evaluating Python packaging specifiers, this function dynamically tests the combined specifier against potential candidates. Since this evaluation can be resource-intensive, the function exits early as soon as one incompatible pair is found.

* `narrow_requirement_selection`
   - This method filters all potential causes to unsatisfied names that are direct conflicts identified by the new functions. Implementing this logic via `get_preferences` would lead to an adverse performance impact, introducing expensive new calls and potentially creating O(n^2) situations.

