### PR TITLE
Use inline dependency metadata for update-rtd-redirects.py

### DIFF
--- a/.github/workflows/update-rtd-redirects.yml
+++ b/.github/workflows/update-rtd-redirects.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install httpx pyyaml rich
-      - run: python tools/update-rtd-redirects.py
+      - run: pipx run tools/update-rtd-redirects.py
         env:
           RTD_API_TOKEN: ${{ secrets.RTD_API_TOKEN }}

--- a/.github/workflows/update-rtd-redirects.yml
+++ b/.github/workflows/update-rtd-redirects.yml
@@ -3,6 +3,9 @@ name: Update documentation redirects
 on:
   push:
     branches: [main]
+    paths:
+      - ".readthedocs-custom-redirects.yml"
+      - ".readthedocs.yml"
   schedule:
     - cron: 0 0 * * MON # Run every Monday at 00:00 UTC
 

--- a/tools/update-rtd-redirects.py
+++ b/tools/update-rtd-redirects.py
@@ -3,6 +3,11 @@
 Relevant API reference: https://docs.readthedocs.io/en/stable/api/v3.html#redirects
 """
 
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["httpx", "rich", "pyyaml"]
+# ///
+
 import operator
 import os
 import sys


### PR DESCRIPTION
This makes it a bit easier to iterate on the script locally if needed.

Also restrict the associated GHA workflow to only run on changes to ReadTheDocs configuration.