### PR TITLE
Update black to 24.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 23.12.1
+  rev: 24.4.0
   hooks:
   - id: black
 

--- a/news/12594.trivial.rst
+++ b/news/12594.trivial.rst
@@ -1,0 +1,1 @@
+Update Black pre-commit to 24.4.0

--- a/src/pip/_internal/__init__.py
+++ b/src/pip/_internal/__init__.py
@@ -7,7 +7,7 @@ from pip._internal.utils import _log
 _log.init_logging()
 
 
-def main(args: (Optional[List[str]]) = None) -> int:
+def main(args: Optional[List[str]] = None) -> int:
     """This is preserved for old console scripts that may still be referencing
     it.
 

--- a/src/pip/_internal/cli/main.py
+++ b/src/pip/_internal/cli/main.py
@@ -1,5 +1,6 @@
 """Primary application entrypoint.
 """
+
 import locale
 import logging
 import os

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -66,7 +66,6 @@ def _create_truststore_ssl_context() -> Optional["SSLContext"]:
 
 
 class SessionCommandMixin(CommandContextMixIn):
-
     """
     A class mixin for command classes needing _build_session().
     """
@@ -155,7 +154,6 @@ class SessionCommandMixin(CommandContextMixIn):
 
 
 class IndexGroupCommand(Command, SessionCommandMixin):
-
     """
     Abstract base class for commands with the index_group options.
 
@@ -442,9 +440,11 @@ class RequirementCommand(IndexGroupCommand):
                     isolated=options.isolated_mode,
                     use_pep517=options.use_pep517,
                     user_supplied=True,
-                    config_settings=parsed_req.options.get("config_settings")
-                    if parsed_req.options
-                    else None,
+                    config_settings=(
+                        parsed_req.options.get("config_settings")
+                        if parsed_req.options
+                        else None
+                    ),
                 )
                 requirements.append(req_to_add)
 

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -196,8 +196,7 @@ class CacheablePageContent:
 
 
 class ParseLinks(Protocol):
-    def __call__(self, page: "IndexContent") -> Iterable[Link]:
-        ...
+    def __call__(self, page: "IndexContent") -> Iterable[Link]: ...
 
 
 def with_cached_index_content(fn: ParseLinks) -> ParseLinks:
@@ -395,7 +394,6 @@ class CollectedSources(NamedTuple):
 
 
 class LinkCollector:
-
     """
     Responsible for collecting Link objects from all configured locations,
     making network requests as needed.

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -106,7 +106,6 @@ class LinkType(enum.Enum):
 
 
 class LinkEvaluator:
-
     """
     Responsible for evaluating links for a particular project.
     """
@@ -324,7 +323,6 @@ def filter_unallowed_hashes(
 
 
 class CandidatePreferences:
-
     """
     Encapsulates some of the preferences for filtering and sorting
     InstallationCandidate objects.
@@ -383,7 +381,6 @@ class BestCandidateResult:
 
 
 class CandidateEvaluator:
-
     """
     Responsible for filtering and sorting candidates for installation based
     on what tags are valid.

--- a/src/pip/_internal/models/direct_url.py
+++ b/src/pip/_internal/models/direct_url.py
@@ -1,4 +1,5 @@
 """ PEP 610 """
+
 import json
 import re
 import urllib.parse

--- a/src/pip/_internal/models/scheme.py
+++ b/src/pip/_internal/models/scheme.py
@@ -5,7 +5,6 @@ For a general overview of available schemes and their context, see
 https://docs.python.org/3/install/index.html#alternate-installation.
 """
 
-
 SCHEME_KEYS = ["platlib", "purelib", "headers", "scripts", "data"]
 
 

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class SearchScope:
-
     """
     Encapsulates the locations that pip is configured to search.
     """

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -8,7 +8,6 @@ from pip._internal.utils.misc import normalize_version_info
 
 
 class TargetPython:
-
     """
     Encapsulates the properties of a Python interpreter one is targeting
     for a package install, download, etc.

--- a/src/pip/_internal/models/wheel.py
+++ b/src/pip/_internal/models/wheel.py
@@ -1,6 +1,7 @@
 """Represents a wheel file and provides access to the various parts of the
 name that have meaning.
 """
+
 import re
 from typing import Dict, Iterable, List
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -3,6 +3,7 @@
 Contains interface (MultiDomainBasicAuth) and associated glue code for
 providing credentials in the context of network requests.
 """
+
 import logging
 import os
 import shutil
@@ -47,12 +48,12 @@ class KeyRingBaseProvider(ABC):
     has_keyring: bool
 
     @abstractmethod
