### PR TITLE
Adding Dev Container config for easier developer workflows

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+&& apt-get -y install --no-install-recommends subversion mercurial python3.10 python3.10-venv software-properties-common
+
+# Bazaar install info: https://launchpad.net/~bzr/+archive/ubuntu/ppa
+RUN add-apt-repository ppa:bzr/ppa -y
+RUN apt-get -y install bzr 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/anaconda
 {
-	"name": "Ubuntu",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:jammy",
-	"features": {
-		"ghcr.io/devcontainers-contrib/features/nox:2": {}
-	}
+	"name": "pip-devcontainer",
+	"build": { 
+		"context": "..",
+		"dockerfile": "Dockerfile"
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.defaultInterpreterPath": "/workspaces/pip/.venv/bin/python"
+			},
+			"extensions": [
+				"ms-python.python",
+				"donjayamanne.python-environment-manager",
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	"postCreateCommand": "python3 -m venv .venv && .venv/bin/activate && pip install nox"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/nox:2": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
After some discussion at PyCon sprints, this is a draft of what it would look like to add a [Dev Container](https://containers.dev) config file to the project. The basic idea is that someone wanting to contribute to pip or needs to review a PR can use a combination of Docker/JSON to run a development environment including things that are hard to specify in just a Docker container like IDE settings or plugins. This spec is supported in GitHub Codespaces, VS Code, PyCharm, and a growing list of other [backends](https://containers.dev/supporting).

Here I have initally working a Dev Container that gets all of the VCS systems installed on an Ubuntu based image with Python 3.10 (what was easily available from apt). I plan on making sure that the tests that are failing when Nox runs are fixed/expected and making what I can for versions of OS/Python parameterizable.

Also very open to other feedback/suggestions/comments! <3



<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
