### PR TITLE
Fix is_within_directory for doubled-slash roots

### DIFF
--- a/news/14001.bugfix.rst
+++ b/news/14001.bugfix.rst
@@ -1,0 +1,2 @@
+Fix installation incorrectly failing when the target path contains a doubled
+slash, such as with ``pip install --root //...``.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -397,17 +397,6 @@ class MissingCallableSuffix(InstallationError):
         )
 
 
-def _script_within_dir(name: str, scripts_dir: str) -> bool:
-    """Return whether script ``name`` resolves to a path inside the ``scripts_dir``.
-
-    distlib joins the entry point name onto the scripts directory, so a name
-    with path separators or ``..`` components can resolve elsewhere.
-    """
-    root = os.path.normpath(scripts_dir)
-    dest = os.path.normpath(os.path.join(scripts_dir, name))
-    return dest.startswith(root + os.sep)
-
-
 def _raise_for_invalid_entrypoint(specification: str, scripts_dir: str) -> None:
     entry = get_export_entry(specification)
     if entry is None:
@@ -416,7 +405,12 @@ def _raise_for_invalid_entrypoint(specification: str, scripts_dir: str) -> None:
     if entry.suffix is None:
         raise MissingCallableSuffix(str(entry))
 
-    if not _script_within_dir(entry.name, scripts_dir):
+    # distlib joins the entry point name onto the scripts directory, so a name
+    # with path separators or ``..`` components can resolve elsewhere. The script
+    # must resolve to a path strictly inside the scripts directory.
+    dest = os.path.join(scripts_dir, entry.name)
+    resolves_to_scripts_dir = os.path.abspath(dest) == os.path.abspath(scripts_dir)
+    if resolves_to_scripts_dir or not is_within_directory(scripts_dir, dest):
         raise InstallationError(
             f"Invalid script entry point name {entry.name!r}: the script "
             f"would be installed outside the scripts directory ({scripts_dir})."

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -79,6 +79,7 @@ def has_leading_dir(paths: Iterable[str]) -> bool:
 def is_within_directory(directory: str, target: str) -> bool:
     """
     Return true if the absolute path of target is within the directory
+    (including when target is equal to the directory).
     """
     abs_directory = os.path.abspath(directory)
     abs_target = os.path.abspath(target)

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -83,8 +83,7 @@ def is_within_directory(directory: str, target: str) -> bool:
     abs_directory = os.path.abspath(directory)
     abs_target = os.path.abspath(target)
 
-    prefix = os.path.commonpath([abs_directory, abs_target])
-    return prefix == abs_directory
+    return abs_target == abs_directory or abs_target.startswith(abs_directory + os.sep)
 
 
 def _get_default_mode_plus_executable() -> int:

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -458,6 +458,14 @@ def test_unpack_tar_unicode(tmpdir: Path) -> None:
         (("parent/", "parent/../sub"), False),
         # Test target sub-string of parent
         (("parent/child", "parent/childfoo"), False),
+        # Test target equal to the directory
+        (("/srv/env/bin", "/srv/env/bin"), True),
+        # Test target within a doubled-slash directory
+        (("//srv/env/bin", "//srv/env/bin/pip"), True),
+        # Test target outside a doubled-slash directory
+        (("//srv/env/bin", "//srv/env/outside"), False),
+        # Test target on a different drive
+        (("C:\\env\\bin", "D:\\outside"), False),
     ],
 )
 def test_is_within_directory(args: tuple[str, str], expected: bool) -> None:

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -694,38 +694,48 @@ def test_get_console_script_specs_replaces_python_version(
 
 
 @pytest.mark.parametrize(
-    "name, within",
+    "name",
     [
-        ("pip", True),
-        ("pip3.13", True),
-        ("foo-bar.baz", True),
-        ("...", True),  # a literal filename, not a path component
-        ("sub/script", True),  # in-tree subdirectory
-        ("a/../b", True),
-        ("sub\\script", True),  # backslash stays in-tree on POSIX and Windows
-        (" ../../inside", True),  # distlib keeps a leading space; resolves in-tree
-        ("../outside", False),
-        ("../../outside", False),
-        ("a/../../outside", False),
-        ("/etc/cron.d/outside", False),  # absolute path; os.path.join drops the root
-        # "." and ".." pass PyPI's [\w.-]+ name check but must be rejected here.
-        (".", False),
-        ("..", False),
-        ("", False),
+        "pip",
+        "pip3.13",
+        "foo-bar.baz",
+        "sub/script",  # in-tree subdirectory
+        "a/../b",
+        "sub\\script",  # backslash stays in-tree on POSIX and Windows
+        " ../../inside",  # distlib keeps a leading space; resolves in-tree
     ],
 )
-def test_script_within_dir(name: str, within: bool) -> None:
-    assert wheel._script_within_dir(name, "/srv/env/bin") is within
+def test_raise_for_invalid_entrypoint_allows_in_tree(name: str) -> None:
+    # Names resolving to a path inside the scripts directory are accepted.
+    wheel._raise_for_invalid_entrypoint(f"{name} = simple:main", "/srv/env/bin")
 
 
-def test_script_within_dir_allows_doubled_slash_root() -> None:
-    # A scripts directory can have a doubled leading slash
-    assert wheel._script_within_dir("pip", "//srv/env/bin") is True
-    assert wheel._script_within_dir("../outside", "//srv/env/bin") is False
+@pytest.mark.parametrize(
+    "name",
+    [
+        "../outside",
+        "../../outside",
+        "a/../../outside",
+        "/etc/cron.d/outside",  # absolute path; os.path.join drops the root
+        ".",  # resolves to the scripts directory itself
+        "..",
+    ],
+)
+def test_raise_for_invalid_entrypoint_rejects_escaping(name: str) -> None:
+    with pytest.raises(InstallationError, match="outside the scripts directory"):
+        wheel._raise_for_invalid_entrypoint(f"{name} = simple:main", "/srv/env/bin")
+
+
+def test_raise_for_invalid_entrypoint_allows_doubled_slash_root() -> None:
+    # A scripts directory can have a doubled leading slash.
+    wheel._raise_for_invalid_entrypoint("pip = simple:main", "//srv/env/bin")
+    with pytest.raises(InstallationError, match="outside the scripts directory"):
+        wheel._raise_for_invalid_entrypoint("../outside = simple:main", "//srv/env/bin")
 
 
 @pytest.mark.skipif(not WINDOWS, reason="drive letters only matter on Windows")
-def test_script_within_dir_rejects_other_drive() -> None:
-    # Validate that a script on a different drive is rejected,
-    # and doesn't throw an error
-    assert wheel._script_within_dir("D:\\outside", "C:\\env\\bin") is False
+def test_raise_for_invalid_entrypoint_rejects_other_drive() -> None:
+    # A name resolving onto a different drive is rejected, and the containment
+    # check must not raise on mismatched drives.
+    with pytest.raises(InstallationError, match="outside the scripts directory"):
+        wheel._raise_for_invalid_entrypoint("D:\\outside = simple:main", "C:\\env\\bin")


### PR DESCRIPTION
Fixes valid installs being rejected when the install path contains a doubled slash, such as `pip install --root //...` (python/cpython#149444).