### PR TITLE
Fix typing issues identified in pip._internal.network

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,12 @@ repos:
   hooks:
   - id: mypy
     exclude: tests/data
-    args: ["--pretty", "--show-error-codes"]
+    args:
+      - "--pretty"
+      - "--show-error-codes"
+      # Since this is only a partial mypy run, we can get false-positives
+      # for unused ignores.
+      - "--no-warn-unused-ignores"
     additional_dependencies: [
         'keyring==24.2.0',
         'nox==2024.03.02',

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 from pip._vendor.requests.auth import AuthBase, HTTPBasicAuth
-from pip._vendor.requests.models import Request, Response
 from pip._vendor.requests.utils import get_netrc_auth
 
 from pip._internal.utils.logging import getLogger
@@ -32,6 +31,10 @@ from pip._internal.utils.misc import (
     split_auth_netloc_from_url,
 )
 from pip._internal.vcs.versioncontrol import AuthInfo
+
+if typing.TYPE_CHECKING:
+    from pip._vendor.requests import PreparedRequest
+    from pip._vendor.requests.models import Response
 
 logger = getLogger(__name__)
 
@@ -437,8 +440,9 @@ class MultiDomainBasicAuth(AuthBase):
 
         return url, username, password
 
-    def __call__(self, req: Request) -> Request:
+    def __call__(self, req: PreparedRequest) -> PreparedRequest:
         # Get credentials for this request
+        assert req.url is not None
         url, username, password = self._get_url_and_credentials(req.url)
 
         # Set the url of the request to the url without any credentials

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -50,8 +50,8 @@ from pip._internal.utils.urls import url_to_path
 if TYPE_CHECKING:
     from ssl import SSLContext
 
+    from pip._vendor.urllib3 import ProxyManager
     from pip._vendor.urllib3.poolmanager import PoolManager
-    from pip._vendor.urllib3.proxymanager import ProxyManager
 
 
 logger = logging.getLogger(__name__)
@@ -212,11 +212,12 @@ class LocalFSAdapter(BaseAdapter):
         self,
         request: PreparedRequest,
         stream: bool = False,
-        timeout: float | tuple[float, float] | None = None,
+        timeout: float | tuple[float, float] | tuple[float, None] | None = None,
         verify: bool | str = True,
-        cert: str | tuple[str, str] | None = None,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
         proxies: Mapping[str, str] | None = None,
     ) -> Response:
+        assert request.url is not None
         pathname = url_to_path(request.url)
 
         resp = Response()
@@ -237,13 +238,13 @@ class LocalFSAdapter(BaseAdapter):
             resp.headers = CaseInsensitiveDict(
                 {
                     "Content-Type": content_type,
-                    "Content-Length": stats.st_size,
+                    "Content-Length": str(stats.st_size),
                     "Last-Modified": modified,
                 }
             )
 
             resp.raw = open(pathname, "rb")
-            resp.close = resp.raw.close
+            resp.close = resp.raw.close  # type: ignore[method-assign]
 
         return resp
 
@@ -277,7 +278,7 @@ class _SSLContextAdapterMixin:
     ) -> PoolManager:
         if self._ssl_context is not None:
             pool_kwargs.setdefault("ssl_context", self._ssl_context)
-        return super().init_poolmanager(  # type: ignore[misc]
+        return super().init_poolmanager(  # type: ignore[misc, no-any-return]
             connections=connections,
             maxsize=maxsize,
             block=block,
@@ -289,7 +290,7 @@ class _SSLContextAdapterMixin:
         # context here too. https://github.com/pypa/pip/issues/13288
         if self._ssl_context is not None:
             proxy_kwargs.setdefault("ssl_context", self._ssl_context)
-        return super().proxy_manager_for(proxy, **proxy_kwargs)  # type: ignore[misc]
+        return super().proxy_manager_for(proxy, **proxy_kwargs)  # type: ignore[misc, no-any-return]
 
 
 class HTTPAdapter(_SSLContextAdapterMixin, _BaseHTTPAdapter):
@@ -351,7 +352,7 @@ class PipSession(requests.Session):
         self.headers["User-Agent"] = user_agent()
 
         # Attach our Authentication handler to the session
-        self.auth = MultiDomainBasicAuth(index_urls=index_urls)
+        self.auth: MultiDomainBasicAuth = MultiDomainBasicAuth(index_urls=index_urls)
 
         # Create our urllib3.Retry instance which will allow us to customize
         # how we handle retries.
@@ -385,8 +386,9 @@ class PipSession(requests.Session):
         # we can't validate the response of an insecurely/untrusted fetched
         # origin, and we don't want someone to be able to poison the cache and
         # require manual eviction from the cache to fix it.
+        self._trusted_host_adapter: InsecureCacheControlAdapter | InsecureHTTPAdapter
         if cache:
-            secure_adapter = CacheControlAdapter(
+            secure_adapter: _BaseHTTPAdapter = CacheControlAdapter(
                 cache=SafeFileCache(cache),
                 max_retries=retries,
                 ssl_context=ssl_context,
@@ -520,7 +522,7 @@ class PipSession(requests.Session):
 
         return False
 
-    def request(self, method: str, url: str, *args: Any, **kwargs: Any) -> Response:
+    def request(self, method: str, url: str, *args: Any, **kwargs: Any) -> Response:  # type: ignore[override]
         # Allow setting a default timeout on a session
         kwargs.setdefault("timeout", self.timeout)
         # Allow setting a default proxies on a session


### PR DESCRIPTION
Fix typing issues with `pip._internal.network`, using the typing issues revealed through https://github.com/pypa/pip/pull/13599.

That this PR has a few interesting points to note:

 * Our existing `mypy` pre-commit hook falsely claims that there are unused ignores with this change. The reason is that it hasn't got the full typing context, and thinks that some types are just `Any`, thus it believes that the ignore is not needed. When you do real typing, you see that it is actually needed.
 * There are actual runtime fixes in these changes:
   * We now do the casting of int to str for the HTTP headers
   * Additional assertions for typing reasons. Without these assertions, we would be getting other runtime errors if the assertions weren't true, so no regression of behaviour