### PR TITLE
Upgrade truststore to 0.10.3

### DIFF
--- a/news/truststore.vendor.rst
+++ b/news/truststore.vendor.rst
@@ -1,0 +1,1 @@
+Upgrade truststore to 0.10.3

--- a/src/pip/_vendor/truststore/__init__.py
+++ b/src/pip/_vendor/truststore/__init__.py
@@ -33,4 +33,4 @@ from ._api import SSLContext, extract_from_ssl, inject_into_ssl  # noqa: E402
 del _api, _sys  # type: ignore[name-defined] # noqa: F821
 
 __all__ = ["SSLContext", "inject_into_ssl", "extract_from_ssl"]
-__version__ = "0.10.1"
+__version__ = "0.10.3"

--- a/src/pip/_vendor/truststore/_api.py
+++ b/src/pip/_vendor/truststore/_api.py
@@ -67,7 +67,7 @@ def extract_from_ssl() -> None:
     try:
         import pip._vendor.urllib3.util.ssl_ as urllib3_ssl
 
-        urllib3_ssl.SSLContext = _original_SSLContext  # type: ignore[assignment]
+        urllib3_ssl.SSLContext = _original_SSLContext
     except ImportError:
         pass
 
@@ -300,7 +300,7 @@ class SSLContext(_truststore_SSLContext_super_class):  # type: ignore[misc]
 if sys.version_info >= (3, 13):
 
     def _get_unverified_chain_bytes(sslobj: ssl.SSLObject) -> list[bytes]:
-        unverified_chain = sslobj.get_unverified_chain() or ()  # type: ignore[attr-defined]
+        unverified_chain = sslobj.get_unverified_chain() or ()
         return [
             cert if isinstance(cert, bytes) else cert.public_bytes(_ssl.ENCODING_DER)
             for cert in unverified_chain

--- a/src/pip/_vendor/truststore/_openssl.py
+++ b/src/pip/_vendor/truststore/_openssl.py
@@ -6,8 +6,10 @@ import typing
 
 # candidates based on https://github.com/tiran/certifi-system-store by Christian Heimes
 _CA_FILE_CANDIDATES = [
-    # Alpine, Arch, Fedora 34+, OpenWRT, RHEL 9+, BSD
+    # Alpine, Arch, Fedora 34-42, OpenWRT, RHEL 9-10, BSD
     "/etc/ssl/cert.pem",
+    # Fedora 43+, RHEL 11+
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
     # Fedora <= 34, RHEL <= 9, CentOS <= 9
     "/etc/pki/tls/cert.pem",
     # Debian, Ubuntu (requires ca-certificates)

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -15,5 +15,5 @@ resolvelib==1.2.0
 setuptools==70.3.0
 tomli==2.2.1
 tomli-w==1.2.0
-truststore==0.10.1
+truststore==0.10.3
 dependency-groups==1.3.1


### PR DESCRIPTION
This is for https://github.com/sethmlarson/truststore/pull/183 which is for https://fedoraproject.org/wiki/Changes/dropingOfCertPemFile

cc @sethmlarson 

----

As a side note, when I run `nox -s vendoring -- --upgrade truststore` it happily added all my dirty files to the commit (including some ages old Python 2 pyc files) :scream:  -- I redid it from a clean tree.
