### PR TITLE
Accommodate for recent pathname2url() changes upstream

### DIFF
--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -40,7 +40,9 @@ from pip._internal.network.session import PipSession
 from tests.lib import (
     TestData,
     make_test_link_collector,
+    skip_needs_new_pathname2url_trailing_slash_behavior_win,
     skip_needs_new_urlun_behavior_win,
+    skip_needs_old_pathname2url_trailing_slash_behavior_win,
     skip_needs_old_urlun_behavior_win,
 )
 
@@ -390,12 +392,26 @@ def test_clean_url_path_with_local_path(path: str, expected: str) -> None:
         pytest.param(
             "file:///T:/path/with spaces/",
             "file:///T:/path/with%20spaces",
-            marks=skip_needs_old_urlun_behavior_win,
+            marks=[
+                skip_needs_old_urlun_behavior_win,
+                skip_needs_old_pathname2url_trailing_slash_behavior_win,
+            ],
         ),
         pytest.param(
             "file:///T:/path/with spaces/",
             "file://///T:/path/with%20spaces",
-            marks=skip_needs_new_urlun_behavior_win,
+            marks=[
+                skip_needs_new_urlun_behavior_win,
+                skip_needs_old_pathname2url_trailing_slash_behavior_win,
+            ],
+        ),
+        pytest.param(
+            "file:///T:/path/with spaces/",
+            "file://///T:/path/with%20spaces/",
+            marks=[
+                skip_needs_new_urlun_behavior_win,
+                skip_needs_new_pathname2url_trailing_slash_behavior_win,
+            ],
         ),
         # URL with Windows drive letter, running on non-windows
         # platform. The `:` after the drive should be quoted.

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -6,11 +6,6 @@ import pytest
 
 from pip._internal.utils.urls import path_to_url, url_to_path
 
-from tests.lib import (
-    skip_needs_new_urlun_behavior_win,
-    skip_needs_old_urlun_behavior_win,
-)
-
 
 @pytest.mark.skipif("sys.platform == 'win32'")
 def test_path_to_url_unix() -> None:
@@ -25,21 +20,20 @@ def test_path_to_url_unix() -> None:
     [
         pytest.param("c:/tmp/file", "file:///C:/tmp/file", id="posix-path"),
         pytest.param("c:\\tmp\\file", "file:///C:/tmp/file", id="nt-path"),
-        pytest.param(
-            r"\\unc\as\path",
-            "file://unc/as/path",
-            marks=skip_needs_old_urlun_behavior_win,
-            id="unc-path",
-        ),
-        pytest.param(
-            r"\\unc\as\path",
-            "file:////unc/as/path",
-            marks=skip_needs_new_urlun_behavior_win,
-        ),
     ],
 )
 def test_path_to_url_win(path: str, url: str) -> None:
     assert path_to_url(path) == url
+
+
+@pytest.mark.skipif("sys.platform != 'win32'")
+def test_unc_path_to_url_win() -> None:
+    # The two and four slash forms are both acceptable for our purposes. CPython's
+    # behaviour has changed several times here, so blindly accept either.
+    # - https://github.com/python/cpython/issues/78457
+    # - https://github.com/python/cpython/issues/126205
+    url = path_to_url(r"\\unc\as\path")
+    assert url in ["file://unc/as/path", "file:////unc/as/path"]
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")


### PR DESCRIPTION
- UNC paths converted to URLs now start with two slashes, like earlier (yes, really!)
- Trailing slashes are now preserved on Windows, matching POSIX behaviour

Fixes #13104.