### PR TITLE
fix: resolve Fatal Internal error [id=1] on pip config unset with multiple config files

### DIFF
--- a/news/12706.bugfix.rst
+++ b/news/12706.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Fatal Internal error [id=1] raised by pip config unset when the target key lives in a lower-priority config file.

--- a/src/pip/_internal/configuration.py
+++ b/src/pip/_internal/configuration.py
@@ -186,30 +186,48 @@ class Configuration:
         assert self.load_only
         fname, parser = self._get_parser_to_modify()
 
-        if (
-            key not in self._config[self.load_only][fname]
-            and key not in self._config[self.load_only]
-        ):
+        # Check across ALL files for this variant, not just the highest-priority
+        # one.  A key set in a lower-priority file is still a valid key to unset.
+        key_exists = any(
+            key in file_values
+            for file_values in self._config[self.load_only].values()
+        )
+        if not key_exists:
             raise ConfigurationError(f"No such key - {orig_key}")
 
         if parser is not None:
             section, name = _disassemble_key(key)
-            if not (
-                parser.has_section(section) and parser.remove_option(section, name)
-            ):
-                # The option was not removed.
+
+            # The key may have been loaded from a lower-priority config file
+            # while _get_parser_to_modify() returns the highest-priority one.
+            # Search all parsers for the load_only variant to find the one
+            # that actually owns this key, so we remove it from the right file.
+            target_fname = fname
+            target_parser = parser
+            for candidate_fname, candidate_parser in self._parsers[self.load_only]:
+                if candidate_parser.has_section(section) and candidate_parser.has_option(
+                    section, name
+                ):
+                    target_fname = candidate_fname
+                    target_parser = candidate_parser
+                    break
+
+            if not target_parser.remove_option(section, name):
+                # The option was not removed — this should not happen given
+                # the search above, but guard against it defensively.
                 raise ConfigurationError(
                     "Fatal Internal error [id=1]. Please report as a bug."
                 )
 
             # The section may be empty after the option was removed.
-            if not parser.items(section):
-                parser.remove_section(section)
-            self._mark_as_modified(fname, parser)
-        try:
-            del self._config[self.load_only][fname][key]
-        except KeyError:
-            del self._config[self.load_only][key]
+            if not target_parser.items(section):
+                target_parser.remove_section(section)
+            self._mark_as_modified(target_fname, target_parser)
+        # Remove the key from whichever file dict in _config actually owns it.
+        for file_values in self._config[self.load_only].values():
+            if key in file_values:
+                del file_values[key]
+                break
 
     def save(self) -> None:
         """Save the current in-memory state."""

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,11 +1,12 @@
 """Tests for all things related to the configuration"""
 
+import configparser
 import re
 from unittest.mock import MagicMock
 
 import pytest
 
-from pip._internal.configuration import get_configuration_files, kinds
+from pip._internal.configuration import Configuration, get_configuration_files, kinds
 from pip._internal.exceptions import ConfigurationError
 
 from tests.lib.configuration_helpers import ConfigurationMixin
@@ -270,3 +271,77 @@ class TestConfigurationModification(ConfigurationMixin):
         pat = r"^No such key - global\.index-url$"
         with pytest.raises(ConfigurationError, match=pat):
             self.configuration.get_value("global.index-url")
+
+
+class TestConfigurationUnsetMultipleFiles:
+    """Tests for unset_value when multiple config files exist (issue #12706).
+
+    When multiple files of the same kind are present (e.g. two global config
+    files), _get_parser_to_modify() returns the highest-priority parser, but
+    the key to be removed may live in a lower-priority file.  The old code
+    would raise 'Fatal Internal error [id=1]' in that case because it tried
+    to remove the option from the wrong parser.
+    """
+
+    def _make_config_with_two_parsers(
+        self, key_in_first: str, value: str
+    ) -> Configuration:
+        """Build a Configuration whose global variant has two parsers.
+
+        The key lives in the *first* (lower-priority) parser; the second
+        (higher-priority) parser is empty.  This is the scenario that
+        triggered the Fatal Internal error [id=1].
+        """
+        config = Configuration(isolated=False)
+        config.load_only = kinds.GLOBAL
+
+        # First parser: owns the key
+        parser_a = configparser.RawConfigParser()
+        section, name = key_in_first.split(".", 1)
+        parser_a.add_section(section)
+        parser_a.set(section, name, value)
+        config._parsers[kinds.GLOBAL].append(("file_a.conf", parser_a))
+        config._config[kinds.GLOBAL]["file_a.conf"] = {key_in_first: value}
+
+        # Second parser: higher priority but empty — simulates a second global
+        # config file that does not contain this key.
+        parser_b = configparser.RawConfigParser()
+        config._parsers[kinds.GLOBAL].append(("file_b.conf", parser_b))
+        config._config[kinds.GLOBAL]["file_b.conf"] = {}
+
+        return config
+
+    def test_unset_from_lower_priority_file_does_not_raise(self) -> None:
+        """unset_value must not raise when the key is in a non-primary parser.
+
+        Before the fix this raised:
+          ConfigurationError: Fatal Internal error [id=1]. Please report as a bug.
+        """
+        config = self._make_config_with_two_parsers("global.no-cache-dir", "true")
+
+        # Must not raise — this is the regression test for #12706
+        config.unset_value("global.no-cache-dir")
+
+    def test_unset_removes_key_from_correct_file(self) -> None:
+        """After unset_value the key must be gone from the config."""
+        config = self._make_config_with_two_parsers("global.index-url", "https://example.com")
+
+        config.unset_value("global.index-url")
+
+        # The key must no longer appear in any file under global
+        all_keys = {}
+        for file_dict in config._config[kinds.GLOBAL].values():
+            all_keys.update(file_dict)
+        assert "global.index-url" not in all_keys
+
+    def test_unset_marks_correct_file_as_modified(self) -> None:
+        """_mark_as_modified must be called with the file that owns the key."""
+        config = self._make_config_with_two_parsers("global.retries", "5")
+
+        modified = []
+        config._mark_as_modified = lambda fname, parser: modified.append(fname)  # type: ignore[method-assign]
+
+        config.unset_value("global.retries")
+
+        # Should have marked file_a (the owner), not file_b (the empty one)
+        assert modified == ["file_a.conf"]


### PR DESCRIPTION
## Summary

Fixes #12706.

Running `pip config unset global.no-cache-dir` (or any key) raises:

```
ERROR: Fatal Internal error [id=1]. Please report as a bug.
```

when multiple configuration files of the same kind exist (e.g. `/etc/xdg/pip/pip.conf` and `/etc/pip.conf` both present as global configs).

## Root cause

Two bugs in `unset_value()`:

1. The "No such key" guard checked only `_config[load_only][fname]` where `fname` comes from `_get_parser_to_modify()` (the highest-priority file). If the key lived in a lower-priority file the check incorrectly raised "No such key".

2. The parser search used only the highest-priority parser. `parser.has_section()` returned `False` because the section lived in a different file, falling through to "Fatal Internal error [id=1]".

## Fix

- Existence check now scans all file dicts for the `load_only` variant
- Parser search iterates all parsers in the variant to find the one that actually owns the section+option
- In-memory `_config` deletion also targets the correct file dict

## Changes

- `configuration.py`: fix `unset_value()` to search all parsers for the target variant
- `tests/unit/test_configuration.py`: add `TestConfigurationUnsetMultipleFiles` with 3 regression tests
- `news/12706.bugfix.rst`: news entry