### PR TITLE
(correctness): fix conflict check whitelist ordering

### DIFF
--- a/news/14074.bugfix.rst
+++ b/news/14074.bugfix.rst
@@ -1,0 +1,1 @@
+Make ``pip install`` conflict checks independent of installed distribution iteration order.

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -167,7 +167,7 @@ def _create_whitelist(
             continue
 
         for req in package_set[package_name].dependencies:
-            if canonicalize_name(req.name) in packages_affected:
+            if canonicalize_name(req.name) in would_be_installed:
                 packages_affected.add(package_name)
                 break
 

--- a/tests/unit/test_operations_check.py
+++ b/tests/unit/test_operations_check.py
@@ -1,0 +1,37 @@
+from pip._vendor.packaging.requirements import Requirement
+from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
+from pip._vendor.packaging.version import Version
+
+from pip._internal.operations.check import (
+    PackageDetails,
+    PackageSet,
+    _create_whitelist,
+)
+
+
+def package_details(*dependencies: str) -> PackageDetails:
+    return PackageDetails(
+        Version("1"),
+        [Requirement(dependency) for dependency in dependencies],
+    )
+
+
+def test_create_whitelist_is_not_order_dependent() -> None:
+    root = canonicalize_name("root")
+    middle = canonicalize_name("middle")
+    leaf = canonicalize_name("leaf")
+    expected: set[NormalizedName] = {leaf, middle}
+
+    package_set_with_dependent_first: PackageSet = {
+        root: package_details("middle"),
+        middle: package_details("leaf"),
+        leaf: package_details(),
+    }
+    package_set_with_dependency_first: PackageSet = {
+        leaf: package_details(),
+        middle: package_details("leaf"),
+        root: package_details("middle"),
+    }
+
+    assert _create_whitelist({leaf}, package_set_with_dependent_first) == expected
+    assert _create_whitelist({leaf}, package_set_with_dependency_first) == expected


### PR DESCRIPTION
Fix `pip install` conflict checks so the affected-package whitelist is independent of installed distribution iteration order.

The whitelist is intended to include the packages being installed/upgraded and their direct dependents. Previously, `_create_whitelist()` tested dependency names against `packages_affected`, the set it mutates while scanning installed packages. That made the result depend on package iteration order and could accidentally include non-direct dependents.

This changes the membership test to compare against the frozen `would_be_installed` set, preserving the existing direct-dependent policy while making the whitelist deterministic.

Fixes #14074