### PR TITLE
Use the stdlib tomllib on python 3.11+

### DIFF
--- a/news/12797.vendor.rst
+++ b/news/12797.vendor.rst
@@ -1,0 +1,1 @@
+Use tomllib from the stdlib if available, rather than tomli

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -1,9 +1,14 @@
 import importlib.util
 import os
+import sys
 from collections import namedtuple
 from typing import Any, List, Optional
 
-from pip._vendor import tomli
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    from pip._vendor import tomli as tomllib
+
 from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
 
 from pip._internal.exceptions import (
@@ -61,7 +66,7 @@ def load_pyproject_toml(
 
     if has_pyproject:
         with open(pyproject_toml, encoding="utf-8") as f:
-            pp_toml = tomli.loads(f.read())
+            pp_toml = tomllib.loads(f.read())
         build_system = pp_toml.get("build-system")
     else:
         build_system = None

--- a/src/pip/_vendor/__init__.py
+++ b/src/pip/_vendor/__init__.py
@@ -111,6 +111,7 @@ if DEBUNDLED:
     vendored("rich.text")
     vendored("rich.traceback")
     vendored("tenacity")
-    vendored("tomli")
+    if sys.version_info < (3, 11):
+        vendored("tomli")
     vendored("truststore")
     vendored("urllib3")


### PR DESCRIPTION
Although a tomli copy is vendored, doing this conditional import allows:
- automatically upgrading the code, when the time comes to drop py3.10 support

- slightly simplifying debundling support, as it's no longer necessary to depend on a tomli(-wheel)? package on sufficiently newer versions of python.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
