### PR TITLE
Fix options and default in `--keyring-provider` help

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -261,7 +261,7 @@ keyring_provider: Callable[..., Option] = partial(
     help=(
         "Enable the credential lookup via the keyring library if user input is allowed."
         " Specify which mechanism to use [auto, disabled, import, subprocess]."
-        " (default: auto)"
+        " (default: %default)"
     ),
 )
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -260,8 +260,8 @@ keyring_provider: Callable[..., Option] = partial(
     default="auto",
     help=(
         "Enable the credential lookup via the keyring library if user input is allowed."
-        " Specify which mechanism to use [disabled, import, subprocess]."
-        " (default: disabled)"
+        " Specify which mechanism to use [auto, disabled, import, subprocess]."
+        " (default: auto)"
     ),
 )
 


### PR DESCRIPTION
The default has been changed in #11942, but the help text was not updated.