### PR TITLE
Cache truststore SSLContext as `load_verify_locations()` is slow

### DIFF
--- a/src/pip/_internal/cli/index_command.py
+++ b/src/pip/_internal/cli/index_command.py
@@ -9,6 +9,7 @@ so commands which don't always hit the network (e.g. list w/o --outdated or
 import logging
 import os
 import sys
+from functools import lru_cache
 from optparse import Values
 from typing import TYPE_CHECKING, List, Optional
 
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@lru_cache
 def _create_truststore_ssl_context() -> Optional["SSLContext"]:
     if sys.version_info < (3, 10):
         logger.debug("Disabling truststore because Python version isn't 3.10+")


### PR DESCRIPTION
SSLContext can be reused across connections [as per the Python docs](https://docs.python.org/3/library/ssl.html#ssl.SSLContext):

> SSLContext is designed to be shared and used by multiple connections. Thus, it is thread-safe as long as it is not reconfigured after being used by a connection.

In addition, [requests has been using a global SSLContext](https://github.com/psf/requests/blob/0e322af87745eff34caffe4df68456ebc20d9068/src/requests/adapters.py#L80-L83) and the sky hasn't fallen on them so I'm going to say this is pretty safe.

See also https://github.com/python/cpython/issues/95031.