### PR TITLE
Handle dlopen(NULL) failure in glibc fallback

### DIFF
--- a/news/12716.bugfix.rst
+++ b/news/12716.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid dlopen failure for glibc detection in musl builds

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -40,7 +40,20 @@ def glibc_version_string_ctypes() -> Optional[str]:
     # manpage says, "If filename is NULL, then the returned handle is for the
     # main program". This way we can let the linker do the work to figure out
     # which libc our process is actually using.
-    process_namespace = ctypes.CDLL(None)
+    #
+    # We must also handle the special case where the executable is not a
+    # dynamically linked executable. This can occur when using musl libc,
+    # for example. In this situation, dlopen() will error, leading to an
+    # OSError. Interestingly, at least in the case of musl, there is no
+    # errno set on the OSError. The single string argument used to construct
+    # OSError comes from libc itself and is therefore not portable to
+    # hard code here. In any case, failure to call dlopen() means we
+    # can proceed, so we bail on our attempt.
+    try:
+        process_namespace = ctypes.CDLL(None)
+    except OSError:
+        return None
+
     try:
         gnu_get_libc_version = process_namespace.gnu_get_libc_version
     except AttributeError:
@@ -50,7 +63,7 @@ def glibc_version_string_ctypes() -> Optional[str]:
 
     # Call gnu_get_libc_version, which returns a string like "2.5"
     gnu_get_libc_version.restype = ctypes.c_char_p
-    version_str = gnu_get_libc_version()
+    version_str: str = gnu_get_libc_version()
     # py2 / py3 compatibility:
     if not isinstance(version_str, str):
         version_str = version_str.decode("ascii")

--- a/src/pip/_internal/utils/glibc.py
+++ b/src/pip/_internal/utils/glibc.py
@@ -48,7 +48,7 @@ def glibc_version_string_ctypes() -> Optional[str]:
     # errno set on the OSError. The single string argument used to construct
     # OSError comes from libc itself and is therefore not portable to
     # hard code here. In any case, failure to call dlopen() means we
-    # can proceed, so we bail on our attempt.
+    # can't proceed, so we bail on our attempt.
     try:
         process_namespace = ctypes.CDLL(None)
     except OSError:


### PR DESCRIPTION
## Summary

This PR applies the same exception handling to `ctypes.CDLL(None)` that already exists for the analogous method in packaging: https://github.com/pypa/packaging/pull/294 (and, similarly, in pip's vendored packaging -- see `src/pip/_vendor/packaging/_manylinux.py`).

The basic idea is that if you're using a Python distribution built against musl libc, `dlopen` will fail (in addition to `import ctypes` itself failing).

Also relevant is https://github.com/indygreg/pip/commit/5139dc494f624039d8a04e8b0a538cbe7c754fd1 and https://github.com/pypa/pip/issues/6543, where @indeygreg added the original `try`-`except` for `ctypes.`
