### PR TITLE
fix: skip files under removed dirs in uninstall output listing

### DIFF
--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -181,6 +181,20 @@ def compress_for_output_listing(paths: Iterable[str]) -> tuple[set[str], set[str
                     os.path.isfile(file_)
                     and os.path.normcase(file_) not in _normcased_files
                 ):
+                    # Skip adding a file to will_skip if any ancestor directory
+                    # is already in paths (and thus will be removed).
+                    ancestor = dirpath
+                    skipped = False
+                    while ancestor:
+                        if os.path.normcase(ancestor) in _normcased_files:
+                            skipped = True
+                            break
+                        parent = os.path.dirname(ancestor)
+                        if parent == ancestor:
+                            break
+                        ancestor = parent
+                    if skipped:
+                        continue
                     # We are skipping this file. Add it to the set.
                     will_skip.add(file_)
 

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -458,3 +458,25 @@ class TestStashedUninstallPathSet:
         # link targets untouched
         assert os.path.isdir(adir)
         assert os.path.isfile(afile)
+
+
+def test_compress_for_output_listing_skips_files_under_removed_dir(tmpdir):
+    """Files inside a directory that's already in paths should not be listed as skipped."""
+    pkg_dir = tmpdir.join("lib", "mypkg")
+    pkg_dir.mkdir(parents=True)
+    pkg_dir.join("__init__.py").write("")
+    pycache = pkg_dir.join("__pycache__")
+    pycache.mkdir()
+    pycache.join("module.cpython-312.pyc").write("pyc")
+    pycache.join("stray_file.txt").write("stray")
+
+    paths = [
+        str(pkg_dir.join("__init__.py")),
+        str(pycache),
+    ]
+
+    will_remove, will_skip = compress_for_output_listing(paths)
+
+    assert str(pycache) in will_remove
+    assert str(pycache.join("module.cpython-312.pyc")) in will_remove
+    assert str(pycache.join("stray_file.txt")) not in will_skip


### PR DESCRIPTION
When a directory (e.g. `__pycache__`) is added to `_paths`, its contents may still appear in `will_skip` because `compress_for_output_listing()` only walks folders derived from `__init__.py` and `.dist-info` paths.

This fix skips adding a file to `will_skip` if any ancestor directory is already in `paths` (and thus will be removed).

Closes #13939