### PR TITLE
Implement --exclude-newer-than

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,7 +259,7 @@ max-complexity = 33  # default is 10
 [tool.ruff.lint.pylint]
 max-args = 15  # default is 5
 max-branches = 28  # default is 12
-max-returns = 13  # default is 6
+max-returns = 14  # default is 6
 max-statements = 134  # default is 50
 
 ######################################################################################

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -798,31 +798,32 @@ ignore_requires_python: Callable[..., Option] = partial(
 )
 
 
-def _handle_upload_before(
+def _handle_exclude_newer_than(
     option: Option, opt: str, value: str, parser: OptionParser
 ) -> None:
     """
-    Process a value provided for the --upload-before option.
+    Process a value provided for the --exclude-newer-than option.
 
-    This is an optparse.Option callback for the --upload-before option.
+    This is an optparse.Option callback for the --exclude-newer-than option.
     """
     if value is None:
         return None
-    upload_before = datetime.datetime.fromisoformat(value)
+    exclude_newer_than = datetime.datetime.fromisoformat(value)
     # Assume local timezone if no offset is given in the ISO string.
-    if upload_before.tzinfo is None:
-        upload_before = upload_before.astimezone()
-    parser.values.upload_before = upload_before
+    if exclude_newer_than.tzinfo is None:
+        exclude_newer_than = exclude_newer_than.astimezone()
+    parser.values.exclude_newer_than = exclude_newer_than
 
 
-upload_before: Callable[..., Option] = partial(
+exclude_newer_than: Callable[..., Option] = partial(
     Option,
-    "--upload-before",
-    dest="upload_before",
+    "--exclude-newer-than",
+    dest="exclude_newer_than",
     metavar="datetime",
     action="callback",
-    callback=_handle_upload_before,
-    help="Skip uploads after given time. This should be an ISO 8601 string.",
+    callback=_handle_exclude_newer_than,
+    type="str",
+    help="Exclude packages newer than given time. This should be an ISO 8601 string.",
 )
 
 no_build_isolation: Callable[..., Option] = partial(

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -11,6 +11,7 @@ pass on state. To be consistent, all options will follow this design.
 # mypy: strict-optional=False
 from __future__ import annotations
 
+import datetime
 import importlib.util
 import logging
 import os
@@ -794,6 +795,34 @@ ignore_requires_python: Callable[..., Option] = partial(
     dest="ignore_requires_python",
     action="store_true",
     help="Ignore the Requires-Python information.",
+)
+
+
+def _handle_upload_before(
+    option: Option, opt: str, value: str, parser: OptionParser
+) -> None:
+    """
+    Process a value provided for the --upload-before option.
+
+    This is an optparse.Option callback for the --upload-before option.
+    """
+    if value is None:
+        return None
+    upload_before = datetime.datetime.fromisoformat(value)
+    # Assume local timezone if no offset is given in the ISO string.
+    if upload_before.tzinfo is None:
+        upload_before = upload_before.astimezone()
+    parser.values.upload_before = upload_before
+
+
+upload_before: Callable[..., Option] = partial(
+    Option,
+    "--upload-before",
+    dest="upload_before",
+    metavar="datetime",
+    action="callback",
+    callback=_handle_upload_before,
+    help="Skip uploads after given time. This should be an ISO 8601 string.",
 )
 
 no_build_isolation: Callable[..., Option] = partial(

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -805,13 +805,16 @@ def _handle_exclude_newer_than(
     Process a value provided for the --exclude-newer-than option.
 
     This is an optparse.Option callback for the --exclude-newer-than option.
+
+    Parses an ISO 8601 datetime string. If no timezone is specified in the string,
+    UTC timezone is applied automatically for consistency with PyPI upload times.
     """
     if value is None:
         return None
     exclude_newer_than = datetime.datetime.fromisoformat(value)
-    # Assume local timezone if no offset is given in the ISO string.
+    # Assume UTC timezone if no offset is given in the ISO string.
     if exclude_newer_than.tzinfo is None:
-        exclude_newer_than = exclude_newer_than.astimezone()
+        exclude_newer_than = exclude_newer_than.replace(tzinfo=datetime.timezone.utc)
     parser.values.exclude_newer_than = exclude_newer_than
 
 
@@ -823,7 +826,11 @@ exclude_newer_than: Callable[..., Option] = partial(
     action="callback",
     callback=_handle_exclude_newer_than,
     type="str",
-    help="Exclude packages newer than given time. This should be an ISO 8601 string.",
+    help=(
+        "Exclude packages newer than given time. "
+        "This should be an ISO 8601 string. "
+        "If no timezone is specified, UTC is assumed."
+    ),
 )
 
 no_build_isolation: Callable[..., Option] = partial(

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -5,8 +5,6 @@ need PackageFinder capability don't unnecessarily import the
 PackageFinder machinery and all its vendored dependencies, etc.
 """
 
-from __future__ import annotations
-
 import logging
 from functools import partial
 from optparse import Values
@@ -328,6 +326,7 @@ class RequirementCommand(IndexGroupCommand):
         session: PipSession,
         target_python: TargetPython | None = None,
         ignore_requires_python: bool | None = None,
+        upload_before: datetime.datetime | None = None,
     ) -> PackageFinder:
         """
         Create a package finder appropriate to this requirement command.
@@ -348,4 +347,5 @@ class RequirementCommand(IndexGroupCommand):
             link_collector=link_collector,
             selection_prefs=selection_prefs,
             target_python=target_python,
+            upload_before=upload_before,
         )

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -5,6 +5,8 @@ need PackageFinder capability don't unnecessarily import the
 PackageFinder machinery and all its vendored dependencies, etc.
 """
 
+from __future__ import annotations
+
 import datetime
 import logging
 from functools import partial

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -5,6 +5,7 @@ need PackageFinder capability don't unnecessarily import the
 PackageFinder machinery and all its vendored dependencies, etc.
 """
 
+import datetime
 import logging
 from functools import partial
 from optparse import Values
@@ -326,7 +327,7 @@ class RequirementCommand(IndexGroupCommand):
         session: PipSession,
         target_python: TargetPython | None = None,
         ignore_requires_python: bool | None = None,
-        upload_before: datetime.datetime | None = None,
+        exclude_newer_than: datetime.datetime | None = None,
     ) -> PackageFinder:
         """
         Create a package finder appropriate to this requirement command.
@@ -347,5 +348,5 @@ class RequirementCommand(IndexGroupCommand):
             link_collector=link_collector,
             selection_prefs=selection_prefs,
             target_python=target_python,
-            upload_before=upload_before,
+            exclude_newer_than=exclude_newer_than,
         )

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -51,6 +51,7 @@ class DownloadCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.no_use_pep517())
         self.cmd_opts.add_option(cmdoptions.check_build_deps())
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
+        self.cmd_opts.add_option(cmdoptions.upload_before())
 
         self.cmd_opts.add_option(
             "-d",
@@ -93,6 +94,7 @@ class DownloadCommand(RequirementCommand):
             session=session,
             target_python=target_python,
             ignore_requires_python=options.ignore_requires_python,
+            upload_before=options.upload_before,
         )
 
         build_tracker = self.enter_context(get_build_tracker())

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -51,7 +51,7 @@ class DownloadCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.no_use_pep517())
         self.cmd_opts.add_option(cmdoptions.check_build_deps())
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
-        self.cmd_opts.add_option(cmdoptions.upload_before())
+        self.cmd_opts.add_option(cmdoptions.exclude_newer_than())
 
         self.cmd_opts.add_option(
             "-d",
@@ -94,7 +94,7 @@ class DownloadCommand(RequirementCommand):
             session=session,
             target_python=target_python,
             ignore_requires_python=options.ignore_requires_python,
-            upload_before=options.upload_before,
+            exclude_newer_than=options.exclude_newer_than,
         )
 
         build_tracker = self.enter_context(get_build_tracker())

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-import json
+import datetime
 import logging
 from collections.abc import Iterable
 from optparse import Values
@@ -40,6 +38,7 @@ class IndexCommand(IndexGroupCommand):
         cmdoptions.add_target_python_options(self.cmd_opts)
 
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
+        self.cmd_opts.add_option(cmdoptions.upload_before())
         self.cmd_opts.add_option(cmdoptions.pre())
         self.cmd_opts.add_option(cmdoptions.json())
         self.cmd_opts.add_option(cmdoptions.no_binary())
@@ -86,6 +85,7 @@ class IndexCommand(IndexGroupCommand):
         session: PipSession,
         target_python: TargetPython | None = None,
         ignore_requires_python: bool | None = None,
+        upload_before: datetime.datetime | None = None,
     ) -> PackageFinder:
         """
         Create a package finder appropriate to the index command.
@@ -103,6 +103,7 @@ class IndexCommand(IndexGroupCommand):
             link_collector=link_collector,
             selection_prefs=selection_prefs,
             target_python=target_python,
+            upload_before=upload_before,
         )
 
     def get_available_package_versions(self, options: Values, args: list[Any]) -> None:
@@ -118,6 +119,7 @@ class IndexCommand(IndexGroupCommand):
                 session=session,
                 target_python=target_python,
                 ignore_requires_python=options.ignore_requires_python,
+                upload_before=options.upload_before,
             )
 
             versions: Iterable[Version] = (

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -38,7 +38,7 @@ class IndexCommand(IndexGroupCommand):
         cmdoptions.add_target_python_options(self.cmd_opts)
 
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
-        self.cmd_opts.add_option(cmdoptions.upload_before())
+        self.cmd_opts.add_option(cmdoptions.exclude_newer_than())
         self.cmd_opts.add_option(cmdoptions.pre())
         self.cmd_opts.add_option(cmdoptions.json())
         self.cmd_opts.add_option(cmdoptions.no_binary())
@@ -85,7 +85,7 @@ class IndexCommand(IndexGroupCommand):
         session: PipSession,
         target_python: TargetPython | None = None,
         ignore_requires_python: bool | None = None,
-        upload_before: datetime.datetime | None = None,
+        exclude_newer_than: datetime.datetime | None = None,
     ) -> PackageFinder:
         """
         Create a package finder appropriate to the index command.
