### PR TITLE
Use ! instead  . to make "--break-system-package" clickable

### DIFF
--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -686,7 +686,7 @@ class ExternallyManagedEnvironment(DiagnosticPipError):
                 "If you believe this is a mistake, please contact your "
                 "Python installation or OS distribution provider. "
                 "You can override this, at the risk of breaking your Python "
-                "installation or OS, by passing --break-system-packages."
+                "installation or OS, by passing --break-system-packages!"
             ),
             hint_stmt=Text("See PEP 668 for the detailed specification."),
         )


### PR DESCRIPTION
This PR changes the `.` as last character to `!`, because then I can double-click-select `--break-system-package` without the `.`.

Workflow:
* I want to install a pip
* pip complains:
```
note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
```
* I double click on `--break-system-packages.`
* I paste it with center mouse button
* I remove the `.` <-- the PR saves this step
* I install the package

