### PR TITLE
✨ feat(resolver): share candidate caches across pip install resolvers

### DIFF
--- a/news/13989.feature.rst
+++ b/news/13989.feature.rst
@@ -1,0 +1,5 @@
+Reuse the in-process build-environment installer's candidate cache across
+build environments. When ``pip install`` builds more than one source
+distribution or editable install with overlapping build dependencies, the
+shared cache amortises candidate construction across the per-build
+resolutions.

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -40,6 +40,11 @@ if TYPE_CHECKING:
     from pip._internal.operations.build.build_tracker import BuildTracker
     from pip._internal.req.req_install import InstallRequirement
     from pip._internal.resolution.base import BaseResolver
+    from pip._internal.resolution.resolvelib.candidates import (
+        EditableCandidate,
+        LinkCandidate,
+    )
+    from pip._internal.resolution.resolvelib.factory import Cache
 
     class ExtraEnviron(TypedDict, total=False):
         extra_environ: dict[str, str]
@@ -103,6 +108,13 @@ class BuildEnvironmentInstaller(Protocol):
     environment.
     """
 
+    # Cache pair the main resolver can share with the build-env installer.
+    # ``None`` means the installer does not share state with the caller's
+    # resolver — e.g. ``SubprocessBuildEnvironmentInstaller`` runs builds in
+    # a separate pip process so the dicts would be useless across the boundary.
+    link_candidate_cache: Cache[LinkCandidate] | None
+    editable_candidate_cache: Cache[EditableCandidate] | None
+
     def install(
         self,
         requirements: Iterable[str],
@@ -117,6 +129,12 @@ class SubprocessBuildEnvironmentInstaller:
     """
     Install build dependencies by calling pip in a subprocess.
     """
+
+    # Subprocess builds run in a separate pip process so candidate caches
+    # cannot cross the boundary; the Protocol attribute is wired but always
+    # ``None``.
+    link_candidate_cache: Cache[LinkCandidate] | None = None
+    editable_candidate_cache: Cache[EditableCandidate] | None = None
 
     def __init__(
         self,
@@ -292,6 +310,14 @@ class InprocessBuildEnvironmentInstaller:
         self._build_constraints = build_constraints
         self._wheel_cache = wheel_cache
         self._level = 0
+        # A pip install with multiple buildable sdists / editable installs runs
+        # this resolver once per build env. Build deps overlap heavily across
+        # those builds (setuptools, wheel, hatchling, etc.) and frequently
+        # overlap with the user's runtime requirements too, so the same dict
+        # pair is shared with the main resolver via the Protocol surface so a
+        # candidate built once is reused everywhere within one ``pip install``.
+        self.link_candidate_cache: Cache[LinkCandidate] | None = {}
+        self.editable_candidate_cache: Cache[EditableCandidate] | None = {}
 
         build_dir = TempDirectory(kind="build-env-install", globally_managed=True)
         self._preparer = RequirementPreparer(
@@ -423,6 +449,8 @@ class InprocessBuildEnvironmentInstaller:
             preparer=self._preparer,
             finder=self._finder,
             wheel_cache=self._wheel_cache,
+            link_candidate_cache=self.link_candidate_cache,
+            editable_candidate_cache=self.editable_candidate_cache,
             # Hard-coded options (that should NOT be inherited).
             ignore_requires_python=False,
             use_user_site=False,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -258,6 +258,12 @@ class RequirementCommand(IndexGroupCommand):
         if resolver_variant == "resolvelib":
             import pip._internal.resolution.resolvelib.resolver
 
+            # Share candidate caches with the build-env installer when one is
+            # available. A package that's both a runtime dep of the user's
+            # request and a build dep of an sdist they're installing is then
+            # constructed once and reused across the main resolver and every
+            # build-env resolver.
+            installer = preparer.build_env_installer
             return pip._internal.resolution.resolvelib.resolver.Resolver(
                 preparer=preparer,
                 finder=finder,
@@ -270,6 +276,8 @@ class RequirementCommand(IndexGroupCommand):
                 force_reinstall=force_reinstall,
                 upgrade_strategy=upgrade_strategy,
                 py_version_info=py_version_info,
+                link_candidate_cache=installer.link_candidate_cache,
+                editable_candidate_cache=installer.editable_candidate_cache,
             )
         import pip._internal.resolution.legacy.resolver
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -100,6 +100,8 @@ class Factory:
         ignore_installed: bool,
         ignore_requires_python: bool,
         py_version_info: tuple[int, ...] | None = None,
+        link_candidate_cache: Cache[LinkCandidate] | None = None,
+        editable_candidate_cache: Cache[EditableCandidate] | None = None,
     ) -> None:
         self._finder = finder
         self.preparer = preparer
@@ -111,8 +113,16 @@ class Factory:
         self._ignore_requires_python = ignore_requires_python
 
         self._build_failures: Cache[InstallationError] = {}
-        self._link_candidate_cache: Cache[LinkCandidate] = {}
-        self._editable_candidate_cache: Cache[EditableCandidate] = {}
+        # The candidate caches are normally owned by this Factory but can be
+        # injected so a caller driving multiple resolutions in one process can
+        # amortise candidate construction across them. ``pip install`` itself
+        # runs one resolution per invocation and never sets these.
+        self._link_candidate_cache: Cache[LinkCandidate] = (
+            link_candidate_cache if link_candidate_cache is not None else {}
+        )
+        self._editable_candidate_cache: Cache[EditableCandidate] = (
+            editable_candidate_cache if editable_candidate_cache is not None else {}
+        )
         self._installed_candidate_cache: dict[str, AlreadyInstalledCandidate] = {}
         self._extras_candidate_cache: dict[
             tuple[int, frozenset[NormalizedName]], ExtrasCandidate

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -32,6 +32,9 @@ from .factory import Factory
 if TYPE_CHECKING:
     from pip._vendor.resolvelib.resolvers import Result as RLResult
 
+    from .candidates import EditableCandidate, LinkCandidate
+    from .factory import Cache
+
     Result = RLResult[Requirement, Candidate, str]
 
 
@@ -54,6 +57,8 @@ class Resolver(BaseResolver):
         force_reinstall: bool,
         upgrade_strategy: str,
         py_version_info: tuple[int, ...] | None = None,
+        link_candidate_cache: Cache[LinkCandidate] | None = None,
+        editable_candidate_cache: Cache[EditableCandidate] | None = None,
     ):
         super().__init__()
         assert upgrade_strategy in self._allowed_strategies
@@ -68,6 +73,8 @@ class Resolver(BaseResolver):
             ignore_installed=ignore_installed,
             ignore_requires_python=ignore_requires_python,
             py_version_info=py_version_info,
+            link_candidate_cache=link_candidate_cache,
+            editable_candidate_cache=editable_candidate_cache,
         )
         self.ignore_dependencies = ignore_dependencies
         self.upgrade_strategy = upgrade_strategy

--- a/tests/unit/resolution_resolvelib/test_resolver.py
+++ b/tests/unit/resolution_resolvelib/test_resolver.py
@@ -13,6 +13,11 @@ from pip._internal.index.package_finder import PackageFinder
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.req.req_set import RequirementSet
+from pip._internal.resolution.resolvelib.candidates import (
+    EditableCandidate,
+    LinkCandidate,
+)
+from pip._internal.resolution.resolvelib.factory import Cache
 from pip._internal.resolution.resolvelib.resolver import (
     Resolver,
     get_topological_weights,
@@ -300,3 +305,70 @@ def test_new_resolver_topological_weights(
 
     weights = get_topological_weights(graph, requirement_keys)
     assert weights == expected_weights
+
+
+def test_resolver_uses_injected_candidate_caches(
+    preparer: RequirementPreparer, finder: PackageFinder
+) -> None:
+    # Identity, not equality: amortising candidate construction across resolver
+    # invocations only works if the caller's dict is the one the Factory writes
+    # into.
+    link_cache: Cache[LinkCandidate] = {}
+    editable_cache: Cache[EditableCandidate] = {}
+
+    resolver = Resolver(
+        preparer=preparer,
+        finder=finder,
+        wheel_cache=None,
+        make_install_req=mock.Mock(),
+        use_user_site=False,
+        ignore_dependencies=False,
+        ignore_installed=False,
+        ignore_requires_python=False,
+        force_reinstall=False,
+        upgrade_strategy="to-satisfy-only",
+        link_candidate_cache=link_cache,
+        editable_candidate_cache=editable_cache,
+    )
+
+    assert resolver.factory._link_candidate_cache is link_cache
+    assert resolver.factory._editable_candidate_cache is editable_cache
+
+
+def test_resolver_creates_fresh_candidate_caches_by_default(
+    preparer: RequirementPreparer, finder: PackageFinder
+) -> None:
+    # Without explicit injection each Factory must own its own dicts;
+    # otherwise default callers would silently share state.
+    first = Resolver(
+        preparer=preparer,
+        finder=finder,
+        wheel_cache=None,
+        make_install_req=mock.Mock(),
+        use_user_site=False,
+        ignore_dependencies=False,
+        ignore_installed=False,
+        ignore_requires_python=False,
+        force_reinstall=False,
+        upgrade_strategy="to-satisfy-only",
+    )
+    second = Resolver(
+        preparer=preparer,
+        finder=finder,
+        wheel_cache=None,
+        make_install_req=mock.Mock(),
+        use_user_site=False,
+        ignore_dependencies=False,
+        ignore_installed=False,
+        ignore_requires_python=False,
+        force_reinstall=False,
+        upgrade_strategy="to-satisfy-only",
+    )
+
+    assert (
+        first.factory._link_candidate_cache is not second.factory._link_candidate_cache
+    )
+    assert (
+        first.factory._editable_candidate_cache
+        is not second.factory._editable_candidate_cache
+    )

--- a/tests/unit/test_build_env.py
+++ b/tests/unit/test_build_env.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from pip._internal.build_env import InprocessBuildEnvironmentInstaller
+
+
+def test_inprocess_installer_shares_candidate_caches_across_resolvers() -> None:
+    # A pip install builds every sdist / editable in its own build env, and
+    # this installer spawns one resolver per env. Build deps overlap heavily
+    # across builds (setuptools, wheel, hatchling), so the per-resolver
+    # candidate cache has to outlive any single ``_make_resolver`` call.
+    with mock.patch("pip._internal.operations.prepare.RequirementPreparer"):
+        installer = InprocessBuildEnvironmentInstaller(
+            finder=mock.MagicMock(),
+            build_tracker=mock.MagicMock(),
+            wheel_cache=mock.MagicMock(),
+        )
+
+    first = installer._make_resolver()
+    second = installer._make_resolver()
+
+    assert (
+        first.factory._link_candidate_cache  # type: ignore[attr-defined]
+        is second.factory._link_candidate_cache  # type: ignore[attr-defined]
+        is installer.link_candidate_cache
+    )
+    assert (
+        first.factory._editable_candidate_cache  # type: ignore[attr-defined]
+        is second.factory._editable_candidate_cache  # type: ignore[attr-defined]
+        is installer.editable_candidate_cache
+    )
+
+
+def test_subprocess_installer_exposes_none_candidate_caches() -> None:
+    # Subprocess builds run in a separate pip process so the dicts cannot
+    # cross the boundary; the Protocol attribute is wired but always ``None``
+    # so the main resolver knows not to share.
+    from pip._internal.build_env import SubprocessBuildEnvironmentInstaller
+
+    installer = SubprocessBuildEnvironmentInstaller(finder=mock.MagicMock())
+
+    assert installer.link_candidate_cache is None
+    assert installer.editable_candidate_cache is None


### PR DESCRIPTION
A `pip install` invocation runs more than one resolver. The user's request goes through one main `Resolver`, and every in-process build environment that has to install build dependencies for an sdist or editable spawns its own. ⚡ Build deps overlap heavily across builds (`setuptools`, `wheel`, `hatchling`, and friends), and many of them also overlap with the user's runtime requirements. Today every resolver pays the cost of building every `LinkCandidate` from scratch because the cache that amortises construction lives on the per-invocation `Factory` and dies with it. Downstream tools that drive even more resolutions in one process (`pip-tools`'s lock pipeline fans out tens of resolvers per command) feel this much harder.

Both new parameters default to `None`, so every existing caller keeps the current per-invocation ownership. Pass a dict and `Factory` writes into the caller's dict instead of its own; identity, not equality, is what makes the optimisation composable across `Resolver` instances. The cache type stays the existing `Cache[LinkCandidate]` / `Cache[EditableCandidate]` aliases the module already uses internally.

`InprocessBuildEnvironmentInstaller` uses the new API end-to-end. It owns one cache pair as instance state and threads it into every `_make_resolver()` call, so a `pip install foo bar` that builds two sdists with overlapping build deps amortises candidate construction across the two build envs. The `BuildEnvironmentInstaller` Protocol exposes the pair as `link_candidate_cache` / `editable_candidate_cache` attributes (typed `Cache[…] | None`); the main resolver picks them up off `preparer.build_env_installer` and joins the same cache, so a package that's both a runtime dep of the user's request and a build dep of an sdist they're installing is constructed exactly once for the whole `pip install`. `SubprocessBuildEnvironmentInstaller` reports `None` because its builds run in a separate pip process and the dicts cannot cross the boundary, so the main resolver falls back to per-instance ownership in that path.

Behaviour for direct-URL resolution, build failures (which stay per-`Factory` deliberately), the installed-candidate cache, and the extras-candidate cache is untouched. The Protocol is internal to pip; downstream `BuildEnvironmentInstaller` implementations need to add two attributes returning `None` to satisfy the typing.

Benchmark on `pip install --use-feature inprocess-build-deps --no-binary :all: --no-deps` against six hatchling-built sdists (`h11`, `anyio`, `sniffio`, `httpcore`, `httpx`, `idna` — overlapping `build-system.requires`), n=4 paired alternating runs:

|         mode         | baseline real | patched real | baseline user | patched user | speedup (user) |
| -------------------- | ------------- | ------------ | ------------- | ------------ | -------------- |
| cold HTTP cache (`--no-cache-dir`) | 8.65 s | 8.30 s | 5.29 s | 5.18 s | **+2.3%** |
| hot HTTP cache, no wheel cache     | 7.86 s | 7.65 s | 5.20 s | 5.01 s | **+3.8%** |

The hot scenario clears pip's wheel cache between iterations so build envs actually run; HTTP metadata stays cached, which matches typical CI / fresh-checkout state with prior pip cache. Cold-cache iterations re-fetch every metadata document from the index. Patched wins 4/4 paired iterations in both modes; the user-CPU number is the cleaner signal because real time mixes in network/build subprocess waits the cache cannot affect.

The win scales with the number of resolvers per command. With six sdists the main resolver plus six build envs share one cache pair; the more sdists or the more they overlap, the larger the amortisation. Downstream consumer at the other extreme: `pip-tools` profiled at 9.3 s of CPU in `_iter_built` across 15 k calls on `--all-extras --all-groups --jobs 1` of `datamodel-code-generator` (~22 resolution passes per cohort × 3 cohorts). The duplicated `LinkCandidate.__init__` work between passes is the main remaining lever after the bytes/Distribution caches `pip-tools` already shares via monkey-patches; this PR is what lets that tool drop the patch and feed the cache through a stable API instead.