### PR TITLE
Upgrade tenacity to 8.3.0

### DIFF
--- a/news/tenacity.vendor.rst
+++ b/news/tenacity.vendor.rst
@@ -1,0 +1,1 @@
+Upgrade tenacity to 8.3.0

--- a/src/pip/_vendor/tenacity/_asyncio.py
+++ b/src/pip/_vendor/tenacity/_asyncio.py
@@ -18,22 +18,33 @@
 import functools
 import sys
 import typing as t
-from asyncio import sleep
 
 from pip._vendor.tenacity import AttemptManager
 from pip._vendor.tenacity import BaseRetrying
 from pip._vendor.tenacity import DoAttempt
 from pip._vendor.tenacity import DoSleep
 from pip._vendor.tenacity import RetryCallState
+from pip._vendor.tenacity import _utils
 
 WrappedFnReturnT = t.TypeVar("WrappedFnReturnT")
 WrappedFn = t.TypeVar("WrappedFn", bound=t.Callable[..., t.Awaitable[t.Any]])
 
 
+def asyncio_sleep(duration: float) -> t.Awaitable[None]:
+    # Lazy import asyncio as it's expensive (responsible for 25-50% of total import overhead).
+    import asyncio
+
+    return asyncio.sleep(duration)
+
+
 class AsyncRetrying(BaseRetrying):
     sleep: t.Callable[[float], t.Awaitable[t.Any]]
 
