### PR TITLE
Pass -vv to pip install build env subprocess

### DIFF
--- a/news/12577.bugfix.rst
+++ b/news/12577.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure ``-vv`` gets passed to any ``pip install`` build environment subprocesses.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -19,6 +19,7 @@ from pip import __file__ as pip_location
 from pip._internal.cli.spinners import open_spinner
 from pip._internal.locations import get_platlib, get_purelib, get_scheme
 from pip._internal.metadata import get_default_environment, get_environment
+from pip._internal.utils.logging import VERBOSE
 from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 
@@ -242,6 +243,8 @@ class BuildEnvironment:
             "--no-warn-script-location",
         ]
         if logger.getEffectiveLevel() <= logging.DEBUG:
+            args.append("-vv")
+        elif logger.getEffectiveLevel() <= VERBOSE:
             args.append("-v")
         for format_control in ("no_binary", "only_binary"):
             formats = getattr(finder.format_control, format_control)


### PR DESCRIPTION
Fixes #12577

This looks like it was an oversight in #9450 - we should pass the correct verbosity level to build env install subprocesses.

Tested with:

```
rm -rf ~/.cache/pip && rm -f *.whl && pip wheel --no-binary :all: hatchling
```

and all three verbosity levels, before and after this change, giving the following logs:

```
     33 patched-verbosity0.log
   2549 patched-verbosity1.log
  11938 patched-verbosity2.log
     33 unpatched-verbosity0.log
     99 unpatched-verbosity1.log
   1030 unpatched-verbosity2.log
```

i.e. currently a lot of useful logs are being dropped from these install subprocesess even with -vvv

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
