### PR TITLE
sample Apparmor profile (pip ELF wrapper)

### DIFF
--- a/tools/apparmor/local/abstractions/deny-info-stealer
+++ b/tools/apparmor/local/abstractions/deny-info-stealer
@@ -1,0 +1,47 @@
+# SSH keys and config
+deny @{HOME}/.ssh/** r,
+
+# Cloud provider credentials
+deny @{HOME}/.aws/** r,
+deny @{HOME}/.config/gcloud/** r,
+deny @{HOME}/.azure/** r,
+deny @{HOME}/.kube/** r,
+deny @{HOME}/.docker/config.json r,
+
+# Version control credentials
+deny @{HOME}/.gitconfig r,
+deny @{HOME}/.git-credentials r,
+deny @{HOME}/.config/git/credentials r,
+
+# Package manager tokens
+deny @{HOME}/.npmrc r,
+# deny @{HOME}/.pypirc r, # not for pip
+deny @{HOME}/.gem/credentials r,
+deny @{HOME}/.cargo/credentials{,.toml} r,
+deny @{HOME}/.netrc r,
+
+# Database credentials
+deny @{HOME}/.my.cnf r,
+deny @{HOME}/.pgpass r,
+deny @{HOME}/.mongorc.js r,
+
+# Shell history (contains secrets in commands)
+deny @{HOME}/.bash_history r,
+deny @{HOME}/.zsh_history r,
+deny @{HOME}/.{mysql,psql,sqlite}_history r,
+
+# GPG keys
+deny @{HOME}/.gnupg/** r,
+
+# Browser profiles (saved passwords, cookies, session tokens)
+deny @{HOME}/.mozilla/** r,
+deny @{HOME}/.config/{google-chrome,chromium,BraveSoftware}/** r,
+
+# Password managers
+deny @{HOME}/.password-store/** r,
+deny @{HOME}/.local/share/keyrings/** r,
+deny @{HOME}/.config/{1Password,Bitwarden,KeePass}/** r,
+
+# System identification (fingerprinting)
+deny /etc/machine-id r,
+deny /var/lib/dbus/machine-id r,

--- a/tools/apparmor/local/python-build-wheel
+++ b/tools/apparmor/local/python-build-wheel
@@ -1,0 +1,38 @@
+# Build tools for compiling C/C++ extensions
+/usr/bin/{gcc,g++,cc,c++} rix,
+/usr/bin/{ld,ar,ranlib,strip,objcopy,objdump} rix,
+/usr/bin/{make,cmake,ninja} rix,
+/usr/bin/{pkg-config,pkgconf} rix,
+
+# Additional build utilities
+/usr/bin/{as,nm,readelf,size,strings} rix,
+/usr/lib/gcc/** rix,
+/usr/lib/llvm-*/bin/* rix,
+
+# Build system access
+/usr/include/** r,
+/usr/lib/@{multiarch}/** r,
+/usr/local/include/** r,
+/usr/local/lib/** r,
+
+# Compiler configuration
+/usr/lib/gcc/** r,
+/usr/share/gcc-*/** r,
+/etc/alternatives/{cc,c++,gcc,g++} r,
+
+# Build dependencies metadata
+/usr/lib/python3*/config-*/** r,
+/usr/lib/@{multiarch}/pkgconfig/** r,
+/usr/share/pkgconfig/** r,
+
+# Temporary build artifacts (write access)
+@{HOME}/@{python_project_dirs}/**/build/** rwkl,
+@{HOME}/@{python_project_dirs}/**/.eggs/** rwkl,
+@{HOME}/@{python_project_dirs}/**/*.egg-info/** rwkl,
+
+# Wheel building in pip cache
+@{HOME}/.cache/pip/wheels/** rwkl,
+
+# setuptools/distutils build directories
+/tmp/pip-{build,install,req-build,wheel}-*/** rwkl,
+/tmp/tmp*/** rwkl,

--- a/tools/apparmor/pip
+++ b/tools/apparmor/pip
@@ -1,0 +1,165 @@
+abi <abi/4.0>,
+
+include <tunables/global>
+
+# - /usr/bin/pip, /usr/bin/pip3, /usr/bin/pip3.X
+# - /usr/local/bin/pip*
+# - python -m pip
+# but will only work if pip wrapped by a a distinct ELF
+@{pip_exe} = /usr/{local/,}bin/pip{,3{,.[0-9]{,[0-9]}}}{,-safe}
+
+profile pip @{pip_exe} flags=(attach_disconnected) {
+
+  # read/write/lock access to Python projects (to be configured inside `tunables/home.d/`
+  @{HOME}/@{python_project_dirs}{,/**} rwkl,
+
+  include <abstractions/base>
+  include <abstractions/python>
+
+  # Pip executable and Python interpreter
+  @{pip_exe} rmix,
+  # TODO: use a specific profile for Python execution or just inherit?
+  /usr/bin/python3{,.[0-9]{,[0-9]}} rix,
+
+
+  # Network access
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
+
+  # Terminal and random access
+  /dev/{null,tty,ptmx,urandom} rw,
+  /dev/pts/[0-9]* rw,
+  /usr/bin/stty rix,
+
+  # System configuration for networking
+  @{etc_ro}/{gnutls/config,ssl/openssl.cnf,host.conf,gai.conf,hosts,nsswitch.conf,resolv.conf} r,
+  @{etc_ro}/ssl/certs/** r,
+
+  # System information needed by pip
+  /usr/share/zoneinfo/** r,
+  /run/systemd/userdb/* r,
+  @{etc_ro}/timezone r,
+  @{etc_ro}/localtime r,
+
+  # Python configuration
+  /etc/python3*/** r,
+  /usr/lib/python3*/** r,
+
+  # Process information
+  owner @{PROC}/@{pid}/{maps,mountinfo,stat,status,cmdline} r,
+
+  # Locale and timezone
+  /usr/{lib,share}/locale/** r,
+  @{etc_ro}/{locale.alias,timezone,localtime} r,
+
+  # Common utilities for package installation (setup.py, build scripts)
+  /usr/bin/{bash,dash,sh,env,cat,echo,grep,sed,cut,dirname,basename,which*} rix,
+  /usr/bin/{cp,mv,mkdir,chmod,ln,touch,rm} rix,
+  /usr/bin/{tar,gzip,bzip2,xz,unzip} rix,
+  /usr/bin/{curl,wget} rix,
+
+  # Git for VCS installations (pip install git+https://...)
+  /usr/lib/git-core/git Px -> git-pip,
+  /usr/bin/git Px -> git-pip,
+
+  # conditional wheel building
+  # (whether pip install --only-binary or not)
+  include <local/python-build-wheel>
+
+  # SSL/TLS certificates for HTTPS downloads
+  /etc/ssl/certs/{,*} r,
+  /etc/ca-certificates/** r,
+  /usr/share/ca-certificates/** r,
+
+  # Pip cache and configuration
+  @{HOME}/.{cache,config}/pip{,/**} rwkl,
+  @{HOME}/.pip{,/**} rwkl,
+
+  # Python package directories (write access for installation)
+  @{HOME}/.local/lib/python3*/site-packages/** rwkl,
+  /usr/lib/python3*/site-packages/** r,
+  /usr/local/lib/python3*/site-packages/** rwkl,
+
+  # Virtual environments (scoped to project directories)
+  @{HOME}/@{python_project_dirs}/**/{venv,.venv,env}/** rwkl,
+
+  # read-only project files
+  @{HOME}/@{python_project_dirs}/**/requirements{,-dev,-test}.txt r,
+  @{HOME}/@{python_project_dirs}/**/setup.{py,cfg} r,
+  @{HOME}/@{python_project_dirs}/**/pyproject.toml r,
+  @{HOME}/@{python_project_dirs}/**/MANIFEST.in r,
+
+  # Temporary directories (downloads/unzip)
+  /tmp/pip-{download,unpack,target}-*/** rwkl,
+  /tmp/tmp*/** rwkl,
+  /var/tmp/** rwkl,
+
+  # Python bytecode cache
+  @{HOME}/@{python_project_dirs}/**/__pycache__/** rwkl,
+
+  # Distribution metadata (editable installs)
+  @{HOME}/@{python_project_dirs}/**/*.egg-info/** rwkl,
+
+  # DENIALS
+  # sensitive credential and configuration files
+  # in memory of the poor dudes who once got these exfiltrated
+  include <local/abstractions/deny-info-stealer>
+
+  # Prevent Python bootstrapping hijacks (executed on every Python startup)
+  # Reserved for rare trusted packages
+  deny /usr/lib/python3*/sitecustomize.py w,
+  deny /usr/local/lib/python3*/site-packages/sitecustomize.py w,
+  deny @{HOME}/.local/lib/python3*/site-packages/sitecustomize.py w,
+  deny /etc/python3*/sitecustomize.py w,
+
+  # Prevent privilege escalation and system modification
+  deny /usr/bin/{sudo,su,pkexec,doas} x,
+  deny /etc/{passwd,shadow,group,sudoers{,.d/**}} w,
+  deny /etc/{crontab,cron.d/**} w,
+  deny /etc/systemd/system/** w,
+}
+
+# Restricted git profile for pip VCS installations
+profile git-pip flags=(attach_disconnected) {
+  network inet dgram,
+  network inet6 dgram,
+  network inet stream,
+  network inet6 stream,
+  network netlink raw,
+
+  /dev/{urandom,null,tty} rw,
+
+  /usr/bin/git rmix,
+  /usr/lib/git-core/git{,-remote-*} rmix,
+  /usr/share/git-core/templates/** r,
+
+  # SSL/TLS and networking
+  /etc/ssl/certs/** r,
+  @{etc_ro}/{resolv.conf,hosts,nsswitch.conf,gnutls/config} r,
+
+  # Git configuration (read-only)
+  /etc/gitconfig r,
+  @{HOME}/@{python_project_dirs}/**/.git/** r,
+
+  # Utilities
+  /usr/bin/{bash,dash,mkdir} ix,
+  @{pip_exe} rPx -> pip,
+
+  # System libraries
+  /etc/ld.so.cache r,
+  /usr/lib/@{multiarch}/*.so* rm,
+  /usr/lib/locale/** r,
+
+  # Temporary and cache directories (git clones to pip cache, not project dir)
+  /tmp/** rwkl,
+  @{HOME}/.cache/pip/vcs/** rwkl,
+  @{HOME}/.cache/pip/http/** rwkl,
+
+  owner @{PROC}/@{pid}/{maps,stat} r,
+
+  # explicit blacklist
+  include <local/abstractions/deny-info-stealer>
+}

--- a/tools/apparmor/pip-wrapper.c
+++ b/tools/apparmor/pip-wrapper.c
@@ -1,0 +1,40 @@
+/*
+ * pip-wrapper.c - ELF wrapper for pip
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+#define PYTHON_BIN "/usr/bin/python3"
+#define PIP_MODULE "pip"
+
+int main(int argc, char *argv[]) {
+    // Allocate array for new arguments
+    // Format: python3 -m pip [original args...]
+    char **args = malloc((argc + 3) * sizeof(char*));
+    if (args == NULL) {
+        perror("malloc failed");
+        return 1;
+    }
+
+    // Build argument list
+    args[0] = PYTHON_BIN;
+    args[1] = "-m";
+    args[2] = PIP_MODULE;
+
+    // skip argv[0] (wrapper name)
+    for (int i = 1; i < argc; i++) {
+        args[i + 2] = argv[i];
+    }
+    args[argc + 2] = NULL;
+
+    // `python3 -m pip`
+    execv(PYTHON_BIN, args);
+
+    // If execv returns, an error occurred
+    perror("execv failed");
+    free(args);
+    return 1;
+}

--- a/tools/apparmor/tunables-python-example.conf
+++ b/tools/apparmor/tunables-python-example.conf
@@ -1,0 +1,4 @@
+# AppArmor tunables for Python projects
+# Add this content to a file inside /etc/apparmor.d/tunables/home.d/
+
+@{python_project_dirs} = {projects,dev,workspace,code,src,git,repos,work,python,py}/**


### PR DESCRIPTION
1. There is not a week without a pool of tears from supply-chain attacks
2. security-wise, repositories are given much more attention than package managers themselves 
3. Neither multi-users, nor virtualization achieved the level of adoption/convenience (and it's not been a goal of virtualenvs)
4. Same is true for npm, composer, ...

Pip doesn't come with a sandbox out of the box (and no distribution account for this).
But **Apparmor** is the most obvious (and underrated) answer to this.
While Apparmor doesn't:
- offer all the flexibility a non-privileged user may want ([still needs root to tweaks user-directories](https://gitlab.com/apparmor/apparmor/-/work_items/264#note_2652187792))
- nor cleanups the environment from possible `$*{SECRET,TOKEN,KEY,API}*`
- nor offers network finetuning
- nor protects from **installing** a malicious library

it could still protect the user from the malware being automatically **loaded** by the pm during the installation process (setup.py/hooks/autoload/`autorun.inf` in existence today or in 5 years) (as already seen in several infection scenarios)

Bad code could still reach the install dir but that wouldn't be _as_ disastrous as it is currently (and careful users could still get an apparmor notification in time). If adopted, malware would be forced to postpone their activation to a later, non-sandboxed, usage. 

Sandboxing the interpreter is another level of protection (even though protecting `$HOME/*` isn't _that_ complex) and outside the scope of this RFC/PR which concentrate on the low-hanging fruit.

General-purpose (interpreted) language can't be easily sandboxed: **Distinguishing between the package manager and the general interpreter (eg: custom binary/wrapper)** would be a wise move easing focused sandboxing (different features/usages = different binaries for different profiles)

sandbox **profiles depends on intrinsic characteristics** of the software at runtime (readable/writable resources) and as such it **wouldn't be fair to throw up that problem upon individual distributions' maintainers** who don't have all the inner-knowledge about the pm permission scope.

So let me just bootstrap/reactivate the necessary reflection on this moot topic.

- [/etc/apparmor.d/pip](https://github.com/drzraf/pip/blob/4507578b0797e05dcf2fc2cfb67858e68d5801ca/tools/apparmor/pip) : An initial Apparmor profile
- [/etc/apparmor.d/local/python-build-wheel](https://github.com/drzraf/pip/blob/4507578b0797e05dcf2fc2cfb67858e68d5801ca/tools/apparmor/local/python-build-wheel) : Basic/untested handling for wheels
- [/etc/apparmor.d/local/abstractions/deny-info-stealer](https://github.com/drzraf/pip/blob/4507578b0797e05dcf2fc2cfb67858e68d5801ca/tools/apparmor/local/abstractions/deny-info-stealer) : A reminder for what is at stake :)
- [pip-wrapper.c](https://github.com/drzraf/pip/blob/4507578b0797e05dcf2fc2cfb67858e68d5801ca/tools/apparmor/pip-wrapper.c) : A wrapper to avoid sandboxing the whole python interpreter.

This is a draft/PoC and a pip+apparmor expert would probably see many ways to improve it.

It should also be pretty easy to activate a profile, build some thousands of packages then look at the `audit.log` and tweak the profile accordingly (it's mostly what is already been done when scanning pypi and the investment would pay for itself by the time the next malware hidden in a mainstream package is discovered (= next week ? :D)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pypa/pip/13868)
<!-- Reviewable:end -->
