### PR TITLE
Also patch time.time_ns() in unit tests

### DIFF
--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -17,8 +17,12 @@ from pip._internal.utils.temp_dir import TempDirectory
 
 @pytest.fixture
 def fixed_time() -> Iterator[None]:
-    with patch("time.time", lambda: 1547704837.040001 + time.timezone):
-        yield
+    # Patch time so logs contain a constant timestamp. time.time_ns is used by
+    # logging starting with Python 3.13.
+    year2019 = 1547704837.040001 + time.timezone
+    with patch("time.time", lambda: year2019):
+        with patch("time.time_ns", lambda: int(year2019 * 1e9)):
+            yield
 
 
 class FakeCommand(Command):


### PR DESCRIPTION
The logging implementation in Python 3.13.0b1 uses time.time_ns() instead of time.time(). https://github.com/python/cpython/commit/1316692e8c7c1e1f3b6639e51804f9db5ed892ea

This is currently failing main CI: https://github.com/pypa/pip/actions/runs/9038557284/job/24839935776#step:5:3094

