### PR TITLE
Pass --proxy to build subprocesses

### DIFF
--- a/news/6018.bugfix.rst
+++ b/news/6018.bugfix.rst
@@ -1,0 +1,1 @@
+The ``--proxy`` command-line option is now respected while installing build dependencies.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -272,6 +272,8 @@ class BuildEnvironment:
         for link in finder.find_links:
             args.extend(["--find-links", link])
 
+        if finder.proxy:
+            args.extend(["--proxy", finder.proxy])
         for host in finder.trusted_hosts:
             args.extend(["--trusted-host", host])
         if finder.client_cert:

--- a/src/pip/_internal/cli/index_command.py
+++ b/src/pip/_internal/cli/index_command.py
@@ -123,6 +123,7 @@ class SessionCommandMixin(CommandContextMixIn):
                 "https": options.proxy,
             }
             session.trust_env = False
+            session.pip_proxy = options.proxy
 
         # Determine if we can prompt the user for authentication or not
         session.auth.prompting = not options.no_input

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -662,6 +662,10 @@ class PackageFinder:
         return self.search_scope.index_urls
 
     @property
+    def proxy(self) -> Optional[str]:
+        return self._link_collector.session.pip_proxy
+
+    @property
     def trusted_hosts(self) -> Iterable[str]:
         for host_port in self._link_collector.session.pip_trusted_origins:
             yield build_netloc(*host_port)

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -339,6 +339,7 @@ class PipSession(requests.Session):
         # Namespace the attribute with "pip_" just in case to prevent
         # possible conflicts with the base class.
         self.pip_trusted_origins: List[Tuple[str, Optional[int]]] = []
+        self.pip_proxy = None
 
         # Attach our User Agent to the request
         self.headers["User-Agent"] = user_agent()


### PR DESCRIPTION
Similar to `--cert` and `--client-cert`, the --proxy flag was not passed down to the isolated build environment. This was simply an oversight.

I opted to store the original proxy string in a new attribute on the session as digging into the .proxies dictionary felt janky, and so did passing the proxy string to the finder as an argument.

Fixes https://github.com/pypa/pip/issues/6018. This supersedes and closes https://github.com/pypa/pip/pull/13075.