### PR TITLE
docs: remove .html from Warehouse docs link

### DIFF
--- a/docs/html/cli/pip_search.rst
+++ b/docs/html/cli/pip_search.rst
@@ -23,7 +23,7 @@ Description
 
 .. attention::
     PyPI no longer supports ``pip search`` (or XML-RPC search). Please use https://pypi.org/search (via a browser)
-    instead. See https://warehouse.pypa.io/api-reference/xml-rpc.html#deprecated-methods for more information.
+    instead. See https://warehouse.pypa.io/api-reference/xml-rpc/#deprecated-methods for more information.
 
     However, XML-RPC search (and this command) may still be supported by indexes other than PyPI.
 


### PR DESCRIPTION
Noticed while looking at #14036, Warehouse no longer has a `.html` in their docs URLs, causing this link to 404.

[skip news?]