### PR TITLE
show: populate missing home-page from project-urls if possible

### DIFF
--- a/news/11221.feature.rst
+++ b/news/11221.feature.rst
@@ -1,0 +1,4 @@
+Fallback to displaying "Home-page" Project-URL when the Home-Page metadata field is not set in ``pip show``.
+
+The Project-URL fallback is case-insensitive and ignores any dashes or
+underscores that may be present.

--- a/news/11221.feature.rst
+++ b/news/11221.feature.rst
@@ -1,4 +1,3 @@
-Fallback to displaying "Home-page" Project-URL when the Home-Page metadata field is not set in ``pip show``.
+Display the Project-URL value under key "Home-page" in ``pip show`` when the Home-Page metadata field is not set.
 
-The Project-URL fallback is case-insensitive and ignores any dashes or
-underscores that may be present.
+The Project-URL key detection is case-insensitive, and ignores any dashes and underscores.


### PR DESCRIPTION
Resolves #11221.

Logic taken from warehouse: https://github.com/pypi/warehouse/blob/39daea188d2e1e6494c50753cd48cb5a8da3e8c4/warehouse/packaging/models.py#L537-L558