### PR TITLE
Update ruff to v0.3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.2.0
+  rev: v0.3.6
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/news/12595.trivial.rst
+++ b/news/12595.trivial.rst
@@ -1,0 +1,1 @@
+Update ruff pre-commit to v0.3.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ max-complexity = 33  # default is 10
 "src/pip/_internal/*" = ["PERF203"]
 "tests/*" = ["B011"]
 "tests/unit/test_finder.py" = ["C414"]
+"src/pip/__pip-runner__.py" = ["UP"] # Must be compatible with Python 2.7
 
 [tool.ruff.lint.pylint]
 max-args = 15  # default is 5

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -75,7 +75,9 @@ class SearchCommand(Command, SessionCommandMixin):
         try:
             hits = pypi.search({"name": query, "summary": query}, "or")
         except xmlrpc.client.Fault as fault:
-            message = f"XMLRPC request failed [code: {fault.faultCode}]\n{fault.faultString}"
+            message = (
+                f"XMLRPC request failed [code: {fault.faultCode}]\n{fault.faultString}"
+            )
             raise CommandError(message)
         assert isinstance(hits, list)
         return hits

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -75,10 +75,7 @@ class SearchCommand(Command, SessionCommandMixin):
         try:
             hits = pypi.search({"name": query, "summary": query}, "or")
         except xmlrpc.client.Fault as fault:
-            message = "XMLRPC request failed [code: {code}]\n{string}".format(
-                code=fault.faultCode,
-                string=fault.faultString,
-            )
+            message = f"XMLRPC request failed [code: {fault.faultCode}]\n{fault.faultString}"
             raise CommandError(message)
         assert isinstance(hits, list)
         return hits

--- a/src/pip/_internal/models/candidate.py
+++ b/src/pip/_internal/models/candidate.py
@@ -20,7 +20,9 @@ class InstallationCandidate(KeyBasedCompareMixin):
         )
 
     def __repr__(self) -> str:
-        return f"<InstallationCandidate({self.name!r}, {self.version!r}, {self.link!r})>"
+        return (
+            f"<InstallationCandidate({self.name!r}, {self.version!r}, {self.link!r})>"
+        )
 
     def __str__(self) -> str:
         return f"{self.name!r} candidate (version {self.version} at {self.link})"

--- a/src/pip/_internal/models/candidate.py
+++ b/src/pip/_internal/models/candidate.py
@@ -20,11 +20,7 @@ class InstallationCandidate(KeyBasedCompareMixin):
         )
 
     def __repr__(self) -> str:
-        return "<InstallationCandidate({!r}, {!r}, {!r})>".format(
-            self.name,
-            self.version,
-            self.link,
-        )
+        return f"<InstallationCandidate({self.name!r}, {self.version!r}, {self.link!r})>"
 
     def __str__(self) -> str:
         return f"{self.name!r} candidate (version {self.version} at {self.link})"

--- a/src/pip/_internal/operations/build/build_tracker.py
+++ b/src/pip/_internal/operations/build/build_tracker.py
@@ -3,9 +3,8 @@ import hashlib
 import logging
 import os
 from types import TracebackType
-from typing import Dict, Generator, Optional, Set, Type, Union
+from typing import Dict, Generator, Optional, Type, Union
 
-from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.temp_dir import TempDirectory
 

--- a/src/pip/_internal/operations/build/wheel_legacy.py
+++ b/src/pip/_internal/operations/build/wheel_legacy.py
@@ -40,16 +40,16 @@ def get_legacy_build_wheel_path(
     # Sort for determinism.
     names = sorted(names)
     if not names:
-        msg = ("Legacy build of wheel for {!r} created no files.\n").format(name)
+        msg = (f"Legacy build of wheel for {name!r} created no files.\n")
         msg += format_command_result(command_args, command_output)
         logger.warning(msg)
         return None
 
     if len(names) > 1:
         msg = (
-            "Legacy build of wheel for {!r} created more than one file.\n"
-            "Filenames (choosing first): {}\n"
-        ).format(name, names)
+            f"Legacy build of wheel for {name!r} created more than one file.\n"
+            f"Filenames (choosing first): {names}\n"
+        )
         msg += format_command_result(command_args, command_output)
         logger.warning(msg)
 

