### PR TITLE
Revert "Allow editable installs to satisfy direct-URL dependencies"

### DIFF
--- a/news/10216.bugfix.rst
+++ b/news/10216.bugfix.rst
@@ -1,2 +1,0 @@
-Allow installing a package as editable alongside another package that
-depends on it, via a direct URL reference to the same location.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -221,8 +221,6 @@ class Factory:
                     return None
 
             return self._editable_candidate_cache[link]
-        elif link in self._editable_candidate_cache:
-            return self._editable_candidate_cache[link]
         else:
             if link not in self._link_candidate_cache:
                 try:

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -328,53 +328,6 @@ def test_new_resolver_installs_editable(script: PipTestEnvironment) -> None:
     script.assert_installed_editable("dep")
 
 
-def test_new_resolver_editable_satisfies_direct_url_dep(
-    script: PipTestEnvironment,
-) -> None:
-    """Regression test for https://github.com/pypa/pip/issues/10216.
-
-    Installing ``-e A -e B`` used to fail with ``ResolutionImpossible`` when ``A``
-    depends on ``B`` via a direct URL (PEP 440) reference pointing at the same
-    location as the editable ``B``:
-
-    > Cannot install package-a and package-b because these package versions have
-    > conflicting dependencies.
-
-    This was because the resolver created both an ``EditableCandidate`` (from the
-    user-supplied ``-e B``) and a ``LinkCandidate`` (from ``A``'s transitive
-    direct-URL dependency) for the same link, and treated them as conflicting.
-    """
-    dep_path = create_test_package_with_setup(script, name="dep", version="0.1.0")
-    dep_url = dep_path.as_uri()
-    base_path = script.scratch_path / "base"
-    base_path.mkdir()
-    base_path.joinpath("setup.py").write_text(
-        textwrap.dedent(
-            f"""
-            from setuptools import setup
-            setup(
-                name="base",
-                version="0.1.0",
-                install_requires=["dep @ {dep_url}"],
-            )
-            """
-        )
-    )
-    script.pip(
-        "install",
-        "--no-build-isolation",
-        "--no-cache-dir",
-        "--no-index",
-        "-e",
-        base_path,
-        "-e",
-        dep_path,
-    )
-    script.assert_installed(base="0.1.0", dep="0.1.0")
-    script.assert_installed_editable("base")
-    script.assert_installed_editable("dep")
-
-
 @pytest.mark.parametrize(
     "requires_python, ignore_requires_python, dep_version",
     [


### PR DESCRIPTION
Reverts pypa/pip#13888

Reverting following https://github.com/pypa/pip/pull/13888#issuecomment-4279107941 and https://github.com/pypa/pip/pull/13904#issuecomment-4277253155 and https://github.com/pypa/pip/pull/13904#issuecomment-4285129477, to work on a complete and coherent view on how we approach that topic of mixed editable/non-editables requirements/constraints for the same package.

Reopens #10216
Reopens #12533 