### PR TITLE
perf: reduce repeated metadata parsing during dependency resolution

### DIFF
--- a/news/cache-dependency-metadata-parsing.trivial.rst
+++ b/news/cache-dependency-metadata-parsing.trivial.rst
@@ -1,0 +1,2 @@
+Cache parsed Requires-Dist entries and ``iter_provided_extras()`` results
+to avoid redundant parsing during dependency resolution.

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -109,6 +109,7 @@ class Distribution(BaseDistribution):
         self._dist = dist
         self._info_location = info_location
         self._installed_location = installed_location
+        self._parsed_requirements: dict[str, Requirement] = {}
 
     @classmethod
     def from_directory(cls, directory: str) -> BaseDistribution:
@@ -226,7 +227,12 @@ class Distribution(BaseDistribution):
         for req_string in self.metadata.get_all("Requires-Dist", []):
             # strip() because email.message.Message.get_all() may return a leading \n
             # in case a long header was wrapped.
-            req = get_requirement(req_string.strip())
+            stripped = req_string.strip()
+            try:
+                req = self._parsed_requirements[stripped]
+            except KeyError:
+                req = get_requirement(stripped)
+                self._parsed_requirements[stripped] = req
             if not req.marker:
                 yield req
             elif not extras and req.marker.evaluate({"extra": ""}):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -234,8 +234,8 @@ class _InstallRequirementBackedCandidate(Candidate):
                 str(dist.version),
             )
         # check dependencies are valid
-        # TODO performance: this means we iterate the dependencies at least twice,
-        # we may want to cache parsed Requires-Dist
+        # Note: dist.iter_dependencies() caches parsed Requires-Dist internally,
+        # so the subsequent call from iter_dependencies() avoids re-parsing.
         try:
             list(dist.iter_dependencies(list(dist.iter_provided_extras())))
         except InvalidRequirement as e:

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -532,8 +532,9 @@ class ExtrasCandidate(Candidate):
 
         # The user may have specified extras that the candidate doesn't
         # support. We ignore any unsupported extras here.