-    def get_auth_info(self, url: str, username: Optional[str]) -> Optional[AuthInfo]:
-        ...
+    def get_auth_info(
+        self, url: str, username: Optional[str]
+    ) -> Optional[AuthInfo]: ...
 
     @abstractmethod
-    def save_auth_info(self, url: str, username: str, password: str) -> None:
-        ...
+    def save_auth_info(self, url: str, username: str, password: str) -> None: ...
 
 
 class KeyRingNullProvider(KeyRingBaseProvider):

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -1,5 +1,6 @@
 """Download files with progress indicators.
 """
+
 import email.message
 import logging
 import mimetypes

--- a/src/pip/_internal/operations/install/editable_legacy.py
+++ b/src/pip/_internal/operations/install/editable_legacy.py
@@ -1,5 +1,6 @@
 """Legacy editable installation process, i.e. `setup.py develop`.
 """
+
 import logging
 from typing import Optional, Sequence
 

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -245,9 +245,9 @@ class Resolver(BaseResolver):
             return [install_req], None
 
         try:
-            existing_req: Optional[
-                InstallRequirement
-            ] = requirement_set.get_requirement(install_req.name)
+            existing_req: Optional[InstallRequirement] = (
+                requirement_set.get_requirement(install_req.name)
+            )
         except KeyError:
             existing_req = None
 

--- a/src/pip/_internal/utils/deprecation.py
+++ b/src/pip/_internal/utils/deprecation.py
@@ -87,9 +87,11 @@ def deprecated(
         (reason, f"{DEPRECATION_MSG_PREFIX}{{}}"),
         (
             gone_in,
-            "pip {} will enforce this behaviour change."
-            if not is_gone
-            else "Since pip {}, this is no longer supported.",
+            (
+                "pip {} will enforce this behaviour change."
+                if not is_gone
+                else "Since pip {}, this is no longer supported."
+            ),
         ),
         (
             replacement,
@@ -97,9 +99,11 @@ def deprecated(
         ),
         (
             feature_flag,
-            "You can use the flag --use-feature={} to test the upcoming behaviour."
-            if not is_gone
-            else None,
+            (
+                "You can use the flag --use-feature={} to test the upcoming behaviour."
+                if not is_gone
+                else None
+            ),
         ),
         (
             issue,

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -212,7 +212,6 @@ class MaxLevelFilter(Filter):
 
 
 class ExcludeLoggerFilter(Filter):
-
     """
     A logging Filter that excludes records from a logger (or its children).
     """

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -115,7 +115,6 @@ class RemoteNotValidError(Exception):
 
 
 class RevOptions:
-
     """
     Encapsulates a VCS-specific revision to install, along with any VCS
     install options.

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -1,5 +1,6 @@
 """Basic CLI functionality checks.
 """
+
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -126,8 +126,7 @@ class DoAutocomplete(Protocol):
         cwd: Union[Path, str, None] = None,
         include_env: bool = True,
         expect_error: bool = True,
-    ) -> Tuple[TestPipResult, PipTestEnvironment]:
-        ...
+    ) -> Tuple[TestPipResult, PipTestEnvironment]: ...
 
 
 @pytest.fixture

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -1,5 +1,6 @@
 """Tests for the config command
 """
+
 import re
 import textwrap
 

--- a/tests/functional/test_hash.py
+++ b/tests/functional/test_hash.py
@@ -1,4 +1,5 @@
 """Tests for the ``pip hash`` command"""
+
 from pathlib import Path
 
 from tests.lib import PipTestEnvironment

--- a/tests/functional/test_install_compat.py
+++ b/tests/functional/test_install_compat.py
@@ -2,6 +2,7 @@
 Tests for compatibility workarounds.
 
 """
+
 import os
 from pathlib import Path
 

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -29,8 +29,7 @@ class ArgRecordingSdist:
 
 
 class ArgRecordingSdistMaker(Protocol):
-    def __call__(self, name: str, **kwargs: Any) -> ArgRecordingSdist:
-        ...
+    def __call__(self, name: str, **kwargs: Any) -> ArgRecordingSdist: ...
 
 
 @pytest.fixture()

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -1,6 +1,7 @@
 """
 tests specific to "pip install --user"
 """
+
 import os
 import textwrap
 from os.path import curdir, isdir, isfile

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -930,8 +930,7 @@ if TYPE_CHECKING:
             version: str,
             requires: List[str],
             extras: Dict[str, List[str]],
-        ) -> str:
-            ...
+        ) -> str: ...
 
 
 def _local_with_setup(

--- a/tests/functional/test_no_color.py
+++ b/tests/functional/test_no_color.py
@@ -1,6 +1,7 @@
 """
 Test specific for the --no-color option
 """
+
 import os
 import shutil
 import subprocess

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -1,6 +1,7 @@
 """
 tests specific to uninstalling --user installs
 """
+
 from os.path import isdir, isfile, normcase
 
 import pytest

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -1,6 +1,7 @@
 """
 Contains functional tests of the Git class.
 """
+
 import logging
 import os
 import pathlib

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -1,4 +1,5 @@
 """'pip wheel' tests"""
+
 import os
 import re
 import sys

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1371,8 +1371,7 @@ class ScriptFactory(Protocol):
         tmpdir: pathlib.Path,
         virtualenv: Optional[VirtualEnvironment] = None,
         environ: Optional[Dict[AnyStr, AnyStr]] = None,
-    ) -> PipTestEnvironment:
-        ...
+    ) -> PipTestEnvironment: ...
 
 
 CertFactory = Callable[[], str]

