### PR TITLE
DOC: Clarify lack of index priority

### DIFF
--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -212,11 +212,12 @@ and `there <https://www.python.org/dev/peps/pep-0503/>`_.
 pip offers a number of package index options for modifying how packages are
 found.
 
-pip looks for packages in a number of places: on PyPI (if not disabled via
-``--no-index``), in the local filesystem, and in any additional repositories
-specified via ``--find-links`` or ``--index-url``. There is no ordering in
-the locations that are searched. Rather they are all checked, and the "best"
-match for the requirements (in terms of version number - see the
+pip looks for packages in a number of places: on PyPI (or the index given as
+``--index-url``, if not disabled via ``--no-index``), in the local filesystem,
+and in any additional repositories specified via ``--find-links`` or
+``--extra-index-url``. There is no priority in the locations that are searched.
+Rather they are all checked, and the "best" match for the requirements (in
+terms of version number - see the
 :ref:`specification <pypug:version-specifiers>` for details) is selected.
 
 See the :ref:`pip install Examples<pip install Examples>`.


### PR DESCRIPTION
* Specifically mention that --index-url and --extra-index-url both provide locations for pip to look for packages in the 'Finding Packages' section. However, explicitly state that there is no priority ordering for the search locations.
   - Text adapted from https://github.com/pypa/packaging-problems/issues/736#issuecomment-2013499245
* This is a recurring point of confusion on the pip GitHub issue tracker as well as on https://github.com/pypa/packaging-problems/issues/, so additional clarification could help here.

## Related Issues

* https://github.com/pypa/packaging-problems/issues/736
* https://github.com/scientific-python/upload-nightly-action/issues/76


<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
