### PR TITLE
fix: recommend `--ignore-installed` when RECORD is missing

### DIFF
--- a/news/12645.bugfix.rst
+++ b/news/12645.bugfix.rst
@@ -1,0 +1,2 @@
+Fix recovery hint for missing RECORD file to use --ignore-installed
+instead of --force-reinstall.

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -769,7 +769,7 @@ class UninstallMissingRecord(DiagnosticPipError):
             dep = f"{distribution.raw_name}=={distribution.version}"
             hint = Text.assemble(
                 "You might be able to recover from this via: ",
-                (f"pip install --force-reinstall --no-deps {dep}", "green"),
+                (f"pip install --ignore-installed --no-deps {dep}", "green"),
             )
         else:
             hint = Text(

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -595,7 +595,7 @@ def test_uninstall_without_record_fails(
     if not isinstance(installer, str) or not installer.strip() or installer == "pip":
         hint = (
             "You might be able to recover from this via: "
-            "pip install --force-reinstall --no-deps simple.dist==0.1"
+            "pip install --ignore-installed --no-deps simple.dist==0.1"
         )
     elif installer:
         hint = f"The package was installed by {installer}."


### PR DESCRIPTION
Previously, --force-reinstall was recommended which is useless since reinstallation requires an uninstall which is what is failing in the first place.

... because I want to close the sloppy PR #13918.

Towards #12645 although we should potentially use Direct URL information when available to provide an even more precise command.