### PR TITLE
Upgrade typing_extensions to 4.12.0

### DIFF
--- a/news/typing_extensions.vendor.rst
+++ b/news/typing_extensions.vendor.rst
@@ -1,0 +1,1 @@
+Upgrade typing_extensions to 4.12.0

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -11,7 +11,7 @@ requests==2.32.0
     urllib3==1.26.18
 rich==13.7.1
     pygments==2.17.2
-    typing_extensions==4.11.0
+    typing_extensions==4.12.0
 resolvelib==1.0.1
 setuptools==69.5.1
 tenacity==8.2.3


### PR DESCRIPTION
This is necessary for https://github.com/pypa/pip/pull/12705 as `ParamSpec` currently crashes on Python 3.13.