### PR TITLE
Fix #12667: there is very little documetation for the --target flag

### DIFF
--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -442,6 +442,32 @@ Examples
          py -m pip install "SomeProject @ http://my.package.repo/SomeProject-1.2.3-py33-none-any.whl"
          py -m pip install "SomeProject@http://my.package.repo/1.2.3.tar.gz"
 
+#. Install to a custom directory using ``--target``.
+
+   Install packages into a specific directory without creating a site-packages structure.
+
+   .. tab:: Unix/macOS
+
+      .. code-block:: shell
+
+         python -m pip install --target ./custom_dir SomePackage
+         python -m pip install --target ~/.local/python-packages SomePackage
+
+   .. tab:: Windows
+
+      .. code-block:: shell
+
+         py -m pip install --target .\custom_dir SomePackage
+         py -m pip install --target %APPDATA%\Python-Packages SomePackage
+
+   .. note::
+
+      The ``--target`` option is useful when you want to install packages into a custom
+      location such as a bundled Python environment, an application-specific directory,
+      or a staging directory. Unlike ``--prefix``, which creates a structure with lib,
+      bin, and other standard directories, ``--target`` installs directly into the
+      specified directory. If you need to upgrade packages, use ``--target`` with ``--upgrade``.
+
 #. Install from alternative package repositories.
 
    Install from a different index, and not `PyPI`_

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -110,9 +110,14 @@ class InstallCommand(RequirementCommand):
             default=None,
             help=(
                 "Install packages into <dir>. "
+                "This option can be used to install packages into a custom path, "
+                "such as a custom Python environment, application-specific directory, "
+                "or a location you're preparing for deployment. "
                 "By default this will not replace existing files/folders in "
                 "<dir>. Use --upgrade to replace existing packages in <dir> "
-                "with new versions."
+                "with new versions. "
+                "Unlike --prefix or --root, --target installs directly into the "
+                "specified directory without using site-packages paths."
             ),
         )
         cmdoptions.add_target_python_options(self.cmd_opts)
@@ -139,7 +144,12 @@ class InstallCommand(RequirementCommand):
             dest="root_path",
             metavar="dir",
             default=None,
-            help="Install everything relative to this alternate root directory.",
+            help=(
+                "Install everything relative to this alternate root directory. "
+                "This option is useful for creating a staged installation for packaging, "
+                "where the installed files maintain their structure relative to the root. "
+                "Cannot be used with --user or --target."
+            ),
         )
         self.cmd_opts.add_option(
             "--prefix",
@@ -148,9 +158,13 @@ class InstallCommand(RequirementCommand):
             default=None,
             help=(
                 "Installation prefix where lib, bin and other top-level "
-                "folders are placed. Note that the resulting installation may "
+                "folders are placed. This option is useful when you want to install "
+                "packages with a structure similar to a virtual environment or Python "
+                "installation, with lib, bin, and other standard directories created "
+                "automatically. Note that the resulting installation may "
                 "contain scripts and other resources which reference the "
                 "Python interpreter of pip, and not that of ``--prefix``. "
+                "If you just want to install packages into a flat directory, use --target instead. "
                 "See also the ``--python`` option if the intention is to "
                 "install packages into another (possibly pip-free) "
                 "environment."


### PR DESCRIPTION
Fixes #12667

## Summary
This PR fixes: there is very little documetation for the --target flag

## Changes
```
docs/html/cli/pip_install.rst         | 26 ++++++++++++++++++++++++++
 src/pip/_internal/commands/install.py | 20 +++++++++++++++++---
 2 files changed, 43 insertions(+), 3 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).