### PR TITLE
Remove PyPI package direct URL dependency check

### DIFF
--- a/news/a457e1c0-068a-449b-9496-982087f308f0.trivial.rst
+++ b/news/a457e1c0-068a-449b-9496-982087f308f0.trivial.rst
@@ -1,0 +1,3 @@
+Stop raising an InstallationError when a direct URL requirement comes from a
+PyPI package. The check is redundant as PyPI has been rejecting uploads of
+packages which depend on external packages for at least the past 8 years.

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -19,7 +19,6 @@ from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
 from pip._vendor.packaging.specifiers import Specifier
 
 from pip._internal.exceptions import InstallationError
-from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.req.req_file import ParsedRequirement
@@ -447,23 +446,6 @@ def install_req_from_req_string(
         req = get_requirement(req_string)
     except InvalidRequirement:
         raise InstallationError(f"Invalid requirement: '{req_string}'")
-
-    domains_not_allowed = [
-        PyPI.file_storage_domain,
-        TestPyPI.file_storage_domain,
-    ]
-    if (
-        req.url
-        and comes_from
-        and comes_from.link
-        and comes_from.link.netloc in domains_not_allowed
-    ):
-        # Explicitly disallow pypi packages that depend on external urls
-        raise InstallationError(
-            "Packages installed from PyPI cannot depend on packages "
-            "which are not also hosted on PyPI.\n"
-            f"{comes_from.name} depends on {req} "
-        )
 
     return InstallRequirement(
         req,

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -12,7 +12,6 @@ from typing import Dict, Iterable, List, Optional, Tuple
 import pytest
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.utils.misc import rmtree
 from pip._internal.utils.urls import path_to_url
 from tests.lib import (
@@ -1998,31 +1997,6 @@ def test_install_pep508_with_url_in_install_requires(
     )
     res = script.pip("install", pkga_path)
     assert "Successfully installed packaging-15.3" in str(res), str(res)
-
-
-@pytest.mark.network
-@pytest.mark.parametrize("index", (PyPI.simple_url, TestPyPI.simple_url))
-def test_install_from_test_pypi_with_ext_url_dep_is_blocked(
-    script: PipTestEnvironment, index: str
-) -> None:
-    res = script.pip(
-        "install",
-        "--index-url",
-        index,
-        "pep-508-url-deps",
-        expect_error=True,
-    )
-    error_message = (
-        "Packages installed from PyPI cannot depend on packages "
-        "which are not also hosted on PyPI."
-    )
-    error_cause = (
-        "pep-508-url-deps depends on sampleproject@ "
-        "https://github.com/pypa/sampleproject/archive/master.zip"
-    )
-    assert res.returncode == 1
-    assert error_message in res.stderr, str(res)
-    assert error_cause in res.stderr, str(res)
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
This check was added as a stopgap measure when PyPI did not reject packages that depended on external URLs. This is no longer the case: https://github.com/pypi/warehouse/blame/dc1d9543ac4db87f1d0ba4d6e627f92eb0b1fde2/warehouse/forklift/legacy.py#L282.

![image](https://github.com/pypa/pip/assets/63936253/6c03b36c-2a2f-47d0-8b7b-b22e50f9e7ad)

TBH, I'm fairly certain that `install_req_from_req_string` isn't needed anymore, but a surprising amount of code depends on it. I wasn't able to remove the function and end up with a patch I was happy with. 