### PR TITLE
refactor: Add BuildEnvironmentInstaller protocol

### DIFF
--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -11,7 +11,7 @@ import textwrap
 from collections import OrderedDict
 from collections.abc import Iterable
 from types import TracebackType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from pip._vendor.packaging.version import Version
 
@@ -26,6 +26,7 @@ from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 
 if TYPE_CHECKING:
     from pip._internal.index.package_finder import PackageFinder
+    from pip._internal.req.req_install import InstallRequirement
 
 logger = logging.getLogger(__name__)
 
@@ -79,10 +80,108 @@ def _get_system_sitepackages() -> set[str]:
     return {os.path.normcase(path) for path in system_sites}
 
 
+class BuildEnvironmentInstaller(Protocol):
+    """
+    Interface for installing build dependencies into an isolated build
+    environment.
+    """
+
+    def install(
+        self,
+        requirements: Iterable[str],
+        prefix: _Prefix,
+        *,
+        kind: str,
+        for_req: InstallRequirement | None,
+    ) -> None: ...
+
+
+class SubprocessBuildEnvironmentInstaller:
+    """
+    Install build dependencies by calling pip in a subprocess.
+    """
+
+    def __init__(self, finder: PackageFinder) -> None:
+        self.finder = finder
+
+    def install(
+        self,
+        requirements: Iterable[str],
+        prefix: _Prefix,
+        *,
+        kind: str,
+        for_req: InstallRequirement | None,
+    ) -> None:
+        finder = self.finder
+        args: list[str] = [
+            sys.executable,
+            get_runnable_pip(),
+            "install",
+            "--ignore-installed",
+            "--no-user",
+            "--prefix",
+            prefix.path,
+            "--no-warn-script-location",
+            "--disable-pip-version-check",
+            # As the build environment is ephemeral, it's wasteful to
+            # pre-compile everything, especially as not every Python
+            # module will be used/compiled in most cases.
+            "--no-compile",
+            # The prefix specified two lines above, thus
+            # target from config file or env var should be ignored
+            "--target",
+            "",
+        ]
+        if logger.getEffectiveLevel() <= logging.DEBUG:
+            args.append("-vv")
+        elif logger.getEffectiveLevel() <= VERBOSE:
+            args.append("-v")
+        for format_control in ("no_binary", "only_binary"):
+            formats = getattr(finder.format_control, format_control)
+            args.extend(
+                (
+                    "--" + format_control.replace("_", "-"),
+                    ",".join(sorted(formats or {":none:"})),
+                )
+            )
+
+        index_urls = finder.index_urls
+        if index_urls:
+            args.extend(["-i", index_urls[0]])
+            for extra_index in index_urls[1:]:
+                args.extend(["--extra-index-url", extra_index])
+        else:
+            args.append("--no-index")
+        for link in finder.find_links:
+            args.extend(["--find-links", link])
+
+        if finder.proxy:
+            args.extend(["--proxy", finder.proxy])
+        for host in finder.trusted_hosts:
+            args.extend(["--trusted-host", host])
+        if finder.custom_cert:
+            args.extend(["--cert", finder.custom_cert])
+        if finder.client_cert:
+            args.extend(["--client-cert", finder.client_cert])
+        if finder.allow_all_prereleases:
+            args.append("--pre")
+        if finder.prefer_binary:
+            args.append("--prefer-binary")
+        args.append("--")
+        args.extend(requirements)
+        with open_spinner(f"Installing {kind}") as spinner:
+            call_subprocess(
+                args,
+                command_desc=f"pip subprocess to install {kind}",
+                spinner=spinner,
+            )
+
+
 class BuildEnvironment:
     """Creates and manages an isolated environment to install build deps"""
 
