### PR TITLE
docs: clarify dependency-confusion warning refers to --extra-index-url

### DIFF
--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -479,12 +479,11 @@ Examples
 
    .. warning::
 
-       Using this option to search for packages which are not in the main
-       repository (such as private packages) is unsafe, per a security
-       vulnerability called
-       `dependency confusion <https://azure.microsoft.com/en-us/resources/3-ways-to-mitigate-risk-using-private-package-feeds/>`_:
-       an attacker can claim the package on the public repository in a way that
-       will ensure it gets chosen over the private package.
+       Using the ``--extra-index-url`` option to search for packages which are
+       not in the main repository (for example, private packages) is unsafe.
+       This is a class of security issue known as dependency confusion — an
+       attacker can publish a package with the same name to a public index,
+       which may then be chosen instead of your private package.
 
    .. tab:: Unix/macOS
 


### PR DESCRIPTION
This small docs change makes it explicit that the dependency-confusion warning applies to the `--extra-index-url` option. The previous wording ("Using this option...") can be ambiguous in the surrounding examples.
No code changes — docs-only fix. Closes pypa/pip#13609.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
