### PR TITLE
fix: invalidate self-check cache when local pip version changes

### DIFF
--- a/news/13839.bugfix.rst
+++ b/news/13839.bugfix.rst
@@ -1,0 +1,1 @@
+"Invalidate self-check cache when local pip version changes to avoid false upgrade warnings." 

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -74,7 +74,7 @@ class SelfCheckState:
     def key(self) -> str:
         return sys.prefix
 
-    def get(self, current_time: datetime.datetime) -> str | None:
+    def get(self, current_time: datetime.datetime, current_pip_version: str) -> str | None:
         """Check if we have a not-outdated version loaded already."""
         if not self._state:
             return None
@@ -85,15 +85,20 @@ class SelfCheckState:
         if "pypi_version" not in self._state:
             return None
 
+        # If pip was upgraded since last check, treat cache as stale
+        if self._state.get("pip_version") != current_pip_version:
+            return None
+
         # Determine if we need to refresh the state
         last_check = parse_iso_datetime(self._state["last_check"])
         time_since_last_check = current_time - last_check
+
         if time_since_last_check > _WEEK:
             return None
-
+        
         return self._state["pypi_version"]
 
-    def set(self, pypi_version: str, current_time: datetime.datetime) -> None:
+    def set(self, pypi_version: str, current_time: datetime.datetime, current_pip_version: str) -> None:
         # If we do not have a path to cache in, don't bother saving.
         if not self._statefile_path:
             return
@@ -114,6 +119,7 @@ class SelfCheckState:
             "key": self.key,
             "last_check": current_time.isoformat(),
             "pypi_version": pypi_version,
+            "pip_version": current_pip_version
         }
 
         text = json.dumps(state, sort_keys=True, separators=(",", ":"))
@@ -201,13 +207,14 @@ def _self_version_check_logic(
     local_version: Version,
     get_remote_version: Callable[[], str | None],
 ) -> UpgradePrompt | None:
-    remote_version_str = state.get(current_time)
+    local_version_str = str(local_version)
+    remote_version_str = state.get(current_time, local_version_str)
     if remote_version_str is None:
         remote_version_str = get_remote_version()
         if remote_version_str is None:
             logger.debug("No remote pip version found")
             return None
-        state.set(remote_version_str, current_time)
+        state.set(remote_version_str, current_time, local_version_str)
 
     remote_version = parse_version(remote_version_str)
     logger.debug("Remote version of pip: %s", remote_version)

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -114,7 +114,7 @@ def test_core_logic(
         )
 
     # THEN
-    mock_state.get.assert_called_once_with(fake_time)
+    mock_state.get.assert_called_once_with(fake_time, installed_version)
     assert caplog.messages == [
         f"Remote version of pip: {version_that_should_be_checked}",
         f"Local version of pip:  {installed_version}",
@@ -125,7 +125,7 @@ def test_core_logic(
         mock_state.set.assert_not_called()
     else:
         mock_state.set.assert_called_once_with(
-            version_that_should_be_checked, fake_time
+            version_that_should_be_checked, fake_time, installed_version
         )
 
     if not should_show_prompt:
@@ -178,6 +178,7 @@ class TestSelfCheckState:
         state.set(
             "1.0.0",
             datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc),
+            "1.0"
         )
 
         # THEN
@@ -188,6 +189,7 @@ class TestSelfCheckState:
             "key": sys.prefix,
             "last_check": "2000-01-01T00:00:00+00:00",
             "pypi_version": "1.0.0",
+            "pip_version": "1.0"
         }
         # Check that the self-check cache entries inherit the root cache permissions.
         statefile_permissions = os.stat(expected_path).st_mode & 0o666


### PR DESCRIPTION
Fixes #13839 

When pip is upgraded, the self-check cache was not being invalidated, causing pip to incorrectly warn that a newer version is available even after upgrading.

This fix stores the local pip version in the cache and treats the cache as stale if the running pip version differs from the cached one.
