### PR TITLE
Avoid cache warning on vary mismatch

### DIFF
--- a/news/13979.bugfix.rst
+++ b/news/13979.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid warning about cache deserialization when a cached response only misses
+because of its Vary headers.

--- a/src/pip/_vendor/README.rst
+++ b/src/pip/_vendor/README.rst
@@ -100,7 +100,8 @@ Modifications
 * ``packaging`` has been modified to import its dependencies from
   ``pip._vendor``.
 * ``CacheControl`` has been modified to import its dependencies from
-  ``pip._vendor``.
+  ``pip._vendor`` and to distinguish cache deserialization failures from
+  vary-header mismatches when loading cache entries.
 * ``requests`` has been modified to import its other dependencies from
   ``pip._vendor`` and to *not* load ``simplejson`` (all platforms) and
   ``pyopenssl`` (Windows).

--- a/src/pip/_vendor/cachecontrol/controller.py
+++ b/src/pip/_vendor/cachecontrol/controller.py
@@ -14,7 +14,7 @@ import re
 import time
 import weakref
 from email.utils import parsedate_tz
-from typing import TYPE_CHECKING, Collection, Mapping
+from typing import TYPE_CHECKING, Collection, Mapping, cast
 
 from pip._vendor.requests.structures import CaseInsensitiveDict
 
@@ -161,10 +161,15 @@ class CacheController:
         else:
             body_file = None
 
-        result = self.serializer.loads(request, cache_data, body_file)
+        result = self.serializer.loads_with_vary_mismatch(
+            request, cache_data, body_file
+        )
+        if result is self.serializer.vary_mismatch:
+            logger.debug("Cached response ignored: request headers do not match vary")
+            return None
         if result is None:
             logger.warning("Cache entry deserialization failed, entry ignored")
