### PR TITLE
Fix locate_file() type hints for older Pythons

### DIFF
--- a/news/13181.bugfix.rst
+++ b/news/13181.bugfix.rst
@@ -1,0 +1,2 @@
+Restore opt-in ``importlib.metadata`` backend support on Python 3.10 and lower
+by fixing an unsupported type annotation.

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -11,6 +11,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Union,
     cast,
 )
 
@@ -96,7 +97,7 @@ class WheelDistribution(importlib.metadata.Distribution):
             raise UnsupportedWheel(error)
         return text
 
-    def locate_file(self, path: str | PathLike[str]) -> pathlib.Path:
+    def locate_file(self, path: Union[str, "PathLike[str]"]) -> pathlib.Path:
         # This method doesn't make sense for our in-memory wheel, but the API
         # requires us to define it.
         raise NotImplementedError


### PR DESCRIPTION
🤦

See https://github.com/pypa/pip/pull/11685#discussion_r1929802395.

Admittedly, `_PIP_USE_IMPORTLIB_METADATA` is probably pretty rare and the backend seems to be broken on the older Pythons already, but it can work in some limited situations. Unless people complain on mass, this doesn't warrant a bugfix release.
