### PR TITLE
Revert "Add `render: shell` to the bug report template to format output as code"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -61,13 +61,11 @@ body:
       description: >-
         Provide the output of the steps above, including the commands
         themselves and pip's output/traceback etc.
-        (The output will auto-rendered as code, no need for backticks.)
 
         If you want to present output from multiple commands, please prefix
         the line containing the command with `$ `. Please also ensure that
         the "How to reproduce" section contains matching instructions for
         reproducing this.
-      render: shell
 
   - type: checkboxes
     attributes:


### PR DESCRIPTION
Reverts pypa/pip#12630

See https://github.com/pypa/pip/commit/7485260b4e741ddf7b0fbcf5efe54feac768321e where we'd removed this because GitHub does not correctly close out the final parts of the issue.