### PR TITLE
Fix zsh completion: ensure compdef is available before use (#12738)

### DIFF
--- a/src/pip/_internal/commands/completion.py
+++ b/src/pip/_internal/commands/completion.py
@@ -33,6 +33,9 @@ COMPLETION_SCRIPTS = {
           __pip "$@"
         else
           # eval/source/. command, register function for later
+          if (( ! $+functions[compdef] )); then
+            autoload -Uz compinit && compinit
+          fi
           compdef __pip -P 'pip[0-9.]#'
         fi
     """,

--- a/tests/functional/test_completion.py
+++ b/tests/functional/test_completion.py
@@ -55,6 +55,9 @@ if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
   __pip "$@"
 else
   # eval/source/. command, register function for later
+  if (( ! $+functions[compdef] )); then
+    autoload -Uz compinit && compinit
+  fi
   compdef __pip -P 'pip[0-9.]#'
 fi""",
     ),


### PR DESCRIPTION
## Fix zsh auto-completion error 'command not found: compdef' (closes #12738)

### Problem
When users add `pip completion --zsh` output to their `.zprofile`, they get the error:
```
command not found: compdef
```

This happens because `compdef` is a zsh builtin function provided by `compinit`, but on fresh shells it may not be loaded yet. When the completion script is sourced from `.zprofile` (which runs on shell startup), `compdef` might not be available.

### Solution
Before calling `compdef`, check if the function exists. If it doesn't, autoload `compinit` (which provides `compdef`) first.

### Changes
- **`src/pip/_internal/commands/completion.py`**: Add a check before `compdef` — if the function doesn't exist, autoload `compinit` first.
- **`tests/functional/test_completion.py`**: Updated expected zsh completion output to match.

### Testing
The existing test `COMPLETION_FOR_SUPPORTED_SHELLS_TESTS` validates the zsh completion output; it has been updated to reflect the fix.
