### PR TITLE
Revert 5cc540b 

### DIFF
--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -1,6 +1,7 @@
 import re
 import textwrap
 from os.path import join
+from pathlib import Path
 
 import pytest
 
@@ -252,3 +253,23 @@ def test_install_extras(script: PipTestEnvironment) -> None:
         "a",
     )
     script.assert_installed(a="1", b="1", dep="1", meh="1")
+
+
+def test_install_setuptools_extras_inconsistency(
+    script: PipTestEnvironment, tmp_path: Path
+) -> None:
+    test_project_path = tmp_path.joinpath("test")
+    test_project_path.mkdir()
+    test_project_path.joinpath("setup.py").write_text(
+        textwrap.dedent(
+            """
+                from setuptools import setup
+                setup(
+                    name='test',
+                    version='0.1',
+                    extras_require={'extra_underscored': ['packaging']},
+                )
+            """
+        )
+    )
+    script.pip("install", "--dry-run", test_project_path)

--- a/tests/unit/metadata/test_metadata_pkg_resources.py
+++ b/tests/unit/metadata/test_metadata_pkg_resources.py
@@ -40,17 +40,17 @@ class _MockWorkingSet(List[mock.Mock]):
 
 workingset = _MockWorkingSet(
     (
-        mock.Mock(test_name="global", project_name="global"),
-        mock.Mock(test_name="editable", project_name="editable"),
-        mock.Mock(test_name="normal", project_name="normal"),
-        mock.Mock(test_name="user", project_name="user"),
+        mock.Mock(test_name="global", project_name="global", extras=[]),
+        mock.Mock(test_name="editable", project_name="editable", extras=[]),
+        mock.Mock(test_name="normal", project_name="normal", extras=[]),
+        mock.Mock(test_name="user", project_name="user", extras=[]),
     )
 )
 
 workingset_stdlib = _MockWorkingSet(
     (
-        mock.Mock(test_name="normal", project_name="argparse"),
-        mock.Mock(test_name="normal", project_name="wsgiref"),
+        mock.Mock(test_name="normal", project_name="argparse", extras=[]),
+        mock.Mock(test_name="normal", project_name="wsgiref", extras=[]),
     )
 )
 


### PR DESCRIPTION
This adds a failing test for setuptools projects with extras names containing `_` characters.

Then attemtp to revert https://github.com/pypa/pip/commit/5cc540be94dbccfaaa3c6b458dd3bd7c0877ce65.

Fixes #12688
