### PR TITLE
fix: use --ignore-installed in RECORD-missing recovery hint

### DIFF
--- a/news/12645.bugfix.rst
+++ b/news/12645.bugfix.rst
@@ -1,0 +1,1 @@
+Fix recovery hint for missing RECORD file to use --ignore-installed instead of --force-reinstall.

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -769,7 +769,7 @@ class UninstallMissingRecord(DiagnosticPipError):
             dep = f"{distribution.raw_name}=={distribution.version}"
             hint = Text.assemble(
                 "You might be able to recover from this via: ",
-                (f"pip install --force-reinstall --no-deps {dep}", "green"),
+                (f"pip install --ignore-installed --no-deps {dep}", "green"),
             )
         else:
             hint = Text(

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -595,7 +595,7 @@ def test_uninstall_without_record_fails(
     if not isinstance(installer, str) or not installer.strip() or installer == "pip":
         hint = (
             "You might be able to recover from this via: "
-            "pip install --force-reinstall --no-deps simple.dist==0.1"
+            "pip install --ignore-installed --no-deps simple.dist==0.1"
         )
     elif installer:
         hint = f"The package was installed by {installer}."

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -8,12 +8,11 @@ import logging
 import pathlib
 import sys
 import textwrap
+from unittest.mock import MagicMock
 
 import pytest
 
 from pip._vendor import rich
-
-from unittest.mock import MagicMock
 
 from pip._internal.exceptions import (
     DiagnosticPipError,
@@ -493,7 +492,7 @@ class TestUninstallMissingRecord:
         dist.raw_name = name
         dist.version = version
         dist.installer = installer
-        dist.__str__ = lambda self: f"{name} {version}"
+        dist.__str__ = MagicMock(return_value=f"{name} {version}")  # type: ignore[method-assign]
         return dist
 
     def test_pip_installed_hint_uses_ignore_installed(

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -13,7 +13,13 @@ import pytest
 
 from pip._vendor import rich
 
-from pip._internal.exceptions import DiagnosticPipError, ExternallyManagedEnvironment
+from unittest.mock import MagicMock
+
+from pip._internal.exceptions import (
+    DiagnosticPipError,
+    ExternallyManagedEnvironment,
+    UninstallMissingRecord,
+)
 
 
 class TestDiagnosticPipErrorCreation:
@@ -479,6 +485,52 @@ class TestDiagnosticPipErrorPresentation_Unicode:
               It broke. :(
             """
         )
+
+
+class TestUninstallMissingRecord:
+    def _make_dist(self, name: str, version: str, installer: str = "pip") -> MagicMock:
+        dist = MagicMock()
+        dist.raw_name = name
+        dist.version = version
+        dist.installer = installer
+        dist.__str__ = lambda self: f"{name} {version}"
+        return dist
+
+    def test_pip_installed_hint_uses_ignore_installed(
+        self,
+    ) -> None:
+        """Recovery hint must use --ignore-installed, not --force-reinstall.
+
+        --force-reinstall triggers an uninstall first, which fails with the
+        same RECORD-missing error, creating an infinite loop.  --ignore-installed
+        skips the uninstall step and writes fresh package files directly.
+        """
+        dist = self._make_dist("mypackage", "1.2.3", installer="pip")
+        err = UninstallMissingRecord(distribution=dist)
+        hint_text = str(err.hint_stmt)
+        assert "--ignore-installed" in hint_text
+        assert "--force-reinstall" not in hint_text
+        assert "--no-deps" in hint_text
+        assert "mypackage==1.2.3" in hint_text
+
+    def test_empty_installer_also_uses_ignore_installed(self) -> None:
+        """Empty installer string is treated the same as pip-installed."""
+        dist = self._make_dist("mypkg", "0.1", installer="")
+        err = UninstallMissingRecord(distribution=dist)
+        hint_text = str(err.hint_stmt)
+        assert "--ignore-installed" in hint_text
+        assert "--force-reinstall" not in hint_text
+
+    def test_third_party_installer_hint(
+        self,
+    ) -> None:
+        """Non-pip installer produces a different hint pointing to that tool."""
+        dist = self._make_dist("mypkg", "0.1", installer="conda")
+        err = UninstallMissingRecord(distribution=dist)
+        hint_text = str(err.hint_stmt)
+        assert "conda" in hint_text
+        assert "--ignore-installed" not in hint_text
+        assert "--force-reinstall" not in hint_text
 
 
 class TestExternallyManagedEnvironment:


### PR DESCRIPTION
## Summary

Fixes #12645.

The recovery hint shown when a package RECORD file is missing currently suggests:

```
pip install --force-reinstall --no-deps <pkg>
```

This is circular — `--force-reinstall` attempts an uninstall first, which fails immediately with the same RECORD-missing error, leaving the user stuck in a loop with no way out except manually editing their pip config.

The correct flag is `--ignore-installed`, which skips the uninstall step entirely and writes fresh package files directly.

## Changes

- `exceptions.py`: replace `--force-reinstall` with `--ignore-installed` in `UninstallMissingRecord` hint
- `tests/unit/test_exceptions.py`: add `TestUninstallMissingRecord` covering pip-installed, empty-installer, and third-party-installer cases
- `tests/functional/test_uninstall.py`: update existing functional test to match corrected hint text
- `news/12645.bugfix.rst`: news entry