### PR TITLE
mnt: Bump black to 26.5.1

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -35,3 +35,4 @@ c7ee560e00b85f7486b452c14ff49e4737996eda  # Blacken tools/
 585037a80a1177f1fa92e159a7079855782e543e  # Cleanup implicit string concatenation
 8a6f6ac19b80a6dc35900a47016c851d9fcd2ee2  # Blacken src/pip/_internal/resolution directory
 acfcae8941bb12ecfc372a05c875a7b414992604  # Reformat with Black's 2025 code style
+7518d235a574826b83e27d66c276a966059f31a6  # Reformat with Black's 2026 code style

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -35,3 +35,4 @@ c7ee560e00b85f7486b452c14ff49e4737996eda  # Blacken tools/
 585037a80a1177f1fa92e159a7079855782e543e  # Cleanup implicit string concatenation
 8a6f6ac19b80a6dc35900a47016c851d9fcd2ee2  # Blacken src/pip/_internal/resolution directory
 acfcae8941bb12ecfc372a05c875a7b414992604  # Reformat with Black's 2025 code style
+79176693d4166757031f4b4d0c118ba4a0332d06  # Reformat with Black's 2026 code style

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 25.12.0
+  rev: 26.3.1
   hooks:
   - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 25.12.0
+  rev: 26.5.1
   hooks:
   - id: black
 

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -463,9 +463,7 @@ class BuildEnvironment:
         with open(
             os.path.join(self._site_dir, "sitecustomize.py"), "w", encoding="utf-8"
         ) as fp:
