### PR TITLE
Support passing multiple packages to "--exclude" option

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -977,9 +977,8 @@ list_exclude: Callable[..., Option] = partial(
     PipOption,
     "--exclude",
     dest="excludes",
-    action="append",
     metavar="package",
-    type="package_name",
+    type="string",
     help="Exclude specified package from the output",
 )
 

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -174,7 +174,8 @@ class ListCommand(IndexGroupCommand):
 
         skip = set(stdlib_pkgs)
         if options.excludes:
-            skip.update(canonicalize_name(n) for n in options.excludes)
+            opts = options.excludes.split(" ")
+            skip.update(canonicalize_name(n) for n in opts)
 
         packages: "_ProcessedDists" = [
             cast("_DistWithLatestInfo", d)


### PR DESCRIPTION
This pull request serves as a proof of concept. The provided code represents the minimal implementation required to achieve the intended functionality. I have tested it using the `list` command as follows: `python -m pip list --exclude "argcomplete cffi"`.

The main proposal is to allow passing multiple package names with the `--exclude` option, rather than requiring multiple uses of the same option. Alternatively, we could consider introducing a new option for this purpose.

I currently do not have enough expertise with `optparse` to offer a more refined implementation. If this proposal is accepted, I will commit to enhancing the implementation in the future.