### PR TITLE
Deprecate Python 2 relic `--no-python-version-warning`

### DIFF
--- a/news/13154.removal.rst
+++ b/news/13154.removal.rst
@@ -1,0 +1,2 @@
+Deprecate the ``no-python-version-warning`` flag as it has long done nothing
+since Python 2 support was removed in pip 21.0.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -29,6 +29,7 @@ from pip._internal.exceptions import (
     NetworkConnectionError,
     PreviousBuildDirError,
 )
+from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
 from pip._internal.utils.misc import get_prog, normalize_path
@@ -227,5 +228,13 @@ class Command(CommandContextMixIn):
                     options.cache_dir,
                 )
                 options.cache_dir = None
+
+        if options.no_python_version_warning:
+            deprecated(
+                reason="--no-python-verison-warning is deprecated.",
+                replacement="to remove the flag as it's a no-op",
+                gone_in="25.1",
+                issue=13154,
+            )
 
         return self._run_wrapper(level_number, options, args)


### PR DESCRIPTION
Towards https://github.com/pypa/pip/issues/13154.