### PR TITLE
Update ruff, fix E721

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.0
+  rev: v0.5.6
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/news/12893.trivial.rst
+++ b/news/12893.trivial.rst
@@ -1,0 +1,1 @@
+Update ruff in pre-commit to 0.5.6

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -555,7 +555,7 @@ class HiddenText:
 
     # This is useful for testing.
     def __eq__(self, other: Any) -> bool:
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
 
         # The string being used for redaction doesn't also have to match,


### PR DESCRIPTION
The latest version of ruff (0.5.6) raises a new E721 (https://docs.astral.sh/ruff/rules/type-comparison/) violation that must be manually fixed.