### PR TITLE
Suggestion to check 'pip config debug' in case of InvalidProxyURL exception

### DIFF
--- a/news/12649.feature.rst
+++ b/news/12649.feature.rst
@@ -1,0 +1,1 @@
+Suggest checking "pip config debug" in case of an InvalidProxyURL error.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -8,6 +8,7 @@ from optparse import SUPPRESS_HELP, Values
 from typing import List, Optional
 
 from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.requests.exceptions import InvalidProxyURL
 from pip._vendor.rich import print_json
 
 # Eagerly import self_outdated_check to avoid crashes. Otherwise,
@@ -764,6 +765,13 @@ def create_os_error_message(
             )
         else:
             parts.append(permissions_part)
+        parts.append(".\n")
+
+    # Suggest to check "pip config debug" in case of invalid proxy
+    if type(error) is InvalidProxyURL:
+        parts.append(
+            'Consider checking your local proxy configuration with "pip config debug"'
+        )
         parts.append(".\n")
 
     # Suggest the user to enable Long Paths if path length is

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -3,6 +3,8 @@ from unittest import mock
 
 import pytest
 
+from pip._vendor.requests.exceptions import InvalidProxyURL
+
 from pip._internal.commands import install
 from pip._internal.commands.install import create_os_error_message, decide_user_install
 
@@ -107,6 +109,16 @@ class TestDecideUserInstall:
             "Could not install packages due to an OSError: [Errno 13] No"
             " file permission\nConsider using the `--user` option or check the"
             " permissions.\n",
+        ),
+        # Testing custom InvalidProxyURL with help message
+        #  show_traceback = True, using_user_site = True
+        (
+            InvalidProxyURL(),
+            True,
+            True,
+            "Could not install packages due to an OSError.\n"
+            "Consider checking your local proxy configuration"
+            ' with "pip config debug".\n',
         ),
     ],
 )


### PR DESCRIPTION
When an `InvalidProxyURL` exception happens, an additional suggestion to check `pip config debug` is added. Attempt to fix issue #12649.

This is done by checking in function `create_os_error_message` if the type of the error corresponds to `InvalidProxyURL`.

A unit test is added in `tests/unit/test_command_install.py`, alongside with other existing tests for `create_os_error_message`.