### PR TITLE
Support pip install from git repo with no HEAD

### DIFF
--- a/news/13935.bugfix.rst
+++ b/news/13935.bugfix.rst
@@ -1,0 +1,1 @@
+Support installation from a git repository without branches.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -268,7 +268,14 @@ class Git(VersionControl):
             # Then avoid an unnecessary subprocess call.
             return False
 
-        return cls.get_revision(dest) == name
+        current_rev = cls._get_head_commit(dest)
+
+        # HEAD does not point at a commit. This happens if a repo that has no
+        # branches, a valid (if not unusual repository).
+        if current_rev is None:
+            return False
+
+        return current_rev == name
 
     def fetch_new(
         self, dest: str, url: HiddenText, rev_options: RevOptions, verbosity: int
@@ -473,6 +480,35 @@ class Git(VersionControl):
             cwd=location,
         )
         return current_rev.strip()
+
+    @classmethod
+    def _get_head_commit(cls, location: str) -> str | None:
+        """
+        Returns the commit sha pointed to by HEAD.
+
+        Returns `None` if HEAD does not point at a commit. This happens if a
+        repo that has no branches, a valid (if not unusual repository).
+        """
+
+        # `git-rev-parse -q --verify` exits with empty stdout and exit code 1 if
+        # HEAD does not point at a commit.
+        current_rev = cls.run_command(
+            ["rev-parse", "-q", "--verify", "HEAD"],
+            show_stdout=False,
+            stdout_only=True,
+            extra_ok_returncodes=(1,),
+            cwd=location,
+        )
+
+        current_rev = current_rev.strip()
+
+        if not current_rev:
+            logger.warning(
+                "Repository '%s' does not have a currently checked out commit", location
+            )
+            return None
+
+        return current_rev
 
     @classmethod
     def get_subdirectory(cls, location: str) -> str | None:

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -226,14 +226,43 @@ def test_is_commit_id_equal(script: PipTestEnvironment) -> None:
     """
     version_pkg_path = os.fspath(_create_test_package(script.scratch_path))
     script.run("git", "branch", "branch0.1", cwd=version_pkg_path)
+    script.run("git", "tag", "-a", "v0.1.2", "-m", "description", cwd=version_pkg_path)
     commit = script.run("git", "rev-parse", "HEAD", cwd=version_pkg_path).stdout.strip()
+
+    # Create a repo that has no branches and therefore does not have a valid
+    # HEAD ref. This is a valid (if not unusual repository) that pip should be
+    # able to clone.
+    repo_without_head_path = os.fspath(script.scratch_path / "repo_without_head")
+    pathlib.Path(repo_without_head_path).mkdir()
+
+    script.run("git", "init", cwd=repo_without_head_path)
+    script.run(
+        "git",
+        "push",
+        os.fspath(version_pkg_path),
+        "v0.1.2",
+        cwd=os.fspath(version_pkg_path),
+    )
 
     assert Git.is_commit_id_equal(version_pkg_path, commit)
     assert not Git.is_commit_id_equal(version_pkg_path, commit[:7])
     assert not Git.is_commit_id_equal(version_pkg_path, "branch0.1")
     assert not Git.is_commit_id_equal(version_pkg_path, "abc123")
+    assert not Git.is_commit_id_equal(version_pkg_path, "v0.1.2")
     # Also check passing a None value.
     assert not Git.is_commit_id_equal(version_pkg_path, None)
+
+    # Confirm that HEAD does not point at anything in repo_without_head_path
+    script.run(
+        "git",
+        "rev-parse",
+        "HEAD",
+        cwd=repo_without_head_path,
+        expect_error=True,
+    )
+
+    assert not Git.is_commit_id_equal(repo_without_head_path, commit)
+    assert not Git.is_commit_id_equal(repo_without_head_path, "v0.1.2")
 
 
 def test_is_immutable_rev_checkout(script: PipTestEnvironment) -> None:

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -310,15 +310,18 @@ def test_git_resolve_revision_not_found_warning(
         (None, False),
     ],
 )
-@mock.patch("pip._internal.vcs.git.Git.get_revision")
+@mock.patch("pip._internal.vcs.git.Git._get_head_commit")
 def test_git_is_commit_id_equal(
-    mock_get_revision: mock.Mock, rev_name: str | None, result: bool
+    mock_get_head_commit: mock.Mock, rev_name: str | None, result: bool
 ) -> None:
     """
     Test Git.is_commit_id_equal().
     """
-    mock_get_revision.return_value = "5547fa909e83df8bd743d3978d6667497983a4b7"
+    mock_get_head_commit.return_value = "5547fa909e83df8bd743d3978d6667497983a4b7"
     assert Git.is_commit_id_equal("/path", rev_name) is result
+
+    mock_get_head_commit.return_value = None
+    assert Git.is_commit_id_equal("/path", rev_name) is False
 
 
 # The non-SVN backends all use the same get_netloc_and_auth(), so only test


### PR DESCRIPTION
A git repository can have a HEAD does not point at a commit if a repo has no branches which is a valid (if not unusual repository).

A git repository with no branches can be created by pushing a tag to an empty git repository which is how this commit creates an regression test.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
