### PR TITLE
Remove `import re` from script template

### DIFF
--- a/news/13165.feature.rst
+++ b/news/13165.feature.rst
@@ -1,0 +1,1 @@
+Speed up small CLI tools by removing ``import re`` from the executable template.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -418,10 +418,8 @@ class PipScriptMaker(ScriptMaker):
 import sys
 from %(module)s import %(import_name)s
 if __name__ == '__main__':
-    if sys.argv[0].endswith('-script.pyw'):
-        sys.argv[0] = sys.argv[0][: -11]
-    elif sys.argv[0].endswith('.exe'):
-        sys.argv[0] = sys.argv[0][: -4]
+    if sys.argv[0].endswith('.exe'):
+        sys.argv[0] = sys.argv[0][:-4]
     sys.exit(%(func)s())
 """
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -412,6 +412,19 @@ def _raise_for_invalid_entrypoint(specification: str) -> None:
 
 
 class PipScriptMaker(ScriptMaker):
+    # Override distlib's default script template with one that
+    # doesn't import `re` module, allowing scripts to load faster.
+    script_template = r"""# -*- coding: utf-8 -*-
+import sys
+from %(module)s import %(import_name)s
+if __name__ == '__main__':
+    if sys.argv[0].endswith('-script.pyw'):
+        sys.argv[0] = sys.argv[0][: -11]
+    elif sys.argv[0].endswith('.exe'):
+        sys.argv[0] = sys.argv[0][: -4]
+    sys.exit(%(func)s())
+"""
+
     def make(
         self, specification: str, options: Optional[Dict[str, Any]] = None
     ) -> List[str]:

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -11,6 +11,7 @@ import os.path
 import re
 import shutil
 import sys
+import textwrap
 import warnings
 from base64 import urlsafe_b64encode
 from email.message import Message
@@ -414,13 +415,16 @@ def _raise_for_invalid_entrypoint(specification: str) -> None:
 class PipScriptMaker(ScriptMaker):
     # Override distlib's default script template with one that
     # doesn't import `re` module, allowing scripts to load faster.
-    script_template = r"""import sys
-from %(module)s import %(import_name)s
-if __name__ == '__main__':
-    if sys.argv[0].endswith('.exe'):
-        sys.argv[0] = sys.argv[0][:-4]
-    sys.exit(%(func)s())
+    script_template = textwrap.dedent(
+        """\
+        import sys
+        from %(module)s import %(import_name)s
+        if __name__ == '__main__':
+            if sys.argv[0].endswith('.exe'):
+                sys.argv[0] = sys.argv[0][:-4]
+            sys.exit(%(func)s())
 """
+    )
 
     def make(
         self, specification: str, options: Optional[Dict[str, Any]] = None

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -414,8 +414,7 @@ def _raise_for_invalid_entrypoint(specification: str) -> None:
 class PipScriptMaker(ScriptMaker):
     # Override distlib's default script template with one that
     # doesn't import `re` module, allowing scripts to load faster.
-    script_template = r"""# -*- coding: utf-8 -*-
-import sys
+    script_template = r"""import sys
 from %(module)s import %(import_name)s
 if __name__ == '__main__':
     if sys.argv[0].endswith('.exe'):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Overrides `distlib.scripts.ScripMaker.script_template` with a template that doesn't `import re`.

Closes https://github.com/pypa/pip/issues/13165
