### PR TITLE
perf: importlib reuse cached metadata for raw_version

### DIFF
--- a/news/14089.bugfix.rst
+++ b/news/14089.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid reparsing distribution metadata when formatting the default ``pip list``
+columns output with the importlib backend.

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -177,7 +177,7 @@ class Distribution(BaseDistribution):
 
     @property
     def raw_version(self) -> str:
-        return self._dist.version
+        return self.metadata["Version"]
 
     def is_file(self, path: InfoPath) -> bool:
         return self._dist.read_text(str(path)) is not None


### PR DESCRIPTION
Fixes #14089

this changes `raw_version` in the importlib backend to read `Version` from pip's cached metadata object, instead of going through `importlib.metadata.Distribution.version`.

<details>
<summary>Profile</summary>

profiled the default `pip list` columns formatting path in a local environment with 31 installed distributions. the profile repeats the path 200 times.

```python
import cProfile
from optparse import Values

from pip._internal.commands.list import format_for_columns
from pip._internal.metadata import get_environment

options = Values({"outdated": False, "verbose": 0})


def run_list_columns():
    env = get_environment(None)
    packages = sorted(
        env.iter_installed_distributions(local_only=False, skip=()),
        key=lambda dist: dist.canonical_name,
    )
    format_for_columns(packages, options)


profiler = cProfile.Profile()
profiler.enable()

for _ in range(200):
    run_list_columns()

profiler.disable()
profiler.dump_stats("pip-list-columns.pstats")
``` 

Before:

```text
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2    0.000    0.000    6.906    3.453 console.py:179(runcode)
     10/2    0.000    0.000    6.906    3.453 {built-in method builtins.exec}
      200    0.001    0.000    6.894    0.034 <python-input-0>:10(run_list_columns)
      200    0.010    0.000    6.115    0.031 list.py:322(format_for_columns)
    12400    0.033    0.000    4.760    0.000 __init__.py:448(metadata)
    18600    0.037    0.000    4.215    0.000 parser.py:56(parsestr)
    18600    0.027    0.000    4.178    0.000 parser.py:41(parse)
```

After:

```text
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2    0.000    0.000    4.335    2.167 console.py:179(runcode)
     10/2    0.000    0.000    4.335    2.167 {built-in method builtins.exec}
      200    0.001    0.000    4.323    0.022 <python-input-0>:10(run_list_columns)
      200    0.008    0.000    3.575    0.018 list.py:322(format_for_columns) 
     6200    0.016    0.000    2.330    0.000 __init__.py:448(metadata)
    12400    0.021    0.000    2.184    0.000 parser.py:56(parsestr)
    12400    0.017    0.000    2.163    0.000 parser.py:41(parse)
 
```
</details>