### PR TITLE
Mark failing tests on Windows + Py3.13 as xfail

### DIFF
--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -383,14 +383,10 @@ def test_clean_url_path_with_local_path(path: str, expected: str) -> None:
         pytest.param(
             "file:///T:/path/with spaces/",
             "file:///T:/path/with%20spaces",
-            marks=[
-                pytest.mark.skipif("sys.platform != 'win32'"),
-                pytest.mark.xfail(
-                    reason="Failing in Python 3.13.0a1, fixed in python/cpython#113563",
-                    condition="sys.version_info >= (3, 13)",
-                    strict=True,
-                ),
-            ],
+            marks=pytest.mark.skipif(
+                "sys.platform != 'win32' or "
+                "sys.version_info == (3, 13, 0, 'beta', 2)"
+            ),
         ),
         # URL with Windows drive letter, running on non-windows
         # platform. The `:` after the drive should be quoted.
@@ -403,14 +399,10 @@ def test_clean_url_path_with_local_path(path: str, expected: str) -> None:
         pytest.param(
             "git+file:///T:/with space/repo.git@1.0#egg=my-package-1.0",
             "git+file:///T:/with%20space/repo.git@1.0#egg=my-package-1.0",
-            marks=[
-                pytest.mark.skipif("sys.platform != 'win32'"),
-                pytest.mark.xfail(
-                    reason="Failing in Python 3.13.0a1, fixed in python/cpython#113563",
-                    condition="sys.version_info >= (3, 13)",
-                    strict=True,
-                ),
-            ],
+            marks=pytest.mark.skipif(
+                "sys.platform != 'win32' or "
+                "sys.version_info == (3, 13, 0, 'beta', 2)"
+            ),
         ),
         # Test a VCS URL with a Windows drive letter and revision,
         # running on non-windows platform.

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -383,7 +383,14 @@ def test_clean_url_path_with_local_path(path: str, expected: str) -> None:
         pytest.param(
             "file:///T:/path/with spaces/",
             "file:///T:/path/with%20spaces",
-            marks=pytest.mark.skipif("sys.platform != 'win32'"),
+            marks=[
+                pytest.mark.skipif("sys.platform != 'win32'"),
+                pytest.mark.xfail(
+                    reason="Failing in Python 3.13.0a1, fixed in python/cpython#113563",
+                    condition="sys.version_info >= (3, 13)",
+                    strict=True,
+                ),
+            ],
         ),
         # URL with Windows drive letter, running on non-windows
         # platform. The `:` after the drive should be quoted.
@@ -396,7 +403,14 @@ def test_clean_url_path_with_local_path(path: str, expected: str) -> None:
         pytest.param(
             "git+file:///T:/with space/repo.git@1.0#egg=my-package-1.0",
             "git+file:///T:/with%20space/repo.git@1.0#egg=my-package-1.0",
-            marks=pytest.mark.skipif("sys.platform != 'win32'"),
+            marks=[
+                pytest.mark.skipif("sys.platform != 'win32'"),
+                pytest.mark.xfail(
+                    reason="Failing in Python 3.13.0a1, fixed in python/cpython#113563",
+                    condition="sys.version_info >= (3, 13)",
+                    strict=True,
+                ),
+            ],
         ),
         # Test a VCS URL with a Windows drive letter and revision,
         # running on non-windows platform.

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -15,12 +15,31 @@ def test_path_to_url_unix() -> None:
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")
-def test_path_to_url_win() -> None:
-    assert path_to_url("c:/tmp/file") == "file:///C:/tmp/file"
-    assert path_to_url("c:\\tmp\\file") == "file:///C:/tmp/file"
-    assert path_to_url(r"\\unc\as\path") == "file://unc/as/path"
-    path = os.path.join(os.getcwd(), "file")
-    assert path_to_url("file") == "file:" + urllib.request.pathname2url(path)
+@pytest.mark.parametrize(
+    "path, url",
+    [
+        pytest.param("c:/tmp/file", "file:///C:/tmp/file", id="posix-path"),
+        pytest.param("c:\\tmp\\file", "file:///C:/tmp/file", id="nt-path"),
+        pytest.param(
+            r"\\unc\as\path",
+            "file://unc/as/path",
+            marks=pytest.mark.xfail(
+                reason="Failing in Python 3.13.0a1, fixed in python/cpython#113563",
+                condition="sys.version_info >= (3, 13)",
+                strict=True,
+            ),
+            id="unc-path",
+        ),
+    ],
+)
+def test_path_to_url_win(path: str, url: str) -> None:
+    assert path_to_url(path) == url
+
+
+@pytest.mark.skipif("sys.platform != 'win32'")
+def test_relative_path_to_url_win() -> None:
+    resolved_path = os.path.join(os.getcwd(), "file")
+    assert path_to_url("file") == "file:" + urllib.request.pathname2url(resolved_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -23,10 +23,9 @@ def test_path_to_url_unix() -> None:
         pytest.param(
             r"\\unc\as\path",
             "file://unc/as/path",
-            marks=pytest.mark.xfail(
-                reason="Failing in Python 3.13.0a1, fixed in python/cpython#113563",
-                condition="sys.version_info >= (3, 13)",
-                strict=True,
+            marks=pytest.mark.skipif(
+                "sys.platform != 'win32' or "
+                "sys.version_info == (3, 13, 0, 'beta', 2)"
             ),
             id="unc-path",
         ),


### PR DESCRIPTION
This test should start passing when 3.13.0a2 is released. Since the xfail marker is set to `strict=True`, it will start causing the CI to error to prompt us to revert this.

See discussion in https://github.com/python/cpython/issues/102511 for cause analysis and reference to fix.