### PR TITLE
Postpone removal of eggs discovery when using the importlib.metadata backend to 26.3

### DIFF
--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -156,7 +156,7 @@ def _emit_egg_deprecation(location: Optional[str]) -> None:
     deprecated(
         reason=f"Loading egg at {location} is deprecated.",
         replacement="to use pip for package installation",
-        gone_in="25.1",
+        gone_in="26.3",
         issue=12330,
     )
 
@@ -181,7 +181,8 @@ class Environment(BaseEnvironment):
             yield from finder.find(location)
             if sys.version_info < (3, 14):
                 for dist in finder.find_eggs(location):
-                    _emit_egg_deprecation(dist.location)
+                    if sys.version_info >= (3, 11):
+                        _emit_egg_deprecation(dist.location)
                     yield dist
             # This must go last because that's how pkg_resources tie-breaks.
             yield from finder.find_linked(location)


### PR DESCRIPTION
We postpone removal of eggs support to 26.3 (which is the earliest version when we may remove Python 3.10 support), and stop warning for Python < 3.11 (because we don't plan to remove pkg_resources for these Python versions while pip supports them).

Towards #12330

See also https://github.com/pypa/pip/issues/13185#issuecomment-2706886837