### PR TITLE
Fix directory/file removal during package uninstall

### DIFF
--- a/news/13964.bugfix.rst
+++ b/news/13964.bugfix.rst
@@ -1,0 +1,1 @@
+Fix orphaned paths from package removal by fixing wildcard calculations.

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -114,7 +114,7 @@ def compress_for_rename(paths: Iterable[str]) -> set[str]:
     """
     case_map = {os.path.normcase(p): p for p in paths}
     remaining = set(case_map)
-    unchecked = sorted({os.path.split(p)[0] for p in case_map.values()}, key=len)
+    unchecked = sorted({os.path.join(os.path.dirname(p), "") for p in case_map.values()}, key=len)
     wildcards: set[str] = set()
 
     def norm_join(*a: str) -> str:
@@ -133,7 +133,7 @@ def compress_for_rename(paths: Iterable[str]) -> set[str]:
         # for the directory.
         if not (all_files - remaining):
             remaining.difference_update(all_files)
-            wildcards.add(root + os.sep)
+            wildcards.add(root)
 
     return set(map(case_map.__getitem__, remaining)) | wildcards
 

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -126,9 +126,7 @@ def compress_for_rename(paths: Iterable[str]) -> set[str]:
             continue
 
         all_files: set[str] = set()
-        all_subdirs: set[str] = set()
-        for dirname, subdirs, files in os.walk(root):
-            all_subdirs.update(norm_join(root, dirname, d) for d in subdirs)
+        for dirname, _, files in os.walk(root):
             all_files.update(norm_join(root, dirname, f) for f in files)
         # If all the files we found are in our remaining set of files to
         # remove, then remove them from the latter set and add a wildcard

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -192,12 +192,24 @@ def compress_for_output_listing(paths: Iterable[str]) -> tuple[set[str], set[str
 
     _normcased_files = set(map(os.path.normcase, files))
 
+    _scheduled_dirs = {
+        os.path.normcase(p)
+        for p in will_remove
+        if os.path.isdir(p) and not os.path.islink(p)
+    }
+
     folders = compact(folders)
 
     # This walks the tree using os.walk to not miss extra folders
     # that might get added.
     for folder in folders:
-        for dirpath, _, dirfiles in os.walk(folder):
+        for dirpath, subdirs, dirfiles in os.walk(folder):
+            subdirs[:] = [
+                d
+                for d in subdirs
+                if os.path.normcase(os.path.join(dirpath, d)) not in _scheduled_dirs
+            ]
+
             for fname in dirfiles:
                 if fname.endswith(".pyc"):
                     continue

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -115,13 +115,14 @@ def compress_for_rename(paths: Iterable[str]) -> set[str]:
     case_map = {os.path.normcase(p): p for p in paths}
     remaining = set(case_map)
     unchecked = sorted({os.path.join(os.path.dirname(p), "") for p in case_map.values()}, key=len)
-    wildcards: set[str] = set()
+    wildcards: dict[str, str] = {}
 
     def norm_join(*a: str) -> str:
         return os.path.normcase(os.path.join(*a))
 
     for root in unchecked:
-        if any(os.path.normcase(root).startswith(w) for w in wildcards):
+        norm_root = os.path.normcase(root)
+        if any(norm_root.startswith(w) for w in wildcards):
             # This directory has already been handled.
             continue
 
@@ -133,9 +134,9 @@ def compress_for_rename(paths: Iterable[str]) -> set[str]:
         # for the directory.
         if not (all_files - remaining):
             remaining.difference_update(all_files)
-            wildcards.add(root)
+            wildcards[norm_root] = root
 
-    return set(map(case_map.__getitem__, remaining)) | wildcards
+    return set(map(case_map.__getitem__, remaining)) | set(wildcards.values())
 
 
 def compress_for_output_listing(paths: Iterable[str]) -> tuple[set[str], set[str]]:

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -112,22 +112,49 @@ def compress_for_rename(paths: Iterable[str]) -> set[str]:
     This set may include directories when the original sequence of paths
     included every file on disk.
     """
-    case_map = {os.path.normcase(p): p for p in paths}
-    remaining = set(case_map)
-    unchecked = sorted({os.path.join(os.path.dirname(p), "") for p in case_map.values()}, key=len)
+    case_map: dict[str, str] = {}
+    remaining: set[str] = set()
+    unchecked: set[str] = set()
     wildcards: dict[str, str] = {}
 
     def norm_join(*a: str) -> str:
         return os.path.normcase(os.path.join(*a))
 
