### PR TITLE
Requires-Python error message should sort versions numerically, not alphabetically

### DIFF
--- a/news/13367.feature.rst
+++ b/news/13367.feature.rst
@@ -1,0 +1,1 @@
+Requires-Python error message should not sort versions numerically, not alphabetically

--- a/news/13367.feature.rst
+++ b/news/13367.feature.rst
@@ -1,1 +1,1 @@
-Requires-Python error message should not sort versions numerically, not alphabetically
+Requires-Python error message now sorts versions numerically.

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -250,18 +250,12 @@ class LinkEvaluator:
         if not supports_python:
             requires_python = link.requires_python
             if requires_python:
-                try:
-                    rp_ver_spec_list = []
-                    for rp_spec in specifiers.SpecifierSet(requires_python):
-                        rp_version = rp_spec.version
-                        if rp_spec.operator == "==" and rp_version.endswith(".*"):
-                            rp_version = rp_version[:-2]
-                        rp_ver_spec_list.append((Version(rp_version), rp_spec))
-                    requires_python = ",".join(
-                        [str(s) for _, s in sorted(rp_ver_spec_list)]
-                    )
-                except InvalidVersion:
-                    pass
+                def get_version_sort_key(v: str) -> tuple[int, ...]:
+                    return tuple(int(s) for s in v.split(".") if s.isdigit())
+                requires_python = ",".join(sorted(
+                    (str(s) for s in specifiers.SpecifierSet(requires_python)),
+                    key=get_version_sort_key,
+                ))
             reason = f"{version} Requires-Python {requires_python}"
             return (LinkType.requires_python_mismatch, reason)
 

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -18,7 +18,7 @@ from typing import (
 from pip._vendor.packaging import specifiers
 from pip._vendor.packaging.tags import Tag
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import InvalidVersion, Version, _BaseVersion
+from pip._vendor.packaging.version import InvalidVersion, _BaseVersion
 from pip._vendor.packaging.version import parse as parse_version
 
 from pip._internal.exceptions import (
@@ -250,12 +250,16 @@ class LinkEvaluator:
         if not supports_python:
             requires_python = link.requires_python
             if requires_python:
+
                 def get_version_sort_key(v: str) -> tuple[int, ...]:
                     return tuple(int(s) for s in v.split(".") if s.isdigit())
-                requires_python = ",".join(sorted(
-                    (str(s) for s in specifiers.SpecifierSet(requires_python)),
-                    key=get_version_sort_key,
-                ))
+
+                requires_python = ",".join(
+                    sorted(
+                        (str(s) for s in specifiers.SpecifierSet(requires_python)),
+                        key=get_version_sort_key,
+                    )
+                )
             reason = f"{version} Requires-Python {requires_python}"
             return (LinkType.requires_python_mismatch, reason)
 

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -248,17 +248,20 @@ class LinkEvaluator:
             ignore_requires_python=self._ignore_requires_python,
         )
         if not supports_python:
-            rp_specs = specifiers.SpecifierSet(link.requires_python)
-            rp_versions = []
-            for rp_spec in rp_specs:
-                rp_version = rp_spec.version
-                if rp_spec.operator in ["==", "!="] and rp_version.endswith(".*"):
-                    rp_version = rp_version[:-2]
-                rp_versions.append(Version(rp_version))
-            sorted_requires_python = ",".join(
-                [str(s) for _, s in sorted(zip(rp_versions, rp_specs))]
-            )
-            reason = f"{version} Requires-Python {sorted_requires_python}"
+            requires_python = link.requires_python
+            try:
+                rp_ver_spec_list = []
+                for rp_spec in specifiers.SpecifierSet(requires_python):
+                    rp_version = rp_spec.version
+                    if rp_spec.operator == "==" and rp_version.endswith(".*"):
+                        rp_version = rp_version[:-2]
+                    rp_ver_spec_list.append((Version(rp_version), rp_spec))
+                requires_python = ",".join(
+                    [str(s) for _, s in sorted(rp_ver_spec_list)]
+                )
+            except InvalidVersion:
+                pass
+            reason = f"{version} Requires-Python {requires_python}"
             return (LinkType.requires_python_mismatch, reason)
 
         logger.debug("Found link %s, version: %s", link, version)

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -249,18 +249,19 @@ class LinkEvaluator:
         )
         if not supports_python:
             requires_python = link.requires_python
