### PR TITLE
Simplify, fix, and add unit tests for `PipProvider.get_preference`

### DIFF
--- a/docs/html/topics/more-dependency-resolution.md
+++ b/docs/html/topics/more-dependency-resolution.md
@@ -158,7 +158,8 @@ follows:
 
 * If equal, prefer if any requirement is "pinned", i.e. contains
     operator ``===`` or ``==``.
-* If a requirement is part of the current cause for backtracking.
+* If equal, prefer if any requirement is part of the current causes
+    for backtracking.
 * If equal, calculate an approximate "depth" and resolve requirements
     closer to the user-specified requirements first.
 * Order user-specified requirements by the order they are specified.

--- a/docs/html/topics/more-dependency-resolution.md
+++ b/docs/html/topics/more-dependency-resolution.md
@@ -156,10 +156,9 @@ grey parts of the graph).
 Pip's current implementation of the provider implements `get_preference` as
 follows:
 
-* Prefer if any of the known requirements is "direct", e.g. points to an
-    explicit URL.
 * If equal, prefer if any requirement is "pinned", i.e. contains
     operator ``===`` or ``==``.
+* If a requirement is part of the current cause for backtracking.
 * If equal, calculate an approximate "depth" and resolve requirements
     closer to the user-specified requirements first.
 * Order user-specified requirements by the order they are specified.

--- a/news/12982.bugfix.rst
+++ b/news/12982.bugfix.rst
@@ -1,0 +1,1 @@
+Improve consistency in package selection during dependency resolution.

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -118,18 +118,17 @@ class PipProvider(_ProviderBase):
         The lower the return value is, the more preferred this group of
         arguments is.
 
-        Currently pip considers the following in order:
+        Currently, pip considers the following in order:
 
-        * Prefer if any of the known requirements is "direct", e.g. points to an
-          explicit URL.
-        * If equal, prefer if any requirement is "pinned", i.e. contains
+        * If equal, prefer if any requirement is "pinned", i.e., contains
           operator ``===`` or ``==``.
+        * If the a member of backtrack causes.
         * If equal, calculate an approximate "depth" and resolve requirements
           closer to the user-specified requirements first. If the depth cannot
-          by determined (eg: due to no matching parents), it is considered
+          be determined (e.g., due to no matching parents), it is considered
           infinite.
         * Order user-specified requirements by the order they are specified.
-        * If equal, prefers "non-free" requirements, i.e. contains at least one
+        * If equal, prefer "non-free" requirements, i.e., contains at least one
           operator, such as ``>=`` or ``<``.
         * If equal, order alphabetically for consistency (helps debuggability).
         """
@@ -144,9 +143,9 @@ class PipProvider(_ProviderBase):
 
         if has_information:
             lookups = (r.get_candidate_lookup() for r, _ in information[identifier])
-            candidate, ireqs = zip(*lookups)
+            _icandidates, ireqs = zip(*lookups)
         else:
-            candidate, ireqs = None, ()
+            _icandidates, ireqs = (), ()
 
         operators = [
             specifier.operator
@@ -154,27 +153,25 @@ class PipProvider(_ProviderBase):
             for specifier in specifier_set
         ]
 
-        direct = candidate is not None
-        pinned = any(op[:2] == "==" for op in operators)
+        pinned = any(op in ("==", "===") for op in operators)
         unfree = bool(operators)
 
-        try:
-            requested_order: Union[int, float] = self._user_requested[identifier]
-        except KeyError:
-            requested_order = math.inf
-            if has_information:
-                parent_depths = (
-                    self._known_depths[parent.name] if parent is not None else 0.0
-                    for _, parent in information[identifier]
-                )
-                inferred_depth = min(d for d in parent_depths) + 1.0
-            else:
-                inferred_depth = math.inf
-        else:
+        if identifier in self._user_requested:
+            requested_order: float = self._user_requested[identifier]
             inferred_depth = 1.0
-        self._known_depths[identifier] = inferred_depth
+        elif not has_information:
+            requested_order = math.inf
+            inferred_depth = math.inf
+        else:
+            requested_order = math.inf
+            parent_depths = (
+                0.0 if parent is None else self._known_depths[parent.name]
+                for _, parent in information[identifier]
+            )
+            inferred_depth = min(parent_depths) + 1.0
 
-        requested_order = self._user_requested.get(identifier, math.inf)
+
+        self._known_depths[identifier] = inferred_depth
 
         # Requires-Python has only one candidate and the check is basically
         # free, so we always do it first to avoid needless work if it fails.
@@ -187,7 +184,6 @@ class PipProvider(_ProviderBase):
 
         return (
             not requires_python,
-            not direct,
             not pinned,
             not backtrack_cause,
             inferred_depth,

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -122,7 +122,8 @@ class PipProvider(_ProviderBase):
 
         * If equal, prefer if any requirement is "pinned", i.e., contains
           operator ``===`` or ``==``.
-        * If the a member of backtrack causes.
+        * If equal, prefer if any requirement is part of the current causes
+          for backtracking.
         * If equal, calculate an approximate "depth" and resolve requirements
           closer to the user-specified requirements first. If the depth cannot
           be determined (e.g., due to no matching parents), it is considered

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -170,7 +170,6 @@ class PipProvider(_ProviderBase):
             )
             inferred_depth = min(parent_depths) + 1.0
 
-
         self._known_depths[identifier] = inferred_depth
 
         # Requires-Python has only one candidate and the check is basically

--- a/tests/unit/resolution_resolvelib/test_provider.py
+++ b/tests/unit/resolution_resolvelib/test_provider.py
@@ -2,6 +2,7 @@ import math
 from typing import TYPE_CHECKING, Dict, Iterable, Optional, Sequence
 
 import pytest
+
 from pip._vendor.resolvelib.resolvers import RequirementInformation
 
 from pip._internal.models.candidate import InstallationCandidate


### PR DESCRIPTION
Fixes: https://github.com/pypa/pip/issues/12975

This PR does the following:

 * Removes `direct` as a preference based on this reasoning: https://github.com/pypa/pip/issues/12975#issuecomment-2372564691
 * Simplifies the code in `get_preference` (removes logic flow via exception)
 * Adds a unit test for each preference in `get_preference`
 * Small update to the docs for `get_preference`

Side note: I think I've found a bug in the way `parent_depths` is calculated when a requirement with an extra is involved, but it was too involved to fix in this PR, once I've pinned it down I will make a follow up PR.