### PR TITLE
Surface X-Error-Message response header in HTTP error details

### DIFF
--- a/news/14020.feature.rst
+++ b/news/14020.feature.rst
@@ -1,0 +1,3 @@
+When a server returns an ``X-Error-Message`` response header alongside a
+4xx or 5xx error response, pip now uses that header's value as the error
+detail instead of the HTTP reason phrase.

--- a/src/pip/_internal/network/lazy_wheel.py
+++ b/src/pip/_internal/network/lazy_wheel.py
@@ -209,7 +209,7 @@ class LazyZipOverHTTP:
             right = bisect_right(self._left, end)
             for start, end in self._merge(start, end, left, right):
                 response = self._stream_response(start, end)
-                response.raise_for_status()
+                raise_for_status(response)
                 self.seek(start)
                 for chunk in response_chunks(response, self._chunk_size):
                     self._file.write(chunk)

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -42,6 +42,10 @@ def raise_for_status(resp: Response) -> None:
     else:
         reason = resp.reason
 
+    x_error_message = resp.headers.get("X-Error-Message")
+    if x_error_message:
+        reason = x_error_message
+
     if 400 <= resp.status_code < 500:
         http_error_msg = (
             f"{resp.status_code} Client Error: {reason} for url: {resp.url}"

--- a/tests/unit/test_network_lazy_wheel.py
+++ b/tests/unit/test_network_lazy_wheel.py
@@ -1,18 +1,22 @@
 from collections.abc import Iterator
+from tempfile import NamedTemporaryFile
+from unittest.mock import patch
 
 import pytest
 
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import Version
 
-from pip._internal.exceptions import InvalidWheel
+from pip._internal.exceptions import InvalidWheel, NetworkConnectionError
 from pip._internal.network.lazy_wheel import (
     HTTPRangeRequestUnsupported,
+    LazyZipOverHTTP,
     dist_from_wheel_url,
 )
 from pip._internal.network.session import PipSession
 
 from tests.lib import TestData
+from tests.lib.requests_mocks import MockResponse
 from tests.lib.server import MockServer, file_response
 
 MYPY_0_782_WHL = (
@@ -60,6 +64,27 @@ def test_dist_from_wheel_url_no_range(
     """Test handling when HTTP range requests are not supported."""
     with pytest.raises(HTTPRangeRequestUnsupported):
         dist_from_wheel_url(canonicalize_name("mypy"), mypy_whl_no_range, session)
+
+
+def test_download_range_request_403_uses_x_error_message() -> None:
+    """_download raises NetworkConnectionError with X-Error-Message on 403."""
+    resp = MockResponse(b"")
+    resp.status_code = 403
+    resp.url = "https://files.pythonhosted.org/packages/example.whl"
+    resp.reason = "Forbidden"
+    resp.headers["X-Error-Message"] = "This package is not available from this index."
+
+    obj = LazyZipOverHTTP.__new__(LazyZipOverHTTP)
+    obj._left = []
+    obj._right = []
+    obj._chunk_size = 4096
+    obj._file = NamedTemporaryFile()
+
+    with patch.object(obj, "_stream_response", return_value=resp):
+        with pytest.raises(NetworkConnectionError) as excinfo:
+            obj._download(0, 100)
+    assert "not available" in str(excinfo.value)
+    assert "Forbidden" not in str(excinfo.value)
 
 
 @pytest.mark.network

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -34,3 +34,42 @@ def test_raise_for_status_does_not_raises_exception() -> None:
     resp.url = "http://www.example.com/whatever.tgz"
     resp.reason = "No error"
     raise_for_status(resp)
+
+
+@pytest.mark.parametrize(
+    "status_code, error_type",
+    [
+        (401, "Client Error"),
+        (501, "Server Error"),
+    ],
+)
+def test_raise_for_status_uses_x_error_message_header(
+    status_code: int, error_type: str
+) -> None:
+    """X-Error-Message header takes priority over the HTTP reason phrase."""
+    contents = b""
+    resp = MockResponse(contents)
+    resp.status_code = status_code
+    resp.url = "http://www.example.com/package.whl"
+    resp.reason = "Network Error"
+    resp.headers["X-Error-Message"] = "This package is not available from this index."
+    with pytest.raises(NetworkConnectionError) as excinfo:
+        raise_for_status(resp)
+    assert str(excinfo.value) == (
+        f"{status_code} {error_type}:"
+        " This package is not available from this index."
+        f" for url: {resp.url}"
+    )
+    assert "Network Error" not in str(excinfo.value)
+
+
+def test_raise_for_status_falls_back_to_reason_when_no_x_error_message() -> None:
+    """Without X-Error-Message the reason phrase is used unchanged."""
+    contents = b""
+    resp = MockResponse(contents)
+    resp.status_code = 403
+    resp.url = "http://www.example.com/package.whl"
+    resp.reason = "Forbidden"
+    with pytest.raises(NetworkConnectionError) as excinfo:
+        raise_for_status(resp)
+    assert "Forbidden" in str(excinfo.value)


### PR DESCRIPTION
# Surface `X-Error-Message` response header in HTTP error details

Closes #14020

## Problem

`pip._internal.network.utils.raise_for_status` builds its error message from
`resp.reason` (the HTTP reason phrase). The reason phrase is an unreliable
channel for actionable error detail:

- HTTP/2 has no reason phrase at all (RFC 7540 §8.1.2.4). Client
  libraries synthesize a default ("Forbidden", "Not Found") from the
  status code when none is present on the wire. In modern deployments
  the client almost always speaks HTTP/2 to a CDN or edge proxy, so any
  reason phrase set by the origin is lost at protocol translation.
- HTTP/1.1 allows any value for the reason phrase, including empty
  (RFC 7230 §3.1.2).

The result is that users see `403 Client Error: Forbidden for url: ...`
with no explanation, even when the server has a useful explanation to
give (e.g. "blocked by policy", "package not in this index", "MFA
required").

## Change

When a server returns an `X-Error-Message` response header on a 4xx or
5xx response, `raise_for_status` now uses that header's value as the
error detail in place of `resp.reason`. Servers that don't send the
header see no change in behaviour.

This also aligns the two `raise_for_status` call sites in
`network/lazy_wheel.py` — one was using pip's helper, the other was
using the `requests` built-in. Both now raise the same exception type
and both honour `X-Error-Message`.

## Alternative considered: `application/problem+json` (RFC 7807)

RFC 7807 defines a standardised JSON body format for HTTP error details
(`application/problem+json` with `type`, `title`, `status`, `detail`,
`instance` fields).

We chose `X-Error-Message` over RFC 7807 for two reasons:

1. **Simpler.** Reading one header is a smaller, more contained change
   than parsing a JSON body with a new content type — and a single
   human-readable string is all `raise_for_status` needs today.
2. **Existing precedent.** Hugging Face Hub and RubyGems already use
   `X-Error-Message` for this; NuGet uses `X-NuGet-Warning` (same
   pattern). See #14020 for details. Matching the convention gives a
   server one header that lights up actionable errors across multiple
   clients.

If a future change wants richer structured error details, RFC 7807
remains a clean additive option — this header does not preclude it.

## What is _not_ in this PR

- `index/collector.py` simple-index 4xx responses are still logged at
  `logger.debug` level via `_handle_get_simple_fail`. A useful
  `X-Error-Message` on a 403 from a simple index would still be silent
  at default verbosity. That's a pre-existing behaviour, separate from
  this header change.
- `network/auth.py`'s 401 retry path does not read `X-Error-Message`.
  Out of scope here; worth a follow-up.

## News entry

`news/14020.feature.rst` (towncrier `feature` fragment).