### PR TITLE
Trim pyproject.toml and MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,21 +7,16 @@ include pyproject.toml
 
 include src/pip/_vendor/README.rst
 include src/pip/_vendor/vendor.txt
-include src/pip/_vendor/pyparsing/diagram/template.jinja2
 recursive-include  src/pip/_vendor *LICENSE*
 recursive-include  src/pip/_vendor *COPYING*
 
-include docs/docutils.conf
 include docs/requirements.txt
 
 exclude .git-blame-ignore-revs
-exclude .coveragerc
 exclude .mailmap
-exclude .appveyor.yml
 exclude .readthedocs.yml
 exclude .pre-commit-config.yaml
 exclude .readthedocs-custom-redirects.yml
-exclude tox.ini
 exclude noxfile.py
 
 recursive-include src/pip/_vendor *.pem
@@ -34,6 +29,5 @@ recursive-exclude src/pip/_vendor *.pyi
 prune .github
 prune docs/build
 prune news
-prune tasks
 prune tests
 prune tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,6 @@ exclude = ["contrib", "docs", "tests*", "tasks"]
 "pip" = ["py.typed"]
 "pip._vendor" = ["vendor.txt"]
 "pip._vendor.certifi" = ["*.pem"]
-"pip._vendor.requests" = ["*.pem"]
-"pip._vendor.distlib._backport" = ["sysconfig.cfg"]
 "pip._vendor.distlib" = [
     "t32.exe",
     "t64.exe",
@@ -307,10 +305,7 @@ source0 = [
 ]
 
 [tool.coverage.report]
-exclude_lines = [
-    # We must re-state the default because the `exclude_lines` option overrides
-    # it.
-    "pragma: no cover",
+exclude_also = [
     # This excludes typing-specific code, which will be validated by mypy anyway.
     "if TYPE_CHECKING",
 ]


### PR DESCRIPTION
This mostly removes legacy references to files that do not exist anymore. In addition, the smarter [`exclude_also` coverage](https://coverage.readthedocs.io/en/7.6.10/config.html#config-report-exclude-also) option is used instead of `exclude_lines` so we don't need to readd the default exclude.