### PR TITLE
Increase wait and rerun amount for flaky network tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def pytest_collection_modifyitems(config: Config, items: List[pytest.Function]) 
         if "CI" in os.environ:
             # Mark network tests as flaky
             if item.get_closest_marker("network") is not None:
-                item.add_marker(pytest.mark.flaky(reruns=3, reruns_delay=2))
+                item.add_marker(pytest.mark.flaky(reruns=5, reruns_delay=5))
 
         if (
             item.get_closest_marker("incompatible_with_venv")


### PR DESCRIPTION
Should help with https://github.com/pypa/pip/issues/13153

Launchpad is known to be occasionally flaky and the current wait / rerun amount isn't cutting it. If a retry can wait/try enough to complete it saves more time than rerunning a test.

It also doesn't significantly increase the amount of time to fail, assuming each timeout is a few seconds, and each wait is 5 seconds, we're still only talking about 35 seconds to fail.

If we continue to see more failures, it may be worth considering remove the launchpad tests, while keeping local bzr tests.