### PR TITLE
Update docs to add git+ssh install example

### DIFF
--- a/docs/html/topics/vcs-support.md
+++ b/docs/html/topics/vcs-support.md
@@ -18,9 +18,9 @@ The supported schemes are `git+file`, `git+https`, `git+ssh`, `git+http`,
 `git+git` and `git`. Here are some of the supported forms:
 
 ```none
-MyProject @ git+ssh://git@git.example.com/MyProject
 MyProject @ git+file:///home/user/projects/MyProject
 MyProject @ git+https://git.example.com/MyProject
+MyProject @ git+ssh://git@git.example.com/MyProject
 ```
 
 ```{warning}
@@ -44,6 +44,13 @@ MyProject @ git+https://git.example.com/MyProject.git@refs/pull/123/head
 When passing a commit hash, specifying a full hash is preferable to a partial
 hash because a full hash allows pip to operate more efficiently (e.g. by
 making fewer network calls).
+
+- To use ssh scheme, just replace `https://` to `ssh://git@`. For example:
+
+```{pip-cli}
+pip install "wheel@git+ssh://git@github.com/pypa/wheel.git@main"
+```
+
 
 ### Mercurial
 

--- a/docs/html/topics/vcs-support.md
+++ b/docs/html/topics/vcs-support.md
@@ -45,11 +45,13 @@ When passing a commit hash, specifying a full hash is preferable to a partial
 hash because a full hash allows pip to operate more efficiently (e.g. by
 making fewer network calls).
 
-- To use ssh scheme, just replace `https://` to `ssh://git@`. For example:
+- To use ssh scheme, just replace `https://` to `ssh://git@`
 
+````{admonition} Example
 ```{pip-cli}
-pip install "wheel@git+ssh://git@github.com/pypa/wheel.git@main"
+$ pip install "wheel @ git+ssh://git@github.com/pypa/wheel.git@main"
 ```
+````
 
 
 ### Mercurial


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
1. Move line 21 to be line 23, so that it is easy to compare git+ssh with git+https
2. Add a real sample for install with git+ssh 