### PR TITLE
fix 26.0 news

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -54,6 +54,7 @@ Bug Fixes
 - Fix ``pip index versions`` to honor only-binary/no-binary options. (`#13682 <https://github.com/pypa/pip/issues/13682>`_)
 - Fix fallthrough logic for options, allowing overriding global options with
   defaults from user config. (`#13703 <https://github.com/pypa/pip/issues/13703>`_)
+- Use a path-segment prefix comparison, not char-by-char. (`#13777 <https://github.com/pypa/pip/issues/13777>`_)
 
 Vendored Libraries
 ------------------

--- a/news/+1ee322a1.bugfix.rst
+++ b/news/+1ee322a1.bugfix.rst
@@ -1,1 +1,0 @@
-Use a path-segment prefix comparison, not char-by-char.


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
