### PR TITLE
docs nox session: delete old build beforehand

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -156,6 +156,7 @@ def docs(session: nox.Session) -> None:
         ]
         # fmt: on
 
+    shutil.rmtree("docs/build", ignore_errors=True)
     session.run(*get_sphinx_build_command("html"))
     session.run(*get_sphinx_build_command("man"))
 


### PR DESCRIPTION
While Sphinx is good at only rebuilding what was changed, it often doesn't rebuild *enough*. For example, if you update a document that is referenced by another, the embedded reference title in the latter is not updated on the next build. This also hide warnings (which then fail the docs CI ... which is quite annoying).

To fix this, simply delete the old docs build output entirely beforehand. If a developer wants a fast edit-build-view cycle, then the docs-live session is what they should be using.
