### PR TITLE
Fix: Fixes hardcoded commit SHA on test_install_vcs_git.py

### DIFF
--- a/news/13491.bugfix.rst
+++ b/news/13491.bugfix.rst
@@ -1,1 +1,0 @@
-Fix test_install_vcs_git.py hardcoded commit SHA error.

--- a/news/13491.bugfix.rst
+++ b/news/13491.bugfix.rst
@@ -1,1 +1,1 @@
-Fix test_install_vcs_git.py harcoded commit SHA error.
+Fix test_install_vcs_git.py hardcoded commit SHA error.

--- a/news/13491.bugfix.rst
+++ b/news/13491.bugfix.rst
@@ -1,0 +1,1 @@
+Fix test_install_vcs_git.py harcoded commit SHA error.

--- a/tests/functional/test_install_vcs_git.py
+++ b/tests/functional/test_install_vcs_git.py
@@ -315,7 +315,7 @@ def test_git_install_then_install_ref(script: PipTestEnvironment) -> None:
     "rev, expected_sha",
     [
         # Clone the default branch
-        ("", "5547fa909e83df8bd743d3978d6667497983a4b7"),
+        ("", "96d6d72ac54132aecbdd5adac88bc8d1f8fb986b"),
         # Clone a specific tag
         ("@0.1.1", "7d654e66c8fa7149c165ddeffa5b56bc06619458"),
         # Clone a specific commit


### PR DESCRIPTION
Fixes #13491,

I tried to fix this bug to the best of my ability. I’d appreciate any feedback or suggestions on how to make it better.
