### PR TITLE
Remove gone_in for issue 11859 (deprecation of --build-option and --global-option)

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -925,7 +925,7 @@ def check_legacy_setup_py_options(
             reason="--build-option and --global-option are deprecated.",
             issue=11859,
             replacement="to use --config-settings",
-            gone_in="25.0",
+            gone_in=None,
         )
         logger.warning(
             "Implying --no-binary=:all: due to the presence of "


### PR DESCRIPTION
Setuptools has not stabilised their interface to pass build options, and forcing user to change from `--build-option` to two successive flavors of `--config-settings` is not ideal.

The setuptools tracking issue seems to be https://github.com/pypa/setuptools/issues/3896, with some design discussion in https://github.com/pypa/setuptools/discussions/4083. 

This does not mean that we will not want to remove these legacy options if setuptools does not move, but for now this is not a huge maintenance burden.