### PR TITLE
Tests: Stop requiring wheel.whl in common_wheels

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -450,11 +450,6 @@ def setuptools_install(
 
 
 @pytest.fixture(scope="session")
-def wheel_install(tmpdir_factory: pytest.TempPathFactory, common_wheels: Path) -> Path:
-    return _common_wheel_editable_install(tmpdir_factory, common_wheels, "wheel")
-
-
-@pytest.fixture(scope="session")
 def coverage_install(
     tmpdir_factory: pytest.TempPathFactory, common_wheels: Path
 ) -> Path:
@@ -476,7 +471,6 @@ def virtualenv_template(
     pip_src: Path,
     pip_editable_parts: Tuple[Path, ...],
     setuptools_install: Path,
-    wheel_install: Path,
     coverage_install: Path,
 ) -> VirtualEnvironment:
     venv_type: VirtualEnvironmentType
@@ -491,7 +485,6 @@ def virtualenv_template(
 
     # Install setuptools, wheel and pip.
     install_pth_link(venv, "setuptools", setuptools_install)
-    install_pth_link(venv, "wheel", wheel_install)
 
     pth, dist_info = pip_editable_parts
 

--- a/tests/requirements-common_wheels.txt
+++ b/tests/requirements-common_wheels.txt
@@ -7,7 +7,7 @@
 
 # We pin setuptools<80 because our test suite currently
 # depends on setup.py develop to generate egg-link files.
-setuptools >= 40.8.0, != 60.6.0, <80
-wheel
+# We require >= 70.1 to support bdist_wheel without the wheel package
+setuptools >= 70.1, <80
 # As required by pytest-cov.
 coverage >= 4.4


### PR DESCRIPTION
In Fedora, we are using a packaged wheel.whl to run the tests (well, at least that was the idea), but considering [wheel now has runtime dependencies](https://github.com/pypa/wheel/pull/655), we are trying to get rid of it. I thought this would be an easy way to not require it here, after https://github.com/pypa/pip/pull/13330 -- but clearly I am missing something.

This is a proof of concept, it doesn't work, some tests fail with:

```
      ERROR: Could not find a version that satisfies the requirement setuptools>=40.8.0 (from versions: none)
      ERROR: No matching distribution found for setuptools>=40.8.0
```

And I am not entirely sure why yet.
