### PR TITLE
Suppor editable constraints

### DIFF
--- a/news/13904.feature.rst
+++ b/news/13904.feature.rst
@@ -1,0 +1,1 @@
+Support editable constraints.

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -260,9 +260,6 @@ def install_req_from_editable(
     permit_editable_wheels: bool = False,
     config_settings: dict[str, str | list[str]] | None = None,
 ) -> InstallRequirement:
-    if constraint:
-        raise InstallationError("Editable requirements are not allowed as constraints")
-
     parts = parse_req_from_editable(editable_req)
     return InstallRequirement(
         parts.requirement,

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -796,8 +796,6 @@ def check_invalid_constraint_type(req: InstallRequirement) -> str:
     problem = ""
     if not req.name:
         problem = "Unnamed requirements are not allowed as constraints"
-    elif req.editable:
-        problem = "Editable requirements are not allowed as constraints"
     elif req.extras:
         problem = "Constraints cannot have extras"
 

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -92,7 +92,11 @@ class Constraint:
     def format_for_error(self) -> str:
         s = str(self.specifier)
         if self.links:
-            s += f" (from {', '.join(str(link) for link in self.links)})"
+            links_text = ", ".join(
+                f"{'editable ' if link.editable else ''}{link.link}"
+                for link in self.links
+            )
+            s += f" (from {links_text})"
         return s
 
 

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -78,10 +78,9 @@ class Constraint:
 
     def is_satisfied_by(self, candidate: Candidate) -> bool:
         # Reject if there are any mismatched URL constraints on this package.
-        # The editableness of links is ignored when matching, so equivalent links
-        # match if one is editable and the other is not.
         if self.links and not all(
-            _match_link(link.link, candidate) for link in self.links
+            _match_link(link.link, candidate) and link.editable == candidate.is_editable
+            for link in self.links
         ):
             return False
         # We can safely always allow prereleases here since PackageFinder

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -22,12 +22,18 @@ def format_name(project: NormalizedName, extras: frozenset[NormalizedName]) -> s
     return f"{project}[{extras_expr}]"
 
 
+@dataclass(slots=True, eq=True, frozen=True)
+class ConstraintLink:
+    link: Link
+    editable: bool
+
+
 @dataclass(frozen=True)
 class Constraint:
     specifier: SpecifierSet
     hashes: Hashes
     hash_options: dict[str, list[str]]
-    links: frozenset[Link]
+    links: frozenset[ConstraintLink]
 
     @classmethod
     def empty(cls) -> Constraint:
@@ -35,7 +41,11 @@ class Constraint:
 
     @classmethod
     def from_ireq(cls, ireq: InstallRequirement) -> Constraint:
-        links = frozenset([ireq.link]) if ireq.link else frozenset()
+        links = (
+            frozenset([ConstraintLink(ireq.link, ireq.editable)])
+            if ireq.link
+            else frozenset()
+        )
         hash_options = {alg: list(v) for alg, v in ireq.hash_options.items()}
         return Constraint(
             ireq.specifier,
@@ -63,12 +73,16 @@ class Constraint:
             }
         links = self.links
         if other.link:
-            links = links.union([other.link])
+            links = links.union([ConstraintLink(other.link, other.editable)])
         return Constraint(specifier, hashes, hash_options, links)
 
     def is_satisfied_by(self, candidate: Candidate) -> bool:
         # Reject if there are any mismatched URL constraints on this package.
-        if self.links and not all(_match_link(link, candidate) for link in self.links):
+        # The editableness of links is ignored when matching, so equivalent links
+        # match if one is editable and the other is not.
+        if self.links and not all(
+            _match_link(link.link, candidate) for link in self.links
+        ):
             return False
         # We can safely always allow prereleases here since PackageFinder
         # already implements the prerelease logic, and would have filtered out

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -90,7 +90,6 @@ def make_install_req_from_link(
 def make_install_req_from_editable(
     link: Link, template: InstallRequirement
 ) -> InstallRequirement:
-    assert template.editable, "template not editable"
     if template.name:
         req_string = f"{template.name} @ {link.url}"
     else:

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -191,6 +191,7 @@ class Factory:
         template: InstallRequirement,
         name: NormalizedName | None,
         version: Version | None,
+        editable: bool = False,
     ) -> BaseCandidate | None:
         # TODO: Check already installed candidate, and use it if the link and
         # editable flag match.
@@ -200,7 +201,7 @@ class Factory:
             # Don't bother trying again.
             return None
 
-        if template.editable:
+        if template.editable or editable:
             if link not in self._editable_candidate_cache:
                 try:
                     self._editable_candidate_cache[link] = EditableCandidate(
@@ -399,12 +400,13 @@ class Factory:
                 extras = frozenset(parsed_requirement.extras)
 
         for link in constraint.links:
-            self._fail_if_link_is_unsupported_wheel(link)
+            self._fail_if_link_is_unsupported_wheel(link.link)
             base_candidate = self._make_base_candidate_from_link(
-                link,
-                template=install_req_from_link_and_ireq(link, template),
+                link.link,
+                template=install_req_from_link_and_ireq(link.link, template),
                 name=canonicalize_name(base_identifier),
                 version=None,
+                editable=link.editable,
             )
             if base_candidate is None:
                 continue

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -482,7 +482,6 @@ def test_constraints_only_causes_error(
 def test_constraints_local_editable_install_causes_error(
     script: PipTestEnvironment,
     data: TestData,
-    resolver_variant: ResolverVariant,
 ) -> None:
     script.scratch_path.joinpath("constraints.txt").write_text("singlemodule==0.0.0")
     to_install = data.src.joinpath("singlemodule")
@@ -515,7 +514,6 @@ def test_constraints_local_editable_install_pep518(
 def test_constraints_local_install_causes_error(
     script: PipTestEnvironment,
     data: TestData,
-    resolver_variant: ResolverVariant,
 ) -> None:
     script.scratch_path.joinpath("constraints.txt").write_text("singlemodule==0.0.0")
     to_install = data.src.joinpath("singlemodule")
@@ -537,31 +535,22 @@ def test_constraints_local_install_causes_error(
 def test_constraints_constrain_to_local_editable(
     script: PipTestEnvironment,
     data: TestData,
-    resolver_variant: ResolverVariant,
 ) -> None:
     to_install = data.src.joinpath("singlemodule")
     script.scratch_path.joinpath("constraints.txt").write_text(
-        f"-e {to_install.as_uri()}#egg=singlemodule"
+        f'-e "singlemodule @ {to_install.as_uri()}"'
     )
-    result = script.pip(
-        "install",
-        "--no-index",
-        "-f",
-        data.find_links,
+    script.pip_install_local(
         "-c",
         script.scratch_path / "constraints.txt",
         "singlemodule",
         allow_stderr_warning=True,
-        expect_error=(resolver_variant == "resolvelib"),
     )
-    if resolver_variant == "resolvelib":
-        assert "Editable requirements are not allowed as constraints" in result.stderr
-    else:
-        assert "Running setup.py develop for singlemodule" in result.stdout
+    script.assert_installed_editable("singlemodule")
 
 
 def test_constraints_constrain_to_local(
-    script: PipTestEnvironment, data: TestData, resolver_variant: ResolverVariant
+    script: PipTestEnvironment, data: TestData
 ) -> None:
     to_install = data.src.joinpath("singlemodule")
     script.scratch_path.joinpath("constraints.txt").write_text(
@@ -735,7 +724,7 @@ def test_install_with_extras_editable_joined(
 ) -> None:
     to_install = data.packages.joinpath("LocalExtras")
     file = script.temporary_file(
-        "constraints.txt", f"-e LocalExtras[bar] @ {to_install.as_uri()}"
+        "constraints.txt", f'-e "LocalExtras[bar] @ {to_install.as_uri()}"'
     )
     result = script.pip_install_local(
         "-c",
@@ -745,7 +734,7 @@ def test_install_with_extras_editable_joined(
         expect_error=(resolver_variant == "resolvelib"),
     )
     if resolver_variant == "resolvelib":
-        assert "Editable requirements are not allowed as constraints" in result.stderr
+        assert "Constraints cannot have extras" in result.stderr
     else:
         result.did_create(script.site_packages / "simple")
         result.did_create(script.site_packages / "singlemodule.py")
@@ -943,6 +932,48 @@ def test_config_settings_local_to_package(
     assert "--verbose" not in simple3_args
     simple2_args = simple2_sdist.args()
     assert "--verbose" not in simple2_args
+
+
+def test_editable_constraints(script: PipTestEnvironment, tmp_path: Path) -> None:
+    pkgs_path = tmp_path / "pkgs"
+    pkgs_path.mkdir()
+    pkga_path = pkgs_path / "pkga"
+    pkga_path.mkdir()
+    pkga_path.joinpath("pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "pkga"
+            version = "1.1"
+            dependencies = ["pkgb"]
+            """
+        )
+    )
+    pkgb_path = pkgs_path / "pkgb"
+    pkgb_path.mkdir()
+    pkgb_path.joinpath("pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "pkgb"
+            version = "1.2"
+            dependencies = ["singlemodule==0.0.1"]
+            """
+        )
+    )
+    constraints_path = tmp_path / "constraints.txt"
+    constraints_path.write_text(
+        textwrap.dedent(
+            f"""\
+            -e "pkga @ {pkga_path.as_uri()}"
+            -e "pkgb @ {pkgb_path.as_uri()}"
+            """
+        )
+    )
+    script.pip_install_local("pkga", "-c", constraints_path)
+    script.assert_installed(singlemodule="0.0.1")
+    script.assert_installed_editable("pkga")
+    script.assert_installed_editable("pkgb")
 
 
 class TestEditableDirectURL:

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -767,10 +767,6 @@ def test_new_resolver_constraint_no_specifier(script: PipTestEnvironment) -> Non
             "Unnamed requirements are not allowed as constraints",
         ),
         (
-            "-e git+https://example.com/dist.git#egg=req",
-            "Editable requirements are not allowed as constraints",
-        ),
-        (
             "pkg[extra]",
             "Constraints cannot have extras",
         ),


### PR DESCRIPTION
This provides a way to address monorepo use cases, like this:

`pkgs/pkga`:

```toml
[project]
name = "pkga"
version = "1.1"
dependencies = ["pkgb"]
```

`pkgs/pkgb`:

```toml
[project]
name = "pkgb"
version = "1.1"
dependencies = []
```

`constraints.txt`:

```
-e "pkga @ file://${PWD}/pkgs/pkga"
-e "pkgb @ file://${PWD}/pkgs/pkgb"
```

`pip install pkga -c constraints.txt` resulting in an editable install of pkga and pkgb.