### PR TITLE
[DO-NOT-MERGE] populate requirement.specifier on demand

### DIFF
--- a/src/pip/_vendor/packaging/requirements.py
+++ b/src/pip/_vendor/packaging/requirements.py
@@ -3,6 +3,7 @@
 # for complete details.
 from __future__ import annotations
 
+from functools import cached_property
 from typing import Any, Iterator
 
 from ._parser import parse_requirement as _parse_requirement
@@ -40,11 +41,15 @@ class Requirement:
         self.name: str = parsed.name
         self.url: str | None = parsed.url or None
         self.extras: set[str] = set(parsed.extras or [])
-        self.specifier: SpecifierSet = SpecifierSet(parsed.specifier)
+        self._raw_specifier = parsed.specifier
         self.marker: Marker | None = None
         if parsed.marker is not None:
             self.marker = Marker.__new__(Marker)
             self.marker._markers = _normalize_extra_values(parsed.marker)
+
+    @cached_property
+    def specifier(self) -> SpecifierSet:
+        return SpecifierSet(self._raw_specifier)
 
     def _iter_parts(self, name: str) -> Iterator[str]:
         yield name


### PR DESCRIPTION
I was looking at the distribution discovery performance improvements of #12308 and I realized that ~1/3 of packaging `Requirement` construction is spent on creating the `specifier` (SpecifierSet) attribute. It's expensive as each of the contained specifiers have to be hashed immediately.

While the `specifier` attribute is accessed frequently, not all operations need it. For example, `pip show six` sped up by ~20ms with 114 packages installed if modify packaging to populate the `specifier` attribute on-demand.

@notatallshaw I'm curious to whether this has any impact on dependency resolution. While any requirement considered during dependency resolution is obviously going to require the the version specifier, there are a lot of requirements that aren't ever considered. Typically these are all of the requirements from extras.

For example, if I further modify packaging to keep track of how many `Requirement` objects are constructed and how many have their `specifier` attribute materialize, I get 23/180 for `pip install --dry-run --ignore-installed black pytest mypy nox`.

If you have time, I'd be interested in whether this results in a measurable improvement.