### PR TITLE
Switch license metadata to the PEP 639 format

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,3 @@
-include AUTHORS.txt
-include LICENSE.txt
 include NEWS.rst
 include README.rst
 include SECURITY.md
@@ -12,8 +10,6 @@ include build-project/.python-version
 
 include src/pip/_vendor/README.rst
 include src/pip/_vendor/vendor.txt
-recursive-include  src/pip/_vendor *LICENSE*
-recursive-include  src/pip/_vendor *COPYING*
 
 include docs/requirements.txt
 

--- a/news/13335.process.rst
+++ b/news/13335.process.rst
@@ -1,0 +1,3 @@
+pip's own licensing metadata now follows PEP 639.
+In addition, the licenses of pip's vendored dependencies are now included
+in the ``License-File`` metadata field and in the wheel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,16 @@ dynamic = ["version"]
 name = "pip"
 description = "The PyPA recommended tool for installing Python packages."
 readme = "README.rst"
-license = {text = "MIT"}
+license = "MIT"
+license-files = [
+  "AUTHORS.txt",
+  "LICENSE.txt",
+  "src/pip/_vendor/**/*COPYING*",
+  "src/pip/_vendor/**/*LICENSE*",
+]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Topic :: Software Development :: Build Tools",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
@@ -40,8 +45,7 @@ Source = "https://github.com/pypa/pip"
 Changelog = "https://pip.pypa.io/en/stable/news/"
 
 [build-system]
-# The lower bound is for <https://github.com/pypa/setuptools/issues/3865>.
-requires = ["setuptools>=67.6.1"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
Also, include all license files for the vendored dependencies inside the wheel, and in the `License-File` package metadata field.

License files are included in distributions automatically, so remove them from `MANIFEST.in`.

Fixes #8330