### PR TITLE
Deprecate wheel filenames that are not compliant with PEP 440

### DIFF
--- a/news/12918.removal.rst
+++ b/news/12918.removal.rst
@@ -1,0 +1,1 @@
+Deprecate wheel filenames that are not compliant with PEP 440.

--- a/tests/unit/test_models_wheel.py
+++ b/tests/unit/test_models_wheel.py
@@ -3,7 +3,7 @@ from pip._vendor.packaging.tags import Tag
 
 from pip._internal.exceptions import InvalidWheelFilename
 from pip._internal.models.wheel import Wheel
-from pip._internal.utils import compatibility_tags
+from pip._internal.utils import compatibility_tags, deprecation
 
 
 class TestWheelFile:
@@ -175,5 +175,6 @@ class TestWheelFile:
         Test that we convert '_' to '-' for versions parsed out of wheel
         filenames
         """
-        w = Wheel("simple-0.1_1-py2-none-any.whl")
+        with pytest.warns(deprecation.PipDeprecationWarning):
+            w = Wheel("simple-0.1_1-py2-none-any.whl")
         assert w.version == "0.1-1"


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/12914

It should be noted that because of https://github.com/pypa/pip/pull/12327, which already uses `parse_wheel_filename` instead of `Wheel.wheel_file_re` a wheel that uses a `_` in the version part of the string will not be found using `--find-links=<path-to-dir>`. This was an unintended side effect, but no one has raised an issue about it.

Once the depreciation cycle is complete https://github.com/pypa/pip/pull/12917 can land.

I thought about merging this PR and https://github.com/pypa/pip/pull/12917  by first parsing with `parse_wheel_filename` and then falling back to `Wheel.wheel_file_re` with a depreciation error, but it introduced a lot of additional complexity.

I did some reading on the motivation to allow `_` in the wheel version part, and it seemed to be supporting tools which have long since been fixed or are themselves no longer maintained.
