### PR TITLE
Update PR template and verify its completion in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,3 @@ Thank you for your pull request! Before submitting, please make sure you've:
 - [ ] I have added a news file fragment (or this PR does not need one).
 - [ ] This PR was generated or assisted using an AI tool.
 <!-- If checked, add a line below: Assisted-by: <tool name, e.g. Claude> -->
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Thank you for your pull request! Before submitting, please make sure you've:
 ## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [ ] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
-- [ ] I have read and have followed the **CONTRIBUTING.md** file.
+- [ ] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
 - [ ] I have added a news file fragment (or this PR does not need one).
-- [ ] I have read and followed the AI_POLICY.md file, and if any AI tools were used, I have disclosed it below.
+- [ ] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
 <!-- If checked, add a line below: Assisted-by: <tool name, e.g. Claude> -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@ Thank you for your pull request! Before submitting, please make sure you've:
 - [ ] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
 - [ ] I have added a news file fragment (or this PR does not need one).
 - [ ] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
-<!-- If checked, add a line below: Assisted-by: <tool name, e.g. Claude> -->
+<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,5 @@ Thank you for your pull request! Before submitting, please make sure you've:
 - [ ] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
 - [ ] I have read and have followed the **CONTRIBUTING.md** file.
 - [ ] I have added a news file fragment (or this PR does not need one).
-- [ ] This PR was generated or assisted using an AI tool.
+- [ ] I have read and followed the AI_POLICY.md file, and if any AI tools were used, I have disclosed it below.
 <!-- If checked, add a line below: Assisted-by: <tool name, e.g. Claude> -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,18 @@
 <!---
-Thank you for your soon to be pull request. Before you submit this, please
-double check to make sure that you've added a news file fragment. In pip we
-generate our NEWS.rst from multiple news fragment files, and all pull requests
-require either a news file fragment or a marker to indicate they don't require
-one.
-
-To read more about adding a news file fragment for your PR, please check out
-our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
+Thank you for your pull request! Before submitting, please make sure you've:
+- Read the CONTRIBUTING.md file carefully
+- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
 -->
+
+## What does this PR do?
+
+<!-- What problem does this solve? Include the issue number if applicable. -->
+
+## PR Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
+- [ ] I have read and have followed the **CONTRIBUTING.md** file.
+- [ ] I have added a news file fragment (or this PR does not need one).
+- [ ] This PR was generated or assisted using an AI tool.
+<!-- If checked, add a line below: Assisted-by: <tool name, e.g. Claude> -->
+

--- a/.github/scripts/check_pr_template.sh
+++ b/.github/scripts/check_pr_template.sh
@@ -13,7 +13,7 @@ if [ "$PR_USER_LOGIN" = "dependabot[bot]" ]; then
   exit 0
 fi
 
-if [ "$PR_NUMBER" -le 14069 ]; then
+if [ "$PR_NUMBER" -le 14068 ]; then
   echo "Skipping old PR."
   exit 0
 fi

--- a/.github/scripts/check_pr_template.sh
+++ b/.github/scripts/check_pr_template.sh
@@ -8,6 +8,16 @@ require() {
     fi
 }
 
+if [ "$PR_USER_LOGIN" = "dependabot[bot]" ]; then
+  echo "Skipping dependabot PR."
+  exit 0
+fi
+
+if [ "$PR_NUMBER" -le 14069 ]; then
+  echo "Skipping old PR."
+  exit 0
+fi
+
 require "^[[:space:]]*- \[" \
 "Could not find the pip PR checklist in the pull request body. This probably means you've used a tool to submit your PR rather than the GitHub UI. Please add the required checklist from CONTRIBUTING.md."
 

