### PR TITLE
Enable linting rule FA102 (future-required-type-annotation)

### DIFF
--- a/build-project.py
+++ b/build-project.py
@@ -7,13 +7,14 @@ import venv
 from os import PathLike
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Union
 
 
 class EnvBuilder(venv.EnvBuilder):
     """A subclass of venv.EnvBuilder that exposes the python executable command."""
 
     def ensure_directories(
-        self, env_dir: str | bytes | PathLike[str] | PathLike[bytes]
+        self, env_dir: Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
     ) -> SimpleNamespace:
         context = super().ensure_directories(env_dir)
         self.env_exec_cmd = context.env_exec_cmd

--- a/news/13182.trivial.rst
+++ b/news/13182.trivial.rst
@@ -1,0 +1,1 @@
+Enabling linting rule FA102.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ select = [
     "W",
     "RUF100",
     "UP",
-    "FA102",
+    "FA102",  # future-required-type-annotation
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ select = [
     "W",
     "RUF100",
     "UP",
+    "FA102",
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
This catches a common error when developing for pip, which is that you use PEP 585- and PEP 604-style type annotations because your local environment is Python 3.11+, but pip currently supports back to Python 3.8.

I have often done this myself, and it usually gets caught in CI when running the test suite, but with this rule it would get caught much earlier, either locally in pre-commit, or as part of the pre-commit CI test.

Note, that while [the rule](https://docs.astral.sh/ruff/rules/future-required-type-annotation/) suggests using `from __future__ import annotations` it is not marked as safe so will not automatically suggest it, and currently pip coding style is to simply avoid PEP 585- and PEP 604-style type annotations.

This PR is waiting for https://github.com/pypa/pip/pull/13181 to land, as I didn't want to clash with that PR.