### PR TITLE
Add initial support for -r pylock.toml (experimental)

### DIFF
--- a/news/13876.feature.rst
+++ b/news/13876.feature.rst
@@ -1,0 +1,1 @@
+Add experimental support to read requirements from standardized pylock.toml files (``-r pylock.toml``).

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -542,8 +542,12 @@ def requirements() -> Option:
         action="append",
         default=[],
         metavar="file",
-        help="Install from the given requirements file. "
-        "This option can be used multiple times.",
+        help=(
+            "Install from the given requirements file. "
+            "The file or URL can be in pip's requirements.txt format "
+            "or pylock.toml format. "
+            "This option can be used multiple times."
+        ),
     )
 
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -22,6 +22,7 @@ from optparse import SUPPRESS_HELP, Option, OptionGroup, OptionParser, Values
 from textwrap import dedent
 from typing import Any, Callable
 
+from pip._vendor.packaging import pylock
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.cli.parser import ConfigOptionParser
@@ -101,6 +102,15 @@ def check_dist_restriction(options: Values, check_target: bool = False) -> None:
             raise CommandError(
                 "Can not use any platform or abi specific options unless "
                 "installing via '--target' or using '--dry-run'"
+            )
+
+    for filename in options.requirements:
+        # TODO: filename may be a URL, so pathlib.Path may not be entirely correct
+        if dist_restriction_set and pylock.is_valid_pylock_path(pathlib.Path(filename)):
+            raise CommandError(
+                "Patform and interpreter constraints using "
+                "--python-version, --platform, --abi, or --implementation, "
+                f"are not supported when selecting requirements from {filename!r}"
             )
 
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -22,7 +22,6 @@ from optparse import SUPPRESS_HELP, Option, OptionGroup, OptionParser, Values
 from textwrap import dedent
 from typing import Any, Callable
 
-from pip._vendor.packaging import pylock
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.cli.parser import ConfigOptionParser
@@ -32,6 +31,7 @@ from pip._internal.models.format_control import FormatControl
 from pip._internal.models.index import PyPI
 from pip._internal.models.release_control import ReleaseControl
 from pip._internal.models.target_python import TargetPython
+from pip._internal.utils import pylock as pylock_utils
 from pip._internal.utils.datetime import parse_iso_datetime
 from pip._internal.utils.hashes import STRONG_HASHES
 from pip._internal.utils.misc import strtobool
@@ -105,8 +105,7 @@ def check_dist_restriction(options: Values, check_target: bool = False) -> None:
             )
 
     for filename in options.requirements:
-        # TODO: filename may be a URL, so pathlib.Path may not be entirely correct
-        if dist_restriction_set and pylock.is_valid_pylock_path(pathlib.Path(filename)):
+        if dist_restriction_set and pylock_utils.is_valid_pylock_filename(filename):
             raise CommandError(
                 "Patform and interpreter constraints using "
                 "--python-version, --platform, --abi, or --implementation, "

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -544,8 +544,8 @@ def requirements() -> Option:
         metavar="file",
         help=(
             "Install from the given requirements file. "
-            "The file or URL can be in pip's requirements.txt format "
-            "or pylock.toml format. "
+            "The file or URL can be in pip's requirements.txt format, "
+            "or pylock.toml format. pylock.toml support is experimental. "
             "This option can be used multiple times."
         ),
     )

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -337,6 +337,7 @@ class RequirementCommand(IndexGroupCommand):
 
         # NOTE: options.require_hashes may be set if --require-hashes is True
         for filename in options.requirements:
+            # TODO: filename may be a URL, so pathlib.Path may not be entirely correct
             if pylock.is_valid_pylock_path(Path(filename)):
                 logger.warning(
                     "Using pylock.toml as a requirements source "
@@ -344,19 +345,6 @@ class RequirementCommand(IndexGroupCommand):
                     "It may be removed/changed in a future release "
                     "without prior warning."
                 )
-                if any(
-                    [
-                        options.python_version,
-                        options.platforms,
-                        options.abis,
-                        options.implementation,
-                    ]
-                ):
-                    raise CommandError(
-                        "Patform and interpreter constraints using "
-                        "--python-version, --platform, --abi, or --implementation, "
-                        f"are not supported when installing from {filename!r}"
-                    )
                 for package, package_dist in select_from_pylock_path_or_url(
                     filename, session=session
                 ):

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -11,7 +11,10 @@ import logging
 import os
 from functools import partial
 from optparse import Values
+from pathlib import Path
 from typing import Any, Callable, TypeVar
