### PR TITLE
Split the pip self-version check to get info before run

### DIFF
--- a/news/13923.trivial.rst
+++ b/news/13923.trivial.rst
@@ -1,0 +1,2 @@
+Split the pip self-version check into a fetch phase before the command
+body and an emit phase afterwards.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import logging.config
 import optparse
 import os
 import sys
 import traceback
+from collections.abc import Iterator
 from optparse import Values
 from typing import Callable
 
@@ -80,7 +82,8 @@ class Command(CommandContextMixIn):
     def add_options(self) -> None:
         pass
 
-    def handle_pip_version_check(self, options: Values) -> None:
+    @contextlib.contextmanager
+    def pip_version_check(self, options: Values) -> Iterator[None]:
         """
         This is a no-op so that commands by default do not do the pip version
         check.
@@ -88,16 +91,15 @@ class Command(CommandContextMixIn):
         # Make sure we do the pip version check if the index_group options
         # are present.
         assert not hasattr(options, "no_index")
+        yield
 
     def run(self, options: Values, args: list[str]) -> int:
         raise NotImplementedError
 
     def _run_wrapper(self, level_number: int, options: Values, args: list[str]) -> int:
         def _inner_run() -> int:
-            try:
+            with self.pip_version_check(options):
                 return self.run(options, args)
-            finally:
-                self.handle_pip_version_check(options)
 
         if options.debug_mode:
             rich_traceback.install(show_locals=True)

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -83,7 +83,7 @@ class Command(CommandContextMixIn):
         pass
 
     @contextlib.contextmanager
-    def pip_version_check(self, options: Values) -> Iterator[None]:
+    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
         """
         This is a no-op so that commands by default do not do the pip version
         check.
@@ -98,7 +98,7 @@ class Command(CommandContextMixIn):
 
     def _run_wrapper(self, level_number: int, options: Values, args: list[str]) -> int:
         def _inner_run() -> int:
-            with self.pip_version_check(options):
+            with self.pip_version_check(options, args):
                 return self.run(options, args)
 
         if options.debug_mode:

--- a/src/pip/_internal/cli/index_command.py
+++ b/src/pip/_internal/cli/index_command.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from pip._vendor.packaging.utils import NormalizedName
 
     from pip._internal.network.session import PipSession
+    from pip._internal.self_outdated_check import UpgradePrompt
 
 logger = logging.getLogger(__name__)
 
@@ -136,16 +137,18 @@ class SessionCommandMixin(CommandContextMixIn):
         return session
 
 
-def _pip_self_version_check_fetch(session: PipSession, options: Values) -> str | None:
+def _pip_self_version_check_fetch(
+    session: PipSession, options: Values
+) -> UpgradePrompt | None:
     from pip._internal.self_outdated_check import pip_self_version_check_fetch
 
     return pip_self_version_check_fetch(session, options)
 
 
-def _pip_self_version_check_emit(remote_version_str: str | None) -> None:
+def _pip_self_version_check_emit(upgrade_prompt: UpgradePrompt | None) -> None:
     from pip._internal.self_outdated_check import pip_self_version_check_emit
 
-    pip_self_version_check_emit(remote_version_str)
+    pip_self_version_check_emit(upgrade_prompt)
 
 
 class IndexGroupCommand(Command, SessionCommandMixin):
@@ -173,7 +176,7 @@ class IndexGroupCommand(Command, SessionCommandMixin):
         return True
 
     @contextlib.contextmanager
