### PR TITLE
Reverse deprecation of --no-python-version-warning

### DIFF
--- a/news/13303.removal.rst
+++ b/news/13303.removal.rst
@@ -1,0 +1,4 @@
+Hide ``--no-python-version-warning`` from CLI help and documentation
+as it's useless since Python 2 support was removed. Despite being
+formerly slated for removal, the flag will remain as a no-op to
+avoid breakage.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -29,7 +29,6 @@ from pip._internal.exceptions import (
     NetworkConnectionError,
     PreviousBuildDirError,
 )
-from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
 from pip._internal.utils.misc import get_prog, normalize_path
@@ -230,13 +229,5 @@ class Command(CommandContextMixIn):
                     options.cache_dir,
                 )
                 options.cache_dir = None
-
-        if options.no_python_version_warning:
-            deprecated(
-                reason="--no-python-version-warning is deprecated.",
-                replacement="to remove the flag as it's a no-op",
-                gone_in="25.1",
-                issue=13154,
-            )
 
         return self._run_wrapper(level_number, options, args)

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -1039,7 +1039,7 @@ no_python_version_warning: Callable[..., Option] = partial(
     dest="no_python_version_warning",
     action="store_true",
     default=False,
-    help="Silence deprecation warnings for upcoming unsupported Pythons.",
+    help=SUPPRESS_HELP,  # No-op, a hold-over from the Python 2->3 transition.
 )
 
 


### PR DESCRIPTION
See https://github.com/pypa/pip/issues/13154#issuecomment-2675819709.

This flag is way more prevalent than initially thought. Since this flag is already a no-op, it's better to hide it from CLI help. This way, we can avoid unnecessary churn, but avoid/discourage new occurances of the flag.

The deprecation has achieved the goal of communicating that this flag is
unnecessary today.

Supersedes and closes #13180.
