### PR TITLE
Fix `ProtocolError` exceptions bypassing download resume logic

### DIFF
--- a/news/14079.bugfix.rst
+++ b/news/14079.bugfix.rst
@@ -1,1 +1,2 @@
-Fix ProtocolError exceptions bypassing download resume logic.
+Fix ``ProtocolError`` exceptions raised after an incomplete download from bypassing
+download resume logic and leading to a crash.

--- a/news/14079.bugfix.rst
+++ b/news/14079.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ProtocolError exceptions bypassing download resume logic.

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -15,7 +15,7 @@ from pip._vendor.requests import PreparedRequest
 from pip._vendor.requests.models import Response
 from pip._vendor.urllib3 import HTTPResponse as URLlib3Response
 from pip._vendor.urllib3._collections import HTTPHeaderDict
-from pip._vendor.urllib3.exceptions import ReadTimeoutError
+from pip._vendor.urllib3.exceptions import ReadTimeoutError, ProtocolError
 
 from pip._internal.cli.progress_bars import BarType, get_download_progress_renderer
 from pip._internal.exceptions import IncompleteDownloadError, NetworkConnectionError
@@ -209,12 +209,12 @@ class Downloader:
         try:
             for chunk in chunks:
                 download.write_chunk(chunk)
-        except ReadTimeoutError as e:
+        except (ReadTimeoutError, ProtocolError) as e:
             # If the download size is not known, then give up downloading the file.
             if download.size is None:
                 raise e
 
-            logger.warning("Connection timed out while downloading.")
+            logger.warning("Connection interrupted while downloading.")
 
     def _attempt_resumes_or_redownloads(
         self, download: _FileDownload, first_resp: Response
@@ -243,7 +243,7 @@ class Downloader:
                     first_resp = resume_resp
 
                 self._process_response(download, resume_resp)
-            except (ConnectionError, ReadTimeoutError, OSError):
+            except (ConnectionError, ReadTimeoutError, ProtocolError, OSError):
                 continue
 
         # No more resume attempts. Raise an error if the download is still incomplete.

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -15,7 +15,7 @@ from pip._vendor.requests import PreparedRequest
 from pip._vendor.requests.models import Response
 from pip._vendor.urllib3 import HTTPResponse as URLlib3Response
 from pip._vendor.urllib3._collections import HTTPHeaderDict
-from pip._vendor.urllib3.exceptions import ReadTimeoutError, ProtocolError
+from pip._vendor.urllib3.exceptions import ProtocolError, ReadTimeoutError
 
 from pip._internal.cli.progress_bars import BarType, get_download_progress_renderer
 from pip._internal.exceptions import IncompleteDownloadError, NetworkConnectionError

--- a/tests/lib/requests_mocks.py
+++ b/tests/lib/requests_mocks.py
@@ -9,7 +9,6 @@ from typing import Any
 from pip._vendor.requests.models import Response
 from pip._vendor.urllib3.exceptions import ProtocolError
 
-
 _Hook = Callable[["MockResponse"], None]
 
 

--- a/tests/lib/requests_mocks.py
+++ b/tests/lib/requests_mocks.py
@@ -7,6 +7,8 @@ from io import BytesIO
 from typing import Any
 
 from pip._vendor.requests.models import Response
+from pip._vendor.urllib3.exceptions import ProtocolError
+
 
 _Hook = Callable[["MockResponse"], None]
 
@@ -58,3 +60,11 @@ class MockRequest:
 
     def register_hook(self, event_name: str, callback: _Hook) -> None:
         self.hooks.setdefault(event_name, []).append(callback)
+
+
+class BrokenStream(FakeStream):
+    """A stream that raises ProtocolError after yielding its contents."""
+
+    def stream(self, size: int, decode_content: bool | None = None) -> Iterator[bytes]:
+        yield self._io.read(size)
+        raise ProtocolError("Connection broken: IncompleteRead")

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -19,7 +19,7 @@ from pip._internal.network.download import (
 from pip._internal.network.session import PipSession
 from pip._internal.network.utils import HEADERS
 
-from tests.lib.requests_mocks import MockResponse, BrokenStream
+from tests.lib.requests_mocks import BrokenStream, MockResponse
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -19,7 +19,7 @@ from pip._internal.network.download import (
 from pip._internal.network.session import PipSession
 from pip._internal.network.utils import HEADERS
 
-from tests.lib.requests_mocks import MockResponse
+from tests.lib.requests_mocks import MockResponse, BrokenStream
 
 
 @pytest.mark.parametrize(
@@ -350,6 +350,32 @@ def test_downloader(
 
     # Make sure that the downloader makes additional requests for resumption
     _http_get_mock.assert_has_calls(calls)
+
+
+def test_downloader_resumes_on_protocol_error(tmpdir: Path) -> None:
+    """A ProtocolError mid-stream should trigger resume logic, not crash."""
+    session = PipSession(resume_retries=3)
+    link = Link("http://example.com/foo.tgz")
+    downloader = Downloader(session, "on")
+
+    # First response: raises ProtocolError after partial read
+    broken_resp = MockResponse(b"0cfa7e9d-1868-4dd7-9fb3-")
+    broken_resp.headers.update({"content-length": "36"})
+    broken_resp.status_code = 200
+    broken_resp.raw = BrokenStream(b"0cfa7e9d-1868-4dd7-9fb3-")
+
+    # Second response: successful resume
+    resume_resp = MockResponse(b"f2561d5dfd89")
+    resume_resp.headers.update({"content-length": "12"})
+    resume_resp.status_code = 206
+
+    _http_get_mock = MagicMock(side_effect=[broken_resp, resume_resp])
+
+    with patch.object(Downloader, "_http_get", _http_get_mock):
+        filepath, _ = downloader(link, str(tmpdir))
+
+    with open(filepath, "rb") as f:
+        assert f.read() == b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89"
 
 
 def test_downloader_without_content_length(tmpdir: Path) -> None:

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+
+from pip._vendor.urllib3.exceptions import ProtocolError
 
 from pip._internal.exceptions import IncompleteDownloadError
 from pip._internal.models.link import Link
@@ -20,6 +23,10 @@ from pip._internal.network.session import PipSession
 from pip._internal.network.utils import HEADERS
 
 from tests.lib.requests_mocks import BrokenStream, MockResponse
+from tests.lib.server import Body, MockServer
+
+if TYPE_CHECKING:
+    from _typeshed.wsgi import StartResponse, WSGIEnvironment
 
 
 @pytest.mark.parametrize(
@@ -376,6 +383,70 @@ def test_downloader_resumes_on_protocol_error(tmpdir: Path) -> None:
 
     with open(filepath, "rb") as f:
         assert f.read() == b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89"
+
+
+def test_downloader_retries_protocol_error_during_resume(tmpdir: Path) -> None:
+    """A ProtocolError raised while fetching a resume response is retried."""
+    session = PipSession(resume_retries=5)
+    link = Link("http://example.com/foo.tgz")
+    downloader = Downloader(session, "on")
+
+    # Initial response: raises ProtocolError after a partial read
+    broken_resp = MockResponse(b"0cfa7e9d-1868-4dd7-9fb3-")
+    broken_resp.headers.update({"content-length": "36"})
+    broken_resp.status_code = 200
+    broken_resp.raw = BrokenStream(b"0cfa7e9d-1868-4dd7-9fb3-")
+
+    # Final resume that completes the file
+    resume_resp = MockResponse(b"f2561d5dfd89")
+    resume_resp.headers.update({"content-length": "12"})
+    resume_resp.status_code = 206
+
+    # The first resume attempt drops with a ProtocolError before responding
+    _http_get_mock = MagicMock(
+        side_effect=[broken_resp, ProtocolError("Connection broken"), resume_resp]
+    )
+
+    with patch.object(Downloader, "_http_get", _http_get_mock):
+        filepath, _ = downloader(link, str(tmpdir))
+
+    assert _http_get_mock.call_count == 3
+    with open(filepath, "rb") as f:
+        assert f.read() == b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89"
+
+
+def test_downloader_resumes_on_truncated_http_stream(
+    mock_server: MockServer, tmpdir: Path
+) -> None:
+    """A truncated stream raises a real urllib3 ProtocolError that resume recovers."""
+    body = b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89"
+
+    def truncated(environ: WSGIEnvironment, start_response: StartResponse) -> Body:
+        # Advertise the full length but send only part of the body
+        start_response("200 OK", [("Content-Length", str(len(body)))])
+        return [body[:10]]
+
+    def resumed(environ: WSGIEnvironment, start_response: StartResponse) -> Body:
+        start = int(environ["HTTP_RANGE"].split("=", 1)[1].split("-", 1)[0])
+        start_response(
+            "206 Partial Content",
+            [
+                ("Content-Length", str(len(body) - start)),
+                ("Content-Range", f"bytes {start}-{len(body) - 1}/{len(body)}"),
+            ],
+        )
+        return [body[start:]]
+
+    mock_server.set_responses([truncated, resumed])
+    mock_server.start()
+    url = f"http://{mock_server.host}:{mock_server.port}/foo.tgz"
+
+    session = PipSession(resume_retries=3)
+    downloader = Downloader(session, "on")
+    filepath, _ = downloader(Link(url), str(tmpdir))
+
+    with open(filepath, "rb") as f:
+        assert f.read() == body
 
 
 def test_downloader_without_content_length(tmpdir: Path) -> None:


### PR DESCRIPTION
When a download is interrupted mid-stream by a sudden network drop, urllib3 raises a `ProtocolError` (wrapping an `IncompleteRead`). Because `_process_response()` only caught `ReadTimeoutError`, the `ProtocolError` propagated uncaught, skipping the `is_incomplete()` check in `__call__()` and never reaching `_attempt_resumes_or_redownloads()`. This means pip's built-in resume logic was never triggered.

Fixes #14079

**What I changed:**
- Added `ProtocolError` to the `except` clause in `_process_response()` so broken connections are handled the same as timeouts.
- Added `ProtocolError` to the retry loop's `except` clause in `_attempt_resumes_or_redownloads()` so resume attempts that also drop don't crash either.
- Updated the warning message to `"Connection interrupted while downloading."` since it now covers both timeouts and broken connections.

**Testing:**
Added a unit test that simulates a `ProtocolError` being raised mid-stream and verifies pip resumes and completes the download instead of crashing. Also verified manually using the reproduction script from the issue.