### PR TITLE
Show helpful hint when installing a stdlib module

### DIFF
--- a/news/12731.feature.rst
+++ b/news/12731.feature.rst
@@ -1,0 +1,2 @@
+Show a helpful hint when attempting to install a standard library module,
+informing users that the module is built-in and can be imported directly.

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -22,7 +22,7 @@ from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
-from pip._internal.utils.compat import stdlib_module_names
+from pip._internal.utils.compat import warn_stdlib_module
 from pip._internal.utils.misc import write_output
 
 logger = logging.getLogger(__name__)
@@ -140,15 +140,7 @@ class IndexCommand(IndexGroupCommand):
             versions = set(versions)
 
             if not versions:
-                # Check if the user is trying to find a standard library module
-                if query in stdlib_module_names:
-                    logger.info(
-                        "HINT: %s is part of the Python standard library and does "
-                        "not need to be installed. You can use it by importing it "
-                        "directly: 'import %s'",
-                        query,
-                        query,
-                    )
+                warn_stdlib_module(query)
                 raise DistributionNotFound(
                     f"No matching distribution found for {query}"
                 )

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -22,6 +22,7 @@ from pip._internal.index.package_finder import PackageFinder
 from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.models.target_python import TargetPython
 from pip._internal.network.session import PipSession
+from pip._internal.utils.compat import stdlib_module_names
 from pip._internal.utils.misc import write_output
 
 logger = logging.getLogger(__name__)
@@ -139,6 +140,15 @@ class IndexCommand(IndexGroupCommand):
             versions = set(versions)
 
             if not versions:
+                # Check if the user is trying to find a standard library module
+                if query in stdlib_module_names:
+                    logger.info(
+                        "HINT: %s is part of the Python standard library and does "
+                        "not need to be installed. You can use it by importing it "
+                        "directly: 'import %s'",
+                        query,
+                        query,
+                    )
                 raise DistributionNotFound(
                     f"No matching distribution found for {query}"
                 )

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -41,7 +41,7 @@ from pip._internal.models.target_python import TargetPython
 from pip._internal.models.wheel import Wheel
 from pip._internal.req import InstallRequirement
 from pip._internal.utils._log import getLogger
-from pip._internal.utils.compat import stdlib_module_names
+from pip._internal.utils.compat import warn_stdlib_module
 from pip._internal.utils.filetypes import WHEEL_EXTENSION
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.logging import indent_log
@@ -1038,17 +1038,10 @@ class PackageFinder:
                 _format_versions(best_candidate_result.all_candidates),
             )
 
-            # Check if the user is trying to install a standard library module.
-            # Only show this hint for top-level requirements (not dependencies).
+            # Only show stdlib hint for top-level requirements (not dependencies).
             is_top_level = not isinstance(req.comes_from, InstallRequirement)
-            if is_top_level and name in stdlib_module_names:
-                logger.info(
-                    "HINT: %s is part of the Python standard library and does not "
-                    "need to be installed. You can use it by importing it directly: "
-                    "'import %s'",
-                    name,
-                    name,
-                )
+            if is_top_level:
+                warn_stdlib_module(name)
 
             raise DistributionNotFound(f"No matching distribution found for {req}")
 

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -41,6 +41,7 @@ from pip._internal.models.target_python import TargetPython
 from pip._internal.models.wheel import Wheel
 from pip._internal.req import InstallRequirement
 from pip._internal.utils._log import getLogger
+from pip._internal.utils.compat import stdlib_module_names
 from pip._internal.utils.filetypes import WHEEL_EXTENSION
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.logging import indent_log
@@ -1036,6 +1037,18 @@ class PackageFinder:
                 req,
                 _format_versions(best_candidate_result.all_candidates),
             )
