### PR TITLE
Split up Windows tests relying on urlunparse behaviour

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -28,6 +28,7 @@ from typing import (
     Union,
     cast,
 )
+from urllib.parse import urlparse, urlunparse
 from zipfile import ZipFile
 
 import pytest
@@ -1375,3 +1376,19 @@ class ScriptFactory(Protocol):
 
 
 CertFactory = Callable[[], str]
+
+# versions containing fix/backport from https://github.com/python/cpython/pull/113563
+# which changed the behavior of `urllib.parse.urlun{parse,split}`
+url = "////path/to/file"
+has_new_urlun_behavior = url == urlunparse(urlparse(url))
+
+# the above change seems to only impact tests on Windows, so just add skips for that
+skip_needs_new_urlun_behavior_win = pytest.mark.skipif(
+    sys.platform != "win32" or not has_new_urlun_behavior,
+    reason="testing windows behavior for newer CPython",
+)
+
+skip_needs_old_urlun_behavior_win = pytest.mark.skipif(
+    sys.platform != "win32" or has_new_urlun_behavior,
+    reason="testing windows behavior for older CPython",
+)

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -35,7 +35,12 @@ from pip._internal.models.link import (
     _ensure_quoted_url,
 )
 from pip._internal.network.session import PipSession
-from tests.lib import TestData, make_test_link_collector
+from tests.lib import (
+    TestData,
+    make_test_link_collector,
+    skip_needs_new_urlun_behavior_win,
+    skip_needs_old_urlun_behavior_win,
+)
 
 ACCEPT = ", ".join(
     [
@@ -383,10 +388,12 @@ def test_clean_url_path_with_local_path(path: str, expected: str) -> None:
         pytest.param(
             "file:///T:/path/with spaces/",
             "file:///T:/path/with%20spaces",
-            marks=pytest.mark.skipif(
-                "sys.platform != 'win32' or "
-                "sys.version_info == (3, 13, 0, 'beta', 2)"
-            ),
+            marks=skip_needs_old_urlun_behavior_win,
+        ),
+        pytest.param(
+            "file:///T:/path/with spaces/",
+            "file://///T:/path/with%20spaces",
+            marks=skip_needs_new_urlun_behavior_win,
         ),
         # URL with Windows drive letter, running on non-windows
         # platform. The `:` after the drive should be quoted.
@@ -399,10 +406,12 @@ def test_clean_url_path_with_local_path(path: str, expected: str) -> None:
         pytest.param(
             "git+file:///T:/with space/repo.git@1.0#egg=my-package-1.0",
             "git+file:///T:/with%20space/repo.git@1.0#egg=my-package-1.0",
-            marks=pytest.mark.skipif(
-                "sys.platform != 'win32' or "
-                "sys.version_info == (3, 13, 0, 'beta', 2)"
-            ),
+            marks=skip_needs_old_urlun_behavior_win,
+        ),
+        pytest.param(
+            "git+file:///T:/with space/repo.git@1.0#egg=my-package-1.0",
+            "git+file://///T:/with%20space/repo.git@1.0#egg=my-package-1.0",
+            marks=skip_needs_new_urlun_behavior_win,
         ),
         # Test a VCS URL with a Windows drive letter and revision,
         # running on non-windows platform.

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -5,6 +5,10 @@ import urllib.request
 import pytest
 
 from pip._internal.utils.urls import path_to_url, url_to_path
+from tests.lib import (
+    skip_needs_new_urlun_behavior_win,
+    skip_needs_old_urlun_behavior_win,
+)
 
 
 @pytest.mark.skipif("sys.platform == 'win32'")
@@ -23,11 +27,13 @@ def test_path_to_url_unix() -> None:
         pytest.param(
             r"\\unc\as\path",
             "file://unc/as/path",
-            marks=pytest.mark.skipif(
-                "sys.platform != 'win32' or "
-                "sys.version_info == (3, 13, 0, 'beta', 2)"
-            ),
+            marks=skip_needs_old_urlun_behavior_win,
             id="unc-path",
+        ),
+        pytest.param(
+            r"\\unc\as\path",
+            "file:////unc/as/path",
+            marks=skip_needs_new_urlun_behavior_win,
         ),
     ],
 )


### PR DESCRIPTION
There was a behavioural change to `urllib.parse.urlunparse`[1] that
affects some of our tests on Windows. With the understanding that the
new behaviour is indeed desired, split up some tests relying on this
behaviour depending on the version of Python.

The sample URL used to check this behaviour was taken from a test in the
upstream change (with the new behaviour this URL will round-trip
parsing)

[1] https://github.com/python/cpython/pull/113563