### PR TITLE
Mark more tests as requiring network

### DIFF
--- a/news/13378.bugfix.rst
+++ b/news/13378.bugfix.rst
@@ -1,0 +1,2 @@
+Fix missing ``network`` test markings, making the suite pass in offline
+environments again.

--- a/tests/functional/test_config_settings.py
+++ b/tests/functional/test_config_settings.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 from zipfile import ZipFile
 
+import pytest
+
 from pip._internal.utils.urls import path_to_url
 
 from tests.lib import PipTestEnvironment, create_basic_sdist_for_package
@@ -179,6 +181,7 @@ def test_backend_sees_config_via_constraint(script: PipTestEnvironment) -> None:
             assert json.loads(output) == {"FOO": "Hello"}
 
 
+@pytest.mark.network
 def test_backend_sees_config_via_sdist(script: PipTestEnvironment) -> None:
     name, version, project_dir = make_project(script.scratch_path)
     dists_dir = script.scratch_path / "dists"

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1917,6 +1917,7 @@ def test_double_install(script: PipTestEnvironment) -> None:
     assert msg not in result.stderr
 
 
+@pytest.mark.network
 def test_double_install_fail(
     script: PipTestEnvironment, resolver_variant: ResolverVariant
 ) -> None:
@@ -2677,6 +2678,7 @@ def test_install_pip_prints_req_chain_pypi(script: PipTestEnvironment) -> None:
 
 
 @pytest.mark.parametrize("common_prefix", ["", "linktest-1.0/"])
+@pytest.mark.network
 def test_install_sdist_links(script: PipTestEnvironment, common_prefix: str) -> None:
     """
     Test installing an sdist with hard and symbolic links.

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -417,6 +417,7 @@ def flags(
     return flags
 
 
+@pytest.mark.network
 def test_prompt_for_keyring_if_needed(
     data: TestData,
     cert_factory: CertFactory,

--- a/tests/functional/test_lock.py
+++ b/tests/functional/test_lock.py
@@ -1,6 +1,8 @@
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from pip._internal.utils.compat import tomllib
 from pip._internal.utils.urls import path_to_url
 
@@ -181,6 +183,7 @@ def test_lock_local_editable_with_dep(
     ]
 
 
+@pytest.mark.network
 def test_lock_vcs(script: PipTestEnvironment, shared_data: TestData) -> None:
     result = script.pip(
         "lock",
@@ -205,6 +208,7 @@ def test_lock_vcs(script: PipTestEnvironment, shared_data: TestData) -> None:
     ]
 
 
+@pytest.mark.network
 def test_lock_archive(script: PipTestEnvironment, shared_data: TestData) -> None:
     result = script.pip(
         "lock",


### PR DESCRIPTION
Apply the `network` mark to more tests that attempt to install packages from PyPI and other online sources, and therefore fail without Internet access.

To reproduce:

```
nox -e test-3.13
sudo unshare -n sh -c "ifconfig lo up && sudo -u $USER sh -c \". .nox/test-3-13/bin/activate && pytest -n auto -m 'not network'\""
```