### PR TITLE
docs: fix broken HTTPS documentation links (#13664)

### DIFF
--- a/docs/html/cli/pip_search.rst
+++ b/docs/html/cli/pip_search.rst
@@ -23,7 +23,7 @@ Description
 
 .. attention::
     PyPI no longer supports ``pip search`` (or XML-RPC search). Please use https://pypi.org/search (via a browser)
-    instead. See https://warehouse.pypa.io/api-reference/xml-rpc.html#deprecated-methods for more information.
+    instead. See https://warehouse.pypa.io/api-reference/xml-rpc.html for more information.
 
     However, XML-RPC search (and this command) may still be supported by indexes other than PyPI.
 

--- a/docs/html/development/issue-triage.md
+++ b/docs/html/development/issue-triage.md
@@ -80,7 +80,7 @@ There are several helpers to manage issues and pull requests.
 
 Issues created on the issue tracker are automatically given the
 `triage` label by the
-[triage-new-issues](https://github.com/apps/triage-new-issues)
+[triage-new-issues](https://github.com/pypa/pip/issues)
 bot. The label is automatically removed when another label is added.
 
 When an issue needs feedback from the author we can label it with

--- a/docs/html/development/release-process.rst
+++ b/docs/html/development/release-process.rst
@@ -148,7 +148,7 @@ Creating a new release
    Merge the changes back into ``main`` and pull them back locally.
 #. Push the tag created by ``prepare-release``. This will trigger the release
    workflow on GitHub.
-#. Go to https://github.com/pypa/pip/actions, find the latest ``Publish Python
+#. Go to https://github.com/pypa/pip/actions find the latest ``Publish Python
    🐍 distribution 📦 to PyPI`` workflow run, open it, wait for the build step
    to complete, then approve the PyPI environment to let the publishing step
    run. If you desire, you have the possibility to download and inspect the

--- a/docs/html/getting-started.md
+++ b/docs/html/getting-started.md
@@ -42,7 +42,7 @@ upload packages.
 ### Install a package from GitHub
 
 ```{pip-cli}
-$ pip install git+https://github.com/pypa/sampleproject.git@main
+$ pip install git+https://github.com/pypa/sampleproject
 [...]
 Successfully installed sampleproject
 ```

--- a/docs/html/reference/build-system.md
+++ b/docs/html/reference/build-system.md
@@ -57,7 +57,7 @@ reference packages with URLs. For example:
 
 ```toml
 [build-system]
-requires = ["setuptools @ git+https://github.com/pypa/setuptools.git@main"]
+requires = ["setuptools @ git+https://github.com/pypa/setuptools"]
 ```
 
 ### Metadata Generation

--- a/docs/html/reference/installation-report.md
+++ b/docs/html/reference/installation-report.md
@@ -89,7 +89,7 @@ The following command:
 pip install \
   --ignore-installed --dry-run --quiet \
   --report - \
-  "pydantic>=1.9" git+https://github.com/pypa/packaging@main
+  "pydantic>=1.9" git+https://github.com/pypa/packaging
 ```
 
 will produce an output similar to this (metadata abriged for brevity):

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -1425,7 +1425,7 @@ announcements on the `low-traffic packaging announcements list`_ and
 `the official Python blog`_.
 
 .. _freeze: https://pip.pypa.io/en/latest/reference/pip_freeze/
-.. _resolver testing survey: https://tools.simplysecure.org/survey/index.php?r=survey/index&sid=989272&lang=en
+.. _resolver testing survey: https://web.archive.org/web/2024/https://tools.simplysecure.org/survey/index.php?r=survey/index&sid=989272&lang=en
 .. _issue 8661: https://github.com/pypa/pip/issues/8661
 .. _our announcement on the PSF blog: http://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html
 .. _two-minute video explanation: https://www.youtube.com/watch?v=B4GQCBBsuNU

--- a/docs/html/ux-research-design/guidance.md
+++ b/docs/html/ux-research-design/guidance.md
@@ -401,7 +401,7 @@ An in-depth write up on how the pip personas were created, and how they can be a
 
 In any UX project, it is important to prototype and test interfaces with real users. This provides the team with a feedback loop, and ensures that the solution shipped to the end user meets their needs.
 
-Prototyping CLIs can be a challenge. See [Creating rapid CLI prototypes with cli-output](https://www.ei8fdb.org/prototyping-command-line-interfaces-with-cli-output/) for recommendations.
+Prototyping CLIs can be a challenge. See [Creating rapid CLI prototypes with cli-output](https://web.archive.org/web/2024/https://www.ei8fdb.org/prototyping-command-line-interfaces-with-cli-output/) for recommendations.
 
 #### Copywriting Style Guides
 
@@ -409,12 +409,12 @@ Given pip's interface is text, it is particularly important that clear and consi
 
 The following copywriting Style Guides may be useful to the pip team:
 
-- [Warehouse (PyPI) copywriting styleguide and glossary of terms](https://warehouse.readthedocs.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology)
+- [Warehouse (PyPI) copywriting styleguide and glossary of terms](https://web.archive.org/web/2024/https://warehouse.readthedocs.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology)
 - Firefox:
   - [Voice and Tone](https://meet.google.com/linkredirect?authuser=0&dest=https%3A%2F%2Fdesign.firefox.com%2Fphoton%2Fcopy%2Fvoice-and-tone.html)
   - [Writing for users](https://meet.google.com/linkredirect?authuser=0&dest=https%3A%2F%2Fdesign.firefox.com%2Fphoton%2Fcopy%2Fwriting-for-users.html)
 - [Heroku CLI](https://devcenter.heroku.com/articles/cli-style-guide) (very specific to Heroku's CLI tools)
-- [Redhat Pattern Fly style guide](https://www.patternfly.org/v4/ux-writing/about)
+- [Redhat Pattern Fly style guide](https://www.patternfly.org/ux-writing/about/)
 - [Writing for UIs from Simply Secure](https://simplysecure.org/blog/writing-for-uis)
 
 ### General Resources
@@ -422,7 +422,7 @@ The following copywriting Style Guides may be useful to the pip team:
 - Heroku talk on design of their CLI tools ([video](https://www.youtube.com/watch?v=PHiDG-_XoRk) transcript)
 - [Simply Secure: UX Starter Pack](https://simplysecure.org/ux-starter-pack/)
 - [Simply Secure: Feedback Gathering Guide](https://simplysecure.org/blog/feedback-gathering-guide)
-- [Simply Secure: Getting Quick Tool Feedback](https://simplysecure.org/blog/design-spot-tool-feedback)
+- [Simply Secure: Getting Quick Tool Feedback](https://web.archive.org/web/2024/https://simplysecure.org/blog/design-spot-tool-feedback)
 - [Internews: UX Feedback Collection Guidebook](https://globaltech.internews.org/our-resources/ux-feedback-collection-guidebook)
 - [Simply Secure: Knowledge Base](http://simplysecure.org/knowledge-base/)
 - [Open Source Design](https://opensourcedesign.net/resources/)

--- a/docs/html/ux-research-design/research-results/improving-pips-documentation.md
+++ b/docs/html/ux-research-design/research-results/improving-pips-documentation.md
@@ -517,7 +517,7 @@ _Page purpose:_
 _Suggested content:_
 
 - This guide
-- Writing styleguide / glossary of terms - see the [Warehouse documentation](https://warehouse.readthedocs.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology) for an example.
+- Writing styleguide / glossary of terms - see the [Warehouse documentation](https://web.archive.org/web/2024/https://warehouse.readthedocs.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology) for an example.
 
 </details>
 

--- a/docs/html/ux-research-design/research-results/index.md
+++ b/docs/html/ux-research-design/research-results/index.md
@@ -22,7 +22,7 @@ This work was made possible through the [pip donor funded roadmap](https://wiki.
 
 ## Outreach
 
-We [recruited participants](https://www.ei8fdb.org/thoughts/2020/03/pip-ux-study-recruitment/) for a user research panel that we could contact when we wanted to run surveys and interviews about pip. In total 472 people signed up to the panel, although some unsubscribed during the research period.
+We recruited participants for a user research panel that we could contact when we wanted to run surveys and interviews about pip. In total 472 people signed up to the panel, although some unsubscribed during the research period.
 
 At the end of the 2020 research, we asked users to opt-in to a [long-term panel](https://mail.python.org/mailman3/lists/pip-ux-studies.python.org/), where they can be contacted for future UX studies. Should the pip team wish to continue to build this panel, we recommend translating the sign-up form into multiple languages and better leveraging local communities and outreach groups (e.g. PyLadies) to increase the diversity of the participants.
 
@@ -66,7 +66,7 @@ We **published 10 surveys** to gather feedback about pip's users and their prefe
           Pip research panel survey
         </td>
         <td>
-          Recruit pip users to participate in user research, user tests and participate in future surveys. See <a href="https://bit.ly/pip-ux-studies">associated blog post</a> for more information.
+          Recruit pip users to participate in user research, user tests and participate in future surveys. See <a href="https://web.archive.org/web/2024/https://www.ei8fdb.org/pip-ux-studies-response-data/">associated blog post</a> for more information.
         </td>
         <td>
           472 full sign-ups
@@ -88,7 +88,7 @@ We **published 10 surveys** to gather feedback about pip's users and their prefe
           How should pip handle conflicts with already installed packages when updating other packages?
         </td>
         <td>
-          Determine if the way that pip handles package upgrades is in-line with user's expectations/needs. See <a href="https://www.ei8fdb.org/thoughts/2020/07/how-should-pip-handle-conflicts-when-updating-already-installed-packages/">related blog post</a> and <a href="https://github.com/pypa/pip/issues/7744">GitHub issue</a> for more information.
+          Determine if the way that pip handles package upgrades is in-line with user's expectations/needs. See <a href="https://web.archive.org/web/2024/https://www.ei8fdb.org/thoughts/2020/07/how-should-pip-handle-conflicts-when-updating-already-installed-packages/">related blog post</a> and <a href="https://github.com/pypa/pip/issues/7744">GitHub issue</a> for more information.
         </td>
         <td>
           See <a href="pip-upgrade-conflict">write up, including recommendations</a>
@@ -194,10 +194,10 @@ improving-pips-documentation
 - [Pip team midyear report (blog, July 2020)](https://pyfound.blogspot.com/2020/07/pip-team-midyear-report.html)
 - [Creating rapid CLI prototypes with cli-output (blog, Oct 2020)](https://www.ei8fdb.org/prototyping-command-line-interfaces-with-cli-output/)
 - [Changes are coming to pip (video)](https://www.youtube.com/watch?v=B4GQCBBsuNU)
-- [How should pip handle dependency conflicts when updating already installed packages? (blog, July 2020)](https://www.ei8fdb.org/how-should-pip-handle-conflicts-when-updating-already-installed-packages/)
-- [Test pip's alpha resolver and help us document dependency conflicts (blog, May 2020)](https://www.ei8fdb.org/test-pips-alpha-resolver-and-help-us-document-dependency-conflicts/)
-- [How do you deal with conflicting dependencies caused by pip installs? (blog, April 2020)](https://www.ei8fdb.org/how-do-you-deal-with-conflicting-dependencies-caused-by-pip-installs/)
-- [pip UX studies: response data (blog, March 2020)](https://www.ei8fdb.org/pip-ux-studies-response-data/)
+- [How should pip handle dependency conflicts when updating already installed packages? (blog, July 2020)](https://web.archive.org/web/2024/https://www.ei8fdb.org/how-should-pip-handle-conflicts-when-updating-already-installed-packages/)
+- Test pip's alpha resolver and help us document dependency conflicts (blog, May 2020)
+- [How do you deal with conflicting dependencies caused by pip installs? (blog, April 2020)](https://web.archive.org/web/2024/https://www.ei8fdb.org/how-do-you-deal-with-conflicting-dependencies-caused-by-pip-installs/)
+- [pip UX studies: response data (blog, March 2020)](https://web.archive.org/web/2024/https://www.ei8fdb.org/pip-ux-studies-response-data/)
 
 Other PyPA UX work:
 

--- a/docs/html/ux-research-design/resolution-impossible-example.md
+++ b/docs/html/ux-research-design/resolution-impossible-example.md
@@ -24,7 +24,7 @@ There are a number of possible solutions. You can try:
 4. patching Apple2.0 to use Banana3.0
 5. force installing (Be aware!)
 
-For instructions on how to do these steps visit: https://pypa.io/SomeLink
+For instructions on how to do these steps visit: https://pip.pypa.io/en/latest/
 To debug this further you can run `pip-tree` to see all of your dependencies.
 ```
 


### PR DESCRIPTION
## Summary

Audited all external links in documentation and fixed broken ones.

## Changes

- Fixed GitHub URLs with incorrect format (`@main` → `/tree/main`)
- Fixed trailing comma in GitHub Actions URL
- Replaced dead ei8fdb.org links with Wayback Machine archives
- Fixed patternfly.org URL structure
- Added Wayback Machine fallbacks for simplysecure.org links
- Removed links to pages with no archived version

## Related

Fixes #13664