### PR TITLE
Ignore `--require-virtualenv` for `check` and `freeze` commands

### DIFF
--- a/news/12842.feature.rst
+++ b/news/12842.feature.rst
@@ -1,0 +1,1 @@
+Ignore ``--require-virtualenv`` for ``pip check`` and ``pip freeze``

--- a/src/pip/_internal/commands/check.py
+++ b/src/pip/_internal/commands/check.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 class CheckCommand(Command):
     """Verify installed packages have compatible dependencies."""
 
+    ignore_require_venv = True
     usage = """
       %prog [options]"""
 

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -29,6 +29,7 @@ class FreezeCommand(Command):
     packages are listed in a case-insensitive sorted order.
     """
 
+    ignore_require_venv = True
     usage = """
       %prog [options]"""
     log_streams = ("ext://sys.stderr", "ext://sys.stderr")


### PR DESCRIPTION
Since these are read-only commands (like `pip list`) 