### PR TITLE
Fix pip debug error in Python 3.13

### DIFF
--- a/news/12590.bugfix.rst
+++ b/news/12590.bugfix.rst
@@ -1,0 +1,1 @@
+This change fixes ``AttributeError`` while running ``pip debug`` since Python 3.13.

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -35,7 +35,7 @@ def show_sys_implementation() -> None:
 
 
 def create_vendor_txt_map() -> Dict[str, str]:
-    with importlib.resources.open_text("pip._vendor", "vendor.txt") as f:
+    with importlib.resources.files("pip._vendor").joinpath("vendor.txt").open("r") as f:
         # Purge non version specifying lines.
         # Also, remove any space prefix or suffixes (including comments).
         lines = [

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -5,7 +5,7 @@ import os
 import sys
 from optparse import Values
 from types import ModuleType
-from typing import Any, Dict, List, Optional
+from typing import IO, Any, Dict, List, Optional
 
 import pip._vendor
 from pip._vendor.certifi import where
@@ -34,8 +34,19 @@ def show_sys_implementation() -> None:
         show_value("name", implementation_name)
 
 
+if sys.version_info < (3, 9):
+    # Python 3.8 compatibility
+    def _open_text(package: str, resource: str) -> IO[str]:
+        return importlib.resources.open_text(package, resource)
+
+else:
+
+    def _open_text(package: str, resource: str) -> IO[str]:
+        return importlib.resources.files(package).joinpath(resource).open("r")
+
+
 def create_vendor_txt_map() -> Dict[str, str]:
-    with importlib.resources.files("pip._vendor").joinpath("vendor.txt").open("r") as f:
+    with _open_text("pip._vendor", "vendor.txt") as f:
         # Purge non version specifying lines.
         # Also, remove any space prefix or suffixes (including comments).
         lines = [


### PR DESCRIPTION
Closes: #12590

Replaced Python>3.8:
`importlib.resources.open_text(package, resource)`

with:
`files(package).joinpath(resource).open('r')`

Ref:
https://docs.python.org/3.12/library/importlib.resources.html#importlib.resources.open_text