### PR TITLE
Remove even moar legacy Python 3.8 code

### DIFF
--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -5,7 +5,7 @@ import textwrap
 import xmlrpc.client
 from collections import OrderedDict
 from optparse import Values
-from typing import TYPE_CHECKING, Dict, List, Optional, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 from pip._vendor.packaging.version import parse as parse_version
 
@@ -19,12 +19,11 @@ from pip._internal.network.xmlrpc import PipXmlrpcTransport
 from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import write_output
 
-if TYPE_CHECKING:
 
-    class TransformedHit(TypedDict):
-        name: str
-        summary: str
-        versions: List[str]
+class TransformedHit(TypedDict):
+    name: str
+    summary: str
+    versions: List[str]
 
 
 logger = logging.getLogger(__name__)

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -2,16 +2,11 @@ import contextlib
 import functools
 import os
 import sys
-from typing import TYPE_CHECKING, List, Optional, Type, cast
+from typing import List, Literal, Optional, Protocol, Type, cast
 
 from pip._internal.utils.misc import strtobool
 
 from .base import BaseDistribution, BaseEnvironment, FilesystemWheel, MemoryWheel, Wheel
-
-if TYPE_CHECKING:
-    from typing import Literal, Protocol
-else:
-    Protocol = object
 
 __all__ = [
     "BaseDistribution",

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -13,10 +13,10 @@ import sys
 import warnings
 from base64 import urlsafe_b64encode
 from email.message import Message
+from io import StringIO
 from itertools import chain, filterfalse, starmap
 from typing import (
     IO,
-    TYPE_CHECKING,
     Any,
     BinaryIO,
     Callable,
@@ -50,7 +50,7 @@ from pip._internal.metadata import (
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
 from pip._internal.models.scheme import SCHEME_KEYS, Scheme
 from pip._internal.utils.filesystem import adjacent_tmp_file, replace
-from pip._internal.utils.misc import StreamWrapper, ensure_dir, hash_file, partition
+from pip._internal.utils.misc import ensure_dir, hash_file, partition
 from pip._internal.utils.unpacking import (
     current_umask,
     is_within_directory,
@@ -59,15 +59,14 @@ from pip._internal.utils.unpacking import (
 )
 from pip._internal.utils.wheel import parse_wheel
 
-if TYPE_CHECKING:
 
-    class File(Protocol):
-        src_record_path: "RecordPath"
-        dest_path: str
-        changed: bool
+class File(Protocol):
+    src_record_path: "RecordPath"
+    dest_path: str
+    changed: bool
 
-        def save(self) -> None:
-            pass
+    def save(self) -> None:
+        pass
 
 
 logger = logging.getLogger(__name__)
@@ -608,9 +607,7 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
 
     # Compile all of the pyc files for the installed files
     if pycompile:
-        with contextlib.redirect_stdout(
-            StreamWrapper.from_stream(sys.stdout)
-        ) as stdout:
+        with contextlib.redirect_stdout(StringIO()) as stdout:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore")
                 for path in pyc_source_file_paths():

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -11,7 +11,6 @@ import sysconfig
 import urllib.parse
 from dataclasses import dataclass
 from functools import partial
-from io import StringIO
 from itertools import filterfalse, tee, zip_longest
 from pathlib import Path
 from types import FunctionType, TracebackType
@@ -26,7 +25,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    TextIO,
     Tuple,
     Type,
     TypeVar,
@@ -373,22 +371,6 @@ def is_local(path: str) -> bool:
 
 def write_output(msg: Any, *args: Any) -> None:
     logger.info(msg, *args)
-
-
-class StreamWrapper(StringIO):
-    orig_stream: TextIO
-
-    @classmethod
-    def from_stream(cls, orig_stream: TextIO) -> "StreamWrapper":
-        ret = cls()
-        ret.orig_stream = orig_stream
-        return ret
-
-    # compileall.compile_dir() needs stdout.encoding to print to stdout
-    # type ignore is because TextIOBase.encoding is writeable
-    @property
-    def encoding(self) -> str:  # type: ignore
-        return self.orig_stream.encoding
 
 
 # Simulates an enum


### PR DESCRIPTION
I wasn't expecting to be dropping Python 3.8 in this release cycle (see #13185 for discussion), but if this is the direction we're going in, here's some more legacy code that can be removed. This will help simplify my parallel bytecode compilation work.
