### PR TITLE
Lazily prepare distribution for candidate

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -138,7 +138,6 @@ class _InstallRequirementBackedCandidate(Candidate):
         found remote link (e.g. from pypi.org).
     """
 
-    dist: BaseDistribution
     is_installed = False
 
     def __init__(
@@ -156,8 +155,16 @@ class _InstallRequirementBackedCandidate(Candidate):
         self._ireq = ireq
         self._name = name
         self._version = version
-        self.dist = self._prepare()
+        self._dist: Optional[BaseDistribution] = None
         self._hash: Optional[int] = None
+
+    @property
+    def dist(self) -> BaseDistribution:
+        if self._dist is not None:
+            return self._dist
+
+        self._dist = self._prepare()
+        return self._dist
 
     def __str__(self) -> str:
         return f"{self.name} {self.version}"


### PR DESCRIPTION
Often during resolution it would be useful to check the name & version of a potential distribution, but it's not required to actually prepare the distribution if the version doesn't match the requirements.

I’m still investigating if this is the best solution, but this certainly makes writing test cases for the resolver code easier.
