### PR TITLE
Calculate candidate string versions only once in `get_applicable_candidates`

### DIFF
--- a/news/12664.feature.rst
+++ b/news/12664.feature.rst
@@ -1,0 +1,1 @@
+Minor performance improvement of finding applicable package candidates by not repeatedly calculating their versions

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -452,24 +452,23 @@ class CandidateEvaluator:
         # Using None infers from the specifier instead.
         allow_prereleases = self._allow_all_prereleases or None
         specifier = self._specifier
-        versions = {
-            str(v)
-            for v in specifier.filter(
-                # We turn the version object into a str here because otherwise
-                # when we're debundled but setuptools isn't, Python will see
-                # packaging.version.Version and
-                # pkg_resources._vendor.packaging.version.Version as different
-                # types. This way we'll use a str as a common data interchange
-                # format. If we stop using the pkg_resources provided specifier
-                # and start using our own, we can drop the cast to str().
-                (str(c.version) for c in candidates),
+
+        # We turn the version object into a str here because otherwise
+        # when we're debundled but setuptools isn't, Python will see
+        # packaging.version.Version and
+        # pkg_resources._vendor.packaging.version.Version as different
+        # types. This way we'll use a str as a common data interchange
+        # format. If we stop using the pkg_resources provided specifier
+        # and start using our own, we can drop the cast to str().
+        candidates_and_versions = [(c, str(c.version)) for c in candidates]
+        versions = set(
+            specifier.filter(
+                (v for _, v in candidates_and_versions),
                 prereleases=allow_prereleases,
             )
-        }
+        )
 
-        # Again, converting version to str to deal with debundling.
-        applicable_candidates = [c for c in candidates if str(c.version) in versions]
-
+        applicable_candidates = [c for c, v in candidates_and_versions if v in versions]
         filtered_applicable_candidates = filter_unallowed_hashes(
             candidates=applicable_candidates,
             hashes=self._hashes,


### PR DESCRIPTION
This is a minor performance, I measure it at 1% fairly consistently across different resolutions I've tried.

I was looking at the "After call graph" in https://github.com/pypa/pip/pull/12663 and noticed that `get_applicable_candidates` was taking 16% of run time, and even though it was only called 921 times it is calling other methods hundreds of thousands of times.

The only obvious thing I spotted though is it effectively calculating `[c.version for c in candidates]` twice, and can be seen on this part of the call graph:

<details>
  <summary>Highlighted call graph</summary>

![image](https://github.com/pypa/pip/assets/8070352/ec58bd53-cfc0-41f7-8292-fb640926b0ec)
</details>

I suspect though that this function has further significant optimization, so I will leave it as draft for now and think on it and take any suggestions, before marking it ready for review. 
