### PR TITLE
Draft: Fix warning message for missing METADATA file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+- Updated warning message for invalid dist-info directory due to missing `METADATA` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# Changelog
-
-## [Unreleased]
-
-### Changed
-- Updated warning message for invalid dist-info directory due to missing `METADATA` file.

--- a/news/12446.bugfix.rst
+++ b/news/12446.bugfix.rst
@@ -1,0 +1,3 @@
+* Updated warning message for invalid dist-info directory due to missing `METADATA` file.
+* Added a check for the existence of the `METADATA` file in the `get_dist_canonical_name` function.
+* Added a test case to verify the new warning message for a missing `METADATA` file.

--- a/news/12446.bugfix.rst
+++ b/news/12446.bugfix.rst
@@ -1,3 +1,1 @@
-* Updated warning message for invalid dist-info directory due to missing `METADATA` file.
-* Added a check for the existence of the `METADATA` file in the `get_dist_canonical_name` function.
-* Added a test case to verify the new warning message for a missing `METADATA` file.
+Updated warning message for invalid dist-info directory due to missing METADATA file.

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -1,6 +1,6 @@
 import importlib.metadata
 import os
-from typing import Any, Optional, Protocol, Tuple, cast
+from typing import Any, Optional, Protocol, Tuple, Union, cast
 
 from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 
@@ -33,7 +33,10 @@ class BasePath(Protocol):
     def parent(self) -> "BasePath":
         raise NotImplementedError()
 
-    def joinpath(self, *other) -> "BasePath":
+    def joinpath(self, *args: Union[str, os.PathLike[str]]) -> "BasePath":
+        raise NotImplementedError()
+
+    def exists(self) -> bool:
         raise NotImplementedError()
 
 
@@ -85,7 +88,7 @@ def get_dist_canonical_name(dist: importlib.metadata.Distribution) -> Normalized
     name = cast(Any, dist).name
     if not isinstance(name, str):
         info_location = get_info_location(dist)
-        if info_location and not info_location.joinpath("METADATA").exists():
+        if info_location and not info_location.joinpath("METADATA"):
             raise BadMetadata(dist, reason="missing `METADATA` file")
         raise BadMetadata(dist, reason="invalid metadata entry 'name'")
     return canonicalize_name(name)

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -81,5 +81,8 @@ def get_dist_canonical_name(dist: importlib.metadata.Distribution) -> Normalized
 
     name = cast(Any, dist).name
     if not isinstance(name, str):
+        info_location = get_info_location(dist)
+        if info_location and not info_location.joinpath("METADATA").exists():
+            raise BadMetadata(dist, reason="missing `METADATA` file")
         raise BadMetadata(dist, reason="invalid metadata entry 'name'")
     return canonicalize_name(name)

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -33,6 +33,9 @@ class BasePath(Protocol):
     def parent(self) -> "BasePath":
         raise NotImplementedError()
 
+    def joinpath(self, *other) -> "BasePath":
+        raise NotImplementedError()
+
 
 def get_info_location(d: importlib.metadata.Distribution) -> Optional[BasePath]:
     """Find the path to the distribution's metadata directory.

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -11,6 +11,7 @@ from typing import (
     Optional,
     Sequence,
     Union,
+    cast,
 )
 
 from pip._vendor.packaging.requirements import Requirement
@@ -199,7 +200,7 @@ class Distribution(BaseDistribution):
         # a ton of fields that we need, including get() and get_payload(). We
         # rely on the implementation that the object is actually a Message now,
         # until upstream can improve the protocol. (python/cpython#94952)
-        return self._dist.metadata
+        return cast(email.message.Message, self._dist.metadata)
 
     def iter_provided_extras(self) -> Iterable[NormalizedName]:
         return [

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -10,7 +10,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    cast,
+    Union,
 )
 
 from pip._vendor.packaging.requirements import Requirement
@@ -100,8 +100,8 @@ class Distribution(BaseDistribution):
     def __init__(
         self,
         dist: importlib.metadata.Distribution,
-        info_location: Optional[BasePath],
-        installed_location: Optional[BasePath],
+        info_location: Optional[Union[BasePath, pathlib.PurePosixPath]],
+        installed_location: Optional[Union[BasePath, pathlib.PurePosixPath]],
     ) -> None:
         self._dist = dist
         self._info_location = info_location
@@ -199,7 +199,7 @@ class Distribution(BaseDistribution):
         # a ton of fields that we need, including get() and get_payload(). We
         # rely on the implementation that the object is actually a Message now,
         # until upstream can improve the protocol. (python/cpython#94952)
-        return cast(email.message.Message, self._dist.metadata)
+        return self._dist.metadata
 
     def iter_provided_extras(self) -> Iterable[NormalizedName]:
         return [

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -755,7 +755,8 @@ def test_list_pep610_editable(script: PipTestEnvironment) -> None:
 
 def test_list_missing_metadata_warning(script: PipTestEnvironment) -> None:
     """
-    Test that a warning is shown when a dist-info directory is missing the METADATA file.
+    Test that a warning is shown when a dist-info directory is missing the
+    METADATA file.
     """
     # Create a test package and create .dist-info dir without METADATA file
     pkg_path = create_test_package_with_setup(script, name="testpkg", version="1.0")
@@ -766,4 +767,6 @@ def test_list_missing_metadata_warning(script: PipTestEnvironment) -> None:
     # List should show a warning about the missing METADATA file
     result = script.pip("list", expect_stderr=True)
     assert "WARNING: Skipping" in result.stderr
-    assert "due to invalid dist-info directory: missing `METADATA` file" in result.stderr
+    assert (
+        "due to invalid dist-info directory: missing `METADATA` file" in result.stderr
+    )

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -751,3 +751,19 @@ def test_list_pep610_editable(script: PipTestEnvironment) -> None:
             break
     else:
         pytest.fail("package 'testpkg' not found in pip list result")
+
+
+def test_list_missing_metadata_warning(script: PipTestEnvironment) -> None:
+    """
+    Test that a warning is shown when a dist-info directory is missing the METADATA file.
+    """
+    # Create a test package and create .dist-info dir without METADATA file
+    pkg_path = create_test_package_with_setup(script, name="testpkg", version="1.0")
+    dist_info_path = pkg_path / "testpkg-1.0.dist-info"
+    dist_info_path.mkdir()
+    dist_info_path.joinpath("RECORD").write_text("")
+
+    # List should show a warning about the missing METADATA file
+    result = script.pip("list", expect_stderr=True)
+    assert "WARNING: Skipping" in result.stderr
+    assert "due to invalid dist-info directory: missing `METADATA` file" in result.stderr


### PR DESCRIPTION
Fixes #12446

Update the warning message for missing `METADATA` file in dist-info directories.

* Update the warning message in `src/pip/_internal/metadata/importlib/_compat.py` to differentiate between a missing `METADATA` file and other metadata issues.
* Add a check for the existence of the `METADATA` file in the `get_dist_canonical_name` function.
* Add a test case in `tests/functional/test_list.py` to verify the new warning message for a missing `METADATA` file.