### PR TITLE
Fix mypy type checking via creating a nox typecheck session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,18 @@ jobs:
       - run: pip install nox
       - run: nox -s docs
 
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install nox
+      - run: nox -s typecheck
+
   determine-changes:
     runs-on: ubuntu-22.04
     outputs:
@@ -252,6 +264,7 @@ jobs:
 
     needs:
       - determine-changes
+      - typecheck
       - docs
       - packaging
       - tests-unix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,22 +27,6 @@ repos:
     - id: ruff-check
       args: [--fix]
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.10.0
-  hooks:
-  - id: mypy
-    exclude: tests/data
-    args: ["--pretty", "--show-error-codes"]
-    additional_dependencies: [
-        'keyring==24.2.0',
-        'nox==2023.4.22',
-        'pytest',
-        'types-docutils==0.20.0.3',
-        'types-setuptools==68.2.0.0',
-        'types-freezegun==1.1.10',
-        'types-pyyaml==6.0.12.12',
-    ]
-
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,14 +28,14 @@ repos:
       args: [--fix]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.16.1
+  rev: v1.10.0
   hooks:
   - id: mypy
     exclude: tests/data
     args: ["--pretty", "--show-error-codes"]
     additional_dependencies: [
         'keyring==24.2.0',
-        'nox==2024.03.02',
+        'nox==2023.4.22',
         'pytest',
         'types-docutils==0.20.0.3',
         'types-setuptools==68.2.0.0',

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -148,6 +148,23 @@ To use linters locally, run:
     readability problems.
 
 
+Type Checking
+=============
+
+pip uses :pypi:`mypy` for static type checking to help catch type errors early.
+Type checking is configured to run across the entire codebase to ensure type safety.
+
+To run type checking locally:
+
+.. code-block:: console
+
+    $ nox -s typecheck
+
+This will run mypy on the ``src/pip``, ``tests``, and ``tools`` directories,
+as well as ``noxfile.py``. Type checking helps maintain code quality by
+catching type-related issues before they make it into the codebase.
+
+
 Running pip under a debugger
 ============================
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -175,6 +175,29 @@ def docs_live(session: nox.Session) -> None:
 
 
 @nox.session
+def typecheck(session: nox.Session) -> None:
+    session.install(
+        "mypy",
+        "keyring",
+        "nox",
+        "pytest",
+        "types-docutils",
+        "types-setuptools",
+        "types-freezegun",
+        "types-pyyaml",
+    )
+
+    session.run(
+        "mypy",
+        "src/pip",
+        "tests",
+        "tools",
+        "noxfile.py",
+        "--exclude=tests/data",
+    )
+
+
+@nox.session
 def lint(session: nox.Session) -> None:
     session.install("pre-commit")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,9 +24,6 @@ LOCATIONS = {
     "common-wheels": "tests/data/common_wheels",
     "protected-pip": "tools/protected_pip.py",
 }
-REQUIREMENTS = {
-    "docs": "docs/requirements.txt",
-}
 
 AUTHORS_FILE = "AUTHORS.txt"
 VERSION_FILE = "src/pip/__init__.py"
@@ -132,7 +129,7 @@ def test(session: nox.Session) -> None:
 
 @nox.session
 def docs(session: nox.Session) -> None:
-    session.install("-r", REQUIREMENTS["docs"])
+    session.install("--group", "docs")
 
     def get_sphinx_build_command(kind: str) -> list[str]:
         # Having the conf.py in the docs/html is weird but needed because we
@@ -161,7 +158,7 @@ def docs(session: nox.Session) -> None:
 
 @nox.session(name="docs-live")
 def docs_live(session: nox.Session) -> None:
-    session.install("-r", REQUIREMENTS["docs"], "sphinx-autobuild")
+    session.install("--group", "docs", "sphinx-autobuild")
 
     session.run(
         "sphinx-autobuild",
@@ -176,15 +173,12 @@ def docs_live(session: nox.Session) -> None:
 
 @nox.session
 def typecheck(session: nox.Session) -> None:
-    session.install(
-        "mypy",
-        "keyring",
-        "nox",
-        "pytest",
-        "types-docutils",
-        "types-setuptools",
-        "types-freezegun",
-        "types-pyyaml",
+    # Install test and test-types dependency groups
+    run_with_protected_pip(
+        session,
+        "install",
+        "--group",
+        "type-check",
     )
 
     session.run(
@@ -290,7 +284,7 @@ def coverage(session: nox.Session) -> None:
     run_with_protected_pip(session, "install", ".")
 
     # Install test dependencies
-    run_with_protected_pip(session, "install", "-r", REQUIREMENTS["tests"])
+    run_with_protected_pip(session, "install", "--group", "docs")
 
     if not os.path.exists(".coverage-output"):
         os.mkdir(".coverage-output")

--- a/noxfile.py
+++ b/noxfile.py
@@ -178,7 +178,7 @@ def typecheck(session: nox.Session) -> None:
         session,
         "install",
         "--group",
-        "type-check",
+        "all",
     )
 
     session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,45 @@ test-common-wheels = [
     "coverage >= 4.4",
 ]
 
+docs = [
+  "sphinx ~= 7.0",
+  # currently incompatible with sphinxcontrib-towncrier
+  # https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/92
+  "towncrier < 24",
+  "furo",
+  "myst_parser",
+  "sphinx-copybutton",
+  "sphinx-inline-tabs",
+  "sphinxcontrib-towncrier >= 0.2.0a0",
+  "sphinx-issues"
+]
+
+# Libraries that are not required for pip to run, 
+# but are used in some optional features.
+all-optional = ["keyring"]
+
+nox = ["nox"] # noxfile.py
+update-rtd-redirects = ["httpx", "rich"] # tools/update-rtd-redirects.py
+
+type-check = [
+  # Actual type checker:
+  "mypy",
+
+  # Stub libraries that contain type hints as a separate package:
+  "types-docutils", # via sphinx (test dependency)
+  "types-requests", # vendored
+  "types-urllib3", # vendored (can be removed when we upgrade to urllib3 >= 2.0)
+  "types-setuptools", # test dependency and used in distutils_hack
+  "types-six", # via python-dateutil via freezegun (test dependency)
+
+  # Everything else that could contain type hints:
+  {include-group = "test"},
+  {include-group = "docs"},
+  {include-group = "nox"},
+  {include-group = "all-optional"},
+  {include-group = "update-rtd-redirects"},
+]
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 include-package-data = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ docs = [
   "sphinx-issues"
 ]
 
-# Libraries that are not required for pip to run, 
+# Libraries that are not required for pip to run,
 # but are used in some optional features.
 all-optional = ["keyring"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ all-optional = ["keyring"]
 nox = ["nox"] # noxfile.py
 update-rtd-redirects = ["httpx", "rich", "PyYAML"] # tools/update-rtd-redirects.py
 
-type-check = [
+type-checking = [
   # Actual type checker:
   "mypy",
 
@@ -109,13 +109,15 @@ type-check = [
   "types-setuptools", # test dependency and used in distutils_hack
   "types-six", # via python-dateutil via freezegun (test dependency)
   "types-PyYAML", # update-rtd-redirects dependency
+]
 
-  # Everything else that could contain type hints:
+all = [
   {include-group = "test"},
   {include-group = "docs"},
   {include-group = "nox"},
   {include-group = "all-optional"},
   {include-group = "update-rtd-redirects"},
+  {include-group = "type-checking"},
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ docs = [
 all-optional = ["keyring"]
 
 nox = ["nox"] # noxfile.py
-update-rtd-redirects = ["httpx", "rich"] # tools/update-rtd-redirects.py
+update-rtd-redirects = ["httpx", "rich", "PyYAML"] # tools/update-rtd-redirects.py
 
 type-check = [
   # Actual type checker:
@@ -108,6 +108,7 @@ type-check = [
   "types-urllib3", # vendored (can be removed when we upgrade to urllib3 >= 2.0)
   "types-setuptools", # test dependency and used in distutils_hack
   "types-six", # via python-dateutil via freezegun (test dependency)
+  "types-PyYAML", # update-rtd-redirects dependency
 
   # Everything else that could contain type hints:
   {include-group = "test"},

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -7,9 +7,9 @@ import os
 import shutil
 import site
 from optparse import SUPPRESS_HELP, Values
+from typing import TYPE_CHECKING
 
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.requests.exceptions import InvalidProxyURL
 from pip._vendor.rich import print_json
 
 # Eagerly import self_outdated_check to avoid crashes. Otherwise,
@@ -59,6 +59,12 @@ from pip._internal.utils.virtualenv import (
     virtualenv_no_global,
 )
 from pip._internal.wheel_builder import build, should_build_for_install_command
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from requests.exceptions import InvalidProxyURL
+else:
+    from pip._vendor.requests.exceptions import InvalidProxyURL
 
 logger = getLogger(__name__)
 

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -27,7 +27,8 @@ from pip._vendor.rich.text import Text
 if TYPE_CHECKING:
     from hashlib import _Hash
 
-    from pip._vendor.requests.models import Request, Response
+    # Vendored libraries with type stubs
+    from requests.models import Request, Response
 
     from pip._internal.metadata import BaseDistribution
     from pip._internal.network.download import _FileDownload

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from hashlib import _Hash
 
     # Vendored libraries with type stubs
-    from requests.models import Request, Response
+    from requests.models import PreparedRequest, Request, Response
 
     from pip._internal.metadata import BaseDistribution
     from pip._internal.network.download import _FileDownload
@@ -298,7 +298,7 @@ class NetworkConnectionError(PipError):
         self,
         error_msg: str,
         response: Response | None = None,
-        request: Request | None = None,
+        request: Request | PreparedRequest | None = None,
     ) -> None:
         """
         Initialize NetworkConnectionError with  `request` and `response`

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -86,6 +86,7 @@ def _ensure_api_header(response: Response) -> None:
     ):
         return
 
+    assert response.request.method is not None
     raise _NotAPIContent(content_type, response.request.method)
 
 

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -18,14 +18,11 @@ from dataclasses import dataclass
 from html.parser import HTMLParser
 from optparse import Values
 from typing import (
+    TYPE_CHECKING,
     Callable,
     NamedTuple,
     Protocol,
 )
-
-from pip._vendor import requests
-from pip._vendor.requests import Response
-from pip._vendor.requests.exceptions import RetryError, SSLError
 
 from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.models.link import Link
@@ -37,6 +34,15 @@ from pip._internal.utils.misc import redact_auth_from_url
 from pip._internal.vcs import vcs
 
 from .sources import CandidatesFromPage, LinkSource, build_source
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    import requests
+    from requests import Response
+    from requests.exceptions import RetryError, SSLError
+else:
+    from pip._vendor import requests
+    from pip._vendor.requests.exceptions import RetryError, SSLError
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import sys
 import sysconfig
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pip._internal.models.scheme import SCHEME_KEYS, Scheme
 from pip._internal.utils.compat import WINDOWS
@@ -131,8 +131,13 @@ def _looks_like_red_hat_scheme() -> bool:
     (fortunately?) done quite unconditionally, so we create a default command
     object without any configuration to detect this.
     """
-    from distutils.command.install import install
-    from distutils.dist import Distribution
+    if TYPE_CHECKING:
+        # Vendored libraries with type stubs
+        from setuptools._distutils.command.install import install
+        from setuptools._distutils.dist import Distribution
+    else:
+        from distutils.command.install import install
+        from distutils.dist import Distribution
 
     cmd: Any = install(Distribution())
     cmd.finalize_options()

--- a/src/pip/_internal/locations/__init__.py
+++ b/src/pip/_internal/locations/__init__.py
@@ -80,7 +80,7 @@ def _looks_like_bpo_44860() -> bool:
 
     See <https://bugs.python.org/issue44860>.
     """
-    from distutils.command.install import INSTALL_SCHEMES
+    from distutils.command.install import INSTALL_SCHEMES  # type: ignore
 
     try:
         unix_user_platlib = INSTALL_SCHEMES["unix_user"]["platlib"]
@@ -105,7 +105,7 @@ def _looks_like_red_hat_lib() -> bool:
 
     This is the only way I can see to tell a Red Hat-patched Python.
     """
-    from distutils.command.install import INSTALL_SCHEMES
+    from distutils.command.install import INSTALL_SCHEMES  # type: ignore
 
     return all(
         k in INSTALL_SCHEMES
@@ -117,7 +117,7 @@ def _looks_like_red_hat_lib() -> bool:
 @functools.cache
 def _looks_like_debian_scheme() -> bool:
     """Debian adds two additional schemes."""
-    from distutils.command.install import INSTALL_SCHEMES
+    from distutils.command.install import INSTALL_SCHEMES  # type: ignore
 
     return "deb_system" in INSTALL_SCHEMES and "unix_local" in INSTALL_SCHEMES
 

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -57,8 +57,7 @@ def distutils_scheme(
     """
     Return a distutils install scheme
     """
-    if not TYPE_CHECKING:
-        from distutils.dist import Distribution
+    from distutils.dist import Distribution
 
     dist_args: dict[str, str | list[str]] = {"name": dist_name}
     if isolated:

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -19,16 +19,27 @@ except (ImportError, AttributeError):
 import logging
 import os
 import sys
-from distutils.cmd import Command as DistutilsCommand
 from distutils.command.install import SCHEME_KEYS
-from distutils.command.install import install as distutils_install_command
-from distutils.sysconfig import get_python_lib
+from typing import TYPE_CHECKING
 
 from pip._internal.models.scheme import Scheme
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
 from .base import get_major_minor_version
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from setuptools._distutils.cmd import Command as DistutilsCommand
+    from setuptools._distutils.command.install import (
+        install as distutils_install_command,
+    )
+    from setuptools._distutils.dist import Distribution  # noqa: F401
+    from setuptools._distutils.sysconfig import get_python_lib
+else:
+    from distutils.command.install import install as distutils_install_command
+    from distutils.sysconfig import get_python_lib
+
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +57,8 @@ def distutils_scheme(
     """
     Return a distutils install scheme
     """
-    from distutils.dist import Distribution
+    if not TYPE_CHECKING:
+        from distutils.dist import Distribution
 
     dist_args: dict[str, str | list[str]] = {"name": dist_name}
     if isolated:

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -19,7 +19,7 @@ except (ImportError, AttributeError):
 import logging
 import os
 import sys
-from distutils.command.install import SCHEME_KEYS
+from distutils.command.install import SCHEME_KEYS  # type: ignore
 from typing import TYPE_CHECKING
 
 from pip._internal.models.scheme import Scheme

--- a/src/pip/_internal/locations/_distutils.py
+++ b/src/pip/_internal/locations/_distutils.py
@@ -20,7 +20,7 @@ import logging
 import os
 import sys
 from distutils.command.install import SCHEME_KEYS  # type: ignore
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from pip._internal.models.scheme import Scheme
 from pip._internal.utils.compat import WINDOWS
@@ -77,7 +77,7 @@ def distutils_scheme(
     obj: DistutilsCommand | None = None
     obj = d.get_command_obj("install", create=True)
     assert obj is not None
-    i: distutils_install_command = obj
+    i = cast(distutils_install_command, obj)
     # NOTE: setting user or home has the side-effect of creating the home dir
     # or user base for installations during finalize_options()
     # ideally, we'd prefer a scheme class that has no side-effects.

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -176,7 +176,7 @@ class Distribution(BaseDistribution):
         # provider has a "path" attribute not present anywhere else. Not the
         # best introspection logic, but pip has been doing this for a long time.
         try:
-            return bool(self._dist._provider.path) # type: ignore
+            return bool(self._dist._provider.path)  # type: ignore
         except AttributeError:
             return False
 

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -125,7 +125,7 @@ class Distribution(BaseDistribution):
         }
         dist = pkg_resources.DistInfoDistribution(
             location=filename,
-            metadata=InMemoryMetadata(metadata_dict, filename),
+            metadata=InMemoryMetadata(metadata_dict, filename),  # type: ignore[arg-type]
             project_name=project_name,
         )
         return cls(dist)
@@ -146,7 +146,7 @@ class Distribution(BaseDistribution):
             raise UnsupportedWheel(f"{name} has an invalid wheel, {e}")
         dist = pkg_resources.DistInfoDistribution(
             location=wheel.location,
-            metadata=InMemoryMetadata(metadata_dict, wheel.location),
+            metadata=InMemoryMetadata(metadata_dict, wheel.location),  # type: ignore[arg-type]
             project_name=name,
         )
         return cls(dist)
@@ -176,7 +176,7 @@ class Distribution(BaseDistribution):
         # provider has a "path" attribute not present anywhere else. Not the
         # best introspection logic, but pip has been doing this for a long time.
         try:
-            return bool(self._dist._provider.path)
+            return bool(self._dist._provider.path) # type: ignore
         except AttributeError:
             return False
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -17,11 +17,7 @@ from abc import ABC, abstractmethod
 from functools import cache
 from os.path import commonprefix
 from pathlib import Path
-from typing import Any, NamedTuple
-
-from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
-from pip._vendor.requests.models import Request, Response
-from pip._vendor.requests.utils import get_netrc_auth
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from pip._internal.utils.logging import getLogger
 from pip._internal.utils.misc import (
@@ -32,6 +28,16 @@ from pip._internal.utils.misc import (
     split_auth_netloc_from_url,
 )
 from pip._internal.vcs.versioncontrol import AuthInfo
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from requests.auth import AuthBase, HTTPBasicAuth
+    from requests.models import Request, Response
+    from requests.utils import get_netrc_auth
+else:
+    from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
+    from pip._vendor.requests.utils import get_netrc_auth
+
 
 logger = getLogger(__name__)
 

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -32,7 +32,7 @@ from pip._internal.vcs.versioncontrol import AuthInfo
 if TYPE_CHECKING:
     # Vendored libraries with type stubs
     from requests.auth import AuthBase, HTTPBasicAuth
-    from requests.models import Request, Response
+    from requests.models import PreparedRequest, Response
     from requests.utils import get_netrc_auth
 else:
     from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
@@ -443,8 +443,9 @@ class MultiDomainBasicAuth(AuthBase):
 
         return url, username, password
 
-    def __call__(self, req: Request) -> Request:
+    def __call__(self, req: PreparedRequest) -> PreparedRequest:
         # Get credentials for this request
+        assert req.url is not None, f"{req} URL should not be None"
         url, username, password = self._get_url_and_credentials(req.url)
 
         # Set the url of the request to the url without any credentials

--- a/src/pip/_internal/network/cache.py
+++ b/src/pip/_internal/network/cache.py
@@ -7,14 +7,17 @@ import shutil
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, BinaryIO, Callable
+from typing import TYPE_CHECKING, Any, BinaryIO, Callable
 
 from pip._vendor.cachecontrol.cache import SeparateBodyBaseCache
 from pip._vendor.cachecontrol.caches import SeparateBodyFileCache
-from pip._vendor.requests.models import Response
 
 from pip._internal.utils.filesystem import adjacent_tmp_file, replace
 from pip._internal.utils.misc import ensure_dir
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from requests.models import Response
 
 
 def is_from_cache(response: Response) -> bool:

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -9,13 +9,7 @@ import os
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import BinaryIO
-
-from pip._vendor.requests import PreparedRequest
-from pip._vendor.requests.models import Response
-from pip._vendor.urllib3 import HTTPResponse as URLlib3Response
-from pip._vendor.urllib3._collections import HTTPHeaderDict
-from pip._vendor.urllib3.exceptions import ReadTimeoutError
+from typing import TYPE_CHECKING, BinaryIO
 
 from pip._internal.cli.progress_bars import BarType, get_download_progress_renderer
 from pip._internal.exceptions import IncompleteDownloadError, NetworkConnectionError
@@ -25,6 +19,19 @@ from pip._internal.network.cache import SafeFileCache, is_from_cache
 from pip._internal.network.session import CacheControlAdapter, PipSession
 from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
 from pip._internal.utils.misc import format_size, redact_auth_from_url, splitext
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from requests import PreparedRequest
+    from requests.models import Response
+    from urllib3 import HTTPResponse as URLlib3Response
+    from urllib3._collections import HTTPHeaderDict
+    from urllib3.exceptions import ReadTimeoutError
+else:
+    from pip._vendor.requests import PreparedRequest
+    from pip._vendor.urllib3 import HTTPResponse as URLlib3Response
+    from pip._vendor.urllib3._collections import HTTPHeaderDict
+    from pip._vendor.urllib3.exceptions import ReadTimeoutError
 
 logger = logging.getLogger(__name__)
 

--- a/src/pip/_internal/network/lazy_wheel.py
+++ b/src/pip/_internal/network/lazy_wheel.py
@@ -8,15 +8,20 @@ from bisect import bisect_left, bisect_right
 from collections.abc import Generator
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from zipfile import BadZipFile, ZipFile
 
 from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
 
 from pip._internal.metadata import BaseDistribution, MemoryWheel, get_wheel_distribution
 from pip._internal.network.session import PipSession
 from pip._internal.network.utils import HEADERS, raise_for_status, response_chunks
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from requests.models import CONTENT_CHUNK_SIZE, Response
+else:
+    from pip._vendor.requests.models import CONTENT_CHUNK_SIZE
 
 
 class HTTPRangeRequestUnsupported(Exception):

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -26,15 +26,6 @@ from typing import (
     Union,
 )
 
-from pip._vendor import requests, urllib3
-from pip._vendor.cachecontrol import CacheControlAdapter as _BaseCacheControlAdapter
-from pip._vendor.requests.adapters import DEFAULT_POOLBLOCK, BaseAdapter
-from pip._vendor.requests.adapters import HTTPAdapter as _BaseHTTPAdapter
-from pip._vendor.requests.models import PreparedRequest, Response
-from pip._vendor.requests.structures import CaseInsensitiveDict
-from pip._vendor.urllib3.connectionpool import ConnectionPool
-from pip._vendor.urllib3.exceptions import InsecureRequestWarning
-
 from pip import __version__
 from pip._internal.metadata import get_default_environment
 from pip._internal.models.link import Link
@@ -50,8 +41,28 @@ from pip._internal.utils.urls import url_to_path
 if TYPE_CHECKING:
     from ssl import SSLContext
 
-    from pip._vendor.urllib3.poolmanager import PoolManager
-    from pip._vendor.urllib3.proxymanager import ProxyManager
+    # Vendored libraries with type stubs
+    import requests
+    import urllib3
+    from requests.adapters import DEFAULT_POOLBLOCK, BaseAdapter
+    from requests.adapters import HTTPAdapter as _BaseHTTPAdapter
+    from requests.models import PreparedRequest, Response
+    from requests.structures import CaseInsensitiveDict
+    from urllib3 import ProxyManager
+    from urllib3.connectionpool import ConnectionPool
+    from urllib3.exceptions import InsecureRequestWarning
+    from urllib3.poolmanager import PoolManager
+
+    from pip._vendor.cachecontrol import CacheControlAdapter as _BaseCacheControlAdapter
+
+else:
+    from pip._vendor import requests, urllib3
+    from pip._vendor.cachecontrol import CacheControlAdapter as _BaseCacheControlAdapter
+    from pip._vendor.requests.adapters import DEFAULT_POOLBLOCK, BaseAdapter
+    from pip._vendor.requests.adapters import HTTPAdapter as _BaseHTTPAdapter
+    from pip._vendor.requests.models import PreparedRequest, Response
+    from pip._vendor.requests.structures import CaseInsensitiveDict
+    from pip._vendor.urllib3.exceptions import InsecureRequestWarning
 
 
 logger = logging.getLogger(__name__)

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -1,8 +1,13 @@
-from collections.abc import Generator
+from __future__ import annotations
 
-from pip._vendor.requests.models import Response
+from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 from pip._internal.exceptions import NetworkConnectionError
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from requests.models import Response
 
 # The following comments and HTTP headers were originally added by
 # Donald Stufft in git commit 22c562429a61bb77172039e480873fb239dd8c03.

--- a/src/pip/_internal/network/xmlrpc.py
+++ b/src/pip/_internal/network/xmlrpc.py
@@ -3,7 +3,8 @@
 import logging
 import urllib.parse
 import xmlrpc.client
-from typing import TYPE_CHECKING
+from http.client import HTTPResponse
+from typing import TYPE_CHECKING, cast
 
 from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.network.session import PipSession
@@ -44,13 +45,13 @@ class PipXmlrpcTransport(xmlrpc.client.Transport):
             headers = {"Content-Type": "text/xml"}
             response = self._session.post(
                 url,
-                data=request_body,
+                data=cast(bytes, request_body),
                 headers=headers,
                 stream=True,
             )
             raise_for_status(response)
             self.verbose = verbose
-            return self.parse_response(response.raw)
+            return self.parse_response(cast(HTTPResponse, response.raw))
         except NetworkConnectionError as exc:
             assert exc.response
             logger.critical(

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -5,7 +5,7 @@ from base64 import b64encode
 from collections.abc import Iterable, Iterator
 from contextlib import ExitStack, contextmanager
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 from unittest.mock import Mock
 
 from werkzeug.serving import BaseWSGIServer, WSGIRequestHandler
@@ -99,7 +99,7 @@ def make_mock_server(**kwargs: Any) -> _MockServer:
 
     mock = Mock()
     app = _mock_wsgi_adapter(mock)
-    server = _make_server("localhost", 0, app=app, **kwargs)
+    server = cast(_MockServer, _make_server("localhost", 0, app=app, **kwargs))
     server.mock = mock
     return server
 

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -15,22 +15,13 @@ from hashlib import sha256
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
     AnyStr,
     TypeVar,
     Union,
-    cast,
 )
 from zipfile import ZipFile
 
 from pip._internal.metadata import BaseDistribution, MemoryWheel, get_wheel_distribution
-
-if TYPE_CHECKING:
-    # Vendored libraries with type stubs
-    from requests.structures import CaseInsensitiveDict
-else:
-    from pip._vendor.requests.structures import CaseInsensitiveDict
-
 
 # As would be used in metadata
 HeaderValue = Union[str, list[str]]

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -19,6 +19,7 @@ from typing import (
     AnyStr,
     TypeVar,
     Union,
+    cast,
 )
 from zipfile import ZipFile
 
@@ -91,13 +92,11 @@ def make_metadata_file(
     if value is not _default:
         return File(path, ensure_binary(value))
 
-    metadata = CaseInsensitiveDict(
-        {
-            "Metadata-Version": "2.1",
-            "Name": name,
-            "Version": version,
-        }
-    )
+    metadata: dict[str, HeaderValue] = {
+        "Metadata-Version": "2.1",
+        "Name": name,
+        "Version": version,
+    }
     if updates is not _default:
         metadata.update(updates)
 
@@ -123,14 +122,12 @@ def make_wheel_metadata_file(
     if value is not _default:
         return File(path, ensure_binary(value))
 
-    metadata = CaseInsensitiveDict(
-        {
-            "Wheel-Version": "1.0",
-            "Generator": "pip-test-suite",
-            "Root-Is-Purelib": "true",
-            "Tag": ["-".join(parts) for parts in tags],
-        }
-    )
+    metadata: dict[str, HeaderValue] = {
+        "Wheel-Version": "1.0",
+        "Generator": "pip-test-suite",
+        "Root-Is-Purelib": "true",
+        "Tag": ["-".join(parts) for parts in tags],
+    }
 
     if updates is not _default:
         metadata.update(updates)

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -15,15 +15,21 @@ from hashlib import sha256
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     AnyStr,
     TypeVar,
     Union,
 )
 from zipfile import ZipFile
 
-from pip._vendor.requests.structures import CaseInsensitiveDict
-
 from pip._internal.metadata import BaseDistribution, MemoryWheel, get_wheel_distribution
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from requests.structures import CaseInsensitiveDict
+else:
+    from pip._vendor.requests.structures import CaseInsensitiveDict
+
 
 # As would be used in metadata
 HeaderValue = Union[str, list[str]]

--- a/tests/unit/metadata/test_metadata_pkg_resources.py
+++ b/tests/unit/metadata/test_metadata_pkg_resources.py
@@ -18,7 +18,8 @@ from pip._internal.metadata.pkg_resources import (
 )
 
 pkg_resources = pytest.importorskip("pip._vendor.pkg_resources")
-from pip._vendor.pkg_resources import WorkingSet
+from pip._vendor.pkg_resources import WorkingSet  # noqa: E402
+
 
 def _dist_is_local(dist: mock.Mock) -> bool:
     return dist.kind != "global" and dist.kind != "user"

--- a/tests/unit/metadata/test_metadata_pkg_resources.py
+++ b/tests/unit/metadata/test_metadata_pkg_resources.py
@@ -18,7 +18,7 @@ from pip._internal.metadata.pkg_resources import (
 )
 
 pkg_resources = pytest.importorskip("pip._vendor.pkg_resources")
-
+from pip._vendor.pkg_resources import WorkingSet
 
 def _dist_is_local(dist: mock.Mock) -> bool:
     return dist.kind != "global" and dist.kind != "user"
@@ -71,13 +71,13 @@ workingset_stdlib = _MockWorkingSet(
 )
 def test_get_distribution(ws: _MockWorkingSet, req_name: str) -> None:
     """Ensure get_distribution() finds all kinds of distributions."""
-    dist = Environment(ws).get_distribution(req_name)
+    dist = Environment(cast(WorkingSet, ws)).get_distribution(req_name)
     assert dist is not None
     assert cast(Distribution, dist)._dist.project_name == req_name
 
 
 def test_get_distribution_nonexist() -> None:
-    dist = Environment(workingset).get_distribution("non-exist")
+    dist = Environment(cast(WorkingSet, workingset)).get_distribution("non-exist")
     assert dist is None
 
 

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -8,11 +8,11 @@ import re
 import uuid
 from pathlib import Path
 from textwrap import dedent
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
 
-from pip._vendor import requests
 from pip._vendor.packaging.requirements import Requirement
 
 from pip._internal.exceptions import NetworkConnectionError
@@ -46,6 +46,12 @@ from tests.lib import (
     skip_needs_old_pathname2url_trailing_slash_behavior_win,
     skip_needs_old_urlun_behavior_win,
 )
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    import requests
+else:
+    from pip._vendor import requests
 
 ACCEPT = ", ".join(
     [

--- a/tests/unit/test_command_install.py
+++ b/tests/unit/test_command_install.py
@@ -1,12 +1,17 @@
 import errno
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
 
-from pip._vendor.requests.exceptions import InvalidProxyURL
-
 from pip._internal.commands import install
 from pip._internal.commands.install import create_os_error_message, decide_user_install
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from requests.exceptions import InvalidProxyURL
+else:
+    from pip._vendor.requests.exceptions import InvalidProxyURL
 
 
 class TestDecideUserInstall:

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -10,12 +10,16 @@ import sys
 import sysconfig
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
 
 from pip._internal.locations import SCHEME_KEYS, _should_use_sysconfig, get_scheme
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    from setuptools._distutils.dist import Distribution  # noqa: F401
 
 if sys.platform == "win32":
     pwd = Mock()
@@ -129,7 +133,9 @@ class TestDistutilsScheme:
         f = tmpdir / "config" / "setup.cfg"
         f.parent.mkdir()
         f.write_text("[install]\ninstall-scripts=" + install_scripts)
-        from distutils.dist import Distribution
+
+        if not TYPE_CHECKING:
+            from distutils.dist import Distribution
 
         # patch the function that returns what config files are present
         monkeypatch.setattr(
@@ -155,7 +161,8 @@ class TestDistutilsScheme:
         f = tmpdir / "config" / "setup.cfg"
         f.parent.mkdir()
         f.write_text("[install]\ninstall-lib=" + install_lib)
-        from distutils.dist import Distribution
+        if not TYPE_CHECKING:
+            from distutils.dist import Distribution
 
         # patch the function that returns what config files are present
         monkeypatch.setattr(

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -134,8 +134,7 @@ class TestDistutilsScheme:
         f.parent.mkdir()
         f.write_text("[install]\ninstall-scripts=" + install_scripts)
 
-        if not TYPE_CHECKING:
-            from distutils.dist import Distribution
+        from distutils.dist import Distribution
 
         # patch the function that returns what config files are present
         monkeypatch.setattr(
@@ -161,8 +160,7 @@ class TestDistutilsScheme:
         f = tmpdir / "config" / "setup.cfg"
         f.parent.mkdir()
         f.write_text("[install]\ninstall-lib=" + install_lib)
-        if not TYPE_CHECKING:
-            from distutils.dist import Distribution
+        from distutils.dist import Distribution
 
         # patch the function that returns what config files are present
         monkeypatch.setattr(

--- a/tests/unit/test_network_auth.py
+++ b/tests/unit/test_network_auth.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -13,6 +13,11 @@ import pip._internal.network.auth
 from pip._internal.network.auth import MultiDomainBasicAuth
 
 from tests.lib.requests_mocks import MockConnection, MockRequest, MockResponse
+
+if TYPE_CHECKING:
+    from requests.models import Response
+else:
+    from pip._vendor.requests.models import Response
 
 
 @pytest.fixture(autouse=True)
@@ -320,7 +325,7 @@ def test_keyring_set_password(
     resp.status_code = 401
     resp.connection = connection
 
-    auth.handle_401(resp)
+    auth.handle_401(cast("Response", resp))
 
     if expect_save:
         assert keyring.saved_passwords == [("example.com", creds[0], creds[1])]
@@ -536,7 +541,7 @@ def test_keyring_cli_set_password(
     resp.status_code = 401
     resp.connection = connection
 
-    auth.handle_401(resp)
+    auth.handle_401(cast("Response", resp))
 
     if expect_save:
         assert keyring.saved_passwords == [("example.com", creds[0], creds[1])]

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -20,6 +21,11 @@ from pip._internal.network.session import PipSession
 from pip._internal.network.utils import HEADERS
 
 from tests.lib.requests_mocks import MockResponse
+
+if TYPE_CHECKING:
+    from requests.models import Response
+else:
+    from pip._vendor.requests.models import Response
 
 
 @pytest.mark.parametrize(
@@ -91,9 +97,9 @@ def test_log_download(
     if from_cache:
         resp.from_cache = from_cache
     link = Link(url)
-    total_length = _get_http_response_size(resp)
+    total_length = _get_http_response_size(cast("Response", resp))
     _log_download(
-        resp,
+        cast("Response", resp),
         link,
         progress_bar="on",
         total_length=total_length,

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 from urllib.request import getproxies
 
 import pytest
-
-from pip._vendor import requests
 
 from pip import __version__
 from pip._internal.models.link import Link
@@ -18,6 +16,12 @@ from pip._internal.network.session import (
     PipSession,
     user_agent,
 )
+
+if TYPE_CHECKING:
+    # Vendored libraries with type stubs
+    import requests
+else:
+    from pip._vendor import requests
 
 
 def get_user_agent() -> str:

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -28,7 +28,7 @@ def get_user_agent() -> str:
     # These tests are testing the computation of the user agent, so we want to
     # avoid reusing cached values.
     user_agent.cache_clear()
-    return PipSession().headers["User-Agent"]
+    return str(PipSession().headers["User-Agent"])
 
 
 def test_user_agent() -> None:

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -1,9 +1,16 @@
+from typing import TYPE_CHECKING, cast
+
 import pytest
 
 from pip._internal.exceptions import NetworkConnectionError
 from pip._internal.network.utils import raise_for_status
 
 from tests.lib.requests_mocks import MockResponse
+
+if TYPE_CHECKING:
+    from requests.models import Response
+else:
+    from pip._vendor.requests.models import Response
 
 
 @pytest.mark.parametrize(
@@ -20,7 +27,7 @@ def test_raise_for_status_raises_exception(status_code: int, error_type: str) ->
     resp.url = "http://www.example.com/whatever.tgz"
     resp.reason = "Network Error"
     with pytest.raises(NetworkConnectionError) as excinfo:
-        raise_for_status(resp)
+        raise_for_status(cast("Response", resp))
     assert str(excinfo.value) == (
         f"{status_code} {error_type}: Network Error for url:"
         " http://www.example.com/whatever.tgz"
@@ -33,4 +40,4 @@ def test_raise_for_status_does_not_raises_exception() -> None:
     resp.status_code = 201
     resp.url = "http://www.example.com/whatever.tgz"
     resp.reason = "No error"
-    raise_for_status(resp)
+    raise_for_status(cast("Response", resp))

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -3,7 +3,7 @@ import shutil
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -18,6 +18,11 @@ from pip._internal.utils.hashes import Hashes
 from tests.lib import TestData
 from tests.lib.requests_mocks import MockResponse
 
+if TYPE_CHECKING:
+    from requests.models import Response
+else:
+    from pip._vendor.requests.models import Response
+
 
 def test_unpack_url_with_urllib_response_without_content_type(data: TestData) -> None:
     """
@@ -25,7 +30,7 @@ def test_unpack_url_with_urllib_response_without_content_type(data: TestData) ->
     """
     _real_session = PipSession()
 
-    def _fake_session_get(*args: Any, **kwargs: Any) -> dict[str, str]:
+    def _fake_session_get(*args: Any, **kwargs: Any) -> Response:
         resp = _real_session.get(*args, **kwargs)
         del resp.headers["Content-Type"]
         return resp


### PR DESCRIPTION
This moves type checking out of the pre-commit and into a dedicated `nox -s typecheck`, this was inspired by and succeeds https://github.com/pypa/pip/pull/12866.

On top of the reasons outlined there there are two big issues with pip's type checking:

### 1. The additional dependencies in the `.pre-commit.yaml` are rarely updated and currently obsolete

This PR fixes that by making the `nox -s typecheck` a new type-check dependency groups, which inherits from the existing test dependency group, a new docs dependency group, and a couple of other dependency groups that define various parts of pip.

Taking the changes from https://github.com/pypa/pip/pull/12866 and apply this increased the number of mypy errors from 0 to 48.

### 2. Vendored dependencies that use type stubs are not currently type checked

Pip vendors libraries like requests which do not include type hints, normally this is fixed by installing a stubs package, `types-requests` at type hint time, however this was not being picked up by mypy because it does not recognized `pip._vendor.requests` as `requests`.

This can be fixed by doing all the imports of vendored libraries that don't include type hints like this (fortunately there are only a few libraries that need this):

```python
if TYPE_CHECKING:
    import requests
else:
    from pip._vendor import requests
```

Doing this increased the number of mypy errors from 48 to 71.

The rest of the PR is simply about fixing all the type check errors, I tried to be very conservative, using `# type: ignore` and `cast` rather than making complicated refactors, removing this can be done by follow up PRs if someone is so inclined.

A side benefit is pre-commit runs much much faster, allowing you to enable it locally and it not be painful.