### PR TITLE
Fix devcontainer definition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "pip",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3",
+	"image": "mcr.microsoft.com/devcontainers/python:3",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
 			"packages": "mercurial,subversion,bzr"


### PR DESCRIPTION
I tried playing around with the dev container today and I consistently get this error:

```
1.922 W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
1.922 E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
1.924 ERROR: Feature "apt packages" (ghcr.io/rocker-org/devcontainer-features/apt-packages) failed to install! Look at the documentation at https://github.com/rocker-org/devcontainer-features/tree/main/src/apt-packages for help troubleshooting this error.
```

It appears the container version is too old or it hasn't been updated in a timely manner? I don't know, it looks like "3" is generally the latest version of Python 3 and seems to be updated? I can't find any documentation on this but it works without an error.