### PR TITLE
Upgrade requests to 2.33.0

### DIFF
--- a/news/requests.vendor.rst
+++ b/news/requests.vendor.rst
@@ -1,0 +1,1 @@
+Upgrade requests to 2.33.0

--- a/src/pip/_vendor/requests/__init__.py
+++ b/src/pip/_vendor/requests/__init__.py
@@ -68,8 +68,8 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
     if chardet_version:
         major, minor, patch = chardet_version.split(".")[:3]
         major, minor, patch = int(major), int(minor), int(patch)
-        # chardet_version >= 3.0.2, < 6.0.0
-        assert (3, 0, 2) <= (major, minor, patch) < (6, 0, 0)
+        # chardet_version >= 3.0.2, < 8.0.0
+        assert (3, 0, 2) <= (major, minor, patch) < (8, 0, 0)
     elif charset_normalizer_version:
         major, minor, patch = charset_normalizer_version.split(".")[:3]
         major, minor, patch = int(major), int(minor), int(patch)
@@ -88,8 +88,8 @@ def _check_cryptography(cryptography_version):
         return
 
     if cryptography_version < [1, 3, 4]:
-        warning = "Old version of cryptography ({}) may cause slowdown.".format(
-            cryptography_version
+        warning = (
+            f"Old version of cryptography ({cryptography_version}) may cause slowdown."
         )
         warnings.warn(warning, RequestsDependencyWarning)
 
@@ -101,10 +101,9 @@ try:
     )
 except (AssertionError, ValueError):
     warnings.warn(
-        "urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
-        "version!".format(
-            urllib3.__version__, chardet_version, charset_normalizer_version
-        ),
+        f"urllib3 ({urllib3.__version__}) or chardet "
+        f"({chardet_version})/charset_normalizer ({charset_normalizer_version}) "
+        "doesn't match a supported version!",
         RequestsDependencyWarning,
     )
 

--- a/src/pip/_vendor/requests/__version__.py
+++ b/src/pip/_vendor/requests/__version__.py
@@ -5,8 +5,8 @@
 __title__ = "requests"
 __description__ = "Python HTTP for Humans."
 __url__ = "https://requests.readthedocs.io"
-__version__ = "2.32.5"
-__build__ = 0x023205
+__version__ = "2.33.0"
+__build__ = 0x023300
 __author__ = "Kenneth Reitz"
 __author_email__ = "me@kennethreitz.org"
 __license__ = "Apache-2.0"

