### PR TITLE
Revert StreamWrapper removal to restore Python 3.9.{0,6} compat

### DIFF
--- a/news/13364.bugfix.rst
+++ b/news/13364.bugfix.rst
@@ -1,0 +1,2 @@
+Fix crash on Python 3.9.6 and lower when pip failed to compile a Python module
+during installation.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -13,7 +13,6 @@ import sys
 import warnings
 from base64 import urlsafe_b64encode
 from email.message import Message
-from io import StringIO
 from itertools import chain, filterfalse, starmap
 from typing import (
     IO,
@@ -50,7 +49,7 @@ from pip._internal.metadata import (
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
 from pip._internal.models.scheme import SCHEME_KEYS, Scheme
 from pip._internal.utils.filesystem import adjacent_tmp_file, replace
-from pip._internal.utils.misc import ensure_dir, hash_file, partition
+from pip._internal.utils.misc import StreamWrapper, ensure_dir, hash_file, partition
 from pip._internal.utils.unpacking import (
     current_umask,
     is_within_directory,
@@ -607,7 +606,9 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
 
     # Compile all of the pyc files for the installed files
     if pycompile:
-        with contextlib.redirect_stdout(StringIO()) as stdout:
+        with contextlib.redirect_stdout(
+            StreamWrapper.from_stream(sys.stdout)
+        ) as stdout:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore")
                 for path in pyc_source_file_paths():

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -11,6 +11,7 @@ import sysconfig
 import urllib.parse
 from dataclasses import dataclass
 from functools import partial
+from io import StringIO
 from itertools import filterfalse, tee, zip_longest
 from pathlib import Path
 from types import FunctionType, TracebackType
@@ -25,6 +26,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    TextIO,
     Tuple,
     Type,
     TypeVar,
@@ -371,6 +373,22 @@ def is_local(path: str) -> bool:
 
 def write_output(msg: Any, *args: Any) -> None:
     logger.info(msg, *args)
+
+
+class StreamWrapper(StringIO):
+    orig_stream: TextIO
+
+    @classmethod
+    def from_stream(cls, orig_stream: TextIO) -> "StreamWrapper":
+        ret = cls()
+        ret.orig_stream = orig_stream
+        return ret
+
+    # compileall.compile_dir() needs stdout.encoding to print to stdout
+    # type ignore is because TextIOBase.encoding is writeable
+    @property
+    def encoding(self) -> str:  # type: ignore
+        return self.orig_stream.encoding
 
 
 # Simulates an enum


### PR DESCRIPTION
Partial revert of commit 502d08cc404625c9687e0c1aa08f502994e0fc18 which is incompatible with Python 3.9.6 and older.

Fixes #13359.