### PR TITLE
GitHub Actions: Replace deprecated macos-12 with macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-12, macos-latest]
+        os: [ubuntu-latest, macos-13, macos-latest]
         python:
           - "3.8"
           - "3.9"


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

> **macOS12 runner image**
We are beginning the deprecation process for the macOS 12 runner image, which allows us to balance our fleet capacity ahead of our upcoming [macOS 15 launch](https://github.com/github/roadmap/issues/986). This image will be fully retired by the December 3rd, 2024. We recommend updating workflows to use `macos-14`, `macos-13`, or `macos-latest`.

https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

* macos-12 and macos-13 are Intel
* macos-14 is M1 and the same as macos-latest (although macos-15 will become macos-latest in the near future)

We currently test macos-12 (Intel) and macos-latest (M1), so replace macos-12 with macos-13 to retain Intel + M1 testing.
