### PR TITLE
Add vendored and test import groups to import sorting

### DIFF
--- a/news/12974.trivial.rst
+++ b/news/12974.trivial.rst
@@ -1,0 +1,1 @@
+Create two new import groups, "vendored" and "import", this only affects tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,9 +185,19 @@ select = [
 ]
 
 [tool.ruff.lint.isort]
-# Explicitly make tests "first party" as it's not in the "src" directory
-known-first-party = ["tests"]
-known-third-party = ["pip._vendor"]
+section-order = [
+  "future",
+  "standard-library",
+  "third-party",
+  "vendored",
+  "first-party",
+  "tests",
+  "local-folder",
+]
+
+[tool.ruff.lint.isort.sections]
+"vendored" = ["pip._vendor"]
+"tests" = ["tests"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 33  # default is 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ from installer.sources import WheelFile
 from pip import __file__ as pip_location
 from pip._internal.locations import _USE_SYSCONFIG
 from pip._internal.utils.temp_dir import global_tempdir_manager
+
 from tests.lib import (
     DATA_DIR,
     SRC_DIR,

--- a/tests/functional/test_build_env.py
+++ b/tests/functional/test_build_env.py
@@ -6,6 +6,7 @@ from typing import Optional
 import pytest
 
 from pip._internal.build_env import BuildEnvironment, _get_system_sitepackages
+
 from tests.lib import (
     PipTestEnvironment,
     TestPipResult,

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 import pytest
 
 from pip._internal.commands import commands_dict
+
 from tests.lib import PipTestEnvironment
 
 

--- a/tests/functional/test_config_settings.py
+++ b/tests/functional/test_config_settings.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Tuple
 from zipfile import ZipFile
 
 from pip._internal.utils.urls import path_to_url
+
 from tests.lib import PipTestEnvironment, create_basic_sdist_for_package
 
 PYPROJECT_TOML = """\

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -6,6 +6,7 @@ import textwrap
 
 from pip._internal.cli.status_codes import ERROR
 from pip._internal.configuration import CONFIG_BASENAME, get_configuration_files
+
 from tests.lib import PipTestEnvironment
 from tests.lib.configuration_helpers import ConfigurationMixin, kinds
 from tests.lib.venv import VirtualEnvironment

--- a/tests/functional/test_debug.py
+++ b/tests/functional/test_debug.py
@@ -2,10 +2,12 @@ import re
 from typing import List
 
 import pytest
+
 from pip._vendor.packaging.version import Version
 
 from pip._internal.commands.debug import create_vendor_txt_map
 from pip._internal.utils import compatibility_tags
+
 from tests.lib import PipTestEnvironment
 
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -11,6 +11,7 @@ import pytest
 
 from pip._internal.cli.status_codes import ERROR
 from pip._internal.utils.urls import path_to_url
+
 from tests.lib import (
     PipTestEnvironment,
     ScriptFactory,

--- a/tests/functional/test_fast_deps.py
+++ b/tests/functional/test_fast_deps.py
@@ -7,9 +7,11 @@ from os.path import basename
 from typing import Iterable
 
 import pytest
+
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.utils.misc import hash_file
+
 from tests.lib import PipTestEnvironment, TestData, TestPipResult
 
 

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -6,9 +6,11 @@ from doctest import ELLIPSIS, OutputChecker
 from pathlib import Path
 
 import pytest
+
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.models.direct_url import DirectUrl, DirInfo
+
 from tests.lib import (
     PipTestEnvironment,
     TestData,

--- a/tests/functional/test_help.py
+++ b/tests/functional/test_help.py
@@ -5,6 +5,7 @@ import pytest
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.commands import commands_dict, create_command
 from pip._internal.exceptions import CommandError
+
 from tests.lib import InMemoryPip, PipTestEnvironment
 
 

--- a/tests/functional/test_index.py
+++ b/tests/functional/test_index.py
@@ -2,6 +2,7 @@ import pytest
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.commands import create_command
+
 from tests.lib import PipTestEnvironment
 
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -17,6 +17,7 @@ from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.utils.misc import rmtree
 from pip._internal.utils.urls import path_to_url
+
 from tests.lib import (
     CertFactory,
     PipTestEnvironment,

--- a/tests/functional/test_install_direct_url.py
+++ b/tests/functional/test_install_direct_url.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pip._internal.models.direct_url import VcsInfo
+
 from tests.lib import PipTestEnvironment, TestData, _create_test_package
 from tests.lib.direct_url import get_created_direct_url
 

--- a/tests/functional/test_invalid_versions_and_specifiers.py
+++ b/tests/functional/test_invalid_versions_and_specifiers.py
@@ -3,6 +3,7 @@ import zipfile
 import pytest
 
 from pip._internal.metadata import select_backend
+
 from tests.lib import PipTestEnvironment, TestData
 
 

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from pip._internal.models.direct_url import DirectUrl, DirInfo
+
 from tests.lib import (
     PipTestEnvironment,
     ScriptFactory,

--- a/tests/functional/test_new_resolver_target.py
+++ b/tests/functional/test_new_resolver_target.py
@@ -4,6 +4,7 @@ from typing import Callable, Optional
 import pytest
 
 from pip._internal.cli.status_codes import ERROR, SUCCESS
+
 from tests.lib import PipTestEnvironment
 from tests.lib.wheel import make_wheel
 

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -7,6 +7,7 @@ import tomli_w
 
 from pip._internal.build_env import BuildEnvironment
 from pip._internal.req import InstallRequirement
+
 from tests.lib import (
     PipTestEnvironment,
     TestData,

--- a/tests/functional/test_pip_runner_script.py
+++ b/tests/functional/test_pip_runner_script.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 from pip import __version__
+
 from tests.lib import PipTestEnvironment
 
 

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -7,6 +7,7 @@ import pytest
 from pip._internal.cli.status_codes import NO_MATCHES_FOUND, SUCCESS
 from pip._internal.commands import create_command
 from pip._internal.commands.search import highest_version, print_results, transform_hits
+
 from tests.lib import PipTestEnvironment
 
 if TYPE_CHECKING:

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -8,6 +8,7 @@ import pytest
 from pip import __version__
 from pip._internal.commands.show import search_packages_info
 from pip._internal.utils.unpacking import untar_file
+
 from tests.lib import (
     PipTestEnvironment,
     TestData,

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -12,6 +12,7 @@ import pytest
 
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.utils.misc import rmtree
+
 from tests.lib import (
     PipTestEnvironment,
     TestData,

--- a/tests/functional/test_vcs_bazaar.py
+++ b/tests/functional/test_vcs_bazaar.py
@@ -10,6 +10,7 @@ import pytest
 
 from pip._internal.vcs.bazaar import Bazaar
 from pip._internal.vcs.versioncontrol import RemoteNotFoundError
+
 from tests.lib import PipTestEnvironment, is_bzr_installed, need_bzr
 
 

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -13,6 +13,7 @@ import pytest
 from pip._internal.utils.misc import HiddenText
 from pip._internal.vcs import vcs
 from pip._internal.vcs.git import Git, RemoteNotFoundError
+
 from tests.lib import PipTestEnvironment, _create_test_package, _git_commit
 
 

--- a/tests/functional/test_vcs_mercurial.py
+++ b/tests/functional/test_vcs_mercurial.py
@@ -1,6 +1,7 @@
 import os
 
 from pip._internal.vcs.mercurial import Mercurial
+
 from tests.lib import PipTestEnvironment, _create_test_package, need_mercurial
 
 

--- a/tests/functional/test_vcs_subversion.py
+++ b/tests/functional/test_vcs_subversion.py
@@ -4,6 +4,7 @@ import pytest
 
 from pip._internal.vcs.subversion import Subversion
 from pip._internal.vcs.versioncontrol import RemoteNotFoundError
+
 from tests.lib import PipTestEnvironment, _create_svn_repo, need_svn
 
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from pip._internal.cli.status_codes import ERROR
+
 from tests.lib import (
     PipTestEnvironment,
     TestData,

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -32,8 +32,9 @@ from urllib.parse import urlparse, urlunparse
 from zipfile import ZipFile
 
 import pytest
-from pip._vendor.packaging.utils import canonicalize_name
 from scripttest import FoundDir, FoundFile, ProcResult, TestFileEnvironment
+
+from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.cli.main import main as pip_entry_point
 from pip._internal.index.collector import LinkCollector
@@ -44,6 +45,7 @@ from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
 from pip._internal.utils.egg_link import _egg_link_names
+
 from tests.lib.venv import VirtualEnvironment
 from tests.lib.wheel import make_wheel
 

--- a/tests/lib/direct_url.py
+++ b/tests/lib/direct_url.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
+
 from tests.lib import TestPipResult
 
 

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -5,6 +5,7 @@ from typing import cast
 from unittest import mock
 
 import pytest
+
 from pip._vendor.packaging.utils import NormalizedName
 
 from pip._internal.metadata import (
@@ -15,6 +16,7 @@ from pip._internal.metadata import (
 )
 from pip._internal.metadata.base import FilesystemWheel
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, ArchiveInfo
+
 from tests.lib.wheel import make_wheel
 
 

--- a/tests/unit/metadata/test_metadata_pkg_resources.py
+++ b/tests/unit/metadata/test_metadata_pkg_resources.py
@@ -4,6 +4,7 @@ from typing import List, cast
 from unittest import mock
 
 import pytest
+
 from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -17,6 +17,7 @@ from pip._internal.req.constructors import install_req_from_line
 from pip._internal.resolution.resolvelib.factory import Factory
 from pip._internal.resolution.resolvelib.provider import PipProvider
 from pip._internal.utils.temp_dir import TempDirectory, global_tempdir_manager
+
 from tests.lib import TestData
 
 

--- a/tests/unit/resolution_resolvelib/test_requirement.py
+++ b/tests/unit/resolution_resolvelib/test_requirement.py
@@ -3,11 +3,13 @@ from pathlib import Path
 from typing import List, Tuple
 
 import pytest
+
 from pip._vendor.resolvelib import BaseReporter, Resolver
 
 from pip._internal.resolution.resolvelib.base import Candidate, Constraint, Requirement
 from pip._internal.resolution.resolvelib.factory import Factory
 from pip._internal.resolution.resolvelib.provider import PipProvider
+
 from tests.lib import TestData
 
 # NOTE: All tests are prefixed `test_rlr` (for "test resolvelib resolver").

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional, Set, Tuple, cast
 from unittest import mock
 
 import pytest
+
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.resolvelib.resolvers import Result
 from pip._vendor.resolvelib.structs import DirectedGraph

--- a/tests/unit/test_appdirs.py
+++ b/tests/unit/test_appdirs.py
@@ -5,6 +5,7 @@ import sys
 from unittest import mock
 
 import pytest
+
 from pip._vendor import platformdirs
 
 from pip._internal.utils import appdirs

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 from unittest import mock
 
 import pytest
+
 from pip._vendor import requests
 from pip._vendor.packaging.requirements import Requirement
 
@@ -35,6 +36,7 @@ from pip._internal.models.link import (
     _ensure_quoted_url,
 )
 from pip._internal.network.session import PipSession
+
 from tests.lib import (
     TestData,
     make_test_link_collector,

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -8,6 +8,7 @@ import pytest
 
 from pip._internal.configuration import get_configuration_files, kinds
 from pip._internal.exceptions import ConfigurationError
+
 from tests.lib.configuration_helpers import ConfigurationMixin
 
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -9,6 +9,7 @@ import textwrap
 from typing import Optional, Tuple
 
 import pytest
+
 from pip._vendor import rich
 
 from pip._internal.exceptions import DiagnosticPipError, ExternallyManagedEnvironment

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -3,6 +3,7 @@ from typing import Iterable
 from unittest.mock import Mock, patch
 
 import pytest
+
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.tags import Tag
 from pip._vendor.packaging.version import parse as parse_version
@@ -18,6 +19,7 @@ from pip._internal.index.package_finder import (
 )
 from pip._internal.models.target_python import TargetPython
 from pip._internal.req.constructors import install_req_from_line
+
 from tests.lib import TestData, make_test_finder
 
 

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -2,6 +2,7 @@ import logging
 from typing import FrozenSet, List, Optional, Set, Tuple
 
 import pytest
+
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.tags import Tag
 
@@ -25,6 +26,7 @@ from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
 from pip._internal.utils.compatibility_tags import get_supported
 from pip._internal.utils.hashes import Hashes
+
 from tests.lib import CURRENT_PY_VERSION_INFO
 from tests.lib.index import make_mock_candidate
 

--- a/tests/unit/test_models_wheel.py
+++ b/tests/unit/test_models_wheel.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pip._vendor.packaging.tags import Tag
 
 from pip._internal.exceptions import InvalidWheelFilename

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -8,6 +8,7 @@ import pytest
 
 import pip._internal.network.auth
 from pip._internal.network.auth import MultiDomainBasicAuth
+
 from tests.lib.requests_mocks import MockConnection, MockRequest, MockResponse
 
 

--- a/tests/unit/test_network_cache.py
+++ b/tests/unit/test_network_cache.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+
 from pip._vendor.cachecontrol.caches import FileCache
 
 from pip._internal.network.cache import SafeFileCache
+
 from tests.lib.filesystem import chmod
 
 

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -10,6 +10,7 @@ from pip._internal.network.download import (
     parse_content_disposition,
     sanitize_content_filename,
 )
+
 from tests.lib.requests_mocks import MockResponse
 
 

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -1,6 +1,7 @@
 from typing import Iterator
 
 import pytest
+
 from pip._vendor.packaging.version import Version
 
 from pip._internal.exceptions import InvalidWheel
@@ -9,6 +10,7 @@ from pip._internal.network.lazy_wheel import (
     dist_from_wheel_url,
 )
 from pip._internal.network.session import PipSession
+
 from tests.lib import TestData
 from tests.lib.server import MockServer, file_response
 

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from urllib.request import getproxies
 
 import pytest
+
 from pip._vendor import requests
 
 from pip import __version__

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.network.utils import raise_for_status
+
 from tests.lib.requests_mocks import MockResponse
 
 

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -14,6 +14,7 @@ from pip._internal.network.download import Downloader
 from pip._internal.network.session import PipSession
 from pip._internal.operations.prepare import unpack_url
 from pip._internal.utils.hashes import Hashes
+
 from tests.lib import TestData
 from tests.lib.requests_mocks import MockResponse
 

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -11,6 +11,7 @@ from pip._internal.cli.main import main
 from pip._internal.commands import create_command
 from pip._internal.commands.configuration import ConfigurationCommand
 from pip._internal.exceptions import PipError
+
 from tests.lib.options_helpers import AddFakeCommandMixin
 
 

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,6 +1,7 @@
 from typing import Optional, Tuple
 
 import pytest
+
 from pip._vendor.packaging import specifiers
 from pip._vendor.packaging.requirements import Requirement
 

--- a/tests/unit/test_pep517.py
+++ b/tests/unit/test_pep517.py
@@ -7,6 +7,7 @@ import pytest
 
 from pip._internal.exceptions import InstallationError, InvalidPyProjectBuildRequires
 from pip._internal.req import InstallRequirement
+
 from tests.lib import TestData
 
 

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -10,6 +10,7 @@ from typing import Iterator, Optional, Set, Tuple, cast
 from unittest import mock
 
 import pytest
+
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 
@@ -46,6 +47,7 @@ from pip._internal.req.req_file import (
     handle_requirement_line,
 )
 from pip._internal.resolution.legacy.resolver import Resolver
+
 from tests.lib import TestData, make_test_finder, requirements_file, wheel
 
 

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -28,6 +28,7 @@ from pip._internal.req.req_file import (
     preprocess,
 )
 from pip._internal.req.req_install import InstallRequirement
+
 from tests.lib import TestData, make_test_finder, requirements_file
 
 

--- a/tests/unit/test_req_install.py
+++ b/tests/unit/test_req_install.py
@@ -3,6 +3,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.exceptions import InstallationError

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -16,6 +16,7 @@ from pip._internal.req.req_uninstall import (
     compress_for_rename,
     uninstallation_paths,
 )
+
 from tests.lib import create_file
 
 

--- a/tests/unit/test_resolution_legacy_resolver.py
+++ b/tests/unit/test_resolution_legacy_resolver.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Type, TypeVar, cast
 from unittest import mock
 
 import pytest
+
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import NormalizedName
 
@@ -21,6 +22,7 @@ from pip._internal.resolution.legacy.resolver import (
     Resolver,
     _check_dist_requires_python,
 )
+
 from tests.lib import TestData, make_test_finder
 from tests.lib.index import make_mock_candidate
 

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -10,6 +10,7 @@ from unittest.mock import ANY, Mock, patch
 
 import pytest
 from freezegun import freeze_time
+
 from pip._vendor.packaging.version import Version
 
 from pip._internal import self_outdated_check

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -2,9 +2,11 @@ from typing import Any, Dict, Optional, Tuple
 from unittest import mock
 
 import pytest
+
 from pip._vendor.packaging.tags import Tag
 
 from pip._internal.models.target_python import TargetPython
+
 from tests.lib import CURRENT_PY_VERSION_INFO, pyversion
 
 

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -5,6 +5,7 @@ import urllib.request
 import pytest
 
 from pip._internal.utils.urls import path_to_url, url_to_path
+
 from tests.lib import (
     skip_needs_new_urlun_behavior_win,
     skip_needs_old_urlun_behavior_win,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Iterator, List, NoReturn, Optional, Tuple, Typ
 from unittest.mock import Mock, patch
 
 import pytest
+
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -14,6 +14,7 @@ import pytest
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.utils.unpacking import is_within_directory, untar_file, unzip_file
+
 from tests.lib import TestData
 
 

--- a/tests/unit/test_utils_wheel.py
+++ b/tests/unit/test_utils_wheel.py
@@ -10,6 +10,7 @@ import pytest
 
 from pip._internal.exceptions import UnsupportedWheel
 from pip._internal.utils import wheel
+
 from tests.lib import TestData
 
 _ZipDir = Callable[[Path], ZipFile]

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -14,6 +14,7 @@ from pip._internal.vcs.git import Git, RemoteNotValidError, looks_like_hash
 from pip._internal.vcs.mercurial import Mercurial
 from pip._internal.vcs.subversion import Subversion
 from pip._internal.vcs.versioncontrol import RevOptions, VersionControl
+
 from tests.lib import is_svn_installed, need_svn
 
 

--- a/tests/unit/test_vcs_mercurial.py
+++ b/tests/unit/test_vcs_mercurial.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from pip._internal.utils.misc import hide_url
 from pip._internal.vcs.mercurial import Mercurial
+
 from tests.lib import need_mercurial
 
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Tuple, cast
 from unittest.mock import patch
 
 import pytest
+
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.exceptions import InstallationError
@@ -32,6 +33,7 @@ from pip._internal.operations.install.wheel import (
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.misc import hash_file
 from pip._internal.utils.unpacking import unpack_file
+
 from tests.lib import DATA_DIR, TestData, assert_paths_equal
 from tests.lib.wheel import make_wheel
 

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -11,6 +11,7 @@ from pip._internal.models.link import Link
 from pip._internal.operations.build.wheel_legacy import format_command_result
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.vcs.git import Git
+
 from tests.lib import _create_test_package
 
 


### PR DESCRIPTION
I've always found import groups a little weird in the test directory, because vendored libraries are mixed with third party libraries, and test imports are mixed with pip internal imports.

This change explicitly defines all the import groups, adding two new groups, "vendored" and "tests", because these are otherwise in the same order as the implicit import groups but with two new ones it just adds additional spaces to those groups.