### PR TITLE
Add a function to check the security of symbolic links.

### DIFF
--- a/news/13550.bugfix.rst
+++ b/news/13550.bugfix.rst
@@ -1,2 +1,2 @@
-Add the _check_link_targetfunction to validate the file pointed to by a symlink. If path traversal 
+Add the _check_link_targetfunction to validate the file pointed to by a symlink. If path traversal
 is detected, it should raise an InstallationErrorexception, similar to is_within_directory.

--- a/news/13550.bugfix.rst
+++ b/news/13550.bugfix.rst
@@ -1,2 +1,2 @@
-Pip will now raise an installation error for a source distribution when it includes a symlink that
-points outside the source distribution archive.
+For Python versions that do not support PEP 706, pip will now raise an installation error for a 
+source distribution when it includes a symlink that points outside the source distribution archive.

--- a/news/13550.bugfix.rst
+++ b/news/13550.bugfix.rst
@@ -1,0 +1,2 @@
+Add the _check_link_targetfunction to validate the file pointed to by a symlink. If path traversal 
+is detected, it should raise an InstallationErrorexception, similar to is_within_directory.

--- a/news/13550.bugfix.rst
+++ b/news/13550.bugfix.rst
@@ -1,2 +1,2 @@
-For Python versions that do not support PEP 706, pip will now raise an installation error for a 
+For Python versions that do not support PEP 706, pip will now raise an installation error for a
 source distribution when it includes a symlink that points outside the source distribution archive.

