### PR TITLE
docs(pip_freeze): clarify --all; explain Python version differences

### DIFF
--- a/docs/html/topics/dependency-resolution.md
+++ b/docs/html/topics/dependency-resolution.md
@@ -165,6 +165,9 @@ will avoid performing dependency resolution during deployment.
 
 ## Dealing with dependency conflicts
 
+This section uses imaginary packages (`package_coffee`, `package_tea`, and
+`package_water`) to explain how pip resolves conflicts.
+
 This section provides practical suggestions to pip users who encounter
 a `ResolutionImpossible` error, where pip cannot install their specified
 packages due to conflicting dependencies.
@@ -193,6 +196,11 @@ because they each depend on different versions of the same package
   ``2.4.2``
 - ``package_tea`` version ``4.3.0`` depends on version ``2.3.1`` of
   ``package_water``
+
+Note: `package_coffee`, `package_tea`, and `package_water` are imaginary
+packages used only to illustrate dependency conflicts. They are not real
+projects you can install.
+
 
 Sometimes these messages are straightforward to read, because they use
 commonly understood comparison operators to specify the required version
@@ -252,10 +260,10 @@ the same version of `package_water`, you might consider:
 
 In the second case, pip will automatically find a version of both
 `package_coffee` and `package_tea` that depend on the same version of
-`package_water`, installing:
+`package_water`, for example:
 
 - `package_coffee 0.44.1`, which depends on `package_water 2.6.1`
-- `package_tea 4.4.3` which _also_ depends on `package_water 2.6.1`
+- `package_tea 4.4.3`, which also depends on `package_water 2.6.1`
 
 If you want to prioritize one package over another, you can add version
 specifiers to _only_ the more important package:

--- a/news/13561.doc.rst
+++ b/news/13561.doc.rst
@@ -1,0 +1,1 @@
+Clarified dependency resolution docs: added note on imaginary packages, fixed version mismatch, and added introduction line.

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -25,7 +25,7 @@ class FreezeCommand(Command):
     """
     Output installed packages in requirements format.
 
-    packages are listed in a case-insensitive sorted order.
+    Packages are listed in a case-insensitive sorted order.
     """
 
     ignore_require_venv = True
@@ -70,15 +70,17 @@ class FreezeCommand(Command):
             dest="freeze_all",
             action="store_true",
             help=(
-                "Do not skip these packages in the output:"
-                " {}".format(", ".join(_dev_pkgs()))
+                "Do not skip certain development-related packages in the output. "
+                "On Python 3.12 and later, only `pip` is skipped by default. "
+                "On Python 3.11 and earlier, the following packages are also "
+                "skipped by default: `setuptools`, `wheel`, and `distribute`."
             ),
         )
         self.cmd_opts.add_option(
             "--exclude-editable",
             dest="exclude_editable",
             action="store_true",
-            help="Exclude editable package from output.",
+            help="Exclude editable packages from output.",
         )
         self.cmd_opts.add_option(cmdoptions.list_exclude())
 


### PR DESCRIPTION
This PR fixes the inconsistency in the pip freeze --all documentation. In Python 3.11 and earlier, pip, setuptools, wheel, and distribute are skipped by default, while in Python 3.12 and later only pip is skipped. The docs still showed the old behavior, so I updated the help text to make it consistent and added a note explaining the difference between versions. Fixes #13557.