### PR TITLE
Fix `Git.has_commit` to detect locally-present commits

### DIFF
--- a/news/14055.bugfix.rst
+++ b/news/14055.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid re-fetching a pinned Git commit that is already present locally.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -453,7 +453,7 @@ class Git(VersionControl):
         """
         try:
             cls.run_command(
-                ["rev-parse", "-q", "--verify", "sha^" + rev],
+                ["rev-parse", "-q", "--verify", rev + "^{commit}"],
                 cwd=location,
                 log_failed_cmd=False,
             )

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -460,3 +460,16 @@ def test_clone_without_partial_clone_support(
         "warning: filtering not recognized by server, ignoring"
         not in script.run("git", "pull", cwd=clone_path).stderr
     )
+
+
+def test_git_has_commit(script: PipTestEnvironment) -> None:
+    """
+    Test Git.has_commit().
+    """
+    repo_dir = str(script.scratch_path)
+
+    script.run("git", "init", cwd=repo_dir)
+    sha = do_commit(script, repo_dir)
+
+    assert Git.has_commit(repo_dir, sha)
+    assert not Git.has_commit(repo_dir, "0" * 40)

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import pathlib
+import subprocess
 from typing import Any
 from unittest import mock
 
@@ -297,6 +298,30 @@ def test_git_resolve_revision_not_found_warning(
     assert messages == [
         "Did not find branch or tag 'aaaaaa', assuming revision or ref."
     ]
+
+
+@pytest.mark.git
+def test_git_has_commit(tmp_path: pathlib.Path) -> None:
+    """Git.has_commit() reports whether a commit exists in the local repo."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "pip",
+        "GIT_AUTHOR_EMAIL": "pip@example.com",
+        "GIT_COMMITTER_NAME": "pip",
+        "GIT_COMMITTER_EMAIL": "pip@example.com",
+    }
+    subprocess.check_call(["git", "init", "-q"], cwd=repo, env=env)
+    subprocess.check_call(
+        ["git", "commit", "-q", "--allow-empty", "-m", "initial"], cwd=repo, env=env
+    )
+    sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, env=env, text=True
+    ).strip()
+
+    assert Git.has_commit(os.fspath(repo), sha)
+    assert not Git.has_commit(os.fspath(repo), "0" * 40)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import os
 import pathlib
-import subprocess
 from typing import Any
 from unittest import mock
 
@@ -298,30 +297,6 @@ def test_git_resolve_revision_not_found_warning(
     assert messages == [
         "Did not find branch or tag 'aaaaaa', assuming revision or ref."
     ]
-
-
-@pytest.mark.git
-def test_git_has_commit(tmp_path: pathlib.Path) -> None:
-    """Git.has_commit() reports whether a commit exists in the local repo."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    env = {
-        **os.environ,
-        "GIT_AUTHOR_NAME": "pip",
-        "GIT_AUTHOR_EMAIL": "pip@example.com",
-        "GIT_COMMITTER_NAME": "pip",
-        "GIT_COMMITTER_EMAIL": "pip@example.com",
-    }
-    subprocess.check_call(["git", "init", "-q"], cwd=repo, env=env)
-    subprocess.check_call(
-        ["git", "commit", "-q", "--allow-empty", "-m", "initial"], cwd=repo, env=env
-    )
-    sha = subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], cwd=repo, env=env, text=True
-    ).strip()
-
-    assert Git.has_commit(os.fspath(repo), sha)
-    assert not Git.has_commit(os.fspath(repo), "0" * 40)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`Git.has_commit` answers "is `rev` a commit that already exists in the local repository", and `_should_fetch` uses it to skip a network `git fetch` when a hash-pinned commit is already present. It builds the revision to verify as `"sha^" + rev`, i.e. `sha^<commit>`:

```python
cls.run_command(["rev-parse", "-q", "--verify", "sha^" + rev], ...)
```

Git does not read that as the commit `<rev>`. It reads `sha` as a ref name and `^` as the parent operator. From [gitrevisions]:

> A suffix `^` to a revision parameter means the first parent of that commit object. `^<n>` means the <n>th parent (i.e. `<rev>^` is equivalent to `<rev>^1`).

There is no ref named `sha`, and `^<commit>` is not a valid parent selector, so the string never names a single object. Under `--verify` that is an error, and `-q` turns it into a silent non-zero exit. From [git-rev-parse]:

> `--verify`: Verify that exactly one parameter is provided, and that it can be turned into a raw 20-byte SHA-1 that can be used to access the object database. If so, emit it to the standard output; otherwise, error out.

> `-q`, `--quiet`: Only meaningful in `--verify` mode. Do not output an error message if the first argument is not a valid object name; instead exit with non-zero status silently.

So the check fails for every input. The correct form is `<rev>^{commit}`. From [gitrevisions]:

> A suffix `^` followed by an object type name enclosed in brace pair means dereference the object at `<rev>` recursively until an object of type `<type>` is found [...]. For example, if `<rev>` is a commit-ish, `<rev>^{commit}` describes the corresponding commit object.

Real example:

```console
$ sha=$(git rev-parse HEAD)
$ git rev-parse -q --verify "sha^$sha"; echo "exit=$?"      # old form
exit=1
$ git rev-parse -q --verify "$sha^{commit}"; echo "exit=$?"  # new form
<sha>
exit=0
```

[gitrevisions]: https://git-scm.com/docs/gitrevisions
[git-rev-parse]: https://git-scm.com/docs/git-rev-parse