### PR TITLE
list: disable pip version self check unless given --outdated/--uptodate

### DIFF
--- a/news/11677.feature.rst
+++ b/news/11677.feature.rst
@@ -1,0 +1,1 @@
+``pip list`` no longer performs the pip version check unless ``--outdated`` or ``--uptodate`` is given.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -135,6 +135,10 @@ class ListCommand(IndexGroupCommand):
         self.parser.insert_option_group(0, index_opts)
         self.parser.insert_option_group(0, self.cmd_opts)
 
+    def handle_pip_version_check(self, options: Values) -> None:
+        if options.outdated or options.uptodate:
+            super().handle_pip_version_check(options)
+
     def _build_package_finder(
         self, options: Values, session: PipSession
     ) -> PackageFinder:


### PR DESCRIPTION
Resolves #11677.

Writing the test here was a painful experience as I didn't realize that the `PIP_DISABLE_PIP_VERSION_CHECK` environment variable was being set by default. 