### PR TITLE
Document NETRC environment variable support

### DIFF
--- a/docs/html/topics/authentication.md
+++ b/docs/html/topics/authentication.md
@@ -42,6 +42,10 @@ URL's hostname from the user's `.netrc` file. This behaviour comes from the
 underlying use of {pypi}`requests`, which in turn delegates it to the
 [Python standard library's `netrc` module][netrc-std-lib].
 
+By default, pip looks for `.netrc` or `_netrc` in the user's home directory.
+To use a different file, set the `NETRC` environment variable to the file's
+path before running pip.
+
 ```{note}
 As mentioned in the [standard library documentation for netrc][netrc-std-lib],
 only ASCII characters are allowed in `.netrc` files. Whitespace and

--- a/news/11023.doc.rst
+++ b/news/11023.doc.rst
@@ -1,0 +1,1 @@
+Document support for the ``NETRC`` environment variable.


### PR DESCRIPTION
Fixes #11023.

Summary:
- Document that NETRC can point pip to a custom netrc file.
- Mention the default home-directory netrc filenames.

Checks:
- uv run --with pre-commit pre-commit run --files docs/html/topics/authentication.md news/11023.doc.rst
- uv run --with nox nox -s docs