### PR TITLE
ci: remove unnecessary dependency on packaging for zipapp tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
     # nature, and we don't care where they run, so we pick the fastest one.
     runs-on: macos-latest
 
-    needs: [packaging, determine-changes]
+    needs: [determine-changes]
     if: >-
       needs.determine-changes.outputs.tests == 'true' ||
       github.event_name != 'pull_request'


### PR DESCRIPTION
I was investigating ways to speed up CI, and found one of the reasons we are often waiting for zipapp to finish up is has `packaging` as an extra dependency none of our other Python tests have.