### PR TITLE
Add support for PEP 792 project status markers

### DIFF
--- a/news/13543.feature.rst
+++ b/news/13543.feature.rst
@@ -1,0 +1,4 @@
+Support :pep:`792` project status markers. When a user-requested project is
+marked as ``archived``, ``deprecated``, or ``quarantined`` on the index, a
+warning is emitted during resolution, and resolution errors mention the
+project's status.

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -220,21 +220,22 @@ def with_cached_index_content(fn: ParseLinks) -> ParseLinks:
     return wrapper_wrapper
 
 
-@with_cached_index_content
-def parse_links(page: IndexContent) -> Iterable[Link]:
-    """
-    Parse a Simple API's Index Content, and yield its anchor elements as Link objects.
-    """
+def parse_index_response(page: IndexContent) -> tuple[list[Link], ProjectStatus]:
+    """Parse a Simple API's Index Content in a single pass.
 
+    Returns the page's anchor elements as Link objects together with the
+    project's PEP 792 status. Parsing both at once avoids decoding and
+    deserializing the (potentially large) page twice.
+    """
     content_type_l = page.content_type.lower()
     if content_type_l.startswith("application/vnd.pypi.simple.v1+json"):
         data = json.loads(page.content)
+        links = []
         for file in data.get("files", []):
             link = Link.from_json(file, page.url)
-            if link is None:
-                continue
-            yield link
-        return
+            if link is not None:
+                links.append(link)
+        return links, _project_status_from_json(data)
 
     parser = HTMLLinkParser(page.url)
     encoding = page.encoding or "utf-8"
@@ -242,11 +243,59 @@ def parse_links(page: IndexContent) -> Iterable[Link]:
 
     url = page.url
     base_url = parser.base_url or url
+    links = []
     for anchor in parser.anchors:
         link = Link.from_element(anchor, page_url=url, base_url=base_url)
-        if link is None:
-            continue
-        yield link
+        if link is not None:
+            links.append(link)
+    return links, _project_status_from_parser(parser)
+
+
+@with_cached_index_content
+def parse_links(page: IndexContent) -> Iterable[Link]:
+    """
+    Parse a Simple API's Index Content, and yield its anchor elements as Link objects.
+    """
+    return parse_index_response(page)[0]
+
+
+@dataclass(frozen=True)
+class ProjectStatus:
+    """The status of a project on an index, as defined by PEP 792.
+
+    https://packaging.python.org/en/latest/specifications/project-status-markers/
+    """
+
+    status: str = "active"
+    reason: str | None = None
+
+
+def _project_status_from_json(data: object) -> ProjectStatus:
+    """Extract a PEP 792 status from a parsed JSON Simple API response.
+
+    Absent or malformed status information is treated as "active", per the
+    specification.
+    """
+    project_status = data.get("project-status") if isinstance(data, dict) else None
+    if not isinstance(project_status, dict):
+        return ProjectStatus()
+    status = project_status.get("status", "active")
+    if not isinstance(status, str):
+        return ProjectStatus()
+    reason = project_status.get("reason")
+    if not isinstance(reason, str):
+        reason = None
+    return ProjectStatus(status=status, reason=reason)
+
+
+def _project_status_from_parser(parser: HTMLLinkParser) -> ProjectStatus:
+    """Extract a PEP 792 status from a fed HTML Simple API parser."""
+    if parser.project_status is None:
+        return ProjectStatus()
+    return ProjectStatus(
+        status=parser.project_status,
+        reason=parser.project_status_reason,
+    )
 
 
 @dataclass(frozen=True)
@@ -282,6 +331,8 @@ class HTMLLinkParser(HTMLParser):
         self.url: str = url
         self.base_url: str | None = None
         self.anchors: list[dict[str, str | None]] = []
+        self.project_status: str | None = None
+        self.project_status_reason: str | None = None
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         if tag == "base" and self.base_url is None:
@@ -290,6 +341,15 @@ class HTMLLinkParser(HTMLParser):
                 self.base_url = href
         elif tag == "a":
             self.anchors.append(dict(attrs))
+        elif tag == "meta":
+            attributes = dict(attrs)
+            content = attributes.get("content")
+            if content is None:
+                return
+            if attributes.get("name") == "pypi:project-status":
+                self.project_status = content
+            elif attributes.get("name") == "pypi:project-status-reason":
+                self.project_status_reason = content
 
     def get_href(self, attrs: list[tuple[str, str | None]]) -> str | None:
         for name, value in attrs:

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -17,8 +17,11 @@ from dataclasses import dataclass
 from html.parser import HTMLParser
 from optparse import Values
 from typing import (
+    Literal,
     NamedTuple,
     Protocol,
+    cast,
+    get_args,
 )
 
 from pip._vendor.requests import Response
@@ -235,7 +238,7 @@ def parse_index_response(page: IndexContent) -> tuple[list[Link], ProjectStatus]
             link = Link.from_json(file, page.url)
             if link is not None:
                 links.append(link)
-        return links, _project_status_from_json(data)
+        return links, _project_status_from_json(data, page.url)
 
     parser = HTMLLinkParser(page.url)
     encoding = page.encoding or "utf-8"
