### PR TITLE
Update classifier to support Python 3.13

### DIFF
--- a/news/12678.trivial.rst
+++ b/news/12678.trivial.rst
@@ -1,0 +1,1 @@
+Update classifier to support Python 3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
Based on CI, pip should already support Python 3.13, so the classifier should also have Python 3.13 included.

https://github.com/pypa/pip/blob/a7369ba1452b93dc70cb2f5c21c1ffa249202ec8/.github/workflows/ci.yml#L117