### PR TITLE
Improve presentation of non-verbose downloads with non-PyPI indexes

### DIFF
--- a/news/13494.bugfix.rst
+++ b/news/13494.bugfix.rst
@@ -1,0 +1,1 @@
+Show the filename rather than the full URL when downloading files from non-PyPI indexes in non-verbose mode.

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -19,7 +19,6 @@ from pip._vendor.urllib3.exceptions import ReadTimeoutError
 
 from pip._internal.cli.progress_bars import BarType, get_download_progress_renderer
 from pip._internal.exceptions import IncompleteDownloadError, NetworkConnectionError
-from pip._internal.models.index import PyPI
 from pip._internal.models.link import Link
 from pip._internal.network.cache import SafeFileCache, is_from_cache
 from pip._internal.network.session import CacheControlAdapter, PipSession
@@ -51,10 +50,10 @@ def _log_download(
     total_length: int | None,
     range_start: int | None = 0,
 ) -> Iterable[bytes]:
-    if link.netloc == PyPI.file_storage_domain:
-        url = link.show_url
-    else:
+    if logger.getEffectiveLevel() > logging.INFO:
         url = link.url_without_fragment
+    else:
+        url = link.show_url
 
     logged_url = redact_auth_from_url(url)
 

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -30,21 +30,21 @@ from tests.lib.requests_mocks import MockResponse
             {},
             False,
             None,
-            "Downloading http://example.com/foo.tgz",
+            "Downloading foo.tgz",
         ),
         (
             "http://example.com/foo.tgz",
             {"content-length": "2"},
             False,
             None,
-            "Downloading http://example.com/foo.tgz (2 bytes)",
+            "Downloading foo.tgz (2 bytes)",
         ),
         (
             "http://example.com/foo.tgz",
             {"content-length": "2"},
             True,
             None,
-            "Using cached http://example.com/foo.tgz (2 bytes)",
+            "Using cached foo.tgz (2 bytes)",
         ),
         (
             "https://files.pythonhosted.org/foo.tgz",
@@ -72,7 +72,7 @@ from tests.lib.requests_mocks import MockResponse
             {"content-length": "200"},
             False,
             100,
-            "Resuming download http://example.com/foo.tgz (100 bytes/200 bytes)",
+            "Resuming download foo.tgz (100 bytes/200 bytes)",
         ),
     ],
 )


### PR DESCRIPTION
Before:

```
❯ pip download --index-url https://www.piwheels.org/simple --dest /tmp/throwaway revpy
Looking in indexes: https://www.piwheels.org/simple
Collecting revpy
  Using cached https://archive1.piwheels.org/simple/revpy/revpy-0.1.1-py3-none-any.whl (11 kB)
Saved /private/tmp/throwaway/revpy-0.1.1-py3-none-any.whl
Successfully downloaded revpy
```

After:

```
❯ pip download --index-url https://www.piwheels.org/simple --dest /tmp/throwaway revpy
Looking in indexes: https://www.piwheels.org/simple
Collecting revpy
  Downloading revpy-0.1.1-py3-none-any.whl (11 kB)
Saved /private/tmp/throwaway/revpy-0.1.1-py3-none-any.whl
Successfully downloaded revpy
```

This is a notable improvement if you end up mirroring PyPI's artifact structure in a different index, and end up with URLs like `https://files.pythonhosted.org/packages/29/a2/d40fb2460e883eca5199c62cfc2463fd261f760556ae6290f88488c362c0/pip-25.1.1-py3-none-any.whl` that end up being really verbose for long install sessions.