--- a/news/13550.bugfix.rst
+++ b/news/13550.bugfix.rst
@@ -1,2 +1,2 @@
-Add the _check_link_targetfunction to validate the file pointed to by a symlink. If path traversal
-is detected, it should raise an InstallationErrorexception, similar to is_within_directory.
+Pip will now raise an installation error for a source distribution when it includes a symlink that
+points outside the source distribution archive.

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -275,7 +275,8 @@ def _untar_without_filter(
                     tar.getmember(linkname)
                 except KeyError:
                     raise KeyError(linkname)
-            raise KeyError(linkname)
+            else:
+                raise KeyError(linkname)
 
     for member in tar.getmembers():
         fn = member.name

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -266,6 +266,15 @@ def _untar_without_filter(
         try:
             tar.getmember(linkname)
         except KeyError:
+            if "\\" in linkname or "/" in linkname:
+                if "\\" in linkname:
+                    linkname = linkname.replace("\\", "/")
+                else:
+                    linkname = linkname.replace("/", "\\")
+                try:
+                    tar.getmember(linkname)
+                except KeyError:
+                    raise KeyError(linkname)
             raise KeyError(linkname)
 
     for member in tar.getmembers():

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -261,6 +261,8 @@ def _untar_without_filter(
             filter(None, (os.path.dirname(tarinfo.name), tarinfo.linkname))
         )
 
+        linkname = os.path.normpath(linkname)
+
         try:
             tar.getmember(linkname)
         except KeyError:

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -253,8 +253,7 @@ def is_symlink_target_in_tar(tar: tarfile.TarFile, tarinfo: tarfile.TarInfo) -> 
     linkname = os.path.join(os.path.dirname(tarinfo.name), tarinfo.linkname)
 
     linkname = os.path.normpath(linkname)
-    if "\\" in linkname:
-        linkname = linkname.replace("\\", "/")
+    linkname = linkname.replace("\\", "/")
 
     try:
         tar.getmember(linkname)

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -336,7 +336,10 @@ class TestUnpackArchives:
         with pytest.raises(InstallationError) as e:
             untar_file(tar_filepath, extract_path)
 
-        msg = "The tar file ({}) has a file ({}) trying to install outside target directory ({})"
+        msg = (
+            "The tar file ({}) has a file ({}) trying to install outside "
+            "target directory ({})"
+        )
         assert msg.format(tar_filepath, "evil_symlink", import_filepath) in str(e.value)
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
@@ -370,7 +373,10 @@ class TestUnpackArchives:
         with pytest.raises(InstallationError) as e:
             untar_file(tar_filepath, extract_path)
 
-        msg = "The tar file ({}) has a file ({}) trying to install outside target directory ({})"
+        msg = (
+            "The tar file ({}) has a file ({}) trying to install outside "
+            "target directory ({})"
+        )
         assert msg.format(tar_filepath, "evil_symlink", link_path) in str(e.value)
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -10,6 +10,7 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.utils.unpacking import is_within_directory, untar_file, unzip_file
@@ -237,6 +238,105 @@ class TestUnpackArchives:
 
         with open(os.path.join(unpack_dir, "symlink.txt"), "rb") as f:
             assert f.read() == content
+
+    def test_unpack_normal_tar_links_no_data_filter(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Test unpacking a normal tar with file containing soft links, but no data_filter
+        """
+        if hasattr(tarfile, "data_filter"):
+            monkeypatch.delattr("tarfile.data_filter")
+
+        tar_filename = "test_tar_links_no_data_filter.tar"
+        tar_filepath = os.path.join(self.tempdir, tar_filename)
+
+        extract_path = os.path.join(self.tempdir, "extract_path")
+
+        with tarfile.open(tar_filepath, "w") as tar:
+            file_data = io.BytesIO(b"normal\n")
+            normal_file_tarinfo = tarfile.TarInfo(name="normal_file")
+            normal_file_tarinfo.size = len(file_data.getbuffer())
+            tar.addfile(normal_file_tarinfo, fileobj=file_data)
+
+            info = tarfile.TarInfo("normal_symlink")
+            info.type = tarfile.SYMTYPE
+            info.linkpath = "normal_file"
+            tar.addfile(info)
+
+        untar_file(tar_filepath, extract_path)
+
+        assert os.path.islink(os.path.join(extract_path, "normal_symlink"))
+
+        link_path = os.readlink(os.path.join(extract_path, "normal_symlink"))
+        assert link_path == "normal_file"
+
+        with open(os.path.join(extract_path, "normal_symlink"), "rb") as f:
+            assert f.read() == b"normal\n"
+
+    def test_unpack_evil_tar_link1_no_data_filter(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Test unpacking a evil tar with file containing soft links, but no data_filter
+        """
+        if hasattr(tarfile, "data_filter"):
+            monkeypatch.delattr("tarfile.data_filter")
+
+        tar_filename = "test_tar_links_no_data_filter.tar"
+        tar_filepath = os.path.join(self.tempdir, tar_filename)
+
+        import_filename = "import_file"
+        import_filepath = os.path.join(self.tempdir, import_filename)
+        open(import_filepath, "w").close()
+
+        extract_path = os.path.join(self.tempdir, "extract_path")
+
+        with tarfile.open(tar_filepath, "w") as tar:
+            info = tarfile.TarInfo("evil_symlink")
+            info.type = tarfile.SYMTYPE
+            info.linkpath = import_filepath
+            tar.addfile(info)
+
+        with pytest.raises(InstallationError) as e:
+            untar_file(tar_filepath, extract_path)
+
+        assert "trying to install outside target directory" in str(e.value)
+        assert "import_file" in str(e.value)
+
+        assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
+
+    def test_unpack_evil_tar_link2_no_data_filter(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Test unpacking a evil tar with file containing soft links, but no data_filter
+        """
+        if hasattr(tarfile, "data_filter"):
+            monkeypatch.delattr("tarfile.data_filter")
+
+        tar_filename = "test_tar_links_no_data_filter.tar"
+        tar_filepath = os.path.join(self.tempdir, tar_filename)
+
+        import_filename = "import_file"
+        import_filepath = os.path.join(self.tempdir, import_filename)
+        open(import_filepath, "w").close()
+
+        extract_path = os.path.join(self.tempdir, "extract_path")
+
+        with tarfile.open(tar_filepath, "w") as tar:
+            info = tarfile.TarInfo("evil_symlink")
+            info.type = tarfile.SYMTYPE
+            info.linkpath = ".." + os.sep + import_filename
+            tar.addfile(info)
+
+        with pytest.raises(InstallationError) as e:
+            untar_file(tar_filepath, extract_path)
+
+        assert "trying to install outside target directory" in str(e.value)
+        assert ".." + os.sep + import_filename in str(e.value)
+
+        assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 
 
 def test_unpack_tar_unicode(tmpdir: Path) -> None:

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -336,8 +336,8 @@ class TestUnpackArchives:
         with pytest.raises(InstallationError) as e:
             untar_file(tar_filepath, extract_path)
 
-        assert "trying to install outside target directory" in str(e.value)
-        assert "import_file" in str(e.value)
+        msg = "The tar file ({}) has a file ({}) trying to install outside target directory ({})"
+        assert msg.format(tar_filepath, "evil_symlink", import_filepath) in str(e.value)
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 
@@ -359,18 +359,19 @@ class TestUnpackArchives:
 
         extract_path = os.path.join(self.tempdir, "extract_path")
 
+        link_path = ".." + os.sep + import_filename
+
         with tarfile.open(tar_filepath, "w") as tar:
             info = tarfile.TarInfo("evil_symlink")
             info.type = tarfile.SYMTYPE
-            info.linkpath = ".." + os.sep + import_filename
+            info.linkpath = link_path
             tar.addfile(info)
 
         with pytest.raises(InstallationError) as e:
             untar_file(tar_filepath, extract_path)
 
-        assert "trying to install outside target directory" in str(e.value)
-        assert ".." in str(e.value)
-        assert import_filename in str(e.value)
+        msg = "The tar file ({}) has a file ({}) trying to install outside target directory ({})"
+        assert msg.format(tar_filepath, "evil_symlink", link_path) in str(e.value)
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -334,7 +334,8 @@ class TestUnpackArchives:
             untar_file(tar_filepath, extract_path)
 
         assert "trying to install outside target directory" in str(e.value)
-        assert ".." + os.sep + import_filename in str(e.value)
+        assert ".." in str(e.value)
+        assert import_filename in str(e.value)
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/13537

Add the **_check_link_targetfunction** to validate the file pointed to by a symlink. If path traversal is detected, it should raise an InstallationErrorexception, similar to **is_within_directory**.

Add test cases for symlink:
- Test Case 1​​: Tests the extraction of a normal symlink.
- ​​Test Case 2​​: Tests the extraction of a malicious symlink pointing to an absolute path.
- Test Case 3​​: Tests the extraction of a malicious symlink pointing to a relative path.