### PR TITLE
Update Windows CI tests to run on Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,12 @@ jobs:
         os: [Windows]
         python:
           - "3.8"
-          # Commented out, since Windows tests are expensively slow.
+          # Commented out, since Windows tests are expensively slow,
+          # only test the oldest and newest Python supported by pip
           # - "3.9"
           # - "3.10"
-          - "3.11"
+          # - "3.11"
+          - "3.12"
         group: [1, 2]
 
     steps:

--- a/news/12562.trivial.rst
+++ b/news/12562.trivial.rst
@@ -1,0 +1,1 @@
+Update CI tests for Windows to run on Python 3.12

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -238,7 +238,6 @@ def test_uninstall_overlapping_package(
     "console_scripts",
     [
         "test_ = distutils_install:test",
-        "test_:test_ = distutils_install:test_test",
         ",test_ = distutils_install:test_test",
         ", = distutils_install:test_test",
     ],


### PR DESCRIPTION
My understanding is that Windows tests are slow, so the compromise is to run the tests on the newest and oldest versions that pip supports.

It seems the Windows tests were never updated to Python 3.12, this update that and adds a comment justifying this so when new versions of Python are added and removed from the CI hopefully the updater will notice this and update Windows as well.