### PR TITLE
doc: Provide advice if ZSH completion is uninitialized

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -771,7 +771,11 @@ To setup for bash::
 
 To setup for zsh::
 
-    python -m pip completion --zsh >> ~/.zprofile
+    python -m pip completion --zsh >> ~/.zshrc
+
+If you see ``command not found: compdef``, ensure your ``~/.zshrc`` initializes
+auto-completion (for example, by running ``autoload -Uz compinit && compinit``)
+before the appended pip snippet.
 
 To setup for fish::
 


### PR DESCRIPTION
Closes #13805. Resolves #12738.

I was chatting with some people more familiar with zsh on the PyPA Discord and they warned against loading `compinit` automatically for the user. Since the original context is that someone ran into the issue while manually setting up completion, let's just add a note to the documentation since this is really PEBCAK (load your shell's completion support).