### PR TITLE
Skip .egg-info build metadata during distribution discovery

### DIFF
--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -73,6 +73,25 @@ class _DistributionFinder:
                 continue
             if name in self._found_names:
                 continue
+
+            # Skip .egg-info directories that are build metadata rather than
+            # installed packages. Build metadata lacks installation records
+            # (installed-files.txt or RECORD) and will cause uninstall to fail.
+            # This happens when running pip from a directory containing .egg-info
+            # created by 'pip install .'
+            # See: https://github.com/pypa/pip/issues/13459
+            if info_location is not None and str(info_location).endswith(".egg-info"):
+                if isinstance(info_location, pathlib.Path):
+                    has_installed_files = (info_location / "installed-files.txt").exists()
+                    has_record = (info_location / "RECORD").exists()
+                    if not has_installed_files and not has_record:
+                        logger.debug(
+                            "Skipping %s as it appears to be build metadata "
+                            "(no installation records found)",
+                            info_location,
+                        )
+                        continue
+
             self._found_names.add(name)
             yield dist, info_location
 

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -82,7 +82,9 @@ class _DistributionFinder:
             # See: https://github.com/pypa/pip/issues/13459
             if info_location is not None and str(info_location).endswith(".egg-info"):
                 if isinstance(info_location, pathlib.Path):
-                    has_installed_files = (info_location / "installed-files.txt").exists()
+                    has_installed_files = (
+                        info_location / "installed-files.txt"
+                    ).exists()
                     has_record = (info_location / "RECORD").exists()
                     if not has_installed_files and not has_record:
                         logger.debug(


### PR DESCRIPTION
Fixes #13459.

When the current directory is in sys.path and contains .egg-info without installation records, pip would incorrectly identify it as the installed package location instead of the actual installation in site-packages, causing uninstall to fail with 'No files were found to uninstall'.

This fix adds a check to skip .egg-info directories that lack installation record files (installed-files.txt or RECORD), ensuring pip finds the actual installed package.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
