### PR TITLE
Document `pip` Discord channel

### DIFF
--- a/docs/html/development/index.rst
+++ b/docs/html/development/index.rst
@@ -8,7 +8,8 @@ testing, and documentation.
 
 You can also join ``#pypa`` (general packaging discussion and user support) and
 ``#pypa-dev`` (discussion about development of packaging tools) `on Libera.chat`_,
-or the `distutils-sig mailing list`_, to ask questions or get involved.
+or the ``#pip`` channel on the `PyPA Discord`_, or the `distutils-sig mailing list`_,
+to ask questions or get involved.
 
 .. toctree::
     :maxdepth: 2
@@ -28,3 +29,4 @@ or the `distutils-sig mailing list`_, to ask questions or get involved.
 
 .. _`on Libera.chat`: https://kiwiirc.com/nextclient/#ircs://irc.libera.chat:+6697/pypa-dev
 .. _`distutils-sig mailing list`: https://mail.python.org/mailman3/lists/distutils-sig.python.org/
+.. _`PyPA Discord`: https://discord.gg/pypa

--- a/docs/html/development/index.rst
+++ b/docs/html/development/index.rst
@@ -8,8 +8,7 @@ testing, and documentation.
 
 You can also join ``#pypa`` (general packaging discussion and user support) and
 ``#pypa-dev`` (discussion about development of packaging tools) `on Libera.chat`_,
-or the ``#pip`` channel on the `PyPA Discord`_, or the `distutils-sig mailing list`_,
-to ask questions or get involved.
+or the ``#pip`` channel on the `PyPA Discord`_, to ask questions or get involved.
 
 .. toctree::
     :maxdepth: 2
@@ -28,5 +27,4 @@ to ask questions or get involved.
     references might be broken.
 
 .. _`on Libera.chat`: https://kiwiirc.com/nextclient/#ircs://irc.libera.chat:+6697/pypa-dev
-.. _`distutils-sig mailing list`: https://mail.python.org/mailman3/lists/distutils-sig.python.org/
 .. _`PyPA Discord`: https://discord.gg/pypa


### PR DESCRIPTION
- Document `pip` Discord channel

    A link is provided to the PyPA Discord, rather than the specific
    channel, because the former presents the user with an invite, but for
    channel links I'm not sure how nice the process is for users who aren't
    already part of the Discord.

    The channel is only document under the development docs, since we want
    to keep it focussed on questions around developing on the codebase, and
    not move more general discussions from GitHub issues

- Remove link to `distutils-sig` mailing list

    This list has been made read-only, so it's no longer possible to "ask
    questions or get involved" there