### PR TITLE
perf: Lazy import utils.pylock in cli.cmdoptions

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -104,16 +104,17 @@ def check_dist_restriction(options: Values, check_target: bool = False) -> None:
                 "installing via '--target' or using '--dry-run'"
             )
 
-    for filename in options.requirements:
-        # Lazy import to keep CLI snappy
+    if dist_restriction_set:
+        # Lazy import to keep CLI startup fast
         from pip._internal.utils import pylock as pylock_utils
 
-        if dist_restriction_set and pylock_utils.is_valid_pylock_filename(filename):
-            raise CommandError(
-                "Patform and interpreter constraints using "
-                "--python-version, --platform, --abi, or --implementation, "
-                f"are not supported when selecting requirements from {filename!r}"
-            )
+        for filename in options.requirements:
+            if pylock_utils.is_valid_pylock_filename(filename):
+                raise CommandError(
+                    "Platform and interpreter constraints using "
+                    "--python-version, --platform, --abi, or --implementation, "
+                    f"are not supported when selecting requirements from {filename!r}"
+                )
 
 
 def check_build_constraints(options: Values) -> None:

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -32,7 +32,6 @@ from pip._internal.models.format_control import FormatControl
 from pip._internal.models.index import PyPI
 from pip._internal.models.release_control import ReleaseControl
 from pip._internal.models.target_python import TargetPython
-from pip._internal.utils import pylock as pylock_utils
 from pip._internal.utils.datetime import parse_iso_datetime
 from pip._internal.utils.hashes import STRONG_HASHES
 from pip._internal.utils.misc import strtobool
@@ -106,6 +105,9 @@ def check_dist_restriction(options: Values, check_target: bool = False) -> None:
             )
 
     for filename in options.requirements:
+        # Lazy import to keep CLI snappy
+        from pip._internal.utils import pylock as pylock_utils
+
         if dist_restriction_set and pylock_utils.is_valid_pylock_filename(filename):
             raise CommandError(
                 "Patform and interpreter constraints using "


### PR DESCRIPTION
This is a follow-up to #13735. After it was merged, I profiled `pip --help` again and noticed a regression introduced by the pylock.toml work. 

This reduced `pip --help` time by 10ms on my machine

```console
pip on  lazy-import-lock [$?] via 🐍 v3.14.3 (pip) took 2s 
❯ hyperfine -w 5 "python -m pip --help"
Benchmark 1: python -m pip --help
  Time (mean ± σ):     101.4 ms ±   5.7 ms    [User: 82.5 ms, System: 17.9 ms]
  Range (min … max):    95.5 ms … 118.8 ms    28 runs
 
pip on  lazy-import-lock [$?] via 🐍 v3.14.3 (pip) took 3s 
❯ git switch main
pip on  main [$?] via 🐍 v3.14.3 (pip) 
❯ hyperfine -w 5 "python -m pip --help"
Benchmark 1: python -m pip --help
  Time (mean ± σ):     112.3 ms ±   3.2 ms    [User: 92.1 ms, System: 19.1 ms]
  Range (min … max):   107.7 ms … 121.8 ms    26 runs
```