-            fp.write(
-                textwrap.dedent(
-                    """
+            fp.write(textwrap.dedent("""
                 import os, site, sys
 
                 # First, drop system-sites related paths.
@@ -488,9 +486,7 @@ class BuildEnvironment:
                 for path in {lib_dirs!r}:
                     assert not path in sys.path
                     site.addsitedir(path)
-                """
-                ).format(system_sites=system_sites, lib_dirs=self._lib_dirs)
-            )
+                """).format(system_sites=system_sites, lib_dirs=self._lib_dirs))
 
     def __enter__(self) -> None:
         self._save_env = {

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -463,9 +463,7 @@ class BuildEnvironment:
         with open(
             os.path.join(self._site_dir, "sitecustomize.py"), "w", encoding="utf-8"
         ) as fp:
-            fp.write(
-                textwrap.dedent(
-                    """
+            fp.write(textwrap.dedent("""
                 import os, site, sys
 
                 # First, discover all system-sites related paths.
@@ -492,9 +490,7 @@ class BuildEnvironment:
                 for path in {lib_dirs!r}:
                     assert not path in sys.path
                     site.addsitedir(path)
-                """
-                ).format(system_sites=system_sites, lib_dirs=self._lib_dirs)
-            )
+                """).format(system_sites=system_sites, lib_dirs=self._lib_dirs))
 
     def __enter__(self) -> None:
         self._save_env = {

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -808,15 +808,13 @@ python_version: Callable[..., Option] = partial(
     callback=_handle_python_version,
     type="str",
     default=None,
-    help=dedent(
-        """\
+    help=dedent("""\
     The Python interpreter version to use for wheel and "Requires-Python"
     compatibility checks. Defaults to a version derived from the running
     interpreter. The version can be specified using up to three dot-separated
     integers (e.g. "3" for 3.0.0, "3.7" for 3.7.0, or "3.7.3"). A major-minor
     version can also be given as a string without dots (e.g. "37" for 3.7.0).
-    """
-    ),
+    """),
 )
 
 

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -822,15 +822,13 @@ python_version: Callable[..., Option] = partial(
     callback=_handle_python_version,
     type="str",
     default=None,
-    help=dedent(
-        """\
+    help=dedent("""\
     The Python interpreter version to use for wheel and "Requires-Python"
     compatibility checks. Defaults to a version derived from the running
     interpreter. The version can be specified using up to three dot-separated
     integers (e.g. "3" for 3.0.0, "3.7" for 3.7.0, or "3.7.3"). A major-minor
     version can also be given as a string without dots (e.g. "37" for 3.7.0).
-    """
-    ),
+    """),
 )
 
 

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -107,8 +107,7 @@ class CacheCommand(Command):
         wheels_cache_size = filesystem.format_directory_size(wheels_cache_location)
 
         message = (
-            textwrap.dedent(
-                """
+            textwrap.dedent("""
                     Package index page cache location (pip v23.3+): {http_cache_location}
                     Package index page cache location (older pips): {old_http_cache_location}
                     Package index page cache size: {http_cache_size}
@@ -116,8 +115,7 @@ class CacheCommand(Command):
                     Locally built wheels location: {wheels_cache_location}
                     Locally built wheels size: {wheels_cache_size}
                     Number of locally built wheels: {package_count}
-                """  # noqa: E501
-            )
+                """)  # noqa: E501
             .format(
                 http_cache_location=http_cache_location,
                 old_http_cache_location=old_http_cache_location,

--- a/src/pip/_internal/locations/base.py
+++ b/src/pip/_internal/locations/base.py
@@ -41,7 +41,7 @@ def change_root(new_root: str, pathname: str) -> str:
             return os.path.join(new_root, pathname[1:])
 
     elif os.name == "nt":
-        (drive, path) = os.path.splitdrive(pathname)
+        drive, path = os.path.splitdrive(pathname)
         if path[0] == "\\":
             path = path[1:]
         return os.path.join(new_root, path)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -406,15 +406,13 @@ def _raise_for_invalid_entrypoint(specification: str) -> None:
 class PipScriptMaker(ScriptMaker):
     # Override distlib's default script template with one that
     # doesn't import `re` module, allowing scripts to load faster.
-    script_template = textwrap.dedent(
-        """\
+    script_template = textwrap.dedent("""\
         import sys
         from %(module)s import %(import_name)s
         if __name__ == '__main__':
             sys.argv[0] = sys.argv[0].removesuffix('.exe')
             sys.exit(%(func)s())
-"""
-    )
+""")
 
     def make(
         self, specification: str, options: dict[str, Any] | None = None

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -420,15 +420,13 @@ def _raise_for_invalid_entrypoint(specification: str, scripts_dir: str) -> None:
 class PipScriptMaker(ScriptMaker):
     # Override distlib's default script template with one that
     # doesn't import `re` module, allowing scripts to load faster.
-    script_template = textwrap.dedent(
-        """\
+    script_template = textwrap.dedent("""\
         import sys
         from %(module)s import %(import_name)s
         if __name__ == '__main__':
             sys.argv[0] = sys.argv[0].removesuffix('.exe')
             sys.exit(%(func)s())
-"""
-    )
+""")
 
     def make(
         self, specification: str, options: dict[str, Any] | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -775,14 +775,12 @@ class FakePackage:
     def generate_metadata(self) -> bytes:
         """This is written to `self.metadata_filename()` and will override the actual
         dist's METADATA, unless `self.metadata == MetadataKind.NoFile`."""
-        return dedent(
-            f"""\
+        return dedent(f"""\
         Metadata-Version: 2.1
         Name: {self.metadata_name or self.name}
         Version: {self.version}
         {self.requires_str()}
-        """
-        ).encode("utf-8")
+        """).encode("utf-8")
 
 
 @pytest.fixture(scope="session")
@@ -892,8 +890,7 @@ def html_index_for_packages(
     )
     # Output won't be nicely indented because dedent() acts after f-string
     # arg insertion.
-    index_html = dedent(
-        f"""\
+    index_html = dedent(f"""\
         <!DOCTYPE html>
         <html>
           <head>
@@ -903,8 +900,7 @@ def html_index_for_packages(
           <body>
           {pkg_links}
           </body>
-        </html>"""
-    )
+        </html>""")
     # (2) Generate the index.html in a new subdirectory of the temp directory.
     (html_dir / "index.html").write_text(index_html)
 
@@ -935,8 +931,7 @@ def html_index_for_packages(
         # write an index.html with the generated download links for each
         # copied file for this specific package name.
         download_links_str = "\n".join(download_links)
-        pkg_index_content = dedent(
-            f"""\
+        pkg_index_content = dedent(f"""\
             <!DOCTYPE html>
             <html>
               <head>
@@ -947,8 +942,7 @@ def html_index_for_packages(
                 <h1>Links for {pkg}</h1>
                 {download_links_str}
               </body>
-            </html>"""
-        )
+            </html>""")
         with open(pkg_subdir / "index.html", "w") as f:
             f.write(pkg_index_content)
 

--- a/tests/functional/test_build_env.py
+++ b/tests/functional/test_build_env.py
@@ -61,8 +61,7 @@ def run_with_build_env(
     build_env_script = script.scratch_path / "build_env.py"
     scratch_path = str(script.scratch_path)
     build_env_script.write_text(
-        dedent(
-            f"""
+        dedent(f"""
             import subprocess
             import sys
 
@@ -104,17 +103,14 @@ def run_with_build_env(
                         wheel_cache=WheelCache(None),
                     )
                 build_env = BuildEnvironment(installer)
-            """
-        )
+            """)
         + indent(dedent(setup_script_contents), "    ")
         + indent(
-            dedent(
-                """
+            dedent("""
                 if len(sys.argv) > 1:
                     with build_env:
                         subprocess.check_call((sys.executable, sys.argv[1]))
-                """
-            ),
+                """),
             "    ",
         )
     )

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -26,9 +26,7 @@ def test_entrypoints_work(entrypoint: str, script: PipTestEnvironment) -> None:
 
     fake_pkg = script.scratch_path / "fake_pkg"
     fake_pkg.mkdir()
-    fake_pkg.joinpath("setup.py").write_text(
-        dedent(
-            f"""
+    fake_pkg.joinpath("setup.py").write_text(dedent(f"""
     from setuptools import setup
 
     setup(
@@ -40,9 +38,7 @@ def test_entrypoints_work(entrypoint: str, script: PipTestEnvironment) -> None:
             ]
         }}
     )
-    """
-        )
-    )
+    """))
 
     # expect_temp because pip install will generate fake_pkg.egg-info
     script.pip(

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -104,17 +104,13 @@ class TestBasicLoading(ConfigurationMixin):
 
         config_file = script.scratch_path / "test-pip.cfg"
         script.environ["PIP_CONFIG_FILE"] = str(config_file)
-        config_file.write_text(
-            textwrap.dedent(
-                """\
+        config_file.write_text(textwrap.dedent("""\
             [global]
             timeout = 60
 
             [freeze]
             timeout = 10
-            """
-            )
-        )
+            """))
 
         result = script.pip("config", "debug")
         assert f"{config_file}, exists: True" in result.stdout

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -632,14 +632,12 @@ def make_wheel_with_python_requires(
     package_dir = script.scratch_path / package_name
     package_dir.mkdir()
 
-    text = textwrap.dedent(
-        """\
+    text = textwrap.dedent("""\
     from setuptools import setup
     setup(name='{}',
           python_requires='{}',
           version='1.0')
-    """
-    ).format(package_name, python_requires)
+    """).format(package_name, python_requires)
     package_dir.joinpath("setup.py").write_text(text)
     script.run(
         "python",
@@ -936,14 +934,10 @@ def test_prefer_binary_tarball_higher_than_wheel_req_file(
     script: PipTestEnvironment, data: TestData
 ) -> None:
     fake_wheel(data, "source-0.8-py2.py3-none-any.whl")
-    script.scratch_path.joinpath("test-req.txt").write_text(
-        textwrap.dedent(
-            """
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
                 --prefer-binary
                  source
-                """
-        )
-    )
+                """))
     result = script.pip(
         "download",
         "-r",
@@ -963,13 +957,9 @@ def test_download_prefer_binary_when_wheel_doesnt_satisfy_req(
     script: PipTestEnvironment, data: TestData
 ) -> None:
     fake_wheel(data, "source-0.8-py2.py3-none-any.whl")
-    script.scratch_path.joinpath("test-req.txt").write_text(
-        textwrap.dedent(
-            """
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
         source>0.9
-        """
-        )
-    )
+        """))
 
     result = script.pip(
         "download",
@@ -991,14 +981,10 @@ def test_prefer_binary_when_wheel_doesnt_satisfy_req_req_file(
     script: PipTestEnvironment, data: TestData
 ) -> None:
     fake_wheel(data, "source-0.8-py2.py3-none-any.whl")
-    script.scratch_path.joinpath("test-req.txt").write_text(
-        textwrap.dedent(
-            """
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
         --prefer-binary
         source>0.9
-        """
-        )
-    )
+        """))
 
     result = script.pip(
         "download",
@@ -1035,14 +1021,10 @@ def test_download_prefer_binary_when_only_tarball_exists(
 def test_prefer_binary_when_only_tarball_exists_req_file(
     script: PipTestEnvironment, data: TestData
 ) -> None:
-    script.scratch_path.joinpath("test-req.txt").write_text(
-        textwrap.dedent(
-            """
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
             --prefer-binary
             source
-            """
-        )
-    )
+            """))
     result = script.pip(
         "download",
         "--no-build-isolation",

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -65,26 +65,20 @@ def test_basic_freeze(script: PipTestEnvironment) -> None:
     currently it is not).
 
     """
-    script.scratch_path.joinpath("initools-req.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("initools-req.txt").write_text(textwrap.dedent("""\
         simple==2.0
         # and something else to test out:
         simple2<=3.0
-        """
-        )
-    )
+        """))
     script.pip_install_local(
         "-r",
         script.scratch_path / "initools-req.txt",
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         ...simple==2.0
         simple2==3.0...
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
 
 
@@ -162,15 +156,11 @@ def test_freeze_with_invalid_names(script: PipTestEnvironment) -> None:
             ),
         )
         with open(egg_info_path, "w") as egg_info_file:
-            egg_info_file.write(
-                textwrap.dedent(
-                    f"""\
+            egg_info_file.write(textwrap.dedent(f"""\
                 Metadata-Version: 1.0
                 Name: {pkgname}
                 Version: 1.0
-                """
-                )
-            )
+                """))
 
     valid_pkgnames = ("middle-dash", "middle_underscore", "middle.dot")
     invalid_pkgnames = (
@@ -216,12 +206,10 @@ def test_freeze_editable_not_vcs(script: PipTestEnvironment) -> None:
 
     # We need to apply os.path.normcase() to the path since that is what
     # the freeze code does.
-    expected = textwrap.dedent(
-        f"""\
+    expected = textwrap.dedent(f"""\
     ...# Editable install with no version control (version...pkg==0.1)
     -e {os.path.normcase(pkg_path)}
-    ..."""
-    )
+    ...""")
     _check_output(result.stdout, expected)
 
 
@@ -241,12 +229,10 @@ def test_freeze_editable_git_with_no_remote(
 
     # We need to apply os.path.normcase() to the path since that is what
     # the freeze code does.
-    expected = textwrap.dedent(
-        f"""\
+    expected = textwrap.dedent(f"""\
     ...# Editable Git install with no remote (version...pkg==0.1)
     -e {os.path.normcase(pkg_path)}
-    ..."""
-    )
+    ...""")
     _check_output(result.stdout, expected)
 
 
@@ -259,11 +245,9 @@ def test_freeze_svn(script: PipTestEnvironment) -> None:
     # Install with develop
     script.run("python", "setup.py", "develop", cwd=checkout_path, expect_stderr=True)
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         ...-e svn+...#egg=version_pkg
-        ..."""
-    )
+        ...""")
     _check_output(result.stdout, expected)
 
 
@@ -297,12 +281,10 @@ def test_freeze_exclude_editable(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", "--exclude-editable", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e git+...#egg=version_pkg
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -330,12 +312,10 @@ def test_freeze_git_clone(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e git+...#egg=version_pkg
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
     # Check that slashes in branch or tag names are translated.
@@ -355,12 +335,10 @@ def test_freeze_git_clone(script: PipTestEnvironment) -> None:
     script.run("git", "add", "newfile", cwd=repo_dir)
     _git_commit(script, repo_dir, message="...")
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e ...@...#egg=version_pkg
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -390,12 +368,10 @@ def test_freeze_git_clone_srcdir(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e git+...#egg=version_pkg&subdirectory=subdir
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -413,12 +389,10 @@ def test_freeze_mercurial_clone_srcdir(script: PipTestEnvironment) -> None:
     repo_dir = script.scratch_path / "pip-test-package"
     result = script.run("python", "setup.py", "develop", cwd=repo_dir / "subdir")
     result = script.pip("freeze")
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e hg+...#egg=version_pkg&subdirectory=subdir
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -448,60 +422,38 @@ def test_freeze_git_remote(script: PipTestEnvironment) -> None:
     origin_remote = pkg_version
     # check frozen remote after clone
     result = script.pip("freeze", expect_stderr=True)
-    expected = (
-        textwrap.dedent(
-            """
+    expected = textwrap.dedent("""
             ...-e git+{remote}@...#egg=version_pkg
             ...
-        """
-        )
-        .format(remote=origin_remote.as_uri())
-        .strip()
-    )
+        """).format(remote=origin_remote.as_uri()).strip()
     _check_output(result.stdout, expected)
     # check frozen remote when there is no remote named origin
     script.run("git", "remote", "rename", "origin", "other", cwd=repo_dir)
     result = script.pip("freeze", expect_stderr=True)
-    expected = (
-        textwrap.dedent(
-            """
+    expected = textwrap.dedent("""
             ...-e git+{remote}@...#egg=version_pkg
             ...
-        """
-        )
-        .format(remote=origin_remote.as_uri())
-        .strip()
-    )
+        """).format(remote=origin_remote.as_uri()).strip()
     _check_output(result.stdout, expected)
     # When the remote is a local path, it must exist.
     # If it doesn't, it gets flagged as invalid.
     other_remote = f"{pkg_version}-other"
     script.run("git", "remote", "set-url", "other", other_remote, cwd=repo_dir)
     result = script.pip("freeze", expect_stderr=True)
-    expected = os.path.normcase(
-        textwrap.dedent(
-            f"""
+    expected = os.path.normcase(textwrap.dedent(f"""
             ...# Editable Git...(version...pkg...)...
             # '{other_remote}'
             -e {repo_dir}...
-        """
-        ).strip()
-    )
+        """).strip())
     _check_output(os.path.normcase(result.stdout), expected)
     # when there are more than one origin, priority is given to the
     # remote named origin
     script.run("git", "remote", "add", "origin", os.fspath(origin_remote), cwd=repo_dir)
     result = script.pip("freeze", expect_stderr=True)
-    expected = (
-        textwrap.dedent(
-            """
+    expected = textwrap.dedent("""
             ...-e git+{remote}@...#egg=version_pkg
             ...
-        """
-        )
-        .format(remote=origin_remote.as_uri())
-        .strip()
-    )
+        """).format(remote=origin_remote.as_uri()).strip()
     _check_output(result.stdout, expected)
 
 
@@ -530,12 +482,10 @@ def test_freeze_mercurial_clone(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e hg+...#egg=version_pkg
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -559,11 +509,9 @@ def test_freeze_bazaar_clone(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         ...-e bzr+file://...@1#egg=version_pkg
-        ..."""
-    )
+        ...""")
     _check_output(result.stdout, expected)
 
 
@@ -608,8 +556,7 @@ def test_freeze_nested_vcs(
 
 
 # used by the test_freeze_with_requirement_* tests below
-_freeze_req_opts = textwrap.dedent(
-    """\
+_freeze_req_opts = textwrap.dedent("""\
     # Unchanged requirements below this line
     -r ignore.txt
     --requirement ignore.txt
@@ -622,8 +569,7 @@ _freeze_req_opts = textwrap.dedent(
     --find-links http://ignore
     --index-url http://ignore
     --use-feature resolvelib
-"""
-)
+""")
 
 
 def test_freeze_with_requirement_option_file_url_egg_not_installed(
@@ -660,26 +606,16 @@ def test_freeze_with_requirement_option(script: PipTestEnvironment) -> None:
 
     """
 
-    script.scratch_path.joinpath("hint1.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("hint1.txt").write_text(textwrap.dedent("""\
         INITools==0.1
         NoExist==4.2  # A comment that ensures end of line comments work.
         simple==3.0; python_version > '1.0'
-        """
-        )
-        + _freeze_req_opts
-    )
-    script.scratch_path.joinpath("hint2.txt").write_text(
-        textwrap.dedent(
-            """\
+        """) + _freeze_req_opts)
+    script.scratch_path.joinpath("hint2.txt").write_text(textwrap.dedent("""\
         iniTools==0.1
         Noexist==4.2  # A comment that ensures end of line comments work.
         Simple==3.0; python_version > '1.0'
-        """
-        )
-        + _freeze_req_opts
-    )
+        """) + _freeze_req_opts)
     result = script.pip_install_local("initools==0.2")
     result = script.pip_install_local("simple")
     result = script.pip(
@@ -688,12 +624,10 @@ def test_freeze_with_requirement_option(script: PipTestEnvironment) -> None:
         "hint1.txt",
         expect_stderr=True,
     )
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         INITools==0.2
         simple==3.0
-    """
-    )
+    """)
     expected += _freeze_req_opts
     expected += "## The following requirements were added by pip freeze:..."
     _check_output(result.stdout, expected)
@@ -720,25 +654,15 @@ def test_freeze_with_requirement_option_multiple(script: PipTestEnvironment) -> 
     --requirement hints
 
     """
-    script.scratch_path.joinpath("hint1.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("hint1.txt").write_text(textwrap.dedent("""\
         INITools==0.1
         NoExist==4.2
         simple==3.0; python_version > '1.0'
-    """
-        )
-        + _freeze_req_opts
-    )
-    script.scratch_path.joinpath("hint2.txt").write_text(
-        textwrap.dedent(
-            """\
+    """) + _freeze_req_opts)
+    script.scratch_path.joinpath("hint2.txt").write_text(textwrap.dedent("""\
         NoExist2==2.0
         simple2==1.0
-    """
-        )
-        + _freeze_req_opts
-    )
+    """) + _freeze_req_opts)
     result = script.pip_install_local("initools==0.2")
     result = script.pip_install_local("simple")
     result = script.pip_install_local("simple2==1.0")
@@ -751,24 +675,18 @@ def test_freeze_with_requirement_option_multiple(script: PipTestEnvironment) -> 
         "hint2.txt",
         expect_stderr=True,
     )
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         INITools==0.2
         simple==1.0
-    """
-    )
+    """)
     expected += _freeze_req_opts
-    expected += textwrap.dedent(
-        """\
+    expected += textwrap.dedent("""\
         simple2==1.0
-    """
-    )
+    """)
     expected += "## The following requirements were added by pip freeze:"
-    expected += "\n" + textwrap.dedent(
-        """\
+    expected += "\n" + textwrap.dedent("""\
         ...meta==1.0...
-    """
-    )
+    """)
     _check_output(result.stdout, expected)
     assert (
         "Requirement file [hint1.txt] contains NoExist==4.2, but package "
@@ -790,16 +708,11 @@ def test_freeze_with_requirement_option_package_repeated_one_file(
     Test freezing with single requirements file that contains a package
     multiple times
     """
-    script.scratch_path.joinpath("hint1.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("hint1.txt").write_text(textwrap.dedent("""\
         simple2
         simple2
         NoExist
-    """
-        )
-        + _freeze_req_opts
-    )
+    """) + _freeze_req_opts)
     result = script.pip_install_local("simple2==1.0")
     result = script.pip_install_local("meta")
     result = script.pip(
@@ -808,18 +721,14 @@ def test_freeze_with_requirement_option_package_repeated_one_file(
         "hint1.txt",
         expect_stderr=True,
     )
-    expected_out = textwrap.dedent(
-        """\
+    expected_out = textwrap.dedent("""\
         simple2==1.0
-    """
-    )
+    """)
     expected_out += _freeze_req_opts
     expected_out += "## The following requirements were added by pip freeze:"
-    expected_out += "\n" + textwrap.dedent(
-        """\
+    expected_out += "\n" + textwrap.dedent("""\
         ...meta==1.0...
-    """
-    )
+    """)
     _check_output(result.stdout, expected_out)
     err1 = (
         "Requirement file [hint1.txt] contains NoExist, "
@@ -838,23 +747,13 @@ def test_freeze_with_requirement_option_package_repeated_multi_file(
     """
     Test freezing with multiple requirements file that contain a package
     """
-    script.scratch_path.joinpath("hint1.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("hint1.txt").write_text(textwrap.dedent("""\
         simple
-    """
-        )
-        + _freeze_req_opts
-    )
-    script.scratch_path.joinpath("hint2.txt").write_text(
-        textwrap.dedent(
-            """\
+    """) + _freeze_req_opts)
+    script.scratch_path.joinpath("hint2.txt").write_text(textwrap.dedent("""\
         simple
         NoExist
-    """
-        )
-        + _freeze_req_opts
-    )
+    """) + _freeze_req_opts)
     result = script.pip_install_local("simple==1.0")
     result = script.pip_install_local("meta")
     result = script.pip(
@@ -865,18 +764,14 @@ def test_freeze_with_requirement_option_package_repeated_multi_file(
         "hint2.txt",
         expect_stderr=True,
     )
-    expected_out = textwrap.dedent(
-        """\
+    expected_out = textwrap.dedent("""\
         simple==1.0
-    """
-    )
+    """)
     expected_out += _freeze_req_opts
     expected_out += "## The following requirements were added by pip freeze:"
-    expected_out += "\n" + textwrap.dedent(
-        """\
+    expected_out += "\n" + textwrap.dedent("""\
         ...meta==1.0...
-    """
-    )
+    """)
     _check_output(result.stdout, expected_out)
 
     err1 = (
@@ -900,11 +795,9 @@ def test_freeze_user(
     script.pip_install_local("--find-links", data.find_links, "--user", "simple==2.0")
     script.pip_install_local("--find-links", data.find_links, "simple2==3.0")
     result = script.pip("freeze", "--user", expect_stderr=True)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==2.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
     assert "simple2" not in result.stdout
 
@@ -915,11 +808,9 @@ def test_freeze_path(tmpdir: Path, script: PipTestEnvironment, data: TestData) -
     """
     script.pip_install_local("--target", tmpdir, "simple==2.0")
     result = script.pip("freeze", "--path", tmpdir)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==2.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
 
 
@@ -934,18 +825,14 @@ def test_freeze_path_exclude_user(
     script.pip_install_local("--find-links", data.find_links, "--user", "simple2")
     script.pip_install_local("--target", tmpdir, "simple==1.0")
     result = script.pip("freeze", "--user")
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple2==3.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
     result = script.pip("freeze", "--path", tmpdir)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==1.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
 
 
@@ -962,19 +849,15 @@ def test_freeze_path_multiple(
     script.pip_install_local("--target", path1, "simple==2.0")
     script.pip_install_local("--target", path2, "simple2==3.0")
     result = script.pip("freeze", "--path", path1)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==2.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
     result = script.pip("freeze", "--path", path1, "--path", path2)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==2.0
         simple2==3.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
 
 

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -64,26 +64,20 @@ def test_basic_freeze(script: PipTestEnvironment) -> None:
     currently it is not).
 
     """
-    script.scratch_path.joinpath("initools-req.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("initools-req.txt").write_text(textwrap.dedent("""\
         simple==2.0
         # and something else to test out:
         simple2<=3.0
-        """
-        )
-    )
+        """))
     script.pip_install_local(
         "-r",
         script.scratch_path / "initools-req.txt",
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         ...simple==2.0
         simple2==3.0...
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
 
 
@@ -161,15 +155,11 @@ def test_freeze_with_invalid_names(script: PipTestEnvironment) -> None:
             ),
         )
         with open(egg_info_path, "w") as egg_info_file:
-            egg_info_file.write(
-                textwrap.dedent(
-                    f"""\
+            egg_info_file.write(textwrap.dedent(f"""\
                 Metadata-Version: 1.0
                 Name: {pkgname}
                 Version: 1.0
-                """
-                )
-            )
+                """))
 
     valid_pkgnames = ("middle-dash", "middle_underscore", "middle.dot")
     invalid_pkgnames = (
@@ -215,12 +205,10 @@ def test_freeze_editable_not_vcs(script: PipTestEnvironment) -> None:
 
     # We need to apply os.path.normcase() to the path since that is what
     # the freeze code does.
-    expected = textwrap.dedent(
-        f"""\
+    expected = textwrap.dedent(f"""\
     ...# Editable install with no version control (version...pkg==0.1)
     -e {os.path.normcase(pkg_path)}
-    ..."""
-    )
+    ...""")
     _check_output(result.stdout, expected)
 
 
@@ -240,12 +228,10 @@ def test_freeze_editable_git_with_no_remote(
 
     # We need to apply os.path.normcase() to the path since that is what
     # the freeze code does.
-    expected = textwrap.dedent(
-        f"""\
+    expected = textwrap.dedent(f"""\
     ...# Editable Git install with no remote (version...pkg==0.1)
     -e {os.path.normcase(pkg_path)}
-    ..."""
-    )
+    ...""")
     _check_output(result.stdout, expected)
 
 
@@ -258,11 +244,9 @@ def test_freeze_svn(script: PipTestEnvironment) -> None:
     # Install with develop
     script.run("python", "setup.py", "develop", cwd=checkout_path, expect_stderr=True)
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         ...-e svn+...#egg=version_pkg
-        ..."""
-    )
+        ...""")
     _check_output(result.stdout, expected)
 
 
@@ -296,12 +280,10 @@ def test_freeze_exclude_editable(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", "--exclude-editable", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e git+...#egg=version_pkg
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -329,12 +311,10 @@ def test_freeze_git_clone(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e git+...#egg=version_pkg
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
     # Check that slashes in branch or tag names are translated.
@@ -354,12 +334,10 @@ def test_freeze_git_clone(script: PipTestEnvironment) -> None:
     script.run("git", "add", "newfile", cwd=repo_dir)
     _git_commit(script, repo_dir, message="...")
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e ...@...#egg=version_pkg
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -389,12 +367,10 @@ def test_freeze_git_clone_srcdir(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e git+...#egg=version_pkg&subdirectory=subdir
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -412,12 +388,10 @@ def test_freeze_mercurial_clone_srcdir(script: PipTestEnvironment) -> None:
     repo_dir = script.scratch_path / "pip-test-package"
     result = script.run("python", "setup.py", "develop", cwd=repo_dir / "subdir")
     result = script.pip("freeze")
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e hg+...#egg=version_pkg&subdirectory=subdir
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -447,60 +421,38 @@ def test_freeze_git_remote(script: PipTestEnvironment) -> None:
     origin_remote = pkg_version
     # check frozen remote after clone
     result = script.pip("freeze", expect_stderr=True)
-    expected = (
-        textwrap.dedent(
-            """
+    expected = textwrap.dedent("""
             ...-e git+{remote}@...#egg=version_pkg
             ...
-        """
-        )
-        .format(remote=origin_remote.as_uri())
-        .strip()
-    )
+        """).format(remote=origin_remote.as_uri()).strip()
     _check_output(result.stdout, expected)
     # check frozen remote when there is no remote named origin
     script.run("git", "remote", "rename", "origin", "other", cwd=repo_dir)
     result = script.pip("freeze", expect_stderr=True)
-    expected = (
-        textwrap.dedent(
-            """
+    expected = textwrap.dedent("""
             ...-e git+{remote}@...#egg=version_pkg
             ...
-        """
-        )
-        .format(remote=origin_remote.as_uri())
-        .strip()
-    )
+        """).format(remote=origin_remote.as_uri()).strip()
     _check_output(result.stdout, expected)
     # When the remote is a local path, it must exist.
     # If it doesn't, it gets flagged as invalid.
     other_remote = f"{pkg_version}-other"
     script.run("git", "remote", "set-url", "other", other_remote, cwd=repo_dir)
     result = script.pip("freeze", expect_stderr=True)
-    expected = os.path.normcase(
-        textwrap.dedent(
-            f"""
+    expected = os.path.normcase(textwrap.dedent(f"""
             ...# Editable Git...(version...pkg...)...
             # '{other_remote}'
             -e {repo_dir}...
-        """
-        ).strip()
-    )
+        """).strip())
     _check_output(os.path.normcase(result.stdout), expected)
     # when there are more than one origin, priority is given to the
     # remote named origin
     script.run("git", "remote", "add", "origin", os.fspath(origin_remote), cwd=repo_dir)
     result = script.pip("freeze", expect_stderr=True)
-    expected = (
-        textwrap.dedent(
-            """
+    expected = textwrap.dedent("""
             ...-e git+{remote}@...#egg=version_pkg
             ...
-        """
-        )
-        .format(remote=origin_remote.as_uri())
-        .strip()
-    )
+        """).format(remote=origin_remote.as_uri()).strip()
     _check_output(result.stdout, expected)
 
 
@@ -529,12 +481,10 @@ def test_freeze_mercurial_clone(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
             ...-e hg+...#egg=version_pkg
             ...
-        """
-    ).strip()
+        """).strip()
     _check_output(result.stdout, expected)
 
 
@@ -558,11 +508,9 @@ def test_freeze_bazaar_clone(script: PipTestEnvironment) -> None:
         expect_stderr=True,
     )
     result = script.pip("freeze", expect_stderr=True)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         ...-e bzr+file://...@1#egg=version_pkg
-        ..."""
-    )
+        ...""")
     _check_output(result.stdout, expected)
 
 
@@ -607,8 +555,7 @@ def test_freeze_nested_vcs(
 
 
 # used by the test_freeze_with_requirement_* tests below
-_freeze_req_opts = textwrap.dedent(
-    """\
+_freeze_req_opts = textwrap.dedent("""\
     # Unchanged requirements below this line
     -r ignore.txt
     --requirement ignore.txt
@@ -621,8 +568,7 @@ _freeze_req_opts = textwrap.dedent(
     --find-links http://ignore
     --index-url http://ignore
     --use-feature resolvelib
-"""
-)
+""")
 
 
 def test_freeze_with_requirement_option_file_url_egg_not_installed(
@@ -659,26 +605,16 @@ def test_freeze_with_requirement_option(script: PipTestEnvironment) -> None:
 
     """
 
-    script.scratch_path.joinpath("hint1.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("hint1.txt").write_text(textwrap.dedent("""\
         INITools==0.1
         NoExist==4.2  # A comment that ensures end of line comments work.
         simple==3.0; python_version > '1.0'
-        """
-        )
-        + _freeze_req_opts
-    )
-    script.scratch_path.joinpath("hint2.txt").write_text(
-        textwrap.dedent(
-            """\
+        """) + _freeze_req_opts)
+    script.scratch_path.joinpath("hint2.txt").write_text(textwrap.dedent("""\
         iniTools==0.1
         Noexist==4.2  # A comment that ensures end of line comments work.
         Simple==3.0; python_version > '1.0'
-        """
-        )
-        + _freeze_req_opts
-    )
+        """) + _freeze_req_opts)
     result = script.pip_install_local("initools==0.2")
     result = script.pip_install_local("simple")
     result = script.pip(
@@ -687,12 +623,10 @@ def test_freeze_with_requirement_option(script: PipTestEnvironment) -> None:
         "hint1.txt",
         expect_stderr=True,
     )
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         INITools==0.2
         simple==3.0
-    """
-    )
+    """)
     expected += _freeze_req_opts
     expected += "## The following requirements were added by pip freeze:..."
     _check_output(result.stdout, expected)
@@ -719,25 +653,15 @@ def test_freeze_with_requirement_option_multiple(script: PipTestEnvironment) -> 
     --requirement hints
 
     """
-    script.scratch_path.joinpath("hint1.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("hint1.txt").write_text(textwrap.dedent("""\
         INITools==0.1
         NoExist==4.2
         simple==3.0; python_version > '1.0'
-    """
-        )
-        + _freeze_req_opts
-    )
-    script.scratch_path.joinpath("hint2.txt").write_text(
-        textwrap.dedent(
-            """\
+    """) + _freeze_req_opts)
+    script.scratch_path.joinpath("hint2.txt").write_text(textwrap.dedent("""\
         NoExist2==2.0
         simple2==1.0
-    """
-        )
-        + _freeze_req_opts
-    )
+    """) + _freeze_req_opts)
     result = script.pip_install_local("initools==0.2")
     result = script.pip_install_local("simple")
     result = script.pip_install_local("simple2==1.0")
@@ -750,24 +674,18 @@ def test_freeze_with_requirement_option_multiple(script: PipTestEnvironment) -> 
         "hint2.txt",
         expect_stderr=True,
     )
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         INITools==0.2
         simple==1.0
-    """
-    )
+    """)
     expected += _freeze_req_opts
-    expected += textwrap.dedent(
-        """\
+    expected += textwrap.dedent("""\
         simple2==1.0
-    """
-    )
+    """)
     expected += "## The following requirements were added by pip freeze:"
-    expected += "\n" + textwrap.dedent(
-        """\
+    expected += "\n" + textwrap.dedent("""\
         ...meta==1.0...
-    """
-    )
+    """)
     _check_output(result.stdout, expected)
     assert (
         "Requirement file [hint1.txt] contains NoExist==4.2, but package "
@@ -789,16 +707,11 @@ def test_freeze_with_requirement_option_package_repeated_one_file(
     Test freezing with single requirements file that contains a package
     multiple times
     """
-    script.scratch_path.joinpath("hint1.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("hint1.txt").write_text(textwrap.dedent("""\
         simple2
         simple2
         NoExist
-    """
-        )
-        + _freeze_req_opts
-    )
+    """) + _freeze_req_opts)
     result = script.pip_install_local("simple2==1.0")
     result = script.pip_install_local("meta")
     result = script.pip(
@@ -807,18 +720,14 @@ def test_freeze_with_requirement_option_package_repeated_one_file(
         "hint1.txt",
         expect_stderr=True,
     )
-    expected_out = textwrap.dedent(
-        """\
+    expected_out = textwrap.dedent("""\
         simple2==1.0
-    """
-    )
+    """)
     expected_out += _freeze_req_opts
     expected_out += "## The following requirements were added by pip freeze:"
-    expected_out += "\n" + textwrap.dedent(
-        """\
+    expected_out += "\n" + textwrap.dedent("""\
         ...meta==1.0...
-    """
-    )
+    """)
     _check_output(result.stdout, expected_out)
     err1 = (
         "Requirement file [hint1.txt] contains NoExist, "
@@ -837,23 +746,13 @@ def test_freeze_with_requirement_option_package_repeated_multi_file(
     """
     Test freezing with multiple requirements file that contain a package
     """
-    script.scratch_path.joinpath("hint1.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("hint1.txt").write_text(textwrap.dedent("""\
         simple
-    """
-        )
-        + _freeze_req_opts
-    )
-    script.scratch_path.joinpath("hint2.txt").write_text(
-        textwrap.dedent(
-            """\
+    """) + _freeze_req_opts)
+    script.scratch_path.joinpath("hint2.txt").write_text(textwrap.dedent("""\
         simple
         NoExist
-    """
-        )
-        + _freeze_req_opts
-    )
+    """) + _freeze_req_opts)
     result = script.pip_install_local("simple==1.0")
     result = script.pip_install_local("meta")
     result = script.pip(
@@ -864,18 +763,14 @@ def test_freeze_with_requirement_option_package_repeated_multi_file(
         "hint2.txt",
         expect_stderr=True,
     )
-    expected_out = textwrap.dedent(
-        """\
+    expected_out = textwrap.dedent("""\
         simple==1.0
-    """
-    )
+    """)
     expected_out += _freeze_req_opts
     expected_out += "## The following requirements were added by pip freeze:"
-    expected_out += "\n" + textwrap.dedent(
-        """\
+    expected_out += "\n" + textwrap.dedent("""\
         ...meta==1.0...
-    """
-    )
+    """)
     _check_output(result.stdout, expected_out)
 
     err1 = (
@@ -899,11 +794,9 @@ def test_freeze_user(
     script.pip_install_local("--find-links", data.find_links, "--user", "simple==2.0")
     script.pip_install_local("--find-links", data.find_links, "simple2==3.0")
     result = script.pip("freeze", "--user", expect_stderr=True)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==2.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
     assert "simple2" not in result.stdout
 
@@ -914,11 +807,9 @@ def test_freeze_path(tmpdir: Path, script: PipTestEnvironment, data: TestData) -
     """
     script.pip_install_local("--target", tmpdir, "simple==2.0")
     result = script.pip("freeze", "--path", tmpdir)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==2.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
 
 
@@ -933,18 +824,14 @@ def test_freeze_path_exclude_user(
     script.pip_install_local("--find-links", data.find_links, "--user", "simple2")
     script.pip_install_local("--target", tmpdir, "simple==1.0")
     result = script.pip("freeze", "--user")
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple2==3.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
     result = script.pip("freeze", "--path", tmpdir)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==1.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
 
 
@@ -961,19 +848,15 @@ def test_freeze_path_multiple(
     script.pip_install_local("--target", path1, "simple==2.0")
     script.pip_install_local("--target", path2, "simple2==3.0")
     result = script.pip("freeze", "--path", path1)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==2.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
     result = script.pip("freeze", "--path", path1, "--path", path2)
-    expected = textwrap.dedent(
-        """\
+    expected = textwrap.dedent("""\
         simple==2.0
         simple2==3.0
-        <BLANKLINE>"""
-    )
+        <BLANKLINE>""")
     _check_output(result.stdout, expected)
 
 

--- a/tests/functional/test_index_invalid_wheels.py
+++ b/tests/functional/test_index_invalid_wheels.py
@@ -23,16 +23,12 @@ def _create_test_index_with_invalid_wheels(
     index_dir = tmpdir / "test_index"
     index_dir.mkdir()
 
-    (index_dir / "index.html").write_text(
-        textwrap.dedent(
-            f"""\
+    (index_dir / "index.html").write_text(textwrap.dedent(f"""\
         <!DOCTYPE html>
         <html>
           <body><a href="{package_name}/index.html">{package_name}</a></body>
         </html>
-        """
-        )
-    )
+        """))
 
     pkg_dir = index_dir / package_name
     pkg_dir.mkdir()
@@ -59,18 +55,14 @@ def _create_test_index_with_invalid_wheels(
     links = [
         f'<a href="{wheel_name}">{wheel_name}</a><br/>' for wheel_name, _ in all_wheels
     ]
-    (pkg_dir / "index.html").write_text(
-        textwrap.dedent(
-            f"""\
+    (pkg_dir / "index.html").write_text(textwrap.dedent(f"""\
         <!DOCTYPE html>
         <html>
           <body>
             {''.join(links)}
           </body>
         </html>
-        """
-        )
-    )
+        """))
 
     return index_dir
 

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -337,12 +337,10 @@ def test_install_exit_status_code_when_empty_dependency_group(
     """
     Test install exit status code is 0 when empty dependency group specified
     """
-    script.scratch_path.joinpath("pyproject.toml").write_text(
-        """\
+    script.scratch_path.joinpath("pyproject.toml").write_text("""\
 [dependency-groups]
 empty = []
-"""
-    )
+""")
     script.pip("install", "--group", "empty")
 
 
@@ -356,12 +354,10 @@ def test_install_dependency_group_bad_filename_error(
     """
     if file_exists:
         script.scratch_path.joinpath("not-pyproject.toml").write_text(
-            textwrap.dedent(
-                """
+            textwrap.dedent("""
                 [dependency-groups]
                 publish = ["twine"]
-                """
-            )
+                """)
         )
     result = script.pip(
         "install", "--group", "not-pyproject.toml:publish", expect_error=True
@@ -734,16 +730,12 @@ def test_link_hash_in_dep_fails_require_hashes(
     )
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            f"""\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent(f"""\
             [project]
             name = "pkga"
             version = "1.0"
             dependencies = ["simple @ {simple_url_with_hash}"]
-            """
-        )
-    )
+            """))
     # Build a wheel for pkga and compute its hash.
     wheelhouse = tmp_path / "wheehouse"
     wheelhouse.mkdir()
@@ -778,16 +770,12 @@ def test_bad_link_hash_in_dep_install_failure(
     url = f"{url}#sha256=invalidhash"
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            f"""\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent(f"""\
             [project]
             name = "pkga"
             version = "1.0"
             dependencies = ["simple @ {url}"]
-            """
-        )
-    )
+            """))
     result = script.pip_install_local(
         "--no-build-isolation", project_path, expect_error=True
     )
@@ -1040,12 +1028,10 @@ def test_install_package_with_same_name_in_curdir(
     result.did_create(dist_info_folder)
 
 
-mock100_setup_py = textwrap.dedent(
-    """\
+mock100_setup_py = textwrap.dedent("""\
                         from setuptools import setup
                         setup(name='mock',
-                              version='100.1')"""
-)
+                              version='100.1')""")
 
 
 def test_install_folder_using_dot_slash(script: PipTestEnvironment) -> None:
@@ -1242,9 +1228,7 @@ def test_install_with_target_or_prefix_and_scripts_no_warning(
     target_dir = script.scratch_path / "target"
     pkga_path = script.scratch_path / "pkga"
     pkga_path.mkdir()
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1',
@@ -1253,16 +1237,10 @@ def test_install_with_target_or_prefix_and_scripts_no_warning(
                   'console_scripts': ['pkga=pkga:main']
               }
         )
-    """
-        )
-    )
-    pkga_path.joinpath("pkga.py").write_text(
-        textwrap.dedent(
-            """
+    """))
+    pkga_path.joinpath("pkga.py").write_text(textwrap.dedent("""
         def main(): pass
-    """
-        )
-    )
+    """))
     result = script.pip("install", "--no-build-isolation", opt, target_dir, pkga_path)
     # This assertion isn't actually needed, if we get the script warning
     # the script.pip() call will fail with "stderr not expected". But we
@@ -1373,17 +1351,13 @@ def _test_install_editable_with_prefix(
 def test_install_editable_with_target(script: PipTestEnvironment) -> None:
     pkg_path = script.scratch_path / "pkg"
     pkg_path.mkdir()
-    pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(
             name='pkg',
             install_requires=['simplewheel==2.0']
         )
-    """
-        )
-    )
+    """))
 
     target = script.scratch_path / "target"
     target.mkdir()
@@ -1625,31 +1599,23 @@ def test_install_upgrade_editable_depending_on_other_editable(
 ) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1')
-    """
-        )
-    )
+    """))
     script.pip("install", "--no-build-isolation", "--editable", pkga_path)
     result = script.pip("list", "--format=freeze")
     assert "pkga==0.1" in result.stdout
 
     script.scratch_path.joinpath("pkgb").mkdir()
     pkgb_path = script.scratch_path / "pkgb"
-    pkgb_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkgb_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkgb',
               version='0.1',
               install_requires=['pkga'])
-    """
-        )
-    )
+    """))
     script.pip(
         "install",
         "--no-build-isolation",
@@ -1852,15 +1818,11 @@ def test_install_editable_with_wrong_egg_name(
 ) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1')
-    """
-        )
-    )
+    """))
     result = script.pip(
         "install",
         "--no-build-isolation",
@@ -1938,16 +1900,12 @@ def _get_expected_error_text() -> str:
 def test_install_incompatible_python_requires(script: PipTestEnvironment) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='<1.0',
               version='0.1')
-    """
-        )
-    )
+    """))
     result = script.pip("install", "--no-build-isolation", pkga_path, expect_error=True)
     assert _get_expected_error_text() in result.stderr, str(result)
 
@@ -1957,16 +1915,12 @@ def test_install_incompatible_python_requires_editable(
 ) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='<1.0',
               version='0.1')
-    """
-        )
-    )
+    """))
     result = script.pip(
         "install", "--no-build-isolation", f"--editable={pkga_path}", expect_error=True
     )
@@ -1976,16 +1930,12 @@ def test_install_incompatible_python_requires_editable(
 def test_install_incompatible_python_requires_wheel(script: PipTestEnvironment) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='<1.0',
               version='0.1')
-    """
-        )
-    )
+    """))
     script.run(
         "python",
         "setup.py",
@@ -2002,16 +1952,12 @@ def test_install_incompatible_python_requires_wheel(script: PipTestEnvironment) 
 def test_install_compatible_python_requires(script: PipTestEnvironment) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='>1.0',
               version='0.1')
