### PR TITLE
Tests: Add various missing @pytest.mark.network markers

### DIFF
--- a/tests/functional/test_config_settings.py
+++ b/tests/functional/test_config_settings.py
@@ -179,6 +179,7 @@ def test_backend_sees_config_via_constraint(script: PipTestEnvironment) -> None:
             assert json.loads(output) == {"FOO": "Hello"}
 
 
+@pytest.mark.network
 def test_backend_sees_config_via_sdist(script: PipTestEnvironment) -> None:
     name, version, project_dir = make_project(script.scratch_path)
     dists_dir = script.scratch_path / "dists"

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1917,6 +1917,7 @@ def test_double_install(script: PipTestEnvironment) -> None:
     assert msg not in result.stderr
 
 
+@pytest.mark.network
 def test_double_install_fail(
     script: PipTestEnvironment, resolver_variant: ResolverVariant
 ) -> None:

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2677,6 +2677,7 @@ def test_install_pip_prints_req_chain_pypi(script: PipTestEnvironment) -> None:
     )
 
 
+@pytest.mark.network
 @pytest.mark.parametrize("common_prefix", ["", "linktest-1.0/"])
 def test_install_sdist_links(script: PipTestEnvironment, common_prefix: str) -> None:
     """

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -417,6 +417,7 @@ def flags(
     return flags
 
 
+@pytest.mark.network
 def test_prompt_for_keyring_if_needed(
     data: TestData,
     cert_factory: CertFactory,

--- a/tests/functional/test_lock.py
+++ b/tests/functional/test_lock.py
@@ -181,6 +181,7 @@ def test_lock_local_editable_with_dep(
     ]
 
 
+@pytest.mark.network
 def test_lock_vcs(script: PipTestEnvironment, shared_data: TestData) -> None:
     result = script.pip(
         "lock",
@@ -205,6 +206,7 @@ def test_lock_vcs(script: PipTestEnvironment, shared_data: TestData) -> None:
     ]
 
 
+@pytest.mark.network
 def test_lock_archive(script: PipTestEnvironment, shared_data: TestData) -> None:
     result = script.pip(
         "lock",


### PR DESCRIPTION
It pip installs keyring

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
