### PR TITLE
Fix: ensure upgrade message shows actual installed version

### DIFF
--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -22,6 +22,7 @@ from pip._vendor.pyproject_hooks import BuildBackendHookCaller
 
 from pip._internal.build_env import BuildEnvironment, NoOpBuildEnvironment
 from pip._internal.exceptions import InstallationError, PreviousBuildDirError
+from pip._internal.metadata import get_default_environment
 from pip._internal.locations import get_scheme
 from pip._internal.metadata import (
     BaseDistribution,
@@ -879,6 +880,18 @@ class InstallRequirement:
         )
         self.install_succeeded = True
 
+        installed_version = get_installed_version(self.req.name)
+        if installed_version:
+            logger.info("Successfully installed %s-%s", self.req.name, installed_version)
+        else:
+            logger.info("Successfully installed %s (version unknown)", self.req.name)
+
+        self.install_succeeded = True
+
+def get_installed_version(package_name: str) -> str | None:
+    env = get_default_environment()
+    dist = env.get_distribution(package_name)
+    return dist.version if dist else None
 
 def check_invalid_constraint_type(req: InstallRequirement) -> str:
     # Check for unsupported forms

--- a/tests/unit/test_upgrade_shows_correct_version.py
+++ b/tests/unit/test_upgrade_shows_correct_version.py
@@ -1,0 +1,4 @@
+def test_upgrade_shows_correct_version(script):
+    script.pip_install('pip==25.0.1')
+    result = script.pip('install', '--upgrade', 'pip')
+    assert "Successfully installed pip-25.1.1" in result.stdout


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fix #13434

Previously, when upgrading pip, the output message showed the old version number instead of the new one. This fix makes sure that the success message shows the correct installed version, giving clear feedback during pip upgrades.