### PR TITLE
docs: Audit HTTPS documentation links (#13664)

### DIFF
--- a/docs/html/cli/pip_show.rst
+++ b/docs/html/cli/pip_show.rst
@@ -43,7 +43,7 @@ Examples
          Name: Sphinx
          Version: 1.4.5
          Summary: Python documentation generator
-         Home-page: http://sphinx-doc.org/
+         Home-page: https://www.sphinx-doc.org/
          Author: Georg Brandl
          Author-email: georg@python.org
          License: BSD
@@ -58,7 +58,7 @@ Examples
          Name: Sphinx
          Version: 1.4.5
          Summary: Python documentation generator
-         Home-page: http://sphinx-doc.org/
+         Home-page: https://www.sphinx-doc.org/
          Author: Georg Brandl
          Author-email: georg@python.org
          License: BSD
@@ -75,7 +75,7 @@ Examples
          Name: Sphinx
          Version: 1.4.5
          Summary: Python documentation generator
-         Home-page: http://sphinx-doc.org/
+         Home-page: https://www.sphinx-doc.org/
          Author: Georg Brandl
          Author-email: georg@python.org
          License: BSD
@@ -118,7 +118,7 @@ Examples
          Name: Sphinx
          Version: 1.4.5
          Summary: Python documentation generator
-         Home-page: http://sphinx-doc.org/
+         Home-page: https://www.sphinx-doc.org/
          Author: Georg Brandl
          Author-email: georg@python.org
          License: BSD

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -1427,7 +1427,7 @@ announcements on the `low-traffic packaging announcements list`_ and
 .. _freeze: https://pip.pypa.io/en/latest/reference/pip_freeze/
 .. _resolver testing survey: https://tools.simplysecure.org/survey/index.php?r=survey/index&sid=989272&lang=en
 .. _issue 8661: https://github.com/pypa/pip/issues/8661
-.. _our announcement on the PSF blog: http://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html
+.. _our announcement on the PSF blog: https://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html
 .. _two-minute video explanation: https://www.youtube.com/watch?v=B4GQCBBsuNU
 .. _tensorflow: https://pypi.org/project/tensorflow/
 .. _low-traffic packaging announcements list: https://mail.python.org/mailman3/lists/pypi-announce.python.org/

--- a/docs/html/ux-research-design/guidance.md
+++ b/docs/html/ux-research-design/guidance.md
@@ -424,7 +424,7 @@ The following copywriting Style Guides may be useful to the pip team:
 - [Simply Secure: Feedback Gathering Guide](https://simplysecure.org/blog/feedback-gathering-guide)
 - [Simply Secure: Getting Quick Tool Feedback](https://simplysecure.org/blog/design-spot-tool-feedback)
 - [Internews: UX Feedback Collection Guidebook](https://globaltech.internews.org/our-resources/ux-feedback-collection-guidebook)
-- [Simply Secure: Knowledge Base](http://simplysecure.org/knowledge-base/)
+- [Simply Secure: Knowledge Base](https://simplysecure.org/knowledge-base/)
 - [Open Source Design](https://opensourcedesign.net/resources/)
 - [Nielsen Norman Group](https://www.nngroup.com/articles/)
 - [Interaction Design Foundation](https://www.interaction-design.org/literature)


### PR DESCRIPTION
## Summary

This PR audits and fixes HTTP documentation links that should use HTTPS, as requested in issue #13664.

### Changes

- **docs/html/cli/pip_show.rst**: Updated 4 occurrences of `http://sphinx-doc.org/` → `https://www.sphinx-doc.org/` (the HTTP version redirects to HTTPS anyway, this ensures users land directly on the secure URL)

- **docs/html/user_guide.rst**: Updated `http://pyfound.blogspot.com/...` → `https://pyfound.blogspot.com/...`

- **docs/html/ux-research-design/guidance.md**: Updated `http://simplysecure.org/knowledge-base/` → `https://simplysecure.org/knowledge-base/`


## Verification

All three HTTPS URLs return HTTP 200:
- `https://www.sphinx-doc.org/` → 200
- `https://pyfound.blogspot.com/2020/03/new-pip-resolver-to-roll-out-this-year.html` → 200
- `https://simplysecure.org/knowledge-base/` → 200

Fixes #13664