### PR TITLE
Fix: include sub-actions in tab completion

### DIFF
--- a/news/0741cad6-3007-47f8-9c53-984e9116c7ff.bugfix.rst
+++ b/news/0741cad6-3007-47f8-9c53-984e9116c7ff.bugfix.rst
@@ -1,0 +1,1 @@
+Include sub-commands in tab completion.

--- a/src/pip/_internal/cli/autocompletion.py
+++ b/src/pip/_internal/cli/autocompletion.py
@@ -103,6 +103,12 @@ def autocomplete() -> None:
             if option[1] and option[0][:2] == "--":
                 opt_label += "="
             print(opt_label)
+
+        # Complete sub-commands (unless one is already given).
+        if not any(name in cwords for name in subcommand.handler_map()):
+            for handler_name in subcommand.handler_map():
+                if handler_name.startswith(current):
+                    print(handler_name)
     else:
         # show main parser options only when necessary
 

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -9,6 +9,7 @@ import os
 import sys
 import traceback
 from optparse import Values
+from typing import Callable
 
 from pip._vendor.rich import reconfigure
 from pip._vendor.rich import traceback as rich_traceback
@@ -232,3 +233,9 @@ class Command(CommandContextMixIn):
                 options.cache_dir = None
 
         return self._run_wrapper(level_number, options, args)
+
+    def handler_map(self) -> dict[str, Callable[[Values, list[str]], None]]:
+        """
+        map of names to handler actions for commands with sub-actions
+        """
+        return {}

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -429,3 +429,36 @@ def test_completion_uses_same_executable_name(
         expect_stderr=deprecated_python,
     )
     assert executable_name in result.stdout
+
+
+@pytest.mark.parametrize(
+    "subcommand, handler_prefix, expected",
+    [
+        ("cache", "d", "dir"),
+        ("cache", "in", "info"),
+        ("cache", "l", "list"),
+        ("cache", "re", "remove"),
+        ("cache", "pu", "purge"),
+        ("config", "li", "list"),
+        ("config", "e", "edit"),
+        ("config", "ge", "get"),
+        ("config", "se", "set"),
+        ("config", "unse", "unset"),
+        ("config", "d", "debug"),
+        ("index", "ve", "versions"),
+    ],
+)
+def test_completion_for_action_handler(
+    subcommand: str, handler_prefix: str, expected: str, autocomplete: DoAutocomplete
+) -> None:
+    res, _ = autocomplete(f"pip {subcommand} {handler_prefix}", cword="2")
+
+    assert [expected] == res.stdout.split()
+
+
+def test_completion_for_action_handler_handler_not_repeated(
+    autocomplete: DoAutocomplete,
+) -> None:
+    res, _ = autocomplete("pip cache remove re", cword="3")
+
+    assert [] == res.stdout.split()


### PR DESCRIPTION
For commands like `pip cache` with sub-actions like `remove`, so that e.g. `pip cache re<TAB>` completes to `pip cache remove`.

All the existing commands that used such sub-actions followed the same approach for: using a dictionary of names to methods to run, so the implementation is just  teaching the `Command` object about this mapping and using it in the autocompletion function.

There's no handling for the position of the argument, so e.g. `pip cache re<TAB>` and `pip  cache --user re<TAB>` will both complete the final word to `remove`. This is mostly because it was simpler to implement like this, but also I think due to how `optparse` works such invocations are valid, e.g. `pip config --user set global.timeout 60`. Similarly, there's no duplication handling so `pip cache remove re<TAB>` will also complete.

This is a feature that may be simpler to implement, or just work out of the box, with some argument parsing libraries, but moving to another such library looks to be quite a bit of work (see discussion[1]).

I also took the opportunity to tighten some typing: dropping some use of `Any`

Link: https://github.com/pypa/pip/issues/4659 [1]
Fixes: https://github.com/pypa/pip/issues/13133