### PR TITLE
Consistently use `get_requirement` to cache `Requirement` construction

### DIFF
--- a/news/12663.feature.rst
+++ b/news/12663.feature.rst
@@ -1,0 +1,1 @@
+Improve performance when the same requirement string appears many times during resolution, by consistently caching the parsed requirement string.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -12,7 +12,6 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple, Type, Union
 
 from pip._vendor.certifi import where
-from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.version import Version
 
 from pip import __file__ as pip_location
@@ -20,6 +19,7 @@ from pip._internal.cli.spinners import open_spinner
 from pip._internal.locations import get_platlib, get_purelib, get_scheme
 from pip._internal.metadata import get_default_environment, get_environment
 from pip._internal.utils.logging import VERBOSE
+from pip._internal.utils.packaging import get_requirement
 from pip._internal.utils.subprocess import call_subprocess
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 
@@ -184,7 +184,7 @@ class BuildEnvironment:
                 else get_default_environment()
             )
             for req_str in reqs:
-                req = Requirement(req_str)
+                req = get_requirement(req_str)
                 # We're explicitly evaluating with an empty extra value, since build
                 # environments are not provided any mechanism to select specific extras.
                 if req.marker is not None and not req.marker.evaluate({"extra": ""}):

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -27,6 +27,7 @@ from pip._internal.metadata.base import (
     Wheel,
 )
 from pip._internal.utils.misc import normalize_path
+from pip._internal.utils.packaging import get_requirement
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
 
@@ -219,7 +220,7 @@ class Distribution(BaseDistribution):
         for req_string in self.metadata.get_all("Requires-Dist", []):
             # strip() because email.message.Message.get_all() may return a leading \n
             # in case a long header was wrapped.
-            req = Requirement(req_string.strip())
+            req = get_requirement(req_string.strip())
             if not req.marker:
                 yield req
             elif not extras and req.marker.evaluate({"extra": ""}):

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -9,13 +9,14 @@ if sys.version_info >= (3, 11):
 else:
     from pip._vendor import tomli as tomllib
 
-from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+from pip._vendor.packaging.requirements import InvalidRequirement
 
 from pip._internal.exceptions import (
     InstallationError,
     InvalidPyProjectBuildRequires,
     MissingPyProjectBuildRequires,
 )
+from pip._internal.utils.packaging import get_requirement
 
 
 def _is_list_of_str(obj: Any) -> bool:
