### PR TITLE
Stop collecting links for non-working deduping - Reduce peak memory by 50% during long resolves

### DIFF
--- a/news/13843.bugfix.rst
+++ b/news/13843.bugfix.rst
@@ -1,0 +1,1 @@
+Reduce memory usage when resolving large dependency trees.

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -660,8 +660,10 @@ class PackageFinder:
 
         self.format_control = format_control
 
-        # These are boring links that have already been logged somehow.
-        self._logged_links: set[tuple[Link, LinkType, str]] = set()
+        # Collects the detail strings for links skipped due to Requires-Python
+        # incompatibility.  Used by requires_python_skipped_reasons() to build
+        # the error message when resolution fails.
+        self._requires_python_skipped: set[str] = set()
 
         # Cache of the result of finding candidates
         self._all_candidates: dict[str, list[InstallationCandidate]] = {}
@@ -772,12 +774,7 @@ class PackageFinder:
         return self._uploaded_prior_to
 
     def requires_python_skipped_reasons(self) -> list[str]:
-        reasons = {
-            detail
-            for _, result, detail in self._logged_links
-            if result == LinkType.requires_python_mismatch
-        }
-        return sorted(reasons)
+        return sorted(self._requires_python_skipped)
 
     def make_link_evaluator(self, project_name: str) -> LinkEvaluator:
         canonical_name = canonicalize_name(project_name)
@@ -810,12 +807,11 @@ class PackageFinder:
         return no_eggs + eggs
 
     def _log_skipped_link(self, link: Link, result: LinkType, detail: str) -> None:
-        entry = (link, result, detail)
-        if entry not in self._logged_links:
-            # Put the link at the end so the reason is more visible and because
-            # the link string is usually very long.
-            logger.debug("Skipping link: %s: %s", detail, link)
-            self._logged_links.add(entry)
+        # Put the link at the end so the reason is more visible and because
+        # the link string is usually very long.
+        logger.debug("Skipping link: %s: %s", detail, link)
+        if result == LinkType.requires_python_mismatch:
+            self._requires_python_skipped.add(detail)
 
     def get_install_candidate(
         self, link_evaluator: LinkEvaluator, link: Link


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/12834

`_logged_links` stored `(Link, LinkType, str)` tuples to deduplicate "Skipping link" debug messages. Because each `Link` hashes by URL, every entry was unique the dedupe never fired, the set just accumulated Link references, preventing GC of anything the Link object was referencing.

As this never worked I'm just removing it, keeping only a `set[str]` for Requires-Python skip reasons (the only data read back from the set).

Using the following large resolve as a test:

```
pip install --dry-run apache-airflow[amazon,celery,cncf-kubernetes,docker,elasticsearch,google,mysql,postgres,redis,slack,snowflake,ssh]==3.0.6 --uploaded-prior-to 2026-01-01T00:00:00Z
```

~120k Link objects were not stored in the set, and peak memory went down from ~350 MiB to ~180 MiB.
