### PR TITLE
Bump black, ruff, mypy, and codespell pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,18 +17,18 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.4.0
+  rev: 24.4.2
   hooks:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.1
+  rev: v0.4.7
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.9.0
+  rev: v1.10.0
   hooks:
   - id: mypy
     exclude: tests/data
@@ -55,7 +55,7 @@ repos:
     exclude: NEWS.rst  # The errors flagged in NEWS.rst are old.
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.6
+  rev: v2.3.0
   hooks:
     - id: codespell
       exclude: AUTHORS.txt|tests/data

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 import textwrap
 from contextlib import suppress
-from typing import Any, Dict, Generator, List, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 from pip._internal.cli.status_codes import UNKNOWN_ERROR
 from pip._internal.configuration import Configuration, ConfigurationError
@@ -67,7 +67,7 @@ class PrettyHelpFormatter(optparse.IndentedHelpFormatter):
         msg = "\nUsage: {}\n".format(self.indent_lines(textwrap.dedent(usage), "  "))
         return msg
 
-    def format_description(self, description: str) -> str:
+    def format_description(self, description: Optional[str]) -> str:
         # leave full control over description to us
         if description:
             if hasattr(self.parser, "main"):
@@ -85,7 +85,7 @@ class PrettyHelpFormatter(optparse.IndentedHelpFormatter):
         else:
             return ""
 
-    def format_epilog(self, epilog: str) -> str:
+    def format_epilog(self, epilog: Optional[str]) -> str:
         # leave full control over epilog to us
         if epilog:
             return epilog

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -28,10 +28,7 @@ def mock_permitted(ups: UninstallPathSet, path: str) -> bool:
 def test_uninstallation_paths() -> None:
     class dist:
         def iter_declared_entries(self) -> Optional[Iterator[str]]:
-            yield "file.py"
-            yield "file.pyc"
-            yield "file.so"
-            yield "nopyc.py"
+            return iter(["file.py", "file.pyc", "file.so", "nopyc.py"])
 
         location = ""
 

--- a/tools/codespell-ignore.txt
+++ b/tools/codespell-ignore.txt
@@ -3,6 +3,7 @@ lousily
 followings
 # A contributor first name
 wil
+Whit
 # Codebase variable or class names
 uptodate
 afile


### PR DESCRIPTION
New mypy errors are:

    src/pip/_internal/cli/parser.py:70: error: Argument 1 of "format_description"
    is incompatible with supertype "HelpFormatter"; supertype defines the argument
    type as "str | None"  [override]
            def format_description(self, description: str) -> str:
                                         ^~~~~~~~~~~~~~~~
    src/pip/_internal/cli/parser.py:88: error: Argument 1 of "format_epilog" is
    incompatible with supertype "HelpFormatter"; supertype defines the argument type
    as "str | None"  [override]
            def format_epilog(self, epilog: str) -> str:
                                    ^~~~~~~~~~~
    tests/unit/test_req_uninstall.py:30: error: Missing return statement  [return]
                def iter_declared_entries(self) -> Optional[Iterator[str]]:
                ^
    Found 3 errors in 2 files (checked 296 source files)

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
