### PR TITLE
ci: fix PYTHON_GIL gate for free-threaded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
           allow-prereleases: true
 
       - name: Set PYTHON_GIL
-        if: endsWith(matrix.python-version, 't')
+        if: endsWith(matrix.python.version || matrix.python, 't')
         run: |
           echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
 
@@ -241,7 +241,7 @@ jobs:
           allow-prereleases: true
 
       - name: Set PYTHON_GIL
-        if: endsWith(matrix.python-version, 't')
+        if: endsWith(matrix.python, 't')
         run: |
           echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
 

--- a/tests/functional/test_vcs_bazaar.py
+++ b/tests/functional/test_vcs_bazaar.py
@@ -4,6 +4,7 @@ Contains functional tests of the Bazaar class.
 
 import os
 import sys
+import sysconfig
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,11 @@ from tests.lib import PipTestEnvironment, is_bzr_installed, need_bzr
     # instead of the system Python, but the breezy module is only installed
     # in the system site-packages. See pypa/pip#13568.
     reason="Bazaar is only available under CI on macOS",
+)
+@pytest.mark.skipif(
+    bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
+    # PYTHON_GIL=0 from free-threaded CI crashes the macOS Homebrew bzr.
+    reason="bzr subprocess aborts under PYTHON_GIL=0 on free-threaded builds",
 )
 def test_ensure_bzr_available() -> None:
     """Make sure that bzr is available when running in CI."""


### PR DESCRIPTION
`Set PYTHON_GIL` gated on `matrix.python-version`, but the matrix key is `python`, so it never fired on the 3.14t free-threaded rows.

This activates `PYTHON_GIL=0` on free-threaded runs, which crashes the macOS Homebrew bzr subprocess, so the bzr availability test is skipped on free-threaded builds.
