### PR TITLE
Remove unnecessary gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-# Byte-compiled / optimized / DLL files
+# Byte-compiled files
 __pycache__/
-*.py[cod]
 *$py.class
 
 # Distribution / packaging


### PR DESCRIPTION
* `.pyc` files can now only occur inside `__pycache__` directories, wich are already ignored separately.

* `.pyo` files were obsoleted in Python 3.5 (PEP 488).

* `.pyd` files should never legitimately occur in the pip source tree, as it is a pure Python project.
