### PR TITLE
mnt: `__package__` → `__spec__.parent`

### DIFF
--- a/src/pip/__main__.py
+++ b/src/pip/__main__.py
@@ -10,7 +10,7 @@ if sys.path[0] in ("", os.getcwd()):
 
 # If we are running from a wheel, add the wheel to sys.path
 # This allows the usage python pip-*.whl/pip install pip-*.whl
-if __package__ == "":
+if not __spec__ or __spec__.parent == "":
     # __file__ is pip-*.whl/pip/__main__.py
     # first dirname call strips of '/__main__.py', second strips off '/pip'
     # Resulting path is the name of the wheel itself


### PR DESCRIPTION
Removed deprecated `__package__`, scheduled for [removal in Python 3.15](https://docs.python.org/3.15/reference/datamodel.html#module.__package__).

[skip news]