### PR TITLE
docs: fix broken links in development docs

### DIFF
--- a/docs/html/development/getting-started.rst
+++ b/docs/html/development/getting-started.rst
@@ -211,6 +211,6 @@ in order to start contributing.
 .. _`good first issues`: https://github.com/pypa/pip/labels/good%20first%20issue
 .. _`pip's architecture`: https://pip.pypa.io/en/latest/development/architecture/
 .. _`triaging issues`: https://pip.pypa.io/en/latest/development/issue-triage/
-.. _`Hello World for Git`: https://guides.github.com/activities/hello-world/
-.. _`Understanding the GitHub flow`: https://guides.github.com/introduction/flow/
-.. _`Start using Git on the command line`: https://docs.gitlab.com/ee/topics/git/
+.. _`Hello World for Git`: https://docs.github.com/en/get-started/start-your-journey/hello-world
+.. _`Understanding the GitHub flow`: https://docs.github.com/en/get-started/using-github/github-flow
+.. _`Start using Git on the command line`: https://docs.gitlab.com/topics/git/

--- a/docs/html/ux-research-design/guidance.md
+++ b/docs/html/ux-research-design/guidance.md
@@ -409,7 +409,7 @@ Given pip's interface is text, it is particularly important that clear and consi
 
 The following copywriting Style Guides may be useful to the pip team:
 
-- [Warehouse (PyPI) copywriting styleguide and glossary of terms](https://warehouse.readthedocs.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology)
+- [Warehouse (PyPI) copywriting styleguide and glossary of terms](https://warehouse.pypa.io/ui-principles/#4-write-clearly-with-consistent-style-and-terminology)
 - Firefox:
   - [Voice and Tone](https://meet.google.com/linkredirect?authuser=0&dest=https%3A%2F%2Fdesign.firefox.com%2Fphoton%2Fcopy%2Fvoice-and-tone.html)
   - [Writing for users](https://meet.google.com/linkredirect?authuser=0&dest=https%3A%2F%2Fdesign.firefox.com%2Fphoton%2Fcopy%2Fwriting-for-users.html)

--- a/docs/html/ux-research-design/research-results/improving-pips-documentation.md
+++ b/docs/html/ux-research-design/research-results/improving-pips-documentation.md
@@ -517,7 +517,7 @@ _Page purpose:_
 _Suggested content:_
 
 - This guide
-- Writing styleguide / glossary of terms - see the [Warehouse documentation](https://warehouse.readthedocs.io/ui-principles.html#write-clearly-with-consistent-style-and-terminology) for an example.
+- Writing styleguide / glossary of terms - see the [Warehouse documentation](https://warehouse.pypa.io/ui-principles/#4-write-clearly-with-consistent-style-and-terminology) for an example.
 
 </details>
 


### PR DESCRIPTION
This way we can close #13664 which has been a constant source of low-quality PRs.