### PR TITLE
Never use pkg_resources metadata backend on python 3.14+

### DIFF
--- a/news/13010.removal.rst
+++ b/news/13010.removal.rst
@@ -1,0 +1,2 @@
+On python 3.14+, the ``pkg_resources`` metadata backend is not used anymore,
+and pip does not attempt to detect installed ``.egg`` distributions.

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -25,20 +25,30 @@ def _should_use_importlib_metadata() -> bool:
     """Whether to use the ``importlib.metadata`` or ``pkg_resources`` backend.
 
     By default, pip uses ``importlib.metadata`` on Python 3.11+, and
-    ``pkg_resources`` otherwise. This can be overridden by a couple of ways:
+    ``pkg_resources`` otherwise. Up to Python 3.13, This can be
+    overridden by a couple of ways:
 
     * If environment variable ``_PIP_USE_IMPORTLIB_METADATA`` is set, it
-      dictates whether ``importlib.metadata`` is used, regardless of Python
-      version.
-    * On Python 3.11+, Python distributors can patch ``importlib.metadata``
-      to add a global constant ``_PIP_USE_IMPORTLIB_METADATA = False``. This
-      makes pip use ``pkg_resources`` (unless the user set the aforementioned
-      environment variable to *True*).
+      dictates whether ``importlib.metadata`` is used, for Python <3.14.
+    * On Python 3.11, 3.12 and 3.13, Python distributors can patch
+      ``importlib.metadata`` to add a global constant
+      ``_PIP_USE_IMPORTLIB_METADATA = False``. This makes pip use
+      ``pkg_resources`` (unless the user set the aforementioned environment
+      variable to *True*).
+
+    On Python 3.14+, the ``pkg_resources`` backend cannot be used.
     """
+    if sys.version_info >= (3, 14):
+        # On Python >=3.14 we only support importlib.metadata.
+        return True
     with contextlib.suppress(KeyError, ValueError):
+        # On Python <3.14, if the environment variable is set, we obey what it says.
         return bool(strtobool(os.environ["_PIP_USE_IMPORTLIB_METADATA"]))
     if sys.version_info < (3, 11):
+        # On Python <3.11, we always use pkg_resources, unless the environment
+        # variable was set.
         return False
+    # On Python 3.11, 3.12 and 3.13, we check if the global constant is set.
     import importlib.metadata
 
     return bool(getattr(importlib.metadata, "_PIP_USE_IMPORTLIB_METADATA", True))

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -179,9 +179,10 @@ class Environment(BaseEnvironment):
         finder = _DistributionFinder()
         for location in self._paths:
             yield from finder.find(location)
-            for dist in finder.find_eggs(location):
-                _emit_egg_deprecation(dist.location)
-                yield dist
+            if sys.version_info < (3, 14):
+                for dist in finder.find_eggs(location):
+                    _emit_egg_deprecation(dist.location)
+                    yield dist
             # This must go last because that's how pkg_resources tie-breaks.
             yield from finder.find_linked(location)
 

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -628,6 +628,10 @@ def test_uninstall_with_symlink(
     assert symlink_target.stat().st_mode == st_mode
 
 
+@pytest.mark.skipif(
+    "sys.version_info >= (3, 14)",
+    reason="Uninstall of .egg distributions not supported in Python 3.14+",
+)
 def test_uninstall_setuptools_develop_install(
     script: PipTestEnvironment, data: TestData
 ) -> None:


### PR DESCRIPTION
On python 3.13+ we don't support the fallback to the `pkg_resources` metadata backend, and don't attempt to detect `.egg` installed distributions (#12330).

In effect, this means `pkg_resources` is never used at all by pip on python 3.13 (to the best of my knowledge).

This does not mean we will not want to drop support for the pkg_resources backend before we drop support for python 3.12, but at least this places a limit on it.

@pypa/pip-committers what do you think?
