### PR TITLE
pip index versions: honor only-binary/no-binary options

### DIFF
--- a/news/13682.bugfix.rst
+++ b/news/13682.bugfix.rst
@@ -1,0 +1,1 @@
+Fix "pip index versions" to honor only-binary/no-binary options

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -95,6 +95,7 @@ class IndexCommand(IndexGroupCommand):
         # Pass allow_yanked=False to ignore yanked versions.
         selection_prefs = SelectionPreferences(
             allow_yanked=False,
+            format_control=options.format_control,
             allow_all_prereleases=options.pre,
             ignore_requires_python=ignore_requires_python,
         )


### PR DESCRIPTION
Currently, the `pip index versions` command does not honor the --only-binary and --no-binary switches, meaning that even with --only-binary we get all available versions including source distributions:

  $ pip index versions lxml --platform=manylinux_2_39_riscv64
  lxml (6.0.2)
  Available versions: 6.0.2, 6.0.1, 6.0.0, 5.4.0, 5.3.2, 5.3.1, 5.3.0,
  5.2.2, 5.2.1, 5.2.0, 5.1.1, 5.1.0, 5.0.2, 5.0.1, 5.0.0, 4.9.4, 4.9.3,
  4.9.2, 4.9.1, 4.9.0, 4.8.0, 4.7.1, 4.6.5, 4.6.4, 4.6.3, 4.6.2, 4.6.1,
  4.6.0, 4.5.2, 4.5.1, 4.5.0, 4.4.3, 4.4.2, 4.4.1, 4.4.0, 4.3.5, 4.3.4,
  4.3.3, 4.3.2, 4.3.0, 4.2.6, 4.2.5, 4.2.4, 4.2.3, 4.2.2, 4.2.1, 4.2.0,
  4.1.1, 4.1.0, 4.0.0, 3.8.0, 3.7.3, 3.7.2, 3.7.1, 3.7.0, 3.6.4, 3.6.3,
  3.6.2, 3.6.1, 3.6.0, 3.5.0, 3.4.4, 3.4.3, 3.4.2, 3.4.1, 3.4.0, 3.3.6,
  3.3.5, 3.3.4, 3.3.3, 3.3.2, 3.3.1, 3.3.0, 3.2.5, 3.2.4, 3.2.3, 3.2.2,
  3.2.1, 3.2.0, 3.1.2, 3.1.1, 3.1.0, 3.0.2, 3.0, 2.3.6, 2.3.5, 2.3.4,
  2.3.3, 2.3.2, 2.3.1, 2.3, 2.2.8, 2.2.7, 2.2.6, 2.2.5, 2.2.4, 2.2.3,
  2.2.2, 2.2.1, 2.2, 2.1.5, 2.1.4, 2.1.3, 2.1.2, 2.1.1, 2.1, 2.0.11,
  2.0.10, 2.0.9, 2.0.8, 2.0.7, 2.0.6, 2.0.5, 2.0.4, 2.0, 1.3.6, 1.3.5,
  1.3.4, 1.3.3, 1.3.2

Fix this by propagating format_control in SelectionPreferences, which results in:

  $ pip index versions lxml --platform=manylinux_2_39_riscv64 --only-binary lxml
  lxml (6.0.2)
  Available versions: 6.0.2, 6.0.1
  
  Fixes: #13682 
