### PR TITLE
Cache requires-python checks & skip debug logging

### DIFF
--- a/news/13128.feature.rst
+++ b/news/13128.feature.rst
@@ -1,0 +1,1 @@
+Cache ``python-requires`` checks while filtering potential installation candidates.

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -736,6 +736,11 @@ class PackageFinder:
         return no_eggs + eggs
 
     def _log_skipped_link(self, link: Link, result: LinkType, detail: str) -> None:
+        # This is a hot method so don't waste time hashing links unless we're
+        # actually going to log 'em.
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+
         entry = (link, result, detail)
         if entry not in self._logged_links:
             # Put the link at the end so the reason is more visible and because

--- a/src/pip/_internal/utils/packaging.py
+++ b/src/pip/_internal/utils/packaging.py
@@ -11,6 +11,7 @@ NormalizedExtra = NewType("NormalizedExtra", str)
 logger = logging.getLogger(__name__)
 
 
+@functools.lru_cache(maxsize=32)
 def check_requires_python(
     requires_python: Optional[str], version_info: Tuple[int, ...]
 ) -> bool:


### PR DESCRIPTION
The `requires-python` check is pretty fast, but when performed for 10000 links, the checks consume a nontrival amount of time. For example, while installing (pre-cached + --dry-run) a pared down list of homeassistant dependencies (117 in total), link evaluation took 15% of the total runtime, with  check_requires_python() accounting for half (7.5%) of that.

The cache can be kept pretty small as `requires-python` specifiers often repeat, and when they do change, it's often in chunks (or between entirely different packages). For example, setuptools has like 1500 links, but only ~30 different `requires-python` specifiers.

In addition, `_log_skipped_link()` is a hot method and unfortunately expensive as it hashes the link on every call. Fortunately, we can return early when debug logging is not enabled. In the same homeassistant run, this saves 0.7% of the runtime.

---

Command: `python -m cProfile -o profile.pstats -m pip install -r temp/homeassistant/requirements.txt --dry-run`

<details><summary>Before</summary>
<p>

![image](https://github.com/user-attachments/assets/f26fba98-d5ab-40ea-b5e4-72d3d4a369b5)
![image](https://github.com/user-attachments/assets/883a1cb1-33f7-4809-ad72-ea4212cb4f4f)

</p>
</details> 

<details><summary>After</summary>
<p>

![image](https://github.com/user-attachments/assets/2250ca47-7504-41dc-b7de-8e5f65146307)

</p>
</details> 

The `Link.from_json()` classmethod is surprisingly expensive. I'll take a look at speeding that up next. 
