### PR TITLE
Handle pathologically connected dependency graphs

### DIFF
--- a/news/13416.feature.rst
+++ b/news/13416.feature.rst
@@ -1,0 +1,1 @@
+Handle pathologically connected dependency graphs in reasonable time.

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -199,7 +199,8 @@ class Resolver(BaseResolver):
         arbitrary points. We make no guarantees about where the cycle
         would be broken, other than it *would* be broken.
         """
-        def has_children(node: str | None):
+
+        def has_children(node: str | None) -> bool:
             for _ in graph.iter_children(node):
                 return True
             return False
@@ -237,8 +238,9 @@ class Resolver(BaseResolver):
                 # leaf-to-root distance semantics across all the leaves.
                 pruning = False
                 named_nodes = [n for n in graph if n is not None]
-                for node in [n for n in sorted(named_nodes, reverse=True)
-                             if not has_children(n)]:
+                for node in [
+                    n for n in sorted(named_nodes, reverse=True) if not has_children(n)
+                ]:
                     pruning = True
                     names.append(node)
                     graph.remove(node)
@@ -255,7 +257,7 @@ class Resolver(BaseResolver):
                 target: Tuple[str | None, int, int] = (None, -1, sys.maxsize)
                 named_nodes = [n for n in graph if n is not None]
                 for node in sorted(named_nodes, reverse=True):
-                    num_parents  = len(tuple(graph.iter_parents(node)))
+                    num_parents = len(tuple(graph.iter_parents(node)))
                     num_children = len(tuple(graph.iter_children(node)))
                     if num_parents > target[1] and num_children < target[2]:
                         target = (node, num_parents, num_children)

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -4,7 +4,7 @@ import contextlib
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, Tuple, cast
+from typing import TYPE_CHECKING, cast
 
 from pip._vendor.resolvelib import BaseReporter, ResolutionImpossible, ResolutionTooDeep
 from pip._vendor.resolvelib import Resolver as RLResolver
@@ -254,7 +254,7 @@ class Resolver(BaseResolver):
             # preference to other nodes anyhow. Since we'll keep doing this we
             # are going to break the cycle _eventually_.
             if len(graph) > 0:
-                target: Tuple[str | None, int, int] = (None, -1, sys.maxsize)
+                target: tuple[str | None, int, int] = (None, -1, sys.maxsize)
                 named_nodes = [n for n in graph if n is not None]
                 for node in sorted(named_nodes, reverse=True):
                     num_parents = len(tuple(graph.iter_parents(node)))


### PR DESCRIPTION
The pip install process looks to install packages in the order of distance from the root of the graph; i.e. packages furthest down the dependency tree will be installed first. The idea being, AFAICT, that one wants to have a package's dependencies in place before it is installed, so that an issue with the installation does not leave the system in a bad state.

This works well when you have a graph with no cycles in it but less well when you have cycles. Once the graph has been pruned of leaves the algorithm looks to determine the node distance with the recursive `visit()` method. The `visit()` method attempts to do an exhaustive walk of the dependency graph which, for a densely connected graph results in exponential time, for example (right now for me):
```
    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND 
3720492 user      20   0  805276 127112   8896 R  99.7   0.2  21696:31 pip     
```

In order to address this we change the walk to be a heuristic which looks to break the graph cycles optimistically, whilst still keeping with the spirit of the install semantics. The leaf-pruning step of the previous algorithm is maintained (but rewritten) so semantics are preserved, but it is combined with the cycle-breaking, since it's cycles which break the leaf-pruning for working.

The proposed implementation runs the ordering step in just under 7ms for the pathological case above (which is still running at the time of writing).

It is noted that this patch changes the behavior of the cycle breaking and so, if there are package trees which have a strong dependency on the order in which the packages are _installed_ then there is a possibility of breakage when there is a cycle in the dependency tree. However, this is weighed against the argument that the new algorithm is a distinct improvement in speed and that it is reasonable to believe that few packages will fall into the set whereby they have cycles in their dependency trees and also have a strict requirement about installation order, and which might have issues during the installation process.

The semantics of installation order in graphs without cycles are preserved in this change (per the unit tests).