### PR TITLE
Replace custom enums with stdlib enums

### DIFF
--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -10,7 +10,6 @@ from pip._internal.configuration import (
     Configuration,
     Kind,
     get_configuration_files,
-    kinds,
 )
 from pip._internal.exceptions import PipError
 from pip._internal.utils.logging import indent_log
@@ -142,9 +141,9 @@ class ConfigurationCommand(Command):
         file_options = [
             key
             for key, value in (
-                (kinds.USER, options.user_file),
-                (kinds.GLOBAL, options.global_file),
-                (kinds.SITE, options.site_file),
+                (Kind.USER, options.user_file),
+                (Kind.GLOBAL, options.global_file),
+                (Kind.SITE, options.site_file),
             )
             if value
         ]
@@ -155,11 +154,11 @@ class ConfigurationCommand(Command):
             # Default to user, unless there's a site file.
             elif any(
                 os.path.exists(site_config_file)
-                for site_config_file in get_configuration_files()[kinds.SITE]
+                for site_config_file in get_configuration_files()[Kind.SITE]
             ):
-                return kinds.SITE
+                return Kind.SITE
             else:
-                return kinds.USER
+                return Kind.USER
         elif len(file_options) == 1:
             return file_options[0]
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -373,14 +373,6 @@ def write_output(msg: Any, *args: Any) -> None:
     logger.info(msg, *args)
 
 
-# Simulates an enum
-def enum(*sequential: Any, **named: Any) -> Type[Any]:
-    enums = dict(zip(sequential, range(len(sequential))), **named)
-    reverse = {value: key for key, value in enums.items()}
-    enums["reverse_mapping"] = reverse
-    return type("Enum", (), enums)
-
-
 def build_netloc(host: str, port: Optional[int]) -> str:
     """
     Build a netloc from a host-port pair

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -5,6 +5,7 @@ import os.path
 import tempfile
 import traceback
 from contextlib import ExitStack, contextmanager
+from enum import StrEnum
 from pathlib import Path
 from typing import (
     Any,
@@ -17,7 +18,7 @@ from typing import (
     Union,
 )
 
-from pip._internal.utils.misc import enum, rmtree
+from pip._internal.utils.misc import rmtree
 
 logger = logging.getLogger(__name__)
 
@@ -26,11 +27,10 @@ _T = TypeVar("_T", bound="TempDirectory")
 
 # Kinds of temporary directories. Only needed for ones that are
 # globally-managed.
-tempdir_kinds = enum(
-    BUILD_ENV="build-env",
-    EPHEM_WHEEL_CACHE="ephem-wheel-cache",
-    REQ_BUILD="req-build",
-)
+class tempdir_kinds(StrEnum):
+    BUILD_ENV = "build-env"
+    EPHEM_WHEEL_CACHE = "ephem-wheel-cache"
+    REQ_BUILD = "req-build"
 
 
 _tempdir_manager: Optional[ExitStack] = None

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -7,7 +7,7 @@ from pip._internal.cli.status_codes import ERROR
 from pip._internal.configuration import CONFIG_BASENAME, get_configuration_files
 
 from tests.lib import PipTestEnvironment
-from tests.lib.configuration_helpers import ConfigurationMixin, kinds
+from tests.lib.configuration_helpers import ConfigurationMixin, Kind
 from tests.lib.venv import VirtualEnvironment
 
 
@@ -100,7 +100,7 @@ class TestBasicLoading(ConfigurationMixin):
         """
 
         # Use new config file
-        new_config_file = get_configuration_files()[kinds.USER][1]
+        new_config_file = get_configuration_files()[Kind.USER][1]
 
         script.pip("config", "--user", "set", "global.timeout", "60")
         script.pip("config", "--user", "set", "freeze.timeout", "10")
@@ -138,7 +138,7 @@ class TestBasicLoading(ConfigurationMixin):
         # locations. Additionally we cannot patch those paths since pip config
         # commands runs inside a subprocess.
         # So we just check if the file can be identified
