### PR TITLE
Support MacOS 14 github runner (which is now default)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-latest]
         python:
           - "3.8"
           - "3.9"
@@ -129,8 +129,10 @@ jobs:
           sudo apt-get install bzr
 
       - name: Install MacOS dependencies
-        if: matrix.os == 'macos-12'
-        run: brew install breezy
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install breezy
+          brew install subversion
 
       - run: pip install nox
 

--- a/news/12617.trivial.rst
+++ b/news/12617.trivial.rst
@@ -1,0 +1,1 @@
+Install subversion for macos-latest CI Runner so macos-14 tests do not fail

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,8 +7,7 @@ pytest-rerunfailures
 pytest-xdist
 scripttest
 setuptools
-virtualenv < 20.0 ; python_version < '3.10'
-virtualenv >= 20.0 ; python_version >= '3.10'
+virtualenv
 werkzeug
 wheel
 tomli-w


### PR DESCRIPTION
Github's macos-14 runner is rolling out as macos-latest over the following weeks: https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

macos-14 no longer includes SVN by defeault: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
Where as macos-12 (the previous macos and the one pip runners still appear to be on) did: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md

When pip's macos-latest runners get updated to macos-14 CI tests will currently fail due to lack of subversion. This PR preempts that by explicitly installing SVN.

I have a secondary PR to explictly support both x86 and M1 runners: https://github.com/pypa/pip/pull/12593
