### PR TITLE
Reconcile PEP 658 sidecar metadata with the downloaded wheel

### DIFF
--- a/news/13983.bugfix.rst
+++ b/news/13983.bugfix.rst
@@ -1,3 +1,3 @@
-Abort installation when a wheel's :pep:`658` ``.metadata`` sidecar disagrees
-with the wheel's embedded ``METADATA`` on ``Name``, ``Version``,
-``Requires-Dist``, ``Requires-Python`` or ``Provides-Extra``.
+Raise an error when the :pep:`658` ``.metadata`` file used during dependency
+resolution disagrees with the downloaded wheel's ``METADATA`` on ``Name``,
+``Version``, ``Requires-Dist``, ``Requires-Python`` or ``Provides-Extra``.

--- a/news/13983.bugfix.rst
+++ b/news/13983.bugfix.rst
@@ -1,1 +1,3 @@
-Abort installation when PEP 658 sidecar metadata differs from wheel metadata.
+Abort installation when a wheel's :pep:`658` ``.metadata`` sidecar disagrees
+with the wheel's embedded ``METADATA`` on ``Name``, ``Version``,
+``Requires-Dist``, ``Requires-Python`` or ``Provides-Extra``.

--- a/news/13983.bugfix.rst
+++ b/news/13983.bugfix.rst
@@ -1,0 +1,1 @@
+Abort installation when PEP 658 sidecar metadata differs from wheel metadata.

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -380,7 +380,7 @@ class MetadataInconsistent(InstallationError):
 
 
 class SidecarMetadataInconsistent(MetadataInconsistent):
-    """The wheel's built metadata disagrees with its PEP 658 ``.metadata`` file.
+    """The wheel's METADATA disagrees with its PEP 658 ``.metadata`` file.
 
     Raised after the wheel has been downloaded and hash-verified, when a
     resolver-affecting field in the wheel's embedded ``METADATA`` does not

--- a/src/pip/_internal/exceptions.py
+++ b/src/pip/_internal/exceptions.py
@@ -379,6 +379,23 @@ class MetadataInconsistent(InstallationError):
         )
 
 
+class SidecarMetadataInconsistent(MetadataInconsistent):
+    """The wheel's built metadata disagrees with its PEP 658 ``.metadata`` file.
+
+    Raised after the wheel has been downloaded and hash-verified, when a
+    resolver-affecting field in the wheel's embedded ``METADATA`` does not
+    match the value taken from the remote ``.metadata`` sidecar that drove
+    resolution. ``f_val`` is the sidecar value, ``m_val`` is the wheel value.
+    """
+
+    def __str__(self) -> str:
+        return (
+            f"Requested {self.ireq} has inconsistent {self.field} between "
+            f"its PEP 658 .metadata file and the wheel's METADATA: "
+            f"sidecar has {self.f_val!r}, wheel has {self.m_val!r}"
+        )
+
+
 class MetadataInvalid(InstallationError):
     """Metadata is invalid."""
 

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+from pip._vendor.packaging.requirements import InvalidRequirement
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.build_env import BuildEnvironmentInstaller, BuildIsolationMode
@@ -55,6 +55,7 @@ from pip._internal.utils.misc import (
     hide_url,
     redact_auth_from_requirement,
 )
+from pip._internal.utils.packaging import get_requirement
 from pip._internal.utils.temp_dir import TempDirectory
 from pip._internal.utils.unpacking import unpack_file
 from pip._internal.vcs import vcs
@@ -232,8 +233,13 @@ def _canonicalize_requirement(raw: str) -> str:
     for the same distribution without being confused by superficial
     differences in name casing, extra casing, or extras ordering. May raise
     ``InvalidRequirement`` if ``raw`` is not a valid PEP 508 string.
