### PR TITLE
Update non PEP 440 wheel filename deprecation notice

### DIFF
--- a/news/12939.trivial.rst
+++ b/news/12939.trivial.rst
@@ -1,0 +1,1 @@
+Update non PEP 440 wheel filename deprecation notice.

--- a/src/pip/_internal/models/wheel.py
+++ b/src/pip/_internal/models/wheel.py
@@ -39,17 +39,15 @@ class Wheel:
         self.name = wheel_info.group("name").replace("_", "-")
         _version = wheel_info.group("ver")
         if "_" in _version:
-            _version = _version.replace("_", "-")
-
             try:
                 parse_wheel_filename(filename)
-            except (PackagingInvalidWheelName, InvalidVersion):
+            except InvalidVersion as e:
                 deprecated(
                     reason=(
-                        f"Wheel filename {filename!r} uses an invalid filename format, "
-                        f"as the version part {_version!r} is not correctly "
-                        "normalised, and contains an underscore character. Future "
-                        "versions of pip will fail to recognise this wheel."
+                        f"Wheel filename version part {_version!r} is not correctly "
+                        "normalised, and contained an underscore character in the "
+                        "version part. Future versions of pip will fail to recognise "
+                        f"this wheel and report the error: {e.args[0]}."
                     ),
                     replacement=(
                         "rename the wheel to use a correctly normalised "
@@ -59,6 +57,23 @@ class Wheel:
                     gone_in="25.1",
                     issue=12938,
                 )
+            except PackagingInvalidWheelName as e:
+                deprecated(
+                    reason=(
+                        f"The wheel filename {filename!r} is not correctly normalised. "
+                        "Future versions of pip will fail to recognise this wheel. "
+                        f"and report the error: {e.args[0]}."
+                    ),
+                    replacement=(
+                        "rename the wheel to use a correctly normalised "
+                        "name (this may require updating the version in "
+                        "the project metadata)"
+                    ),
+                    gone_in="25.1",
+                    issue=12938,
+                )
+
+            _version = _version.replace("_", "-")
 
         self.version = _version
         self.build_tag = wheel_info.group("build")


### PR DESCRIPTION
As requested in https://github.com/pypa/pip/pull/12918#discussion_r1728546685 this creates an issue and points to the deprecation notice to that issue (https://github.com/pypa/pip/issues/12938).

Further, upon testing pip main for a little bit I found several packages that use `_` to separate the version and build number, which is valid, but the deprecation was pretty noisey as the current logic can't distinguish this, so I updated the deprecation to not fire unless `parse_wheel_filename` identified it as invalid.

<summary> 
E.g
<details>

```
$ pip install --dry-run marshmallow==1.0.0
  DEPRECATION: Wheel filename 'marshmallow-1.0.0_a-py2.py3-none-any.whl' uses an invalid filename format, as the version part '1.0.0_a' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
Collecting marshmallow==1.0.0
  Downloading marshmallow-1.0.0-py2.py3-none-any.whl.metadata (15 kB)
Downloading marshmallow-1.0.0-py2.py3-none-any.whl (45 kB)
Would install marshmallow-1.0.0


$ pip install --dry-run protobuf==4.21.0rc1
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_1-cp310-abi3-win_amd64.whl' uses an invalid filename format, as the version part '4.21.0_rc_1' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_1-cp37-abi3-macosx_10_9_universal2.whl' uses an invalid filename format, as the version part '4.21.0_rc_1' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_1-cp37-abi3-manylinux2014_aarch64.whl' uses an invalid filename format, as the version part '4.21.0_rc_1' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_1-cp37-abi3-manylinux2014_x86_64.whl' uses an invalid filename format, as the version part '4.21.0_rc_1' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_1-cp37-cp37m-win_amd64.whl' uses an invalid filename format, as the version part '4.21.0_rc_1' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_1-cp38-cp38-win_amd64.whl' uses an invalid filename format, as the version part '4.21.0_rc_1' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_1-cp39-cp39-win_amd64.whl' uses an invalid filename format, as the version part '4.21.0_rc_1' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_1-py3-none-any.whl' uses an invalid filename format, as the version part '4.21.0_rc_1' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp310-abi3-win32.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp310-abi3-win_amd64.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp37-abi3-macosx_10_9_universal2.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp37-abi3-manylinux2014_aarch64.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp37-abi3-manylinux2014_x86_64.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp37-cp37m-win32.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp37-cp37m-win_amd64.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp38-cp38-win32.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp38-cp38-win_amd64.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp39-cp39-win32.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-cp39-cp39-win_amd64.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
  DEPRECATION: Wheel filename 'protobuf-4.21.0_rc_2-py3-none-any.whl' uses an invalid filename format, as the version part '4.21.0_rc_2' is not correctly normalised, and contains an underscore character. Future versions of pip may fail to recognise this wheel. pip 25.1 will enforce this behaviour change. A possible replacement is rename the wheel to use a correctly normalised version part (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12914
Collecting protobuf==4.21.0rc1
  Downloading protobuf-4.21.0_rc_1-cp37-abi3-manylinux2014_x86_64.whl.metadata (67 bytes)
Downloading protobuf-4.21.0_rc_1-cp37-abi3-manylinux2014_x86_64.whl (407 kB)
Would install protobuf-4.21.0-rc-1
```

</details>
</summary>

These examples no longer fire the deprecation notice with this PR.
