### PR TITLE
Fix Accept-Encoding to gzip, deflate

### DIFF
--- a/news/14012.bugfix.rst
+++ b/news/14012.bugfix.rst
@@ -1,0 +1,2 @@
+Send a consistent ``Accept-Encoding`` header to avoid a spurious ``Cache entry
+deserialization failed`` warning.

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -351,6 +351,11 @@ class PipSession(requests.Session):
         # Attach our User Agent to the request
         self.headers["User-Agent"] = user_agent()
 
+        # Pin Accept-Encoding so it doesn't vary with zstd availability (Python
+        # 3.14+ or backports.zstd); a varying value misses the cache for "Vary:
+        # Accept-Encoding" responses shared across interpreters (pypa/pip#13979).
+        self.headers["Accept-Encoding"] = "gzip, deflate"
+
         # Attach our Authentication handler to the session
         self.auth: MultiDomainBasicAuth = MultiDomainBasicAuth(index_urls=index_urls)
 

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -33,6 +33,12 @@ def test_user_agent() -> None:
     assert user_agent.startswith(f"pip/{__version__}")
 
 
+def test_accept_encoding_is_fixed() -> None:
+    # Pinned so it doesn't vary with zstd availability, which would break cache
+    # reuse across interpreters (pypa/pip#13979).
+    assert PipSession().headers["Accept-Encoding"] == "gzip, deflate"
+
+
 @pytest.mark.parametrize(
     "name, expected_like_ci",
     [


### PR DESCRIPTION
Fixes #13979

Fixes the accept encoding to pre-pip 26.1, which both prevents warnings and avoids redownloading file in a multi-Python CI environment.