+
+    TODO: once https://github.com/pypa/packaging/pull/1278 is released and
+    vendored, ``Requirement.__eq__`` will canonicalize requested extras and
+    this manual normalization can be dropped in favour of comparing
+    ``Requirement`` objects directly.
     """
-    parsed = Requirement(raw)
+    parsed = get_requirement(raw)
     parts: list[str] = [canonicalize_name(parsed.name)]
     if parsed.extras:
         normalized_extras = sorted(canonicalize_name(e) for e in parsed.extras)

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.build_env import BuildEnvironmentInstaller, BuildIsolationMode
@@ -23,6 +24,7 @@ from pip._internal.exceptions import (
     HashUnpinned,
     InstallationError,
     MetadataInconsistent,
+    MetadataInvalid,
     NetworkConnectionError,
     VcsHashUnsupported,
 )
@@ -220,6 +222,94 @@ def _check_download_dir(
             os.unlink(download_path)
             return None
     return download_path
+
+
+def _canonicalize_requirement(raw: str) -> str:
+    """Return a normalized form of a PEP 508 requirement string.
+
+    Used to compare ``Requires-Dist`` entries from two sources of metadata
+    for the same distribution without being confused by superficial
+    differences in name casing, extra casing, or extras ordering. May raise
+    ``InvalidRequirement`` if ``raw`` is not a valid PEP 508 string.
+    """
+    parsed = Requirement(raw)
+    parts: list[str] = [canonicalize_name(parsed.name)]
+    if parsed.extras:
+        normalized_extras = sorted(canonicalize_name(e) for e in parsed.extras)
+        parts.append(f"[{','.join(normalized_extras)}]")
+    if parsed.specifier:
+        parts.append(str(parsed.specifier))
+    if parsed.url:
+        parts.append(f" @ {parsed.url}")
+    if parsed.marker:
+        parts.append(f"; {parsed.marker}")
+    return "".join(parts)
+
+
+def _reconcile_metadata_against_wheel(
+    req: InstallRequirement,
+    sidecar_dist: BaseDistribution,
+    wheel_dist: BaseDistribution,
+) -> None:
+    """Verify a PEP 658 sidecar's resolver-affecting fields match the wheel.
+
+    The PEP 658 sidecar at ``<wheel>.metadata`` is fetched ahead of the
+    wheel itself and drives dependency resolution. The wheel's own
+    ``.dist-info/METADATA`` is the canonical source for the artifact pip
+    is actually about to install. When an index serves a sidecar without
+    a hash (PEP 658 explicitly permits this), the two are not transitively
+    bound by the wheel's hash check.
+
+    Compare ``Name``, ``Requires-Dist``, ``Requires-Python`` and
+    ``Provides-Extra`` between the two and abort the install on any mismatch.
+    """
+
+    def _canonical_requires(dist: BaseDistribution) -> frozenset[str]:
+        canonical: set[str] = set()
+        for raw in dist.iter_raw_dependencies():
+            try:
+                canonical.add(_canonicalize_requirement(raw))
+            except InvalidRequirement as e:
+                raise MetadataInvalid(req, str(e))
+        return frozenset(canonical)
+
+    # PEP 658 says the sidecar "MUST be identical" to the wheel's metadata,
+    # so cross-check the resolver-affecting fields. For set-valued fields,
+    # only report the symmetric difference: dumping every Requires-Dist
+    # entry from both sides drowns the real mismatch in noise for packages
+    # with large dependency sets.
+    sidecar_name = canonicalize_name(sidecar_dist.raw_name)
+    wheel_name = canonicalize_name(wheel_dist.raw_name)
+    if sidecar_name != wheel_name:
+        raise MetadataInconsistent(req, "Name", sidecar_name, wheel_name)
+
+    sidecar_requires = _canonical_requires(sidecar_dist)
+    wheel_requires = _canonical_requires(wheel_dist)
+    if sidecar_requires != wheel_requires:
+        raise MetadataInconsistent(
+            req,
+            "Requires-Dist",
+            ", ".join(sorted(sidecar_requires - wheel_requires)),
+            ", ".join(sorted(wheel_requires - sidecar_requires)),
+        )
+
+    if sidecar_dist.requires_python != wheel_dist.requires_python:
+        raise MetadataInconsistent(
+            req,
+            "Requires-Python",
+            str(sidecar_dist.requires_python),
+            str(wheel_dist.requires_python),
+        )
+
+    sidecar_extras = frozenset(sidecar_dist.iter_provided_extras())
+    wheel_extras = frozenset(wheel_dist.iter_provided_extras())
+    if sidecar_extras != wheel_extras:
+        raise MetadataInconsistent(
+            req,
+            "Provides-Extra",
+            ", ".join(sorted(sidecar_extras - wheel_extras)),
+            ", ".join(sorted(wheel_extras - sidecar_extras)),
+        )
 
 
 class RequirementPreparer:
@@ -665,6 +755,20 @@ class RequirementPreparer:
             self.build_isolation,
             self.check_build_deps,
         )
+
+        # If a PEP 658 sidecar drove resolution for this wheel, reconcile its
+        # dependency-relevant fields against the wheel's embedded METADATA now
+        # that the wheel is on disk and hash-verified. The sidecar itself may
+        # have been served without a hash, so this is the only point at which
+        # the two can be cross-checked.
+        if (
+            link.is_wheel
+            and req._distribution is not None
+            and req._distribution is not dist
+            and link.metadata_link() is not None
+        ):
+            _reconcile_metadata_against_wheel(req, req._distribution, dist)
+
         return dist
 
     def save_linked_requirement(self, req: InstallRequirement) -> None:

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -26,6 +26,7 @@ from pip._internal.exceptions import (
     MetadataInconsistent,
     MetadataInvalid,
     NetworkConnectionError,
+    SidecarMetadataInconsistent,
     VcsHashUnsupported,
 )
 from pip._internal.index.package_finder import PackageFinder
@@ -246,12 +247,12 @@ def _canonicalize_requirement(raw: str) -> str:
     return "".join(parts)
 
 
-def _reconcile_metadata_against_wheel(
+def _check_sidecar_matches_wheel(
     req: InstallRequirement,
     sidecar_dist: BaseDistribution,
     wheel_dist: BaseDistribution,
 ) -> None:
-    """Verify a PEP 658 sidecar's resolver-affecting fields match the wheel.
+    """Check that a PEP 658 sidecar's resolver-affecting fields match the wheel.
 
     The PEP 658 sidecar at ``<wheel>.metadata`` is fetched ahead of the
     wheel itself and drives dependency resolution. The wheel's own
@@ -260,8 +261,9 @@ def _reconcile_metadata_against_wheel(
     a hash (PEP 658 explicitly permits this), the two are not transitively
     bound by the wheel's hash check.
 
-    Compare ``Name``, ``Requires-Dist``, ``Requires-Python`` and
-    ``Provides-Extra`` between the two and abort the install on any mismatch.
+    Compare ``Name``, ``Version``, ``Requires-Dist``, ``Requires-Python``
+    and ``Provides-Extra`` between the two and abort the install on any
+    mismatch.
     """
 
     def _canonical_requires(dist: BaseDistribution) -> frozenset[str]:
