### PR TITLE
Improve presentation of build-time errors

### DIFF
--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -169,10 +169,14 @@ class SubprocessBuildEnvironmentInstaller:
             args.append("--prefer-binary")
         args.append("--")
         args.extend(requirements)
+
+        identify_requirement = (
+            f" for {for_req.name}" if for_req and for_req.name else ""
+        )
         with open_spinner(f"Installing {kind}") as spinner:
             call_subprocess(
                 args,
-                command_desc=f"pip subprocess to install {kind}",
+                command_desc=f"installing {kind}{identify_requirement}",
                 spinner=spinner,
             )
 

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -190,6 +190,23 @@ class InstallationError(PipError):
     """General exception during installation"""
 
 
+class FailedToPrepareCandidate(InstallationError):
+    """Raised when we fail to prepare a candidate (i.e. fetch and generate metadata).
+
+    This is intentionally not a diagnostic error, since the output will be presented
+    above this error, when this occurs. This should instead present information to the
+    user.
+    """
+
+    def __init__(
+        self, *, package_name: str, requirement_chain: str, failed_step: str
+    ) -> None:
+        super().__init__(f"Failed to build '{package_name}' when {failed_step.lower()}")
+        self.package_name = package_name
+        self.requirement_chain = requirement_chain
+        self.failed_step = failed_step
+
+
 class MissingPyProjectBuildRequires(DiagnosticPipError):
     """Raised when pyproject.toml has `build-system`, but no `build-system.requires`."""
 
@@ -384,7 +401,7 @@ class InstallationSubprocessError(DiagnosticPipError, InstallationError):
         output_lines: list[str] | None,
     ) -> None:
         if output_lines is None:
-            output_prompt = Text("See above for output.")
+            output_prompt = Text("No available output.")
         else:
             output_prompt = (
                 Text.from_markup(f"[red][{len(output_lines)} lines of output][/]\n")

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -429,7 +429,7 @@ class InstallationSubprocessError(DiagnosticPipError, InstallationError):
         return f"{self.command_description} exited with {self.exit_code}"
 
 
-class MetadataGenerationFailed(InstallationSubprocessError, InstallationError):
+class MetadataGenerationFailed(DiagnosticPipError, InstallationError):
     reference = "metadata-generation-failed"
 
     def __init__(
@@ -437,7 +437,7 @@ class MetadataGenerationFailed(InstallationSubprocessError, InstallationError):
         *,
         package_details: str,
     ) -> None:
-        super(InstallationSubprocessError, self).__init__(
+        super().__init__(
             message="Encountered error while generating package metadata.",
             context=escape(package_details),
             hint_stmt="See above for details.",

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -10,6 +10,7 @@ from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import Version
 
 from pip._internal.exceptions import (
+    FailedToPrepareCandidate,
     HashError,
     InstallationSubprocessError,
     InvalidInstalledPackage,
@@ -244,9 +245,19 @@ class _InstallRequirementBackedCandidate(Candidate):
             e.req = self._ireq
             raise
         except InstallationSubprocessError as exc:
-            # The output has been presented already, so don't duplicate it.
-            exc.context = "See above for output."
-            raise
+            if isinstance(self._ireq.comes_from, InstallRequirement):
+                request_chain = self._ireq.comes_from.from_path()
+            else:
+                request_chain = self._ireq.comes_from
+
+            if request_chain is None:
+                request_chain = "directly requested"
+
+            raise FailedToPrepareCandidate(
+                package_name=self._ireq.name or str(self._link),
+                requirement_chain=request_chain,
+                failed_step=exc.command_description,
+            )
 
         self._check_metadata_consistency(dist)
         return dist


### PR DESCRIPTION
This changes how the final blurb is presented.

Before:

```
$ pip install shrinkwrap --dry-run --no-binary :all:
Collecting shrinkwrap
  Using cached shrinkwrap-0.10.tar.gz (6.0 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      Traceback (most recent call last):
        File "/Users/pradyunsg/.cache/uv/archive-v0/o8zM1DP1sbfKLaej0Unsx/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "/Users/pradyunsg/.cache/uv/archive-v0/o8zM1DP1sbfKLaej0Unsx/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/pradyunsg/.cache/uv/archive-v0/o8zM1DP1sbfKLaej0Unsx/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/y1/j465wvf92vs938kmgqh63bj80000gn/T/pip-build-env-28rs3nu0/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/y1/j465wvf92vs938kmgqh63bj80000gn/T/pip-build-env-28rs3nu0/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/private/var/folders/y1/j465wvf92vs938kmgqh63bj80000gn/T/pip-build-env-28rs3nu0/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/y1/j465wvf92vs938kmgqh63bj80000gn/T/pip-build-env-28rs3nu0/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 44
          print '%s/bin/activate has been updated' % VIRTUAL_ENV
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

After:

```
$ pip install shrinkwrap --dry-run --no-binary :all:    
Collecting shrinkwrap
  Using cached shrinkwrap-0.10.tar.gz (6.0 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      Traceback (most recent call last):
        File "/Users/pradyunsg/Developer/github/pip/src/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "/Users/pradyunsg/Developer/github/pip/src/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/pradyunsg/Developer/github/pip/src/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/y1/j465wvf92vs938kmgqh63bj80000gn/T/pip-build-env-oytda564/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/y1/j465wvf92vs938kmgqh63bj80000gn/T/pip-build-env-oytda564/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/private/var/folders/y1/j465wvf92vs938kmgqh63bj80000gn/T/pip-build-env-oytda564/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/y1/j465wvf92vs938kmgqh63bj80000gn/T/pip-build-env-oytda564/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 44
          print '%s/bin/activate has been updated' % VIRTUAL_ENV
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: Failed to build 'shrinkwrap' when getting requirements to build wheel
```