### PR TITLE
Detect recursively referencing requirements files

### DIFF
--- a/news/12653.feature.rst
+++ b/news/12653.feature.rst
@@ -1,0 +1,2 @@
+Detect recursively referencing requirements files and help users identify
+the source.

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -371,7 +371,7 @@ class RequirementsFileParser:
                         if initial_file is not None
                         else ""
                     )
-                    raise RecursionError(
+                    raise RequirementsFileParseError(
                         f"{req_path} recursively references itself in {filename} {tail}"
                     )
                 # Keeping a track where was each file first included in

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -330,8 +330,9 @@ class RequirementsFileParser:
         self, filename: str, constraint: bool
     ) -> Generator[ParsedLine, None, None]:
         """Parse a given file, yielding parsed lines."""
-        filename = os.path.abspath(filename)
-        self._parsed_files[filename] = None  # The primary requirements file passed
+        self._parsed_files[os.path.abspath(filename)] = (
+            None  # The primary requirements file passed
+        )
         yield from self._parse_and_recurse(filename, constraint)
 
     def _parse_and_recurse(

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -364,7 +364,7 @@ class RequirementsFileParser:
                             req_path,
                         )
                     )
-                if req_path in self._parsed_files.keys():
+                if req_path in self._parsed_files:
                     initial_file = self._parsed_files[req_path]
                     tail = (
                         f" and again in {initial_file}"

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -367,12 +367,12 @@ class RequirementsFileParser:
                 if req_path in self._parsed_files.keys():
                     initial_file = self._parsed_files[req_path]
                     tail = (
-                        f"and again in {initial_file}"
+                        f" and again in {initial_file}"
                         if initial_file is not None
                         else ""
                     )
                     raise RequirementsFileParseError(
-                        f"{req_path} recursively references itself in {filename} {tail}"
+                        f"{req_path} recursively references itself in {filename}{tail}"
                     )
                 # Keeping a track where was each file first included in
                 self._parsed_files[req_path] = filename

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -324,11 +324,14 @@ class RequirementsFileParser:
     ) -> None:
         self._session = session
         self._line_parser = line_parser
+        self._parsed_files: dict[str, Optional[str]] = {}
 
     def parse(
         self, filename: str, constraint: bool
     ) -> Generator[ParsedLine, None, None]:
         """Parse a given file, yielding parsed lines."""
