### PR TITLE
Support relative values/durations in `--uploaded-prior-to`

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -365,14 +365,14 @@ packages that were available at a known point in time.
    .. code-block:: shell
 
       python -m pip install --uploaded-prior-to=2025-03-16T00:00:00Z SomePackage
-      python -m pip install --uploaded-prior-to=P1D SomePackage
+      python -m pip install --uploaded-prior-to=P3D SomePackage
 
 .. tab:: Windows
 
    .. code-block:: shell
 
       py -m pip install --uploaded-prior-to=2025-03-16T00:00:00Z SomePackage
-      py -m pip install --uploaded-prior-to=P1D SomePackage
+      py -m pip install --uploaded-prior-to=P3D SomePackage
 
 The option accepts ISO 8601 datetime strings in several formats:
 
@@ -381,18 +381,19 @@ The option accepts ISO 8601 datetime strings in several formats:
 * ``2025-03-16T12:30:00Z`` - Datetime in UTC
 * ``2025-03-16T12:30:00+05:00`` - Datetime in UTC offset
 
-It also accepts a duration in the ``PnD`` format, where ``n`` is the number of
-days. This only considers packages uploaded at least ``n`` days ago.
+For consistency across machines, use either UTC format (with 'Z' suffix) or UTC offset
+format (with timezone offset like '+05:00'). Local timezone formats may produce different
+results on different machines.
 
-* ``P1D`` - uploaded at least 1 day ago
+It also accepts a duration in the ``PnD`` format, where ``n`` is the number of
+days. This only considers packages uploaded at least ``n`` days ago. A day is
+always 24 hours; daylight savings and other time zone transitions are ignored.
+
+* ``P3D`` - uploaded at least 3 days ago
 * ``P7D`` - uploaded at least 7 days ago
 * ``P30D`` - uploaded at least 30 days ago
 
 To override a duration set in configuration, pass ``P0D`` on the command line.
-
-For consistency across machines, use either UTC format (with 'Z' suffix) or UTC offset
-format (with timezone offset like '+05:00'). Local timezone formats may produce different
-results on different machines.
 
 .. warning::
 

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -356,21 +356,24 @@ Filtering by Upload Time
 .. versionadded:: 26.0
 
 The ``--uploaded-prior-to`` option allows you to filter packages by their upload time
-to an index, only considering packages that were uploaded before a specified datetime.
+to an index, only considering packages that were uploaded before a specified value.
 This can be useful for creating reproducible builds by ensuring you only install
-packages that were available at a known point in time.
+packages that were available at a known point in time, or as a dependency cooldown to
+protect against supply chain attacks.
 
 .. tab:: Unix/macOS
 
    .. code-block:: shell
 
       python -m pip install --uploaded-prior-to=2025-03-16T00:00:00Z SomePackage
+      python -m pip install --uploaded-prior-to=P7D SomePackage
 
 .. tab:: Windows
 
    .. code-block:: shell
 
       py -m pip install --uploaded-prior-to=2025-03-16T00:00:00Z SomePackage
+      py -m pip install --uploaded-prior-to=P7D SomePackage
 
 The option accepts ISO 8601 datetime strings in several formats:
 
@@ -378,6 +381,14 @@ The option accepts ISO 8601 datetime strings in several formats:
 * ``2025-03-16T12:30:00`` - Datetime in local timezone
 * ``2025-03-16T12:30:00Z`` - Datetime in UTC
 * ``2025-03-16T12:30:00+05:00`` - Datetime in UTC offset
+
+It also accepts ISO 8601 durations in the ``PnD`` format, where ``n`` is the number of
+days. This provides a dependency cooldown: a rolling window that only considers packages
+uploaded at least ``n`` days ago.
+
+* ``P3D`` - 3 days ago
+* ``P7D`` - 7 days ago
+* ``P30D`` - 30 days ago
 
 For consistency across machines, use either UTC format (with 'Z' suffix) or UTC offset
 format (with timezone offset like '+05:00'). Local timezone formats may produce different

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -358,22 +358,21 @@ Filtering by Upload Time
 The ``--uploaded-prior-to`` option allows you to filter packages by their upload time
 to an index, only considering packages that were uploaded before a specified value.
 This can be useful for creating reproducible builds by ensuring you only install
