### PR TITLE
Check symlink target in tar extraction fallback for Pythons without `data_filter`

### DIFF
--- a/news/13537.bugfix.rst
+++ b/news/13537.bugfix.rst
@@ -1,0 +1,3 @@
+Changed the tar unpacking fallback to check the existence of a symlink target file
+before extraction. This tar unpacking fallback is only used on Python versions
+that don't implement ``data_filter`` for the ``tarfile`` module.

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -270,7 +270,15 @@ def _untar_without_filter(
             ensure_dir(path)
         elif member.issym():
             try:
-                tar._find_link_target(member)  # type: ignore[attr-defined]
+                # Try to verify that the link points to
+                # a file that exists within the tar file.
+                try:
+                    tar._find_link_target(member)  # type: ignore[attr-defined]
+                except AttributeError:
+                    logger.warning(
+                        "Could not verify link %s in tar file %s", member.name, filename
+                    )
+
                 tar._extract_member(member, path)
             except Exception as exc:
                 # Some corrupt tar files seem to produce this

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -270,6 +270,7 @@ def _untar_without_filter(
             ensure_dir(path)
         elif member.issym():
             try:
+                tar._find_link_target(member)  # type: ignore[attr-defined]
                 tar._extract_member(member, path)
             except Exception as exc:
                 # Some corrupt tar files seem to produce this


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Closes #13537