### PR TITLE
Preserve mtime of files installed from wheels

### DIFF
--- a/news/13207.bugfix.rst
+++ b/news/13207.bugfix.rst
@@ -1,0 +1,1 @@
+Preserve ``mtime`` of files installed from wheels.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -8,6 +8,7 @@ import contextlib
 import csv
 import importlib
 import logging
+import os
 import os.path
 import re
 import shutil
@@ -16,6 +17,7 @@ import textwrap
 import warnings
 from base64 import urlsafe_b64encode
 from collections.abc import Generator, Iterable, Iterator, Sequence
+from datetime import datetime
 from email.message import Message
 from itertools import chain, filterfalse, starmap
 from typing import (
@@ -370,6 +372,9 @@ class ZipBackedFile:
                 with self._zip_file.open(zipinfo) as f:
                     blocksize = min(zipinfo.file_size, 1024 * 1024)
                     shutil.copyfileobj(f, dest, blocksize)
+
+        mtime = datetime(*zipinfo.date_time).timestamp()
+        os.utime(self.dest_path, (mtime, mtime))
 
         if zip_item_is_executable(zipinfo):
             set_extracted_file_to_default_mode_plus_executable(self.dest_path)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -373,7 +373,7 @@ class ZipBackedFile:
                     blocksize = min(zipinfo.file_size, 1024 * 1024)
                     shutil.copyfileobj(f, dest, blocksize)
 
-        mtime = datetime(*zipinfo.date_time).timestamp()
+        mtime = datetime(*zipinfo.date_time).astimezone().timestamp()
         os.utime(self.dest_path, (mtime, mtime))
 
         if zip_item_is_executable(zipinfo):

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -801,3 +801,15 @@ def test_wheel_with_unknown_subdir_in_data_dir_has_reasonable_error(
 
     result = script.pip("install", "--no-index", str(wheel_path), expect_error=True)
     assert "simple-0.1.0.data/unknown/hello.txt" in result.stderr
+
+
+def test_wheel_install_mtime(script: PipTestEnvironment, data: TestData) -> None:
+    """Check that installed file mtime matches value inside the given wheel"""
+    to_install = data.packages.joinpath("simplewheel-1.0-py2.py3-none-any.whl")
+    result = script.pip("install", to_install)
+    result.assert_installed("simplewheel", editable=False)
+
+    pth = script.site_packages / "simplewheel" / "__init__.py"
+    item = result.files_created[pth]
+
+    assert int(item.mtime) == 1523973424, "mtime does not match expected value"

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 import shutil
 import sysconfig
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -812,4 +813,9 @@ def test_wheel_install_mtime(script: PipTestEnvironment, data: TestData) -> None
     pth = script.site_packages / "simplewheel" / "__init__.py"
     item = result.files_created[pth]
 
-    assert int(item.mtime) == 1523973424, "mtime does not match expected value"
+    # These are both naive, so it is reasonable to compare them, and a bit more
+    # legible than comparing to a timestamp expectation
+    dt = datetime.fromtimestamp(item.mtime)
+    expected_dt = datetime(2018, 4, 17, 9, 57, 4)
+
+    assert dt == expected_dt, "Extracted file mtime does not match expected value"


### PR DESCRIPTION
This changeset modifies the `mtime` of files extracted from a `.whl` to match the stored timestamp.

Closes #13207.