### PR TITLE
Directly parse .pth files for build isolation

### DIFF
--- a/src/pip/_internal/build_env.py
+++ b/src/pip/_internal/build_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import locale
 import logging
 import os
 import pathlib
@@ -95,6 +96,67 @@ def _get_system_sitepackages() -> set[str]:
         # where getsitepackages() has been removed (inside a virtualenv)
         system_sites = [get_purelib(), get_platlib()]
     return {os.path.normcase(path) for path in system_sites}
+
+
+def _get_system_paths() -> set[str]:
+    """Get the system paths to exclude from an isolated build environment.
+
+    These are the paths the system site directories contribute to ``sys.path``:
+    the site directories themselves, plus any directories added by their .pth
+    files.
+
+    Returns a normalized set of strings.
+    """
+    # Read each site directory's .pth files directly, the way CPython's
+    # site.addpackage() does. We parse them ourselves instead of calling
+    # site.addsitedir() because since Python 3.15 (PEP 829) site no longer
+    # re-adds a path already on sys.path (so observing what it appends finds
+    # nothing), and calling it would re-run .pth import lines and .start entry
+    # points.
+    paths = set()
+    for sitedir in _get_system_sitepackages():
+        # The site directory itself is on sys.path.
+        paths.add(os.path.normcase(sitedir))
+
+        # Inspect the directory's .pth files for the paths they add.
+        try:
+            names = os.listdir(sitedir)
+        except OSError:
+            continue
+
+        for name in names:
+            # Only .pth files add paths; skip hidden files, as site does.
+            if name.startswith(".") or not name.endswith(".pth"):
+                continue
+
+            try:
+                with open(os.path.join(sitedir, name), "rb") as f:
+                    content = f.read()
+            except OSError:
+                continue
+
+            # site reads .pth files as UTF-8 (accepting a BOM) since Python
+            # 3.15; older Pythons fall back to the locale encoding, so do the
+            # same here for parity.
+            try:
+                lines = content.decode("utf-8-sig").splitlines()
+            except UnicodeDecodeError:
+                lines = content.decode(
+                    locale.getpreferredencoding(False), "replace"
+                ).splitlines()
+
+            for line in lines:
+                line = line.strip()
+                # A line names a path to add, unless it is blank, a comment, or
+                # an "import" line, which site runs as code rather than a path.
+                if not line or line.startswith(("#", "import ", "import\t")):
+                    continue
+
+                # Relative lines are resolved against the site directory.
+                path = os.path.abspath(os.path.join(sitedir, line))
+                paths.add(os.path.normcase(path))
+
+    return paths
 
 
 class BuildEnvironmentInstaller(Protocol):
@@ -455,7 +517,7 @@ class BuildEnvironment:
         # Customize site to:
         # - ensure .pth files are honored
         # - prevent access to system site packages
-        system_sites = _get_system_sitepackages()
+        system_paths = _get_system_paths()
 
         self._site_dir = os.path.join(temp_dir.path, "site")
         if not os.path.exists(self._site_dir):
@@ -468,28 +530,21 @@ class BuildEnvironment:
                     """
                 import os, site, sys
 
-                # First, drop system-sites related paths.
-                original_sys_path = sys.path[:]
-                known_paths = set()
-                for path in {system_sites!r}:
-                    site.addsitedir(path, known_paths=known_paths)
-                system_paths = set(
-                    os.path.normcase(path)
-                    for path in sys.path[len(original_sys_path):]
-                )
-                original_sys_path = [
-                    path for path in original_sys_path
+                # First, drop the system site paths (computed by pip; see
+                # build_env._get_system_paths).
+                system_paths = {system_paths!r}
+                sys.path = [
+                    path for path in sys.path
                     if os.path.normcase(path) not in system_paths
                 ]
-                sys.path = original_sys_path
 
-                # Second, add lib directories.
-                # ensuring .pth file are processed.
+                # Second, add lib directories, ensuring .pth files are
+                # processed.
                 for path in {lib_dirs!r}:
-                    assert not path in sys.path
+                    assert path not in sys.path
                     site.addsitedir(path)
                 """
-                ).format(system_sites=system_sites, lib_dirs=self._lib_dirs)
+                ).format(system_paths=system_paths, lib_dirs=self._lib_dirs)
             )
 
     def __enter__(self) -> None:

--- a/tests/lib/venv.py
+++ b/tests/lib/venv.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 import sys
 import sysconfig
-import textwrap
 import venv as _venv
 from pathlib import Path
 from typing import Literal
@@ -14,6 +13,48 @@ from typing import Literal
 import virtualenv as _virtualenv
 
 VirtualEnvironmentType = Literal["virtualenv", "venv"]
