### PR TITLE
Add protection against devendored packaging.

### DIFF
--- a/news/13053.bugfix.rst
+++ b/news/13053.bugfix.rst
@@ -1,0 +1,1 @@
+An ImportError seen when using a devendored version of packaging <= 24.1 has been resolved.


### PR DESCRIPTION
PR #12962 introduced a patch adding iOS support that included a vendored component that has been submitted and accepted upstream, but not yet included in a formal release. 

This breaks for uses that use devendored versions of packaging.

This adds an import catch so that devendored installs won't break. They won't have iOS support, but they won't break.

Fixes #13053.