### PR TITLE
import tomllib via utils.compat

### DIFF
--- a/src/pip/_internal/req/pep723.py
+++ b/src/pip/_internal/req/pep723.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any
 
-from pip._vendor import tomli as tomllib
+from pip._internal.utils.compat import tomllib
 
 REGEX = r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"
 


### PR DESCRIPTION
Referring directly to `pip._vendor.tomli` will break debundling on Python versions that are supposed to use the standard library only.
