### PR TITLE
Override rich.console pipe handler for rich 13.8.0+

### DIFF
--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -137,12 +137,19 @@ class IndentedRenderable:
             yield Segment("\n")
 
 
+class PipConsole(Console):
+    def on_broken_pipe(self) -> None:
+        # Reraise the original exception, rich 13.8.0+ exits by default
+        # instead, preventing our handler from firing.
+        raise BrokenPipeError() from None
+
+
 class RichPipStreamHandler(RichHandler):
     KEYWORDS: ClassVar[Optional[List[str]]] = []
 
     def __init__(self, stream: Optional[TextIO], no_color: bool) -> None:
         super().__init__(
-            console=Console(file=stream, no_color=no_color, soft_wrap=True),
+            console=PipConsole(file=stream, no_color=no_color, soft_wrap=True),
             show_time=False,
             show_level=False,
             show_path=False,


### PR DESCRIPTION
Explicitly override `rich.console.Console.on_broken_pipe()` to reraise the original exception, to bring the behavior of rich 13.8.0+ in line with older versions.  The new versions instead close output fds and exit with error instead, which prevents pip's pipe handler from firing. This is the minimal change needed to make pip's test suite pass after upgrading vendored rich.

Bug #13006
Bug #13072

(I'm assuming this doesn't need a news item, since vendored `rich` update itself will have one)