### PR TITLE
Eagerly import `self_outdated_check` when modifying pip

### DIFF
--- a/news/12675.bugfix.rst
+++ b/news/12675.bugfix.rst
@@ -1,0 +1,2 @@
+Eagerly import the self version check logic to avoid crashes while upgrading
+or downgrading pip at the same time.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -406,6 +406,12 @@ class InstallCommand(RequirementCommand):
                 # If we're not replacing an already installed pip,
                 # we're not modifying it.
                 modifying_pip = pip_req.satisfied_by is None
+                if modifying_pip:
+                    # Eagerly import this module to avoid crashes. Otherwise, this
+                    # module would be imported *after* pip was replaced, resulting in
+                    # crashes if the new self_outdated_check module was incompatible
+                    # with the rest of pip that's already imported.
+                    import pip._internal.self_outdated_check  # noqa: F401
             protect_pip_from_modification_on_windows(modifying_pip=modifying_pip)
 
             reqs_to_build = [


### PR DESCRIPTION
The `self_outdated_check` module should be loaded *before* pip is replaced as otherwise the module is liable to blow up if there are any incompatibities between the `self_outdated_check` from new pip and the old pip already loaded.

Alternative to #12676.
Fixes https://github.com/pypa/pip/issues/12675.