### PR TITLE
Add missing space in running as root warning message

### DIFF
--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -764,7 +764,7 @@ def warn_if_run_as_root() -> None:
     logger.warning(
         "Running pip as the 'root' user can result in broken permissions and "
         "conflicting behaviour with the system package manager, possibly "
-        "rendering your system unusable."
+        "rendering your system unusable. "
         "It is recommended to use a virtual environment instead: "
         "https://pip.pypa.io/warnings/venv. "
         "Use the --root-user-action option if you know what you are doing and "


### PR DESCRIPTION
A trivial formatting fix.