@@ -103,7 +103,7 @@ class IndexCommand(IndexGroupCommand):
             link_collector=link_collector,
             selection_prefs=selection_prefs,
             target_python=target_python,
-            upload_before=upload_before,
+            exclude_newer_than=exclude_newer_than,
         )
 
     def get_available_package_versions(self, options: Values, args: list[Any]) -> None:
@@ -119,7 +119,7 @@ class IndexCommand(IndexGroupCommand):
                 session=session,
                 target_python=target_python,
                 ignore_requires_python=options.ignore_requires_python,
-                upload_before=options.upload_before,
+                exclude_newer_than=options.exclude_newer_than,
             )
 
             versions: Iterable[Version] = (

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import datetime
+import json
 import logging
 from collections.abc import Iterable
 from optparse import Values

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -207,7 +207,7 @@ class InstallCommand(RequirementCommand):
             ),
         )
 
-        self.cmd_opts.add_option(cmdoptions.upload_before())
+        self.cmd_opts.add_option(cmdoptions.exclude_newer_than())
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
         self.cmd_opts.add_option(cmdoptions.no_build_isolation())
         self.cmd_opts.add_option(cmdoptions.use_pep517())
@@ -345,7 +345,7 @@ class InstallCommand(RequirementCommand):
             session=session,
             target_python=target_python,
             ignore_requires_python=options.ignore_requires_python,