-        global_config_file = get_configuration_files()[kinds.GLOBAL][0]
+        global_config_file = get_configuration_files()[Kind.GLOBAL][0]
         result = script.pip("config", "debug")
         assert f"{global_config_file}, exists:" in result.stdout
 

--- a/tests/lib/configuration_helpers.py
+++ b/tests/lib/configuration_helpers.py
@@ -8,11 +8,8 @@ import textwrap
 from typing import Any, Dict, Iterator
 
 import pip._internal.configuration
+from pip._internal.configuration import Kind
 from pip._internal.utils.misc import ensure_dir
-
-# This is so that tests don't need to import pip._internal.configuration.
-Kind = pip._internal.configuration.Kind
-kinds = pip._internal.configuration.kinds
 
 
 class ConfigurationMixin:

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pip._internal.configuration import get_configuration_files, kinds
+from pip._internal.configuration import Kind, get_configuration_files
 from pip._internal.exceptions import ConfigurationError
 
 from tests.lib.configuration_helpers import ConfigurationMixin
@@ -13,19 +13,19 @@ from tests.lib.configuration_helpers import ConfigurationMixin
 
 class TestConfigurationLoading(ConfigurationMixin):
     def test_global_loading(self) -> None:
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "1"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "1"})
 
         self.configuration.load()
         assert self.configuration.get_value("test.hello") == "1"
 
     def test_user_loading(self) -> None:
-        self.patch_configuration(kinds.USER, {"test.hello": "2"})
+        self.patch_configuration(Kind.USER, {"test.hello": "2"})
 
         self.configuration.load()
         assert self.configuration.get_value("test.hello") == "2"
 
     def test_site_loading(self) -> None:
-        self.patch_configuration(kinds.SITE, {"test.hello": "3"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "3"})
 
         self.configuration.load()
         assert self.configuration.get_value("test.hello") == "3"
@@ -89,7 +89,7 @@ class TestConfigurationLoading(ConfigurationMixin):
         )
 
     def test_no_such_key_error_message_no_command(self) -> None:
