### PR TITLE
Pause in `prepare-release` for updating the NEWS file

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -294,6 +294,11 @@ def prepare_release(session: nox.Session) -> None:
 
     session.log("# Generating NEWS")
     release.generate_news(session, version)
+    if sys.stdin.isatty():
+        input(
+            "Please review the NEWS file, make necessary edits, and stage them.\n"
+            "Press Enter to continue..."
+        )
 
     session.log(f"# Bumping for release {version}")
     release.update_version_file(version, VERSION_FILE)


### PR DESCRIPTION
This enables making fixes to the NEWS file to fix issues prior to moving
forward with the rest of the release process.

x-ref https://github.com/pypa/pip/issues/12509