### PR TITLE
Remove FIXME comments in req_uninstall.py

### DIFF
--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -480,9 +480,7 @@ class UninstallPathSet:
             if installed_files is not None:
                 for installed_file in installed_files:
                     paths_to_remove.add(os.path.join(dist_location, installed_file))
-            # FIXME: need a test for this elif block
-            # occurs with --single-version-externally-managed/--record outside
-            # of pip
+            
             elif dist.is_file("top_level.txt"):
                 try:
                     namespace_packages = dist.read_text("namespace_packages.txt")


### PR DESCRIPTION
Removed FIXME comments regarding testing for the elif block related to single-version externally managed installations.

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
