### PR TITLE
DRY tomllib compatibility

### DIFF
--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -1,13 +1,7 @@
 import importlib.util
 import os
-import sys
 from collections import namedtuple
 from typing import Any, List, Optional
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    from pip._vendor import tomli as tomllib
 
 from pip._vendor.packaging.requirements import InvalidRequirement
 
@@ -16,6 +10,7 @@ from pip._internal.exceptions import (
     InvalidPyProjectBuildRequires,
     MissingPyProjectBuildRequires,
 )
+from pip._internal.utils.compat import tomllib
 from pip._internal.utils.packaging import get_requirement
 
 

--- a/src/pip/_internal/req/req_dependency_group.py
+++ b/src/pip/_internal/req/req_dependency_group.py
@@ -1,14 +1,9 @@
-import sys
 from typing import Any, Dict, Iterable, Iterator, List, Tuple
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    from pip._vendor import tomli as tomllib
 
 from pip._vendor.dependency_groups import DependencyGroupResolver
 
 from pip._internal.exceptions import InstallationError
+from pip._internal.utils.compat import tomllib
 
 
 def parse_dependency_groups(groups: List[Tuple[str, str]]) -> List[str]:

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -7,7 +7,7 @@ import os
 import sys
 from typing import IO
 
-__all__ = ["get_path_uid", "stdlib_pkgs", "WINDOWS"]
+__all__ = ["get_path_uid", "stdlib_pkgs", "tomllib", "WINDOWS"]
 
 
 logger = logging.getLogger(__name__)
@@ -65,6 +65,12 @@ else:
         return (importlib.resources.files(package) / resource).open(
             "r", encoding=encoding, errors=errors
         )
+
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    from pip._vendor import tomli as tomllib
 
 
 # packages in the stdlib that may have installation metadata, but should not be

--- a/tests/functional/test_lock.py
+++ b/tests/functional/test_lock.py
@@ -1,15 +1,10 @@
-import sys
 import textwrap
 from pathlib import Path
 
+from pip._internal.utils.compat import tomllib
 from pip._internal.utils.urls import path_to_url
 
 from ..lib import PipTestEnvironment, TestData
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    from pip._vendor import tomli as tomllib
 
 
 def test_lock_wheel_from_findlinks(


### PR DESCRIPTION
Since the tomli vs tomllib import dance is repeated in several places, move it to `utils.compat`.

To be updated when #13356 is merged