### PR TITLE
Fix `test_trailing_slash_directory_metadata` for Python 3.15

### DIFF
--- a/news/13901.trivial.rst
+++ b/news/13901.trivial.rst
@@ -1,0 +1,2 @@
+Fixed ``test_trailing_slash_directory_metadata`` to use a real temporary
+directory with metadata, for compatibility with Python 3.15.

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -135,15 +135,15 @@ def test_dist_found_in_zip(tmp_path: Path) -> None:
     assert Path(dist.location) == Path(location)
 
 
-@pytest.mark.parametrize(
-    "path",
-    [
-        "/path/to/foo.egg-info".replace("/", os.path.sep),
-        # Tests issue fixed by https://github.com/pypa/pip/pull/2530
-        "/path/to/foo.egg-info/".replace("/", os.path.sep),
-    ],
-)
-def test_trailing_slash_directory_metadata(path: str) -> None:
+@pytest.mark.parametrize("trailing_slash", [False, True])
+def test_trailing_slash_directory_metadata(
+    tmp_path: Path, trailing_slash: bool
+) -> None:
+    # Tests issue fixed by https://github.com/pypa/pip/pull/2530
+    egg_info = tmp_path / "foo.egg-info"
+    egg_info.mkdir()
+    (egg_info / "PKG-INFO").write_text("Metadata-Version: 1.0\nName: foo\n")
+    path = str(egg_info) + (os.sep if trailing_slash else "")
     dist = get_directory_distribution(path)
     assert dist.raw_name == dist.canonical_name == "foo"
-    assert dist.location == "/path/to".replace("/", os.path.sep)
+    assert dist.location == str(tmp_path)


### PR DESCRIPTION
## Summary

Python 3.15 alpha tightened `importlib.metadata` to raise `MetadataNotFound` eagerly when no metadata files exist on disk. The test used a fake non-existent path (`/path/to/foo.egg-info`) to verify trailing-slash handling — this worked on older Pythons where metadata access was lazy, but now fails on 3.15.

Replace the fake path with a real temp directory containing a minimal `PKG-INFO` file. The test still verifies the same behavior (name parsing and trailing-slash normalization).

Fixes #13901.

## Test plan

- [x] `nox -s test-3.15 -- tests/unit/metadata/test_metadata.py::test_trailing_slash_directory_metadata` — 2 passed (Python 3.15.0a8)
- [x] `nox -s test-3.12 -- tests/unit/metadata/test_metadata.py::test_trailing_slash_directory_metadata` — 2 passed (Python 3.12.3)