### PR TITLE
Cache calculated hashes for requirements and _InstallRequirementBackedCandidate

### DIFF
--- a/news/12657.feature.rst
+++ b/news/12657.feature.rst
@@ -1,0 +1,1 @@
+Further improve resolution performance of large dependency trees, by caching hash calculations.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -154,6 +154,7 @@ class _InstallRequirementBackedCandidate(Candidate):
         self._name = name
         self._version = version
         self.dist = self._prepare()
+        self._hash: Optional[int] = None
 
     def __str__(self) -> str:
         return f"{self.name} {self.version}"
@@ -162,7 +163,11 @@ class _InstallRequirementBackedCandidate(Candidate):
         return f"{self.__class__.__name__}({str(self._link)!r})"
 
     def __hash__(self) -> int:
-        return hash((self.__class__, self._link))
+        if self._hash is not None:
+            return self._hash
+
+        self._hash = hash((self.__class__, self._link))
+        return self._hash
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, self.__class__):


### PR DESCRIPTION
This builds on @sbidoul PR https://github.com/pypa/pip/pull/12453.

I was profiling the scenario here https://github.com/pypa/pip/issues/12314#issuecomment-2081187124, and found over 30% of the time is spent calculating the hash of specifier requirements, which is mostly spent calculating the string of the install requirement, and is done repeatedly.

After this PR installing all the homeassistant wheels from local directory went from ~48 seconds to ~35 seconds, and dry-run install of apache-airflow[all] with all packages cached on Python 3.12 went from ~4 minutes to ~3 minutes.