### PR TITLE
Enable resumable downloads by default

### DIFF
--- a/news/13464.feature.rst
+++ b/news/13464.feature.rst
@@ -1,0 +1,1 @@
+Automatic download resumption and retrying is enabled by default.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -290,7 +290,7 @@ resume_retries: Callable[..., Option] = partial(
     "--resume-retries",
     dest="resume_retries",
     type="int",
-    default=0,
+    default=5,
     help="Maximum attempts to resume or restart an incomplete download. "
     "(default: %default)",
 )


### PR DESCRIPTION
Resolves #13398. If anyone has concerns with the fact that there were two major changes to this functionality during this development cycle, please let me know:

- https://github.com/pypa/pip/pull/13383
- https://github.com/pypa/pip/pull/13441