### PR TITLE
Tests: Open SVN dump file in binary mode to prevent UnicodeDecodeError

### DIFF
--- a/news/13670.bugfix.rst
+++ b/news/13670.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a crash when creating the SVN INITools test repository by opening the dump file in binary mode.


### PR DESCRIPTION
This PR fixes a UnicodeDecodeError in tests/lib/local_repos.py that occurs on Windows when running SVN-related tests.

The Bug The function _create_svn_initools_repo downloads a binary SVN dump file (INITools_modified.dump) but opens it using the default text mode (open(filename)).

On Windows, this attempts to decode raw binary bytes using the default encoding (often CP1252 or UTF-8), causing a crash.

It also causes newline translation (\n -> \r\n), which corrupts the stream sent to svnadmin.

The Fix Changed the open() call to use binary mode ('rb') to ensure raw bytes are passed correctly to subprocess.

Verification Verified locally on Windows. The test code now successfully opens the file without crashing.

Fixes #13669