### PR TITLE
Don't attempt to build requirements that don't need to be installed

### DIFF
--- a/news/13353.bugfix.rst
+++ b/news/13353.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``req.source_dir`` AssertionError when using the legacy resolver.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -420,7 +420,7 @@ class InstallCommand(RequirementCommand):
 
             reqs_to_build = [
                 r
-                for r in requirement_set.requirements.values()
+                for r in requirement_set.requirements_to_install
                 if should_build_for_install_command(r)
             ]
 


### PR DESCRIPTION
`requirements_to_install` is scheduled for removal together with the legacy resolver, at which point we should be able to use all requirements returned by `resolve()` unconditionally.

fixes #13353

I still need to to look for variants of this problem in the `wheel`, `lock` and `download` commands. 

This indeed only happens with the legacy resolver which can return things such as constraints in the RequirementsSet, and unfortunately the logic to filter these out after resolution is dispersed in several places. 

@pfmoore I tentatively assigned this to 25.1, but we may sill decide this is not worth a bugfix release and say that affected users need to stop using the legacy resolver or stick to 25.0.