### PR TITLE
Add support for custom message headers from external registries

### DIFF
--- a/news/13605.feature.rst
+++ b/news/13605.feature.rst
@@ -1,0 +1,1 @@
+Add support for X-Error-Message header in HTTP error responses.

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -31,7 +31,7 @@ HEADERS: dict[str, str] = {"Accept-Encoding": "identity"}
 DOWNLOAD_CHUNK_SIZE = 256 * 1024
 
 
-def _extract_custom_error_message(response: Response) -> Optional[str]:
+def _extract_custom_error_message(response: Response) -> str | None:
     """
     Extract custom error message from response headers.
 

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Generator
 from typing import Optional
 

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator
 from typing import Optional
 

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pip._internal.exceptions import NetworkConnectionError
-from pip._internal.network.utils import raise_for_status
+from pip._internal.network.utils import _extract_custom_error_message, raise_for_status
 
 from tests.lib.requests_mocks import MockResponse
 
@@ -34,3 +34,85 @@ def test_raise_for_status_does_not_raises_exception() -> None:
     resp.url = "http://www.example.com/whatever.tgz"
     resp.reason = "No error"
     raise_for_status(resp)
+
+
+class TestExtractCustomErrorMessage:
+    def test_extract_custom_error_message_with_x_error_message_header(self) -> None:
+        contents = b"test"
+        resp = MockResponse(contents)
+        resp.headers["X-Error-Message"] = "Custom registry error message"
+
+        result = _extract_custom_error_message(resp)
+        assert result == "Custom registry error message"
+
+    def test_extract_custom_error_message_with_empty_x_error_message(self) -> None:
+        contents = b"test"
+        resp = MockResponse(contents)
+        resp.headers["X-Error-Message"] = ""
+
+        result = _extract_custom_error_message(resp)
+        assert result is None
+
+    def test_extract_custom_error_message_strips_whitespace(self) -> None:
+        contents = b"test"
+        resp = MockResponse(contents)
+        resp.headers["X-Error-Message"] = "  \t Custom error message  \n "
+
+        result = _extract_custom_error_message(resp)
+        assert result == "Custom error message"
+
+    def test_extract_custom_error_message_no_header(self) -> None:
+        contents = b"test"
+        resp = MockResponse(contents)
+
+        result = _extract_custom_error_message(resp)
+        assert result is None
+
+
+class TestRaiseForStatusWithCustomErrorMessage:
+    def test_raise_for_status_uses_custom_error_message_for_4xx(self) -> None:
+        contents = b"test"
+        resp = MockResponse(contents)
+        resp.status_code = 403
+        resp.url = "http://example.com/package"
+        resp.reason = "Forbidden"
+        resp.headers["X-Error-Message"] = "Access denied by registry policy"
+
+        with pytest.raises(NetworkConnectionError) as excinfo:
+            raise_for_status(resp)
+
+        assert str(excinfo.value) == (
+            "403 Client Error: Access denied by registry policy "
+            "for url: http://example.com/package"
+        )
+
+    def test_raise_for_status_falls_back_to_reason_for_4xx_without_custom_message(
+        self,
+    ) -> None:
+        contents = b"test"
+        resp = MockResponse(contents)
+        resp.status_code = 404
+        resp.url = "http://example.com/package"
+        resp.reason = "Not Found"
+
+        with pytest.raises(NetworkConnectionError) as excinfo:
+            raise_for_status(resp)
+
+        assert str(excinfo.value) == (
+            "404 Client Error: Not Found for url: http://example.com/package"
+        )
+
+    def test_raise_for_status_ignores_custom_message_for_5xx(self) -> None:
+        contents = b"test"
+        resp = MockResponse(contents)
+        resp.status_code = 500
+        resp.url = "http://example.com/package"
+        resp.reason = "Internal Server Error"
+        resp.headers["X-Error-Message"] = "Custom server error"
+
+        with pytest.raises(NetworkConnectionError) as excinfo:
+            raise_for_status(resp)
+
+        assert str(excinfo.value) == (
+            "500 Server Error: Internal Server Error for url: http://example.com/package"
+        )


### PR DESCRIPTION
  **Summary**

This PR adds support for extracting custom error messages from the X-Error-Message HTTP header in network error responses, providing users with more detailed and actionable error information from package registries.

**Problem**

Currently, pip relies on the standard [HTTP/1.1 reasonPhrase](https://www.rfc-editor.org/rfc/rfc9112.html#name-status-line) field to provide error context to users when encountering client errors from package registries. However, [HTTP/2](https://www.rfc-editor.org/rfc/rfc9113) drops this reasonPhrase field, leaving only the status code available. This results in less informative error messages for users. 

**Solution**

  - Added _extract_custom_error_message() function to parse the X-Error-Message header from HTTP responses
  - Modified raise_for_status() to utilize custom error messages for 4xx client errors when available
  - Maintained backward compatibility by falling back to standard HTTP reason phrases when the header is missing or empty
  - Implemented registry-agnostic approach that works with any server using the X-Error-Message header

**Testing**

  Added comprehensive test coverage including:
  - Successful extraction of custom error messages
  - Fallback behavior when headers are missing, empty, or whitespace-only
  - Integration with raise_for_status() for both success and fallback scenarios