-    def pip_version_check(self, options: Values) -> Iterator[None]:
+    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
         """
         Do the pip version check if not disabled.
 
@@ -186,7 +189,7 @@ class IndexGroupCommand(Command, SessionCommandMixin):
             yield
             return
 
-        remote_version_str: str | None = None
+        upgrade_prompt: UpgradePrompt | None = None
         try:
             session = self._build_session(
                 options,
@@ -194,20 +197,16 @@ class IndexGroupCommand(Command, SessionCommandMixin):
                 timeout=min(5, options.timeout),
             )
             with session:
-                remote_version_str = _pip_self_version_check_fetch(session, options)
+                upgrade_prompt = _pip_self_version_check_fetch(session, options)
         except Exception:
             logger.warning("There was an error checking the latest version of pip.")
             logger.debug("See below for error", exc_info=True)
-
-        if remote_version_str is None:
-            yield
-            return
 
         try:
             yield
         finally:
             try:
-                _pip_self_version_check_emit(remote_version_str)
+                _pip_self_version_check_emit(upgrade_prompt)
             except Exception:
                 logger.warning("There was an error checking the latest version of pip.")
                 logger.debug("See below for error", exc_info=True)

--- a/src/pip/_internal/cli/index_command.py
+++ b/src/pip/_internal/cli/index_command.py
@@ -8,8 +8,10 @@ so commands which don't always hit the network (e.g. list w/o --outdated or
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
+from collections.abc import Iterator
 from functools import lru_cache
 from optparse import Values
 from typing import TYPE_CHECKING
@@ -134,10 +136,16 @@ class SessionCommandMixin(CommandContextMixIn):
         return session
 
 
-def _pip_self_version_check(session: PipSession, options: Values) -> None:
-    from pip._internal.self_outdated_check import pip_self_version_check as check
+def _pip_self_version_check_fetch(session: PipSession, options: Values) -> str | None:
+    from pip._internal.self_outdated_check import pip_self_version_check_fetch
 
-    check(session, options)
+    return pip_self_version_check_fetch(session, options)
+
+
+def _pip_self_version_check_emit(remote_version_str: str | None) -> None:
+    from pip._internal.self_outdated_check import pip_self_version_check_emit
+
+    pip_self_version_check_emit(remote_version_str)
 
 
 class IndexGroupCommand(Command, SessionCommandMixin):
@@ -164,7 +172,8 @@ class IndexGroupCommand(Command, SessionCommandMixin):
         # No specific setting: exclude prereleases by default
         return True
 
-    def handle_pip_version_check(self, options: Values) -> None:
+    @contextlib.contextmanager
+    def pip_version_check(self, options: Values) -> Iterator[None]:
         """
         Do the pip version check if not disabled.
 
@@ -174,17 +183,31 @@ class IndexGroupCommand(Command, SessionCommandMixin):
         assert hasattr(options, "no_index")
 
         if options.disable_pip_version_check or options.no_index:
+            yield
             return
 
+        remote_version_str: str | None = None
         try:
-            # Otherwise, check if we're using the latest version of pip available.
             session = self._build_session(
                 options,
                 retries=0,
                 timeout=min(5, options.timeout),
             )
             with session:
-                _pip_self_version_check(session, options)
+                remote_version_str = _pip_self_version_check_fetch(session, options)
         except Exception:
             logger.warning("There was an error checking the latest version of pip.")
             logger.debug("See below for error", exc_info=True)
+
+        if remote_version_str is None:
+            yield
+            return
+
+        try:
+            yield
+        finally:
+            try:
+                _pip_self_version_check_emit(remote_version_str)
+            except Exception:
+                logger.warning("There was an error checking the latest version of pip.")
+                logger.debug("See below for error", exc_info=True)

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import contextlib
 import errno
 import json
 import operator
 import os
 import shutil
 import site
+from collections.abc import Iterator
 from optparse import SUPPRESS_HELP, Values
 from pathlib import Path
 
+from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.requests.exceptions import InvalidProxyURL
 from pip._vendor.rich import print_json
@@ -61,6 +64,14 @@ from pip._internal.utils.virtualenv import (
 from pip._internal.wheel_builder import build
 
 logger = getLogger(__name__)
+
+
+def _arg_refers_to_pip(arg: str) -> bool:
+    try:
+        req = Requirement(arg)
+    except InvalidRequirement:
+        return False
+    return canonicalize_name(req.name) == "pip"
 
 
 class InstallCommand(RequirementCommand):
@@ -277,6 +288,17 @@ class InstallCommand(RequirementCommand):
                 "to avoid mixing pip logging output with JSON output."
             ),
         )
+
+    @contextlib.contextmanager
+    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
+        # Skip the self-version check when pip itself is a requirement. The
+        # running pip may be replaced mid-command, and the upgrade prompt
+        # is redundant.
+        if any(_arg_refers_to_pip(arg) for arg in args):
+            yield
+            return
+        with super().pip_version_check(options, args):
+            yield
 
     @with_cleanup
     def run(self, options: Values, args: list[str]) -> int:

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -137,11 +137,11 @@ class ListCommand(IndexGroupCommand):
         self.parser.insert_option_group(0, self.cmd_opts)
 
     @contextlib.contextmanager
-    def pip_version_check(self, options: Values) -> Iterator[None]:
+    def pip_version_check(self, options: Values, args: list[str]) -> Iterator[None]:
         if not (options.outdated or options.uptodate):
             yield
             return
