### PR TITLE
test: Pre-compile common wheels in base test env

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,6 +420,7 @@ def _common_wheel_editable_install(
                 },
                 interpreter=sys.executable,
                 script_kind="posix",
+                bytecode_optimization_levels=[0],
             ),
             additional_metadata={},
         )


### PR DESCRIPTION
The test suite disables Python bytecode caching so if we don't pre-compile the bytecode for coverage, setuptools, and pytest-subket which are all preinstalled in the test environments, we pay a heavy import time penalty (e.g., setuptools during a PEP 517 build). pip is already pre-compiled FWIW.

This is doubly bad for coverage and pytest-subket since they are imported on every Python process startup.

Locally, this shaves a full minute from a full test suite run down to 2:45 from 3:45.

Towards #13707.

---

Another idea I have is to stop copying the test data for every test that requests it. This will need some work since AFAIU some tests depend on being to write freely to the temporary test data folder, but there's no reason why they can't use the normal temporary directory pytest provides. This will hopefully partially alleviate the issues we have with abysmal file I/O performance on Windows. 
