### PR TITLE
pip list: Incorrect version displayed with pip list when using --target and PYTHONPATH

### DIFF
--- a/news/12890.bugfix.rst
+++ b/news/12890.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the incorrect vesion displayed with pip list when using --target and PYTHONPATH


### PR DESCRIPTION
Fixes: https://github.com/pypa/pip/issues/12890

This will fix the incorrect version displayed with pip list when using --target and PYTHONPATH.
This is a potential fix as the community has not yet confirmed it as a bug. Please let me know if there are **any areas** that need improvement. 
