### PR TITLE
Fix description of --no-binary to reflect current behavior

### DIFF
--- a/news/13087.doc.rst
+++ b/news/13087.doc.rst
@@ -1,0 +1,1 @@
+Fix description of --no-binary to reflect current behavior.

--- a/news/13087.doc.rst
+++ b/news/13087.doc.rst
@@ -1,1 +1,0 @@
-Fix description of --no-binary to reflect current behavior.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -646,7 +646,7 @@ def no_binary() -> Option:
         callback=_handle_no_binary,
         type="str",
         default=format_control,
-        help="Do not use binary packages. Can be supplied multiple times, and "
+        help="Do not download binary packages. Cached binary packages may still be used. Can be supplied multiple times, and "
         'each time adds to the existing value. Accepts either ":all:" to '
         'disable all binary packages, ":none:" to empty the set (notice '
         "the colons), or one or more package names with commas between "

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -646,12 +646,13 @@ def no_binary() -> Option:
         callback=_handle_no_binary,
         type="str",
         default=format_control,
-        help="Do not download binary packages. Cached binary packages may still be used. Can be supplied multiple times, and "
-        'each time adds to the existing value. Accepts either ":all:" to '
-        'disable all binary packages, ":none:" to empty the set (notice '
-        "the colons), or one or more package names with commas between "
-        "them (no colons). Note that some packages are tricky to compile "
-        "and may fail to install when this option is used on them.",
+        help="Do not download binary packages. Cached binary packages may still "
+        "be used. Can be supplied multiple times, and each time adds to "
+        "the existing value. Accepts either ':all:' to disable all binary "
+        "packages, ':none:' to empty the set (notice the colons), or one "
+        "or more package names with commas between them (no colons). "
+        "Note that some packages are tricky to compile and may fail to "
+        "install when this option is used on them.",
     )
 
 


### PR DESCRIPTION
## Summary

Update the description of `--no-binary` to reflect behavior introduced in pip 23.1.

## Details

The current help text says "Do not use binary packages", which is misleading.
Since pip 23.1, the option prevents downloading binary distributions, but cached wheels may still be used.

Closes #13087

No news entry needed (docs-only change).