-packages that were available at a known point in time, or as a dependency cooldown to
-protect against supply chain attacks.
+packages that were available at a known point in time.
 
 .. tab:: Unix/macOS
 
    .. code-block:: shell
 
       python -m pip install --uploaded-prior-to=2025-03-16T00:00:00Z SomePackage
-      python -m pip install --uploaded-prior-to=P7D SomePackage
+      python -m pip install --uploaded-prior-to=P1D SomePackage
 
 .. tab:: Windows
 
    .. code-block:: shell
 
       py -m pip install --uploaded-prior-to=2025-03-16T00:00:00Z SomePackage
-      py -m pip install --uploaded-prior-to=P7D SomePackage
+      py -m pip install --uploaded-prior-to=P1D SomePackage
 
 The option accepts ISO 8601 datetime strings in several formats:
 
@@ -382,17 +381,26 @@ The option accepts ISO 8601 datetime strings in several formats:
 * ``2025-03-16T12:30:00Z`` - Datetime in UTC
 * ``2025-03-16T12:30:00+05:00`` - Datetime in UTC offset
 
-It also accepts ISO 8601 durations in the ``PnD`` format, where ``n`` is the number of
-days. This provides a dependency cooldown: a rolling window that only considers packages
-uploaded at least ``n`` days ago.
+It also accepts a duration in the ``PnD`` format, where ``n`` is the number of
+days. This only considers packages uploaded at least ``n`` days ago.
 
-* ``P3D`` - 3 days ago
-* ``P7D`` - 7 days ago
-* ``P30D`` - 30 days ago
+* ``P1D`` - uploaded at least 1 day ago
+* ``P7D`` - uploaded at least 7 days ago
+* ``P30D`` - uploaded at least 30 days ago
+
+To override a duration set in configuration, pass ``P0D`` on the command line.
 
 For consistency across machines, use either UTC format (with 'Z' suffix) or UTC offset
 format (with timezone offset like '+05:00'). Local timezone formats may produce different
 results on different machines.
+
+.. warning::
+
+    While a duration can help protect against supply chain attacks by avoiding
+    newly published packages, it will also delay security fixes reaching your
+    environment. If you use this option, pair it with a vulnerability scanning
+    tool such as Dependabot or pip-audit so that you are notified of security
+    issues independently of your update schedule.
 
 .. note::
 

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -385,9 +385,11 @@ For consistency across machines, use either UTC format (with 'Z' suffix) or UTC 
 format (with timezone offset like '+05:00'). Local timezone formats may produce different
 results on different machines.
 
-It also accepts a duration in the ``PnD`` format, where ``n`` is the number of
-days. This only considers packages uploaded at least ``n`` days ago. A day is
-always 24 hours; daylight savings and other time zone transitions are ignored.
+.. versionchanged:: 26.1
+
+``--uploaded-prior-to`` also accepts a duration in the ``PnD`` format, where ``n`` is
+the number of days. This only considers packages uploaded at least ``n`` days ago.
+A day is always 24 hours; daylight savings and other time zone transitions are ignored.
 
 * ``P3D`` - uploaded at least 3 days ago
 * ``P7D`` - uploaded at least 7 days ago

--- a/news/13674.feature.rst
+++ b/news/13674.feature.rst
@@ -1,1 +1,1 @@
-Allow ``--uploaded-prior-to`` to accept a duration in days (e.g., ``P1D`` for 1 day ago).
+Allow ``--uploaded-prior-to`` to accept a duration in days (e.g., ``P3D`` for 3 days ago).

--- a/news/13674.feature.rst
+++ b/news/13674.feature.rst
@@ -1,1 +1,1 @@
-Allow ``--uploaded-prior-to`` to accept ISO 8601 durations (e.g., ``P7D``) as a dependency cooldown.
+Allow ``--uploaded-prior-to`` to accept a duration in days (e.g., ``P1D`` for 1 day ago).

