### PR TITLE
Convert installable wheel build error to diagnostic

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -27,7 +27,11 @@ from pip._internal.cli.req_command import (
     with_cleanup,
 )
 from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.exceptions import CommandError, InstallationError
+from pip._internal.exceptions import (
+    CommandError,
+    InstallationError,
+    InstallWheelBuildError,
+)
 from pip._internal.locations import get_scheme
 from pip._internal.metadata import get_environment
 from pip._internal.models.installation_report import InstallationReport
@@ -434,12 +438,7 @@ class InstallCommand(RequirementCommand):
             )
 
             if build_failures:
-                raise InstallationError(
-                    "Failed to build installable wheels for some "
-                    "pyproject.toml based projects ({})".format(
-                        ", ".join(r.name for r in build_failures)  # type: ignore
-                    )
-                )
+                raise InstallWheelBuildError(build_failures)
 
             to_install = resolver.get_installation_order(requirement_set)
 

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -865,3 +865,17 @@ class ResolutionTooDeepError(DiagnosticPipError):
             ),
             link="https://pip.pypa.io/en/stable/topics/dependency-resolution/#handling-resolution-too-deep-errors",
         )
+
+
+class InstallWheelBuildError(DiagnosticPipError):
+    reference = "failed-wheel-build-for-install"
+
+    def __init__(self, failed: list[InstallRequirement]) -> None:
+        super().__init__(
+            message=(
+                "Failed to build installable wheels for some "
+                "pyproject.toml based projects"
+            ),
+            context=", ".join(r.name for r in failed),  # type: ignore
+            hint_stmt=None,
+        )


### PR DESCRIPTION
Broken out of #13450. Here's how it looks:

![image](https://github.com/user-attachments/assets/5882e95e-756c-456c-a011-0230bcbe9224)

This also makes this error easier to reuse (which is needed for #13450).
