### PR TITLE
Docs: fix broken and outdated documentation links

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4284,7 +4284,7 @@ Improved Documentation
 
 - Added global --user flag as shortcut for --install-option="--user". From
   Ronny Pfannschmidt.
-- Added support for `PyPI mirrors <http://pypi.org/mirrors>`_ as
+- Added support for `PyPI mirrors <http://pypi.python.org/mirrors>`_ as
   defined in `PEP 381 <https://www.python.org/dev/peps/pep-0381/>`_, from
   Jannis Leidel.
 - Fixed git revisions being ignored. Thanks John-Scott Atlakson. (#138)

--- a/docs/html/development/architecture/overview.rst
+++ b/docs/html/development/architecture/overview.rst
@@ -101,7 +101,7 @@ IN OTHER WORDS
 While all dependencies have not been resolved, do the following:
 
 1.  Following the API defined in :pep:`503`, fetch the index page from
-    `http://{pypi_index}/simple/{package_name} <https://pypi.org/simple/{package_name}>`_
+    `https://{pypi_index}/simple/{package_name} <https://pypi.org/simple/{package_name}>`_
 2.  Parse all of the file links from the page.
 3.  Select a single file to download from the list of links.
 4.  Extract the metadata from the downloaded package.

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -131,7 +131,6 @@ Requirements files can also be served via a URL, e.g.
 http://example.com/requirements.txt besides as local files, so that they can
 be stored and served in a centralized place.
 
-
 In practice, there are 4 common uses of Requirements files:
 
 1. Requirements files are used to hold the result from :ref:`pip freeze` for the


### PR DESCRIPTION
This PR fixes several broken and outdated external links in the documentation,
identified during the HTTPS link audit.

This is a documentation-only change, so no news fragment is required.

Fixes part of #13664.

