### PR TITLE
docs: use 'python3 --version' instead of 'python --version' in getting-started

### DIFF
--- a/docs/html/getting-started.md
+++ b/docs/html/getting-started.md
@@ -11,7 +11,7 @@ installed. This can be done by running the following commands and making
 sure that the output looks similar.
 
 ```{pip-cli}
-$ python --version
+$ python3 --version
 Python 3.N.N
 $ pip --version
 pip X.Y.Z from ... (python 3.N.N)


### PR DESCRIPTION
Good day

Fixes `python --version` → `python3 --version` in the getting-started guide.

### Problem
macOS no longer ships with a `python` command by default (Python 2 was removed in macOS 12.3). Users following the pip getting-started guide on modern macOS get a `command not found` error when they run `python --version`.

### Fix
Changed the example in `docs/html/getting-started.md` from:
```
$ python --version
```
to:
```
$ python3 --version
```

This is a one-line documentation fix that aligns the guide with modern macOS reality.

Fixes pypa/pip#13800

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly,
RoomWithRoof