### PR TITLE
Use higher precision time source in retry decorator/tests and avoid flaky failures

### DIFF
--- a/src/pip/_internal/utils/retry.py
+++ b/src/pip/_internal/utils/retry.py
@@ -1,5 +1,5 @@
 import functools
-from time import monotonic, sleep
+from time import perf_counter, sleep
 from typing import Callable, TypeVar
 
 from pip._vendor.typing_extensions import ParamSpec
@@ -26,12 +26,14 @@ def retry(
 
         @functools.wraps(func)
         def retry_wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
-            start_time = monotonic()
+            # The performance counter is monotonic on all platforms we care
+            # about and has much better resolution than time.monotonic().
+            start_time = perf_counter()
             while True:
                 try:
                     return func(*args, **kwargs)
                 except Exception:
-                    if monotonic() - start_time > stop_after_delay:
+                    if perf_counter() - start_time > stop_after_delay:
                         raise
                     sleep(wait)
 


### PR DESCRIPTION
Despite my best efforts to account for Windows' coarse timer precision, the `test_retry_wait` and `test_retry_time_limit` tests are still randomly failing as it isn't sleeping for long enough by a small margin:

Example 1: 472.171 - 472.156 >= 0.015 (~1% too low)
Example 2: 554.406 - 554.265 >= 0.15 (~7% too low)

(call_time - test_start_time >= expected sleep duration between retries)

To avoid these random failures, I've adjusted the required sleep duration to be 10% less which should be enough.

I've also replaced `time.monotonic()` with `time.perf_counter()` in the retry utility and test suite since it's effectively monotonic[^1] while providing much higher resolution (esp. on Windows).

[^1]: It's not guaranteed to be monotonic in the Python docs, but it is
      _indeed_ monotonic on all platforms we care about.

@pradyunsg this should fix the CI failures on main. Sorry for the trouble!