+
+            # Check if the user is trying to install a standard library module.
+            # Only show this hint for top-level requirements (not dependencies).
+            is_top_level = not isinstance(req.comes_from, InstallRequirement)
+            if is_top_level and name in stdlib_module_names:
+                logger.info(
+                    "HINT: %s is part of the Python standard library and does not "
+                    "need to be installed. You can use it by importing it directly: "
+                    "'import %s'",
+                    name,
+                    name,
+                )
 
             raise DistributionNotFound(f"No matching distribution found for {req}")
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -43,7 +43,7 @@ from pip._internal.req.req_install import (
     check_invalid_constraint_type,
 )
 from pip._internal.resolution.base import InstallRequirementProvider
-from pip._internal.utils.compat import stdlib_module_names
+from pip._internal.utils.compat import warn_stdlib_module
 from pip._internal.utils.compatibility_tags import get_supported
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.packaging import get_requirement
@@ -721,16 +721,9 @@ class Factory:
                 "requirements.txt"
             )
 
-        # Check if the user is trying to install a standard library module.
-        # Only show this hint for top-level requirements (not dependencies).
-        if parent is None and req.project_name in stdlib_module_names:
-            logger.info(
-                "HINT: %s is part of the Python standard library and does not "
-                "need to be installed. You can use it by importing it directly: "
-                "'import %s'",
-                req.project_name,
-                req.project_name,
-            )
+        # Only show stdlib hint for top-level requirements (not dependencies).
+        if parent is None:
+            warn_stdlib_module(req.project_name)
 
         return DistributionNotFound(f"No matching distribution found for {req}")
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -43,6 +43,7 @@ from pip._internal.req.req_install import (
     check_invalid_constraint_type,
 )
 from pip._internal.resolution.base import InstallRequirementProvider
+from pip._internal.utils.compat import stdlib_module_names
 from pip._internal.utils.compatibility_tags import get_supported
 from pip._internal.utils.hashes import Hashes
 from pip._internal.utils.packaging import get_requirement
@@ -718,6 +719,17 @@ class Factory:
                 'named "requirements.txt" (which cannot exist). Consider '
                 "using the '-r' flag to install the packages listed in "
                 "requirements.txt"
+            )
+
+        # Check if the user is trying to install a standard library module.
+        # Only show this hint for top-level requirements (not dependencies).
+        if parent is None and req.project_name in stdlib_module_names:
+            logger.info(
+                "HINT: %s is part of the Python standard library and does not "
+                "need to be installed. You can use it by importing it directly: "
+                "'import %s'",
+                req.project_name,
+                req.project_name,
             )
 
         return DistributionNotFound(f"No matching distribution found for {req}")

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -7,7 +7,14 @@ import os
 import sys
 from typing import IO
 
-__all__ = ["get_path_uid", "stdlib_pkgs", "stdlib_module_names", "tomllib", "WINDOWS"]
+__all__ = [
+    "get_path_uid",
+    "stdlib_pkgs",
+    "stdlib_module_names",
+    "tomllib",
+    "warn_stdlib_module",
+    "WINDOWS",
+]
 
 
 logger = logging.getLogger(__name__)
@@ -84,6 +91,17 @@ stdlib_pkgs = {"python", "wsgiref", "argparse"}
 # This is used to provide helpful error messages when users try to install
 # standard library modules
 stdlib_module_names: frozenset[str] = getattr(sys, "stdlib_module_names", frozenset())
+
+
+def warn_stdlib_module(name: str) -> None:
+    """Warn if a package name matches a Python standard library module."""
+    if name in stdlib_module_names:
+        logger.warning(
+            "%r is a Python standard library module name; it likely does not "
+            "need to be installed. Installing a package with the same name "
+            "may override it and break imports.",
+            name,
+        )
 
 
 # windows detection, covers cpython and ironpython

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -7,7 +7,7 @@ import os
 import sys
 from typing import IO
 
-__all__ = ["get_path_uid", "stdlib_pkgs", "tomllib", "WINDOWS"]
+__all__ = ["get_path_uid", "stdlib_pkgs", "stdlib_module_names", "tomllib", "WINDOWS"]
 
 
 logger = logging.getLogger(__name__)