+
+
+# sitecustomize for test venvs: enable user-site and order it before the
+# system sites. To do that the system-site paths are dropped and then re-added
+# after user-site. The paths a system site contributes (its directory plus any
+# its .pth files add) are read from the .pth files directly; this mirrors
+# pip._internal.build_env._get_system_paths.
+_USER_SITE_CUSTOMIZE_TEMPLATE = """\
+import os, site, sys
+
+if not os.environ.get("PYTHONNOUSERSITE", False):
+    site.ENABLE_USER_SITE = {user_site}
+
+    system_paths = set()
+    for sitedir in site.getsitepackages():
+        system_paths.add(os.path.normcase(sitedir))
+        try:
+            names = os.listdir(sitedir)
+        except OSError:
+            continue
+        for name in names:
+            if name.startswith(".") or not name.endswith(".pth"):
+                continue
+            try:
+                with open(os.path.join(sitedir, name), "rb") as f:
+                    content = f.read()
+            except OSError:
+                continue
+            for line in content.decode("utf-8-sig", "replace").splitlines():
+                line = line.strip()
+                if not line or line.startswith(("#", "import ", "import\\t")):
+                    continue
+                path = os.path.abspath(os.path.join(sitedir, line))
+                system_paths.add(os.path.normcase(path))
+
+    sys.path = [p for p in sys.path if os.path.normcase(p) not in system_paths]
+
+    if {user_site}:
+        site.addsitedir(site.getusersitepackages())
+    for path in site.getsitepackages():
+        site.addsitedir(path)
+"""
 
 
 class VirtualEnvironment:
@@ -166,30 +207,9 @@ class VirtualEnvironment:
         if self._legacy_virtualenv:
             contents = ""
         else:
-            # Enable user site (before system).
-            contents = textwrap.dedent(
-                f"""
-                import os, site, sys
-                if not os.environ.get('PYTHONNOUSERSITE', False):
-                    site.ENABLE_USER_SITE = {self._user_site_packages}
-                    # First, drop system-sites related paths.
-                    original_sys_path = sys.path[:]
-                    known_paths = set()
-                    for path in site.getsitepackages():
-                        site.addsitedir(path, known_paths=known_paths)
-                    system_paths = sys.path[len(original_sys_path):]
-                    for path in system_paths:
-                        if path in original_sys_path:
-                            original_sys_path.remove(path)
-                    sys.path = original_sys_path
-                    # Second, add user-site.
-                    if {self._user_site_packages}:
-                        site.addsitedir(site.getusersitepackages())
-                    # Third, add back system-sites related paths.
-                    for path in site.getsitepackages():
-                        site.addsitedir(path)
-                """
-            ).strip()
+            contents = _USER_SITE_CUSTOMIZE_TEMPLATE.format(
+                user_site=self._user_site_packages
+            )
         if self._sitecustomize is not None:
             contents += "\n" + self._sitecustomize
         sitecustomize = self.site / "sitecustomize.py"

--- a/tests/unit/test_build_env.py
+++ b/tests/unit/test_build_env.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from _pytest.monkeypatch import MonkeyPatch
+
+from pip._internal import build_env
+
+
+def _norm(path: str) -> str:
+    return os.path.normcase(os.path.abspath(path))
+
+
+def test_get_system_paths_collects_sitedirs_and_pth_paths(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    sitedir = tmp_path / "site-packages"
+    sitedir.mkdir()
+    (sitedir / "absolute.pth").write_text(str(tmp_path / "abs_target") + "\n")
+    (sitedir / "relative.pth").write_text("sub/leaf\n")
+    (sitedir / "parent.pth").write_text("../sibling\n")
+    # A .pth saved with a UTF-8 BOM must still be read (Python 3.15 reads .pth
+    # files as UTF-8, accepting a BOM).
+    (sitedir / "bom.pth").write_text("bom_target\n", encoding="utf-8-sig")
+
+    monkeypatch.setattr(
+        build_env, "_get_system_sitepackages", lambda: {os.path.normcase(str(sitedir))}
+    )
+
+    assert build_env._get_system_paths() == {
+        os.path.normcase(str(sitedir)),
+        _norm(str(tmp_path / "abs_target")),
+        _norm(str(sitedir / "sub" / "leaf")),
+        _norm(str(tmp_path / "sibling")),
+        _norm(str(sitedir / "bom_target")),
+    }
+
+
+def test_get_system_paths_skips_comments_imports_and_non_pth(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    sitedir = tmp_path / "site-packages"
+    sitedir.mkdir()
+    (sitedir / "comments.pth").write_text("# a comment\n\n   \n")
+    # import lines are code, not paths, and are deprecated by PEP 829; the path
+    # they reference must not be collected.
+    (sitedir / "code.pth").write_text("import sys; sys.path.append('injected')\n")
+    (sitedir / "not_a_pth.txt").write_text("ignored\n")
+    (sitedir / ".hidden.pth").write_text("hidden_target\n")
+
+    monkeypatch.setattr(
+        build_env, "_get_system_sitepackages", lambda: {os.path.normcase(str(sitedir))}
+    )
+
+    # Only the site directory itself is collected.
+    assert build_env._get_system_paths() == {os.path.normcase(str(sitedir))}
+
+
+def test_get_system_paths_skips_missing_directory(monkeypatch: MonkeyPatch) -> None:
+    missing = os.path.normcase(os.path.abspath("does-not-exist"))
+    monkeypatch.setattr(build_env, "_get_system_sitepackages", lambda: {missing})
+
+    # A site directory that cannot be listed still contributes itself.
+    assert build_env._get_system_paths() == {missing}


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
