### PR TITLE
Build should not use global target directory when running from install

### DIFF
--- a/news/8438.bugfix.rst
+++ b/news/8438.bugfix.rst
@@ -1,0 +1,10 @@
+If the user's pip.conf includes a target directory setting,
+attempting to install a package in editable mode or from source
+results in a fatal error during the installation of setuptools.
+
+The following assertion triggers:
+assert not (home and prefix), "home={} prefix={}".format(home, prefix)
+
+To avoid this issue when building a package, the target
+setting should be ignored. This can be achieved by passing an empty
+target when installing dependencies in the BuildEnvironment class.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -242,6 +242,10 @@ class BuildEnvironment:
             prefix.path,
             "--no-warn-script-location",
             "--disable-pip-version-check",
+            # The prefix specified two lines above, thus
+            # target from config file or env var should be ignored
+            "--target",
+            "",
         ]
         if logger.getEffectiveLevel() <= logging.DEBUG:
             args.append("-vv")


### PR DESCRIPTION
If the user's pip.conf includes a target directory setting, attempting to install a package in editable mode or from source results in a fatal error during the installation of setuptools.

The following assertion triggers:
assert not (home and prefix), "home={} prefix={}".format(home, prefix)

To avoid this issue when building a package, the target setting should be ignored. This can be achieved by passing an empty target when installing dependencies in the BuildEnvironment class because it already has --home  set.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
