### PR TITLE
Replace private `Specifier_operators` with explicit version specifier operators

### DIFF
--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass
 
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
-from pip._vendor.packaging.specifiers import Specifier
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.models.index import PyPI, TestPyPI
@@ -40,7 +39,10 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
-operators = Specifier._operators.keys()
+
+# All standard version specifier operators
+# https://packaging.python.org/en/latest/specifications/version-specifiers/#id5
+operators = ("~=", "==", "!=", "<=", ">=", "<", ">", "===")
 
 
 def _strip_extras(path: str) -> tuple[str, str | None]:


### PR DESCRIPTION
I may eventually remove this from packaging, and in general we should not be using private parts of packaging.