### PR TITLE
Remove cffi workaround in tests requirements

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-cffi >= 1.17.0rc1 ; python_version > "3.12" # Temporary workaround for Python 3.13 until final CFFI release
 cryptography
 freezegun
 installer


### PR DESCRIPTION
cffi 1.17.0 has been released on PyPI

