### PR TITLE
refactor: Split build environment module and add build env ABC

### DIFF
--- a/src/pip/_internal/build_env/__init__.py
+++ b/src/pip/_internal/build_env/__init__.py
@@ -1,4 +1,4 @@
-"""Build Environment used for isolation during sdist building"""
+"""Build environments used for isolation during build backend calls."""
 
 from pip._internal.build_env.base import (
     BuildEnvironment,

--- a/src/pip/_internal/build_env/__init__.py
+++ b/src/pip/_internal/build_env/__init__.py
@@ -4,17 +4,13 @@ from pip._internal.build_env.base import (
     BuildEnvironment,
     BuildEnvironmentInstaller,
     BuildIsolationMode,
-    _Prefix,
 )
 from pip._internal.build_env.installer import (
     InprocessBuildEnvironmentInstaller,
     SubprocessBuildEnvironmentInstaller,
 )
 from pip._internal.build_env.noop import NoOpBuildEnvironment
-from pip._internal.build_env.virtual import (
-    VirtualBuildEnvironment,
-    _get_system_sitepackages,
-)
+from pip._internal.build_env.virtual import VirtualBuildEnvironment
 
 __all__ = [
     "BuildEnvironment",
@@ -24,6 +20,4 @@ __all__ = [
     "NoOpBuildEnvironment",
     "SubprocessBuildEnvironmentInstaller",
     "VirtualBuildEnvironment",
-    "_Prefix",
-    "_get_system_sitepackages",
 ]

--- a/src/pip/_internal/build_env/__init__.py
+++ b/src/pip/_internal/build_env/__init__.py
@@ -1,0 +1,29 @@
+"""Build Environment used for isolation during sdist building"""
+
+from pip._internal.build_env.base import (
+    BuildEnvironment,
+    BuildEnvironmentInstaller,
+    BuildIsolationMode,
+    _Prefix,
+)
+from pip._internal.build_env.installer import (
+    InprocessBuildEnvironmentInstaller,
+    SubprocessBuildEnvironmentInstaller,
+)
+from pip._internal.build_env.noop import NoOpBuildEnvironment
+from pip._internal.build_env.virtual import (
+    VirtualBuildEnvironment,
+    _get_system_sitepackages,
+)
+
+__all__ = [
+    "BuildEnvironment",
+    "BuildEnvironmentInstaller",
+    "BuildIsolationMode",
+    "InprocessBuildEnvironmentInstaller",
+    "NoOpBuildEnvironment",
+    "SubprocessBuildEnvironmentInstaller",
+    "VirtualBuildEnvironment",
+    "_Prefix",
+    "_get_system_sitepackages",
+]

--- a/src/pip/_internal/build_env/base.py
+++ b/src/pip/_internal/build_env/base.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import abc
+from collections.abc import Iterable
+from contextlib import AbstractContextManager as ContextManager
+from typing import TYPE_CHECKING, Literal, Protocol
+
+from pip._vendor.packaging.version import Version
+
+from pip._internal.locations import get_scheme
+from pip._internal.metadata import get_default_environment, get_environment
+from pip._internal.utils.packaging import get_requirement
+
+if TYPE_CHECKING:
+    from pip._internal.req.req_install import InstallRequirement
+
+
+BuildIsolationMode = Literal["off", "virtual"]
+
+
+def _dedup(a: str, b: str) -> tuple[str] | tuple[str, str]:
+    return (a, b) if a != b else (a,)
+
+
+class _Prefix:
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.setup = False
+        scheme = get_scheme("", prefix=path)
+        self.bin_dir = scheme.scripts
+        self.lib_dirs = _dedup(scheme.purelib, scheme.platlib)
+
+
+class BuildEnvironmentInstaller(Protocol):
+    """
+    Interface for installing build dependencies into an isolated build
+    environment.
+    """
+
+    def install(
+        self,
+        requirements: Iterable[str],
+        prefix: _Prefix,
+        *,
+        kind: str,
+        for_req: InstallRequirement | None,
+    ) -> None: ...
+
+
+class BuildEnvironment(ContextManager[None], metaclass=abc.ABCMeta):
+    """Creates and manages an isolated environment to install build deps"""
+
+    lib_dirs: list[str]
+
+    def check_requirements(
+        self, reqs: Iterable[str]
+    ) -> tuple[set[tuple[str, str]], set[str]]:
+        """Return 2 sets:
+        - conflicting requirements: set of (installed, wanted) reqs tuples
+        - missing requirements: set of reqs
+        """
+        missing = set()
+        conflicting = set()
+        if reqs:
+            env = (
+                get_environment(self.lib_dirs)
+                if hasattr(self, "lib_dirs")
+                else get_default_environment()
+            )
+            for req_str in reqs:
+                req = get_requirement(req_str)
+                # We're explicitly evaluating with an empty extra value, since build
+                # environments are not provided any mechanism to select specific extras.
+                if req.marker is not None and not req.marker.evaluate({"extra": ""}):
+                    continue
+                dist = env.get_distribution(req.name)
+                if not dist:
+                    missing.add(req_str)
+                    continue
+                if isinstance(dist.version, Version):
+                    installed_req_str = f"{req.name}=={dist.version}"
+                else:
+                    installed_req_str = f"{req.name}==={dist.version}"
+                if not req.specifier.contains(dist.version, prereleases=True):
+                    conflicting.add((installed_req_str, req_str))
+                # FIXME: Consider direct URL?
+        return conflicting, missing
+
+    @abc.abstractmethod
+    def install_requirements(
+        self,
+        requirements: Iterable[str],
+        prefix_as_string: str,
+        *,
+        kind: str,
+        for_req: InstallRequirement | None = None,
+    ) -> None: ...

--- a/src/pip/_internal/build_env/base.py
+++ b/src/pip/_internal/build_env/base.py
@@ -22,7 +22,7 @@ def _dedup(a: str, b: str) -> tuple[str] | tuple[str, str]:
     return (a, b) if a != b else (a,)
 
 
-class _Prefix:
+class Prefix:
     def __init__(self, path: str) -> None:
         self.path = path
         self.setup = False
@@ -40,7 +40,7 @@ class BuildEnvironmentInstaller(Protocol):
     def install(
         self,
         requirements: Iterable[str],
-        prefix: _Prefix,
+        prefix: Prefix,
         *,
         kind: str,
         for_req: InstallRequirement | None,

--- a/src/pip/_internal/build_env/installer.py
+++ b/src/pip/_internal/build_env/installer.py
@@ -10,7 +10,7 @@ from contextlib import nullcontext
 from io import StringIO
 from typing import TYPE_CHECKING, TypedDict
 
-from pip._internal.build_env.base import _Prefix
+from pip._internal.build_env.base import Prefix
 from pip._internal.cli.spinners import open_rich_spinner, open_spinner
 from pip._internal.exceptions import (
     BuildDependencyInstallError,
@@ -86,7 +86,7 @@ class SubprocessBuildEnvironmentInstaller:
     def install(
         self,
         requirements: Iterable[str],
-        prefix: _Prefix,
+        prefix: Prefix,
         *,
         kind: str,
         for_req: InstallRequirement | None,
@@ -246,7 +246,7 @@ class InprocessBuildEnvironmentInstaller:
     def install(
         self,
         requirements: Iterable[str],
-        prefix: _Prefix,
+        prefix: Prefix,
         *,
         kind: str,
         for_req: InstallRequirement | None,
@@ -295,7 +295,7 @@ class InprocessBuildEnvironmentInstaller:
         finally:
             self._level -= 1
 
-    def _install_impl(self, requirements: Iterable[str], prefix: _Prefix) -> None:
+    def _install_impl(self, requirements: Iterable[str], prefix: Prefix) -> None:
         """Core build dependency install logic."""
         from pip._internal.commands.install import installed_packages_summary
         from pip._internal.req import install_given_reqs

--- a/src/pip/_internal/build_env/installer.py
+++ b/src/pip/_internal/build_env/installer.py
@@ -1,22 +1,16 @@
-"""Build Environment used for isolation during sdist building"""
-
 from __future__ import annotations
 
 import logging
 import os
-import site
 import sys
 import textwrap
-from collections import OrderedDict
 from collections.abc import Iterable, Sequence
 from contextlib import AbstractContextManager as ContextManager
 from contextlib import nullcontext
 from io import StringIO
-from types import TracebackType
-from typing import TYPE_CHECKING, Protocol, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
-from pip._vendor.packaging.version import Version
-
+from pip._internal.build_env.base import _Prefix
 from pip._internal.cli.spinners import open_rich_spinner, open_spinner
 from pip._internal.exceptions import (
     BuildDependencyInstallError,
@@ -24,14 +18,12 @@ from pip._internal.exceptions import (
     InstallWheelBuildError,
     PipError,
 )
-from pip._internal.locations import get_scheme
-from pip._internal.metadata import get_default_environment, get_environment
+from pip._internal.metadata import get_environment
 from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.logging import VERBOSE, capture_logging
 from pip._internal.utils.misc import get_runnable_pip
-from pip._internal.utils.packaging import get_requirement
 from pip._internal.utils.subprocess import call_subprocess
-from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
+from pip._internal.utils.temp_dir import TempDirectory
 
 if TYPE_CHECKING:
     from pip._internal.cache import WheelCache
@@ -45,41 +37,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-def _dedup(a: str, b: str) -> tuple[str] | tuple[str, str]:
-    return (a, b) if a != b else (a,)
-
-
-class _Prefix:
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.setup = False
-        scheme = get_scheme("", prefix=path)
-        self.bin_dir = scheme.scripts
-        self.lib_dirs = _dedup(scheme.purelib, scheme.platlib)
-
-
-def _get_system_sitepackages() -> set[str]:
-    """Get system site packages, as a normalized set of strings."""
-    system_sites = site.getsitepackages()
-    return {os.path.normcase(path) for path in system_sites}
-
-
-class BuildEnvironmentInstaller(Protocol):
-    """
-    Interface for installing build dependencies into an isolated build
-    environment.
-    """
-
-    def install(
-        self,
-        requirements: Iterable[str],
-        prefix: _Prefix,
-        *,
-        kind: str,
-        for_req: InstallRequirement | None,
-    ) -> None: ...
 
 
 class SubprocessBuildEnvironmentInstaller:
@@ -275,7 +232,7 @@ class InprocessBuildEnvironmentInstaller:
             src_dir="",
             # Hard-coded options (that should NOT be inherited).
             download_dir=None,
-            build_isolation=True,
+            build_isolation="virtual",
             check_build_deps=False,
             progress_bar="off",
             # TODO: hash-checking should be extended to build deps, but that is
@@ -401,175 +358,3 @@ class InprocessBuildEnvironmentInstaller:
             upgrade_strategy="to-satisfy-only",
             py_version_info=None,
         )
-
-
-class BuildEnvironment:
-    """Creates and manages an isolated environment to install build deps"""
-
-    def __init__(self, installer: BuildEnvironmentInstaller) -> None:
-        self.installer = installer
-        temp_dir = TempDirectory(kind=tempdir_kinds.BUILD_ENV, globally_managed=True)
-
-        self._prefixes = OrderedDict(
-            (name, _Prefix(os.path.join(temp_dir.path, name)))
-            for name in ("normal", "overlay")
-        )
-
-        self._bin_dirs: list[str] = []
-        self._lib_dirs: list[str] = []
-        for prefix in reversed(list(self._prefixes.values())):
-            self._bin_dirs.append(prefix.bin_dir)
-            self._lib_dirs.extend(prefix.lib_dirs)
-
-        # Customize site to:
-        # - ensure .pth files are honored
-        # - prevent access to system site packages
-        system_sites = _get_system_sitepackages()
-
-        self._site_dir = os.path.join(temp_dir.path, "site")
-        if not os.path.exists(self._site_dir):
-            os.mkdir(self._site_dir)
-        with open(
-            os.path.join(self._site_dir, "sitecustomize.py"), "w", encoding="utf-8"
-        ) as fp:
-            fp.write(textwrap.dedent("""
-                import os, site, sys
-
-                # First, discover all system-sites related paths.
-                original_sys_path = sys.path[:]
-                # Clear sys.path so addsitedir() will add system site paths and paths
-                # added by contained .pth files to sys.path reliably. This is necessary
-                # since Python 3.15, which notably no longer re-executes .pth files for
-                # known paths.
-                sys.path = []
-                known_paths = set()
-                for path in {system_sites!r}:
-                    site.addsitedir(path, known_paths=known_paths)
-                system_paths = set(os.path.normcase(path) for path in sys.path)
-
-                # Drop discovered system-sites related paths.
-                original_sys_path = [
-                    path for path in original_sys_path
-                    if os.path.normcase(path) not in system_paths
-                ]
-                sys.path = original_sys_path
-
-                # Second, add lib directories.
-                # ensuring .pth file are processed.
-                for path in {lib_dirs!r}:
-                    assert not path in sys.path
-                    site.addsitedir(path)
-                """).format(system_sites=system_sites, lib_dirs=self._lib_dirs))
-
-    def __enter__(self) -> None:
-        self._save_env = {
-            name: os.environ.get(name, None)
-            for name in ("PATH", "PYTHONNOUSERSITE", "PYTHONPATH")
-        }
-
-        path = self._bin_dirs[:]
-        old_path = self._save_env["PATH"]
-        if old_path:
-            path.extend(old_path.split(os.pathsep))
-
-        pythonpath = [self._site_dir]
-
-        os.environ.update(
-            {
-                "PATH": os.pathsep.join(path),
-                "PYTHONNOUSERSITE": "1",
-                "PYTHONPATH": os.pathsep.join(pythonpath),
-            }
-        )
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        for varname, old_value in self._save_env.items():
-            if old_value is None:
-                os.environ.pop(varname, None)
-            else:
-                os.environ[varname] = old_value
-
-    def check_requirements(
-        self, reqs: Iterable[str]
-    ) -> tuple[set[tuple[str, str]], set[str]]:
-        """Return 2 sets:
-        - conflicting requirements: set of (installed, wanted) reqs tuples
-        - missing requirements: set of reqs
-        """
-        missing = set()
-        conflicting = set()
-        if reqs:
-            env = (
-                get_environment(self._lib_dirs)
-                if hasattr(self, "_lib_dirs")
-                else get_default_environment()
-            )
-            for req_str in reqs:
-                req = get_requirement(req_str)
-                # We're explicitly evaluating with an empty extra value, since build
-                # environments are not provided any mechanism to select specific extras.
-                if req.marker is not None and not req.marker.evaluate({"extra": ""}):
-                    continue
-                dist = env.get_distribution(req.name)
-                if not dist:
-                    missing.add(req_str)
-                    continue
-                if isinstance(dist.version, Version):
-                    installed_req_str = f"{req.name}=={dist.version}"
-                else:
-                    installed_req_str = f"{req.name}==={dist.version}"
-                if not req.specifier.contains(dist.version, prereleases=True):
-                    conflicting.add((installed_req_str, req_str))
-                # FIXME: Consider direct URL?
-        return conflicting, missing
-
-    def install_requirements(
-        self,
-        requirements: Iterable[str],
-        prefix_as_string: str,
-        *,
-        kind: str,
-        for_req: InstallRequirement | None = None,
-    ) -> None:
-        prefix = self._prefixes[prefix_as_string]
-        assert not prefix.setup
-        prefix.setup = True
-        if not requirements:
-            return
-        self.installer.install(requirements, prefix, kind=kind, for_req=for_req)
-
-
-class NoOpBuildEnvironment(BuildEnvironment):
-    """A no-op drop-in replacement for BuildEnvironment"""
-
-    def __init__(self) -> None:
-        pass
-
-    def __enter__(self) -> None:
-        pass
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        pass
-
-    def cleanup(self) -> None:
-        pass
-
-    def install_requirements(
-        self,
-        requirements: Iterable[str],
-        prefix_as_string: str,
-        *,
-        kind: str,
-        for_req: InstallRequirement | None = None,
-    ) -> None:
-        raise NotImplementedError()

--- a/src/pip/_internal/build_env/noop.py
+++ b/src/pip/_internal/build_env/noop.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from types import TracebackType
+from typing import TYPE_CHECKING
+
+from pip._internal.build_env.base import BuildEnvironment
+
+if TYPE_CHECKING:
+    from pip._internal.req.req_install import InstallRequirement
+
+
+class NoOpBuildEnvironment(BuildEnvironment):
+    """A no-op drop-in replacement for BuildEnvironment"""
+
+    def __init__(self) -> None:
+        pass
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    def cleanup(self) -> None:
+        pass
+
+    def install_requirements(
+        self,
+        requirements: Iterable[str],
+        prefix_as_string: str,
+        *,
+        kind: str,
+        for_req: InstallRequirement | None = None,
+    ) -> None:
+        raise NotImplementedError()

--- a/src/pip/_internal/build_env/virtual.py
+++ b/src/pip/_internal/build_env/virtual.py
@@ -26,7 +26,10 @@ def get_system_sitepackages() -> set[str]:
 
 
 class VirtualBuildEnvironment(BuildEnvironment):
-    """Legacy build environment implementation. Patches sys.path"""
+    """Legacy build environment implementation.
+
+    Patches sys.path and uses sitecustomize.py to isolate Python processes.
+    """
 
     def __init__(self, installer: BuildEnvironmentInstaller) -> None:
         self.installer = installer

--- a/src/pip/_internal/build_env/virtual.py
+++ b/src/pip/_internal/build_env/virtual.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from pip._internal.build_env.base import (
     BuildEnvironment,
     BuildEnvironmentInstaller,
-    _Prefix,
+    Prefix,
 )
 from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from pip._internal.req.req_install import InstallRequirement
 
 
-def _get_system_sitepackages() -> set[str]:
+def get_system_sitepackages() -> set[str]:
     """Get system site packages, as a normalized set of strings."""
     system_sites = site.getsitepackages()
     return {os.path.normcase(path) for path in system_sites}
@@ -33,7 +33,7 @@ class VirtualBuildEnvironment(BuildEnvironment):
         temp_dir = TempDirectory(kind=tempdir_kinds.BUILD_ENV, globally_managed=True)
 
         self._prefixes = OrderedDict(
-            (name, _Prefix(os.path.join(temp_dir.path, name)))
+            (name, Prefix(os.path.join(temp_dir.path, name)))
             for name in ("normal", "overlay")
         )
 
@@ -46,7 +46,7 @@ class VirtualBuildEnvironment(BuildEnvironment):
         # Customize site to:
         # - ensure .pth files are honored
         # - prevent access to system site packages
-        system_sites = _get_system_sitepackages()
+        system_sites = get_system_sitepackages()
 
         self._site_dir = os.path.join(temp_dir.path, "site")
         if not os.path.exists(self._site_dir):

--- a/src/pip/_internal/build_env/virtual.py
+++ b/src/pip/_internal/build_env/virtual.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import os
+import site
+import textwrap
+from collections import OrderedDict
+from collections.abc import Iterable
+from types import TracebackType
+from typing import TYPE_CHECKING
+
+from pip._internal.build_env.base import (
+    BuildEnvironment,
+    BuildEnvironmentInstaller,
+    _Prefix,
+)
+from pip._internal.utils.temp_dir import TempDirectory, tempdir_kinds
+
+if TYPE_CHECKING:
+    from pip._internal.req.req_install import InstallRequirement
+
+
+def _get_system_sitepackages() -> set[str]:
+    """Get system site packages, as a normalized set of strings."""
+    system_sites = site.getsitepackages()
+    return {os.path.normcase(path) for path in system_sites}
+
+
+class VirtualBuildEnvironment(BuildEnvironment):
+    """Legacy build environment implementation. Patches sys.path"""
+
+    def __init__(self, installer: BuildEnvironmentInstaller) -> None:
+        self.installer = installer
+        temp_dir = TempDirectory(kind=tempdir_kinds.BUILD_ENV, globally_managed=True)
+
+        self._prefixes = OrderedDict(
+            (name, _Prefix(os.path.join(temp_dir.path, name)))
+            for name in ("normal", "overlay")
+        )
+
+        self._bin_dirs: list[str] = []
+        self.lib_dirs: list[str] = []
+        for prefix in reversed(list(self._prefixes.values())):
+            self._bin_dirs.append(prefix.bin_dir)
+            self.lib_dirs.extend(prefix.lib_dirs)
+
+        # Customize site to:
+        # - ensure .pth files are honored
+        # - prevent access to system site packages
+        system_sites = _get_system_sitepackages()
+
+        self._site_dir = os.path.join(temp_dir.path, "site")
+        if not os.path.exists(self._site_dir):
+            os.mkdir(self._site_dir)
+        with open(
+            os.path.join(self._site_dir, "sitecustomize.py"), "w", encoding="utf-8"
+        ) as fp:
+            fp.write(textwrap.dedent("""
+                import os, site, sys
+
+                # First, discover all system-sites related paths.
+                original_sys_path = sys.path[:]
+                # Clear sys.path so addsitedir() will add system site paths and paths
+                # added by contained .pth files to sys.path reliably. This is necessary
+                # since Python 3.15, which notably no longer re-executes .pth files for
+                # known paths.
+                sys.path = []
+                known_paths = set()
+                for path in {system_sites!r}:
+                    site.addsitedir(path, known_paths=known_paths)
+                system_paths = set(os.path.normcase(path) for path in sys.path)
+
+                # Drop discovered system-sites related paths.
+                original_sys_path = [
+                    path for path in original_sys_path
+                    if os.path.normcase(path) not in system_paths
+                ]
+                sys.path = original_sys_path
+
+                # Second, add lib directories.
+                # ensuring .pth file are processed.
+                for path in {lib_dirs!r}:
+                    assert not path in sys.path
+                    site.addsitedir(path)
+                """).format(system_sites=system_sites, lib_dirs=self.lib_dirs))
+
+    def __enter__(self) -> None:
+        self._save_env = {
+            name: os.environ.get(name, None)
+            for name in ("PATH", "PYTHONNOUSERSITE", "PYTHONPATH")
+        }
+
+        path = self._bin_dirs[:]
+        old_path = self._save_env["PATH"]
+        if old_path:
+            path.extend(old_path.split(os.pathsep))
+
+        pythonpath = [self._site_dir]
+
+        os.environ.update(
+            {
+                "PATH": os.pathsep.join(path),
+                "PYTHONNOUSERSITE": "1",
+                "PYTHONPATH": os.pathsep.join(pythonpath),
+            }
+        )
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        for varname, old_value in self._save_env.items():
+            if old_value is None:
+                os.environ.pop(varname, None)
+            else:
+                os.environ[varname] = old_value
+
+    def install_requirements(
+        self,
+        requirements: Iterable[str],
+        prefix_as_string: str,
+        *,
+        kind: str,
+        for_req: InstallRequirement | None = None,
+    ) -> None:
+        prefix = self._prefixes[prefix_as_string]
+        assert not prefix.setup
+        prefix.setup = True
+        if not requirements:
+            return
+        self.installer.install(requirements, prefix, kind=kind, for_req=for_req)

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -217,7 +217,7 @@ class RequirementCommand(IndexGroupCommand):
             build_dir=temp_build_dir_path,
             src_dir=options.src_dir,
             download_dir=download_dir,
-            build_isolation=options.build_isolation,
+            build_isolation="virtual" if options.build_isolation else "off",
             build_isolation_installer=env_installer,
             check_build_deps=options.check_build_deps,
             build_tracker=build_tracker,

--- a/src/pip/_internal/distributions/base.py
+++ b/src/pip/_internal/distributions/base.py
@@ -7,7 +7,7 @@ from pip._internal.metadata.base import BaseDistribution
 from pip._internal.req import InstallRequirement
 
 if TYPE_CHECKING:
-    from pip._internal.build_env import BuildEnvironmentInstaller
+    from pip._internal.build_env import BuildEnvironmentInstaller, BuildIsolationMode
 
 
 class AbstractDistribution(metaclass=abc.ABCMeta):
@@ -49,7 +49,7 @@ class AbstractDistribution(metaclass=abc.ABCMeta):
     def prepare_distribution_metadata(
         self,
         build_env_installer: BuildEnvironmentInstaller,
-        build_isolation: bool,
+        build_isolation: BuildIsolationMode,
         check_build_deps: bool,
     ) -> None:
         raise NotImplementedError()

--- a/src/pip/_internal/distributions/installed.py
+++ b/src/pip/_internal/distributions/installed.py
@@ -6,7 +6,7 @@ from pip._internal.distributions.base import AbstractDistribution
 from pip._internal.metadata import BaseDistribution
 
 if TYPE_CHECKING:
-    from pip._internal.build_env import BuildEnvironmentInstaller
+    from pip._internal.build_env import BuildEnvironmentInstaller, BuildIsolationMode
 
 
 class InstalledDistribution(AbstractDistribution):
@@ -27,7 +27,7 @@ class InstalledDistribution(AbstractDistribution):
     def prepare_distribution_metadata(
         self,
         build_env_installer: BuildEnvironmentInstaller,
-        build_isolation: bool,
+        build_isolation: BuildIsolationMode,
         check_build_deps: bool,
     ) -> None:
         pass

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-from pip._internal.build_env import BuildEnvironment
+from pip._internal.build_env import BuildIsolationMode, VirtualBuildEnvironment
 from pip._internal.distributions.base import AbstractDistribution
 from pip._internal.exceptions import InstallationError
 from pip._internal.metadata import BaseDistribution
@@ -35,17 +35,17 @@ class SourceDistribution(AbstractDistribution):
     def prepare_distribution_metadata(
         self,
         build_env_installer: BuildEnvironmentInstaller,
-        build_isolation: bool,
+        build_isolation: BuildIsolationMode,
         check_build_deps: bool,
     ) -> None:
         # Load pyproject.toml
         self.req.load_pyproject_toml()
 
         # Set up the build isolation, if this requirement should be isolated
-        if build_isolation:
+        if build_isolation != "off":
             # Setup an isolated environment and install the build backend static
             # requirements in it.
-            self._prepare_build_backend(build_env_installer)
+            self._prepare_build_backend(build_isolation, build_env_installer)
             # Check that the build backend supports PEP 660. This cannot be done
             # earlier because we need to setup the build backend to verify it
             # supports build_editable, nor can it be done later, because we want
@@ -71,14 +71,17 @@ class SourceDistribution(AbstractDistribution):
         self.req.prepare_metadata()
 
     def _prepare_build_backend(
-        self, build_env_installer: BuildEnvironmentInstaller
+        self,
+        build_isolation: BuildIsolationMode,
+        build_env_installer: BuildEnvironmentInstaller,
     ) -> None:
         # Isolate in a BuildEnvironment and install the build-time
         # requirements.
         pyproject_requires = self.req.pyproject_requires
         assert pyproject_requires is not None
 
-        self.req.build_env = BuildEnvironment(build_env_installer)
+        if build_isolation == "virtual":
+            self.req.build_env = VirtualBuildEnvironment(build_env_installer)
         self.req.build_env.install_requirements(
             pyproject_requires, "overlay", kind="build dependencies", for_req=self.req
         )

--- a/src/pip/_internal/distributions/wheel.py
+++ b/src/pip/_internal/distributions/wheel.py
@@ -12,7 +12,7 @@ from pip._internal.metadata import (
 )
 
 if TYPE_CHECKING:
-    from pip._internal.build_env import BuildEnvironmentInstaller
+    from pip._internal.build_env import BuildEnvironmentInstaller, BuildIsolationMode
 
 
 class WheelDistribution(AbstractDistribution):
@@ -38,7 +38,7 @@ class WheelDistribution(AbstractDistribution):
     def prepare_distribution_metadata(
         self,
         build_env_installer: BuildEnvironmentInstaller,
-        build_isolation: bool,
+        build_isolation: BuildIsolationMode,
         check_build_deps: bool,
     ) -> None:
         pass

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from pip._vendor.packaging.utils import canonicalize_name
 
-from pip._internal.build_env import BuildEnvironmentInstaller
+from pip._internal.build_env import BuildEnvironmentInstaller, BuildIsolationMode
 from pip._internal.distributions import make_distribution_for_install_requirement
 from pip._internal.distributions.installed import InstalledDistribution
 from pip._internal.exceptions import (
@@ -66,7 +66,7 @@ def _get_prepared_distribution(
     req: InstallRequirement,
     build_tracker: BuildTracker,
     build_env_installer: BuildEnvironmentInstaller,
-    build_isolation: bool,
+    build_isolation: BuildIsolationMode,
     check_build_deps: bool,
 ) -> BaseDistribution:
     """Prepare a distribution for installation."""
@@ -231,7 +231,7 @@ class RequirementPreparer:
         build_dir: str,
         download_dir: str | None,
         src_dir: str,
-        build_isolation: bool,
+        build_isolation: BuildIsolationMode,
         build_isolation_installer: BuildEnvironmentInstaller,
         check_build_deps: bool,
         build_tracker: BuildTracker,

--- a/tests/functional/test_build_env.py
+++ b/tests/functional/test_build_env.py
@@ -10,10 +10,10 @@ from typing import Literal
 import pytest
 
 from pip._internal.build_env import (
-    BuildEnvironment,
     BuildEnvironmentInstaller,
     InprocessBuildEnvironmentInstaller,
     SubprocessBuildEnvironmentInstaller,
+    VirtualBuildEnvironment,
     _get_system_sitepackages,
 )
 from pip._internal.cache import WheelCache
@@ -66,9 +66,9 @@ def run_with_build_env(
             import sys
 
             from pip._internal.build_env import (
-                BuildEnvironment,
                 InprocessBuildEnvironmentInstaller,
                 SubprocessBuildEnvironmentInstaller,
+                VirtualBuildEnvironment,
             )
             from pip._internal.cache import WheelCache
             from pip._internal.index.collector import LinkCollector
@@ -102,7 +102,7 @@ def run_with_build_env(
                         build_tracker=tracker,
                         wheel_cache=WheelCache(None),
                     )
-                build_env = BuildEnvironment(installer)
+                build_env = VirtualBuildEnvironment(installer)
             """)
         + indent(dedent(setup_script_contents), "    ")
         + indent(
@@ -128,7 +128,7 @@ def test_build_env_allow_empty_requirements_install(
 ) -> None:
     finder = make_test_finder()
     with make_test_build_env_installer(install_method, finder) as installer:
-        build_env = BuildEnvironment(installer)
+        build_env = VirtualBuildEnvironment(installer)
         for prefix in ("normal", "overlay"):
             build_env.install_requirements(
                 [], prefix, kind="Installing build dependencies"
@@ -143,7 +143,7 @@ def test_build_env_allow_only_one_install(
     create_basic_wheel_for_package(script, "bar", "1.0")
     finder = make_test_finder(find_links=[os.fspath(script.scratch_path)])
     with make_test_build_env_installer(install_method, finder) as installer:
-        build_env = BuildEnvironment(installer)
+        build_env = VirtualBuildEnvironment(installer)
         for prefix in ("normal", "overlay"):
             build_env.install_requirements(
                 ["foo"], prefix, kind=f"installing foo in {prefix}"

--- a/tests/functional/test_build_env.py
+++ b/tests/functional/test_build_env.py
@@ -14,8 +14,8 @@ from pip._internal.build_env import (
     InprocessBuildEnvironmentInstaller,
     SubprocessBuildEnvironmentInstaller,
     VirtualBuildEnvironment,
-    _get_system_sitepackages,
 )
+from pip._internal.build_env.virtual import get_system_sitepackages
 from pip._internal.cache import WheelCache
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.operations.build.build_tracker import get_build_tracker
@@ -308,7 +308,7 @@ def test_build_env_isolation(
     script.pip_install_local("-t", target, pkg_whl)
     script.environ["PYTHONPATH"] = target
 
-    system_sites = _get_system_sitepackages()
+    system_sites = get_system_sitepackages()
     # there should always be something to exclude
     assert system_sites
 

--- a/tests/functional/test_pep517.py
+++ b/tests/functional/test_pep517.py
@@ -8,8 +8,8 @@ import pytest
 import tomli_w
 
 from pip._internal.build_env import (
-    BuildEnvironment,
     SubprocessBuildEnvironmentInstaller,
+    VirtualBuildEnvironment,
 )
 from pip._internal.req import InstallRequirement
 
@@ -47,7 +47,7 @@ def test_backend(tmpdir: Path, data: TestData) -> None:
     req.source_dir = os.fspath(project_dir)  # make req believe it has been unpacked
     req.load_pyproject_toml()
     finder = make_test_finder(find_links=[data.backends])
-    env = BuildEnvironment(SubprocessBuildEnvironmentInstaller(finder))
+    env = VirtualBuildEnvironment(SubprocessBuildEnvironmentInstaller(finder))
     env.install_requirements(["dummy_backend"], "normal", kind="Installing")
     conflicting, missing = env.check_requirements(["dummy_backend"])
     assert not conflicting
@@ -76,7 +76,7 @@ def test_backend_path(tmpdir: Path, data: TestData) -> None:
     req.source_dir = os.fspath(project_dir)  # make req believe it has been unpacked
     req.load_pyproject_toml()
 
-    env = BuildEnvironment(object())  # type: ignore
+    env = VirtualBuildEnvironment(object())  # type: ignore
     assert hasattr(req.pep517_backend, "build_wheel")
     with env:
         assert req.pep517_backend is not None
@@ -95,7 +95,7 @@ def test_backend_path_and_dep(tmpdir: Path, data: TestData) -> None:
     req.source_dir = os.fspath(project_dir)  # make req believe it has been unpacked
     req.load_pyproject_toml()
     finder = make_test_finder(find_links=[data.backends])
-    env = BuildEnvironment(SubprocessBuildEnvironmentInstaller(finder))
+    env = VirtualBuildEnvironment(SubprocessBuildEnvironmentInstaller(finder))
     env.install_requirements(["dummy_backend"], "normal", kind="Installing")
 
     assert hasattr(req.pep517_backend, "build_wheel")

--- a/tests/unit/test_build_constraints.py
+++ b/tests/unit/test_build_constraints.py
@@ -8,7 +8,8 @@ from unittest import mock
 
 import pytest
 
-from pip._internal.build_env import SubprocessBuildEnvironmentInstaller, _Prefix
+from pip._internal.build_env import SubprocessBuildEnvironmentInstaller
+from pip._internal.build_env.base import Prefix
 from pip._internal.utils.deprecation import PipDeprecationWarning
 
 from tests.lib import make_test_finder
@@ -100,7 +101,7 @@ class TestSubprocessBuildEnvironmentInstaller:
             finder,
             build_constraint_feature_enabled=False,
         )
-        prefix = _Prefix(str(tmp_path))
+        prefix = Prefix(str(tmp_path))
 
         with pytest.warns(PipDeprecationWarning):
             installer.install(

--- a/tests/unit/test_build_constraints.py
+++ b/tests/unit/test_build_constraints.py
@@ -89,7 +89,7 @@ class TestSubprocessBuildEnvironmentInstaller:
             "--build-constraint or PIP_BUILD_CONSTRAINT" in message
         )
 
-    @mock.patch("pip._internal.build_env.call_subprocess")
+    @mock.patch("pip._internal.build_env.installer.call_subprocess")
     @mock.patch.dict(os.environ, {"PIP_CONSTRAINT": "constraints.txt"})
     def test_install_calls_deprecation_check(
         self, mock_call_subprocess: mock.Mock, tmp_path: Path

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -17,7 +17,10 @@ import pytest
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement
 
-from pip._internal.build_env import SubprocessBuildEnvironmentInstaller
+from pip._internal.build_env import (
+    BuildIsolationMode,
+    SubprocessBuildEnvironmentInstaller,
+)
 from pip._internal.cache import WheelCache
 from pip._internal.commands import create_command
 from pip._internal.commands.install import InstallCommand
@@ -90,7 +93,7 @@ class TestRequirementSet:
         finder: PackageFinder,
         require_hashes: bool = False,
         wheel_cache: WheelCache | None = None,
-        build_isolation: bool = True,
+        build_isolation: BuildIsolationMode = "virtual",
     ) -> Iterator[Resolver]:
         make_install_req = partial(
             install_req_from_req_string,
@@ -165,7 +168,7 @@ class TestRequirementSet:
         req.user_supplied = True
         reqset.add_unnamed_requirement(req)
         finder = make_test_finder(find_links=[data.find_links])
-        with self._basic_resolver(finder, build_isolation=False) as resolver:
+        with self._basic_resolver(finder, build_isolation="off") as resolver:
             reqset = resolver.resolve(reqset.all_requirements, True)
         assert not reqset.has_requirement("simple")
 
@@ -319,7 +322,7 @@ class TestRequirementSet:
         )
 
         with self._basic_resolver(
-            finder, require_hashes=True, build_isolation=False
+            finder, require_hashes=True, build_isolation="off"
         ) as resolver:
             with pytest.raises(
                 HashErrors,
@@ -361,7 +364,7 @@ class TestRequirementSet:
     def test_download_info_find_links(self, data: TestData) -> None:
         """Test that download_info is set for requirements via find_links."""
         finder = make_test_finder(find_links=[data.find_links])
-        with self._basic_resolver(finder, build_isolation=False) as resolver:
+        with self._basic_resolver(finder, build_isolation="off") as resolver:
             ireq = get_processed_req_from_line("simple")
             reqset = resolver.resolve([ireq], True)
             assert len(reqset.all_requirements) == 1
@@ -386,7 +389,7 @@ class TestRequirementSet:
     def test_download_info_web_archive(self) -> None:
         """Test that download_info is set for requirements from a web archive."""
         finder = make_test_finder()
-        with self._basic_resolver(finder, build_isolation=False) as resolver:
+        with self._basic_resolver(finder, build_isolation="off") as resolver:
             ireq = get_processed_req_from_line(
                 "pip-test-package @ "
                 "https://github.com/pypa/pip-test-package/tarball/0.1.1"
@@ -500,7 +503,7 @@ class TestRequirementSet:
     def test_download_info_local_dir(self, data: TestData) -> None:
         """Test that download_info is set for requirements from a local dir."""
         finder = make_test_finder()
-        with self._basic_resolver(finder, build_isolation=False) as resolver:
+        with self._basic_resolver(finder, build_isolation="off") as resolver:
             ireq_url = data.packages.joinpath("FSPkg").as_uri()
             ireq = get_processed_req_from_line(f"FSPkg @ {ireq_url}")
             reqset = resolver.resolve([ireq], True)
@@ -513,7 +516,7 @@ class TestRequirementSet:
     def test_download_info_local_editable_dir(self, data: TestData) -> None:
         """Test that download_info is set for requirements from a local editable dir."""
         finder = make_test_finder()
-        with self._basic_resolver(finder, build_isolation=False) as resolver:
+        with self._basic_resolver(finder, build_isolation="off") as resolver:
             ireq_url = data.packages.joinpath("FSPkg").as_uri()
             ireq = get_processed_req_from_line(f"-e {ireq_url}#egg=FSPkg")
             reqset = resolver.resolve([ireq], True)
@@ -528,7 +531,7 @@ class TestRequirementSet:
     def test_download_info_vcs(self) -> None:
         """Test that download_info is set for requirements from git."""
         finder = make_test_finder()
-        with self._basic_resolver(finder, build_isolation=False) as resolver:
+        with self._basic_resolver(finder, build_isolation="off") as resolver:
             ireq = get_processed_req_from_line(
                 "pip-test-package @ git+https://github.com/pypa/pip-test-package"
             )


### PR DESCRIPTION
This will make it easier to extend which is important since the transition to the rewritten build environment logic is likely to take a while.

It's somewhat to likely probable that we may need to keep the old custom build isolation around indefinitely (Android, iOS) and for other distributions where `venv` isn't functional at all. However, _eventually,_ I'd like to kill the old subprocess installer.

This precedes PR #14070.

> [!tip]
> This is probably easier to review with a local git diff viewer so you can see that vast majority of the changes are just moved lines. 

Assisted-by: Codex:gpt-5.5