### PR TITLE
CI: retry winget SVN install on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,12 @@ jobs:
       - name: Install Subversion
         shell: pwsh
         run: |
-          winget install --accept-source-agreements --accept-package-agreements -e --id Slik.Subversion
+          for ($i = 1; $i -le 3; $i++) {
+            winget install --accept-source-agreements --accept-package-agreements -e --id Slik.Subversion
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($i -eq 3) { exit $LASTEXITCODE }
+            Start-Sleep -Seconds (10 * $i)
+          }
           echo "C:\Program Files\SlikSvn\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - run: pip install nox

--- a/news/13937.trivial.rst
+++ b/news/13937.trivial.rst
@@ -1,0 +1,2 @@
+Retry winget install of Slik.Subversion on Windows CI to tolerate transient
+source-refresh failures.


### PR DESCRIPTION
The `winget install Slik.Subversion` step occasionally fails because the winget source refresh errors out with `0x8a15000f : Data required by the source is missing`. This is a known upstream winget flake (see microsoft/winget-cli#4799). Add a small retry loop around the install so a single CDN hiccup doesn't kill Windows CI.

Example failing run:
https://github.com/pypa/pip/actions/runs/24807818338/job/72606093866