### PR TITLE
fix: uses RST substitution to put badges in 1 line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,19 @@
 pip - The Python Package Installer
 ==================================
 
-.. image:: https://img.shields.io/pypi/v/pip.svg
+.. |pypi-version| image:: https://img.shields.io/pypi/v/pip.svg
    :target: https://pypi.org/project/pip/
    :alt: PyPI
 
-.. image:: https://img.shields.io/pypi/pyversions/pip
+.. |python-versions| image:: https://img.shields.io/pypi/pyversions/pip
    :target: https://pypi.org/project/pip
    :alt: PyPI - Python Version
 
-.. image:: https://readthedocs.org/projects/pip/badge/?version=latest
+.. |docs-badge| image:: https://readthedocs.org/projects/pip/badge/?version=latest
    :target: https://pip.pypa.io/en/latest
    :alt: Documentation
+
+|pypi-version| |python-versions| |docs-badge|
 
 pip is the `package installer`_ for Python. You can use pip to install packages from the `Python Package Index`_ and other indexes.
 

--- a/news/12615.trivial.rst
+++ b/news/12615.trivial.rst
@@ -1,0 +1,1 @@
+uses RST substitution to put badges in 1 line.


### PR DESCRIPTION
It might be some update to Github's RST renderer caused badges to display in multiple lines. 

uses RST substitution to put badges in 1 line.

Before the change

![image](https://github.com/pypa/pip/assets/3353385/e553d0d7-6d1a-4245-8fd8-a5a9dc81f8a4)

After the change

![image](https://github.com/pypa/pip/assets/3353385/11a7fc30-80c6-4519-8c7f-51b758dc3391)

