### PR TITLE
Add earlier Python version syntax check for `__pip-runner__.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,6 +272,11 @@ max-branches = 28  # default is 12
 max-returns = 13  # default is 6
 max-statements = 134  # default is 50
 
+[tool.ruff.per-file-target-version]
+# `__pip-runner__.py` should be Python 2.7 compatible but the
+# earliest version of Python ruff will check is 3.7
+"src/pip/__pip-runner__.py" = "py37"
+
 ######################################################################################
 # mypy
 #


### PR DESCRIPTION
Ruff added version related syntax errors in 0.12: https://astral.sh/blog/ruff-v0.12.0#version-related-syntax-errors

As part of this you can specify individual files must work against earlier versions of Python than your project version is set to. This specifically checks `__pip-runner__.py` and calls out it should be Python 2.7 compatible.

While ruff will be able to protect against Python 3 features, this will prevent users from accidentally adding Python 3.8+ syntax, and prevent ruff itself from trying to enforce any rules which require Python 3.8+.