### PR TITLE
Show install progress when using `--progress-bar=raw`

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -458,6 +458,7 @@ class InstallCommand(RequirementCommand):
                 warn_script_location=warn_script_location,
                 use_user_site=options.use_user_site,
                 pycompile=options.compile,
+                progress_bar=options.progress_bar,
             )
 
             lib_locations = get_lib_location_guesses(

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -2,6 +2,7 @@ import collections
 import logging
 from typing import Generator, List, Optional, Sequence, Tuple
 
+from pip._internal.cli.progress_bars import get_install_progress_renderer
 from pip._internal.utils.logging import indent_log
 
 from .req_file import parse_requirements
@@ -43,6 +44,7 @@ def install_given_reqs(
     warn_script_location: bool,
     use_user_site: bool,
     pycompile: bool,
+    progress_bar: str,
 ) -> List[InstallationResult]:
     """
     Install everything in the given list.
@@ -59,8 +61,17 @@ def install_given_reqs(
 
     installed = []
 
+    show_progress = logger.getEffectiveLevel() <= logging.INFO
+
+    items = to_install.items()
+    if show_progress:
+        renderer = get_install_progress_renderer(
+            bar_type=progress_bar, total=len(to_install)
+        )
+        items = renderer(items)
+
     with indent_log():
-        for req_name, requirement in to_install.items():
+        for req_name, requirement in items:
             if requirement.should_reinstall:
                 logger.info("Attempting uninstall: %s", req_name)
                 with indent_log():


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

This PR is a follow-up to #11508 / #12586 which adds machine-readable install progress outputs.

Right now, unless pip is uninstalling a package to upgrade it, pip does not output any progress information for installs. This means that any GUI wrapping pip cannot accurately display the current progress of the install. For example, if I wanted to be able to display "installing opencv-python", I would have no idea when opencv-python is actually installing. The best I would be able to do would be to display an indeterminate progress spinner and maybe guess where the install progress is at based on the uninstalling messages.

So, this PR solves that issue by outputting the current install progress when the `--progress-bar` setting is set to "raw". I did try to add a regular progress bar to this as well, but due to the extra logging it does sometimes (like during uninstalls), a regular progress bar is not a good fit for this specific feature. Besides, this is only useful for those who want to display extra information that they cannot currently get from pip's output (which is why someone would be using the "raw" option anyway).

Example screenshot:
![image](https://github.com/pypa/pip/assets/34788790/5aa60908-c43e-4031-8139-13af0db9ba4a)