+        filename = os.path.abspath(filename)
+        self._parsed_files[filename] = None  # The primary requirements file passed
         yield from self._parse_and_recurse(filename, constraint)
 
     def _parse_and_recurse(
@@ -353,11 +356,25 @@ class RequirementsFileParser:
                 # original file and nested file are paths
                 elif not SCHEME_RE.search(req_path):
                     # do a join so relative paths work
-                    req_path = os.path.join(
-                        os.path.dirname(filename),
-                        req_path,
+                    # and then abspath so that we can identify recursive references
+                    req_path = os.path.abspath(
+                        os.path.join(
+                            os.path.dirname(filename),
+                            req_path,
+                        )
                     )
-
+                if req_path in self._parsed_files.keys():
+                    initial_file = self._parsed_files[req_path]
+                    tail = (
+                        f"and again in {initial_file}"
+                        if initial_file is not None
+                        else ""
+                    )
+                    raise RecursionError(
+                        f"{req_path} recursively references itself in {filename} {tail}"
+                    )
+                # Keeping a track where was each file first included in
+                self._parsed_files[req_path] = filename
                 yield from self._parse_and_recurse(req_path, nested_constraint)
             else:
                 yield line

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -9,7 +9,6 @@ from unittest import mock
 
 import pytest
 
-import pip._internal.exceptions
 import pip._internal.req.req_file  # this will be monkeypatched
 from pip._internal.exceptions import InstallationError, RequirementsFileParseError
 from pip._internal.index.package_finder import PackageFinder
@@ -364,7 +363,7 @@ class TestProcessLine:
 
         # When the passed requirements file recursively references itself
         with pytest.raises(
-            RecursionError,
+            RequirementsFileParseError,
             match=(
                 f"{path_to_string(req_files[0])} recursively references itself"
                 f" in {path_to_string(req_files[req_file_count - 1])}"
@@ -378,7 +377,7 @@ class TestProcessLine:
             f"-r {req_files[req_file_count - 2].name}"
         )
         with pytest.raises(
-            RecursionError,
+            RequirementsFileParseError,
             match=(
                 f"{path_to_string(req_files[req_file_count - 2])} recursively"
                 " references itself in"
@@ -401,7 +400,7 @@ class TestProcessLine:
         level_2_req_file.write_text("-r ../../root.txt")
 
         with pytest.raises(
-            RecursionError,
+            RequirementsFileParseError,
             match=(
                 f"{path_to_string(root_req_file)} recursively references itself in"
                 f" {path_to_string(level_2_req_file)}"

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -403,7 +403,7 @@ class TestProcessLine:
         monkeypatch.setattr(os.path, "abspath", lambda x: x)
         with pytest.raises(
             pip._internal.exceptions.InstallationError,
-            match=r"Could not open requirements file: \[Errno 36\] File name too long:",
+            match="Could not open requirements file: .* File name too long:",
         ):
             list(parse_requirements(filename=str(root_req_file), session=session))
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 import os
+import re
 import textwrap
 from optparse import Values
 from pathlib import Path
@@ -76,12 +77,6 @@ def parse_reqfile(
                 else None
             ),
         )
-
-
-def path_to_string(p: Path) -> str:
-    # Escape the back slashes in windows path before using it
-    # in a regex
-    return str(p).replace("\\", "\\\\")
 
 
 def test_read_file_url(tmp_path: Path, session: PipSession) -> None:
@@ -365,8 +360,8 @@ class TestProcessLine:
         with pytest.raises(
             RequirementsFileParseError,
             match=(
-                f"{path_to_string(req_files[0])} recursively references itself"
-                f" in {path_to_string(req_files[req_file_count - 1])}"
+                f"{re.escape(str(req_files[0]))} recursively references itself"
+                f" in {re.escape(str(req_files[req_file_count - 1]))}"
             ),
         ):
             list(parse_requirements(filename=str(req_files[0]), session=session))
@@ -379,10 +374,10 @@ class TestProcessLine:
         with pytest.raises(
             RequirementsFileParseError,
             match=(
-                f"{path_to_string(req_files[req_file_count - 2])} recursively"
+                f"{re.escape(str(req_files[req_file_count - 2]))} recursively"
                 " references itself in"
-                f" {path_to_string(req_files[req_file_count - 1])} and again in"
-                f" {path_to_string(req_files[req_file_count - 3])}"
+                f" {re.escape(str(req_files[req_file_count - 1]))} and again in"
+                f" {re.escape(str(req_files[req_file_count - 3]))}"
             ),
         ):
             list(parse_requirements(filename=str(req_files[0]), session=session))
@@ -402,8 +397,8 @@ class TestProcessLine:
         with pytest.raises(
             RequirementsFileParseError,
             match=(
-                f"{path_to_string(root_req_file)} recursively references itself in"
-                f" {path_to_string(level_2_req_file)}"
+                f"{re.escape(str(root_req_file))} recursively references itself in"
+                f" {re.escape(str(level_2_req_file))}"
             ),
         ):
             list(parse_requirements(filename=str(root_req_file), session=session))

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -79,6 +79,12 @@ def parse_reqfile(
         )
 
 
+def path_to_string(p: Path) -> str:
+    # Escape the back slashes in windows path before using it
+    # in a regex
+    return str(p).replace("\\", "\\\\")
+
+
 def test_read_file_url(tmp_path: Path, session: PipSession) -> None:
     reqs = tmp_path.joinpath("requirements.txt")
     reqs.write_text("foo")
@@ -360,8 +366,8 @@ class TestProcessLine:
         with pytest.raises(
             RecursionError,
             match=(
-                f"{req_files[0]} recursively references itself"
-                f" in {req_files[req_file_count - 1]}"
+                f"{path_to_string(req_files[0])} recursively references itself"
+                f" in {path_to_string(req_files[req_file_count - 1])}"
             ),
         ):
             list(parse_requirements(filename=str(req_files[0]), session=session))
@@ -371,9 +377,10 @@ class TestProcessLine:
         with pytest.raises(
             RecursionError,
             match=(
-                f"{req_files[req_file_count - 2]} recursively references itself "
-                f"in {req_files[req_file_count - 1]} and again in"
-                f" {req_files[req_file_count - 3]}"
+                f"{path_to_string(req_files[req_file_count - 2])} recursively"
+                " references itself in"
+                f" {path_to_string(req_files[req_file_count - 1])} and again in"
+                f" {path_to_string(req_files[req_file_count - 3])}"
             ),
         ):
             list(parse_requirements(filename=str(req_files[0]), session=session))
@@ -393,7 +400,8 @@ class TestProcessLine:
         with pytest.raises(
             RecursionError,
             match=(
-                f"{root_req_file} recursively references itself in {level_2_req_file}"
+                f"{path_to_string(root_req_file)} recursively references itself in"
+                f" {path_to_string(level_2_req_file)}"
             ),
         ):
             list(parse_requirements(filename=str(root_req_file), session=session))

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 import pytest
 
+import pip._internal.exceptions
 import pip._internal.req.req_file  # this will be monkeypatched
 from pip._internal.exceptions import InstallationError, RequirementsFileParseError
 from pip._internal.index.package_finder import PackageFinder
@@ -358,8 +359,10 @@ class TestProcessLine:
         # When the passed requirements file recursively references itself
         with pytest.raises(
             RecursionError,
-            match=f"{req_files[0]} recursively references itself"
-            f" in {req_files[req_file_count - 1]}",
+            match=(
+                f"{req_files[0]} recursively references itself"
+                f" in {req_files[req_file_count - 1]}"
+            ),
         ):
             list(parse_requirements(filename=str(req_files[0]), session=session))
 
@@ -367,11 +370,42 @@ class TestProcessLine:
         req_files[req_file_count - 1].write_text(f"-r {req_files[req_file_count - 2]}")
         with pytest.raises(
             RecursionError,
-            match=f"{req_files[req_file_count - 2]} recursively references itself "
-            f"in {req_files[req_file_count - 1]} and again in"
-            f" {req_files[req_file_count - 3]}",
+            match=(
+                f"{req_files[req_file_count - 2]} recursively references itself "
+                f"in {req_files[req_file_count - 1]} and again in"
+                f" {req_files[req_file_count - 3]}"
+            ),
         ):
             list(parse_requirements(filename=str(req_files[0]), session=session))
+
+    def test_recursive_relative_requirements_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmpdir: Path, session: PipSession
+    ) -> None:
+        root_req_file = tmpdir / "root.txt"
+        (tmpdir / "nest" / "nest").mkdir(parents=True)
+        level_1_req_file = tmpdir / "nest" / "level_1.txt"
+        level_2_req_file = tmpdir / "nest" / "nest" / "level_2.txt"
+
+        root_req_file.write_text("-r nest/level_1.txt")
+        level_1_req_file.write_text("-r nest/level_2.txt")
+        level_2_req_file.write_text("-r ../../root.txt")
+
+        with pytest.raises(
+            RecursionError,
+            match=(
+                f"{root_req_file} recursively references itself in {level_2_req_file}"
+            ),
+        ):
+            list(parse_requirements(filename=str(root_req_file), session=session))
+
+        # If we don't use absolute path, it keeps on chaining the filename resulting in
+        # a huge filename, since a != a/b/c/../../
+        monkeypatch.setattr(os.path, "abspath", lambda x: x)
+        with pytest.raises(
+            pip._internal.exceptions.InstallationError,
+            match=r"Could not open requirements file: \[Errno 36\] File name too long:",
+        ):
+            list(parse_requirements(filename=str(root_req_file), session=session))
 
     def test_options_on_a_requirement_line(self, line_processor: LineProcessor) -> None:
         line = (


### PR DESCRIPTION
Fixes #12653

I am not sure if I am allowed to put out patches for issues with "needs triage" labels, but seems like simple fix and I got to scratch my own itch too.

Also I am not exactly sure that this is how it should be fixed, but it does catch the files with the problem in the correct order. Had to convert the files to absolute path, else in case of nested references which goes up the directory hierarchy it can't catch the recursion.
