### PR TITLE
Add warning for pip install <common-file> (#9943)

### DIFF
--- a/news/9943.feature.rst
+++ b/news/9943.feature.rst
@@ -1,1 +1,2 @@
-Warn when installing packages named like local files (e.g. ``pyproject.toml``).
+Add a warning when a package name matches a common local file that exists in
+the current directory (e.g. ``pip install pyproject.toml``).

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -385,16 +385,11 @@ def parse_req_from_line(name: str, line_source: str | None) -> RequirementParts:
             "setup.cfg",
             "requirements.txt",
         }
-        if name in suspicious_names and os.path.exists(name):
-            if name == "requirements.txt":
-                flag = "-r"
-                hint = f"use '{flag} {name}' to install from the file"
+        if name.lower() in suspicious_names and os.path.exists(name):
+            if name.lower() == "requirements.txt":
+                hint = f"use '-r {name}' to install from the requirements file"
             else:
-                flag = "-e" if name != "setup.cfg" else ""
-                hint = (
-                    f"use './' prefix (e.g. 'pip install ./' or 'pip install "
-                    f"{flag} ./') to install from the current directory"
-                )
+                hint = "use 'pip install .' to install the local project"
 
             logger.warning(
                 "It looks like you are trying to install a local file (%s) "

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -805,7 +805,9 @@ class TestInstallRequirement:
         [
             ("pyproject.toml", True),
             ("setup.py", True),
+            ("setup.cfg", True),
             ("requirements.txt", True),
+            ("Setup.py", True),  # case-insensitive match
             ("requests", False),
             ("./pyproject.toml", False),
         ],
@@ -827,6 +829,19 @@ class TestInstallRequirement:
                 assert warning_msg in caplog.text
             else:
                 assert warning_msg not in caplog.text
+
+    def test_install_req_from_line_typosquatting_no_warning_when_file_missing(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No warning should be emitted when the suspicious file does not exist."""
+        with mock.patch("pip._internal.req.constructors.os.path.exists") as mock_exists:
+            mock_exists.return_value = False
+            with contextlib.suppress(Exception):
+                install_req_from_line("pyproject.toml")
+
+            assert "It looks like you are trying to install a local file" not in (
+                caplog.text
+            )
 
     @pytest.mark.parametrize(
         "inp, extras, out",


### PR DESCRIPTION
# PR Description: Add warning for pip install <common-file> (#9943)

This PR adds a warning when a user tries to install a package whose name matches a common configuration file (like `pyproject.toml`, `setup.py`, or `requirements.txt`) that exists in the current directory.

This addresses issue #9943 by helping users avoid accidentally installing malicious packages from PyPI when they actually intended to install the local project or use a requirements file.

The warning is triggered in `parse_req_from_line` when the requirement is treated as a package name and matches one of the suspicious files in the current working directory.