--- a/.github/scripts/check_pr_template.sh
+++ b/.github/scripts/check_pr_template.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require() {
+    if ! grep -qE -- "$1" <<< "$PR_BODY"; then
+        echo "::error::$2"
+        exit 1
+    fi
+}
+
+require "^[[:space:]]*- \[" \
+"Could not find the pip PR checklist in the pull request body. This probably means you've used a tool to submit your PR rather than the GitHub UI. Please add the required checklist from CONTRIBUTING.md."
+
+require "^[[:space:]]*- \[\s*[xX]\s*\] I agree to follow the \[PSF Code of Conduct\]" \
+"The 'PSF Code of Conduct' checkbox in the PR checklist must be checked."
+
+require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and have followed the \[CONTRIBUTING\.md\]" \
+"The 'CONTRIBUTING.md' checkbox in the PR checklist must be checked."
+
+require "^[[:space:]]*- \[\s*[xX]\s*\] I have added a news file fragment" \
+"The 'news file fragment' checkbox in the PR checklist must be checked. If this PR does not need a news fragment, check the box anyway to confirm you have considered it."
+
+require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and followed the \[AI_POLICY\.md\]" \
+"The 'AI_POLICY.md' checkbox in the PR checklist must be checked."
+
+if grep -qE -- "^[[:space:]]*(-\s+)?Assisted-by:[[:space:]]*\S" <<< "$PR_BODY"; then
+    # Assisted-by is present and non-empty — no further action needed
+    true
+elif grep -qE -- "^[[:space:]]*(-\s+)?Assisted-by:" <<< "$PR_BODY"; then
+    echo "::error::An 'Assisted-by:' line was found but no tool was specified. Please add the tool name, e.g. 'Assisted-by: Claude'."
+    exit 1
+fi
+
+echo "PR Checklist verification passed."

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -1,0 +1,43 @@
+name: PR Checklist
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-pr-template:
+    name: Check PR template
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.number > 14069
+    steps:
+      - name: Check PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          require() {
+              if ! grep -qE -- "$1" <<< "$PR_BODY"; then
+                  echo "::error::$2"
+                  exit 1
+              fi
+          }
+
+          require "^[[:space:]]*- \[" \
+            "Could not find the pip PR checklist in the pull request comment. This probably means you've used a tool to submit your PR, rather than the GitHub UI which violates pip's AI policy. See https://pip.pypa.io/en/latest/development/contributing/#ai-policy for more details."
+
+          require "^[[:space:]]*- \[\s*[xX]\s*\] I agree to follow the \[PSF Code of Conduct\]" \
+            "The 'PSF Code of Conduct' checkbox in the PR checklist must be checked."
+
+          require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and have followed the \*\*CONTRIBUTING.md\*\* file" \
+            "The 'CONTRIBUTING.md' checkbox in the PR checklist must be checked."
+
+          if grep -qE -- "^[[:space:]]*- \[\s*[xX]\s*\] This PR was generated or assisted using an AI tool" <<< "$PR_BODY"; then
+              require "^[[:space:]]*(-\s+)?Assisted-by:" "'Assisted-by:' line is missing."
+              ASSISTED_BY_VAL=$(grep -E "^[[:space:]]*(-\s+)?Assisted-by:" <<< "$PR_BODY" | sed -r -e 's/^[[:space:]]*(-\s+)?Assisted-by://' -e 's/<!--.*-->//' | tr -d '[:space:]')
+              if [ -z "$ASSISTED_BY_VAL" ]; then
+                  echo "::error::You checked the AI tool checkbox in the PR template, but did not specify the tool used in 'Assisted-by:'."
+                  exit 1
+              fi
+          fi
+
+          echo "PR Checklist verification passed."

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -6,9 +6,13 @@ on:
       - opened
       - edited
       - reopened
+      - labeled
+      - unlabeled
 
 jobs:
   check-pr-template:
+    if: >
+      !contains(github.event.pull_request.labels.*.name, 'skip PR template check')
     name: Check PR template
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -14,7 +14,7 @@ jobs:
     if: >
       !contains(github.event.pull_request.labels.*.name, 'skip PR template check')
     name: Check PR template
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions: {}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -23,21 +23,26 @@ jobs:
           }
 
           require "^[[:space:]]*- \[" \
-            "Could not find the pip PR checklist in the pull request comment. This probably means you've used a tool to submit your PR, rather than the GitHub UI which violates pip's AI policy. See https://pip.pypa.io/en/latest/development/contributing/#ai-policy for more details."
+            "Could not find the pip PR checklist in the pull request body. This probably means you've used a tool to submit your PR rather than the GitHub UI. Please add the required checklist from CONTRIBUTING.md."
 
           require "^[[:space:]]*- \[\s*[xX]\s*\] I agree to follow the \[PSF Code of Conduct\]" \
             "The 'PSF Code of Conduct' checkbox in the PR checklist must be checked."
 
