### PR TITLE
Restore original permissions in unit tests to allow pytest to clean up

### DIFF
--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -2,9 +2,11 @@
 """
 
 import os
+from contextlib import contextmanager
 from functools import partial
 from itertools import chain
-from typing import Iterator, List, Set
+from pathlib import Path
+from typing import Iterator, List, Set, Union
 
 
 def get_filelist(base: str) -> Set[str]:
@@ -17,3 +19,14 @@ def get_filelist(base: str) -> Set[str]:
         )
 
     return set(chain.from_iterable(join(*dirinfo) for dirinfo in os.walk(base)))
+
+
+@contextmanager
+def chmod(path: Union[str, Path], mode: int) -> Iterator[None]:
+    """Contextmanager to temporarily update a path's mode."""
+    old_mode = os.stat(path).st_mode
+    try:
+        os.chmod(path, mode)
+        yield
+    finally:
+        os.chmod(path, old_mode)

--- a/tests/unit/test_network_cache.py
+++ b/tests/unit/test_network_cache.py
@@ -7,6 +7,7 @@ import pytest
 from pip._vendor.cachecontrol.caches import FileCache
 
 from pip._internal.network.cache import SafeFileCache
+from tests.lib.filesystem import chmod
 
 
 @pytest.fixture(scope="function")
@@ -57,26 +58,23 @@ class TestSafeFileCache:
     def test_safe_get_no_perms(
         self, cache_tmpdir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        os.chmod(cache_tmpdir, 000)
-
         monkeypatch.setattr(os.path, "exists", lambda x: True)
 
-        cache = SafeFileCache(os.fspath(cache_tmpdir))
-        cache.get("foo")
+        with chmod(cache_tmpdir, 000):
+            cache = SafeFileCache(os.fspath(cache_tmpdir))
+            cache.get("foo")
 
     @pytest.mark.skipif("sys.platform == 'win32'")
     def test_safe_set_no_perms(self, cache_tmpdir: Path) -> None:
-        os.chmod(cache_tmpdir, 000)
-
-        cache = SafeFileCache(os.fspath(cache_tmpdir))
-        cache.set("foo", b"bar")
+        with chmod(cache_tmpdir, 000):
+            cache = SafeFileCache(os.fspath(cache_tmpdir))
+            cache.set("foo", b"bar")
 
     @pytest.mark.skipif("sys.platform == 'win32'")
     def test_safe_delete_no_perms(self, cache_tmpdir: Path) -> None:
-        os.chmod(cache_tmpdir, 000)
-
-        cache = SafeFileCache(os.fspath(cache_tmpdir))
-        cache.delete("foo")
+        with chmod(cache_tmpdir, 000):
+            cache = SafeFileCache(os.fspath(cache_tmpdir))
+            cache.delete("foo")
 
     def test_cache_hashes_are_same(self, cache_tmpdir: Path) -> None:
         cache = SafeFileCache(os.fspath(cache_tmpdir))


### PR DESCRIPTION
This is necessary to address warnings like these:

```
/home/ichard26/dev/oss/pip/venv/lib/python3.12/site-packages/_pytest/pathlib.py:95: PytestWarning: (rm_rf) error removing /tmp-ram/pytest-of-ichard26/garbage-ae7b86cb-23ec-453e-a72e-fd0b70d07ba2/test_safe_delete_no_perms0
<class 'OSError'>: [Errno 39] Directory not empty: '/tmp-ram/pytest-of-ichard26/garbage-ae7b86cb-23ec-453e-a72e-fd0b70d07ba2/test_safe_delete_no_perms0'
  warnings.warn(
/home/ichard26/dev/oss/pip/venv/lib/python3.12/site-packages/_pytest/pathlib.py:95: PytestWarning: (rm_rf) error removing /tmp-ram/pytest-of-ichard26/garbage-ae7b86cb-23ec-453e-a72e-fd0b70d07ba2/test_safe_set_no_perms0
<class 'OSError'>: [Errno 39] Directory not empty: '/tmp-ram/pytest-of-ichard26/garbage-ae7b86cb-23ec-453e-a72e-fd0b70d07ba2/test_safe_set_no_perms0'
  warnings.warn(
/home/ichard26/dev/oss/pip/venv/lib/python3.12/site-packages/_pytest/pathlib.py:95: PytestWarning: (rm_rf) error removing /tmp-ram/pytest-of-ichard26/garbage-ae7b86cb-23ec-453e-a72e-fd0b70d07ba2/test_safe_get_no_perms0
<class 'OSError'>: [Errno 39] Directory not empty: '/tmp-ram/pytest-of-ichard26/garbage-ae7b86cb-23ec-453e-a72e-fd0b70d07ba2/test_safe_get_no_perms0'
  warnings.warn(
```

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
