### PR TITLE
Do not prefer star specified package as though it were a pinned package

### DIFF
--- a/news/13252.bugfix.rst
+++ b/news/13252.bugfix.rst
@@ -1,0 +1,3 @@
+When choosing a preferred requirement for resolving dependencies
+do not consider a specifier with a * in it, e.g. "==1.*", to be a
+pinned specifier.

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -142,14 +142,14 @@ class PipProvider(_ProviderBase):
         else:
             candidate, ireqs = None, ()
 
-        operators = [
-            specifier.operator
+        operators: list[tuple[str, str]] = [
+            (specifier.operator, specifier.version)
             for specifier_set in (ireq.specifier for ireq in ireqs if ireq)
             for specifier in specifier_set
         ]
 
         direct = candidate is not None
-        pinned = any(op[:2] == "==" for op in operators)
+        pinned = any(((op[:2] == "==") and ("*" not in ver)) for op, ver in operators)
         unfree = bool(operators)
         requested_order = self._user_requested.get(identifier, math.inf)
 

--- a/tests/unit/resolution_resolvelib/test_provider.py
+++ b/tests/unit/resolution_resolvelib/test_provider.py
@@ -52,6 +52,14 @@ def build_req_info(
             {},
             (True, False, False, True, math.inf, False, "pinned-package"),
         ),
+        # Star-specified package, i.e. with "*"
+        (
+            "star-specified-package",
+            {"star-specified-package": [build_req_info("star-specified-package==1.*")]},
+            [],
+            {},
+            (True, False, True, True, math.inf, False, "star-specified-package"),
+        ),
         # Package that caused backtracking
         (
             "backtrack-package",


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/13030

This is pretty simple, currently pip prefers pinned requirements, e.g. `requests==2.32.2`, when resolving so as to follow a path through the requirement graph that does not increase the number of possibilities.

However, the current code considers a requirement like `requests==2.*` to be pinned, which it is not. This fixes that.