### PR TITLE
Don't pass --cert to build subprocesses unless also given on CLI

### DIFF
--- a/news/13186.bugfix.rst
+++ b/news/13186.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression where truststore would never be used while installing build dependencies.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -11,7 +11,6 @@ from collections import OrderedDict
 from types import TracebackType
 from typing import TYPE_CHECKING, Iterable, List, Optional, Set, Tuple, Type, Union
 
-from pip._vendor.certifi import where
 from pip._vendor.packaging.version import Version
 
 from pip import __file__ as pip_location
@@ -246,8 +245,6 @@ class BuildEnvironment:
             # target from config file or env var should be ignored
             "--target",
             "",
-            "--cert",
-            finder.custom_cert or where(),
         ]
         if logger.getEffectiveLevel() <= logging.DEBUG:
             args.append("-vv")
@@ -276,6 +273,8 @@ class BuildEnvironment:
             args.extend(["--proxy", finder.proxy])
         for host in finder.trusted_hosts:
             args.extend(["--trusted-host", host])
+        if finder.custom_cert:
+            args.extend(["--cert", finder.custom_cert])
         if finder.client_cert:
             args.extend(["--client-cert", finder.client_cert])
         if finder.allow_all_prereleases:


### PR DESCRIPTION
This fixes a regression introduced by commit 34fc0e20bd91f7facd1. After that patch, --cert would always be given to the nested pip call, either pointing to pip's CA bundle, or to whatever the user had set on the CLI. This means truststore is always disabled... which is bad.

We used to have to do some shenanigans to pass the CA bundle to the subprocess as certifi doesn't (didn't?) really play nice when in a zipfile. Regardless, we stopped packing pip into a zipfile to provision the build environment a while ago, so we can simply do the normal thing and pass --cert when it's actually given. Otherwise, the subprocess will find its CA bundle without fuss.

There apparently aren't any truststore tests (as testing system CAs is probably a pain), so I didn't add one here either. At some point, we should, though.

Fixes #13186.
