### PR TITLE
fix: handle None version in package metadata during conflict check

### DIFF
--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -186,7 +186,10 @@ class Distribution(BaseDistribution):
 
     @property
     def version(self) -> Version:
-        return parse_version(self._dist.version)
+        raw = self._dist.version
+        if raw is None:
+            raise ValueError(f"Package {self.raw_name!r} has no version metadata")
+        return parse_version(raw)
 
     @property
     def raw_version(self) -> str:

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -51,7 +51,7 @@ def create_package_set_from_installed() -> tuple[PackageSet, bool]:
         try:
             dependencies = list(dist.iter_dependencies())
             package_set[name] = PackageDetails(dist.version, dependencies)
-        except (OSError, ValueError) as e:
+        except (OSError, ValueError, TypeError) as e:
             # Don't crash on unreadable or broken metadata.
             logger.warning("Error parsing dependencies of %s: %s", name, e)
             problems = True


### PR DESCRIPTION
## Summary
Fixes #13856.
**Root cause:** `parse_version()` received `None` from packages with invalid metadata, causing `TypeError: expected string or bytes-like object, got 'NoneType'`.
**Fix:** Added defensive check for `None` version before calling `parse_version()`.
## Changes
- `src/pip/_internal/metadata/pkg_resources.py`: Raise `ValueError` when `_dist.version` is `None` before calling `parse_version()`
- `src/pip/_internal/operations/check.py`: Added `TypeError` to exception handling for robustness
## Testing
- Verified fix handles packages with missing version metadata
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)