### PR TITLE
Revert "Apply ruff/flake8-comprehensions rule C420 (#13284)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ ignore = [
     "B020",
     "B904", # Ruff enables opinionated warnings by default
     "B905", # Ruff enables opinionated warnings by default
+    "C420", # unnecessary-dict-comprehension-for-iterable (worsens readability)
 ]
 select = [
     "ASYNC",

--- a/src/pip/_internal/locations/_sysconfig.py
+++ b/src/pip/_internal/locations/_sysconfig.py
@@ -161,9 +161,9 @@ def get_scheme(
         scheme_name = "posix_prefix"
 
     if home is not None:
-        variables = dict.fromkeys(_HOME_KEYS, home)
+        variables = {k: home for k in _HOME_KEYS}
     elif prefix is not None:
-        variables = dict.fromkeys(_HOME_KEYS, prefix)
+        variables = {k: prefix for k in _HOME_KEYS}
     else:
         variables = {}
 


### PR DESCRIPTION
I forgot about the fact we can ignore specific rules in advance.

I'm gonna leave this PR open for a few days for what I assume are obvious reasons. There's really no point in making our code less readable over this. 