### PR TITLE
Fix extras being dropped from the 'Discarding' log message

### DIFF
--- a/news/12023.bugfix.rst
+++ b/news/12023.bugfix.rst
@@ -1,0 +1,1 @@
+Stop dropping extras from messages about candidates with inconsistent metadata.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -18,6 +18,7 @@ from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import InvalidVersion, Version
 from pip._vendor.resolvelib import ResolutionImpossible
+from pip._vendor.rich.markup import escape
 
 from pip._internal.cache import CacheEntry, WheelCache
 from pip._internal.exceptions import (
@@ -213,8 +214,8 @@ class Factory:
                 except (MetadataInconsistent, MetadataInvalid) as e:
                     logger.info(
                         "Discarding [blue underline]%s[/]: [yellow]%s[reset]",
-                        link,
-                        e,
+                        escape(str(link)),
+                        escape(str(e)),
                         extra={"markup": True},
                     )
                     self._build_failures[link] = e
@@ -234,8 +235,8 @@ class Factory:
                 except MetadataInconsistent as e:
                     logger.info(
                         "Discarding [blue underline]%s[/]: [yellow]%s[reset]",
-                        link,
-                        e,
+                        escape(str(link)),
+                        escape(str(e)),
                         extra={"markup": True},
                     )
                     self._build_failures[link] = e

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -1393,6 +1393,29 @@ def test_new_resolver_skip_inconsistent_metadata(script: PipTestEnvironment) -> 
     script.assert_installed(a="1")
 
 
+def test_new_resolver_inconsistent_metadata_keeps_extras(
+    script: PipTestEnvironment,
+) -> None:
+    create_basic_wheel_for_package(script, "A", "1", extras={"foo": []})
+
+    a_2 = create_basic_wheel_for_package(script, "A", "2", extras={"foo": []})
+    a_2.rename(a_2.parent.joinpath("a-3-py2.py3-none-any.whl"))
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "--verbose",
+        "A[foo]",
+        allow_stderr_warning=True,
+    )
+
+    assert "Requested A[foo]" in result.stdout, str(result)
+    script.assert_installed(a="1")
+
+
 @pytest.mark.parametrize(
     "upgrade",
     [True, False],


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fixes #12023.

escaping the interpolated values in the `Discarding …` log, so extras like `package[extra]` are no longer parsed away as Rich markup.