### PR TITLE
typo: space required after the URL in root user warning

### DIFF
--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -765,7 +765,7 @@ def warn_if_run_as_root() -> None:
         "conflicting behaviour with the system package manager, possibly "
         "rendering your system unusable. "
         "It is recommended to use a virtual environment instead: "
-        "https://pip.pypa.io/warnings/venv. "
+        "https://pip.pypa.io/warnings/venv ."
         "Use the --root-user-action option if you know what you are doing and "
         "want to suppress this warning."
     )


### PR DESCRIPTION
<img width="766" height="151" alt="image" src="https://github.com/user-attachments/assets/a9d89cb4-1911-41a0-bf7a-a93a1d0ee5d6" />
The link is rendered incorrectly in github actions otherwise

A changelog/news entry is not needed for this.