### PR TITLE
Pass CA and client TLS certificates to build subprocesses 

### DIFF
--- a/news/5502.bugfix.rst
+++ b/news/5502.bugfix.rst
@@ -1,1 +1,2 @@
 Configured TLS server and client certificates are now used while installing build dependencies.
+Consequently, the private ``_PIP_STANDALONE_CERT`` environment variable is no longer used.

--- a/news/5502.bugfix.rst
+++ b/news/5502.bugfix.rst
@@ -1,0 +1,1 @@
+Configured TLS server and client certificates are now used while installing build dependencies.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -246,6 +246,8 @@ class BuildEnvironment:
             # target from config file or env var should be ignored
             "--target",
             "",
+            "--cert",
+            finder.custom_cert or where(),
         ]
         if logger.getEffectiveLevel() <= logging.DEBUG:
             args.append("-vv")
@@ -272,19 +274,19 @@ class BuildEnvironment:
 
         for host in finder.trusted_hosts:
             args.extend(["--trusted-host", host])
+        if finder.client_cert:
+            args.extend(["--client-cert", finder.client_cert])
         if finder.allow_all_prereleases:
             args.append("--pre")
         if finder.prefer_binary:
             args.append("--prefer-binary")
         args.append("--")
         args.extend(requirements)
-        extra_environ = {"_PIP_STANDALONE_CERT": where()}
         with open_spinner(f"Installing {kind}") as spinner:
             call_subprocess(
                 args,
                 command_desc=f"pip subprocess to install {kind}",
                 spinner=spinner,
-                extra_environ=extra_environ,
             )
 
 

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -681,6 +681,20 @@ class PackageFinder:
             yield build_netloc(*host_port)
 
     @property
+    def custom_cert(self) -> Optional[str]:
+        # session.verify is either a boolean (use default bundle/no SSL
+        # verification) or a string path to a custom CA bundle to use. We only
+        # care about the latter.
+        verify = self._link_collector.session.verify
+        return verify if isinstance(verify, str) else None
+
+    @property
+    def client_cert(self) -> Optional[str]:
+        cert = self._link_collector.session.cert
+        assert not isinstance(cert, tuple), "pip only supports PEM client certs"
+        return cert
+
+    @property
     def allow_all_prereleases(self) -> bool:
         return self._candidate_prefs.allow_all_prereleases
 

--- a/src/pip/_vendor/requests/certs.py
+++ b/src/pip/_vendor/requests/certs.py
@@ -11,14 +11,7 @@ If you are packaging Requests, e.g., for a Linux distribution or a managed
 environment, you can change the definition of where() to return a separately
 packaged CA bundle.
 """
-
-import os
-
-if "_PIP_STANDALONE_CERT" not in os.environ:
-    from pip._vendor.certifi import where
-else:
-    def where():
-        return os.environ["_PIP_STANDALONE_CERT"]
+from pip._vendor.certifi import where
 
 if __name__ == "__main__":
     print(where())

--- a/tools/vendoring/patches/requests.patch
+++ b/tools/vendoring/patches/requests.patch
@@ -84,26 +84,6 @@ index 8fbcd656..094e2046 100644
  
  try:
      from urllib3.contrib import pyopenssl
-diff --git a/src/pip/_vendor/requests/certs.py b/src/pip/_vendor/requests/certs.py
-index be422c3e..3daf06f6 100644
---- a/src/pip/_vendor/requests/certs.py
-+++ b/src/pip/_vendor/requests/certs.py
-@@ -11,7 +11,14 @@ If you are packaging Requests, e.g., for a Linux distribution or a managed
- environment, you can change the definition of where() to return a separately
- packaged CA bundle.
- """
--from certifi import where
-+
-+import os
-+
-+if "_PIP_STANDALONE_CERT" not in os.environ:
-+    from certifi import where
-+else:
-+    def where():
-+        return os.environ["_PIP_STANDALONE_CERT"]
- 
- if __name__ == "__main__":
-     print(where())
 diff --git a/src/pip/_vendor/requests/__init__.py b/src/pip/_vendor/requests/__init__.py
 index 9d4e72c60..04230fc8d 100644
 --- a/src/pip/_vendor/requests/__init__.py


### PR DESCRIPTION
The _PIP_STANDALONE_CERT environment variable hack is no longer required as pip doesn't run a zip archive of itself to provision build dependencies these days (which due to a CPython bug would leave behind temporary certifi files).

Fixes #5502.