### PR TITLE
Draft index_priority

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -364,6 +364,17 @@ def extra_index_url() -> Option:
         "--index-url.",
     )
 
+def index_groups() -> Option:
+    return Option(
+        "--index-groups",
+        dest="index_groups",
+        metavar="URL",
+        action="append",
+        default=[],
+        help="Index Groups of package indexes to use in addition to "
+        "--index-url. Should follow the similar rules as but applies for groups."
+        "--index-url.",
+    )
 
 no_index: Callable[..., Option] = partial(
     Option,
@@ -1118,6 +1129,7 @@ index_group: Dict[str, Any] = {
     "options": [
         index_url,
         extra_index_url,
+        index_groups,
         no_index,
         find_links,
     ],

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -32,7 +32,7 @@ from pip._vendor import requests
 from pip._vendor.requests import Response
 from pip._vendor.requests.exceptions import RetryError, SSLError
 
-from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.exceptions import NetworkConnectionError, CommandError
 from pip._internal.models.link import Link
 from pip._internal.models.search_scope import SearchScope
 from pip._internal.network.session import PipSession
@@ -416,6 +416,12 @@ class LinkCollector:
             when constructing the SearchScope object.
         """
         index_urls = [options.index_url] + options.extra_index_urls
+        index_priority = False
+        if (options.index_groups is not None and len(options.index_groups) > 0):
+            print(options.index_groups[0])
+            index_urls = options.index_groups[0].split(",")
+            index_priority = True
+            
         if options.no_index and not suppress_no_index:
             logger.debug(
                 "Ignoring indexes: %s",
@@ -430,6 +436,7 @@ class LinkCollector:
             find_links=find_links,
             index_urls=index_urls,
             no_index=options.no_index,
+            index_priority=index_priority,
         )
         link_collector = LinkCollector(
             session=session,

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -21,11 +21,12 @@ class SearchScope:
     Encapsulates the locations that pip is configured to search.
     """
 
-    __slots__ = ["find_links", "index_urls", "no_index"]
+    __slots__ = ["find_links", "index_urls", "no_index", "index_priority"]
 
     find_links: List[str]
     index_urls: List[str]
     no_index: bool
+    index_priority: bool
 
     @classmethod
     def create(
@@ -33,6 +34,7 @@ class SearchScope:
         find_links: List[str],
         index_urls: List[str],
         no_index: bool,
+        index_priority: bool = False,
     ) -> "SearchScope":
         """
         Create a SearchScope object after normalizing the `find_links`.
@@ -67,6 +69,7 @@ class SearchScope:
             find_links=built_find_links,
             index_urls=index_urls,
             no_index=no_index,
+            index_priority=index_priority,
         )
 
     def get_formatted_locations(self) -> str:

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -52,6 +52,7 @@ ENV_VAR_RE = re.compile(r"(?P<var>\$\{(?P<name>[A-Z0-9_]+)\})")
 SUPPORTED_OPTIONS: List[Callable[..., optparse.Option]] = [
     cmdoptions.index_url,
     cmdoptions.extra_index_url,
+    cmdoptions.index_groups,
     cmdoptions.no_index,
     cmdoptions.constraints,
     cmdoptions.requirements,


### PR DESCRIPTION
Working with @msarahan on Index Priority. https://github.com/pypa/pip/pull/13210

Hack way of prioritizing indexes

Test 1:
`` pip install torch --index-groups https://download.pytorch.org/whl/test/cpu,https://download.pytorch.org/whl/nightly/cpu --force-reinstall --dry-run``

Output:
```
 pip install torch --index-groups https://download.pytorch.org/whl/test/cpu,https://download.pytorch.org/whl/nightly/cpu --force-reinstall --dry-run
https://download.pytorch.org/whl/test/cpu,https://download.pytorch.org/whl/nightly/cpu
Looking in indexes: https://download.pytorch.org/whl/test/cpu, https://download.pytorch.org/whl/nightly/cpu
Collecting torch
  Using cached https://download.pytorch.org/whl/test/cpu/torch-2.7.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (27 kB)
Collecting filelock (from torch)
  Using cached https://download.pytorch.org/whl/test/filelock-3.13.1-py3-none-any.whl (11 kB)
Collecting typing-extensions>=4.10.0 (from torch)
  Using cached https://download.pytorch.org/whl/test/typing_extensions-4.12.2-py3-none-any.whl (37 kB)
Collecting sympy>=1.13.3 (from torch)
  Using cached https://download.pytorch.org/whl/test/sympy-1.13.3-py3-none-any.whl.metadata (12 kB)
Collecting networkx (from torch)
  Using cached https://download.pytorch.org/whl/test/networkx-3.3-py3-none-any.whl (1.7 MB)
Collecting jinja2 (from torch)
  Using cached https://download.pytorch.org/whl/test/Jinja2-3.1.4-py3-none-any.whl (133 kB)
Collecting fsspec (from torch)
  Using cached https://download.pytorch.org/whl/test/fsspec-2024.6.1-py3-none-any.whl (177 kB)
Collecting mpmath<1.4,>=1.1.0 (from sympy>=1.13.3->torch)
  Using cached https://download.pytorch.org/whl/test/mpmath-1.3.0-py3-none-any.whl (536 kB)
Collecting MarkupSafe>=2.0 (from jinja2->torch)
  Using cached https://download.pytorch.org/whl/test/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (28 kB)
Using cached https://download.pytorch.org/whl/test/cpu/torch-2.7.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl (176.0 MB)
Using cached https://download.pytorch.org/whl/test/sympy-1.13.3-py3-none-any.whl (6.2 MB)
Would install Jinja2-3.1.4 MarkupSafe-2.1.5 filelock-3.13.1 fsspec-2024.6.1 mpmath-1.3.0 networkx-3.3 sympy-1.13.3 torch-2.7.0+cpu typing_extensions-4.12.2
```

Test 2:
`` pip install torch --index-groups https://download.pytorch.org/whl/nightly/cpu,https://download.pytorch.org/whl/test/cpu --force-reinstall --dry-run``

Output:
```
pip install torch --index-groups https://download.pytorch.org/whl/nightly/cpu,https://download.pytorch.org/whl/test/cpu --force-reinstall --dry-run
https://download.pytorch.org/whl/nightly/cpu,https://download.pytorch.org/whl/test/cpu
Looking in indexes: https://download.pytorch.org/whl/nightly/cpu, https://download.pytorch.org/whl/test/cpu
Collecting torch
  Using cached https://download.pytorch.org/whl/nightly/cpu/torch-2.8.0.dev20250320%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (27 kB)
Collecting filelock (from torch)
  Using cached https://download.pytorch.org/whl/nightly/filelock-3.16.1-py3-none-any.whl (16 kB)
Collecting typing-extensions>=4.10.0 (from torch)
  Using cached https://download.pytorch.org/whl/nightly/typing_extensions-4.12.2-py3-none-any.whl (37 kB)
Collecting sympy>=1.13.3 (from torch)
  Using cached https://download.pytorch.org/whl/nightly/sympy-1.13.3-py3-none-any.whl (6.2 MB)
Collecting networkx (from torch)
  Using cached https://download.pytorch.org/whl/nightly/networkx-3.4.2-py3-none-any.whl (1.7 MB)
Collecting jinja2 (from torch)
  Using cached https://download.pytorch.org/whl/nightly/jinja2-3.1.4-py3-none-any.whl (133 kB)
Collecting fsspec (from torch)
  Using cached https://download.pytorch.org/whl/nightly/fsspec-2024.10.0-py3-none-any.whl (179 kB)
Collecting mpmath<1.4,>=1.1.0 (from sympy>=1.13.3->torch)
  Using cached https://download.pytorch.org/whl/nightly/mpmath-1.3.0-py3-none-any.whl (536 kB)
Collecting MarkupSafe>=2.0 (from jinja2->torch)
  Using cached https://download.pytorch.org/whl/nightly/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (28 kB)
Using cached https://download.pytorch.org/whl/nightly/cpu/torch-2.8.0.dev20250320%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl (177.6 MB)
Would install Jinja2-3.1.4 MarkupSafe-2.1.5 filelock-3.16.1 fsspec-2024.10.0 mpmath-1.3.0 networkx-3.4.2 sympy-1.13.3 torch-2.8.0.dev20250320+cpu typing_extensions-4.12.2
```