### PR TITLE
Fix TestUnpackArchives for ACL used in codespaces

### DIFF
--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -104,7 +104,7 @@ class TestUnpackArchives:
                 assert contents == expected_contents, f"fname: {fname}"
             if sys.platform == "win32":
                 # the permissions tests below don't apply in windows
-                # due to os.chmod being a noop
+                # because os.chmod() ignores the execute bit
                 continue
             mode = self.mode(path)
             assert (
@@ -131,7 +131,10 @@ class TestUnpackArchives:
                 file_tarinfo = tarfile.TarInfo(item)
                 mytar.addfile(file_tarinfo, io.BytesIO(b"file content"))
         return test_tar
-    
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="os.chmod() ignores execute bit on Windows"
+    )
     def test_confirm_files_mode_preconditions(self) -> None:
         assert self.executable_mode == 0o755
         assert not (self.default_file_mode & 0o111), (


### PR DESCRIPTION
I was playing around with GitHub codespaces now that we have a dev container that is useful: https://github.com/pypa/pip/pull/13804

This will open a full IDE for you from your webbrowser in GitHub:
<img width="502" height="508" alt="image" src="https://github.com/user-attachments/assets/ad33c1e5-ccdb-415a-b4cb-199e4245295f" />

Seems like it might be useful when you don't have anything locally installed for whatever reason.

Anyway, two unit tests fail in codespaces: `test_unpack_tgz` and `test_unpack_zip` with expected permissions 422 and got permission 420. It appears this is due to ACL, which overrides permissions masks on a system level. This fixes that by probing the masks on the system and adjusting the tests appropriately. 

