### PR TITLE
Implement PEP 753 normalization for Home-Page fallback

### DIFF
--- a/news/13135.feature.rst
+++ b/news/13135.feature.rst
@@ -1,0 +1,3 @@
+Use :pep:`753` "Well-known Project URLs in Metadata" normalization rules when
+identifying an equivalent project URL to replace a missing ``Home-Page`` field
+in ``pip show``.

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -1,4 +1,5 @@
 import logging
+import string
 from optparse import Values
 from typing import Generator, Iterable, Iterator, List, NamedTuple, Optional
 
@@ -11,6 +12,13 @@ from pip._internal.metadata import BaseDistribution, get_default_environment
 from pip._internal.utils.misc import write_output
 
 logger = logging.getLogger(__name__)
+
+
+def normalize_project_url_label(label: str) -> str:
+    # This logic is from PEP 753 (Well-known Project URLs in Metadata).
+    chars_to_remove = string.punctuation + string.whitespace
+    removal_map = str.maketrans("", "", chars_to_remove)
+    return label.translate(removal_map).lower()
 
 
 class ShowCommand(Command):
@@ -135,13 +143,9 @@ def search_packages_info(query: List[str]) -> Generator[_PackageInfo, None, None
         if not homepage:
             # It's common that there is a "homepage" Project-URL, but Home-page
             # remains unset (especially as PEP 621 doesn't surface the field).
-            #
-            # This logic was taken from PyPI's codebase.
             for url in project_urls:
                 url_label, url = url.split(",", maxsplit=1)
-                normalized_label = (
-                    url_label.casefold().replace("-", "").replace("_", "").strip()
-                )
+                normalized_label = normalize_project_url_label(url_label)
                 if normalized_label == "homepage":
                     homepage = url.strip()
                     break

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -408,7 +408,8 @@ def test_show_deduplicate_requirements(script: PipTestEnvironment) -> None:
 
 
 @pytest.mark.parametrize(
-    "project_url", ["Home-page", "home-page", "Homepage", "homepage"]
+    "project_url",
+    ["Home-page", "home-page", "Homepage", "homepage", "home_PAGE", "home page"],
 )
 def test_show_populate_homepage_from_project_urls(
     script: PipTestEnvironment, project_url: str


### PR DESCRIPTION
We treat "homepage" as a well-known project URL, using it to populate the Home-Page core metadata field if it's undefined. This patch updates the normalization logic to follow PEP 753.

**Feedback wanted**: The logic emitting the raw project URLs was left unchanged as we don't really care for well-known vs. boring URLs here. I believe this is the right call, but I can be convinced to also apply normalization here (although that could break anyone who is using `pip show` to inspect metadata which is actually a valid use-case as the show output format is documented.)

```
$ pip show pip --verbose
Name: pip
Version: 25.1.dev0
Summary: The PyPA recommended tool for installing Python packages.
Home-page: https://pip.pypa.io/
Author: 
Author-email: The pip developers <distutils-sig@python.org>
License: MIT
Location: /home/ichard26/dev/oss/pip/venv/lib/python3.12/site-packages
Editable project location: /home/ichard26/dev/oss/pip
Requires: 
Required-by: flit
Metadata-Version: 2.2
Installer: pip
Classifiers:
  [... a bunch of classifiers]
Entry-points:
  [console_scripts]
  pip = pip._internal.cli.main:main
  pip3 = pip._internal.cli.main:main
Project-URLs:
  Homepage, https://pip.pypa.io/
  Documentation, https://pip.pypa.io
  Source, https://github.com/pypa/pip
  Changelog, https://pip.pypa.io/en/stable/news/
```