### PR TITLE
Fix new dependency-groups feature to use the stdlib tomllib where possible

### DIFF
--- a/news/13356.vendor.rst
+++ b/news/13356.vendor.rst
@@ -1,0 +1,1 @@
+Fix issues with using tomllib from the stdlib if available, rather than tomli

--- a/src/pip/_internal/req/req_dependency_group.py
+++ b/src/pip/_internal/req/req_dependency_group.py
@@ -1,6 +1,11 @@
+import sys
 from typing import Any, Dict, Iterable, Iterator, List, Tuple
 
-from pip._vendor import tomli
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    from pip._vendor import tomli as tomllib
+
 from pip._vendor.dependency_groups import DependencyGroupResolver
 
 from pip._internal.exceptions import InstallationError
@@ -65,10 +70,10 @@ def _load_pyproject(path: str) -> Dict[str, Any]:
     """
     try:
         with open(path, "rb") as fp:
-            return tomli.load(fp)
+            return tomllib.load(fp)
     except FileNotFoundError:
         raise InstallationError(f"{path} not found. Cannot resolve '--group' option.")
-    except tomli.TOMLDecodeError as e:
+    except tomllib.TOMLDecodeError as e:
         raise InstallationError(f"Error parsing {path}: {e}") from e
     except OSError as e:
         raise InstallationError(f"Error reading {path}: {e}") from e

--- a/tests/unit/test_req_dependency_group.py
+++ b/tests/unit/test_req_dependency_group.py
@@ -120,7 +120,7 @@ def test_parse_gets_unexpected_oserror(
         raise OSError(errno.EPIPE, "Broken pipe")
 
     monkeypatch.setattr(
-        "pip._internal.req.req_dependency_group.tomli.load", epipe_toml_load
+        "pip._internal.req.req_dependency_group.tomllib.load", epipe_toml_load
     )
 
     with pytest.raises(InstallationError, match=r"Error reading pyproject\.toml"):


### PR DESCRIPTION
Previously, commit 88c9f31ad8a5ffe0bb31ab500b8ddd1b9ff6a5dd modified pip to use the stdlib on versions of python where this module is in the stdlib. As justified there:

Although a tomli copy is vendored, doing this conditional import allows:
- automatically upgrading the code, when the time comes to drop py3.10 support

- slightly simplifying debundling support, as it's no longer necessary to depend on a tomli(-wheel)? package on sufficiently newer versions of python.

https://github.com/pypa/pip/pull/13065 added a new feature, including a vendored "dependency_groups" library that likewise supports using the stdlib tomllib via `dependency_groups/_toml_compat.py`. But the code in pip itself to use dependency_groups manually loads pyproject.toml and passes it to dependency_groups, and fails to use the same compatibility dispatch as both the pre-existing pip code and dependency_groups itself.

Add back the conditional logic.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
