### PR TITLE
Import `urllib.request` lazily in all non-network commands

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -76,6 +76,7 @@ _MISSING_MODULES: set[str] = set()
 # after installation has started. Importing them eagerly keeps the audit
 # hook from misattributing them to a freshly installed distribution.
 _EAGER_IMPORTS: tuple[str, ...] = (
+    "pip._internal.operations.install.wheel",
     # Used by rich when emitting output to a legacy Windows console.
     "pip._vendor.rich._windows_renderer",
 )

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -8,7 +8,6 @@ import os
 import posixpath
 import re
 import urllib.parse
-import urllib.request
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import (
@@ -125,6 +124,8 @@ def _clean_file_url_path(part: str) -> str:
     Clean the first part of a URL path that corresponds to a local
     filesystem path (i.e. the first part after splitting on "@" characters).
     """
+    import urllib.request
+
     # We unquote prior to quoting to make sure nothing is double quoted.
     # Also, on Windows the path part might contain a drive letter which
     # should not be quoted. On Linux where drive letters do not

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -774,6 +774,11 @@ class InstallRequirement:
         use_user_site: bool = False,
         pycompile: bool = True,
     ) -> None:
+        # Lazy import to avoid transitively importing `_vendor.distlib.compat`
+        # which in turn imports `urllib.request` which is slow.
+        # During an actual installation, `urllib.request` will end up imported anyway,
+        # but `req.req_install` (this module) is also imported from commands that
+        # don't actually install anything (e.g. `pip freeze` or `pip show`).
         from pip._internal.operations.install.wheel import install_wheel
 
         assert self.req is not None

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -34,7 +34,6 @@ from pip._internal.models.direct_url import DirectUrl
 from pip._internal.models.link import Link
 from pip._internal.operations.build.metadata import generate_metadata
 from pip._internal.operations.build.metadata_editable import generate_editable_metadata
-from pip._internal.operations.install.wheel import install_wheel
 from pip._internal.pyproject import load_pyproject_toml, make_pyproject_path
 from pip._internal.req.req_uninstall import UninstallPathSet
 from pip._internal.utils.deprecation import deprecated
@@ -775,6 +774,8 @@ class InstallRequirement:
         use_user_site: bool = False,
         pycompile: bool = True,
     ) -> None:
+        from pip._internal.operations.install.wheel import install_wheel
+
         assert self.req is not None
         scheme = get_scheme(
             self.req.name,

--- a/src/pip/_internal/utils/urls.py
+++ b/src/pip/_internal/utils/urls.py
@@ -1,7 +1,6 @@
 import os
 import string
-import urllib.parse
-import urllib.request
+import urllib.parse  # noqa: F401
 
 from .compat import WINDOWS
 
@@ -11,6 +10,8 @@ def path_to_url(path: str) -> str:
     Convert a path to a file: URL.  The path will be made absolute and have
     quoted path parts.
     """
+    import urllib.request
+
     path = os.path.normpath(os.path.abspath(path))
     url = urllib.parse.urljoin("file://", urllib.request.pathname2url(path))
     return url
@@ -20,6 +21,8 @@ def url_to_path(url: str) -> str:
     """
     Convert a file: URL to a path.
     """
+    import urllib.request
+
     assert url.startswith(
         "file:"
     ), f"You can only turn file: urls into filenames (not {url!r})"

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -5,7 +5,6 @@ import os.path
 import pathlib
 import re
 import urllib.parse
-import urllib.request
 from dataclasses import replace
 from typing import Any
 
@@ -500,6 +499,8 @@ class Git(VersionControl):
         work with a ssh:// scheme (e.g. GitHub). But we need a scheme for
         parsing. Hence we remove it again afterwards and return it as a stub.
         """
+        import urllib.request
+
         # Works around an apparent Git bug
         # (see https://article.gmane.org/gmane.comp.version-control.git/146500)
         scheme, netloc, path, query, fragment = urlsplit(url)

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -136,3 +136,6 @@ finally:
     assert not any("pip._internal.network" in mod for mod in imported)
     assert not any("requests" in mod for mod in imported)
     assert not any("urllib3" in mod for mod in imported)
+
+    if command not in ("check", "freeze", "uninstall"):
+        assert not any("urllib.request" in mod for mod in imported)

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -136,6 +136,4 @@ finally:
     assert not any("pip._internal.network" in mod for mod in imported)
     assert not any("requests" in mod for mod in imported)
     assert not any("urllib3" in mod for mod in imported)
-
-    if command not in ("check", "freeze", "uninstall"):
-        assert not any("urllib.request" in mod for mod in imported)
+    assert not any("urllib.request" in mod for mod in imported)


### PR DESCRIPTION
This speeds up startup of many commands by avoiding `urllib.request` import. On my machine this is about ~10ms saving.

Build on #14054 which has to be merged first