### PR TITLE
Prefer upper bounds when resolving/backtracking

### DIFF
--- a/docs/html/topics/more-dependency-resolution.md
+++ b/docs/html/topics/more-dependency-resolution.md
@@ -160,7 +160,7 @@ follows:
     operator ``===`` or ``==``.
 * If equal, prefer if any requirement is restricted by upper bounds, i.e.
     contains operators ``<``, ``<=``, ``~=``, or the specifier ``==N.*``.
-* If equal, check if a a requirement is part of the current cause
+* If equal, prefer if any requirement is part of the current causes
     for backtracking.
 * If equal, calculate an approximate "depth" and resolve requirements
     closer to the user-specified requirements first.

--- a/docs/html/topics/more-dependency-resolution.md
+++ b/docs/html/topics/more-dependency-resolution.md
@@ -158,7 +158,10 @@ follows:
 
 * If equal, prefer if any requirement is "pinned", i.e. contains
     operator ``===`` or ``==``.
-* If a requirement is part of the current cause for backtracking.
+* If equal, prefer if any requirement is restricted by upper bounds, i.e.
+    contains operators ``<``, ``<=``, ``~=``, or the specifier ``==N.*``.
+* If equal, check if a a requirement is part of the current cause
+    for backtracking.
 * If equal, calculate an approximate "depth" and resolve requirements
     closer to the user-specified requirements first.
 * Order user-specified requirements by the order they are specified.

--- a/docs/html/topics/more-dependency-resolution.md
+++ b/docs/html/topics/more-dependency-resolution.md
@@ -156,10 +156,9 @@ grey parts of the graph).
 Pip's current implementation of the provider implements `get_preference` as
 follows:
 
-* Prefer if any of the known requirements is "direct", e.g. points to an
-    explicit URL.
 * If equal, prefer if any requirement is "pinned", i.e. contains
     operator ``===`` or ``==``.
+* If a requirement is part of the current cause for backtracking.
 * If equal, calculate an approximate "depth" and resolve requirements
     closer to the user-specified requirements first.
 * Order user-specified requirements by the order they are specified.

--- a/news/13017.bugfix.rst
+++ b/news/13017.bugfix.rst
@@ -1,0 +1,1 @@
+Better resolution choices for large dependency trees which include upper bounds.

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -118,18 +118,17 @@ class PipProvider(_ProviderBase):
         The lower the return value is, the more preferred this group of
         arguments is.
 
-        Currently pip considers the following in order:
+        Currently, pip considers the following in order:
 
-        * Prefer if any of the known requirements is "direct", e.g. points to an
-          explicit URL.
-        * If equal, prefer if any requirement is "pinned", i.e. contains
+        * If equal, prefer if any requirement is "pinned", i.e., contains
           operator ``===`` or ``==``.
+        * If the a member of backtrack causes.
         * If equal, calculate an approximate "depth" and resolve requirements
           closer to the user-specified requirements first. If the depth cannot
-          by determined (eg: due to no matching parents), it is considered
+          be determined (e.g., due to no matching parents), it is considered
           infinite.
         * Order user-specified requirements by the order they are specified.