@@ -156,7 +157,7 @@ def load_pyproject_toml(
     # Each requirement must be valid as per PEP 508
     for requirement in requires:
         try:
-            Requirement(requirement)
+            get_requirement(requirement)
         except InvalidRequirement as error:
             raise InvalidPyProjectBuildRequires(
                 package=req_name,

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -81,7 +81,7 @@ def _set_requirement_extras(req: Requirement, new_extras: Set[str]) -> Requireme
         pre is not None and post is not None
     ), f"regex group selection for requirement {req} failed, this should never happen"
     extras: str = "[%s]" % ",".join(sorted(new_extras)) if new_extras else ""
-    return Requirement(f"{pre}{extras}{post}")
+    return get_requirement(f"{pre}{extras}{post}")
 
 
 def parse_editable(editable_req: str) -> Tuple[Optional[str], str, Set[str]]:
@@ -163,7 +163,7 @@ def check_first_requirement_in_file(filename: str) -> None:
             # If there is a line continuation, drop it, and append the next line.
             if line.endswith("\\"):
                 line = line[:-2].strip() + next(lines, "")
-            Requirement(line)
+            get_requirement(line)
             return
 
 
@@ -205,7 +205,7 @@ def parse_req_from_editable(editable_req: str) -> RequirementParts:
 
     if name is not None:
         try:
-            req: Optional[Requirement] = Requirement(name)
+            req: Optional[Requirement] = get_requirement(name)
         except InvalidRequirement as exc:
             raise InstallationError(f"Invalid requirement: {name!r}: {exc}")
     else:

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -52,6 +52,7 @@ from pip._internal.utils.misc import (
     redact_auth_from_requirement,
     redact_auth_from_url,
 )
+from pip._internal.utils.packaging import get_requirement
 from pip._internal.utils.subprocess import runner_with_spinner_message
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 from pip._internal.utils.unpacking import unpack_file
@@ -395,7 +396,7 @@ class InstallRequirement:
         else:
             op = "==="
 
-        self.req = Requirement(
+        self.req = get_requirement(
             "".join(
                 [
                     self.metadata["Name"],
@@ -421,7 +422,7 @@ class InstallRequirement:
             metadata_name,
             self.name,
         )
-        self.req = Requirement(metadata_name)
+        self.req = get_requirement(metadata_name)
 
     def check_if_exists(self, use_user_site: bool) -> None:
         """Find an installed distribution that satisfies or conflicts

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -34,7 +34,7 @@ def check_requires_python(
     return python_version in requires_python_specifier
 
 
-@functools.lru_cache(maxsize=512)
+@functools.lru_cache(maxsize=2048)
 def get_requirement(req_string: str) -> Requirement:
     """Construct a packaging.Requirement object with caching"""
     # Parsing requirement strings is expensive, and is also expected to happen


### PR DESCRIPTION
I have been investigating other easy performance improvements when encountering long backtracking times, so I profiled `pip install --dry-run --ignore-installed apache-airflow[all]` where all packages are cached and with https://github.com/pypa/pip/pull/12657 already applied.

<details>
  <summary>Before call graph</summary>

  ![airflow-before-cache](https://github.com/pypa/pip/assets/8070352/814c085e-2686-436f-8c81-6e4c8876e33a)

</details>

For this scenario [ `_parseNoCache`](https://github.com/pypa/pip/blob/f18bebdddbb04372169a617ebdd865974125c196/src/pip/_vendor/pyparsing/core.py#L804) is taking almost 28% of the run time during profiling, partly because it is being called many times by constructing [`Requirement`](https://github.com/pypa/pip/blob/f18bebdddbb04372169a617ebdd865974125c196/src/pip/_vendor/packaging/requirements.py#L87) in a [loop](https://github.com/pypa/pip/blob/f18bebdddbb04372169a617ebdd865974125c196/src/pip/_internal/metadata/importlib/_dists.py#L219)

Caching the construction of  `Requirement` the performance of `apache-airflow[all]` went from 174 seconds to 143 seconds and  `_parseNoCache` reduced to 3% of the run time during profiling:

<details>
  <summary>After call graph</summary>

![airflow-all-cache-requirements](https://github.com/pypa/pip/assets/8070352/19b2dec4-abca-436c-b8a8-c4aace1b9b41)
</details>

Further, testing performance of the highly pathological requirements `"urllib3>2" "boto3<1.20"` total time went from 559 seconds to 117 seconds.

Testing very simple requirements such as `requests` and `pandas` performance appeared to be about 1-3% better, but they were within the margin of error. However I did observe for these requirements all `Requirement`s objects were constructed at least twice, e.g. for `requests` the final `CacheInfo` was `CacheInfo(hits=11, misses=11, maxsize=None, currsize=11)`, and for `pandas` the final one was `CacheInfo(hits=86, misses=86, maxsize=None, currsize=86)`. So it does make sense there would be a small saving for even requirements that don't backtrack.

I set the maxsize to 1024 preemptively for questions about unlimited memory usage, out of the requirements I tested only `apache-airflow[all]` exceeded the cache size, so I tested a few data points:

* 128 maxsize: `CacheInfo(hits=2176, misses=60088, maxsize=128, currsize=128)`
* 256 maxsize: `CacheInfo(hits=2402, misses=59862, maxsize=256, currsize=256)`
* 512: maxsize: `CacheInfo(hits=55408, misses=6856, maxsize=512, currsize=512)`
* 1024 maxsize: `CacheInfo(hits=56087, misses=6127, maxsize=1024, currsize=1024)`
* 2048 maxsize: `CacheInfo(hits=56307, misses=5906, maxsize=2048, currsize=2048)`
* None maxsize: `CacheInfo(hits=59185, misses=3079, maxsize=None, currsize=3079)`

It appears there's some arbitrary point, which depends on the dependency graph, where once the maxsize is over the hit rate goes up significantly. Out of all the graphs I tested, 1024 seemed to be firmly above that number.

For the `apache-airflow[all]`, the time difference between 1024 and None on my machine was 146 seconds vs. 143 seconds.

Happy to take a different approach if someone spots one.
