### PR TITLE
Fix `pip debug` cert configuration level detection

### DIFF
--- a/news/14056.bugfix.rst
+++ b/news/14056.bugfix.rst
@@ -1,0 +1,1 @@
+Report the correct configuration level for ``cert`` in ``pip debug`` output.

--- a/src/pip/_internal/commands/debug.py
+++ b/src/pip/_internal/commands/debug.py
@@ -134,7 +134,7 @@ def show_tags(options: Values) -> None:
 
 
 def ca_bundle_info(config: Configuration) -> str:
-    levels = {key.split(".", 1)[0] for key, _ in config.items()}
+    levels = {key.split(".", 1)[0] for _, options in config.items() for key in options}
     if not levels:
         return "Not specified"
 

--- a/tests/unit/test_command_debug.py
+++ b/tests/unit/test_command_debug.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pip._internal.commands.debug import ca_bundle_info
+
+from tests.lib.configuration_helpers import ConfigurationMixin, kinds
+
+
+class TestCABundleInfo(ConfigurationMixin):
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            ({"global.cert": "/g"}, "global"),
+            ({"install.cert": "/i"}, "install"),
+            ({"global.cert": "/g", "install.cert": "/i"}, "install"),
+        ],
+    )
+    def test_reports_configured_level(
+        self,
+        config: dict[str, str],
+        expected: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        for name in list(os.environ):
+            if name.startswith("PIP_"):
+                monkeypatch.delenv(name)
+        self.patch_configuration(kinds.USER, config)
+        self.configuration.load()
+        assert ca_bundle_info(self.configuration) == expected


### PR DESCRIPTION
`ca_bundle_info` reports which configuration level sets the `cert` value in `pip debug` output. It derives the levels from `config.items()`, but since #12201 the configuration dictionary is keyed by file name rather than by `section.option`. The function still splits the outer key on `.`, so it collects file-path fragments (e.g. `/etc/pip` from `/etc/pip.conf`) instead of section names, never matches `install`/`wheel`/`download`, and always reports `global`.

Iterate the per-file option dictionaries so the section names are read from the option keys, restoring the intended level detection.
