### PR TITLE
Disable or apply ruff/pyupgrade rules (UP)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ ignore = [
     "B904",   # Ruff enables opinionated warnings by default
     "B905",   # Ruff enables opinionated warnings by default
     "UP027",  # deprecated
+    "UP038",  # https://github.com/astral-sh/ruff/issues/7871
 ]
 select = [
     "ASYNC",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,9 +181,9 @@ select = [
     "PERF",
     "PLE",
     "PLR0",
-    "W",
     "RUF100",
     "UP",
+    "W",
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,8 +163,9 @@ extend-exclude = [
 ignore = [
     "B019",
     "B020",
-    "B904", # Ruff enables opinionated warnings by default
-    "B905", # Ruff enables opinionated warnings by default
+    "B904",   # Ruff enables opinionated warnings by default
+    "B905",   # Ruff enables opinionated warnings by default
+    "UP027",  # deprecated
 ]
 select = [
     "ASYNC",

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -63,7 +63,7 @@ def _raw_progress_bar(
     size: Optional[int],
 ) -> Generator[bytes, None, None]:
     def write_progress(current: int, total: int) -> None:
-        sys.stdout.write("Progress %d of %d\n" % (current, total))
+        sys.stdout.write(f"Progress {current} of {total}\n")
         sys.stdout.flush()
 
     current = 0


### PR DESCRIPTION
Disable these rules:
* [UP027](https://docs.astral.sh/ruff/rules/unpacked-list-comprehension/) — https://github.com/astral-sh/ruff/issues/12754
* [UP038](https://github.com/astral-sh/ruff/issues/7871) — https://github.com/astral-sh/ruff/issues/7871

Apply this preview rule:
* [UP031](https://docs.astral.sh/ruff/rules/printf-string-formatting/#printf-string-formatting-up031) — involves a single change and results in consistent use of f-strings in the code base