### PR TITLE
Force build to provision its own pip in nox test session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -88,8 +88,12 @@ def test(session: nox.Session) -> None:
     if os.path.exists(sdist_dir):
         shutil.rmtree(sdist_dir, ignore_errors=True)
 
+    run_with_protected_pip(session, "install", "build")
+    # build uses the pip present in the outer environment (aka the nox environment)
+    # as an optimization. This will crash if the last test run installed a broken
+    # pip, so uninstall pip to force build to provision a known good version of pip.
+    run_with_protected_pip(session, "uninstall", "pip", "-y")
     # fmt: off
-    session.install("build")
     session.run(
         "python", "-I", "-m", "build", "--sdist", "--outdir", sdist_dir,
         silent=True,


### PR DESCRIPTION
Modern versions of build use the pip from the environment it's installed in, taking advantage of --python to avoid needing to provision pip in the temporary build environment. This is a neat optimization, but it breaks when a broken pip is installed from a previous test run.

```console
(venv) ichard26@asus-ubuntu:~/dev/oss/pip$ echo "assert False" >> src/pip/_internal/__init__.py 
(venv) ichard26@asus-ubuntu:~/dev/oss/pip$ nox -s test-3.12 -- tests/unit/test_utils_retry.py 
nox > Running session test-3.12
nox > Re-using existing virtual environment at .nox/test-3-12.
nox > Re-using existing common-wheels at tests/data/common_wheels.
nox > python -m pip install build
nox > python -I -m build --sdist --outdir /home/ichard26/dev/oss/pip/.nox/test-3-12/sdist
nox > python tools/protected_pip.py install /home/ichard26/dev/oss/pip/.nox/test-3-12/sdist/pip-24.2.dev0.tar.gz
nox > python tools/protected_pip.py install -r tests/requirements.txt
nox > pytest tests/unit/test_utils_retry.py
ImportError while loading conftest '/home/ichard26/dev/oss/pip/tests/conftest.py'.
tests/conftest.py:48: in <module>
    from pip._internal.locations import _USE_SYSCONFIG
.nox/test-3-12/lib/python3.12/site-packages/pip/_internal/__init__.py:19: in <module>
    assert False
E   AssertionError
nox > Command pytest tests/unit/test_utils_retry.py failed with exit code 4
nox > Session test-3.12 failed.
(venv) ichard26@asus-ubuntu:~/dev/oss/pip$ nox -s test-3.12 -- tests/unit/test_utils_retry.py 
nox > Running session test-3.12
nox > Re-using existing virtual environment at .nox/test-3-12.
nox > Re-using existing common-wheels at tests/data/common_wheels.
nox > python -m pip install build
nox > Command python -m pip install build failed with exit code 1:
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/ichard26/dev/oss/pip/.nox/test-3-12/lib/python3.12/site-packages/pip/__main__.py", line 22, in <module>
    from pip._internal.cli.main import main as _main
  File "/home/ichard26/dev/oss/pip/.nox/test-3-12/lib/python3.12/site-packages/pip/_internal/__init__.py", line 19, in <module>
    assert False
           ^^^^^
AssertionError
nox > Session test-3.12 failed.

```

When this happens, you have to clear out the old Nox session environment to get build functioning again. This is annoying and clearly works against the goal of `run_with_protected_pip()` which is meant to prevent such issues.

We can force build to provision its own pip by simply uninstalling pip before invoking the sdist build.
