### PR TITLE
Handle multiple paths in `appdirs.site_config_dirs` on MacOS

### DIFF
--- a/news/12903.bugfix.rst
+++ b/news/12903.bugfix.rst
@@ -1,0 +1,1 @@
+Handle multiple paths in ``appdirs.site_config_dirs`` on MacOS.

--- a/news/12903.bugfix.rst
+++ b/news/12903.bugfix.rst
@@ -1,1 +1,1 @@
-Handle multiple paths in ``appdirs.site_config_dirs`` on MacOS.
+Support multiple global configuration paths returned by ``platformdirs`` on MacOS.

--- a/src/pip/_internal/utils/appdirs.py
+++ b/src/pip/_internal/utils/appdirs.py
@@ -42,7 +42,8 @@ def user_config_dir(appname: str, roaming: bool = True) -> str:
 # see <https://github.com/pypa/pip/issues/1733>
 def site_config_dirs(appname: str) -> List[str]:
     if sys.platform == "darwin":
-        return [_appdirs.site_data_dir(appname, appauthor=False, multipath=True)]
+        dirval = _appdirs.site_data_dir(appname, appauthor=False, multipath=True)
+        return dirval.split(os.pathsep)
 
     dirval = _appdirs.site_config_dir(appname, appauthor=False, multipath=True)
     if sys.platform == "win32":

--- a/tests/unit/test_appdirs.py
+++ b/tests/unit/test_appdirs.py
@@ -109,6 +109,17 @@ class TestSiteConfigDirs:
             "/Library/Application Support/pip",
         ]
 
+    @pytest.mark.skipif(sys.platform != "darwin", reason="MacOS-only test")
+    def test_site_config_dirs_osx_homebrew(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "prefix", "/opt/homebrew/")
+
+        assert appdirs.site_config_dirs("pip") == [
+            "/opt/homebrew/share/pip",
+            "/Library/Application Support/pip",
+        ]
+
     @pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
     def test_site_config_dirs_linux(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("XDG_CONFIG_DIRS", raising=False)


### PR DESCRIPTION
This occurs when using Homebrew, for example.

Resolves #12903

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->