### PR TITLE
Add command tests for --require-virtualenv

### DIFF
--- a/tests/unit/test_base_command.py
+++ b/tests/unit/test_base_command.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from pip._internal.cli.base_command import Command
-from pip._internal.cli.status_codes import SUCCESS
+from pip._internal.cli.status_codes import SUCCESS, VIRTUALENV_NOT_FOUND
 from pip._internal.utils import temp_dir
 from pip._internal.utils.logging import BrokenStdoutLoggingError
 from pip._internal.utils.temp_dir import TempDirectory
@@ -64,6 +64,10 @@ class FakeCommandWithUnicode(FakeCommand):
         return SUCCESS
 
 
+class FakeCommandIgnoringRequireVenv(FakeCommand):
+    ignore_require_venv = True
+
+
 class TestCommand:
     def call_main(self, capfd: pytest.CaptureFixture[str], args: list[str]) -> str:
         """
@@ -98,6 +102,52 @@ class TestCommand:
 
         assert "ERROR: Pipe to stdout was broken" in stderr
         assert "Traceback (most recent call last):" in stderr
+
+    def test_require_virtualenv_exits_when_not_in_venv(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "pip._internal.cli.base_command.running_under_virtualenv",
+            lambda: False,
+        )
+        run_func = Mock(return_value=SUCCESS)
+
+        with pytest.raises(SystemExit) as excinfo:
+            FakeCommand(run_func=run_func).main(["--require-virtualenv"])
+
+        assert excinfo.value.code == VIRTUALENV_NOT_FOUND
+        run_func.assert_not_called()
+
+    def test_require_virtualenv_runs_when_in_venv(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "pip._internal.cli.base_command.running_under_virtualenv",
+            lambda: True,
+        )
+        run_func = Mock(return_value=SUCCESS)
+
+        assert FakeCommand(run_func=run_func).main(["--require-virtualenv"]) == SUCCESS
+
+        run_func.assert_called_once()
+
+    def test_require_virtualenv_can_be_ignored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "pip._internal.cli.base_command.running_under_virtualenv",
+            lambda: False,
+        )
+        run_func = Mock(return_value=SUCCESS)
+
+        assert (
+            FakeCommandIgnoringRequireVenv(run_func=run_func).main(
+                ["--require-virtualenv"]
+            )
+            == SUCCESS
+        )
+
+        run_func.assert_called_once()
 
 
 @patch("pip._internal.cli.index_command.Command.pip_version_check")


### PR DESCRIPTION
Closes pypa/pip#12843.

This adds command-level tests for `--require-virtualenv` so the option is
covered where `Command._main()` enforces it.

The new cases cover:

- exiting before `run()` when `--require-virtualenv` is used outside a virtualenv
- running normally when `--require-virtualenv` is used inside a virtualenv
- allowing commands with `ignore_require_venv = True` to bypass the check

The tests monkeypatch the `running_under_virtualenv` symbol imported by
`pip._internal.cli.base_command`, which keeps the coverage focused on the
command gate without mutating interpreter prefix state.

Local checks:

- `TZ=UTC TMPDIR=.codex-tmp/pip-tmp PIP_CACHE_DIR=.codex-tmp/pip-cache .codex-tmp/pip-nox-venv/bin/python -m nox -s test-3.13 -- tests/unit/test_base_command.py -k 'require_virtualenv'`
- `TZ=UTC TMPDIR=.codex-tmp/pip-tmp PIP_CACHE_DIR=.codex-tmp/pip-cache .codex-tmp/pip-nox-venv/bin/python -m nox -s test-3.13 -- tests/unit/test_base_command.py tests/unit/test_options.py`
- `TMPDIR=.codex-tmp/pip-tmp PIP_CACHE_DIR=.codex-tmp/pip-cache .codex-tmp/pip-nox-venv/bin/python -m nox -s lint`
- `TMPDIR=.codex-tmp/pip-tmp PIP_CACHE_DIR=.codex-tmp/pip-cache .nox/lint/bin/pre-commit run --files tests/unit/test_base_command.py news/7b532b34-346d-46ee-acb8-8e1a65df5d53.trivial.rst`
