### PR TITLE
Adjust path_to_url et al. to produce the same results on Python 3.14+

### DIFF
--- a/news/13423.bugfix.rst
+++ b/news/13423.bugfix.rst
@@ -1,0 +1,1 @@
+Fix remaining test failures in Python 3.14 by adjusting ``path_to_url`` and similar functions.

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -6,6 +6,7 @@ import logging
 import os
 import posixpath
 import re
+import sys
 import urllib.parse
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -131,7 +132,11 @@ def _clean_file_url_path(part: str) -> str:
     # should not be quoted. On Linux where drive letters do not
     # exist, the colon should be quoted. We rely on urllib.request
     # to do the right thing here.
-    return urllib.request.pathname2url(urllib.request.url2pathname(part))
+    ret = urllib.request.pathname2url(urllib.request.url2pathname(part))
+    if sys.version_info >= (3, 14):
+        # https://discuss.python.org/t/pathname2url-changes-in-python-3-14-breaking-pip-tests/97091
+        ret = ret.removeprefix("//")
+    return ret
 
 
 # percent-encoded:                   /

--- a/src/pip/_internal/utils/urls.py
+++ b/src/pip/_internal/utils/urls.py
@@ -12,7 +12,7 @@ def path_to_url(path: str) -> str:
     quoted path parts.
     """
     path = os.path.normpath(os.path.abspath(path))
-    url = urllib.parse.urljoin("file:", urllib.request.pathname2url(path))
+    url = urllib.parse.urljoin("file://", urllib.request.pathname2url(path))
     return url
 
 

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -11,7 +11,7 @@ from pip._internal.utils.urls import path_to_url, url_to_path
 def test_path_to_url_unix() -> None:
     assert path_to_url("/tmp/file") == "file:///tmp/file"
     path = os.path.join(os.getcwd(), "file")
-    assert path_to_url("file") == "file://" + urllib.request.pathname2url(path)
+    assert path_to_url("file") == "file://" + path
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")


### PR DESCRIPTION
See https://github.com/python/cpython/issues/125974 and https://github.com/pypa/pip/pull/13138#issuecomment-2567715303

This makes the tests pass on Fedora with Python 3.14.0b2 (except test_get_index_content_directory_append_index, which segfaults https://github.com/python/cpython/issues/135448)

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
