### PR TITLE
Update ruff config to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.9
+  rev: v0.2.0
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/news/12510.trivial.rst
+++ b/news/12510.trivial.rst
@@ -1,0 +1,1 @@
+Update ruff to 0.2.0 and update ruff config to reflect

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,7 @@ import nox
 
 # fmt: off
 sys.path.append(".")
-from tools import release  # isort:skip  # noqa
+from tools import release  # isort:skip
 sys.path.pop()
 # fmt: on
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ distlib = "https://bitbucket.org/pypa/distlib/raw/master/LICENSE.txt"
 webencodings = "https://github.com/SimonSapin/python-webencodings/raw/master/LICENSE"
 
 [tool.ruff]
+src = ["src"]
 target-version = "py37"
 line-length = 88
 extend-exclude = [
@@ -173,9 +174,8 @@ select = [
 ]
 
 [tool.ruff.lint.isort]
-# We need to explicitly make pip "first party" as it's imported by code in
-# the docs and tests directories.
-known-first-party = ["pip"]
+# Explicitly make tests "first party" as it's not in the "src" directory
+known-first-party = ["tests"]
 known-third-party = ["pip._vendor"]
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,20 +138,22 @@ distlib = "https://bitbucket.org/pypa/distlib/raw/master/LICENSE.txt"
 webencodings = "https://github.com/SimonSapin/python-webencodings/raw/master/LICENSE"
 
 [tool.ruff]
+target-version = "py37"
+line-length = 88
 extend-exclude = [
     "_vendor",
     "./build",
     ".scratch",
     "data",
 ]
+
+[tool.ruff.lint]
 ignore = [
     "B019",
     "B020",
     "B904", # Ruff enables opinionated warnings by default
     "B905", # Ruff enables opinionated warnings by default
 ]
-target-version = "py37"
-line-length = 88
 select = [
     "ASYNC",
     "B",
@@ -170,22 +172,22 @@ select = [
     "UP032",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 # We need to explicitly make pip "first party" as it's imported by code in
 # the docs and tests directories.
 known-first-party = ["pip"]
 known-third-party = ["pip._vendor"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 33  # default is 10
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "noxfile.py" = ["G"]
 "src/pip/_internal/*" = ["PERF203"]
 "tests/*" = ["B011"]
 "tests/unit/test_finder.py" = ["C414"]
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-args = 15  # default is 5
 max-branches = 28  # default is 12
 max-returns = 13  # default is 6


### PR DESCRIPTION
This PR updates ruff in CI pipeline to 0.2.0 and provides a few fixes:

1. Moves linting config options from "tool.ruff" to "tool.ruff.lint" (linting options are now depricated in the top level ruff config)
2. Fixes 1 new error that ruff 0.2.0 raises
3. Specifies the source directory as "src" (ruff defaults to "." which is not true for Pip)