### PR TITLE
Replace deprecated `os.path.commonprefix` with `os.path.commonpath`

### DIFF
--- a/news/13847.bugfix.rst
+++ b/news/13847.bugfix.rst
@@ -1,0 +1,1 @@
+Use a path-segment prefix comparison, not char-by-char.

--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -15,7 +15,7 @@ import typing
 import urllib.parse
 from abc import ABC, abstractmethod
 from functools import cache
-from os.path import commonprefix
+from os.path import commonpath
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -325,12 +325,14 @@ class MultiDomainBasicAuth(AuthBase):
 
         candidates.sort(
             reverse=True,
-            key=lambda candidate: commonprefix(
-                [
-                    parsed_url.path,
-                    candidate.path,
-                ]
-            ).rfind("/"),
+            key=lambda candidate: len(
+                commonpath(
+                    [
+                        parsed_url.path,
+                        candidate.path,
+                    ]
+                )
+            ),
         )
 
         return urllib.parse.urlunsplit(candidates[0])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,7 @@ def pytest_collection_modifyitems(config: Config, items: list[pytest.Function]) 
 
         module_file = item.module.__file__
         module_path = os.path.relpath(
-            module_file, os.path.commonprefix([__file__, module_file])
+            module_file, os.path.commonpath([__file__, module_file])
         )
 
         module_root_dir = module_path.split(os.pathsep)[0]


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Follow on from https://github.com/pypa/pip/pull/13777.

https://docs.python.org/3.15/whatsnew/3.15.html#pending-removal-in-future-versions

There's a few uses in vendored pygments and pyproject_hooks, which are fixed and pending release:

* https://github.com/pygments/pygments/pull/3040
* https://github.com/pypa/pyproject-hooks/pull/222