--- a/src/pip/_vendor/requests/_internal_utils.py
+++ b/src/pip/_vendor/requests/_internal_utils.py
@@ -5,6 +5,7 @@ requests._internal_utils
 Provides utility functions that are consumed internally by Requests
 which depend on extremely few external helpers (such as compat)
 """
+
 import re
 
 from .compat import builtin_str

--- a/src/pip/_vendor/requests/adapters.py
+++ b/src/pip/_vendor/requests/adapters.py
@@ -11,17 +11,19 @@ import socket  # noqa: F401
 import typing
 import warnings
 
-from pip._vendor.urllib3.exceptions import ClosedPoolError, ConnectTimeoutError
-from pip._vendor.urllib3.exceptions import HTTPError as _HTTPError
-from pip._vendor.urllib3.exceptions import InvalidHeader as _InvalidHeader
 from pip._vendor.urllib3.exceptions import (
+    ClosedPoolError,
+    ConnectTimeoutError,
     LocationValueError,
     MaxRetryError,
     NewConnectionError,
     ProtocolError,
+    ReadTimeoutError,
+    ResponseError,
 )
+from pip._vendor.urllib3.exceptions import HTTPError as _HTTPError
+from pip._vendor.urllib3.exceptions import InvalidHeader as _InvalidHeader
 from pip._vendor.urllib3.exceptions import ProxyError as _ProxyError
-from pip._vendor.urllib3.exceptions import ReadTimeoutError, ResponseError
 from pip._vendor.urllib3.exceptions import SSLError as _SSLError
 from pip._vendor.urllib3.poolmanager import PoolManager, proxy_from_url
 from pip._vendor.urllib3.util import Timeout as TimeoutSauce
@@ -47,7 +49,6 @@ from .models import Response
 from .structures import CaseInsensitiveDict
 from .utils import (
     DEFAULT_CA_BUNDLE_PATH,
-    extract_zipped_paths,
     get_auth_from_url,
     get_encoding_from_headers,
     prepend_scheme_if_needed,
@@ -76,9 +77,9 @@ DEFAULT_POOL_TIMEOUT = None
 def _urllib3_request_context(
     request: "PreparedRequest",
     verify: "bool | str | None",
-    client_cert: "typing.Tuple[str, str] | str | None",
+    client_cert: "tuple[str, str] | str | None",
     poolmanager: "PoolManager",
-) -> "(typing.Dict[str, typing.Any], typing.Dict[str, typing.Any])":
+) -> "(dict[str, typing.Any], dict[str, typing.Any])":
     host_params = {}
     pool_kwargs = {}
     parsed_request_url = urlparse(request.url)
@@ -297,7 +298,7 @@ class HTTPAdapter(BaseAdapter):
                 cert_loc = verify
 
             if not cert_loc:
-                cert_loc = extract_zipped_paths(DEFAULT_CA_BUNDLE_PATH)
+                cert_loc = DEFAULT_CA_BUNDLE_PATH
 
             if not cert_loc or not os.path.exists(cert_loc):
                 raise OSError(

--- a/src/pip/_vendor/requests/auth.py
+++ b/src/pip/_vendor/requests/auth.py
@@ -35,9 +35,9 @@ def _basic_auth_str(username, password):
     if not isinstance(username, basestring):
         warnings.warn(
             "Non-string usernames will no longer be supported in Requests "
-            "3.0.0. Please convert the object you've passed in ({!r}) to "
+            f"3.0.0. Please convert the object you've passed in ({username!r}) to "
             "a string or bytes object in the near future to avoid "
-            "problems.".format(username),
+            "problems.",
             category=DeprecationWarning,
         )
         username = str(username)
@@ -45,9 +45,9 @@ def _basic_auth_str(username, password):
     if not isinstance(password, basestring):
         warnings.warn(
             "Non-string passwords will no longer be supported in Requests "
-            "3.0.0. Please convert the object you've passed in ({!r}) to "
+            f"3.0.0. Please convert the object you've passed in ({type(password)!r}) to "
             "a string or bytes object in the near future to avoid "
-            "problems.".format(type(password)),
+            "problems.",
             category=DeprecationWarning,
         )
         password = str(password)

--- a/src/pip/_vendor/requests/certs.py
+++ b/src/pip/_vendor/requests/certs.py
@@ -11,6 +11,7 @@ If you are packaging Requests, e.g., for a Linux distribution or a managed
 environment, you can change the definition of where() to return a separately
 packaged CA bundle.
 """
+
 from pip._vendor.certifi import where
 
 if __name__ == "__main__":

--- a/src/pip/_vendor/requests/exceptions.py
+++ b/src/pip/_vendor/requests/exceptions.py
@@ -4,6 +4,7 @@ requests.exceptions
 
 This module contains the set of Requests' exceptions.
 """
+
 from pip._vendor.urllib3.exceptions import HTTPError as BaseHTTPError
 
 from .compat import JSONDecodeError as CompatJSONDecodeError

--- a/src/pip/_vendor/requests/help.py
+++ b/src/pip/_vendor/requests/help.py
@@ -40,11 +40,8 @@ def _implementation():
     if implementation == "CPython":
         implementation_version = platform.python_version()
     elif implementation == "PyPy":
-        implementation_version = "{}.{}.{}".format(
-            sys.pypy_version_info.major,
-            sys.pypy_version_info.minor,
-            sys.pypy_version_info.micro,
-        )
+        pypy = sys.pypy_version_info
+        implementation_version = f"{pypy.major}.{pypy.minor}.{pypy.micro}"
         if sys.pypy_version_info.releaselevel != "final":
             implementation_version = "".join(
                 [implementation_version, sys.pypy_version_info.releaselevel]

--- a/src/pip/_vendor/requests/hooks.py
+++ b/src/pip/_vendor/requests/hooks.py
@@ -9,6 +9,7 @@ Available hooks:
 ``response``:
     The response generated from a Request.
 """