-            upload_before=options.upload_before,
+            exclude_newer_than=options.exclude_newer_than,
         )
         build_tracker = self.enter_context(get_build_tracker())
 

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -207,6 +207,7 @@ class InstallCommand(RequirementCommand):
             ),
         )
 
+        self.cmd_opts.add_option(cmdoptions.upload_before())
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
         self.cmd_opts.add_option(cmdoptions.no_build_isolation())
         self.cmd_opts.add_option(cmdoptions.use_pep517())
@@ -344,6 +345,7 @@ class InstallCommand(RequirementCommand):
             session=session,
             target_python=target_python,
             ignore_requires_python=options.ignore_requires_python,
+            upload_before=options.upload_before,
         )
         build_tracker = self.enter_context(get_build_tracker())
 

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -143,8 +143,10 @@ class ListCommand(IndexGroupCommand):
             super().handle_pip_version_check(options)
 
     def _build_package_finder(
-        self, options: Values, session: PipSession
-    ) -> PackageFinder:
+        self,
+        options: Values,
+        session: "PipSession",
+    ) -> "PackageFinder":
         """
         Create a package finder appropriate to this list command.
         """

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -145,8 +145,8 @@ class ListCommand(IndexGroupCommand):
     def _build_package_finder(
         self,
         options: Values,
-        session: "PipSession",
-    ) -> "PackageFinder":
+        session: PipSession,
+    ) -> PackageFinder:
         """
         Create a package finder appropriate to this list command.
         """

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -64,7 +64,7 @@ class WheelCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.requirements())
         self.cmd_opts.add_option(cmdoptions.src())
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
-        self.cmd_opts.add_option(cmdoptions.upload_before())
+        self.cmd_opts.add_option(cmdoptions.exclude_newer_than())
         self.cmd_opts.add_option(cmdoptions.no_deps())
         self.cmd_opts.add_option(cmdoptions.progress_bar())
 
