### PR TITLE
Remove --no-python-version-warning as Python 2 is dead

### DIFF
--- a/news/13154.removal.rst
+++ b/news/13154.removal.rst
@@ -1,0 +1,2 @@
+Remove the ``no-python-version-warning`` flag as it was a relic of the Python
+2 sunset transition.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -29,7 +29,6 @@ from pip._internal.exceptions import (
     NetworkConnectionError,
     PreviousBuildDirError,
 )
-from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
 from pip._internal.utils.misc import get_prog, normalize_path
@@ -228,13 +227,5 @@ class Command(CommandContextMixIn):
                     options.cache_dir,
                 )
                 options.cache_dir = None
-
-        if options.no_python_version_warning:
-            deprecated(
-                reason="--no-python-version-warning is deprecated.",
-                replacement="to remove the flag as it's a no-op",
-                gone_in="25.1",
-                issue=13154,
-            )
 
         return self._run_wrapper(level_number, options, args)

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -983,17 +983,6 @@ list_exclude: Callable[..., Option] = partial(
     help="Exclude specified package from the output",
 )
 
-
-no_python_version_warning: Callable[..., Option] = partial(
-    Option,
-    "--no-python-version-warning",
-    dest="no_python_version_warning",
-    action="store_true",
-    default=False,
-    help="Silence deprecation warnings for upcoming unsupported Pythons.",
-)
-
-
 # Features that are now always on. A warning is printed if they are used.
 ALWAYS_ENABLED_FEATURES = [
     "truststore",  # always on since 24.2
@@ -1058,7 +1047,6 @@ general_group: Dict[str, Any] = {
         no_cache,
         disable_pip_version_check,
         no_color,
-        no_python_version_warning,
         use_new_feature,
         use_deprecated_feature,
     ],

--- a/tests/functional/test_warning.py
+++ b/tests/functional/test_warning.py
@@ -43,24 +43,6 @@ def test_deprecation_warnings_can_be_silenced(
     assert result.stderr == ""
 
 
-DEPRECATION_TEXT = "drop support for Python 2.7"
-CPYTHON_DEPRECATION_TEXT = "January 1st, 2020"
-
-
-def test_version_warning_is_not_shown_if_python_version_is_not_2(
-    script: PipTestEnvironment,
-) -> None:
-    result = script.pip("debug", allow_stderr_warning=True)
-    assert DEPRECATION_TEXT not in result.stderr, str(result)
-    assert CPYTHON_DEPRECATION_TEXT not in result.stderr, str(result)
-
-
-def test_flag_does_nothing_if_python_version_is_not_2(
-    script: PipTestEnvironment,
-) -> None:
-    script.pip("list", "--no-python-version-warning")
-
-
 @pytest.mark.skipif(
     sys.version_info >= (3, 10), reason="distutils is deprecated in 3.10+"
 )


### PR DESCRIPTION
Towards #13154 which is due for removal in the next release.