### PR TITLE
Strip extra marker from installation error messages

### DIFF
--- a/news/13618.bugfix.rst
+++ b/news/13618.bugfix.rst
@@ -1,0 +1,4 @@
+Strip extra markers (e.g., ``; extra == "optimizer"``) from error messages
+when a package distribution cannot be found, so the message now reads
+"No matching distribution found for torch" instead of the confusing
+"No matching distribution found for torch; extra == \"optimizer\"".


### PR DESCRIPTION
## Summary
- Added `_strip_extras_marker()` helper that removes `extra == "..."` conditions from requirement strings in error messages
- Applied it to `_report_single_requirement_conflict()` so both the "Could not find a version" and "No matching distribution found" messages show clean requirement names
- Added news fragment and unit tests covering various marker combinations

Before:
```
ERROR: Could not find a version that satisfies the requirement torch; extra == "optimizer" (from fsrs[optimizer]) (from versions: none)
ERROR: No matching distribution found for torch; extra == "optimizer"
```

After:
```
ERROR: Could not find a version that satisfies the requirement torch (from fsrs[optimizer]) (from versions: none)
ERROR: No matching distribution found for torch
```

Fixes #13618

## Test plan
- [x] Added 7 parametrized unit tests covering: standalone extra marker, extra with version specifier, extra combined with other markers (both positions), and cases without extra markers
- [x] All existing resolver unit tests continue to pass
- [x] Passes ruff lint and format checks