@@ -107,7 +107,7 @@ class WheelCommand(RequirementCommand):
         finder = self._build_package_finder(
             options=options,
             session=session,
-            upload_before=options.upload_before,
+            exclude_newer_than=options.exclude_newer_than,
         )
 
         options.wheel_dir = normalize_path(options.wheel_dir)

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -64,6 +64,7 @@ class WheelCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.requirements())
         self.cmd_opts.add_option(cmdoptions.src())
         self.cmd_opts.add_option(cmdoptions.ignore_requires_python())
+        self.cmd_opts.add_option(cmdoptions.upload_before())
         self.cmd_opts.add_option(cmdoptions.no_deps())
         self.cmd_opts.add_option(cmdoptions.progress_bar())
 
@@ -103,7 +104,11 @@ class WheelCommand(RequirementCommand):
     def run(self, options: Values, args: list[str]) -> int:
         session = self.get_default_session(options)
 
-        finder = self._build_package_finder(options, session)
+        finder = self._build_package_finder(
+            options=options,
+            session=session,
+            upload_before=options.upload_before,
+        )
 
         options.wheel_dir = normalize_path(options.wheel_dir)
         ensure_dir(options.wheel_dir)

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -1,5 +1,7 @@
 """Routines related to PyPI, indexes"""
+from __future__ import annotations
 
+import datetime
 import enum
 import functools
 import itertools
@@ -131,7 +133,7 @@ class LinkEvaluator:
         target_python: TargetPython,
         allow_yanked: bool,
         ignore_requires_python: Optional[bool] = None,
-        upload_before: Optional[datetime.datetime] = None,
+        exclude_newer_than: Optional[datetime.datetime] = None,
     ) -> None:
         """
         :param project_name: The user supplied package name.
@@ -149,7 +151,7 @@ class LinkEvaluator:
         :param ignore_requires_python: Whether to ignore incompatible
             PEP 503 "data-requires-python" values in HTML links. Defaults
             to False.
-        :param upload_before: If set, only allow links prior to the given date.
+        :param exclude_newer_than: If set, only allow links prior to the given date.
         """
         if ignore_requires_python is None:
             ignore_requires_python = False
@@ -159,7 +161,7 @@ class LinkEvaluator:
         self._ignore_requires_python = ignore_requires_python
         self._formats = formats
         self._target_python = target_python
-        self._upload_before = upload_before
+        self._exclude_newer_than = exclude_newer_than
 
         self.project_name = project_name
 
@@ -178,9 +180,9 @@ class LinkEvaluator:
             reason = link.yanked_reason or "<none given>"
             return (LinkType.yanked, f"yanked for reason: {reason}")
 
-        if link.upload_time is not None and self._upload_before is not None:
-            if link.upload_time > self._upload_before:
-                reason = f"Upload time {link.upload_time} after {self._upload_before}"
+        if link.upload_time is not None and self._exclude_newer_than is not None:
+            if link.upload_time > self._exclude_newer_than:
+                reason = f"Upload time {link.upload_time} after {self._exclude_newer_than}"
                 return (LinkType.upload_too_late, reason)
 
         if link.egg_fragment:
