### PR TITLE
Fix broken and outdated documentation links

### DIFF
--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -194,7 +194,7 @@ The ``pip install`` command also supports a :ref:`--pre <install_--pre>` flag
 that enables installation of pre-releases and development releases.
 
 
-.. _pre-releases: https://www.python.org/dev/peps/pep-0440/#handling-of-pre-releases
+.. _pre-releases: https://peps.python.org/pep-0440/#handling-of-pre-releases
 
 .. _`0-vcs-support`:
 .. rubric:: VCS Support
@@ -207,7 +207,7 @@ Finding Packages
 pip searches for packages on `PyPI`_ using the
 `HTTP simple interface <https://pypi.org/simple/>`_,
 which is documented `here <https://packaging.python.org/specifications/simple-repository-api/>`_
-and `there <https://www.python.org/dev/peps/pep-0503/>`_.
+and `there <https://peps.python.org/pep-0503/>`_.
 
 pip offers a number of package index options for modifying how packages are
 found.

--- a/docs/html/development/architecture/overview.rst
+++ b/docs/html/development/architecture/overview.rst
@@ -139,4 +139,4 @@ files on PyPI. It’s for getting all files of Flask.)
 
 .. _`tracking issue`: https://github.com/pypa/pip/issues/6831
 .. _PyPI: https://pypi.org/
-.. _PyPI Simple API: https://warehouse.readthedocs.io/api-reference/legacy/
+.. _PyPI Simple API: https://docs.pypi.org/api/index-api/

--- a/docs/html/development/architecture/package-finding.rst
+++ b/docs/html/development/architecture/package-finding.rst
@@ -237,4 +237,4 @@ The class is the return type of both the ``CandidateEvaluator`` class's
 ``find_best_candidate()`` method.
 
 
-.. _`PEP 503`: https://www.python.org/dev/peps/pep-0503/
+.. _`PEP 503`: https://peps.python.org/pep-0503/

--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -211,6 +211,6 @@ in order to start contributing.
 .. _`good first issues`: https://github.com/pypa/pip/labels/good%20first%20issue
 .. _`pip's architecture`: https://pip.pypa.io/en/latest/development/architecture/
 .. _`triaging issues`: https://pip.pypa.io/en/latest/development/issue-triage/
-.. _`Hello World for Git`: https://guides.github.com/activities/hello-world/
-.. _`Understanding the GitHub flow`: https://guides.github.com/introduction/flow/
-.. _`Start using Git on the command line`: https://docs.gitlab.com/ee/topics/git/
+.. _`Hello World for Git`: https://docs.github.com/en/get-started/start-your-journey/hello-world
+.. _`Understanding the GitHub flow`: https://docs.github.com/en/get-started/using-github/github-flow
+.. _`Start using Git on the command line`: https://docs.gitlab.com/topics/git/

