### PR TITLE
Fix `sitecustomize.py` used for build isolation on Python 3.15+

### DIFF
--- a/news/14033.bugfix.rst
+++ b/news/14033.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent system packages from leaking into isolated build environments on Python 3.15

--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -468,15 +468,19 @@ class BuildEnvironment:
                     """
                 import os, site, sys
 
-                # First, drop system-sites related paths.
+                # First, discover all system-sites related paths.
                 original_sys_path = sys.path[:]
+                # Clear sys.path so addsitedir() will add system site paths and paths
+                # added by contained .pth files to sys.path reliably. This is necessary
+                # since Python 3.15, which notably no longer re-executes .pth files for
+                # known paths.
+                sys.path = []
                 known_paths = set()
                 for path in {system_sites!r}:
                     site.addsitedir(path, known_paths=known_paths)
-                system_paths = set(
-                    os.path.normcase(path)
-                    for path in sys.path[len(original_sys_path):]
-                )
+                system_paths = set(os.path.normcase(path) for path in sys.path)
+
+                # Drop discovered system-sites related paths.
                 original_sys_path = [
                     path for path in original_sys_path
                     if os.path.normcase(path) not in system_paths

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -174,11 +174,13 @@ class VirtualEnvironment:
                     site.ENABLE_USER_SITE = {self._user_site_packages}
                     # First, drop system-sites related paths.
                     original_sys_path = sys.path[:]
+                    # To discover system-sites related paths, clear sys.path
+                    # and build a new one with only system paths.
+                    sys.path = []
                     known_paths = set()
                     for path in site.getsitepackages():
                         site.addsitedir(path, known_paths=known_paths)
-                    system_paths = sys.path[len(original_sys_path):]
-                    for path in system_paths:
+                    for path in sys.path:
                         if path in original_sys_path:
                             original_sys_path.remove(path)
                     sys.path = original_sys_path


### PR DESCRIPTION
The `sitecustomize.py` file pip uses to isolate build subprocesses from the parent environment discovers system related paths by calling `site.addsitedir()` for every system site-packages path and observing what new entries are appended to `sys.path`.

This breaks since Python 3.15b2 due to two changes:

- `site.addsitedir()` won't add a path if it already exists in `sys.path`

- `site.addsitedir()` won't re-execute .`pth` files if called for a known directory (which includes the system sites because known_path is mutated by `addsitedir()` before it checks for `.pth` files)

To cope with this, temporarily clear sys.path before using `site.addsitedir()` to discover all system paths for exclusion.

The proper fix is to use real virtual environments, but that's a bigger change with a larger risk of breakage. So, unless we're okay with switching to use real virtual environments exclusively on Python 3.15+, this is probably our best next option.