@@ -600,7 +602,7 @@ class PackageFinder:
         format_control: Optional[FormatControl] = None,
         candidate_prefs: Optional[CandidatePreferences] = None,
         ignore_requires_python: Optional[bool] = None,
-        upload_before: Optional[datetime.datetime] = None,
+        exclude_newer_than: Optional[datetime.datetime] = None,
     ) -> None:
         """
         This constructor is primarily meant to be used by the create() class
@@ -622,7 +624,7 @@ class PackageFinder:
         self._ignore_requires_python = ignore_requires_python
         self._link_collector = link_collector
         self._target_python = target_python
-        self._upload_before = upload_before
+        self._exclude_newer_than = exclude_newer_than
 
         self.format_control = format_control
 
@@ -646,7 +648,7 @@ class PackageFinder:
         link_collector: LinkCollector,
         selection_prefs: SelectionPreferences,
         target_python: Optional[TargetPython] = None,
-        upload_before: Optional[datetime.datetime] = None,
+        exclude_newer_than: Optional[datetime.datetime] = None,
     ) -> "PackageFinder":
         """Create a PackageFinder.
 
@@ -655,7 +657,7 @@ class PackageFinder:
         :param target_python: The target Python interpreter to use when
             checking compatibility. If None (the default), a TargetPython
             object will be constructed from the running Python.
-        :param upload_before: If set, only find links prior to the given date.
+        :param exclude_newer_than: If set, only find links prior to the given date.
         """
         if target_python is None:
             target_python = TargetPython()
@@ -672,7 +674,7 @@ class PackageFinder:
             allow_yanked=selection_prefs.allow_yanked,
             format_control=selection_prefs.format_control,
             ignore_requires_python=selection_prefs.ignore_requires_python,
-            upload_before=upload_before,
+            exclude_newer_than=exclude_newer_than,
         )
 
     @property
@@ -751,7 +753,7 @@ class PackageFinder:
             target_python=self._target_python,
             allow_yanked=self._allow_yanked,
             ignore_requires_python=self._ignore_requires_python,
-            upload_before=self._upload_before,
+            exclude_newer_than=self._exclude_newer_than,
         )
 
     def _sort_links(self, links: Iterable[Link]) -> list[Link]:

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -1,4 +1,5 @@
 """Routines related to PyPI, indexes"""
+
 from __future__ import annotations
 
 import datetime
@@ -132,8 +133,8 @@ class LinkEvaluator:
         formats: frozenset[str],
         target_python: TargetPython,
         allow_yanked: bool,
-        ignore_requires_python: Optional[bool] = None,
-        exclude_newer_than: Optional[datetime.datetime] = None,
+        ignore_requires_python: bool | None = None,
+        exclude_newer_than: datetime.datetime | None = None,
     ) -> None:
         """
         :param project_name: The user supplied package name.
@@ -152,6 +153,8 @@ class LinkEvaluator:
             PEP 503 "data-requires-python" values in HTML links. Defaults
             to False.
         :param exclude_newer_than: If set, only allow links prior to the given date.
+            This should be a timezone-aware datetime. If a timezone-naive datetime
+            is provided to the command line option, UTC is assumed.
         """
         if ignore_requires_python is None:
             ignore_requires_python = False
@@ -181,8 +184,15 @@ class LinkEvaluator:
             return (LinkType.yanked, f"yanked for reason: {reason}")
 
         if link.upload_time is not None and self._exclude_newer_than is not None:
-            if link.upload_time > self._exclude_newer_than:
-                reason = f"Upload time {link.upload_time} after {self._exclude_newer_than}"
+            upload_time = link.upload_time
+            assert upload_time.tzinfo is not None
+            exclude_cutoff = self._exclude_newer_than
+            assert exclude_cutoff.tzinfo is not None
+
+            if upload_time > exclude_cutoff:
+                reason = (
+                    f"Upload time {link.upload_time} after {self._exclude_newer_than}"
+                )
                 return (LinkType.upload_too_late, reason)
 
         if link.egg_fragment:
@@ -599,10 +609,10 @@ class PackageFinder:
         link_collector: LinkCollector,
         target_python: TargetPython,
         allow_yanked: bool,
-        format_control: Optional[FormatControl] = None,
-        candidate_prefs: Optional[CandidatePreferences] = None,
-        ignore_requires_python: Optional[bool] = None,
-        exclude_newer_than: Optional[datetime.datetime] = None,
+        format_control: FormatControl | None = None,
+        candidate_prefs: CandidatePreferences | None = None,
+        ignore_requires_python: bool | None = None,
+        exclude_newer_than: datetime.datetime | None = None,
     ) -> None:
         """
         This constructor is primarily meant to be used by the create() class
