### PR TITLE
Add missing import in `pip._internal.models.link` module

### DIFF
--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -7,6 +7,7 @@ import os
 import posixpath
 import re
 import urllib.parse
+import urllib.request
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import (


### PR DESCRIPTION
This code worked only by accident as `urllib.request` is imported elsewhere. Somehow, mypy doesn't complain, but `ty` does:

```python
❯ ty check src/pip/_internal/models/link.py
warning[possibly-missing-attribute]: Submodule `request` may not be available as an attribute on module `urllib`
   --> src/pip/_internal/models/link.py:135:11
    |
133 |     # exist, the colon should be quoted. We rely on urllib.request
134 |     # to do the right thing here.
135 |     ret = urllib.request.pathname2url(urllib.request.url2pathname(part))
    |           ^^^^^^^^^^^^^^
136 |     if ret.startswith("///"):
137 |         # Remove any URL authority section, leaving only the URL path.
    |
help: Consider explicitly importing `urllib.request`
info: rule `possibly-missing-attribute` is enabled by default

warning[possibly-missing-attribute]: Submodule `request` may not be available as an attribute on module `urllib`
   --> src/pip/_internal/models/link.py:135:39
    |
133 |     # exist, the colon should be quoted. We rely on urllib.request
134 |     # to do the right thing here.
135 |     ret = urllib.request.pathname2url(urllib.request.url2pathname(part))
    |                                       ^^^^^^^^^^^^^^
136 |     if ret.startswith("///"):
137 |         # Remove any URL authority section, leaving only the URL path.
```

Found this when looking for opportunities for import speed optimizations per #4768.
Once this is merged, we could gain a minor speedup (5-10ms) for `pip -h` and possibly other commands by inlining `urllib.requests` import in `pip._internal.utils.urls` module with the following patch. 

```diff
❯ git diff src/pip/_internal/utils/urls.py
diff --git a/src/pip/_internal/utils/urls.py b/src/pip/_internal/utils/urls.py
index e951a5e4e..ceb94d817 100644
--- a/src/pip/_internal/utils/urls.py
+++ b/src/pip/_internal/utils/urls.py
@@ -1,7 +1,6 @@
 import os
 import string
 import urllib.parse
-import urllib.request
 
 from .compat import WINDOWS
 
@@ -11,6 +10,8 @@ def path_to_url(path: str) -> str:
     Convert a path to a file: URL.  The path will be made absolute and have
     quoted path parts.
     """
+    import urllib.request
+
     path = os.path.normpath(os.path.abspath(path))
     url = urllib.parse.urljoin("file://", urllib.request.pathname2url(path))
     return url
@@ -20,6 +21,8 @@ def url_to_path(url: str) -> str:
     """
     Convert a file: URL to a path.
     """
+    import urllib.request
+
     assert url.startswith(
         "file:"
     ), f"You can only turn file: urls into filenames (not {url!r})"

```