### PR TITLE
Optimise logic for displaying packages at the end of `pip install`

### DIFF
--- a/news/12791.bugfix.rst
+++ b/news/12791.bugfix.rst
@@ -1,2 +1,2 @@
-Improve performance. Fix code to display installed packages at the end of
- pip install, was O(n^2) to enumerate packages due to accidental loop in loop.
+Improve pip install performance. The installed packages printout is
+now calculated in linear time instead of quadratic time.

--- a/news/12791.bugfix.rst
+++ b/news/12791.bugfix.rst
@@ -1,0 +1,2 @@
+Improve performance. Fix code to display installed packages at the end of
+ pip install, was O(n^2) to enumerate packages due to accidental loop in loop.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -476,15 +476,18 @@ class InstallCommand(RequirementCommand):
             # Display a summary of installed packages, with extra care to
             # display a package name as it was requested by the user.
             installed.sort(key=operator.attrgetter("name"))
-            items = []
+            summary = []
             installed_versions = {}
             for distribution in env.iter_all_distributions():
                 installed_versions[distribution.canonical_name] = distribution.version
             for package in installed:
                 display_name = package.name
                 version = installed_versions.get(canonicalize_name(display_name), None)
-                item = f"{display_name}-{version}"
-                items.append(item)
+                if version:
+                    text = f"{display_name}-{version}"
+                else:
+                    text = display_name
+                summary.append(text)
 
             if conflicts is not None:
                 self._warn_about_conflicts(
@@ -492,7 +495,7 @@ class InstallCommand(RequirementCommand):
                     resolver_variant=self.determine_resolver_variant(options),
                 )
 
-            installed_desc = " ".join(items)
+            installed_desc = " ".join(summary)
             if installed_desc:
                 write_output(
                     "Successfully installed %s",

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -181,9 +181,10 @@ class Environment(BaseEnvironment):
             yield from finder.find_linked(location)
 
     def get_distribution(self, name: str) -> Optional[BaseDistribution]:
+        canonical_name = canonicalize_name(name)
         matches = (
             distribution
             for distribution in self.iter_all_distributions()
-            if distribution.canonical_name == canonicalize_name(name)
+            if distribution.canonical_name == canonical_name
         )
         return next(matches, None)


### PR DESCRIPTION
PERF: 5% faster pip install. algorithmic bug at the end of pip install in the code to display installed packages. O(n^2) to enumerate installed packages due to accidental loop in loop.

`get_distribution(package_name)` does a loop over all installed packages. 
that is quite surprising and unexpected. it should not be used inside a loop.

I rewrote the loop to iterate with iter_all_distributions(). that's what was called under the hood.

by the way, this code to display installed packages is more complex than it ought to be. I think it was intentional to display the package name exactly as it was provided by the user. 

on a pip install run that takes 11 seconds:
the loop takes 0.735960 seconds on main branch.
the loop takes 0.064672 seconds with this fix.