-          require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and have followed the \*\*CONTRIBUTING.md\*\* file" \
+          require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and have followed the \[CONTRIBUTING\.md\]" \
             "The 'CONTRIBUTING.md' checkbox in the PR checklist must be checked."
 
-          if grep -qE -- "^[[:space:]]*- \[\s*[xX]\s*\] I have read and followed the \*\*AI_POLICY\.md\*\* file" <<< "$PR_BODY"; then
-              require "^[[:space:]]*(-\s+)?Assisted-by:" "'Assisted-by:' line is missing."
-              ASSISTED_BY_VAL=$(grep -E "^[[:space:]]*(-\s+)?Assisted-by:" <<< "$PR_BODY" | sed -r -e 's/^[[:space:]]*(-\s+)?Assisted-by://' -e 's/<!--.*-->//' | tr -d '[:space:]')
-              if [ -z "$ASSISTED_BY_VAL" ]; then
-                  echo "::error::You checked the AI tool checkbox in the PR template, but did not specify the tool used in 'Assisted-by:'."
-                  exit 1
-              fi
+          require "^[[:space:]]*- \[\s*[xX]\s*\] I have added a news file fragment" \
+            "The 'news file fragment' checkbox in the PR checklist must be checked. If this PR does not need a news fragment, check the box anyway to confirm you have considered it."
+
+          require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and followed the \[AI_POLICY\.md\]" \
+            "The 'AI_POLICY.md' checkbox in the PR checklist must be checked."
+
+          if grep -qE -- "^[[:space:]]*(-\s+)?Assisted-by:[[:space:]]*\S" <<< "$PR_BODY"; then
+              # Assisted-by is present and non-empty — no further action needed
+              true
+          elif grep -qE -- "^[[:space:]]*(-\s+)?Assisted-by:" <<< "$PR_BODY"; then
+              echo "::error::An 'Assisted-by:' line was found but no tool was specified. Please add the tool name, e.g. 'Assisted-by: Claude'."
+              exit 1
           fi
 
           echo "PR Checklist verification passed."

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -3,6 +3,7 @@ name: PR Checklist
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
+  workflow_call:
 
 jobs:
   check-pr-template:

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check PR template
     runs-on: ubuntu-latest
     permissions: {}
-    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.number > 14069
+    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.number >= 14069
     steps:
       - name: Check PR body
         env:

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -1,8 +1,6 @@
 name: PR Checklist
 
 on:
-  pull_request:
-    types: [opened, edited, reopened, synchronize]
   workflow_call:
 
 jobs:

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -11,38 +11,10 @@ jobs:
     permissions: {}
     if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.number >= 14069
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Check PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          require() {
-              if ! grep -qE -- "$1" <<< "$PR_BODY"; then
-                  echo "::error::$2"
-                  exit 1
-              fi
-          }
-
-          require "^[[:space:]]*- \[" \
-            "Could not find the pip PR checklist in the pull request body. This probably means you've used a tool to submit your PR rather than the GitHub UI. Please add the required checklist from CONTRIBUTING.md."
-
-          require "^[[:space:]]*- \[\s*[xX]\s*\] I agree to follow the \[PSF Code of Conduct\]" \
-            "The 'PSF Code of Conduct' checkbox in the PR checklist must be checked."
-
-          require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and have followed the \[CONTRIBUTING\.md\]" \
-            "The 'CONTRIBUTING.md' checkbox in the PR checklist must be checked."
-
-          require "^[[:space:]]*- \[\s*[xX]\s*\] I have added a news file fragment" \
-            "The 'news file fragment' checkbox in the PR checklist must be checked. If this PR does not need a news fragment, check the box anyway to confirm you have considered it."
-
-          require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and followed the \[AI_POLICY\.md\]" \
-            "The 'AI_POLICY.md' checkbox in the PR checklist must be checked."
-
-          if grep -qE -- "^[[:space:]]*(-\s+)?Assisted-by:[[:space:]]*\S" <<< "$PR_BODY"; then
-              # Assisted-by is present and non-empty — no further action needed
-              true
-          elif grep -qE -- "^[[:space:]]*(-\s+)?Assisted-by:" <<< "$PR_BODY"; then
-              echo "::error::An 'Assisted-by:' line was found but no tool was specified. Please add the tool name, e.g. 'Assisted-by: Claude'."
-              exit 1
-          fi
-
-          echo "PR Checklist verification passed."
+        run: bash .github/scripts/check_pr_template.sh

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -31,7 +31,7 @@ jobs:
           require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and have followed the \*\*CONTRIBUTING.md\*\* file" \
             "The 'CONTRIBUTING.md' checkbox in the PR checklist must be checked."
 