-    for root in unchecked:
+    # Immediately add directories from `paths` to the list of wildcards
+    for path in sorted(paths, key=len):
+        norm_path = os.path.normcase(path)
+
+        # We do _not_ add the files within wildcard paths.
+        if any(norm_path.startswith(w) for w in wildcards):
+            continue
+
+        if os.path.isdir(path) and not os.path.islink(path):
+            wildcards[os.path.join(norm_path, "")] = os.path.join(path, "")
+        else:
+            case_map[norm_path] = path
+            remaining.add(norm_path)
+            # unchecked -> root -> wildcard so must be display case
+            # ensure it's terminated so it can match against wildcards
+            unchecked.add(os.path.join(os.path.dirname(path), ""))
+
+    # Note: we start at the highest level directory. We do _not_ collapse common
+    # roots (/A/B/C is not elided if /A/B is in the set) because with the current
+    # logic we must descend into the children to determine if _they_ can become
+    # wildcards even if the  parent cannot. This is why we also cannot keep a set
+    # of visited descendants since the wildcard is calculated for the root. This
+    # means that we evaluate the same subdirectory multiple times.
+
+    for root in sorted(unchecked, key=len):
         norm_root = os.path.normcase(root)
         if any(norm_root.startswith(w) for w in wildcards):
             # This directory has already been handled.
             continue
 
         all_files: set[str] = set()
-        for dirname, _, files in os.walk(root):
+        for dirname, subdirs, files in os.walk(root):
+            subdirs[:] = [
+                d for d in subdirs if norm_join(dirname, d, "") not in wildcards
+            ]
             all_files.update(norm_join(dirname, f) for f in files)
         # If all the files we found are in our remaining set of files to
         # remove, then remove them from the latter set and add a wildcard

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -127,7 +127,7 @@ def compress_for_rename(paths: Iterable[str]) -> set[str]:
 
         all_files: set[str] = set()
         for dirname, _, files in os.walk(root):
-            all_files.update(norm_join(root, dirname, f) for f in files)
+            all_files.update(norm_join(dirname, f) for f in files)
         # If all the files we found are in our remaining set of files to
         # remove, then remove them from the latter set and add a wildcard
         # for the directory.

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -306,43 +306,7 @@ class TestStashedUninstallPathSet:
     ]
 
     @classmethod
-    def mock_walk(cls, root: str) -> Iterator[tuple[str, list[str], list[str]]]:
-        for dirname, subdirs, files in cls.WALK_RESULT:
-            dirname = os.path.sep.join(dirname.split("/"))
-            if dirname.startswith(root):
-                yield dirname[len(root) + 1 :], subdirs, files
-
-    def test_compress_for_rename(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        paths = [
-            os.path.sep.join(p.split("/"))
-            for p in [
-                "A/B/b.py",
-                "A/B/D/c.py",
-                "A/C/d.py",
-                "A/E/f.py",
-                "A/G/g.py",
-            ]
-        ]
-
-        expected_paths = [
-            os.path.sep.join(p.split("/"))
-            for p in [
-                "A/B/",  # selected everything below A/B
-                "A/C/d.py",  # did not select everything below A/C
-                "A/E/",  # only empty folders remain under A/E
-                "A/G/g.py",  # non-empty folder remains under A/G
-            ]
-        ]
-
-        monkeypatch.setattr("os.walk", self.mock_walk)
-
-        actual_paths = compress_for_rename(paths)
-        assert set(expected_paths) == set(actual_paths)
-
-    @classmethod
-    def make_stash(
-        cls, tmpdir: Path, paths: list[str]
-    ) -> tuple[StashedUninstallPathSet, list[tuple[str, str]]]:
+    def make_files(cls, tmpdir: Path) -> None:
         for dirname, subdirs, files in cls.WALK_RESULT:
             root = os.path.join(tmpdir, *dirname.split("/"))
             if not os.path.exists(root):
@@ -352,6 +316,50 @@ class TestStashedUninstallPathSet:
             for f in files:
                 with open(os.path.join(root, f), "wb"):
                     pass
+
+    def test_compress_for_rename(self, tmpdir: Path) -> None:
+        def in_tmpdir(paths: list[str]) -> list[str]:
+            return [
+                str(os.path.join(tmpdir, path.replace("/", os.path.sep)))
+                for path in paths
+            ]
+
+        self.make_files(tmpdir)
+
+        paths = in_tmpdir(
+            [
+                os.path.sep.join(p.split("/"))
+                for p in [
+                    "A/B/b.py",
+                    "A/B/D/c.py",
+                    "A/C/d.py",
+                    "A/E/f.py",
+                    "A/G/g.py",
+                ]
+            ]
+        )
+
+        expected_paths = in_tmpdir(
+            [
+                os.path.sep.join(p.split("/"))
+                for p in [
+                    "A/B/",  # selected everything below A/B
+                    "A/C/d.py",  # did not select everything below A/C
+                    "A/E/",  # only empty folders remain under A/E
+                    "A/G/g.py",  # non-empty folder remains under A/G
+                ]
+            ]
+        )
+
+        actual_paths = compress_for_rename(paths)
+        assert set(expected_paths) == set(actual_paths)
+
+    @classmethod
+    def make_stash(
+        cls, tmpdir: Path, paths: list[str]
+    ) -> tuple[StashedUninstallPathSet, list[tuple[str, str]]]:
+
+        cls.make_files(tmpdir)
 
         pathset = StashedUninstallPathSet()
 

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -335,6 +335,7 @@ class TestStashedUninstallPathSet:
                     "A/C/d.py",
                     "A/E/f.py",
                     "A/G/g.py",
+                    "A/B/D",
                 ]
             ]
         )
