### PR TITLE
list: disable pip version self check unless given --outdated/--uptodate

### DIFF
--- a/news/11677.feature.rst
+++ b/news/11677.feature.rst
@@ -1,0 +1,1 @@
+``pip list`` no longer performs the pip version check unless ``--outdated`` or ``--uptodate`` is given.

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -161,6 +161,10 @@ class IndexGroupCommand(Command, SessionCommandMixin):
     This also corresponds to the commands that permit the pip version check.
     """
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.allow_pip_version_check = True
+
     def handle_pip_version_check(self, options: Values) -> None:
         """
         Do the pip version check if not disabled.
@@ -170,7 +174,11 @@ class IndexGroupCommand(Command, SessionCommandMixin):
         # Make sure the index_group options are present.
         assert hasattr(options, "no_index")
 
-        if options.disable_pip_version_check or options.no_index:
+        if (
+            options.disable_pip_version_check
+            or options.no_index
+            or not self.allow_pip_version_check
+        ):
             return
 
         # Otherwise, check if we're using the latest version of pip available.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -155,6 +155,7 @@ class ListCommand(IndexGroupCommand):
         )
 
     def run(self, options: Values, args: List[str]) -> int:
+        self.allow_pip_version_check = options.outdated or options.uptodate
         if options.outdated and options.uptodate:
             raise CommandError("Options --outdated and --uptodate cannot be combined.")
 


### PR DESCRIPTION
Resolves #11677.

Not sure how to write a test for this, suggestions are welcome...