### PR TITLE
split_leading_dir gives an incorrect result on a bare filename

### DIFF
--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -57,7 +57,7 @@ def split_leading_dir(path: str) -> List[str]:
     elif "\\" in path:
         return path.split("\\", 1)
     else:
-        return [path, ""]
+        return ["", path]
 
 
 def has_leading_dir(paths: Iterable[str]) -> bool:


### PR DESCRIPTION
When passed a bare filename, `pip._internal.utils.unpacking.split_leading_dir` returns a 2-element list with the *first* part being the filename supplied. This is backwards - the first part is meant to be the leading directory.

This doesn't currently trigger a bug because `split_leading_dir` isn't ever called in a situation where the argument is a bare filename (except in `has_leading_dir`, where the bug is extremely unlikely to give an incorrect result). But it's worth fixing in case this ever changes.