### PR TITLE
Simplify _should_build

### DIFF
--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -16,7 +16,7 @@ from pip._internal.req.req_install import (
 )
 from pip._internal.utils.misc import ensure_dir, normalize_path
 from pip._internal.utils.temp_dir import TempDirectory
-from pip._internal.wheel_builder import build, should_build_for_wheel_command
+from pip._internal.wheel_builder import build
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +150,7 @@ class WheelCommand(RequirementCommand):
         for req in requirement_set.requirements.values():
             if req.is_wheel:
                 preparer.save_linked_requirement(req)
-            elif should_build_for_wheel_command(req):
+            else:
                 reqs_to_build.append(req)
 
         preparer.prepare_linked_requirements_more(requirement_set.requirements.values())

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -50,8 +50,7 @@ def _should_build(
     if req.is_wheel:
         return False
 
-    if not req.source_dir:
-        return False
+    assert req.source_dir
 
     if req.editable:
         # we only build PEP 660 editable requirements

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -43,25 +43,12 @@ def _contains_egg_info(s: str) -> bool:
 
 def _should_build(
     req: InstallRequirement,
-    need_wheel: bool,
 ) -> bool:
     """Return whether an InstallRequirement should be built into a wheel."""
     assert not req.constraint
 
     if req.is_wheel:
-        if need_wheel:
-            logger.info(
-                "Skipping %s, due to already being wheel.",
-                req.name,
-            )
         return False
-
-    if need_wheel:
-        # i.e. pip wheel, not pip install
-        return True
-
-    # From this point, this concerns the pip install command only
-    # (need_wheel=False).
 
     if not req.source_dir:
         return False
@@ -76,7 +63,7 @@ def _should_build(
 def should_build_for_install_command(
     req: InstallRequirement,
 ) -> bool:
-    return _should_build(req, need_wheel=False)
+    return _should_build(req)
 
 
 def _should_cache(

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -73,12 +73,6 @@ def _should_build(
     return True
 
 
-def should_build_for_wheel_command(
-    req: InstallRequirement,
-) -> bool:
-    return _should_build(req, need_wheel=True)
-
-
 def should_build_for_install_command(
     req: InstallRequirement,
 ) -> bool:

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -46,9 +46,8 @@ def _should_build(
     need_wheel: bool,
 ) -> bool:
     """Return whether an InstallRequirement should be built into a wheel."""
-    if req.constraint:
-        # never build requirements that are merely constraints
-        return False
+    assert not req.constraint
+
     if req.is_wheel:
         if need_wheel:
             logger.info(

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -51,8 +51,6 @@ class ReqMock:
         # We build, whether pep 517 is enabled or not.
         (ReqMock(use_pep517=True), True),
         (ReqMock(use_pep517=False), True),
-        # We don't build constraints.
-        (ReqMock(constraint=True), False),
         # We don't build reqs that are already wheels.
         (ReqMock(is_wheel=True), False),
         # We build editables if the backend supports PEP 660.
@@ -90,7 +88,6 @@ def test_should_build_for_install_command(req: ReqMock, expected: bool) -> None:
     "req, expected",
     [
         (ReqMock(), True),
-        (ReqMock(constraint=True), False),
         (ReqMock(is_wheel=True), False),
         (ReqMock(editable=True, use_pep517=False), True),
         (ReqMock(editable=True, use_pep517=True), True),

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -87,24 +87,6 @@ def test_should_build_for_install_command(req: ReqMock, expected: bool) -> None:
 @pytest.mark.parametrize(
     "req, expected",
     [
-        (ReqMock(), True),
-        (ReqMock(is_wheel=True), False),
-        (ReqMock(editable=True, use_pep517=False), True),
-        (ReqMock(editable=True, use_pep517=True), True),
-        (ReqMock(source_dir=None), True),
-        (ReqMock(link=Link("git+https://g.c/org/repo")), True),
-    ],
-)
-def test_should_build_for_wheel_command(req: ReqMock, expected: bool) -> None:
-    should_build = wheel_builder.should_build_for_wheel_command(
-        cast(InstallRequirement, req)
-    )
-    assert should_build is expected
-
-
-@pytest.mark.parametrize(
-    "req, expected",
-    [
         (ReqMock(editable=True, use_pep517=False), False),
         (ReqMock(editable=True, use_pep517=True), False),
         (ReqMock(source_dir=None), False),

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -63,8 +63,6 @@ class ReqMock:
             ReqMock(editable=True, use_pep517=True, supports_pyproject_editable=False),
             False,
         ),
-        # We don't build if there is no source dir (whatever that means!).
-        (ReqMock(source_dir=None), False),
         # By default (i.e. when binaries are allowed), VCS requirements
         # should be built in install mode.
         (


### PR DESCRIPTION
This is a suite of simple commits to simplify `_should_build`, as the circumstances in which it is invoked have evolved over time.

Each individual commit explains the reasoning.

towards #11457



