### PR TITLE
add a failsafe for cases where a file is detected but not found

### DIFF
--- a/news/13992.bugfix.rst
+++ b/news/13992.bugfix.rst
@@ -1,0 +1,1 @@
+Add a fail-safe for cases where a file is detected but does not actually exist.

--- a/src/pip/_vendor/distlib/resources.py
+++ b/src/pip/_vendor/distlib/resources.py
@@ -199,10 +199,11 @@ class ResourceFinder(object):
                         else:
                             new_name = '/'.join([rname, name])
                         child = self.find(new_name)
-                        if child.is_container:
-                            todo.append(child)
-                        else:
-                            yield child
+                        if child is not None:
+                            if child.is_container:
+                                todo.append(child)
+                            else:
+                                yield child
 
 
 class ZipResourceFinder(ResourceFinder):


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
