### PR TITLE
Fix zsh completion when compdef is unavailable

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -743,7 +743,11 @@ To setup for bash::
 
 To setup for zsh::
 
-    python -m pip completion --zsh >> ~/.zprofile
+    python -m pip completion --zsh >> ~/.zshrc
+
+If you see ``command not found: compdef``, ensure your ``~/.zshrc`` initializes
+completion (for example, by running ``autoload -Uz compinit && compinit``)
+before this snippet.
 
 To setup for fish::
 

--- a/news/12738.bugfix.rst
+++ b/news/12738.bugfix.rst
@@ -1,0 +1,2 @@
+Fix zsh completion setup to avoid startup errors when the completion system
+isn't initialized yet.

--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -33,7 +33,12 @@ COMPLETION_SCRIPTS = {
           __pip "$@"
         else
           # eval/source/. command, register function for later
-          compdef __pip -P 'pip[0-9.]#'
+          if [[ -o interactive ]] && ! command -v compdef >/dev/null; then
+            autoload -Uz compinit && compinit
+          fi
+          if command -v compdef >/dev/null; then
+            compdef __pip -P 'pip[0-9.]#'
+          fi
         fi
     """,
     "fish": """

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -55,7 +55,12 @@ if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
   __pip "$@"
 else
   # eval/source/. command, register function for later
-  compdef __pip -P 'pip[0-9.]#'
+  if [[ -o interactive ]] && ! command -v compdef >/dev/null; then
+    autoload -Uz compinit && compinit
+  fi
+  if command -v compdef >/dev/null; then
+    compdef __pip -P 'pip[0-9.]#'
+  fi
 fi""",
     ),
     (


### PR DESCRIPTION
Fixes #12738.

- Make zsh completion output resilient when compdef isn't available yet by initializing compinit in interactive shells.
- Update docs to recommend adding zsh completion to ~/.zshrc (and ensure completion is initialized) instead of ~/.zprofile.
- Update functional completion test expectations.

Tests:
- python -m pytest tests/functional/test_completion.py -q
