### PR TITLE
Fix package update exitcode

### DIFF
--- a/news/13406.bugfix.rst
+++ b/news/13406.bugfix.rst
@@ -1,0 +1,1 @@
+Fail package upgrade when the package index cannot be accessed.

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -361,6 +361,7 @@ def _get_index_content(link: Link, *, session: PipSession) -> IndexContent | Non
         )
     except NetworkConnectionError as exc:
         _handle_get_simple_fail(link, exc)
+        session.index_access_failed = True
     except RetryError as exc:
         _handle_get_simple_fail(link, exc)
     except SSLError as exc:
@@ -369,8 +370,10 @@ def _get_index_content(link: Link, *, session: PipSession) -> IndexContent | Non
         _handle_get_simple_fail(link, reason, meth=logger.info)
     except requests.ConnectionError as exc:
         _handle_get_simple_fail(link, f"connection error: {exc}")
+        session.index_access_failed = True
     except requests.Timeout:
         _handle_get_simple_fail(link, "timed out")
+        session.index_access_failed = True
     else:
         return _make_index_content(resp, cache_link_parsing=link.cache_link_parsing)
     return None

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -297,6 +297,13 @@ class Factory:
             return candidate
 
         def iter_index_candidate_infos() -> Iterator[IndexCandidateInfo]:
+            session = self._finder._link_collector.session
+
+            if getattr(session, "index_access_failed", False) and not prefers_installed:
+                raise InstallationError(
+                    "Failed to access package index while checking for upgrades."
+                )
+
             result = self._finder.find_best_candidate(
                 project_name=name,
                 specifier=specifier,

--- a/tests/functional/test_install_upgrade.py
+++ b/tests/functional/test_install_upgrade.py
@@ -251,6 +251,29 @@ def test_upgrade_to_same_version_from_url(script: PipTestEnvironment) -> None:
     assert_all_changes(result, result3, [script.venv / "build", "cache"])
 
 
+@pytest.mark.network
+def test_upgrade_fails_if_index_unreachable(script: PipTestEnvironment) -> None:
+    """
+    pip should fail during upgrade if the index cannot be accessed.
+    """
+
+    result = script.pip("install", "INITools==0.2")
+    result.did_create(script.site_packages / "initools")
+
+    result2 = script.pip(
+        "install",
+        "--upgrade",
+        "--index-url",
+        "http://127.0.0.1:9/simple",
+        "INITools",
+        expect_error=True,
+    )
+
+    assert (
+        "Failed to access package index while checking for upgrades." in result2.stderr
+    )
+
+
 def test_upgrade_from_reqs_file(script: PipTestEnvironment) -> None:
     """
     Upgrade from a requirements file.


### PR DESCRIPTION
Fixes: #13406 

## Summary

When running ```pip install --upgrade```, if the package index cannot be accessed (e.g. due to invalid credentials or network errors) and the package is already installed, pip may incorrectly report “Requirement already satisfied” and exit with status code 0.

This change tracks index access failures during index page retrieval and records them on the PipSession. During candidate generation in the resolver, pip checks this flag and raises an InstallationError if the index could not be accessed and index candidates are required.

This ensures ```pip install --upgrade``` fails with a non-zero exit code when pip cannot access the configured package index to determine available versions.

## Logs

#### Correct Password
```
(.venv) lk@lk-V:~/pip$ python -m pip install mylibrary --upgrade --index-url http://user:correctpassword@localhost:8080/simple
Looking in indexes: http://user:****@localhost:8080/simple
Requirement already satisfied: mylibrary in ./.venv/lib/python3.12/site-packages (1.0.0)
(.venv) lk@lk-V:~/pip$ echo $?
0
```
#### Incorrect Password
```
(.venv) lk@lk-V:~/pip$ python -m pip install mylibrary --upgrade --index-url http://user:wrongpassword@localhost:8080/simple
Looking in indexes: http://user:****@localhost:8080/simple
Requirement already satisfied: mylibrary in ./.venv/lib/python3.12/site-packages (1.0.0)
ERROR: Failed to access package index while checking for upgrades.
(.venv) lk@lk-V:~/pip$ echo $?
1
```