-    def __init__(self) -> None:
+    def __init__(self, installer: BuildEnvironmentInstaller) -> None:
+        self.installer = installer
         temp_dir = TempDirectory(kind=tempdir_kinds.BUILD_ENV, globally_managed=True)
 
         self._prefixes = OrderedDict(
@@ -205,96 +304,18 @@ class BuildEnvironment:
 
     def install_requirements(
         self,
-        finder: PackageFinder,
         requirements: Iterable[str],
         prefix_as_string: str,
         *,
         kind: str,
+        for_req: InstallRequirement | None = None,
     ) -> None:
         prefix = self._prefixes[prefix_as_string]
         assert not prefix.setup
         prefix.setup = True
         if not requirements:
             return
-        self._install_requirements(
-            get_runnable_pip(),
-            finder,
-            requirements,
-            prefix,
-            kind=kind,
-        )
-
-    @staticmethod
-    def _install_requirements(
-        pip_runnable: str,
-        finder: PackageFinder,
-        requirements: Iterable[str],
-        prefix: _Prefix,
-        *,
-        kind: str,
-    ) -> None:
-        args: list[str] = [
-            sys.executable,
-            pip_runnable,
-            "install",
-            "--ignore-installed",
-            "--no-user",
-            "--prefix",
-            prefix.path,
-            "--no-warn-script-location",
-            "--disable-pip-version-check",
-            # As the build environment is ephemeral, it's wasteful to
-            # pre-compile everything, especially as not every Python
-            # module will be used/compiled in most cases.
-            "--no-compile",
-            # The prefix specified two lines above, thus
-            # target from config file or env var should be ignored
-            "--target",
-            "",
-        ]
-        if logger.getEffectiveLevel() <= logging.DEBUG:
-            args.append("-vv")
-        elif logger.getEffectiveLevel() <= VERBOSE:
-            args.append("-v")
-        for format_control in ("no_binary", "only_binary"):
-            formats = getattr(finder.format_control, format_control)
-            args.extend(
-                (
-                    "--" + format_control.replace("_", "-"),
-                    ",".join(sorted(formats or {":none:"})),
-                )
-            )
-
-        index_urls = finder.index_urls
-        if index_urls:
-            args.extend(["-i", index_urls[0]])
-            for extra_index in index_urls[1:]:
-                args.extend(["--extra-index-url", extra_index])
-        else:
-            args.append("--no-index")
-        for link in finder.find_links:
-            args.extend(["--find-links", link])
-
-        if finder.proxy:
-            args.extend(["--proxy", finder.proxy])
-        for host in finder.trusted_hosts:
-            args.extend(["--trusted-host", host])
-        if finder.custom_cert:
-            args.extend(["--cert", finder.custom_cert])
-        if finder.client_cert:
-            args.extend(["--client-cert", finder.client_cert])
-        if finder.allow_all_prereleases:
-            args.append("--pre")
-        if finder.prefer_binary:
-            args.append("--prefer-binary")
-        args.append("--")
-        args.extend(requirements)
-        with open_spinner(f"Installing {kind}") as spinner:
-            call_subprocess(
-                args,
-                command_desc=f"pip subprocess to install {kind}",
-                spinner=spinner,
-            )
+        self.installer.install(requirements, prefix, kind=kind, for_req=for_req)
 
 
 class NoOpBuildEnvironment(BuildEnvironment):
@@ -319,10 +340,10 @@ class NoOpBuildEnvironment(BuildEnvironment):
 
     def install_requirements(
         self,
-        finder: PackageFinder,
         requirements: Iterable[str],
         prefix_as_string: str,
         *,
         kind: str,
+        for_req: InstallRequirement | None = None,
     ) -> None:
         raise NotImplementedError()

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -12,6 +12,7 @@ from functools import partial
 from optparse import Values
 from typing import Any
 
+from pip._internal.build_env import SubprocessBuildEnvironmentInstaller
 from pip._internal.cache import WheelCache
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.index_command import IndexGroupCommand
@@ -136,6 +137,7 @@ class RequirementCommand(IndexGroupCommand):
             src_dir=options.src_dir,
             download_dir=download_dir,
             build_isolation=options.build_isolation,
+            build_isolation_installer=SubprocessBuildEnvironmentInstaller(finder),
             check_build_deps=options.check_build_deps,
             build_tracker=build_tracker,
             session=session,

--- a/src/pip/_internal/distributions/base.py
+++ b/src/pip/_internal/distributions/base.py
@@ -7,7 +7,7 @@ from pip._internal.metadata.base import BaseDistribution
 from pip._internal.req import InstallRequirement
 
 if TYPE_CHECKING:
-    from pip._internal.index.package_finder import PackageFinder
+    from pip._internal.build_env import BuildEnvironmentInstaller
 
 
 class AbstractDistribution(metaclass=abc.ABCMeta):
@@ -48,7 +48,7 @@ class AbstractDistribution(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def prepare_distribution_metadata(
         self,
-        finder: PackageFinder,
+        build_env_installer: BuildEnvironmentInstaller,
         build_isolation: bool,
         check_build_deps: bool,
     ) -> None:

--- a/src/pip/_internal/distributions/installed.py
+++ b/src/pip/_internal/distributions/installed.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pip._internal.distributions.base import AbstractDistribution
-from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import BaseDistribution
+
+if TYPE_CHECKING:
+    from pip._internal.build_env import BuildEnvironmentInstaller
 
 
 class InstalledDistribution(AbstractDistribution):
@@ -22,7 +26,7 @@ class InstalledDistribution(AbstractDistribution):
 
     def prepare_distribution_metadata(
         self,
-        finder: PackageFinder,
+        build_env_installer: BuildEnvironmentInstaller,
         build_isolation: bool,
         check_build_deps: bool,
     ) -> None:

--- a/src/pip/_internal/distributions/wheel.py
+++ b/src/pip/_internal/distributions/wheel.py
@@ -12,7 +12,7 @@ from pip._internal.metadata import (
 )
 
 if TYPE_CHECKING:
-    from pip._internal.index.package_finder import PackageFinder
+    from pip._internal.build_env import BuildEnvironmentInstaller
 
 
 class WheelDistribution(AbstractDistribution):
@@ -37,7 +37,7 @@ class WheelDistribution(AbstractDistribution):
 
     def prepare_distribution_metadata(
         self,
-        finder: PackageFinder,
+        build_env_installer: BuildEnvironmentInstaller,
         build_isolation: bool,
         check_build_deps: bool,
     ) -> None:

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -7,7 +7,10 @@ from typing import Any
 import pytest
 import tomli_w
 
-from pip._internal.build_env import BuildEnvironment
+from pip._internal.build_env import (
+    BuildEnvironment,
+    SubprocessBuildEnvironmentInstaller,
+)
 from pip._internal.req import InstallRequirement
 
 from tests.lib import (
@@ -43,9 +46,9 @@ def test_backend(tmpdir: Path, data: TestData) -> None:
     req = InstallRequirement(None, None)
     req.source_dir = os.fspath(project_dir)  # make req believe it has been unpacked
     req.load_pyproject_toml()
-    env = BuildEnvironment()
     finder = make_test_finder(find_links=[data.backends])
-    env.install_requirements(finder, ["dummy_backend"], "normal", kind="Installing")
+    env = BuildEnvironment(SubprocessBuildEnvironmentInstaller(finder))
+    env.install_requirements(["dummy_backend"], "normal", kind="Installing")
     conflicting, missing = env.check_requirements(["dummy_backend"])
     assert not conflicting
     assert not missing
@@ -73,7 +76,7 @@ def test_backend_path(tmpdir: Path, data: TestData) -> None:
     req.source_dir = os.fspath(project_dir)  # make req believe it has been unpacked
     req.load_pyproject_toml()
 
-    env = BuildEnvironment()
+    env = BuildEnvironment(object())  # type: ignore
     assert hasattr(req.pep517_backend, "build_wheel")
     with env:
         assert req.pep517_backend is not None
@@ -91,9 +94,9 @@ def test_backend_path_and_dep(tmpdir: Path, data: TestData) -> None:
     req = InstallRequirement(None, None)
     req.source_dir = os.fspath(project_dir)  # make req believe it has been unpacked
     req.load_pyproject_toml()
-    env = BuildEnvironment()
     finder = make_test_finder(find_links=[data.backends])
-    env.install_requirements(finder, ["dummy_backend"], "normal", kind="Installing")
+    env = BuildEnvironment(SubprocessBuildEnvironmentInstaller(finder))
+    env.install_requirements(["dummy_backend"], "normal", kind="Installing")
 
     assert hasattr(req.pep517_backend, "build_wheel")
     with env:

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -17,6 +17,7 @@ import pytest
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 
+from pip._internal.build_env import SubprocessBuildEnvironmentInstaller
 from pip._internal.cache import WheelCache
 from pip._internal.commands import create_command
 from pip._internal.commands.install import InstallCommand
@@ -97,11 +98,13 @@ class TestRequirementSet:
         session = PipSession()
 
         with get_build_tracker() as tracker:
+            installer = SubprocessBuildEnvironmentInstaller(finder)
             preparer = RequirementPreparer(
                 build_dir=os.path.join(self.tempdir, "build"),
                 src_dir=os.path.join(self.tempdir, "src"),
                 download_dir=None,
                 build_isolation=True,
+                build_isolation_installer=installer,
                 check_build_deps=False,
                 build_tracker=tracker,
                 session=session,


### PR DESCRIPTION
Towards #13450. This enables alternative build dependency installers to be added. This is a step towards installing build dependencies in-process.