--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -1,5 +1,6 @@
 """Helpers for filesystem-dependent tests.
 """
+
 import os
 from functools import partial
 from itertools import chain

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -1,4 +1,5 @@
 """Test the test support."""
+
 import filecmp
 import pathlib
 import re

--- a/tests/lib/test_wheel.py
+++ b/tests/lib/test_wheel.py
@@ -1,5 +1,6 @@
 """Tests for wheel helper.
 """
+
 import csv
 from email import message_from_string
 from email.message import Message

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -1,5 +1,6 @@
 """Helper for building wheels as would be in test cases.
 """
+
 import csv
 import itertools
 from base64 import urlsafe_b64encode

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -2,6 +2,7 @@
 locations.py tests
 
 """
+
 import getpass
 import os
 import shutil

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -195,7 +195,6 @@ class TestOptionPrecedence(AddFakeCommandMixin):
 
 
 class TestUsePEP517Options:
-
     """
     Test options related to using --use-pep517.
     """

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -70,9 +70,11 @@ def parse_reqfile(
         yield install_req_from_parsed_requirement(
             parsed_req,
             isolated=isolated,
-            config_settings=parsed_req.options.get("config_settings")
-            if parsed_req.options
-            else None,
+            config_settings=(
+                parsed_req.options.get("config_settings")
+                if parsed_req.options
+                else None
+            ),
         )
 
 
@@ -196,8 +198,7 @@ class LineProcessor(Protocol):
         options: Optional[Values] = None,
         session: Optional[PipSession] = None,
         constraint: bool = False,
-    ) -> List[InstallRequirement]:
-        ...
+    ) -> List[InstallRequirement]: ...
 
 
 @pytest.fixture

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,6 +2,7 @@
 util tests
 
 """
+
 import codecs
 import os
 import shutil

--- a/tests/unit/test_utils_subprocess.py
+++ b/tests/unit/test_utils_subprocess.py
@@ -89,7 +89,6 @@ class FakeSpinner(SpinnerInterface):
 
 
 class TestCallSubprocess:
-
     """
     Test call_subprocess().
     """

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -1,4 +1,5 @@
 """Tests for wheel binary packages and .dist-info."""
+
 import csv
 import logging
 import os

--- a/tools/update-rtd-redirects.py
+++ b/tools/update-rtd-redirects.py
@@ -2,6 +2,7 @@
 
 Relevant API reference: https://docs.readthedocs.io/en/stable/api/v3.html#redirects
 """
+
 import operator
 import os
 import sys


### PR DESCRIPTION
A couple of important changes to black since the last update, the new 2024 stable style: https://github.com/psf/black/releases/tag/24.1.0. And a minor CVE (which I guess someone could use to attack pip's github workers?): https://github.com/psf/black/releases/tag/24.3.0

Most the noise in the new stable style comes from more opinionated choices about where new lines should or shouldn't be, and that `...` shouldn't be on it's own line for empty class or method definitions.

But there are a few nice things, like get item syntax is strongly preffered to keep on the same line, e.g.

```python
            existing_req: Optional[
                InstallRequirement
            ] = requirement_set.get_requirement(install_req.name)
```

Turns in to this:

```python
            existing_req: Optional[InstallRequirement] = (
                requirement_set.get_requirement(install_req.name)
            )
```

ruff also has already adopted the black 2024 stable style, so were pip to eventually switch to ruff (https://github.com/pypa/pip/pull/12478) for formatting this would produce a smaller diff with the most recent versions of ruff.