### PR TITLE
Fix uncaught TypeError accessing setuptools_dist.version

### DIFF
--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -176,7 +176,12 @@ def user_agent() -> str:
 
     setuptools_dist = get_default_environment().get_distribution("setuptools")
     if setuptools_dist is not None:
-        data["setuptools_version"] = str(setuptools_dist.version)
+        try:
+            setuptools_version = setuptools_dist.version
+        except TypeError:
+            logging.debug("Caught TypeError accessing setuptools_dist.version")
+        else:
+            data["setuptools_version"] = str(setuptools_version)
 
     if shutil.which("rustc") is not None:
         # If for any reason `rustc --version` fails, silently ignore it


### PR DESCRIPTION
The latest version of pip is missing some defensive code when trying to populate the User-Agent header and the setuptools_dist.version is not as expected, leading to errors like the following:
```
38.33 ERROR: Exception:
38.33 Traceback (most recent call last):
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_internal/cli/base_command.py", line 105, in _run_wrapper
38.33     status = _inner_run()
38.33              ^^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_internal/cli/base_command.py", line 96, in _inner_run
38.33     return self.run(options, args)
38.33            ^^^^^^^^^^^^^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_internal/cli/req_command.py", line 67, in wrapper
38.33     return func(self, options, args)
38.33            ^^^^^^^^^^^^^^^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_internal/commands/install.py", line 325, in run
38.33     session = self.get_default_session(options)
38.33               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_internal/cli/index_command.py", line 76, in get_default_session
38.33     self._session = self.enter_context(self._build_session(options))
38.33                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_internal/cli/index_command.py", line 99, in _build_session
38.33     session = PipSession(
38.33               ^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_internal/network/session.py", line 344, in __init__
38.33     self.headers["User-Agent"] = user_agent()
38.33                                  ^^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_internal/network/session.py", line 179, in user_agent
38.33     data["setuptools_version"] = str(setuptools_dist.version)
38.33                                      ^^^^^^^^^^^^^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_internal/metadata/importlib/_dists.py", line 168, in version
38.33     return parse_version(self._dist.version)
38.33            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_vendor/packaging/version.py", line 56, in parse
38.33     return Version(version)
38.33            ^^^^^^^^^^^^^^^^
38.33   File "/opt/conda/lib/python3.12/site-packages/pip/_vendor/packaging/version.py", line 200, in __init__
38.33     match = self._regex.search(version)
38.33             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
38.33 TypeError: expected string or bytes-like object, got 'NoneType'
```

This looks similar to #11352.

One example of where this occurs is when attempting to `pip install` a package in the "base" conda environment in the docker images provided by https://github.com/jupyter/docker-stacks. This occurs both with the latest release version of pip installed in the environment, as well as the latest development version. While this issue is unaddressed, I am working around it by reinstalling setuptools in this environment, which allows subsequent pip install invocations to succeed.

This patch addresses the issue by catching the TypeError and skipping the population of the setuptools_version in this case. Better to allow installation to continue with a User-Agent header that is missing the setuptools version than to hard fail just because of some missing telemetry.

In that spirit, perhaps there should be a broader `try/except Exception` around the entire `self.headers["User-Agent"] = user_agent()` call, but I'm starting with the most minimal patch that would address the issue.

If any changes are required to this patch before it will be merged, I will do my best, but unfortunately can't  promise anything more than this initial submission. I hope this is helpful in any case.