### PR TITLE
Verify wheel RECORD file hashes during installation (PEP 427)

### DIFF
--- a/news/4705.bugfix.rst
+++ b/news/4705.bugfix.rst
@@ -1,0 +1,2 @@
+Verify file hashes in wheel RECORD during installation, rejecting tampered
+or corrupted wheels per PEP 427.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -455,6 +455,20 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     else:
         lib_dir = scheme.platlib
 
+    # Parse RECORD file for hash verification (PEP 427).
+    # We read the RECORD from the wheel zip *before* extracting files so we
+    # can verify each file's integrity as it is written to disk.
+    distribution = get_wheel_distribution(
+        FilesystemWheel(wheel_path),
+        canonicalize_name(name),
+    )
+    record_text = distribution.read_text("RECORD")
+    record_rows = list(csv.reader(record_text.splitlines()))
+    record_hashes: dict[RecordPath, str] = {}
+    for row in record_rows:
+        if len(row) >= 2 and row[1]:
+            record_hashes[cast("RecordPath", row[0])] = row[1]
+
     # Record details of the files moved
     #   installed = files copied from the wheel to the destination
     #   changed = files changed while installing (scripts #! line typically)
@@ -552,11 +566,7 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     other_scheme_files = map(make_data_scheme_file, other_scheme_paths)
     files = chain(files, other_scheme_files)
 
-    # Get the defined entry points
-    distribution = get_wheel_distribution(
-        FilesystemWheel(wheel_path),
-        canonicalize_name(name),
-    )
+    # Get the defined entry points (reuse the distribution parsed earlier)
     console, gui = get_entrypoints(distribution)
 
     def is_entrypoint_wrapper(file: File) -> bool:
@@ -592,6 +602,26 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
             ensure_dir(parent_dir)
             existing_parents.add(parent_dir)
         file.save()
+
+        # Verify the extracted file's hash against RECORD (PEP 427).
+        # Files that have empty hashes in RECORD (e.g. the RECORD file
+        # itself) are skipped.
+        expected_hash = record_hashes.get(file.src_record_path)
+        if expected_hash and not file.changed:
+            algo, _, expected_digest = expected_hash.partition("=")
+            if algo == "sha256":
+                h, _ = hash_file(file.dest_path)
+                actual_digest = (
+                    urlsafe_b64encode(h.digest()).decode("latin1").rstrip("=")
+                )
+                if actual_digest != expected_digest:
+                    raise InstallationError(
+                        f"RECORD hash mismatch for {file.src_record_path!r} "
+                        f"in {wheel_path!r}: expected {expected_hash}, got "
+                        f"{algo}={actual_digest}. The wheel may be corrupted "
+                        f"or tampered with."
+                    )
+
         record_installed(file.src_record_path, file.dest_path, file.changed)
 
     def pyc_source_file_paths() -> Generator[str, None, None]:
@@ -691,8 +721,7 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
             pass
         generated.append(requested_path)
 
-    record_text = distribution.read_text("RECORD")
-    record_rows = list(csv.reader(record_text.splitlines()))
+    # Reuse the record_rows parsed earlier for hash verification
 
     rows = get_csv_rows_for_installed(
         record_rows,

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -463,6 +463,72 @@ class TestInstallUnpackedWheel:
         assert entrypoint in exc_text
 
 
+
+class TestRecordHashVerification:
+    """Tests for RECORD hash verification during wheel installation (PEP 427)."""
+
+    def test_tampered_wheel_raises_error(self, tmp_path: Path) -> None:
+        """A wheel with a file whose hash doesn't match RECORD should fail."""
+        import zipfile
+
+        tmpdir = str(tmp_path)
+        # Create a valid wheel
+        wheel_path = make_wheel(
+            "sample",
+            "1.0.0",
+            extra_files={"sample/__init__.py": "original content"},
+        ).save_to_dir(tmpdir)
+
+        # Tamper with a file inside the wheel without updating RECORD
+        with zipfile.ZipFile(wheel_path, "a") as zf:
+            zf.writestr("sample/__init__.py", "tampered content!!!")
+
+        scheme = Scheme(
+            purelib=os.path.join(tmpdir, "lib"),
+            platlib=os.path.join(tmpdir, "lib"),
+            headers=os.path.join(tmpdir, "headers"),
+            scripts=os.path.join(tmpdir, "bin"),
+            data=os.path.join(tmpdir, "data"),
+        )
+
+        with pytest.raises(InstallationError, match="RECORD hash mismatch"):
+            wheel.install_wheel(
+                "sample",
+                str(wheel_path),
+                scheme=scheme,
+                req_description="sample==1.0.0",
+            )
+
+    def test_valid_wheel_installs_successfully(self, tmp_path: Path) -> None:
+        """A valid wheel with correct RECORD hashes should install fine."""
+        tmpdir = str(tmp_path)
+        wheel_path = make_wheel(
+            "sample",
+            "1.0.0",
+            extra_files={"sample/__init__.py": "valid content"},
+        ).save_to_dir(tmpdir)
+
+        scheme = Scheme(
+            purelib=os.path.join(tmpdir, "lib"),
+            platlib=os.path.join(tmpdir, "lib"),
+            headers=os.path.join(tmpdir, "headers"),
+            scripts=os.path.join(tmpdir, "bin"),
+            data=os.path.join(tmpdir, "data"),
+        )
+
+        # Should not raise
+        wheel.install_wheel(
+            "sample",
+            str(wheel_path),
+            scheme=scheme,
+            req_description="sample==1.0.0",
+        )
+
+        # Verify the file was actually installed
+        installed_init = os.path.join(tmpdir, "lib", "sample", "__init__.py")
+        assert os.path.isfile(installed_init)
+
+
 class TestMessageAboutScriptsNotOnPATH:
     tilde_warning_msg = (
         "NOTE: The current PATH contains path(s) starting with `~`, "


### PR DESCRIPTION
## Summary

pip now verifies each extracted file's sha256 hash against the wheel's RECORD file during installation. If a mismatch is detected, the install fails with a clear error message.

**Fixes #4705**  pip silently installed tampered wheels without checking RECORD hashes.

## Changes

- Parse RECORD hashes *before* file extraction in _install_wheel()
- After each file is saved, compute its sha256 and compare against RECORD
- Skip files with empty hashes (RECORD itself, per PEP 427 spec)
- Reuse distribution object to avoid duplicate wheel parsing
- Add tests for tampered and valid wheel scenarios
- Add news entry

## Test Plan

- 	est_tampered_wheel_raises_error: Creates a valid wheel, modifies a file in the zip without updating RECORD, verifies InstallationError is raised
- 	est_valid_wheel_installs_successfully: Creates and installs a normal wheel, verifies success

## Security Impact

This closes a 7+ year old security gap (filed Sep 2017) where an attacker who could intercept or modify a wheel file on a mirror/CDN could inject malicious code that pip would silently install.