### PR TITLE
Add missing `pyproject_hooks` to DEBUNDLED preload list

### DIFF
--- a/news/12796.vendor.rst
+++ b/news/12796.vendor.rst
@@ -1,1 +1,1 @@
-Update the preload list for the ``DEBUNDLED`` case.
+Update the preload list for the ``DEBUNDLED`` case, to replace `pep517` that has been renamed to `pyproject_hooks`.

--- a/news/12796.vendor.rst
+++ b/news/12796.vendor.rst
@@ -1,0 +1,1 @@
+Update the preload list for the ``DEBUNDLED`` case.

--- a/news/12796.vendor.rst
+++ b/news/12796.vendor.rst
@@ -1,1 +1,1 @@
-Update the preload list for the ``DEBUNDLED`` case, to replace `pep517` that has been renamed to `pyproject_hooks`.
+Update the preload list for the ``DEBUNDLED`` case, to replace ``pep517`` that has been renamed to ``pyproject_hooks``.

--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -69,6 +69,7 @@ if DEBUNDLED:
     vendored("pkg_resources")
     vendored("platformdirs")
     vendored("progress")
+    vendored("pyproject_hooks")
     vendored("requests")
     vendored("requests.exceptions")
     vendored("requests.packages")

--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -65,7 +65,6 @@ if DEBUNDLED:
     vendored("packaging")
     vendored("packaging.version")
     vendored("packaging.specifiers")
-    vendored("pep517")
     vendored("pkg_resources")
     vendored("platformdirs")
     vendored("progress")


### PR DESCRIPTION
Otherwise, tests fail to load:

```
ImportError while loading conftest '/tmp/portage/dev-python/pip-24.1-r1/work/pip-24.1/tests/conftest.py'.
tests/conftest.py:49: in <module>
    from pip._internal.utils.temp_dir import global_tempdir_manager
../pip-24.1-python3_13/install/usr/lib/python3.13/site-packages/pip/_internal/utils/temp_dir.py:20: in <module>
    from pip._internal.utils.misc import enum, rmtree
../pip-24.1-python3_13/install/usr/lib/python3.13/site-packages/pip/_internal/utils/misc.py:38: in <module>
    from pip._vendor.pyproject_hooks import BuildBackendHookCaller
E   ModuleNotFoundError: No module named 'pip._vendor.pyproject_hooks'
```