### PR TITLE
Fix issue 12769 mimetypes windows error

### DIFF
--- a/news/12769.bugfix.rst
+++ b/news/12769.bugfix.rst
@@ -1,1 +1,1 @@
-Fixes `[WinError 5] Access is denied` when `mimetypes` fails to read `HKEY_CLASSES_ROOT`.
+Gracefully handle Windows registry access errors while guessing the MIME type of a file.

--- a/news/12769.bugfix.rst
+++ b/news/12769.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes `[WinError 5] Access is denied` when `mimetypes` fails to read `HKEY_CLASSES_ROOT`.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -88,13 +88,11 @@ class File:
 
     def __post_init__(self) -> None:
         if self.content_type is None:
+            # Try to guess the file's MIME type. If the system MIME tables
+            # can't be loaded, give up.
             try:
                 self.content_type = mimetypes.guess_type(self.path)[0]
             except OSError:
-                # Thown when `mimetypes` can't access a key inside
-                # `HKEY_CLASSES_ROOT` on Windows. We can safely ignore
-                # this because `pip/_internal/utils/unpacking.py#L309 unpack_file()`
-                # can handle content_type being None and it is not used anywhere else.
                 pass
 
 

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -88,7 +88,14 @@ class File:
 
     def __post_init__(self) -> None:
         if self.content_type is None:
-            self.content_type = mimetypes.guess_type(self.path)[0]
+            try:
+                self.content_type = mimetypes.guess_type(self.path)[0]
+            except OSError:
+                # Thown when `mimetypes` can't access a key inside
+                # `HKEY_CLASSES_ROOT` on Windows. We can safely ignore
+                # this because `pip/_internal/utils/unpacking.py#L309 unpack_file()`
+                # can handle content_type being None and it is not used anywhere else.
+                pass
 
 
 def get_http_url(


### PR DESCRIPTION
Fixes #12769 by ignoring the error `mimetypes` raises and keeping `content_type` as `None`.

The only function referencing this variable is [`unpack_url(...)`](https://github.com/pypa/pip/blob/main/src/pip/_internal/operations/prepare.py#L180) calling [`unpack_file()`](https://github.com/pypa/pip/blob/main/src/pip/_internal/utils/unpacking.py#L309) which already accepts `None` as the content type as is.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
