### PR TITLE
Postpone removal of non-bare names in egg fragment to 25.1

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -231,7 +231,7 @@ class Command(CommandContextMixIn):
 
         if options.no_python_version_warning:
             deprecated(
-                reason="--no-python-verison-warning is deprecated.",
+                reason="--no-python-version-warning is deprecated.",
                 replacement="to remove the flag as it's a no-op",
                 gone_in="25.1",
                 issue=13154,

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -466,10 +466,10 @@ class Link:
         project_name = match.group(1)
         if not self._project_name_re.match(project_name):
             deprecated(
-                reason=f"{self} contains an egg fragment with a non-PEP 508 name",
+                reason=f"{self} contains an egg fragment with a non-PEP 508 name.",
                 replacement="to use the req @ url syntax, and remove the egg fragment",
-                gone_in="25.0",
-                issue=11617,
+                gone_in="25.1",
+                issue=13157,
             )
 
         return project_name


### PR DESCRIPTION
The only way for editable VCS URL installs to request an extra is to place them in the egg fragment. Of course, this is undocumented and deprecated behaviour, but we should ensure `pip install -e name[extra] @ VCS_URL` actually works (aka PR https://github.com/pypa/pip/pull/9471) before breaking our users.

See also: #13157 and https://github.com/pypa/pip/issues/1289