### PR TITLE
Inject SSL context into urllib3 ProxyManager, too

### DIFF
--- a/news/13343.bugfix.rst
+++ b/news/13343.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure truststore feature remains active even when a proxy is also in use.

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from ssl import SSLContext
 
     from pip._vendor.urllib3.poolmanager import PoolManager
+    from pip._vendor.urllib3.proxymanager import ProxyManager
 
 
 logger = logging.getLogger(__name__)
@@ -285,6 +286,13 @@ class _SSLContextAdapterMixin:
             block=block,
             **pool_kwargs,
         )
+
+    def proxy_manager_for(self, proxy: str, **proxy_kwargs: Any) -> "ProxyManager":
+        # Proxy manager replaces the pool manager, so inject our SSL
+        # context here too. https://github.com/pypa/pip/issues/13288
+        if self._ssl_context is not None:
+            proxy_kwargs.setdefault("ssl_context", self._ssl_context)
+        return super().proxy_manager_for(proxy, **proxy_kwargs)  # type: ignore[misc]
 
 
 class HTTPAdapter(_SSLContextAdapterMixin, _BaseHTTPAdapter):


### PR DESCRIPTION
When a proxy is involved, requests uses a urllib3 proxy manager instead of the pool manager. We only inject our SSL context into the pool manager, which means the truststore context is lost when a proxy is set.

We can modify proxy manager construction by overriding `proxy_manager_for` on the requests adapters as described here: https://github.com/psf/requests/issues/6109#issuecomment-1100898596

I have no idea how to write a test for this (at least for the time being), so @schribl I'd appreciate if you could check whether this fixes your issue or not. You can install this branch via `pip install https://github.com/ichard26/pip/archive/bug/lost-ssl-context.zip`. No rush!

Should fix #13288.