@@ -281,10 +283,10 @@ def _reconcile_metadata_against_wheel(
     sidecar_name = canonicalize_name(sidecar_dist.raw_name)
     wheel_name = canonicalize_name(wheel_dist.raw_name)
     if sidecar_name != wheel_name:
-        raise MetadataInconsistent(req, "Name", sidecar_name, wheel_name)
+        raise SidecarMetadataInconsistent(req, "Name", sidecar_name, wheel_name)
 
     if sidecar_dist.version != wheel_dist.version:
-        raise MetadataInconsistent(
+        raise SidecarMetadataInconsistent(
             req,
             "Version",
             str(sidecar_dist.version),
@@ -294,7 +296,7 @@ def _reconcile_metadata_against_wheel(
     sidecar_requires = _canonical_requires(sidecar_dist)
     wheel_requires = _canonical_requires(wheel_dist)
     if sidecar_requires != wheel_requires:
-        raise MetadataInconsistent(
+        raise SidecarMetadataInconsistent(
             req,
             "Requires-Dist",
             ", ".join(sorted(sidecar_requires - wheel_requires)),
@@ -302,7 +304,7 @@ def _reconcile_metadata_against_wheel(
         )
 
     if sidecar_dist.requires_python != wheel_dist.requires_python:
-        raise MetadataInconsistent(
+        raise SidecarMetadataInconsistent(
             req,
             "Requires-Python",
             str(sidecar_dist.requires_python),
@@ -312,7 +314,7 @@ def _reconcile_metadata_against_wheel(
     sidecar_extras = frozenset(sidecar_dist.iter_provided_extras())
     wheel_extras = frozenset(wheel_dist.iter_provided_extras())
     if sidecar_extras != wheel_extras:
-        raise MetadataInconsistent(
+        raise SidecarMetadataInconsistent(
             req,
             "Provides-Extra",
             ", ".join(sorted(sidecar_extras - wheel_extras)),
@@ -764,18 +766,21 @@ class RequirementPreparer:
             self.check_build_deps,
         )
 
-        # If a PEP 658 sidecar drove resolution for this wheel, reconcile its
-        # dependency-relevant fields against the wheel's embedded METADATA now
-        # that the wheel is on disk and hash-verified. The sidecar itself may
-        # have been served without a hash, so this is the only point at which
-        # the two can be cross-checked.
+        # If a PEP 658 .metadata file was used, check that fields relevant for
+        # dependency resolution match with the wheel's METADATA file.
+        #
+        # NOTE: PEP 658 also permits .metadata files for source distributions,
+        # but pip's sdist install path builds the wheel locally from the sdist
+        # and then re-reads METADATA from it, so the sidecar would already have
+        # been superseded by built metadata before this point. This check is
+        # therefore wheel-only.
         if (
             link.is_wheel
             and req._distribution is not None
             and req._distribution is not dist
             and link.metadata_link() is not None
         ):
-            _reconcile_metadata_against_wheel(req, req._distribution, dist)
+            _check_sidecar_matches_wheel(req, req._distribution, dist)
 
         return dist
 

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -258,18 +258,18 @@ def _check_sidecar_matches_wheel(
     sidecar_dist: BaseDistribution,
     wheel_dist: BaseDistribution,
 ) -> None:
-    """Check that a PEP 658 sidecar's resolver-affecting fields match the wheel.
-
-    The PEP 658 sidecar at ``<wheel>.metadata`` is fetched ahead of the
-    wheel itself and drives dependency resolution. The wheel's own
-    ``.dist-info/METADATA`` is the canonical source for the artifact pip
-    is actually about to install. When an index serves a sidecar without
-    a hash (PEP 658 explicitly permits this), the two are not transitively
-    bound by the wheel's hash check.
+    """Check that a .metadata-based distribution matches the wheel's METADATA.
 
     Compare ``Name``, ``Version``, ``Requires-Dist``, ``Requires-Python``
     and ``Provides-Extra`` between the two and abort the install on any
-    mismatch.
+    mismatch as PEP 658 requires the metadata files "MUST be identical".
+
+    While the PEP doesn't mandate that consumers enforce the identical
+    requirement, it's good nonetheless to check to prevent confusing
+    behaviour when an index misbehaves.
+
+    Also note for name and version, pip usually rejects wheels if they're
+    inconsistent already. Checking them again here is purely defensive.
     """
 
     def _canonical_requires(dist: BaseDistribution) -> frozenset[str]:
@@ -281,11 +281,8 @@ def _check_sidecar_matches_wheel(
                 raise MetadataInvalid(req, str(e))
         return frozenset(canonical)
 
-    # PEP 658 says the sidecar "MUST be identical" to the wheel's metadata,
-    # so cross-check the resolver-affecting fields. For set-valued fields,
-    # only report the symmetric difference: dumping every Requires-Dist
-    # entry from both sides drowns the real mismatch in noise for packages
-    # with large dependency sets.
+    # For multi-use fields, only report the symmetric difference to avoid
+    # unnecessarily flagging matching values.
     sidecar_name = canonicalize_name(sidecar_dist.raw_name)
     wheel_name = canonicalize_name(wheel_dist.raw_name)
     if sidecar_name != wheel_name:
@@ -776,10 +773,13 @@ class RequirementPreparer:
         # dependency resolution match with the wheel's METADATA file.
         #
         # NOTE: PEP 658 also permits .metadata files for source distributions,
-        # but pip's sdist install path builds the wheel locally from the sdist
-        # and then re-reads METADATA from it, so the sidecar would already have
-        # been superseded by built metadata before this point. This check is
-        # therefore wheel-only.
+        # but PyPI doesn't serve such files. In addition, pip seems to use the
+        # locally built metadata for resolution anyway, so it's been decided
+        # to skip this check for sdists. This can change later if needed.
+        #
+        # TODO: this is a hack for checking whether a distribution is metadata-
+        # only or not. If/when we refactor distributions to delineate between
+        # metadata-only and concrete distributions, clean this up.
         if (
             link.is_wheel
             and req._distribution is not None

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -283,6 +283,14 @@ def _reconcile_metadata_against_wheel(
     if sidecar_name != wheel_name:
         raise MetadataInconsistent(req, "Name", sidecar_name, wheel_name)
 
+    if sidecar_dist.version != wheel_dist.version:
+        raise MetadataInconsistent(
+            req,
+            "Version",
+            str(sidecar_dist.version),
+            str(wheel_dist.version),
+        )
+
     sidecar_requires = _canonical_requires(sidecar_dist)
     wheel_requires = _canonical_requires(wheel_dist)
     if sidecar_requires != wheel_requires:

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -253,6 +253,26 @@ def _canonicalize_requirement(raw: str) -> str:
     return "".join(parts)
 
 
+def _canonical_requires(
+    req: InstallRequirement, dist: BaseDistribution, source: str
+) -> frozenset[str]:
+    """Return the canonicalized ``Requires-Dist`` entries of ``dist``.
+
+    ``source`` describes which metadata file ``dist`` was parsed from, for
+    use in error messages.
+    """
+    canonical: set[str] = set()
+    for raw in dist.iter_raw_dependencies():
+        try:
+            # strip() because a folded metadata header may be returned
+            # with a leading newline; iter_dependencies() strips for the
+            # same reason.
+            canonical.add(_canonicalize_requirement(raw.strip()))
+        except InvalidRequirement as e:
+            raise MetadataInvalid(req, f"Requires-Dist in {source}: {e}")
+    return frozenset(canonical)
+
+
 def _check_sidecar_matches_wheel(
     req: InstallRequirement,
     sidecar_dist: BaseDistribution,
@@ -272,17 +292,6 @@ def _check_sidecar_matches_wheel(
     inconsistent already. Checking them again here is purely defensive.
     """
 
-    def _canonical_requires(dist: BaseDistribution) -> frozenset[str]:
-        canonical: set[str] = set()
-        for raw in dist.iter_raw_dependencies():
-            try:
-                canonical.add(_canonicalize_requirement(raw))
-            except InvalidRequirement as e:
-                raise MetadataInvalid(req, str(e))
-        return frozenset(canonical)
-
-    # For multi-use fields, only report the symmetric difference to avoid
-    # unnecessarily flagging matching values.
     sidecar_name = canonicalize_name(sidecar_dist.raw_name)
     wheel_name = canonicalize_name(wheel_dist.raw_name)
     if sidecar_name != wheel_name:
@@ -296,8 +305,12 @@ def _check_sidecar_matches_wheel(
             str(wheel_dist.version),
         )
 
-    sidecar_requires = _canonical_requires(sidecar_dist)
-    wheel_requires = _canonical_requires(wheel_dist)
+    # For multi-use fields, only report the symmetric difference to avoid
+    # unnecessarily flagging matching values.
+    sidecar_requires = _canonical_requires(
+        req, sidecar_dist, "the PEP 658 .metadata file"
+    )
+    wheel_requires = _canonical_requires(req, wheel_dist, "the wheel's METADATA")
     if sidecar_requires != wheel_requires:
         raise SidecarMetadataInconsistent(
             req,
@@ -773,9 +786,10 @@ class RequirementPreparer:
         # dependency resolution match with the wheel's METADATA file.
         #
         # NOTE: PEP 658 also permits .metadata files for source distributions,
-        # but PyPI doesn't serve such files. In addition, pip seems to use the
-        # locally built metadata for resolution anyway, so it's been decided
-        # to skip this check for sdists. This can change later if needed.
+        # but PyPI doesn't serve such files. In addition, an sdist's metadata
+        # is generated at build time and may legitimately differ from what the
+        # index declared, so it's been decided to skip this check for sdists.
+        # This can change later if needed.
         #
         # TODO: this is a hack for checking whether a distribution is metadata-
         # only or not. If/when we refactor distributions to delineate between

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -746,6 +746,8 @@ class FakePackage:
     metadata: MetadataKind
     # This will override any dependencies specified in the actual dist's METADATA.
     requires_dist: tuple[str, ...] = ()
+    # This will override the Provides-Extra entries in the actual dist's METADATA.
+    provides_extra: tuple[str, ...] = ()
     # This will override the Name specified in the actual dist's METADATA.
     metadata_name: str | None = None
 
@@ -766,21 +768,17 @@ class FakePackage:
         checksum = sha256(self.generate_metadata()).hexdigest()
         return f'data-dist-info-metadata="sha256={checksum}"'
 
-    def requires_str(self) -> str:
-        if not self.requires_dist:
-            return ""
-        joined = " and ".join(self.requires_dist)
-        return f"Requires-Dist: {joined}"
-
     def generate_metadata(self) -> bytes:
         """This is written to `self.metadata_filename()` and will override the actual
         dist's METADATA, unless `self.metadata == MetadataKind.NoFile`."""
-        return dedent(f"""\
-        Metadata-Version: 2.1
-        Name: {self.metadata_name or self.name}
-        Version: {self.version}
-        {self.requires_str()}
-        """).encode("utf-8")
+        lines = [
+            "Metadata-Version: 2.1",
+            f"Name: {self.metadata_name or self.name}",
+            f"Version: {self.version}",
+        ]
+        lines.extend(f"Requires-Dist: {entry}" for entry in self.requires_dist)
+        lines.extend(f"Provides-Extra: {extra}" for extra in self.provides_extra)
+        return ("\n".join(lines) + "\n").encode("utf-8")
 
 
 @pytest.fixture(scope="session")
@@ -825,8 +823,8 @@ def fake_packages() -> dict[str, list[FakePackage]]:
             ),
         ],
         "compilewheel": [
-            # Ensure we can override the dependencies of a wheel file by injecting PEP
-            # 658 metadata.
+            # The sidecar declares a dependency the wheel's embedded METADATA
+            # does not, which must be rejected as a Requires-Dist mismatch.
             FakePackage(
                 "compilewheel",
                 "1.0",
@@ -862,12 +860,16 @@ def fake_packages() -> dict[str, list[FakePackage]]:
             ),
         ],
         "requires-simple-extra": [
-            # Metadata name is not canonicalized.
+            # Metadata name is not canonicalized. The sidecar mirrors the
+            # wheel's embedded Requires-Dist and Provides-Extra so the
+            # post-download metadata reconciliation accepts it.
             FakePackage(
                 "requires-simple-extra",
                 "0.1",
                 "requires_simple_extra-0.1-py2.py3-none-any.whl",
                 MetadataKind.Sha256,
+                requires_dist=("simple==1.0; extra == 'extra'",),
+                provides_extra=("extra",),
                 metadata_name="Requires_Simple.Extra",
             ),
         ],

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1262,10 +1262,6 @@ def download_server_html_index(
             "colander",
             ["colander-0.9.9-py2.py3-none-any.whl", "translationstring-1.1.tar.gz"],
         ),
-        (
-            "compilewheel",
-            ["compilewheel-1.0-py2.py3-none-any.whl", "simple-1.0.tar.gz"],
-        ),
     ],
 )
 def test_download_metadata(
@@ -1294,14 +1290,6 @@ def test_download_metadata(
             "colander",
             ["colander-0.9.9-py2.py3-none-any.whl", "translationstring-1.1.tar.gz"],
             "/colander/colander-0.9.9-py2.py3-none-any.whl",
-        ),
-        (
-            "compilewheel",
-            [
-                "compilewheel-1.0-py2.py3-none-any.whl",
-                "simple-1.0.tar.gz",
-            ],
-            "/compilewheel/compilewheel-1.0-py2.py3-none-any.whl",
         ),
     ],
 )
@@ -1337,11 +1325,11 @@ def test_download_metadata_server(
     [
         (
             "simple==3.0",
-            "95e0f200b6302989bcf2cead9465cf229168295ea330ca30d1ffeab5c0fed996",
+            "d522f4676f4d22e3d8954b7f1cf9e81f4f25bf623d0bf5e86def76299b23c9dd",
         ),
         (
             "has-script",
-            "16ba92d7f6f992f6de5ecb7d58c914675cf21f57f8e674fb29dcb4f4c9507e5b",
+            "45f8bb847670cb7306de7b8609f8b7b57b770e44f267cea3be46c50e84343804",
         ),
     ],
 )
@@ -1403,6 +1391,27 @@ def test_produces_error_for_mismatched_package_name_in_metadata(
         "simple2-3.0.tar.gz has inconsistent Name: expected 'simple2', but metadata "
         "has 'not-simple2'"
     ) in result.stdout
+
+
+def test_produces_error_for_mismatched_requires_dist_in_metadata(
+    download_local_html_index: Callable[..., tuple[TestPipResult, Path]],
+) -> None:
+    """Verify that a PEP 658 sidecar declaring dependencies absent from the
+    downloaded wheel's embedded METADATA causes the install to abort.
+
+    The ``compilewheel`` fixture serves a sidecar with
+    ``Requires-Dist: simple==1.0`` while the wheel itself declares no
+    dependencies; pip must reject this rather than resolving against the
+    sidecar's claim.
+    """
+    result, _ = download_local_html_index(
+        ["compilewheel"],
+        allow_error=True,
+    )
+    assert result.returncode != 0
+    assert (
+        "has inconsistent Requires-Dist: expected 'simple==1.0', but metadata has ''"
+    ) in result.stderr, str(result)
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1410,7 +1410,8 @@ def test_produces_error_for_mismatched_requires_dist_in_metadata(
     )
     assert result.returncode != 0
     assert (
-        "has inconsistent Requires-Dist: expected 'simple==1.0', but metadata has ''"
+        "has inconsistent Requires-Dist between its PEP 658 .metadata file "
+        "and the wheel's METADATA: sidecar has 'simple==1.0', wheel has ''"
     ) in result.stderr, str(result)
 
 

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -150,17 +150,13 @@ class Test_unpack_url:
 
 
 def _metadata(*lines: str, name: str = "pkg", version: str = "1.0") -> str:
-    return (
-        "\n".join(
-            [
-                "Metadata-Version: 2.1",
-                f"Name: {name}",
-                f"Version: {version}",
-                *lines,
-            ]
-        )
-        + "\n"
-    )
+    metadata = [
+        "Metadata-Version: 2.1",
+        f"Name: {name}",
+        f"Version: {version}",
+        *lines,
+    ]
+    return "\n".join(metadata) + "\n"
 
 
 def _make_distribution(metadata: str) -> BaseDistribution:

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -12,15 +12,15 @@ from pip._vendor.requests import Response
 
 from pip._internal.exceptions import (
     HashMismatch,
-    MetadataInconsistent,
     MetadataInvalid,
+    SidecarMetadataInconsistent,
 )
 from pip._internal.metadata import BaseDistribution, get_metadata_distribution
 from pip._internal.models.link import Link
 from pip._internal.network.download import Downloader
 from pip._internal.network.session import PipSession
 from pip._internal.operations.prepare import (
-    _reconcile_metadata_against_wheel,
+    _check_sidecar_matches_wheel,
     unpack_url,
 )
 from pip._internal.utils.hashes import Hashes
@@ -171,14 +171,14 @@ def _make_distribution(metadata: str) -> BaseDistribution:
     )
 
 
-class TestReconcileMetadataAgainstWheel:
-    """Exercise :func:`_reconcile_metadata_against_wheel` for each of the
+class TestCheckSidecarMatchesWheel:
+    """Exercise :func:`_check_sidecar_matches_wheel` for each of the
     fields it cross-checks between a PEP 658 sidecar and a downloaded wheel.
     """
 
     def _req(self) -> Mock:
-        # The reconciliation helper only uses the ``req`` argument to build
-        # the resulting exception, so a stand-in object is enough.
+        # The helper only uses the ``req`` argument to build the resulting
+        # exception, so a stand-in object is enough.
         return Mock()
 
     def test_matching_metadata_does_not_raise(self) -> None:
@@ -189,18 +189,18 @@ class TestReconcileMetadataAgainstWheel:
                 "Provides-Extra: extra",
             )
         )
-        _reconcile_metadata_against_wheel(self._req(), dist, dist)
+        _check_sidecar_matches_wheel(self._req(), dist, dist)
 
     def test_requires_dist_canonicalization_is_tolerated(self) -> None:
         sidecar = _make_distribution(_metadata("Requires-Dist: Requests >= 2.0"))
         wheel = _make_distribution(_metadata("Requires-Dist: requests>=2.0"))
-        _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
 
     def test_requires_dist_mismatch_raises(self) -> None:
         sidecar = _make_distribution(_metadata("Requires-Dist: shadow-pkg"))
         wheel = _make_distribution(_metadata())
-        with pytest.raises(MetadataInconsistent) as excinfo:
-            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        with pytest.raises(SidecarMetadataInconsistent) as excinfo:
+            _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
         assert excinfo.value.field == "Requires-Dist"
         assert excinfo.value.f_val == "shadow-pkg"
         assert excinfo.value.m_val == ""
@@ -220,8 +220,8 @@ class TestReconcileMetadataAgainstWheel:
                 "Requires-Dist: only-in-wheel",
             )
         )
-        with pytest.raises(MetadataInconsistent) as excinfo:
-            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        with pytest.raises(SidecarMetadataInconsistent) as excinfo:
+            _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
         assert excinfo.value.field == "Requires-Dist"
         assert excinfo.value.f_val == "only-in-sidecar"
         assert excinfo.value.m_val == "only-in-wheel"
@@ -229,8 +229,8 @@ class TestReconcileMetadataAgainstWheel:
     def test_requires_python_mismatch_raises(self) -> None:
         sidecar = _make_distribution(_metadata("Requires-Python: >=3.9"))
         wheel = _make_distribution(_metadata())
-        with pytest.raises(MetadataInconsistent) as excinfo:
-            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        with pytest.raises(SidecarMetadataInconsistent) as excinfo:
+            _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
         assert excinfo.value.field == "Requires-Python"
         assert excinfo.value.f_val == ">=3.9"
         assert excinfo.value.m_val == ""
@@ -238,8 +238,8 @@ class TestReconcileMetadataAgainstWheel:
     def test_provides_extra_mismatch_raises(self) -> None:
         sidecar = _make_distribution(_metadata("Provides-Extra: extra"))
         wheel = _make_distribution(_metadata())
-        with pytest.raises(MetadataInconsistent) as excinfo:
-            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        with pytest.raises(SidecarMetadataInconsistent) as excinfo:
+            _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
         assert excinfo.value.field == "Provides-Extra"
         assert excinfo.value.f_val == "extra"
         assert excinfo.value.m_val == ""
@@ -247,8 +247,8 @@ class TestReconcileMetadataAgainstWheel:
     def test_name_mismatch_raises(self) -> None:
         sidecar = _make_distribution(_metadata(name="other-pkg"))
         wheel = _make_distribution(_metadata(name="pkg"))
-        with pytest.raises(MetadataInconsistent) as excinfo:
-            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        with pytest.raises(SidecarMetadataInconsistent) as excinfo:
+            _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
         assert excinfo.value.field == "Name"
         assert excinfo.value.f_val == "other-pkg"
         assert excinfo.value.m_val == "pkg"
@@ -256,13 +256,13 @@ class TestReconcileMetadataAgainstWheel:
     def test_name_canonicalization_is_tolerated(self) -> None:
         sidecar = _make_distribution(_metadata(name="Pkg_Name"))
         wheel = _make_distribution(_metadata(name="pkg-name"))
-        _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
 
     def test_version_mismatch_raises(self) -> None:
         sidecar = _make_distribution(_metadata(version="1.0"))
         wheel = _make_distribution(_metadata(version="2.0"))
-        with pytest.raises(MetadataInconsistent) as excinfo:
-            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        with pytest.raises(SidecarMetadataInconsistent) as excinfo:
+            _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
         assert excinfo.value.field == "Version"
         assert excinfo.value.f_val == "1.0"
         assert excinfo.value.m_val == "2.0"
@@ -270,7 +270,7 @@ class TestReconcileMetadataAgainstWheel:
     def test_version_normalization_is_tolerated(self) -> None:
         sidecar = _make_distribution(_metadata(version="1.0"))
         wheel = _make_distribution(_metadata(version="1.0.0"))
-        _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
 
     def test_invalid_requires_dist_raises_metadata_invalid(self) -> None:
         sidecar = _make_distribution(
@@ -278,4 +278,4 @@ class TestReconcileMetadataAgainstWheel:
         )
         wheel = _make_distribution(_metadata())
         with pytest.raises(MetadataInvalid):
-            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+            _check_sidecar_matches_wheel(self._req(), sidecar, wheel)

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -149,13 +149,13 @@ class Test_unpack_url:
             )
 
 
-def _metadata(*lines: str, name: str = "pkg") -> str:
+def _metadata(*lines: str, name: str = "pkg", version: str = "1.0") -> str:
     return (
         "\n".join(
             [
                 "Metadata-Version: 2.1",
                 f"Name: {name}",
-                "Version: 1.0",
+                f"Version: {version}",
                 *lines,
             ]
         )
@@ -256,6 +256,20 @@ class TestReconcileMetadataAgainstWheel:
     def test_name_canonicalization_is_tolerated(self) -> None:
         sidecar = _make_distribution(_metadata(name="Pkg_Name"))
         wheel = _make_distribution(_metadata(name="pkg-name"))
+        _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+
+    def test_version_mismatch_raises(self) -> None:
+        sidecar = _make_distribution(_metadata(version="1.0"))
+        wheel = _make_distribution(_metadata(version="2.0"))
+        with pytest.raises(MetadataInconsistent) as excinfo:
+            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        assert excinfo.value.field == "Version"
+        assert excinfo.value.f_val == "1.0"
+        assert excinfo.value.m_val == "2.0"
+
+    def test_version_normalization_is_tolerated(self) -> None:
+        sidecar = _make_distribution(_metadata(version="1.0"))
+        wheel = _make_distribution(_metadata(version="1.0.0"))
         _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
 
     def test_invalid_requires_dist_raises_metadata_invalid(self) -> None:

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -192,6 +192,19 @@ class TestCheckSidecarMatchesWheel:
         wheel = _make_distribution(_metadata("Requires-Dist: requests>=2.0"))
         _check_sidecar_matches_wheel(self._req(), sidecar, wheel)
 
+    def test_folded_requires_dist_header_is_tolerated(self) -> None:
+        # For a folded Requires-Dist header, the email parser preserves a
+        # leading newline in the raw value on Python versions without the
+        # python/cpython#124452 fix (3.10, 3.11, <3.12.8, 3.13.0). The check
+        # must strip it, like iter_dependencies() does.
+        dist = _make_distribution(
+            _metadata(
+                "Requires-Dist:",
+                " some-package-with-a-very-long-name[extra-one]>=2.31.0,<3.0.0",
+            )
+        )
+        _check_sidecar_matches_wheel(self._req(), dist, dist)
+
     def test_requires_dist_mismatch_raises(self) -> None:
         sidecar = _make_distribution(_metadata("Requires-Dist: shadow-pkg"))
         wheel = _make_distribution(_metadata())

--- a/tests/unit/test_operations_prepare.py
+++ b/tests/unit/test_operations_prepare.py
@@ -10,11 +10,19 @@ import pytest
 
 from pip._vendor.requests import Response
 
-from pip._internal.exceptions import HashMismatch
+from pip._internal.exceptions import (
+    HashMismatch,
+    MetadataInconsistent,
+    MetadataInvalid,
+)
+from pip._internal.metadata import BaseDistribution, get_metadata_distribution
 from pip._internal.models.link import Link
 from pip._internal.network.download import Downloader
 from pip._internal.network.session import PipSession
-from pip._internal.operations.prepare import unpack_url
+from pip._internal.operations.prepare import (
+    _reconcile_metadata_against_wheel,
+    unpack_url,
+)
 from pip._internal.utils.hashes import Hashes
 
 from tests.lib import TestData
@@ -139,3 +147,121 @@ class Test_unpack_url:
                 hashes=Hashes({"md5": ["bogus"]}),
                 verbosity=0,
             )
+
+
+def _metadata(*lines: str, name: str = "pkg") -> str:
+    return (
+        "\n".join(
+            [
+                "Metadata-Version: 2.1",
+                f"Name: {name}",
+                "Version: 1.0",
+                *lines,
+            ]
+        )
+        + "\n"
+    )
+
+
+def _make_distribution(metadata: str) -> BaseDistribution:
+    return get_metadata_distribution(
+        metadata.encode("utf-8"),
+        "pkg-1.0-py3-none-any.whl",
+        "pkg",
+    )
+
+
+class TestReconcileMetadataAgainstWheel:
+    """Exercise :func:`_reconcile_metadata_against_wheel` for each of the
+    fields it cross-checks between a PEP 658 sidecar and a downloaded wheel.
+    """
+
+    def _req(self) -> Mock:
+        # The reconciliation helper only uses the ``req`` argument to build
+        # the resulting exception, so a stand-in object is enough.
+        return Mock()
+
+    def test_matching_metadata_does_not_raise(self) -> None:
+        dist = _make_distribution(
+            _metadata(
+                "Requires-Python: >=3.9",
+                "Requires-Dist: requests>=2.0",
+                "Provides-Extra: extra",
+            )
+        )
+        _reconcile_metadata_against_wheel(self._req(), dist, dist)
+
+    def test_requires_dist_canonicalization_is_tolerated(self) -> None:
+        sidecar = _make_distribution(_metadata("Requires-Dist: Requests >= 2.0"))
+        wheel = _make_distribution(_metadata("Requires-Dist: requests>=2.0"))
+        _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+
+    def test_requires_dist_mismatch_raises(self) -> None:
+        sidecar = _make_distribution(_metadata("Requires-Dist: shadow-pkg"))
+        wheel = _make_distribution(_metadata())
+        with pytest.raises(MetadataInconsistent) as excinfo:
+            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        assert excinfo.value.field == "Requires-Dist"
+        assert excinfo.value.f_val == "shadow-pkg"
+        assert excinfo.value.m_val == ""
+
+    def test_requires_dist_diff_reports_only_differences(self) -> None:
+        sidecar = _make_distribution(
+            _metadata(
+                "Requires-Dist: shared-a",
+                "Requires-Dist: shared-b",
+                "Requires-Dist: only-in-sidecar",
+            )
+        )
+        wheel = _make_distribution(
+            _metadata(
+                "Requires-Dist: shared-a",
+                "Requires-Dist: shared-b",
+                "Requires-Dist: only-in-wheel",
+            )
+        )
+        with pytest.raises(MetadataInconsistent) as excinfo:
+            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        assert excinfo.value.field == "Requires-Dist"
+        assert excinfo.value.f_val == "only-in-sidecar"
+        assert excinfo.value.m_val == "only-in-wheel"
+
+    def test_requires_python_mismatch_raises(self) -> None:
+        sidecar = _make_distribution(_metadata("Requires-Python: >=3.9"))
+        wheel = _make_distribution(_metadata())
+        with pytest.raises(MetadataInconsistent) as excinfo:
+            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        assert excinfo.value.field == "Requires-Python"
+        assert excinfo.value.f_val == ">=3.9"
+        assert excinfo.value.m_val == ""
+
+    def test_provides_extra_mismatch_raises(self) -> None:
+        sidecar = _make_distribution(_metadata("Provides-Extra: extra"))
+        wheel = _make_distribution(_metadata())
+        with pytest.raises(MetadataInconsistent) as excinfo:
+            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        assert excinfo.value.field == "Provides-Extra"
+        assert excinfo.value.f_val == "extra"
+        assert excinfo.value.m_val == ""
+
+    def test_name_mismatch_raises(self) -> None:
+        sidecar = _make_distribution(_metadata(name="other-pkg"))
+        wheel = _make_distribution(_metadata(name="pkg"))
+        with pytest.raises(MetadataInconsistent) as excinfo:
+            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+        assert excinfo.value.field == "Name"
+        assert excinfo.value.f_val == "other-pkg"
+        assert excinfo.value.m_val == "pkg"
+
+    def test_name_canonicalization_is_tolerated(self) -> None:
+        sidecar = _make_distribution(_metadata(name="Pkg_Name"))
+        wheel = _make_distribution(_metadata(name="pkg-name"))
+        _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)
+
+    def test_invalid_requires_dist_raises_metadata_invalid(self) -> None:
+        sidecar = _make_distribution(
+            _metadata("Requires-Dist: not a valid requirement")
+        )
+        wheel = _make_distribution(_metadata())
+        with pytest.raises(MetadataInvalid):
+            _reconcile_metadata_against_wheel(self._req(), sidecar, wheel)


### PR DESCRIPTION
Refs #13983.

## Summary

This adds a post-download consistency check between PEP 658 sidecar metadata and the embedded `METADATA` of the downloaded wheel.

PEP 658 metadata can be used by pip during dependency resolution before the wheel itself is downloaded. Once the wheel is available locally, pip now checks that the resolver-affecting fields from the sidecar-derived distribution match the canonical metadata embedded in the wheel. If `Requires-Dist`, `Requires-Python`, or `Provides-Extra` differ, pip raises `MetadataInconsistent` and aborts the install. If either side contains an unparseable `Requires-Dist` entry, pip raises `MetadataInvalid`, matching the existing metadata validation pattern.

This is the hardening improvement discussed in #13983. It does not change pip's threat model, but it does enforce the expectation that PEP 658 metadata used for resolution remains consistent with the downloaded artifact's canonical metadata.

## Scope

- Add `_canonicalize_requirement` and `_reconcile_metadata_against_wheel` helpers in `src/pip/_internal/operations/prepare.py`.
- Invoke the reconciliation after the downloaded wheel has been prepared, gated on the link being a wheel, a sidecar distribution being stored on the requirement, and the link advertising a PEP 658 `metadata_link`. 
- Adjust the existing `FakePackage` test fixture to emit one metadata header per `Requires-Dist` / `Provides-Extra` entry. 
- Update fixtures so existing positive-path tests remain valid under the new reconciliation. 
- Add unit tests for `Requires-Dist`, `Requires-Python`, `Provides-Extra`, canonicalization tolerance, and invalid requirement metadata. 
- Add one functional test covering the end-to-end `Requires-Dist` mismatch path using the existing `download_local_html_index` fixture. 
- Add a news fragment.

## Test plan

- [x] `pre-commit run` on all touched files: all hooks green. 
- [x] `pytest tests/unit/test_operations_prepare.py -q --no-cov`: 10 passed. 
- [x] `pytest tests/functional/test_download.py -k "metadata or canonicalizes or mismatch" -q --no-cov`: 15 passed. 
- [x] Manual end-to-end smoke test with a local PEP 658-style index where the sidecar declares a `Requires-Dist` entry not present in the wheel metadata. Patched pip rejects the install with `has inconsistent Requires-Dist`.

I also ran the broader functional matrix:

`pytest tests/functional/test_download.py tests/functional/test_install.py tests/functional/test_new_resolver.py -q --no-cov -p no:cacheprovider`

This produced `321 passed, 2 failed, 5 skipped, 1 xfailed, 2 xpassed`.

The two failed cases were:

- `tests/functional/test_install.py::test_pep518_with_user_pip` 
- `tests/functional/test_install.py::test_install_existing_memory_distribution`

I reproduced both of the above on a clean `origin/main` worktree at `f7bfe280f`, so they are unrelated to this PR's PEP 658 metadata reconciliation path.