### PR TITLE
perf: cache dependency names in conflict checks

### DIFF
--- a/news/14088.bugfix.rst
+++ b/news/14088.bugfix.rst
@@ -1,0 +1,1 @@
+Cache canonical dependency names in conflict checks to avoid repeated normalization.

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 class PackageDetails(NamedTuple):
     version: Version
     dependencies: list[Requirement]
+    dependency_names: list[NormalizedName]
 
 
 # Shorthands
@@ -49,7 +50,12 @@ def create_package_set_from_installed() -> tuple[PackageSet, bool]:
         name = dist.canonical_name
         try:
             dependencies = list(dist.iter_dependencies())
-            package_set[name] = PackageDetails(dist.version, dependencies)
+            dependency_names = [canonicalize_name(req.name) for req in dependencies]
+            package_set[name] = PackageDetails(
+                dist.version,
+                dependencies,
+                dependency_names,
+            )
         except (OSError, ValueError) as e:
             # Don't crash on unreadable or broken metadata.
             logger.warning("Error parsing dependencies of %s: %s", name, e)
@@ -77,8 +83,9 @@ def check_package_set(
         if should_ignore and should_ignore(package_name):
             continue
 
-        for req in package_detail.dependencies:
-            name = canonicalize_name(req.name)
+        for req, name in zip(
+            package_detail.dependencies, package_detail.dependency_names, strict=True
+        ):
 
             # Check if it's missing
             if name not in package_set:
@@ -150,7 +157,12 @@ def _simulate_installation_of(
         abstract_dist = make_distribution_for_install_requirement(inst_req)
         dist = abstract_dist.get_metadata_distribution()
         name = dist.canonical_name
-        package_set[name] = PackageDetails(dist.version, list(dist.iter_dependencies()))
+        dependencies = list(dist.iter_dependencies())
+        package_set[name] = PackageDetails(
+            dist.version,
+            dependencies,
+            [canonicalize_name(req.name) for req in dependencies],
+        )
 
         installed.add(name)
 
@@ -166,8 +178,8 @@ def _create_whitelist(
         if package_name in packages_affected:
             continue
 
-        for req in package_set[package_name].dependencies:
-            if canonicalize_name(req.name) in would_be_installed:
+        for dependency_name in package_set[package_name].dependency_names:
+            if dependency_name in would_be_installed:
                 packages_affected.add(package_name)
                 break
 

--- a/tests/unit/test_operations_check.py
+++ b/tests/unit/test_operations_check.py
@@ -10,9 +10,11 @@ from pip._internal.operations.check import (
 
 
 def package_details(*dependencies: str) -> PackageDetails:
+    dependency_requirements = [Requirement(dependency) for dependency in dependencies]
     return PackageDetails(
         Version("1"),
-        [Requirement(dependency) for dependency in dependencies],
+        dependency_requirements,
+        [canonicalize_name(req.name) for req in dependency_requirements],
     )
 
 


### PR DESCRIPTION
Depends on #14075 being merged first.

This PR keeps the whitelist scope unchanged and caches normalized dependency names to reduce repeated canonicalization in conflict-check paths.