### PR TITLE
Strip extras marker from 'No matching distribution found' error

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -1037,7 +1037,7 @@ class PackageFinder:
                 _format_versions(best_candidate_result.all_candidates),
             )
 
-            raise DistributionNotFound(f"No matching distribution found for {req}")
+            raise DistributionNotFound(f"No matching distribution found for {name}")
 
         def _should_install_candidate(
             candidate: InstallationCandidate | None,

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -720,7 +720,7 @@ class Factory:
                 "requirements.txt"
             )
 
-        return DistributionNotFound(f"No matching distribution found for {req}")
+        return DistributionNotFound(f"No matching distribution found for {req.project_name}")
 
     def _has_any_candidates(self, project_name: str) -> bool:
         """


### PR DESCRIPTION
Fixes #13618.

When a requirement includes an environment marker like `; extra == "..."`, the final DistributionNotFound message currently shows the marker (e.g. `torch; extra == "optimizer"`). This change keeps the error focused on the project name only.

Changes (minimal):
- package_finder: use `name` instead of `req` in DistributionNotFound
- resolvelib factory: use `req.project_name` instead of `req` in DistributionNotFound

Tests:
- python -m pytest -q tests/unit/test_finder.py tests/unit/resolution_resolvelib/
