### PR TITLE
Add ruff rules PIE810 multiple-starts-ends-with

### DIFF
--- a/news/13426.trivial.rst
+++ b/news/13426.trivial.rst
@@ -1,0 +1,1 @@
+Add ruff rules PIE for minor optimizations to avoid repeated calls to str.startswith and str.endswith.

--- a/news/13426.trivial.rst
+++ b/news/13426.trivial.rst
@@ -1,1 +1,1 @@
-Add ruff rules PIE for minor optimizations to avoid repeated calls to str.startswith and str.endswith.
+Add ruff rule PIE810 for minor optimizations to avoid repeated calls to str.startswith and str.endswith.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ select = [
     "I",
     "ISC",
     "PERF",
-    "PIE",
+    "PIE810",
     "PLE",
     "PLR0",
     "RUF100",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,16 +178,17 @@ select = [
     "C90",
     "E",
     "F",
+    "FA",
     "G",
     "I",
     "ISC",
     "PERF",
+    "PIE",
     "PLE",
     "PLR0",
-    "W",
     "RUF100",
     "UP",
-    "FA",
+    "W",
 ]
 
 [tool.ruff.lint.isort]

--- a/src/pip/_internal/operations/freeze.py
+++ b/src/pip/_internal/operations/freeze.py
@@ -86,7 +86,7 @@ def freeze(
                             yield line
                         continue
 
-                    if line.startswith("-e") or line.startswith("--editable"):
+                    if line.startswith(("-e", "--editable")):
                         if line.startswith("-e"):
                             line = line[2:].strip()
                         else:

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -456,7 +456,7 @@ def break_args_options(line: str) -> tuple[str, str]:
     args = []
     options = tokens[:]
     for token in tokens:
-        if token.startswith("-") or token.startswith("--"):
+        if token.startswith(("-", "--")):
             break
         else:
             args.append(token)

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -133,7 +133,7 @@ def unzip_file(filename: str, location: str, flatten: bool = True) -> None:
                     "outside target directory ({})"
                 )
                 raise InstallationError(message.format(filename, fn, location))
-            if fn.endswith("/") or fn.endswith("\\"):
+            if fn.endswith(("/", "\\")):
                 # A directory
                 ensure_dir(fn)
             else:

--- a/src/pip/_internal/vcs/subversion.py
+++ b/src/pip/_internal/vcs/subversion.py
@@ -140,7 +140,7 @@ class Subversion(VersionControl):
             data = ""
 
         url = None
-        if data.startswith("8") or data.startswith("9") or data.startswith("10"):
+        if data.startswith(("8", "9", "10")):
             entries = list(map(str.splitlines, data.split("\n\x0c\n")))
             del entries[0][0]  # get rid of the '8'
             url = entries[0][3]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,11 +122,7 @@ def pytest_collection_modifyitems(config: Config, items: list[pytest.Function]) 
         )
 
         module_root_dir = module_path.split(os.pathsep)[0]
-        if (
-            module_root_dir.startswith("functional")
-            or module_root_dir.startswith("integration")
-            or module_root_dir.startswith("lib")
-        ):
+        if module_root_dir.startswith(("functional", "integration", "lib")):
             item.add_marker(pytest.mark.integration)
         elif module_root_dir.startswith("unit"):
             item.add_marker(pytest.mark.unit)
@@ -503,10 +499,7 @@ def virtualenv_template(
 
     # Drop (non-relocatable) launchers.
     for exe in os.listdir(venv.bin):
-        if not (
-            exe.startswith("python")
-            or exe.startswith("libpy")  # Don't remove libpypy-c.so...
-        ):
+        if not exe.startswith(("python", "libpy")):  # Don't remove libpypy-c.so...
             (venv.bin / exe).unlink()
 
     # Rename original virtualenv directory to make sure

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -462,9 +462,7 @@ def _check_stderr(
         # sent directly to stderr and so bypass any configured log formatter.
         # The "--- Logging error ---" string is used in Python 3.4+, and
         # "Logged from file " is used in Python 2.
-        if line.startswith("--- Logging error ---") or line.startswith(
-            "Logged from file "
-        ):
+        if line.startswith(("--- Logging error ---", "Logged from file ")):
             reason = "stderr has a logging error, which is never allowed"
             msg = make_check_stderr_message(stderr, line=line, reason=reason)
             raise RuntimeError(msg)
@@ -595,7 +593,7 @@ class PipTestEnvironment(TestFileEnvironment):
         self.user_site_path.joinpath("easy-install.pth").touch()
 
     def _ignore_file(self, fn: str) -> bool:
-        if fn.endswith("__pycache__") or fn.endswith(".pyc"):
+        if fn.endswith(("__pycache__", ".pyc")):
             result = True
         elif self.zipapp and fn.endswith("cacert.pem"):
             # Temporary copies of cacert.pem are extracted


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/#flake8-pie-pie
* https://docs.astral.sh/ruff/rules/multiple-starts-ends-with

Fix eight instances of:
% `ruff rule PIE810`
> The `startswith` and `endswith` methods accept tuples of prefixes or suffixes respectively.
Passing a tuple of prefixes or suffixes is more efficient and readable than calling the method multiple times.

> References
- [Python documentation: `str.startswith`](https://docs.python.org/3/library/stdtypes.html#str.startswith)
- [Python documentation: `str.endswith`](https://docs.python.org/3/library/stdtypes.html#str.endswith)

These transformations to reduce unnecessary repetitive function calls have been recommended since 2006 when [they were introduced](https://docs.python.org/2/whatsnew/2.5.html#other-language-changes) in Python 2.5