### PR TITLE
This tightens pip's tar extraction fallback for Python runtimes where `tarfile.data_filter` is unavailable.

### DIFF
--- a/news/14004.bugfix.rst
+++ b/news/14004.bugfix.rst
@@ -1,0 +1,1 @@
+Reject tar symlinks that escape the extraction directory in fallback extraction.

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -262,6 +262,14 @@ def is_symlink_target_in_tar(tar: tarfile.TarFile, tarinfo: tarfile.TarInfo) -> 
         return False
 
 
+def is_symlink_target_within_directory(
+    location: str, path: str, tarinfo: tarfile.TarInfo
+) -> bool:
+    """Check if a symbolic link points inside the extraction directory."""
+    link_target = os.path.join(os.path.dirname(path), tarinfo.linkname)
+    return is_within_directory(location, link_target)
+
+
 def _untar_without_filter(
     filename: str,
     location: str,
@@ -287,6 +295,14 @@ def _untar_without_filter(
             ensure_dir(path)
         elif member.issym():
             if not is_symlink_target_in_tar(tar, member):
+                message = (
+                    "The tar file ({}) has a file ({}) trying to install "
+                    "outside target directory ({})"
+                )
+                raise InstallationError(
+                    message.format(filename, member.name, member.linkname)
+                )
+            if not is_symlink_target_within_directory(location, path, member):
                 message = (
                     "The tar file ({}) has a file ({}) trying to install "
                     "outside target directory ({})"

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -425,6 +425,49 @@ class TestUnpackArchives:
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 
+    def test_unpack_tar_link_target_member_cannot_escape_no_data_filter(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Test that an archive member matching the symlink target is not enough
+        to allow writes through the symlink outside the extraction directory.
+        """
+        if hasattr(tarfile, "data_filter"):
+            monkeypatch.delattr("tarfile.data_filter")
+
+        tar_filename = "test_tar_link_escape_no_data_filter.tar"
+        tar_filepath = os.path.join(self.tempdir, tar_filename)
+
+        extract_path = os.path.join(self.tempdir, "extract_path")
+        escaped_path = os.path.join(self.tempdir, "escaped_file")
+
+        with tarfile.open(tar_filepath, "w") as tar:
+            info = tarfile.TarInfo("dir")
+            info.type = tarfile.SYMTYPE
+            info.linkpath = ".."
+            tar.addfile(info)
+
+            file_data = io.BytesIO(b"escaped\n")
+            escaped_file = tarfile.TarInfo("dir/escaped_file")
+            escaped_file.size = len(file_data.getbuffer())
+            tar.addfile(escaped_file, fileobj=file_data)
+
+            target = tarfile.TarInfo("..")
+            target.type = tarfile.DIRTYPE
+            tar.addfile(target)
+
+        with pytest.raises(InstallationError) as e:
+            untar_file(tar_filepath, extract_path)
+
+        msg = (
+            "The tar file ({}) has a file ({}) trying to install outside "
+            "target directory ({})"
+        )
+        assert msg.format(tar_filepath, "dir", "..") in str(e.value)
+
+        assert not os.path.exists(os.path.join(extract_path, "dir"))
+        assert not os.path.exists(escaped_path)
+
 
 def test_unpack_tar_unicode(tmpdir: Path) -> None:
     test_tar = tmpdir / "test.tar"


### PR DESCRIPTION
 ## Summary

  This tightens pip's tar extraction fallback for Python runtimes where `tarfile.data_filter` is unavailable.

  The fallback already checks that a symlink target exists somewhere in the archive before extracting the symlink. That is not sufficient by itself: a crafted archive can include a symlink to `..`, add a file
  below that symlink, and include a later archive member named `..`. The symlink target check passes, then the following file can be written through the symlink outside the extraction directory before
  extraction later rejects the `..` member.

  This patch keeps the existing archive-membership check and adds a directory containment check for the resolved symlink target before the symlink is created.

  ## Changes

  - Add a helper that verifies a tar symlink target resolves within the extraction directory.
  - Reject fallback tar symlinks whose target would escape the extraction directory.
  - Add a regression test covering the bypass shape.
  - Keep existing valid in-archive symlink behavior working.

  ## Validation

  ```bash
  PYTHONPATH=src python3 -m pytest tests/unit/test_utils_unpacking.py -q
  PYTHONPATH=src python3 -m py_compile src/pip/_internal/utils/unpacking.py tests/unit/test_utils_unpacking.py
  git diff --check HEAD~1..HEAD

  Result:

  58 passed