### PR TITLE
Bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'src/pip/_vendor/'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: check-builtin-literals
   - id: check-added-large-files
@@ -22,13 +22,13 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.6
+  rev: v0.4.1
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v1.9.0
   hooks:
   - id: mypy
     exclude: tests/data

--- a/news/a870a527-a6ea-46fd-b4aa-c0b0d9b669b0.trivial.rst
+++ b/news/a870a527-a6ea-46fd-b4aa-c0b0d9b669b0.trivial.rst
@@ -1,0 +1,1 @@
+Bump pre-commit hooks.

--- a/src/pip/_internal/metadata/_json.py
+++ b/src/pip/_internal/metadata/_json.py
@@ -2,7 +2,7 @@
 
 from email.header import Header, decode_header, make_header
 from email.message import Message
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, cast
 
 METADATA_FIELDS = [
     # Name, Multiple-Use
@@ -77,7 +77,7 @@ def msg_to_json(msg: Message) -> Dict[str, Any]:
                     value = value.split()
         result[key] = value
 
-    payload = msg.get_payload()
+    payload = cast(str, msg.get_payload())
     if payload:
         result["description"] = payload
 


### PR DESCRIPTION
There was one new mypy error:

```
src/pip/_internal/metadata/_json.py:82: error: Incompatible types in assignment (expression has type "Message | Any | str | list[Message | str]", target has type "str | list[str]")  [assignment]
            result["description"] = payload
                                    ^~~~~~~
Found 1 error in 1 file (checked 294 source files)
```

Closes https://github.com/pypa/pip/pull/12605.