### PR TITLE
Fix duplicate "the" in pip lock example

### DIFF
--- a/docs/html/cli/pip_lock.rst
+++ b/docs/html/cli/pip_lock.rst
@@ -35,7 +35,7 @@ Options
 Examples
 ========
 
-#. Emit a ``pylock.toml`` for the the project in the current directory
+#. Emit a ``pylock.toml`` for the project in the current directory
 
    .. tab:: Unix/macOS
 


### PR DESCRIPTION
(I don't think this trivial typo fix needs a NEWS entry)