### PR TITLE
fix: replace 3 bare except clauses with except Exception

### DIFF
--- a/src/pip/_vendor/msgpack/fallback.py
+++ b/src/pip/_vendor/msgpack/fallback.py
@@ -800,7 +800,7 @@ class Packer:
     def pack(self, obj):
         try:
             self._pack(obj)
-        except:
+        except Exception:
             self._buffer = BytesIO()  # force reset
             raise
         if self._autoreset:

--- a/src/pip/_vendor/rich/logging.py
+++ b/src/pip/_vendor/rich/logging.py
@@ -287,7 +287,7 @@ if __name__ == "__main__":  # pragma: no cover
         log.debug("in divide")
         try:
             number / divisor
-        except:
+        except Exception:
             log.exception("An error of some kind occurred!")
 
     divide()


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.