-        with super().pip_version_check(options):
+        with super().pip_version_check(options, args):
             yield
 
     def _build_package_finder(

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, Iterator, Sequence
 from email.parser import Parser
 from optparse import Values
 from typing import TYPE_CHECKING, cast
@@ -135,9 +136,13 @@ class ListCommand(IndexGroupCommand):
         self.parser.insert_option_group(0, selection_opts)
         self.parser.insert_option_group(0, self.cmd_opts)
 
-    def handle_pip_version_check(self, options: Values) -> None:
-        if options.outdated or options.uptodate:
-            super().handle_pip_version_check(options)
+    @contextlib.contextmanager
+    def pip_version_check(self, options: Values) -> Iterator[None]:
+        if not (options.outdated or options.uptodate):
+            yield
+            return
+        with super().pip_version_check(options):
+            yield
 
     def _build_package_finder(
         self, options: Values, session: PipSession

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import functools
 import hashlib
 import json
 import logging
@@ -194,21 +193,9 @@ def _get_current_remote_pip_version(
     return str(best_candidate.version)
 
 
-def _self_version_check_logic(
-    *,
-    state: SelfCheckState,
-    current_time: datetime.datetime,
-    local_version: Version,
-    get_remote_version: Callable[[], str | None],
+def _compute_upgrade_prompt(
+    local_version: Version, remote_version_str: str
 ) -> UpgradePrompt | None:
-    remote_version_str = state.get(current_time)
-    if remote_version_str is None:
-        remote_version_str = get_remote_version()
-        if remote_version_str is None:
-            logger.debug("No remote pip version found")
-            return None
-        state.set(remote_version_str, current_time)
-
     remote_version = parse_version(remote_version_str)
     logger.debug("Remote version of pip: %s", remote_version)
     logger.debug("Local version of pip:  %s", local_version)
@@ -228,13 +215,57 @@ def _self_version_check_logic(
     return None
 
 
-def pip_self_version_check(session: PipSession, options: optparse.Values) -> None:
-    """Check for an update for pip.
+def _self_version_check_logic(
+    *,
+    state: SelfCheckState,
+    current_time: datetime.datetime,
+    local_version: Version,
+    get_remote_version: Callable[[], str | None],
+) -> UpgradePrompt | None:
+    remote_version_str = state.get(current_time)
+    if remote_version_str is None:
+        remote_version_str = get_remote_version()
+        if remote_version_str is None:
+            logger.debug("No remote pip version found")
+            return None
+        state.set(remote_version_str, current_time)
+    return _compute_upgrade_prompt(local_version, remote_version_str)
 
-    Limit the frequency of checks to once per week. State is stored either in
-    the active virtualenv or in the user's USER_CACHE_DIR keyed off the prefix
-    of the pip script path.
+
+def pip_self_version_check_fetch(
+    session: PipSession, options: optparse.Values
+) -> str | None:
+    """Return the latest pip version from the index, or None.
+
+    Pair with :func:`pip_self_version_check_emit`.
     """
+    installed_dist = get_default_environment().get_distribution("pip")
+    if not installed_dist:
+        return None
+    try:
+        check_externally_managed()
+    except ExternallyManagedEnvironment:
+        return None
+
+    state = SelfCheckState(cache_dir=options.cache_dir)
+    current_time = datetime.datetime.now(datetime.timezone.utc)
+    remote_version_str = state.get(current_time)
+    if remote_version_str is not None:
+        return remote_version_str
+
+    remote_version_str = _get_current_remote_pip_version(session, options)
+    if remote_version_str is None:
+        logger.debug("No remote pip version found")
+        return None
+    state.set(remote_version_str, current_time)
+    return remote_version_str
+
+
+def pip_self_version_check_emit(remote_version_str: str | None) -> None:
+    """Emit the upgrade prompt if the installed pip is older than the remote."""
+    if remote_version_str is None:
+        return
+
     installed_dist = get_default_environment().get_distribution("pip")
     if not installed_dist:
         return
@@ -243,13 +274,6 @@ def pip_self_version_check(session: PipSession, options: optparse.Values) -> Non
     except ExternallyManagedEnvironment:
         return
 
-    upgrade_prompt = _self_version_check_logic(
-        state=SelfCheckState(cache_dir=options.cache_dir),
-        current_time=datetime.datetime.now(datetime.timezone.utc),
-        local_version=installed_dist.version,
-        get_remote_version=functools.partial(
-            _get_current_remote_pip_version, session, options
-        ),
-    )
+    upgrade_prompt = _compute_upgrade_prompt(installed_dist.version, remote_version_str)
     if upgrade_prompt is not None:
         logger.warning("%s", upgrade_prompt, extra={"rich": True})

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -8,7 +8,6 @@ import optparse
 import os.path
 import sys
 from dataclasses import dataclass
-from typing import Callable
 
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
@@ -155,16 +154,6 @@ class UpgradePrompt:
         )
 
 
-def was_installed_by_pip(pkg: str) -> bool:
-    """Checks whether pkg was installed by pip
-
-    This is used not to display the upgrade message when pip is in fact
-    installed by system package manager, such as dnf on Fedora.
-    """
-    dist = get_default_environment().get_distribution(pkg)
-    return dist is not None and "pip" == dist.installer
-
-
 def _get_current_remote_pip_version(
     session: PipSession, options: optparse.Values
 ) -> str | None:
@@ -194,15 +183,14 @@ def _get_current_remote_pip_version(
 
 
 def _compute_upgrade_prompt(
-    local_version: Version, remote_version_str: str
+    local_version: Version, remote_version_str: str, installed_by_pip: bool
 ) -> UpgradePrompt | None:
     remote_version = parse_version(remote_version_str)
     logger.debug("Remote version of pip: %s", remote_version)
     logger.debug("Local version of pip:  %s", local_version)
+    logger.debug("Was pip installed by pip? %s", installed_by_pip)
 
-    pip_installed_by_pip = was_installed_by_pip("pip")
-    logger.debug("Was pip installed by pip? %s", pip_installed_by_pip)
-    if not pip_installed_by_pip:
+    if not installed_by_pip:
         return None  # Only suggest upgrade if pip is installed by pip.
 
     local_version_is_older = (
@@ -215,29 +203,17 @@ def _compute_upgrade_prompt(
     return None
 
 
-def _self_version_check_logic(
-    *,
-    state: SelfCheckState,
-    current_time: datetime.datetime,
-    local_version: Version,
-    get_remote_version: Callable[[], str | None],
-) -> UpgradePrompt | None:
-    remote_version_str = state.get(current_time)
-    if remote_version_str is None:
-        remote_version_str = get_remote_version()
-        if remote_version_str is None:
-            logger.debug("No remote pip version found")
-            return None
-        state.set(remote_version_str, current_time)
-    return _compute_upgrade_prompt(local_version, remote_version_str)
-
-
 def pip_self_version_check_fetch(
     session: PipSession, options: optparse.Values
-) -> str | None:
-    """Return the latest pip version from the index, or None.
+) -> UpgradePrompt | None:
+    """Compute the pip upgrade prompt, if any, before the command runs.
 
-    Pair with :func:`pip_self_version_check_emit`.
+    Limit the frequency of checks to once per week. State is stored either in
+    the active virtualenv or in the user's USER_CACHE_DIR keyed off the prefix
+    of the pip script path.
+
+    Pair with :func:`pip_self_version_check_emit`, which displays the prompt
+    after the command body runs.
     """
     installed_dist = get_default_environment().get_distribution("pip")
     if not installed_dist:
@@ -250,30 +226,21 @@ def pip_self_version_check_fetch(
     state = SelfCheckState(cache_dir=options.cache_dir)
     current_time = datetime.datetime.now(datetime.timezone.utc)
     remote_version_str = state.get(current_time)
-    if remote_version_str is not None:
-        return remote_version_str
-
-    remote_version_str = _get_current_remote_pip_version(session, options)
     if remote_version_str is None:
-        logger.debug("No remote pip version found")
-        return None
-    state.set(remote_version_str, current_time)
-    return remote_version_str
+        remote_version_str = _get_current_remote_pip_version(session, options)
+        if remote_version_str is None:
+            logger.debug("No remote pip version found")
+            return None
+        state.set(remote_version_str, current_time)
+
+    return _compute_upgrade_prompt(
+        local_version=installed_dist.version,
+        remote_version_str=remote_version_str,
+        installed_by_pip=installed_dist.installer == "pip",
+    )
 
 
-def pip_self_version_check_emit(remote_version_str: str | None) -> None:
-    """Emit the upgrade prompt if the installed pip is older than the remote."""
-    if remote_version_str is None:
-        return
-
-    installed_dist = get_default_environment().get_distribution("pip")
-    if not installed_dist:
-        return
-    try:
-        check_externally_managed()
-    except ExternallyManagedEnvironment:
-        return
-
-    upgrade_prompt = _compute_upgrade_prompt(installed_dist.version, remote_version_str)
+def pip_self_version_check_emit(upgrade_prompt: UpgradePrompt | None) -> None:
+    """Emit the upgrade prompt captured by :func:`pip_self_version_check_fetch`."""
     if upgrade_prompt is not None:
         logger.warning("%s", upgrade_prompt, extra={"rich": True})

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -100,14 +100,14 @@ class TestCommand:
         assert "Traceback (most recent call last):" in stderr
 
 
-@patch("pip._internal.cli.index_command.Command.handle_pip_version_check")
-def test_handle_pip_version_check_called(mock_handle_version_check: Mock) -> None:
+@patch("pip._internal.cli.index_command.Command.pip_version_check")
+def test_pip_version_check_called(mock_version_check: Mock) -> None:
     """
-    Check that Command.handle_pip_version_check() is called.
+    Check that ``Command.pip_version_check()`` wraps the command body.
     """
     cmd = FakeCommand()
     cmd.main([])
-    mock_handle_version_check.assert_called_once()
+    mock_version_check.assert_called_once()
 
 
 def test_debug_enables_verbose_logs() -> None:

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -126,12 +126,36 @@ def test_index_group_pip_version_check(
     if command_name == "list":
         expected_called = False
 
-    with command.pip_version_check(options):
+    with command.pip_version_check(options, []):
         pass
     if expected_called:
         mock_version_check.assert_called_once()
     else:
         mock_version_check.assert_not_called()
+
+
+@mock.patch("pip._internal.cli.index_command._pip_self_version_check_fetch")
+def test_install_pip_version_check_skipped_when_pip_is_a_requirement(
+    mock_version_check: mock.Mock,
+) -> None:
+    """``pip install pip`` must skip the self-version check: the running pip
+    may be replaced before emit."""
+    command = create_command("install")
+    options = command.parser.get_default_values()
+    options.disable_pip_version_check = False
+    options.no_index = False
+
+    with command.pip_version_check(options, ["pip"]):
+        pass
+    mock_version_check.assert_not_called()
+
+    with command.pip_version_check(options, ["pip==25.0"]):
+        pass
+    mock_version_check.assert_not_called()
+
+    with command.pip_version_check(options, ["some-other-pkg"]):
+        pass
+    mock_version_check.assert_called_once()
 
 
 def test_requirement_commands() -> None:

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -95,16 +95,16 @@ def test_index_group_commands() -> None:
 @pytest.mark.parametrize(
     "disable_pip_version_check, no_index, expected_called",
     [
-        # pip_self_version_check() is only called when both
-        # disable_pip_version_check and no_index are False.
+        # The fetch phase only runs when both disable_pip_version_check
+        # and no_index are False.
         (False, False, True),
         (False, True, False),
         (True, False, False),
         (True, True, False),
     ],
 )
-@mock.patch("pip._internal.cli.index_command._pip_self_version_check")
-def test_index_group_handle_pip_version_check(
+@mock.patch("pip._internal.cli.index_command._pip_self_version_check_fetch")
+def test_index_group_pip_version_check(
     mock_version_check: mock.Mock,
     command_name: str,
     disable_pip_version_check: bool,
@@ -112,20 +112,22 @@ def test_index_group_handle_pip_version_check(
     expected_called: bool,
 ) -> None:
     """
-    Test whether pip_self_version_check() is called when
-    handle_pip_version_check() is called, for each of the
-    IndexGroupCommand classes.
+    Test whether the pre-body fetch runs when ``pip_version_check()`` is
+    entered, for each of the IndexGroupCommand classes.
     """
     command = create_command(command_name)
     options = command.parser.get_default_values()
     options.disable_pip_version_check = disable_pip_version_check
     options.no_index = no_index
+    # Return None so the emit branch is a no-op.
+    mock_version_check.return_value = None
 
     # See test test_list_pip_version_check() below.
     if command_name == "list":
         expected_called = False
 
-    command.handle_pip_version_check(options)
+    with command.pip_version_check(options):
+        pass
     if expected_called:
         mock_version_check.assert_called_once()
     else:
@@ -144,7 +146,7 @@ def test_requirement_commands() -> None:
 
 
 @pytest.mark.parametrize("flag", ["", "--outdated", "--uptodate"])
-@mock.patch("pip._internal.cli.index_command._pip_self_version_check")
+@mock.patch("pip._internal.cli.index_command._pip_self_version_check_fetch")
 @mock.patch.dict(os.environ, {"PIP_DISABLE_PIP_VERSION_CHECK": "no"})
 def test_list_pip_version_check(version_check_mock: mock.Mock, flag: str) -> None:
     """

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -7,7 +7,7 @@ import os
 import sys
 from optparse import Values
 from pathlib import Path
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from freezegun import freeze_time
@@ -15,7 +15,11 @@ from freezegun import freeze_time
 from pip._vendor.packaging.version import Version
 
 from pip._internal import self_outdated_check
-from pip._internal.self_outdated_check import UpgradePrompt, pip_self_version_check
+from pip._internal.self_outdated_check import (
+    UpgradePrompt,
+    pip_self_version_check_emit,
+    pip_self_version_check_fetch,
+)
 from pip._internal.utils.misc import ExternallyManagedEnvironment
 
 
@@ -37,30 +41,46 @@ def test_get_statefile_name_known_values(key: str, expected: str) -> None:
 
 
 @freeze_time("1970-01-02T11:00:00Z")
-@patch("pip._internal.self_outdated_check._self_version_check_logic")
+@patch("pip._internal.self_outdated_check._get_current_remote_pip_version")
 @patch("pip._internal.self_outdated_check.SelfCheckState")
 @patch("pip._internal.self_outdated_check.check_externally_managed", new=lambda: None)
-def test_pip_self_version_check_calls_underlying_implementation(
-    mocked_state: Mock, mocked_function: Mock, tmpdir: Path
+def test_pip_self_version_check_fetch_calls_underlying_implementation(
+    mocked_state: Mock, mocked_get_remote: Mock, tmpdir: Path
 ) -> None:
     # GIVEN
     mock_session = Mock()
     fake_options = Values({"cache_dir": str(tmpdir)})
-    mocked_function.return_value = None
+    mocked_state.return_value.get.return_value = None
+    mocked_get_remote.return_value = "5.0"
 
     # WHEN
-    self_outdated_check.pip_self_version_check(mock_session, fake_options)
+    result = pip_self_version_check_fetch(mock_session, fake_options)
 
     # THEN
+    assert result == "5.0"
     mocked_state.assert_called_once_with(cache_dir=str(tmpdir))
-    mocked_function.assert_called_once_with(
-        state=mocked_state(cache_dir=str(tmpdir)),
-        current_time=datetime.datetime(
-            1970, 1, 2, 11, 0, 0, tzinfo=datetime.timezone.utc
-        ),
-        local_version=ANY,
-        get_remote_version=ANY,
+    mocked_get_remote.assert_called_once_with(mock_session, fake_options)
+    mocked_state.return_value.set.assert_called_once_with(
+        "5.0",
+        datetime.datetime(1970, 1, 2, 11, 0, 0, tzinfo=datetime.timezone.utc),
     )
+
+
+@patch("pip._internal.self_outdated_check._compute_upgrade_prompt")
+@patch("pip._internal.self_outdated_check.get_default_environment")
+@patch("pip._internal.self_outdated_check.check_externally_managed", new=lambda: None)
+def test_pip_self_version_check_emit_calls_underlying_implementation(
+    mocked_env: Mock, mocked_compute: Mock
+) -> None:
+    # GIVEN
+    mocked_env.return_value.get_distribution.return_value.version = Version("1.0")
+    mocked_compute.return_value = UpgradePrompt(old="1.0", new="2.0")
+
+    # WHEN
+    pip_self_version_check_emit("2.0")
+
+    # THEN
+    mocked_compute.assert_called_once_with(Version("1.0"), "2.0")
 
 
 @pytest.mark.parametrize(
@@ -196,13 +216,30 @@ class TestSelfCheckState:
         assert statefile_permissions == selfcheckdir_permissions == cache_permissions
 
 
-@patch("pip._internal.self_outdated_check._self_version_check_logic")
-def test_suppressed_by_externally_managed(mocked_function: Mock, tmpdir: Path) -> None:
-    mocked_function.return_value = UpgradePrompt(old="1.0", new="2.0")
+@patch("pip._internal.self_outdated_check._get_current_remote_pip_version")
+def test_fetch_suppressed_by_externally_managed(
+    mocked_get_remote: Mock, tmpdir: Path
+) -> None:
     fake_options = Values({"cache_dir": str(tmpdir)})
     with patch(
         "pip._internal.self_outdated_check.check_externally_managed",
         side_effect=ExternallyManagedEnvironment("nope"),
     ):
-        pip_self_version_check(session=Mock(), options=fake_options)
-    mocked_function.assert_not_called()
+        result = pip_self_version_check_fetch(session=Mock(), options=fake_options)
+    assert result is None
+    mocked_get_remote.assert_not_called()
+
+
+@patch("pip._internal.self_outdated_check._compute_upgrade_prompt")
+@patch("pip._internal.self_outdated_check.get_default_environment")
+def test_emit_suppressed_by_externally_managed(
+    mocked_env: Mock, mocked_compute: Mock
+) -> None:
+    mocked_env.return_value.get_distribution.return_value.version = Version("1.0")
+    mocked_compute.return_value = UpgradePrompt(old="1.0", new="2.0")
+    with patch(
+        "pip._internal.self_outdated_check.check_externally_managed",
+        side_effect=ExternallyManagedEnvironment("nope"),
+    ):
+        pip_self_version_check_emit("2.0")
+    mocked_compute.assert_not_called()

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -23,6 +23,14 @@ from pip._internal.self_outdated_check import (
 from pip._internal.utils.misc import ExternallyManagedEnvironment
 
 
+def _make_installed_dist(version: str, installer: str = "pip") -> Mock:
+    """Build a stand-in for the installed pip distribution."""
+    installed_dist = Mock()
+    installed_dist.version = Version(version)
+    installed_dist.installer = installer
+    return installed_dist
+
+
 @pytest.mark.parametrize(
     "key, expected",
     [
@@ -43,13 +51,15 @@ def test_get_statefile_name_known_values(key: str, expected: str) -> None:
 @freeze_time("1970-01-02T11:00:00Z")
 @patch("pip._internal.self_outdated_check._get_current_remote_pip_version")
 @patch("pip._internal.self_outdated_check.SelfCheckState")
+@patch("pip._internal.self_outdated_check.get_default_environment")
 @patch("pip._internal.self_outdated_check.check_externally_managed", new=lambda: None)
 def test_pip_self_version_check_fetch_calls_underlying_implementation(
-    mocked_state: Mock, mocked_get_remote: Mock, tmpdir: Path
+    mocked_env: Mock, mocked_state: Mock, mocked_get_remote: Mock, tmpdir: Path
 ) -> None:
     # GIVEN
     mock_session = Mock()
     fake_options = Values({"cache_dir": str(tmpdir)})
+    mocked_env.return_value.get_distribution.return_value = _make_installed_dist("1.0")
     mocked_state.return_value.get.return_value = None
     mocked_get_remote.return_value = "5.0"
 
@@ -57,7 +67,7 @@ def test_pip_self_version_check_fetch_calls_underlying_implementation(
     result = pip_self_version_check_fetch(mock_session, fake_options)
 
     # THEN
-    assert result == "5.0"
+    assert result == UpgradePrompt(old="1.0", new="5.0")
     mocked_state.assert_called_once_with(cache_dir=str(tmpdir))
     mocked_get_remote.assert_called_once_with(mock_session, fake_options)
     mocked_state.return_value.set.assert_called_once_with(
@@ -66,23 +76,33 @@ def test_pip_self_version_check_fetch_calls_underlying_implementation(
     )
 
 
-@patch("pip._internal.self_outdated_check._compute_upgrade_prompt")
-@patch("pip._internal.self_outdated_check.get_default_environment")
-@patch("pip._internal.self_outdated_check.check_externally_managed", new=lambda: None)
-def test_pip_self_version_check_emit_calls_underlying_implementation(
-    mocked_env: Mock, mocked_compute: Mock
+def test_pip_self_version_check_emit_logs_prompt(
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     # GIVEN
-    mocked_env.return_value.get_distribution.return_value.version = Version("1.0")
-    mocked_compute.return_value = UpgradePrompt(old="1.0", new="2.0")
+    prompt = UpgradePrompt(old="1.0", new="2.0")
 
     # WHEN
-    pip_self_version_check_emit("2.0")
+    with caplog.at_level(logging.WARNING):
+        pip_self_version_check_emit(prompt)
 
     # THEN
-    mocked_compute.assert_called_once_with(Version("1.0"), "2.0")
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
 
 
+def test_pip_self_version_check_emit_no_prompt_is_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # WHEN
+    with caplog.at_level(logging.WARNING):
+        pip_self_version_check_emit(None)
+
+    # THEN
+    assert caplog.records == []
+
+
+@freeze_time("2000-01-01T00:00:00Z")
 @pytest.mark.parametrize(
     [  # noqa: PT006 - String representation is too long
         "installed_version",
@@ -114,27 +134,41 @@ def test_core_logic(
     should_show_prompt: bool,
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
+    tmpdir: Path,
 ) -> None:
     # GIVEN
-    monkeypatch.setattr(
-        self_outdated_check, "was_installed_by_pip", lambda _: installed_by_pip
+    installed_dist = _make_installed_dist(
+        installed_version, installer="pip" if installed_by_pip else "apt"
     )
-    mock_state = Mock()
-    mock_state.get.return_value = stored_version
-    fake_time = datetime.datetime(2000, 1, 1, 0, 0, 0)
+    monkeypatch.setattr(
+        self_outdated_check,
+        "get_default_environment",
+        lambda: Mock(get_distribution=Mock(return_value=installed_dist)),
+    )
+    monkeypatch.setattr(self_outdated_check, "check_externally_managed", lambda: None)
+    monkeypatch.setattr(
+        self_outdated_check,
+        "_get_current_remote_pip_version",
+        lambda session, options: remote_version,
+    )
+    mock_state_instance = Mock()
+    mock_state_instance.get.return_value = stored_version
+    monkeypatch.setattr(
+        self_outdated_check,
+        "SelfCheckState",
+        Mock(return_value=mock_state_instance),
+    )
+    fake_time = datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
     version_that_should_be_checked = stored_version or remote_version
 
     # WHEN
     with caplog.at_level(logging.DEBUG):
-        return_value = self_outdated_check._self_version_check_logic(
-            state=mock_state,
-            current_time=fake_time,
-            local_version=Version(installed_version),
-            get_remote_version=lambda: remote_version,
+        return_value = pip_self_version_check_fetch(
+            session=Mock(), options=Values({"cache_dir": str(tmpdir)})
         )
 
     # THEN
-    mock_state.get.assert_called_once_with(fake_time)
+    mock_state_instance.get.assert_called_once_with(fake_time)
     assert caplog.messages == [
         f"Remote version of pip: {version_that_should_be_checked}",
         f"Local version of pip:  {installed_version}",
@@ -142,9 +176,9 @@ def test_core_logic(
     ]
 
     if stored_version:
-        mock_state.set.assert_not_called()
+        mock_state_instance.set.assert_not_called()
     else:
-        mock_state.set.assert_called_once_with(
+        mock_state_instance.set.assert_called_once_with(
             version_that_should_be_checked, fake_time
         )
 
@@ -217,9 +251,11 @@ class TestSelfCheckState:
 
 
 @patch("pip._internal.self_outdated_check._get_current_remote_pip_version")
+@patch("pip._internal.self_outdated_check.get_default_environment")
 def test_fetch_suppressed_by_externally_managed(
-    mocked_get_remote: Mock, tmpdir: Path
+    mocked_env: Mock, mocked_get_remote: Mock, tmpdir: Path
 ) -> None:
+    mocked_env.return_value.get_distribution.return_value = _make_installed_dist("1.0")
     fake_options = Values({"cache_dir": str(tmpdir)})
     with patch(
         "pip._internal.self_outdated_check.check_externally_managed",
@@ -230,16 +266,13 @@ def test_fetch_suppressed_by_externally_managed(
     mocked_get_remote.assert_not_called()
 
 
-@patch("pip._internal.self_outdated_check._compute_upgrade_prompt")
+@patch("pip._internal.self_outdated_check._get_current_remote_pip_version")
 @patch("pip._internal.self_outdated_check.get_default_environment")
-def test_emit_suppressed_by_externally_managed(
-    mocked_env: Mock, mocked_compute: Mock
+def test_fetch_skipped_when_pip_not_installed(
+    mocked_env: Mock, mocked_get_remote: Mock, tmpdir: Path
 ) -> None:
-    mocked_env.return_value.get_distribution.return_value.version = Version("1.0")
-    mocked_compute.return_value = UpgradePrompt(old="1.0", new="2.0")
-    with patch(
-        "pip._internal.self_outdated_check.check_externally_managed",
-        side_effect=ExternallyManagedEnvironment("nope"),
-    ):
-        pip_self_version_check_emit("2.0")
-    mocked_compute.assert_not_called()
+    mocked_env.return_value.get_distribution.return_value = None
+    fake_options = Values({"cache_dir": str(tmpdir)})
+    result = pip_self_version_check_fetch(session=Mock(), options=fake_options)
+    assert result is None
+    mocked_get_remote.assert_not_called()


### PR DESCRIPTION
This means that everything that needs lazily importing is done before installation happens, while still not importing the network stack for uninstall and list (https://github.com/pypa/pip/pull/12637)