@@ -79,6 +79,11 @@ else:
 # py26:sysconfig.get_config_vars('LIBDEST')), but fear platform variation may
 # make this ineffective, so hard-coding
 stdlib_pkgs = {"python", "wsgiref", "argparse"}
+
+# sys.stdlib_module_names is only available in Python 3.10+
+# This is used to provide helpful error messages when users try to install
+# standard library modules
+stdlib_module_names: frozenset[str] = getattr(sys, "stdlib_module_names", frozenset())
 
 
 # windows detection, covers cpython and ironpython

--- a/tests/functional/test_index.py
+++ b/tests/functional/test_index.py
@@ -171,7 +171,7 @@ def test_index_versions_only_final_for_package(script: PipTestEnvironment) -> No
 )
 def test_index_versions_stdlib_module_hint(script: PipTestEnvironment) -> None:
     """
-    Test that pip index shows a helpful hint when querying a stdlib module.
+    Test that pip index shows a warning when querying a stdlib module name.
     """
     result = script.pip(
         "index",
@@ -182,7 +182,4 @@ def test_index_versions_stdlib_module_hint(script: PipTestEnvironment) -> None:
     )
 
     assert "No matching distribution found for os" in result.stderr, str(result)
-    assert "HINT: os is part of the Python standard library" in result.stdout, str(
-        result
-    )
-    assert "import os" in result.stdout, str(result)
+    assert "is a Python standard library module name" in result.stderr, str(result)

--- a/tests/functional/test_index.py
+++ b/tests/functional/test_index.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import pytest
 
@@ -162,3 +163,26 @@ def test_index_versions_only_final_for_package(script: PipTestEnvironment) -> No
     )
     assert "1.0" in result.stdout
     assert "2.0a1" not in result.stdout
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="sys.stdlib_module_names only available in Python 3.10+",
+)
+def test_index_versions_stdlib_module_hint(script: PipTestEnvironment) -> None:
+    """
+    Test that pip index shows a helpful hint when querying a stdlib module.
+    """
+    result = script.pip(
+        "index",
+        "versions",
+        "--no-index",
+        "os",  # stdlib module
+        expect_error=True,
+    )
+
+    assert "No matching distribution found for os" in result.stderr, str(result)
+    assert "HINT: os is part of the Python standard library" in result.stdout, str(
+        result
+    )
+    assert "import os" in result.stdout, str(result)

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -301,6 +301,31 @@ def test_new_resolver_no_dist_message(script: PipTestEnvironment) -> None:
     assert "No matching distribution found for B" in result.stderr, str(result)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="sys.stdlib_module_names only available in Python 3.10+",
+)
+def test_new_resolver_stdlib_module_hint(script: PipTestEnvironment) -> None:
+    """
+    Test that pip shows a helpful hint when the user tries to install
+    a standard library module.
+    """
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "os",  # stdlib module
+        expect_error=True,
+        expect_stderr=True,
+    )
+
+    assert "No matching distribution found for os" in result.stderr, str(result)
+    assert "HINT: os is part of the Python standard library" in result.stdout, str(
+        result
+    )
+    assert "import os" in result.stdout, str(result)
+
+
 def test_new_resolver_installs_editable(script: PipTestEnvironment) -> None:
     create_basic_wheel_for_package(
         script,

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -307,8 +307,8 @@ def test_new_resolver_no_dist_message(script: PipTestEnvironment) -> None:
 )
 def test_new_resolver_stdlib_module_hint(script: PipTestEnvironment) -> None:
     """
-    Test that pip shows a helpful hint when the user tries to install
-    a standard library module.
+    Test that pip shows a warning when the user tries to install
+    a standard library module name.
     """
     result = script.pip(
         "install",
@@ -320,10 +320,7 @@ def test_new_resolver_stdlib_module_hint(script: PipTestEnvironment) -> None:
     )
 
     assert "No matching distribution found for os" in result.stderr, str(result)
