### PR TITLE
Clarify hash-checking build dependency scope

### DIFF
--- a/docs/html/topics/secure-installs.md
+++ b/docs/html/topics/secure-installs.md
@@ -39,6 +39,10 @@ FooProject == 1.2 \
 
   If there is a dependency that is not spelled out and hashed in the requirements file, it will result in an error.
 
+  This applies to dependencies that pip is installing into the target
+  environment. Build dependencies installed into an isolated build environment
+  are not currently checked against hashes.
+
 - Requirements must be pinned (either to a URL, filesystem path or using `==`).
 
   This prevents a surprising hash mismatch upon the release of a new version that matches the requirement specifier.

--- a/news/11974.doc.rst
+++ b/news/11974.doc.rst
@@ -1,0 +1,1 @@
+Clarify that hash-checking mode does not cover build dependencies.


### PR DESCRIPTION
Fixes #11974.

Summary:
- Clarify that hash-checking mode applies to target environment dependencies.
- Note that isolated build dependencies are not currently hash-checked.

Checks:
- uv run --with pre-commit pre-commit run --files docs/html/topics/secure-installs.md news/11974.doc.rst
- uv run --with nox nox -s docs