### PR TITLE
[typing] Improve the typing of the with_cleanup decorator

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -65,11 +65,7 @@ def with_cleanup(
         for t in KEEPABLE_TEMPDIR_TYPES:
             registry.set_delete(t, False)
 
-    def wrapper(
-        self: _CommandT,
-        options: Values,
-        args: list[str],
-    ) -> int:
+    def wrapper(self: _CommandT, options: Values, args: list[str]) -> int:
         assert self.tempdir_registry is not None
         if options.no_clean:
             configure_tempdir_registry(self.tempdir_registry)


### PR DESCRIPTION
Improve the typing of the `with_cleanup` decorator, as used by the `download`, `install`, `lock`, and `wheel` commands.

There is zero functional change in this PR, and the typing usage is functional back to Python 3.7 (at least), so should be no compatibility issues.

Originally identified as a result of #13599.