### PR TITLE
Add repr to RequiresPythonCandidate

### DIFF
--- a/news/13216.trivial.rst
+++ b/news/13216.trivial.rst
@@ -1,0 +1,1 @@
+ Add repr to RequiresPythonCandidate.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -552,6 +552,9 @@ class RequiresPythonCandidate(Candidate):
     def __str__(self) -> str:
         return f"Python {self._version}"
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._version!r})"
+
     @property
     def project_name(self) -> NormalizedName:
         return REQUIRES_PYTHON_IDENTIFIER


### PR DESCRIPTION
This is very minor, but not having a repr creates diffs when you compare logs with `PIP_RESOLVER_DEBUG` enabled, e.g. https://github.com/pypa/pip/pull/13160#issuecomment-2645843220.