### PR TITLE
test: Don't include coverage in test env unless needed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -512,12 +512,13 @@ def virtualenv_template(
     # detects changed files.
     venv.site.joinpath("easy-install.pth").touch()
 
-    # Install coverage and pth file for executing it in any spawned processes
-    # in this virtual environment.
-    install_pth_link(venv, "coverage", coverage_install)
-    # zz prefix ensures the file is after easy-install.pth.
-    with open(venv.site / "zz-coverage-helper.pth", "a") as f:
-        f.write("import coverage; coverage.process_startup()")
+    if request.config.getoption("--cov"):
+        # Install coverage and pth file for executing it in any spawned processes
+        # in this virtual environment.
+        install_pth_link(venv, "coverage", coverage_install)
+        # zz prefix ensures the file is after easy-install.pth.
+        with open(venv.site / "zz-coverage-helper.pth", "a") as f:
+            f.write("import coverage; coverage.process_startup()")
 
     # Drop (non-relocatable) launchers.
     for exe in os.listdir(venv.bin):

--- a/tests/functional/test_inspect.py
+++ b/tests/functional/test_inspect.py
@@ -29,14 +29,14 @@ def test_inspect_basic(simple_script: PipTestEnvironment) -> None:
     """
     result = simple_script.pip("inspect")
     report = json.loads(result.stdout)
-    installed = report["installed"]
-    assert len(installed) == 5
-    installed_by_name = {i["metadata"]["name"]: i for i in installed}
+    installed_by_name = {i["metadata"]["name"]: i for i in report["installed"]}
+    # Coverage is only installed if test coverage is being collected.
+    installed_by_name.pop("coverage", None)
+    assert len(installed_by_name) == 4
     assert installed_by_name.keys() == {
         "pip",
         "setuptools",
         "wheel",
-        "coverage",
         "simplewheel",
     }
     assert installed_by_name["simplewheel"]["metadata"]["version"] == "1.0"


### PR DESCRIPTION
We don't want coverage to be imported for every Python process spawned unless we're collecting coverage. I checked and even after importing `pip._internal.commands.install`, importing coverage afterwards still takes 10ms which is nontrivial.

Towards #13707.