### PR TITLE
Clarify --target behavior with --upgrade

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -110,9 +110,9 @@ class InstallCommand(RequirementCommand):
             default=None,
             help=(
                 "Install packages into <dir>. "
-                "By default this will not replace existing files/folders in "
-                "<dir>. Use --upgrade to replace existing packages in <dir> "
-                "with new versions."
+                "This option is intended for installing into an empty directory. "
+                "It does not reliably uninstall or replace packages already present in "
+                "<dir>; to upgrade, remove the existing contents first."
             ),
         )
         cmdoptions.add_target_python_options(self.cmd_opts)


### PR DESCRIPTION
This updates the help text for `pip install --target` to clarify that it is intended for use with an empty directory, and that `--upgrade` does not reliably uninstall or replace packages already present in the target directory.

Closes #13763
Related: #9605, #11366