### PR TITLE
Make `pip index versions` no longer experimental

### DIFF
--- a/docs/man/commands/index.rst
+++ b/docs/man/commands/index.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+===========
+pip-index
+===========
+
+Description
+***********
+
+.. pip-command-description:: index
+
+Usage
+*****
+
+.. pip-command-usage:: index
+
+Options
+*******
+
+.. pip-command-options:: index

--- a/news/13188.feature.rst
+++ b/news/13188.feature.rst
@@ -1,0 +1,2 @@
+Remove `experimental` warning from `pip index versions` command and
+add json output support.


### PR DESCRIPTION
See https://github.com/pypa/pip/issues/13188

This PR will:
1. remove the warning log
2. add the docs
3. add a `--json` flag