### PR TITLE
Minor: Remove unnecessary `canonicalize_name` calls and validate via `NormalizedName` type

### DIFF
--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -143,7 +143,7 @@ class SimpleWheelCache(Cache):
                 wheel = Wheel(wheel_name)
             except InvalidWheelFilename:
                 continue
-            if canonicalize_name(wheel.name) != canonical_package_name:
+            if wheel.name != canonical_package_name:
                 logger.debug(
                     "Ignoring cached wheel %s for %s as it "
                     "does not match the expected distribution name %s.",

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -17,7 +17,7 @@ from typing import (
 
 from pip._vendor.packaging import specifiers
 from pip._vendor.packaging.tags import Tag
-from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import InvalidVersion, _BaseVersion
 from pip._vendor.packaging.version import parse as parse_version
 
@@ -127,7 +127,7 @@ class LinkEvaluator:
     def __init__(
         self,
         project_name: str,
-        canonical_name: str,
+        canonical_name: NormalizedName,
         formats: frozenset[str],
         target_python: TargetPython,
         allow_yanked: bool,
@@ -201,7 +201,7 @@ class LinkEvaluator:
                         LinkType.format_invalid,
                         "invalid wheel filename",
                     )
-                if canonicalize_name(wheel.name) != self._canonical_name:
+                if wheel.name != self._canonical_name:
                     reason = f"wrong project name (not {self.project_name})"
                     return (LinkType.different_project, reason)
 

--- a/src/pip/_internal/metadata/__init__.py
+++ b/src/pip/_internal/metadata/__init__.py
@@ -4,12 +4,15 @@ import contextlib
 import functools
 import os
 import sys
-from typing import Literal, Protocol, cast
+from typing import TYPE_CHECKING, Literal, Protocol, cast
 
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.misc import strtobool
 
 from .base import BaseDistribution, BaseEnvironment, FilesystemWheel, MemoryWheel, Wheel
+
+if TYPE_CHECKING:
+    from pip._vendor.packaging.utils import NormalizedName
 
 __all__ = [
     "BaseDistribution",
@@ -131,7 +134,9 @@ def get_directory_distribution(directory: str) -> BaseDistribution:
     return select_backend().Distribution.from_directory(directory)
 
 
-def get_wheel_distribution(wheel: Wheel, canonical_name: str) -> BaseDistribution:
+def get_wheel_distribution(
+    wheel: Wheel, canonical_name: NormalizedName
+) -> BaseDistribution:
     """Get the representation of the specified wheel's distribution metadata.
 
     This returns a Distribution instance from the chosen backend based on

--- a/src/pip/_internal/network/lazy_wheel.py
+++ b/src/pip/_internal/network/lazy_wheel.py
@@ -11,7 +11,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any
 from zipfile import BadZipFile, ZipFile
 
-from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.utils import NormalizedName
 from pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
 
 from pip._internal.metadata import BaseDistribution, MemoryWheel, get_wheel_distribution
@@ -23,7 +23,9 @@ class HTTPRangeRequestUnsupported(Exception):
     pass
 
 
-def dist_from_wheel_url(name: str, url: str, session: PipSession) -> BaseDistribution:
+def dist_from_wheel_url(
+    name: NormalizedName, url: str, session: PipSession
+) -> BaseDistribution:
     """Return a distribution object from the given wheel URL.
 
     This uses HTTP range requests to only fetch the portion of the wheel
@@ -37,7 +39,7 @@ def dist_from_wheel_url(name: str, url: str, session: PipSession) -> BaseDistrib
         wheel = MemoryWheel(zf.name, zf)  # type: ignore
         # After context manager exit, wheel.name
         # is an invalid file by intention.
-        return get_wheel_distribution(wheel, canonicalize_name(name))
+        return get_wheel_distribution(wheel, name)
 
 
 class LazyZipOverHTTP:

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -444,7 +444,7 @@ class RequirementPreparer:
             return None
 
         wheel = Wheel(link.filename)
-        name = canonicalize_name(wheel.name)
+        name = wheel.name
         logger.info(
             "Obtaining dependency information from %s %s",
             name,

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -283,7 +283,7 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
         assert ireq.link == link
         if ireq.link.is_wheel and not ireq.link.is_file:
             wheel = Wheel(ireq.link.filename)
-            wheel_name = canonicalize_name(wheel.name)
+            wheel_name = wheel.name
             assert name == wheel_name, f"{name!r} != {wheel_name!r} for wheel"
             # Version may not be present for PEP 508 direct URLs
             if version is not None:

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -118,7 +118,7 @@ def _get_cache_dir(
 def _verify_one(req: InstallRequirement, wheel_path: str) -> None:
     canonical_name = canonicalize_name(req.name or "")
     w = Wheel(os.path.basename(wheel_path))
-    if canonicalize_name(w.name) != canonical_name:
+    if w.name != canonical_name:
         raise InvalidWheelFilename(
             f"Wheel has unexpected file name: expected {canonical_name!r}, "
             f"got {w.name!r}",

--- a/tests/lib/wheel.py
+++ b/tests/lib/wheel.py
@@ -21,6 +21,7 @@ from typing import (
 )
 from zipfile import ZipFile
 
+from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.requests.structures import CaseInsensitiveDict
 
 from pip._internal.metadata import BaseDistribution, MemoryWheel, get_wheel_distribution
@@ -281,7 +282,9 @@ class WheelBuilder:
 
     def as_distribution(self, name: str) -> BaseDistribution:
         stream = BytesIO(self.as_bytes())
-        return get_wheel_distribution(MemoryWheel(self._name, stream), name)
+        return get_wheel_distribution(
+            MemoryWheel(self._name, stream), canonicalize_name(name)
+        )
 
 
 def make_wheel(

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from pip._vendor.packaging.utils import NormalizedName
+from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 
 from pip._internal.metadata import (
     BaseDistribution,
@@ -102,7 +102,7 @@ def test_metadata_dict(tmp_path: Path) -> None:
     """
     wheel_path = make_wheel(name="pkga", version="1.0.1").save_to_dir(tmp_path)
     wheel = FilesystemWheel(wheel_path)
-    dist = get_wheel_distribution(wheel, "pkga")
+    dist = get_wheel_distribution(wheel, canonicalize_name("pkga"))
     metadata_dict = dist.metadata_dict
     assert metadata_dict["name"] == "pkga"
     assert metadata_dict["version"] == "1.0.1"

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -6,6 +6,7 @@ import pytest
 
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.tags import Tag
+from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import parse as parse_version
 
 import pip._internal.utils.compatibility_tags
@@ -481,7 +482,7 @@ class TestLinkEvaluator:
         target_python = TargetPython()
         return LinkEvaluator(
             project_name="pytest",
-            canonical_name="pytest",
+            canonical_name=canonicalize_name("pytest"),
             formats=frozenset(formats),
             target_python=target_python,
             allow_yanked=True,

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -6,6 +6,7 @@ import pytest
 
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.tags import Tag
+from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import (
@@ -154,7 +155,7 @@ class TestLinkEvaluator:
         target_python = TargetPython(py_version_info=py_version_info)
         evaluator = LinkEvaluator(
             project_name="twine",
-            canonical_name="twine",
+            canonical_name=canonicalize_name("twine"),
             formats=frozenset(["source"]),
             target_python=target_python,
             allow_yanked=True,
@@ -205,7 +206,7 @@ class TestLinkEvaluator:
         target_python = TargetPython(py_version_info=(3, 6, 4))
         evaluator = LinkEvaluator(
             project_name="twine",
-            canonical_name="twine",
+            canonical_name=canonicalize_name("twine"),
             formats=frozenset(["source"]),
             target_python=target_python,
             allow_yanked=allow_yanked,
@@ -226,7 +227,7 @@ class TestLinkEvaluator:
         target_python._valid_tags = []
         evaluator = LinkEvaluator(
             project_name="sample",
-            canonical_name="sample",
+            canonical_name=canonicalize_name("sample"),
             formats=frozenset(["binary"]),
             target_python=target_python,
             allow_yanked=True,

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 
 import pytest
 
+from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 
 from pip._internal.exceptions import InvalidWheel
@@ -45,7 +46,7 @@ def mypy_whl_no_range(mock_server: MockServer, shared_data: TestData) -> Iterato
 @pytest.mark.network
 def test_dist_from_wheel_url(session: PipSession) -> None:
     """Test if the acquired distribution contain correct information."""
-    dist = dist_from_wheel_url("mypy", MYPY_0_782_WHL, session)
+    dist = dist_from_wheel_url(canonicalize_name("mypy"), MYPY_0_782_WHL, session)
     assert dist.canonical_name == "mypy"
     assert dist.version == Version("0.782")
     extras = list(dist.iter_provided_extras())
@@ -58,11 +59,13 @@ def test_dist_from_wheel_url_no_range(
 ) -> None:
     """Test handling when HTTP range requests are not supported."""
     with pytest.raises(HTTPRangeRequestUnsupported):
-        dist_from_wheel_url("mypy", mypy_whl_no_range, session)
+        dist_from_wheel_url(canonicalize_name("mypy"), mypy_whl_no_range, session)
 
 
 @pytest.mark.network
 def test_dist_from_wheel_url_not_zip(session: PipSession) -> None:
     """Test handling with the given URL does not point to a ZIP."""
     with pytest.raises(InvalidWheel):
-        dist_from_wheel_url("python", "https://www.python.org/", session)
+        dist_from_wheel_url(
+            canonicalize_name("python"), "https://www.python.org/", session
+        )

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import pytest
 
 from pip._vendor.packaging.requirements import Requirement
+from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.locations import get_scheme
@@ -266,7 +267,9 @@ def test_dist_from_broken_wheel_fails(data: TestData) -> None:
 
     package = data.packages.joinpath("corruptwheel-1.0-py2.py3-none-any.whl")
     with pytest.raises(InvalidWheel):
-        get_wheel_distribution(FilesystemWheel(os.fspath(package)), "brokenwheel")
+        get_wheel_distribution(
+            FilesystemWheel(os.fspath(package)), canonicalize_name("brokenwheel")
+        )
 
 
 class TestWheelFile:


### PR DESCRIPTION
This is a small follow up to https://github.com/pypa/pip/pull/13581, the `name` attribute of the `Wheel` model class is now guaranteed to be canonicalized, this means there are many places where it is now redundant to call `canonicalize_name`.

To validate this is always true I have set some parameters to use the `NormalizedName` type from packaging, which is the type of the canonicalized name.  I tried to keep this fairly minimal, there were many more places where a canonicalized name is always being used but changing the type on all of them started to make this PR a lot bigger than it needed to be.

We could also use the `Version` type for the version attribute instead of a str in the `Wheel` model, which would save a couple of calls to `Version` elsewhere, but this ended up being non-trivial in the `LinkEvaluator.evaluate_link` method, so I left it a more brave PR than this one.