-    """
-        )
-    )
+    """))
     res = script.pip("install", "--no-build-isolation", pkga_path)
     assert "Successfully installed pkga-0.1" in res.stdout, res
 
@@ -2175,14 +2121,10 @@ def test_target_install_ignores_distutils_config_install_prefix(
     distutils_config = Path.home().joinpath(
         "pydistutils.cfg" if sys.platform == "win32" else ".pydistutils.cfg",
     )
-    distutils_config.write_text(
-        textwrap.dedent(
-            f"""
+    distutils_config.write_text(textwrap.dedent(f"""
         [install]
         prefix={prefix}
-        """
-        )
-    )
+        """))
     target = script.scratch_path / "target"
     result = script.pip_install_local("simplewheel", "-t", target)
 
@@ -2571,8 +2513,7 @@ def test_install_dry_run_nothing_installed(
     reason="3.11 required to find distributions via importlib metadata",
 )
 def test_install_existing_memory_distribution(script: PipTestEnvironment) -> None:
-    sitecustomize_text = textwrap.dedent(
-        """
+    sitecustomize_text = textwrap.dedent("""
         import sys
         from importlib.metadata import Distribution, DistributionFinder
 
@@ -2598,8 +2539,7 @@ def test_install_existing_memory_distribution(script: PipTestEnvironment) -> Non
 
 
         sys.meta_path.append(CustomFinder())
-        """
-    )
+        """)
     with open(script.site_packages_path / "sitecustomize.py", "w") as sitecustomize:
         sitecustomize.write(sitecustomize_text)
 
@@ -2735,13 +2675,11 @@ def test_install_sdist_links(
         add_file(
             sdist_tar,
             "PKG-INFO",
-            textwrap.dedent(
-                """
+            textwrap.dedent("""
                     Metadata-Version: 2.1
                     Name: linktest
                     Version: 1.0
-                """
-            ),
+                """),
         )
 
         add_file(sdist_tar, "src/linktest/__init__.py", "")
@@ -2774,8 +2712,7 @@ def test_install_sdist_links(
         add_file(
             sdist_tar,
             "pyproject.toml",
-            textwrap.dedent(
-                """
+            textwrap.dedent("""
                     [build-system]
                     requires = ["setuptools"]
                     build-backend = "setuptools.build_meta"
@@ -2788,15 +2725,13 @@ def test_install_sdist_links(
                     where = ["src"]
                     [tool.setuptools.package-data]
                     "*" = ["*.dat"]
-                """
-            ),
+                """),
         )
 
         add_file(
             sdist_tar,
             "src/linktest/__main__.py",
-            textwrap.dedent(
-                f"""
+            textwrap.dedent(f"""
                     from pathlib import Path
                     linknames = {linknames!r}
 
@@ -2808,8 +2743,7 @@ def test_install_sdist_links(
                         data_text = res_path.joinpath(name).read_text()
                         assert data_text == "Data"
                     print(str(len(linknames)) + ' files checked')
-                """
-            ),
+                """),
         )
 
     # Show sdist content, for debugging the test

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -321,9 +321,7 @@ def test_install_warns_on_unexpected_post_install_import(
     """
     wheel_path = create_basic_wheel_for_package(script, "mypackage", "1.0")
     runner = script.scratch_path / "run_install.py"
-    runner.write_text(
-        textwrap.dedent(
-            """\
+    runner.write_text(textwrap.dedent("""\
             import sys
             import pip._internal.commands.install as _install_mod
             _orig_get_environment = _install_mod.get_environment
@@ -347,9 +345,7 @@ def test_install_warns_on_unexpected_post_install_import(
                 "mypackage"
                 ])
             )
-        """
-        )
-    )
+        """))
 
     result = script.run(
         "python", str(runner), str(wheel_path.parent), expect_stderr=True
@@ -388,12 +384,10 @@ def test_install_exit_status_code_when_empty_dependency_group(
     """
     Test install exit status code is 0 when empty dependency group specified
     """
-    script.scratch_path.joinpath("pyproject.toml").write_text(
-        """\
+    script.scratch_path.joinpath("pyproject.toml").write_text("""\
 [dependency-groups]
 empty = []
-"""
-    )
+""")
     script.pip("install", "--group", "empty")
 
 
@@ -407,12 +401,10 @@ def test_install_dependency_group_bad_filename_error(
     """
     if file_exists:
         script.scratch_path.joinpath("not-pyproject.toml").write_text(
-            textwrap.dedent(
-                """
+            textwrap.dedent("""
                 [dependency-groups]
                 publish = ["twine"]
-                """
-            )
+                """)
         )
     result = script.pip(
         "install", "--group", "not-pyproject.toml:publish", expect_error=True
@@ -785,16 +777,12 @@ def test_link_hash_in_dep_fails_require_hashes(
     )
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            f"""\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent(f"""\
             [project]
             name = "pkga"
             version = "1.0"
             dependencies = ["simple @ {simple_url_with_hash}"]
-            """
-        )
-    )
+            """))
     # Build a wheel for pkga and compute its hash.
     wheelhouse = tmp_path / "wheehouse"
     wheelhouse.mkdir()
@@ -829,16 +817,12 @@ def test_bad_link_hash_in_dep_install_failure(
     url = f"{url}#sha256=invalidhash"
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            f"""\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent(f"""\
             [project]
             name = "pkga"
             version = "1.0"
             dependencies = ["simple @ {url}"]
-            """
-        )
-    )
+            """))
     result = script.pip_install_local(
         "--no-build-isolation", project_path, expect_error=True
     )
@@ -1091,12 +1075,10 @@ def test_install_package_with_same_name_in_curdir(
     result.did_create(dist_info_folder)
 
 
-mock100_setup_py = textwrap.dedent(
-    """\
+mock100_setup_py = textwrap.dedent("""\
                         from setuptools import setup
                         setup(name='mock',
-                              version='100.1')"""
-)
+                              version='100.1')""")
 
 
 def test_install_folder_using_dot_slash(script: PipTestEnvironment) -> None:
@@ -1293,9 +1275,7 @@ def test_install_with_target_or_prefix_and_scripts_no_warning(
     target_dir = script.scratch_path / "target"
     pkga_path = script.scratch_path / "pkga"
     pkga_path.mkdir()
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1',
@@ -1304,16 +1284,10 @@ def test_install_with_target_or_prefix_and_scripts_no_warning(
                   'console_scripts': ['pkga=pkga:main']
               }
         )
-    """
-        )
-    )
-    pkga_path.joinpath("pkga.py").write_text(
-        textwrap.dedent(
-            """
+    """))
+    pkga_path.joinpath("pkga.py").write_text(textwrap.dedent("""
         def main(): pass
-    """
-        )
-    )
+    """))
     result = script.pip("install", "--no-build-isolation", opt, target_dir, pkga_path)
     # This assertion isn't actually needed, if we get the script warning
     # the script.pip() call will fail with "stderr not expected". But we
@@ -1424,17 +1398,13 @@ def _test_install_editable_with_prefix(
 def test_install_editable_with_target(script: PipTestEnvironment) -> None:
     pkg_path = script.scratch_path / "pkg"
     pkg_path.mkdir()
-    pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(
             name='pkg',
             install_requires=['simplewheel==2.0']
         )
-    """
-        )
-    )
+    """))
 
     target = script.scratch_path / "target"
     target.mkdir()
@@ -1676,31 +1646,23 @@ def test_install_upgrade_editable_depending_on_other_editable(
 ) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1')
-    """
-        )
-    )
+    """))
     script.pip("install", "--no-build-isolation", "--editable", pkga_path)
     result = script.pip("list", "--format=freeze")
     assert "pkga==0.1" in result.stdout
 
     script.scratch_path.joinpath("pkgb").mkdir()
     pkgb_path = script.scratch_path / "pkgb"
