### PR TITLE
Add pytest ruff checks to test directory

### DIFF
--- a/news/12894.trivial.rst
+++ b/news/12894.trivial.rst
@@ -1,0 +1,1 @@
+Add Ruff's Pytest rules to the tests directory.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -477,7 +477,7 @@ def virtualenv_template(
     setuptools_install: Path,
     wheel_install: Path,
     coverage_install: Path,
-) -> Iterator[VirtualEnvironment]:
+) -> VirtualEnvironment:
     venv_type: VirtualEnvironmentType
     if request.config.getoption("--use-venv"):
         venv_type = "venv"
@@ -522,7 +522,7 @@ def virtualenv_template(
     # it's not reused by mistake from one of the copies.
     venv_template = tmpdir / "venv_template"
     venv.move(venv_template)
-    yield venv
+    return venv
 
 
 @pytest.fixture(scope="session")
@@ -538,14 +538,14 @@ def virtualenv_factory(
 @pytest.fixture
 def virtualenv(
     virtualenv_factory: Callable[[Path], VirtualEnvironment], tmpdir: Path
-) -> Iterator[VirtualEnvironment]:
+) -> VirtualEnvironment:
     """
     Return a virtual environment which is unique to each test function
     invocation created inside of a sub directory of the test function's
     temporary directory. The returned object is a
     ``tests.lib.venv.VirtualEnvironment`` object.
     """
-    yield virtualenv_factory(tmpdir.joinpath("workspace", "venv"))
+    return virtualenv_factory(tmpdir.joinpath("workspace", "venv"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -973,7 +973,7 @@ class OneTimeDownloadHandler(http.server.SimpleHTTPRequestHandler):
             self._seen_paths.add(self.path)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def html_index_with_onetime_server(
     html_index_for_packages: Path,
 ) -> Iterator[http.server.ThreadingHTTPServer]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,7 +216,7 @@ def tmp_path(request: pytest.FixtureRequest, tmp_path: Path) -> Iterator[Path]:
         shutil.rmtree(tmp_path, ignore_errors=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def tmpdir(tmp_path: Path) -> Path:
     """Override Pytest's ``tmpdir`` with our pathlib implementation.
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1234,7 +1234,7 @@ def test_download_use_pep517_propagation(
     assert len(downloads) == 2
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def download_local_html_index(
     script: PipTestEnvironment,
     html_index_for_packages: Path,
@@ -1265,7 +1265,7 @@ def download_local_html_index(
     return run_for_generated_index
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def download_server_html_index(
     script: PipTestEnvironment,
     tmpdir: Path,

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1450,11 +1450,11 @@ def test_produces_error_for_mismatched_package_name_in_metadata(
 
 @pytest.mark.parametrize(
     "requirement",
-    (
+    [
         "requires-simple-extra==0.1",
         "REQUIRES_SIMPLE-EXTRA==0.1",
         "REQUIRES....simple-_-EXTRA==0.1",
-    ),
+    ],
 )
 def test_canonicalizes_package_name_before_verifying_metadata(
     download_local_html_index: Callable[..., Tuple[TestPipResult, Path]],

--- a/tests/functional/test_fast_deps.py
+++ b/tests/functional/test_fast_deps.py
@@ -33,10 +33,10 @@ def assert_installed(script: PipTestEnvironment, names: str) -> None:
 @mark.network
 @mark.parametrize(
     "requirement, expected",
-    (
+    [
         ("Paste==3.4.2", ("Paste", "six")),
         ("Paste[flup]==3.4.2", ("Paste", "six", "flup")),
-    ),
+    ],
 )
 def test_install_from_pypi(
     requirement: str, expected: str, script: PipTestEnvironment
@@ -48,10 +48,10 @@ def test_install_from_pypi(
 @mark.network
 @mark.parametrize(
     "requirement, expected",
-    (
+    [
         ("Paste==3.4.2", ("Paste-3.4.2-*.whl", "six-*.whl")),
         ("Paste[flup]==3.4.2", ("Paste-3.4.2-*.whl", "six-*.whl", "flup-*")),
-    ),
+    ],
 )
 def test_download_from_pypi(
     requirement: str, expected: Iterable[str], script: PipTestEnvironment

--- a/tests/functional/test_fast_deps.py
+++ b/tests/functional/test_fast_deps.py
@@ -7,7 +7,7 @@ from os.path import basename
 from typing import Iterable
 
 from pip._vendor.packaging.utils import canonicalize_name
-from pytest import mark
+import pytest
 
 from pip._internal.utils.misc import hash_file
 from tests.lib import PipTestEnvironment, TestData, TestPipResult
@@ -30,8 +30,8 @@ def assert_installed(script: PipTestEnvironment, names: str) -> None:
     assert installed.issuperset(map(canonicalize_name, names))
 
 
-@mark.network
-@mark.parametrize(
+@pytest.mark.network
+@pytest.mark.parametrize(
     "requirement, expected",
     [
         ("Paste==3.4.2", ("Paste", "six")),
@@ -45,8 +45,8 @@ def test_install_from_pypi(
     assert_installed(script, expected)
 
 
-@mark.network
-@mark.parametrize(
+@pytest.mark.network
+@pytest.mark.parametrize(
     "requirement, expected",
     [
         ("Paste==3.4.2", ("Paste-3.4.2-*.whl", "six-*.whl")),
@@ -61,7 +61,7 @@ def test_download_from_pypi(
     assert all(fnmatch.filter(created, f) for f in expected)
 
 
-@mark.network
+@pytest.mark.network
 def test_build_wheel_with_deps(data: TestData, script: PipTestEnvironment) -> None:
     result = pip(script, "wheel", os.fspath(data.packages / "requiresPaste"))
     created = [basename(f) for f in result.files_created]
@@ -70,7 +70,7 @@ def test_build_wheel_with_deps(data: TestData, script: PipTestEnvironment) -> No
     assert fnmatch.filter(created, "six-*.whl")
 
 
-@mark.network
+@pytest.mark.network
 def test_require_hash(script: PipTestEnvironment, tmp_path: pathlib.Path) -> None:
     reqs = tmp_path / "requirements.txt"
     reqs.write_text(
@@ -91,7 +91,7 @@ def test_require_hash(script: PipTestEnvironment, tmp_path: pathlib.Path) -> Non
     assert fnmatch.filter(created, "idna-2.10*")
 
 
-@mark.network
+@pytest.mark.network
 def test_hash_mismatch(script: PipTestEnvironment, tmp_path: pathlib.Path) -> None:
     reqs = tmp_path / "requirements.txt"
     reqs.write_text("idna==2.10 --hash=sha256:irna")
@@ -105,7 +105,7 @@ def test_hash_mismatch(script: PipTestEnvironment, tmp_path: pathlib.Path) -> No
     assert "DO NOT MATCH THE HASHES" in result.stderr
 
 
-@mark.network
+@pytest.mark.network
 def test_hash_mismatch_existing_download_for_metadata_only_wheel(
     script: PipTestEnvironment, tmp_path: pathlib.Path
 ) -> None:

--- a/tests/functional/test_fast_deps.py
+++ b/tests/functional/test_fast_deps.py
@@ -32,7 +32,7 @@ def assert_installed(script: PipTestEnvironment, names: str) -> None:
 
 @mark.network
 @mark.parametrize(
-    ("requirement", "expected"),
+    "requirement, expected",
     (
         ("Paste==3.4.2", ("Paste", "six")),
         ("Paste[flup]==3.4.2", ("Paste", "six", "flup")),
@@ -47,7 +47,7 @@ def test_install_from_pypi(
 
 @mark.network
 @mark.parametrize(
-    ("requirement", "expected"),
+    "requirement, expected",
     (
         ("Paste==3.4.2", ("Paste-3.4.2-*.whl", "six-*.whl")),
         ("Paste[flup]==3.4.2", ("Paste-3.4.2-*.whl", "six-*.whl", "flup-*")),

--- a/tests/functional/test_fast_deps.py
+++ b/tests/functional/test_fast_deps.py
@@ -6,8 +6,8 @@ import re
 from os.path import basename
 from typing import Iterable
 
-from pip._vendor.packaging.utils import canonicalize_name
 import pytest
+from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.utils.misc import hash_file
 from tests.lib import PipTestEnvironment, TestData, TestPipResult

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -105,16 +105,13 @@ def test_pep518_refuses_conflicting_requires(
     result = script.pip_install_local(
         "-f", script.scratch_path, project_dir, expect_error=True
     )
+    assert result.returncode != 0
     assert (
-        result.returncode != 0
-        and (
             f"Some build dependencies for {project_dir.as_uri()} conflict "
             "with PEP 517/518 supported "
             "requirements: setuptools==1.0 is incompatible with "
             "setuptools>=40.8.0."
-        )
-        in result.stderr
-    ), str(result)
+        ) in result.stderr, str(result)
 
 
 def test_pep518_refuses_invalid_requires(
@@ -2309,10 +2306,8 @@ def test_error_all_yanked_files_and_no_pin(
         expect_error=True,
     )
     # Make sure an error is raised
-    assert (
-        result.returncode == 1
-        and "ERROR: No matching distribution found for simple\n" in result.stderr
-    ), str(result)
+    assert result.returncode == 1
+    assert "ERROR: No matching distribution found for simple\n" in result.stderr, str(result)
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -107,11 +107,11 @@ def test_pep518_refuses_conflicting_requires(
     )
     assert result.returncode != 0
     assert (
-            f"Some build dependencies for {project_dir.as_uri()} conflict "
-            "with PEP 517/518 supported "
-            "requirements: setuptools==1.0 is incompatible with "
-            "setuptools>=40.8.0."
-        ) in result.stderr, str(result)
+        f"Some build dependencies for {project_dir.as_uri()} conflict "
+        "with PEP 517/518 supported "
+        "requirements: setuptools==1.0 is incompatible with "
+        "setuptools>=40.8.0."
+    ) in result.stderr, str(result)
 
 
 def test_pep518_refuses_invalid_requires(
@@ -2307,7 +2307,9 @@ def test_error_all_yanked_files_and_no_pin(
     )
     # Make sure an error is raised
     assert result.returncode == 1
-    assert "ERROR: No matching distribution found for simple\n" in result.stderr, str(result)
+    assert "ERROR: No matching distribution found for simple\n" in result.stderr, str(
+        result
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -42,8 +42,8 @@ from tests.lib.server import (
 )
 
 
-@pytest.mark.parametrize("command", ("install", "wheel"))
-@pytest.mark.parametrize("variant", ("missing_setuptools", "bad_setuptools"))
+@pytest.mark.parametrize("command", ["install", "wheel"])
+@pytest.mark.parametrize("variant", ["missing_setuptools", "bad_setuptools"])
 def test_pep518_uses_build_env(
     script: PipTestEnvironment,
     data: TestData,
@@ -243,10 +243,10 @@ def test_pep518_with_namespace_package(
     )
 
 
-@pytest.mark.parametrize("command", ("install", "wheel"))
+@pytest.mark.parametrize("command", ["install", "wheel"])
 @pytest.mark.parametrize(
     "package",
-    ("pep518_forkbomb", "pep518_twin_forkbombs_first", "pep518_twin_forkbombs_second"),
+    ["pep518_forkbomb", "pep518_twin_forkbombs_first", "pep518_twin_forkbombs_second"],
 )
 def test_pep518_forkbombs(
     script: PipTestEnvironment,
@@ -1253,7 +1253,7 @@ def test_install_nonlocal_compatible_wheel_path(
     assert result.returncode == ERROR
 
 
-@pytest.mark.parametrize("opt", ("--target", "--prefix"))
+@pytest.mark.parametrize("opt", ["--target", "--prefix"])
 def test_install_with_target_or_prefix_and_scripts_no_warning(
     opt: str, script: PipTestEnvironment
 ) -> None:
@@ -2027,7 +2027,7 @@ def test_install_pep508_with_url_in_install_requires(
 
 
 @pytest.mark.network
-@pytest.mark.parametrize("index", (PyPI.simple_url, TestPyPI.simple_url))
+@pytest.mark.parametrize("index", [PyPI.simple_url, TestPyPI.simple_url])
 def test_install_from_test_pypi_with_ext_url_dep_is_blocked(
     script: PipTestEnvironment, index: str
 ) -> None:
@@ -2392,7 +2392,7 @@ def test_install_skip_work_dir_pkg(script: PipTestEnvironment, data: TestData) -
 
 
 @pytest.mark.parametrize(
-    "package_name", ("simple-package", "simple_package", "simple.package")
+    "package_name", ["simple-package", "simple_package", "simple.package"]
 )
 def test_install_verify_package_name_normalization(
     script: PipTestEnvironment, package_name: str
@@ -2449,7 +2449,7 @@ def install_find_links(
 
 @pytest.mark.parametrize(
     "with_target_dir",
-    (True, False),
+    [True, False],
 )
 def test_install_dry_run_nothing_installed(
     script: PipTestEnvironment,
@@ -2618,7 +2618,7 @@ def test_install_pip_prints_req_chain_pypi(script: PipTestEnvironment) -> None:
     )
 
 
-@pytest.mark.parametrize("common_prefix", ("", "linktest-1.0/"))
+@pytest.mark.parametrize("common_prefix", ["", "linktest-1.0/"])
 def test_install_sdist_links(script: PipTestEnvironment, common_prefix: str) -> None:
     """
     Test installing an sdist with hard and symbolic links.

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -361,7 +361,7 @@ def keyring_provider_implementation(request: pytest.FixtureRequest) -> str:
     return request.param
 
 
-@pytest.fixture()
+@pytest.fixture
 def flags(
     request: pytest.FixtureRequest,
     interactive: bool,

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -624,9 +624,9 @@ def test_install_distribution_duplicate_extras(
 ) -> None:
     to_install = data.packages.joinpath("LocalExtras")
     package_name = f"{to_install}[bar]"
+    result = script.pip_install_local(package_name, package_name)
+    expected = f"Double requirement given: {package_name}"
     with pytest.raises(AssertionError):
-        result = script.pip_install_local(package_name, package_name)
-        expected = f"Double requirement given: {package_name}"
         assert expected in result.stderr
 
 

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -625,9 +625,8 @@ def test_install_distribution_duplicate_extras(
     to_install = data.packages.joinpath("LocalExtras")
     package_name = f"{to_install}[bar]"
     result = script.pip_install_local(package_name, package_name)
-    expected = f"Double requirement given: {package_name}"
-    with pytest.raises(AssertionError):
-        assert expected in result.stderr
+    unexpected = f"Double requirement given: {package_name}"
+    assert unexpected not in result.stderr
 
 
 def test_install_distribution_union_with_constraints(

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -32,7 +32,7 @@ class ArgRecordingSdistMaker(Protocol):
     def __call__(self, name: str, **kwargs: Any) -> ArgRecordingSdist: ...
 
 
-@pytest.fixture()
+@pytest.fixture
 def arg_recording_sdist_maker(
     script: PipTestEnvironment,
 ) -> ArgRecordingSdistMaker:

--- a/tests/functional/test_invalid_versions_and_specifiers.py
+++ b/tests/functional/test_invalid_versions_and_specifiers.py
@@ -136,4 +136,4 @@ def test_show_require_invalid_version(
     elif select_backend().NAME == "pkg_resources":
         assert "Required-by: \n" in result.stdout
     else:
-        assert False, "Unknown metadata backend"
+        pytest.fail("Unknown metadata backend")

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -749,4 +749,4 @@ def test_list_pep610_editable(script: PipTestEnvironment) -> None:
             assert item["editable_project_location"]
             break
     else:
-        assert False, "package 'testpkg' not found in pip list result"
+        pytest.fail("package 'testpkg' not found in pip list result")

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -35,7 +35,7 @@ def assert_editable(script: PipTestEnvironment, *args: str) -> None:
     ), f"{args!r} not all found in {script.site_packages_path!r}"
 
 
-@pytest.fixture()
+@pytest.fixture
 def make_fake_wheel(script: PipTestEnvironment) -> MakeFakeWheel:
     def _make_fake_wheel(name: str, version: str, wheel_tag: str) -> pathlib.Path:
         wheel_house = script.scratch_path.joinpath("wheelhouse")

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -2299,8 +2299,8 @@ def test_new_resolver_dont_backtrack_on_extra_if_base_constrained(
     script.assert_installed(pkg="1.0", dep="1.0")
 
 
-@pytest.mark.parametrize("swap_order", (True, False))
-@pytest.mark.parametrize("two_extras", (True, False))
+@pytest.mark.parametrize("swap_order", [True, False])
+@pytest.mark.parametrize("two_extras", [True, False])
 def test_new_resolver_dont_backtrack_on_extra_if_base_constrained_in_requirement(
     script: PipTestEnvironment, swap_order: bool, two_extras: bool
 ) -> None:
@@ -2337,8 +2337,8 @@ def test_new_resolver_dont_backtrack_on_extra_if_base_constrained_in_requirement
     script.assert_installed(pkg="1.0", dep="1.0")
 
 
-@pytest.mark.parametrize("swap_order", (True, False))
-@pytest.mark.parametrize("two_extras", (True, False))
+@pytest.mark.parametrize("swap_order", [True, False])
+@pytest.mark.parametrize("two_extras", [True, False])
 def test_new_resolver_dont_backtrack_on_conflicting_constraints_on_extras(
     tmpdir: pathlib.Path,
     virtualenv: VirtualEnvironment,
@@ -2518,7 +2518,7 @@ def test_new_resolver_works_when_failing_package_builds_are_disallowed(
     script.assert_installed(pkg2="1.0", pkg1="1.0")
 
 
-@pytest.mark.parametrize("swap_order", (True, False))
+@pytest.mark.parametrize("swap_order", [True, False])
 def test_new_resolver_comes_from_with_extra(
     script: PipTestEnvironment, swap_order: bool
 ) -> None:

--- a/tests/functional/test_new_resolver_target.py
+++ b/tests/functional/test_new_resolver_target.py
@@ -10,7 +10,7 @@ from tests.lib.wheel import make_wheel
 MakeFakeWheel = Callable[[str], str]
 
 
-@pytest.fixture()
+@pytest.fixture
 def make_fake_wheel(script: PipTestEnvironment) -> MakeFakeWheel:
     def _make_fake_wheel(wheel_tag: str) -> str:
         wheel_house = script.scratch_path.joinpath("wheelhouse")

--- a/tests/functional/test_new_resolver_user.py
+++ b/tests/functional/test_new_resolver_user.py
@@ -91,7 +91,7 @@ def test_new_resolver_install_user_conflict_in_user_site(
     result.did_not_create(base_2_dist_info)
 
 
-@pytest.fixture()
+@pytest.fixture
 def patch_dist_in_site_packages(virtualenv: VirtualEnvironment) -> None:
     # Since the tests are run from a virtualenv, and to avoid the "Will not
     # install to the usersite because it will lack sys.path precedence..."

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -164,7 +164,8 @@ def test_conflicting_pep517_backend_requirements(
         "dependencies: simplewheel==1.0 is incompatible with "
         "simplewheel==2.0."
     )
-    assert result.returncode != 0 and msg in result.stderr, str(result)
+    assert result.returncode != 0
+    assert msg in result.stderr, str(result)
 
 
 def test_no_check_build_deps(
@@ -209,7 +210,8 @@ def test_validate_missing_pep517_backend_requirements(
         f"Some build dependencies for {project_dir.as_uri()} are missing: "
         "'simplewheel==1.0', 'test_backend'."
     )
-    assert result.returncode != 0 and msg in result.stderr, str(result)
+    assert result.returncode != 0
+    assert msg in result.stderr, str(result)
 
 
 def test_validate_conflicting_pep517_backend_requirements(
@@ -236,7 +238,8 @@ def test_validate_conflicting_pep517_backend_requirements(
         "dependencies: simplewheel==2.0 is incompatible with "
         "simplewheel==1.0."
     )
-    assert result.returncode != 0 and msg in result.stderr, str(result)
+    assert result.returncode != 0
+    assert msg in result.stderr, str(result)
 
 
 def test_pep517_backend_requirements_satisfied_by_prerelease(

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -44,7 +44,8 @@ def test_backend(tmpdir: Path, data: TestData) -> None:
     finder = make_test_finder(find_links=[data.backends])
     env.install_requirements(finder, ["dummy_backend"], "normal", kind="Installing")
     conflicting, missing = env.check_requirements(["dummy_backend"])
-    assert not conflicting and not missing
+    assert not conflicting
+    assert not missing
     assert hasattr(req.pep517_backend, "build_wheel")
     with env:
         assert req.pep517_backend is not None

--- a/tests/functional/test_pep668.py
+++ b/tests/functional/test_pep668.py
@@ -9,7 +9,7 @@ from tests.lib import PipTestEnvironment, create_basic_wheel_for_package
 from tests.lib.venv import VirtualEnvironment
 
 
-@pytest.fixture()
+@pytest.fixture
 def patch_check_externally_managed(virtualenv: VirtualEnvironment) -> None:
     # Since the tests are run from a virtual environment, and we can't
     # guarantee access to the actual stdlib location (where EXTERNALLY-MANAGED

--- a/tests/functional/test_truststore.py
+++ b/tests/functional/test_truststore.py
@@ -7,7 +7,7 @@ from tests.lib import PipTestEnvironment, TestPipResult
 PipRunner = Callable[..., TestPipResult]
 
 
-@pytest.fixture()
+@pytest.fixture
 def pip_no_truststore(script: PipTestEnvironment) -> PipRunner:
     def pip(*args: str, **kwargs: Any) -> TestPipResult:
         return script.pip(*args, "--use-deprecated=legacy-certs", **kwargs)

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -669,7 +669,7 @@ def test_uninstall_editable_and_pip_install(
     script.assert_not_installed("FSPkg")
 
 
-@pytest.fixture()
+@pytest.fixture
 def move_easy_install_pth(script: PipTestEnvironment) -> Iterator[None]:
     """Move easy-install.pth out of the way for testing easy_install."""
     easy_install_pth = join(script.site_packages_path, "easy-install.pth")

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -319,11 +319,11 @@ def _initialize_clonetest_server(
 
 @pytest.mark.parametrize(
     "version_out, expected_message",
-    (
+    [
         ("git version -2.25.1", "Can't parse git version: git version -2.25.1"),
         ("git version 2.a.1", "Can't parse git version: git version 2.a.1"),
         ("git ver. 2.25.1", "Can't parse git version: git ver. 2.25.1"),
-    ),
+    ],
 )
 @patch("pip._internal.vcs.versioncontrol.VersionControl.run_command")
 def test_git_parse_fail_warning(

--- a/tests/lib/test_lib.py
+++ b/tests/lib/test_lib.py
@@ -115,11 +115,11 @@ class TestPipTestEnvironment:
 
     @pytest.mark.parametrize(
         "prefix",
-        (
+        [
             "DEBUG",
             "INFO",
             "FOO",
-        ),
+        ],
     )
     def test_run__allowed_stderr(self, script: PipTestEnvironment, prefix: str) -> None:
         """
@@ -150,10 +150,10 @@ class TestPipTestEnvironment:
 
     @pytest.mark.parametrize(
         "prefix",
-        (
+        [
             "WARNING",
             "ERROR",
-        ),
+        ],
     )
     def test_run__allow_stderr_error(
         self, script: PipTestEnvironment, prefix: str
@@ -166,10 +166,10 @@ class TestPipTestEnvironment:
 
     @pytest.mark.parametrize(
         "prefix, expected_start",
-        (
+        [
             ("WARNING", "stderr has an unexpected warning"),
             ("ERROR", "stderr has an unexpected error"),
-        ),
+        ],
     )
     def test_run__unexpected_stderr(
         self, script: PipTestEnvironment, prefix: str, expected_start: str
@@ -227,10 +227,10 @@ class TestPipTestEnvironment:
 
     @pytest.mark.parametrize(
         "arg_name",
-        (
+        [
             "expect_error",
             "allow_stderr_error",
-        ),
+        ],
     )
     def test_run__allow_stderr_warning_false_error(
         self, script: PipTestEnvironment, arg_name: str

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -1,0 +1,14 @@
+# Extend the `pyproject.toml` file in the parent directory.
+extend = "../pyproject.toml"
+
+# And extend linting to include pytest specific rules and configuration
+[lint]
+extend-select = ["PT"]
+ignore = ["PT004", "PT011"]
+
+[lint.flake8-pytest-style]
+mark-parentheses = false
+fixture-parentheses = false
+parametrize-names-type = "csv"
+parametrize-values-type = "list"
+parametrize-values-row-type = "tuple"

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -119,7 +119,8 @@ def test_dist_found_in_directory_named_whl(tmp_path: Path) -> None:
     info_path.joinpath("METADATA").write_text("Name: pkg")
     location = os.fspath(dir_path)
     dist = get_environment([location]).get_distribution("pkg")
-    assert dist is not None and dist.location is not None
+    assert dist is not None
+    assert dist.location is not None
     assert Path(dist.location) == Path(location)
 
 
@@ -127,7 +128,8 @@ def test_dist_found_in_zip(tmp_path: Path) -> None:
     location = os.fspath(tmp_path.joinpath("pkg.zip"))
     make_wheel(name="pkg", version="1").save_to(location)
     dist = get_environment([location]).get_distribution("pkg")
-    assert dist is not None and dist.location is not None
+    assert dist is not None
+    assert dist.location is not None
     assert Path(dist.location) == Path(location)
 
 

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -133,11 +133,11 @@ def test_dist_found_in_zip(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     "path",
-    (
+    [
         "/path/to/foo.egg-info".replace("/", os.path.sep),
         # Tests issue fixed by https://github.com/pypa/pip/pull/2530
         "/path/to/foo.egg-info/".replace("/", os.path.sep),
-    ),
+    ],
 )
 def test_trailing_slash_directory_metadata(path: str) -> None:
     dist = get_directory_distribution(path)

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -21,13 +21,13 @@ from tests.lib import TestData
 
 
 @pytest.fixture
-def finder(data: TestData) -> Iterator[PackageFinder]:
+def finder(data: TestData) -> PackageFinder:
     session = PipSession()
     scope = SearchScope([str(data.packages)], [], False)
     collector = LinkCollector(session, scope)
     prefs = SelectionPreferences(allow_yanked=False)
     finder = PackageFinder.create(collector, prefs)
-    yield finder
+    return finder
 
 
 @pytest.fixture
@@ -53,8 +53,8 @@ def preparer(finder: PackageFinder) -> Iterator[RequirementPreparer]:
 
 
 @pytest.fixture
-def factory(finder: PackageFinder, preparer: RequirementPreparer) -> Iterator[Factory]:
-    yield Factory(
+def factory(finder: PackageFinder, preparer: RequirementPreparer) -> Factory:
+    return Factory(
         finder=finder,
         preparer=preparer,
         make_install_req=install_req_from_line,
@@ -68,8 +68,8 @@ def factory(finder: PackageFinder, preparer: RequirementPreparer) -> Iterator[Fa
 
 
 @pytest.fixture
-def provider(factory: Factory) -> Iterator[PipProvider]:
-    yield PipProvider(
+def provider(factory: Factory) -> PipProvider:
+    return PipProvider(
         factory=factory,
         constraints={},
         ignore_dependencies=False,

--- a/tests/unit/resolution_resolvelib/test_requirement.py
+++ b/tests/unit/resolution_resolvelib/test_requirement.py
@@ -32,7 +32,7 @@ def _is_satisfied_by(requirement: Requirement, candidate: Candidate) -> bool:
 
 
 @pytest.fixture
-def test_cases(data: TestData) -> Iterator[List[Tuple[str, str, int]]]:
+def test_cases(data: TestData) -> List[Tuple[str, str, int]]:
     def _data_file(name: str) -> Path:
         return data.packages.joinpath(name)
 
@@ -61,7 +61,7 @@ def test_cases(data: TestData) -> Iterator[List[Tuple[str, str, int]]]:
         # TODO: directory, editables
     ]
 
-    yield test_cases
+    return test_cases
 
 
 def test_new_resolver_requirement_has_name(

--- a/tests/unit/resolution_resolvelib/test_requirement.py
+++ b/tests/unit/resolution_resolvelib/test_requirement.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Iterator, List, Tuple
+from typing import List, Tuple
 
 import pytest
 from pip._vendor.resolvelib import BaseReporter, Resolver

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -16,7 +16,7 @@ from pip._internal.resolution.resolvelib.resolver import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def resolver(preparer: RequirementPreparer, finder: PackageFinder) -> Resolver:
     resolver = Resolver(
         preparer=preparer,

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -880,11 +880,9 @@ def test_collect_sources__file_expand_dir(data: TestData) -> None:
         project_name="",
         candidates_from_page=None,  # type: ignore[arg-type]
     )
-    assert (
-        not sources.index_urls
-        and len(sources.find_links) == 1
-        and isinstance(sources.find_links[0], _FlatDirectorySource)
-    ), (
+    assert not sources.index_urls
+    assert len(sources.find_links) == 1
+    assert isinstance(sources.find_links[0], _FlatDirectorySource), (
         "Directory source should have been found "
         f"at find-links url: {data.find_links}"
     )
@@ -909,11 +907,9 @@ def test_collect_sources__file_not_find_link(data: TestData) -> None:
         # Shouldn't be used.
         candidates_from_page=None,  # type: ignore[arg-type]
     )
-    assert (
-        not sources.find_links
-        and len(sources.index_urls) == 1
-        and isinstance(sources.index_urls[0], _IndexDirectorySource)
-    ), "Directory specified as index should be treated as a page"
+    assert not sources.find_links
+    assert len(sources.index_urls) == 1
+    assert isinstance(sources.index_urls[0], _IndexDirectorySource), "Directory specified as index should be treated as a page"
 
 
 def test_collect_sources__non_existing_path() -> None:
@@ -934,9 +930,8 @@ def test_collect_sources__non_existing_path() -> None:
         project_name=None,  # type: ignore[arg-type]
         candidates_from_page=None,  # type: ignore[arg-type]
     )
-    assert not sources.index_urls and sources.find_links == [
-        None
-    ], "Nothing should have been found"
+    assert not sources.index_urls
+    assert sources.find_links == [None], "Nothing should have been found"
 
 
 def check_links_include(links: List[Link], names: List[str]) -> None:

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -909,7 +909,9 @@ def test_collect_sources__file_not_find_link(data: TestData) -> None:
     )
     assert not sources.find_links
     assert len(sources.index_urls) == 1
-    assert isinstance(sources.index_urls[0], _IndexDirectorySource), "Directory specified as index should be treated as a page"
+    assert isinstance(
+        sources.index_urls[0], _IndexDirectorySource
+    ), "Directory specified as index should be treated as a page"
 
 
 def test_collect_sources__non_existing_path() -> None:

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -1208,4 +1208,5 @@ def test_metadata_file_info_parsing_html(
     page_url = "dummy_for_comes_from"
     base_url = "https://index.url/simple"
     link = Link.from_element(attribs, page_url, base_url)
-    assert link is not None and link.metadata_file_data == expected
+    assert link is not None
+    assert link.metadata_file_data == expected

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -259,7 +259,7 @@ def test_get_simple_response_dont_log_clear_text_password(
 
 
 @pytest.mark.parametrize(
-    ("path", "expected"),
+    "path, expected",
     [
         # Test a character that needs quoting.
         ("a b", "a%20b"),
@@ -299,7 +299,7 @@ def test_clean_url_path(path: str, expected: str, is_local_path: bool) -> None:
 
 
 @pytest.mark.parametrize(
-    ("path", "expected"),
+    "path, expected",
     [
         # Test a VCS path with a Windows drive letter and revision.
         pytest.param(
@@ -322,7 +322,7 @@ def test_clean_url_path_with_local_path(path: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("url", "clean_url"),
+    "url, clean_url",
     [
         # URL with hostname and port. Port separator should not be quoted.
         (

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -500,7 +500,7 @@ class TestExternallyManagedEnvironment:
 
         monkeypatch.setattr(locale, "getlocale", fake_getlocale)
 
-    @pytest.fixture()
+    @pytest.fixture
     def marker(self, tmp_path: pathlib.Path) -> pathlib.Path:
         marker = tmp_path.joinpath("EXTERNALLY-MANAGED")
         marker.touch()

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -819,7 +819,7 @@ class TestPackageFinder:
 
 
 @pytest.mark.parametrize(
-    ("fragment", "canonical_name", "expected"),
+    "fragment, canonical_name, expected",
     [
         # Trivial.
         ("pip-18.0", "pip", 3),
@@ -851,7 +851,7 @@ def test_find_name_version_sep(
 
 
 @pytest.mark.parametrize(
-    ("fragment", "canonical_name"),
+    "fragment, canonical_name",
     [
         # A dash must follow the package name.
         ("zope.interface4.5.0", "zope-interface"),
@@ -868,7 +868,7 @@ def test_find_name_version_sep_failure(fragment: str, canonical_name: str) -> No
 
 
 @pytest.mark.parametrize(
-    ("fragment", "canonical_name", "expected"),
+    "fragment, canonical_name, expected",
     [
         # Trivial.
         ("pip-18.0", "pip", "18.0"),

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -11,7 +11,7 @@ from pip._internal.network.auth import MultiDomainBasicAuth
 from tests.lib.requests_mocks import MockConnection, MockRequest, MockResponse
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def reset_keyring() -> Iterable[None]:
     yield None
     # Reset the state of the module between tests

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -177,7 +177,7 @@ class KeyringModuleV1:
 
 @pytest.mark.parametrize(
     "url, expect",
-    (
+    [
         ("http://example.com/path1", (None, None)),
         # path1 URLs will be resolved by netloc
         ("http://user@example.com/path3", ("user", "user!netloc")),
@@ -185,7 +185,7 @@ class KeyringModuleV1:
         # path2 URLs will be resolved by index URL
         ("http://example.com/path2/path3", (None, None)),
         ("http://foo@example.com/path2/path3", ("foo", "foo!url")),
-    ),
+    ],
 )
 def test_keyring_get_password(
     monkeypatch: pytest.MonkeyPatch,
@@ -257,7 +257,7 @@ def test_keyring_get_password_username_in_index(
 
 @pytest.mark.parametrize(
     "response_status, creds, expect_save",
-    (
+    [
         (403, ("user", "pass", True), False),
         (
             200,
@@ -269,7 +269,7 @@ def test_keyring_get_password_username_in_index(
             ("user", "pass", False),
             False,
         ),
-    ),
+    ],
 )
 def test_keyring_set_password(
     monkeypatch: pytest.MonkeyPatch,
@@ -345,11 +345,11 @@ class KeyringModuleV2:
 
 @pytest.mark.parametrize(
     "url, expect",
-    (
+    [
         ("http://example.com/path1", ("username", "netloc")),
         ("http://example.com/path2/path3", ("username", "url")),
         ("http://user2@example.com/path2/path3", ("username", "url")),
-    ),
+    ],
 )
 def test_keyring_get_credential(
     monkeypatch: pytest.MonkeyPatch, url: str, expect: Tuple[str, str]
@@ -442,7 +442,7 @@ class KeyringSubprocessResult(KeyringModuleV1):
 
 @pytest.mark.parametrize(
     "url, expect",
-    (
+    [
         ("http://example.com/path1", (None, None)),
         # path1 URLs will be resolved by netloc
         ("http://user@example.com/path3", ("user", "user!netloc")),
@@ -450,7 +450,7 @@ class KeyringSubprocessResult(KeyringModuleV1):
         # path2 URLs will be resolved by index URL
         ("http://example.com/path2/path3", (None, None)),
         ("http://foo@example.com/path2/path3", ("foo", "foo!url")),
-    ),
+    ],
 )
 def test_keyring_cli_get_password(
     monkeypatch: pytest.MonkeyPatch,
@@ -472,7 +472,7 @@ def test_keyring_cli_get_password(
 
 @pytest.mark.parametrize(
     "response_status, creds, expect_save",
-    (
+    [
         (403, ("user", "pass", True), False),
         (
             200,
@@ -484,7 +484,7 @@ def test_keyring_cli_get_password(
             ("user", "pass", False),
             False,
         ),
-    ),
+    ],
 )
 def test_keyring_cli_set_password(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -291,7 +291,7 @@ def test_keyring_set_password(
         # when _prompt_for_password indicates not to save, we should
         # never call this function
         def should_save_password_to_keyring(*a: Any) -> bool:
-            assert False, "_should_save_password_to_keyring should not be called"
+            pytest.fail("_should_save_password_to_keyring should not be called")
 
     monkeypatch.setattr(
         auth, "_should_save_password_to_keyring", should_save_password_to_keyring
@@ -333,7 +333,7 @@ class KeyringModuleV2:
             self.password = password
 
     def get_password(self, system: str, username: str) -> None:
-        assert False, "get_password should not ever be called"
+        pytest.fail("get_password should not ever be called")
 
     def get_credential(self, system: str, username: str) -> Optional[Credential]:
         if system == "http://example.com/path2/":
@@ -507,7 +507,7 @@ def test_keyring_cli_set_password(
         # when _prompt_for_password indicates not to save, we should
         # never call this function
         def should_save_password_to_keyring(*a: Any) -> bool:
-            assert False, "_should_save_password_to_keyring should not be called"
+            pytest.fail("_should_save_password_to_keyring should not be called")
 
     monkeypatch.setattr(
         auth, "_should_save_password_to_keyring", should_save_password_to_keyring

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -20,7 +20,7 @@ def reset_keyring() -> Iterable[None]:
 
 
 @pytest.mark.parametrize(
-    ["input_url", "url", "username", "password"],
+    "input_url, url, username, password",
     [
         (
             "http://user%40email.com:password@example.com/path",

--- a/tests/unit/test_network_cache.py
+++ b/tests/unit/test_network_cache.py
@@ -10,7 +10,7 @@ from pip._internal.network.cache import SafeFileCache
 from tests.lib.filesystem import chmod
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def cache_tmpdir(tmpdir: Path) -> Path:
     cache_dir = tmpdir.joinpath("cache")
     cache_dir.mkdir(parents=True)

--- a/tests/unit/test_network_cache.py
+++ b/tests/unit/test_network_cache.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Iterator
 from unittest.mock import Mock
 
 import pytest

--- a/tests/unit/test_network_cache.py
+++ b/tests/unit/test_network_cache.py
@@ -11,10 +11,10 @@ from tests.lib.filesystem import chmod
 
 
 @pytest.fixture(scope="function")
-def cache_tmpdir(tmpdir: Path) -> Iterator[Path]:
+def cache_tmpdir(tmpdir: Path) -> Path:
     cache_dir = tmpdir.joinpath("cache")
     cache_dir.mkdir(parents=True)
-    yield cache_dir
+    return cache_dir
 
 
 class TestSafeFileCache:

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -1,7 +1,7 @@
 from typing import Iterator
 
+import pytest
 from pip._vendor.packaging.version import Version
-from pytest import fixture, mark, raises
 
 from pip._internal.exceptions import InvalidWheel
 from pip._internal.network.lazy_wheel import (
@@ -25,12 +25,12 @@ MYPY_0_782_REQS = {
 }
 
 
-@fixture
+@pytest.fixture
 def session() -> PipSession:
     return PipSession()
 
 
-@fixture
+@pytest.fixture
 def mypy_whl_no_range(mock_server: MockServer, shared_data: TestData) -> Iterator[str]:
     mypy_whl = shared_data.packages / "mypy-0.782-py3-none-any.whl"
     mock_server.set_responses([file_response(mypy_whl)])
@@ -40,7 +40,7 @@ def mypy_whl_no_range(mock_server: MockServer, shared_data: TestData) -> Iterato
     mock_server.stop()
 
 
-@mark.network
+@pytest.mark.network
 def test_dist_from_wheel_url(session: PipSession) -> None:
     """Test if the acquired distribution contain correct information."""
     dist = dist_from_wheel_url("mypy", MYPY_0_782_WHL, session)
@@ -55,12 +55,12 @@ def test_dist_from_wheel_url_no_range(
     session: PipSession, mypy_whl_no_range: str
 ) -> None:
     """Test handling when HTTP range requests are not supported."""
-    with raises(HTTPRangeRequestUnsupported):
+    with pytest.raises(HTTPRangeRequestUnsupported):
         dist_from_wheel_url("mypy", mypy_whl_no_range, session)
 
 
-@mark.network
+@pytest.mark.network
 def test_dist_from_wheel_url_not_zip(session: PipSession) -> None:
     """Test handling with the given URL does not point to a ZIP."""
-    with raises(InvalidWheel):
+    with pytest.raises(InvalidWheel):
         dist_from_wheel_url("python", "https://www.python.org/", session)

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -6,7 +6,7 @@ from tests.lib.requests_mocks import MockResponse
 
 
 @pytest.mark.parametrize(
-    ("status_code", "error_type"),
+    "status_code, error_type",
     [
         (401, "Client Error"),
         (501, "Server Error"),

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -68,7 +68,7 @@ class TestOptionPrecedence(AddFakeCommandMixin):
         options, args = cast(Tuple[Values, List[str]], main(["fake"]))
         assert options.timeout == -1
 
-    @pytest.mark.parametrize("values", (["F1"], ["F1", "F2"]))
+    @pytest.mark.parametrize("values", [["F1"], ["F1", "F2"]])
     def test_env_override_default_append(
         self, values: List[str], monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -80,7 +80,7 @@ class TestOptionPrecedence(AddFakeCommandMixin):
         options, args = cast(Tuple[Values, List[str]], main(["fake"]))
         assert options.find_links == values
 
-    @pytest.mark.parametrize("choices", (["w"], ["s", "w"]))
+    @pytest.mark.parametrize("choices", [["w"], ["s", "w"]])
     def test_env_override_default_choice(
         self, choices: List[str], monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -92,7 +92,7 @@ class TestOptionPrecedence(AddFakeCommandMixin):
         options, args = cast(Tuple[Values, List[str]], main(["fake"]))
         assert options.exists_action == choices
 
-    @pytest.mark.parametrize("name", ("PIP_LOG_FILE", "PIP_LOCAL_LOG"))
+    @pytest.mark.parametrize("name", ["PIP_LOG_FILE", "PIP_LOCAL_LOG"])
     def test_env_alias_override_default(
         self, name: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -316,7 +316,7 @@ def tmpconfig(option: str, value: Any, section: str = "global") -> Iterator[str]
 
 
 class TestCountOptions(AddFakeCommandMixin):
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
     @pytest.mark.parametrize("value", range(4))
     def test_cli_long(self, option: str, value: int) -> None:
         flags = [f"--{option}"] * value
@@ -325,7 +325,7 @@ class TestCountOptions(AddFakeCommandMixin):
         opt2, args2 = cast(Tuple[Values, List[str]], main(["fake"] + flags))
         assert getattr(opt1, option) == getattr(opt2, option) == value
 
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
     @pytest.mark.parametrize("value", range(1, 4))
     def test_cli_short(self, option: str, value: int) -> None:
         flag = "-" + option[0] * value
@@ -334,7 +334,7 @@ class TestCountOptions(AddFakeCommandMixin):
         opt2, args2 = cast(Tuple[Values, List[str]], main(["fake", flag]))
         assert getattr(opt1, option) == getattr(opt2, option) == value
 
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
     @pytest.mark.parametrize("value", range(4))
     def test_env_var(
         self, option: str, value: int, monkeypatch: pytest.MonkeyPatch
@@ -344,7 +344,7 @@ class TestCountOptions(AddFakeCommandMixin):
         options, args = cast(Tuple[Values, List[str]], main(["fake"]))
         assert getattr(options, option) == value
 
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
     @pytest.mark.parametrize("value", range(3))
     def test_env_var_integrate_cli(
         self, option: str, value: int, monkeypatch: pytest.MonkeyPatch
@@ -354,8 +354,8 @@ class TestCountOptions(AddFakeCommandMixin):
         options, args = cast(Tuple[Values, List[str]], main(["fake", "--" + option]))
         assert getattr(options, option) == value + 1
 
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
-    @pytest.mark.parametrize("value", (-1, "foobar"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
+    @pytest.mark.parametrize("value", [-1, "foobar"])
     def test_env_var_invalid(
         self,
         option: str,
@@ -368,8 +368,8 @@ class TestCountOptions(AddFakeCommandMixin):
             main(["fake"])
 
     # Undocumented, support for backward compatibility
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
-    @pytest.mark.parametrize("value", ("no", "false"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
+    @pytest.mark.parametrize("value", ["no", "false"])
     def test_env_var_false(
         self, option: str, value: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -379,8 +379,8 @@ class TestCountOptions(AddFakeCommandMixin):
         assert getattr(options, option) == 0
 
     # Undocumented, support for backward compatibility
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
-    @pytest.mark.parametrize("value", ("yes", "true"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
+    @pytest.mark.parametrize("value", ["yes", "true"])
     def test_env_var_true(
         self, option: str, value: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -389,7 +389,7 @@ class TestCountOptions(AddFakeCommandMixin):
         options, args = cast(Tuple[Values, List[str]], main(["fake"]))
         assert getattr(options, option) == 1
 
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
     @pytest.mark.parametrize("value", range(4))
     def test_config_file(
         self, option: str, value: int, monkeypatch: pytest.MonkeyPatch
@@ -400,7 +400,7 @@ class TestCountOptions(AddFakeCommandMixin):
             options, args = cast(Tuple[Values, List[str]], main(["fake"]))
             assert getattr(options, option) == value
 
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
     @pytest.mark.parametrize("value", range(3))
     def test_config_file_integrate_cli(
         self, option: str, value: int, monkeypatch: pytest.MonkeyPatch
@@ -413,8 +413,8 @@ class TestCountOptions(AddFakeCommandMixin):
             )
             assert getattr(options, option) == value + 1
 
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
-    @pytest.mark.parametrize("value", (-1, "foobar"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
+    @pytest.mark.parametrize("value", [-1, "foobar"])
     def test_config_file_invalid(
         self,
         option: str,
@@ -428,8 +428,8 @@ class TestCountOptions(AddFakeCommandMixin):
                 main(["fake"])
 
     # Undocumented, support for backward compatibility
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
-    @pytest.mark.parametrize("value", ("no", "false"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
+    @pytest.mark.parametrize("value", ["no", "false"])
     def test_config_file_false(
         self, option: str, value: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -440,8 +440,8 @@ class TestCountOptions(AddFakeCommandMixin):
             assert getattr(options, option) == 0
 
     # Undocumented, support for backward compatibility
-    @pytest.mark.parametrize("option", ("verbose", "quiet"))
-    @pytest.mark.parametrize("value", ("yes", "true"))
+    @pytest.mark.parametrize("option", ["verbose", "quiet"])
+    @pytest.mark.parametrize("value", ["yes", "true"])
     def test_config_file_true(
         self, option: str, value: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -590,7 +590,7 @@ class TestOptionsConfigFiles:
 
     @pytest.mark.parametrize(
         "args, expect",
-        (
+        [
             ([], None),
             (["--global"], "global"),
             (["--site"], "site"),
@@ -598,7 +598,7 @@ class TestOptionsConfigFiles:
             (["--global", "--user"], PipError),
             (["--global", "--site"], PipError),
             (["--global", "--site", "--user"], PipError),
-        ),
+        ],
     )
     def test_config_file_options(
         self,

--- a/tests/unit/test_pep517.py
+++ b/tests/unit/test_pep517.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from textwrap import dedent
+from typing import Tuple
 
 import pytest
 
@@ -73,12 +74,12 @@ def test_disabling_pep517_invalid(shared_data: TestData, source: str, msg: str) 
 @pytest.mark.parametrize(
     "spec", [("./foo",), ("git+https://example.com/pkg@dev#egg=myproj",)]
 )
-def test_pep517_parsing_checks_requirements(tmpdir: Path, spec: str) -> None:
+def test_pep517_parsing_checks_requirements(tmpdir: Path, spec: Tuple[str]) -> None:
     tmpdir.joinpath("pyproject.toml").write_text(
         dedent(
             f"""
             [build-system]
-            requires = [{spec!r}]
+            requires = [{spec[0]!r}]
             build-backend = "foo"
             """
         )

--- a/tests/unit/test_pep517.py
+++ b/tests/unit/test_pep517.py
@@ -10,7 +10,7 @@ from tests.lib import TestData
 
 
 @pytest.mark.parametrize(
-    ("source", "expected"),
+    "source, expected",
     [
         ("pep517_setup_and_pyproject", True),
         ("pep517_setup_only", False),
@@ -45,7 +45,7 @@ def test_use_pep517_rejects_setup_cfg_only(shared_data: TestData) -> None:
 
 
 @pytest.mark.parametrize(
-    ("source", "msg"),
+    "source, msg",
     [
         ("pep517_setup_and_pyproject", "specifies a build backend"),
         ("pep517_pyproject_only", "does not have a setup.py"),
@@ -71,7 +71,7 @@ def test_disabling_pep517_invalid(shared_data: TestData, source: str, msg: str) 
 
 
 @pytest.mark.parametrize(
-    ("spec",), [("./foo",), ("git+https://example.com/pkg@dev#egg=myproj",)]
+    "spec", [("./foo",), ("git+https://example.com/pkg@dev#egg=myproj",)]
 )
 def test_pep517_parsing_checks_requirements(tmpdir: Path, spec: str) -> None:
     tmpdir.joinpath("pyproject.toml").write_text(

--- a/tests/unit/test_pyproject_config.py
+++ b/tests/unit/test_pyproject_config.py
@@ -6,7 +6,7 @@ from pip._internal.commands import create_command
 
 
 @pytest.mark.parametrize(
-    ("command", "expected"),
+    "command, expected",
     [
         ("install", True),
         ("wheel", True),
@@ -39,7 +39,7 @@ def test_set_config_empty_value() -> None:
 
 
 @pytest.mark.parametrize(
-    ("passed", "expected"),
+    "passed, expected",
     [
         (["x=hello", "x=world"], {"x": ["hello", "world"]}),
         (["x=hello", "x=world", "x=other"], {"x": ["hello", "world", "other"]}),

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -519,7 +519,7 @@ class TestProcessLine:
                 return None, "-r reqs.txt"
             elif filename == "http://me.com/me/reqs.txt":
                 return None, req_name
-            assert False, f"Unexpected file requested {filename}"
+            pytest.fail(f"Unexpected file requested {filename}")
 
         monkeypatch.setattr(
             pip._internal.req.req_file, "get_file_content", get_file_content
@@ -588,7 +588,7 @@ class TestProcessLine:
                 return None, f"-r {nested_req_file}"
             elif filename == nested_req_file:
                 return None, req_name
-            assert False, f"Unexpected file requested {filename}"
+            pytest.fail(f"Unexpected file requested {filename}")
 
         monkeypatch.setattr(
             pip._internal.req.req_file, "get_file_content", get_file_content

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -380,8 +380,10 @@ class TestStashedUninstallPathSet:
         # stash removed, links removed
         for stashed_path in stashed_paths:
             assert not os.path.lexists(stashed_path)
-        assert not os.path.lexists(dirlink) and not os.path.isdir(dirlink)
-        assert not os.path.lexists(filelink) and not os.path.isfile(filelink)
+        assert not os.path.lexists(dirlink)
+        assert not os.path.isdir(dirlink)
+        assert not os.path.lexists(filelink)
+        assert not os.path.isfile(filelink)
 
         # link targets untouched
         assert os.path.isdir(adir)
@@ -412,8 +414,10 @@ class TestStashedUninstallPathSet:
         # stash removed, links restored
         for stashed_path in stashed_paths:
             assert not os.path.lexists(stashed_path)
-        assert os.path.lexists(dirlink) and os.path.isdir(dirlink)
-        assert os.path.lexists(filelink) and os.path.isfile(filelink)
+        assert os.path.lexists(dirlink)
+        assert os.path.isdir(dirlink)
+        assert os.path.lexists(filelink)
+        assert os.path.isfile(filelink)
 
         # link targets untouched
         assert os.path.isdir(adir)

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -16,7 +16,7 @@ from pip._internal import self_outdated_check
 
 
 @pytest.mark.parametrize(
-    ["key", "expected"],
+    "key, expected",
     [
         (
             "/hello/world/venv",
@@ -59,7 +59,7 @@ def test_pip_self_version_check_calls_underlying_implementation(
 
 
 @pytest.mark.parametrize(
-    [
+    [  # noqa: PT006 - String representation is too long
         "installed_version",
         "remote_version",
         "stored_version",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -559,7 +559,7 @@ def test_normalize_version_info(
 
 class TestGetProg:
     @pytest.mark.parametrize(
-        ("argv", "executable", "expected"),
+        "argv, executable, expected",
         [
             ("/usr/bin/pip", "", "pip"),
             ("-c", "/usr/bin/python", "/usr/bin/python -m pip"),
@@ -1061,7 +1061,7 @@ def test_format_size(size: int, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("rows", "table", "sizes"),
+    "rows, table, sizes",
     [
         ([], [], []),
         (

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -860,7 +860,7 @@ def test_hide_url() -> None:
     assert hidden_url.secret == "https://user:password@example.com"
 
 
-@pytest.fixture()
+@pytest.fixture
 def patch_deprecation_check_version() -> Iterator[None]:
     # We do this, so that the deprecation tests are easier to write.
     import pip._internal.utils.deprecation as d

--- a/tests/unit/test_utils_retry.py
+++ b/tests/unit/test_utils_retry.py
@@ -42,13 +42,9 @@ def test_retry_last_error_is_reraised() -> None:
 
     function = Mock(wraps=_raise_error)
     wrapped = retry(wait=0, stop_after_delay=0.01)(function)
-    try:
+    with pytest.raises(RuntimeError) as exc_info:
         wrapped()
-    except Exception as e:
-        assert isinstance(e, RuntimeError)
-        assert e is errors[-1]
-    else:
-        assert pytest.fail("unexpected return")
+    assert exc_info.value is errors[-1]
 
     assert function.call_count > 1, "expected at least one retry"
 

--- a/tests/unit/test_utils_retry.py
+++ b/tests/unit/test_utils_retry.py
@@ -48,7 +48,7 @@ def test_retry_last_error_is_reraised() -> None:
         assert isinstance(e, RuntimeError)
         assert e is errors[-1]
     else:
-        assert False, "unexpected return"
+        assert pytest.fail("unexpected return")
 
     assert function.call_count > 1, "expected at least one retry"
 

--- a/tests/unit/test_utils_subprocess.py
+++ b/tests/unit/test_utils_subprocess.py
@@ -39,7 +39,7 @@ def test_format_command_args(args: CommandArgs, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("stdout_only", "expected"),
+    "stdout_only, expected",
     [
         (True, ("out\n", "out\r\n")),
         (False, ("out\nerr\n", "out\r\nerr\r\n", "err\nout\n", "err\r\nout\r\n")),
@@ -312,7 +312,7 @@ class TestCallSubprocess:
         )
 
     @pytest.mark.parametrize(
-        ("exit_status", "show_stdout", "extra_ok_returncodes", "log_level", "expected"),
+        "exit_status, show_stdout, extra_ok_returncodes, log_level, expected",
         [
             # The spinner should show here because show_stdout=False means
             # the subprocess should get logged at DEBUG level, but the passed

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -198,7 +198,7 @@ class TestUnpackArchives:
         assert "is outside the destination" in str(e.value)
 
     @pytest.mark.parametrize(
-        ("input_prefix", "unpack_prefix"),
+        "input_prefix, unpack_prefix",
         [
             ("", ""),
             ("dir/", ""),  # pip ignores a common leading directory

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -61,7 +61,7 @@ def test_rev_options_repr() -> None:
 
 
 @pytest.mark.parametrize(
-    ("vc_class", "expected1", "expected2", "kwargs"),
+    "vc_class, expected1, expected2, kwargs",
     [
         # First check VCS-specific RevOptions behavior.
         (Bazaar, [], ["-r", "123"], {}),
@@ -599,7 +599,7 @@ def test_get_git_version() -> None:
 
 
 @pytest.mark.parametrize(
-    ("version", "expected"),
+    "version, expected",
     [
         ("git version 2.17", (2, 17)),
         ("git version 2.18.1", (2, 18)),

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -291,14 +291,14 @@ def test_git_resolve_revision_not_found_warning(
 
 @pytest.mark.parametrize(
     "rev_name,result",
-    (
+    [
         ("5547fa909e83df8bd743d3978d6667497983a4b7", True),
         ("5547fa909", False),
         ("5678", False),
         ("abc123", False),
         ("foo", False),
         (None, False),
-    ),
+    ],
 )
 @mock.patch("pip._internal.vcs.git.Git.get_revision")
 def test_git_is_commit_id_equal(


### PR DESCRIPTION
Ruff has a lot of Pytest rules, to apply them only to the test directory I created a `ruff.toml` for the test directory itself, another solution could have been to add per-file ignore rules in the main `pyproject.toml`.

Here are the current violations in the pip test directory. I have gone through each one of these rules and you can see my analysis below:

```
$ ruff check . --select PT --statistics
156 	PT023   [*] pytest-incorrect-mark-parentheses-style
146 	PT006   [*] pytest-parametrize-names-wrong-type
 51 	PT007   [*] pytest-parametrize-values-wrong-type
 35 	PT001   [*] pytest-fixture-incorrect-parentheses-style
 16 	PT018   [ ] pytest-composite-assertion
 11 	PT004   [ ] pytest-missing-fixture-name-underscore
  9 	PT011   [ ] pytest-raises-too-broad
  8 	PT015   [ ] pytest-assert-always-false
  7 	PT022   [*] pytest-useless-yield-fixture
  5 	PT003   [*] pytest-extraneous-scope-function
  2 	PT013   [ ] pytest-incorrect-pytest-import
  2 	PT017   [ ] pytest-assert-in-except
  1 	PT012   [ ] pytest-raises-with-multiple-statements
```


### PT023 - [pytest-incorrect-mark-parentheses-style](https://docs.astral.sh/ruff/rules/pytest-incorrect-mark-parentheses-style/)

Use `@pytest.mark.foo` should be `@pytest.mark.foo()`.

I have set [lint.flake8-pytest-style.mark-parentheses](https://docs.astral.sh/ruff/settings/#lint_flake8-pytest-style_mark-parentheses) to `false`, which will be the default value in a future version of ruff anyway

### PT006 -  [pytest-parametrize-names-wrong-type](https://docs.astral.sh/ruff/rules/pytest-parametrize-names-wrong-type/)

A consistency check of the type of parameter names passed to pytest.mark.parametrize, the choices are `list`, `tuple`, and `csv`.

Ruff's default value is `tuple`, but the large majority of pip's pytest are `csv`, so I have set [lint.flake8-pytest-style.parametrize-names-type](https://docs.astral.sh/ruff/settings/#lint_flake8-pytest-style_parametrize-names-type) to that. Required manual fixing of 1 test as giving a single element csv and a single element tuple does not quite produce quite the same argument type.

### PT007 -  [pytest-parametrize-values-wrong-type](https://docs.astral.sh/ruff/rules/pytest-parametrize-values-wrong-type/)

A consistency check for the type of parameter values passed to pytest.mark.parametrize.

Pip mostly uses `list` for the value type, so I set [lint.flake8-pytest-style.parametrize-values-type](https://docs.astral.sh/ruff/settings/#lint_flake8-pytest-style_parametrize-values-type) to that.

Pip mostly uses `tuple` for value row type, so I set [lint.flake8-pytest-style.parametrize-values-row-type](https://docs.astral.sh/ruff/settings/#lint_flake8-pytest-style_parametrize-values-row-type) to that.

### PT001 -  [pytest-fixture-incorrect-parentheses-style](https://docs.astral.sh/ruff/rules/pytest-fixture-incorrect-parentheses-style/)

Use `@pytest.fixture` should be `@pytest.fixture()`, this is a style choice.

I have set [lint.flake8-pytest-style.fixture-parentheses](https://docs.astral.sh/ruff/settings/#lint_flake8-pytest-style_fixture-parentheses) to false, which will be the default value in a future version of ruff anyway

### PT018  - [pytest-composite-assertion](https://docs.astral.sh/ruff/rules/pytest-composite-assertion/)

That assertions should be broken out instead of composite with `and` statements, this certainly makes failures easier to debug.

Fixes were not automatic when there was a comment, so this required additional manual fixes

### PT004 -  [pytest-missing-fixture-name-underscore](https://docs.astral.sh/ruff/rules/pytest-missing-fixture-name-underscore/)

A convention that fixtures that don't return anything should start with an `_`, required manually fixing.

I have excluded this rule as it was not clear what the convention purpose is to me, and because of the dynamic nature of `pytest.mark.usefixtures` requires some tricky manual updating.

I did however end up noticing `patch_distribution_lookups`, `patch_locale`, `scoped_global_tempdir_manager`, and `isolate` fixtures never appear to be used, should I attempt removing them?

### PT011 -  [pytest-raises-too-broad](https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/)

Rule expects a subset of  exceptions to specify an error message that `pytest.raises` should always match on. For relatively narrow tests this seemed overly prescriptive to me, so I added PT011  to the ignore list, but let me know and I will add these in.

### PT015  - [pytest-assert-always-false](https://docs.astral.sh/ruff/rules/pytest-assert-always-false/)

Convention to use `pytest.fail(msg)` instead of `assert False, msg`, manually fixed.

### PT022 -   [pytest-useless-yield-fixture](https://docs.astral.sh/ruff/rules/pytest-useless-yield-fixture/)

A yield in a fixture so that fixture can have a teardown, with no teardown the yield is pointless, automatically fixed.

### PT003 -  [pytest-extraneous-scope-function](https://docs.astral.sh/ruff/rules/pytest-extraneous-scope-function/)

A "function" scope in a fixture is default, automatically fixed.

### PT017  - [pytest-assert-in-except](https://docs.astral.sh/ruff/rules/pytest-assert-in-except/)

Use `pytest.raises` not an asset inside an exception, manually fixed.

### PT013  - [pytest-incorrect-pytest-import](https://docs.astral.sh/ruff/rules/pytest-incorrect-pytest-import/)

Use `import pytest` not `from pytest import ...` not `import pytest as pt`, manually fixed

### PT012 -  [pytest-raises-with-multiple-statements](https://docs.astral.sh/ruff/rules/pytest-raises-with-multiple-statements/)

Only put 1 statement inside a pytest raises, manually fixed.