### PR TITLE
Stop explicitly listing wheel as a build dependency

### DIFF
--- a/news/12728.feature.rst
+++ b/news/12728.feature.rst
@@ -1,0 +1,5 @@
+``wheel`` is no longer explicitly listed as a build depepndency of ``pip``.
+``setuptools`` already injects this dependency in the ``get_requires_for_build_wheel()`` hook.
+This makes no difference for users of ``pip``.
+This makes no difference when building wheels of ``pip``.
+This avoids an unnecessary dependency on ``wheel`` wehn bulding the source distribution of ``pip``.

--- a/news/12728.feature.rst
+++ b/news/12728.feature.rst
@@ -2,4 +2,4 @@
 ``setuptools`` already injects this dependency in the ``get_requires_for_build_wheel()`` hook.
 This makes no difference for users of ``pip``.
 This makes no difference when building wheels of ``pip``.
-This avoids an unnecessary dependency on ``wheel`` wehn bulding the source distribution of ``pip``.
+This avoids an unnecessary dependency on ``wheel`` when building the source distribution of ``pip``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Changelog = "https://pip.pypa.io/en/stable/news/"
 
 [build-system]
 # The lower bound is for <https://github.com/pypa/setuptools/issues/3865>.
-requires = ["setuptools>=67.6.1", "wheel"]
+requires = ["setuptools>=67.6.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
setuptools' get_requires_for_build_wheel() hook already injects this dependency when building wheels is requested.

See also 64d89385ce4b5ae2d05d176e7746bff0baaabafd.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

cc @webknjaz 