-    pkgb_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkgb_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkgb',
               version='0.1',
               install_requires=['pkga'])
-    """
-        )
-    )
+    """))
     script.pip(
         "install",
         "--no-build-isolation",
@@ -1903,15 +1865,11 @@ def test_install_editable_with_wrong_egg_name(
 ) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1')
-    """
-        )
-    )
+    """))
     result = script.pip(
         "install",
         "--no-build-isolation",
@@ -1989,16 +1947,12 @@ def _get_expected_error_text() -> str:
 def test_install_incompatible_python_requires(script: PipTestEnvironment) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='<1.0',
               version='0.1')
-    """
-        )
-    )
+    """))
     result = script.pip("install", "--no-build-isolation", pkga_path, expect_error=True)
     assert _get_expected_error_text() in result.stderr, str(result)
 
@@ -2008,16 +1962,12 @@ def test_install_incompatible_python_requires_editable(
 ) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='<1.0',
               version='0.1')
-    """
-        )
-    )
+    """))
     result = script.pip(
         "install", "--no-build-isolation", f"--editable={pkga_path}", expect_error=True
     )
@@ -2027,16 +1977,12 @@ def test_install_incompatible_python_requires_editable(
 def test_install_incompatible_python_requires_wheel(script: PipTestEnvironment) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='<1.0',
               version='0.1')
