### PR TITLE
Ensure selfcheck file inherits directory permissions

### DIFF
--- a/news/13528.bugfix.rst
+++ b/news/13528.bugfix.rst
@@ -1,1 +1,1 @@
-selfcheck file in cache directory has same permissions as the rest of the cache.
+Ensure the self-check files in the cache has same permissions as the rest of the cache.

--- a/news/13528.bugfix.rst
+++ b/news/13528.bugfix.rst
@@ -1,0 +1,1 @@
+selfcheck file in cache directory has same permissions as the rest of the cache.

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -154,8 +154,7 @@ def format_directory_size(path: str) -> str:
 
 def copy_directory_permissions(directory: str, target_file: BinaryIO) -> None:
     mode = (
-        os.stat(directory).st_mode
-        & 0o666  # select read/write permissions of directory
+        os.stat(directory).st_mode & 0o666  # select read/write permissions of directory
         | 0o600  # set owner read/write permissions
     )
     # Change permissions only if there is no risk of following a symlink.

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -150,3 +150,16 @@ def directory_size(path: str) -> int | float:
 
 def format_directory_size(path: str) -> str:
     return format_size(directory_size(path))
+
+
+def copy_directory_permissions(directory: str, target_file: BinaryIO) -> None:
+    mode = (
+        os.stat(directory).st_mode
+        & 0o666  # select read/write permissions of cache directory
+        | 0o600  # set owner read/write permissions
+    )
+    # Change permissions only if there is no risk of following a symlink.
+    if os.chmod in os.supports_fd:
+        os.chmod(target_file.fileno(), mode)
+    elif os.chmod in os.supports_follow_symlinks:
+        os.chmod(target_file.name, mode, follow_symlinks=False)

--- a/src/pip/_internal/utils/filesystem.py
+++ b/src/pip/_internal/utils/filesystem.py
@@ -155,7 +155,7 @@ def format_directory_size(path: str) -> str:
 def copy_directory_permissions(directory: str, target_file: BinaryIO) -> None:
     mode = (
         os.stat(directory).st_mode
-        & 0o666  # select read/write permissions of cache directory
+        & 0o666  # select read/write permissions of directory
         | 0o600  # set owner read/write permissions
     )
     # Change permissions only if there is no risk of following a symlink.

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -189,10 +189,11 @@ class TestSelfCheckState:
             "last_check": "2000-01-01T00:00:00+00:00",
             "pypi_version": "1.0.0",
         }
-
+		# Check that the self-check cache entries inherit the root cache permissions.
         statefile_permissions = os.stat(expected_path).st_mode & 0o666
         selfcheckdir_permissions = os.stat(cache_dir / "selfcheck").st_mode & 0o666
-        assert statefile_permissions == selfcheckdir_permissions
+        cache_permissions = os.stat(cache_dir).st_mode & 0o666
+        assert statefile_permissions == selfcheckdir_permissions == cache_permissions
 
 
 @patch("pip._internal.self_outdated_check._self_version_check_logic")

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -189,7 +189,7 @@ class TestSelfCheckState:
             "last_check": "2000-01-01T00:00:00+00:00",
             "pypi_version": "1.0.0",
         }
-		# Check that the self-check cache entries inherit the root cache permissions.
+        # Check that the self-check cache entries inherit the root cache permissions.
         statefile_permissions = os.stat(expected_path).st_mode & 0o666
         selfcheckdir_permissions = os.stat(cache_dir / "selfcheck").st_mode & 0o666
         cache_permissions = os.stat(cache_dir).st_mode & 0o666

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -190,6 +190,10 @@ class TestSelfCheckState:
             "pypi_version": "1.0.0",
         }
 
+        statefile_permissions = os.stat(expected_path).st_mode & 0o666
+        selfcheckdir_permissions = os.stat(cache_dir / "selfcheck").st_mode & 0o666
+        assert statefile_permissions == selfcheckdir_permissions
+
 
 @patch("pip._internal.self_outdated_check._self_version_check_logic")
 def test_suppressed_by_externally_managed(mocked_function: Mock, tmpdir: Path) -> None:


### PR DESCRIPTION
When writing files to cache pip does copy the permissions from the cache directory, this is an expected behaviour to ensure that any user that has access to the cache has also access to its content.

Copying the permissions explicitly is necessary due to the use of `adjacent_tmp_file` which by virtue of `tempfile.mkstemp` (indirectly via `NamedTemporaryFile`) causes all files to be created with `600` permissions.

This is not happening for `selfcheck/XXXXX` by the way, which makes the selfcheck unaccessible by users different from the one that created the cache.

This PullRequest creates an helper method `copy_directory_permissions` which allows both the cache and the selfcheck file to share the same logic in copying directory permissions and thus ensure consistency in cache files permissions.