### PR TITLE
Fix "Platform" typo in pylock constraint error

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -108,7 +108,7 @@ def check_dist_restriction(options: Values, check_target: bool = False) -> None:
     for filename in options.requirements:
         if dist_restriction_set and pylock_utils.is_valid_pylock_filename(filename):
             raise CommandError(
-                "Patform and interpreter constraints using "
+                "Platform and interpreter constraints using "
                 "--python-version, --platform, --abi, or --implementation, "
                 f"are not supported when selecting requirements from {filename!r}"
             )


### PR DESCRIPTION
Correct the spelling of "Platform" in the error raised when platform or interpreter constraints (`--python-version`, `--platform`, `--abi`, `--implementation`) are combined with a `pylock.toml` requirements file.
