### PR TITLE
Add documentation for self-referential extras (#11296)

### DIFF
--- a/docs/html/topics/self-referential-extras.md
+++ b/docs/html/topics/self-referential-extras.md
@@ -1,0 +1,11 @@
+# Self-referential extras
+
+pip supports declaring optional dependencies that reference other optional dependencies of the same project.
+
+Example:
+
+```toml
+[project.optional-dependencies]
+all = ["pkg[a]", "pkg[b]"]
+a = ["dependencyA"]
+b = ["dependencyB"]


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
### Summary

Adds documentation for self-referential extras, allowing users to understand
how to declare optional dependencies that reference other optional dependencies
in the same project.

### Changes

- Added `docs/html/topics/self-referential-extras.md` with an example using `[project.optional-dependencies]`.

### Related issue

Fixes #11296
