### PR TITLE
Add `actions/stale` to close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 30
+          days-before-close: 5
+          only-issue-labels: 'S: awaiting response'

--- a/news/12640.trivial.rst
+++ b/news/12640.trivial.rst
@@ -1,0 +1,1 @@
+Add ``actions/stale`` to close stale issues


### PR DESCRIPTION
I get inspired from this issue https://github.com/pypa/pip/issues/6715#issuecomment-2065482886, it would be helpful to consider implementing `actions/stale` that automatically alert to issues only labeled `S: awaiting reply` and eventually close (if there is no reply) to minimize the maintainer's workload. 

Please advise if needed to include other labels, maybe `state: needs reproducer`?

Apologies if this is a trivial improvement causes trouble.