-        valid_extras = self.extras.intersection(self.base.dist.iter_provided_extras())
-        invalid_extras = self.extras.difference(self.base.dist.iter_provided_extras())
+        provided_extras = set(self.base.dist.iter_provided_extras())
+        valid_extras = self.extras.intersection(provided_extras)
+        invalid_extras = self.extras.difference(provided_extras)
         for extra in sorted(invalid_extras):
             logger.warning(
                 "%s %s does not provide the extra '%s'",

--- a/tests/unit/resolution_resolvelib/test_candidates.py
+++ b/tests/unit/resolution_resolvelib/test_candidates.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import email.message
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pip._internal.resolution.resolvelib.candidates import (
+    ExtrasCandidate,
+    _InstallRequirementBackedCandidate,
+)
+
+
+def _make_distribution_mock(
+    provided_extras: list[str] | None = None,
+) -> Mock:
+    """Create a minimal mock distribution for ExtrasCandidate tests.
+
+    iter_provided_extras() is expected to return already-normalized names
+    (PEP 685). The mock returns them as-is.
+    """
+    dist = Mock()
+    dist.iter_provided_extras.return_value = provided_extras or []
+    dist.iter_dependencies.return_value = []
+    return dist
+
+
+def _make_base_mock(
+    provided_extras: list[str] | None = None,
+) -> Mock:
+    """Create a mock base candidate for ExtrasCandidate tests."""
+    dist = _make_distribution_mock(provided_extras)
+    base = Mock()
+    base.dist = dist
+    base._factory.make_requirement_from_candidate.return_value = None
+    base._factory.make_requirements_from_spec.return_value = []
+    base.name = "test-pkg"
+    base.version = "1.0"
+    base._ireq = Mock()
+    return base
+
+
+class TestExtrasCandidateIterDependencies:
+    def test_calls_iter_provided_extras_once(self) -> None:
+        """iter_provided_extras() should be called only once."""
+        base = _make_base_mock(["extra1", "extra2"])
+        candidate = ExtrasCandidate(base, frozenset({"extra1"}))
+        base.dist.iter_provided_extras.reset_mock()
+
+        list(candidate.iter_dependencies(with_requires=True))
+
+        assert base.dist.iter_provided_extras.call_count == 1
+
+    def test_short_circuits_when_with_requires_is_false(self) -> None:
+        """iter_provided_extras should not be called when with_requires=False."""
+        base = _make_base_mock(["extra1"])
+        candidate = ExtrasCandidate(base, frozenset({"extra1"}))
+        base.dist.iter_provided_extras.reset_mock()
+
+        list(candidate.iter_dependencies(with_requires=False))
+
+        assert base.dist.iter_provided_extras.call_count == 0
+
+    def test_computes_valid_and_invalid_extras(self) -> None:
+        """valid_extras and invalid_extras should be correctly computed."""
+        base = _make_base_mock(["extra-a", "extra-b"])
+        candidate = ExtrasCandidate(base, frozenset({"extra-a", "extra-c"}))
+        base.dist.iter_provided_extras.reset_mock()
+
+        list(candidate.iter_dependencies(with_requires=True))
+
+        base.dist.iter_dependencies.assert_called_once_with(
+            frozenset({"extra-a"})
+        )
+
+    def test_all_extras_invalid(self) -> None:
+        """When no extras match, valid_extras should be empty."""
+        base = _make_base_mock(["extra-a"])
+        candidate = ExtrasCandidate(base, frozenset({"extra-x", "extra-y"}))
+        base.dist.iter_provided_extras.reset_mock()
+
+        list(candidate.iter_dependencies(with_requires=True))
+
+        base.dist.iter_dependencies.assert_called_once_with(frozenset())
+
+    def test_extras_are_normalized_before_comparison(self) -> None:
+        """Extras are canonicalized in __init__ and iter_provided_extras
+        returns already-normalized names (PEP 685)."""
+        base = _make_base_mock(["extra-a", "extra-b"])
+        candidate = ExtrasCandidate(base, frozenset({"extra_A"}))
+        base.dist.iter_provided_extras.reset_mock()
+
+        list(candidate.iter_dependencies(with_requires=True))
+
+        base.dist.iter_dependencies.assert_called_once_with(
+            frozenset({"extra-a"})
+        )
+
+
+class TestDistributionIterDependenciesCache:
+    """Tests for the importlib metadata Distribution's Requires-Dist cache."""
+
+    @pytest.fixture
+    def metadata(self) -> email.message.Message:
+        msg = email.message.Message()
+        msg["Requires-Dist"] = "requests>=2.0"
+        msg["Requires-Dist"] = "urllib3>=1.25"
+        return msg
+
+    @pytest.fixture
+    def distribution(self, metadata: email.message.Message) -> object:
+        """Create a minimal importlib Distribution with Requires-Dist entries.
+
+        We patch get_requirement to track parse calls, and use a real
+        Distribution instance from the importlib backend.
+        """
+        from pip._internal.metadata.importlib._dists import Distribution
+
+        importlib_dist = Mock()
+        importlib_dist.metadata = metadata
+        importlib_dist.read_text.return_value = None
+        importlib_dist.locate_file.side_effect = NotImplementedError
+
+        dist = Distribution(importlib_dist, None, None)
+        return dist
+
+    def test_caches_parsed_requirement_across_calls(
+        self,
+        distribution: object,
+        metadata: email.message.Message,
+    ) -> None:
+        """get_requirement should be called once per unique Requires-Dist string,
+        even when iter_dependencies is called multiple times with different args."""
+        from pip._internal.metadata.importlib._dists import (
+            get_requirement as real_get_requirement,
+        )
+
+        with patch(
+            "pip._internal.metadata.importlib._dists.get_requirement",
+            side_effect=real_get_requirement,
+        ) as mock_get_req:
+            list(distribution.iter_dependencies())  # type: ignore[union-attr]
+            list(distribution.iter_dependencies(["extra1"]))  # type: ignore[union-attr]
+
+            assert mock_get_req.call_count == 2
+
+    def test_does_not_reparse_on_identical_metadata(
+        self,
+        distribution: object,
+    ) -> None:
+        """Calling iter_dependencies twice with the same extras should not
+        call get_requirement more than once per unique string."""
+        from pip._internal.metadata.importlib._dists import (
+            get_requirement as real_get_requirement,
+        )
+
+        with patch(
+            "pip._internal.metadata.importlib._dists.get_requirement",
+            side_effect=real_get_requirement,
+        ) as mock_get_req:
+            list(distribution.iter_dependencies())  # type: ignore[union-attr]
+            list(distribution.iter_dependencies())  # type: ignore[union-attr]
+
+            assert mock_get_req.call_count == 2
+
+    def test_cache_hit_returns_same_objects(
+        self,
+        distribution: object,
+    ) -> None:
+        """The same Requirement object should be returned on cache hits."""
+        deps1 = list(distribution.iter_dependencies())  # type: ignore[union-attr]
+        deps2 = list(distribution.iter_dependencies())  # type: ignore[union-attr]
+
+        for r1, r2 in zip(deps1, deps2):
+            assert r1 is r2


### PR DESCRIPTION
Two small caching fixes to avoid redundant metadata parsing:

1. `ExtrasCandidate.iter_dependencies()` called `iter_provided_extras()`
   twice (once for `intersection`, once for `difference`). Store the
   result in a local variable instead.

2. `Distribution.iter_dependencies()` in the importlib backend parses
   `Requires-Dist` entries via `get_requirement()` on every call. Cache
   parsed `Requirement` objects by raw string so subsequent calls (with
   different extras filtering) skip the parse.

New unit tests verify call counts and cache hit behavior. (including them failing on main branch)