### PR TITLE
Remove empty `http-v2` directories on `pip cache purge`

### DIFF
--- a/news/14058.bugfix.rst
+++ b/news/14058.bugfix.rst
@@ -1,0 +1,1 @@
+Remove empty ``http-v2`` cache directories when running ``pip cache purge``.

--- a/src/pip/_internal/commands/cache.py
+++ b/src/pip/_internal/commands/cache.py
@@ -189,10 +189,13 @@ class CacheCommand(Command):
             logger.verbose("Removed %s", filename)
 
         http_dirs = filesystem.subdirs_without_files(self._cache_dir(options, "http"))
+        http_v2_dirs = filesystem.subdirs_without_files(
+            self._cache_dir(options, "http-v2")
+        )
         wheel_dirs = filesystem.subdirs_without_wheels(
             self._cache_dir(options, "wheels")
         )
-        dirs = [*http_dirs, *wheel_dirs]
+        dirs = [*http_dirs, *http_v2_dirs, *wheel_dirs]
 
         for subdir in dirs:
             try:

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -440,6 +440,11 @@ def populate_http_cache_with_empty_dirs(cache_dir: str) -> None:
     os.makedirs(empty1)
     os.makedirs(empty2)
 
+    http_v2_cache_dir = os.path.join(cache_dir, "http-v2")
+    empty3 = os.path.join(http_v2_cache_dir, "empty3", "nested")
+
+    os.makedirs(empty3)
+
 
 @pytest.fixture
 def create_selfcheck_json(cache_dir: str) -> None:
@@ -477,12 +482,14 @@ def test_cache_purge_removes_empty_dirs_and_legacy_files(
     """
     selfcheck_path = os.path.join(cache_dir, "selfcheck.json")
     http_cache_dir = os.path.join(cache_dir, "http")
+    http_v2_cache_dir = os.path.join(cache_dir, "http-v2")
     metadata_dir = os.path.join(wheel_cache_dir, "metadata_only")
 
     # Verify setup
     assert os.path.exists(selfcheck_path)
     assert os.path.exists(metadata_dir)
     assert os.path.exists(os.path.join(http_cache_dir, "empty1"))
+    assert os.path.exists(os.path.join(http_v2_cache_dir, "empty3"))
 
     result = script.pip("cache", "purge", "--verbose", allow_stderr_warning=True)
 
@@ -492,6 +499,7 @@ def test_cache_purge_removes_empty_dirs_and_legacy_files(
     assert not os.path.exists(metadata_dir)
     assert not os.path.exists(os.path.join(wheel_cache_dir, "completely_empty"))
     assert not os.path.exists(os.path.join(http_cache_dir, "empty1"))
+    assert not os.path.exists(os.path.join(http_v2_cache_dir, "empty3"))
     assert "Directories removed:" in result.stdout
 
     # Verify directory count is positive


### PR DESCRIPTION
`pip cache purge` deletes cached response files from both the legacy `http` directory and the current `http-v2` directory, but the follow-up empty-directory cleanup only scans `http`. Because `http-v2` stores each entry several directories deep, every purge leaves behind the now-empty directory trees, and the reported "Directories removed" count omits them.

Scan `http-v2` for empty directories as well, matching the set of directories that `_find_http_files` already cleans.
