### PR TITLE
do not break apart when no common appdata location is set in registry

### DIFF
--- a/news/13567.bugfix.rst
+++ b/news/13567.bugfix.rst
@@ -1,0 +1,1 @@
+Do not break with FileNotFoundError when loading site-config-dir location from windows registry (CSIDL_COMMON_APPDATA).

--- a/src/pip/_internal/utils/appdirs.py
+++ b/src/pip/_internal/utils/appdirs.py
@@ -44,9 +44,15 @@ def site_config_dirs(appname: str) -> list[str]:
         dirval = _appdirs.site_data_dir(appname, appauthor=False, multipath=True)
         return dirval.split(os.pathsep)
 
-    dirval = _appdirs.site_config_dir(appname, appauthor=False, multipath=True)
     if sys.platform == "win32":
-        return [dirval]
+        try:
+            # Causes FileNotFoundError on attempt to access a registry key that does
+            # not exist. This should not break apart pip configuration loading.
+            dirval = _appdirs.site_config_dir(appname, appauthor=False, multipath=True)
+            return [dirval]
+        except FileNotFoundError:
+            return []
 
     # Unix-y system. Look in /etc as well.
+    dirval = _appdirs.site_config_dir(appname, appauthor=False, multipath=True)
     return dirval.split(os.pathsep) + ["/etc"]


### PR DESCRIPTION
When `_pick_get_win_folder` in `platformdirs/windows.py` uses registry to find common appdata path and
there is no key in 'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders\Common AppData', configuration loading procedure in PIP throws an exception and fails 'install' procedure.

Error example:
```
  File "C:\example\venv\Lib\site-packages\pip\_internal\configuration.py", line 70, in get_configuration_files
    os.path.join(path, CONFIG_BASENAME) for path in appdirs.site_config_dirs("pip")
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\example\venv\Lib\site-packages\pip\_internal\utils\appdirs.py", line 48, in site_config_dirs
    dirval = _appdirs.site_config_dir(appname, appauthor=False, multipath=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\example\venv\Lib\site-packages\pip\_vendor\platformdirs\__init__.py", line 146, in site_config_dir
    ).site_config_dir
      ^^^^^^^^^^^^^^^
  File "C:\example\venv\Lib\site-packages\pip\_vendor\platformdirs\windows.py", line 67, in site_config_dir
    return self.site_data_dir
           ^^^^^^^^^^^^^^^^^^
  File "C:\example\venv\Lib\site-packages\pip\_vendor\platformdirs\windows.py", line 56, in site_data_dir
    path = os.path.normpath(get_win_folder("CSIDL_COMMON_APPDATA"))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\example\venv\Lib\site-packages\pip\_vendor\platformdirs\windows.py", line 209, in get_win_folder_from_registry
    directory, _ = winreg.QueryValueEx(key, shell_folder_name)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 2] The system cannot find the file specified
```