### PR TITLE
Refactor HTTP download logic 

### DIFF
--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -40,7 +40,7 @@ def _get_http_response_etag_or_last_modified(resp: Response) -> str | None:
     return resp.headers.get("etag", resp.headers.get("last-modified"))
 
 
-def _prepare_download(
+def _log_download(
     resp: Response,
     link: Link,
     progress_bar: str,
@@ -175,13 +175,13 @@ class Downloader:
     def batch(
         self, links: Iterable[Link], location: str
     ) -> Iterable[tuple[Link, tuple[str, str]]]:
-        """Download the files given by links into location."""
+        """Convenience method to download multiple links."""
         for link in links:
             filepath, content_type = self(link, location)
             yield link, (filepath, content_type)
 
     def __call__(self, link: Link, location: str) -> tuple[str, str]:
-        """Download the file given by link into location."""
+        """Download a link and save it under location."""
         resp = self._http_get(link)
         download_size = _get_http_response_size(resp)
 
@@ -190,14 +190,14 @@ class Downloader:
             download = _FileDownload(link, content_file, download_size)
             self._process_response(download, resp)
             if download.is_incomplete():
-                self._attempt_resume(download, resp)
+                self._attempt_resumes_or_redownloads(download, resp)
 
         content_type = resp.headers.get("Content-Type", "")
         return filepath, content_type
 
     def _process_response(self, download: _FileDownload, resp: Response) -> None:
-        """Process the response and write the chunks to the file."""
-        chunks = _prepare_download(
+        """Download and save chunks from a response."""
+        chunks = _log_download(
             resp,
             download.link,
             self._progress_bar,
@@ -214,8 +214,10 @@ class Downloader:
 
             logger.warning("Connection timed out while downloading.")
 
-    def _attempt_resume(self, download: _FileDownload, resp: Response) -> None:
-        """Attempt to resume the download if connection was dropped."""
+    def _attempt_resumes_or_redownloads(
+        self, download: _FileDownload, resp: Response
+    ) -> None:
+        """Attempt to resume/restart the download if connection was dropped."""
 
         while download.reattempts < self._resume_retries and download.is_incomplete():
             assert download.size is not None
@@ -250,6 +252,8 @@ class Downloader:
         self, download: _FileDownload, should_match: Response
     ) -> Response:
         """Issue a HTTP range request to resume the download."""
+        # To better understand the download resumption logic, see the mdn web docs:
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests
         headers = HEADERS.copy()
         headers["Range"] = f"bytes={download.bytes_received}-"
         # If possible, use a conditional range request to avoid corrupted

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -216,7 +216,7 @@ class Downloader:
             logger.warning("Connection timed out while downloading.")
 
     def _attempt_resumes_or_redownloads(
-        self, download: _FileDownload, resp: Response
+        self, download: _FileDownload, first_resp: Response
     ) -> None:
         """Attempt to resume/restart the download if connection was dropped."""
 
@@ -231,7 +231,7 @@ class Downloader:
             )
 
             try:
-                resume_resp = self._http_get_resume(download, should_match=resp)
+                resume_resp = self._http_get_resume(download, should_match=first_resp)
                 # Fallback: if the server responded with 200 (i.e., the file has
                 # since been modified or range requests are unsupported) or any
                 # other unexpected status, restart the download from the beginning.
@@ -239,6 +239,7 @@ class Downloader:
                 if must_restart:
                     download.reset_file()
                     download.size = _get_http_response_size(resume_resp)
+                    first_resp = resume_resp
 
                 self._process_response(download, resume_resp)
             except (ConnectionError, ReadTimeoutError, OSError):

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -172,6 +172,14 @@ class Downloader:
         self._progress_bar = progress_bar
         self._resume_retries = resume_retries
 
+    def batch(
+        self, links: Iterable[Link], location: str
+    ) -> Iterable[tuple[Link, tuple[str, str]]]:
+        """Download the files given by links into location."""
+        for link in links:
+            filepath, content_type = self(link, location)
+            yield link, (filepath, content_type)
+
     def __call__(self, link: Link, location: str) -> tuple[str, str]:
         """Download the file given by link into location."""
         resp = _http_get_download(self._session, link)
@@ -297,21 +305,3 @@ class Downloader:
         etag_or_last_modified = _get_http_response_etag_or_last_modified(resp)
 
         return bytes_received, total_length, etag_or_last_modified
-
-
-class BatchDownloader:
-    def __init__(
-        self,
-        session: PipSession,
-        progress_bar: str,
-        resume_retries: int,
-    ) -> None:
-        self._downloader = Downloader(session, progress_bar, resume_retries)
-
-    def __call__(
-        self, links: Iterable[Link], location: str
-    ) -> Iterable[tuple[Link, tuple[str, str]]]:
-        """Download the files given by links into location."""
-        for link in links:
-            filepath, content_type = self._downloader(link, location)
-            yield link, (filepath, content_type)

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -6,9 +6,10 @@ import email.message
 import logging
 import mimetypes
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from http import HTTPStatus
-from typing import BinaryIO, Mapping
+from typing import BinaryIO
 
 from pip._vendor.requests.models import Response
 from pip._vendor.urllib3.exceptions import ReadTimeoutError
@@ -140,7 +141,7 @@ class _FileDownload:
 
     link: Link
     output_file: BinaryIO
-    size: Optional[int]
+    size: int | None
     bytes_received: int = 0
     reattempts: int = 0
 

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -29,7 +29,7 @@ from pip._internal.metadata import BaseDistribution, get_metadata_distribution
 from pip._internal.models.direct_url import ArchiveInfo
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
-from pip._internal.network.download import BatchDownloader, Downloader
+from pip._internal.network.download import Downloader
 from pip._internal.network.lazy_wheel import (
     HTTPRangeRequestUnsupported,
     dist_from_wheel_url,
@@ -245,7 +245,6 @@ class RequirementPreparer:
         self.build_tracker = build_tracker
         self._session = session
         self._download = Downloader(session, progress_bar, resume_retries)
-        self._batch_download = BatchDownloader(session, progress_bar, resume_retries)
         self.finder = finder
 
         # Where still-packed archives should be written to. If None, they are
@@ -468,10 +467,7 @@ class RequirementPreparer:
             assert req.link
             links_to_fully_download[req.link] = req
 
-        batch_download = self._batch_download(
-            links_to_fully_download.keys(),
-            temp_dir,
-        )
+        batch_download = self._download.batch(links_to_fully_download.keys(), temp_dir)
         for link, (filepath, _) in batch_download:
             logger.debug("Downloading link %s to %s", link, filepath)
             req = links_to_fully_download[link]

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -12,7 +12,6 @@ from pip._internal.models.link import Link
 from pip._internal.network.download import (
     Downloader,
     _get_http_response_size,
-    _http_get_download,
     _prepare_download,
     parse_content_disposition,
     sanitize_content_filename,
@@ -147,29 +146,6 @@ def test_sanitize_content_filename__platform_dependent(
     else:
         expected = non_win_expected
     assert sanitize_content_filename(filename) == expected
-
-
-@pytest.mark.parametrize(
-    "range_start, if_range, expected_headers",
-    [
-        (None, None, HEADERS),
-        (1234, None, {**HEADERS, "Range": "bytes=1234-"}),
-        (1234, '"etag"', {**HEADERS, "Range": "bytes=1234-", "If-Range": '"etag"'}),
-    ],
-)
-def test_http_get_download(
-    range_start: int | None,
-    if_range: str | None,
-    expected_headers: dict[str, str],
-) -> None:
-    session = PipSession()
-    session.get = MagicMock()
-    link = Link("http://example.com/foo.tgz")
-    with patch("pip._internal.network.download.raise_for_status"):
-        _http_get_download(session, link, range_start, if_range)
-    session.get.assert_called_once_with(
-        "http://example.com/foo.tgz", headers=expected_headers, stream=True
-    )
 
 
 @pytest.mark.parametrize(
@@ -323,7 +299,7 @@ def test_downloader(
     resume_retries: int,
     mock_responses: list[tuple[dict[str, str], int, bytes]],
     # list of (range_start, if_range)
-    expected_resume_args: list[tuple[int | None, int | None]],
+    expected_resume_args: list[tuple[int | None, str | None]],
     # expected_bytes is None means the download should fail
     expected_bytes: bytes | None,
     tmpdir: Path,
@@ -338,9 +314,9 @@ def test_downloader(
         resp.headers = headers
         resp.status_code = status_code
         responses.append(resp)
-    _http_get_download = MagicMock(side_effect=responses)
+    _http_get_mock = MagicMock(side_effect=responses)
 
-    with patch("pip._internal.network.download._http_get_download", _http_get_download):
+    with patch.object(Downloader, "_http_get", _http_get_mock):
         if expected_bytes is None:
             remove = MagicMock(return_value=None)
             with patch("os.remove", remove):
@@ -354,9 +330,12 @@ def test_downloader(
                 downloaded_bytes = downloaded_file.read()
                 assert downloaded_bytes == expected_bytes
 
-    calls = [call(session, link)]  # the initial request
+    calls = [call(link)]  # the initial GET request
     for range_start, if_range in expected_resume_args:
-        calls.append(call(session, link, range_start=range_start, if_range=if_range))
+        headers = {**HEADERS, "Range": f"bytes={range_start}-"}
+        if if_range:
+            headers["If-Range"] = if_range
+        calls.append(call(link, headers))
 
-    # Make sure that the download makes additional requests for resumption
-    _http_get_download.assert_has_calls(calls)
+    # Make sure that the downloader makes additional requests for resumption
+    _http_get_mock.assert_has_calls(calls)

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -229,9 +229,9 @@ def test_parse_content_disposition(
             [(24, None), (36, None)],
             b"new-0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
         ),
-        # The downloader should fail after n resume_retries attempts.
+        # The downloader should fail after N resume_retries attempts.
         # This prevents the downloader from getting stuck if the connection
-        # is unstable and the server doesn't not support range requests.
+        # is unstable and the server does NOT support range requests.
         (
             1,
             [
@@ -241,7 +241,7 @@ def test_parse_content_disposition(
             [(24, None)],
             None,
         ),
-        # The downloader should use If-Range header to make the range
+        # The downloader should use the If-Range header to make the range
         # request conditional if it is possible to check for modifications
         # (e.g. if we know the creation time of the initial response).
         (
@@ -257,15 +257,26 @@ def test_parse_content_disposition(
                 ),
                 (
                     {
+                        "content-length": "42",
+                        "last-modified": "Wed, 21 Oct 2015 07:30:00 GMT",
+                    },
+                    200,
+                    b"new-0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+                ),
+                (
+                    {
                         "content-length": "12",
                         "last-modified": "Wed, 21 Oct 2015 07:54:00 GMT",
                     },
-                    206,
+                    200,
                     b"f2561d5dfd89",
                 ),
             ],
-            [(24, "Wed, 21 Oct 2015 07:28:00 GMT")],
-            b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+            [
+                (24, "Wed, 21 Oct 2015 07:28:00 GMT"),
+                (40, "Wed, 21 Oct 2015 07:30:00 GMT"),
+            ],
+            b"f2561d5dfd89",
         ),
         # ETag is preferred over Last-Modified for the If-Range condition.
         (
@@ -286,12 +297,12 @@ def test_parse_content_disposition(
                         "last-modified": "Wed, 21 Oct 2015 07:54:00 GMT",
                         "etag": '"33a64df551425fcc55e4d42a148795d9f25f89d4"',
                     },
-                    206,
+                    200,
                     b"f2561d5dfd89",
                 ),
             ],
             [(24, '"33a64df551425fcc55e4d42a148795d9f25f89d4"')],
-            b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89",
+            b"f2561d5dfd89",
         ),
     ],
 )

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -12,7 +12,7 @@ from pip._internal.models.link import Link
 from pip._internal.network.download import (
     Downloader,
     _get_http_response_size,
-    _prepare_download,
+    _log_download,
     parse_content_disposition,
     sanitize_content_filename,
 )
@@ -76,7 +76,7 @@ from tests.lib.requests_mocks import MockResponse
         ),
     ],
 )
-def test_prepare_download__log(
+def test_log_download(
     caplog: pytest.LogCaptureFixture,
     url: str,
     headers: dict[str, str],
@@ -92,7 +92,7 @@ def test_prepare_download__log(
         resp.from_cache = from_cache
     link = Link(url)
     total_length = _get_http_response_size(resp)
-    _prepare_download(
+    _log_download(
         resp,
         link,
         progress_bar="on",


### PR DESCRIPTION
I was never really happy with how the download logic turned out after PR #12991. This is my second attempt at refactoring the downloading logic to be easier to read/follow. The main change is refactoring the `Downloader` class to use a separate dataclass to store state for individual downloads. This greatly reduces the number of names being passed around in the download logic.

It's easiest this to review by reviewing commit-by-commit. 