### PR TITLE
Fix pep668 tests on ubuntu 24.04+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   docs:
     name: docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
@@ -36,7 +36,7 @@ jobs:
       - run: nox -s docs
 
   determine-changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
       vendoring: ${{ steps.filter.outputs.vendoring }}
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v5
@@ -86,7 +86,7 @@ jobs:
 
   vendoring:
     name: vendoring
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     needs: [determine-changes]
     if: >-
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python:
           - "3.9"
           - "3.10"
@@ -132,10 +132,10 @@ jobs:
           allow-prereleases: true
 
       - name: Install Ubuntu dependencies
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install bzr
+          sudo apt-get install bzr subversion
 
       - name: Install MacOS dependencies
         if: runner.os == 'macOS'
@@ -267,7 +267,7 @@ jobs:
       - tests-zipapp
       - vendoring
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/tests/functional/test_pep668.py
+++ b/tests/functional/test_pep668.py
@@ -8,11 +8,29 @@ from tests.lib import PipTestEnvironment, create_basic_wheel_for_package
 from tests.lib.venv import VirtualEnvironment
 
 
+def _has_system_sitecustomize() -> bool:
+    """Check if there's a system sitecustomize.py that would override venv's."""
+    import os
+    import sys
+
+    # Look for sitecustomize.py in system Python paths (not site-packages)
+    for path in sys.path:
+        if "site-packages" not in path and path.endswith(
+            f"python{sys.version_info.major}.{sys.version_info.minor}"
+        ):
+            sitecustomize_path = os.path.join(path, "sitecustomize.py")
+            if os.path.exists(sitecustomize_path):
+                return True
+    return False
+
+
 @pytest.fixture
 def patch_check_externally_managed(virtualenv: VirtualEnvironment) -> None:
     # Since the tests are run from a virtual environment, and we can't
     # guarantee access to the actual stdlib location (where EXTERNALLY-MANAGED
     # needs to go into), we patch the check to always raise a simple message.
+
+    # Set up standard sitecustomize patching
     virtualenv.sitecustomize = textwrap.dedent(
         """\
         from pip._internal.exceptions import ExternallyManagedEnvironment
@@ -24,6 +42,50 @@ def patch_check_externally_managed(virtualenv: VirtualEnvironment) -> None:
         misc.check_externally_managed = check_externally_managed
         """
     )
+
+    if not _has_system_sitecustomize():
+        return
+
+    # On systems with system sitecustomize.py (like Ubuntu 24.04+), the system file
+    # takes intefers with this test. So we create a custom pip wrapper that applies
+    # patches directly when this situation is detected.
+    pip_wrapper = virtualenv.bin / "pip"
+    pip_wrapper.write_text(
+        textwrap.dedent(
+            f'''\
+        #!/usr/bin/env python
+        """Custom pip wrapper for systems with system sitecustomize.py precedence"""
+        import sys
+
+        # Make pip think it's not in a virtualenv
+        from pip._internal.utils import virtualenv as venv_module
+        venv_module.running_under_virtualenv = lambda: False
+        venv_module._running_under_venv = lambda: False
+        venv_module._running_under_legacy_virtualenv = lambda: False
+
+        # Create EXTERNALLY-MANAGED file and patch sysconfig to find it
+        import sysconfig
+        from pathlib import Path
+
+        temp_stdlib = Path("{virtualenv.lib}") / "temp_stdlib"
+        temp_stdlib.mkdir(exist_ok=True)
+        (temp_stdlib / "EXTERNALLY-MANAGED").write_text(
+            "[externally-managed]\\nError=I am externally managed\\n"
+        )
+
+        original_get_path = sysconfig.get_path
+        def patched_get_path(name):
+            return str(temp_stdlib) if name == "stdlib" else original_get_path(name)
+        sysconfig.get_path = patched_get_path
+
+        # Run pip normally
+        if __name__ == "__main__":
+            from pip._internal.cli.main import main
+            sys.exit(main())
+    '''
+        )
+    )
+    pip_wrapper.chmod(0o755)
 
 
 @pytest.mark.parametrize(
@@ -37,7 +99,11 @@ def patch_check_externally_managed(virtualenv: VirtualEnvironment) -> None:
 )
 @pytest.mark.usefixtures("patch_check_externally_managed")
 def test_fails(script: PipTestEnvironment, arguments: list[str]) -> None:
-    result = script.pip(*arguments, "pip", expect_error=True)
+    # Use custom pip wrapper only when system sitecustomize.py
+    use_wrapper = _has_system_sitecustomize()
+    result = script.pip(
+        *arguments, "pip", expect_error=True, use_module=not use_wrapper
+    )
     assert "I am externally managed" in result.stderr
 
 


### PR DESCRIPTION
Towards https://github.com/pypa/pip/issues/13568

This PR will not enable `ubuntu-latest` so to show that these changes working I am going to add a commit one at a time and let CI run:

1. Update to `ubuntu-latest` and show failures
2. Fix pep668 tests
3. Go back to `ubuntu-22.04`

Once this is done I will add a more detailed comment on my approach.