### PR TITLE
Pin build<1.4.1 to fix CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -136,7 +136,9 @@ def test(session: nox.Session) -> None:
     if not no_install and os.path.exists(sdist_dir):
         shutil.rmtree(sdist_dir, ignore_errors=True)
 
-    run_with_protected_pip(session, "install", "build")
+    # build 1.4.1 doesn't fall back to virtualenv when pip is missing,
+    # breaking the uninstall workaround below. See pypa/build#1003.
+    run_with_protected_pip(session, "install", "build<1.4.1")
     # build uses the pip present in the outer environment (aka the nox environment)
     # as an optimization. This will crash if the last test run installed a broken
     # pip, so uninstall pip to force build to provision a known good version of pip.


### PR DESCRIPTION
build 1.4.1 (released today) changed the control flow of `_has_valid_outer_pip` (pypa/build#980) and introduced a regression where missing pip is treated as valid. This breaks the existing workaround from #12848 that uninstalls pip before running `build --sdist` to force build to provision its own clean pip.

Pinning to build<1.4.1 until the regression is fixed upstream in pypa/build#1003.