### PR TITLE
Fix invalid origin test to check all the logged messages

### DIFF
--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -464,7 +464,9 @@ class TestRequirementSet:
             assert len(reqset.all_requirements) == 1
             req = reqset.all_requirements[0]
             assert req.is_wheel_from_cache
-            assert "Ignoring invalid cache entry origin file" in caplog.messages[0]
+            assert any(
+                "Ignoring invalid cache entry origin file" in x for x in caplog.messages
+            )
 
     def test_download_info_local_wheel(self, data: TestData) -> None:
         """Test that download_info is set for requirements from a local wheel."""


### PR DESCRIPTION
Fixes #12152 

Pretty simple fix, the log also contains stuff from other tests, so when everything is ran together, the first message is not what we expect. It works as expected if we run it solo.