### PR TITLE
Fix Ubuntu CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,9 @@ jobs:
 
       - name: Install Ubuntu dependencies
         if: matrix.os == 'Ubuntu'
-        run: sudo apt-get install bzr
+        run: |
+          sudo apt-get update
+          sudo apt-get install bzr
 
       - name: Install MacOS dependencies
         if: matrix.os == 'MacOS'
@@ -224,7 +226,9 @@ jobs:
           python-version: "3.10"
 
       - name: Install Ubuntu dependencies
-        run: sudo apt-get install bzr
+        run: |
+          sudo apt-get update
+          sudo apt-get install bzr
 
       - run: pip install nox 'virtualenv<20' 'setuptools != 60.6.0'
 

--- a/news/12559.trivial.rst
+++ b/news/12559.trivial.rst
@@ -1,0 +1,1 @@
+Fix Ubuntu CI Tests


### PR DESCRIPTION
According to the docs (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners) you should run `sudo apt-get update` before installing any software on the ubuntu runners to prevent package installation failures.

I think this is the issue causing this failure: https://github.com/pypa/pip/actions/runs/8196242959/job/22416085986