### PR TITLE
Remove duplication from invalid wheel error message

### DIFF
--- a/news/12579.bugfix.rst
+++ b/news/12579.bugfix.rst
@@ -1,0 +1,1 @@
+Remove duplication in invalid wheel error message

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -133,8 +133,6 @@ class Distribution(BaseDistribution):
                 dist = WheelDistribution.from_zipfile(zf, name, wheel.location)
         except zipfile.BadZipFile as e:
             raise InvalidWheel(wheel.location, name) from e
-        except UnsupportedWheel as e:
-            raise UnsupportedWheel(f"{name} has an invalid wheel, {e}")
         return cls(dist, dist.info_location, pathlib.PurePosixPath(wheel.location))
 
     @property

--- a/src/pip/_internal/utils/wheel.py
+++ b/src/pip/_internal/utils/wheel.py
@@ -28,7 +28,7 @@ def parse_wheel(wheel_zip: ZipFile, name: str) -> Tuple[str, Message]:
         metadata = wheel_metadata(wheel_zip, info_dir)
         version = wheel_version(metadata)
     except UnsupportedWheel as e:
-        raise UnsupportedWheel(f"{name} has an invalid wheel, {str(e)}")
+        raise UnsupportedWheel(f"{name} has an invalid wheel, {e}")
 
     check_compatibility(version, name)
 


### PR DESCRIPTION
Reproducer:

```
$ pip install 'dateutil @ file:///tmp/python_dateutil-2.9.0.post0-py2.py3-none-any.whl'
Processing /tmp/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
ERROR: dateutil has an invalid wheel, dateutil has an invalid wheel, .dist-info directory 'python_dateutil-2.9.0.post0.dist-info' does not start with 'dateutil'
```

It says twice in the error message: "_dateutil has an invalid wheel, dateutil has an invalid wheel, ..._"