### PR TITLE
Fix some incorrect indents in the document

### DIFF
--- a/docs/html/cli/pip_download.rst
+++ b/docs/html/cli/pip_download.rst
@@ -204,9 +204,9 @@ Examples
          pip-8.1.1-py2.py3-none-any.whl
 
 #. Download a package supporting one of several ABIs and platforms.
-    This is useful when fetching wheels for a well-defined interpreter, whose
-    supported ABIs and platforms are known and fixed, different than the one pip is
-    running under.
+   This is useful when fetching wheels for a well-defined interpreter, whose
+   supported ABIs and platforms are known and fixed, different than the one pip is
+   running under.
 
    .. tab:: Unix/macOS
 

--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -321,7 +321,7 @@ Examples
 
          py -m pip install --upgrade SomePackage
 
-    .. note::
+   .. note::
 
       This will guarantee an update to ``SomePackage`` as it is a direct
       requirement, and possibly upgrade dependencies if their installed

--- a/docs/html/cli/pip_list.rst
+++ b/docs/html/cli/pip_list.rst
@@ -142,10 +142,10 @@ Examples
 
 #. List packages installed in editable mode
 
-When some packages are installed in editable mode, ``pip list`` outputs an
-additional column that shows the directory where the editable project is
-located (i.e. the directory that contains the ``pyproject.toml`` or
-``setup.py`` file).
+   When some packages are installed in editable mode, ``pip list`` outputs an
+   additional column that shows the directory where the editable project is
+   located (i.e. the directory that contains the ``pyproject.toml`` or
+   ``setup.py`` file).
 
    .. tab:: Unix/macOS
 
@@ -172,7 +172,7 @@ located (i.e. the directory that contains the ``pyproject.toml`` or
          setuptools       57.4.0
          wheel            0.36.2
 
-The json format outputs an additional ``editable_project_location`` field.
+   The json format outputs an additional ``editable_project_location`` field.
 
    .. tab:: Unix/macOS
 

--- a/docs/html/development/architecture/overview.rst
+++ b/docs/html/development/architecture/overview.rst
@@ -42,13 +42,13 @@ In sequence, what does pip do?:
    user-given requirements, and where to get them from.
 
    a. this step is convoluted - also exploratory, involves dependency
-         resolution -- we need to get to the index, see what versions
-         are available
+      resolution -- we need to get to the index, see what versions
+      are available
 
    b. Sometimes you need to build the package itself in order to get
-         dependency information, which means fetching the package from
-         package index, which means knowing whether it exists. For a
-         single package,
+      dependency information, which means fetching the package from
+      package index, which means knowing whether it exists. For a
+      single package,
 
 4. Install the actual items to be installed.
 


### PR DESCRIPTION
Incorrect indents cause some texts to be misinterpreted and render incorrectly.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
