### PR TITLE
Set `slots=True` on dataclasses

### DIFF
--- a/news/13913.feature.rst
+++ b/news/13913.feature.rst
@@ -1,0 +1,1 @@
+Use ``slots=True`` for dataclasses now Python 3.9 has been dropped.

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -422,7 +422,7 @@ class RequirementCommand(IndexGroupCommand):
         options: Values,
         session: PipSession,
         target_python: TargetPython | None = None,
-        ignore_requires_python: bool | None = None,
+        ignore_requires_python: bool = False,
     ) -> PackageFinder:
         """
         Create a package finder appropriate to this requirement command.

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -91,7 +91,7 @@ class IndexCommand(IndexGroupCommand):
         options: Values,
         session: PipSession,
         target_python: TargetPython | None = None,
-        ignore_requires_python: bool | None = None,
+        ignore_requires_python: bool = False,
     ) -> PackageFinder:
         """
         Create a package finder appropriate to the index command.

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -137,7 +137,7 @@ class LinkEvaluator:
         formats: frozenset[str],
         target_python: TargetPython,
         allow_yanked: bool,
-        ignore_requires_python: bool | None = None,
+        ignore_requires_python: bool = False,
         uploaded_prior_to: datetime.datetime | None = None,
     ) -> None:
         """
@@ -159,8 +159,6 @@ class LinkEvaluator:
         :param uploaded_prior_to: If set, only allow links uploaded prior to
             the given datetime.
         """
-        if ignore_requires_python is None:
-            ignore_requires_python = False
 
         self._allow_yanked = allow_yanked
         self._canonical_name = canonical_name
@@ -633,7 +631,7 @@ class PackageFinder:
         allow_yanked: bool,
         format_control: FormatControl | None = None,
         candidate_prefs: CandidatePreferences | None = None,
-        ignore_requires_python: bool | None = None,
+        ignore_requires_python: bool = False,
         uploaded_prior_to: datetime.datetime | None = None,
     ) -> None:
         """

--- a/src/pip/_internal/models/candidate.py
+++ b/src/pip/_internal/models/candidate.py
@@ -6,11 +6,9 @@ from pip._vendor.packaging.version import parse as parse_version
 from pip._internal.models.link import Link
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class InstallationCandidate:
     """Represents a potential "candidate" for installation."""
-
-    __slots__ = ["name", "version", "link"]
 
     name: str
     version: Version

--- a/src/pip/_internal/models/release_control.py
+++ b/src/pip/_internal/models/release_control.py
@@ -7,8 +7,7 @@ from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._internal.exceptions import CommandError
 
 
-# TODO: add slots=True when Python 3.9 is dropped
-@dataclass
+@dataclass(slots=True)
 class ReleaseControl:
     """Helper for managing which release types can be installed."""
 

--- a/src/pip/_internal/models/scheme.py
+++ b/src/pip/_internal/models/scheme.py
@@ -10,13 +10,11 @@ from dataclasses import dataclass
 SCHEME_KEYS = ["platlib", "purelib", "headers", "scripts", "data"]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Scheme:
     """A Scheme holds paths which are used as the base directories for
     artifacts associated with a Python package.
     """
-
-    __slots__ = SCHEME_KEYS
 
     platlib: str
     purelib: str

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -14,13 +14,11 @@ from pip._internal.utils.misc import normalize_path, redact_auth_from_url
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SearchScope:
     """
     Encapsulates the locations that pip is configured to search.
     """
-
-    __slots__ = ["find_links", "index_urls", "no_index"]
 
     find_links: list[str]
     index_urls: list[str]

--- a/src/pip/_internal/models/selection_prefs.py
+++ b/src/pip/_internal/models/selection_prefs.py
@@ -1,56 +1,36 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from pip._internal.models.format_control import FormatControl
 from pip._internal.models.release_control import ReleaseControl
 
 
-# TODO: This needs Python 3.10's improved slots support for dataclasses
-# to be converted into a dataclass.
+@dataclass(slots=True)
 class SelectionPreferences:
     """
     Encapsulates the candidate selection preferences for downloading
     and installing files.
-    """
 
-    __slots__ = [
-        "allow_yanked",
-        "release_control",
-        "format_control",
-        "prefer_binary",
-        "ignore_requires_python",
-    ]
+    :param allow_yanked: Whether files marked as yanked (in the sense
+        of PEP 592) are permitted to be candidates for install.
+    :param release_control: A ReleaseControl object or None. Used to control
+        whether pre-releases are allowed for specific packages.
+    :param format_control: A FormatControl object or None. Used to control
+        the selection of source packages / binary packages when consulting
+        the index and links.
+    :param prefer_binary: Whether to prefer an old, but valid, binary
+        dist over a new source dist.
+    :param ignore_requires_python: Whether to ignore incompatible
+        "Requires-Python" values in links. Defaults to False.
+    """
 
     # Don't include an allow_yanked default value to make sure each call
     # site considers whether yanked releases are allowed. This also causes
     # that decision to be made explicit in the calling code, which helps
     # people when reading the code.
-    def __init__(
-        self,
-        allow_yanked: bool,
-        release_control: ReleaseControl | None = None,
-        format_control: FormatControl | None = None,
-        prefer_binary: bool = False,
-        ignore_requires_python: bool | None = None,
-    ) -> None:
-        """Create a SelectionPreferences object.
-
-        :param allow_yanked: Whether files marked as yanked (in the sense
-            of PEP 592) are permitted to be candidates for install.
-        :param release_control: A ReleaseControl object or None. Used to control
-            whether pre-releases are allowed for specific packages.
-        :param format_control: A FormatControl object or None. Used to control
-            the selection of source packages / binary packages when consulting
-            the index and links.
-        :param prefer_binary: Whether to prefer an old, but valid, binary
-            dist over a new source dist.
-        :param ignore_requires_python: Whether to ignore incompatible
-            "Requires-Python" values in links. Defaults to False.
-        """
-        if ignore_requires_python is None:
-            ignore_requires_python = False
-
-        self.allow_yanked = allow_yanked
-        self.release_control = release_control
-        self.format_control = format_control
-        self.prefer_binary = prefer_binary
-        self.ignore_requires_python = ignore_requires_python
+    allow_yanked: bool
+    release_control: ReleaseControl | None = None
+    format_control: FormatControl | None = None
+    prefer_binary: bool = False
+    ignore_requires_python: bool = False

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -101,18 +101,8 @@ DEFAULT_ENCODING = "utf-8"
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ParsedRequirement:
-    # TODO: replace this with slots=True when dropping Python 3.9 support.
-    __slots__ = (
-        "requirement",
-        "is_editable",
-        "comes_from",
-        "constraint",
-        "options",
-        "line_source",
-    )
-
     requirement: str
     is_editable: bool
     comes_from: str
@@ -121,10 +111,8 @@ class ParsedRequirement:
     line_source: str | None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ParsedLine:
-    __slots__ = ("filename", "lineno", "args", "opts", "constraint")
-
     filename: str
     lineno: int
     args: str


### PR DESCRIPTION
Fixes https://github.com/pypa/pip/issues/13325

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Split out from the Python 3.9 drop PR: https://github.com/pypa/pip/pull/13905#issuecomment-4231780357.