### PR TITLE
(maintainability): refactor package details construction

### DIFF
--- a/news/14088.bugfix.rst
+++ b/news/14088.bugfix.rst
@@ -1,0 +1,1 @@
+Cache canonical dependency names in conflict checks to avoid repeated normalization.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -691,7 +691,7 @@ class InstallCommand(RequirementCommand):
 
         # NOTE: There is some duplication here, with commands/check.py
         for project_name in missing:
-            version = package_set[project_name][0]
+            version = package_set[project_name].version
             for dependency in missing[project_name]:
                 message = (
                     f"{project_name} {version} requires {dependency[1]}, "
@@ -700,7 +700,7 @@ class InstallCommand(RequirementCommand):
                 parts.append(message)
 
         for project_name in conflicting:
-            version = package_set[project_name][0]
+            version = package_set[project_name].version
             for dep_name, dep_version, req in conflicting[project_name]:
                 message = (
                     "{name} {version} requires {requirement}, but {you} have "

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Generator, Iterable
 from contextlib import suppress
+from dataclasses import dataclass
 from email.parser import Parser
 from functools import reduce
-from typing import (
-    NamedTuple,
-)
 
 from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.tags import Tag, parse_tag
@@ -24,10 +22,21 @@ from pip._internal.req.req_install import InstallRequirement
 logger = logging.getLogger(__name__)
 
 
-class PackageDetails(NamedTuple):
+@dataclass(frozen=True)
+class PackageDetails:
     version: Version
     dependencies: list[Requirement]
     dependency_names: list[NormalizedName]
+
+    @classmethod
+    def from_dependencies(
+        cls, version: Version, dependencies: list[Requirement]
+    ) -> PackageDetails:
+        return cls(
+            version,
+            dependencies,
+            [canonicalize_name(req.name) for req in dependencies],
+        )
 
 
 # Shorthands
@@ -50,11 +59,9 @@ def create_package_set_from_installed() -> tuple[PackageSet, bool]:
         name = dist.canonical_name
         try:
             dependencies = list(dist.iter_dependencies())
-            dependency_names = [canonicalize_name(req.name) for req in dependencies]
-            package_set[name] = PackageDetails(
+            package_set[name] = PackageDetails.from_dependencies(
                 dist.version,
                 dependencies,
-                dependency_names,
             )
         except (OSError, ValueError) as e:
             # Don't crash on unreadable or broken metadata.
@@ -158,10 +165,9 @@ def _simulate_installation_of(
         dist = abstract_dist.get_metadata_distribution()
         name = dist.canonical_name
         dependencies = list(dist.iter_dependencies())
-        package_set[name] = PackageDetails(
+        package_set[name] = PackageDetails.from_dependencies(
             dist.version,
             dependencies,
-            [canonicalize_name(req.name) for req in dependencies],
         )
 
         installed.add(name)

--- a/src/pip/_internal/operations/check.py
+++ b/src/pip/_internal/operations/check.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 class PackageDetails(NamedTuple):
     version: Version
     dependencies: list[Requirement]
+    dependency_names: list[NormalizedName]
 
 
 # Shorthands
@@ -49,7 +50,12 @@ def create_package_set_from_installed() -> tuple[PackageSet, bool]:
         name = dist.canonical_name
         try:
             dependencies = list(dist.iter_dependencies())
-            package_set[name] = PackageDetails(dist.version, dependencies)
+            dependency_names = [canonicalize_name(req.name) for req in dependencies]
+            package_set[name] = PackageDetails(
+                dist.version,
+                dependencies,
+                dependency_names,
+            )
         except (OSError, ValueError) as e:
             # Don't crash on unreadable or broken metadata.
             logger.warning("Error parsing dependencies of %s: %s", name, e)
@@ -77,8 +83,9 @@ def check_package_set(
         if should_ignore and should_ignore(package_name):
             continue
 
-        for req in package_detail.dependencies:
-            name = canonicalize_name(req.name)
+        for req, name in zip(
+            package_detail.dependencies, package_detail.dependency_names, strict=True
+        ):
 
             # Check if it's missing
             if name not in package_set:
@@ -150,7 +157,12 @@ def _simulate_installation_of(
         abstract_dist = make_distribution_for_install_requirement(inst_req)
         dist = abstract_dist.get_metadata_distribution()
         name = dist.canonical_name
-        package_set[name] = PackageDetails(dist.version, list(dist.iter_dependencies()))
+        dependencies = list(dist.iter_dependencies())
+        package_set[name] = PackageDetails(
+            dist.version,
+            dependencies,
+            [canonicalize_name(req.name) for req in dependencies],
+        )
 
         installed.add(name)
 
@@ -166,8 +178,8 @@ def _create_whitelist(
         if package_name in packages_affected:
             continue
 
-        for req in package_set[package_name].dependencies:
-            if canonicalize_name(req.name) in would_be_installed:
+        for dependency_name in package_set[package_name].dependency_names:
+            if dependency_name in would_be_installed:
                 packages_affected.add(package_name)
                 break
 

--- a/tests/unit/test_operations_check.py
+++ b/tests/unit/test_operations_check.py
@@ -9,30 +9,22 @@ from pip._internal.operations.check import (
 )
 
 
-def package_details(*dependencies: str) -> PackageDetails:
-    dependency_requirements = [Requirement(dependency) for dependency in dependencies]
-    return PackageDetails(
-        Version("1"),
-        dependency_requirements,
-        [canonicalize_name(req.name) for req in dependency_requirements],
-    )
-
-
 def test_create_whitelist_is_not_order_dependent() -> None:
     root = canonicalize_name("root")
     middle = canonicalize_name("middle")
     leaf = canonicalize_name("leaf")
+    version = Version("1")
     expected: set[NormalizedName] = {leaf, middle}
 
     package_set_with_dependent_first: PackageSet = {
-        root: package_details("middle"),
-        middle: package_details("leaf"),
-        leaf: package_details(),
+        root: PackageDetails.from_dependencies(version, [Requirement("middle")]),
+        middle: PackageDetails.from_dependencies(version, [Requirement("leaf")]),
+        leaf: PackageDetails.from_dependencies(version, []),
     }
     package_set_with_dependency_first: PackageSet = {
-        leaf: package_details(),
-        middle: package_details("leaf"),
-        root: package_details("middle"),
+        leaf: PackageDetails.from_dependencies(version, []),
+        middle: PackageDetails.from_dependencies(version, [Requirement("leaf")]),
+        root: PackageDetails.from_dependencies(version, [Requirement("middle")]),
     }
 
     assert _create_whitelist({leaf}, package_set_with_dependent_first) == expected

--- a/tests/unit/test_operations_check.py
+++ b/tests/unit/test_operations_check.py
@@ -10,9 +10,11 @@ from pip._internal.operations.check import (
 
 
 def package_details(*dependencies: str) -> PackageDetails:
+    dependency_requirements = [Requirement(dependency) for dependency in dependencies]
     return PackageDetails(
         Version("1"),
-        [Requirement(dependency) for dependency in dependencies],
+        dependency_requirements,
+        [canonicalize_name(req.name) for req in dependency_requirements],
     )
 
 


### PR DESCRIPTION
Depends on #14088 and should be merged after it.

This moves `PackageDetails` construction behind a classmethod so cached dependency-name construction lives in one place instead of being repeated by callers and test helpers.

The change is intended to be maintainability-only: it keeps the conflict-check behavior and the cached dependency-name representation introduced by #14088.

Closes #14092