### PR TITLE
Remove check for wheel in --no-use-pep517

### DIFF
--- a/news/13330.bugfix.rst
+++ b/news/13330.bugfix.rst
@@ -1,0 +1,1 @@
+Don't require the ``wheel`` library to be installed to use ``--no-use-pep517``, any more.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -824,9 +824,9 @@ def _handle_no_use_pep517(
         """
         raise_option_error(parser, option=option, msg=msg)
 
-    # If user doesn't wish to use pep517, we check if setuptools and wheel are installed
+    # If user doesn't wish to use pep517, we check if setuptools is installed
     # and raise error if it is not.
-    packages = ("setuptools", "wheel")
+    packages = ("setuptools",)
     if not all(importlib.util.find_spec(package) for package in packages):
         msg = (
             f"It is not possible to use --no-use-pep517 "


### PR DESCRIPTION
setuptools includes native bdist_wheel support since 70.1.0, we don't need the wheel library.