@@ -347,6 +348,7 @@ class TestStashedUninstallPathSet:
                     "A/C/d.py",  # did not select everything below A/C
                     "A/E/",  # only empty folders remain under A/E
                     "A/G/g.py",  # non-empty folder remains under A/G
+                    "A/B/D/",  # selected due to directory in list
                 ]
             ]
         )

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -78,6 +78,12 @@ def test_compressed_listing(tmpdir: Path) -> None:
             "lib/mypkg/support/__pycache__/support_file-magic.pyc",
             "lib/random_other_place/file_without_a_dot_pyc",
             "bin/mybin",
+            # Test to ensure files added outside of a "RECORD" that are in a
+            # directory marked for removal (__pycache__) get rolled up into
+            # an appropriate wildcard
+            "lib/mypkg2/__init__.py",
+            "lib/mypkg2/my_awesome_code.py",
+            "lib/mypkg2/__pycache__/my_awesome_code-magic.skip.pyc",
         ]
     )
 
@@ -88,12 +94,24 @@ def test_compressed_listing(tmpdir: Path) -> None:
     # Remove the files to be skipped from the paths
     sample = [path for path in sample if ".skip." not in path]
 
+    # UninstallPathSet adds adjacent __pycache__ entries to capture pyc files
+    sample.extend(
+        in_tmpdir(
+            [
+                "lib/mypkg/__pycache__",
+                "lib/mypkg/support/__pycache__",
+                "lib/mypkg2/__pycache__",
+            ]
+        )
+    )
+
     expected_remove = in_tmpdir(
         [
             "bin/mybin",
             "lib/mypkg.dist-info/*",
             "lib/mypkg/*",
             "lib/random_other_place/file_without_a_dot_pyc",
+            "lib/mypkg2/*",
         ]
     )
 
@@ -116,6 +134,7 @@ def test_compressed_listing(tmpdir: Path) -> None:
             "lib/mypkg/support/more_support.py",
             "lib/mypkg/support/__pycache__/",
             "lib/random_other_place/",
+            "lib/mypkg2/",
         ]
     )
 

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -72,6 +72,7 @@ def test_compressed_listing(tmpdir: Path) -> None:
             "lib/mypkg/__init__.py",
             "lib/mypkg/my_awesome_code.py",
             "lib/mypkg/__pycache__/my_awesome_code-magic.pyc",
+            "lib/mypkg/__pycache__/.skip.garbage",
             "lib/mypkg/support/support_file.py",
             "lib/mypkg/support/more_support.py",
             "lib/mypkg/support/would_be_skipped.skip.py",


### PR DESCRIPTION
Address the situation where a file exists on disk but is not captured in an installation record and where its owning directory is selected for removal.

If a path is selected, all files in that path should be globbed and treated as if they were also selected.

This fixes an issue where orphaned directories could linger due to the directories not collapsing appropriately.

Fixes: <commit>(title)

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
