### PR TITLE
Show OS error reason for pip self-version check failures

### DIFF
--- a/news/13352.bugfix.rst
+++ b/news/13352.bugfix.rst
@@ -1,0 +1,1 @@
+Show the reason when pip's self-version check fails while accessing local files.

--- a/src/pip/_internal/cli/index_command.py
+++ b/src/pip/_internal/cli/index_command.py
@@ -151,6 +151,19 @@ def _pip_self_version_check_emit(upgrade_prompt: UpgradePrompt | None) -> None:
     pip_self_version_check_emit(upgrade_prompt)
 
 
+def _log_pip_self_version_check_error(error: Exception) -> None:
+    message = "There was an error checking the latest version of pip."
+    if isinstance(error, OSError):
+        reason = str(error)
+        if reason:
+            logger.warning("%s (%s)", message, reason)
+            logger.debug("See below for error", exc_info=True)
+            return
+
+    logger.warning(message)
+    logger.debug("See below for error", exc_info=True)
+
+
 class IndexGroupCommand(Command, SessionCommandMixin):
     """
     Abstract base class for commands with the index_group options.
@@ -198,15 +211,13 @@ class IndexGroupCommand(Command, SessionCommandMixin):
             )
             with session:
                 upgrade_prompt = _pip_self_version_check_fetch(session, options)
-        except Exception:
-            logger.warning("There was an error checking the latest version of pip.")
-            logger.debug("See below for error", exc_info=True)
+        except Exception as error:
+            _log_pip_self_version_check_error(error)
 
         try:
             yield
         finally:
             try:
                 _pip_self_version_check_emit(upgrade_prompt)
-            except Exception:
-                logger.warning("There was an error checking the latest version of pip.")
-                logger.debug("See below for error", exc_info=True)
+            except Exception as error:
+                _log_pip_self_version_check_error(error)

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Callable
 from unittest import mock
@@ -132,6 +133,119 @@ def test_index_group_pip_version_check(
         mock_version_check.assert_called_once()
     else:
         mock_version_check.assert_not_called()
+
+
+@mock.patch("pip._internal.cli.index_command._pip_self_version_check_fetch")
+def test_index_group_pip_version_check_shows_os_error_reason(
+    mock_version_check: mock.Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    command = create_command("download")
+    options = command.parser.get_default_values()
+    options.disable_pip_version_check = False
+    options.no_index = False
+    mock_version_check.side_effect = OSError("failed to read cache")
+
+    with caplog.at_level(logging.WARNING):
+        with command.pip_version_check(options, []):
+            pass
+
+    assert caplog.messages == [
+        "There was an error checking the latest version of pip. (failed to read cache)",
+    ]
+
+
+@mock.patch("pip._internal.cli.index_command._pip_self_version_check_fetch")
+def test_index_group_pip_version_check_hides_empty_os_error_reason(
+    mock_version_check: mock.Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    command = create_command("download")
+    options = command.parser.get_default_values()
+    options.disable_pip_version_check = False
+    options.no_index = False
+    mock_version_check.side_effect = OSError()
+
+    with caplog.at_level(logging.WARNING):
+        with command.pip_version_check(options, []):
+            pass
+
+    assert caplog.messages == [
+        "There was an error checking the latest version of pip.",
+    ]
+
+
+@mock.patch("pip._internal.cli.index_command._pip_self_version_check_fetch")
+def test_index_group_pip_version_check_hides_non_os_error_reason(
+    mock_version_check: mock.Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    command = create_command("download")
+    options = command.parser.get_default_values()
+    options.disable_pip_version_check = False
+    options.no_index = False
+    mock_version_check.side_effect = RuntimeError("token=secret")
+
+    with caplog.at_level(logging.WARNING):
+        with command.pip_version_check(options, []):
+            pass
+
+    assert caplog.messages == [
+        "There was an error checking the latest version of pip.",
+    ]
+
+
+@mock.patch("pip._internal.cli.index_command._pip_self_version_check_fetch")
+def test_index_group_pip_version_check_keeps_debug_traceback(
+    mock_version_check: mock.Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    command = create_command("download")
+    options = command.parser.get_default_values()
+    options.disable_pip_version_check = False
+    options.no_index = False
+    mock_version_check.side_effect = OSError("failed to read cache")
+
+    with caplog.at_level(logging.DEBUG, logger="pip._internal.cli.index_command"):
+        with command.pip_version_check(options, []):
+            pass
+
+    assert [
+        record.message
+        for record in caplog.records
+        if record.name == "pip._internal.cli.index_command"
+    ] == [
+        "There was an error checking the latest version of pip. (failed to read cache)",
+        "See below for error",
+    ]
+    debug_record = caplog.records[-1]
+    assert debug_record.levelno == logging.DEBUG
+    assert debug_record.exc_info is not None
+
+
+@mock.patch("pip._internal.cli.index_command._pip_self_version_check_emit")
+@mock.patch("pip._internal.cli.index_command._pip_self_version_check_fetch")
+def test_index_group_pip_version_check_emit_shows_os_error_reason(
+    mock_version_check: mock.Mock,
+    mock_emit: mock.Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    command = create_command("download")
+    options = command.parser.get_default_values()
+    options.disable_pip_version_check = False
+    options.no_index = False
+    mock_version_check.return_value = mock.sentinel.upgrade_prompt
+    mock_emit.side_effect = OSError("failed to write cache")
+
+    with caplog.at_level(logging.WARNING):
+        with command.pip_version_check(options, []):
+            pass
+
+    mock_emit.assert_called_once_with(mock.sentinel.upgrade_prompt)
+    assert caplog.messages == [
+        "There was an error checking the latest version of pip. "
+        "(failed to write cache)",
+    ]
 
 
 @mock.patch("pip._internal.cli.index_command._pip_self_version_check_fetch")


### PR DESCRIPTION
Fixes #13352.

This keeps the self-version check best-effort, but includes the concrete `OSError` reason in the warning when the failure comes from local file access, such as an inaccessible cache directory. Other exception types still use the generic warning, while `--debug` continues to include the traceback.

Tests run:

- `python -m pytest tests/unit/test_commands.py -q`
- `python -m ruff check src/pip/_internal/cli/index_command.py tests/unit/test_commands.py`
- `python -m ruff format --check src/pip/_internal/cli/index_command.py tests/unit/test_commands.py`
- `git diff --check`