### PR TITLE
Improve error handling in unpacking utilities

### DIFF
--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -34,7 +34,6 @@ except ImportError:
     logger.debug("bz2 module is not available")
 
 try:
-    # Only for Python 3.3+
     import lzma  # noqa
 
     SUPPORTED_EXTENSIONS += XZ_EXTENSIONS
@@ -325,8 +324,7 @@ def unpack_file(
     ):
         untar_file(filename, location)
     else:
-        # FIXME: handle?
-        # FIXME: magic signatures?
+        # Cannot determine archive format from file extension, content-type, or file contents
         logger.critical(
             "Cannot unpack file %s (downloaded from %s, content-type: %s); "
             "cannot detect archive format",
@@ -334,4 +332,4 @@ def unpack_file(
             location,
             content_type,
         )
-        raise InstallationError(f"Cannot determine archive format of {location}")
+        raise InstallationError(f"Cannot determine archive format of {filename}")


### PR DESCRIPTION
## Summary
This PR improves error handling and code clarity in the unpacking utilities module.

## Changes
- Remove outdated Python 3.3+ comment for lzma module since pip requires Python 3.9+
- Fix error message to show filename instead of location for archive format errors  
- Replace vague FIXME comments with descriptive explanation of error condition

## Test plan
- [x] Verified that SUPPORTED_EXTENSIONS still includes all expected formats
- [x] Tested error path to confirm InstallationError now shows correct filename
- [x] Confirmed no functional changes to unpacking logic

## Background
The InstallationError previously showed the extraction location instead of the problematic filename, making debugging more difficult for users. This change makes the error message more helpful by clearly indicating which file caused the issue.

The outdated comment removal is a minor cleanup since pip's minimum Python version is now 3.9.