+
+from pip._vendor.packaging import pylock
 
 from pip._internal.build_env import (
     BuildEnvironmentInstaller,
@@ -39,6 +42,7 @@ from pip._internal.req.constructors import (
     install_req_from_editable,
     install_req_from_line,
     install_req_from_parsed_requirement,
+    install_req_from_pylock_package,
     install_req_from_req_string,
 )
 from pip._internal.req.pep723 import PEP723Exception, pep723_metadata
@@ -47,6 +51,7 @@ from pip._internal.req.req_file import parse_requirements
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.resolution.base import BaseResolver
 from pip._internal.utils.packaging import check_requires_python
+from pip._internal.utils.pylock import select_from_pylock_path_or_url
 from pip._internal.utils.temp_dir import (
     TempDirectory,
     TempDirectoryTypeRegistry,
@@ -332,6 +337,29 @@ class RequirementCommand(IndexGroupCommand):
 
         # NOTE: options.require_hashes may be set if --require-hashes is True
         for filename in options.requirements:
+            if pylock.is_valid_pylock_path(Path(filename)):
+                if any(
+                    [
+                        options.python_version,
+                        options.platforms,
+                        options.abis,
+                        options.implementation,
+                    ]
+                ):
+                    raise CommandError(
+                        "Patform and interpreter constraints using "
+                        "--python-version, --platform, --abi, or --implementation, "
+                        f"are not supported when installing from {filename!r}"
+                    )
+                for package, package_dist in select_from_pylock_path_or_url(
+                    filename, session=session
+                ):
+                    requirements.append(
+                        install_req_from_pylock_package(
+                            package, package_dist, filename, options.format_control
+                        )
+                    )
+                continue
             for parsed_req in parse_requirements(
                 filename, finder=finder, options=options, session=session
             ):

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -338,6 +338,12 @@ class RequirementCommand(IndexGroupCommand):
         # NOTE: options.require_hashes may be set if --require-hashes is True
         for filename in options.requirements:
             if pylock.is_valid_pylock_path(Path(filename)):
+                logger.warning(
+                    "Using pylock.toml as a requirements source "
+                    "is an experimental feature. "
+                    "It may be removed/changed in a future release "
+                    "without prior warning."
+                )
                 if any(
                     [
                         options.python_version,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -11,10 +11,7 @@ import logging
 import os
 from functools import partial
 from optparse import Values
-from pathlib import Path
 from typing import Any, Callable, TypeVar
-
-from pip._vendor.packaging import pylock
 
 from pip._internal.build_env import (
     BuildEnvironmentInstaller,
@@ -51,7 +48,10 @@ from pip._internal.req.req_file import parse_requirements
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.resolution.base import BaseResolver
 from pip._internal.utils.packaging import check_requires_python
-from pip._internal.utils.pylock import select_from_pylock_path_or_url
+from pip._internal.utils.pylock import (
+    is_valid_pylock_filename,
+    select_from_pylock_path_or_url,
+)
 from pip._internal.utils.temp_dir import (
     TempDirectory,
     TempDirectoryTypeRegistry,
@@ -337,8 +337,7 @@ class RequirementCommand(IndexGroupCommand):
 
         # NOTE: options.require_hashes may be set if --require-hashes is True
         for filename in options.requirements:
-            # TODO: filename may be a URL, so pathlib.Path may not be entirely correct
-            if pylock.is_valid_pylock_path(Path(filename)):
+            if is_valid_pylock_filename(filename):
                 logger.warning(
                     "Using pylock.toml as a requirements source "
                     "is an experimental feature. "

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -362,7 +362,11 @@ class RequirementCommand(IndexGroupCommand):
                 ):
                     requirements.append(
                         install_req_from_pylock_package(
-                            package, package_dist, filename, options.format_control
+                            package,
+                            package_dist,
+                            filename,
+                            options.format_control,
+                            user_supplied=True,
                         )
                     )
                 continue

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -595,9 +595,9 @@ def install_req_from_pylock_package(
     ),
     pylock_path_or_url: str,
     format_control: FormatControl,
+    user_supplied: bool,
 ) -> InstallRequirement:
     pass
-    # TODO: user_supplied
     # TODO: validate file size
     if isinstance(package_dist, pylock.PackageVcs):
         return InstallRequirement(
@@ -606,6 +606,7 @@ def install_req_from_pylock_package(
                 f"{package_vcs_requirement_url(pylock_path_or_url, package_dist)}"
             ),
             comes_from=pylock_path_or_url,
+            user_supplied=user_supplied,
         )
     elif isinstance(package_dist, pylock.PackageArchive):
         return InstallRequirement(
@@ -615,17 +616,20 @@ def install_req_from_pylock_package(
             ),
             comes_from=pylock_path_or_url,
             hash_options=_pylock_hashes_to_hash_options(package_dist.hashes),
+            user_supplied=user_supplied,
         )
     elif isinstance(package_dist, pylock.PackageDirectory):
         if package_dist.editable:
             return install_req_from_editable(
                 package_directory_requirement_url(pylock_path_or_url, package_dist),
                 comes_from=pylock_path_or_url,
+                user_supplied=user_supplied,
             )
         else:
             return install_req_from_line(
                 package_directory_requirement_url(pylock_path_or_url, package_dist),
                 comes_from=pylock_path_or_url,
+                user_supplied=user_supplied,
             )
     else:
         # wheel or sdist
@@ -655,6 +659,7 @@ def install_req_from_pylock_package(
             comes_from=pylock_path_or_url,
             link=Link(requirement_url),
             hash_options=_pylock_hashes_to_hash_options(package_dist.hashes),
+            user_supplied=user_supplied,
         )
         ireq.original_link = None  # not a direct URL
         return ireq

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -634,8 +634,19 @@ def install_req_from_pylock_package(
             )
     else:
         # wheel or sdist
-        allow_binary = "binary" in format_control.get_allowed_formats(package.name)
-        if isinstance(package_dist, pylock.PackageWheel) and not allow_binary:
+        allowed_formats = format_control.get_allowed_formats(package.name)
+        if (
+            isinstance(package_dist, pylock.PackageSdist)
+            and "source" not in allowed_formats
+        ):
+            raise InstallationError(
+                f"source distributions are not permitted for package {package.name!r} "
+                f"and there is no compatible wheel for it in {pylock_path_or_url!r}"
+            )
+        if (
+            isinstance(package_dist, pylock.PackageWheel)
+            and "binary" not in allowed_formats
+        ):
             if not package.sdist:
                 raise InstallationError(
                     f"binaries are not permitted for package {package.name!r} and "

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -657,9 +657,9 @@ def install_req_from_pylock_package(
         ireq = InstallRequirement(
             req=Requirement(f"{package.name}=={version}"),
             comes_from=pylock_path_or_url,
-            link=Link(requirement_url),
+            locked_link=Link(requirement_url),
+            locked_version=version,
             hash_options=_pylock_hashes_to_hash_options(package_dist.hashes),
             user_supplied=user_supplied,
         )
-        ireq.original_link = None  # not a direct URL
         return ireq

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -619,15 +619,16 @@ def install_req_from_pylock_package(
             user_supplied=user_supplied,
         )
     elif isinstance(package_dist, pylock.PackageDirectory):
+        req = package_directory_requirement_url(pylock_path_or_url, package_dist)
         if package_dist.editable:
             return install_req_from_editable(
-                package_directory_requirement_url(pylock_path_or_url, package_dist),
+                req,
                 comes_from=pylock_path_or_url,
                 user_supplied=user_supplied,
             )
         else:
             return install_req_from_line(
-                package_directory_requirement_url(pylock_path_or_url, package_dist),
+                req,
                 comes_from=pylock_path_or_url,
                 user_supplied=user_supplied,
             )

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -14,13 +14,16 @@ import copy
 import logging
 import os
 import re
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 
+from pip._vendor.packaging import pylock
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+from pip._vendor.packaging.utils import parse_sdist_filename, parse_wheel_filename
 
 from pip._internal.exceptions import InstallationError
+from pip._internal.models.format_control import FormatControl
 from pip._internal.models.index import PyPI, TestPyPI
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
@@ -29,6 +32,13 @@ from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.filetypes import is_archive_file
 from pip._internal.utils.misc import is_installable_dir
 from pip._internal.utils.packaging import get_requirement
+from pip._internal.utils.pylock import (
+    package_archive_requirement_url,
+    package_directory_requirement_url,
+    package_sdist_requirement_url,
+    package_vcs_requirement_url,
+    package_wheel_requirement_url,
+)
 from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import is_url, vcs
 
@@ -568,3 +578,83 @@ def install_req_extend_extras(
         else None
     )
     return result
+
+
+def _pylock_hashes_to_hash_options(hashes: Mapping[str, str]) -> dict[str, list[str]]:
+    return {k: [v] for k, v in hashes.items()}
+
+
+def install_req_from_pylock_package(
+    package: pylock.Package,
+    package_dist: (
+        pylock.PackageVcs
+        | pylock.PackageArchive
+        | pylock.PackageDirectory
+        | pylock.PackageSdist
+        | pylock.PackageWheel
+    ),
+    pylock_path_or_url: str,
+    format_control: FormatControl,
+) -> InstallRequirement:
+    pass
+    # TODO: user_supplied
+    # TODO: validate file size
+    if isinstance(package_dist, pylock.PackageVcs):
+        return InstallRequirement(
+            req=Requirement(
+                f"{package.name} @ "
+                f"{package_vcs_requirement_url(pylock_path_or_url, package_dist)}"
+            ),
+            comes_from=pylock_path_or_url,
+        )
+    elif isinstance(package_dist, pylock.PackageArchive):
+        return InstallRequirement(
+            req=Requirement(
+                f"{package.name} @ "
+                f"{package_archive_requirement_url(pylock_path_or_url, package_dist)}"
+            ),
+            comes_from=pylock_path_or_url,
+            hash_options=_pylock_hashes_to_hash_options(package_dist.hashes),
+        )
+    elif isinstance(package_dist, pylock.PackageDirectory):
+        if package_dist.editable:
+            return install_req_from_editable(
+                package_directory_requirement_url(pylock_path_or_url, package_dist),
+                comes_from=pylock_path_or_url,
+            )
+        else:
+            return install_req_from_line(
+                package_directory_requirement_url(pylock_path_or_url, package_dist),
+                comes_from=pylock_path_or_url,
+            )
+    else:
+        # wheel or sdist
+        allow_binary = "binary" in format_control.get_allowed_formats(package.name)
+        if isinstance(package_dist, pylock.PackageWheel) and not allow_binary:
+            if not package.sdist:
+                raise InstallationError(
+                    f"binaries are not permitted for package {package.name!r} and "
+                    f"there is no source distribution for it in {pylock_path_or_url!r}"
+                )
+            package_dist = package.sdist
+        version = package.version
+        if isinstance(package_dist, pylock.PackageWheel):
+            if not version:
+                _, version, _, _ = parse_wheel_filename(package_dist.filename)
+            requirement_url = package_wheel_requirement_url(
+                pylock_path_or_url, package_dist
+            )
+        elif isinstance(package_dist, pylock.PackageSdist):
+            if not version:
+                _, version = parse_sdist_filename(package_dist.filename)
+            requirement_url = package_sdist_requirement_url(
+                pylock_path_or_url, package_dist
+            )
+        ireq = InstallRequirement(
+            req=Requirement(f"{package.name}=={version}"),
+            comes_from=pylock_path_or_url,
+            link=Link(requirement_url),
+            hash_options=_pylock_hashes_to_hash_options(package_dist.hashes),
+        )
+        ireq.original_link = None  # not a direct URL
+        return ireq

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -81,6 +81,8 @@ class InstallRequirement:
         extras: Collection[str] = (),
         user_supplied: bool = False,
         permit_editable_wheels: bool = False,
+        locked_link: Link | None = None,
+        locked_version: Version | None = None,
     ) -> None:
         assert req is None or isinstance(req, Requirement), req
         self.req = req
@@ -106,6 +108,14 @@ class InstallRequirement:
             # PEP 508 URL requirement
             link = Link(req.url)
         self.link = self.original_link = link
+
+        # locked_link is the link from the lock file that must be used.
+        # A locked link InstallRequirement behaves similarly as a regular requirement
+        # that would be searched in indexes, except its artifact URL is known
+        # in advance. Notably, and contrarily to direct URL requirements and direct URL
+        # constraints, they do not cause the recording of direct_url.json.
+        self.locked_link = locked_link
+        self.locked_version = locked_version
 
         # When this InstallRequirement is a wheel obtained from the cache of locally
         # built wheels, this is the source link corresponding to the cache entry, which

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -245,6 +245,31 @@ class Factory:
                     return None
             return self._link_candidate_cache[link]
 
+    def _get_locked_installation_candidate(
+        self, ireqs: Sequence[InstallRequirement], name: str, specifier: SpecifierSet
+    ) -> InstallationCandidate | None:
+        locked_ireqs = [ireq for ireq in ireqs if ireq.locked_link]
+        if not locked_ireqs:
+            return None
+        if len(locked_ireqs) > 1:
+            raise InstallationError(
+                f"Multiple locks provided for package {name!r} in "
+                f"{', '.join(str(lir.comes_from) for lir in locked_ireqs)}"
+            )
+        locked_ireq = locked_ireqs[0]
+        assert locked_ireq.locked_link
+        assert locked_ireq.locked_version
+        if not specifier.contains(locked_ireq.locked_version):
+            raise InstallationError(
+                f"Locked version {locked_ireq.locked_version!s} "
+                f"for package {name!r} from {locked_ireq.comes_from!r} "
+                f"is not compatible with other requirements "
+                f"for the same package ({specifier!s})"
+            )
+        return InstallationCandidate(
+            name, str(locked_ireq.locked_version), locked_ireq.locked_link
+        )
+
     def _iter_found_candidates(
         self,
         ireqs: Sequence[InstallRequirement],
@@ -312,31 +337,13 @@ class Factory:
             return candidate
 
         def iter_index_candidate_infos() -> Iterator[IndexCandidateInfo]:
-            locked_ireqs = [ireq for ireq in ireqs if ireq.locked_link]
-            if locked_ireqs:
+            if locked_ican := self._get_locked_installation_candidate(
+                ireqs, name, specifier
+            ):
                 # Locked InstallRequirements must behave as if they would have
                 # been found on an index, except the link is already known, so we don't
-                # ask the finder for the best candidate.
-                if len(locked_ireqs) > 1:
-                    raise InstallationError(
-                        f"Multiple locks provided for package {name!r} in "
-                        f"{', '.join(str(lir.comes_from) for lir in locked_ireqs)}"
-                    )
-                locked_ireq = locked_ireqs[0]
-                assert locked_ireq.locked_link
-                assert locked_ireq.locked_version
-                if not specifier.contains(locked_ireq.locked_version):
-                    raise InstallationError(
-                        f"Locked version {locked_ireq.locked_version!s} "
-                        f"for package {name!r} from {locked_ireq.comes_from!r} "
-                        f"is not compatible with other constraints "
-                        f"for the same package ({specifier!s})"
-                    )
-                icans = [
-                    InstallationCandidate(
-                        name, str(locked_ireq.locked_version), locked_ireq.locked_link
-                    )
-                ]
+                # ask the finder for the best candidate in that case.
+                icans = [locked_ican]
             else:
                 result = self._finder.find_best_candidate(
                     project_name=name,
@@ -760,8 +767,7 @@ class Factory:
                 version_type = "final version"
 
         logger.critical(
-            "Could not find a %s that satisfies the requirement %s "
-            "(from versions: %s)",
+            "Could not find a %s that satisfies the requirement %s (from versions: %s)",
             version_type,
             req_disp,
             ", ".join(versions) or "none",

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -32,6 +32,7 @@ from pip._internal.exceptions import (
 )
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import BaseDistribution, get_default_environment
+from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.operations.prepare import RequirementPreparer
@@ -311,12 +312,38 @@ class Factory:
             return candidate
 
         def iter_index_candidate_infos() -> Iterator[IndexCandidateInfo]:
-            result = self._finder.find_best_candidate(
-                project_name=name,
-                specifier=specifier,
-                hashes=hashes,
-            )
-            icans = result.applicable_candidates
+            locked_ireqs = [ireq for ireq in ireqs if ireq.locked_link]
+            if locked_ireqs:
+                # Locked InstallRequirements must behave as if they would have
+                # been found on an index, except the link is already known, so we don't
+                # ask the finder for the best candidate.
+                if len(locked_ireqs) > 1:
+                    raise InstallationError(
+                        f"Multiple locks provided for package {name!r} in "
+                        f"{', '.join(str(lir.comes_from) for lir in locked_ireqs)}"
+                    )
+                locked_ireq = locked_ireqs[0]
+                assert locked_ireq.locked_link
+                assert locked_ireq.locked_version
+                if not specifier.contains(locked_ireq.locked_version):
+                    raise InstallationError(
+                        f"Locked version {locked_ireq.locked_version!s} "
+                        f"for package {name!r} from {locked_ireq.comes_from!r} "
+                        f"is not compatible with other constraints "
+                        f"for the same package ({specifier!s})"
+                    )
+                icans = [
+                    InstallationCandidate(
+                        name, str(locked_ireq.locked_version), locked_ireq.locked_link
+                    )
+                ]
+            else:
+                result = self._finder.find_best_candidate(
+                    project_name=name,
+                    specifier=specifier,
+                    hashes=hashes,
+                )
+                icans = result.applicable_candidates
 
             # PEP 592: Yanked releases are ignored unless the specifier
             # explicitly pins a version (via '==' or '===') that can be

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -18,6 +18,7 @@ from pip._vendor.packaging.pylock import (
 )
 from pip._vendor.packaging.version import Version
 
+from pip._internal.exceptions import InstallationError
 from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.compat import tomllib
@@ -238,10 +239,23 @@ def select_from_pylock_path_or_url(
         PackageVcs | PackageDirectory | PackageArchive | PackageWheel | PackageSdist,
     ]
 ]:
-    lock = Pylock.from_dict(
-        tomllib.loads(
-            _get_pylock_path_or_url_content(pylock_path_or_url, session),
-        )
-    )
-    # TODO: Exception handling on PylockValidationError and PylockSelectError
-    yield from lock.select()
+    try:
+        pylock_content = _get_pylock_path_or_url_content(pylock_path_or_url, session)
+    except Exception as exc:
+        raise InstallationError(
+            f"Error reading pylock file {pylock_path_or_url!r}: {exc}"
+        ) from exc
+
+    try:
+        lock = Pylock.from_dict(tomllib.loads(pylock_content))
+    except Exception as exc:
+        raise InstallationError(
+            f"Invalid pylock file {pylock_path_or_url!r}: {exc}"
+        ) from exc
+
+    try:
+        yield from lock.select()
+    except Exception as exc:
+        raise InstallationError(
+            f"Cannot select requirements from pylock file {pylock_path_or_url!r}: {exc}"
+        ) from exc

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -15,17 +15,18 @@ from pip._vendor.packaging.pylock import (
     PackageVcs,
     PackageWheel,
     Pylock,
+    is_valid_pylock_path,
 )
 from pip._vendor.packaging.version import Version
 
 from pip._internal.exceptions import InstallationError
 from pip._internal.models.link import Link
-from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.compat import tomllib
 from pip._internal.utils.urls import path_to_url, url_to_path
 
 if TYPE_CHECKING:
     from pip._internal.network.session import PipSession
+    from pip._internal.req.req_install import InstallRequirement
 
 
 def _pylock_package_from_install_requirement(
@@ -133,6 +134,14 @@ _SCHEME_RE = re.compile("^(http|https|file)://", re.IGNORECASE)
 
 def _is_url(s: str) -> bool:
     return bool(_SCHEME_RE.match(s))
+
+
+def is_valid_pylock_filename(filename: str) -> bool:
+    if _is_url(filename):
+        path = Path(urlsplit(filename).path.rpartition("/")[-1])
+    else:
+        path = Path(filename)
+    return is_valid_pylock_path(path)
 
 
 def _package_dist_url(

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -147,6 +147,7 @@ def _package_dist_url(
     """
     if path is not None:
         if not os.path.isabs(path):
+            # relative path, join to pylock location
             if _is_url(pylock_path_or_url):
                 return urljoin(pylock_path_or_url, path)
             else:
@@ -154,6 +155,12 @@ def _package_dist_url(
                     os.path.join(os.path.dirname(pylock_path_or_url), path)
                 )
         else:
+            # absolute path, reject if pylock comes from a URL
+            if _is_url(pylock_path_or_url):
+                raise InstallationError(
+                    f"Absolute path are not supported in pylock file obtained "
+                    f"from a URL: {pylock_path_or_url!r}"
+                )
             return path_to_url(path)
     else:
         assert url is not None  # guaranteed by packaging.pylock validation
@@ -171,7 +178,11 @@ def package_vcs_requirement_url(
         + package_vcs.commit_id
     )
     if package_vcs.subdirectory:
-        assert "#" not in url  # TODO: prorper exception
+        if "#" in url:
+            raise InstallationError(
+                f"Package URL {url!r} cannot contain fragments in combination "
+                f"with subdirectory field (in {pylock_path_or_url!r})"
+            )
         url += "#subdirectory=" + package_vcs.subdirectory
     return url
 
@@ -183,7 +194,11 @@ def package_archive_requirement_url(
         pylock_path_or_url, package_archive.path, package_archive.url
     )
     if package_archive.subdirectory:
-        assert "#" not in url  # TODO: prorper exception
+        if "#" in url:
+            raise InstallationError(
+                f"Package URL {url!r} cannot contain fragments in combination "
+                f"with subdirectory field (in {pylock_path_or_url!r})"
+            )
         url += "#subdirectory=" + package_archive.subdirectory
     return url
 
@@ -192,7 +207,7 @@ def package_directory_requirement_url(
     pylock_path_or_url: str, package_directory: PackageDirectory
 ) -> str:
     url = _package_dist_url(pylock_path_or_url, package_directory.path, None)
-    assert url.startswith("file://")  # TODO: proper exception
+    assert url.startswith("file://")  # rejected in _package_dist_url
     if not url.endswith("/"):
         url += "/"
     if package_directory.subdirectory:

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -136,9 +136,7 @@ def _is_url(s: str) -> bool:
 
 
 def _package_dist_url(
-    pylock_path_or_url: str,
-    path: str | None,
-    url: str | None,
+    pylock_path_or_url: str, path: str | None, url: str | None
 ) -> str:
     """Compute an url from a Pylock package path and url.
 
@@ -158,7 +156,7 @@ def _package_dist_url(
             # absolute path, reject if pylock comes from a URL
             if _is_url(pylock_path_or_url):
                 raise InstallationError(
-                    f"Absolute path are not supported in pylock files obtained "
+                    f"Absolute paths are not supported in pylock files obtained "
                     f"from a URL: {path!r} in {pylock_path_or_url!r}"
                 )
             return path_to_url(path)
@@ -170,13 +168,8 @@ def _package_dist_url(
 def package_vcs_requirement_url(
     pylock_path_or_url: str, package_vcs: PackageVcs
 ) -> str:
-    url = (
-        package_vcs.type
-        + "+"
-        + _package_dist_url(pylock_path_or_url, package_vcs.path, package_vcs.url)
-        + "@"
-        + package_vcs.commit_id
-    )
+    dist_url = _package_dist_url(pylock_path_or_url, package_vcs.path, package_vcs.url)
+    url = f"{package_vcs.type}+{dist_url}@{package_vcs.commit_id}"
     if package_vcs.subdirectory:
         if "#" in url:
             raise InstallationError(

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -208,8 +208,13 @@ def package_archive_requirement_url(
 def package_directory_requirement_url(
     pylock_path_or_url: str, package_directory: PackageDirectory
 ) -> str:
+    if _is_url(pylock_path_or_url) and not pylock_path_or_url.startswith("file://"):
+        raise InstallationError(
+            f"Directory entries are not supported in remote pylock.toml "
+            f"{pylock_path_or_url!r}"
+        )
     url = _package_dist_url(pylock_path_or_url, package_directory.path, None)
-    assert url.startswith("file://")  # rejected in _package_dist_url
+    assert url.startswith("file://")
     if not url.endswith("/"):
         url += "/"
     if package_directory.subdirectory:

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -171,7 +171,7 @@ def package_vcs_requirement_url(
     )
     if package_vcs.subdirectory:
         assert "#" not in url  # TODO: prorper exception
-        url += "#" + package_vcs.subdirectory
+        url += "#subdirectory=" + package_vcs.subdirectory
     return url
 
 
@@ -183,7 +183,7 @@ def package_archive_requirement_url(
     )
     if package_archive.subdirectory:
         assert "#" not in url  # TODO: prorper exception
-        url += "#" + package_archive.subdirectory
+        url += "#subdirectory=" + package_archive.subdirectory
     return url
 
 

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -158,8 +158,8 @@ def _package_dist_url(
             # absolute path, reject if pylock comes from a URL
             if _is_url(pylock_path_or_url):
                 raise InstallationError(
-                    f"Absolute path are not supported in pylock file obtained "
-                    f"from a URL: {pylock_path_or_url!r}"
+                    f"Absolute path are not supported in pylock files obtained "
+                    f"from a URL: {path!r} in {pylock_path_or_url!r}"
                 )
             return path_to_url(path)
     else:

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -1,5 +1,11 @@
-from collections.abc import Iterable
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Iterable, Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin, urlsplit
 
 from pip._vendor.packaging.pylock import (
     Package,
@@ -14,7 +20,11 @@ from pip._vendor.packaging.version import Version
 
 from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.urls import url_to_path
+from pip._internal.utils.compat import tomllib
+from pip._internal.utils.urls import path_to_url, url_to_path
+
+if TYPE_CHECKING:
+    from pip._internal.network.session import PipSession
 
 
 def _pylock_package_from_install_requirement(
@@ -115,3 +125,123 @@ def pylock_from_install_requirements(
             key=lambda p: p.name,
         ),
     )
+
+
+_SCHEME_RE = re.compile("^(http|https|file)://", re.IGNORECASE)
+
+
+def _is_url(s: str) -> bool:
+    return bool(_SCHEME_RE.match(s))
+
+
+def _package_dist_url(
+    pylock_path_or_url: str,
+    path: str | None,
+    url: str | None,
+) -> str:
+    """Compute an url from a Pylock package path and url.
+
+    Give priority to path over url. If path is relative,
+    compute an url using the pylock file location as base.
+    """
+    if path is not None:
+        if not os.path.isabs(path):
+            if _is_url(pylock_path_or_url):
+                return urljoin(pylock_path_or_url, path)
+            else:
+                return path_to_url(
+                    os.path.join(os.path.dirname(pylock_path_or_url), path)
+                )
+        else:
+            return path_to_url(path)
+    else:
+        assert url is not None  # guaranteed by packaging.pylock validation
+        return url
+
+
+def package_vcs_requirement_url(
+    pylock_path_or_url: str, package_vcs: PackageVcs
+) -> str:
+    url = (
+        package_vcs.type
+        + "+"
+        + _package_dist_url(pylock_path_or_url, package_vcs.path, package_vcs.url)
+        + "@"
+        + package_vcs.commit_id
+    )
+    if package_vcs.subdirectory:
+        assert "#" not in url  # TODO: prorper exception
+        url += "#" + package_vcs.subdirectory
+    return url
+
+
+def package_archive_requirement_url(
+    pylock_path_or_url: str, package_archive: PackageArchive
+) -> str:
+    url = _package_dist_url(
+        pylock_path_or_url, package_archive.path, package_archive.url
+    )
+    if package_archive.subdirectory:
+        assert "#" not in url  # TODO: prorper exception
+        url += "#" + package_archive.subdirectory
+    return url
+
+
+def package_directory_requirement_url(
+    pylock_path_or_url: str, package_directory: PackageDirectory
+) -> str:
+    url = _package_dist_url(pylock_path_or_url, package_directory.path, None)
+    assert url.startswith("file://")  # TODO: proper exception
+    if not url.endswith("/"):
+        url += "/"
+    if package_directory.subdirectory:
+        url += package_directory.subdirectory
+        if not url.endswith("/"):
+            url += "/"
+    return url
+
+
+def package_sdist_requirement_url(
+    pylock_path_or_url: str, package_sdist: PackageSdist
+) -> str:
+    return _package_dist_url(pylock_path_or_url, package_sdist.path, package_sdist.url)
+
+
+def package_wheel_requirement_url(
+    pylock_path_or_url: str, package_wheel: PackageWheel
+) -> str:
+    return _package_dist_url(pylock_path_or_url, package_wheel.path, package_wheel.url)
+
+
+def _get_pylock_path_or_url_content(path_or_url: str, session: PipSession) -> str:
+    # TODO: refactor - this is similar to req_file.get_file_content
+    scheme = urlsplit(path_or_url).scheme
+    # Pip has special support for file:// URLs (LocalFSAdapter).
+    if scheme in ["http", "https", "file"]:
+        # Delay importing heavy network modules until absolutely necessary.
+        from pip._internal.network.utils import raise_for_status
+
+        resp = session.get(path_or_url)
+        raise_for_status(resp)
+        return resp.text
+
+    # Assume this is a bare path.
+    return Path(path_or_url).read_text(encoding="utf-8")
+
+
+def select_from_pylock_path_or_url(
+    pylock_path_or_url: str,
+    session: PipSession,
+) -> Iterator[
+    tuple[
+        Package,
+        PackageVcs | PackageDirectory | PackageArchive | PackageWheel | PackageSdist,
+    ]
+]:
+    lock = Pylock.from_dict(
+        tomllib.loads(
+            _get_pylock_path_or_url_content(pylock_path_or_url, session),
+        )
+    )
+    # TODO: Exception handling on PylockValidationError and PylockSelectError
+    yield from lock.select()

--- a/tests/data/lockfiles/pylock.directory.toml
+++ b/tests/data/lockfiles/pylock.directory.toml
@@ -1,0 +1,6 @@
+lock-version = "1.0"
+created-by = "pip"
+packages = [
+    { name = "simplewheel", directory = { path = "../src/simplewheel-2.0", editable = true } },
+    { name = "singlemodule", directory = { path = "../src/singlemodule" } },
+]

--- a/tests/data/lockfiles/pylock.invalid.toml
+++ b/tests/data/lockfiles/pylock.invalid.toml
@@ -1,0 +1,5 @@
+created-by = "pip"
+
+[[packages]]
+name = "simple"
+version = "2.0"

--- a/tests/data/lockfiles/pylock.invalidhash.toml
+++ b/tests/data/lockfiles/pylock.invalidhash.toml
@@ -1,0 +1,13 @@
+lock-version = "1.0"
+created-by = "pip"
+
+[[packages]]
+name = "simple"
+version = "2.0"
+
+[packages.sdist]
+name = "simple-2.0.tar.gz"
+path = "../packages/simple-2.0.tar.gz"
+
+[packages.sdist.hashes]
+sha256 = "3a084929238d13bcd3bb928af04f3bac7ca2357d419e29f01459dc848e2d69a0"

--- a/tests/data/lockfiles/pylock.oldpython.toml
+++ b/tests/data/lockfiles/pylock.oldpython.toml
@@ -1,0 +1,14 @@
+lock-version = "1.0"
+created-by = "pip"
+requires-python = "==3.6.*"
+
+[[packages]]
+name = "simple"
+version = "2.0"
+
+[packages.sdist]
+name = "simple-2.0.tar.gz"
+path = "../packages/simple-2.0.tar.gz"
+
+[packages.sdist.hashes]
+sha256 = "3a084929238d13bcd3bb928af04f3bac7ca2357d419e29f01459dc848e2d69a4"

--- a/tests/data/lockfiles/pylock.onearchive.toml
+++ b/tests/data/lockfiles/pylock.onearchive.toml
@@ -1,0 +1,11 @@
+lock-version = "1.0"
+created-by = "pip"
+
+[[packages]]
+name = "simple2"
+
+[packages.archive]
+path = "../packages/simple2-3.0.tar.gz"
+
+[packages.archive.hashes]
+sha256 = "3ad45e1e9aa48b4462af0123f6a7e44a9115db1ef945d4d92c123dfe21815a06"

--- a/tests/data/lockfiles/pylock.onesdist.toml
+++ b/tests/data/lockfiles/pylock.onesdist.toml
@@ -1,0 +1,13 @@
+lock-version = "1.0"
+created-by = "pip"
+
+[[packages]]
+name = "simple"
+version = "2.0"
+
+[packages.sdist]
+name = "simple-2.0.tar.gz"
+path = "../packages/simple-2.0.tar.gz"
+
+[packages.sdist.hashes]
+sha256 = "3a084929238d13bcd3bb928af04f3bac7ca2357d419e29f01459dc848e2d69a4"

--- a/tests/data/lockfiles/pylock.onewheel.toml
+++ b/tests/data/lockfiles/pylock.onewheel.toml
@@ -1,0 +1,13 @@
+lock-version = "1.0"
+created-by = "pip"
+
+[[packages]]
+name = "simplewheel"
+version = "2.0"
+
+[[packages.wheels]]
+name = "simplewheel-2.0-1-py2.py3-none-any.whl"
+path = "../packages/simplewheel-2.0-1-py2.py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "71e1ca6b16ae3382a698c284013f66504f2581099b2ce4801f60e9536236ceee"

--- a/tests/data/lockfiles/pylock.toml
+++ b/tests/data/lockfiles/pylock.toml
@@ -1,0 +1,33 @@
+lock-version = "1.0"
+created-by = "pip"
+
+[[packages]]
+name = "simple"
+version = "2.0"
+
+[packages.sdist]
+name = "simple-2.0.tar.gz"
+path = "../packages/simple-2.0.tar.gz"
+
+[packages.sdist.hashes]
+sha256 = "3a084929238d13bcd3bb928af04f3bac7ca2357d419e29f01459dc848e2d69a4"
+
+[[packages]]
+name = "simple2"
+
+[packages.archive]
+path = "../packages/simple2-3.0.tar.gz"
+
+[packages.archive.hashes]
+sha256 = "3ad45e1e9aa48b4462af0123f6a7e44a9115db1ef945d4d92c123dfe21815a06"
+
+[[packages]]
+name = "simplewheel"
+version = "2.0"
+
+[[packages.wheels]]
+name = "simplewheel-2.0-1-py2.py3-none-any.whl"
+path = "../packages/simplewheel-2.0-1-py2.py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "71e1ca6b16ae3382a698c284013f66504f2581099b2ce4801f60e9536236ceee"

--- a/tests/functional/test_install_pylock_reqs.py
+++ b/tests/functional/test_install_pylock_reqs.py
@@ -22,6 +22,30 @@ def test_install_pylock(
     assert "Would install simple-2.0 simple2-3.0 simplewheel-2.0\n" in result.stdout
 
 
+def test_install_pylock_wheel_cache(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    """Installing the same sdist twice triggered a hash checking bug."""
+    pylock_path = data.lockfiles.joinpath("pylock.onesdist.toml")
+    args: list[str | Path] = [
+        "--no-index",
+        "--find-links",
+        data.common_wheels,  # to obtain build backend to build sdist
+        "-r",
+        pylock_path,
+    ]
+    result = script.pip("install", *args, allow_stderr_warning=True)
+    assert "experimental" in result.stderr
+    assert "Successfully installed simple-2.0" in result.stdout
+    result = script.pip("install", *args, allow_stderr_warning=True)
+    assert "Requirement already satisfied: simple==2.0" in result.stdout
+    result = script.pip(
+        "install", *args, "--ignore-installed", allow_stderr_warning=True
+    )
+    assert "Successfully installed simple-2.0" in result.stdout
+
+
 def test_install_pylock_directory(
     script: PipTestEnvironment,
     data: TestData,

--- a/tests/functional/test_install_pylock_reqs.py
+++ b/tests/functional/test_install_pylock_reqs.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from tests.lib import PipTestEnvironment, TestData
@@ -13,13 +14,30 @@ def test_install_pylock(
         "--no-index",
         "--find-links",
         data.common_wheels,  # to obtain build backend to build sdist
+        "--quiet",
+        "--report",
+        "-",
         "--dry-run",
         "-r",
         pylock_path,
         allow_stderr_warning=True,
     )
     assert "experimental" in result.stderr
-    assert "Would install simple-2.0 simple2-3.0 simplewheel-2.0\n" in result.stdout
+    report = json.loads(result.stdout)
+    installed = sorted(report["install"], key=lambda r: r["metadata"]["name"])
+    assert [
+        (
+            r["metadata"]["name"],
+            r["metadata"]["version"],
+            r["is_direct"],
+            r["requested"],
+        )
+        for r in installed
+    ] == [
+        ("simple", "2.0", False, True),  # sdist
+        ("simple2", "3.0", True, True),  # archive (direct URL)
+        ("simplewheel", "2.0", False, True),  # wheel
+    ]
 
 
 def test_install_pylock_wheel_cache(

--- a/tests/functional/test_install_pylock_reqs.py
+++ b/tests/functional/test_install_pylock_reqs.py
@@ -136,3 +136,64 @@ def test_install_pylock_select_error(
         "install", "--no-index", "--dry-run", "-r", pylock_path, expect_error=True
     )
     assert "Cannot select requirements from pylock file" in result.stderr
+
+
+def test_install_pylock_no_binary(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.onewheel.toml")
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--dry-run",
+        "-r",
+        pylock_path,
+        "--no-binary=simplewheel",
+        expect_error=True,
+    )
+    assert (
+        "binaries are not permitted for package 'simplewheel' and "
+        "there is no source distribution for it in" in result.stderr
+    )
+
+
+def test_install_pylock_only_binary(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.onesdist.toml")
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--dry-run",
+        "-r",
+        pylock_path,
+        "--only-binary=:all:",
+        expect_error=True,
+    )
+    assert (
+        "source distributions are not permitted for package 'simple' and "
+        "there is no compatible wheel for it in" in result.stderr
+    )
+
+
+def test_install_pylock_only_binary_ignored_for_archives(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    """--only-binary is ignored for direct URL"""
+    pylock_path = data.lockfiles.joinpath("pylock.onearchive.toml")
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--find-links",
+        data.common_wheels,  # to obtain build backend to build sdist
+        "--dry-run",
+        "-r",
+        pylock_path,
+        "--only-binary=simple2,simplewheel",
+        allow_stderr_warning=True,
+    )
+    assert "experimental" in result.stderr
+    assert "Would install simple2-3.0" in result.stdout

--- a/tests/functional/test_install_pylock_reqs.py
+++ b/tests/functional/test_install_pylock_reqs.py
@@ -1,0 +1,61 @@
+from tests.lib import PipTestEnvironment, TestData
+
+
+def test_install_pylock(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.toml")
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--find-links",
+        data.common_wheels,  # to obtain build backend to build sdist
+        "--dry-run",
+        "-r",
+        pylock_path,
+        allow_stderr_warning=True,
+    )
+    assert "experimental" in result.stderr
+    assert "Would install simple-2.0 simple2-3.0 simplewheel-2.0\n" in result.stdout
+
+
+def test_install_pylock_directory(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.directory.toml")
+    result = script.pip(
+        "install",
+        "--no-index",
+        "--find-links",
+        data.common_wheels,  # to obtain build backend to build sdist
+        "-r",
+        pylock_path,
+        allow_stderr_warning=True,
+    )
+    assert "experimental" in result.stderr
+    assert (
+        "Successfully installed simplewheel-2.0 singlemodule-0.0.1\n" in result.stdout
+    )
+    script.assert_installed_editable("simplewheel")
+    script.assert_installed(singlemodule="0.0.1")
+
+
+def test_install_pylock_invalid_hash(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.invalidhash.toml")
+    result = script.pip(
+        "install", "--no-index", "--dry-run", "-r", pylock_path, expect_error=True
+    )
+    assert (
+        "Expected sha256 "
+        "3a084929238d13bcd3bb928af04f3bac7ca2357d419e29f01459dc848e2d69a0"
+        in result.stderr
+    )
+    assert (
+        "Got        3a084929238d13bcd3bb928af04f3bac7ca2357d419e29f01459dc848e2d69a4"
+        in result.stderr
+    )

--- a/tests/functional/test_install_pylock_reqs.py
+++ b/tests/functional/test_install_pylock_reqs.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from tests.lib import PipTestEnvironment, TestData
 
 
@@ -59,3 +61,36 @@ def test_install_pylock_invalid_hash(
         "Got        3a084929238d13bcd3bb928af04f3bac7ca2357d419e29f01459dc848e2d69a4"
         in result.stderr
     )
+
+
+def test_install_pylock_not_found(
+    script: PipTestEnvironment,
+    tmp_path: Path,
+) -> None:
+    pylock_path = tmp_path / "pylock.doesnotexist.toml"
+    result = script.pip(
+        "install", "--no-index", "--dry-run", "-r", pylock_path, expect_error=True
+    )
+    assert "Error reading pylock file" in result.stderr
+
+
+def test_install_pylock_invalid_lockfile(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.invalid.toml")
+    result = script.pip(
+        "install", "--no-index", "--dry-run", "-r", pylock_path, expect_error=True
+    )
+    assert "Invalid pylock file" in result.stderr
+
+
+def test_install_pylock_select_error(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.oldpython.toml")
+    result = script.pip(
+        "install", "--no-index", "--dry-run", "-r", pylock_path, expect_error=True
+    )
+    assert "Cannot select requirements from pylock file" in result.stderr

--- a/tests/functional/test_lock.py
+++ b/tests/functional/test_lock.py
@@ -1,5 +1,6 @@
 import textwrap
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -235,3 +236,44 @@ def test_lock_archive(script: PipTestEnvironment, shared_data: TestData) -> None
             },
         },
     ]
+
+
+def test_lock_roundtrip(script: PipTestEnvironment, data: TestData) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.toml")
+    pylock_result_path = pylock_path.parent / "pylock.result.toml"
+    script.pip(
+        "lock",
+        "--quiet",
+        "--no-build-isolation",  # to use the pre-installed setuptools
+        "--no-index",
+        "-r",
+        pylock_path,
+        "--output",
+        pylock_result_path,
+        expect_stderr=True,  # for the experimental warning
+    )
+
+    def simplify_path_and_url(d: dict[str, Any]) -> None:
+        """Keep last part of path/url as filename key"""
+        if path := d.get("path"):
+            d["filename"] = path.rpartition("/")[-1]
+            del d["path"]
+        if url := d.get("url"):
+            d["filename"] = url.rpartition("/")[-1]
+            del d["url"]
+
+    def simplify_paths_and_urls(d: dict[str, Any]) -> None:
+        for p in d["packages"]:
+            if "archive" in p:
+                simplify_path_and_url(p["archive"])
+            elif "sdist" in p:
+                simplify_path_and_url(p["sdist"])
+            elif "wheels" in p:
+                for wheel in p["wheels"]:
+                    simplify_path_and_url(wheel)
+
+    pylock = tomllib.loads(pylock_path.read_text(encoding="utf-8"))
+    simplify_paths_and_urls(pylock)
+    pylock_result = tomllib.loads(pylock_result_path.read_text(encoding="utf-8"))
+    simplify_paths_and_urls(pylock_result)
+    assert pylock_result == pylock

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -463,3 +463,46 @@ def test_legacy_wheels_are_not_confused_with_other_files(
     wheel_file_name = f"simplewheel-1.0-py{pyversion[0]}-none-any.whl"
     wheel_file_path = script.scratch / wheel_file_name
     result.did_create(wheel_file_path)
+
+
+def test_wheel_pylock(
+    script: PipTestEnvironment, data: TestData, tmp_path: Path
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.toml")
+    result = script.pip(
+        "wheel",
+        "--no-index",
+        "--no-build-isolation",  # to use pre-installed setuptools
+        "-w",
+        tmp_path,
+        "-r",
+        pylock_path,
+        allow_stderr_warning=True,
+    )
+    assert "experimental" in result.stderr
+    assert sorted(p.name for p in tmp_path.glob("*.whl")) == [
+        "simple-2.0-py3-none-any.whl",
+        "simple2-3.0-py3-none-any.whl",
+        "simplewheel-2.0-1-py2.py3-none-any.whl",
+    ]
+
+
+def test_wheel_pylock_directories(
+    script: PipTestEnvironment, data: TestData, tmp_path: Path
+) -> None:
+    pylock_path = data.lockfiles.joinpath("pylock.directory.toml")
+    result = script.pip(
+        "wheel",
+        "--no-index",
+        "--no-build-isolation",  # to use pre-installed setuptools
+        "-w",
+        tmp_path,
+        "-r",
+        pylock_path,
+        allow_stderr_warning=True,
+    )
+    assert "experimental" in result.stderr
+    assert sorted(p.name for p in tmp_path.glob("*.whl")) == [
+        "simplewheel-2.0-py3-none-any.whl",
+        "singlemodule-0.0.1-py2.py3-none-any.whl",
+    ]

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -172,6 +172,10 @@ class TestData:
         return self.root.joinpath("packages3")
 
     @property
+    def lockfiles(self) -> pathlib.Path:
+        return self.root.joinpath("lockfiles")
+
+    @property
     def pypi_packages(self) -> pathlib.Path:
         return self.root.joinpath("pypi_packages")
 

--- a/tests/unit/test_utils_pylock.py
+++ b/tests/unit/test_utils_pylock.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from pip._internal.utils.pylock import _package_dist_url
+from pip._internal.utils.urls import path_to_url
+
+
+@pytest.mark.parametrize(
+    "pylock_filename_or_url,path,url,expected",
+    [
+        (
+            # URL, no path
+            "pylock.toml",
+            None,
+            "https://example.com/foo.tar.gz",
+            "https://example.com/foo.tar.gz",
+        ),
+        (
+            # path over URL, joined with pylock.toml dir
+            "/base/pylock.toml",
+            "foo.tar.gz",
+            "https://example.com/foo.tar.gz",
+            "file:///base/foo.tar.gz",
+        ),
+        (
+            # absolute path over URL, not joined with pylock.toml dir
+            "/base/pylock.toml",
+            "/there/foo.tar.gz",
+            "https://example.com/foo.tar.gz",
+            "file:///there/foo.tar.gz",
+        ),
+        (
+            # relative path joined with pylock.toml http url
+            "https://example.com/pylock.toml",
+            "./there/foo.tar.gz",
+            None,
+            "https://example.com/there/foo.tar.gz",
+        ),
+    ],
+)
+def test_package_dist_url(
+    pylock_filename_or_url: str,
+    path: str | None,
+    url: str | None,
+    expected: str,
+) -> None:
+    if expected.startswith("file:///"):
+        expected = expected.replace("file:///", path_to_url("/"))
+    assert _package_dist_url(pylock_filename_or_url, path, url) == expected

--- a/tests/unit/test_utils_pylock.py
+++ b/tests/unit/test_utils_pylock.py
@@ -1,9 +1,33 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
-from pip._internal.utils.pylock import _package_dist_url
+from pip._vendor.packaging.pylock import (
+    PackageArchive,
+    PackageDirectory,
+    PackageSdist,
+    PackageVcs,
+    PackageWheel,
+)
+
+from pip._internal.utils.pylock import (
+    _package_dist_url,
+    package_archive_requirement_url,
+    package_directory_requirement_url,
+    package_sdist_requirement_url,
+    package_vcs_requirement_url,
+    package_wheel_requirement_url,
+)
 from pip._internal.utils.urls import path_to_url
+
+
+def _adapt_full_path_url(url: str) -> str:
+    """A little hack to adapt absolute file:/// url to windows drive letter."""
+    if sys.platform == "win32" and url.startswith("file:///"):
+        return url.replace("file:///", path_to_url("/a")[:-1])
+    return url
 
 
 @pytest.mark.parametrize(
@@ -45,6 +69,149 @@ def test_package_dist_url(
     url: str | None,
     expected: str,
 ) -> None:
-    if expected.startswith("file:///"):
-        expected = expected.replace("file:///", path_to_url("/"))
-    assert _package_dist_url(pylock_filename_or_url, path, url) == expected
+    assert _package_dist_url(pylock_filename_or_url, path, url) == _adapt_full_path_url(
+        expected
+    )
+
+
+@pytest.mark.parametrize(
+    "pylock_path_or_url,package_vcs,expected",
+    [
+        (
+            "pylock.toml",
+            PackageVcs(
+                type="git",
+                url="https://g.c/o/p.git",
+                commit_id="ccc",
+            ),
+            "git+https://g.c/o/p.git@ccc",
+        ),
+        (
+            "pylock.toml",
+            PackageVcs(
+                type="git",
+                url="https://g.c/o/p.git",
+                commit_id="ccc",
+                subdirectory="setup",
+            ),
+            "git+https://g.c/o/p.git@ccc#subdirectory=setup",
+        ),
+    ],
+)
+def test_package_vcs_requirement_url(
+    pylock_path_or_url: str, package_vcs: PackageVcs, expected: str
+) -> None:
+    assert package_vcs_requirement_url(
+        pylock_path_or_url, package_vcs
+    ) == _adapt_full_path_url(expected)
+
+
+@pytest.mark.parametrize(
+    "pylock_path_or_url,package_archive,expected",
+    [
+        (
+            "pylock.toml",
+            PackageArchive(
+                url="https://example.com/archive.tgz",
+                hashes={"sha256": "aaa"},
+            ),
+            "https://example.com/archive.tgz",
+        ),
+        (
+            "pylock.toml",
+            PackageArchive(
+                url="https://example.com/archive.tgz",
+                subdirectory="subdir",
+                hashes={"sha256": "aaa"},
+            ),
+            "https://example.com/archive.tgz#subdirectory=subdir",
+        ),
+        (
+            "https://example.com/pylock.toml",
+            PackageArchive(
+                path="archive.tgz",
+                hashes={"sha256": "aaa"},
+            ),
+            "https://example.com/archive.tgz",
+        ),
+        (
+            "/path/to/pylock.toml",
+            PackageArchive(
+                path="archive.tgz",
+                hashes={"sha256": "aaa"},
+            ),
+            "file:///path/to/archive.tgz",
+        ),
+    ],
+)
+def test_package_archive_requirement_url(
+    pylock_path_or_url: str, package_archive: PackageArchive, expected: str
+) -> None:
+    assert package_archive_requirement_url(
+        pylock_path_or_url, package_archive
+    ) == _adapt_full_path_url(expected)
+
+
+@pytest.mark.parametrize(
+    "pylock_path_or_url,package_directory,expected",
+    [
+        (
+            "/path/to/pylock.toml",
+            PackageDirectory(path="dir"),
+            "file:///path/to/dir/",
+        ),
+        (
+            "/path/to/pylock.toml",
+            PackageDirectory(path="dir", subdirectory="subdir"),
+            "file:///path/to/dir/subdir/",
+        ),
+    ],
+)
+def test_package_directory_requirement_url(
+    pylock_path_or_url: str, package_directory: PackageDirectory, expected: str
+) -> None:
+    assert package_directory_requirement_url(
+        pylock_path_or_url, package_directory
+    ) == _adapt_full_path_url(expected)
+
+
+@pytest.mark.parametrize(
+    "pylock_path_or_url,package_sdist,expected",
+    [
+        (
+            "https://example.com/pylock.toml",
+            PackageSdist(
+                path="pkga-1.0.tar.gz",
+                hashes={"sha256": "aaa"},
+            ),
+            "https://example.com/pkga-1.0.tar.gz",
+        ),
+    ],
+)
+def test_package_sdist_requirement_url(
+    pylock_path_or_url: str, package_sdist: PackageSdist, expected: str
+) -> None:
+    assert package_sdist_requirement_url(
+        pylock_path_or_url, package_sdist
+    ) == _adapt_full_path_url(expected)
+
+
+@pytest.mark.parametrize(
+    "pylock_path_or_url,package_wheel,expected",
+    [
+        (
+            "pylock.toml",
+            PackageWheel(
+                url="https://there.org/wheel_1.0_py3-none-any.whl",
+                hashes={"sha256": "aaa"},
+            ),
+            "https://there.org/wheel_1.0_py3-none-any.whl",
+        ),
+    ],
+)
+def test_package_wheel_requirement_url(
+    pylock_path_or_url: str, package_wheel: PackageWheel, expected: str
+) -> None:
+    assert package_wheel_requirement_url(
+        pylock_path_or_url, package_wheel
+    ) == _adapt_full_path_url(expected)

--- a/tests/unit/test_utils_pylock.py
+++ b/tests/unit/test_utils_pylock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -12,6 +13,7 @@ from pip._vendor.packaging.pylock import (
     PackageWheel,
 )
 
+from pip._internal.exceptions import InstallationError
 from pip._internal.utils.pylock import (
     _package_dist_url,
     package_archive_requirement_url,
@@ -72,6 +74,16 @@ def test_package_dist_url(
     assert _package_dist_url(pylock_filename_or_url, path, url) == _adapt_full_path_url(
         expected
     )
+
+
+def test_package_dist_url_abs_path_remote_lock_file() -> None:
+    """A remote lock file cannot have package with absolute paths."""
+    with pytest.raises(InstallationError):
+        _package_dist_url(
+            "https://example.com/pylock.toml",
+            path=str(Path("/here/pkg.tgz").absolute()),
+            url=None,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_utils_pylock.py
+++ b/tests/unit/test_utils_pylock.py
@@ -187,6 +187,16 @@ def test_package_directory_requirement_url(
     ) == _adapt_full_path_url(expected)
 
 
+def test_package_directory_requirement_remote_url() -> None:
+    with pytest.raises(
+        InstallationError,
+        match="Directory entries are not supported in remote pylock.toml ",
+    ):
+        package_directory_requirement_url(
+            "https://example.com/pylock.toml", PackageDirectory(path="dir")
+        )
+
+
 @pytest.mark.parametrize(
     "pylock_path_or_url,package_sdist,expected",
     [

--- a/tests/unit/test_utils_pylock.py
+++ b/tests/unit/test_utils_pylock.py
@@ -78,7 +78,7 @@ def test_package_dist_url(
 
 def test_package_dist_url_abs_path_remote_lock_file() -> None:
     """A remote lock file cannot have package with absolute paths."""
-    with pytest.raises(InstallationError, match="Absolute path are not supported"):
+    with pytest.raises(InstallationError, match="Absolute paths are not supported"):
         _package_dist_url(
             "https://example.com/pylock.toml",
             path=str(Path("/here/pkg.tgz").absolute()),

--- a/tests/unit/test_utils_pylock.py
+++ b/tests/unit/test_utils_pylock.py
@@ -78,7 +78,7 @@ def test_package_dist_url(
 
 def test_package_dist_url_abs_path_remote_lock_file() -> None:
     """A remote lock file cannot have package with absolute paths."""
-    with pytest.raises(InstallationError):
+    with pytest.raises(InstallationError, match="Absolute path are not supported"):
         _package_dist_url(
             "https://example.com/pylock.toml",
             path=str(Path("/here/pkg.tgz").absolute()),


### PR DESCRIPTION
- [x] this requires a new packaging release to have `Pylock.select()`
- [ ] to install vcs entries from a lock file which also has other entries with hashes, we'll need https://github.com/pypa/pip/pull/11968
- [ ] to install directory entries from a lock file which also has other entries with hashes, we'll need https://github.com/pypa/pip/issues/4995#issuecomment-1566779975
- [x] paths relative to lockfile location
- [x] tests
- [x] docs
- [x] and address the most important TODO's

But this works.

Closes #13334