-    """
-        )
-    )
+    """))
     script.run(
         "python",
         "setup.py",
@@ -2053,16 +1999,12 @@ def test_install_incompatible_python_requires_wheel(script: PipTestEnvironment) 
 def test_install_compatible_python_requires(script: PipTestEnvironment) -> None:
     script.scratch_path.joinpath("pkga").mkdir()
     pkga_path = script.scratch_path / "pkga"
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               python_requires='>1.0',
               version='0.1')
-    """
-        )
-    )
+    """))
     res = script.pip("install", "--no-build-isolation", pkga_path)
     assert "Successfully installed pkga-0.1" in res.stdout, res
 
@@ -2226,14 +2168,10 @@ def test_target_install_ignores_distutils_config_install_prefix(
     distutils_config = Path.home().joinpath(
         "pydistutils.cfg" if sys.platform == "win32" else ".pydistutils.cfg",
     )
-    distutils_config.write_text(
-        textwrap.dedent(
-            f"""
+    distutils_config.write_text(textwrap.dedent(f"""
         [install]
         prefix={prefix}
-        """
-        )
-    )
+        """))
     target = script.scratch_path / "target"
     result = script.pip_install_local("simplewheel", "-t", target)
 
@@ -2622,8 +2560,7 @@ def test_install_dry_run_nothing_installed(
     reason="3.11 required to find distributions via importlib metadata",
 )
 def test_install_existing_memory_distribution(script: PipTestEnvironment) -> None:
-    sitecustomize_text = textwrap.dedent(
-        """
+    sitecustomize_text = textwrap.dedent("""
         import sys
         from importlib.metadata import Distribution, DistributionFinder
 
@@ -2649,8 +2586,7 @@ def test_install_existing_memory_distribution(script: PipTestEnvironment) -> Non
 
 
         sys.meta_path.append(CustomFinder())
-        """
-    )
+        """)
     with open(script.site_packages_path / "sitecustomize.py", "w") as sitecustomize:
         sitecustomize.write(sitecustomize_text)
 
@@ -2786,13 +2722,11 @@ def test_install_sdist_links(
         add_file(
             sdist_tar,
             "PKG-INFO",
-            textwrap.dedent(
-                """
+            textwrap.dedent("""
                     Metadata-Version: 2.1
                     Name: linktest
                     Version: 1.0
-                """
-            ),
+                """),
         )
 
         add_file(sdist_tar, "src/linktest/__init__.py", "")
@@ -2825,8 +2759,7 @@ def test_install_sdist_links(
         add_file(
             sdist_tar,
             "pyproject.toml",
-            textwrap.dedent(
-                """
+            textwrap.dedent("""
                     [build-system]
                     requires = ["setuptools"]
                     build-backend = "setuptools.build_meta"
@@ -2839,15 +2772,13 @@ def test_install_sdist_links(
                     where = ["src"]
                     [tool.setuptools.package-data]
                     "*" = ["*.dat"]
-                """
-            ),
+                """),
         )
 
         add_file(
             sdist_tar,
             "src/linktest/__main__.py",
-            textwrap.dedent(
-                f"""
+            textwrap.dedent(f"""
                     from pathlib import Path
                     linknames = {linknames!r}
 
@@ -2859,8 +2790,7 @@ def test_install_sdist_links(
                         data_text = res_path.joinpath(name).read_text()
                         assert data_text == "Data"
                     print(str(len(linknames)) + ' files checked')
-                """
-            ),
+                """),
         )
 
     # Show sdist content, for debugging the test

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -71,14 +71,10 @@ def test_env_vars_override_config_file(
     # because there is/was a bug which only shows up in cases in which
     # 'config-item' and 'config_item' hash to the same value modulo the size
     # of the config dictionary.
-    config_file.write_text(
-        textwrap.dedent(
-            """\
+    config_file.write_text(textwrap.dedent("""\
         [global]
         no-index = 1
-        """
-        )
-    )
+        """))
     result = script.pip("install", "-vvv", "INITools", expect_error=True)
     msg = "DistributionNotFound: No matching distribution found for INITools"
     # Case insensitive as the new resolver canonicalizes the project name
@@ -175,27 +171,19 @@ def test_config_file_override_stack(
     # set this to make pip load it
     script.environ["PIP_CONFIG_FILE"] = str(config_file)
 
-    config_file.write_text(
-        textwrap.dedent(
-            f"""\
+    config_file.write_text(textwrap.dedent(f"""\
         [global]
         index-url = {base_address}/simple1
-        """
-        )
-    )
+        """))
     script.pip("install", "-vvv", "INITools", expect_error=True)
     virtualenv.clear()
 
-    config_file.write_text(
-        textwrap.dedent(
-            f"""\
+    config_file.write_text(textwrap.dedent(f"""\
         [global]
         index-url = {base_address}/simple1
         [install]
         index-url = {base_address}/simple2
-        """
-        )
-    )
+        """))
     script.pip("install", "-vvv", "INITools", expect_error=True)
     script.pip(
         "install",
@@ -241,14 +229,10 @@ def test_install_no_binary_via_config_disables_cached_wheels(
     config_file = tempfile.NamedTemporaryFile(mode="wt", delete=False)
     try:
         script.environ["PIP_CONFIG_FILE"] = config_file.name
-        config_file.write(
-            textwrap.dedent(
-                """\
+        config_file.write(textwrap.dedent("""\
             [global]
             no-binary = :all:
-            """
-            )
-        )
+            """))
         config_file.close()
         res = script.pip(
             "install",
@@ -480,8 +464,7 @@ def test_prompt_for_keyring_if_needed(
 
     url = f"https://USERNAME@{server.host}:{server.port}/simple"
 
-    keyring_content = textwrap.dedent(
-        """\
+    keyring_content = textwrap.dedent("""\
         import os
         import sys
         import keyring
@@ -501,8 +484,7 @@ def test_prompt_for_keyring_if_needed(
 
             def set_password(self, url, username):
                 pass
-    """
-    )
+    """)
     keyring_path = keyring_script.site_packages_path / "keyring_test.py"
     keyring_path.write_text(keyring_content)
 

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -218,9 +218,7 @@ def test_install_extra_merging(
     # Check that extra specifications in the extras section are honoured.
     pkga_path = script.scratch_path / "pkga"
     pkga_path.mkdir()
-    pkga_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkga_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from setuptools import setup
         setup(name='pkga',
               version='0.1',
@@ -228,9 +226,7 @@ def test_install_extra_merging(
               extras_require={'extra1': ['simple<3'],
                               'extra2': ['simple==1.*']},
         )
-    """
-        )
-    )
+    """))
 
     result = script.pip_install_local(
         f"{pkga_path}{extra_to_install}",
@@ -264,16 +260,12 @@ def test_install_setuptools_extras_inconsistency(
 ) -> None:
     test_project_path = tmp_path.joinpath("test")
     test_project_path.mkdir()
-    test_project_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    test_project_path.joinpath("setup.py").write_text(textwrap.dedent("""
                 from setuptools import setup
                 setup(
                     name='test',
                     version='0.1',
                     extras_require={'extra_underscored': ['packaging']},
                 )
-            """
-        )
-    )
+            """))
     script.pip("install", "--no-build-isolation", "--dry-run", test_project_path)

--- a/tests/functional/test_install_index.py
+++ b/tests/functional/test_install_index.py
@@ -41,15 +41,11 @@ def test_find_links_requirements_file_relative_path(
     script: PipTestEnvironment, data: TestData
 ) -> None:
     """Test find-links as a relative path to a reqs file."""
-    script.scratch_path.joinpath("test-req.txt").write_text(
-        textwrap.dedent(
-            f"""
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent(f"""
         --no-index
         --find-links={data.packages.as_posix()}
         parent==0.1
-        """
-        )
-    )
+        """))
     result = script.pip(
         "install",
         "--no-build-isolation",

--- a/tests/functional/test_install_report.py
+++ b/tests/functional/test_install_report.py
@@ -305,18 +305,14 @@ def test_install_report_local_path_with_extras(
     """Test report remote editable."""
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            """\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent("""\
             [project]
             name = "pkga"
             version = "1.0"
 
             [project.optional-dependencies]
             test = ["simple"]
-            """
-        )
-    )
+            """))
     report_path = tmp_path / "report.json"
     script.pip(
         "install",
@@ -349,18 +345,14 @@ def test_install_report_editable_local_path_with_extras(
     """Test report remote editable."""
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            """\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent("""\
             [project]
             name = "pkga"
             version = "1.0"
 
             [project.optional-dependencies]
             test = ["simple"]
-            """
-        )
-    )
+            """))
     report_path = tmp_path / "report.json"
     script.pip(
         "install",

--- a/tests/functional/test_install_reqs.py
+++ b/tests/functional/test_install_reqs.py
@@ -37,8 +37,7 @@ class ArgRecordingSdistMaker(Protocol):
 def arg_recording_sdist_maker(
     script: PipTestEnvironment,
 ) -> ArgRecordingSdistMaker:
-    arg_writing_setup_py_prelude = textwrap.dedent(
-        """
+    arg_writing_setup_py_prelude = textwrap.dedent("""
         import io
         import json
         import os
@@ -47,8 +46,7 @@ def arg_recording_sdist_maker(
         args_path = os.path.join(os.environ["OUTPUT_DIR"], "{name}.json")
         with open(args_path, 'w') as f:
             json.dump(sys.argv, f)
-        """
-    )
+        """)
     output_dir = script.scratch_path.joinpath("args_recording_sdist_maker_output")
     output_dir.mkdir(parents=True)
     script.environ["OUTPUT_DIR"] = str(output_dir)
@@ -249,12 +247,10 @@ def test_multiple_requirements_files(script: PipTestEnvironment, tmpdir: Path) -
     """
     other_lib_name, other_lib_version = "six", "1.16.0"
     script.scratch_path.joinpath("initools-req.txt").write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             -e {}@10#egg=INITools
             -r {}-req.txt
-        """
-        ).format(
+        """).format(
             local_checkout("svn+http://svn.colorstudy.com/INITools", tmpdir),
             other_lib_name,
         ),
@@ -293,14 +289,10 @@ def test_constraints_apply_to_dependency_groups(
 ) -> None:
     script.scratch_path.joinpath("constraints.txt").write_text("TopoRequires==0.0.1")
     pyproject = script.scratch_path / "pyproject.toml"
-    pyproject.write_text(
-        textwrap.dedent(
-            """\
+    pyproject.write_text(textwrap.dedent("""\
             [dependency-groups]
             mylibs = ["TopoRequires2"]
-            """
-        )
-    )
+            """))
     result = script.pip(
         "install",
         "--no-build-isolation",
@@ -335,15 +327,11 @@ def test_multiple_constraints_files(script: PipTestEnvironment, data: TestData) 
 def test_respect_order_in_requirements_file(
     script: PipTestEnvironment, data: TestData
 ) -> None:
-    script.scratch_path.joinpath("frameworks-req.txt").write_text(
-        textwrap.dedent(
-            """\
+    script.scratch_path.joinpath("frameworks-req.txt").write_text(textwrap.dedent("""\
         parent
         child
         simple
-        """
-        )
-    )
+        """))
 
     result = script.pip(
         "install",
@@ -425,13 +413,9 @@ def test_wheel_user_with_prefix_in_pydistutils_cfg(
     user_cfg = os.path.join(os.path.expanduser("~"), user_filename)
     script.scratch_path.joinpath("bin").mkdir()
     with open(user_cfg, "w") as cfg:
-        cfg.write(
-            textwrap.dedent(
-                f"""
+        cfg.write(textwrap.dedent(f"""
             [install]
-            prefix={script.scratch_path}"""
-            )
-        )
+            prefix={script.scratch_path}"""))
 
     result = script.pip(
         "install",
@@ -835,11 +819,9 @@ def test_install_distribution_union_conflicting_extras(
 
 def test_install_unsupported_wheel_link_with_marker(script: PipTestEnvironment) -> None:
     script.scratch_path.joinpath("with-marker.txt").write_text(
-        textwrap.dedent(
-            """\
+        textwrap.dedent("""\
             {url}; {req}
-        """
-        ).format(
+        """).format(
             url="https://github.com/a/b/c/asdf-1.5.2-cp27-none-xyz.whl",
             req='sys_platform == "xyz"',
         )
@@ -878,13 +860,11 @@ def test_config_settings_local_to_package(
     common_wheels: Path,
     arg_recording_sdist_maker: ArgRecordingSdistMaker,
 ) -> None:
-    pyproject_toml = textwrap.dedent(
-        """
+    pyproject_toml = textwrap.dedent("""
         [build-system]
         requires = ["setuptools"]
         build-backend = "setuptools.build_meta"
-        """
-    )
+        """)
     simple0_sdist = arg_recording_sdist_maker(
         "simple0",
         extra_files={"pyproject.toml": pyproject_toml},
@@ -913,16 +893,12 @@ def test_config_settings_local_to_package(
     )
 
     reqs_file = script.scratch_path.joinpath("reqs.txt")
-    reqs_file.write_text(
-        textwrap.dedent(
-            """
+    reqs_file.write_text(textwrap.dedent("""
             simple0 --config-settings "--build-option=--verbose"
             foo --config-settings "--build-option=--quiet"
             simple1 --config-settings "--build-option=--verbose"
             simple2
-            """
-        )
-    )
+            """))
 
     script.pip_install_local(
         "--no-build-isolation",

--- a/tests/functional/test_install_script.py
+++ b/tests/functional/test_install_script.py
@@ -10,9 +10,7 @@ def test_script_file(script: PipTestEnvironment) -> None:
     """
 
     script_path = script.scratch_path.joinpath("script.py")
-    script_path.write_text(
-        textwrap.dedent(
-            """\
+    script_path.write_text(textwrap.dedent("""\
             # /// script
             # dependencies = [
             #   "INITools==0.2",
@@ -21,9 +19,7 @@ def test_script_file(script: PipTestEnvironment) -> None:
             # ///
 
             print("Hello world from a dummy program")
-            """
-        )
-    )
+            """))
     script.pip_install_local("--requirements-from-script", script_path)
     script.assert_installed(initools="0.2", simple="1.0")
 
@@ -54,9 +50,7 @@ def test_script_file_python_version(script: PipTestEnvironment) -> None:
 
     script_path = script.scratch_path.joinpath("script.py")
 
-    script_path.write_text(
-        textwrap.dedent(
-            f"""\
+    script_path.write_text(textwrap.dedent(f"""\
             # /// script
             # requires-python = "!={sys.version_info.major}.{sys.version_info.minor}.*"
             # dependencies = [
@@ -66,9 +60,7 @@ def test_script_file_python_version(script: PipTestEnvironment) -> None:
             # ///
 
             print("Hello world from a dummy program")
-            """
-        )
-    )
+            """))
 
     result = script.pip_install_local(
         "--requirements-from-script",
@@ -90,18 +82,14 @@ def test_script_invalid_TOML(script: PipTestEnvironment) -> None:
 
     script_path = script.scratch_path.joinpath("script.py")
 
-    script_path.write_text(
-        textwrap.dedent(
-            f"""\
+    script_path.write_text(textwrap.dedent(f"""\
             # /// script
             # requires-python = "!={sys.version_info.major}.{sys.version_info.minor}.*"
             # dependencies = [
             # ///
 
             print("Hello world from a dummy program")
-            """
-        )
-    )
+            """))
 
     result = script.pip_install_local(
         "--requirements-from-script",
@@ -122,9 +110,7 @@ def test_script_multiple_blocks(script: PipTestEnvironment) -> None:
 
     script_path = script.scratch_path.joinpath("script.py")
 
-    script_path.write_text(
-        textwrap.dedent(
-            f"""\
+    script_path.write_text(textwrap.dedent(f"""\
             # /// script
             # requires-python = "!={sys.version_info.major}.{sys.version_info.minor}.*"
             # dependencies = [
@@ -142,9 +128,7 @@ def test_script_multiple_blocks(script: PipTestEnvironment) -> None:
             # ///
 
             print("Hello world from a dummy program")
-            """
-        )
-    )
+            """))
 
     result = script.pip_install_local(
         "--requirements-from-script",

--- a/tests/functional/test_install_user.py
+++ b/tests/functional/test_install_user.py
@@ -25,15 +25,13 @@ def _patch_dist_in_site_packages(virtualenv: VirtualEnvironment) -> None:
     # install to the usersite because it will lack sys.path precedence..."
     # error: Monkey patch the Distribution class so it's possible to install a
     # conflicting distribution in the user site.
-    virtualenv.sitecustomize = textwrap.dedent(
-        """
+    virtualenv.sitecustomize = textwrap.dedent("""
         def dist_in_site_packages(dist):
             return False
 
         from pip._internal.metadata.base import BaseDistribution
         BaseDistribution.in_site_packages = property(dist_in_site_packages)
-    """
-    )
+    """)
 
 
 @pytest.mark.usefixtures("enable_user_site")
@@ -343,9 +341,7 @@ class Tests_UserSite:
 
         # Create a custom Python script that disables user site and runs pip via exec
         test_script = script.scratch_path / "test_disable_user_site.py"
-        test_script.write_text(
-            textwrap.dedent(
-                f"""
+        test_script.write_text(textwrap.dedent(f"""
             import site
             import sys
 
@@ -369,9 +365,7 @@ class Tests_UserSite:
             # Import and run pip's main
             from pip._internal.cli.main import main
             sys.exit(main())
-            """
-            )
-        )
+            """))
 
         result = script.run("python", str(test_script), expect_error=True)
         assert (

--- a/tests/functional/test_lock.py
+++ b/tests/functional/test_lock.py
@@ -95,15 +95,11 @@ def test_lock_local_directory(
 ) -> None:
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            """\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent("""\
             [project]
             name = "pkga"
             version = "1.0"
-            """
-        )
-    )
+            """))
     result = script.pip(
         "lock",
         ".",
@@ -130,16 +126,12 @@ def test_lock_local_editable_with_dep(
 ) -> None:
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            """\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent("""\
             [project]
             name = "pkga"
             version = "1.0"
             dependencies = ["simplewheel==2.0"]
-            """
-        )
-    )
+            """))
     result = script.pip(
         "lock",
         "-e",

--- a/tests/functional/test_lock.py
+++ b/tests/functional/test_lock.py
@@ -96,15 +96,11 @@ def test_lock_local_directory(
 ) -> None:
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            """\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent("""\
             [project]
             name = "pkga"
             version = "1.0"
-            """
-        )
-    )
+            """))
     result = script.pip(
         "lock",
         ".",
@@ -131,16 +127,12 @@ def test_lock_local_editable_with_dep(
 ) -> None:
     project_path = tmp_path / "pkga"
     project_path.mkdir()
-    project_path.joinpath("pyproject.toml").write_text(
-        textwrap.dedent(
-            """\
+    project_path.joinpath("pyproject.toml").write_text(textwrap.dedent("""\
             [project]
             name = "pkga"
             version = "1.0"
             dependencies = ["simplewheel==2.0"]
-            """
-        )
-    )
+            """))
     result = script.pip(
         "lock",
         "-e",

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -814,12 +814,10 @@ def test_new_resolver_constraint_only_marker_match(script: PipTestEnvironment) -
     create_basic_wheel_for_package(script, "pkg", "2.0")
     create_basic_wheel_for_package(script, "pkg", "3.0")
 
-    constraints_content = textwrap.dedent(
-        """
+    constraints_content = textwrap.dedent("""
         pkg==1.0; python_version == "{ver[0]}.{ver[1]}"  # Always satisfies.
         pkg==2.0; python_version < "0"  # Never satisfies.
-        """
-    ).format(ver=sys.version_info)
+        """).format(ver=sys.version_info)
     constraints_txt = script.scratch_path / "constraints.txt"
     constraints_txt.write_text(constraints_content)
 

--- a/tests/functional/test_new_resolver_hashes.py
+++ b/tests/functional/test_new_resolver_hashes.py
@@ -23,13 +23,11 @@ def _create_find_links(script: PipTestEnvironment) -> _FindLinks:
     wheel_hash = hashlib.sha256(wheel_path.read_bytes()).hexdigest()
 
     index_html = script.scratch_path / "index.html"
-    index_html.write_text(
-        f"""
+    index_html.write_text(f"""
         <!DOCTYPE html>
         <a href="{sdist_path.as_uri()}#sha256={sdist_hash}">{sdist_path.stem}</a>
         <a href="{wheel_path.as_uri()}#sha256={wheel_hash}">{wheel_path.stem}</a>
-        """.strip()
-    )
+        """.strip())
 
     return _FindLinks(index_html, sdist_hash, wheel_hash)
 

--- a/tests/functional/test_new_resolver_user.py
+++ b/tests/functional/test_new_resolver_user.py
@@ -97,15 +97,13 @@ def patch_dist_in_site_packages(virtualenv: VirtualEnvironment) -> None:
     # install to the usersite because it will lack sys.path precedence..."
     # error: Monkey patch `pip._internal.utils.misc.dist_in_site_packages`
     # so it's possible to install a conflicting distribution in the user site.
-    virtualenv.sitecustomize = textwrap.dedent(
-        """
+    virtualenv.sitecustomize = textwrap.dedent("""
         def dist_in_site_packages(dist):
             return False
 
         from pip._internal.metadata.base import BaseDistribution
         BaseDistribution.in_site_packages = property(dist_in_site_packages)
-    """
-    )
+    """)
 
 
 @pytest.mark.usefixtures("enable_user_site", "patch_dist_in_site_packages")

--- a/tests/functional/test_pep668.py
+++ b/tests/functional/test_pep668.py
@@ -15,8 +15,7 @@ def patch_check_externally_managed(
     # Since the tests are run from a virtual environment, and we can't
     # guarantee access to the actual stdlib location (where EXTERNALLY-MANAGED
     # needs to go into), we patch the check to always raise a simple message.
-    virtualenv.sitecustomize = textwrap.dedent(
-        """\
+    virtualenv.sitecustomize = textwrap.dedent("""\
         from pip._internal.exceptions import ExternallyManagedEnvironment
         from pip._internal.utils import misc
 
@@ -24,8 +23,7 @@ def patch_check_externally_managed(
             raise ExternallyManagedEnvironment("I am externally managed")
 
         misc.check_externally_managed = check_externally_managed
-        """
-    )
+        """)
     # The ubuntu-24.04 GitHub Actions runner has /etc/pip.conf that sets
     # break-system-packages = true, which causes pip to skip the
     # externally-managed check entirely. Override it here so the

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -85,17 +85,13 @@ def test_show_with_files_from_legacy(
     # Emulate the installed-files.txt generation which previous pip version did
     # after running setup.py install (write_installed_files_from_setuptools_record).
     egg_info_dir = script.site_packages_path / f"simple-1.0-py{pyversion}.egg-info"
-    egg_info_dir.joinpath("installed-files.txt").write_text(
-        textwrap.dedent(
-            """\
+    egg_info_dir.joinpath("installed-files.txt").write_text(textwrap.dedent("""\
                 ../simple/__init__.py
                 PKG-INFO
                 SOURCES.txt
                 dependency_links.txt
                 top_level.txt
-            """
-        )
-    )
+            """))
 
     result = script.pip("show", "--files", "simple")
     lines = result.stdout.splitlines()

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -48,17 +48,13 @@ def test_basic_uninstall_distutils(script: PipTestEnvironment) -> None:
     """
     script.scratch_path.joinpath("distutils_install").mkdir()
     pkg_path = script.scratch_path / "distutils_install"
-    pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
         from distutils.core import setup
         setup(
             name='distutils-install',
             version='0.1',
         )
-    """
-        )
-    )
+    """))
     result = script.run("python", os.fspath(pkg_path / "setup.py"), "install")
     result = script.pip("list", "--format=json")
     script.assert_installed(distutils_install="0.1")
@@ -457,19 +453,13 @@ def test_uninstall_from_reqs_file(script: PipTestEnvironment, tmpdir: Path) -> N
         "svn+http://svn.colorstudy.com/INITools",
         tmpdir,
     )
-    script.scratch_path.joinpath("test-req.txt").write_text(
-        textwrap.dedent(
-            """
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
             -e {url}#egg=initools
             # and something else to test out:
             PyLogo<0.4
-        """
-        ).format(url=local_svn_url)
-    )
+        """).format(url=local_svn_url))
     result = script.pip("install", "-r", "test-req.txt")
-    script.scratch_path.joinpath("test-req.txt").write_text(
-        textwrap.dedent(
-            """
+    script.scratch_path.joinpath("test-req.txt").write_text(textwrap.dedent("""
             # -f, -i, and --extra-index-url should all be ignored by uninstall
             -f http://www.example.com
             -i http://www.example.com
@@ -478,9 +468,7 @@ def test_uninstall_from_reqs_file(script: PipTestEnvironment, tmpdir: Path) -> N
             -e {url}#egg=initools
             # and something else to test out:
             PyLogo<0.4
-        """
-        ).format(url=local_svn_url)
-    )
+        """).format(url=local_svn_url))
     result2 = script.pip("uninstall", "-r", "test-req.txt", "-y")
     assert_all_changes(
         result,

--- a/tests/functional/test_warning.py
+++ b/tests/functional/test_warning.py
@@ -10,9 +10,7 @@ from tests.lib import PipTestEnvironment
 @pytest.fixture
 def warnings_demo(tmpdir: Path) -> Path:
     demo = tmpdir.joinpath("warnings_demo.py")
-    demo.write_text(
-        textwrap.dedent(
-            """
+    demo.write_text(textwrap.dedent("""
         from logging import basicConfig
         from pip._internal.utils import deprecation
 
@@ -20,9 +18,7 @@ def warnings_demo(tmpdir: Path) -> Path:
         basicConfig()
 
         deprecation.deprecated(reason="deprecated!", replacement=None, gone_in=None)
-    """
-        )
-    )
+    """))
     return demo
 
 

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -78,14 +78,10 @@ def test_pip_wheel_success_with_dependency_group(
     Test 'pip wheel' success.
     """
     pyproject = script.scratch_path / "pyproject.toml"
-    pyproject.write_text(
-        textwrap.dedent(
-            """\
+    pyproject.write_text(textwrap.dedent("""\
             [dependency-groups]
             simple = ["simple==3.0"]
-            """
-        )
-    )
+            """))
     result = script.pip(
         "wheel",
         "--no-build-isolation",

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -365,15 +365,11 @@ class TestPipResult:
         if pkg_dir and (pkg_dir in self.files_created) == (os.curdir in without_files):
             maybe = "not " if os.curdir in without_files else ""
             files = sorted(p.as_posix() for p in self.files_created)
-            raise TestFailure(
-                textwrap.dedent(
-                    f"""
+            raise TestFailure(textwrap.dedent(f"""
                     expected package directory {pkg_dir!r} {maybe}to be created
                     actually created:
                     {files}
-                    """
-                )
-            )
+                    """))
 
         for f in with_files:
             normalized_path = os.path.normpath(pkg_dir / f)
@@ -414,13 +410,11 @@ def make_check_stderr_message(stderr: str, line: str, reason: str) -> str:
     """
     Create an exception message to use inside check_stderr().
     """
-    return dedent(
-        """\
+    return dedent("""\
     {reason}:
      Caused by line: {line!r}
      Complete stderr: {stderr}
-    """
-    ).format(stderr=stderr, line=line, reason=reason)
+    """).format(stderr=stderr, line=line, reason=reason)
 
 
 def _check_stderr(
@@ -903,12 +897,10 @@ def _create_main_file(
         name = "version_pkg"
     if output is None:
         output = "0.1"
-    text = textwrap.dedent(
-        f"""
+    text = textwrap.dedent(f"""
         def main():
             print({output!r})
-        """
-    )
+        """)
     filename = f"{name}.py"
     dir_path.joinpath(filename).write_text(text)
 
@@ -1015,9 +1007,7 @@ def _create_test_package_with_subdirectory(
     script.scratch_path.joinpath("version_pkg").mkdir()
     version_pkg_path = script.scratch_path / "version_pkg"
     _create_main_file(version_pkg_path, name="version_pkg", output="0.1")
-    version_pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    version_pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
             from setuptools import setup, find_packages
 
             setup(
@@ -1027,17 +1017,13 @@ def _create_test_package_with_subdirectory(
                 py_modules=["version_pkg"],
                 entry_points=dict(console_scripts=["version_pkg=version_pkg:main"]),
             )
-            """
-        )
-    )
+            """))
 
     subdirectory_path = version_pkg_path.joinpath(subdirectory)
     subdirectory_path.mkdir()
     _create_main_file(subdirectory_path, name="version_subpkg", output="0.1")
 
-    subdirectory_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    subdirectory_path.joinpath("setup.py").write_text(textwrap.dedent("""
             from setuptools import find_packages, setup
 
             setup(
@@ -1047,9 +1033,7 @@ def _create_test_package_with_subdirectory(
                 py_modules=["version_subpkg"],
                 entry_points=dict(console_scripts=["version_pkg=version_subpkg:main"]),
             )
-            """
-        )
-    )
+            """))
 
     script.run("git", "init", cwd=version_pkg_path)
     script.run("git", "add", ".", cwd=version_pkg_path)
@@ -1070,9 +1054,7 @@ def _create_test_package_with_srcdir(
     pkg_path = src_path.joinpath("pkg")
     pkg_path.mkdir()
     pkg_path.joinpath("__init__.py").write_text("")
-    subdir_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            f"""
+    subdir_path.joinpath("setup.py").write_text(textwrap.dedent(f"""
                 from setuptools import setup, find_packages
                 setup(
                     name="{name}",
@@ -1080,9 +1062,7 @@ def _create_test_package_with_srcdir(
                     packages=find_packages(),
                     package_dir={{"": "src"}},
                 )
-            """
-        )
-    )
+            """))
     return _vcs_add(dir_path, version_pkg_path, vcs)
 
 
@@ -1092,9 +1072,7 @@ def _create_test_package(
     dir_path.joinpath(name).mkdir()
     version_pkg_path = dir_path / name
     _create_main_file(version_pkg_path, name=name, output="0.1")
-    version_pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            f"""
+    version_pkg_path.joinpath("setup.py").write_text(textwrap.dedent(f"""
                 from setuptools import setup, find_packages
                 setup(
                     name="{name}",
@@ -1103,9 +1081,7 @@ def _create_test_package(
                     py_modules=["{name}"],
                     entry_points=dict(console_scripts=["{name}={name}:main"]),
                 )
-            """
-        )
-    )
+            """))
     return _vcs_add(dir_path, version_pkg_path, vcs)
 
 
@@ -1159,15 +1135,11 @@ def create_test_package_with_setup(
     assert "name" in setup_kwargs, setup_kwargs
     pkg_path = script.scratch_path / setup_kwargs["name"]
     pkg_path.mkdir()
-    pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            f"""
+    pkg_path.joinpath("setup.py").write_text(textwrap.dedent(f"""
                 from setuptools import setup
                 kwargs = {setup_kwargs!r}
                 setup(**kwargs)
-            """
-        )
-    )
+            """))
     return pkg_path
 
 
@@ -1191,22 +1163,18 @@ def create_really_basic_wheel(name: str, version: str) -> bytes:
     with ZipFile(buf, "w") as z:
         add_file(
             f"{dist_info}/WHEEL",
-            dedent(
-                """\
+            dedent("""\
                 Wheel-Version: 1.0
                 Root-Is-Purelib: true
-                """
-            ),
+                """),
         )
         add_file(
             f"{dist_info}/METADATA",
-            dedent(
-                f"""\
+            dedent(f"""\
                 Metadata-Version: 2.1
                 Name: {name}
                 Version: {version}
-                """
-            ),
+                """),
         )
         z.writestr(record_path, "\n".join(",".join(r) for r in records))
     buf.seek(0)
@@ -1284,8 +1252,7 @@ def create_basic_sdist_for_package(
     setup_py_prelude: str = "",
 ) -> pathlib.Path:
     files = {
-        "setup.py": textwrap.dedent(
-            """\
+        "setup.py": textwrap.dedent("""\
             import sys
             from setuptools import find_packages, setup
 
@@ -1298,8 +1265,7 @@ def create_basic_sdist_for_package(
 
             setup(name={name!r}, version={version!r},
                 install_requires={depends!r})
-        """
-        ).format(
+        """).format(
             name=name,
             version=version,
             depends=depends or [],

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -369,15 +369,11 @@ class TestPipResult:
         if pkg_dir and (pkg_dir in self.files_created) == (os.curdir in without_files):
             maybe = "not " if os.curdir in without_files else ""
             files = sorted(p.as_posix() for p in self.files_created)
-            raise TestFailure(
-                textwrap.dedent(
-                    f"""
+            raise TestFailure(textwrap.dedent(f"""
                     expected package directory {pkg_dir!r} {maybe}to be created
                     actually created:
                     {files}
-                    """
-                )
-            )
+                    """))
 
         for f in with_files:
             normalized_path = os.path.normpath(pkg_dir / f)
@@ -418,13 +414,11 @@ def make_check_stderr_message(stderr: str, line: str, reason: str) -> str:
     """
     Create an exception message to use inside check_stderr().
     """
-    return dedent(
-        """\
+    return dedent("""\
     {reason}:
      Caused by line: {line!r}
      Complete stderr: {stderr}
-    """
-    ).format(stderr=stderr, line=line, reason=reason)
+    """).format(stderr=stderr, line=line, reason=reason)
 
 
 def _check_stderr(
@@ -907,12 +901,10 @@ def _create_main_file(
         name = "version_pkg"
     if output is None:
         output = "0.1"
-    text = textwrap.dedent(
-        f"""
+    text = textwrap.dedent(f"""
         def main():
             print({output!r})
-        """
-    )
+        """)
     filename = f"{name}.py"
     dir_path.joinpath(filename).write_text(text)
 
@@ -1019,9 +1011,7 @@ def _create_test_package_with_subdirectory(
     script.scratch_path.joinpath("version_pkg").mkdir()
     version_pkg_path = script.scratch_path / "version_pkg"
     _create_main_file(version_pkg_path, name="version_pkg", output="0.1")
-    version_pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    version_pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""
             from setuptools import setup, find_packages
 
             setup(
@@ -1031,17 +1021,13 @@ def _create_test_package_with_subdirectory(
                 py_modules=["version_pkg"],
                 entry_points=dict(console_scripts=["version_pkg=version_pkg:main"]),
             )
-            """
-        )
-    )
+            """))
 
     subdirectory_path = version_pkg_path.joinpath(subdirectory)
     subdirectory_path.mkdir()
     _create_main_file(subdirectory_path, name="version_subpkg", output="0.1")
 
-    subdirectory_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """
+    subdirectory_path.joinpath("setup.py").write_text(textwrap.dedent("""
             from setuptools import find_packages, setup
 
             setup(
@@ -1051,9 +1037,7 @@ def _create_test_package_with_subdirectory(
                 py_modules=["version_subpkg"],
                 entry_points=dict(console_scripts=["version_pkg=version_subpkg:main"]),
             )
-            """
-        )
-    )
+            """))
 
     script.run("git", "init", cwd=version_pkg_path)
     script.run("git", "add", ".", cwd=version_pkg_path)
@@ -1074,9 +1058,7 @@ def _create_test_package_with_srcdir(
     pkg_path = src_path.joinpath("pkg")
     pkg_path.mkdir()
     pkg_path.joinpath("__init__.py").write_text("")
-    subdir_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            f"""
+    subdir_path.joinpath("setup.py").write_text(textwrap.dedent(f"""
                 from setuptools import setup, find_packages
                 setup(
                     name="{name}",
@@ -1084,9 +1066,7 @@ def _create_test_package_with_srcdir(
                     packages=find_packages(),
                     package_dir={{"": "src"}},
                 )
-            """
-        )
-    )
+            """))
     return _vcs_add(dir_path, version_pkg_path, vcs)
 
 
@@ -1096,9 +1076,7 @@ def _create_test_package(
     dir_path.joinpath(name).mkdir()
     version_pkg_path = dir_path / name
     _create_main_file(version_pkg_path, name=name, output="0.1")
-    version_pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            f"""
+    version_pkg_path.joinpath("setup.py").write_text(textwrap.dedent(f"""
                 from setuptools import setup, find_packages
                 setup(
                     name="{name}",
@@ -1107,9 +1085,7 @@ def _create_test_package(
                     py_modules=["{name}"],
                     entry_points=dict(console_scripts=["{name}={name}:main"]),
                 )
-            """
-        )
-    )
+            """))
     return _vcs_add(dir_path, version_pkg_path, vcs)
 
 
@@ -1163,15 +1139,11 @@ def create_test_package_with_setup(
     assert "name" in setup_kwargs, setup_kwargs
     pkg_path = script.scratch_path / setup_kwargs["name"]
     pkg_path.mkdir()
-    pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            f"""
+    pkg_path.joinpath("setup.py").write_text(textwrap.dedent(f"""
                 from setuptools import setup
                 kwargs = {setup_kwargs!r}
                 setup(**kwargs)
-            """
-        )
-    )
+            """))
     return pkg_path
 
 
@@ -1195,22 +1167,18 @@ def create_really_basic_wheel(name: str, version: str) -> bytes:
     with ZipFile(buf, "w") as z:
         add_file(
             f"{dist_info}/WHEEL",
-            dedent(
-                """\
+            dedent("""\
                 Wheel-Version: 1.0
                 Root-Is-Purelib: true
-                """
-            ),
+                """),
         )
         add_file(
             f"{dist_info}/METADATA",
-            dedent(
-                f"""\
+            dedent(f"""\
                 Metadata-Version: 2.1
                 Name: {name}
                 Version: {version}
-                """
-            ),
+                """),
         )
         z.writestr(record_path, "\n".join(",".join(r) for r in records))
     buf.seek(0)
@@ -1288,8 +1256,7 @@ def create_basic_sdist_for_package(
     setup_py_prelude: str = "",
 ) -> pathlib.Path:
     files = {
-        "setup.py": textwrap.dedent(
-            """\
+        "setup.py": textwrap.dedent("""\
             import sys
             from setuptools import find_packages, setup
 
@@ -1302,8 +1269,7 @@ def create_basic_sdist_for_package(
 
             setup(name={name!r}, version={version!r},
                 install_requires={depends!r})
-        """
-        ).format(
+        """).format(
             name=name,
             version=version,
             depends=depends or [],

--- a/tests/lib/git_submodule_helpers.py
+++ b/tests/lib/git_submodule_helpers.py
@@ -52,17 +52,13 @@ def _create_test_package_with_submodule(
 
     pkg_path.joinpath("__init__.py").write_text("# hello there")
     _create_main_file(pkg_path, name="version_pkg", output="0.1")
-    version_pkg_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            """\
+    version_pkg_path.joinpath("setup.py").write_text(textwrap.dedent("""\
                         from setuptools import setup, find_packages
                         setup(name='version_pkg',
                               version='0.1',
                               packages=find_packages(),
                              )
-                        """
-        )
-    )
+                        """))
     env.run("git", "init", cwd=version_pkg_path)
     env.run("git", "add", ".", cwd=version_pkg_path)
     _git_commit(env, version_pkg_path, message="initial version")

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -149,20 +149,14 @@ def text_html_response(text: str) -> "WSGIApplication":
 
 
 def html5_page(text: str) -> str:
-    return (
-        dedent(
-            """
+    return dedent("""
     <!DOCTYPE html>
     <html>
       <body>
         {}
       </body>
     </html>
-    """
-        )
-        .strip()
-        .format(text)
-    )
+    """).strip().format(text)
 
 
 def package_page(spec: dict[str, str]) -> "WSGIApplication":

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -167,8 +167,7 @@ class VirtualEnvironment:
             contents = ""
         else:
             # Enable user site (before system).
-            contents = textwrap.dedent(
-                f"""
+            contents = textwrap.dedent(f"""
                 import os, site, sys
                 if not os.environ.get('PYTHONNOUSERSITE', False):
                     site.ENABLE_USER_SITE = {self._user_site_packages}
@@ -188,8 +187,7 @@ class VirtualEnvironment:
                     # Third, add back system-sites related paths.
                     for path in site.getsitepackages():
                         site.addsitedir(path)
-                """
-            ).strip()
+                """).strip()
         if self._sitecustomize is not None:
             contents += "\n" + self._sitecustomize
         sitecustomize = self.site / "sitecustomize.py"

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -167,8 +167,7 @@ class VirtualEnvironment:
             contents = ""
         else:
             # Enable user site (before system).
-            contents = textwrap.dedent(
-                f"""
+            contents = textwrap.dedent(f"""
                 import os, site, sys
                 if not os.environ.get('PYTHONNOUSERSITE', False):
                     site.ENABLE_USER_SITE = {self._user_site_packages}
@@ -190,8 +189,7 @@ class VirtualEnvironment:
                     # Third, add back system-sites related paths.
                     for path in site.getsitepackages():
                         site.addsitedir(path)
-                """
-            ).strip()
+                """).strip()
         if self._sitecustomize is not None:
             contents += "\n" + self._sitecustomize
         sitecustomize = self.site / "sitecustomize.py"

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -823,14 +823,12 @@ def make_fake_html_response(url: str) -> mock.Mock:
     """
     Create a fake requests.Response object.
     """
-    html = dedent(
-        """\
+    html = dedent("""\
     <html><head><meta name="api-version" value="2" /></head>
     <body>
     <a href="/abc-1.0.tar.gz#md5=000000000">abc-1.0.tar.gz</a>
     </body></html>
-    """
-    )
+    """)
     content = html.encode("utf-8")
     return mock.Mock(content=content, url=url, headers={"Content-Type": "text/html"})
 
@@ -1008,11 +1006,9 @@ class TestLinkCollector:
         # Check that index URLs are marked as *un*cacheable.
         assert not pages[0].link.cache_link_parsing
 
-        expected_message = dedent(
-            """\
+        expected_message = dedent("""\
         1 location(s) to search for versions of twine:
-        * https://pypi.org/simple/twine/"""
-        )
+        * https://pypi.org/simple/twine/""")
         assert caplog.record_tuples == [
             ("pip._internal.index.collector", logging.DEBUG, expected_message),
         ]
@@ -1054,11 +1050,9 @@ class TestLinkCollector:
         assert len(files) > 0
         check_links_include(files, names=["singlemodule-0.0.1.tar.gz"])
 
-        expected_message = dedent(
-            """\
+        expected_message = dedent("""\
         1 location(s) to search for versions of singlemodule:
-        * https://pypi.org/simple/singlemodule/"""
-        )
+        * https://pypi.org/simple/singlemodule/""")
         assert caplog.record_tuples == [
             ("pip._internal.index.collector", logging.DEBUG, expected_message),
         ]

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -87,8 +87,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             hint_stmt="Do it better next time, by trying harder.",
         )
 
-        assert rendered_in_ascii(err) == textwrap.dedent(
-            """\
+        assert rendered_in_ascii(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             Oh no!
@@ -99,8 +98,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
 
             note: You did something wrong, which is what caused this error.
             hint: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_complete_color(self) -> None:
         err = DiagnosticPipError(
@@ -114,8 +112,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
         def esc(code: str = "0") -> str:
             return f"\x1b[{code}m"
 
-        assert rendered_in_ascii(err, color=True) == textwrap.dedent(
-            f"""\
+        assert rendered_in_ascii(err, color=True) == textwrap.dedent(f"""\
             {esc("1;31")}error{esc("0")}: {esc("1")}test-diagnostic{esc("0")}
 
             Oh no!
@@ -126,8 +123,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
 
             {esc("1;35")}note{esc("0")}: You did something wrong.
             {esc("1;36")}hint{esc("0")}: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_no_context(self) -> None:
         err = DiagnosticPipError(
@@ -138,8 +134,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             hint_stmt="Do it better next time, by trying harder.",
         )
 
-        assert rendered_in_ascii(err) == textwrap.dedent(
-            """\
+        assert rendered_in_ascii(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             Oh no!
@@ -147,8 +142,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
 
             note: You did something wrong, which is what caused this error.
             hint: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_no_note(self) -> None:
         err = DiagnosticPipError(
@@ -159,8 +153,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             hint_stmt="Do it better next time, by trying harder.",
         )
 
-        assert rendered_in_ascii(err) == textwrap.dedent(
-            """\
+        assert rendered_in_ascii(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             Oh no!
@@ -170,8 +163,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             very wrong.
 
             hint: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_no_hint(self) -> None:
         err = DiagnosticPipError(
@@ -182,8 +174,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             hint_stmt=None,
         )
 
-        assert rendered_in_ascii(err) == textwrap.dedent(
-            """\
+        assert rendered_in_ascii(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             Oh no!
@@ -193,8 +184,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             very wrong.
 
             note: You did something wrong, which is what caused this error.
-            """
-        )
+            """)
 
     def test_no_context_no_hint(self) -> None:
         err = DiagnosticPipError(
@@ -205,16 +195,14 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             hint_stmt=None,
         )
 
-        assert rendered_in_ascii(err) == textwrap.dedent(
-            """\
+        assert rendered_in_ascii(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             Oh no!
             It broke. :(
 
             note: You did something wrong, which is what caused this error.
-            """
-        )
+            """)
 
     def test_no_context_no_note(self) -> None:
         err = DiagnosticPipError(
@@ -225,16 +213,14 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             hint_stmt="Do it better next time, by trying harder.",
         )
 
-        assert rendered_in_ascii(err) == textwrap.dedent(
-            """\
+        assert rendered_in_ascii(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             Oh no!
             It broke. :(
 
             hint: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_no_hint_no_note(self) -> None:
         err = DiagnosticPipError(
@@ -245,8 +231,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             hint_stmt=None,
         )
 
-        assert rendered_in_ascii(err) == textwrap.dedent(
-            """\
+        assert rendered_in_ascii(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             Oh no!
@@ -254,8 +239,7 @@ class TestDiagnosticPipErrorPresentation_ASCII:
 
             Something went wrong
             very wrong.
-            """
-        )
+            """)
 
     def test_no_hint_no_note_no_context(self) -> None:
         err = DiagnosticPipError(
@@ -266,14 +250,12 @@ class TestDiagnosticPipErrorPresentation_ASCII:
             note_stmt=None,
         )
 
-        assert rendered_in_ascii(err) == textwrap.dedent(
-            """\
+        assert rendered_in_ascii(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             Oh no!
             It broke. :(
-            """
-        )
+            """)
 
 
 def rendered(error: DiagnosticPipError, *, color: bool = False) -> str:
@@ -297,8 +279,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
             hint_stmt="Do it better next time, by trying harder.",
         )
 
-        assert rendered(err) == textwrap.dedent(
-            """\
+        assert rendered(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             × Oh no!
@@ -308,8 +289,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
 
             note: You did something wrong, which is what caused this error.
             hint: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_complete_color(self) -> None:
         err = DiagnosticPipError(
@@ -323,8 +303,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
         def esc(code: str = "0") -> str:
             return f"\x1b[{code}m"
 
-        assert rendered(err, color=True) == textwrap.dedent(
-            f"""\
+        assert rendered(err, color=True) == textwrap.dedent(f"""\
             {esc("1;31")}error{esc("0")}: {esc("1")}test-diagnostic{esc("0")}
 
             {esc("31")}×{esc("0")} Oh no!
@@ -334,8 +313,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
 
             {esc("1;35")}note{esc("0")}: You did something wrong.
             {esc("1;36")}hint{esc("0")}: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_no_context(self) -> None:
         err = DiagnosticPipError(
@@ -346,8 +324,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
             hint_stmt="Do it better next time, by trying harder.",
         )
 
-        assert rendered(err) == textwrap.dedent(
-            """\
+        assert rendered(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             × Oh no!
@@ -355,8 +332,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
 
             note: You did something wrong, which is what caused this error.
             hint: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_no_note(self) -> None:
         err = DiagnosticPipError(
@@ -367,8 +343,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
             hint_stmt="Do it better next time, by trying harder.",
         )
 
-        assert rendered(err) == textwrap.dedent(
-            """\
+        assert rendered(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             × Oh no!
@@ -377,8 +352,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
                 very wrong.
 
             hint: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_no_hint(self) -> None:
         err = DiagnosticPipError(
@@ -389,8 +363,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
             hint_stmt=None,
         )
 
-        assert rendered(err) == textwrap.dedent(
-            """\
+        assert rendered(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             × Oh no!
@@ -399,8 +372,7 @@ class TestDiagnosticPipErrorPresentation_Unicode:
                 very wrong.
 
             note: You did something wrong, which is what caused this error.
-            """
-        )
+            """)
 
     def test_no_context_no_hint(self) -> None:
         err = DiagnosticPipError(
@@ -411,16 +383,14 @@ class TestDiagnosticPipErrorPresentation_Unicode:
             hint_stmt=None,
         )
 
-        assert rendered(err) == textwrap.dedent(
-            """\
+        assert rendered(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             × Oh no!
               It broke. :(
 
             note: You did something wrong, which is what caused this error.
-            """
-        )
+            """)
 
     def test_no_context_no_note(self) -> None:
         err = DiagnosticPipError(
@@ -431,16 +401,14 @@ class TestDiagnosticPipErrorPresentation_Unicode:
             hint_stmt="Do it better next time, by trying harder.",
         )
 
-        assert rendered(err) == textwrap.dedent(
-            """\
+        assert rendered(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             × Oh no!
               It broke. :(
 
             hint: Do it better next time, by trying harder.
-            """
-        )
+            """)
 
     def test_no_hint_no_note(self) -> None:
         err = DiagnosticPipError(
@@ -451,16 +419,14 @@ class TestDiagnosticPipErrorPresentation_Unicode:
             hint_stmt=None,
         )
 
-        assert rendered(err) == textwrap.dedent(
-            """\
+        assert rendered(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             × Oh no!
             │ It broke. :(
             ╰─> Something went wrong
                 very wrong.
-            """
-        )
+            """)
 
     def test_no_hint_no_note_no_context(self) -> None:
         err = DiagnosticPipError(
@@ -471,14 +437,12 @@ class TestDiagnosticPipErrorPresentation_Unicode:
             note_stmt=None,
         )
 
-        assert rendered(err) == textwrap.dedent(
-            """\
+        assert rendered(err) == textwrap.dedent("""\
             error: test-diagnostic
 
             × Oh no!
               It broke. :(
-            """
-        )
+            """)
 
 
 class TestExternallyManagedEnvironment:

--- a/tests/unit/test_pep517.py
+++ b/tests/unit/test_pep517.py
@@ -12,15 +12,11 @@ from pip._internal.req import InstallRequirement
     "spec", [("./foo",), ("git+https://example.com/pkg@dev#egg=myproj",)]
 )
 def test_pep517_parsing_checks_requirements(tmpdir: Path, spec: tuple[str]) -> None:
-    tmpdir.joinpath("pyproject.toml").write_text(
-        dedent(
-            f"""
+    tmpdir.joinpath("pyproject.toml").write_text(dedent(f"""
             [build-system]
             requires = [{spec[0]!r}]
             build-backend = "foo"
-            """
-        )
-    )
+            """))
     req = InstallRequirement(None, None)
     req.source_dir = os.fspath(tmpdir)  # make req believe it has been unpacked
 

--- a/tests/unit/test_req_dependency_group.py
+++ b/tests/unit/test_req_dependency_group.py
@@ -13,14 +13,10 @@ def test_parse_simple_dependency_groups(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pyproject = tmp_path.joinpath("pyproject.toml")
-    pyproject.write_text(
-        textwrap.dedent(
-            """\
+    pyproject.write_text(textwrap.dedent("""\
             [dependency-groups]
             foo = ["bar"]
-            """
-        )
-    )
+            """))
     monkeypatch.chdir(tmp_path)
 
     result = list(parse_dependency_groups([("pyproject.toml", "foo")]))
@@ -33,15 +29,11 @@ def test_parse_cyclic_dependency_groups(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pyproject = tmp_path.joinpath("pyproject.toml")
-    pyproject.write_text(
-        textwrap.dedent(
-            """\
+    pyproject.write_text(textwrap.dedent("""\
             [dependency-groups]
             foo = [{include-group="bar"}]
             bar = [{include-group="foo"}]
-            """
-        )
-    )
+            """))
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(
@@ -86,14 +78,10 @@ def test_parse_with_malformed_pyproject_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pyproject = tmp_path.joinpath("pyproject.toml")
-    pyproject.write_text(
-        textwrap.dedent(
-            """\
+    pyproject.write_text(textwrap.dedent("""\
             [dependency-groups  # no closing bracket
             foo = ["bar"]
-            """
-        )
-    )
+            """))
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(InstallationError, match=r"Error parsing pyproject\.toml"):
@@ -104,14 +92,10 @@ def test_parse_gets_unexpected_oserror(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     pyproject = tmp_path.joinpath("pyproject.toml")
-    pyproject.write_text(
-        textwrap.dedent(
-            """\
+    pyproject.write_text(textwrap.dedent("""\
             [dependency-groups]
             foo = ["bar"]
-            """
-        )
-    )
+            """))
     monkeypatch.chdir(tmp_path)
 
     # inject an implementation of `tomli.load()` which emits an 'OSError(EPIPE, ...)'

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -115,34 +115,28 @@ class TestPreprocess:
     """tests for `preprocess`"""
 
     def test_comments_and_joins_case1(self) -> None:
-        content = textwrap.dedent(
-            """\
+        content = textwrap.dedent("""\
           req1 \\
           # comment \\
           req2
-        """
-        )
+        """)
         result = preprocess(content)
         assert list(result) == [(1, "req1"), (3, "req2")]
 
     def test_comments_and_joins_case2(self) -> None:
-        content = textwrap.dedent(
-            """\
+        content = textwrap.dedent("""\
           req1\\
           # comment
-        """
-        )
+        """)
         result = preprocess(content)
         assert list(result) == [(1, "req1")]
 
     def test_comments_and_joins_case3(self) -> None:
-        content = textwrap.dedent(
-            """\
+        content = textwrap.dedent("""\
           req1 \\
           # comment
           req2
-        """
-        )
+        """)
         result = preprocess(content)
         assert list(result) == [(1, "req1"), (3, "req2")]
 
@@ -954,15 +948,13 @@ class TestParseRequirements:
         Test parsing a requirements file without a finder
         """
         with open(tmpdir.joinpath("req.txt"), "w") as fp:
-            fp.write(
-                """
+            fp.write("""
     --find-links https://example.com/
     --index-url https://example.com/
     --extra-index-url https://two.example.com/
     --no-use-wheel
     --no-index
-            """
-            )
+            """)
 
         parse_reqfile(tmpdir.joinpath("req.txt"), session=PipSession())
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -145,12 +145,10 @@ def call_get_csv_rows_for_installed(tmpdir: Path, text: str) -> list[InstalledCS
 def test_get_csv_rows_for_installed(
     tmpdir: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    text = textwrap.dedent(
-        """\
+    text = textwrap.dedent("""\
     a,b,c
     d,e,f
-    """
-    )
+    """)
     outrows = call_get_csv_rows_for_installed(tmpdir, text)
 
     expected = [
@@ -165,13 +163,11 @@ def test_get_csv_rows_for_installed(
 def test_get_csv_rows_for_installed__long_lines(
     tmpdir: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    text = textwrap.dedent(
-        """\
+    text = textwrap.dedent("""\
     a,b,c,d
     e,f,g
     h,i,j,k
-    """
-    )
+    """)
     outrows = call_get_csv_rows_for_installed(tmpdir, text)
     assert outrows == [
         ("z", "b", "c"),
@@ -234,38 +230,32 @@ class TestInstallUnpackedWheel:
         self.wheelpath = make_wheel(
             "sample",
             "1.2.0",
-            metadata_body=textwrap.dedent(
-                """
+            metadata_body=textwrap.dedent("""
                 A sample Python project
                 =======================
 
                 ...
-                """
-            ),
+                """),
             metadata_updates={
                 "Requires-Dist": ["peppercorn"],
             },
             extra_files={
-                "sample/__init__.py": textwrap.dedent(
-                    '''
+                "sample/__init__.py": textwrap.dedent('''
                     __version__ = '1.2.0'
 
                     def main():
                         """Entry point for the application script"""
                         print("Call your main application code here")
-                    '''
-                ),
+                    '''),
                 "sample/package_data.dat": "some data",
             },
             extra_metadata_files={
-                "DESCRIPTION.rst": textwrap.dedent(
-                    """
+                "DESCRIPTION.rst": textwrap.dedent("""
                     A sample Python project
                     =======================
 
                     ...
-                    """
-                ),
+                    """),
                 "top_level.txt": "sample\n",
                 "empty_dir/empty_dir/": "",
             },


### PR DESCRIPTION
> [!Important]
>
> **This needs to be merged via a merge commit** as to not rewrite the commit SHAs and render `.git-blame-ignore-revs` useless. 
>
> This should also be merged **after** the pip 26.1 release to avoid unnecessary churn.

Black's 2026 code style seems to focus on vastly improving the handling of multi-line string literals, which IMO, has been a long-standing pain point.