### PR TITLE
CI: Test on macOS arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
   schedule:
     - cron: 0 0 * * MON # Run every Monday at 00:00 UTC
+  workflow_dispatch:
+    # allow manual runs on branches without a PR
 
 env:
   # The "FORCE_COLOR" variable, when set to 1,
@@ -107,7 +109,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-12, macos-latest]
         python:
           - "3.8"
           - "3.9"
@@ -130,8 +132,13 @@ jobs:
           sudo apt-get install bzr
 
       - name: Install MacOS dependencies
-        if: matrix.os == 'macos-12'
-        run: brew install breezy
+        if: runner.os == 'macOS'
+        run: |
+          DEPS=breezy
+          if ! which svn; then
+            DEPS="${DEPS} subversion"
+          fi
+          brew install ${DEPS}
 
       - run: pip install nox
 

--- a/tests/functional/test_uninstall_user.py
+++ b/tests/functional/test_uninstall_user.py
@@ -2,6 +2,8 @@
 tests specific to uninstalling --user installs
 """
 
+import platform
+import sys
 from os.path import isdir, isfile, normcase
 
 import pytest
@@ -74,6 +76,12 @@ class Tests_UninstallUserSite:
         dist_info_folder = script.base_path / script.site_packages / "pkg-0.1.dist-info"
         assert isdir(dist_info_folder)
 
+    @pytest.mark.xfail(
+        sys.platform == "darwin"
+        and platform.machine() == "arm64"
+        and sys.version_info[:2] in {(3, 8), (3, 9)},
+        reason="Unexpected egg-link install path",
+    )
     def test_uninstall_editable_from_usersite(
         self, script: PipTestEnvironment, data: TestData
     ) -> None:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,6 +8,8 @@ pytest-rerunfailures
 pytest-xdist
 scripttest
 setuptools
+# macOS (darwin) arm64 always uses virtualenv >= 20.0
+# for other platforms, it depends on python version
 virtualenv < 20.0 ; python_version < '3.10' and (sys_platform != 'darwin' or platform_machine != 'arm64')
 virtualenv >= 20.0 ; python_version >= '3.10' or (sys_platform == 'darwin' and platform_machine == 'arm64')
 werkzeug

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,8 +8,8 @@ pytest-rerunfailures
 pytest-xdist
 scripttest
 setuptools
-virtualenv < 20.0 ; python_version < '3.10'
-virtualenv >= 20.0 ; python_version >= '3.10'
+virtualenv < 20.0 ; python_version < '3.10' and (sys_platform != 'darwin' or platform_machine != 'arm64')
+virtualenv >= 20.0 ; python_version >= '3.10' or (sys_platform == 'darwin' and platform_machine == 'arm64')
 werkzeug
 wheel
 tomli-w


### PR DESCRIPTION
Fix #12908

The 2 failing tests mentioned in the issue are indeed present and marked as fail in the PR.
The tests required virtualenv >= 20.0 to pass on python 3.8 & 3.9 on arm64 thus the requirements have been updated.

Side note: it seems all tests are passing with virtualenv >= 20.0 on other platforms. The pin to virtualenv<20.0 might not be needed anymore (introduced in #11288, @uranusjr might have some valuable insight about this).