### PR TITLE
Apply ruff/flake8-comprehensions rule C420

### DIFF
--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -161,9 +161,9 @@ def get_scheme(
         scheme_name = "posix_prefix"
 
     if home is not None:
-        variables = {k: home for k in _HOME_KEYS}
+        variables = dict.fromkeys(_HOME_KEYS, home)
     elif prefix is not None:
-        variables = {k: prefix for k in _HOME_KEYS}
+        variables = dict.fromkeys(_HOME_KEYS, prefix)
     else:
         variables = {}
 


### PR DESCRIPTION
```
C420 Unnecessary dict comprehension for iterable; use `dict.fromkeys` instead
```
Starting with ruff 0.10.0, the above rule has been stabilized and is no longer in preview.