### PR TITLE
fix: catch BrokenPipeError in _run_wrapper to avoid crash traceback when piping output

### DIFF
--- a/NEWS.d/13877.bugfix.rst
+++ b/NEWS.d/13877.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a crash where piping pip output to a process that exits early (e.g. ``pip show pip | head -1``) raised an unhandled ``BrokenPipeError`` traceback instead of the friendly 'Pipe to stdout was broken' message.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -131,9 +131,13 @@ class Command(CommandContextMixIn):
             logger.debug("Exception information:", exc_info=True)
 
             return ERROR
-        except BrokenStdoutLoggingError:
+        except (BrokenStdoutLoggingError, BrokenPipeError):
             # Bypass our logger and write any remaining messages to
             # stderr because stdout no longer works.
+            # BrokenPipeError can surface directly from PipConsole.on_broken_pipe()
+            # (rich 13.8.0+ changed Console.on_broken_pipe to sys.exit(); pip
+            # overrides it to reraise BrokenPipeError so our handler fires, but
+            # that means the raw BrokenPipeError must also be caught here).
             print("ERROR: Pipe to stdout was broken", file=sys.stderr)
             if level_number <= logging.DEBUG:
                 traceback.print_exc(file=sys.stderr)


### PR DESCRIPTION
Fixes #13877
Related: #11608

## What happened

`PipConsole.on_broken_pipe()` intentionally re-raises a raw `BrokenPipeError` so that pip's broken-pipe handler can fire (rich 13.8.0+ changed the default behaviour of `Console.on_broken_pipe` to `sys.exit()`, which would bypass pip's custom error handling).

However, `_run_wrapper` only caught `BrokenStdoutLoggingError`. The raw `BrokenPipeError` fell through all the typed `except` clauses and landed in the `except BaseException` handler, which printed an ugly crash traceback instead of the clean `"ERROR: Pipe to stdout was broken"` message.

## Reproduction

```sh
pip show pip 2>&1 | head -1
```

## Fix

Extend the existing `except BrokenStdoutLoggingError` clause to also catch `BrokenPipeError`:

```python
except (BrokenStdoutLoggingError, BrokenPipeError):
```

Both exception types represent the same situation (stdout pipe is broken) and should receive identical handling — print to stderr and return `ERROR`.

## Testing

The fix is a one-line change to the exception catch clause. The existing test suite covers the `BrokenStdoutLoggingError` path; the `BrokenPipeError` path follows the exact same branch.