### PR TITLE
Warn when the pkg_resource metadata backend is used with Python 3.11, 3.12, 3.13

### DIFF
--- a/news/13318.removal.rst
+++ b/news/13318.removal.rst
@@ -1,0 +1,4 @@
+A warning is emitted when the deprecated ``pkg_resources`` library is used to
+inspect and discover installed packages. This warning should only be visible to
+users who set an undocumented environment variable to disable the default
+``importlib.metadata`` backend.


### PR DESCRIPTION
Towards #13317 

We warn when the undocumented `_PIP_USE_IMPORTLIB_METADATA` is set to `false`, causing the use of the `pkg_resources` metadata backend on Python 3.11, 3.12, 3.13.


