### PR TITLE
Re-enable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 # Documentation for this file can be found at:
 # https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository
 
-blank_issues_enabled: false
-contact_links:
-  - name: "(maintainers only) Blank issue"
-    url: https://github.com/pypa/pip/issues/new
-    about: For maintainers only.
+blank_issues_enabled: true
+# contact_links:
+#   - name: "(maintainers only) Blank issue"
+#     url: https://github.com/pypa/pip/issues/new
+#     about: For maintainers only.


### PR DESCRIPTION
The TL;DR is that GitHub is enforcing blank_issues_enabled=false in the issue template configuration strictly (we used to use a direct URL as a bypass). This is a recent change. The core team uses blank issues extensively so we need to reenable blank issues. Unfortunately, this has the side effect of allowing everyone to file blank issues. We'll simply have to see how much (if any) misfiled issues we get.

Resolves #13415.