### PR TITLE
Fix BrokenPipeError crash when pip output is piped

### DIFF
--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -144,6 +144,13 @@ class Command(CommandContextMixIn):
             logger.debug("Exception information:", exc_info=True)
 
             return ERROR
+        except BrokenPipeError:
+            # Python raises BrokenPipeError when stdout is piped to a process
+            # that exits early (e.g. `pip show pip | head -1`). Suppress the
+            # traceback and exit cleanly per Python SIGPIPE convention.
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(devnull, sys.stdout.fileno())
+            return ERROR
         except BaseException:
             logger.critical("Exception:", exc_info=True)
 


### PR DESCRIPTION
## Problem

When pip's output is piped to a command that exits early, pip crashes with an uncaught `BrokenPipeError`:

```bash
pip show pip 2>&1 | head -1
# BrokenPipeError: [Errno 32] Broken pipe
```

## Fix

Catch `BrokenPipeError` explicitly before `BaseException` and exit cleanly.

**Closing in favor of #13878 which was opened earlier and addresses the same issue.**