### PR TITLE
docs: add example documenting pip install --target

### DIFF
--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -291,6 +291,24 @@ Examples
          py -m pip install "SomePackage==1.0.4"   # specific version
          py -m pip install "SomePackage>=1.0.4"   # minimum version
 
+#. Install packages into a custom target directory.
+
+   This is useful when working with embedded or custom Python distributions
+   where virtual environments are not practical.
+
+   .. tab:: Unix/macOS
+
+      .. code-block:: shell
+
+         python -m pip install requests numpy \
+             --target ./extern/python/lib/python3.11/site-packages
+
+   .. tab:: Windows
+
+      .. code-block:: shell
+
+         py -m pip install requests numpy ^
+             --target .\extern\python\lib\python3.11\site-packages
 
 #. Install a list of requirements specified in a file.  See the :ref:`Requirements files <Requirements Files>`.
 

--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -301,14 +301,14 @@ Examples
       .. code-block:: shell
 
          python -m pip install requests numpy \
-             --target ./extern/python/lib/python3.11/site-packages
+             --target ./extern/python_deps
 
    .. tab:: Windows
 
       .. code-block:: shell
 
          py -m pip install requests numpy ^
-             --target .\extern\python\lib\python3.11\site-packages
+             --target .\extern\python_deps
 
 #. Install a list of requirements specified in a file.  See the :ref:`Requirements files <Requirements Files>`.
 

--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -291,10 +291,16 @@ Examples
          py -m pip install "SomePackage==1.0.4"   # specific version
          py -m pip install "SomePackage>=1.0.4"   # minimum version
 
-#. Install packages into a custom target directory.
+#. Install packages into a specified directory instead of the default
+   site-packages location.
 
-   This is useful when working with embedded or custom Python distributions
-   where virtual environments are not practical.
+   .. warning::
+
+      The ``--target`` option is intended for specialized scenarios, such as
+      embedding Python where a new, empty directory is explicitly added to
+      ``sys.path``. Using it for general-purpose installation can lead to unexpected
+      behavior, since ``pip`` is designed to install packages into standard
+      environments.
 
    .. tab:: Unix/macOS
 


### PR DESCRIPTION
Adds a usage example for the --target flag to improve discoverability.

Fixes #12667