### PR TITLE
Remove redundant prefix in failed PEP 517 builds error message

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -433,7 +433,7 @@ class InstallCommand(RequirementCommand):
 
             if build_failures:
                 raise InstallationError(
-                    "ERROR: Failed to build installable wheels for some "
+                    "Failed to build installable wheels for some "
                     "pyproject.toml based projects ({})".format(
                         ", ".join(r.name for r in build_failures)  # type: ignore
                     )


### PR DESCRIPTION
The error handling logic will add the ERROR: prefix already. Including one in the error message results in two ERROR: prefixes.

    ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (simplewheel, singlemodule)