-          if grep -qE -- ""^[[:space:]]*- \[\s*[xX]\s*\] I have read and followed the \*\*AI_POLICY\.md\*\* file" <<< "$PR_BODY"; then
+          if grep -qE -- "^[[:space:]]*- \[\s*[xX]\s*\] I have read and followed the \*\*AI_POLICY\.md\*\* file" <<< "$PR_BODY"; then
               require "^[[:space:]]*(-\s+)?Assisted-by:" "'Assisted-by:' line is missing."
               ASSISTED_BY_VAL=$(grep -E "^[[:space:]]*(-\s+)?Assisted-by:" <<< "$PR_BODY" | sed -r -e 's/^[[:space:]]*(-\s+)?Assisted-by://' -e 's/<!--.*-->//' | tr -d '[:space:]')
               if [ -z "$ASSISTED_BY_VAL" ]; then

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -10,7 +10,6 @@ jobs:
     name: Check PR template
     runs-on: ubuntu-latest
     permissions: {}
-    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.number >= 14069
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -18,4 +17,6 @@ jobs:
       - name: Check PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_USER_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: bash .github/scripts/check_pr_template.sh

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -31,7 +31,7 @@ jobs:
           require "^[[:space:]]*- \[\s*[xX]\s*\] I have read and have followed the \*\*CONTRIBUTING.md\*\* file" \
             "The 'CONTRIBUTING.md' checkbox in the PR checklist must be checked."
 
-          if grep -qE -- "^[[:space:]]*- \[\s*[xX]\s*\] This PR was generated or assisted using an AI tool" <<< "$PR_BODY"; then
+          if grep -qE -- ""^[[:space:]]*- \[\s*[xX]\s*\] I have read and followed the \*\*AI_POLICY\.md\*\* file" <<< "$PR_BODY"; then
               require "^[[:space:]]*(-\s+)?Assisted-by:" "'Assisted-by:' line is missing."
               ASSISTED_BY_VAL=$(grep -E "^[[:space:]]*(-\s+)?Assisted-by:" <<< "$PR_BODY" | sed -r -e 's/^[[:space:]]*(-\s+)?Assisted-by://' -e 's/<!--.*-->//' | tr -d '[:space:]')
               if [ -z "$ASSISTED_BY_VAL" ]; then

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -1,7 +1,11 @@
 name: PR Checklist
 
 on:
-  workflow_call:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
 
 jobs:
   check-pr-template:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr-template:
+    name: Check PR template
+    uses: ./.github/workflows/check-pr-template.yml
+
   docs:
     name: docs
     runs-on: ubuntu-latest
@@ -319,6 +323,7 @@ jobs:
       - tests-windows
       - tests-zipapp
       - vendoring
+      - pr-template
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-template:
-    name: Check PR template
-    uses: ./.github/workflows/check-pr-template.yml
-
   docs:
     name: docs
     runs-on: ubuntu-latest
@@ -323,7 +319,6 @@ jobs:
       - tests-windows
       - tests-zipapp
       - vendoring
-      - pr-template
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Following recent discussions and @pradyunsg's suggestions, this PR introduces a required pull request template inspired by @BeeWare's approach.
I'm a bit skeptical about adding CI enforcement right now (as it might flag existing open PRs), but I'm more than happy to adjust the approach based on feedback :).

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.