### PR TITLE
test: Move `create_file()` helper and add `script.temporary_file()`

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -35,6 +35,7 @@ from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
 
+from tests.lib.filesystem import create_file
 from tests.lib.venv import VirtualEnvironment
 from tests.lib.wheel import make_wheel
 
@@ -49,18 +50,6 @@ CURRENT_PY_VERSION_INFO = sys.version_info[:3]
 
 _Test = Callable[..., None]
 _FilesState = dict[str, Union[FoundDir, FoundFile]]
-
-
-def create_file(path: str, contents: str | None = None) -> None:
-    """Create a file on the path, with the given contents"""
-    from pip._internal.utils.misc import ensure_dir
-
-    ensure_dir(os.path.dirname(path))
-    with open(path, "w") as f:
-        if contents is not None:
-            f.write(contents)
-        else:
-            f.write("\n")
 
 
 def make_test_search_scope(
@@ -758,6 +747,12 @@ class PipTestEnvironment(TestFileEnvironment):
             if canonicalize_name(x["name"]) == dist_name
             and x.get("editable_project_location")
         )
+
+    def temporary_file(self, filename: str, contents: str) -> pathlib.Path:
+        """Create a temporary file with the given filename and contents."""
+        path = self.scratch_path.joinpath(filename)
+        create_file(path, contents)
+        return path
 
 
 # FIXME ScriptTest does something similar, but only within a single

--- a/tests/lib/filesystem.py
+++ b/tests/lib/filesystem.py
@@ -31,3 +31,14 @@ def chmod(path: str | Path, mode: int) -> Iterator[None]:
         yield
     finally:
         os.chmod(path, old_mode)
+
+
+def create_file(path: str | Path, contents: str | None = None) -> None:
+    """Create a file on the path, with the given contents"""
+    _path = Path(path)
+    _path.parent.mkdir(exist_ok=True, parents=True)
+    with _path.open("w") as f:
+        if contents is not None:
+            f.write(contents)
+        else:
+            f.write("\n")

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -19,7 +19,7 @@ from pip._internal.req.req_uninstall import (
     uninstallation_paths,
 )
 
-from tests.lib import create_file
+from tests.lib.filesystem import create_file
 
 
 # Pretend all files are local, so UninstallPathSet accepts files in the tmpdir,


### PR DESCRIPTION
Towards #13707.

This will be useful for requirements/constraints files.