### PR TITLE
Update version of `dependency-groups` to v1.3.1

### DIFF
--- a/news/13372.bugfix.rst
+++ b/news/13372.bugfix.rst
@@ -1,0 +1,2 @@
+- Names in dependency group includes are now normalized before lookup, which
+  fixes incorrect ``Dependency group '...' not found`` errors.

--- a/news/dependency-groups.vendor.rst
+++ b/news/dependency-groups.vendor.rst
@@ -1,0 +1,2 @@
+- Update to ``dependency-groups==1.3.1``, which resolves a bug in which include
+  resolution was not normalizing names.

--- a/news/dependency-groups.vendor.rst
+++ b/news/dependency-groups.vendor.rst
@@ -1,2 +1,1 @@
-- Update to ``dependency-groups==1.3.1``, which resolves a bug in which include
-  resolution was not normalizing names.
+- Upgrade dependency-groups to 1.3.1

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -17,4 +17,4 @@ setuptools==70.3.0
 tomli==2.2.1
 tomli-w==1.2.0
 truststore==0.10.1
-dependency-groups==1.3.0
+dependency-groups==1.3.1


### PR DESCRIPTION
This is a bugfix release of `dependency-groups` which resolves #13372

---

I assume no further changes are needed, and that the upstream testing for the bug surfaced in #13372 is sufficient.
Please let me know if the news entry isn't quite right -- I wasn't sure if I should include a bugfix entry as well.
