### PR TITLE
Report `pip wheel` copy failures as copy failures

### DIFF
--- a/news/14059.bugfix.rst
+++ b/news/14059.bugfix.rst
@@ -1,0 +1,1 @@
+Report a copy failure in ``pip wheel`` instead of a misleading build failure.

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -160,8 +160,9 @@ class WheelCommand(RequirementCommand):
                 shutil.copy(req.local_file_path, options.wheel_dir)
             except OSError as e:
                 logger.warning(
-                    "Building wheel for %s failed: %s",
+                    "Failed to copy built wheel %s to %s: %s",
                     req.name,
+                    options.wheel_dir,
                     e,
                 )
                 build_failures.append(req)

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -213,6 +213,36 @@ def test_pip_wheel_readonly_cache(
     assert "The cache has been disabled." in str(res), str(res)
 
 
+def test_pip_wheel_copy_failure_is_reported_as_copy_failure(
+    script: PipTestEnvironment, data: TestData
+) -> None:
+    """A wheel that builds but cannot be copied to the output directory should
+    be reported as a copy failure, not a build failure."""
+    wheel_dir = script.scratch_path / "wheels"
+    wheel_dir.mkdir()
+    wheel_file_name = f"simple-3.0-py{pyversion[0]}-none-any.whl"
+    # Occupy the destination path with a directory so copying the built wheel
+    # there fails after the build itself has already succeeded.
+    (wheel_dir / wheel_file_name).mkdir()
+
+    result = script.pip(
+        "wheel",
+        "--no-build-isolation",
+        "--no-index",
+        "-f",
+        data.find_links,
+        "-w",
+        wheel_dir,
+        "simple==3.0",
+        expect_error=True,
+        allow_stderr_warning=True,
+    )
+
+    assert "Successfully built simple" in result.stdout, str(result)
+    assert "Failed to copy built wheel" in str(result), str(result)
+    assert "Building wheel for simple failed" not in str(result), str(result)
+
+
 def test_pip_wheel_builds_editable_deps(
     script: PipTestEnvironment, data: TestData
 ) -> None:


### PR DESCRIPTION
When `pip wheel` builds a wheel successfully but cannot copy it from the cache into the output directory (for example a read-only or full `--wheel-dir`), it logs "Building wheel for <name> failed". The build actually succeeded and only the copy failed, so the message points users at their build backend instead of the output directory.

Report the copy failure for what it is.
