### PR TITLE
Add Python version header to pip freeze

### DIFF
--- a/news/14038.feature.rst
+++ b/news/14038.feature.rst
@@ -1,0 +1,1 @@
+Include the Python version as a comment in ``pip freeze`` output.

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -94,6 +94,7 @@ class FreezeCommand(Command):
 
         cmdoptions.check_list_path_option(options)
 
+        sys.stdout.write(f"# Python {sys.version.split()[0]}\n")
         for line in freeze(
             requirement=options.requirements,
             local_only=options.local,

--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -28,9 +28,14 @@ from tests.lib.venv import VirtualEnvironment
 distribute_re = re.compile("^distribute==[0-9.]+\n", re.MULTILINE)
 
 
+def _python_version_comment() -> str:
+    return f"# Python {sys.version.split()[0]}\n"
+
+
 def _check_output(result: str, expected: str) -> None:
     checker = OutputChecker()
     actual = str(result)
+    expected = _python_version_comment() + expected
 
     # FIXME!  The following is a TOTAL hack.  For some reason the
     # __str__ result for pkg_resources.Requirement gets downcased on
@@ -53,6 +58,11 @@ def _check_output(result: str, expected: str) -> None:
     assert checker.check_output(expected, actual, ELLIPSIS), (
         banner("EXPECTED") + expected + banner("ACTUAL") + actual + banner(6 * "=")
     )
+
+
+def test_freeze_outputs_python_version_comment(script: PipTestEnvironment) -> None:
+    result = script.pip("freeze")
+    assert result.stdout.splitlines()[0] == _python_version_comment().rstrip()
 
 
 def test_basic_freeze(script: PipTestEnvironment) -> None:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Add the running Python version as the first comment line in `pip freeze` output.
This makes generated requirements easier to trace back to the Python runtime that produced them.
