### PR TITLE
Remove unneeded installs from zipapp ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install bzr
 
-      - run: pip install nox 'virtualenv<20' 'setuptools != 60.6.0'
+      - run: pip install nox
 
       # Main check
       - name: Run integration tests

--- a/news/12561.trivial.rst
+++ b/news/12561.trivial.rst
@@ -1,0 +1,1 @@
+Remove virtualenv and setuptools installs from zipapp CI tests


### PR DESCRIPTION
I was going through pip's tests, and found in the CI scripts it was weird that one test runner needs both setuptools and virtualenv (and a very old one) where as all the others seem to rely on nox to build the test suite.

It seems to have come from this PR https://github.com/pypa/pip/pull/11250 when that was standard for all test runners. 

If either of these dependencies are needed it would be nice to remove the upperbound on virtualenv. I found a lot of old discussion about it that seemed to relate to supporting Python 2. But I guess it was resolved as other test runners don't specify it.