### PR TITLE
PipConsole safely avoid ctypes features from rich

### DIFF
--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -143,6 +143,20 @@ class IndentedRenderable:
 
 
 class PipConsole(Console):
+    try:
+        import ctypes
+    except ImportError:
+        ctypes = None
+
+    def __init__(self, **kwargs):
+        # To support environments where ctypes is not available,
+        # Disable legacy Windows console rendering if ctypes is unavailable
+        # (LegacyWindowsTerm requires ctypes for Windows API calls)
+        if "legacy_windows" not in kwargs:
+            if PipConsole.ctypes is None:
+                kwargs["legacy_windows"] = False
+        super().__init__(**kwargs)
+
     def on_broken_pipe(self) -> None:
         # Reraise the original exception, rich 13.8.0+ exits by default
         # instead, preventing our handler from firing.


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Note: I will add an issue and news entry soon.

Modify PipConsole so that it doesn’t use the `rich` features that require ctypes when running in environments where ctypes is unavailable.
This helps ensure that pip works properly on Python implementations that do not provide ctypes.

Please tell me if patching rich will be a better idea. 