### PR TITLE
Correct usage of invalid file URL in test

### DIFF
--- a/news/12964.trivial.rst
+++ b/news/12964.trivial.rst
@@ -1,0 +1,1 @@
+A valid, but non-existent URL used in a test case was corrected to be a valid URL.

--- a/tests/functional/test_bad_url.py
+++ b/tests/functional/test_bad_url.py
@@ -7,7 +7,7 @@ from typing import Any
 def test_filenotfound_error_message(script: Any) -> None:
     # Test the error message returned when using a bad 'file:' URL.
     # make pip to fail and get an error message
-    # by running "pip install -r file:nonexistent_file"
+    # by running "pip install -r file:///nonexistent_file"
     proc = script.pip("install", "-r", "file:///unexistent_file", expect_error=True)
     assert proc.returncode == 1
     expect = (

--- a/tests/functional/test_bad_url.py
+++ b/tests/functional/test_bad_url.py
@@ -8,7 +8,7 @@ def test_filenotfound_error_message(script: Any) -> None:
     # Test the error message returned when using a bad 'file:' URL.
     # make pip to fail and get an error message
     # by running "pip install -r file:nonexistent_file"
-    proc = script.pip("install", "-r", "file:unexistent_file", expect_error=True)
+    proc = script.pip("install", "-r", "file:///unexistent_file", expect_error=True)
     assert proc.returncode == 1
     expect = (
         "ERROR: 404 Client Error: FileNotFoundError for url: file:///unexistent_file"


### PR DESCRIPTION
In the process of diagnosing test failures in #12962, I discovered that there has been a change in Python 3.13.0rc2 (that wasn't in rc1) that breaks the pip test suite.

The underlying cause is python/cpython#85110, which has been back ported to 3.13 and 3.12. Previously, the following code:
```
>>> from urllib.parse import urlunsplit
>>> urlunsplit(('file', '', 'nonexistent', '', ''))
'file:///nonexistent'
```
whereas it now returns:
```
file:nonexistent
```
This poses a problem because the absence of the `file://` means that the appropriate URL handler isn't installed, resulting in a failure of "ERROR: Could not install packages due to an OSError: No connection adapters were found for 'file:unexistent_file'" rather than "ERROR: 404 Client Error: FileNotFoundError for url: file:///unexistent_file".

The new behavior seems correct - `file:unexistent_file` *isn't* a valid File URL; and it definitely isn't equivalent to `file:///unexistent_file` (at best, it would be equivalent to `file://unexistent_file`). 

This PR updates the test case to use a valid, but non-existent file URL (which seems to be the point of the test).