### PR TITLE
resolvelib: emit Requires-Python dependency first

### DIFF
--- a/news/13270.bugfix.rst
+++ b/news/13270.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a regression that causes dependencies to be checked *before* ``Requires-Python``
+project metadata is checked, leading to wasted cycles when the Python version is
+unsupported.

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -249,6 +249,8 @@ class _InstallRequirementBackedCandidate(Candidate):
         return dist
 
     def iter_dependencies(self, with_requires: bool) -> Iterable[Optional[Requirement]]:
+        # Emit the Requires-Python requirement first to fail fast on
+        # unsupported candidates and avoid pointless downloads/preparation.
         yield self._factory.make_requires_python_requirement(self.dist.requires_python)
         requires = self.dist.iter_dependencies() if with_requires else ()
         for r in requires:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -249,10 +249,10 @@ class _InstallRequirementBackedCandidate(Candidate):
         return dist
 
     def iter_dependencies(self, with_requires: bool) -> Iterable[Optional[Requirement]]:
+        yield self._factory.make_requires_python_requirement(self.dist.requires_python)
         requires = self.dist.iter_dependencies() if with_requires else ()
         for r in requires:
             yield from self._factory.make_requirements_from_spec(str(r), self._ireq)
-        yield self._factory.make_requires_python_requirement(self.dist.requires_python)
 
     def get_install_requirement(self) -> Optional[InstallRequirement]:
         return self._ireq

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -218,9 +218,10 @@ class PipProvider(_ProviderBase):
     def is_satisfied_by(self, requirement: Requirement, candidate: Candidate) -> bool:
         return requirement.is_satisfied_by(candidate)
 
-    def get_dependencies(self, candidate: Candidate) -> Sequence[Requirement]:
+    def get_dependencies(self, candidate: Candidate) -> Iterable[Requirement]:
         with_requires = not self._ignore_dependencies
-        return [r for r in candidate.iter_dependencies(with_requires) if r is not None]
+        # iter_dependencies() can perform nontrivial work so delay until needed.
+        return (r for r in candidate.iter_dependencies(with_requires) if r is not None)
 
     @staticmethod
     def is_backtrack_cause(

--- a/tests/functional/test_new_resolver_errors.py
+++ b/tests/functional/test_new_resolver_errors.py
@@ -126,7 +126,9 @@ def test_new_resolver_checks_requires_python_before_dependencies(
         expect_error=True,
     )
 
-    # Resolution should fail because of pkg-a's Requires-Python.
-    # This check should be done before pkg-b, so pkg-b should never be pulled.
+    # Resolution should fail because of pkg-root's Requires-Python.
+    # This is done before dependencies so pkg-dep should never be pulled.
     assert incompatible_python in result.stderr, str(result)
-    assert "pkg-b" not in result.stderr, str(result)
+    # Setuptools produces wheels with normalized names.
+    assert "pkg_dep" not in result.stderr, str(result)
+    assert "pkg_dep" not in result.stdout, str(result)


### PR DESCRIPTION
Revived version of https://github.com/pypa/pip/pull/11398. This is a rewrite of #13160, focused on minimizing the diff to the strictly necessary changes. 

Closes https://github.com/pypa/pip/pull/11398.
Fixes https://github.com/pypa/pip/issues/13146.
Fixes https://github.com/pypa/pip/issues/11142.

@pfmoore PTAL. I believe I have addressed all of your concerns (namely the confusion with the tests and adding a comment about why the change to a generator is important).