-        * If equal, prefers "non-free" requirements, i.e. contains at least one
+        * If equal, prefer "non-free" requirements, i.e., contains at least one
           operator, such as ``>=`` or ``<``.
         * If equal, order alphabetically for consistency (helps debuggability).
         """
@@ -144,9 +143,9 @@ class PipProvider(_ProviderBase):
 
         if has_information:
             lookups = (r.get_candidate_lookup() for r, _ in information[identifier])
-            candidate, ireqs = zip(*lookups)
+            _icandidates, ireqs = zip(*lookups)
         else:
-            candidate, ireqs = None, ()
+            _icandidates, ireqs = (), ()
 
         operators = [
             specifier.operator
@@ -154,27 +153,25 @@ class PipProvider(_ProviderBase):
             for specifier in specifier_set
         ]
 
-        direct = candidate is not None
-        pinned = any(op[:2] == "==" for op in operators)
+        pinned = any(op in ("==", "===") for op in operators)
         unfree = bool(operators)
 
-        try:
-            requested_order: Union[int, float] = self._user_requested[identifier]
-        except KeyError:
-            requested_order = math.inf
-            if has_information:
-                parent_depths = (
-                    self._known_depths[parent.name] if parent is not None else 0.0
-                    for _, parent in information[identifier]
-                )
-                inferred_depth = min(d for d in parent_depths) + 1.0
-            else:
-                inferred_depth = math.inf
-        else:
+        if identifier in self._user_requested:
+            requested_order: float = self._user_requested[identifier]
             inferred_depth = 1.0
-        self._known_depths[identifier] = inferred_depth
+        elif not has_information:
+            requested_order = math.inf
+            inferred_depth = math.inf
+        else:
+            requested_order = math.inf
+            parent_depths = (
+                0.0 if parent is None else self._known_depths[parent.name]
+                for _, parent in information[identifier]
+            )
+            inferred_depth = min(parent_depths) + 1.0
 
-        requested_order = self._user_requested.get(identifier, math.inf)
+
+        self._known_depths[identifier] = inferred_depth
 
         # Requires-Python has only one candidate and the check is basically
         # free, so we always do it first to avoid needless work if it fails.
@@ -187,7 +184,6 @@ class PipProvider(_ProviderBase):
 
         return (
             not requires_python,
-            not direct,
             not pinned,
             not backtrack_cause,
             inferred_depth,

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -122,7 +122,8 @@ class PipProvider(_ProviderBase):
 
         * If equal, prefer if any requirement is "pinned", i.e., contains
           operator ``===`` or ``==``.
-        * If the a member of backtrack causes.
+        * If equal, prefer if any requirement is part of the current causes
+          for backtracking.
         * If equal, calculate an approximate "depth" and resolve requirements
           closer to the user-specified requirements first. If the depth cannot
           be determined (e.g., due to no matching parents), it is considered

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -170,7 +170,6 @@ class PipProvider(_ProviderBase):
             )
             inferred_depth = min(parent_depths) + 1.0
 
-
         self._known_depths[identifier] = inferred_depth
 
         # Requires-Python has only one candidate and the check is basically

--- a/tests/unit/resolution_resolvelib/test_provider.py
+++ b/tests/unit/resolution_resolvelib/test_provider.py
@@ -2,6 +2,7 @@ import math
 from typing import TYPE_CHECKING, Dict, Iterable, Optional, Sequence
 
 import pytest
+
 from pip._vendor.resolvelib.resolvers import RequirementInformation
 
 from pip._internal.models.candidate import InstallationCandidate
@@ -95,7 +96,7 @@ def test_provider_known_depths(factory: Factory) -> None:
             [],
             {REQUIRES_PYTHON_IDENTIFIER: 1},
             {},
-            (False, True, True, 1.0, 1, True, REQUIRES_PYTHON_IDENTIFIER),
+            (False, True, True, True, 1.0, 1, True, REQUIRES_PYTHON_IDENTIFIER),
         ),
         # Pinned package with "=="
         (
@@ -104,7 +105,16 @@ def test_provider_known_depths(factory: Factory) -> None:
             [],
             {"pinned-package": 1},
             {},
-            (True, False, True, 1.0, 1, False, "pinned-package"),
+            (True, False, True, True, 1.0, 1, False, "pinned-package"),
+        ),
+        # Upper bound package with "<"
+        (
+            "upper-bound-package",
+            {"upper-bound-package": [build_req_info("upper-bound-package<1.0")]},
+            [],
+            {"upper-bound-package": 1},
+            {},
+            (True, True, False, True, 1.0, 1, False, "upper-bound-package"),
         ),
         # Package that caused backtracking
         (
@@ -113,7 +123,7 @@ def test_provider_known_depths(factory: Factory) -> None:
             [build_req_info("backtrack-package")],
             {"backtrack-package": 1},
             {},
-            (True, True, False, 1.0, 1, True, "backtrack-package"),
+            (True, True, True, False, 1.0, 1, True, "backtrack-package"),
         ),
         # Depth inference for child package
         (
@@ -132,7 +142,7 @@ def test_provider_known_depths(factory: Factory) -> None:
             [],
             {"parent-package": 1},
             {"parent-package": 1.0},
-            (True, True, True, 2.0, math.inf, True, "child-package"),
+            (True, True, True, True, 2.0, math.inf, True, "child-package"),
         ),
         # Root package requested by user
         (
@@ -141,16 +151,16 @@ def test_provider_known_depths(factory: Factory) -> None:
             [],
             {"root-package": 1},
             {},
-            (True, True, True, 1.0, 1, True, "root-package"),
+            (True, True, True, True, 1.0, 1, True, "root-package"),
         ),
         # Unfree package (with specifier operator)
         (
             "unfree-package",
-            {"unfree-package": [build_req_info("unfree-package<1")]},
+            {"unfree-package": [build_req_info("unfree-package>1")]},
             [],
             {"unfree-package": 1},
             {},
-            (True, True, True, 1.0, 1, False, "unfree-package"),
+            (True, True, True, True, 1.0, 1, False, "unfree-package"),
         ),
         # Free package (no operator)
         (
@@ -159,7 +169,7 @@ def test_provider_known_depths(factory: Factory) -> None:
             [],
             {"free-package": 1},
             {},
-            (True, True, True, 1.0, 1, True, "free-package"),
+            (True, True, True, True, 1.0, 1, True, "free-package"),
         ),
     ],
 )

--- a/tests/unit/resolution_resolvelib/test_provider.py
+++ b/tests/unit/resolution_resolvelib/test_provider.py
@@ -116,6 +116,15 @@ def test_provider_known_depths(factory: Factory) -> None:
             {},
             (True, True, False, True, 1.0, 1, False, "upper-bound-package"),
         ),
+        # Test "==N.*" which is not pinned but does create implicit upper bound
+        (
+            "equal-star-package",
+            {"equal-star-package": [build_req_info("equal-star-package==1.*")]},
+            [],
+            {"equal-star-package": 1},
+            {},
+            (True, True, False, True, 1.0, 1, False, "equal-star-package"),
+        ),
         # Package that caused backtracking
         (
             "backtrack-package",


### PR DESCRIPTION
Fixes: https://github.com/pypa/pip/issues/12993
Fixes: https://github.com/pypa/pip/issues/12990
Fixes: https://github.com/pypa/pip/issues/12430
Fixes: https://github.com/pypa/pip/issues/13030

This PR is built on top of https://github.com/pypa/pip/pull/12982 so that the unit tests can be expanded, either that PR can be reviewed first, or this PR can supplant that PR.

I have developed some benchmark scripts to ensure that changes to pip's resolution algorithm don't regress common real world requirements: https://github.com/notatallshaw/Pip-Resolution-Scenarios-and-Benchmarks.

I plan to keep building out more scenarios, you can see the current ones so far here: https://github.com/notatallshaw/Pip-Resolution-Scenarios-and-Benchmarks/tree/main/scenarios

Upon testing this PR compared to pip 24.2 I see one small regressions and two big improvements:

```
Difference for scenario scenarios/problematic.toml - autogluon:
    	Success: False -> True.
    	Failure Reason: Build Failure -> None.

Difference for scenario scenarios/problematic.toml - boto3-urllib3-transient:
    	Number of packages processed: 869 -> 871

Difference for scenario scenarios/big-packages.toml - apache-airflow-all:
    	Number of requirements processed: 593 -> 592
    	Number of packages processed: 681 -> 661
```

The fact that autogluon can resolve is a big improvement, apache-airflow[all] gets a noticeable improvement in how many packages it has to process (and this has real time improvement, as the number of packages processed can have O(n^2) complexity) , and a scenario involving boto3 and urllib3 as transient requirements gets a small regression in having to process 2 more packages.

I am hoping to find more real world scenarios where this has a noticeable difference, but I think these results are sufficient to show this approach is a net positive.
