### PR TITLE
perf: pass `--no-compile` for build dependencies

### DIFF
--- a/news/7294.feature.rst
+++ b/news/7294.feature.rst
@@ -1,0 +1,2 @@
+Build environment dependencies are no longer compiled to bytecode during
+installation for a minor performance improvement.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -242,6 +242,10 @@ class BuildEnvironment:
             prefix.path,
             "--no-warn-script-location",
             "--disable-pip-version-check",
+            # As the build environment is ephemeral, it's wasteful to
+            # pre-compile everything, especially as not every Python
+            # module will be used/compiled in most cases.
+            "--no-compile",
             # The prefix specified two lines above, thus
             # target from config file or env var should be ignored
             "--target",


### PR DESCRIPTION
As the build environment is ephemeral, it's wasteful to pre-compile everything, especially as not every Python module will be used/compiled in most cases. In addition, the argument is that compilation ensures read-only installations are not slower than necessary is moot as the build environment is by design writable.

This saves ~200ms while installing setuptools while building pip itself. For context, a `pip install .` (with `--no-index` and `--find-links`) takes 3400ms and `pip wheel .` takes 2200ms on main.

So, it's not a major win, but it's also nothing to sneeze at. Packages using smaller backends, like flit, will likely see smaller improvements.

Towards #7294 

---

To try this out for yourself, you can use `--no-index --find-links tests/data/common_wheels/` to pull setuptools from disk and eliminate the network as variable. 