### PR TITLE
Remove __pycache__ when package is removed

### DIFF
--- a/news/13725.bugfix.rst
+++ b/news/13725.bugfix.rst
@@ -1,0 +1,1 @@
+Remove the adjacent __pycache__ directory when a .py file is removed.

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -5,7 +5,6 @@ import os
 import sys
 import sysconfig
 from collections.abc import Generator, Iterable
-from importlib.util import cache_from_source
 from typing import Any, Callable
 
 from pip._internal.exceptions import LegacyDistutilsInstall, UninstallMissingRecord
@@ -337,8 +336,14 @@ class UninstallPathSet:
 
         # __pycache__ files can show up after 'installed-files.txt' is created,
         # due to imports
+        # Add the adjacent __pycache__ directory to the UninstallPathSet when a
+        # .py file is removed. We do this to avoid the risk of orphaned .pyc
+        # files created by a different interpreter version than the one running
+        # pip at the time of package installation and uninstallation or an
+        # interpreter run at a different optimization level (PYTHONOPTIMIZE).
         if os.path.splitext(path)[1] == ".py":
-            self.add(cache_from_source(path))
+            pycache = os.path.join(os.path.dirname(path), "__pycache__")
+            self.add(pycache)
 
     def add_pth(self, pth_file: str, entry: str) -> None:
         pth_file = self._normalize_path_cached(pth_file)

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -239,6 +239,39 @@ class TestUninstallPathSet:
         ups.add(path2)
         assert ups._paths == {path1}
 
+    def test_add_py_removes_adjacent_pycache(
+        self, tmpdir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            pip._internal.req.req_uninstall.UninstallPathSet,
+            "_permitted",
+            mock_permitted,
+        )
+
+        pkg_dir = os.path.normcase(os.path.join(tmpdir, "mypkg"))
+        pycache_dir = os.path.join(pkg_dir, "__pycache__")
+        os.makedirs(pycache_dir)
+
+        py_file = os.path.join(pkg_dir, "foo.py")
+        pyc_file = os.path.join(pycache_dir, "foo.cpython-312.pyc")
+        opt_pyc_file = os.path.join(pycache_dir, "foo.cpython-312.opt-1.pyc")
+
+        for f in (py_file, pyc_file, opt_pyc_file):
+            create_file(f)
+
+        ups = UninstallPathSet(dist=Mock())
+        ups.add(py_file)
+
+        # Adding a .py should mark the adjacent __pycache__ and all its
+        # contents for removal, not just the single .pyc for the current
+        # optimization level
+        # Since the entire __pycache__ directory is added to the UninstallPathSet
+        # we should not expect to see the pyc files explicitly
+        assert py_file in ups._paths
+        assert pycache_dir in ups._paths
+        assert pyc_file not in ups._paths
+        assert opt_pyc_file not in ups._paths
+
 
 class TestStashedUninstallPathSet:
     WALK_RESULT: list[tuple[str, list[str], list[str]]] = [


### PR DESCRIPTION
Related to #11835

This PR has been updated to completely remove the adjacent `__pycache__` when a file is selected for removal during package uninstall.

If we find there are issues with not be selective when nuking this directory (due to maybe nuking pyc for packages sharing the same namespace), we can revert to a more conservative approach of including pyc files for each possible optimization level (the initial draft of this PR went this route), but that will not cover scenarios of remnant pyc files having been generated by multiple interpreter versions (as we will only uninstall for the currently active interpreter version and the version used during installation if bytecode was compiled as part of installation).

We pivoted to this method because `uv` seems to nuke the entire `__pycache__` directory with little ill effect. 

~~This should partially address the scenario where a module has been loaded by an interpreter with various optimization levels and has generated multiple pyc files.~~

~~This does not resolve scenarios where pyc files have been generated by multiple versions of an interpreter or multiple interpreter implementations.~~

~~For scenarios where there are files for multiple versions or interpreters, explicit virtual environments may be a more correct solution since dependency trees change based on interpreter and version.~~

~~Otherwise, short of nuking all of `__pycache__` which may affect cached bytecode for packages sharing a namespace or moving it out of the package install directory, this seems like a reasonable stop gap for this specific situation.~~


<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
