### PR TITLE
fix: improve error message for missing METADATA file

### DIFF
--- a/src/pip/_internal/metadata/importlib/_compat.py
+++ b/src/pip/_internal/metadata/importlib/_compat.py
@@ -83,5 +83,11 @@ def get_dist_canonical_name(dist: importlib.metadata.Distribution) -> Normalized
 
     name = cast(Any, dist).name
     if not isinstance(name, str):
+        if info_location := get_info_location(dist):
+            for metadata_name in ["METADATA", "PKG-INFO"]:
+                if (cast(Any, info_location) / metadata_name).is_file():
+                    break
+            else:
+                raise BadMetadata(dist, reason="metadata file missing")
         raise BadMetadata(dist, reason="invalid metadata entry 'name'")
     return canonicalize_name(name)


### PR DESCRIPTION
## Summary
When a `dist-info` directory exists but the METADATA file is missing, pip currently shows a confusing warning:

```
WARNING: Skipping .../foo.dist-info due to invalid metadata entry 'name'
```

This PR improves the error message to be more specific when the METADATA/PKG-INFO file is actually missing:

```
WARNING: Skipping .../foo.dist-info due to metadata file missing
```

## Related Issue
Fixes #12446

## Changes
- Added explicit check for missing METADATA/PKG-INFO files in `_compat.py`
- Raise `BadMetadata` with reason "metadata file missing" when no metadata file is found

## Test Plan
- [x] Manual testing with invalid dist-info directories
- [x] Existing tests pass

## Code Change
```python
if not isinstance(name, str):
    if info_location := get_info_location(dist):
        for metadata_name in ["METADATA", "PKG-INFO"]:
            if (cast(Any, info_location) / metadata_name).is_file():
                break
        else:
            raise BadMetadata(dist, reason="metadata file missing")
    raise BadMetadata(dist, reason="invalid metadata entry 'name'")
```

---
Ahmed Adel Bakr Alderai