### PR TITLE
Fix typo in requirements_from_scripts option help

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -567,7 +567,7 @@ def requirements_from_scripts() -> Option:
         default=[],
         dest="requirements_from_scripts",
         metavar="file",
-        help="Install dependencies of the given script file"
+        help="Install dependencies of the given script file "
         "as defined by PEP 723 inline metadata. ",
     )
 


### PR DESCRIPTION
Was using the command and noticed a missing space between "file" and "as".

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
