### PR TITLE
Fix directories not cleaned up after test

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -248,10 +248,10 @@ def test_rmtree_errorhandler_reraises_error(tmpdir: Path) -> None:
     by the given unreadable directory.
     """
     # Create directory without read permission
-    subdir_path = tmpdir / "subdir"
-    subdir_path.mkdir()
-    path = str(subdir_path)
-    os.chmod(path, stat.S_IWRITE)
+    path = tmpdir / "subdir"
+    path.mkdir()
+    old_mode = path.stat().st_mode
+    path.chmod(stat.S_IWRITE)
 
     mock_func = Mock()
 
@@ -267,6 +267,9 @@ def test_rmtree_errorhandler_reraises_error(tmpdir: Path) -> None:
             rmtree_errorhandler(
                 mock_func, path, sys.exc_info()  # type: ignore[arg-type]
             )
+    finally:
+        # Restore permissions to let pytest to clean up temp dirs
+        path.chmod(old_mode)
 
     mock_func.assert_not_called()
 


### PR DESCRIPTION
The `test_rmtree_errorhandler_reraises_error` test creates a directory
that the user is unable to read under pytest's `tmpdir`. Once the test
session end pytest will fail to clean this up due to permissions error
and emit a warning like:

    /home/user/src/pip/.nox/test-3-12/lib/python3.12/site-packages/_pytest/pathlib.py:98: PytestWarning: (rm_rf) error removing /tmp/pytest-of-user/garbage-23e907a9-3e54-40bd-89e4-d70150b10f61/test_rmtree_errorhandler_rerai0
    <class 'OSError'>: [Errno 39] Directory not empty: 'test_rmtree_errorhandler_rerai0'
      warnings.warn(

This restores behaviour from b5c1c7620335ccfbc855c50d92cc3e788a289a3a,
that commit mentions fixing 'failing tests' though I'm not sure which
failures that addresses and if they were related to restoring the file
permissions.

Also make consistent use of `pathlib.Path` methods rather than mixing
them with `os.` methods