### PR TITLE
Chore: add module docstring to misc utilities

### DIFF
--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -1,3 +1,5 @@
+"""Miscellaneous utility helpers used across pip internals."""
+
 from __future__ import annotations
 
 import errno


### PR DESCRIPTION
### What changed
- Added a module-level docstring to `src/pip/_internal/utils/misc.py` to describe the purpose of the utilities in this module.

### Why
- Improves readability and consistency by documenting the intent of a widely used internal utilities module.
- No functional changes.

### Testing
- Not applicable (documentation-only change).