@@ -647,9 +657,9 @@ class PackageFinder:
         cls,
         link_collector: LinkCollector,
         selection_prefs: SelectionPreferences,
-        target_python: Optional[TargetPython] = None,
-        exclude_newer_than: Optional[datetime.datetime] = None,
-    ) -> "PackageFinder":
+        target_python: TargetPython | None = None,
+        exclude_newer_than: datetime.datetime | None = None,
+    ) -> PackageFinder:
         """Create a PackageFinder.
 
         :param selection_prefs: The candidate selection preferences, as a

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import functools
 import itertools

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import datetime
 import functools
 import itertools
 import logging
@@ -207,6 +206,7 @@ class Link:
         "requires_python",
         "yanked_reason",
         "metadata_file_data",
+        "upload_time",
         "cache_link_parsing",
         "egg_fragment",
     ]
@@ -214,10 +214,11 @@ class Link:
     def __init__(
         self,
         url: str,
-        comes_from: str | IndexContent | None = None,
-        requires_python: str | None = None,
-        yanked_reason: str | None = None,
-        metadata_file_data: MetadataFile | None = None,
+        comes_from: Optional[Union[str, "IndexContent"]] = None,
+        requires_python: Optional[str] = None,
+        yanked_reason: Optional[str] = None,
+        metadata_file_data: Optional[MetadataFile] = None,
+        upload_time: Optional[datetime.datetime] = None,
         cache_link_parsing: bool = True,
         hashes: Mapping[str, str] | None = None,
     ) -> None:
@@ -239,6 +240,8 @@ class Link:
             no such metadata is provided. This argument, if not None, indicates
             that a separate metadata file exists, and also optionally supplies
             hashes for that file.
+        :param upload_time: upload time of the file, or None if the information
+            is not available from the server.
         :param cache_link_parsing: A flag that is used elsewhere to determine
             whether resources retrieved from this link should be cached. PyPI
             URLs should generally have this set to False, for example.
@@ -272,6 +275,7 @@ class Link:
         self.requires_python = requires_python if requires_python else None
         self.yanked_reason = yanked_reason
         self.metadata_file_data = metadata_file_data
+        self.upload_time = upload_time
 
         self.cache_link_parsing = cache_link_parsing
         self.egg_fragment = self._egg_fragment()
@@ -300,6 +304,12 @@ class Link:
         if metadata_info is None:
             metadata_info = file_data.get("dist-info-metadata")
 
+        upload_time: Optional[datetime.datetime]
+        if upload_time_data := file_data.get("upload-time"):
+            upload_time = datetime.datetime.fromisoformat(upload_time_data)
+        else:
+            upload_time = None
+
         # The metadata info value may be a boolean, or a dict of hashes.
         if isinstance(metadata_info, dict):
             # The file exists, and hashes have been supplied
@@ -325,6 +335,7 @@ class Link:
             yanked_reason=yanked_reason,
             hashes=hashes,
             metadata_file_data=metadata_file_data,
+            upload_time=upload_time,
         )
 
     @classmethod

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -10,11 +10,7 @@ import re
 import urllib.parse
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    NamedTuple,
-)
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.filetypes import WHEEL_EXTENSION
@@ -216,11 +212,11 @@ class Link:
     def __init__(
         self,
         url: str,
-        comes_from: Optional[Union[str, "IndexContent"]] = None,
-        requires_python: Optional[str] = None,
-        yanked_reason: Optional[str] = None,
-        metadata_file_data: Optional[MetadataFile] = None,
-        upload_time: Optional[datetime.datetime] = None,
+        comes_from: str | IndexContent | None = None,
+        requires_python: str | None = None,
+        yanked_reason: str | None = None,
+        metadata_file_data: MetadataFile | None = None,
+        upload_time: datetime.datetime | None = None,
         cache_link_parsing: bool = True,
         hashes: Mapping[str, str] | None = None,
     ) -> None:
@@ -306,7 +302,7 @@ class Link:
         if metadata_info is None:
             metadata_info = file_data.get("dist-info-metadata")
 
-        upload_time: Optional[datetime.datetime]
+        upload_time: datetime.datetime | None
         if upload_time_data := file_data.get("upload-time"):
             upload_time = datetime.datetime.fromisoformat(upload_time_data)
         else:

--- a/tests/functional/test_exclude_newer.py
+++ b/tests/functional/test_exclude_newer.py
@@ -1,0 +1,93 @@
+"""Tests for pip install --exclude-newer-than."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.lib import PipTestEnvironment, TestData
+
+
+class TestExcludeNewer:
+    """Test --exclude-newer-than functionality."""
+
+    def test_exclude_newer_than_invalid_date(
+        self, script: PipTestEnvironment, data: TestData
+    ) -> None:
+        """Test that --exclude-newer-than fails with invalid date format."""
+        result = script.pip(
+            "install",
+            "--no-index",
+            "-f",
+            data.packages,
+            "--exclude-newer-than=invalid-date",
+            "simple",
+            expect_error=True,
+        )
+
+        # Should fail with date parsing error
+        assert "invalid" in result.stderr.lower() or "error" in result.stderr.lower()
+
+    def test_exclude_newer_than_help_text(self, script: PipTestEnvironment) -> None:
+        """Test that --exclude-newer-than appears in help text."""
+        result = script.pip("install", "--help")
+        assert "--exclude-newer-than" in result.stdout
+        assert "datetime" in result.stdout
+
+    @pytest.mark.parametrize("command", ["install", "download", "wheel"])
+    def test_exclude_newer_than_available_in_commands(
+        self, script: PipTestEnvironment, command: str
+    ) -> None:
+        """Test that --exclude-newer-than is available in relevant commands."""
+        result = script.pip(command, "--help")
+        assert "--exclude-newer-than" in result.stdout
+
+    @pytest.mark.network
+    def test_exclude_newer_than_with_real_pypi(
+        self, script: PipTestEnvironment
+    ) -> None:
+        """Test exclude-newer functionality against real PyPI with upload times."""
+        # Use a small package with known old versions for testing
+        # requests 2.0.0 was released in 2013
+
+        # Test 1: With an old cutoff date, should find no matching versions
+        result = script.pip(
+            "install",
+            "--dry-run",
+            "--exclude-newer-than=2010-01-01T00:00:00",
+            "requests==2.0.0",
+            expect_error=True,
+        )
+        # Should fail because requests 2.0.0 was uploaded after 2010
+        assert "No matching distribution found" in result.stderr
+
+        # Test 2: With a date that should find the package
+        result = script.pip(
+            "install",
+            "--dry-run",
+            "--exclude-newer-than=2030-01-01T00:00:00",
+            "requests==2.0.0",
+            expect_error=False,
+        )
+        assert "Would install requests-2.0.0" in result.stdout
+
+    @pytest.mark.network
+    def test_exclude_newer_than_date_formats(self, script: PipTestEnvironment) -> None:
+        """Test different date formats work with real PyPI."""
+        # Test various date formats with a well known small package
+        formats = [
+            "2030-01-01",
+            "2030-01-01T00:00:00",
+            "2030-01-01T00:00:00+00:00",
+            "2030-01-01T00:00:00-05:00",
+        ]
+
+        for date_format in formats:
+            result = script.pip(
+                "install",
+                "--dry-run",
+                f"--exclude-newer-than={date_format}",
+                "requests==2.0.0",
+                expect_error=False,
+            )
+            # All dates should allow the package
+            assert "Would install requests-2.0.0" in result.stdout