-        self.configuration.load_only = kinds.GLOBAL
+        self.configuration.load_only = Kind.GLOBAL
         self.configuration.load()
         expected_msg = (
             "Key does not contain dot separated section and key. "
@@ -100,7 +100,7 @@ class TestConfigurationLoading(ConfigurationMixin):
             self.configuration.get_value("index-url")
 
     def test_no_such_key_error_message_missing_option(self) -> None:
-        self.configuration.load_only = kinds.GLOBAL
+        self.configuration.load_only = Kind.GLOBAL
         self.configuration.load()
         expected_msg = "No such key - global.index-url"
         pat = f"^{re.escape(expected_msg)}$"
@@ -113,43 +113,43 @@ class TestConfigurationPrecedence(ConfigurationMixin):
     # configuration options
 
     def test_env_overides_site(self) -> None:
-        self.patch_configuration(kinds.SITE, {"test.hello": "1"})
-        self.patch_configuration(kinds.ENV, {"test.hello": "0"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "1"})
+        self.patch_configuration(Kind.ENV, {"test.hello": "0"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "0"
 
     def test_env_overides_user(self) -> None:
-        self.patch_configuration(kinds.USER, {"test.hello": "2"})
-        self.patch_configuration(kinds.ENV, {"test.hello": "0"})
+        self.patch_configuration(Kind.USER, {"test.hello": "2"})
+        self.patch_configuration(Kind.ENV, {"test.hello": "0"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "0"
 
     def test_env_overides_global(self) -> None:
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "3"})
-        self.patch_configuration(kinds.ENV, {"test.hello": "0"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "3"})
+        self.patch_configuration(Kind.ENV, {"test.hello": "0"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "0"
 
     def test_site_overides_user(self) -> None:
-        self.patch_configuration(kinds.USER, {"test.hello": "2"})
-        self.patch_configuration(kinds.SITE, {"test.hello": "1"})
+        self.patch_configuration(Kind.USER, {"test.hello": "2"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "1"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "1"
 
     def test_site_overides_global(self) -> None:
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "3"})
-        self.patch_configuration(kinds.SITE, {"test.hello": "1"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "3"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "1"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "1"
 
     def test_user_overides_global(self) -> None:
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "3"})
-        self.patch_configuration(kinds.USER, {"test.hello": "2"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "3"})
+        self.patch_configuration(Kind.USER, {"test.hello": "2"})
         self.configuration.load()
 
         assert self.configuration.get_value("test.hello") == "2"
@@ -157,7 +157,7 @@ class TestConfigurationPrecedence(ConfigurationMixin):
     def test_env_not_overriden_by_environment_var(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        self.patch_configuration(kinds.ENV, {"test.hello": "1"})
+        self.patch_configuration(Kind.ENV, {"test.hello": "1"})
         monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
@@ -168,7 +168,7 @@ class TestConfigurationPrecedence(ConfigurationMixin):
     def test_site_not_overriden_by_environment_var(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        self.patch_configuration(kinds.SITE, {"test.hello": "2"})
+        self.patch_configuration(Kind.SITE, {"test.hello": "2"})
         monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
@@ -179,7 +179,7 @@ class TestConfigurationPrecedence(ConfigurationMixin):
     def test_user_not_overriden_by_environment_var(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        self.patch_configuration(kinds.USER, {"test.hello": "3"})
+        self.patch_configuration(Kind.USER, {"test.hello": "3"})
         monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
@@ -190,7 +190,7 @@ class TestConfigurationPrecedence(ConfigurationMixin):
     def test_global_not_overriden_by_environment_var(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        self.patch_configuration(kinds.GLOBAL, {"test.hello": "4"})
+        self.patch_configuration(Kind.GLOBAL, {"test.hello": "4"})
         monkeypatch.setenv("PIP_HELLO", "5")
 
         self.configuration.load()
@@ -209,7 +209,7 @@ class TestConfigurationModification(ConfigurationMixin):
             self.configuration.set_value("test.hello", "10")
 
     def test_site_modification(self) -> None:
-        self.configuration.load_only = kinds.SITE
+        self.configuration.load_only = Kind.SITE
         self.configuration.load()
 
         # Mock out the method
@@ -221,11 +221,11 @@ class TestConfigurationModification(ConfigurationMixin):
 
         # get the path to site config file
         assert mymock.call_count == 1
-        assert mymock.call_args[0][0] == (get_configuration_files()[kinds.SITE][0])
+        assert mymock.call_args[0][0] == (get_configuration_files()[Kind.SITE][0])
 
     def test_user_modification(self) -> None:
         # get the path to local config file
-        self.configuration.load_only = kinds.USER
+        self.configuration.load_only = Kind.USER
         self.configuration.load()
 
         # Mock out the method
@@ -239,12 +239,12 @@ class TestConfigurationModification(ConfigurationMixin):
         assert mymock.call_count == 1
         assert mymock.call_args[0][0] == (
             # Use new config file
-            get_configuration_files()[kinds.USER][1]
+            get_configuration_files()[Kind.USER][1]
         )
 
     def test_global_modification(self) -> None:
         # get the path to local config file
-        self.configuration.load_only = kinds.GLOBAL
+        self.configuration.load_only = Kind.GLOBAL
         self.configuration.load()
 
         # Mock out the method
@@ -256,12 +256,12 @@ class TestConfigurationModification(ConfigurationMixin):
 
         # get the path to user config file
         assert mymock.call_count == 1
-        assert mymock.call_args[0][0] == (get_configuration_files()[kinds.GLOBAL][-1])
+        assert mymock.call_args[0][0] == (get_configuration_files()[Kind.GLOBAL][-1])
 
     def test_normalization(self) -> None:
         # underscores and dashes can be used interchangeably.
         # internally, underscores get converted into dashes before reading/writing file
-        self.configuration.load_only = kinds.GLOBAL
+        self.configuration.load_only = Kind.GLOBAL
         self.configuration.load()
         self.configuration.set_value("global.index_url", "example.org")
         assert self.configuration.get_value("global.index_url") == "example.org"


### PR DESCRIPTION
I also renamed `kinds` to be `Kind` to remove the redundant `Kind` newtype.