### PR TITLE
Postpone removal of non-bare names in egg fragment to 25.2

### DIFF
--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -468,7 +468,7 @@ class Link:
             deprecated(
                 reason=f"{self} contains an egg fragment with a non-PEP 508 name.",
                 replacement="to use the req @ url syntax, and remove the egg fragment",
-                gone_in="25.1",
+                gone_in="25.2",
                 issue=13157,
             )
 


### PR DESCRIPTION
I don't have time to add support for Direct URLs for VCS editables which is needed to finish this deprecation before 25.1.

I'm not happy with how often we're pushing back deprecations (it's likely confusing for anyone paying attention to the removal dates, but don't follow pip's development otherwise), but I suppose there isn't much we do. We could require that deprecations aren't started until most/all of the deprecation changes are ready to go, but that's likely infeasible for most deprecations (since there may be a long lag time between something being deprecated and finally removed which makes writing code in advance untenable). 