--- a/tests/unit/test_cmdoptions.py
+++ b/tests/unit/test_cmdoptions.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import datetime
 import os
+from collections.abc import Callable
+from optparse import Option, OptionParser, Values
 from pathlib import Path
 from venv import EnvBuilder
 
 import pytest
 
-from pip._internal.cli.cmdoptions import _convert_python_version
+from pip._internal.cli.cmdoptions import (
+    _convert_python_version,
+    _handle_exclude_newer_than,
+)
 from pip._internal.cli.main_parser import identify_python_interpreter
 
 
@@ -51,3 +57,105 @@ def test_identify_python_interpreter_venv(tmpdir: Path) -> None:
 
     # Passing a non-existent file returns None
     assert identify_python_interpreter(str(tmpdir / "nonexistent")) is None
+
+
+@pytest.mark.parametrize(
+    "value, expected_check",
+    [
+        # Test with timezone info (should be preserved exactly)
+        (
+            "2023-01-01T00:00:00+00:00",
+            lambda dt: dt
+            == datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        ),
+        (
+            "2023-01-01T12:00:00-05:00",
+            lambda dt: (
+                dt
+                == datetime.datetime(
+                    *(2023, 1, 1, 12, 0, 0),
+                    tzinfo=datetime.timezone(datetime.timedelta(hours=-5)),
+                )
+            ),
+        ),
+    ],
+)
+def test_handle_exclude_newer_than_with_timezone(
+    value: str, expected_check: Callable[[datetime.datetime], bool]
+) -> None:
+    """Test that timezone-aware ISO 8601 date strings are parsed correctly."""
+    option = Option("--exclude-newer-than", dest="exclude_newer_than")
+    opt = "--exclude-newer-than"
+    parser = OptionParser()
+    parser.values = Values()
+
+    _handle_exclude_newer_than(option, opt, value, parser)
+
+    result = parser.values.exclude_newer_than
+    assert isinstance(result, datetime.datetime)
+    assert expected_check(result)
+
+
+@pytest.mark.parametrize(
+    "value, expected_date_time",
+    [
+        # Test basic ISO 8601 formats (timezone-naive, will get UTC timezone)
+        ("2023-01-01T00:00:00", (2023, 1, 1, 0, 0, 0)),
+        ("2023-12-31T23:59:59", (2023, 12, 31, 23, 59, 59)),
+        # Test date only (will be extended to midnight)
+        ("2023-01-01", (2023, 1, 1, 0, 0, 0)),
+    ],
+)
+def test_handle_exclude_newer_than_naive_dates(
+    value: str, expected_date_time: tuple[int, int, int, int, int, int]
+) -> None:
+    """Test that timezone-naive ISO 8601 date strings get UTC timezone applied."""
+    option = Option("--exclude-newer-than", dest="exclude_newer_than")
+    opt = "--exclude-newer-than"
+    parser = OptionParser()
+    parser.values = Values()
+
+    _handle_exclude_newer_than(option, opt, value, parser)
+
+    result = parser.values.exclude_newer_than
+    assert isinstance(result, datetime.datetime)
+
+    # Check that the date/time components match
+    (
+        expected_year,
+        expected_month,
+        expected_day,
+        expected_hour,
+        expected_minute,
+        expected_second,
+    ) = expected_date_time
+    assert result.year == expected_year
+    assert result.month == expected_month
+    assert result.day == expected_day
+    assert result.hour == expected_hour
+    assert result.minute == expected_minute
+    assert result.second == expected_second
+
+    # Check that UTC timezone was applied
+    assert result.tzinfo == datetime.timezone.utc
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        "not-a-date",
+        "2023-13-01",  # Invalid month
+        "2023-01-32",  # Invalid day
+        "2023-01-01T25:00:00",  # Invalid hour
+        "",  # Empty string
+    ],
+)
+def test_handle_exclude_newer_than_invalid_dates(invalid_value: str) -> None:
+    """Test that invalid date strings raise ValueError."""
+    option = Option("--exclude-newer-than", dest="exclude_newer_than")
+    opt = "--exclude-newer-than"
+    parser = OptionParser()
+    parser.values = Values()
+
+    with pytest.raises(ValueError):
+        _handle_exclude_newer_than(option, opt, invalid_value, parser)


### PR DESCRIPTION
Closes https://github.com/pypa/pip/issues/6257
Supplants https://github.com/pypa/pip/pull/12717

Changes from the previous PR:

* `upload-before` -> `exclude-newer-than`
* Uses UTC by default so that is reproducible across environments
* Adds tests

