### PR TITLE
PERF: 7% faster pip install, remove fsync call in temporary file, not necessary

### DIFF
--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -61,18 +61,7 @@ def adjacent_tmp_file(path: str, **kwargs: Any) -> Generator[BinaryIO, None, Non
         try:
             yield result
         finally:
-            import time
-            start = time.perf_counter()
             result.flush()
-            middle = time.perf_counter()
-            os.fsync(result.fileno())
-            end = time.perf_counter()
-            global total_flush
-            global total_fsync
-            total_flush += middle - start
-            total_fsync += end - start
-            print("adjacent_tmp_file({}) flush {:.3f} (cumulative {:.3f})".format(f, middle-start, total_flush))
-            print("adjacent_tmp_file({}) fsync {:.3f} (cumulative {:.3f})".format(f, end-middle, total_fsync))
 
 
 replace = retry(stop_after_delay=1, wait=0.25)(os.replace)

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -38,7 +38,8 @@ def check_path_owner(path: str) -> bool:
             previous, path = path, os.path.dirname(path)
     return False  # assume we don't own the path
 
-
+total_flush = 0.0
+total_fsync = 0.0
 @contextmanager
 def adjacent_tmp_file(path: str, **kwargs: Any) -> Generator[BinaryIO, None, None]:
     """Return a file-like object pointing to a tmp file next to path.
@@ -60,8 +61,18 @@ def adjacent_tmp_file(path: str, **kwargs: Any) -> Generator[BinaryIO, None, Non
         try:
             yield result
         finally:
+            import time
+            start = time.perf_counter()
             result.flush()
+            middle = time.perf_counter()
             os.fsync(result.fileno())
+            end = time.perf_counter()
+            global total_flush
+            global total_fsync
+            total_flush += middle - start
+            total_fsync += end - start
+            print("adjacent_tmp_file({}) flush {:.3f} (cumulative {:.3f})".format(f, middle-start, total_flush))
+            print("adjacent_tmp_file({}) fsync {:.3f} (cumulative {:.3f})".format(f, end-middle, total_fsync))
 
 
 replace = retry(stop_after_delay=1, wait=0.25)(os.replace)


### PR DESCRIPTION
Hello,

could I have a review on this code?

profiling on a run of `pip install jupyter`

`_install_wheel()` function is 3670 ms. that's the installation phase.
`fsync` is 594 ms out of that, about 15% of the install phase (or 7% of the whole pip run).

It is called here 3 times https://github.com/pypa/pip/blob/8eadcab329a765571c849efe370afd5d5bba425c/src/pip/_internal/operations/install/wheel.py#L672

that's the end of the wheel installation, in `_generate_file()` decorator:
* `to create the dist-info/INSTALLER` file that always contains "pip" string
* `to create the dist-info/direct-url-something.json` that contains a one line json file with the path/url.
* `to create the dist-info/RECORD` file that contains a list of all installed files (allegedly the most important file)

the way it works: it creates a temporary file in the same directory as the final path + flush() + fsync() + close() + atomic rename() the file to the final path.
I think the fsync call is not necessary. 

fsync calls are surprisingly expensive, I am always seeing multiple milliseconds on various types of disks on my machine and even on /tmp.

![image](https://github.com/user-attachments/assets/6f8e9563-118f-4954-9f70-24771462ed80)
![image](https://github.com/user-attachments/assets/d4ce6b6e-be39-4dcd-90c3-190e24e5523d)

