### PR TITLE
tests: Use script.scratch_path over script.temp_path

### DIFF
--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -24,7 +24,7 @@ def test_entrypoints_work(entrypoint: str, script: PipTestEnvironment) -> None:
     if script.zipapp:
         pytest.skip("Zipapp does not include entrypoints")
 
-    fake_pkg = script.temp_path / "fake_pkg"
+    fake_pkg = script.scratch_path / "fake_pkg"
     fake_pkg.mkdir()
     fake_pkg.joinpath("setup.py").write_text(
         dedent(

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -252,7 +252,7 @@ def test_pep517_backend_requirements_satisfied_by_prerelease(
     script.pip("install", "test_backend", "--no-index", "-f", data.backends)
 
     project_dir = make_project(
-        script.temp_path,
+        script.scratch_path,
         requires=["test_backend", "myreq"],
         backend="test_backend",
     )


### PR DESCRIPTION
`script.temp_path` is the system temporary directory. scripttest will check that there aren't any dangling files left in there, thus it's inappropriate to write long-lived packages there.

These tests are currently passing as scripttest's temporary file detection logic is broken. However, a newer version of scripttest will fail.

(I'm currently in the midst of modernizing scripttest in preparation for some limited feature development.)
