### PR TITLE
Switch to ubuntu-22.04 for github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   docs:
     name: docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
       - run: nox -s docs
 
   determine-changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
       vendoring: ${{ steps.filter.outputs.vendoring }}
@@ -64,7 +64,7 @@ jobs:
 
   packaging:
     name: packaging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
 
   vendoring:
     name: vendoring
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     needs: [determine-changes]
     if: >-
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-22.04, macos-13, macos-latest]
         python:
           - "3.8"
           - "3.9"
@@ -129,7 +129,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install Ubuntu dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install bzr
@@ -216,7 +216,7 @@ jobs:
 
   tests-zipapp:
     name: tests / zipapp
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     needs: [packaging, determine-changes]
     if: >-
@@ -257,7 +257,7 @@ jobs:
       - tests-zipapp
       - vendoring
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/news/13152.trivial.rst
+++ b/news/13152.trivial.rst
@@ -1,0 +1,1 @@
+Switch to ubuntu-22.04 for github workflow.


### PR DESCRIPTION
The issues running on Ubuntu 24.04 seem non-trivial: https://github.com/pypa/pip/pull/13149#issuecomment-2582795356

While important to solve, I don't think it should block all PRs, I propose we revert to ubuntu-22.04 in the mean time.