--- a/news/13674.feature.rst
+++ b/news/13674.feature.rst
@@ -1,0 +1,1 @@
+Allow ``--uploaded-prior-to`` to accept ISO 8601 durations (e.g., ``P7D``) as a dependency cooldown.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -437,7 +437,8 @@ def _handle_uploaded_prior_to(
     This is an optparse.Option callback for the --uploaded-prior-to option.
 
     Accepts either an ISO 8601 datetime string (e.g., '2023-01-01T00:00:00Z')
-    or an ISO 8601 duration in days (e.g., 'P7D' for 7 days ago).
+    or a strict subset of ISO 8601 durations: PnD where n is a number of days
+    (e.g., 'P7D' for 7 days ago).
 
     Note: This option only works with indexes that provide upload-time metadata
     as specified in the simple repository API:
@@ -446,11 +447,10 @@ def _handle_uploaded_prior_to(
     if value is None:
         return None
 
-    # Try ISO 8601 duration in PnD format (e.g., P7D for 7 days ago).
-    # This is a minimal subset of ISO 8601 durations, using the leading 'P'
-    # to disambiguate from absolute datetimes. Only whole days are supported;
-    # the format may be extended to more of the ISO 8601 duration syntax in
-    # the future if a real need is presented.
+    # Try ISO 8601 duration in PnD format. The leading 'P' disambiguates
+    # from absolute datetimes. Only whole days are supported; the format may
+    # be extended to more of the ISO 8601 duration syntax in the future if
+    # a real need is presented.
     match = re.match(r"^P(\d+)D$", value, re.ASCII)
     if match:
         days = int(match.group(1))
@@ -470,7 +470,7 @@ def _handle_uploaded_prior_to(
             f"invalid value: {value!r}: {exc}. "
             f"Expected an ISO 8601 datetime string "
             f"(e.g., '2023-01-01' or '2023-01-01T00:00:00Z') "
-            f"or an ISO 8601 duration in days (e.g., 'P7D')"
+            f"or a duration in days (e.g., 'P1D')"
         )
         raise_option_error(parser, option=option, msg=msg)
 
@@ -485,11 +485,11 @@ def uploaded_prior_to() -> Option:
         type="str",
         help=(
             "Only consider packages uploaded prior to the given value. "
-            "Accepts an ISO 8601 datetime (e.g., '2023-01-01T00:00:00Z') "
-            "or an ISO 8601 duration in days as a cooldown period "
-            "(e.g., 'P7D' for 7 days). Uses local timezone if none "
-            "specified. Only effective when installing from indexes that "
-            "provide upload-time metadata."
+            "Accepts an ISO 8601 datetime (e.g., '2023-01-01T00:00:00Z', "
+            "uses local timezone if none specified) or a duration in days "
+            "(e.g., 'P1D' for packages uploaded at least 1 day ago). "
+            "Only effective when installing from indexes that provide "
+            "upload-time metadata."
         ),
     )
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -451,7 +451,7 @@ def _handle_uploaded_prior_to(
     # to disambiguate from absolute datetimes. Only whole days are supported;
     # the format may be extended to more of the ISO 8601 duration syntax in
     # the future if a real need is presented.
-    match = re.match(r"^P(\d+)D$", value)
+    match = re.match(r"^P(\d+)D$", value, re.ASCII)
     if match:
         days = int(match.group(1))
         parser.values.uploaded_prior_to = datetime.now(timezone.utc) - timedelta(

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -470,7 +470,7 @@ def _handle_uploaded_prior_to(
             f"invalid value: {value!r}: {exc}. "
             f"Expected an ISO 8601 datetime string "
             f"(e.g., '2023-01-01' or '2023-01-01T00:00:00Z') "
-            f"or a duration in days (e.g., 'P1D')"
+            f"or a duration in days (e.g., 'P3D')"
         )
         raise_option_error(parser, option=option, msg=msg)
 
@@ -487,7 +487,7 @@ def uploaded_prior_to() -> Option:
             "Only consider packages uploaded prior to the given value. "
             "Accepts an ISO 8601 datetime (e.g., '2023-01-01T00:00:00Z', "
             "uses local timezone if none specified) or a duration in days "
-            "(e.g., 'P1D' for packages uploaded at least 1 day ago). "
+            "(e.g., 'P3D' for packages uploaded at least 3 days ago). "
             "Only effective when installing from indexes that provide "
             "upload-time metadata."
         ),

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import logging
 import os
 import pathlib
+import re
 import textwrap
+from datetime import datetime, timedelta, timezone
 from functools import partial
 from optparse import SUPPRESS_HELP, Option, OptionGroup, OptionParser, Values
 from textwrap import dedent
@@ -434,8 +436,8 @@ def _handle_uploaded_prior_to(
     """
     This is an optparse.Option callback for the --uploaded-prior-to option.
 
-    Parses an ISO 8601 datetime string. If no timezone is specified in the string,
-    local timezone is used.
+    Accepts either an ISO 8601 datetime string (e.g., '2023-01-01T00:00:00Z')
+    or an ISO 8601 duration in days (e.g., 'P7D' for 7 days ago).
 
     Note: This option only works with indexes that provide upload-time metadata
     as specified in the simple repository API:
@@ -443,6 +445,19 @@ def _handle_uploaded_prior_to(
     """
     if value is None:
         return None
+
+    # Try ISO 8601 duration in PnD format (e.g., P7D for 7 days ago).
+    # This is a minimal subset of ISO 8601 durations, using the leading 'P'
+    # to disambiguate from absolute datetimes. Only whole days are supported;
+    # the format may be extended to more of the ISO 8601 duration syntax in
+    # the future if a real need is presented.
+    match = re.match(r"^P(\d+)D$", value)
+    if match:
+        days = int(match.group(1))
+        parser.values.uploaded_prior_to = datetime.now(timezone.utc) - timedelta(
+            days=days
+        )
+        return
 
     try:
         uploaded_prior_to = parse_iso_datetime(value)
@@ -453,8 +468,9 @@ def _handle_uploaded_prior_to(
     except ValueError as exc:
         msg = (
             f"invalid value: {value!r}: {exc}. "
-            f"Expected an ISO 8601 datetime string, "
-            f"e.g '2023-01-01' or '2023-01-01T00:00:00Z'"
+            f"Expected an ISO 8601 datetime string "
+            f"(e.g., '2023-01-01' or '2023-01-01T00:00:00Z') "
+            f"or an ISO 8601 duration in days (e.g., 'P7D')"
         )
         raise_option_error(parser, option=option, msg=msg)
 
@@ -463,15 +479,17 @@ def uploaded_prior_to() -> Option:
     return Option(
         "--uploaded-prior-to",
         dest="uploaded_prior_to",
-        metavar="datetime",
+        metavar="datetime_or_duration",
         action="callback",
         callback=_handle_uploaded_prior_to,
         type="str",
         help=(
-            "Only consider packages uploaded prior to the given date time. "
-            "Accepts ISO 8601 strings (e.g., '2023-01-01T00:00:00Z'). "
-            "Uses local timezone if none specified. Only effective when "
-            "installing from indexes that provide upload-time metadata."
+            "Only consider packages uploaded prior to the given value. "
+            "Accepts an ISO 8601 datetime (e.g., '2023-01-01T00:00:00Z') "
+            "or an ISO 8601 duration in days as a cooldown period "
+            "(e.g., 'P7D' for 7 days). Uses local timezone if none "
+            "specified. Only effective when installing from indexes that "
+            "provide upload-time metadata."
         ),
     )
 

--- a/tests/unit/test_cmdoptions.py
+++ b/tests/unit/test_cmdoptions.py
@@ -207,3 +207,21 @@ def test_handle_uploaded_prior_to_invalid_duration(invalid_value: str) -> None:
 
     with pytest.raises(SystemExit):
         _handle_uploaded_prior_to(option, opt, invalid_value, parser)
+
+
+def test_handle_uploaded_prior_to_p0d_overrides_duration() -> None:
+    """P0D on CLI overrides a previously set duration like P10D from env."""
+    option = Option("--uploaded-prior-to", dest="uploaded_prior_to")
+    opt = "--uploaded-prior-to"
+    parser = OptionParser()
+    parser.values = Values()
+
+    _handle_uploaded_prior_to(option, opt, "P10D", parser)
+    p10d_result = parser.values.uploaded_prior_to
+
+    _handle_uploaded_prior_to(option, opt, "P0D", parser)
+    p0d_result = parser.values.uploaded_prior_to
+
+    assert p0d_result > p10d_result
+    now = datetime.datetime.now(datetime.timezone.utc)
+    assert abs((p0d_result - now).total_seconds()) < 1

--- a/tests/unit/test_cmdoptions.py
+++ b/tests/unit/test_cmdoptions.py
@@ -139,3 +139,71 @@ def test_handle_uploaded_prior_to_invalid_dates(invalid_value: str) -> None:
 
     with pytest.raises(SystemExit):
         _handle_uploaded_prior_to(option, opt, invalid_value, parser)
+
+
+@pytest.mark.parametrize(
+    "value, expected_timedelta",
+    [
+        ("P1D", datetime.timedelta(days=1)),
+        ("P7D", datetime.timedelta(days=7)),
+        ("P30D", datetime.timedelta(days=30)),
+        ("P365D", datetime.timedelta(days=365)),
+    ],
+)
+def test_handle_uploaded_prior_to_duration(
+    value: str, expected_timedelta: datetime.timedelta
+) -> None:
+    """Test that ISO 8601 PnD duration strings are parsed correctly."""
+    option = Option("--uploaded-prior-to", dest="uploaded_prior_to")
+    opt = "--uploaded-prior-to"
+    parser = OptionParser()
+    parser.values = Values()
+
+    _handle_uploaded_prior_to(option, opt, value, parser)
+
+    result = parser.values.uploaded_prior_to
+    assert isinstance(result, datetime.datetime)
+    assert result.tzinfo is not None
+
+    expected = datetime.datetime.now(datetime.timezone.utc) - expected_timedelta
+    assert abs((result - expected).total_seconds()) < 1
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        "P7",  # Missing D
+        "PD",  # Missing number
+        "P-7D",  # Negative
+        "P7.5D",  # Fractional
+        "P7W",  # Weeks not supported
+        "p7d",  # Lowercase not valid ISO 8601
+        "p7D",  # Mixed case not valid ISO 8601
+        "P",  # Empty duration
+        "PT",  # Empty time component
+        "PT24H",  # Hours not supported
+        "PT60M",  # Minutes not supported
+        "PT1H30M",  # Hours and minutes not supported
+        "P1DT12H",  # Days with hours not supported
+        "P1DT12H30M",  # Days with hours and minutes not supported
+        "P7DT",  # Valid days but empty time component
+        "P7DTH",  # Valid days but missing hour number
+        "P7DTM",  # Valid days but missing minute number
+        "P7DT-1H",  # Valid days but negative hours
+        "P7DT1.5H",  # Valid days but fractional hours
+        "PT-30M",  # Negative minutes
+        "PT1H-30M",  # Valid hours but negative minutes
+        "2023-01-01P7D",  # Date mixed with duration
+        "P7D2023-01-01",  # Duration mixed with date
+        "P7DT00:00:00Z",  # Duration mixed with time
+    ],
+)
+def test_handle_uploaded_prior_to_invalid_duration(invalid_value: str) -> None:
+    """Test that invalid duration strings raise SystemExit."""
+    option = Option("--uploaded-prior-to", dest="uploaded_prior_to")
+    opt = "--uploaded-prior-to"
+    parser = OptionParser()
+    parser.values = Values()
+
+    with pytest.raises(SystemExit):
+        _handle_uploaded_prior_to(option, opt, invalid_value, parser)


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/13674

As a user, I want to be able to set a relative time to specify the package versions to update. This feature is present in package managers of other repositories, e.g. in npm, as --min-release-age.

This commit introduces a new --min-release-age option to accept relative time spans (e.g., '7d', '168h', '10080m') as an alternative to --uploaded-prior-to.

The callback parses the given time stamp into an absolute time and next uses the logic already present via the uploaded_prior_to. Parsing supports d/days, h/hours, m/minutes, w/weeks as units. Unit tests are added accordingly, following the test pattern of --uploaded-prior-to.

Related issue #13674

### Testing Done

Unit tests check the data parsing code similar to testing for the existing "--uploaded-prior-to" flag.

In addition, I tested the implementation in a local venv:

| Command | Installed Version | Result |
|---------|------------------|--------|
| `pip install certifi` | 2026.2.25 | Latest (no filter) |
| `pip install --min-release-age=10 certifi` | 2026.1.4 | 10+ days old |
| `pip install --min-release-age=365 certifi` | 2025.1.31 | 365+ days old |

#### Testing Executed

Setup and install current pip
```
python3 -m venv demo-env 
source demo-env/bin/activate

(demo-env) pip: pip install -e .
Obtaining file:///home/ANT.AMAZON.COM/nmanthey/projects/npm-pipy-update-delay/pip-repo
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Building wheels for collected packages: pip
  Building editable for pip (pyproject.toml) ... done
  Created wheel for pip: filename=pip-26.1.dev0-py3-none-any.whl size=40741 sha256=ad7788ea88fdd7d993e30c242a50e8c630553f78233d04a1ed1a44c1bb3dcdb5
  Stored in directory: /tmp/pip-ephem-wheel-cache-nb45iy88/wheels/38/60/5f/06b1d14e4f4b87f2b38289c3b11c4928acff547c425b135bba
Successfully built pip
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 22.0.2
    Uninstalling pip-22.0.2:
      Successfully uninstalled pip-22.0.2
Successfully installed pip-26.1.dev0
```

Check versions of certifi package
```
(demo-env) pip: echo "Current date: $(date -u +%Y-%m-%d)"
Current date: 2026-03-04
(demo-env) pip: pip index versions certifi 2>/dev/null | head -6
certifi (2026.2.25)
Available versions: 2026.2.25, 2026.1.4, 2025.11.12, 2025.10.5, 2025.8.3, 2025.7.14, 2025.7.9, 2025.6.15, 2025.4.26, 2025.1.31, 2024.12.14, 2024.8.30, 2024.7.4, 2024.6.2, 2024.2.2, 2023.11.17, 2023.7.22, 2023.5.7, 2022.12.7, 2022.9.24, 2022.9.14, 2022.6.15.2, 2022.6.15.1, 2022.6.15, 2022.5.18.1, 2021.10.8, 2021.5.30, 2020.12.5, 2020.11.8, 2020.6.20, 2020.4.5.2, 2020.4.5.1, 2020.4.5, 2019.11.28, 2019.9.11, 2019.6.16, 2019.3.9, 2018.11.29, 2018.10.15, 2018.8.24, 2018.8.13, 2018.4.16, 2018.1.18, 2017.11.5, 2017.7.27.1, 2017.7.27, 2017.4.17, 2017.1.23, 2016.9.26, 2016.8.31, 2016.8.8, 2016.8.2, 2016.2.28, 2015.11.20.1, 2015.11.20, 2015.9.6.2, 2015.9.6.1, 2015.9.6, 2015.4.28, 14.5.14, 1.0.1, 1.0.0, 0.0.8, 0.0.7, 0.0.6, 0.0.5, 0.0.4, 0.0.3, 0.0.2, 0.0.1
```

Install version from a year ago
```
(demo-env) pip: pip install --min-release-age=365 certifi
Collecting certifi
  Using cached certifi-2025.1.31-py3-none-any.whl.metadata (2.5 kB)
Using cached certifi-2025.1.31-py3-none-any.whl (166 kB)
Installing collected packages: certifi
Successfully installed certifi-2025.1.31
(demo-env) pip: pip show certifi | grep "Version:"
Version: 2025.1.31
```

Uninstall and install version from 10 days ago
```
(demo-env) pip: pip uninstall -y certifi
Found existing installation: certifi 2025.1.31
Uninstalling certifi-2025.1.31:
  Successfully uninstalled certifi-2025.1.31
(demo-env) pip: pip install --min-release-age=10 certifi
Collecting certifi
  Using cached certifi-2026.1.4-py3-none-any.whl.metadata (2.5 kB)
Using cached certifi-2026.1.4-py3-none-any.whl (152 kB)
Installing collected packages: certifi
Successfully installed certifi-2026.1.4
```

Uninstall and install latest version
```
(demo-env) pip: pip uninstall -y certifi
Found existing installation: certifi 2026.1.4
Uninstalling certifi-2026.1.4:
  Successfully uninstalled certifi-2026.1.4
(demo-env) pip: pip install certifi
Collecting certifi
  Using cached certifi-2026.2.25-py3-none-any.whl.metadata (2.5 kB)
Using cached certifi-2026.2.25-py3-none-any.whl (153 kB)
Installing collected packages: certifi
Successfully installed certifi-2026.2.25
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/13837)
<!-- Reviewable:end -->
