### PR TITLE
Fix symlink traversal error message during tar extraction

### DIFF
--- a/news/13000.bugfix.rst
+++ b/news/13000.bugfix.rst
@@ -1,0 +1,1 @@
+Corrected the error message formatting when a tar archive contains a symlink pointing outside the extraction target directory in the fallback extraction code path.

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -288,11 +288,11 @@ def _untar_without_filter(
         elif member.issym():
             if not is_symlink_target_in_tar(tar, member):
                 message = (
-                    "The tar file ({}) has a file ({}) trying to install "
-                    "outside target directory ({})"
+                    "The tar file ({}) has a symlink ({}) pointing to ({}) "
+                    "which resolves outside the target directory ({})"
                 )
                 raise InstallationError(
-                    message.format(filename, member.name, member.linkname)
+                    message.format(filename, member.name, member.linkname, location)
                 )
             try:
                 tar._extract_member(member, path)

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -381,10 +381,10 @@ class TestUnpackArchives:
             untar_file(tar_filepath, extract_path)
 
         msg = (
-            "The tar file ({}) has a file ({}) trying to install outside "
-            "target directory ({})"
+            "The tar file ({}) has a symlink ({}) pointing to ({}) "
+            "which resolves outside the target directory ({})"
         )
-        assert msg.format(tar_filepath, "evil_symlink", import_filepath) in str(e.value)
+        assert msg.format(tar_filepath, "evil_symlink", import_filepath, extract_path) in str(e.value)
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 
@@ -418,10 +418,10 @@ class TestUnpackArchives:
             untar_file(tar_filepath, extract_path)
 
         msg = (
-            "The tar file ({}) has a file ({}) trying to install outside "
-            "target directory ({})"
+            "The tar file ({}) has a symlink ({}) pointing to ({}) "
+            "which resolves outside the target directory ({})"
         )
-        assert msg.format(tar_filepath, "evil_symlink", link_path) in str(e.value)
+        assert msg.format(tar_filepath, "evil_symlink", link_path, extract_path) in str(e.value)
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -380,11 +380,12 @@ class TestUnpackArchives:
         with pytest.raises(InstallationError) as e:
             untar_file(tar_filepath, extract_path)
 
-        msg = (
-            "The tar file ({}) has a symlink ({}) pointing to ({}) "
-            "which resolves outside the target directory ({})"
+        expected_msg = (
+            f"The tar file ({tar_filepath}) has a symlink (evil_symlink) "
+            f"pointing to ({import_filepath}) "
+            f"which resolves outside the target directory ({extract_path})"
         )
-        assert msg.format(tar_filepath, "evil_symlink", import_filepath, extract_path) in str(e.value)
+        assert expected_msg in str(e.value)
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 
@@ -417,11 +418,12 @@ class TestUnpackArchives:
         with pytest.raises(InstallationError) as e:
             untar_file(tar_filepath, extract_path)
 
-        msg = (
-            "The tar file ({}) has a symlink ({}) pointing to ({}) "
-            "which resolves outside the target directory ({})"
+        expected_msg = (
+            f"The tar file ({tar_filepath}) has a symlink (evil_symlink) "
+            f"pointing to ({link_path}) "
+            f"which resolves outside the target directory ({extract_path})"
         )
-        assert msg.format(tar_filepath, "evil_symlink", link_path, extract_path) in str(e.value)
+        assert expected_msg in str(e.value)
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 


### PR DESCRIPTION


This updates the error message raised during tar extraction when a symlink points outside the target directory.

The previous message used the symlink target as the target directory which made the output confusing while debugging extraction issues.

The updated message now clearly shows:

* the symlink entry
* the symlink target
* the extraction directory

Changes

* updated the symlink traversal validation message
* updated the related unit tests
* added a news fragment

Testing

Ran:

pytest tests/unit/test_utils_unpacking.py
