### PR TITLE
doc: Fix documentation typos and grammar errors

### DIFF
--- a/docs/html/development/architecture/command-line-interface.rst
+++ b/docs/html/development/architecture/command-line-interface.rst
@@ -64,7 +64,7 @@ The base ``Command`` has the following methods:
 
 Some commands have more specialized behavior, (see for example ``pip index``).
 These commands instead will inherit from ``IndexGroupCommand``, which inherits from ``Command``
-and  ``SessionCommandMixin`` to build build the pip session for the corresponding requests.
+and  ``SessionCommandMixin`` to build the pip session for the corresponding requests.
 
 Lastly, ``RequirementCommand``, which inherits from ``IndexGroupCommand`` is the base class
 for those commands which make use of requirements in any form, like ``pip install``.

--- a/docs/html/development/ci.rst
+++ b/docs/html/development/ci.rst
@@ -16,7 +16,7 @@ Continuous Integration
 Supported interpreters
 ======================
 
-pip support a variety of Python interpreters:
+pip supports a variety of Python interpreters:
 
 - CPython 3.9
 - CPython 3.10

--- a/docs/html/topics/authentication.md
+++ b/docs/html/topics/authentication.md
@@ -66,7 +66,7 @@ man pages][netrc-docs].
 ## Keyring Support
 
 pip supports loading credentials stored in your keyring using the
-{pypi}`keyring` library, which can be enabled py passing `--keyring-provider`
+{pypi}`keyring` library, which can be enabled by passing `--keyring-provider`
 with a value of `auto`, `disabled`, `import`, or `subprocess`. The default
 value `auto` respects `--no-input` and does not query keyring at all if the option
 is used; otherwise it tries the `import`, `subprocess`, and `disabled`
@@ -84,7 +84,7 @@ configure its usage would be to use a configuration instead:
 ```bash
 $ pip config set --global global.keyring-provider subprocess
 
-# A different user on the same system which has PYTHONPATH configured and and
+# A different user on the same system which has PYTHONPATH configured and
 # wanting to use keyring installed that way could then run
 $ pip config set --user global.keyring-provider import
 


### PR DESCRIPTION
Corrects grammar errors, typos, and duplicate words in documentation files.

Requesting to skip news.

<!-- START COPILOT CODING AGENT SUFFIX -->

Initially created from Copilot CLI via the copilot delegate command.