### PR TITLE
Update CI from `ubuntu-22.04` to `ubuntu-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   docs:
     name: docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
@@ -36,7 +36,7 @@ jobs:
       - run: nox -s docs
 
   determine-changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
       vendoring: ${{ steps.filter.outputs.vendoring }}
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v5
@@ -86,7 +86,7 @@ jobs:
 
   vendoring:
     name: vendoring
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     needs: [determine-changes]
     if: >-
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python:
           - "3.9"
           - "3.10"
@@ -132,7 +132,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install Ubuntu dependencies
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install bzr
@@ -261,7 +261,7 @@ jobs:
       - tests-zipapp
       - vendoring
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install bzr subversion
+          sudo apt-get install brz subversion
 
       - name: Install MacOS dependencies
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install bzr
+          sudo apt-get install bzr subversion
 
       - name: Install MacOS dependencies
         if: runner.os == 'macOS'

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-latest
   tools:
     python: "3.11"
   jobs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-latest
+  os: ubuntu-lts-latest
   tools:
     python: "3.11"
   jobs:


### PR DESCRIPTION
ubuntu-latest, currently based on ubuntu 24.04 previously failed: https://github.com/pypa/pip/pull/13149#issuecomment-2582795356

I was unable to reproduce locally, so I am creating this PR to see if still happens, and if so if I am able to reproduce or fix it.