### PR TITLE
fix: redirect log output to stderr when --report - writes JSON to stdout

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -44,7 +44,7 @@ from pip._internal.req.req_install import (
 )
 from pip._internal.utils.compat import WINDOWS
 from pip._internal.utils.filesystem import test_writable_dir
-from pip._internal.utils.logging import getLogger
+from pip._internal.utils.logging import getLogger, redirect_stdout_logging_to_stderr
 from pip._internal.utils.misc import (
     check_externally_managed,
     ensure_dir,
@@ -273,8 +273,7 @@ class InstallCommand(RequirementCommand):
                 "Can be used in combination with --dry-run and --ignore-installed "
                 "to 'resolve' the requirements. "
                 "When - is used as file name it writes to stdout. "
-                "When writing to stdout, please combine with the --quiet option "
-                "to avoid mixing pip logging output with JSON output."
+                "Log messages are automatically redirected to stderr."
             ),
         )
 
@@ -282,6 +281,9 @@ class InstallCommand(RequirementCommand):
     def run(self, options: Values, args: list[str]) -> int:
         if options.use_user_site and options.target_dir is not None:
             raise CommandError("Can not combine '--user' and '--target'")
+
+        if options.json_report_file == "-":
+            self.enter_context(redirect_stdout_logging_to_stderr())
 
         # Check whether the environment we're installing into is externally
         # managed, as specified in PEP 668. Specifying --root, --target, or
@@ -324,8 +326,8 @@ class InstallCommand(RequirementCommand):
             options.target_dir = os.path.abspath(options.target_dir)
             if (
                 # fmt: off
-                os.path.exists(options.target_dir) and
-                not os.path.isdir(options.target_dir)
+                os.path.exists(options.target_dir)
+                and not os.path.isdir(options.target_dir)
                 # fmt: on
             ):
                 raise CommandError(
@@ -736,8 +738,7 @@ def decide_user_install(
         return False
 
     logger.info(
-        "Defaulting to user installation because normal site-packages "
-        "is not writeable"
+        "Defaulting to user installation because normal site-packages is not writeable"
     )
     return True
 

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -89,6 +89,34 @@ def capture_logging() -> Generator[StringIO, None, None]:
 
 
 @contextlib.contextmanager
+def redirect_stdout_logging_to_stderr() -> Generator[None, None, None]:
+    """Redirect stdout logging handlers to stderr temporarily.
+
+    This is useful when structured output (e.g. JSON) is being written
+    to stdout, to prevent log messages from mixing with it.
+    """
+    handlers = {}
+    for handler in logging.getLogger().handlers:
+        if (
+            isinstance(handler, RichPipStreamHandler)
+            and handler.console.file is sys.stdout
+        ):
+            handlers[handler] = handler.console
+
+    if not handlers:
+        yield
+        return
+
+    try:
+        for handler in handlers:
+            handler.console = _stderr_console
+        yield
+    finally:
+        for handler, original_console in handlers.items():
+            handler.console = original_console
+
+
+@contextlib.contextmanager
 def indent_log(num: int = 2) -> Generator[None, None, None]:
     """
     A context manager which will cause the log output to be indented for any
@@ -210,9 +238,9 @@ class RichPipStreamHandler(RichHandler):
         if getattr(record, "rich", False):
             assert isinstance(record.args, tuple)
             (rich_renderable,) = record.args
-            assert isinstance(
-                rich_renderable, (ConsoleRenderable, RichCast, str)
-            ), f"{rich_renderable} is not rich-console-renderable"
+            assert isinstance(rich_renderable, (ConsoleRenderable, RichCast, str)), (
+                f"{rich_renderable} is not rich-console-renderable"
+            )
 
             renderable: RenderableType = IndentedRenderable(
                 rich_renderable, indent=get_indentation()


### PR DESCRIPTION
## Summary

When `--report -` is used to write the install report to stdout, pip's log messages (`Collecting ...`, `Using cached ...`, etc.) are now automatically redirected to stderr instead of mixing with the JSON output on stdout.

## Problem

`pip install --dry-run --report - somepackage | jq .` would fail because pip's progress messages were interleaved with the JSON report on stdout. Users had to manually combine with `--quiet`, which was a footgun.

## Changes

1. Added `redirect_stdout_logging_to_stderr()` context manager in `pip._internal.utils.logging` that swaps stdout-bound log handlers to stderr using the same pattern as the existing `capture_logging()`.
2. In `pip._internal.commands.install.run()`, enter the redirect context when `options.json_report_file == "-"`.
3. Updated the `--report` help text to reflect the automatic redirection.

## Test Plan

```bash
# Before fix: output is mixed JSON + log messages
pip install --dry-run --ignore-installed --report - click 2>/dev/null | python -m json.tool
# Should now produce valid parseable JSON on stdout
```

Closes #13898