### PR TITLE
Prevent uninstall path traversal via RECORD entries

### DIFF
--- a/news/13227.bugfix.rst
+++ b/news/13227.bugfix.rst
@@ -1,2 +1,2 @@
 Prevent ``pip uninstall`` from processing invalid ``RECORD`` entries that resolve outside
-the installed distribution location.
+trusted installation roots.

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import os
+import site
 import sys
 import sysconfig
 from collections.abc import Generator, Iterable
@@ -16,7 +17,6 @@ from pip._internal.utils.egg_link import egg_link_path_from_location
 from pip._internal.utils.logging import getLogger, indent_log
 from pip._internal.utils.misc import ask, normalize_path, renames, rmtree
 from pip._internal.utils.temp_dir import AdjacentTempDirectory, TempDirectory
-from pip._internal.utils.virtualenv import running_under_virtualenv
 
 logger = getLogger(__name__)
 
@@ -26,6 +26,21 @@ def _is_path_within_directory(directory: str, target: str) -> bool:
         return os.path.commonpath([directory, target]) == directory
     except ValueError:
         return False
+
+
+def _iter_permitted_roots(dist: BaseDistribution) -> Iterable[str]:
+    location = dist.location
+    if location:
+        yield location
+
+    yield sys.prefix
+    yield get_bin_prefix()
+
+    if dist.in_usersite:
+        yield get_bin_user()
+        user_base = site.getuserbase()
+        if user_base:
+            yield user_base
 
 
 def _script_names(
@@ -83,16 +98,8 @@ def uninstallation_paths(dist: BaseDistribution) -> Generator[str, None, None]:
     if entries is None:
         raise UninstallMissingRecord(distribution=dist)
 
-    normalized_location = normalize_path(location)
     for entry in entries:
         path = os.path.join(location, entry)
-        normalized_path = normalize_path(path)
-        if not _is_path_within_directory(normalized_location, normalized_path):
-            logger.warning(
-                "Not uninstalling invalid RECORD entry outside install location: %s",
-                entry,
-            )
-            continue
         yield path
         if path.endswith(".py"):
             dn, fn = os.path.split(path)
@@ -324,6 +331,11 @@ class UninstallPathSet:
         # can result in hundreds/thousands of redundant calls to normalize_path with
         # the same args, which hurts performance.
         self._normalize_path_cached = functools.lru_cache(normalize_path)
+        self._permitted_roots = tuple(
+            dict.fromkeys(
+                self._normalize_path_cached(path) for path in _iter_permitted_roots(dist)
+            )
+        )
 
     def _permitted(self, path: str) -> bool:
         """
@@ -331,10 +343,10 @@ class UninstallPathSet:
         remove/modify, False otherwise.
 
         """
-        # aka is_local, but caching normalized sys.prefix
-        if not running_under_virtualenv():
-            return True
-        return path.startswith(self._normalize_path_cached(sys.prefix))
+        for root in self._permitted_roots:
+            if _is_path_within_directory(root, path):
+                return True
+        return False
 
     def add(self, path: str) -> None:
         head, tail = os.path.split(path)

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -57,51 +57,6 @@ def test_uninstallation_paths() -> None:
     assert paths2 == paths
 
 
-def test_uninstallation_paths_skips_parent_traversal(tmp_path: Path) -> None:
-    class dist:
-        location = str(tmp_path.joinpath("site-packages"))
-
-        def iter_declared_entries(self) -> Iterator[str] | None:
-            return iter(["good.py", "../outside.py", "pkg/../../escape.py"])
-
-    d = dist()
-
-    paths = list(uninstallation_paths(d))
-
-    expected = [
-        os.path.join(d.location, "good.py"),
-        os.path.join(d.location, "good.pyc"),
-        os.path.join(d.location, "good.pyo"),
-    ]
-
-    assert paths == expected
-
-
-def test_uninstallation_paths_skips_absolute_path(tmp_path: Path) -> None:
-    class dist:
-        location = str(tmp_path.joinpath("site-packages"))
-
-        def iter_declared_entries(self) -> Iterator[str] | None:
-            return iter(
-                [
-                    os.path.abspath(os.path.join(os.path.sep, "tmp", "evil.py")),
-                    "pkg/module.py",
-                ]
-            )
-
-    d = dist()
-
-    paths = list(uninstallation_paths(d))
-
-    expected = [
-        os.path.join(d.location, "pkg/module.py"),
-        os.path.join(d.location, "pkg/module.pyc"),
-        os.path.join(d.location, "pkg/module.pyo"),
-    ]
-
-    assert paths == expected
-
-
 def test_compressed_listing(tmpdir: Path) -> None:
     def in_tmpdir(paths: list[str]) -> list[str]:
         return [
@@ -191,6 +146,48 @@ class TestUninstallPathSet:
 
         ups.add(file_nonexistent)
         assert ups._paths == {file_extant}
+
+    def test_add_refuses_path_outside_permitted_roots(self, tmpdir: Path) -> None:
+        allowed_root = os.path.normcase(os.path.join(tmpdir, "allowed"))
+        blocked_root = os.path.normcase(os.path.join(tmpdir, "blocked"))
+        os.makedirs(allowed_root)
+        os.makedirs(blocked_root)
+
+        allowed_file = os.path.join(allowed_root, "allowed.py")
+        blocked_file = os.path.join(blocked_root, "blocked.py")
+
+        with open(allowed_file, "w"):
+            pass
+        with open(blocked_file, "w"):
+            pass
+
+        ups = UninstallPathSet(dist=Mock())
+        ups._permitted_roots = (allowed_root,)
+        ups.add(allowed_file)
+        ups.add(blocked_file)
+
+        assert os.path.normcase(allowed_file) in ups._paths
+        assert os.path.normcase(blocked_file) in ups._refuse
+
+    def test_add_allows_record_style_script_path(self, tmpdir: Path) -> None:
+        root = os.path.normcase(os.path.join(tmpdir, "prefix"))
+        site_packages = os.path.join(root, "Lib", "site-packages")
+        scripts_dir = os.path.join(root, "Scripts")
+        os.makedirs(site_packages)
+        os.makedirs(scripts_dir)
+
+        script = os.path.join(scripts_dir, "docutils.exe")
+        with open(script, "w"):
+            pass
+
+        # Simulate RECORD entry "../../Scripts/docutils.exe" joined to dist.location.
+        record_path = os.path.join(site_packages, "..", "..", "Scripts", "docutils.exe")
+
+        ups = UninstallPathSet(dist=Mock())
+        ups._permitted_roots = (root,)
+        ups.add(record_path)
+
+        assert os.path.normcase(script) in ups._paths
 
     def test_add_pth(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
## Summary
This patch hardens `pip uninstall` against path traversal via malicious `RECORD` entries.

## Problem
`uninstallation_paths()` consumed paths from installed metadata and joined them with the distribution location. Entries like `../...` or absolute paths could resolve outside the package install root and be processed during uninstall.

## Fix
- Added a boundary check in uninstall path collection:
  - normalize distribution location
  - normalize each resolved `RECORD` path
  - skip any entry outside the install root
- Log a warning when invalid `RECORD` entries are ignored.

## Tests
Added unit coverage for:
- parent-directory traversal entries (`../...`)
- absolute-path entries

Both tests verify only in-root paths are returned for uninstall processing.

## Changelog
Added a bugfix news fragment describing the uninstall hardening.

