### PR TITLE
Reject RECORD entries with path traversal outside installation root

### DIFF
--- a/news/13871.bugfix.rst
+++ b/news/13871.bugfix.rst
@@ -1,0 +1,3 @@
+Reject wheel RECORD entries with path-traversal components that resolve outside
+the installation directory, preventing deletion of arbitrary user-writable files
+on uninstall.

--- a/src/pip/_internal/models/scheme.py
+++ b/src/pip/_internal/models/scheme.py
@@ -8,6 +8,7 @@ https://docs.python.org/3/install/index.html#alternate-installation.
 from dataclasses import dataclass
 
 SCHEME_KEYS = ["platlib", "purelib", "headers", "scripts", "data"]
+INSTALL_SCHEME_METADATA_NAME = "pip-install-scheme.json"
 
 
 @dataclass(frozen=True)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -7,6 +7,7 @@ import compileall
 import contextlib
 import csv
 import importlib
+import json
 import logging
 import os.path
 import re
@@ -42,7 +43,11 @@ from pip._internal.metadata import (
     get_wheel_distribution,
 )
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
-from pip._internal.models.scheme import SCHEME_KEYS, Scheme
+from pip._internal.models.scheme import (
+    INSTALL_SCHEME_METADATA_NAME,
+    SCHEME_KEYS,
+    Scheme,
+)
 from pip._internal.utils.filesystem import adjacent_tmp_file, replace
 from pip._internal.utils.misc import StreamWrapper, ensure_dir, hash_file, partition
 from pip._internal.utils.unpacking import (
@@ -230,22 +235,34 @@ def _fs_to_record_path(path: str, lib_dir: str) -> RecordPath:
     return cast("RecordPath", path)
 
 
-def _is_record_path_within_base(record_path: RecordPath, lib_dir: str) -> bool:
-    """Check that a RECORD path, when joined with lib_dir, stays within lib_dir.
-
-    This prevents path-traversal entries (e.g. ``../../../tmp/target``) in a
-    wheel RECORD from being persisted into the installed RECORD and later
-    used to delete files outside the installation root during uninstall.
-    """
-    abs_lib = os.path.normpath(os.path.abspath(lib_dir))
-    abs_target = os.path.normpath(os.path.abspath(os.path.join(lib_dir, record_path)))
-    # Use os.path.commonpath to verify containment.
+def _is_path_within_directory(path: str, directory: str) -> bool:
+    abs_directory = os.path.normpath(os.path.abspath(directory))
+    abs_path = os.path.normpath(os.path.abspath(path))
     try:
-        common = os.path.commonpath([abs_lib, abs_target])
+        common = os.path.commonpath([abs_directory, abs_path])
     except ValueError:
         # On Windows this is raised when paths are on different drives.
         return False
-    return common == abs_lib
+    return common == abs_directory
+
+
+def _is_record_path_within_scheme(
+    record_path: RecordPath,
+    lib_dir: str,
+    scheme_paths: Iterable[str],
+) -> bool:
+    """Check that a RECORD path resolves within one of the installation roots.
+
+    Installed RECORD rows may legitimately point outside ``lib_dir`` (for
+    example, scripts in the ``scripts`` scheme).  However, every row persisted
+    to the installed RECORD must resolve to one of the directories the install
+    scheme is allowed to write to.
+    """
+    abs_target = os.path.normpath(os.path.abspath(os.path.join(lib_dir, record_path)))
+    return any(
+        _is_path_within_directory(abs_target, scheme_path)
+        for scheme_path in scheme_paths
+    )
 
 
 def get_csv_rows_for_installed(
@@ -254,6 +271,7 @@ def get_csv_rows_for_installed(
     changed: set[RecordPath],
     generated: list[str],
     lib_dir: str,
+    scheme_paths: Iterable[str],
 ) -> list[InstalledCSVRow]:
     """
     :param installed: A map from archive RECORD path to installation RECORD
@@ -264,22 +282,24 @@ def get_csv_rows_for_installed(
         if len(row) > 3:
             logger.warning("RECORD line has more than three elements: %s", row)
         old_record_path = cast("RecordPath", row[0])
-        # If the entry was actually installed by pip it will be in the
-        # ``installed`` dict (with a validated destination path).  Entries
-        # that are *not* in the dict come directly from the wheel's RECORD
-        # and could contain path-traversal components injected by a
-        # malicious wheel.
-        if old_record_path in installed:
-            new_record_path = installed.pop(old_record_path)
-        else:
-            new_record_path = old_record_path
-            if not _is_record_path_within_base(new_record_path, lib_dir):
+        new_record_path = installed.pop(old_record_path, None)
+        if new_record_path is None:
+            if not _is_record_path_within_scheme(
+                old_record_path, lib_dir, scheme_paths
+            ):
                 logger.warning(
                     "Skipping RECORD entry that resolves outside the "
-                    "installation directory: %s",
-                    new_record_path,
+                    "installation scheme: %s",
+                    old_record_path,
                 )
-                continue
+            continue
+        if not _is_record_path_within_scheme(new_record_path, lib_dir, scheme_paths):
+            logger.warning(
+                "Skipping RECORD entry that resolves outside the "
+                "installation scheme: %s",
+                new_record_path,
+            )
+            continue
         if new_record_path in changed:
             digest, length = rehash(_record_to_fs_path(new_record_path, lib_dir))
         else:
@@ -288,11 +308,28 @@ def get_csv_rows_for_installed(
         installed_rows.append((new_record_path, digest, length))
     for f in generated:
         path = _fs_to_record_path(f, lib_dir)
+        if not _is_record_path_within_scheme(path, lib_dir, scheme_paths):
+            logger.warning(
+                "Skipping RECORD entry that resolves outside the "
+                "installation scheme: %s",
+                path,
+            )
+            continue
         digest, length = rehash(f)
         installed_rows.append((path, digest, length))
-    return installed_rows + [
-        (installed_record_path, "", "") for installed_record_path in installed.values()
-    ]
+    trailing_rows: list[InstalledCSVRow] = []
+    for installed_record_path in installed.values():
+        if not _is_record_path_within_scheme(
+            installed_record_path, lib_dir, scheme_paths
+        ):
+            logger.warning(
+                "Skipping RECORD entry that resolves outside the "
+                "installation scheme: %s",
+                installed_record_path,
+            )
+            continue
+        trailing_rows.append((installed_record_path, "", ""))
+    return installed_rows + trailing_rows
 
 
 def get_console_script_specs(console: dict[str, str]) -> list[str]:
@@ -724,6 +761,16 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
             pass
         generated.append(requested_path)
 
+    install_scheme_path = os.path.join(dest_info_dir, INSTALL_SCHEME_METADATA_NAME)
+    with _generate_file(install_scheme_path) as install_scheme_file:
+        install_scheme_file.write(
+            json.dumps(
+                {key: getattr(scheme, key) for key in SCHEME_KEYS},
+                sort_keys=True,
+            ).encode("utf-8")
+        )
+    generated.append(install_scheme_path)
+
     record_text = distribution.read_text("RECORD")
     record_rows = list(csv.reader(record_text.splitlines()))
 
@@ -733,10 +780,12 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
         changed=changed,
         generated=generated,
         lib_dir=lib_dir,
+        scheme_paths=[getattr(scheme, key) for key in SCHEME_KEYS],
     )
 
     # Record details of all files installed
     record_path = os.path.join(dest_info_dir, "RECORD")
+    rows.append((_fs_to_record_path(record_path, lib_dir), "", ""))
 
     with _generate_file(record_path, **csv_io_kwargs("w")) as record_file:
         # Explicitly cast to typing.IO[str] as a workaround for the mypy error:

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -230,6 +230,24 @@ def _fs_to_record_path(path: str, lib_dir: str) -> RecordPath:
     return cast("RecordPath", path)
 
 
+def _is_record_path_within_base(record_path: RecordPath, lib_dir: str) -> bool:
+    """Check that a RECORD path, when joined with lib_dir, stays within lib_dir.
+
+    This prevents path-traversal entries (e.g. ``../../../tmp/target``) in a
+    wheel RECORD from being persisted into the installed RECORD and later
+    used to delete files outside the installation root during uninstall.
+    """
+    abs_lib = os.path.normpath(os.path.abspath(lib_dir))
+    abs_target = os.path.normpath(os.path.abspath(os.path.join(lib_dir, record_path)))
+    # Use os.path.commonpath to verify containment.
+    try:
+        common = os.path.commonpath([abs_lib, abs_target])
+    except ValueError:
+        # On Windows this is raised when paths are on different drives.
+        return False
+    return common == abs_lib
+
+
 def get_csv_rows_for_installed(
     old_csv_rows: list[list[str]],
     installed: dict[RecordPath, RecordPath],
@@ -246,7 +264,22 @@ def get_csv_rows_for_installed(
         if len(row) > 3:
             logger.warning("RECORD line has more than three elements: %s", row)
         old_record_path = cast("RecordPath", row[0])
-        new_record_path = installed.pop(old_record_path, old_record_path)
+        # If the entry was actually installed by pip it will be in the
+        # ``installed`` dict (with a validated destination path).  Entries
+        # that are *not* in the dict come directly from the wheel's RECORD
+        # and could contain path-traversal components injected by a
+        # malicious wheel.
+        if old_record_path in installed:
+            new_record_path = installed.pop(old_record_path)
+        else:
+            new_record_path = old_record_path
+            if not _is_record_path_within_base(new_record_path, lib_dir):
+                logger.warning(
+                    "Skipping RECORD entry that resolves outside the "
+                    "installation directory: %s",
+                    new_record_path,
+                )
+                continue
         if new_record_path in changed:
             digest, length = rehash(_record_to_fs_path(new_record_path, lib_dir))
         else:

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import json
 import os
 import sys
 import sysconfig
@@ -9,8 +10,9 @@ from importlib.util import cache_from_source
 from typing import Any, Callable
 
 from pip._internal.exceptions import LegacyDistutilsInstall, UninstallMissingRecord
-from pip._internal.locations import get_bin_prefix, get_bin_user
+from pip._internal.locations import get_bin_prefix, get_bin_user, get_scheme
 from pip._internal.metadata import BaseDistribution
+from pip._internal.models.scheme import INSTALL_SCHEME_METADATA_NAME, SCHEME_KEYS
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.egg_link import egg_link_path_from_location
 from pip._internal.utils.logging import getLogger, indent_log
@@ -19,6 +21,66 @@ from pip._internal.utils.temp_dir import AdjacentTempDirectory, TempDirectory
 from pip._internal.utils.virtualenv import running_under_virtualenv
 
 logger = getLogger(__name__)
+
+
+def _is_path_within_directory(path: str, directory: str) -> bool:
+    try:
+        return os.path.commonpath([directory, path]) == directory
+    except ValueError:
+        # On Windows this is raised when paths are on different drives.
+        return False
+
+
+def _load_installed_scheme_paths(
+    dist: BaseDistribution, normalize: Callable[[str], str]
+) -> tuple[str, ...]:
+    try:
+        text = dist.read_text(INSTALL_SCHEME_METADATA_NAME)
+    except FileNotFoundError:
+        return ()
+
+    try:
+        data = json.loads(text)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Ignoring invalid %s for %s",
+            INSTALL_SCHEME_METADATA_NAME,
+            dist.raw_name,
+        )
+        return ()
+
+    if not isinstance(data, dict):
+        logger.warning(
+            "Ignoring invalid %s for %s",
+            INSTALL_SCHEME_METADATA_NAME,
+            dist.raw_name,
+        )
+        return ()
+
+    roots = []
+    for key in SCHEME_KEYS:
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            roots.append(normalize(value))
+    return tuple(sorted(set(roots)))
+
+
+def _rebase_scheme_paths(
+    installed_location: str,
+    current_scheme: dict[str, str],
+    normalize: Callable[[str], str],
+) -> tuple[str, ...]:
+    roots = set()
+    for anchor_key in ("purelib", "platlib"):
+        current_anchor = current_scheme[anchor_key]
+        for key in SCHEME_KEYS:
+            try:
+                relative = os.path.relpath(current_scheme[key], current_anchor)
+            except ValueError:
+                continue
+            rebased = os.path.join(installed_location, relative)
+            roots.add(normalize(rebased))
+    return tuple(sorted(roots))
 
 
 def _script_names(
@@ -310,15 +372,62 @@ class UninstallPathSet:
         # the same args, which hurts performance.
         self._normalize_path_cached = functools.lru_cache(normalize_path)
 
+    @functools.cached_property
+    def _permitted_roots(self) -> tuple[str, ...]:
+        installed_scheme_roots = _load_installed_scheme_paths(
+            self._dist, self._normalize_path_cached
+        )
+        extra_roots = {
+            self._normalize_path_cached(candidate)
+            for candidate in (
+                self._dist.location,
+                self._dist.info_location,
+                self._dist.installed_location,
+            )
+            if isinstance(candidate, str) and candidate
+        }
+        if installed_scheme_roots:
+            return tuple(sorted(set(installed_scheme_roots) | extra_roots))
+
+        roots = set(extra_roots)
+        if isinstance(self._dist.installed_location, str) and self._dist.installed_location:
+            scheme = get_scheme(self._dist.raw_name, user=self._dist.in_usersite)
+            current_scheme = {
+                key: self._normalize_path_cached(getattr(scheme, key))
+                for key in SCHEME_KEYS
+            }
+            roots.update(
+                _rebase_scheme_paths(
+                    self._dist.installed_location,
+                    current_scheme,
+                    self._normalize_path_cached,
+                )
+            )
+        else:
+            # Without an installed location we cannot reconstruct an old scheme,
+            # so fall back to the current interpreter's scheme as best effort.
+            scheme = get_scheme(self._dist.raw_name, user=self._dist.in_usersite)
+            roots.update(
+                self._normalize_path_cached(getattr(scheme, key)) for key in SCHEME_KEYS
+            )
+        return tuple(sorted(roots))
+
     def _permitted(self, path: str) -> bool:
         """
         Return True if the given path is one we are permitted to
         remove/modify, False otherwise.
 
         """
-        # aka is_local, but caching normalized sys.prefix
-        if not running_under_virtualenv():
+        head, tail = os.path.split(path)
+        path = os.path.join(self._normalize_path_cached(head), os.path.normcase(tail))
+
+        if any(
+            _is_path_within_directory(path, root) for root in self._permitted_roots
+        ):
             return True
+
+        if not running_under_virtualenv():
+            return False
         return path.startswith(self._normalize_path_cached(sys.prefix))
 
     def add(self, path: str) -> None:

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -390,7 +390,10 @@ class UninstallPathSet:
             return tuple(sorted(set(installed_scheme_roots) | extra_roots))
 
         roots = set(extra_roots)
-        if isinstance(self._dist.installed_location, str) and self._dist.installed_location:
+        if (
+            isinstance(self._dist.installed_location, str)
+            and self._dist.installed_location
+        ):
             scheme = get_scheme(self._dist.raw_name, user=self._dist.in_usersite)
             current_scheme = {
                 key: self._normalize_path_cached(getattr(scheme, key))
@@ -421,9 +424,7 @@ class UninstallPathSet:
         head, tail = os.path.split(path)
         path = os.path.join(self._normalize_path_cached(head), os.path.normcase(tail))
 
-        if any(
-            _is_path_within_directory(path, root) for root in self._permitted_roots
-        ):
+        if any(_is_path_within_directory(path, root) for root in self._permitted_roots):
             return True
 
         if not running_under_virtualenv():

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -22,6 +22,7 @@ from tests.lib import (
     need_svn,
 )
 from tests.lib.local_repos import local_checkout, local_repo
+from tests.lib.wheel import make_wheel
 
 
 def test_basic_uninstall(script: PipTestEnvironment, data: TestData) -> None:
@@ -545,6 +546,81 @@ def test_uninstall_wheel(script: PipTestEnvironment, data: TestData) -> None:
     result.did_create(dist_info_folder)
     result2 = script.pip("uninstall", "simple.dist", "-y")
     assert_all_changes(result, result2, [])
+
+
+def test_uninstall_wheel_ignores_phantom_record_entries(
+    script: PipTestEnvironment,
+) -> None:
+    package = "recordpoc"
+    version = "1.0"
+    info_dir = f"{package}-{version}.dist-info"
+
+    target_path = script.bin_path / "recordpoc-target"
+    target_path.write_text("poc\n")
+
+    rel = os.path.relpath(target_path, script.site_packages_path).replace(
+        os.path.sep, "/"
+    )
+    record = "\n".join(
+        [
+            f"{package}/__init__.py,,",
+            f"{info_dir}/WHEEL,,",
+            f"{info_dir}/METADATA,,",
+            f"{info_dir}/RECORD,,",
+            f"{rel},,",
+            "",
+        ]
+    )
+
+    wheel_path = make_wheel(
+        package,
+        version,
+        extra_files={f"{package}/__init__.py": "# installed\n"},
+        record=record,
+    ).save_to_dir(script.scratch_path)
+
+    result = script.pip("install", wheel_path, "--no-index")
+    result.did_create(script.site_packages / info_dir)
+    installed_record = (script.site_packages_path / info_dir / "RECORD").read_text()
+    assert rel not in installed_record
+
+    uninstall_result = script.pip("uninstall", package, "-y")
+    assert target_path not in uninstall_result.files_deleted
+    assert target_path.is_file()
+    script.assert_not_installed(package)
+
+
+def test_uninstall_old_wheel_rejects_record_entries_outside_scheme(
+    script: PipTestEnvironment,
+) -> None:
+    package = "recordfallback"
+    version = "1.0"
+    info_dir = f"{package}-{version}.dist-info"
+
+    wheel_path = make_wheel(
+        package,
+        version,
+        extra_files={f"{package}/__init__.py": "# installed\n"},
+    ).save_to_dir(script.scratch_path)
+    script.pip("install", wheel_path, "--no-index")
+
+    target_path = script.scratch_path / "recordfallback-target"
+    target_path.write_text("poc\n")
+
+    dist_info = script.site_packages_path / info_dir
+    install_scheme_metadata = dist_info / "pip-install-scheme.json"
+    install_scheme_metadata.unlink()
+
+    record_path = dist_info / "RECORD"
+    rel = os.path.relpath(target_path, script.site_packages_path).replace(
+        os.path.sep, "/"
+    )
+    with open(record_path, "a") as f:
+        f.write(f"{rel},,\n")
+
+    uninstall_result = script.pip("uninstall", package, "-y", expect_stderr=True)
+    assert target_path not in uninstall_result.files_deleted
+    assert target_path.is_file()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 import pytest
 
 import pip._internal.req.req_uninstall
+from pip._internal.models.scheme import INSTALL_SCHEME_METADATA_NAME, Scheme
 from pip._internal.req.req_uninstall import (
     StashedUninstallPathSet,
     UninstallPathSet,
@@ -127,6 +128,97 @@ def test_compressed_listing(tmpdir: Path) -> None:
 
 
 class TestUninstallPathSet:
+    def test_permitted_uses_recorded_install_scheme(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        site_packages = tmp_path / "site-packages"
+        dist_info = site_packages / "mypkg-1.0.dist-info"
+        scripts = tmp_path / "bin"
+        headers = tmp_path / "include" / "mypkg"
+        data = tmp_path / "share"
+        for path in (site_packages, dist_info, scripts, headers, data):
+            path.mkdir(parents=True, exist_ok=True)
+
+        metadata_path = dist_info / INSTALL_SCHEME_METADATA_NAME
+        metadata_path.write_text(
+            (
+                "{"
+                f'"platlib": "{site_packages}", '
+                f'"purelib": "{site_packages}", '
+                f'"headers": "{headers}", '
+                f'"scripts": "{scripts}", '
+                f'"data": "{data}"'
+                "}"
+            )
+        )
+
+        monkeypatch.setattr(
+            pip._internal.req.req_uninstall,
+            "get_scheme",
+            lambda *args, **kwargs: Scheme(
+                platlib=str(tmp_path / "other-lib"),
+                purelib=str(tmp_path / "other-lib"),
+                headers=str(tmp_path / "other-headers"),
+                scripts=str(tmp_path / "other-bin"),
+                data=str(tmp_path / "other-data"),
+            ),
+        )
+
+        dist = Mock()
+        dist.raw_name = "mypkg"
+        dist.in_usersite = False
+        dist.location = str(site_packages)
+        dist.info_location = str(dist_info)
+        dist.installed_location = str(site_packages)
+        dist.read_text.side_effect = (
+            lambda path: metadata_path.read_text()
+            if path == INSTALL_SCHEME_METADATA_NAME
+            else (_ for _ in ()).throw(FileNotFoundError())
+        )
+
+        ups = UninstallPathSet(dist=dist)
+
+        assert ups._permitted(str(scripts / "mypkg"))
+        assert not ups._permitted(str(tmp_path / "outside" / "mypkg"))
+
+    def test_permitted_rebases_current_scheme_for_old_install(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        current_prefix = tmp_path / "current"
+        old_prefix = tmp_path / "old"
+        current_scheme = Scheme(
+            platlib=str(current_prefix / "lib" / "python3.13" / "site-packages"),
+            purelib=str(current_prefix / "lib" / "python3.13" / "site-packages"),
+            headers=str(current_prefix / "include" / "site" / "python3.13" / "mypkg"),
+            scripts=str(current_prefix / "bin"),
+            data=str(current_prefix / "share"),
+        )
+        old_site_packages = old_prefix / "lib" / "python3.13" / "site-packages"
+        old_scripts = old_prefix / "bin"
+        old_dist_info = old_site_packages / "mypkg-1.0.dist-info"
+        for path in (old_site_packages, old_scripts, old_dist_info):
+            path.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(
+            pip._internal.req.req_uninstall,
+            "get_scheme",
+            lambda *args, **kwargs: current_scheme,
+        )
+
+        dist = Mock()
+        dist.raw_name = "mypkg"
+        dist.in_usersite = False
+        dist.location = str(old_site_packages)
+        dist.info_location = str(old_dist_info)
+        dist.installed_location = str(old_site_packages)
+        dist.read_text.side_effect = FileNotFoundError()
+
+        ups = UninstallPathSet(dist=dist)
+
+        assert ups._permitted(str(old_scripts / "mypkg"))
+        assert not ups._permitted(str(current_prefix / "bin" / "mypkg"))
+        assert not ups._permitted(str(tmp_path / "outside" / "mypkg"))
+
     def test_add(self, tmpdir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
             pip._internal.req.req_uninstall.UninstallPathSet,

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 from collections.abc import Iterator
@@ -141,14 +142,14 @@ class TestUninstallPathSet:
 
         metadata_path = dist_info / INSTALL_SCHEME_METADATA_NAME
         metadata_path.write_text(
-            (
-                "{"
-                f'"platlib": "{site_packages}", '
-                f'"purelib": "{site_packages}", '
-                f'"headers": "{headers}", '
-                f'"scripts": "{scripts}", '
-                f'"data": "{data}"'
-                "}"
+            json.dumps(
+                {
+                    "platlib": str(site_packages),
+                    "purelib": str(site_packages),
+                    "headers": str(headers),
+                    "scripts": str(scripts),
+                    "data": str(data),
+                }
             )
         )
 
@@ -170,8 +171,8 @@ class TestUninstallPathSet:
         dist.location = str(site_packages)
         dist.info_location = str(dist_info)
         dist.installed_location = str(site_packages)
-        dist.read_text.side_effect = (
-            lambda path: metadata_path.read_text()
+        dist.read_text.side_effect = lambda path: (
+            metadata_path.read_text()
             if path == INSTALL_SCHEME_METADATA_NAME
             else (_ for _ in ()).throw(FileNotFoundError())
         )

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -493,11 +493,7 @@ class TestInstallUnpackedWheel:
         with open(os.path.join(self.dest_dist_info, "RECORD")) as f:
             rows = list(csv.reader(f))
 
-        assert (
-            os.path.join("sample-1.2.0.dist-info", "RECORD"),
-            "",
-            "",
-        ) in [tuple(row) for row in rows]
+        assert ("sample-1.2.0.dist-info/RECORD", "", "") in [tuple(row) for row in rows]
 
     @pytest.mark.parametrize("user_mask, expected_permission", [(0o27, 0o640)])
     def test_std_install_with_custom_umask(

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -186,6 +186,87 @@ def test_get_csv_rows_for_installed__long_lines(
     ]
 
 
+def test_get_csv_rows_for_installed__rejects_path_traversal(
+    tmpdir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    text = textwrap.dedent(
+        """\
+    pkg/__init__.py,sha256=abc,100
+    ../../../tmp/evil.py,,
+    pkg/ok.py,sha256=def,200
+    """
+    )
+    path = tmpdir.joinpath("temp.txt")
+    path.write_text(text)
+
+    lib_dir = str(tmpdir / "lib")
+    os.makedirs(lib_dir, exist_ok=True)
+
+    with open(path, **wheel.csv_io_kwargs("r")) as f:
+        record_rows = list(csv.reader(f))
+    outrows = wheel.get_csv_rows_for_installed(
+        record_rows,
+        installed={},
+        changed=set(),
+        generated=[],
+        lib_dir=lib_dir,
+    )
+
+    # The traversal entry must be filtered out.
+    record_paths = [row[0] for row in outrows]
+    assert "../../../tmp/evil.py" not in record_paths
+    # Legitimate entries must remain.
+    assert "pkg/__init__.py" in record_paths
+    assert "pkg/ok.py" in record_paths
+    # A warning must be logged for the skipped entry.
+    assert any("resolves outside" in rec.message for rec in caplog.records)
+
+
+def test_get_csv_rows_for_installed__allows_installed_paths_outside_lib(
+    tmpdir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Entries in the ``installed`` dict may resolve outside lib_dir.
+
+    For example, scripts on Windows are recorded as ``../../Scripts/foo.exe``
+    relative to the site-packages lib_dir.  These entries must NOT be rejected.
+    """
+    text = textwrap.dedent(
+        """\
+    mypkg-1.0.data/scripts/foo.exe,sha256=abc,100
+    mypkg/__init__.py,sha256=def,200
+    """
+    )
+    path = tmpdir.joinpath("temp.txt")
+    path.write_text(text)
+
+    lib_dir = str(tmpdir / "lib")
+    os.makedirs(lib_dir, exist_ok=True)
+
+    # Simulate pip having installed the script to ../../Scripts/foo.exe
+    # relative to lib_dir (as happens on Windows).
+    installed = cast(
+        dict[RecordPath, RecordPath],
+        {"mypkg-1.0.data/scripts/foo.exe": "../../Scripts/foo.exe"},
+    )
+
+    with open(path, **wheel.csv_io_kwargs("r")) as f:
+        record_rows = list(csv.reader(f))
+    outrows = wheel.get_csv_rows_for_installed(
+        record_rows,
+        installed=installed,
+        changed=set(),
+        generated=[],
+        lib_dir=lib_dir,
+    )
+
+    record_paths = [row[0] for row in outrows]
+    # The ../../Scripts/ entry must be preserved since it was in ``installed``.
+    assert "../../Scripts/foo.exe" in record_paths
+    assert "mypkg/__init__.py" in record_paths
+    # No warnings should be emitted.
+    assert not any("resolves outside" in rec.message for rec in caplog.records)
+
+
 @pytest.mark.parametrize(
     "text,expected",
     [

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -121,23 +121,38 @@ def test_normalized_outrows(
     assert actual == expected
 
 
-def call_get_csv_rows_for_installed(tmpdir: Path, text: str) -> list[InstalledCSVRow]:
+def call_get_csv_rows_for_installed(
+    tmpdir: Path,
+    text: str,
+    *,
+    installed: dict[RecordPath, RecordPath] | None = None,
+    lib_dir: str = "/lib/dir",
+    scheme_paths: list[str] | None = None,
+) -> list[InstalledCSVRow]:
     path = tmpdir.joinpath("temp.txt")
     path.write_text(text)
 
-    # Test that an installed file appearing in RECORD has its filename
-    # updated in the new RECORD file.
-    installed = cast(dict[RecordPath, RecordPath], {"a": "z"})
-    lib_dir = "/lib/dir"
-
     with open(path, **wheel.csv_io_kwargs("r")) as f:
         record_rows = list(csv.reader(f))
+    if installed is None:
+        installed = cast(
+            dict[RecordPath, RecordPath],
+            {
+                cast("RecordPath", row[0]): cast("RecordPath", row[0])
+                for row in record_rows
+            },
+        )
+        if cast("RecordPath", "a") in installed:
+            installed[cast("RecordPath", "a")] = cast("RecordPath", "z")
+    if scheme_paths is None:
+        scheme_paths = [lib_dir]
     outrows = wheel.get_csv_rows_for_installed(
         record_rows,
         installed=installed,
         changed=set(),
         generated=[],
         lib_dir=lib_dir,
+        scheme_paths=scheme_paths,
     )
     return outrows
 
@@ -159,6 +174,25 @@ def test_get_csv_rows_for_installed(
     ]
     assert outrows == expected
     # Check there were no warnings.
+    assert len(caplog.records) == 0
+
+
+def test_get_csv_rows_for_installed__drops_unmatched_entries(
+    tmpdir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    text = textwrap.dedent(
+        """\
+    a,b,c
+    d,e,f
+    """
+    )
+    outrows = call_get_csv_rows_for_installed(
+        tmpdir,
+        text,
+        installed=cast(dict[RecordPath, RecordPath], {"a": "z"}),
+    )
+
+    assert outrows == [("z", "b", "c")]
     assert len(caplog.records) == 0
 
 
@@ -206,10 +240,17 @@ def test_get_csv_rows_for_installed__rejects_path_traversal(
         record_rows = list(csv.reader(f))
     outrows = wheel.get_csv_rows_for_installed(
         record_rows,
-        installed={},
+        installed=cast(
+            dict[RecordPath, RecordPath],
+            {
+                "pkg/__init__.py": "pkg/__init__.py",
+                "pkg/ok.py": "pkg/ok.py",
+            },
+        ),
         changed=set(),
         generated=[],
         lib_dir=lib_dir,
+        scheme_paths=[lib_dir],
     )
 
     # The traversal entry must be filtered out.
@@ -222,14 +263,10 @@ def test_get_csv_rows_for_installed__rejects_path_traversal(
     assert any("resolves outside" in rec.message for rec in caplog.records)
 
 
-def test_get_csv_rows_for_installed__allows_installed_paths_outside_lib(
+def test_get_csv_rows_for_installed__allows_installed_paths_in_scheme(
     tmpdir: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Entries in the ``installed`` dict may resolve outside lib_dir.
-
-    For example, scripts on Windows are recorded as ``../../Scripts/foo.exe``
-    relative to the site-packages lib_dir.  These entries must NOT be rejected.
-    """
+    """Entries in the ``installed`` dict may resolve to other scheme roots."""
     text = textwrap.dedent(
         """\
     mypkg-1.0.data/scripts/foo.exe,sha256=abc,100
@@ -240,13 +277,19 @@ def test_get_csv_rows_for_installed__allows_installed_paths_outside_lib(
     path.write_text(text)
 
     lib_dir = str(tmpdir / "lib")
+    scripts_dir = str(tmpdir / "scripts")
     os.makedirs(lib_dir, exist_ok=True)
+    os.makedirs(scripts_dir, exist_ok=True)
 
-    # Simulate pip having installed the script to ../../Scripts/foo.exe
-    # relative to lib_dir (as happens on Windows).
+    script_path = os.path.join(scripts_dir, "foo.exe")
+    script_record_path = wheel._fs_to_record_path(script_path, lib_dir)
+
     installed = cast(
         dict[RecordPath, RecordPath],
-        {"mypkg-1.0.data/scripts/foo.exe": "../../Scripts/foo.exe"},
+        {
+            "mypkg-1.0.data/scripts/foo.exe": script_record_path,
+            "mypkg/__init__.py": "mypkg/__init__.py",
+        },
     )
 
     with open(path, **wheel.csv_io_kwargs("r")) as f:
@@ -257,14 +300,48 @@ def test_get_csv_rows_for_installed__allows_installed_paths_outside_lib(
         changed=set(),
         generated=[],
         lib_dir=lib_dir,
+        scheme_paths=[lib_dir, scripts_dir],
     )
 
     record_paths = [row[0] for row in outrows]
-    # The ../../Scripts/ entry must be preserved since it was in ``installed``.
-    assert "../../Scripts/foo.exe" in record_paths
+    assert script_record_path in record_paths
     assert "mypkg/__init__.py" in record_paths
-    # No warnings should be emitted.
     assert not any("resolves outside" in rec.message for rec in caplog.records)
+
+
+def test_get_csv_rows_for_installed__rejects_installed_paths_outside_scheme(
+    tmpdir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    text = "mypkg-1.0.data/scripts/foo.exe,sha256=abc,100\n"
+    path = tmpdir.joinpath("temp.txt")
+    path.write_text(text)
+
+    lib_dir = str(tmpdir / "lib")
+    os.makedirs(lib_dir, exist_ok=True)
+
+    outside_path = str(tmpdir / "outside" / "foo.exe")
+    installed = cast(
+        dict[RecordPath, RecordPath],
+        {
+            "mypkg-1.0.data/scripts/foo.exe": wheel._fs_to_record_path(
+                outside_path, lib_dir
+            )
+        },
+    )
+
+    with open(path, **wheel.csv_io_kwargs("r")) as f:
+        record_rows = list(csv.reader(f))
+    outrows = wheel.get_csv_rows_for_installed(
+        record_rows,
+        installed=installed,
+        changed=set(),
+        generated=[],
+        lib_dir=lib_dir,
+        scheme_paths=[lib_dir],
+    )
+
+    assert outrows == []
+    assert any("installation scheme" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.parametrize(
@@ -401,6 +478,26 @@ class TestInstallUnpackedWheel:
             req_description=str(self.req),
         )
         self.assert_installed(0o644)
+
+    def test_std_install_record_contains_itself(
+        self, data: TestData, tmpdir: Path
+    ) -> None:
+        self.prep(data, tmpdir)
+        wheel.install_wheel(
+            self.name,
+            self.wheelpath,
+            scheme=self.scheme,
+            req_description=str(self.req),
+        )
+
+        with open(os.path.join(self.dest_dist_info, "RECORD")) as f:
+            rows = list(csv.reader(f))
+
+        assert (
+            os.path.join("sample-1.2.0.dist-info", "RECORD"),
+            "",
+            "",
+        ) in [tuple(row) for row in rows]
 
     @pytest.mark.parametrize("user_mask, expected_permission", [(0o27, 0o640)])
     def test_std_install_with_custom_umask(


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/13873

## Summary

A malicious wheel can include RECORD entries with path-traversal components (e.g. `../../../tmp/target`) that are never actually installed by pip but get copied verbatim into the installed RECORD file. On uninstall, pip joins these entries with the installation location and deletes the resulting paths — enabling deletion of arbitrary files writable by the current user.

## Vulnerability Details

- **Affected component**: `get_csv_rows_for_installed()` in `src/pip/_internal/operations/install/wheel.py`
- **Attack vector**: A crafted wheel contains extra RECORD entries with `../` path traversal pointing to files outside the installation directory. These entries are not files in the wheel archive and are never extracted, but they are preserved in the installed RECORD. On `pip uninstall`, the paths are resolved and the targeted files are deleted.
- **Impact**: Deletion of arbitrary files writable by the current user when the malicious package is uninstalled. In a virtualenv the effect is constrained to `sys.prefix`; outside a virtualenv, user-writable paths are affected.

## Fix

In `get_csv_rows_for_installed()`, entries that appear in the `installed` dict were placed on disk by pip's own installation process (which already validates paths via `assert_no_path_traversal`). These are trusted regardless of their relative path shape — this is necessary because legitimate entries like `../../Scripts/docutils.exe` on Windows use `../` to reference script directories outside `lib_dir`.

Entries **not** in the `installed` dict come directly from the wheel's original RECORD. These are validated: if they resolve outside `lib_dir` via path traversal, they are skipped with a warning log.

### Why not also check at uninstall time?

Legitimate installed RECORD files contain entries like `../../Scripts/foo.exe` for scripts installed outside `site-packages`. The existing `_permitted()` check in `UninstallPathSet.add()` already enforces virtualenv boundary constraints at uninstall time. Adding a strict containment check on the uninstall side would break uninstallation of packages like docutils that have scripts recorded as `../../Scripts/*.exe`.

## Tests

### Linting (`nox -s lint`)
All checks pass:
- check builtin type constructor use 
- black 
- ruff check 
- mypy 
- codespell 
- All other pre-commit hooks 

### Unit tests (`nox -s test-3.13 -- tests/unit/test_wheel.py tests/unit/test_req_uninstall.py -v`)
**64 tests: 60 passed, 4 xfailed (pre-existing)**

New tests added:
1. `test_get_csv_rows_for_installed__rejects_path_traversal` — Verifies that RECORD entries with `../../../tmp/evil.py` not present in the `installed` dict are filtered from the output and a warning is logged.
2. `test_get_csv_rows_for_installed__allows_installed_paths_outside_lib` — Verifies that entries present in the `installed` dict with `../../Scripts/foo.exe` style paths (as produced by pip on Windows) are preserved without warnings.

### Files changed
- `src/pip/_internal/operations/install/wheel.py` — Added `_is_record_path_within_base()` helper and validation logic in `get_csv_rows_for_installed()`
- `tests/unit/test_wheel.py` — Added 2 new test functions

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
