### PR TITLE
Replace use of "Cf" with "See" for greater clarity in error message

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -391,7 +391,7 @@ class MissingCallableSuffix(InstallationError):
     def __init__(self, entry_point: str) -> None:
         super().__init__(
             f"Invalid script entry point: {entry_point} - A callable "
-            "suffix is required. Cf https://packaging.python.org/"
+            "suffix is required. See https://packaging.python.org/"
             "specifications/entry-points/#use-for-scripts for more "
             "information."
         )


### PR DESCRIPTION
This changes the use of the Latin term [`Cf.`][1] to the word "See" to make the error message simpler and more broadley understandable.

Fixes #13504

[1]: https://en.wikipedia.org/wiki/Cf.