### PR TITLE
Fix duplicated "the the" in docstrings

### DIFF
--- a/docs/pip_sphinxext.py
+++ b/docs/pip_sphinxext.py
@@ -53,7 +53,7 @@ class PipNewsInclude(rst.Directive):
 
         Dots in the version is converted into dash, and a ``v`` is prefixed.
         This makes Sphinx use them as HTML ``id`` verbatim without generating
-        auto numbering (which would make the the anchors unstable).
+        auto numbering (which would make the anchors unstable).
         """
         prev = None
         for line in lines:

--- a/news/fix-duplicate-the-typo.trivial.rst
+++ b/news/fix-duplicate-the-typo.trivial.rst
@@ -1,0 +1,1 @@
+Fix duplicated "the the" typo in docstrings.

--- a/src/pip/_internal/vcs/versioncontrol.py
+++ b/src/pip/_internal/vcs/versioncontrol.py
@@ -75,7 +75,7 @@ def find_path_to_project_root_from_repo_root(
     location: str, repo_root: str
 ) -> str | None:
     """
-    Find the the Python project's root by searching up the filesystem from
+    Find the Python project's root by searching up the filesystem from
     `location`. Return the path to project root relative to `repo_root`.
     Return None if the project root is `repo_root`, or cannot be found.
     """


### PR DESCRIPTION

**Repo:** pypa/pip (⭐ 9500)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-2

## What
Remove a duplicated word "the the" appearing in two docstrings: one in `src/pip/_internal/vcs/versioncontrol.py` (`_find_project_root` helper) and one in `docs/pip_sphinxext.py` (anchor-generation comment). Also adds a `news/*.trivial.rst` entry as required by the project's towncrier-based changelog process.

## Why
Small readability fix to an otherwise correct docstring. Duplicated "the the" is a common editing artefact. The change is purely textual and doesn't affect runtime behavior, while keeping the docstrings clean for contributors reading the code.

## Testing
No runtime behavior changes. Changes are limited to docstring/comment text plus a news fragment; the news fragment filename ends in `.trivial.rst` as permitted by pip's contribution guide, so no user-facing changelog noise is introduced.

## Risk
Low — docstring/comment-only edit, no code paths touched.
