### PR TITLE
Show conflicting candidates at default log level

### DIFF
--- a/news/12650.feature.rst
+++ b/news/12650.feature.rst
@@ -1,0 +1,1 @@
+Show conflicting candidates while resolving at default log level.

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -52,7 +52,7 @@ class PipReporter(BaseReporter):
             else:
                 msg += "The user requested "
             msg += req.format_for_error()
-        logger.debug(msg)
+        logger.info(msg)
 
 
 class PipDebuggingReporter(BaseReporter):


### PR DESCRIPTION
Fixes #12650

As far as I have understood the problem, changing the log level, would let users know the conflicting packages early during the resolution. Or I missed something?