@@ -259,6 +262,12 @@ def parse_links(page: IndexContent) -> Iterable[Link]:
     return parse_index_response(page)[0]
 
 
+# The project statuses defined by PEP 792. Future PEPs may define more; an
+# unrecognized status is treated as "active" (with a warning).
+ProjectStatusValue = Literal["active", "archived", "quarantined", "deprecated"]
+_KNOWN_PROJECT_STATUSES = frozenset(get_args(ProjectStatusValue))
+
+
 @dataclass(frozen=True)
 class ProjectStatus:
     """The status of a project on an index, as defined by PEP 792.
@@ -266,35 +275,60 @@ class ProjectStatus:
     https://packaging.python.org/en/latest/specifications/project-status-markers/
     """
 
-    status: str = "active"
+    status: ProjectStatusValue = "active"
     reason: str | None = None
 
 
-def _project_status_from_json(data: object) -> ProjectStatus:
+def _sanitize_status_reason(reason: str) -> str | None:
+    """Reduce a free-form status reason to a single line of printable ASCII.
+
+    The reason is echoed to the user's terminal, so control characters and
+    other unprintable content supplied by the index must not pass through.
+    """
+    printable = "".join(
+        char if char.isascii() and char.isprintable() else " " for char in reason
+    )
+    return " ".join(printable.split()) or None
+
+
+def _make_project_status(status: str, reason: str | None, url: str) -> ProjectStatus:
+    """Build a ProjectStatus from raw index-supplied values."""
+    if status not in _KNOWN_PROJECT_STATUSES:
+        logger.warning("Ignoring unknown project status %r reported by %s", status, url)
+        return ProjectStatus()
+    return ProjectStatus(
+        status=cast(ProjectStatusValue, status),
+        reason=_sanitize_status_reason(reason) if reason else None,
+    )
+
+
+def _project_status_from_json(data: object, url: str) -> ProjectStatus:
     """Extract a PEP 792 status from a parsed JSON Simple API response.
 
-    Absent or malformed status information is treated as "active", per the
-    specification.
+    An absent status is treated as "active", per the specification, and an
+    unrecognized status value as "active" with a warning. Structurally
+    invalid status information is an error.
     """
     project_status = data.get("project-status") if isinstance(data, dict) else None
-    if not isinstance(project_status, dict):
+    if project_status is None:
         return ProjectStatus()
+    if not isinstance(project_status, dict):
+        raise ValueError(f"Invalid project-status in API response from {url}")
     status = project_status.get("status", "active")
     if not isinstance(status, str):
-        return ProjectStatus()
+        raise ValueError(f"Invalid project-status.status in API response from {url}")
     reason = project_status.get("reason")
-    if not isinstance(reason, str):
-        reason = None
-    return ProjectStatus(status=status, reason=reason)
+    if reason is not None and not isinstance(reason, str):
+        raise ValueError(f"Invalid project-status.reason in API response from {url}")
+    return _make_project_status(status, reason, url)
 
 
 def _project_status_from_parser(parser: HTMLLinkParser) -> ProjectStatus:
     """Extract a PEP 792 status from a fed HTML Simple API parser."""
     if parser.project_status is None:
         return ProjectStatus()
