### PR TITLE
Disable self version check in PEP 517 pip subprocesses

### DIFF
--- a/news/12683.feature.rst
+++ b/news/12683.feature.rst
@@ -1,0 +1,2 @@
+Disable pip's self version check when invoking a pip subprocess to install
+PEP 517 build requirements.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -241,6 +241,7 @@ class BuildEnvironment:
             "--prefix",
             prefix.path,
             "--no-warn-script-location",
+            "--disable-pip-version-check",
         ]
         if logger.getEffectiveLevel() <= logging.DEBUG:
             args.append("-vv")


### PR DESCRIPTION
This eliminates a (very) small unnecessary performance penalty and reduces output clutter when the pip subprocess errors out.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
