### PR TITLE
Workaround test failures with setuptools 80

### DIFF
--- a/tests/requirements-common_wheels.txt
+++ b/tests/requirements-common_wheels.txt
@@ -5,7 +5,9 @@
 # 4. Replacing the `setuptools` entry below with a `file:///...` URL
 # (Adjust artifact directory used based on preference and operating system)
 
-setuptools >= 40.8.0, != 60.6.0
+# We pin setuptools<80 because our test suite currently
+# depends on setup.py develop to generate egg-link files.
+setuptools >= 40.8.0, != 60.6.0, <80
 wheel
 # As required by pytest-cov.
 coverage >= 4.4


### PR DESCRIPTION
IIUC, setuptools 80 changed setup.py develop to use PEP 660?

This breaks our test suite which expects egg-link files to be created.

As part of the removal of the `setup.py develop` code path (scheduled for 25.3), we need to stop relying on egg-link to detect editable installs and use direct_url.json instead, so this will be revisited soon.