### PR TITLE
Add documentation on pip's role as an installer

### DIFF
--- a/docs/html/topics/index.md
+++ b/docs/html/topics/index.md
@@ -21,4 +21,5 @@ repeatable-installs
 secure-installs
 vcs-support
 python-option
+workflow
 ```

--- a/docs/html/topics/workflow.md
+++ b/docs/html/topics/workflow.md
@@ -1,4 +1,4 @@
-# Pip is not a workflow tool
+# Pip is not a workflow management tool
 
 The core purpose of pip is to *install packages*. Whilst installing packages is
 an important part of most Python development workflows, it is only one part.

--- a/docs/html/topics/workflow.md
+++ b/docs/html/topics/workflow.md
@@ -1,0 +1,21 @@
+# Pip is not a workflow tool
+
+The core purpose of pip is to *install packages*. Whilst installing packages is
+an important part of most Python development workflows, it is only one part.
+Managing a development workflow is, in itself, a complex task and one where
+there are many views on the "correct approach".
+
+Pip has a number of features which make it useful in development workflows - for
+example, the ability to install the current project via `pip install .`,
+editable installs, and requirements files. However, there is no intention that
+pip will manage the workflow as a whole.
+
+## The role of `ensurepip`
+
+Pip is available in a standard Python installation, via the `ensurepip` stdlib
+module. This provides users with an "out of the box" installer, which can be
+used to gain access to all of the various tools and libraries available on PyPI.
+In particular, this includes a number of workflow tools.
+
+This "bootstrapping" mechanism was proposed (and accepted) in [PEP
+453](https://www.python.org/dev/peps/pep-0453/).

--- a/docs/html/topics/workflow.md
+++ b/docs/html/topics/workflow.md
@@ -1,21 +1,40 @@
 # Pip is not a workflow management tool
 
-The core purpose of pip is to *install packages*. Whilst installing packages is
-an important part of most Python development workflows, it is only one part.
-Managing a development workflow is, in itself, a complex task and one where
-there are many views on the "correct approach".
+The core purpose of pip is to *manage the packages installed in your
+environment*. Whilst package management is an important part of most Python
+development workflows, it is only one part. Tasks like creating and managing
+environments, configuring and running development tasks, managing the Python
+interpreter itself, and managing the overall "project", are not part of pip's
+scope. Managing a development workflow as a whole is a complex task and one
+where there are many views on the "correct approach".
 
 Pip has a number of features which make it useful in development workflows - for
 example, the ability to install the current project via `pip install .`,
 editable installs, and requirements files. However, there is no intention that
 pip will manage the workflow as a whole.
 
+As an example, pip provides the `pip wheel` command, which can be used to build
+a wheel for your project. However, there is no corresponding command to build a
+source distribution. This is because building a wheel is a fundamental step in
+installing a package (if that package is only available as source code), whereas
+building a source distribution is never needed when installing. Users who need a
+tool to build their project should use a dedicated tool like `build`, which
+provides commands to build wheels and source distributions.
+
+
 ## The role of `ensurepip`
 
 Pip is available in a standard Python installation, via the `ensurepip` stdlib
 module. This provides users with an "out of the box" installer, which can be
 used to gain access to all of the various tools and libraries available on PyPI.
-In particular, this includes a number of workflow tools.
+In particular, this enables the installation of a number of workflow tools.
 
 This "bootstrapping" mechanism was proposed (and accepted) in [PEP
 453](https://www.python.org/dev/peps/pep-0453/).
+
+
+## Further information
+
+The [Packaging User Guide](https://packaging.python.org) discusses Python
+project development, and includes tool recommendations for people looking for
+further information on how to manage their development workflow.


### PR DESCRIPTION
Posting a very initial draft here for comments. This was prompted by [this comment on discourse](https://discuss.python.org/t/why-doesnt-pip-write-installed-packages-to-pyproject-toml/43657/70), which suggests that it would be useful to have somewhere that explains the logic behind not including workflow capabilities in pip.

In order to avoid an extended debate over pip's long-term role (which we might need to have, but I don't think here is the place) I'm taking the view that this PR is documenting the *current* situation. If at some future date we decide that pip *should* become a workflow tool, competing with the likes of hatch, PDM and poetry, then we can revisit and modify this document. But for the moment, having something that explains the current state of affairs is IMO useful.

I've kept this relatively short. I think the basic points are fairly easy to cover, and I don't think it helps to spend a lot of text trying to justify our position - it simply invites arguments which typically end up going nowhere. But if people feel otherwise, I can expand this to cover *why* adding things like environment management and locking would be a significant scope change that we can't currently sustain[^1].

[^1]: Sneak preview there of the arguments I'd make 😉