-    return ProjectStatus(
-        status=parser.project_status,
-        reason=parser.project_status_reason,
+    return _make_project_status(
+        parser.project_status, parser.project_status_reason, parser.url
     )
 
 

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -27,7 +27,12 @@ from pip._internal.exceptions import (
     InvalidWheelFilename,
     UnsupportedWheel,
 )
-from pip._internal.index.collector import LinkCollector, parse_links
+from pip._internal.index.collector import (
+    LinkCollector,
+    ProjectStatus,
+    parse_index_response,
+    parse_links,
+)
 from pip._internal.metadata import select_backend
 from pip._internal.models.candidate import InstallationCandidate
 from pip._internal.models.format_control import FormatControl
@@ -655,6 +660,10 @@ class PackageFinder:
         # the error message when resolution fails.
         self._requires_python_skipped: set[str] = set()
 
+        # Collects the non-active PEP 792 project statuses encountered while
+        # fetching project index pages, keyed by canonicalized project name.
+        self._project_statuses: dict[NormalizedName, ProjectStatus] = {}
+
         # Cache of the result of finding candidates
         self._all_candidates: dict[str, list[InstallationCandidate]] = {}
         self._best_candidates: dict[
@@ -857,7 +866,20 @@ class PackageFinder:
         if index_response is None:
             return []
 
-        page_links = list(parse_links(index_response))
+        # Only record a PEP 792 status from the project's own index page,
+        # which is fetched with link parsing caching disabled. Other pages
+        # (notably --find-links pages, which are fetched with caching
+        # enabled) are shared across projects, so a status found there
+        # cannot be attributed to this project. For those, the cached
+        # parse_links() is used; the project's own page is parsed once for
+        # both its links and its status.
+        if index_response.cache_link_parsing:
+            page_links = list(parse_links(index_response))
+        else:
+            page_links, project_status = parse_index_response(index_response)
+            if project_status.status != "active":
+                canonical_name = canonicalize_name(link_evaluator.project_name)
+                self._project_statuses.setdefault(canonical_name, project_status)
 
         with indent_log():
             package_links = self.evaluate_links(
@@ -866,6 +888,16 @@ class PackageFinder:
             )
 
         return package_links
+
+    def get_project_status(self, project_name: str) -> ProjectStatus | None:
+        """Return the non-active PEP 792 status recorded for a project.
+
+        Only statuses encountered on project index pages fetched during
+        candidate discovery are known; None means no non-active status was
+        seen. If multiple indexes report a non-active status, the first one
+        encountered wins.
+        """
+        return self._project_statuses.get(canonicalize_name(project_name))
 
     def find_all_candidates(self, project_name: str) -> list[InstallationCandidate]:
         """Find all available InstallationCandidate for project_name

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -83,8 +83,8 @@ C = TypeVar("C")
 Cache = dict[Link, C]
 
 # Explanations of the PEP 792 project statuses that warrant informing the
-# user, phrased after the specification's definitions. Unrecognized statuses
-# must be treated as "active", i.e. not reported.
+# user, phrased after the specification's definitions. "active" is not
+# reported.
 _PROJECT_STATUS_NOTES = {
     "archived": "it is not expected to be updated in the future",
     "deprecated": (

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -30,6 +30,7 @@ from pip._internal.exceptions import (
     UnsupportedPythonVersion,
     UnsupportedWheel,
 )
+from pip._internal.index.collector import ProjectStatus
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import BaseDistribution, get_default_environment
 from pip._internal.models.candidate import InstallationCandidate
@@ -80,6 +81,28 @@ logger = logging.getLogger(__name__)
 
 C = TypeVar("C")
 Cache = dict[Link, C]
+
+# Explanations of the PEP 792 project statuses that warrant informing the
+# user, phrased after the specification's definitions. Unrecognized statuses
+# must be treated as "active", i.e. not reported.
+_PROJECT_STATUS_NOTES = {
+    "archived": "it is not expected to be updated in the future",
+    "deprecated": (
+        "it is considered obsolete and may have been superseded by another project"
+    ),
+    "quarantined": "it is considered generally unsafe for use",
+}
+
+
+def _format_project_status(name: str, project_status: ProjectStatus) -> str | None:
+    """Return a user-facing message for a project's status, if warranted."""
+    note = _PROJECT_STATUS_NOTES.get(project_status.status)
+    if note is None:
+        return None
+    message = f"Project {name!r} is {project_status.status}: {note}"
+    if project_status.reason:
+        message += f" (reason: {project_status.reason})"
+    return message
 
 
 class CollectedRootRequirements(NamedTuple):
@@ -718,6 +741,21 @@ class Factory:
             message += f"\n{specifier!r} (required by {package})"
         return UnsupportedPythonVersion(message)
 
+    def _project_status_messages(self, project_names: Iterable[str]) -> Iterator[str]:
+        """Yield user-facing messages for projects with a non-active status."""
+        for name in dict.fromkeys(project_names):
+            project_status = self._finder.get_project_status(name)
+            if project_status is None:
+                continue
+            message = _format_project_status(name, project_status)
+            if message is not None:
+                yield message
+
+    def warn_about_project_statuses(self, project_names: Iterable[str]) -> None:
+        """Warn about projects with a non-active PEP 792 status."""
+        for message in self._project_status_messages(project_names):
+            logger.warning(message)
+
     def _report_single_requirement_conflict(
         self, req: Requirement, parent: Candidate | None
     ) -> DistributionNotFound:
@@ -770,6 +808,12 @@ class Factory:
             req_disp,
             ", ".join(versions) or "none",
         )
+
+        # A non-active PEP 792 project status may explain the lack of
+        # candidates; a quarantined project, notably, offers no files at all.
+        for message in self._project_status_messages([req.project_name]):
+            logger.critical(message)
+
         if str(req) == "requirements.txt":
             logger.info(
                 "HINT: You are attempting to install a package literally "
@@ -895,6 +939,16 @@ class Factory:
                 + "\n    "
                 + "\n    ".join(sorted(no_candidates))
             )
+
+        # A non-active PEP 792 project status may explain a conflict, e.g. a
+        # quarantined project offers no files at all.
+        status_messages = list(
+            self._project_status_messages(
+                sorted({req.project_name for req, _ in e.causes})
+            )
+        )
+        if status_messages:
+            msg = msg + "\n\n" + "\n".join(status_messages)
 
         msg = (
             msg

--- a/src/pip/_internal/resolution/resolvelib/resolver.py
+++ b/src/pip/_internal/resolution/resolvelib/resolver.py
@@ -185,6 +185,15 @@ class Resolver(BaseResolver):
 
             req_set.add_named_requirement(ireq)
 
+        # Warn about non-active PEP 792 project statuses, only for projects
+        # the user explicitly requested; the user cannot act on warnings
+        # about projects pulled in as dependencies.
+        self.factory.warn_about_project_statuses(
+            sorted(
+                {ireq.name for ireq in root_reqs if ireq.user_supplied and ireq.name}
+            )
+        )
+
         if self.only_dependencies:
             for requested in collected.user_requested:
                 project_name = requested.partition("[")[0]

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1024,8 +1024,9 @@ def test_install_pre__setup_requires_with_pyproject(
 def test_upgrade_argparse_shadowed(script: PipTestEnvironment) -> None:
     # If argparse is installed - even if shadowed for imported - we support
     # upgrading it and properly remove the older versions files.
-    script.pip("install", "argparse==1.3")
-    result = script.pip("install", "argparse>=1.4")
+    # argparse is archived on PyPI, so pip warns about its project status.
+    script.pip("install", "argparse==1.3", allow_stderr_warning=True)
+    result = script.pip("install", "argparse>=1.4", allow_stderr_warning=True)
     assert "Not uninstalling argparse" not in result.stdout
 
 

--- a/tests/functional/test_install_index.py
+++ b/tests/functional/test_install_index.py
@@ -1,7 +1,116 @@
 import shutil
 import textwrap
+from pathlib import Path
 
 from tests.lib import PipTestEnvironment, TestData
+
+
+def _make_project_page(
+    index_dir: Path,
+    project: str,
+    archives: list[Path],
+    status: str | None = None,
+    reason: str | None = None,
+) -> None:
+    """Write a Simple API project page, optionally with a PEP 792 status."""
+    project_dir = index_dir / project
+    project_dir.mkdir(parents=True)
+    meta = ""
+    if status is not None:
+        meta += f'<meta name="pypi:project-status" content="{status}">'
+    if reason is not None:
+        meta += f'<meta name="pypi:project-status-reason" content="{reason}">'
+    anchors = ""
+    for archive in archives:
+        shutil.copy(archive, project_dir)
+        anchors += f'<a href="{archive.name}">{archive.name}</a>'
+    project_dir.joinpath("index.html").write_text(
+        f"<!DOCTYPE html><html><head>{meta}</head><body>{anchors}</body></html>"
+    )
+
+
+def test_install_warns_about_archived_project(
+    script: PipTestEnvironment, data: TestData
+) -> None:
+    """A user-requested project with an archived status produces a warning."""
+    index_dir = script.scratch_path / "index"
+    _make_project_page(
+        index_dir,
+        "simple",
+        [data.packages / "simple-1.0.tar.gz"],
+        status="archived",
+        reason="gone fishing",
+    )
+    result = script.pip(
+        "install",
+        "--no-build-isolation",
+        "--index-url",
+        index_dir.as_uri(),
+        "simple",
+        allow_stderr_warning=True,
+    )
+    assert (
+        "Project 'simple' is archived: it is not expected to be updated in the "
+        "future (reason: gone fishing)" in result.stderr
+    )
+    result.did_create(script.site_packages / "simple-1.0.dist-info")
+
+
+def test_install_quarantined_project_shows_status_in_error(
+    script: PipTestEnvironment, data: TestData
+) -> None:
+    """A quarantined project offers no distributions; the resolution error
+    is contextualized with the project's status."""
+    index_dir = script.scratch_path / "index"
+    _make_project_page(
+        index_dir,
+        "simple",
+        [],
+        status="quarantined",
+        reason="the project is haunted",
+    )
+    result = script.pip(
+        "install",
+        "--index-url",
+        index_dir.as_uri(),
+        "simple",
+        expect_error=True,
+    )
+    assert "No matching distribution found for simple" in result.stderr
+    assert (
+        "Project 'simple' is quarantined: it is considered generally unsafe "
+        "for use (reason: the project is haunted)" in result.stderr
+    )
+
+
+def test_install_does_not_warn_about_transitive_project_status(
+    script: PipTestEnvironment, data: TestData
+) -> None:
+    """Status warnings are only emitted for user-requested projects, not
+    for projects pulled in as dependencies."""
+    index_dir = script.scratch_path / "index"
+    _make_project_page(
+        index_dir,
+        "requires-source",
+        [data.packages / "requires_source-1.0-py2.py3-none-any.whl"],
+    )
+    _make_project_page(
+        index_dir,
+        "source",
+        [data.packages / "source-1.0.tar.gz"],
+        status="deprecated",
+        reason="use sink instead",
+    )
+    result = script.pip(
+        "install",
+        "--no-build-isolation",
+        "--index-url",
+        index_dir.as_uri(),
+        "requires-source",
+        allow_stderr_warning=True,
+    )
+    assert "deprecated" not in result.stderr
+    result.did_create(script.site_packages / "source")
 
 
 def test_find_links_relative_path(script: PipTestEnvironment, data: TestData) -> None:

--- a/tests/unit/resolution_resolvelib/test_factory.py
+++ b/tests/unit/resolution_resolvelib/test_factory.py
@@ -1,0 +1,85 @@
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from pip._vendor.resolvelib import ResolutionImpossible
+from pip._vendor.resolvelib.resolvers import RequirementInformation
+
+from pip._internal.index.collector import IndexContent
+from pip._internal.index.package_finder import PackageFinder
+from pip._internal.models.link import Link
+from pip._internal.req.constructors import install_req_from_line
+from pip._internal.resolution.resolvelib.base import Candidate, Requirement
+from pip._internal.resolution.resolvelib.factory import Factory
+from pip._internal.resolution.resolvelib.requirements import SpecifierRequirement
+
+
+def _record_project_status(
+    finder: PackageFinder, name: str, status: str, reason: str | None = None
+) -> None:
+    """Process a project page response carrying a PEP 792 status marker."""
+    project_status: dict[str, str] = {"status": status}
+    if reason is not None:
+        project_status["reason"] = reason
+    page = IndexContent(
+        json.dumps(
+            {
+                "meta": {"api-version": "1.4"},
+                "name": name,
+                "project-status": project_status,
+                "files": [],
+            }
+        ).encode("utf8"),
+        "application/vnd.pypi.simple.v1+json",
+        encoding=None,
+        url=f"https://example.com/simple/{name}/",
+        cache_link_parsing=False,
+    )
+    link_evaluator = finder.make_link_evaluator(name)
+    with patch.object(finder._link_collector, "fetch_response", return_value=page):
+        finder.process_project_url(Link(page.url), link_evaluator=link_evaluator)
+
+
+def test_warn_about_project_statuses(
+    factory: Factory, finder: PackageFinder, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING)
+    _record_project_status(finder, "spam", "deprecated", "use ham instead")
+    _record_project_status(finder, "eggs", "archived")
+    _record_project_status(finder, "brian", "quarantined", "the project is haunted")
+    # Unrecognized status markers must not produce warnings.
+    _record_project_status(finder, "patsy", "on-holiday")
+
+    factory.warn_about_project_statuses(["spam", "eggs", "brian", "patsy", "arthur"])
+
+    assert [record.getMessage() for record in caplog.records] == [
+        "Project 'spam' is deprecated: it is considered obsolete and may have "
+        "been superseded by another project (reason: use ham instead)",
+        "Project 'eggs' is archived: it is not expected to be updated in the future",
+        "Project 'brian' is quarantined: it is considered generally unsafe for "
+        "use (reason: the project is haunted)",
+    ]
+    assert all(record.levelno == logging.WARNING for record in caplog.records)
+
+
+def test_installation_error_includes_project_status(
+    factory: Factory, finder: PackageFinder, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Multi-cause resolution errors mention non-active project statuses."""
+    caplog.set_level(logging.INFO)
+    _record_project_status(finder, "simple", "quarantined", "the project is haunted")
+    causes: list[RequirementInformation[Requirement, Candidate]] = [
+        RequirementInformation(
+            SpecifierRequirement(install_req_from_line("simple>=2")), None
+        ),
+        RequirementInformation(
+            SpecifierRequirement(install_req_from_line("simple<2")), None
+        ),
+    ]
+    factory.get_installation_error(ResolutionImpossible(causes), {})
+    assert (
+        "Project 'simple' is quarantined: it is considered generally unsafe "
+        "for use (reason: the project is haunted)" in caplog.text
+    )

--- a/tests/unit/resolution_resolvelib/test_factory.py
+++ b/tests/unit/resolution_resolvelib/test_factory.py
@@ -49,12 +49,15 @@ def test_warn_about_project_statuses(
     _record_project_status(finder, "spam", "deprecated", "use ham instead")
     _record_project_status(finder, "eggs", "archived")
     _record_project_status(finder, "brian", "quarantined", "the project is haunted")
-    # Unrecognized status markers must not produce warnings.
+    # An unrecognized status marker is warned about at parse time, treated
+    # as active, and not reported again.
     _record_project_status(finder, "patsy", "on-holiday")
 
     factory.warn_about_project_statuses(["spam", "eggs", "brian", "patsy", "arthur"])
 
     assert [record.getMessage() for record in caplog.records] == [
+        "Ignoring unknown project status 'on-holiday' reported by "
+        "https://example.com/simple/patsy/",
         "Project 'spam' is deprecated: it is considered obsolete and may have "
         "been superseded by another project (reason: use ham instead)",
         "Project 'eggs' is archived: it is not expected to be updated in the future",

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -638,22 +638,16 @@ def test_parse_links__yanked_reason(anchor_html: str, expected: str | None) -> N
         ({"status": "archived"}, ProjectStatus(status="archived", reason=None)),
         # Test an empty dictionary defaults to active.
         ({}, ProjectStatus(status="active", reason=None)),
-        # Test malformed (non-dict) data defaults to active.
-        ("quarantined", ProjectStatus(status="active", reason=None)),
-        # Test a malformed (non-string) status defaults to active.
-        ({"status": 123}, ProjectStatus(status="active", reason=None)),
-        # Test a malformed (unhashable) status defaults to active.
-        ({"status": {"x": 1}}, ProjectStatus(status="active", reason=None)),
-        # Test a malformed (non-string) reason is dropped.
-        (
-            {"status": "archived", "reason": ["gone", "fishing"]},
-            ProjectStatus(status="archived", reason=None),
-        ),
     ],
 )
 def test_parse_project_status_json(
-    project_status: dict[str, str] | str | None, expected: ProjectStatus
+    project_status: dict[str, str] | None, expected: ProjectStatus
 ) -> None:
+    page = _make_project_status_json_page(project_status)
+    assert parse_index_response(page)[1] == expected
+
+
+def _make_project_status_json_page(project_status: object) -> IndexContent:
     data: dict[str, object] = {
         "meta": {"api-version": "1.4"},
         "name": "holygrail",
@@ -661,13 +655,42 @@ def test_parse_project_status_json(
     }
     if project_status is not None:
         data["project-status"] = project_status
-    page = IndexContent(
+    return IndexContent(
         json.dumps(data).encode("utf8"),
         "application/vnd.pypi.simple.v1+json",
         encoding=None,
         url="https://example.com/simple/holygrail/",
     )
-    assert parse_index_response(page)[1] == expected
+
+
+@pytest.mark.parametrize(
+    "project_status",
+    [
+        # A non-dict project-status value.
+        "quarantined",
+        # A non-string status.
+        {"status": 123},
+        {"status": {"x": 1}},
+        # A non-string reason.
+        {"status": "archived", "reason": ["gone", "fishing"]},
+    ],
+)
+def test_parse_project_status_json_malformed(project_status: object) -> None:
+    """A structurally invalid project-status is an error, per PEP 792."""
+    page = _make_project_status_json_page(project_status)
+    with pytest.raises(ValueError, match="project-status"):
+        parse_index_response(page)
+
+
+def test_parse_project_status_json_unknown_status(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unrecognized status value falls back to active, with a warning."""
+    caplog.set_level(logging.WARNING)
+    page = _make_project_status_json_page({"status": "haunted", "reason": "spooky"})
+    assert parse_index_response(page)[1] == ProjectStatus(status="active", reason=None)
+    assert "haunted" in caplog.text
+    assert "https://example.com/simple/holygrail/" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -700,18 +723,70 @@ def test_parse_project_status_json(
     ],
 )
 def test_parse_project_status_html(meta_html: str, expected: ProjectStatus) -> None:
+    page = _make_project_status_html_page(meta_html)
+    assert parse_index_response(page)[1] == expected
+
+
+def _make_project_status_html_page(meta_html: str) -> IndexContent:
     html = (
         "<!DOCTYPE html>"
         f'<html><head><meta charset="utf-8">{meta_html}</head>'
         '<body><a href="/pkg-1.0.tar.gz"></a></body></html>'
     )
-    page = IndexContent(
+    return IndexContent(
         html.encode("utf-8"),
         "text/html",
         encoding=None,
         url="https://example.com/simple/pkg/",
     )
-    assert parse_index_response(page)[1] == expected
+
+
+def test_parse_project_status_html_unknown_status(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unrecognized status value falls back to active, with a warning."""
+    caplog.set_level(logging.WARNING)
+    page = _make_project_status_html_page(
+        '<meta name="pypi:project-status" content="haunted">'
+        '<meta name="pypi:project-status-reason" content="spooky">'
+    )
+    assert parse_index_response(page)[1] == ProjectStatus(status="active", reason=None)
+    assert "haunted" in caplog.text
+    assert "https://example.com/simple/pkg/" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "reason, expected",
+    [
+        # Newlines and other whitespace runs collapse to single spaces.
+        ("gone\nfishing", "gone fishing"),
+        (" gone \t fishing ", "gone fishing"),
+        # Terminal escape sequences and other control characters are dropped.
+        ("\x1b[31mboo\x1b[0m", "[31mboo [0m"),
+        # Non-ASCII characters are dropped.
+        ("touch\xe9 ☕", "touch"),
+        # A reason with no printable ASCII at all is treated as absent.
+        ("\x07\x1b鬼", None),
+    ],
+)
+def test_parse_project_status_reason_sanitized(
+    reason: str, expected: str | None
+) -> None:
+    """The free-form reason is reduced to a single line of printable ASCII
+    before being stored, as it is later echoed to the user's terminal."""
+    json_page = _make_project_status_json_page({"status": "archived", "reason": reason})
+    assert parse_index_response(json_page)[1] == ProjectStatus(
+        status="archived", reason=expected
+    )
+
+    escaped = reason.replace("&", "&amp;").replace('"', "&quot;")
+    html_page = _make_project_status_html_page(
+        '<meta name="pypi:project-status" content="archived">'
+        f'<meta name="pypi:project-status-reason" content="{escaped}">'
+    )
+    assert parse_index_response(html_page)[1] == ProjectStatus(
+        status="archived", reason=expected
+    )
 
 
 def test_parse_index_response_json() -> None:

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -26,11 +26,13 @@ from pip._internal.exceptions import (
 from pip._internal.index.collector import (
     IndexContent,
     LinkCollector,
+    ProjectStatus,
     _get_index_content,
     _get_simple_response,
     _make_index_content,
     _NotAPIContent,
     _NotHTTP,
+    parse_index_response,
     parse_links,
 )
 from pip._internal.index.sources import _FlatDirectorySource, _IndexDirectorySource
@@ -620,6 +622,145 @@ def test_parse_links_json() -> None:
 )
 def test_parse_links__yanked_reason(anchor_html: str, expected: str | None) -> None:
     _test_parse_links_data_attribute(anchor_html, "yanked_reason", expected)
+
+
+@pytest.mark.parametrize(
+    "project_status, expected",
+    [
+        # Test not present (pre-1.4 index).
+        (None, ProjectStatus(status="active", reason=None)),
+        # Test a status with a reason.
+        (
+            {"status": "quarantined", "reason": "the project is haunted"},
+            ProjectStatus(status="quarantined", reason="the project is haunted"),
+        ),
+        # Test a status without a reason.
+        ({"status": "archived"}, ProjectStatus(status="archived", reason=None)),
+        # Test an empty dictionary defaults to active.
+        ({}, ProjectStatus(status="active", reason=None)),
+        # Test malformed (non-dict) data defaults to active.
+        ("quarantined", ProjectStatus(status="active", reason=None)),
+        # Test a malformed (non-string) status defaults to active.
+        ({"status": 123}, ProjectStatus(status="active", reason=None)),
+        # Test a malformed (unhashable) status defaults to active.
+        ({"status": {"x": 1}}, ProjectStatus(status="active", reason=None)),
+        # Test a malformed (non-string) reason is dropped.
+        (
+            {"status": "archived", "reason": ["gone", "fishing"]},
+            ProjectStatus(status="archived", reason=None),
+        ),
+    ],
+)
+def test_parse_project_status_json(
+    project_status: dict[str, str] | str | None, expected: ProjectStatus
+) -> None:
+    data: dict[str, object] = {
+        "meta": {"api-version": "1.4"},
+        "name": "holygrail",
+        "files": [],
+    }
+    if project_status is not None:
+        data["project-status"] = project_status
+    page = IndexContent(
+        json.dumps(data).encode("utf8"),
+        "application/vnd.pypi.simple.v1+json",
+        encoding=None,
+        url="https://example.com/simple/holygrail/",
+    )
+    assert parse_index_response(page)[1] == expected
+
+
+@pytest.mark.parametrize(
+    "meta_html, expected",
+    [
+        # Test not present (pre-1.4 index).
+        ("", ProjectStatus(status="active", reason=None)),
+        # Test a status with a reason.
+        (
+            '<meta name="pypi:project-status" content="quarantined">'
+            '<meta name="pypi:project-status-reason" content="the project is haunted">',
+            ProjectStatus(status="quarantined", reason="the project is haunted"),
+        ),
+        # Test a status without a reason.
+        (
+            '<meta name="pypi:project-status" content="archived">',
+            ProjectStatus(status="archived", reason=None),
+        ),
+        # Test a reason with an escaped character.
+        (
+            '<meta name="pypi:project-status" content="deprecated">'
+            '<meta name="pypi:project-status-reason" content="use &quot;spam&quot;">',
+            ProjectStatus(status="deprecated", reason='use "spam"'),
+        ),
+        # Test a status meta tag without content defaults to active.
+        (
+            '<meta name="pypi:project-status">',
+            ProjectStatus(status="active", reason=None),
+        ),
+    ],
+)
+def test_parse_project_status_html(meta_html: str, expected: ProjectStatus) -> None:
+    html = (
+        "<!DOCTYPE html>"
+        f'<html><head><meta charset="utf-8">{meta_html}</head>'
+        '<body><a href="/pkg-1.0.tar.gz"></a></body></html>'
+    )
+    page = IndexContent(
+        html.encode("utf-8"),
+        "text/html",
+        encoding=None,
+        url="https://example.com/simple/pkg/",
+    )
+    assert parse_index_response(page)[1] == expected
+
+
+def test_parse_index_response_json() -> None:
+    """A single parse yields both the links and the project status."""
+    json_bytes = json.dumps(
+        {
+            "meta": {"api-version": "1.4"},
+            "name": "holygrail",
+            "project-status": {"status": "archived", "reason": "gone fishing"},
+            "files": [
+                {
+                    "filename": "holygrail-1.0.tar.gz",
+                    "url": "https://example.com/files/holygrail-1.0.tar.gz",
+                    "hashes": {},
+                },
+            ],
+        }
+    ).encode("utf8")
+    page = IndexContent(
+        json_bytes,
+        "application/vnd.pypi.simple.v1+json",
+        encoding=None,
+        url="https://example.com/simple/holygrail/",
+    )
+    links, status = parse_index_response(page)
+    assert [link.url for link in links] == [
+        "https://example.com/files/holygrail-1.0.tar.gz"
+    ]
+    assert status == ProjectStatus(status="archived", reason="gone fishing")
+
+
+def test_parse_index_response_html() -> None:
+    """A single parse yields both the links and the project status."""
+    html = (
+        "<!DOCTYPE html>"
+        '<html><head><meta charset="utf-8">'
+        '<meta name="pypi:project-status" content="deprecated">'
+        "</head>"
+        '<body><a href="/holygrail-1.0.tar.gz"></a></body></html>'
+    )
+    page = IndexContent(
+        html.encode("utf-8"),
+        "text/html",
+        encoding=None,
+        url="https://example.com/simple/holygrail/",
+    )
+    links, status = parse_index_response(page)
+    assert [link.filename for link in links] == ["holygrail-1.0.tar.gz"]
+    assert status == ProjectStatus(status="deprecated", reason=None)
 
 
 # Requirement objects do not == each other unless they point to the same instance!

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 from collections.abc import Iterable
 from unittest.mock import Mock, patch
@@ -12,12 +13,14 @@ from pip._vendor.packaging.version import parse as parse_version
 
 import pip._internal.utils.compatibility_tags
 from pip._internal.exceptions import BestVersionAlreadyInstalled, DistributionNotFound
+from pip._internal.index.collector import IndexContent, ProjectStatus
 from pip._internal.index.package_finder import (
     CandidateEvaluator,
     InstallationCandidate,
     Link,
     LinkEvaluator,
     LinkType,
+    PackageFinder,
 )
 from pip._internal.models.target_python import TargetPython
 from pip._internal.req.constructors import install_req_from_line
@@ -562,6 +565,91 @@ def test_process_project_url(data: TestData) -> None:
     package_link = actual[0]
     assert package_link.name == "simple"
     assert str(package_link.version) == "1.0"
+
+
+def _process_project_status_page(
+    finder: PackageFinder,
+    project_name: str,
+    project_status: dict[str, str],
+    url: str = "https://example.com/simple/holy-grail/",
+    cache_link_parsing: bool = False,
+) -> None:
+    """Process a project page response carrying a PEP 792 status marker."""
+    json_bytes = json.dumps(
+        {
+            "meta": {"api-version": "1.4"},
+            "name": "holy-grail",
+            "project-status": project_status,
+            "files": [],
+        }
+    ).encode("utf8")
+    page = IndexContent(
+        json_bytes,
+        "application/vnd.pypi.simple.v1+json",
+        encoding=None,
+        url=url,
+        cache_link_parsing=cache_link_parsing,
+    )
+    link_evaluator = finder.make_link_evaluator(project_name)
+    with patch.object(finder._link_collector, "fetch_response", return_value=page):
+        finder.process_project_url(Link(page.url), link_evaluator=link_evaluator)
+
+
+@pytest.mark.parametrize(
+    "project_status, expected",
+    [
+        # An active project is not recorded.
+        ({"status": "active"}, None),
+        # A non-active project status is recorded.
+        (
+            {"status": "archived", "reason": "gone fishing"},
+            ProjectStatus(status="archived", reason="gone fishing"),
+        ),
+    ],
+)
+def test_process_project_url_records_project_status(
+    project_status: dict[str, str], expected: ProjectStatus | None
+) -> None:
+    project_name = "Holy_Grail"
+    finder = make_test_finder(index_urls=["https://example.com/simple/"])
+    _process_project_status_page(finder, project_name, project_status)
+
+    # The status is looked up by canonicalized project name.
+    assert finder.get_project_status("holy-grail") == expected
+    assert finder.get_project_status(project_name) == expected
+
+
+def test_process_project_url_ignores_status_on_shared_pages() -> None:
+    """A page that is not the project's own index page (e.g. a --find-links
+    page, fetched with cache_link_parsing) is shared across projects, so its
+    status cannot be attributed to the project being searched."""
+    finder = make_test_finder(find_links=["https://example.com/links/"])
+    _process_project_status_page(
+        finder,
+        "holy-grail",
+        {"status": "archived"},
+        cache_link_parsing=True,
+    )
+    assert finder.get_project_status("holy-grail") is None
+
+
+def test_process_project_url_first_status_wins() -> None:
+    """With multiple indexes, the first non-active status encountered for a
+    project is kept."""
+    finder = make_test_finder(
+        index_urls=[
+            "https://example.com/simple/",
+            "https://mirror.example.com/simple/",
+        ]
+    )
+    _process_project_status_page(finder, "holy-grail", {"status": "archived"})
+    _process_project_status_page(
+        finder,
+        "holy-grail",
+        {"status": "deprecated"},
+        url="https://mirror.example.com/simple/holy-grail/",
+    )
+    assert finder.get_project_status("holy-grail") == ProjectStatus(status="archived")
 
 
 def test_find_all_candidates_nothing() -> None:


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Parse the `project-status` key (JSON) and `pypi:project-status` meta tags (HTML) from Simple API project pages, record non-active statuses in `PackageFinder`, and warn after resolution for user-requested projects that are archived, deprecated, or quarantined. Resolution errors (single- and multi-cause) mention the status as well, since a quarantined project offers no distributions.

Statuses are only attributed from a project's own index page, never from shared `--find-links` pages. ~~and malformed status data is treated as active per the specification.~~
Structurally invalid project-status data (e.g. a non-dict value, or a non-string status/reason) is an error; an unrecognized status value falls back to active with a warning, matching uv's behavior. The free-form reason is reduced to a single line of printable ASCII before display, since indexes are untrusted input.

The deprecated legacy resolver does not emit these warnings.

Resolves #13543 