### PR TITLE
ci: run zipapp tests on M1 macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,10 @@ jobs:
 
   tests-zipapp:
     name: tests / zipapp
-    runs-on: ubuntu-22.04
+    # The macos-latest (M1) runners are the fastest available on GHA, even
+    # beating out the ubuntu-latest runners. The zipapp tests are slow by
+    # nature, and we don't care where they run, so we pick the fastest one.
+    runs-on: macos-latest
 
     needs: [packaging, determine-changes]
     if: >-
@@ -229,10 +232,8 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install Ubuntu dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install bzr
+      - name: Install MacOS dependencies
+        run: brew install breezy subversion
 
       - run: pip install nox
 


### PR DESCRIPTION
The `macos-latest` runner is significantly faster than even the `ubuntu-latest` runners (11 minutes vs 17 minutes).

Once #13129 is merged, the zipapp job will be one of the slowest jobs, keeping CI runs at 18+ minutes. With a 11 minute zipapp job, the slowest jobs will be the Intel `macos-13` jobs. With just those remaining, we should have 15[^1] minute CI :sparkles:

![image](https://github.com/user-attachments/assets/dbe48877-7919-496a-9db7-8cfa37238375)

[^1]: *although all of the intel macOS runners experience a LOT of run to run variation, so whether a PR takes 15 minutes to pass CI is up to luck