### PR TITLE
Fix wheel name normalization in tests

### DIFF
--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -291,7 +291,7 @@ def test_pip_second_command_line_interface_works(
     args.extend(["install", "INITools==0.2"])
     args.extend(["-f", os.fspath(data.packages)])
     result = script.run(*args)
-    dist_info_folder = script.site_packages / "INITools-0.2.dist-info"
+    dist_info_folder = script.site_packages / "initools-0.2.dist-info"
     initools_folder = script.site_packages / "initools"
     result.did_create(dist_info_folder)
     result.did_create(initools_folder)
@@ -363,7 +363,7 @@ def test_basic_install_from_pypi(script: PipTestEnvironment) -> None:
     Test installing a package from PyPI.
     """
     result = script.pip("install", "INITools==0.2")
-    dist_info_folder = script.site_packages / "INITools-0.2.dist-info"
+    dist_info_folder = script.site_packages / "initools-0.2.dist-info"
     initools_folder = script.site_packages / "initools"
     result.did_create(dist_info_folder)
     result.did_create(initools_folder)
@@ -555,7 +555,7 @@ def test_basic_install_from_local_directory(
     args.append(os.fspath(to_install))
     result = script.pip(*args)
     fspkg_folder = script.site_packages / "fspkg"
-    dist_info_folder = script.site_packages / "FSPkg-0.1.dev0.dist-info"
+    dist_info_folder = script.site_packages / "fspkg-0.1.dev0.dist-info"
     result.did_create(fspkg_folder)
     result.did_create(dist_info_folder)
 
@@ -577,7 +577,7 @@ def test_basic_install_relative_directory(
     """
     Test installing a requirement using a relative path.
     """
-    dist_info_folder = script.site_packages / "FSPkg-0.1.dev0.dist-info"
+    dist_info_folder = script.site_packages / "fspkg-0.1.dev0.dist-info"
     egg_link_file = script.site_packages / "FSPkg.egg-link"
     package_folder = script.site_packages / "fspkg"
 
@@ -871,7 +871,7 @@ def test_install_from_local_directory_with_in_tree_build(
     assert not in_tree_build_dir.exists()
     result = script.pip("install", to_install)
     fspkg_folder = script.site_packages / "fspkg"
-    dist_info_folder = script.site_packages / "FSPkg-0.1.dev0.dist-info"
+    dist_info_folder = script.site_packages / "fspkg-0.1.dev0.dist-info"
     result.did_create(fspkg_folder)
     result.did_create(dist_info_folder)
     assert in_tree_build_dir.exists()
@@ -1025,7 +1025,7 @@ def test_install_curdir(script: PipTestEnvironment, data: TestData) -> None:
         rmtree(egg_info)
     result = script.pip("install", curdir, cwd=run_from)
     fspkg_folder = script.site_packages / "fspkg"
-    dist_info_folder = script.site_packages / "FSPkg-0.1.dev0.dist-info"
+    dist_info_folder = script.site_packages / "fspkg-0.1.dev0.dist-info"
     result.did_create(fspkg_folder)
     result.did_create(dist_info_folder)
 
@@ -1037,7 +1037,7 @@ def test_install_pardir(script: PipTestEnvironment, data: TestData) -> None:
     run_from = data.packages.joinpath("FSPkg", "fspkg")
     result = script.pip("install", pardir, cwd=run_from)
     fspkg_folder = script.site_packages / "fspkg"
-    dist_info_folder = script.site_packages / "FSPkg-0.1.dev0.dist-info"
+    dist_info_folder = script.site_packages / "fspkg-0.1.dev0.dist-info"
     result.did_create(fspkg_folder)
     result.did_create(dist_info_folder)
 
@@ -1550,9 +1550,9 @@ def test_url_req_case_mismatch_no_index(
     )
 
     # only Upper-1.0.tar.gz should get installed.
-    dist_info_folder = script.site_packages / "Upper-1.0.dist-info"
+    dist_info_folder = script.site_packages / "upper-1.0.dist-info"
     result.did_create(dist_info_folder)
-    dist_info_folder = script.site_packages / "Upper-2.0.dist-info"
+    dist_info_folder = script.site_packages / "upper-2.0.dist-info"
     result.did_not_create(dist_info_folder)
 
 
@@ -1578,10 +1578,10 @@ def test_url_req_case_mismatch_file_index(
         "install", "--index-url", data.find_links3, Dinner, "requiredinner"
     )
 
-    # only Upper-1.0.tar.gz should get installed.
-    dist_info_folder = script.site_packages / "Dinner-1.0.dist-info"
+    # only Dinner-1.0.tar.gz should get installed.
+    dist_info_folder = script.site_packages / "dinner-1.0.dist-info"
     result.did_create(dist_info_folder)
-    dist_info_folder = script.site_packages / "Dinner-2.0.dist-info"
+    dist_info_folder = script.site_packages / "dinner-2.0.dist-info"
     result.did_not_create(dist_info_folder)
 
 
@@ -1602,9 +1602,9 @@ def test_url_incorrect_case_no_index(
     )
 
     # only Upper-2.0.tar.gz should get installed.
-    dist_info_folder = script.site_packages / "Upper-1.0.dist-info"
+    dist_info_folder = script.site_packages / "upper-1.0.dist-info"
     result.did_not_create(dist_info_folder)
-    dist_info_folder = script.site_packages / "Upper-2.0.dist-info"
+    dist_info_folder = script.site_packages / "upper-2.0.dist-info"
     result.did_create(dist_info_folder)
 
 
@@ -1624,10 +1624,10 @@ def test_url_incorrect_case_file_index(
         expect_stderr=True,
     )
 
-    # only Upper-2.0.tar.gz should get installed.
-    dist_info_folder = script.site_packages / "Dinner-1.0.dist-info"
+    # only Dinner-2.0.tar.gz should get installed.
+    dist_info_folder = script.site_packages / "dinner-1.0.dist-info"
     result.did_not_create(dist_info_folder)
-    dist_info_folder = script.site_packages / "Dinner-2.0.dist-info"
+    dist_info_folder = script.site_packages / "dinner-2.0.dist-info"
     result.did_create(dist_info_folder)
 
     # Should show index-url location in output
@@ -1798,7 +1798,7 @@ def test_install_builds_wheels(script: PipTestEnvironment, data: TestData) -> No
     # into the cache
     assert wheels != [], str(res)
     assert wheels == [
-        f"Upper-2.0-py{sys.version_info[0]}-none-any.whl",
+        f"upper-2.0-py{sys.version_info[0]}-none-any.whl",
     ]
 
 

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -86,7 +86,7 @@ def test_requirements_file(script: PipTestEnvironment) -> None:
         )
     )
     result = script.pip("install", "-r", script.scratch_path / "initools-req.txt")
-    result.did_create(script.site_packages / "INITools-0.2.dist-info")
+    result.did_create(script.site_packages / "initools-0.2.dist-info")
     result.did_create(script.site_packages / "initools")
     assert result.files_created[script.site_packages / other_lib_name].dir
     fn = f"{other_lib_name}-{other_lib_version}.dist-info"
@@ -130,7 +130,7 @@ def test_dependency_group(
             path = path(pyproject)
         arg = f"{path}:{groupname}"
     result = script.pip("install", "--group", arg)
-    result.did_create(script.site_packages / "INITools-0.2.dist-info")
+    result.did_create(script.site_packages / "initools-0.2.dist-info")
     result.did_create(script.site_packages / "initools")
     assert result.files_created[script.site_packages / "peppercorn"].dir
     assert result.files_created[script.site_packages / "peppercorn-0.6.dist-info"].dir
@@ -153,7 +153,7 @@ def test_multiple_dependency_groups(script: PipTestEnvironment) -> None:
         )
     )
     result = script.pip("install", "--group", "initools", "--group", "peppercorn")
-    result.did_create(script.site_packages / "INITools-0.2.dist-info")
+    result.did_create(script.site_packages / "initools-0.2.dist-info")
     result.did_create(script.site_packages / "initools")
     assert result.files_created[script.site_packages / "peppercorn"].dir
     assert result.files_created[script.site_packages / "peppercorn-0.6.dist-info"].dir
@@ -176,7 +176,7 @@ def test_dependency_group_with_non_normalized_name(script: PipTestEnvironment) -
         )
     )
     result = script.pip("install", "--group", "IniTools")
-    result.did_create(script.site_packages / "INITools-0.2.dist-info")
+    result.did_create(script.site_packages / "initools-0.2.dist-info")
     result.did_create(script.site_packages / "initools")
 
 
@@ -215,7 +215,7 @@ def test_relative_requirements_file(
     URLs, use an egg= definition.
 
     """
-    dist_info_folder = script.site_packages / "FSPkg-0.1.dev0.dist-info"
+    dist_info_folder = script.site_packages / "fspkg-0.1.dev0.dist-info"
     egg_link_file = script.site_packages / "FSPkg.egg-link"
     package_folder = script.site_packages / "fspkg"
 

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -144,8 +144,8 @@ def test_upgrade_to_specific_version(script: PipTestEnvironment) -> None:
     script.pip("install", "INITools==0.1")
     result = script.pip("install", "INITools==0.2")
     assert result.files_created, "pip install with specific version did not upgrade"
-    assert script.site_packages / "INITools-0.1.dist-info" in result.files_deleted
-    result.did_create(script.site_packages / "INITools-0.2.dist-info")
+    assert script.site_packages / "initools-0.1.dist-info" in result.files_deleted
+    result.did_create(script.site_packages / "initools-0.2.dist-info")
 
 
 @pytest.mark.network
@@ -157,7 +157,7 @@ def test_upgrade_if_requested(script: PipTestEnvironment) -> None:
     script.pip("install", "INITools==0.1")
     result = script.pip("install", "--upgrade", "INITools")
     assert result.files_created, "pip install --upgrade did not upgrade"
-    result.did_not_create(script.site_packages / "INITools-0.1.dist-info")
+    result.did_not_create(script.site_packages / "initools-0.1.dist-info")
 
 
 def test_upgrade_with_newest_already_installed(
@@ -319,8 +319,8 @@ def test_should_not_install_always_from_cache(script: PipTestEnvironment) -> Non
     script.pip("install", "INITools==0.2")
     script.pip("uninstall", "-y", "INITools")
     result = script.pip("install", "INITools==0.1")
-    result.did_not_create(script.site_packages / "INITools-0.2.dist-info")
-    result.did_create(script.site_packages / "INITools-0.1.dist-info")
+    result.did_not_create(script.site_packages / "initools-0.2.dist-info")
+    result.did_create(script.site_packages / "initools-0.1.dist-info")
 
 
 @pytest.mark.network
@@ -332,8 +332,8 @@ def test_install_with_ignoreinstalled_requested(script: PipTestEnvironment) -> N
     result = script.pip("install", "-I", "INITools==0.3")
     assert result.files_created, "pip install -I did not install"
     # both the old and new metadata should be present.
-    assert os.path.exists(script.site_packages_path / "INITools-0.1.dist-info")
-    assert os.path.exists(script.site_packages_path / "INITools-0.3.dist-info")
+    assert os.path.exists(script.site_packages_path / "initools-0.1.dist-info")
+    assert os.path.exists(script.site_packages_path / "initools-0.3.dist-info")
 
 
 @pytest.mark.network

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -53,7 +53,7 @@ class Tests_UserSite:
             "('initools').project_name)",
         )
         project_name = result.stdout.strip()
-        assert "INITools" == project_name, project_name
+        assert "initools" == project_name, project_name
 
     @pytest.mark.xfail
     @pytest.mark.network
@@ -95,7 +95,7 @@ class Tests_UserSite:
         fspkg_folder = script.user_site / "fspkg"
         result.did_create(fspkg_folder)
 
-        dist_info_folder = script.user_site / "FSPkg-0.1.dev0.dist-info"
+        dist_info_folder = script.user_site / "fspkg-0.1.dev0.dist-info"
         result.did_create(dist_info_folder)
 
     def test_install_user_venv_nositepkgs_fails(
@@ -133,7 +133,7 @@ class Tests_UserSite:
         result2 = script.pip("install", "--user", "INITools==0.1", "--no-binary=:all:")
 
         # usersite has 0.1
-        dist_info_folder = script.user_site / "INITools-0.1.dist-info"
+        dist_info_folder = script.user_site / "initools-0.1.dist-info"
         initools_v3_file = (
             # file only in 0.3
             script.base_path


### PR DESCRIPTION
Fixes tests with non-normalized filenames that started failing as a result of https://github.com/pypa/setuptools/pull/4766.