### PR TITLE
Update git tests to not use local partial clones

### DIFF
--- a/tests/lib/local_repos.py
+++ b/tests/lib/local_repos.py
@@ -37,7 +37,7 @@ def local_checkout(
         created as a sub directory of the base temp directory.
     """
     assert "+" in remote_repo
-    vcs_name = remote_repo.split("+", 1)[0]
+    vcs_name, vcs_url = remote_repo.split("+", 1)
     repository_name = os.path.basename(remote_repo)
 
     directory = temp_path.joinpath("cache")
@@ -51,6 +51,12 @@ def local_checkout(
         assert repository_name == "INITools"
         _create_svn_initools_repo(repo_url_path)
         repo_url_path = os.path.join(repo_url_path, "trunk")
+    elif vcs_name == "git":
+        # Don't use vcs_backend.obtain() here because we don't want a partial clone:
+        # https://github.com/pypa/pip/issues/12719
+        subprocess.check_call(
+            ["git", "clone", vcs_url, repo_url_path],
+        )
     else:
         vcs_backend = vcs.get_backend(vcs_name)
         assert vcs_backend is not None


### PR DESCRIPTION
This works around a git restriction to fix CVE-2024-32004.

This change only modifies  tests using local git repos to not use partial clones as source repos. Tests using remote git repos continue to work as before.

Users affected by the error `remote: fatal: could not fetch ... from promisor remote` should consider setting a GIT_NO_LAZY_FETCH=0 env var if they trust the source repo.

fixes #12719 