### PR TITLE
Defer removal of --build-option and --global-option to 25.0

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -909,7 +909,7 @@ def check_legacy_setup_py_options(
             reason="--build-option and --global-option are deprecated.",
             issue=11859,
             replacement="to use --config-settings",
-            gone_in="24.2",
+            gone_in="25.0",
         )
         logger.warning(
             "Implying --no-binary=:all: due to the presence of "


### PR DESCRIPTION
We aren't in a rush to remove these and setuptools still isn't ready.

Should I add a changelog entry @sbidoul? I see that you didn't in https://github.com/pypa/pip/pull/12492.
