### PR TITLE
Document how to activate truststore persistently

### DIFF
--- a/docs/html/topics/https-certificates.md
+++ b/docs/html/topics/https-certificates.md
@@ -22,6 +22,7 @@ variables.
 
 ```{versionadded} 22.2
 Experimental support, behind `--use-feature=truststore`.
+As with any other CLI option, this can be enabled globally via config or environment variables.
 ```
 
 It is possible to use the system trust store, instead of the bundled certifi


### PR DESCRIPTION
Based on suggestion in #12689. Most users interested in truststore will likely want to enable the feature persistently instead of opting in on a per-call basis. I would therefore appreciate if the doc is updated to also cover this use-case.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
