### PR TITLE
Fix #12738: Mac zsh auto=completion error "command not found: compdef" 

### DIFF
--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -33,7 +33,9 @@ COMPLETION_SCRIPTS = {
           __pip "$@"
         else
           # eval/source/. command, register function for later
-          compdef __pip -P 'pip[0-9.]#'
+          if (( ${{+functions[compdef]}} )); then
+            compdef __pip -P 'pip[0-9.]#'
+          fi
         fi
     """,
     "fish": """

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -55,7 +55,9 @@ if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
   __pip "$@"
 else
   # eval/source/. command, register function for later
-  compdef __pip -P 'pip[0-9.]#'
+  if (( ${+functions[compdef]} )); then
+    compdef __pip -P 'pip[0-9.]#'
+  fi
 fi""",
     ),
     (


### PR DESCRIPTION
Fixes #12738

## Summary
This PR fixes: Mac zsh auto=completion error "command not found: compdef" 

## Changes
```
src/pip/_internal/commands/completion.py | 4 +++-
 tests/functional/test_completion.py      | 4 +++-
 2 files changed, 6 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Haiku 4.5 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).