### PR TITLE
Support PEP639 License-Expression and License-File in json output

### DIFF
--- a/news/13134.feature.rst
+++ b/news/13134.feature.rst
@@ -1,0 +1,4 @@
+Support :pep:`639` License-Expression and License-File metadata fields in json
+output. ``pip inspect`` and ``pip install --report`` now emit
+``license_expression`` and ``license_file`` fields in the ``metadata`` object,
+if the corresponding fields are present in the installed ``METADATA`` file.

--- a/news/13134.feature.rst
+++ b/news/13134.feature.rst
@@ -1,4 +1,4 @@
-Support :pep:`639` License-Expression and License-File metadata fields in json
+Support :pep:`639` License-Expression and License-File metadata fields in JSON
 output. ``pip inspect`` and ``pip install --report`` now emit
 ``license_expression`` and ``license_file`` fields in the ``metadata`` object,
 if the corresponding fields are present in the installed ``METADATA`` file.

--- a/src/pip/_internal/metadata/_json.py
+++ b/src/pip/_internal/metadata/_json.py
@@ -23,6 +23,8 @@ METADATA_FIELDS = [
     ("Maintainer", False),
     ("Maintainer-email", False),
     ("License", False),
+    ("License-Expression", False),
+    ("License-File", True),
     ("Classifier", True),
     ("Requires-Dist", True),
     ("Requires-Python", False),


### PR DESCRIPTION
Add PEP639 support to `pip inspect` and `pip install --report`.