### PR TITLE
Towncrier: move process section to the end

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,12 +85,12 @@ template = "tools/news/template.rst"
 
 # Grouping of entries, within our changelog
 type = [
-  { name = "Process",                   directory = "process", showcontent = true },
   { name = "Deprecations and Removals", directory = "removal", showcontent = true },
   { name = "Features",                  directory = "feature", showcontent = true },
   { name = "Bug Fixes",                 directory = "bugfix",  showcontent = true },
   { name = "Vendored Libraries",        directory = "vendor",  showcontent = true },
   { name = "Improved Documentation",    directory = "doc",     showcontent = true },
+  { name = "Process",                   directory = "process", showcontent = true },
   { name = "Trivial Changes",           directory = "trivial", showcontent = false },
 ]
 


### PR DESCRIPTION
When doing the releases was surprised to see the process subsection at the beginning of NEWS sections.

My reasoning is that it matters less than the others to end users, so I propose to move it to the end.
