### PR TITLE
Add build-project.py compatibility note

### DIFF
--- a/build-project.py
+++ b/build-project.py
@@ -36,6 +36,9 @@ def get_git_head_timestamp() -> str:
 def main() -> None:
     with tempfile.TemporaryDirectory() as build_env:
         env_builder = EnvBuilder(with_pip=True)
+        # If this venv creation step fails, you may be hitting
+        # https://github.com/astral-sh/python-build-standalone/issues/381
+        # Try running with a another Python distribution.
         env_builder.create(build_env)
         subprocess.run(
             [


### PR DESCRIPTION
Our build script uses `venv.create()`, which is broken in some cases when using python-build-standalone distributions.

Adding a comment mentioning this to avoid future head scratching.

https://github.com/astral-sh/python-build-standalone/issues/381
