### PR TITLE
Apply ruff/refurb rule FURB188

### DIFF
--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -53,8 +53,7 @@ logger = getLogger(__name__)
 def _normalize_name(name: str) -> str:
     """Make a name consistent regardless of source (environment or file)"""
     name = name.lower().replace("_", "-")
-    if name.startswith("--"):
-        name = name[2:]  # only prefer long opts
+    name = name.removeprefix("--")  # only prefer long opts
     return name
 
 


### PR DESCRIPTION
FURB188 Prefer `str.removeprefix()` over conditionally replacing with slice.

Requires Python 3.9.