### PR TITLE
Cache supported tags in resolver factory

### DIFF
--- a/news/12712.feature.rst
+++ b/news/12712.feature.rst
@@ -1,0 +1,2 @@
+Improve dependency resolution performance by caching platform compatibility
+tags during wheel cache lookup.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -121,6 +121,7 @@ class Factory:
         self._extras_candidate_cache: Dict[
             Tuple[int, FrozenSet[NormalizedName]], ExtrasCandidate
         ] = {}
+        self._supported_tags_cache = get_supported()
 
         if not ignore_installed:
             env = get_default_environment()
@@ -608,7 +609,7 @@ class Factory:
         return self._wheel_cache.get_cache_entry(
             link=link,
             package_name=name,
-            supported_tags=get_supported(),
+            supported_tags=self._supported_tags_cache,
         )
 
     def get_dist_to_uninstall(self, candidate: Candidate) -> Optional[BaseDistribution]:


### PR DESCRIPTION
I've observed get_supported() consume up to 10% of the installation step when installing many packages. Each call can take 1-5ms (presumably only on Linux due to the large number of supported tags) and there is one call for every lookup in the cache. As all of these calls are made with no arguments, the tags can be trivially queried in advance during factory initialization.

<details><summary>Example profile</summary>
<p>

`python -m cProfile -o profile.pstats -m pip install --only-binary=:all: --no-index --ignore-installed --no-deps --find-links homeassistant/deps/ -r homeassistant/requirements.txt` (from https://github.com/home-assistant/core/blob/2024.6.0/requirements.txt)

`get_supported()` is left of `install_given_reqs()` which is coloured green.

![pstats](https://github.com/pypa/pip/assets/63936253/4de31d07-1025-421f-a372-449a8a20371b)

</p>
</details> 

Towards #12712.