### PR TITLE
Revert _log_skipped_link() optimization to restore `requires-python` information in skipped links errors

### DIFF
--- a/news/13333.bugfix.rst
+++ b/news/13333.bugfix.rst
@@ -1,0 +1,2 @@
+Fix regression that suppressed errors indicating which packages were ignored
+due to incompatible ``requires-python`` metadata.

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -732,11 +732,6 @@ class PackageFinder:
         return no_eggs + eggs
 
     def _log_skipped_link(self, link: Link, result: LinkType, detail: str) -> None:
-        # This is a hot method so don't waste time hashing links unless we're
-        # actually going to log 'em.
-        if not logger.isEnabledFor(logging.DEBUG):
-            return
-
         entry = (link, result, detail)
         if entry not in self._logged_links:
             # Put the link at the end so the reason is more visible and because


### PR DESCRIPTION
The addition of if not logger.isEnabledFor(logging.DEBUG) in _log_skipped_link() means that skipped links are not stored, preventing requires_python_skipped_reasons() from ever returning anything.

Partial revert of https://github.com/pypa/pip/pull/13128.

Towards #13260, although I'm not going to close that until I write a test. In the interim, I'll simply revert this part of my old PR because it was only intended as an optimization.
