### PR TITLE
docs: clarify that pip search uses XML-RPC search API

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -714,8 +714,8 @@ reference pages.
 Searching for Packages
 ======================
 
-pip can search `PyPI`_ for packages using the ``pip search``
-command:
+pip can search remote indexes that provide an XML-RPC search API (such as
+Artifactory) for packages using the ``pip search`` command:
 
 .. tab:: Unix/macOS
 
@@ -731,6 +731,12 @@ command:
 
 The query will be used to search the names and summaries of all
 packages.
+
+.. note::
+
+   `PyPI`_ has removed its XML-RPC search API, so ``pip search`` no longer
+   works against PyPI. To search for packages on PyPI, use the
+   `PyPI search page <https://pypi.org/search/>`_ in a browser instead.
 
 For more information and examples, see the :ref:`pip search` reference.
 

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -714,8 +714,8 @@ reference pages.
 Searching for Packages
 ======================
 
-pip can search remote indexes that provide an XML-RPC search API (such as
-Artifactory) for packages using the ``pip search`` command:
+pip can search remote indexes that provide an XML-RPC search API for
+packages using the ``pip search`` command:
 
 .. tab:: Unix/macOS
 

--- a/news/13671.doc.rst
+++ b/news/13671.doc.rst
@@ -1,2 +1,0 @@
-Clarify in the user guide that ``pip search`` relies on the XML-RPC search
-API, which PyPI has removed, and point users to the PyPI search page instead.

--- a/news/13671.doc.rst
+++ b/news/13671.doc.rst
@@ -1,0 +1,2 @@
+Clarify in the user guide that ``pip search`` relies on the XML-RPC search
+API, which PyPI has removed, and point users to the PyPI search page instead.


### PR DESCRIPTION
Closes #13671

### Summary

The "Searching for Packages" section of the user guide currently states that
`pip can search PyPI for packages using the pip search command`. However, as
discussed in #13671, PyPI has removed its XML-RPC search API, so `pip search`
no longer works against PyPI. The `pip search` CLI reference page already
documents this, but the user guide did not.

This PR updates `docs/html/user_guide.rst` to:

- Clarify that `pip search` works against indexes that provide an XML-RPC
  search API (such as Artifactory), rather than implying it searches PyPI.
- Add a note that PyPI has removed its XML-RPC search API and direct users to
  the PyPI search page (https://pypi.org/search/) instead.

The wording follows the direction suggested by maintainers in the issue
discussion. A `news/13671.doc.rst` entry is included.

### Verification

Built the docs locally with the same command CI uses
(`sphinx-build -W --keep-going -c docs/html -b html docs/html docs/build/html`)
— the build succeeds with no warnings, and the updated text renders correctly
in `user_guide.html`. `towncrier build --draft` lists the new entry under
"Improved Documentation".

### Disclosure

This contribution was prepared with the assistance of an AI tool (Claude),
with human review of the wording, the maintainer discussion, and the local
documentation build. Disclosed per pip's Generative AI policy.