--- a/docs/html/reference/inspect-report.md
+++ b/docs/html/reference/inspect-report.md
@@ -37,7 +37,7 @@ the following properties:
 
 - `metadata`: the metadata of the distribution, converted to a JSON object according to
   the [PEP 566
-  transformation](https://www.python.org/dev/peps/pep-0566/#json-compatible-metadata).
+  transformation](https://peps.python.org/pep-0566/#json-compatible-metadata).
 
 - `metadata_location`: the location of the metadata of the installed distribution. Most
   of the time this is the `.dist-info` directory. For legacy installs it is the

--- a/docs/html/reference/installation-report.md
+++ b/docs/html/reference/installation-report.md
@@ -50,7 +50,7 @@ package with the following properties:
 
 - `metadata`: the metadata of the distribution, converted to a JSON object according to
   the [PEP 566
-  transformation](https://www.python.org/dev/peps/pep-0566/#json-compatible-metadata).
+  transformation](https://peps.python.org/pep-0566/#json-compatible-metadata).
 
 - `is_direct`: `true` if the requirement was provided as, or constrained to, a direct
   URL reference. `false` if the requirements was provided as a name and version

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -1405,7 +1405,7 @@ announcements on the `low-traffic packaging announcements list`_ and
 .. _freeze: https://pip.pypa.io/en/latest/reference/pip_freeze/
 .. _resolver testing survey: https://tools.simplysecure.org/survey/index.php?r=survey/index&sid=989272&lang=en
 .. _issue 8661: https://github.com/pypa/pip/issues/8661
-.. _our announcement on the PSF blog: http://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html
+.. _our announcement on the PSF blog: https://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html
 .. _two-minute video explanation: https://www.youtube.com/watch?v=B4GQCBBsuNU
 .. _tensorflow: https://pypi.org/project/tensorflow/
 .. _low-traffic packaging announcements list: https://mail.python.org/mailman3/lists/pypi-announce.python.org/

--- a/docs/html/ux-research-design/guidance.md
+++ b/docs/html/ux-research-design/guidance.md
@@ -409,7 +409,7 @@ Given pip's interface is text, it is particularly important that clear and consi
 
 The following copywriting Style Guides may be useful to the pip team:
 
-- [Warehouse (PyPI) copywriting styleguide and glossary of terms](https://warehouse.readthedocs.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology)
+- [Warehouse (PyPI) copywriting styleguide and glossary of terms](https://warehouse.pypa.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology)
 - Firefox:
   - [Voice and Tone](https://meet.google.com/linkredirect?authuser=0&dest=https%3A%2F%2Fdesign.firefox.com%2Fphoton%2Fcopy%2Fvoice-and-tone.html)
   - [Writing for users](https://meet.google.com/linkredirect?authuser=0&dest=https%3A%2F%2Fdesign.firefox.com%2Fphoton%2Fcopy%2Fwriting-for-users.html)
@@ -424,7 +424,7 @@ The following copywriting Style Guides may be useful to the pip team:
 - [Simply Secure: Feedback Gathering Guide](https://simplysecure.org/blog/feedback-gathering-guide)
 - [Simply Secure: Getting Quick Tool Feedback](https://simplysecure.org/blog/design-spot-tool-feedback)
 - [Internews: UX Feedback Collection Guidebook](https://globaltech.internews.org/our-resources/ux-feedback-collection-guidebook)
-- [Simply Secure: Knowledge Base](http://simplysecure.org/knowledge-base/)
+- [Simply Secure: Knowledge Base](https://simplysecure.org/knowledge-base/)
 - [Open Source Design](https://opensourcedesign.net/resources/)
 - [Nielsen Norman Group](https://www.nngroup.com/articles/)
 - [Interaction Design Foundation](https://www.interaction-design.org/literature)

--- a/docs/html/ux-research-design/research-results/improving-pips-documentation.md
+++ b/docs/html/ux-research-design/research-results/improving-pips-documentation.md
@@ -75,7 +75,7 @@ Common feedback that emerged from both surveys and user interviews includes:
 - There should be more instructions specific to each user's different situation (e.g. what operating system they are using)
 - The scope of the documentation is unclear
 - The documentation should recognise that pip exists within an ecosystem of other packaging tools
-- ["There should be one-- and preferably only one --obvious way to do it."](https://www.python.org/dev/peps/pep-0020/) - i.e. the documentation should provide stronger recommendations
+- ["There should be one-- and preferably only one --obvious way to do it."](https://peps.python.org/pep-0020/) - i.e. the documentation should provide stronger recommendations
 
 While some users mentioned that video would be helpful, more said that video was too long, or inappropriate for the kind of problems they experience using pip.
 
@@ -517,7 +517,7 @@ _Page purpose:_
 _Suggested content:_
 
 - This guide
-- Writing styleguide / glossary of terms - see the [Warehouse documentation](https://warehouse.readthedocs.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology) for an example.
+- Writing styleguide / glossary of terms - see the [Warehouse documentation](https://warehouse.pypa.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology) for an example.
 
 </details>
 

--- a/news/13664.doc.rst
+++ b/news/13664.doc.rst
@@ -1,0 +1,1 @@
+Fixed broken and outdated documentation links.


### PR DESCRIPTION
## Summary
- Fixed 14 broken/outdated documentation links across 9 files
- Updated `guides.github.com` URLs to `docs.github.com` equivalents
- Updated `warehouse.readthedocs.io` URLs to `docs.pypi.org` / `warehouse.pypa.io`
- Updated old-style `python.org/dev/peps/` URLs to canonical `peps.python.org/`
- Upgraded `http://` links to `https://` where appropriate
- Added NEWS fragment

Closes #13664

## Test plan
- [ ] Run `nox -s docs -- -b linkcheck` to verify links
- [ ] Review each link change for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)