### PR TITLE
Use tags in docs building to split up requirements

### DIFF
--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -12,6 +12,7 @@ docs_dir = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, docs_dir)
 
 # -- General configuration ------------------------------------------------------------
+
 extensions = [
     # extensions common to all builds
     "pip_sphinxext",

--- a/docs/html/conf.py
+++ b/docs/html/conf.py
@@ -12,21 +12,29 @@ docs_dir = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, docs_dir)
 
 # -- General configuration ------------------------------------------------------------
-
 extensions = [
-    # first-party extensions
-    "sphinx.ext.autodoc",
-    "sphinx.ext.todo",
-    "sphinx.ext.intersphinx",
-    # our extensions
+    # extensions common to all builds
     "pip_sphinxext",
-    # third-party extensions
-    "myst_parser",
-    "sphinx_copybutton",
-    "sphinx_inline_tabs",
-    "sphinxcontrib.towncrier",
-    "sphinx_issues",
 ]
+
+# 'tags' is a injected by sphinx
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-tags
+if "man" not in tags:  # type: ignore[name-defined] # noqa: F821
+    # extensions not needed for building man pages
+    extensions.extend(
+        (
+            # first-party extensions
+            "sphinx.ext.autodoc",
+            "sphinx.ext.todo",
+            "sphinx.ext.intersphinx",
+            # third-party extensions
+            "myst_parser",
+            "sphinx_copybutton",
+            "sphinx_inline_tabs",
+            "sphinxcontrib.towncrier",
+            "sphinx_issues",
+        ),
+    )
 
 # General information about the project.
 project = "pip"

--- a/news/13168.doc.rst
+++ b/news/13168.doc.rst
@@ -1,0 +1,3 @@
+Added support for building only the man pages with minimal dependencies using
+the sphinx-build ``--tag man`` option. This enables distributors to generate man
+pages without requiring HTML documentation dependencies.

--- a/noxfile.py
+++ b/noxfile.py
@@ -145,6 +145,8 @@ def docs(session: nox.Session) -> None:
         return [
             "sphinx-build",
             "--keep-going",
+            "--tag",
+            kind,
             "-W",
             "-c", "docs/html",  # see note above
             "-d", "docs/build/doctrees/" + kind,

--- a/noxfile.py
+++ b/noxfile.py
@@ -145,8 +145,7 @@ def docs(session: nox.Session) -> None:
         return [
             "sphinx-build",
             "--keep-going",
-            "--tag",
-            kind,
+            "--tag", kind,
             "-W",
             "-c", "docs/html",  # see note above
             "-d", "docs/build/doctrees/" + kind,


### PR DESCRIPTION
The goal is to allow a build of just the `man` pages with a minimal set of dependencies, like:

    sphinx-build \
        --tag man \
        -c docs/html \
        -d docs/build/doctrees/man \
        -b man \
        docs/man \
        docs/build/man

This is for the sake of people distributing `pip` who want to build the man pages (but not the HTML ones) along side the application.

This is an alternative to the approach proposed in[1] and similarly addresses[2]

Link: https://github.com/pypa/pip/pull/12900 [1]
Link: https://github.com/pypa/pip/issues/12881 [2]

Resolves https://github.com/pypa/pip/issues/12881.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
