### PR TITLE
ci: don't gate Windows CI on packaging job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
     name: tests / ${{ matrix.python }} / ${{ matrix.os }} / ${{ matrix.group.number }}
     runs-on: ${{ matrix.os }}-latest
 
-    needs: [packaging, determine-changes]
+    needs: [determine-changes]
     if: >-
       needs.determine-changes.outputs.tests == 'true' ||
       github.event_name != 'pull_request'


### PR DESCRIPTION
I already removed the dependency for the Unix jobs in 7eb71fa6fe9734642ec06c9e79aa66e4ee8be899, but I forgot to update the Windows matrix. There's no point starting the Windows jobs 1.5 minutes late by waiting for the packaging jobs to complete.