### PR TITLE
Handle malformed version metadata error and skip the package

### DIFF
--- a/news/13443.bugfix.rst
+++ b/news/13443.bugfix.rst
@@ -1,0 +1,2 @@
+Handle malformed version metadata entires and ignore packages
+with invalid ``Version`` instead of crashing.

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -31,6 +31,7 @@ from ._compat import (
     BasePath,
     get_dist_canonical_name,
     parse_name_and_version_from_info_directory,
+    BadMetadata,
 )
 
 
@@ -165,9 +166,16 @@ class Distribution(BaseDistribution):
 
     @property
     def version(self) -> Version:
-        if version := parse_name_and_version_from_info_directory(self._dist)[1]:
+        try:
+            version = (
+                parse_name_and_version_from_info_directory(self._dist)[1]
+                or self._dist.version
+            )
             return parse_version(version)
-        return parse_version(self._dist.version)
+        except TypeError:
+            raise BadMetadata(
+                self._dist.files[3], reason="invalid metadata entry `version`"
+            )
 
     @property
     def raw_version(self) -> str:

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -68,6 +68,8 @@ class _DistributionFinder:
             info_location = get_info_location(dist)
             try:
                 name = get_dist_canonical_name(dist)
+                distribution = Distribution(dist, info_location, None)
+                version = distribution.version
             except BadMetadata as e:
                 logger.warning("Skipping %s due to %s", info_location, e.reason)
                 continue


### PR DESCRIPTION
Fixes #13443 by wrapping the version property in _dists.py with a try/except block and handling the fallback in _envs.py.
I saw @pfmoore’s suggestion that raising an error might be the better approach, but I chose not to modify the rest of _envs.py that handles error reporting to keep things simple for now. I'm more than happy to revisit that part if needed. Feedback is very welcome!