### PR TITLE
Update ruff to 0.5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.7
+  rev: v0.5.0
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/news/12805.trivial.rst
+++ b/news/12805.trivial.rst
@@ -1,0 +1,1 @@
+Update ruff to 0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,6 @@ distlib = "https://bitbucket.org/pypa/distlib/raw/master/LICENSE.txt"
 
 [tool.ruff]
 src = ["src"]
-target-version = "py38"
 line-length = 88
 extend-exclude = [
     "_vendor",

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -149,7 +149,7 @@ def _onerror_ignore(*_args: Any) -> None:
 
 
 def _onerror_reraise(*_args: Any) -> None:
-    raise
+    raise  # noqa: PLE0704 - Bare exception used to reraise existing exception
 
 
 def rmtree_errorhandler(


### PR DESCRIPTION
A large update to ruff was just released: https://astral.sh/blog/ruff-v0.5.0

There was only 1 new rule break, a bare raise in `src/pip/_internal/utils/misc.py` which looks valid to me so I put a `noqa` on it.

I also removed `target-version` from ruff section of the `pyproject.toml`, as ruff by default reads the `requires-python`: https://docs.astral.sh/ruff/settings/#target-version out of the `pyproject.toml`. This redundancy was introduced because when ruff was first added to pip pip did not use `pyproject.toml` for its build configuration.