--- a/src/pip/_internal/operations/build/wheel_legacy.py
+++ b/src/pip/_internal/operations/build/wheel_legacy.py
@@ -40,7 +40,7 @@ def get_legacy_build_wheel_path(
     # Sort for determinism.
     names = sorted(names)
     if not names:
-        msg = (f"Legacy build of wheel for {name!r} created no files.\n")
+        msg = f"Legacy build of wheel for {name!r} created no files.\n"
         msg += format_command_result(command_args, command_output)
         logger.warning(msg)
         return None

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -505,8 +505,8 @@ def _install_wheel(
                 _, scheme_key, dest_subpath = normed_path.split(os.path.sep, 2)
             except ValueError:
                 message = (
-                    f"Unexpected file in {wheel_path}: {record_path!r}. .data directory contents"
-                    " should be named like: '<scheme key>/<path>'."
+                    f"Unexpected file in {wheel_path}: {record_path!r}. .data directory"
+                    " contents should be named like: '<scheme key>/<path>'."
                 )
                 raise InstallationError(message)
 
@@ -515,9 +515,10 @@ def _install_wheel(
             except KeyError:
                 valid_scheme_keys = ", ".join(sorted(scheme_paths))
                 message = (
-                    f"Unknown scheme key used in {wheel_path}: {scheme_key} (for file {record_path!r}). .data"
-                    " directory contents should be in subdirectories named"
-                    f" with a valid scheme key ({valid_scheme_keys})"
+                    f"Unknown scheme key used in {wheel_path}: {scheme_key} "
+                    f"(for file {record_path!r}). .data directory contents "
+                    f"should be in subdirectories named with a valid scheme "
+                    f"key ({valid_scheme_keys})"
                 )
                 raise InstallationError(message)
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -505,9 +505,9 @@ def _install_wheel(
                 _, scheme_key, dest_subpath = normed_path.split(os.path.sep, 2)
             except ValueError:
                 message = (
-                    "Unexpected file in {}: {!r}. .data directory contents"
+                    f"Unexpected file in {wheel_path}: {record_path!r}. .data directory contents"
                     " should be named like: '<scheme key>/<path>'."
-                ).format(wheel_path, record_path)
+                )
                 raise InstallationError(message)
 
             try:
@@ -515,10 +515,10 @@ def _install_wheel(
             except KeyError:
                 valid_scheme_keys = ", ".join(sorted(scheme_paths))
                 message = (
-                    "Unknown scheme key used in {}: {} (for file {!r}). .data"
+                    f"Unknown scheme key used in {wheel_path}: {scheme_key} (for file {record_path!r}). .data"
                     " directory contents should be in subdirectories named"
-                    " with a valid scheme key ({})"
-                ).format(wheel_path, scheme_key, record_path, valid_scheme_keys)
+                    f" with a valid scheme key ({valid_scheme_keys})"
+                )
                 raise InstallationError(message)
 
             dest_path = os.path.join(scheme_path, dest_subpath)

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -132,8 +132,8 @@ def parse_editable(editable_req: str) -> Tuple[Optional[str], str, Set[str]]:
     package_name = link.egg_fragment
     if not package_name:
         raise InstallationError(
-            "Could not detect requirement name for '{}', please specify one "
-            "with #egg=your_package_name".format(editable_req)
+            f"Could not detect requirement name for '{editable_req}', please specify one "
+            "with #egg=your_package_name"
         )
     return package_name, url, set()
 

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -132,8 +132,8 @@ def parse_editable(editable_req: str) -> Tuple[Optional[str], str, Set[str]]:
     package_name = link.egg_fragment
     if not package_name:
         raise InstallationError(
-            f"Could not detect requirement name for '{editable_req}', please specify one "
-            "with #egg=your_package_name"
+            f"Could not detect requirement name for '{editable_req}', "
+            "please specify one with #egg=your_package_name"
         )
     return package_name, url, set()
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -222,7 +222,10 @@ class InstallRequirement:
         return s
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} object: {str(self)} editable={self.editable!r}>"
+        return (
+            f"<{self.__class__.__name__} object: "
+            f"{str(self)} editable={self.editable!r}>"
+        )
 
     def format_debug(self) -> str:
         """An un-tested helper for getting state, for debugging."""

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -222,9 +222,7 @@ class InstallRequirement:
         return s
 
     def __repr__(self) -> str:
-        return "<{} object: {} editable={!r}>".format(
-            self.__class__.__name__, str(self), self.editable
-        )
+        return f"<{self.__class__.__name__} object: {str(self)} editable={self.editable!r}>"
 
     def format_debug(self) -> str:
         """An un-tested helper for getting state, for debugging."""

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -510,8 +510,8 @@ class UninstallPathSet:
 
         elif dist.installed_by_distutils:
             raise UninstallationError(
-                f"Cannot uninstall {dist.raw_name!r}. It is a distutils installed project "
-                "and thus we cannot accurately determine which files belong "
+                f"Cannot uninstall {dist.raw_name!r}. It is a distutils installed "
+                "project and thus we cannot accurately determine which files belong "
                 "to it which would lead to only a partial uninstall."
             )
 

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -510,11 +510,9 @@ class UninstallPathSet:
 
         elif dist.installed_by_distutils:
             raise UninstallationError(
-                "Cannot uninstall {!r}. It is a distutils installed project "
+                f"Cannot uninstall {dist.raw_name!r}. It is a distutils installed project "
                 "and thus we cannot accurately determine which files belong "
-                "to it which would lead to only a partial uninstall.".format(
-                    dist.raw_name,
-                )
+                "to it which would lead to only a partial uninstall."
             )
 
         elif dist.installed_as_egg:

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -104,9 +104,7 @@ def _check_dist_requires_python(
         return
 
     raise UnsupportedPythonVersion(
-        "Package {!r} requires a different Python: {} not in {!r}".format(
-            dist.raw_name, version, requires_python
-        )
+        f"Package {dist.raw_name!r} requires a different Python: {version} not in {requires_python!r}"
     )
 
 
@@ -263,9 +261,7 @@ class Resolver(BaseResolver):
         )
         if has_conflicting_requirement:
             raise InstallationError(
-                "Double requirement given: {} (already in {}, name={!r})".format(
-                    install_req, existing_req, install_req.name
-                )
+                f"Double requirement given: {install_req} (already in {existing_req}, name={install_req.name!r})"
             )
 
         # When no existing requirement exists, add the requirement as a

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -104,7 +104,8 @@ def _check_dist_requires_python(
         return
 
     raise UnsupportedPythonVersion(
-        f"Package {dist.raw_name!r} requires a different Python: {version} not in {requires_python!r}"
+        f"Package {dist.raw_name!r} requires a different Python: "
+        f"{version} not in {requires_python!r}"
     )
 
 
@@ -261,7 +262,8 @@ class Resolver(BaseResolver):
         )
         if has_conflicting_requirement:
             raise InstallationError(
-                f"Double requirement given: {install_req} (already in {existing_req}, name={install_req.name!r})"
+                f"Double requirement given: {install_req} "
+                f"(already in {existing_req}, name={install_req.name!r})"
             )
 
         # When no existing requirement exists, add the requirement as a

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -191,11 +191,7 @@ class _InstallRequirementBackedCandidate(Candidate):
         return self._version
 
     def format_for_error(self) -> str:
-        return "{} {} (from {})".format(
-            self.name,
-            self.version,
-            self._link.file_path if self._link.is_file else self._link,
-        )
+        return f"{self.name} {self.version} (from {self._link.file_path if self._link.is_file else self._link})"
 
     def _prepare_distribution(self) -> BaseDistribution:
         raise NotImplementedError("Override in subclass")
@@ -269,9 +265,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             # Version may not be present for PEP 508 direct URLs
             if version is not None:
                 wheel_version = Version(wheel.version)
-                assert version == wheel_version, "{!r} != {!r} for wheel {}".format(
-                    version, wheel_version, name
-                )
+                assert version == wheel_version, f"{version!r} != {wheel_version!r} for wheel {name}"
 
         if cache_entry is not None:
             assert ireq.link.is_wheel

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -191,7 +191,10 @@ class _InstallRequirementBackedCandidate(Candidate):
         return self._version
 
     def format_for_error(self) -> str:
-        return f"{self.name} {self.version} (from {self._link.file_path if self._link.is_file else self._link})"
+        return (
+            f"{self.name} {self.version} "
+            f"(from {self._link.file_path if self._link.is_file else self._link})"
+        )
 
     def _prepare_distribution(self) -> BaseDistribution:
         raise NotImplementedError("Override in subclass")
@@ -265,7 +268,9 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             # Version may not be present for PEP 508 direct URLs
             if version is not None:
                 wheel_version = Version(wheel.version)
-                assert version == wheel_version, f"{version!r} != {wheel_version!r} for wheel {name}"
+                assert (
+                    version == wheel_version
+                ), f"{version!r} != {wheel_version!r} for wheel {name}"
 
         if cache_entry is not None:
             assert ireq.link.is_wheel

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -12,7 +12,9 @@ def direct_url_as_pep440_direct_reference(direct_url: DirectUrl, name: str) -> s
     requirement = name + " @ "
     fragments = []
     if isinstance(direct_url.info, VcsInfo):
-        requirement += f"{direct_url.info.vcs}+{direct_url.url}@{direct_url.info.commit_id}"
+        requirement += (
+            f"{direct_url.info.vcs}+{direct_url.url}@{direct_url.info.commit_id}"
+        )
     elif isinstance(direct_url.info, ArchiveInfo):
         requirement += direct_url.url
         if direct_url.info.hash:

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -12,9 +12,7 @@ def direct_url_as_pep440_direct_reference(direct_url: DirectUrl, name: str) -> s
     requirement = name + " @ "
     fragments = []
     if isinstance(direct_url.info, VcsInfo):
-        requirement += "{}+{}@{}".format(
-            direct_url.info.vcs, direct_url.url, direct_url.info.commit_id
-        )
+        requirement += f"{direct_url.info.vcs}+{direct_url.url}@{direct_url.info.commit_id}"
     elif isinstance(direct_url.info, ArchiveInfo):
         requirement += direct_url.url
         if direct_url.info.hash:

--- a/tests/functional/test_build_env.py
+++ b/tests/functional/test_build_env.py
@@ -26,7 +26,7 @@ def run_with_build_env(
     build_env_script = script.scratch_path / "build_env.py"
     build_env_script.write_text(
         dedent(
-            """
+            f"""
             import subprocess
             import sys
 
@@ -42,7 +42,7 @@ def run_with_build_env(
 
             link_collector = LinkCollector(
                 session=PipSession(),
-                search_scope=SearchScope.create([{scratch!r}], [], False),
+                search_scope=SearchScope.create([{str(script.scratch_path)!r}], [], False),
             )
             selection_prefs = SelectionPreferences(
                 allow_yanked=True,
@@ -54,9 +54,7 @@ def run_with_build_env(
 
             with global_tempdir_manager():
                 build_env = BuildEnvironment()
-            """.format(
-                scratch=str(script.scratch_path)
-            )
+            """
         )
         + indent(dedent(setup_script_contents), "    ")
         + indent(

--- a/tests/functional/test_build_env.py
+++ b/tests/functional/test_build_env.py
@@ -24,6 +24,7 @@ def run_with_build_env(
     test_script_contents: Optional[str] = None,
 ) -> TestPipResult:
     build_env_script = script.scratch_path / "build_env.py"
+    scratch_path = str(script.scratch_path)
     build_env_script.write_text(
         dedent(
             f"""
@@ -42,7 +43,7 @@ def run_with_build_env(
 
             link_collector = LinkCollector(
                 session=PipSession(),
-                search_scope=SearchScope.create([{str(script.scratch_path)!r}], [], False),
+                search_scope=SearchScope.create([{scratch_path!r}], [], False),
             )
             selection_prefs = SelectionPreferences(
                 allow_yanked=True,

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -89,15 +89,14 @@ def test_new_resolver_hash_intersect_from_constraint(
     script: PipTestEnvironment,
 ) -> None:
     find_links = _create_find_links(script)
+    sdist_hash = find_links.sdist_hash
 
     constraints_txt = script.scratch_path / "constraints.txt"
-    constraints_txt.write_text(
-        f"base==0.1.0 --hash=sha256:{find_links.sdist_hash}",
-    )
+    constraints_txt.write_text(f"base==0.1.0 --hash=sha256:{sdist_hash}")
     requirements_txt = script.scratch_path / "requirements.txt"
     requirements_txt.write_text(
         f"""
-        base==0.1.0 --hash=sha256:{find_links.sdist_hash} --hash=sha256:{find_links.wheel_hash}
+        base==0.1.0 --hash=sha256:{sdist_hash} --hash=sha256:{find_links.wheel_hash}
         """,
     )
 

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -96,12 +96,9 @@ def test_new_resolver_hash_intersect_from_constraint(
     )
     requirements_txt = script.scratch_path / "requirements.txt"
     requirements_txt.write_text(
-        """
-        base==0.1.0 --hash=sha256:{sdist_hash} --hash=sha256:{wheel_hash}
-        """.format(
-            sdist_hash=find_links.sdist_hash,
-            wheel_hash=find_links.wheel_hash,
-        ),
+        f"""
+        base==0.1.0 --hash=sha256:{find_links.sdist_hash} --hash=sha256:{find_links.wheel_hash}
+        """,
     )
 
     result = script.pip(

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -802,8 +802,8 @@ def test_get_index_content_invalid_content_type(
     assert (
         "pip._internal.index.collector",
         logging.WARNING,
-        f"Skipping page {url} because the GET request got Content-Type: {content_type}. "
-        "The only supported Content-Types are application/vnd.pypi.simple.v1+json, "
+        f"Skipping page {url} because the GET request got Content-Type: {content_type}."
+        " The only supported Content-Types are application/vnd.pypi.simple.v1+json, "
         "application/vnd.pypi.simple.v1+html, and text/html",
     ) in caplog.record_tuples
 

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -802,9 +802,9 @@ def test_get_index_content_invalid_content_type(
     assert (
         "pip._internal.index.collector",
         logging.WARNING,
-        "Skipping page {} because the GET request got Content-Type: {}. "
+        f"Skipping page {url} because the GET request got Content-Type: {content_type}. "
         "The only supported Content-Types are application/vnd.pypi.simple.v1+json, "
-        "application/vnd.pypi.simple.v1+html, and text/html".format(url, content_type),
+        "application/vnd.pypi.simple.v1+html, and text/html",
     ) in caplog.record_tuples
 
 


### PR DESCRIPTION
Updating ruff to v0.3.4 caused two rules to fail, and fixing them caused a third one to fail:

* F401 - Unused imports, this seems like a bug fix on ruff side, these should have been caught before
* UP032 - Use f-strings instead of `.format`, previously this rule was not applied if it would cause the string to exceed the maximum line length, it was decided to change this behavior: https://github.com/astral-sh/ruff/pull/10263
* E501 - With the autofix of UP032 several lines exceeded the maximum line length, with no autofix available I manually fixed each line, in a lot of cases I tried to make what I thought was the best aesthetic choice, in two cases, both multi-line f-strings I was unsure how to handle and instead disabled E501 for those strings. Feel free to give feedback and I will update appropriately.

The other option would be to remove UP032 from the ruff rule selection.