-    assert "HINT: os is part of the Python standard library" in result.stdout, str(
-        result
-    )
-    assert "import os" in result.stdout, str(result)
+    assert "is a Python standard library module name" in result.stderr, str(result)
 
 
 def test_new_resolver_installs_editable(script: PipTestEnvironment) -> None:

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,10 +1,9 @@
 import os
-import sys
 from pathlib import Path
 
 import pytest
 
-from pip._internal.utils.compat import get_path_uid, stdlib_module_names
+from pip._internal.utils.compat import get_path_uid
 
 
 def test_get_path_uid() -> None:
@@ -45,30 +44,3 @@ def test_get_path_uid_symlink_without_NOFOLLOW(
     os.symlink(f, fs)
     with pytest.raises(OSError):
         get_path_uid(fs)
-
-
-def test_stdlib_module_names_type() -> None:
-    """Test that stdlib_module_names is a frozenset."""
-    assert isinstance(stdlib_module_names, frozenset)
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="sys.stdlib_module_names only available in Python 3.10+",
-)
-def test_stdlib_module_names_contains_common_modules() -> None:
-    """Test that stdlib_module_names contains expected stdlib modules."""
-    # These are common stdlib modules that should always be present
-    assert "os" in stdlib_module_names
-    assert "sys" in stdlib_module_names
-    assert "json" in stdlib_module_names
-    assert "collections" in stdlib_module_names
-
-
-@pytest.mark.skipif(
-    sys.version_info >= (3, 10),
-    reason="Testing fallback behavior on Python < 3.10",
-)
-def test_stdlib_module_names_empty_on_older_python() -> None:
-    """Test that stdlib_module_names is empty on Python < 3.10."""
-    assert len(stdlib_module_names) == 0

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,9 +1,10 @@
 import os
+import sys
 from pathlib import Path
 
 import pytest
 
-from pip._internal.utils.compat import get_path_uid
+from pip._internal.utils.compat import get_path_uid, stdlib_module_names
 
 
 def test_get_path_uid() -> None:
@@ -44,3 +45,30 @@ def test_get_path_uid_symlink_without_NOFOLLOW(
     os.symlink(f, fs)
     with pytest.raises(OSError):
         get_path_uid(fs)
+
+
+def test_stdlib_module_names_type() -> None:
+    """Test that stdlib_module_names is a frozenset."""
+    assert isinstance(stdlib_module_names, frozenset)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="sys.stdlib_module_names only available in Python 3.10+",
+)
+def test_stdlib_module_names_contains_common_modules() -> None:
+    """Test that stdlib_module_names contains expected stdlib modules on Python 3.10+."""
+    # These are common stdlib modules that should always be present
+    assert "os" in stdlib_module_names
+    assert "sys" in stdlib_module_names
+    assert "json" in stdlib_module_names
+    assert "collections" in stdlib_module_names
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10),
+    reason="Testing fallback behavior on Python < 3.10",
+)
+def test_stdlib_module_names_empty_on_older_python() -> None:
+    """Test that stdlib_module_names is empty on Python < 3.10."""
+    assert len(stdlib_module_names) == 0

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -57,7 +57,7 @@ def test_stdlib_module_names_type() -> None:
     reason="sys.stdlib_module_names only available in Python 3.10+",
 )
 def test_stdlib_module_names_contains_common_modules() -> None:
-    """Test that stdlib_module_names contains expected stdlib modules on Python 3.10+."""
+    """Test that stdlib_module_names contains expected stdlib modules."""
     # These are common stdlib modules that should always be present
     assert "os" in stdlib_module_names
     assert "sys" in stdlib_module_names


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

When a user tries to `pip install` a standard library module (e.g., `os`, `sys`, `json`), pip now shows a helpful hint explaining that the module is built-in and can be imported directly.

The hint is shown in the new resolver, legacy resolver, and `pip index versions` command. It uses `sys.stdlib_module_names` (Python 3.10+) with a graceful fallback to an empty frozenset on older versions.

Closes #12731