### PR TITLE
Enable verbose logging with `--debug`

### DIFF
--- a/news/12710.feature.rst
+++ b/news/12710.feature.rst
@@ -1,0 +1,1 @@
+Using ``--debug`` also enables verbose logging.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -172,6 +172,8 @@ class Command(CommandContextMixIn):
 
         # Set verbosity so that it can be used elsewhere.
         self.verbosity = options.verbose - options.quiet
+        if options.debug_mode:
+            self.verbosity = 2
 
         reconfigure(no_color=options.no_color)
         level_number = setup_logging(

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -107,6 +107,12 @@ def test_handle_pip_version_check_called(mock_handle_version_check: Mock) -> Non
     mock_handle_version_check.assert_called_once()
 
 
+def test_debug_enables_verbose_logs() -> None:
+    cmd = FakeCommand()
+    cmd.main(["fake", "--debug"])
+    assert cmd.verbosity >= 2
+
+
 def test_log_command_success(fixed_time: None, tmpdir: Path) -> None:
     """Test the --log option logs when command succeeds."""
     cmd = FakeCommand()


### PR DESCRIPTION
This helps ensure that all relevant context is presented when a failure happens and diagnosis is being done through the use of `--debug`.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
