### PR TITLE
test: Patch `socket.getfqdn()` during Werkzeug server startup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ from tests.lib import (
     ScriptFactory,
     TestData,
 )
-from tests.lib.server import MockServer, make_mock_server
+from tests.lib.server import MockServer, make_mock_server, patch_getfqdn
 from tests.lib.venv import VirtualEnvironment, VirtualEnvironmentType
 
 if TYPE_CHECKING:
@@ -1002,7 +1002,7 @@ def html_index_with_onetime_server(
     class Handler(OneTimeDownloadHandler):
         _seen_paths: ClassVar[set[str]] = set()
 
-    with InDirectoryServer(("", 8000), Handler) as httpd:
+    with patch_getfqdn(), InDirectoryServer(("", 8000), Handler) as httpd:
         server_thread = threading.Thread(target=httpd.serve_forever)
         server_thread.start()
 


### PR DESCRIPTION
HTTPServer, which Werkzeug subclasses, will try to query the fully qualified domain name for the socket address during socket binding. This can be extremely slow (30s, even) due to DNS timeouts. It's only used for the SERVER_NAME CGI environment field which is not relevant for our tests, so patch it to immediately return a fake local FQDN.

This should fix the abnormally slow tests that spin up a local HTTP server on the macOS and Windows GHA runners.

See also: https://apple.stackexchange.com/questions/175320/why-is-my-hostname-resolution-taking-so-long

Towards #13707.