### PR TITLE
Remove PERF ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,7 +231,6 @@ select = [
     "G",
     "I",
     "ISC",
-    "PERF",
     "PIE810",
     "PLE",
     "PLR0",

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -189,7 +189,7 @@ class ConfigOptionParser(CustomOptionParser):
             name: [] for name in override_order
         }
 
-        for _, value in self.config.items():  # noqa: PERF102
+        for _, value in self.config.items():
             for section_key, val in value.items():
                 # ignore empty values
                 if not val:


### PR DESCRIPTION
We aren't writing performance critical code here, and these lint rules are meant for users looking to micro-optimize their code (as said in the Ruff documentation). Sometimes, Ruff asks to transform for loops into comprehensions, worsening readability.