### PR TITLE
Remove lru cache from methods [enable ruff rule cached-instance-method (B019)]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ extend-exclude = [
 
 [tool.ruff.lint]
 ignore = [
-    "B019",
     "B020",
     "B904", # Ruff enables opinionated warnings by default
     "B905", # Ruff enables opinionated warnings by default

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -929,9 +929,12 @@ class PackageFinder:
         Returns a InstallationCandidate if found,
         Raises DistributionNotFound or BestVersionAlreadyInstalled otherwise
         """
+        name = req.name
+        assert name is not None, "find_requirement() called with no name"
+
         hashes = req.hashes(trust_internet=False)
         best_candidate_result = self.find_best_candidate(
-            req.name,
+            name,
             specifier=req.specifier,
             hashes=hashes,
         )

--- a/src/pip/_internal/resolution/resolvelib/found_candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/found_candidates.py
@@ -8,7 +8,6 @@ absolutely need, and not "download the world" when we only need one version of
 something.
 """
 
-import functools
 import logging
 from collections.abc import Sequence
 from typing import Any, Callable, Iterator, Optional, Set, Tuple
@@ -129,6 +128,7 @@ class FoundCandidates(Sequence[Candidate]):
         self._installed = installed
         self._prefers_installed = prefers_installed
         self._incompatible_ids = incompatible_ids
+        self._bool: Optional[bool] = None
 
     def __getitem__(self, index: Any) -> Any:
         # Implemented to satisfy the ABC check. This is not needed by the
@@ -152,8 +152,13 @@ class FoundCandidates(Sequence[Candidate]):
         # performance reasons).
         raise NotImplementedError("don't do this")
 
-    @functools.lru_cache(maxsize=1)
     def __bool__(self) -> bool:
+        if self._bool is not None:
+            return self._bool
+
         if self._prefers_installed and self._installed:
+            self._bool = True
             return True
-        return any(self)
+
+        self._bool = any(self)
+        return self._bool

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -257,11 +257,17 @@ class PipProvider(_ProviderBase):
             is_satisfied_by=self.is_satisfied_by,
         )
 
-    @lru_cache(maxsize=None)
     def is_satisfied_by(self, requirement: Requirement, candidate: Candidate) -> bool:
-        return requirement.is_satisfied_by(candidate)
+        return _pip_provider_is_satisfied_by(requirement, candidate)
 
     def get_dependencies(self, candidate: Candidate) -> Iterable[Requirement]:
         with_requires = not self._ignore_dependencies
         # iter_dependencies() can perform nontrivial work so delay until needed.
         return (r for r in candidate.iter_dependencies(with_requires) if r is not None)
+
+
+@lru_cache(maxsize=None)
+def _pip_provider_is_satisfied_by(
+    requirement: Requirement, candidate: Candidate
+) -> bool:
+    return requirement.is_satisfied_by(candidate)

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -319,7 +319,10 @@ def test_finder_priority_file_over_page(data: TestData) -> None:
         find_links=[data.find_links],
         index_urls=["http://pypi.org/simple/"],
     )
-    all_versions = finder.find_all_candidates(req.name)
+    name = req.name
+    assert name == "gmpy"
+
+    all_versions = finder.find_all_candidates(name)
     # 1 file InstallationCandidate followed by all https ones
     assert all_versions[0].link.scheme == "file"
     assert all(
@@ -335,9 +338,11 @@ def test_finder_priority_nonegg_over_eggfragments() -> None:
     """Test PackageFinder prefers non-egg links over "#egg=" links"""
     req = install_req_from_line("bar==1.0")
     links = ["http://foo/bar.py#egg=bar-1.0", "http://foo/bar-1.0.tar.gz"]
+    name = req.name
+    assert name == "bar"
 
     finder = make_test_finder(links)
-    all_versions = finder.find_all_candidates(req.name)
+    all_versions = finder.find_all_candidates(name)
     assert all_versions[0].link.url.endswith("tar.gz")
     assert all_versions[1].link.url.endswith("#egg=bar-1.0")
 
@@ -349,7 +354,7 @@ def test_finder_priority_nonegg_over_eggfragments() -> None:
     links.reverse()
 
     finder = make_test_finder(links)
-    all_versions = finder.find_all_candidates(req.name)
+    all_versions = finder.find_all_candidates(name)
     assert all_versions[0].link.url.endswith("tar.gz")
     assert all_versions[1].link.url.endswith("#egg=bar-1.0")
     found = finder.find_requirement(req, False)


### PR DESCRIPTION
I've been slowly reviewing all ruff rules. I noticed B019 rule is disabled: https://docs.astral.sh/ruff/rules/cached-instance-method/

Upon reviewing I consider it to be a correct rule, you can accidentally keep an instance of an object alive for much longer than expected, if that instance is itself referencing an object holding on to a large amount of memory this can lead to using a lot more memory than expected.

Upon removing the `lru_cache` for `PackageFinder.find_best_candidate` it revealed that some wrong types were being passed to it in `PackageFinder.find_requirement` as `InstallRequirement.name` can be `None`. I *think* it's correct to simply assert here that `req.name` isn't `None`, otherwise you end up down a rabbit hole of adding extra `Optional` types and `None` handling.

This PR makes no appreciable memory saving gain in any of the tests I ran, it's more of a preventative measure from someone incorrectly doing this in the future. I'll understand if reviewers think the refactoring is a little too complex here. I was debating whether to submit this at all after finding no performance improvement, but I do think this rule is correct.



