### PR TITLE
Remove setup.py

### DIFF
--- a/docs/html/development/architecture/anatomy.rst
+++ b/docs/html/development/architecture/anatomy.rst
@@ -14,7 +14,7 @@ Repository anatomy & directory structure
 Root and tools
 ==============
 
-The ``README``, license, ``pyproject.toml``, ``setup.py``, and so on are in the top level.
+The ``README``, license, ``pyproject.toml``, and so on are in the top level.
 
 * ``AUTHORS.txt``
 * ``LICENSE.txt``
@@ -22,8 +22,6 @@ The ``README``, license, ``pyproject.toml``, ``setup.py``, and so on are in the 
 * ``NEWS.rst``
 * ``pyproject.toml``
 * ``README.rst``
-* ``setup.cfg``
-* ``setup.py``
 * ``noxfile.py`` -- ``pip`` uses Nox, an automation tool, configured by this file. ``noxfile.py`` describes a few environments ``pip`` uses during development for simplifying how tests are run (complicated situation there). Example: ``nox -s lint``, ``nox -s test-3.10``. We can run tests for different versions of Python by changing “3.10” to “3.7” or similar.
 * ``.gitattributes``
 * ``.gitignore``

--- a/news/12537.process.rst
+++ b/news/12537.process.rst
@@ -1,0 +1,2 @@
+Remove ``setup.py`` since all the pip project metadata is now declared in
+``pyproject.toml``.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
Our `setup.py` is now empty, and all the configuration has moved to `pyproject.toml`, so I guess it's fine to remove it?