### PR TITLE
Handle invalid versions gracefully for all list formats

### DIFF
--- a/news/13345.bugfix.rst
+++ b/news/13345.bugfix.rst
@@ -1,0 +1,2 @@
+``pip list`` with the ``json`` or ``freeze`` format enabled will no longer
+crash when encountering a package with an invalid version.

--- a/tests/functional/test_invalid_versions_and_specifiers.py
+++ b/tests/functional/test_invalid_versions_and_specifiers.py
@@ -96,12 +96,15 @@ def test_upgrade_require_invalid_version(
     script.pip("install", "--index-url", index_url, "require-invalid-version")
 
 
-def test_list_invalid_version(script: PipTestEnvironment, data: TestData) -> None:
+@pytest.mark.parametrize("format", ["columns", "freeze", "json"])
+def test_list_invalid_version(
+    script: PipTestEnvironment, data: TestData, format: str
+) -> None:
     """
     Test that pip can list an environment containing a package with a legacy version.
     """
     _install_invalid_version(script, data)
-    script.pip("list")
+    script.pip("list", f"--format={format}")
 
 
 def test_freeze_invalid_version(script: PipTestEnvironment, data: TestData) -> None:


### PR DESCRIPTION
~~I'm not sure if it's the right call to always emit the raw version in the JSON format, but given that the columns (default) format does emit the raw version, it seemed better to match that. The freeze format is unique because it's meant to be used for reinstallation so normalized versions are preferable. OTOH, JSON is also meant as a machine-readable format, so perhaps we should display the normalized version if possible.~~ I left the normalization intact since changing it broke the tests.

Resolves #13341.