### PR TITLE
Fix hang in broken-stdout handler when stderr pipe is full

### DIFF
--- a/news/13927.bugfix.rst
+++ b/news/13927.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a hang on Windows when stdout is closed during verbose output.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -138,7 +138,10 @@ class Command(CommandContextMixIn):
             try:
                 os.write(2, b"ERROR: Pipe to stdout was broken\n")
                 if level_number <= logging.DEBUG:
-                    os.write(2, traceback.format_exc().encode("utf-8", "replace"))
+                    encoding = sys.stderr.encoding or "utf-8"
+                    os.write(
+                        2, traceback.format_exc().encode(encoding, "backslashreplace")
+                    )
             except OSError:
                 pass
 

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -138,7 +138,7 @@ class Command(CommandContextMixIn):
             try:
                 os.write(2, b"ERROR: Pipe to stdout was broken\n")
                 if level_number <= logging.DEBUG:
-                    encoding = sys.stderr.encoding or "utf-8"
+                    encoding = getattr(sys.stderr, "encoding", None) or "utf-8"
                     os.write(
                         2, traceback.format_exc().encode(encoding, "backslashreplace")
                     )

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -132,11 +132,15 @@ class Command(CommandContextMixIn):
 
             return ERROR
         except BrokenStdoutLoggingError:
-            # Bypass our logger and write any remaining messages to
-            # stderr because stdout no longer works.
-            print("ERROR: Pipe to stdout was broken", file=sys.stderr)
-            if level_number <= logging.DEBUG:
-                traceback.print_exc(file=sys.stderr)
+            # stdout is broken; write to stderr directly. Use os.write, not
+            # sys.stderr.write, so a full pipe buffer returns EPIPE instead
+            # of deadlocking (Windows anonymous pipes are ~4KB).
+            try:
+                os.write(2, b"ERROR: Pipe to stdout was broken\n")
+                if level_number <= logging.DEBUG:
+                    os.write(2, traceback.format_exc().encode("utf-8", "replace"))
+            except OSError:
+                pass
 
             return ERROR
         except KeyboardInterrupt:

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -65,7 +65,7 @@ class FakeCommandWithUnicode(FakeCommand):
 
 
 class TestCommand:
-    def call_main(self, capsys: pytest.CaptureFixture[str], args: list[str]) -> str:
+    def call_main(self, capfd: pytest.CaptureFixture[str], args: list[str]) -> str:
         """
         Call command.main(), and return the command's stderr.
         """
@@ -76,25 +76,25 @@ class TestCommand:
         cmd = FakeCommand(run_func=raise_broken_stdout)
         status = cmd.main(args)
         assert status == 1
-        stderr = capsys.readouterr().err
+        stderr = capfd.readouterr().err
 
         return stderr
 
-    def test_raise_broken_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_raise_broken_stdout(self, capfd: pytest.CaptureFixture[str]) -> None:
         """
         Test raising BrokenStdoutLoggingError.
         """
-        stderr = self.call_main(capsys, [])
+        stderr = self.call_main(capfd, [])
 
         assert stderr.rstrip() == "ERROR: Pipe to stdout was broken"
 
     def test_raise_broken_stdout__debug_logging(
-        self, capsys: pytest.CaptureFixture[str]
+        self, capfd: pytest.CaptureFixture[str]
     ) -> None:
         """
         Test raising BrokenStdoutLoggingError with debug logging enabled.
         """
-        stderr = self.call_main(capsys, ["-vv"])
+        stderr = self.call_main(capfd, ["-vv"])
 
         assert "ERROR: Pipe to stdout was broken" in stderr
         assert "Traceback (most recent call last):" in stderr


### PR DESCRIPTION
On Windows, anonymous pipes have a ~4KB buffer. When pip's stdout is
closed (e.g. `pip -vv list | head`) and the `BrokenStdoutLoggingError`
handler runs after verbose output has filled the stderr pipe, the
handler's `sys.stderr` writes deadlock and pip hangs forever.

Fix the handler to write via `os.write(2, ...)`, which returns EPIPE
instead of blocking. Unit tests switch to `capfd` for FD-level capture.

Hit in CI on #13923 (Windows 3.15, `test_broken_stdout_pipe__verbose`):
`pip list`'s stderr size on 3.15 just crosses the 4KB threshold.