-            try:
-                rp_ver_spec_list = []
-                for rp_spec in specifiers.SpecifierSet(requires_python):
-                    rp_version = rp_spec.version
-                    if rp_spec.operator == "==" and rp_version.endswith(".*"):
-                        rp_version = rp_version[:-2]
-                    rp_ver_spec_list.append((Version(rp_version), rp_spec))
-                requires_python = ",".join(
-                    [str(s) for _, s in sorted(rp_ver_spec_list)]
-                )
-            except InvalidVersion:
-                pass
+            if requires_python:
+                try:
+                    rp_ver_spec_list = []
+                    for rp_spec in specifiers.SpecifierSet(requires_python):
+                        rp_version = rp_spec.version
+                        if rp_spec.operator == "==" and rp_version.endswith(".*"):
+                            rp_version = rp_version[:-2]
+                        rp_ver_spec_list.append((Version(rp_version), rp_spec))
+                    requires_python = ",".join(
+                        [str(s) for _, s in sorted(rp_ver_spec_list)]
+                    )
+                except InvalidVersion:
+                    pass
             reason = f"{version} Requires-Python {requires_python}"
             return (LinkType.requires_python_mismatch, reason)
 

--- a/src/pip/_vendor/packaging/specifiers.py
+++ b/src/pip/_vendor/packaging/specifiers.py
@@ -256,10 +256,10 @@ class Specifier(BaseSpecifier):
         # operators, and if they are if they are including an explicit
         # prerelease.
         operator, version = self._spec
-        if operator in ["==", "!=", ">=", "<=", "~=", "===", ">", "<"]:
-            # The == and != specifier can include a trailing .*, if it does we
+        if operator in ["==", ">=", "<=", "~=", "===", ">", "<"]:
+            # The == specifier can include a trailing .*, if it does we
             # want to remove before parsing.
-            if operator in ["==", "!="] and version.endswith(".*"):
+            if operator == "==" and version.endswith(".*"):
                 version = version[:-2]
 
             # Parse the version, and if it is a pre-release than this

--- a/src/pip/_vendor/packaging/specifiers.py
+++ b/src/pip/_vendor/packaging/specifiers.py
@@ -256,10 +256,10 @@ class Specifier(BaseSpecifier):
         # operators, and if they are if they are including an explicit
         # prerelease.
         operator, version = self._spec
-        if operator in ["==", ">=", "<=", "~=", "===", ">", "<"]:
-            # The == specifier can include a trailing .*, if it does we
+        if operator in ["==", "!=", ">=", "<=", "~=", "===", ">", "<"]:
+            # The == and != specifier can include a trailing .*, if it does we
             # want to remove before parsing.
-            if operator == "==" and version.endswith(".*"):
+            if operator in ["==", "!="] and version.endswith(".*"):
                 version = version[:-2]
 
             # Parse the version, and if it is a pre-release than this

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -133,7 +133,7 @@ class TestLinkEvaluator:
                 False,
                 (
                     LinkType.requires_python_mismatch,
-                    "1.12 Requires-Python == 3.6.5",
+                    "1.12 Requires-Python ==3.6.5,!=3.13.*",
                 ),
                 id="requires-python-mismatch",
             ),
@@ -162,7 +162,7 @@ class TestLinkEvaluator:
         )
         link = Link(
             "https://example.com/#egg=twine-1.12",
-            requires_python="== 3.6.5",
+            requires_python="!= 3.13.*, == 3.6.5",
         )
         actual = evaluator.evaluate_link(link)
         assert actual == expected

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -133,7 +133,7 @@ class TestLinkEvaluator:
                 False,
                 (
                     LinkType.requires_python_mismatch,
-                    "1.12 Requires-Python ==3.6.5,!=3.13.*",
+                    "1.12 Requires-Python ==3.6.5,!=3.13.3",
                 ),
                 id="requires-python-mismatch",
             ),
@@ -162,7 +162,7 @@ class TestLinkEvaluator:
         )
         link = Link(
             "https://example.com/#egg=twine-1.12",
-            requires_python="!= 3.13.*, == 3.6.5",
+            requires_python="!= 3.13.3, == 3.6.5",
         )
         actual = evaluator.evaluate_link(link)
         assert actual == expected


### PR DESCRIPTION
Implements #13367

Requires-Python is str, so I converted it to a list of Versions and sorted it.
