### PR TITLE
refactor: Store resume retries value on PipSession

### DIFF
--- a/src/pip/_internal/cli/index_command.py
+++ b/src/pip/_internal/cli/index_command.py
@@ -103,6 +103,7 @@ class SessionCommandMixin(CommandContextMixIn):
         session = PipSession(
             cache=os.path.join(cache_dir, "http-v2") if cache_dir else None,
             retries=retries if retries is not None else options.retries,
+            resume_retries=options.resume_retries,
             trusted_hosts=options.trusted_hosts,
             index_urls=self._get_index_urls(options),
             ssl_context=ssl_context,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -179,7 +179,6 @@ class RequirementCommand(IndexGroupCommand):
             lazy_wheel=lazy_wheel,
             verbosity=verbosity,
             legacy_resolver=legacy_resolver,
-            resume_retries=options.resume_retries,
         )
 
     @classmethod

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -167,14 +167,13 @@ class Downloader:
         self,
         session: PipSession,
         progress_bar: BarType,
-        resume_retries: int,
     ) -> None:
-        assert (
-            resume_retries >= 0
-        ), "Number of max resume retries must be bigger or equal to zero"
         self._session = session
         self._progress_bar = progress_bar
-        self._resume_retries = resume_retries
+        self._resume_retries = session.resume_retries
+        assert (
+            self._resume_retries >= 0
+        ), "Number of max resume retries must be bigger or equal to zero"
 
     def batch(
         self, links: Iterable[Link], location: str

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -329,6 +329,7 @@ class PipSession(requests.Session):
         self,
         *args: Any,
         retries: int = 0,
+        resume_retries: int = 0,
         cache: str | None = None,
         trusted_hosts: Sequence[str] = (),
         index_urls: list[str] | None = None,
@@ -370,6 +371,7 @@ class PipSession(requests.Session):
             # order to prevent hammering the service.
             backoff_factor=0.25,
         )  # type: ignore
+        self.resume_retries = resume_retries
 
         # Our Insecure HTTPAdapter disables HTTPS validation. It does not
         # support caching so we'll use it for all http:// URLs.

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -225,7 +225,7 @@ def _check_download_dir(
 class RequirementPreparer:
     """Prepares a Requirement"""
 
-    def __init__(  # noqa: PLR0913 (too many parameters)
+    def __init__(
         self,
         *,
         build_dir: str,
@@ -243,7 +243,6 @@ class RequirementPreparer:
         lazy_wheel: bool,
         verbosity: int,
         legacy_resolver: bool,
-        resume_retries: int,
     ) -> None:
         super().__init__()
 
@@ -251,7 +250,7 @@ class RequirementPreparer:
         self.build_dir = build_dir
         self.build_tracker = build_tracker
         self._session = session
-        self._download = Downloader(session, progress_bar, resume_retries)
+        self._download = Downloader(session, progress_bar)
         self.finder = finder
 
         # Where still-packed archives should be written to. If None, they are

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -315,9 +315,9 @@ def test_downloader(
     expected_bytes: bytes | None,
     tmpdir: Path,
 ) -> None:
-    session = PipSession()
+    session = PipSession(resume_retries=resume_retries)
     link = Link("http://example.com/foo.tgz")
-    downloader = Downloader(session, "on", resume_retries)
+    downloader = Downloader(session, "on")
 
     responses = []
     for headers, status_code, body in mock_responses:
@@ -355,9 +355,9 @@ def test_downloader(
 def test_resumed_download_caching(tmpdir: Path) -> None:
     """Test that resumed downloads are cached properly for future use."""
     cache_dir = tmpdir / "cache"
-    session = PipSession(cache=str(cache_dir))
+    session = PipSession(cache=str(cache_dir), resume_retries=5)
     link = Link("https://example.com/foo.tgz")
-    downloader = Downloader(session, "on", resume_retries=5)
+    downloader = Downloader(session, "on")
 
     # Mock an incomplete download followed by a successful resume
     incomplete_resp = MockResponse(b"0cfa7e9d-1868-4dd7-9fb3-")

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -31,8 +31,9 @@ def test_unpack_url_with_urllib_response_without_content_type(data: TestData) ->
         return resp
 
     session = Mock()
+    session.resume_retries = 0
     session.get = _fake_session_get
-    download = Downloader(session, progress_bar="on", resume_retries=0)
+    download = Downloader(session, progress_bar="on")
 
     uri = data.packages.joinpath("simple-1.0.tar.gz").as_uri()
     link = Link(uri)
@@ -69,6 +70,7 @@ def test_download_http_url__no_directory_traversal(
     link = Link(mock_url)
 
     session = Mock()
+    session.resume_retries = 0
     resp = MockResponse(contents)
     resp.url = mock_url
     resp.headers = {
@@ -78,7 +80,7 @@ def test_download_http_url__no_directory_traversal(
         "content-disposition": 'attachment;filename="../out_dir_file"',
     }
     session.get.return_value = resp
-    download = Downloader(session, progress_bar="on", resume_retries=0)
+    download = Downloader(session, progress_bar="on")
 
     download_dir = os.fspath(tmpdir.joinpath("download"))
     os.mkdir(download_dir)

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -116,7 +116,6 @@ class TestRequirementSet:
                 lazy_wheel=False,
                 verbosity=0,
                 legacy_resolver=True,
-                resume_retries=0,
             )
             yield Resolver(
                 preparer=preparer,


### PR DESCRIPTION
The HTTP session already stores the normal retry option. So for consistency, the resume retry count should also be stored here. This way we don't have to pass it in weird places like the requirement preparer.

Broken out of PR #13450.