### PR TITLE
Import self version check eagerly in install command to fix RCE

### DIFF
--- a/news/13079.bugfix.rst
+++ b/news/13079.bugfix.rst
@@ -1,0 +1,1 @@
+This change fixes a security bug allowing a wheel to execute code during installation.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -10,6 +10,13 @@ from typing import List, Optional
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.rich import print_json
 
+# Eagerly import self_outdated_check to avoid crashes. Otherwise,
+# this module would be imported *after* pip was replaced, resulting
+# in crashes if the new self_outdated_check module was incompatible
+# with the rest of pip that's already imported, or allowing a
+# wheel to execute arbitrary code on install by replacing
+# self_outdated_check.
+import pip._internal.self_outdated_check  # noqa: F401
 from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.cmdoptions import make_target_python
@@ -46,14 +53,6 @@ from pip._internal.utils.virtualenv import (
     virtualenv_no_global,
 )
 from pip._internal.wheel_builder import build, should_build_for_install_command
-
-# Eagerly import this module to avoid crashes. Otherwise, this
-# module would be imported *after* pip was replaced, resulting in
-# crashes if the new self_outdated_check module was incompatible
-# with the rest of pip that's already imported, or allowing a
-# wheel to execute arbitrary code on install by replacing
-# self_outdated_check.
-import pip._internal.self_outdated_check  # noqa: F401
 
 logger = getLogger(__name__)
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -47,6 +47,14 @@ from pip._internal.utils.virtualenv import (
 )
 from pip._internal.wheel_builder import build, should_build_for_install_command
 
+# Eagerly import this module to avoid crashes. Otherwise, this
+# module would be imported *after* pip was replaced, resulting in
+# crashes if the new self_outdated_check module was incompatible
+# with the rest of pip that's already imported, or allowing a
+# wheel to execute arbitrary code on install by replacing
+# self_outdated_check.
+import pip._internal.self_outdated_check  # noqa: F401
+
 logger = getLogger(__name__)
 
 
@@ -408,12 +416,6 @@ class InstallCommand(RequirementCommand):
                 # If we're not replacing an already installed pip,
                 # we're not modifying it.
                 modifying_pip = pip_req.satisfied_by is None
-                if modifying_pip:
-                    # Eagerly import this module to avoid crashes. Otherwise, this
-                    # module would be imported *after* pip was replaced, resulting in
-                    # crashes if the new self_outdated_check module was incompatible
-                    # with the rest of pip that's already imported.
-                    import pip._internal.self_outdated_check  # noqa: F401
             protect_pip_from_modification_on_windows(modifying_pip=modifying_pip)
 
             reqs_to_build = [


### PR DESCRIPTION
Fixes #13079 by moving the import to the top of the module so that it is imported when `install.py` is imported.

Preserve the comment as it is still relevant and add a note about preventing arbitrary code execution.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
