### PR TITLE
Fix trusted-host TLS connection setup

### DIFF
--- a/news/13624.bugfix.rst
+++ b/news/13624.bugfix.rst
@@ -1,0 +1,1 @@
+Build trusted-host connections with TLS verification disabled consistently.

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -302,6 +302,17 @@ class CacheControlAdapter(_SSLContextAdapterMixin, _BaseCacheControlAdapter):
 
 
 class InsecureHTTPAdapter(HTTPAdapter):
+    def get_connection_with_tls_context(
+        self,
+        request: PreparedRequest,
+        verify: bool | str,
+        proxies: Mapping[str, str] | None = None,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+    ) -> ConnectionPool:
+        return super().get_connection_with_tls_context(
+            request=request, verify=False, proxies=proxies, cert=cert
+        )
+
     def cert_verify(
         self,
         conn: ConnectionPool,
@@ -313,6 +324,17 @@ class InsecureHTTPAdapter(HTTPAdapter):
 
 
 class InsecureCacheControlAdapter(CacheControlAdapter):
+    def get_connection_with_tls_context(
+        self,
+        request: PreparedRequest,
+        verify: bool | str,
+        proxies: Mapping[str, str] | None = None,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+    ) -> ConnectionPool:
+        return super().get_connection_with_tls_context(
+            request=request, verify=False, proxies=proxies, cert=cert
+        )
+
     def cert_verify(
         self,
         conn: ConnectionPool,

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 from urllib.request import getproxies
 
@@ -15,6 +15,8 @@ from pip import __version__
 from pip._internal.models.link import Link
 from pip._internal.network.session import (
     CI_ENVIRONMENT_VARIABLES,
+    InsecureCacheControlAdapter,
+    InsecureHTTPAdapter,
     PipSession,
     user_agent,
 )
@@ -90,6 +92,22 @@ class TestPipSession:
         session = PipSession(cache=os.fspath(tmpdir.joinpath("test-cache")))
 
         assert not hasattr(session.adapters["http://"], "cache")
+
+    @pytest.mark.parametrize(
+        "adapter_cls",
+        [InsecureHTTPAdapter, InsecureCacheControlAdapter],
+    )
+    def test_insecure_adapters_build_connection_without_tls_verification(
+        self, adapter_cls: type[InsecureHTTPAdapter | InsecureCacheControlAdapter]
+    ) -> None:
+        request = requests.Request("GET", "https://example.com/simple/").prepare()
+        adapter = adapter_cls()
+
+        connection = cast(
+            Any, adapter.get_connection_with_tls_context(request, verify=True)
+        )
+
+        assert connection.cert_reqs == "CERT_NONE"
 
     def test_trusted_hosts_adapter(self, tmpdir: Path) -> None:
         session = PipSession(


### PR DESCRIPTION
Fixes #13624.

## Summary
- pass `verify=False` into trusted-host connection pool setup, not only `cert_verify`
- cover both insecure HTTP and cache-control adapters with a unit test
- add the required news fragment

## Testing
- `PYTHONPATH=src .venv/bin/python -m pytest tests/unit/test_network_session.py -q`
- `.venv/bin/pre-commit run --files src/pip/_internal/network/session.py tests/unit/test_network_session.py news/13624.bugfix.rst`