### PR TITLE
Remove IRC link from issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,6 @@
 
 blank_issues_enabled: false
 contact_links:
-  - name: "💬 IRC: #pypa"
-    url: https://kiwiirc.com/nextclient/#ircs://irc.libera.chat:+6697/pypa
-    about: Chat with devs
   - name: "(maintainers only) Blank issue"
     url: https://github.com/pypa/pip/issues/new
     about: For maintainers only.

--- a/news/12895.trivial.rst
+++ b/news/12895.trivial.rst
@@ -1,0 +1,1 @@
+Remove IRC link from create issue page

--- a/news/12895.trivial.rst
+++ b/news/12895.trivial.rst
@@ -1,1 +1,1 @@
-Remove IRC link from create issue page
+Remove IRC link from create issue page.


### PR DESCRIPTION
This shows when an issue is created, but I don't think any pip maintainer is using this IRC to chat with users:

![image](https://github.com/user-attachments/assets/6b60173d-9eee-4cb4-b5f1-09369d5e17df)
