### PR TITLE
Support completion of installation extras in zsh

### DIFF
--- a/news/12761.feature.rst
+++ b/news/12761.feature.rst
@@ -1,0 +1,1 @@
+Support completion of installation extras in zsh


### PR DESCRIPTION
When using the `pip install '.[extra,<tab>' ` in zsh, this should list the currently available extras if present in pyproject.toml.

I'm not a big expert in zsh, so there are some limitations, in particular one must use quotes (', or "), otherwise, the completer split the line on `[`, and we don't get called.

The completion does redisplay the full, already types extras, so `.[dev,t<tab>` will suggest things like `.[dev,tests]`, `.[dev,tox]` instead of just `test`, `tox`.

-- 

Test not yet included, but I can add if there is some interest. If you do not think this has a chance to get in, please let me know and I can close, I know you are fairly busy, and can understand this is extra maintenance.

It currently only support cwd for pyproject.toml, and does not suggest to add extras if a `[` is opened.

I also don't believe this needs a corresponding issue and news entry, but can do it if you believe it does.


<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
