### PR TITLE
Remove references to `docs/requirements.txt`

### DIFF
--- a/docs/html/development/architecture/anatomy.rst
+++ b/docs/html/development/architecture/anatomy.rst
@@ -30,7 +30,6 @@ The ``README``, license, ``pyproject.toml``, and so on are in the top level.
   * ``html/`` *[sources to HTML documentation avail. online]*
   * ``man/`` has man pages the distros can use by running ``man pip``
   * ``pip_sphinxext.py`` *[an extension -- pip-specific plugins to Sphinx that do not apply to other packages]*
-  * ``requirements.txt``
 
 * ``news/`` *[pip stores news fragments… Every time pip makes a user-facing change, a file is added to this directory (usually a short note referring to a GitHub issue) with the right extension & name so it gets included in changelog…. So every release the maintainers will be deleting old files in this directory? Yes - we use the towncrier automation to generate a NEWS file, and auto-delete old stuff. There’s more about this in the contributor documentation!]*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,6 @@ include = [
     "build-project/build-project.py",
     "build-project/build-requirements.in",
     "build-project/build-requirements.txt",
-    "docs/requirements.txt",
     "docs/**/*.css",
     "docs/**/*.dot",
     "docs/**/*.md",


### PR DESCRIPTION
It doesn't exist anymore.

On a side note `docs/html/development/architecture/anatomy.rst` appears to be very outdated.