### PR TITLE
Apply preview ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ ignore = [
     "B020",
     "B904", # Ruff enables opinionated warnings by default
     "B905", # Ruff enables opinionated warnings by default
+    "F841",
 ]
 select = [
     "ASYNC",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ ignore = [
     "B020",
     "B904", # Ruff enables opinionated warnings by default
     "B905", # Ruff enables opinionated warnings by default
+    "E226",
     "F841",
 ]
 select = [

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -140,10 +140,8 @@ def print_results(
     if name_column_width is None:
         name_column_width = (
             max(
-                [
-                    len(hit["name"]) + len(highest_version(hit.get("versions", ["-"])))
-                    for hit in hits
-                ]
+                len(hit["name"]) + len(highest_version(hit.get("versions", ["-"])))
+                for hit in hits
             )
             + 4
         )

--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -161,9 +161,9 @@ def get_scheme(
         scheme_name = "posix_prefix"
 
     if home is not None:
-        variables = {k: home for k in _HOME_KEYS}
+        variables = dict.fromkeys(_HOME_KEYS, home)
     elif prefix is not None:
-        variables = {k: prefix for k in _HOME_KEYS}
+        variables = dict.fromkeys(_HOME_KEYS, prefix)
     else:
         variables = {}
 

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -604,7 +604,7 @@ def test_get_git_version() -> None:
         ("git version 2.17", (2, 17)),
         ("git version 2.18.1", (2, 18)),
         ("git version 2.35.GIT", (2, 35)),  # gh:12280
-        ("oh my git version 2.37.GIT", ()),  #  invalid version
+        ("oh my git version 2.37.GIT", ()),  # invalid version
         ("git version 2.GIT", ()),  # invalid version
     ],
 )


### PR DESCRIPTION
These issues appear when running `ruff check --preview`. The rules are not yet applied by default, but should become part of the default rulesets in future versions. The purpose of this PR is to make the code future-proof.

I have **not** addressed code complexity issues:
* [too-many-public-methods (PLR0904)](https://docs.astral.sh/ruff/rules/too-many-public-methods/#too-many-public-methods-plr0904)
* [too-many-locals (PLR0914)](https://docs.astral.sh/ruff/rules/too-many-locals/#too-many-locals-plr0914)
* [too-many-boolean-expressions (PLR0916)](https://docs.astral.sh/ruff/rules/too-many-boolean-expressions/#too-many-boolean-expressions-plr0916)

There are multiple ways to address such issues;
1. Refactor the code to reduce complexity, but that might be a bad idea here.
2. Disable the relevant rules.
3. Modify the threshold value using the associated options
   * [lint.pylint.max-public-methods](https://docs.astral.sh/ruff/settings/#lint_pylint_max-public-methods)
   * [lint.pylint.max-locals](https://docs.astral.sh/ruff/settings/#lint_pylint_max-locals)
   * [lint.pylint.max-bool-expr](https://docs.astral.sh/ruff/settings/#lint_pylint_max-bool-expr)

Finally, note that I cannot silence a residual issue, caused by a ruff bug:
```console
$  ruff check --preview --ignore PLR0904,PLR0914,PLR0916
tests/unit/test_pyproject_config.py:26:9: F841 Local variable `options` is assigned to but never used
   |
24 |     # Invalid argument exits with an error
25 |     with pytest.raises(SystemExit):
26 |         options, _ = i.parse_args(["xxx", "--config-settings", "x"])
   |         ^^^^^^^ F841
   |
   = help: Remove assignment to unused variable `options`

Found 1 error.
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
$ 
```