### PR TITLE
Improve conflict reports that involve direct URLs

### DIFF
--- a/news/13932.feature.rst
+++ b/news/13932.feature.rst
@@ -1,0 +1,1 @@
+Improve conflict reports that involve direct URLs.

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -75,6 +75,12 @@ class Constraint:
         # prerelease candidates if the user does not expect them.
         return self.specifier.contains(candidate.version, prereleases=True)
 
+    def format_for_error(self) -> str:
+        s = str(self.specifier)
+        if self.links:
+            s += f" (from {', '.join(str(link) for link in self.links)})"
+        return s
+
 
 class Requirement:
     @property

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -210,7 +210,8 @@ class _InstallRequirementBackedCandidate(Candidate):
     def format_for_error(self) -> str:
         return (
             f"{self.name} {self.version} "
-            f"(from {self._link.file_path if self._link.is_file else self._link})"
+            f"(from {'editable ' if self.is_editable else ''}"
+            f"{self._link.file_path if self._link.is_file else self._link})"
         )
 
     def _prepare_distribution(self) -> BaseDistribution:

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -844,8 +844,8 @@ class Factory:
                 msg = msg + "The user requested "
             msg = msg + req.format_for_error()
         for key in relevant_constraints:
-            spec = constraints[key].specifier
-            msg += f"\n    The user requested (constraint) {key}{spec}"
+            constraint_text = f"{key}{constraints[key].format_for_error()}"
+            msg += f"\n    The user requested (constraint) {constraint_text}"
 
         # Check for causes that had no candidates
         causes = set()

--- a/src/pip/_internal/resolution/resolvelib/reporter.py
+++ b/src/pip/_internal/resolution/resolvelib/reporter.py
@@ -64,7 +64,7 @@ class PipReporter(BaseReporter[Requirement, Candidate, str]):
             name = candidate.name
             constraint = self._constraints.get(name)
             if constraint and constraint.specifier:
-                constraint_text = f"{name}{constraint.specifier}"
+                constraint_text = f"{name}{constraint.format_for_error()}"
                 msg += f"\n    The user requested (constraint) {constraint_text}"
 
         logger.debug(msg)


### PR DESCRIPTION
This is a simple improvement in conflicts reports to
- display when a link is editable
- display links from direct URL constraints

Before:

```
The conflict is caused by:
    The user requested pkgb 1.0 (from /tmp/test/pkgs/pkgb)
    The user requested (constraint) pkgb
```

After:

```
The conflict is caused by:
    The user requested pkgb 1.0 (from editable /tmp/test/pkgs/pkgb)
    The user requested (constraint) pkgb (from file:///tmp/test/pkgx/pkgb)
```

I added a `format_for_error` to the `Constraint` class, similar to what the `Candidate` class has.