### PR TITLE
Fix "direct" check in PipProvider.get_preference

### DIFF
--- a/news/12973.bugfix.rst
+++ b/news/12973.bugfix.rst
@@ -1,0 +1,1 @@
+Fix prefering explicit requirements when backtracking.

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -146,7 +146,7 @@ class PipProvider(_ProviderBase):
             lookups = (r.get_candidate_lookup() for r, _ in information[identifier])
             candidate, ireqs = zip(*lookups)
         else:
-            candidate, ireqs = None, ()
+            candidate, ireqs = (None,), ()
 
         operators = [
             specifier.operator
@@ -154,7 +154,7 @@ class PipProvider(_ProviderBase):
             for specifier in specifier_set
         ]
 
-        direct = candidate is not None
+        direct = any(candidate)
         pinned = any(op[:2] == "==" for op in operators)
         unfree = bool(operators)
 

--- a/tests/unit/resolution_resolvelib/test_provider.py
+++ b/tests/unit/resolution_resolvelib/test_provider.py
@@ -1,16 +1,34 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+)
+from unittest.mock import Mock
 
+import pytest
 from pip._vendor.resolvelib.resolvers import RequirementInformation
 
 from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.models.link import Link
 from pip._internal.req.constructors import install_req_from_req_string
+from pip._internal.resolution.resolvelib.base import Candidate, Constraint, Requirement
+from pip._internal.resolution.resolvelib.candidates import (
+    REQUIRES_PYTHON_IDENTIFIER,
+    RequiresPythonCandidate,
+)
 from pip._internal.resolution.resolvelib.factory import Factory
 from pip._internal.resolution.resolvelib.provider import PipProvider
 from pip._internal.resolution.resolvelib.requirements import SpecifierRequirement
 
 if TYPE_CHECKING:
-    from pip._internal.resolution.resolvelib.provider import PreferenceInformation
+    from pip._vendor.resolvelib.providers import Preference
+
+    PreferenceInformation = RequirementInformation[Requirement, Candidate]
 
 
 def build_requirement_information(
@@ -76,3 +94,86 @@ def test_provider_known_depths(factory: Factory) -> None:
         transitive_requirement_name: 2.0,
         root_requirement_name: 1.0,
     }
+
+
+def create_mock_factory() -> Factory:
+    # Mock the required components for the Factory initialization
+    finder = Mock()
+    preparer = Mock()
+    make_install_req = Mock()
+    wheel_cache = Mock()
+    use_user_site = False
+    force_reinstall = False
+    ignore_installed = False
+    ignore_requires_python = False
+
+    # Create a Factory instance with mock components
+    return Factory(
+        finder=finder,
+        preparer=preparer,
+        make_install_req=make_install_req,
+        wheel_cache=wheel_cache,
+        use_user_site=use_user_site,
+        force_reinstall=force_reinstall,
+        ignore_installed=ignore_installed,
+        ignore_requires_python=ignore_requires_python,
+    )
+
+
+@pytest.mark.parametrize(
+    "identifier, resolutions, candidates, information, backtrack_causes, expected",
+    [
+        (
+            REQUIRES_PYTHON_IDENTIFIER,
+            {},
+            {REQUIRES_PYTHON_IDENTIFIER: iter([RequiresPythonCandidate((3, 7))])},
+            {REQUIRES_PYTHON_IDENTIFIER: build_requirement_information("python", None)},
+            [],
+            (
+                False,
+                True,
+                True,
+                True,
+                1.0,
+                float("inf"),
+                True,
+                REQUIRES_PYTHON_IDENTIFIER,
+            ),
+        ),
+    ],
+)
+def test_get_preference(
+    identifier: str,
+    resolutions: Mapping[str, Candidate],
+    candidates: Mapping[str, Iterator[Candidate]],
+    information: Mapping[str, Iterable["PreferenceInformation"]],
+    backtrack_causes: Sequence["PreferenceInformation"],
+    expected: "Preference",
+) -> None:
+    # Create the factory with mock components
+    factory = create_mock_factory()
+    constraints: Dict[str, Constraint] = {}
+    user_requested = {"requested-package": 0}
+    ignore_dependencies = False
+    upgrade_strategy = "to-satisfy-only"
+
+    # Initialize PipProvider
+    provider = PipProvider(
+        factory=factory,
+        constraints=constraints,
+        ignore_dependencies=ignore_dependencies,
+        upgrade_strategy=upgrade_strategy,
+        user_requested=user_requested,
+    )
+
+    # Get the preference for the test case
+    preference = provider.get_preference(
+        identifier,
+        resolutions,
+        candidates,
+        information,
+        backtrack_causes,
+    )
+
+    # Assert the calculated preference matches the expected preference
+    assert preference == expected, f"Expected {expected}, got {preference}"


### PR DESCRIPTION
I noticed this while running tests from a user provided scenario in https://github.com/pypa/pip/issues/12972. I'm going to have to think about how to add a test, but I'm confident that the `direct`  is broken, possibly this happened when backjumping happened.

When `has_information` is true, `candidate` is always a tuple, so testing for `candidate` is not None is equivalent to testing `has_information` is true. This is clearly not the intent...

Looking at this tuple, the elements can either be None or an instance of `Candidate` which happens in both the case of `ExplicitRequirement` or `RequiresPythonRequirement`, and I **assume** this logic is trying to detect when a `Candidate` is based on `ExplicitRequirement`, but also being true for `RequiresPythonRequirement` doesn't functionally matter, as `requires_python` is tested for in front of `direct`. 

Fixes https://github.com/pypa/pip/issues/12975