### PR TITLE
Move type checking outside pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,18 @@ jobs:
       - run: pip install nox
       - run: nox -s docs
 
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install nox
+      - run: nox -s typecheck
+
   determine-changes:
     runs-on: ubuntu-latest
     outputs:
@@ -251,6 +263,7 @@ jobs:
 
     needs:
       - determine-changes
+      - typecheck
       - docs
       - packaging
       - tests-unix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,22 +27,6 @@ repos:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.10.0
-  hooks:
-  - id: mypy
-    exclude: tests/data
-    args: ["--pretty", "--show-error-codes"]
-    additional_dependencies: [
-        'keyring==24.2.0',
-        'nox==2023.4.22',
-        'pytest',
-        'types-docutils==0.20.0.3',
-        'types-setuptools==68.2.0.0',
-        'types-freezegun==1.1.10',
-        'types-pyyaml==6.0.12.12',
-    ]
-
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0
   hooks:

--- a/noxfile.py
+++ b/noxfile.py
@@ -168,6 +168,29 @@ def docs_live(session: nox.Session) -> None:
 
 
 @nox.session
+def typecheck(session: nox.Session) -> None:
+    session.install(
+        "mypy",
+        "keyring",
+        "nox",
+        "pytest",
+        "types-docutils",
+        "types-setuptools",
+        "types-freezegun",
+        "types-pyyaml",
+    )
+
+    session.run(
+        "mypy",
+        "src/pip",
+        "tests",
+        "tools",
+        "noxfile.py",
+        "--exclude=tests/data",
+    )
+
+
+@nox.session
 def lint(session: nox.Session) -> None:
     session.install("pre-commit")
 


### PR DESCRIPTION
See https://github.com/python/mypy/issues/13916 and https://jaredkhan.com/blog/mypy-pre-commit

I'm basically taking the approach of "Running Mypy correctly outside of Pre-commit" (from the second link) and stopping there since I don't think we gain a lot by shoving mypy into pre-commit.

Keeping this as a draft to showcase all the new errors that mypy is now capable of flagging.