### PR TITLE
Add initial support for plugins

### DIFF
--- a/src/pip/_internal/models/plugin.py
+++ b/src/pip/_internal/models/plugin.py
@@ -1,0 +1,71 @@
+import abc
+import logging
+from pathlib import Path
+from types import ModuleType
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_TYPE_DIST_INSPECTOR = "dist-inspector"
+SUPPORTED_PLUGIN_TYPES = [PLUGIN_TYPE_DIST_INSPECTOR]
+
+
+class Plugin(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def plugin_type(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        raise NotImplementedError
+
+
+class DistInspectorPlugin(Plugin):
+    def __init__(self, name: str, loaded_module: ModuleType):
+        assert loaded_module.plugin_type() == PLUGIN_TYPE_DIST_INSPECTOR
+        if not hasattr(loaded_module, "pre_download") or not hasattr(
+            loaded_module, "pre_extract"
+        ):
+            raise ValueError(
+                f'Plugin "{name}" of type {PLUGIN_TYPE_DIST_INSPECTOR} is'
+                "missing pre_download and/or pre_extract definitions"
+            )
+
+        self._name = name
+        self._module = loaded_module
+
+    def plugin_type(self) -> str:
+        return self._module.plugin_type()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def pre_download(self, url: str, filename: str, digest: str) -> None:
+        # contract: `pre_download` raises `ValueError` to terminate
+        # the operation that intends to download `filename` from `url`
+        # with hash `digest`
+        self._module.pre_download(url=url, filename=filename, digest=digest)
+
+    def pre_extract(self, dist: Path) -> None:
+        # contract: `pre_extract` raises `ValueError` to terminate
+        # the operation that intends to unarchive `dist`
+        self._module.pre_extract(dist)
+
+
+def plugin_from_module(name: str, loaded_module: ModuleType) -> Optional[Plugin]:
+    if not hasattr(loaded_module, "plugin_type"):
+        logger.warning("Ignoring plugin %s due to missing plugin_type definition", name)
+    plugin_type = loaded_module.plugin_type()
+    if plugin_type not in SUPPORTED_PLUGIN_TYPES:
+        logger.warning(
+            "Ignoring plugin %s due to unknown plugin type: %s", name, plugin_type
+        )
+
+    if plugin_type == PLUGIN_TYPE_DIST_INSPECTOR:
+        try:
+            return DistInspectorPlugin(name, loaded_module)
+        except ValueError as e:
+            logger.warning("Ignoring plugin %s due to error: %s", name, e)
+    return None

--- a/src/pip/_internal/utils/plugins.py
+++ b/src/pip/_internal/utils/plugins.py
@@ -1,0 +1,72 @@
+import contextlib
+import logging
+from pathlib import Path
+from typing import Iterator, List
+
+from pip._vendor.pygments.plugin import iter_entry_points
+
+from pip._internal.models.plugin import DistInspectorPlugin, Plugin, plugin_from_module
+
+logger = logging.getLogger(__name__)
+
+_loaded_plugins: List[Plugin] = []
+for entrypoint in iter_entry_points(group_name="pip.plugins"):
+    try:
+        module = entrypoint.load()
+    except ModuleNotFoundError:
+        logger.warning("Tried to load plugin %s but failed", entrypoint.name)
+        continue
+    plugin = plugin_from_module(entrypoint.name, module)
+    if plugin is not None:
+        _loaded_plugins.append(plugin)
+
+
+@contextlib.contextmanager
+def _only_raise_value_error(plugin_name: str) -> Iterator[None]:
+    try:
+        yield
+    except ValueError as e:
+        raise ValueError(f"Plugin {plugin_name}: {e}") from e
+    except Exception as e:
+        logger.warning(
+            "Plugin %s raised an unexpected exception type: %s",
+            plugin_name,
+            {e.__class__.__name__},
+        )
+        raise ValueError(f"Plugin {plugin_name}: {e}") from e
+
+
+def plugin_pre_download_hook(url: str, filename: str, digest: str) -> None:
+    """Call the pre-download hook of all loaded plugins
+
+    This function should be called right before a distribution is downloaded.
+    It will go through all the loaded plugins and call their `pre_download(url)`
+    function.
+    Only ValueError will be raised. If the plugin (incorrectly) raises another
+    exception type, this function will wrap it as a ValueError and log
+    a warning.
+    """
+
+    for p in _loaded_plugins:
+        if not isinstance(p, DistInspectorPlugin):
+            continue
+        with _only_raise_value_error(p.name):
+            p.pre_download(url=url, filename=filename, digest=digest)
+
+
+def plugin_pre_extract_hook(dist: Path) -> None:
+    """Call the pre-extract hook of all loaded plugins
+
+    This function should be called right before a distribution is extracted.
+    It will go through all the loaded plugins and call their `pre_extract(dist)`
+    function.
+    Only ValueError will be raised. If the plugin (incorrectly) raises another
+    exception type, this function will wrap it as a ValueError and log
+    a warning.
+    """
+
+    for p in _loaded_plugins:
+        if not isinstance(p, DistInspectorPlugin):
+            continue
+        with _only_raise_value_error(p.name):
+            p.pre_extract(dist)

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -8,6 +8,7 @@ import stat
 import sys
 import tarfile
 import zipfile
+from pathlib import Path
 from typing import Iterable, List, Optional
 from zipfile import ZipInfo
 
@@ -19,6 +20,7 @@ from pip._internal.utils.filetypes import (
     ZIP_EXTENSIONS,
 )
 from pip._internal.utils.misc import ensure_dir
+from pip._internal.utils.plugins import plugin_pre_extract_hook
 
 logger = logging.getLogger(__name__)
 
@@ -312,6 +314,11 @@ def unpack_file(
     content_type: Optional[str] = None,
 ) -> None:
     filename = os.path.realpath(filename)
+    try:
+        plugin_pre_extract_hook(Path(filename))
+    except ValueError as e:
+        raise InstallationError(f"Could not unpack file {filename} due to plugin:\n{e}")
+
     if (
         content_type == "application/zip"
         or filename.lower().endswith(ZIP_EXTENSIONS)


### PR DESCRIPTION
This is a PR with an initial implementation of the plugin support discussed in https://github.com/pypa/pip/issues/12766.

## High-level description
Plugins will be detected and loaded via registered entrypoints. For example, a Python package that contains the following in `pyproject.toml`:
```toml
[project.entry-points."pip.plugins"]
example-distinspector = "pip_plugin_example"
```
will register the `example-distinspector` plugin by providing the `pip_plugin_example` module object. This module object will be loaded by `pip` and its methods will be called at different places while pip runs.

The methods that will be called (and the places where they will be called from) depends on the plugin type. For now, this implementation only supports a single plugin type: `dist-inspector`, which should provide three functions:
```python
    def plugin_type(self) -> str:
        return "dist-inspector"

    def pre_download(self, url: str, filename: str, digest: str) -> None:
        # contract: `pre_download` raises `ValueError` to terminate
        # the operation that intends to download `filename` from `url`
        # with hash `digest`
        pass

    def pre_extract(self, dist: Path) -> None:
        # contract: `pre_extract` raises `ValueError` to terminate
        # the operation that intends to unarchive `dist`
        pass
```

These functions (provided by the plugin in module `pip_plugin_example`) will be called by `pip` right before downloading or extracting a distribution file.

A repository with an example plugin package is [here](https://github.com/facutuesca/pip-plugin-example/blob/main/src/pip_plugin_example/__init__.py).


## Implementation details
- I focused on putting most of the plugin logic in new, separate files (`models/plugin.py` and `utils/plugins.py`). The only change to existing files is adding a function call in the specific places the plugin should run (before download and before extraction).
- Plugin loading is conservative: if any of the expected functions is missing from the loaded module, we log a warning and skip using the plugin.
- Since plugins should only raise `ValueError`, in case of other exception types I put a defensive check that logs a warning and converts the exception to a `ValueError`. This means that plugins that don't follow the contract will still work (with a warning). If we want to avoid that and just abort when a plugin misbehaves, this check needs to be changed.

## Open questions
- Are the places where we call the hooks (`pre-download` and `pre-extract`) correct?
- The plugins are loaded by the `utils.plugins` module. This means that any module that imports `utils.plugins` re-loads the plugins. Where is the best place to load the plugins, so that we do it only once?


## TODO
- [ ] Once discussion is done, add tests and docs

cc @woodruffw 