### PR TITLE
docs: update install metadata description

### DIFF
--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -60,11 +60,10 @@ Working Out the Name and Version
 For each candidate item, pip needs to know the project name and version. For
 wheels (identified by the ``.whl`` file extension) this can be obtained from
 the filename, as per the Wheel spec. For local directories, or explicitly
-specified sdist files, the ``setup.py egg_info`` command is used to determine
-the project metadata. For sdists located via an index, the filename is parsed
-for the name and project version (this is in theory slightly less reliable
-than using the ``egg_info`` command, but avoids downloading and processing
-unnecessary numbers of files).
+specified sdist files, pip asks the project build system to prepare metadata.
+For sdists located via an index, the filename is parsed for the name and
+project version (this is in theory slightly less reliable than preparing
+metadata, but avoids downloading and processing unnecessary numbers of files).
 
 The :ref:`Direct URL requirement syntax <pypug:dependency-specifiers>` can be used
 to explicitly state the project name (see :doc:`../topics/vcs-support`).


### PR DESCRIPTION
Fixes #14072.

## What changed

This updates the `pip install` documentation for working out a project name and version. The local directory / explicitly specified sdist paragraph no longer says pip runs `setup.py egg_info`; instead, it describes the current behavior in terms of asking the project build system to prepare metadata.

I also added an empty trivial news fragment, as requested by the PR template for changes that do not need a changelog entry.

## Validation

- `git diff --check`
- confirmed the obsolete `setup.py egg_info` wording is removed from the `Working Out the Name and Version` section

## Duplicate check

Searched open PRs/issues for `14072`, `setup.py egg_info metadata`, `setup.py egg_info pip_install.rst`, and `"setup.py egg_info" "pip install" docs`; no duplicate documentation PR found.