### PR TITLE
Remove `--no-wheel` from virtualenv call in test setup

### DIFF
--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -113,7 +113,6 @@ class VirtualEnvironment:
                 _virtualenv.cli_run(
                     [
                         "--no-pip",
-                        "--no-wheel",
                         "--no-setuptools",
                         os.fspath(self.location),
                     ],


### PR DESCRIPTION
When you run a functional test in verbose mode you will often see this line:

> The --no-wheel and --wheel options are deprecated. They have no effect for Python > 3.8 as wheel is no longer bundled in virtualenv.

I can't find exactly when this message was added to virtualenv, but it appears to have been around v20.13.0.

I am not removing this option from the `_legacy_virtualenv` code path, and instead just letting that code path be removed when we drop Python 3.9 support.