### PR TITLE
mnt: Bump riff, zizmor, and mypy pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,13 +22,13 @@ repos:
   - id: black
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.10
+  rev: v0.15.16
   hooks:
     - id: ruff-check
       args: [--fix]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.20.0
+  rev: v2.1.0
   hooks:
   - id: mypy
     exclude: tests/data
@@ -67,7 +67,7 @@ repos:
       args: ["--ignore-words", tools/codespell-ignore.txt]
 
 - repo: https://github.com/zizmorcore/zizmor-pre-commit
-  rev: v1.23.1
+  rev: v1.25.2
   hooks:
   - id: zizmor
     args: ["--fix=all"]


### PR DESCRIPTION
Closes #13978 which is outdated since we upgraded Black manually. 