### PR TITLE
fix: handle --version flag in subcommand parser

### DIFF
--- a/news/9456.bugfix.rst
+++ b/news/9456.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``--version`` flag handling in subcommand parser so ``pip <cmd> --version`` prints the version and exits successfully instead of ignoring the flag.

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -22,6 +22,7 @@ from pip._internal.cli.parser import ConfigOptionParser, UpdatingDefaultsHelpFor
 from pip._internal.cli.status_codes import (
     ERROR,
     PREVIOUS_BUILD_DIR_ERROR,
+    SUCCESS,
     UNKNOWN_ERROR,
     VIRTUALENV_NOT_FOUND,
 )
@@ -35,7 +36,7 @@ from pip._internal.exceptions import (
 )
 from pip._internal.utils.filesystem import check_path_owner
 from pip._internal.utils.logging import BrokenStdoutLoggingError, setup_logging
-from pip._internal.utils.misc import get_prog, normalize_path
+from pip._internal.utils.misc import get_pip_version, get_prog, normalize_path
 from pip._internal.utils.temp_dir import TempDirectoryTypeRegistry as TempDirRegistry
 from pip._internal.utils.temp_dir import global_tempdir_manager, tempdir_registry
 from pip._internal.utils.virtualenv import running_under_virtualenv
@@ -179,6 +180,11 @@ class Command(CommandContextMixIn):
         self.enter_context(global_tempdir_manager())
 
         options, args = self.parse_args(args)
+
+        if options.version:
+            sys.stdout.write(get_pip_version())
+            sys.stdout.write(os.linesep)
+            return SUCCESS
 
         # Set verbosity so that it can be used elsewhere.
         self.verbosity = options.verbose - options.quiet

--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -216,3 +216,17 @@ def test_base_command_local_tempdir_cleanup(kind: str, exists: bool) -> None:
     c.run = Mock(side_effect=create_temp_dirs)  # type: ignore[method-assign]
     assert c.main(["fake"]) == SUCCESS
     c.run.assert_called_once()
+
+
+@patch("pip._internal.cli.base_command.get_pip_version")
+def test_version_flag_exits(mock_get_pip_version: Mock, capfd: pytest.CaptureFixture[str]) -> None:
+    """
+    Test that --version exits with SUCCESS and prints version.
+    """
+    mock_get_pip_version.return_value = "pip 26.0.1"
+    cmd = Command("fake", "fake")
+    status = cmd.main(["fake", "--version"])
+    assert status == SUCCESS
+    out = capfd.readouterr().out
+    assert "pip 26.0.1" in out
+    assert "fake" not in out


### PR DESCRIPTION
### PR summary

The `--version` flag was parsed by the subcommand parser but never acted upon, causing commands like `pip wheel . --version` to start building wheels instead of exiting with the version string.

Add a check in `Command._main` so that when `--version` is passed to any subcommand, pip prints the version and returns `SUCCESS` immediately.

Closes #9456

#### AI Disclosure

No AI tools used