### PR TITLE
Suppress the progress bar with --quiet and --log

### DIFF
--- a/news/10915.bugfix.rst
+++ b/news/10915.bugfix.rst
@@ -1,0 +1,5 @@
+Suppress the progress bar, when running with ``--log`` and ``--quiet``.
+
+Consequently, a new ``auto`` mode for ``--progress-bar`` has been added.
+``auto`` will enable progress bars unless suppressed by ``--quiet``,
+while ``on`` will always enable progress bars.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -176,6 +176,9 @@ class Command(CommandContextMixIn):
         if options.debug_mode:
             self.verbosity = 2
 
+        if hasattr(options, "progress_bar") and options.progress_bar == "auto":
+            options.progress_bar = "on" if self.verbosity >= 0 else "off"
+
         reconfigure(no_color=options.no_color)
         level_number = setup_logging(
             verbosity=self.verbosity,

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -228,9 +228,13 @@ progress_bar: Callable[..., Option] = partial(
     "--progress-bar",
     dest="progress_bar",
     type="choice",
-    choices=["on", "off", "raw"],
-    default="on",
-    help="Specify whether the progress bar should be used [on, off, raw] (default: on)",
+    choices=["auto", "on", "off", "raw"],
+    default="auto",
+    help=(
+        "Specify whether the progress bar should be used. In 'auto'"
+        " mode, --quiet will suppress all progress bars."
+        " [auto, on, off, raw] (default: auto)"
+    ),
 )
 
 log: Callable[..., Option] = partial(

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import sys
 from collections.abc import Generator, Iterable, Iterator
-from typing import Callable, TypeVar
+from typing import Callable, Literal, TypeVar
 
 from pip._vendor.rich.progress import (
     BarColumn,
@@ -25,12 +25,13 @@ from pip._internal.utils.logging import get_console, get_indentation
 
 T = TypeVar("T")
 ProgressRenderer = Callable[[Iterable[T]], Iterator[T]]
+BarType = Literal["on", "off", "raw"]
 
 
 def _rich_download_progress_bar(
     iterable: Iterable[bytes],
     *,
-    bar_type: str,
+    bar_type: BarType,
     size: int | None,
     initial_progress: int | None = None,
 ) -> Generator[bytes, None, None]:
@@ -112,7 +113,7 @@ def _raw_progress_bar(
 
 
 def get_download_progress_renderer(
-    *, bar_type: str, size: int | None = None, initial_progress: int | None = None
+    *, bar_type: BarType, size: int | None = None, initial_progress: int | None = None
 ) -> ProgressRenderer[bytes]:
     """Get an object that can be used to render the download progress.
 
@@ -136,7 +137,7 @@ def get_download_progress_renderer(
 
 
 def get_install_progress_renderer(
-    *, bar_type: str, total: int
+    *, bar_type: BarType, total: int
 ) -> ProgressRenderer[InstallRequirement]:
     """Get an object that can be used to render the install progress.
     Returns a callable, that takes an iterable to "wrap".

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -17,7 +17,7 @@ from pip._vendor.urllib3 import HTTPResponse as URLlib3Response
 from pip._vendor.urllib3._collections import HTTPHeaderDict
 from pip._vendor.urllib3.exceptions import ReadTimeoutError
 
-from pip._internal.cli.progress_bars import get_download_progress_renderer
+from pip._internal.cli.progress_bars import BarType, get_download_progress_renderer
 from pip._internal.exceptions import IncompleteDownloadError, NetworkConnectionError
 from pip._internal.models.index import PyPI
 from pip._internal.models.link import Link
@@ -47,7 +47,7 @@ def _get_http_response_etag_or_last_modified(resp: Response) -> str | None:
 def _log_download(
     resp: Response,
     link: Link,
-    progress_bar: str,
+    progress_bar: BarType,
     total_length: int | None,
     range_start: int | None = 0,
 ) -> Iterable[bytes]:
@@ -166,7 +166,7 @@ class Downloader:
     def __init__(
         self,
         session: PipSession,
-        progress_bar: str,
+        progress_bar: BarType,
         resume_retries: int,
     ) -> None:
         assert (

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -10,6 +10,7 @@ import shutil
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pip._vendor.packaging.utils import canonicalize_name
 
@@ -53,6 +54,9 @@ from pip._internal.utils.misc import (
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.unpacking import unpack_file
 from pip._internal.vcs import vcs
+
+if TYPE_CHECKING:
+    from pip._internal.cli.progress_bars import BarType
 
 logger = getLogger(__name__)
 
@@ -229,7 +233,7 @@ class RequirementPreparer:
         check_build_deps: bool,
         build_tracker: BuildTracker,
         session: PipSession,
-        progress_bar: str,
+        progress_bar: BarType,
         finder: PackageFinder,
         require_hashes: bool,
         use_user_site: bool,

--- a/src/pip/_internal/req/__init__.py
+++ b/src/pip/_internal/req/__init__.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass
 
-from pip._internal.cli.progress_bars import get_install_progress_renderer
+from pip._internal.cli.progress_bars import BarType, get_install_progress_renderer
 from pip._internal.utils.logging import indent_log
 
 from .req_file import parse_requirements
@@ -44,7 +44,7 @@ def install_given_reqs(
     warn_script_location: bool,
     use_user_site: bool,
     pycompile: bool,
-    progress_bar: str,
+    progress_bar: BarType,
 ) -> list[InstallationResult]:
     """
     Install everything in the given list.

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -539,3 +539,14 @@ def test_prompt_for_keyring_if_needed(
         assert function_name + " was called" in result.stderr
     else:
         assert function_name + " was called" not in result.stderr
+
+
+@pytest.mark.network
+def test_install_quiet_log(script: PipTestEnvironment, data: TestData) -> None:
+    """
+    Test suppressing the progress bar with --quiet and --log.
+    """
+    logfile = script.scratch_path / "log"
+    result = script.pip("install", "-qqq", "setuptools==62.0.0", "--log", logfile)
+    assert result.stdout == ""
+    assert result.stderr == ""


### PR DESCRIPTION
If users still want the progress bar, then --progress-bar on will do the trick. To make this work, a new "auto" mode has been added. It's equivalent to "on" when running at default or higher verbosity, "off" otherwise.

Closes #11024.
Closes #10930.
Fixes #10915.