### PR TITLE
Fix: redirect console logs to stderr when writing JSON report to stdout

### DIFF
--- a/news/13898.bugfix.rst
+++ b/news/13898.bugfix.rst
@@ -1,0 +1,2 @@
+When writing JSON report to stdout (:option:`pip install --report -`), console
+logs are now also sent to stderr, preventing output from being interleaved.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -180,6 +180,7 @@ class Command(CommandContextMixIn):
             options.progress_bar = "on" if self.verbosity >= 0 else "off"
 
         reconfigure(no_color=options.no_color)
+
         level_number = setup_logging(
             verbosity=self.verbosity,
             no_color=options.no_color,

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -280,7 +280,6 @@ def setup_logging(verbosity: int, no_color: bool, user_log_file: str | None) -> 
 
     Returns the requested logging level, as its integer value.
     """
-
     # Determine the level to be logging at.
     if verbosity >= 2:
         level_number = logging.DEBUG
@@ -319,9 +318,10 @@ def setup_logging(verbosity: int, no_color: bool, user_log_file: str | None) -> 
     handlers = ["console", "console_errors", "console_subprocess"] + (
         ["user_log"] if include_user_log else []
     )
-    global _stdout_console, stderr_console
-    _stdout_console = PipConsole(file=sys.stdout, no_color=no_color, soft_wrap=True)
+    global _stdout_console, _stderr_console
     _stderr_console = PipConsole(file=sys.stderr, no_color=no_color, soft_wrap=True)
+    # Globally direct all console logs to stderr to keep stdout clean for command output
+    _stdout_console = PipConsole(file=sys.stderr, no_color=no_color, soft_wrap=True)
 
     logging.config.dictConfig(
         {


### PR DESCRIPTION
Good day,

Thank you for your work on pip!

This PR fixes issue #13898. When using 'pip install --report -' to write JSON report to stdout, pip's log messages (Collecting, Using cached, etc.) were also written to stdout, making the output unparseable as JSON.

This fix automatically redirects console logs to stderr when --report - is used, so users no longer need to add --quiet to get valid JSON output.

I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof