### PR TITLE
fix: skip wheel cache for local directory requirements

### DIFF
--- a/news/14044.bugfix.rst
+++ b/news/14044.bugfix.rst
@@ -1,2 +1,2 @@
-Build direct local directory requirements from the source directory instead of
-reusing a cached wheel.
+Never use persistent wheel cache for local directory requirements even if there
+is a matching entry, somehow.

--- a/news/14044.bugfix.rst
+++ b/news/14044.bugfix.rst
@@ -1,0 +1,2 @@
+Build direct local directory requirements from the source directory instead of
+reusing a cached wheel.

--- a/news/14080.bugfix.rst
+++ b/news/14080.bugfix.rst
@@ -1,0 +1,2 @@
+Fix caching bug where local directory requirements would be cached if the
+directory name contains a dash.

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -134,6 +134,8 @@ class SimpleWheelCache(Cache):
     ) -> Link:
         candidates = []
 
+        if link.is_existing_dir():
+            return link
         if not package_name:
             return link
 

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -49,6 +49,9 @@ def _should_cache(
     if req.editable or not req.source_dir:
         # never cache editable requirements
         return False
+    if req.link and req.link.is_existing_dir():
+        # never cache local directory requirements
+        return False
 
     if req.link and req.link.is_vcs:
         # VCS checkout. Do not cache

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -4,6 +4,7 @@ import hashlib
 import io
 import os
 import re
+import shutil
 import ssl
 import sys
 import sysconfig
@@ -15,9 +16,11 @@ from pathlib import Path
 
 import pytest
 
+from pip._internal.cache import SimpleWheelCache
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.models.direct_url import DirectUrl
 from pip._internal.models.index import PyPI, TestPyPI
+from pip._internal.models.link import Link
 from pip._internal.utils.misc import rmtree
 from pip._internal.utils.urls import path_to_url
 
@@ -1860,6 +1863,32 @@ def test_install_no_binary_uses_cached_wheels(
     assert "Successfully installed upper-2.0" in str(res), str(res)
     # upper is built and not obtained from cache
     assert "Building wheel for upper" not in str(res), str(res)
+
+
+def test_install_local_directory_ignores_cached_wheel(
+    script: PipTestEnvironment, data: TestData
+) -> None:
+    """A cached wheel is not reused for a local directory (#14044)."""
+    cache_dir = script.scratch_path / "cache"
+    link_url = path_to_url(os.fspath(data.packages.joinpath("FSPkg")))
+    cache = SimpleWheelCache(os.fspath(cache_dir))
+    cache_path = cache.get_path_for_link(Link(link_url))
+    os.makedirs(cache_path)
+    stale_wheel = create_basic_wheel_for_package(script, "FSPkg", "9.9")
+    shutil.copy(stale_wheel, os.path.join(cache_path, stale_wheel.name))
+
+    result = script.pip(
+        "install",
+        "--no-build-isolation",
+        "--no-index",
+        "--no-deps",
+        "--cache-dir",
+        os.fspath(cache_dir),
+        f"FSPkg @ {link_url}",
+    )
+    # Built from source (0.1.dev0), not served from the stale cache (9.9).
+    result.did_create(script.site_packages / "fspkg-0.1.dev0.dist-info")
+    result.did_not_create(script.site_packages / "fspkg-9.9.dist-info")
 
 
 def test_install_editable_with_wrong_egg_name(

--- a/tests/functional/test_wheel.py
+++ b/tests/functional/test_wheel.py
@@ -2,17 +2,22 @@
 
 import os
 import re
+import shutil
 import sys
 import textwrap
 from pathlib import Path
 
 import pytest
 
+from pip._internal.cache import SimpleWheelCache
 from pip._internal.cli.status_codes import ERROR
+from pip._internal.models.link import Link
+from pip._internal.utils.urls import path_to_url
 
 from tests.lib import (
     PipTestEnvironment,
     TestData,
+    create_basic_wheel_for_package,
     pyversion,
 )
 
@@ -532,3 +537,33 @@ def test_wheel_pylock_directories(
         "simplewheel-2.0-py3-none-any.whl",
         "singlemodule-0.0.1-py2.py3-none-any.whl",
     ]
+
+
+def test_wheel_local_directory_ignores_cached_wheel(
+    script: PipTestEnvironment, data: TestData
+) -> None:
+    """A cached wheel is rebuilt, not copied, for a local directory (#14044)."""
+    cache_dir = script.scratch_path / "cache"
+    wheel_dir = script.scratch_path / "wheels"
+    link_url = path_to_url(os.fspath(data.packages.joinpath("FSPkg")))
+    cache = SimpleWheelCache(os.fspath(cache_dir))
+    cache_path = cache.get_path_for_link(Link(link_url))
+    os.makedirs(cache_path)
+    stale_wheel = create_basic_wheel_for_package(script, "FSPkg", "9.9")
+    shutil.copy(stale_wheel, os.path.join(cache_path, stale_wheel.name))
+
+    script.pip(
+        "wheel",
+        "--no-build-isolation",
+        "--no-index",
+        "--no-deps",
+        "--cache-dir",
+        os.fspath(cache_dir),
+        "-w",
+        os.fspath(wheel_dir),
+        f"FSPkg @ {link_url}",
+    )
+    wheels = [p.name for p in wheel_dir.glob("*.whl")]
+    # Rebuilt from source (0.1.dev0), not copied from the stale cache (9.9).
+    assert any("0.1.dev0" in w for w in wheels), wheels
+    assert not any("9.9" in w for w in wheels), wheels

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -137,3 +137,18 @@ def test_simple_wheel_cache_ignores_cache_for_existing_directory(
     monkeypatch.setattr(cache, "_get_candidates", fail_if_called)
 
     assert cache.get(link, "example", supported_tags=[]) is link
+
+
+def test_wheel_cache_entry_none_for_existing_directory(tmpdir: Path) -> None:
+    wc = WheelCache(os.fspath(tmpdir))
+    project_dir = tmpdir / "project"
+    project_dir.mkdir()
+    link = Link(path_to_url(str(project_dir)))
+    supported_tags = [Tag("py3", "none", "any")]
+    cache_path = wc.get_path_for_link(link)
+    ensure_dir(cache_path)
+    with open(os.path.join(cache_path, "example-1.0-py3-none-any.whl"), "w"):
+        pass
+
+    assert wc.get_cache_entry(link, "example", supported_tags) is None
+    assert wc.get(link, "example", supported_tags) is link

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,11 +1,15 @@
 import os
 from pathlib import Path
+from typing import NoReturn
+
+import pytest
 
 from pip._vendor.packaging.tags import Tag, interpreter_name, interpreter_version
 
-from pip._internal.cache import WheelCache, _hash_dict
+from pip._internal.cache import SimpleWheelCache, WheelCache, _hash_dict
 from pip._internal.models.link import Link
 from pip._internal.utils.misc import ensure_dir
+from pip._internal.utils.urls import path_to_url
 
 
 def test_falsey_path_none() -> None:
@@ -116,3 +120,20 @@ def test_get_cache_entry(tmpdir: Path) -> None:
     assert not entry.persistent
 
     assert wc.get_cache_entry(other_link, "other", supported_tags) is None
+
+
+def test_simple_wheel_cache_ignores_cache_for_existing_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    link = Link(path_to_url(str(project_dir)))
+    cache = SimpleWheelCache(str(tmp_path / "cache"))
+
+    def fail_if_called(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("local directory links should not check wheel cache")
+
+    monkeypatch.setattr(cache, "_get_candidates", fail_if_called)
+
+    assert cache.get(link, "example", supported_tags=[]) is link

--- a/tests/unit/test_wheel_builder.py
+++ b/tests/unit/test_wheel_builder.py
@@ -10,6 +10,7 @@ import pytest
 from pip._internal import wheel_builder
 from pip._internal.models.link import Link
 from pip._internal.req.req_install import InstallRequirement
+from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs.git import Git
 
 from tests.lib import _create_test_package
@@ -70,4 +71,12 @@ def test_should_cache_git_sha(tmpdir: Path) -> None:
     # a link not referencing a sha should not be cached
     url = "git+https://g.c/o/r@master#egg=mypkg"
     req = ReqMock(link=Link(url), source_dir=repo_path)
+    assert not wheel_builder._should_cache(cast(InstallRequirement, req))
+
+
+@pytest.mark.parametrize("name", ["package", "my-package"])
+def test_should_not_cache_local_directory(tmpdir: Path, name: str) -> None:
+    project_dir = tmpdir / name
+    project_dir.mkdir()
+    req = ReqMock(link=Link(path_to_url(str(project_dir))))
     assert not wheel_builder._should_cache(cast(InstallRequirement, req))


### PR DESCRIPTION
Fixes #14044

This prevents `SimpleWheelCache` from returning a cached wheel when the
requirement link points to an existing local directory, such as
`Package @ file:///path/to/project`.

Added a regression test covering local directory links.