### PR TITLE
Refactor MultiDomainBasicAuth

### DIFF
--- a/src/pip/_internal/cli/index_command.py
+++ b/src/pip/_internal/cli/index_command.py
@@ -86,7 +86,7 @@ class SessionCommandMixin(CommandContextMixIn):
         retries: Optional[int] = None,
         timeout: Optional[int] = None,
     ) -> "PipSession":
-        from pip._internal.network.session import PipSession
+        from pip._internal.network.session import MultiDomainAuthSettings, PipSession
 
         cache_dir = options.cache_dir
         assert not cache_dir or os.path.isabs(cache_dir)
@@ -100,8 +100,13 @@ class SessionCommandMixin(CommandContextMixIn):
             cache=os.path.join(cache_dir, "http-v2") if cache_dir else None,
             retries=retries if retries is not None else options.retries,
             trusted_hosts=options.trusted_hosts,
-            index_urls=self._get_index_urls(options),
             ssl_context=ssl_context,
+            multi_domain_auth_settings=MultiDomainAuthSettings(
+                index_urls=self._get_index_urls(options),
+                # Determine if we can prompt the user for authentication or not
+                prompting=not options.no_input,
+                keyring_provider=options.keyring_provider,
+            ),
         )
 
         # Handle custom ca-bundles from the user
@@ -123,10 +128,6 @@ class SessionCommandMixin(CommandContextMixIn):
                 "https": options.proxy,
             }
             session.trust_env = False
-
-        # Determine if we can prompt the user for authentication or not
-        session.auth.prompting = not options.no_input
-        session.auth.keyring_provider = options.keyring_provider
 
         return session
 

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import urllib.parse
 import warnings
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -317,6 +318,13 @@ class InsecureCacheControlAdapter(CacheControlAdapter):
         super().cert_verify(conn=conn, url=url, verify=False, cert=cert)
 
 
+@dataclass(frozen=True)
+class MultiDomainAuthSettings:
+    prompting: bool = True
+    index_urls: Optional[List[str]] = None
+    keyring_provider: str = "auto"
+
+
 class PipSession(requests.Session):
     timeout: Optional[int] = None
 
@@ -326,8 +334,8 @@ class PipSession(requests.Session):
         retries: int = 0,
         cache: Optional[str] = None,
         trusted_hosts: Sequence[str] = (),
-        index_urls: Optional[List[str]] = None,
         ssl_context: Optional["SSLContext"] = None,
+        multi_domain_auth_settings: Optional[MultiDomainAuthSettings] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -344,7 +352,13 @@ class PipSession(requests.Session):
         self.headers["User-Agent"] = user_agent()
 
         # Attach our Authentication handler to the session
-        self.auth = MultiDomainBasicAuth(index_urls=index_urls)
+        if multi_domain_auth_settings is None:
+            multi_domain_auth_settings = MultiDomainAuthSettings()
+        self.auth = MultiDomainBasicAuth(
+            prompting=multi_domain_auth_settings.prompting,
+            index_urls=multi_domain_auth_settings.index_urls,
+            keyring_provider=multi_domain_auth_settings.keyring_provider,
+        )
 
         # Create our urllib3.Retry instance which will allow us to customize
         # how we handle retries.

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -1012,12 +1012,17 @@ class TestLinkCollector:
         # Check that index URLs are marked as *un*cacheable.
         assert not pages[0].link.cache_link_parsing
 
+        # Skip past a couple of log messages about keyring.
+        record_tuples = caplog.record_tuples
+        assert record_tuples.pop(0)[2].startswith("Keyring provider")
+        assert record_tuples.pop(0)[2].startswith("Keyring provider")
+
         expected_message = dedent(
             """\
         1 location(s) to search for versions of twine:
         * https://pypi.org/simple/twine/"""
         )