-        return result
+        return cast("HTTPResponse | None", result)
 
     def cached_request(self, request: PreparedRequest) -> HTTPResponse | Literal[False]:
         """

--- a/src/pip/_vendor/cachecontrol/serialize.py
+++ b/src/pip/_vendor/cachecontrol/serialize.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 class Serializer:
     serde_version = "4"
+    vary_mismatch = object()
 
     def dumps(
         self,
@@ -68,6 +69,27 @@ class Serializer:
         data: bytes,
         body_file: IO[bytes] | None = None,
     ) -> HTTPResponse | None:
+        return cast(
+            HTTPResponse | None,
+            self._loads(request, data, body_file, return_vary_mismatch=False),
+        )
+
+    def loads_with_vary_mismatch(
+        self,
+        request: PreparedRequest,
+        data: bytes,
+        body_file: IO[bytes] | None = None,
+    ) -> HTTPResponse | object | None:
+        return self._loads(request, data, body_file, return_vary_mismatch=True)
+
+    def _loads(
+        self,
+        request: PreparedRequest,
+        data: bytes,
+        body_file: IO[bytes] | None = None,
+        *,
+        return_vary_mismatch: bool,
+    ) -> HTTPResponse | object | None:
         # Short circuit if we've been given an empty set of data
         if not data:
             return None
@@ -78,14 +100,18 @@ class Serializer:
             return None
 
         data = data[5:]
-        return self._loads_v4(request, data, body_file)
+        return self._loads_v4(
+            request, data, body_file, return_vary_mismatch=return_vary_mismatch
+        )
 
     def prepare_response(
         self,
         request: PreparedRequest,
         cached: Mapping[str, Any],
         body_file: IO[bytes] | None = None,
-    ) -> HTTPResponse | None:
+        *,
+        return_vary_mismatch: bool = False,
+    ) -> HTTPResponse | object | None:
         """Verify our vary headers match and construct a real urllib3
         HTTPResponse object.
         """
@@ -94,13 +120,13 @@ class Serializer:
         # This case is also handled in the controller code when creating
         # a cache entry, but is left here for backwards compatibility.
         if "*" in cached.get("vary", {}):
-            return None
+            return self.vary_mismatch if return_vary_mismatch else None
 
         # Ensure that the Vary headers for the cached response match our
         # request
         for header, value in cached.get("vary", {}).items():
             if request.headers.get(header, None) != value:
-                return None
+                return self.vary_mismatch if return_vary_mismatch else None
 
         body_raw = cached["response"].pop("body")
 
@@ -137,10 +163,14 @@ class Serializer:
         request: PreparedRequest,
         data: bytes,
         body_file: IO[bytes] | None = None,
-    ) -> HTTPResponse | None:
+        *,
+        return_vary_mismatch: bool = False,
+    ) -> HTTPResponse | object | None:
         try:
             cached = msgpack.loads(data, raw=False)
         except ValueError:
             return None
 
-        return self.prepare_response(request, cached, body_file)
+        return self.prepare_response(
+            request, cached, body_file, return_vary_mismatch=return_vary_mismatch
+        )

--- a/tests/unit/test_network_cache.py
+++ b/tests/unit/test_network_cache.py
@@ -4,7 +4,11 @@ from unittest.mock import Mock
 
 import pytest
 
+from pip._vendor.cachecontrol.cache import DictCache
 from pip._vendor.cachecontrol.caches import FileCache
+from pip._vendor.cachecontrol.controller import CacheController
+from pip._vendor.requests import Request
+from pip._vendor.urllib3 import HTTPResponse
 
 from pip._internal.network.cache import SafeFileCache
 
@@ -113,3 +117,40 @@ class TestSafeFileCache:
             cache = SafeFileCache(os.fspath(cache_tmpdir))
             cache.set(key, b"bar")
         assert (os.stat(cache._get_cache_path(key)).st_mode & 0o777) == 0o600
+
+
+def test_vary_mismatch_does_not_warn_about_deserialization(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cache = DictCache()
+    controller = CacheController(cache=cache)
+    request = Request(
+        "GET",
+        "https://example.com/packages/example.whl",
+        headers={"Accept-Encoding": "gzip"},
+    ).prepare()
+    response = HTTPResponse(
+        body=b"cached wheel",
+        headers={
+            "Cache-Control": "max-age=600",
+            "Date": "Thu, 01 Jan 1970 00:00:00 GMT",
+            "Vary": "Accept-Encoding",
+        },
+        status=200,
+    )
+    assert request.url is not None
+    cache.set(
+        request.url,
+        controller.serializer.dumps(request, response, body=b"cached wheel"),
+    )
+
+    changed_request = Request(
+        "GET",
+        request.url,
+        headers={"Accept-Encoding": "gzip, zstd"},
+    ).prepare()
+
+    with caplog.at_level("WARNING", logger="pip._vendor.cachecontrol.controller"):
+        assert controller.cached_request(changed_request) is False
+
+    assert "Cache entry deserialization failed" not in caplog.text

--- a/tools/vendoring/patches/cachecontrol.patch
+++ b/tools/vendoring/patches/cachecontrol.patch
@@ -3,12 +3,138 @@ index 2a63377e0..3f8c36f67 100644
 --- a/src/pip/_vendor/cachecontrol/__init__.py
 +++ b/src/pip/_vendor/cachecontrol/__init__.py
 @@ -15,7 +15,8 @@ from pip._vendor.cachecontrol.wrapper import CacheControl
- 
+
  __author__ = "Eric Larson"
  __email__ = "eric@ionrock.org"
 -__version__ = importlib.metadata.version("cachecontrol")
 +# pip patch: this won't work when vendored, so just patch it out as it's unused
 +# __version__ = importlib.metadata.version("cachecontrol")
- 
+
  __all__ = [
      "__author__",
+
+diff --git a/src/pip/_vendor/cachecontrol/controller.py b/src/pip/_vendor/cachecontrol/controller.py
+index 0bf3801..2a8fe21 100644
+--- a/src/pip/_vendor/cachecontrol/controller.py
++++ b/src/pip/_vendor/cachecontrol/controller.py
+@@ -14,7 +14,7 @@ import re
+ import time
+ import weakref
+ from email.utils import parsedate_tz
+-from typing import TYPE_CHECKING, Collection, Mapping
++from typing import TYPE_CHECKING, Collection, Mapping, cast
+
+ from pip._vendor.requests.structures import CaseInsensitiveDict
+
+@@ -161,10 +161,15 @@ class CacheController:
+         else:
+             body_file = None
+
+-        result = self.serializer.loads(request, cache_data, body_file)
++        result = self.serializer.loads_with_vary_mismatch(
++            request, cache_data, body_file
++        )
++        if result is self.serializer.vary_mismatch:
++            logger.debug("Cached response ignored: request headers do not match vary")
++            return None
+         if result is None:
+             logger.warning("Cache entry deserialization failed, entry ignored")
+-        return result
++        return cast("HTTPResponse | None", result)
+
+     def cached_request(self, request: PreparedRequest) -> HTTPResponse | Literal[False]:
+         """
+diff --git a/src/pip/_vendor/cachecontrol/serialize.py b/src/pip/_vendor/cachecontrol/serialize.py
+index a49487a..5e82dce 100644
+--- a/src/pip/_vendor/cachecontrol/serialize.py
++++ b/src/pip/_vendor/cachecontrol/serialize.py
+@@ -16,6 +16,7 @@ if TYPE_CHECKING:
+
+ class Serializer:
+     serde_version = "4"
++    vary_mismatch = object()
+
+     def dumps(
+         self,
+@@ -68,6 +69,27 @@ class Serializer:
+         data: bytes,
+         body_file: IO[bytes] | None = None,
+     ) -> HTTPResponse | None:
++        return cast(
++            HTTPResponse | None,
++            self._loads(request, data, body_file, return_vary_mismatch=False),
++        )
++
++    def loads_with_vary_mismatch(
++        self,
++        request: PreparedRequest,
++        data: bytes,
++        body_file: IO[bytes] | None = None,
++    ) -> HTTPResponse | object | None:
++        return self._loads(request, data, body_file, return_vary_mismatch=True)
++
++    def _loads(
++        self,
++        request: PreparedRequest,
++        data: bytes,
++        body_file: IO[bytes] | None = None,
++        *,
++        return_vary_mismatch: bool,
++    ) -> HTTPResponse | object | None:
+         # Short circuit if we've been given an empty set of data
+         if not data:
+             return None
+@@ -78,14 +100,18 @@ class Serializer:
+             return None
+
+         data = data[5:]
+-        return self._loads_v4(request, data, body_file)
++        return self._loads_v4(
++            request, data, body_file, return_vary_mismatch=return_vary_mismatch
++        )
+
+     def prepare_response(
+         self,
+         request: PreparedRequest,
+         cached: Mapping[str, Any],
+         body_file: IO[bytes] | None = None,
+-    ) -> HTTPResponse | None:
++        *,
++        return_vary_mismatch: bool = False,
++    ) -> HTTPResponse | object | None:
+         """Verify our vary headers match and construct a real urllib3
+         HTTPResponse object.
+         """
+@@ -94,13 +120,13 @@ class Serializer:
+         # This case is also handled in the controller code when creating
+         # a cache entry, but is left here for backwards compatibility.
+         if "*" in cached.get("vary", {}):
+-            return None
++            return self.vary_mismatch if return_vary_mismatch else None
+
+         # Ensure that the Vary headers for the cached response match our
+         # request
+         for header, value in cached.get("vary", {}).items():
+             if request.headers.get(header, None) != value:
+-                return None
++                return self.vary_mismatch if return_vary_mismatch else None
+
+         body_raw = cached["response"].pop("body")
+
+@@ -137,10 +163,14 @@ class Serializer:
+         request: PreparedRequest,
+         data: bytes,
+         body_file: IO[bytes] | None = None,
+-    ) -> HTTPResponse | None:
++        *,
++        return_vary_mismatch: bool = False,
++    ) -> HTTPResponse | object | None:
+         try:
+             cached = msgpack.loads(data, raw=False)
+         except ValueError:
+             return None
+
+-        return self.prepare_response(request, cached, body_file)
++        return self.prepare_response(
++            request, cached, body_file, return_vary_mismatch=return_vary_mismatch
++        )


### PR DESCRIPTION
## Summary
- keep Vary header mismatches separate from actual CacheControl deserialization failures
- return the normal cache miss path for Vary mismatches without logging a warning
- add a focused network cache test and update the vendoring patch metadata

Fixes #13979

## Tests
- PYTHONPATH=/Users/deepakkudi23/pip-13979-tmp/src /tmp/pip-13979-venv/bin/python -m pytest tests/unit/test_network_cache.py -q
- /tmp/pip-13979-venv/bin/python -m compileall -q src/pip/_vendor/cachecontrol/controller.py src/pip/_vendor/cachecontrol/serialize.py tests/unit/test_network_cache.py
- /tmp/pip-13979-venv/bin/python -m ruff check --select F,E9 src/pip/_vendor/cachecontrol/controller.py src/pip/_vendor/cachecontrol/serialize.py tests/unit/test_network_cache.py
- git diff --check
- git apply --reverse --check tools/vendoring/patches/cachecontrol.patch