### PR TITLE
Clearly document the legacy resolver as unsupported

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -1143,8 +1143,9 @@ Policy`.
 .. attention::
 
     The legacy resolver is deprecated and unsupported. New features, such
-    as :doc:`reference/installation-report`, may not function correctly
-    with the legacy resolver. **These issues will not be fixed.**
+    as :doc:`reference/installation-report`, will not work with the
+    legacy resolver and this resolver will be removed in a future
+    release.
 
 Context and followup
 --------------------

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -1140,6 +1140,12 @@ Since this work will not change user-visible behavior described in the
 pip documentation, this change is not covered by the :ref:`Deprecation
 Policy`.
 
+.. attention::
+
+    The legacy resolver is deprecated and unsupported. New features, such
+    as :doc:`reference/installation-report`, may not function correctly
+    with the legacy resolver. **These issues will not be fixed.**
+
 Context and followup
 --------------------
 


### PR DESCRIPTION
So we have something to point to when we get issues like this one: https://github.com/pypa/pip/issues/12114

![image](https://github.com/pypa/pip/assets/63936253/195a73a7-9b7d-4f78-8768-6c46cf42c578)
