### PR TITLE
Speed up nox docs sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -143,6 +143,7 @@ def docs(session: nox.Session) -> None:
             "-c", "docs/html",  # see note above
             "-d", "docs/build/doctrees/" + kind,
             "-b", kind,
+            "--jobs", "auto",
             "docs/" + kind,
             "docs/build/" + kind,
         ]
@@ -163,6 +164,7 @@ def docs_live(session: nox.Session) -> None:
         "-b=dirhtml",
         "docs/html",
         "docs/build/livehtml",
+        "--jobs=auto",
         *session.posargs,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -127,7 +127,6 @@ def test(session: nox.Session) -> None:
 
 @nox.session
 def docs(session: nox.Session) -> None:
-    session.install("-e", ".")
     session.install("-r", REQUIREMENTS["docs"])
 
     def get_sphinx_build_command(kind: str) -> List[str]:
@@ -155,7 +154,6 @@ def docs(session: nox.Session) -> None:
 
 @nox.session(name="docs-live")
 def docs_live(session: nox.Session) -> None:
-    session.install("-e", ".")
     session.install("-r", REQUIREMENTS["docs"], "sphinx-autobuild")
 
     session.run(


### PR DESCRIPTION
On my 8 core system, a clean cold build takes 5-6 seconds with `--jobs auto` instead of 10-11 seconds. Nothing major, but it's a welcomed QoL improvement. FYI, this flag doesn't work on Windows.

In addition, I've removed the direct editable installation of pip in the nox sessions as it's going to be reinstalled again (normally) via `docs/requirements.txt`. Looking at the history, at some point, `session.install("pip")` in the `docs` and `docs-live` sessions was changed to install pip in editable mode, presumably to enable reruns w/o dependency installation (`-R` nox flag) to pick up changes for our pip sphinx extension. This doesn't do anything though nowadays for the aforementioned reason. 