### PR TITLE
Speed up import of ``pip._internal.cli.main`` module

### DIFF
--- a/src/pip/_internal/cli/main.py
+++ b/src/pip/_internal/cli/main.py
@@ -39,6 +39,11 @@ logger = logging.getLogger(__name__)
 
 
 def main(args: list[str] | None = None) -> int:
+    # NOTE: Lazy imports to speed up import of this module,
+    # which is imported from the pip console script. This doesn't
+    # speed up normal pip execution, but might be important in the future
+    # if we use ``multiprocessing`` module,
+    # which imports __main__ for each spawned subprocess.
     from pip._internal.cli.autocompletion import autocomplete
     from pip._internal.cli.main_parser import parse_command
     from pip._internal.commands import create_command


### PR DESCRIPTION
NOTE: This doesn't speed up pip execution, since the lazily loaded modules are executed
in the main CLI execution path. This might nevertheless help if we use ``multiprocessing` module to parallelize pip operations in the future. See [this comment](https://github.com/pypa/pip/issues/12712#issuecomment-3691802543) for details.

I don't think this requires NEWS since  this shouldn't be a user-visible change.


### Import time on main

<img width="1804" height="1087" alt="image" src="https://github.com/user-attachments/assets/66d75aa1-8900-4f61-9c6d-6d2c21fce7d6" />

### Import time on this branch

<img width="1804" height="1087" alt="image" src="https://github.com/user-attachments/assets/1eca6df4-0b7d-4bf4-b9d3-c6170661c081" />

(note: it doesn't help to lazy import `logging` since it is anyway imported in `pip._internal`)