-    def __init__(self, sleep: t.Callable[[float], t.Awaitable[t.Any]] = sleep, **kwargs: t.Any) -> None:
+    def __init__(
+        self,
+        sleep: t.Callable[[float], t.Awaitable[t.Any]] = asyncio_sleep,
+        **kwargs: t.Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.sleep = sleep
 
@@ -44,7 +55,7 @@ class AsyncRetrying(BaseRetrying):
 
         retry_state = RetryCallState(retry_object=self, fn=fn, args=args, kwargs=kwargs)
         while True:
-            do = self.iter(retry_state=retry_state)
+            do = await self.iter(retry_state=retry_state)
             if isinstance(do, DoAttempt):
                 try:
                     result = await fn(*args, **kwargs)
@@ -58,6 +69,47 @@ class AsyncRetrying(BaseRetrying):
             else:
                 return do  # type: ignore[no-any-return]
 
+    @classmethod
+    def _wrap_action_func(cls, fn: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
+        if _utils.is_coroutine_callable(fn):
+            return fn
+
+        async def inner(*args: t.Any, **kwargs: t.Any) -> t.Any:
+            return fn(*args, **kwargs)
+
+        return inner
+
+    def _add_action_func(self, fn: t.Callable[..., t.Any]) -> None:
+        self.iter_state.actions.append(self._wrap_action_func(fn))
+
+    async def _run_retry(self, retry_state: "RetryCallState") -> None:  # type: ignore[override]
+        self.iter_state.retry_run_result = await self._wrap_action_func(self.retry)(
+            retry_state
+        )
+
+    async def _run_wait(self, retry_state: "RetryCallState") -> None:  # type: ignore[override]
+        if self.wait:
+            sleep = await self._wrap_action_func(self.wait)(retry_state)
+        else:
+            sleep = 0.0
+
+        retry_state.upcoming_sleep = sleep
+
+    async def _run_stop(self, retry_state: "RetryCallState") -> None:  # type: ignore[override]
+        self.statistics["delay_since_first_attempt"] = retry_state.seconds_since_start
+        self.iter_state.stop_run_result = await self._wrap_action_func(self.stop)(
+            retry_state
+        )
+
+    async def iter(
+        self, retry_state: "RetryCallState"
+    ) -> t.Union[DoAttempt, DoSleep, t.Any]:  # noqa: A003
+        self._begin_iter(retry_state)
+        result = None
+        for action in self.iter_state.actions:
+            result = await action(retry_state)
+        return result
+
     def __iter__(self) -> t.Generator[AttemptManager, None, None]:
         raise TypeError("AsyncRetrying object is not iterable")
 
@@ -68,7 +120,7 @@ class AsyncRetrying(BaseRetrying):
 
     async def __anext__(self) -> AttemptManager:
         while True:
-            do = self.iter(retry_state=self._retry_state)
+            do = await self.iter(retry_state=self._retry_state)
             if do is None:
                 raise StopAsyncIteration
             elif isinstance(do, DoAttempt):
@@ -83,7 +135,9 @@ class AsyncRetrying(BaseRetrying):
         fn = super().wraps(fn)
         # Ensure wrapper is recognized as a coroutine function.
 
-        @functools.wraps(fn)
+        @functools.wraps(
+            fn, functools.WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__")
+        )
         async def async_wrapped(*args: t.Any, **kwargs: t.Any) -> t.Any:
             return await fn(*args, **kwargs)
 

--- a/src/pip/_vendor/tenacity/_utils.py
+++ b/src/pip/_vendor/tenacity/_utils.py
@@ -13,7 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import functools
+import inspect
 import sys
 import typing
 from datetime import timedelta
@@ -73,4 +74,16 @@ time_unit_type = typing.Union[int, float, timedelta]
 
 
 def to_seconds(time_unit: time_unit_type) -> float:
-    return float(time_unit.total_seconds() if isinstance(time_unit, timedelta) else time_unit)
+    return float(
+        time_unit.total_seconds() if isinstance(time_unit, timedelta) else time_unit
+    )
+
+
+def is_coroutine_callable(call: typing.Callable[..., typing.Any]) -> bool:
+    if inspect.isclass(call):
+        return False
+    if inspect.iscoroutinefunction(call):
+        return True
+    partial_call = isinstance(call, functools.partial) and call.func
+    dunder_call = partial_call or getattr(call, "__call__", None)
+    return inspect.iscoroutinefunction(dunder_call)

--- a/src/pip/_vendor/tenacity/before.py
+++ b/src/pip/_vendor/tenacity/before.py
@@ -28,7 +28,9 @@ def before_nothing(retry_state: "RetryCallState") -> None:
     """Before call strategy that does nothing."""
 
 
-def before_log(logger: "logging.Logger", log_level: int) -> typing.Callable[["RetryCallState"], None]:
+def before_log(
+    logger: "logging.Logger", log_level: int
+) -> typing.Callable[["RetryCallState"], None]:
     """Before call strategy that logs to some logger the attempt."""
 
     def log_it(retry_state: "RetryCallState") -> None:

--- a/src/pip/_vendor/tenacity/before_sleep.py
+++ b/src/pip/_vendor/tenacity/before_sleep.py
@@ -64,7 +64,8 @@ def before_sleep_log(
 
         logger.log(
             log_level,
-            f"Retrying {fn_name} " f"in {retry_state.next_action.sleep} seconds as it {verb} {value}.",
+            f"Retrying {fn_name} "
+            f"in {retry_state.next_action.sleep} seconds as it {verb} {value}.",
             exc_info=local_exc_info,
         )
 

--- a/src/pip/_vendor/tenacity/retry.py
+++ b/src/pip/_vendor/tenacity/retry.py
@@ -204,7 +204,9 @@ class retry_if_exception_message(retry_if_exception):
         match: typing.Optional[str] = None,
     ) -> None:
         if message and match:
-            raise TypeError(f"{self.__class__.__name__}() takes either 'message' or 'match', not both")
+            raise TypeError(
+                f"{self.__class__.__name__}() takes either 'message' or 'match', not both"
+            )
 
         # set predicate
         if message:
@@ -221,7 +223,9 @@ class retry_if_exception_message(retry_if_exception):
 
             predicate = match_fnc
         else:
-            raise TypeError(f"{self.__class__.__name__}() missing 1 required argument 'message' or 'match'")
+            raise TypeError(
+                f"{self.__class__.__name__}() missing 1 required argument 'message' or 'match'"
+            )
 
         super().__init__(predicate)
 

--- a/src/pip/_vendor/tenacity/stop.py
+++ b/src/pip/_vendor/tenacity/stop.py
@@ -92,7 +92,14 @@ class stop_after_attempt(stop_base):
 
 
 class stop_after_delay(stop_base):
-    """Stop when the time from the first attempt >= limit."""
+    """
+    Stop when the time from the first attempt >= limit.
+
+    Note: `max_delay` will be exceeded, so when used with a `wait`, the actual total delay will be greater
+    than `max_delay` by some of the final sleep period before `max_delay` is exceeded.
+
+    If you need stricter timing with waits, consider `stop_before_delay` instead.
+    """
 
     def __init__(self, max_delay: _utils.time_unit_type) -> None:
         self.max_delay = _utils.to_seconds(max_delay)
@@ -101,3 +108,23 @@ class stop_after_delay(stop_base):
         if retry_state.seconds_since_start is None:
             raise RuntimeError("__call__() called but seconds_since_start is not set")
         return retry_state.seconds_since_start >= self.max_delay
+
+
+class stop_before_delay(stop_base):
+    """
+    Stop right before the next attempt would take place after the time from the first attempt >= limit.
+
+    Most useful when you are using with a `wait` function like wait_random_exponential, but need to make
+    sure that the max_delay is not exceeded.
+    """
+
+    def __init__(self, max_delay: _utils.time_unit_type) -> None:
+        self.max_delay = _utils.to_seconds(max_delay)
+
+    def __call__(self, retry_state: "RetryCallState") -> bool:
+        if retry_state.seconds_since_start is None:
+            raise RuntimeError("__call__() called but seconds_since_start is not set")
+        return (
+            retry_state.seconds_since_start + retry_state.upcoming_sleep
+            >= self.max_delay
+        )

--- a/src/pip/_vendor/tenacity/tornadoweb.py
+++ b/src/pip/_vendor/tenacity/tornadoweb.py
@@ -29,7 +29,11 @@ _RetValT = typing.TypeVar("_RetValT")
 
 
 class TornadoRetrying(BaseRetrying):
-    def __init__(self, sleep: "typing.Callable[[float], Future[None]]" = gen.sleep, **kwargs: typing.Any) -> None:
+    def __init__(
+        self,
+        sleep: "typing.Callable[[float], Future[None]]" = gen.sleep,
+        **kwargs: typing.Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.sleep = sleep
 

--- a/src/pip/_vendor/tenacity/wait.py
+++ b/src/pip/_vendor/tenacity/wait.py
@@ -41,7 +41,9 @@ class wait_base(abc.ABC):
         return self.__add__(other)
 
 
-WaitBaseT = typing.Union[wait_base, typing.Callable[["RetryCallState"], typing.Union[float, int]]]
+WaitBaseT = typing.Union[
+    wait_base, typing.Callable[["RetryCallState"], typing.Union[float, int]]
+]
 
 
 class wait_fixed(wait_base):
@@ -64,12 +66,16 @@ class wait_none(wait_fixed):
 class wait_random(wait_base):
     """Wait strategy that waits a random amount of time between min/max."""
 
-    def __init__(self, min: _utils.time_unit_type = 0, max: _utils.time_unit_type = 1) -> None:  # noqa
+    def __init__(
+        self, min: _utils.time_unit_type = 0, max: _utils.time_unit_type = 1
+    ) -> None:  # noqa
         self.wait_random_min = _utils.to_seconds(min)
         self.wait_random_max = _utils.to_seconds(max)
 
     def __call__(self, retry_state: "RetryCallState") -> float:
-        return self.wait_random_min + (random.random() * (self.wait_random_max - self.wait_random_min))
+        return self.wait_random_min + (
+            random.random() * (self.wait_random_max - self.wait_random_min)
+        )
 
 
 class wait_combine(wait_base):

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -14,6 +14,6 @@ rich==13.7.1
     typing_extensions==4.11.0
 resolvelib==1.0.1
 setuptools==69.5.1
-tenacity==8.2.3
+tenacity==8.3.0
 tomli==2.0.1
 truststore==0.8.0


### PR DESCRIPTION
I'm not sure whether a vendoring bump would be accepted during a beta period, but given I likely won't have time to finish #12705 in time for the final release, I'd like to upgrade our version of tenacity to benefit from https://github.com/jd/tenacity/pull/450. On my system, this reduces the runtime of `pip show --help` from ~140ms to ~130ms.

Towards #4768.