### PR TITLE
PERF: extract files from wheel in 1MB blocks + skip decoding for 0 bytes files

### DIFF
--- a/news/12803.bugfix.rst
+++ b/news/12803.bugfix.rst
@@ -1,0 +1,4 @@
+Improve pip install performance. Files are now extracted in 1MB blocks,
+or in one block matching the file size for smaller files.
+A decompressor is no longer instantiated when extracting 0 bytes files,
+it is not necessary because there is no data to decompress.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -377,10 +377,12 @@ class ZipBackedFile:
 
         zipinfo = self._getinfo()
 
+        # optimization: the file is created by open(),
+        # skip the decompression when there is 0 bytes to decompress.
         with open(self.dest_path, "wb") as dest:
             if zipinfo.file_size > 0:
                 with self._zip_file.open(zipinfo) as f:
-                    blocksize = min(zipinfo.file_size, 1048576)
+                    blocksize = min(zipinfo.file_size, 1_048_576)
                     shutil.copyfileobj(f, dest, blocksize)
 
         if zip_item_is_executable(zipinfo):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -382,7 +382,7 @@ class ZipBackedFile:
         with open(self.dest_path, "wb") as dest:
             if zipinfo.file_size > 0:
                 with self._zip_file.open(zipinfo) as f:
-                    blocksize = min(zipinfo.file_size, 1_048_576)
+                    blocksize = min(zipinfo.file_size, 1024 * 1024)
                     shutil.copyfileobj(f, dest, blocksize)
 
         if zip_item_is_executable(zipinfo):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -377,9 +377,11 @@ class ZipBackedFile:
 
         zipinfo = self._getinfo()
 
-        with self._zip_file.open(zipinfo) as f:
-            with open(self.dest_path, "wb") as dest:
-                shutil.copyfileobj(f, dest)
+        with open(self.dest_path, "wb") as dest:
+            if zipinfo.file_size > 0:
+                with self._zip_file.open(zipinfo) as f:
+                    blocksize = min(zipinfo.file_size, 1048576)
+                    shutil.copyfileobj(f, dest, blocksize)
 
         if zip_item_is_executable(zipinfo):
             set_extracted_file_to_default_mode_plus_executable(self.dest_path)


### PR DESCRIPTION
Hello,

Can I offer you a small fix to optimize extraction of files?
Do you need a news file for <=1% performance improvement?

Testing with a profiler and a pack of internal packages, this removes a lot of function calls and syscalls.

under profiler:
* sh.copyfileobj() -> 11149 calls down to 10774
* read() -> 28645 calls down to 24955
* _read1() -> 17882 calls down to 14182
* decompress() -> 17810 calls down to 14110

5818 ms of extraction time is reduced to 5262 ms. it's not a big difference inside a 30 seconds "pip install ..." run.

shutil.copyfileobj() has a default buffer of 64k. most source files are less than 64k so the improvement is not huge. we're not going from the work case where files are read in 4k blocks.

there is good saving by skipping empty files. there seem to be 5-10% of empty init files in most python packages.

looking at the profiler, a fair amount of work is going to extract the file from the zipfile, the standard library does a lot of operations to read/seek headers, verify metadata, and prepare for extraction with read/write locks in case the file is used concurrently by multiple tasks. it's not necessary for pip install.
I think there is room for a much bigger improvement by rewriting the ExtZipFile extractor class from the standard lib without the clutter.

Regards.
