### PR TITLE
make `--no-input` flag work with install `git+http` and `git+ssh` schemes

### DIFF
--- a/news/12718.bugfix.rst
+++ b/news/12718.bugfix.rst
@@ -1,0 +1,1 @@
+make --no-input flag work with install git+http and git+ssh schemes

--- a/news/12718.bugfix.rst
+++ b/news/12718.bugfix.rst
@@ -1,1 +1,1 @@
-make --no-input flag work with install git+http and git+ssh schemes
+Disable Git and SSH prompts when ``--no-input`` is passed.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -274,7 +274,7 @@ class Git(VersionControl):
         if os.environ.get("PIP_NO_INPUT"):
             extra_environ = {
                 "GIT_TERMINAL_PROMPT": "0",
-                "GIT_SSH_COMMAND": "ssh -oBatchMode=yes"
+                "GIT_SSH_COMMAND": "ssh -oBatchMode=yes",
             }
         else:
             extra_environ = None
@@ -290,10 +290,13 @@ class Git(VersionControl):
                     *flags,
                     url,
                     dest,
-                ), extra_environ=extra_environ,
+                ),
+                extra_environ=extra_environ,
             )
         else:
-            self.run_command(make_command("clone", *flags, url, dest), extra_environ=extra_environ)
+            self.run_command(
+                make_command("clone", *flags, url, dest), extra_environ=extra_environ
+            )
 
         if rev_options.rev:
             # Then a specific revision was requested.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -270,6 +270,7 @@ class Git(VersionControl):
             flags = ()
         else:
             flags = ("--verbose", "--progress")
+        extra_environ = {"GIT_TERMINAL_PROMPT": str(not os.environ.get("PIP_NO_INPUT"))}
         if self.get_git_version() >= (2, 17):
             # Git added support for partial clone in 2.17
             # https://git-scm.com/docs/partial-clone
@@ -281,10 +282,10 @@ class Git(VersionControl):
                     *flags,
                     url,
                     dest,
-                )
+                ), extra_environ=extra_environ,
             )
         else:
-            self.run_command(make_command("clone", *flags, url, dest))
+            self.run_command(make_command("clone", *flags, url, dest), extra_environ=extra_environ)
 
         if rev_options.rev:
             # Then a specific revision was requested.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -270,7 +270,15 @@ class Git(VersionControl):
             flags = ()
         else:
             flags = ("--verbose", "--progress")
-        extra_environ = {"GIT_TERMINAL_PROMPT": str(not os.environ.get("PIP_NO_INPUT"))}
+
+        if os.environ.get("PIP_NO_INPUT"):
+            extra_environ = {
+                "GIT_TERMINAL_PROMPT": "0",
+                "GIT_SSH_COMMAND": "ssh -oBatchMode=yes"
+            }
+        else:
+            extra_environ = None
+
         if self.get_git_version() >= (2, 17):
             # Git added support for partial clone in 2.17
             # https://git-scm.com/docs/partial-clone

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -279,7 +279,6 @@ class Git(VersionControl):
             flags = ()
         else:
             flags = ("--verbose", "--progress")
-
         if self.get_git_version() >= (2, 17):
             # Git added support for partial clone in 2.17
             # https://git-scm.com/docs/partial-clone

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -348,9 +348,8 @@ def test_do_not_prompt_for_authentication_git(
     from a git http url requiring authentication
     """
     server = make_mock_server()
-    script.environ["GIT_ASKPASS"] = (
-        ""  # Disable vscode user/password prompt, will make tests fail inside vscode
-    )
+    # Disable vscode user/password prompt, will make tests fail inside vscode
+    script.environ["GIT_ASKPASS"] = ""
 
     # Return 401 on all URLs
     server.mock.side_effect = lambda _, __: authorization_response(

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -341,6 +341,35 @@ def test_do_not_prompt_for_authentication(
     assert "ERROR: HTTP error 401" in result.stderr
 
 
+def test_do_not_prompt_for_authentication_git(
+    script: PipTestEnvironment, data: TestData, cert_factory: CertFactory
+) -> None:
+    """Test behaviour if --no-input option is given while installing
+    from a git url requiring authentication
+    """
+    server = make_mock_server()
+    script.environ["GIT_ASKPASS"] = (
+        ""  # Disable vscode user/password prompt, will make tests fail inside vscode
+    )
+
+    # Return 401 on all URLs
+    server.mock.side_effect = lambda _, __: authorization_response(
+        data.packages / "simple-3.0.tar.gz"
+    )
+
+    url = f"git+http://{server.host}:{server.port}/simple"
+
+    with server_running(server):
+        result = script.pip(
+            "install",
+            url,
+            "--no-input",
+            expect_error=True,
+        )
+
+    assert "terminal prompts disabled" in result.stderr
+
+
 @pytest.fixture(params=(True, False), ids=("interactive", "noninteractive"))
 def interactive(request: pytest.FixtureRequest) -> bool:
     return request.param

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -345,7 +345,7 @@ def test_do_not_prompt_for_authentication_git(
     script: PipTestEnvironment, data: TestData, cert_factory: CertFactory
 ) -> None:
     """Test behaviour if --no-input option is given while installing
-    from a git url requiring authentication
+    from a git http url requiring authentication
     """
     server = make_mock_server()
     script.environ["GIT_ASKPASS"] = (


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fix https://github.com/pypa/pip/issues/12718
