### PR TITLE
Remove pip-index-options from pip_list.rst

### DIFF
--- a/docs/html/cli/pip_list.rst
+++ b/docs/html/cli/pip_list.rst
@@ -29,8 +29,6 @@ Options
 
 .. pip-command-options:: list
 
-.. pip-index-options:: list
-
 
 Examples
 ========


### PR DESCRIPTION
Removed pip-index-options directive from pip_list.rst.

Justification:
--index-url and --extra-index-url are 2 flags that are irrelevant to this command. `pip list` lists packages that are stored locally, so there's no use in analyzing external indices. `pip list` might not even scan these external indices when passed either of these flags, which would be further reason to remove these 2 flags.

`ListCommand(IndexGroupCommand).add_options(self)` [link](https://github.com/pypa/pip/blob/614e5363639b0e8569300d287913278b74e8679c/src/pip/_internal/commands/list.py#L42) is the function that adds the relevant flags for this command like `-l` and `--format`.

The options that would be removed with this PR would be: -i, --index-url <url>
--extra-index-url <url>
--exclude <package>
--no-index
-f, --find-links <url>

However, the `--exclude` flag allows you to exclude text from the output:
```bash
(venv2) ubuntu@ip-172-31-33-143:~$ pip list
Package Version
------- -------
pip     24.0
(venv2) ubuntu@ip-172-31-33-143:~$ pip list --exclude pip
(venv2) ubuntu@ip-172-31-33-143:~$ pip list
Package Version
------- -------
pip     24.0
```

I'm not sure if those other 2 options do anything when used with this command, but from my initial testing, they're not relevant. Can this PR be adjusted to keep the `--exclude` flag?

Docs page: https://pip.pypa.io/en/stable/cli/pip_list/#cmdoption-extra-index-url

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
