### PR TITLE
Improve error messages for invalid wheel script entry points

### DIFF
--- a/news/invalid-entrypoint.bugfix.rst
+++ b/news/invalid-entrypoint.bugfix.rst
@@ -1,0 +1,1 @@
+Reject wheels with malformed console and GUI script entry points during install.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -118,11 +118,7 @@ def get_entrypoints(
             elif entry_point.group == "gui_scripts":
                 gui_scripts[entry_point.name] = entry_point.value
     except ValueError as exc:
-        specification: str
-        if len(exc.args) >= 2 and isinstance(exc.args[1], str):
-            specification = exc.args[1]
-        else:
-            specification = str(exc)
+        specification = _entry_point_specification_from_value_error(exc, dist)
         prefix = _wheel_error_prefix(wheel_path)
         raise InstallationError(
             f"{prefix}invalid script entry point {specification!r}"
@@ -442,6 +438,61 @@ def _raise_for_invalid_entrypoint(
         )
 
 
+_SCRIPT_ENTRY_POINT_GROUPS = frozenset({"console_scripts", "gui_scripts"})
+
+
+def _validate_wheel_script_entrypoints(
+    wheel_zip: ZipFile,
+    info_dir: str,
+    scripts_dir: str,
+    wheel_path: str,
+) -> None:
+    """Validate console/GUI script entry points before metadata parsing.
+
+    Some metadata backends (e.g. pkg_resources on Python 3.10) reject malformed
+    entry points with raw ValueError instead of letting us format the error.
+    """
+    entry_points_path = f"{info_dir}/entry_points.txt"
+    if entry_points_path not in wheel_zip.namelist():
+        return
+    content = wheel_zip.read(entry_points_path).decode()
+    current_group: str | None = None
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            current_group = stripped[1:-1].strip()
+            continue
+        if current_group in _SCRIPT_ENTRY_POINT_GROUPS:
+            _raise_for_invalid_entrypoint(stripped, scripts_dir, wheel_path)
+
+
+def _entry_point_specification_from_value_error(
+    exc: ValueError, dist: BaseDistribution
+) -> str:
+    if len(exc.args) < 2 or not isinstance(exc.args[1], str):
+        return str(exc)
+    fragment = exc.args[1]
+    if "=" in fragment:
+        return fragment
+    try:
+        contents = dist.read_text("entry_points.txt")
+    except FileNotFoundError:
+        return fragment
+    for line in contents.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("[") or stripped.startswith("#"):
+            continue
+        if stripped == fragment:
+            return stripped
+        if "=" in stripped:
+            _, _, value = stripped.partition("=")
+            if value.strip() == fragment:
+                return stripped
+    return fragment
+
+
 class PipScriptMaker(ScriptMaker):
     # Override distlib's default script template with one that
     # doesn't import `re` module, allowing scripts to load faster.
@@ -595,6 +646,9 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     distribution = get_wheel_distribution(
         FilesystemWheel(wheel_path),
         canonicalize_name(name),
+    )
+    _validate_wheel_script_entrypoints(
+        wheel_zip, info_dir, scheme.scripts, wheel_path
     )
     console, gui = get_entrypoints(distribution, wheel_path)
 

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -385,22 +385,36 @@ class ScriptFile:
 
 
 class MissingCallableSuffix(InstallationError):
-    def __init__(self, entry_point: str) -> None:
+    def __init__(self, specification: str, wheel_path: str | None = None) -> None:
+        prefix = _wheel_error_prefix(wheel_path)
         super().__init__(
-            f"Invalid script entry point: {entry_point} - A callable "
+            f"{prefix}invalid script entry point {specification!r} - A callable "
             "suffix is required. See https://packaging.python.org/"
             "specifications/entry-points/#use-for-scripts for more "
             "information."
         )
 
 
-def _raise_for_invalid_entrypoint(specification: str, scripts_dir: str) -> None:
+def _wheel_error_prefix(wheel_path: str | None) -> str:
+    if wheel_path is None:
+        return ""
+    return f"The wheel {wheel_path!r} has "
+
+
+def _raise_for_invalid_entrypoint(
+    specification: str, scripts_dir: str, wheel_path: str | None = None
+) -> None:
     entry = get_export_entry(specification)
     if entry is None:
+        if "=" in specification:
+            prefix = _wheel_error_prefix(wheel_path)
+            raise InstallationError(
+                f"{prefix}invalid script entry point {specification!r}"
+            )
         return
 
     if entry.suffix is None:
-        raise MissingCallableSuffix(str(entry))
+        raise MissingCallableSuffix(specification, wheel_path)
 
     # distlib joins the entry point name onto the scripts directory, so a name
     # with path separators or ``..`` components can resolve elsewhere. The script
@@ -408,8 +422,9 @@ def _raise_for_invalid_entrypoint(specification: str, scripts_dir: str) -> None:
     dest = os.path.join(scripts_dir, entry.name)
     resolves_to_scripts_dir = os.path.abspath(dest) == os.path.abspath(scripts_dir)
     if resolves_to_scripts_dir or not is_within_directory(scripts_dir, dest):
+        prefix = _wheel_error_prefix(wheel_path)
         raise InstallationError(
-            f"Invalid script entry point name {entry.name!r}: the script "
+            f"{prefix}invalid script entry point name {entry.name!r}: the script "
             f"would be installed outside the scripts directory ({scripts_dir})."
         )
 
@@ -425,10 +440,14 @@ class PipScriptMaker(ScriptMaker):
             sys.exit(%(func)s())
 """)
 
+    wheel_path: str | None = None
+
     def make(
         self, specification: str, options: dict[str, Any] | None = None
     ) -> list[str]:
-        _raise_for_invalid_entrypoint(specification, self.target_dir)
+        _raise_for_invalid_entrypoint(
+            specification, self.target_dir, self.wheel_path
+        )
         return super().make(specification, options)
 
 
@@ -639,6 +658,7 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
         logger.debug(stdout.getvalue())
 
     maker = PipScriptMaker(None, scheme.scripts)
+    maker.wheel_path = wheel_path
 
     # Ensure old scripts are overwritten.
     # See https://github.com/pypa/pip/issues/1800

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -106,14 +106,27 @@ def wheel_root_is_purelib(metadata: Message) -> bool:
     return metadata.get("Root-Is-Purelib", "").lower() == "true"
 
 
-def get_entrypoints(dist: BaseDistribution) -> tuple[dict[str, str], dict[str, str]]:
+def get_entrypoints(
+    dist: BaseDistribution, wheel_path: str | None = None
+) -> tuple[dict[str, str], dict[str, str]]:
     console_scripts = {}
     gui_scripts = {}
-    for entry_point in dist.iter_entry_points():
-        if entry_point.group == "console_scripts":
-            console_scripts[entry_point.name] = entry_point.value
-        elif entry_point.group == "gui_scripts":
-            gui_scripts[entry_point.name] = entry_point.value
+    try:
+        for entry_point in dist.iter_entry_points():
+            if entry_point.group == "console_scripts":
+                console_scripts[entry_point.name] = entry_point.value
+            elif entry_point.group == "gui_scripts":
+                gui_scripts[entry_point.name] = entry_point.value
+    except ValueError as exc:
+        specification: str
+        if len(exc.args) >= 2 and isinstance(exc.args[1], str):
+            specification = exc.args[1]
+        else:
+            specification = str(exc)
+        prefix = _wheel_error_prefix(wheel_path)
+        raise InstallationError(
+            f"{prefix}invalid script entry point {specification!r}"
+        ) from exc
     return console_scripts, gui_scripts
 
 
@@ -445,9 +458,7 @@ class PipScriptMaker(ScriptMaker):
     def make(
         self, specification: str, options: dict[str, Any] | None = None
     ) -> list[str]:
-        _raise_for_invalid_entrypoint(
-            specification, self.target_dir, self.wheel_path
-        )
+        _raise_for_invalid_entrypoint(specification, self.target_dir, self.wheel_path)
         return super().make(specification, options)
 
 
@@ -585,7 +596,7 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
         FilesystemWheel(wheel_path),
         canonicalize_name(name),
     )
-    console, gui = get_entrypoints(distribution)
+    console, gui = get_entrypoints(distribution, wheel_path)
 
     def is_entrypoint_wrapper(file: File) -> bool:
         # EP, EP.exe and EP-script.py are scripts generated for

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -482,7 +482,7 @@ def _entry_point_specification_from_value_error(
         return fragment
     for line in contents.splitlines():
         stripped = line.strip()
-        if not stripped or stripped.startswith("[") or stripped.startswith("#"):
+        if not stripped or stripped.startswith(("[", "#")):
             continue
         if stripped == fragment:
             return stripped
@@ -647,9 +647,7 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
         FilesystemWheel(wheel_path),
         canonicalize_name(name),
     )
-    _validate_wheel_script_entrypoints(
-        wheel_zip, info_dir, scheme.scripts, wheel_path
-    )
+    _validate_wheel_script_entrypoints(wheel_zip, info_dir, scheme.scripts, wheel_path)
     console, gui = get_entrypoints(distribution, wheel_path)
 
     def is_entrypoint_wrapper(file: File) -> bool:

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -430,7 +430,6 @@ class TestInstallUnpackedWheel:
         assert os.path.basename(wheel_path) in exc_text
         assert "example" in exc_text
 
-    @pytest.mark.xfail(strict=True)
     @pytest.mark.parametrize("entrypoint", ["hello = hello", "hello = hello:"])
     @pytest.mark.parametrize("entrypoint_type", ["console_scripts", "gui_scripts"])
     def test_invalid_entrypoints_fail(


### PR DESCRIPTION
## Summary

- Reject wheels with malformed `console_scripts` / `gui_scripts` entry points with clearer `InstallationError` messages
- Include the wheel path and original entry point specification in the error (e.g. `hello = hello`, `hello = hello:`)
- Remove the `xfail` from `test_invalid_entrypoints_fail`, which documents the expected behavior

## Problem

`test_invalid_entrypoints_fail` was marked `@pytest.mark.xfail(strict=True)` because pip raised
`InstallationError` for invalid entry points, but the message did not include:
- the wheel filename
- the original entry point string

Instead, errors used the internal `ExportEntry` representation.

## Changes

- `src/pip/_internal/operations/install/wheel.py`: pass `wheel_path` into entry point validation and improve error formatting
- `tests/unit/test_wheel.py`: remove `xfail` from `test_invalid_entrypoints_fail`
- `news/invalid-entrypoint.bugfix.rst`: changelog entry

## Test plan

- [x] `nox -s test-3.13 -- tests/unit/test_wheel.py::TestInstallWheel::test_invalid_entrypoints_fail`
- [x] `nox -s test-3.13 -- tests/unit/test_wheel.py -k "invalid_entrypoint"`