### PR TITLE
Fix `pip show` crash on missing Metadata-Version

### DIFF
--- a/news/14057.bugfix.rst
+++ b/news/14057.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``pip show`` crash when a distribution has no ``Metadata-Version``.

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -189,7 +189,10 @@ def print_results(
         if i > 0:
             write_output("---")
 
-        metadata_version_tuple = tuple(map(int, dist.metadata_version.split(".")))
+        metadata_version = dist.metadata_version
+        metadata_version_tuple = (
+            tuple(map(int, metadata_version.split("."))) if metadata_version else ()
+        )
 
         write_output("Name: %s", dist.name)
         write_output("Version: %s", dist.version)

--- a/tests/unit/test_command_show.py
+++ b/tests/unit/test_command_show.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from pip._internal.commands.show import _PackageInfo, print_results
+
+
+def _package_info(metadata_version: str) -> _PackageInfo:
+    return _PackageInfo(
+        name="example",
+        version="1.0",
+        location="/loc",
+        editable_project_location=None,
+        requires=[],
+        required_by=[],
+        installer="pip",
+        metadata_version=metadata_version,
+        classifiers=[],
+        summary="",
+        homepage="",
+        project_urls=[],
+        author="",
+        author_email="",
+        license="MIT",
+        license_expression="MIT OR Apache-2.0",
+        entry_points=[],
+        files=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "metadata_version, expected, unexpected",
+    [
+        ("", "License: MIT", "License-Expression: MIT OR Apache-2.0"),
+        ("2.4", "License-Expression: MIT OR Apache-2.0", "License: MIT"),
+    ],
+)
+def test_print_results_license_for_metadata_version(
+    caplog: pytest.LogCaptureFixture,
+    metadata_version: str,
+    expected: str,
+    unexpected: str,
+) -> None:
+    caplog.set_level(logging.INFO)
+
+    assert print_results(
+        [_package_info(metadata_version)], list_files=False, verbose=False
+    )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert expected in messages
+    assert unexpected not in messages


### PR DESCRIPTION
`pip show` parses the distribution's `Metadata-Version` to decide whether to print `License-Expression` (PEP 639) or the legacy `License` field, and the parse runs unconditionally:

```python
metadata_version_tuple = tuple(map(int, dist.metadata_version.split(".")))
```

`Metadata-Version` comes from `metadata.get("Metadata-Version")`, which is `None` when the header is absent; `pip show` stores that as `""`, so `int("")` raises `ValueError` and the command aborts before printing anything for that distribution.

Any installed distribution whose metadata omits `Metadata-Version` triggers this. It is reachable with the default `importlib.metadata` backend: on Python 3.15+, `importlib.metadata` returns no metadata when a distribution directory has no `METADATA`/`PKG-INFO` file, which pip surfaces as an empty message (`_metadata_impl`, python/cpython#132947).

Treat a missing `Metadata-Version` as an empty version tuple, which falls back to printing the `License` field.