### PR TITLE
Add `render: shell` to the bug report template to format output as code

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -60,7 +60,7 @@ body:
       label: Output
       description: >-
         Provide the output of the steps above, including the commands
-        themselves and pip's output/traceback etc. 
+        themselves and pip's output/traceback etc.
         (The output will auto-rendered as code, no need for backticks.)
 
         If you want to present output from multiple commands, please prefix

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -66,6 +66,7 @@ body:
         the line containing the command with `$ `. Please also ensure that
         the "How to reproduce" section contains matching instructions for
         reproducing this.
+      render: shell
 
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -60,7 +60,8 @@ body:
       label: Output
       description: >-
         Provide the output of the steps above, including the commands
-        themselves and pip's output/traceback etc.
+        themselves and pip's output/traceback etc. 
+        (The output will auto-rendered as code, no need for backticks.)
 
         If you want to present output from multiple commands, please prefix
         the line containing the command with `$ `. Please also ensure that

--- a/news/12630.trivial.rst
+++ b/news/12630.trivial.rst
@@ -1,0 +1,1 @@
+Add ``render: shell`` to the bug report template to format output as code


### PR DESCRIPTION
Whenever I see outputs that are not in code format, it always feels hard to read. e.g. https://github.com/pypa/pip/issues/12629

So add `render: shell` to bug-report.yml, then copy and paste any relevant log output, this will be automatically formatted into code, so no need for backticks.