### PR TITLE
12446 - better error msg for missing METADATA file

### DIFF
--- a/news/12446.feature.rst
+++ b/news/12446.feature.rst
@@ -1,0 +1,1 @@
+improve error message shown when pkg.dist-info encounters a missing METADATA file

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -83,7 +83,7 @@ def get_dist_canonical_name(dist: importlib.metadata.Distribution) -> Normalized
 
     name = cast(Any, dist).name
     if name is None:
-        raise BadMetadata(dist, reason="missing METADATA file")
+        raise BadMetadata(dist, reason="missing `METADATA` file")
     if not isinstance(name, str):
         raise BadMetadata(dist, reason="invalid metadata entry 'name'")
     return canonicalize_name(name)

--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -82,6 +82,8 @@ def get_dist_canonical_name(dist: importlib.metadata.Distribution) -> Normalized
         return canonicalize_name(name)
 
     name = cast(Any, dist).name
+    if name is None:
+        raise BadMetadata(dist, reason="missing METADATA file")
     if not isinstance(name, str):
         raise BadMetadata(dist, reason="invalid metadata entry 'name'")
     return canonicalize_name(name)

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -765,3 +765,19 @@ def test_list_wheel_build(script: PipTestEnvironment) -> None:
     result = script.pip("list")
     assert "Build" in result.stdout, str(result)
     assert "123" in result.stdout, str(result)
+
+
+def test_list_missing_metadata_warning(script: PipTestEnvironment) -> None:
+    """
+    Test that a warning is shown when a dist-info directory is missing the
+    METADATA file.
+    """
+    # Create a .dist-info dir without METADATA file
+    dist_info_path = script.site_packages_path / "foo.dist-info"
+    dist_info_path.mkdir()
+
+    # pip list should warn about missing .dist-info/METADATA
+    result = script.pip("list", allow_stderr_warning=True)
+
+    assert "WARNING: Skipping" in result.stderr
+    assert "missing `METADATA` file" in result.stderr

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -778,6 +778,9 @@ def test_list_missing_metadata_warning(script: PipTestEnvironment) -> None:
 
     # pip list should warn about missing .dist-info/METADATA
     result = script.pip("list", allow_stderr_warning=True)
+    print(str(result.stdout))
+    print(str(result.stderr))
+    print(dir(result))
 
-    assert "WARNING: Skipping" in result.stderr
+    assert "Skipping" in result.stderr
     assert "missing `METADATA` file" in result.stderr

--- a/tests/functional/test_list.py
+++ b/tests/functional/test_list.py
@@ -773,7 +773,7 @@ def test_list_missing_metadata_warning(script: PipTestEnvironment) -> None:
     METADATA file.
     """
     # Create a .dist-info dir without METADATA file
-    dist_info_path = script.site_packages_path / "foo.dist-info"
+    dist_info_path = script.site_packages_path / "foo-1.0.dist-info"
     dist_info_path.mkdir()
 
     # pip list should warn about missing .dist-info/METADATA


### PR DESCRIPTION
Closes #12446 

Adds a clear error message for when a package is skipped because the METADATA file is missing. 