### PR TITLE
Use `build` to create `pip` sdist for testing

### DIFF
--- a/news/12545.trivial.rst
+++ b/news/12545.trivial.rst
@@ -1,0 +1,4 @@
+This change will use ``build`` to create the ``pip`` sdist for testing.
+
+It will also remove a direct ``setup.py`` invocation to install ``pip`` in
+editable mode to run from tests.

--- a/noxfile.py
+++ b/noxfile.py
@@ -89,9 +89,9 @@ def test(session: nox.Session) -> None:
         shutil.rmtree(sdist_dir, ignore_errors=True)
 
     # fmt: off
-    session.install("setuptools")
+    session.install("build")
     session.run(
-        "python", "setup.py", "sdist", "--formats=zip", "--dist-dir", sdist_dir,
+        "python", "-m", "build", "--sdist", "--outdir", sdist_dir,
         silent=True,
     )
     # fmt: on

--- a/noxfile.py
+++ b/noxfile.py
@@ -91,7 +91,7 @@ def test(session: nox.Session) -> None:
     # fmt: off
     session.install("build")
     session.run(
-        "python", "-m", "build", "--sdist", "--outdir", sdist_dir,
+        "python", "-I", "-m", "build", "--sdist", "--outdir", sdist_dir,
         silent=True,
     )
     # fmt: on

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import http.server
 import os
 import re
 import shutil
-import subprocess
 import sys
 import threading
 from dataclasses import dataclass
@@ -454,15 +453,14 @@ def virtualenv_template(
     install_pth_link(venv, "wheel", wheel_install)
     pip_editable = tmpdir_factory.mktemp("pip") / "pip"
     shutil.copytree(pip_src, pip_editable, symlinks=True)
+
     # noxfile.py is Python 3 only
     assert compileall.compile_dir(
         str(pip_editable),
         quiet=1,
         rx=re.compile("noxfile.py$"),
     )
-    subprocess.check_call(
-        [os.fspath(venv.bin / "python"), "setup.py", "-q", "develop"], cwd=pip_editable
-    )
+    install_pth_link(venv, "pip", pip_editable / "src")
 
     # Install coverage and pth file for executing it in any spawned processes
     # in this virtual environment.


### PR DESCRIPTION
Also replace a direct `setup.py` invocation in `conftest.py`.
I was not sure whether I should pin `build`, since `setuptools` was not.
