### PR TITLE
chore(ci): disable external network calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,7 +255,7 @@ follow_imports = "skip"
 #
 
 [tool.pytest.ini_options]
-addopts = "--ignore src/pip/_vendor --ignore tests/tests_cache -r aR --color=yes"
+addopts = "--ignore src/pip/_vendor --ignore tests/tests_cache -r aR --color=yes --disable-socket --allow-hosts=localhost"
 xfail_strict = true
 markers = [
     "network: tests that need network",

--- a/tests/functional/test_index.py
+++ b/tests/functional/test_index.py
@@ -50,6 +50,7 @@ def test_list_all_versions_search_with_pre(script: PipTestEnvironment) -> None:
     )
 
 
+@pytest.mark.enable_socket
 @pytest.mark.network
 def test_list_all_versions_returns_no_matches_found_when_name_not_exact() -> None:
     """
@@ -63,6 +64,7 @@ def test_list_all_versions_returns_no_matches_found_when_name_not_exact() -> Non
     assert status == ERROR
 
 
+@pytest.mark.enable_socket
 @pytest.mark.network
 def test_list_all_versions_returns_matches_found_when_name_is_exact() -> None:
     """

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,7 @@ installer
 pytest
 pytest-cov
 pytest-rerunfailures
+pytest-socket
 pytest-xdist
 scripttest
 setuptools

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -42,6 +42,7 @@ def mypy_whl_no_range(mock_server: MockServer, shared_data: TestData) -> Iterato
     mock_server.stop()
 
 
+@pytest.mark.enable_socket
 @pytest.mark.network
 def test_dist_from_wheel_url(session: PipSession) -> None:
     """Test if the acquired distribution contain correct information."""
@@ -53,6 +54,7 @@ def test_dist_from_wheel_url(session: PipSession) -> None:
     assert {str(d) for d in dist.iter_dependencies(extras)} == MYPY_0_782_REQS
 
 
+@pytest.mark.enable_socket
 def test_dist_from_wheel_url_no_range(
     session: PipSession, mypy_whl_no_range: str
 ) -> None:
@@ -61,6 +63,7 @@ def test_dist_from_wheel_url_no_range(
         dist_from_wheel_url("mypy", mypy_whl_no_range, session)
 
 
+@pytest.mark.enable_socket
 @pytest.mark.network
 def test_dist_from_wheel_url_not_zip(session: PipSession) -> None:
     """Test handling with the given URL does not point to a ZIP."""

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -255,6 +255,7 @@ class TestPipSession:
         assert actual_level == "WARNING"
         assert "is not a trusted or secure host" in actual_message
 
+    @pytest.mark.enable_socket
     @pytest.mark.network
     def test_proxy(self, proxy: Optional[str]) -> None:
         session = PipSession(trusted_hosts=[])

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -365,6 +365,7 @@ class TestRequirementSet:
             assert isinstance(req.download_info.info, ArchiveInfo)
             assert req.download_info.info.hash
 
+    @pytest.mark.enable_socket
     @pytest.mark.network
     def test_download_info_index_url(self) -> None:
         """Test that download_info is set for requirements via index."""
@@ -377,6 +378,7 @@ class TestRequirementSet:
             assert req.download_info
             assert isinstance(req.download_info.info, ArchiveInfo)
 
+    @pytest.mark.enable_socket
     @pytest.mark.network
     def test_download_info_web_archive(self) -> None:
         """Test that download_info is set for requirements from a web archive."""

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -725,6 +725,7 @@ class TestOptionVariants:
 class TestParseRequirements:
     """tests for `parse_reqfile`"""
 
+    @pytest.mark.enable_socket
     @pytest.mark.network
     def test_remote_reqs_parse(self) -> None:
         """


### PR DESCRIPTION
As some tests spin up a local server, allow clients to communicate with
local addresses only.

Refs: https://pypi.org/project/pytest-socket/
