### PR TITLE
Handle file access errors in PEP 723 metadata parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,13 +221,6 @@ jobs:
           - { number: 2, pytest-filter: "test_install" }
 
     steps:
-      # The D: drive is significantly faster than the system C: drive.
-      # https://github.com/actions/runner-images/issues/8755
-      - name: Set TEMP to D:/Temp
-        run: |
-          mkdir "D:\\Temp"
-          echo "TEMP=D:\\Temp" >> $env:GITHUB_ENV
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -244,6 +237,7 @@ jobs:
       - name: Install Subversion
         shell: pwsh
         run: |
+          winget source reset --force
           for ($i = 1; $i -le 3; $i++) {
             winget install --accept-source-agreements --accept-package-agreements -e --id Slik.Subversion
             if ($LASTEXITCODE -eq 0) { break }
@@ -251,6 +245,13 @@ jobs:
             Start-Sleep -Seconds (10 * $i)
           }
           echo "C:\Program Files\SlikSvn\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      # The D: drive is significantly faster than the system C: drive.
+      # https://github.com/actions/runner-images/issues/8755
+      - name: Set TEMP to D:/Temp
+        run: |
+          mkdir "D:\\Temp"
+          echo "TEMP=D:\\Temp" >> $env:GITHUB_ENV
 
       - run: pip install nox
 

--- a/news/13100.bugfix.rst
+++ b/news/13100.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent raw tracebacks on missing or unreadable script files passed to --requirements-from-script, raising a proper CommandError instead.

--- a/src/pip/_internal/req/pep723.py
+++ b/src/pip/_internal/req/pep723.py
@@ -14,8 +14,11 @@ class PEP723Exception(ValueError):
 
 
 def pep723_metadata(scriptfile: str) -> dict[str, Any]:
-    with open(scriptfile, encoding="utf8") as f:
-        script = f.read()
+    try:
+        with open(scriptfile, encoding="utf8") as f:
+            script = f.read()
+    except OSError as exc:
+        raise PEP723Exception(f"Failed to read {scriptfile!r}: {exc}") from exc
 
     name = "script"
     matches = list(

--- a/tests/unit/test_pep723.py
+++ b/tests/unit/test_pep723.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+
+from pip._internal.req.pep723 import PEP723Exception, pep723_metadata
+
+
+def test_pep723_metadata_success(tmp_path: Path) -> None:
+    script_content = """\
+# /// script
+# dependencies = [
+#   "requests==2.31.0",
+# ]
+# ///
+print("Hello world")
+"""
+    script_file = tmp_path / "script.py"
+    script_file.write_text(script_content, encoding="utf-8")
+
+    metadata = pep723_metadata(str(script_file))
+    assert metadata == {"dependencies": ["requests==2.31.0"]}
+
+
+def test_pep723_metadata_file_not_found() -> None:
+    with pytest.raises(PEP723Exception) as excinfo:
+        pep723_metadata("non_existent_script_12345.py")
+    assert "Failed to read" in str(excinfo.value)
+    assert "non_existent_script_12345.py" in str(excinfo.value)
+
+
+def test_pep723_metadata_is_a_directory(tmp_path: Path) -> None:
+    with pytest.raises(PEP723Exception) as excinfo:
+        pep723_metadata(str(tmp_path))
+    assert "Failed to read" in str(excinfo.value)
+
+
+def test_pep723_metadata_invalid_toml(tmp_path: Path) -> None:
+    script_content = """\
+# /// script
+# dependencies = [
+# ///
+"""
+    script_file = tmp_path / "script.py"
+    script_file.write_text(script_content, encoding="utf-8")
+
+    with pytest.raises(PEP723Exception) as excinfo:
+        pep723_metadata(str(script_file))
+    assert "Failed to parse TOML" in str(excinfo.value)
+
+
+def test_pep723_metadata_multiple_blocks(tmp_path: Path) -> None:
+    script_content = """\
+# /// script
+# dependencies = []
+# ///
+
+# /// script
+# dependencies = []
+# ///
+"""
+    script_file = tmp_path / "script.py"
+    script_file.write_text(script_content, encoding="utf-8")
+
+    with pytest.raises(PEP723Exception) as excinfo:
+        pep723_metadata(str(script_file))
+    assert "Multiple 'script' blocks" in str(excinfo.value)


### PR DESCRIPTION
Summary
This improves error handling in PEP 723 metadata parsing when reading script files.

Previously file access issues such as missing files or directory paths could raise raw Python exceptions during `--requirements-from-script` processing.

The update now catches filesystem related errors and raises a proper `PEP723Exception` so pip can display a cleaner user facing error message.

Changes
* added `OSError` handling in `pep723_metadata`
* added focused unit tests for PEP 723 parsing
* added news fragment

Testing
Ran:

pytest tests/unit/test_pep723.py
