### PR TITLE
Resolvelib: process Requires-Python before other dependencies

### DIFF
--- a/news/11142.bugfix.rst
+++ b/news/11142.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a regression that causes dependencies to be checked *before* ``Requires-Python``
+project metadata is checked, leading to wasted cycles when the Python version is
+unsupported.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -249,10 +249,10 @@ class _InstallRequirementBackedCandidate(Candidate):
         return dist
 
     def iter_dependencies(self, with_requires: bool) -> Iterable[Optional[Requirement]]:
+        yield self._factory.make_requires_python_requirement(self.dist.requires_python)
         requires = self.dist.iter_dependencies() if with_requires else ()
         for r in requires:
             yield from self._factory.make_requirements_from_spec(str(r), self._ireq)
-        yield self._factory.make_requires_python_requirement(self.dist.requires_python)
 
     def get_install_requirement(self) -> Optional[InstallRequirement]:
         return self._ireq

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -242,9 +242,9 @@ class PipProvider(_ProviderBase):
     def is_satisfied_by(self, requirement: Requirement, candidate: Candidate) -> bool:
         return requirement.is_satisfied_by(candidate)
 
-    def get_dependencies(self, candidate: Candidate) -> Sequence[Requirement]:
+    def get_dependencies(self, candidate: Candidate) -> Iterable[Requirement]:
         with_requires = not self._ignore_dependencies
-        return [r for r in candidate.iter_dependencies(with_requires) if r is not None]
+        return (r for r in candidate.iter_dependencies(with_requires) if r is not None)
 
     @staticmethod
     def is_backtrack_cause(


### PR DESCRIPTION
Revived version of https://github.com/pypa/pip/pull/11398.

Closes https://github.com/pypa/pip/pull/11398.
Fixes https://github.com/pypa/pip/issues/13146.
Fixes https://github.com/pypa/pip/issues/11142.