### PR TITLE
Don't use PEP517 if no build system is specified

### DIFF
--- a/news/13551.bugfix.rst
+++ b/news/13551.bugfix.rst
@@ -1,0 +1,2 @@
+No longer uses the PEP517 build pipeline if pyproject.toml doesn’t specify a build system and backend.
+This stops pip from suddenly changing behaviour if a project decides to move tooling configuration from setup.cfg or tool specific files to [tool.*] entries in pyproject.toml.

--- a/src/pip/_internal/pyproject.py
+++ b/src/pip/_internal/pyproject.py
@@ -91,6 +91,12 @@ def load_pyproject_toml(
             )
         use_pep517 = True
 
+    # Don't use PEP517 if no build system or backend is specified.
+    # This prevents the mere existence of pyproject.toml to change
+    # how a project gets built.
+    elif build_system is None or "build-backend" not in build_system:
+        use_pep517 = False
+
     # If we haven't worked out whether to use PEP 517 yet,
     # and the user hasn't explicitly stated a preference,
     # we do so if the project has a pyproject.toml file

--- a/tests/data/src/pep517_pyproject_no_build_only/pyproject.toml
+++ b/tests/data/src/pep517_pyproject_no_build_only/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["foo"]

--- a/tests/data/src/pep517_setup_and_pyproject_no_build/pyproject.toml
+++ b/tests/data/src/pep517_setup_and_pyproject_no_build/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["foo"]

--- a/tests/data/src/pep517_setup_and_pyproject_no_build/setup.py
+++ b/tests/data/src/pep517_setup_and_pyproject_no_build/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup(name="dummy", version="0.1")

--- a/tests/unit/test_pep517.py
+++ b/tests/unit/test_pep517.py
@@ -14,6 +14,8 @@ from tests.lib import TestData
     "source, expected",
     [
         ("pep517_setup_and_pyproject", True),
+        ("pep517_setup_and_pyproject_no_build", False),
+        ("pep517_pyproject_no_build_only", False),
         ("pep517_setup_only", False),
         ("pep517_pyproject_only", True),
     ],


### PR DESCRIPTION
Currently `pip` will use the PEP517 pipeline for any project where a `pyproject.toml` is present, regardless of whether any build system or build backend is specified in this `pyproject.toml`.

This means that projects that move some tool configuration to `pyproject.toml` may suddenly witness unintended consequences.

See e.g.
https://github.com/PyCQA/flake8/issues/234#issuecomment-812800690 and https://gitlab.archlinux.org/pacman/namcap/-/merge_requests/74#note_303307

This simply adds a check that a build system and backend is actually defined in `pyproject.toml` before deciding to go down the PEP517 pipeline.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
