### PR TITLE
Add wheel build tag to pip list columns output

### DIFF
--- a/news/5210.feature.rst
+++ b/news/5210.feature.rst
@@ -1,0 +1,1 @@
+Display wheel build tag in ``pip list`` columns output if set.

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -324,10 +324,6 @@ def format_for_columns(
     if running_outdated:
         header.extend(["Latest", "Type"])
 
-    has_editables = any(x.editable for x in pkgs)
-    if has_editables:
-        header.append("Editable project location")
-
     def wheel_build_tag(dist: BaseDistribution) -> Optional[str]:
         try:
             wheel_file = dist.read_text("WHEEL")
@@ -345,6 +341,10 @@ def format_for_columns(
     if options.verbose >= 1:
         header.append("Installer")
 
+    has_editables = any(x.editable for x in pkgs)
+    if has_editables:
+        header.append("Editable project location")
+
     data = []
     for i, proj in enumerate(pkgs):
         # if we're working on the 'outdated' list, separate out the
@@ -355,11 +355,11 @@ def format_for_columns(
             row.append(str(proj.latest_version))
             row.append(proj.latest_filetype)
 
-        if has_editables:
-            row.append(proj.editable_project_location or "")
-
         if has_build_tags:
             row.append(build_tags[i] or "")
+
+        if has_editables:
+            row.append(proj.editable_project_location or "")
 
         if options.verbose >= 1:
             row.append(proj.location or "")

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from email.parser import Parser
 from optparse import Values
 from typing import TYPE_CHECKING, Generator, List, Optional, Sequence, Tuple, cast
 
@@ -327,13 +328,25 @@ def format_for_columns(
     if has_editables:
         header.append("Editable project location")
 
+    def wheel_build_tag(dist: BaseDistribution) -> Optional[str]:
+        try:
+            wheel_file = dist.read_text("WHEEL")
+        except FileNotFoundError:
+            return None
+        return Parser().parsestr(wheel_file).get("Build")
+
+    build_tags = [wheel_build_tag(p) for p in pkgs]
+    has_build_tags = any(build_tags)
+    if has_build_tags:
+        header.append("Build")
+
     if options.verbose >= 1:
         header.append("Location")
     if options.verbose >= 1:
         header.append("Installer")
 
     data = []
-    for proj in pkgs:
+    for i, proj in enumerate(pkgs):
         # if we're working on the 'outdated' list, separate out the
         # latest_version and type
         row = [proj.raw_name, proj.raw_version]
@@ -344,6 +357,9 @@ def format_for_columns(
 
         if has_editables:
             row.append(proj.editable_project_location or "")
+
+        if has_build_tags:
+            row.append(build_tags[i] or "")
 
         if options.verbose >= 1:
             row.append(proj.location or "")

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -12,6 +12,7 @@ from tests.lib import (
     TestData,
     _create_test_package,
     create_test_package_with_setup,
+    make_wheel,
     wheel,
 )
 from tests.lib.direct_url import get_created_direct_url_path
@@ -751,3 +752,16 @@ def test_list_pep610_editable(script: PipTestEnvironment) -> None:
             break
     else:
         pytest.fail("package 'testpkg' not found in pip list result")
+
+
+def test_list_wheel_build(script: PipTestEnvironment) -> None:
+    package = make_wheel(
+        name="package",
+        version="3.0",
+        wheel_metadata_updates={"Build": "123"},
+    ).save_to_dir(script.scratch_path)
+    script.pip("install", package, "--no-index")
+
+    result = script.pip("list")
+    assert "Build" in result.stdout, str(result)
+    assert "123" in result.stdout, str(result)


### PR DESCRIPTION
Rebased version of https://github.com/pypa/pip/pull/11531 with an update to the news entry and tweaks to the variable names (builds -> build tag). Fixes https://github.com/pypa/pip/issues/5210.

This is how this looks:

```
Package                       Version         Build
----------------------------- --------------- ------

scripttest                    1.3
setuptools                    75.1.0
six                           1.16.0          1build
```

If a local editable is installed:

```
Package                       Version         Editable project location                   Build
----------------------------- --------------- ------------------------------------------- ------
pip                           25.1.dev0       /home/ichard26/dev/oss/pip
scripttest                    1.3
setuptools                    75.1.0
six                           1.16.0                                                      1build
```

To test this locally, the easiest way is probably to download a wheel, edit its WHEEL metadata file to add a `Build: 2imabuildtag` field, and install it. 