### PR TITLE
ci: work around bad zipfile for 3.13.0b2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python == '3.13' && '3.13.0-beta.1' || matrix.python }}
           allow-prereleases: true
 
       - name: Install Ubuntu dependencies
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python == '3.13' && '3.13.0-beta.1' || matrix.python }}
           allow-prereleases: true
 
       # We use C:\Temp (which is already available on the worker)


### PR DESCRIPTION

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

This is a quick CI patch while https://github.com/actions/setup-python/issues/886 is being worked on.
