### PR TITLE
Fix typo in _envs.py

### DIFF
--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -150,7 +150,7 @@ class _DistributionFinder:
 def _emit_egg_deprecation(location: Optional[str]) -> None:
     deprecated(
         reason=f"Loading egg at {location} is deprecated.",
-        replacement="to use pip for package installation.",
+        replacement="to use pip for package installation",
         gone_in="24.3",
         issue=12330,
     )


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Ran into this warning and discovered a typo “_A possible replacement is to use pip for package installation.**.**_” (one more dot)

In this PR, the extra dot at the end of the line has been removed.
