### PR TITLE
mnt: Bump lock threads action to 6.0.2

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository_owner == 'pypa'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           issue-inactive-days: '30'
           pr-inactive-days: '15'


### PR DESCRIPTION
[GitHub recently rolled out a change to app tokens](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/), which includes workflow tokens, that has the side effect of making them several times longer. This breaks older versions of the lock threads action.

'github-token' length must be less than or equal to 100 characters long.