-        assert caplog.record_tuples == [
+        assert record_tuples == [
             ("pip._internal.index.collector", logging.DEBUG, expected_message),
         ]
 
@@ -1058,12 +1063,17 @@ class TestLinkCollector:
         assert len(files) > 0
         check_links_include(files, names=["singlemodule-0.0.1.tar.gz"])
 
+        # Skip past a couple of log messages about keyring.
+        record_tuples = caplog.record_tuples
+        assert record_tuples.pop(0)[2].startswith("Keyring provider")
+        assert record_tuples.pop(0)[2].startswith("Keyring provider")
+
         expected_message = dedent(
             """\
         1 location(s) to search for versions of singlemodule:
         * https://pypi.org/simple/singlemodule/"""
         )
-        assert caplog.record_tuples == [
+        assert record_tuples == [
             ("pip._internal.index.collector", logging.DEBUG, expected_message),
         ]
 

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -2,21 +2,13 @@ import functools
 import os
 import subprocess
 import sys
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
 import pip._internal.network.auth
 from pip._internal.network.auth import MultiDomainBasicAuth
 from tests.lib.requests_mocks import MockConnection, MockRequest, MockResponse
-
-
-@pytest.fixture(autouse=True)
-def reset_keyring() -> Iterable[None]:
-    yield None
-    # Reset the state of the module between tests
-    pip._internal.network.auth.KEYRING_DISABLED = False
-    pip._internal.network.auth.get_keyring_provider.cache_clear()
 
 
 @pytest.mark.parametrize(
@@ -61,13 +53,13 @@ def test_get_credentials_parses_correctly(
         (username is None and password is None)
         or
         # Credentials were found and "cached" appropriately
-        auth.passwords["example.com"] == (username, password)
+        auth._passwords["example.com"] == (username, password)
     )
 
 
 def test_get_credentials_not_to_uses_cached_credentials() -> None:
     auth = MultiDomainBasicAuth()
-    auth.passwords["example.com"] = ("user", "pass")
+    auth._passwords["example.com"] = ("user", "pass")
 
     got = auth._get_url_and_credentials("http://foo:bar@example.com/path")
     expected = ("http://example.com/path", "foo", "bar")
@@ -76,7 +68,7 @@ def test_get_credentials_not_to_uses_cached_credentials() -> None:
 
 def test_get_credentials_not_to_uses_cached_credentials_only_username() -> None:
     auth = MultiDomainBasicAuth()
-    auth.passwords["example.com"] = ("user", "pass")
+    auth._passwords["example.com"] = ("user", "pass")
 
     got = auth._get_url_and_credentials("http://foo@example.com/path")
     expected = ("http://example.com/path", "foo", "")
@@ -85,7 +77,7 @@ def test_get_credentials_not_to_uses_cached_credentials_only_username() -> None:
 
 def test_get_credentials_uses_cached_credentials() -> None:
     auth = MultiDomainBasicAuth()
-    auth.passwords["example.com"] = ("user", "pass")
+    auth._passwords["example.com"] = ("user", "pass")
 
     got = auth._get_url_and_credentials("http://example.com/path")
     expected = ("http://example.com/path", "user", "pass")
@@ -94,7 +86,7 @@ def test_get_credentials_uses_cached_credentials() -> None:
 
 def test_get_credentials_uses_cached_credentials_only_username() -> None:
     auth = MultiDomainBasicAuth()
-    auth.passwords["example.com"] = ("user", "pass")
+    auth._passwords["example.com"] = ("user", "pass")
 
     got = auth._get_url_and_credentials("http://user@example.com/path")
     expected = ("http://example.com/path", "user", "pass")


### PR DESCRIPTION
(This PR is some refactoring that I want to land before creating a PR to implement https://github.com/pypa/pip/issues/12750. If the additional context is useful, you can see my upcoming changes over in https://github.com/jfly/pip/compare/jfly:issue-12750-pre-work-refactor...jfly:pip:issue-12750-configurable-keyring-subprocess-location)

I was starting to work on https://github.com/pypa/pip/issues/12750, but
got hung up on some strange OOP patterns going on here. In particular, I
found it odd that there are 2 different ways we set some knobs
(`prompting` and `keyring_provider`) and for instances of
`MultiDomainBasicAuth`:

1. In tests, we do it by passing these knobs as constructor
   parameters to `MultiDomainBasicAuth`.
2. In the real cli codepath, we do it by mutating `session.auth` (an
   instance of `MultiDomainBasicAuth`) after it's constructed.

I believe that 2) is the reason for the careful cache management logic
you see me tearing out in the PR. Basically: when a
`MultiDomainBasicAuth` is constructed, it's possible that the keyring
provider will change after the fact, so we can't do any useful caching
in our constructor.

In this PR, I reworked all of this to behave like more normal OOP: I've
tightened up the API of `MultiDomainBasicAuth` so that these knobs are
only passed in as constructor parameters, and the other instance
attributes are now "private" (underscore-prefixed) values that you're
not supposed to read or write to (except for some tests that look at
these attributes to verify things are working).

This change allowed me to get rid of all the careful cache management
code we had, and sets me up to implement
https://github.com/pypa/pip/issues/12750 as I'm going to be adding yet
another knob (`keyring_executable`). This new pattern will allow me to
validate that `keyring_executable` is compatible with `keyring_provider`
in `MultiDomainAuthSettings`'s constructor (it doesn't make any sense to
specify a path to an executable if you're using the import provider, for
example). With the previous code
pattern, there was just no good place to validate that.

You'll notice I did end up touching a couple of tests:

- `test_collector.py`: Logging is slightly different now, as we now
  immediately go fetch the keyring provider, rather than lazily. I could
  rework this to preserve the old behavior, but I don't think it's an
  important difference, it only affects tests that are trying to assert
  on every single log message.
- `test_network_auth.py`: Nothing significant here. Just removing the
  now-unnecessary `reset_keyring` logic, and updating `.password` to
  `._password` to reflect the new api.