### PR TITLE
Clean up non PEP 440 wheel filename deprecation language

### DIFF
--- a/news/13012.trivial.rst
+++ b/news/13012.trivial.rst
@@ -1,0 +1,1 @@
+Clean up non PEP 440 wheel filename deprecation language.

--- a/src/pip/_internal/models/wheel.py
+++ b/src/pip/_internal/models/wheel.py
@@ -7,12 +7,9 @@ from typing import Dict, Iterable, List
 
 from pip._vendor.packaging.tags import Tag
 from pip._vendor.packaging.utils import (
-    InvalidVersion,
-    parse_wheel_filename,
-)
-from pip._vendor.packaging.utils import (
     InvalidWheelFilename as PackagingInvalidWheelName,
 )
+from pip._vendor.packaging.utils import parse_wheel_filename
 
 from pip._internal.exceptions import InvalidWheelFilename
 from pip._internal.utils.deprecation import deprecated

--- a/src/pip/_internal/models/wheel.py
+++ b/src/pip/_internal/models/wheel.py
@@ -41,31 +41,15 @@ class Wheel:
         if "_" in _version:
             try:
                 parse_wheel_filename(filename)
-            except InvalidVersion as e:
-                deprecated(
-                    reason=(
-                        f"Wheel filename version part {_version!r} is not correctly "
-                        "normalised, and contained an underscore character in the "
-                        "version part. Future versions of pip will fail to recognise "
-                        f"this wheel and report the error: {e.args[0]}."
-                    ),
-                    replacement=(
-                        "rename the wheel to use a correctly normalised "
-                        "version part (this may require updating the version "
-                        "in the project metadata)"
-                    ),
-                    gone_in="25.1",
-                    issue=12938,
-                )
             except PackagingInvalidWheelName as e:
                 deprecated(
                     reason=(
-                        f"The wheel filename {filename!r} is not correctly normalised. "
-                        "Future versions of pip will fail to recognise this wheel. "
-                        f"and report the error: {e.args[0]}."
+                        f"Wheel filename {filename!r} is not correctly normalised. "
+                        "Future versions of pip will raise the following error:\n"
+                        f"{e.args[0]}\n\n"
                     ),
                     replacement=(
-                        "rename the wheel to use a correctly normalised "
+                        "to rename the wheel to use a correctly normalised "
                         "name (this may require updating the version in "
                         "the project metadata)"
                     ),

--- a/tests/unit/test_models_wheel.py
+++ b/tests/unit/test_models_wheel.py
@@ -201,3 +201,10 @@ class TestWheelFile:
         with pytest.warns(deprecation.PipDeprecationWarning):
             w = Wheel("simple-0.1_1-py2-none-any.whl")
         assert w.version == "0.1-1"
+
+    def test_invalid_wheel_warning(self) -> None:
+        """
+        Test that wheel with invalid name produces warning
+        """
+        with pytest.warns(deprecation.PipDeprecationWarning):
+            Wheel("six-1.16.0_build1-py3-none-any.whl")


### PR DESCRIPTION
This PR does the following

1. Removes catching `InvalidVersion` as I found out more recent versions of packaging (which are now vendored) no longer raise this for `parse_wheel_filename`: https://github.com/pypa/packaging/pull/721
2. Cleaned up langauge based on @ichard26 suggestions and added an extra test based on the filename example

This is the new warning:

```
DEPRECATION: Wheel filename 'simple-0.1_1-py2-none-any.whl' is not correctly normalised. Future versions of pip will raise the following error:
  Invalid wheel filename (invalid version): simple-0.1_1-py2-none-any
  
   pip 25.1 will enforce this behaviour change. A possible replacement is to rename the wheel to use a correctly normalised name (this may require updating the version in the project metadata). Discussion can be found at https://github.com/pypa/pip/issues/12938
```