### PR TITLE
Use standard ruff check pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,8 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.11.12
   hooks:
-    - id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
+    - id: ruff-check
+      args: [--fix]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.16.0


### PR DESCRIPTION
`ruff` is the legacy the name, the updated name is `ruff-check`.

Further there is no need for `--exit-non-zero-on-fix`, as pre-commit fails automatically if any file is modified.