### PR TITLE
Postpone removal of #12330

### DIFF
--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -150,7 +150,7 @@ def _emit_egg_deprecation(location: Optional[str]) -> None:
     deprecated(
         reason=f"Loading egg at {location} is deprecated.",
         replacement="to use pip for package installation",
-        gone_in="24.3",
+        gone_in="25.1",
         issue=12330,
     )
 


### PR DESCRIPTION
Since, the #12330 deprecation warning is serving its pedagogical purpose, and  this piece of code that lists installed `.egg` when using the importlib metadata backend is not a maintenance burden at the moment, I propose to postpone this removal for another 6 months.