+
 HOOKS = ["response"]
 
 

--- a/src/pip/_vendor/requests/models.py
+++ b/src/pip/_vendor/requests/models.py
@@ -34,9 +34,11 @@ from .compat import (
     builtin_str,
     chardet,
     cookielib,
+    urlencode,
+    urlsplit,
+    urlunparse,
 )
 from .compat import json as complexjson
-from .compat import urlencode, urlsplit, urlunparse
 from .cookies import _copy_cookie_jar, cookiejar_from_dict, get_cookie_header
 from .exceptions import (
     ChunkedEncodingError,
@@ -45,11 +47,11 @@ from .exceptions import (
     HTTPError,
     InvalidJSONError,
     InvalidURL,
+    MissingSchema,
+    StreamConsumedError,
 )
 from .exceptions import JSONDecodeError as RequestsJSONDecodeError
-from .exceptions import MissingSchema
 from .exceptions import SSLError as RequestsSSLError
-from .exceptions import StreamConsumedError
 from .hooks import default_hooks
 from .status_codes import codes
 from .structures import CaseInsensitiveDict

--- a/src/pip/_vendor/requests/sessions.py
+++ b/src/pip/_vendor/requests/sessions.py
@@ -5,6 +5,7 @@ requests.sessions
 This module provides a Session object to manage and persist settings across
 requests (cookies, auth, proxies).
 """
+
 import os
 import sys
 import time
@@ -421,6 +422,8 @@ class Session(SessionRedirectMixin):
         #: expired certificates, which will make your application vulnerable to
         #: man-in-the-middle (MitM) attacks.
         #: Only set this to `False` for testing.
+        #: If verify is set to a string, it must be the path to a CA bundle file
+        #: that will be used to verify the TLS certificate.
         self.verify = True
 
         #: SSL client certificate default, if String, path to ssl client

--- a/src/pip/_vendor/requests/utils.py
+++ b/src/pip/_vendor/requests/utils.py
@@ -39,9 +39,6 @@ from .compat import (
     getproxies_environment,
     integer_types,
     is_urllib3_1,
-)
-from .compat import parse_http_list as _parse_list_header
-from .compat import (
     proxy_bypass,
     proxy_bypass_environment,
     quote,
@@ -50,6 +47,7 @@ from .compat import (
     urlparse,
     urlunparse,
 )
+from .compat import parse_http_list as _parse_list_header
 from .cookies import cookiejar_from_dict
 from .exceptions import (
     FileModeWarning,
@@ -61,6 +59,7 @@ from .structures import CaseInsensitiveDict
 
 NETRC_FILES = (".netrc", "_netrc")
 
+# Certificate is extracted by certifi when needed.
 DEFAULT_CA_BUNDLE_PATH = certs.where()
 
 DEFAULT_PORTS = {"http": 80, "https": 443}
@@ -233,7 +232,7 @@ def get_netrc_auth(url, raise_errors=False):
 
         try:
             _netrc = netrc(netrc_path).authenticators(host)
-            if _netrc:
+            if _netrc and any(_netrc):
                 # Return with login / password
                 login_i = 0 if _netrc[0] else 1
                 return (_netrc[login_i], _netrc[2])
@@ -283,12 +282,13 @@ def extract_zipped_paths(path):
         return path
 
     # we have a valid zip archive and a valid member of that archive
-    tmp = tempfile.gettempdir()
-    extracted_path = os.path.join(tmp, member.split("/")[-1])
-    if not os.path.exists(extracted_path):
-        # use read + write to avoid the creating nested folders, we only want the file, avoids mkdir racing condition
-        with atomic_open(extracted_path) as file_handler:
-            file_handler.write(zip_file.read(member))
+    suffix = os.path.splitext(member.split("/")[-1])[-1]
+    fd, extracted_path = tempfile.mkstemp(suffix=suffix)
+    try:
+        os.write(fd, zip_file.read(member))
+    finally:
+        os.close(fd)
+
     return extracted_path
 
 

--- a/src/pip/_vendor/vendor.txt
+++ b/src/pip/_vendor/vendor.txt
@@ -5,7 +5,7 @@ msgpack==1.1.2
 packaging==26.0
 platformdirs==4.5.1
 pyproject-hooks==1.2.0
-requests==2.32.5
+requests==2.33.0
     certifi==2026.1.4
     idna==3.11
     urllib3==1.26.20

--- a/tools/vendoring/patches/requests.patch
+++ b/tools/vendoring/patches/requests.patch
@@ -1,20 +1,31 @@
 diff --git a/src/pip/_vendor/requests/__init__.py b/src/pip/_vendor/requests/__init__.py
-index 300a16c5..a66f6024 100644
---- a/src/pip/_vendor/requests/__init__.py
-+++ b/src/pip/_vendor/requests/__init__.py
-@@ -49,10 +49,7 @@ try:
- except ImportError:
-     charset_normalizer_version = None
+index 8ecd8b814..81d38590a 100644
+--- b/src/pip/_vendor/requests/__init__.py
++++ a/src/pip/_vendor/requests/__init__.py
+@@ -40,19 +40,12 @@ is at <https://requests.readthedocs.io>.
  
+ import warnings
+ 
+-import urllib3
++from pip._vendor import urllib3
+ 
+ from .exceptions import RequestsDependencyWarning
+ 
+-try:
+-    from charset_normalizer import __version__ as charset_normalizer_version
+-except ImportError:
+-    charset_normalizer_version = None
+-
 -try:
 -    from chardet import __version__ as chardet_version
 -except ImportError:
 -    chardet_version = None
++charset_normalizer_version = None
 +chardet_version = None
  
  
  def check_compatibility(urllib3_version, chardet_version, charset_normalizer_version):
-@@ -76,11 +76,8 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
+@@ -83,11 +76,8 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
          # charset_normalizer >= 2.0.0 < 4.0.0
          assert (2, 0, 0) <= (major, minor, patch) < (4, 0, 0)
      else:
@@ -25,10 +36,10 @@ index 300a16c5..a66f6024 100644
 -        )
 +        # pip does not need or use character detection
 +        pass
-
-
+ 
+ 
  def _check_cryptography(cryptography_version):
-@@ -118,6 +115,11 @@ except (AssertionError, ValueError):
+@@ -121,13 +111,18 @@ except (AssertionError, ValueError):
  # if the standard library doesn't support SNI or the
  # 'ssl' library isn't available.
  try:
@@ -40,11 +51,114 @@ index 300a16c5..a66f6024 100644
      try:
          import ssl
      except ImportError:
+         ssl = None
+ 
+     if not getattr(ssl, "HAS_SNI", False):
+-        from urllib3.contrib import pyopenssl
++        from pip._vendor.urllib3.contrib import pyopenssl
+ 
+         pyopenssl.inject_into_urllib3()
+ 
+@@ -139,7 +134,7 @@ except ImportError:
+     pass
+ 
+ # urllib3's DependencyWarnings should be silenced.
+-from urllib3.exceptions import DependencyWarning
++from pip._vendor.urllib3.exceptions import DependencyWarning
+ 
+ warnings.simplefilter("ignore", DependencyWarning)
+ 
+diff --git a/src/pip/_vendor/requests/adapters.py b/src/pip/_vendor/requests/adapters.py
+index 98f74465f..da8959e77 100644
+--- b/src/pip/_vendor/requests/adapters.py
++++ a/src/pip/_vendor/requests/adapters.py
+@@ -11,7 +11,7 @@ import socket  # noqa: F401
+ import typing
+ import warnings
+ 
+-from urllib3.exceptions import (
++from pip._vendor.urllib3.exceptions import (
+     ClosedPoolError,
+     ConnectTimeoutError,
+     LocationValueError,
+@@ -21,14 +21,14 @@ from urllib3.exceptions import (
+     ReadTimeoutError,
+     ResponseError,
+ )
+-from urllib3.exceptions import HTTPError as _HTTPError
+-from urllib3.exceptions import InvalidHeader as _InvalidHeader
+-from urllib3.exceptions import ProxyError as _ProxyError
+-from urllib3.exceptions import SSLError as _SSLError
+-from urllib3.poolmanager import PoolManager, proxy_from_url
+-from urllib3.util import Timeout as TimeoutSauce
+-from urllib3.util import parse_url
+-from urllib3.util.retry import Retry
++from pip._vendor.urllib3.exceptions import HTTPError as _HTTPError
++from pip._vendor.urllib3.exceptions import InvalidHeader as _InvalidHeader
++from pip._vendor.urllib3.exceptions import ProxyError as _ProxyError
++from pip._vendor.urllib3.exceptions import SSLError as _SSLError
++from pip._vendor.urllib3.poolmanager import PoolManager, proxy_from_url
++from pip._vendor.urllib3.util import Timeout as TimeoutSauce
++from pip._vendor.urllib3.util import parse_url
++from pip._vendor.urllib3.util.retry import Retry
+ 
+ from .auth import _basic_auth_str
+ from .compat import basestring, urlparse
+@@ -57,7 +57,7 @@ from .utils import (
+ )
+ 
+ try:
+-    from urllib3.contrib.socks import SOCKSProxyManager
++    from pip._vendor.urllib3.contrib.socks import SOCKSProxyManager
+ except ImportError:
+ 
+     def SOCKSProxyManager(*args, **kwargs):
+diff --git a/src/pip/_vendor/requests/certs.py b/src/pip/_vendor/requests/certs.py
+index 4f85ac070..c5953485f 100644
+--- b/src/pip/_vendor/requests/certs.py
++++ a/src/pip/_vendor/requests/certs.py
+@@ -12,7 +12,7 @@ environment, you can change the definition of where() to return a separately
+ packaged CA bundle.
+ """
+ 
+-from certifi import where
++from pip._vendor.certifi import where
+ 
+ if __name__ == "__main__":
+     print(where())
 diff --git a/src/pip/_vendor/requests/compat.py b/src/pip/_vendor/requests/compat.py
-index 6776163c..7819bb99 100644
---- a/src/pip/_vendor/requests/compat.py
-+++ b/src/pip/_vendor/requests/compat.py
-@@ -27,19 +24,10 @@ is_py2 = _ver[0] == 2
+index 7f9d75435..b95a92140 100644
+--- b/src/pip/_vendor/requests/compat.py
++++ a/src/pip/_vendor/requests/compat.py
+@@ -7,13 +7,12 @@ between Python 2 and Python 3. It remains for backwards
+ compatibility until the next major version.
+ """
+ 
+-import importlib
+ import sys
+ 
+ # -------
+ # urllib3
+ # -------
+-from urllib3 import __version__ as urllib3_version
++from pip._vendor.urllib3 import __version__ as urllib3_version
+ 
+ # Detect which major version of urllib3 is being used.
+ try:
+@@ -30,12 +29,6 @@ except (TypeError, AttributeError):
+ def _resolve_char_detection():
+     """Find supported character detection libraries."""
+     chardet = None
+-    for lib in ("chardet", "charset_normalizer"):
+-        if chardet is None:
+-            try:
+-                chardet = importlib.import_module(lib)
+-            except ImportError:
+-                pass
+     return chardet
+ 
+ 
+@@ -54,19 +47,10 @@ is_py2 = _ver[0] == 2
  #: Python 3.x?
  is_py3 = _ver[0] == 3
  
@@ -68,86 +182,93 @@ index 6776163c..7819bb99 100644
  
  # Keep OrderedDict for backwards compatibility.
  from collections import OrderedDict
-diff --git a/src/pip/_vendor/requests/help.py b/src/pip/_vendor/requests/help.py
-index 8fbcd656..094e2046 100644
---- a/src/pip/_vendor/requests/help.py
-+++ b/src/pip/_vendor/requests/help.py
-@@ -15,10 +15,7 @@ try:
- except ImportError:
-     charset_normalizer = None
+diff --git a/src/pip/_vendor/requests/exceptions.py b/src/pip/_vendor/requests/exceptions.py
+index 6e71506e9..d84504881 100644
+--- b/src/pip/_vendor/requests/exceptions.py
++++ a/src/pip/_vendor/requests/exceptions.py
+@@ -5,7 +5,7 @@ requests.exceptions
+ This module contains the set of Requests' exceptions.
+ """
  
--try:
--    import chardet
--except ImportError:
--    chardet = None
-+chardet = None
+-from urllib3.exceptions import HTTPError as BaseHTTPError
++from pip._vendor.urllib3.exceptions import HTTPError as BaseHTTPError
  
- try:
-     from urllib3.contrib import pyopenssl
-diff --git a/src/pip/_vendor/requests/__init__.py b/src/pip/_vendor/requests/__init__.py
-index 9d4e72c60..04230fc8d 100644
---- a/src/pip/_vendor/requests/__init__.py
-+++ b/src/pip/_vendor/requests/__init__.py
-@@ -44,11 +44,7 @@ from pip._vendor import urllib3
-
- from .exceptions import RequestsDependencyWarning
-
--try:
--    from charset_normalizer import __version__ as charset_normalizer_version
--except ImportError:
--    charset_normalizer_version = None
--
-+charset_normalizer_version = None
- chardet_version = None
-
-
+ from .compat import JSONDecodeError as CompatJSONDecodeError
+ 
 diff --git a/src/pip/_vendor/requests/help.py b/src/pip/_vendor/requests/help.py
-index 17ca75eda..ddbb6150d 100644
---- a/src/pip/_vendor/requests/help.py
-+++ b/src/pip/_vendor/requests/help.py
-@@ -10,11 +10,7 @@ from pip._vendor import urllib3
-
+index 5d5107895..022cd6062 100644
+--- b/src/pip/_vendor/requests/help.py
++++ a/src/pip/_vendor/requests/help.py
+@@ -5,23 +5,16 @@ import platform
+ import ssl
+ import sys
+ 
+-import idna
+-import urllib3
++from pip._vendor import idna
++from pip._vendor import urllib3
+ 
  from . import __version__ as requests_version
-
+ 
 -try:
 -    import charset_normalizer
 -except ImportError:
 -    charset_normalizer = None
 -
+-try:
+-    import chardet
+-except ImportError:
+-    chardet = None
 +charset_normalizer = None
- chardet = None
-
++chardet = None
+ 
  try:
---- a/src/pip/_vendor/requests/compat.py
-+++ b/src/pip/_vendor/requests/compat.py
-@@ -7,7 +7,6 @@ between Python 2 and Python 3. It remains for backwards
- compatibility until the next major version.
- """
-
--import importlib
- import sys
-
- # -------
-@@ -30,12 +29,6 @@ import sys
- def _resolve_char_detection():
-     """Find supported character detection libraries."""
-     chardet = None
--    for lib in ("chardet", "charset_normalizer"):
--        if chardet is None:
--            try:
--                chardet = importlib.import_module(lib)
--            except ImportError:
--                pass
-     return chardet
-
-
+-    from urllib3.contrib import pyopenssl
++    from pip._vendor.urllib3.contrib import pyopenssl
+ except ImportError:
+     pyopenssl = None
+     OpenSSL = None
+diff --git a/src/pip/_vendor/requests/models.py b/src/pip/_vendor/requests/models.py
+index 2d043f59c..ba7c01d9b 100644
+--- b/src/pip/_vendor/requests/models.py
++++ a/src/pip/_vendor/requests/models.py
+@@ -13,16 +13,16 @@ import datetime
+ import encodings.idna  # noqa: F401
+ from io import UnsupportedOperation
+ 
+-from urllib3.exceptions import (
++from pip._vendor.urllib3.exceptions import (
+     DecodeError,
+     LocationParseError,
+     ProtocolError,
+     ReadTimeoutError,
+     SSLError,
+ )
+-from urllib3.fields import RequestField
+-from urllib3.filepost import encode_multipart_formdata
+-from urllib3.util import parse_url
++from pip._vendor.urllib3.fields import RequestField
++from pip._vendor.urllib3.filepost import encode_multipart_formdata
++from pip._vendor.urllib3.util import parse_url
+ 
+ from ._internal_utils import to_native_string, unicode_is_ascii
+ from .auth import HTTPBasicAuth
+@@ -400,7 +400,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
+ 
+     @staticmethod
+     def _get_idna_encoded_host(host):
+-        import idna
++        from pip._vendor import idna
+ 
+         try:
+             host = idna.encode(host, uts46=True).decode("utf-8")
 diff --git a/src/pip/_vendor/requests/packages.py b/src/pip/_vendor/requests/packages.py
 index 5ab3d8e25..200c38287 100644
---- a/src/pip/_vendor/requests/packages.py
-+++ b/src/pip/_vendor/requests/packages.py
+--- b/src/pip/_vendor/requests/packages.py
++++ a/src/pip/_vendor/requests/packages.py
 @@ -6,12 +6,14 @@ from .compat import chardet
  # I don't like it either. Just look the other way. :)
-
+ 
  for package in ("urllib3", "idna"):
 -    locals()[package] = __import__(package)
 +    vendored_package = "pip._vendor." + package
@@ -160,6 +281,19 @@ index 5ab3d8e25..200c38287 100644
 +        if mod == vendored_package or mod.startswith(vendored_package + '.'):
 +            unprefixed_mod = mod[len("pip._vendor."):]
 +            sys.modules['pip._vendor.requests.packages.' + unprefixed_mod] = sys.modules[mod]
-
+ 
  if chardet is not None:
      target = chardet.__name__
+diff --git a/src/pip/_vendor/requests/utils.py b/src/pip/_vendor/requests/utils.py
+index 54959bb8a..c2732ff04 100644
+--- b/src/pip/_vendor/requests/utils.py
++++ a/src/pip/_vendor/requests/utils.py
+@@ -19,7 +19,7 @@ import warnings
+ import zipfile
+ from collections import OrderedDict
+ 
+-from urllib3.util import make_headers, parse_url
++from pip._vendor.urllib3.util import make_headers, parse_url
+ 
+ from . import certs
+ from .__version__ import __version__

--- a/tools/vendoring/patches/requests.patch
+++ b/tools/vendoring/patches/requests.patch
@@ -1,7 +1,7 @@
 diff --git a/src/pip/_vendor/requests/__init__.py b/src/pip/_vendor/requests/__init__.py
 index 8ecd8b814..81d38590a 100644
---- b/src/pip/_vendor/requests/__init__.py
-+++ a/src/pip/_vendor/requests/__init__.py
+--- a/src/pip/_vendor/requests/__init__.py
++++ b/src/pip/_vendor/requests/__init__.py
 @@ -40,19 +40,12 @@ is at <https://requests.readthedocs.io>.
  
  import warnings
@@ -70,8 +70,8 @@ index 8ecd8b814..81d38590a 100644
  
 diff --git a/src/pip/_vendor/requests/adapters.py b/src/pip/_vendor/requests/adapters.py
 index 98f74465f..da8959e77 100644
---- b/src/pip/_vendor/requests/adapters.py
-+++ a/src/pip/_vendor/requests/adapters.py
+--- a/src/pip/_vendor/requests/adapters.py
++++ b/src/pip/_vendor/requests/adapters.py
 @@ -11,7 +11,7 @@ import socket  # noqa: F401
  import typing
  import warnings
@@ -115,8 +115,8 @@ index 98f74465f..da8959e77 100644
      def SOCKSProxyManager(*args, **kwargs):
 diff --git a/src/pip/_vendor/requests/certs.py b/src/pip/_vendor/requests/certs.py
 index 4f85ac070..c5953485f 100644
---- b/src/pip/_vendor/requests/certs.py
-+++ a/src/pip/_vendor/requests/certs.py
+--- a/src/pip/_vendor/requests/certs.py
++++ b/src/pip/_vendor/requests/certs.py
 @@ -12,7 +12,7 @@ environment, you can change the definition of where() to return a separately
  packaged CA bundle.
  """
@@ -128,8 +128,8 @@ index 4f85ac070..c5953485f 100644
      print(where())
 diff --git a/src/pip/_vendor/requests/compat.py b/src/pip/_vendor/requests/compat.py
 index 7f9d75435..b95a92140 100644
---- b/src/pip/_vendor/requests/compat.py
-+++ a/src/pip/_vendor/requests/compat.py
+--- a/src/pip/_vendor/requests/compat.py
++++ b/src/pip/_vendor/requests/compat.py
 @@ -7,13 +7,12 @@ between Python 2 and Python 3. It remains for backwards
  compatibility until the next major version.
  """
@@ -184,8 +184,8 @@ index 7f9d75435..b95a92140 100644
  from collections import OrderedDict
 diff --git a/src/pip/_vendor/requests/exceptions.py b/src/pip/_vendor/requests/exceptions.py
 index 6e71506e9..d84504881 100644
---- b/src/pip/_vendor/requests/exceptions.py
-+++ a/src/pip/_vendor/requests/exceptions.py
+--- a/src/pip/_vendor/requests/exceptions.py
++++ b/src/pip/_vendor/requests/exceptions.py
 @@ -5,7 +5,7 @@ requests.exceptions
  This module contains the set of Requests' exceptions.
  """
@@ -197,8 +197,8 @@ index 6e71506e9..d84504881 100644
  
 diff --git a/src/pip/_vendor/requests/help.py b/src/pip/_vendor/requests/help.py
 index 5d5107895..022cd6062 100644
---- b/src/pip/_vendor/requests/help.py
-+++ a/src/pip/_vendor/requests/help.py
+--- a/src/pip/_vendor/requests/help.py
++++ b/src/pip/_vendor/requests/help.py
 @@ -5,23 +5,16 @@ import platform
  import ssl
  import sys
@@ -230,8 +230,8 @@ index 5d5107895..022cd6062 100644
      OpenSSL = None
 diff --git a/src/pip/_vendor/requests/models.py b/src/pip/_vendor/requests/models.py
 index 2d043f59c..ba7c01d9b 100644
---- b/src/pip/_vendor/requests/models.py
-+++ a/src/pip/_vendor/requests/models.py
+--- a/src/pip/_vendor/requests/models.py
++++ b/src/pip/_vendor/requests/models.py
 @@ -13,16 +13,16 @@ import datetime
  import encodings.idna  # noqa: F401
  from io import UnsupportedOperation
@@ -264,8 +264,8 @@ index 2d043f59c..ba7c01d9b 100644
              host = idna.encode(host, uts46=True).decode("utf-8")
 diff --git a/src/pip/_vendor/requests/packages.py b/src/pip/_vendor/requests/packages.py
 index 5ab3d8e25..200c38287 100644
---- b/src/pip/_vendor/requests/packages.py
-+++ a/src/pip/_vendor/requests/packages.py
+--- a/src/pip/_vendor/requests/packages.py
++++ b/src/pip/_vendor/requests/packages.py
 @@ -6,12 +6,14 @@ from .compat import chardet
  # I don't like it either. Just look the other way. :)
  
@@ -286,8 +286,8 @@ index 5ab3d8e25..200c38287 100644
      target = chardet.__name__
 diff --git a/src/pip/_vendor/requests/utils.py b/src/pip/_vendor/requests/utils.py
 index 54959bb8a..c2732ff04 100644
---- b/src/pip/_vendor/requests/utils.py
-+++ a/src/pip/_vendor/requests/utils.py
+--- a/src/pip/_vendor/requests/utils.py
++++ b/src/pip/_vendor/requests/utils.py
 @@ -19,7 +19,7 @@ import warnings
  import zipfile
  from collections import OrderedDict


### PR DESCRIPTION
Resources consulted:

 - The [vendoring policy](https://github.com/pypa/pip/blob/fc9550be97a09d3752b7ee77791418f17c27bb6e/src/pip/_vendor/README.rst).
   - Modifications are only to vendored code.
   - The updated `requests` source code here was copied from a PyPI tarball download.
   - ...the only modifications to that are to apply `pip` customisations
   - ...and the `requests.patch` file is updated accordingly (it should apply cleanly and also reverse-apply cleanly).
     - (thanks for the [guidance](https://github.com/pypa/pip/blob/fc9550be97a09d3752b7ee77791418f17c27bb6e/src/pip/_vendor/README.rst#managing-local-patches) about this)
 - (briefly) The [contributing guide](https://pip.pypa.io/en/latest/development/contributing/#news-entries), to check `NEWS` fragment details.
 - The recently-added [AI policy](https://github.com/pypa/pip/blob/fc9550be97a09d3752b7ee77791418f17c27bb6e/AI_POLICY.md).
   - I have not used any LLMs to contribute this code.

NB: For code review purposes, here is a hyperlink to the version range comparison `v2.32.5...v2.33.0` in the `requests` source repo; changes to files within `src` should correspond to the suggested changes here very closely: https://github.com/psf/requests/compare/v2.32.5...v2.33.0