### PR TITLE
Complete PIP_CONSTRAINT build-environment deprecation

### DIFF
--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -263,6 +263,11 @@ Build Constraints
 
 .. versionadded:: 25.3
 
+.. versionchanged:: 26.2
+   Constraints files, including those set with the ``PIP_CONSTRAINT`` environment
+   variable, no longer affect isolated build environments. Use build constraints
+   to constrain build dependencies.
+
 Build constraints are a type of constraints file that applies only to isolated
 build environments used for building packages from source. Unlike regular
 constraints, which affect the packages installed in your environment, build
@@ -295,6 +300,9 @@ Example build constraints file (``build-constraints.txt``):
    setuptools>=45,<80
    # Pin Cython for packages that use it to build
    cython==0.29.24
+
+The ``--build-constraint`` option can be set with the ``PIP_BUILD_CONSTRAINT``
+environment variable.
 
 Controlling Pre-release Installation
 =====================================

--- a/news/14094.removal.rst
+++ b/news/14094.removal.rst
@@ -1,0 +1,6 @@
+The ``PIP_CONSTRAINT`` environment variable no longer affects isolated build
+environments. Use ``--build-constraint`` or the ``PIP_BUILD_CONSTRAINT``
+environment variable to constrain build dependencies instead.
+
+The ``--use-feature=build-constraint`` flag is now always enabled and has no
+effect.

--- a/news/14094.removal.rst
+++ b/news/14094.removal.rst
@@ -1,5 +1,5 @@
-The ``PIP_CONSTRAINT`` environment variable no longer affects isolated build
-environments. Use ``--build-constraint`` or the ``PIP_BUILD_CONSTRAINT``
+Constraints files, including ``PIP_CONSTRAINT``, no longer affect isolated
+build environments. Use ``--build-constraint`` or the ``PIP_BUILD_CONSTRAINT``
 environment variable to constrain build dependencies instead.
 
 The ``--use-feature=build-constraint`` flag is now always enabled and has no

--- a/src/pip/_internal/build_env/installer.py
+++ b/src/pip/_internal/build_env/installer.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable, Sequence
 from contextlib import AbstractContextManager as ContextManager
 from contextlib import nullcontext
 from io import StringIO
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 from pip._internal.build_env.base import Prefix
 from pip._internal.cli.spinners import open_rich_spinner, open_spinner
@@ -29,9 +29,6 @@ if TYPE_CHECKING:
     from pip._internal.operations.build.build_tracker import BuildTracker
     from pip._internal.req.req_install import InstallRequirement
     from pip._internal.resolution.base import BaseResolver
-
-    class ExtraEnviron(TypedDict, total=False):
-        extra_environ: dict[str, str]
 
 
 logger = logging.getLogger(__name__)
@@ -119,17 +116,12 @@ class SubprocessBuildEnvironmentInstaller:
             args.append("--prefer-binary")
 
         # Only build constraints apply in the isolated build environment.
-        extra_environ: ExtraEnviron = {}
-        if self._build_constraints:
-            # Pass each file via both --constraint and --build-constraint, so
-            # that this build environment and any nested builds are constrained.
-            for constraint_file in self._build_constraints:
-                args.extend(["--constraint", constraint_file])
-                args.extend(["--build-constraint", constraint_file])
-        else:
-            # With no build constraints, ignore any constraints files the build
-            # subprocess inherits from the environment (such as PIP_CONSTRAINT).
-            extra_environ = {"extra_environ": {"_PIP_IN_BUILD_IGNORE_CONSTRAINTS": "1"}}
+        # _PIP_IN_BUILD_IGNORE_CONSTRAINTS tells the subprocess to ignore the
+        # regular constraints it inherits (via PIP_CONSTRAINT or config files).
+        # Build constraints reach it through --build-constraint, which also
+        # constrains any nested builds.
+        for constraint_file in self._build_constraints:
+            args.extend(["--build-constraint", constraint_file])
 
         if finder.uploaded_prior_to:
             args.extend(["--uploaded-prior-to", finder.uploaded_prior_to.isoformat()])
@@ -144,7 +136,7 @@ class SubprocessBuildEnvironmentInstaller:
                 args,
                 command_desc=f"installing {kind}{identify_requirement}",
                 spinner=spinner,
-                **extra_environ,
+                extra_environ={"_PIP_IN_BUILD_IGNORE_CONSTRAINTS": "1"},
             )
 
 

--- a/src/pip/_internal/build_env/installer.py
+++ b/src/pip/_internal/build_env/installer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
 import textwrap
 from collections.abc import Iterable, Sequence
@@ -19,7 +18,6 @@ from pip._internal.exceptions import (
     PipError,
 )
 from pip._internal.metadata import get_environment
-from pip._internal.utils.deprecation import deprecated
 from pip._internal.utils.logging import VERBOSE, capture_logging
 from pip._internal.utils.misc import get_runnable_pip
 from pip._internal.utils.subprocess import call_subprocess
@@ -48,40 +46,9 @@ class SubprocessBuildEnvironmentInstaller:
         self,
         finder: PackageFinder,
         build_constraints: list[str] | None = None,
-        build_constraint_feature_enabled: bool = False,
     ) -> None:
         self.finder = finder
         self._build_constraints = build_constraints or []
-        self._build_constraint_feature_enabled = build_constraint_feature_enabled
-
-    def _deprecation_constraint_check(self) -> None:
-        """
-        Check for deprecation warning: PIP_CONSTRAINT affecting build environments.
-
-        This warns when build-constraint feature is NOT enabled and PIP_CONSTRAINT
-        is not empty.
-        """
-        if self._build_constraint_feature_enabled or self._build_constraints:
-            return
-
-        pip_constraint = os.environ.get("PIP_CONSTRAINT")
-        if not pip_constraint or not pip_constraint.strip():
-            return
-
-        deprecated(
-            reason=(
-                "Setting PIP_CONSTRAINT will not affect "
-                "build constraints in the future,"
-            ),
-            replacement=(
-                "to specify build constraints using --build-constraint or "
-                "PIP_BUILD_CONSTRAINT. To disable this warning without "
-                "any build constraints set --use-feature=build-constraint or "
-                'PIP_USE_FEATURE="build-constraint"'
-            ),
-            gone_in="26.2",
-            issue=None,
-        )
 
     def install(
         self,
@@ -91,8 +58,6 @@ class SubprocessBuildEnvironmentInstaller:
         kind: str,
         for_req: InstallRequirement | None,
     ) -> None:
-        self._deprecation_constraint_check()
-
         finder = self.finder
         args: list[str] = [
             sys.executable,
@@ -153,23 +118,17 @@ class SubprocessBuildEnvironmentInstaller:
         if finder.prefer_binary:
             args.append("--prefer-binary")
 
-        # Handle build constraints
-        if self._build_constraint_feature_enabled:
-            args.extend(["--use-feature", "build-constraint"])
-
+        # Only build constraints apply in the isolated build environment.
+        extra_environ: ExtraEnviron = {}
         if self._build_constraints:
-            # Build constraints must be passed as both constraints
-            # and build constraints, so that nested builds receive
-            # build constraints
+            # Pass each file via both --constraint and --build-constraint, so
+            # that this build environment and any nested builds are constrained.
             for constraint_file in self._build_constraints:
                 args.extend(["--constraint", constraint_file])
                 args.extend(["--build-constraint", constraint_file])
-
-        extra_environ: ExtraEnviron = {}
-        if self._build_constraint_feature_enabled and not self._build_constraints:
-            # If there are no build constraints but the build constraints
-            # feature is enabled then we must ignore regular constraints
-            # in the isolated build environment
+        else:
+            # With no build constraints, ignore any constraints files the build
+            # subprocess inherits from the environment (such as PIP_CONSTRAINT).
             extra_environ = {"extra_environ": {"_PIP_IN_BUILD_IGNORE_CONSTRAINTS": "1"}}
 
         if finder.uploaded_prior_to:

--- a/src/pip/_internal/cli/base_command.py
+++ b/src/pip/_internal/cli/base_command.py
@@ -252,17 +252,6 @@ class Command(CommandContextMixIn):
                 )
                 options.cache_dir = None
 
-        if (
-            "inprocess-build-deps" in options.features_enabled
-            and os.environ.get("PIP_CONSTRAINT", "")
-            and "build-constraint" not in options.features_enabled
-        ):
-            logger.warning(
-                "In-process build dependencies are enabled, "
-                "PIP_CONSTRAINT will have no effect for build dependencies"
-            )
-            options.features_enabled.append("build-constraint")
-
         return self._run_wrapper(level_number, options, args)
 
     def handler_map(self) -> dict[str, Callable[[Values, list[str]], None]]:

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -1209,6 +1209,7 @@ no_python_version_warning: Callable[..., Option] = partial(
 ALWAYS_ENABLED_FEATURES = [
     "truststore",  # always on since 24.2
     "no-binary-enable-wheel-cache",  # always on since 23.1
+    "build-constraint",  # always on since 26.2
 ]
 
 use_new_feature: Callable[..., Option] = partial(
@@ -1220,7 +1221,6 @@ use_new_feature: Callable[..., Option] = partial(
     default=[],
     choices=[
         "fast-deps",
-        "build-constraint",
         "inprocess-build-deps",
     ]
     + ALWAYS_ENABLED_FEATURES,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -62,13 +62,14 @@ from pip._internal.utils.temp_dir import (
 logger = logging.getLogger(__name__)
 
 
-def should_ignore_regular_constraints(options: Values) -> bool:
+def should_ignore_regular_constraints() -> bool:
     """
-    Whether this process should ignore the constraints files it inherits.
+    Whether this process should ignore the regular constraints it inherits.
 
-    The parent pip sets ``_PIP_IN_BUILD_IGNORE_CONSTRAINTS`` when it starts an
-    isolated build with no build constraints, so that constraints files the
-    build inherits (such as via ``PIP_CONSTRAINT``) do not affect it.
+    The parent pip sets ``_PIP_IN_BUILD_IGNORE_CONSTRAINTS`` whenever it starts
+    an isolated build in a subprocess, so that regular constraints the build
+    inherits (such as via ``PIP_CONSTRAINT`` or config files) do not affect it.
+    Only build constraints apply there.
     """
 
     return os.environ.get("_PIP_IN_BUILD_IGNORE_CONSTRAINTS") == "1"
@@ -298,11 +299,15 @@ class RequirementCommand(IndexGroupCommand):
         """
         requirements: list[InstallRequirement] = []
 
-        if not should_ignore_regular_constraints(options):
-            constraints = parse_constraint_files(
-                options.constraints, finder, options, session
-            )
-            requirements.extend(constraints)
+        if should_ignore_regular_constraints():
+            # Inside an isolated build subprocess: apply the build constraints
+            # (forwarded via --build-constraint) instead of the inherited ones.
+            constraint_files = getattr(options, "build_constraints", [])
+        else:
+            constraint_files = options.constraints
+
+        constraints = parse_constraint_files(constraint_files, finder, options, session)
+        requirements.extend(constraints)
 
         for req in args:
             if not req.strip():

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -64,9 +64,11 @@ logger = logging.getLogger(__name__)
 
 def should_ignore_regular_constraints(options: Values) -> bool:
     """
-    Check if regular constraints should be ignored because
-    we are in a isolated build process and build constraints
-    feature is enabled but no build constraints were passed.
+    Whether this process should ignore the constraints files it inherits.
+
+    The parent pip sets ``_PIP_IN_BUILD_IGNORE_CONSTRAINTS`` when it starts an
+    isolated build with no build constraints, so that constraints files the
+    build inherits (such as via ``PIP_CONSTRAINT``) do not affect it.
     """
 
     return os.environ.get("_PIP_IN_BUILD_IGNORE_CONSTRAINTS") == "1"
@@ -190,9 +192,6 @@ class RequirementCommand(IndexGroupCommand):
 
         # Handle build constraints
         build_constraints = getattr(options, "build_constraints", [])
-        build_constraint_feature_enabled = (
-            "build-constraint" in options.features_enabled
-        )
 
         env_installer: BuildEnvironmentInstaller
         if "inprocess-build-deps" in options.features_enabled:
@@ -210,7 +209,6 @@ class RequirementCommand(IndexGroupCommand):
             env_installer = SubprocessBuildEnvironmentInstaller(
                 finder,
                 build_constraints=build_constraints,
-                build_constraint_feature_enabled=build_constraint_feature_enabled,
             )
 
         return RequirementPreparer(

--- a/tests/functional/test_build_constraints.py
+++ b/tests/functional/test_build_constraints.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -50,8 +48,6 @@ def _run_pip_install_with_build_constraints(
         "--no-cache-dir",
         "--build-constraint",
         str(build_constraints_file),
-        "--use-feature",
-        "build-constraint",
     ]
 
     if extra_args:
@@ -62,22 +58,6 @@ def _run_pip_install_with_build_constraints(
     return script.pip_install_local(
         *args,
         expect_error=expect_error,
-        build_isolation=True,
-        find_links=data.common_wheels,
-    )
-
-
-def _run_pip_install_with_build_constraints_no_feature_flag(
-    script: PipTestEnvironment,
-    data: TestData,
-    project_dir: Path,
-    constraints_file: Path,
-) -> TestPipResult:
-    """Run pip install with build constraints but without the feature flag."""
-    return script.pip_install_local(
-        "--build-constraint",
-        str(constraints_file),
-        str(project_dir),
         build_isolation=True,
         find_links=data.common_wheels,
     )
@@ -129,8 +109,6 @@ def test_build_constraints_vs_regular_constraints_simple(
         build_constraints_file,
         "--constraint",
         regular_constraints_file,
-        "--use-feature",
-        "build-constraint",
         "--use-pep517",
         str(project_dir),
         expect_error=False,
@@ -176,29 +154,27 @@ def test_build_constraints_file_not_found(
     assert "No such file or directory" in result.stderr
 
 
-def test_build_constraints_without_feature_flag(
-    script: PipTestEnvironment, data: TestData, tmpdir: Path
+def test_use_feature_build_constraint_is_always_enabled(
+    script: PipTestEnvironment,
 ) -> None:
-    """Test that --build-constraint automatically enables the feature."""
-    project_dir = _create_simple_test_package(script=script, name="test_no_feature")
-    constraints_file = _create_constraints_file(
-        script=script, filename="constraints.txt", content="setuptools>=40.0.0\n"
+    """``--use-feature=build-constraint`` is accepted but now a no-op that
+    reports the feature is always enabled."""
+    result = script.pip(
+        "install",
+        "--use-feature=build-constraint",
+        "--no-index",
+        "does-not-exist",
+        expect_error=True,
+        allow_stderr_warning=True,
     )
-    result = _run_pip_install_with_build_constraints_no_feature_flag(
-        script=script,
-        data=data,
-        project_dir=project_dir,
-        constraints_file=constraints_file,
-    )
-    # Should succeed now that --build-constraint auto-enables the feature
-    assert result.returncode == 0
-    result.assert_installed("test-no-feature", editable=False, without_files=["."])
+    assert "always enabled" in result.stderr
+    assert "build-constraint" in result.stderr
 
 
 def test_constraints_dont_pass_through(
     script: PipTestEnvironment, data: TestData, tmpdir: Path
 ) -> None:
-    """When build constraints enabled, check PIP_CONSTRAINT won't affect builds."""
+    """By default, PIP_CONSTRAINT must not affect the isolated build env."""
     project_dir = create_test_package_with_setup(
         script,
         name="test_isolation",
@@ -208,12 +184,11 @@ def test_constraints_dont_pass_through(
     constraints = _create_constraints_file(
         script=script, filename="constraints.txt", content="setuptools==2000\n"
     )
-    with mock.patch.dict(os.environ, {"PIP_CONSTRAINT": path_to_url(str(constraints))}):
-        result = script.pip_install_local(
-            "--no-cache-dir",
-            str(project_dir),
-            "--use-feature=build-constraint",
-            build_isolation=True,
-            find_links=data.common_wheels,
-        )
+    script.environ["PIP_CONSTRAINT"] = path_to_url(str(constraints))
+    result = script.pip_install_local(
+        "--no-cache-dir",
+        str(project_dir),
+        build_isolation=True,
+        find_links=data.common_wheels,
+    )
     result.assert_installed("test_isolation", editable=False, without_files=["."])

--- a/tests/functional/test_build_constraints.py
+++ b/tests/functional/test_build_constraints.py
@@ -15,6 +15,13 @@ from tests.lib import (
     create_test_package_with_setup,
 )
 
+# Build dependencies can be installed in a subprocess (default) or in process
+# (--use-feature=inprocess-build-deps); constraint handling must match for both.
+INSTALLER_ARGS = [
+    pytest.param([], id="subprocess"),
+    pytest.param(["--use-feature=inprocess-build-deps"], id="inprocess"),
+]
+
 
 def _create_simple_test_package(script: PipTestEnvironment, name: str) -> Path:
     """Create a simple test package with minimal setup."""
@@ -171,10 +178,11 @@ def test_use_feature_build_constraint_is_always_enabled(
     assert "build-constraint" in result.stderr
 
 
+@pytest.mark.parametrize("installer_args", INSTALLER_ARGS)
 def test_constraints_dont_pass_through(
-    script: PipTestEnvironment, data: TestData, tmpdir: Path
+    script: PipTestEnvironment, data: TestData, tmpdir: Path, installer_args: list[str]
 ) -> None:
-    """By default, PIP_CONSTRAINT must not affect the isolated build env."""
+    """PIP_CONSTRAINT must not affect the isolated build env."""
     project_dir = create_test_package_with_setup(
         script,
         name="test_isolation",
@@ -187,8 +195,67 @@ def test_constraints_dont_pass_through(
     script.environ["PIP_CONSTRAINT"] = path_to_url(str(constraints))
     result = script.pip_install_local(
         "--no-cache-dir",
+        *installer_args,
         str(project_dir),
         build_isolation=True,
         find_links=data.common_wheels,
     )
     result.assert_installed("test_isolation", editable=False, without_files=["."])
+
+
+@pytest.mark.parametrize("installer_args", INSTALLER_ARGS)
+def test_constraints_dont_pass_through_with_build_constraints(
+    script: PipTestEnvironment, data: TestData, tmpdir: Path, installer_args: list[str]
+) -> None:
+    """PIP_CONSTRAINT must not affect the build env even when build
+    constraints are also passed."""
+    project_dir = create_test_package_with_setup(
+        script,
+        name="test_isolation",
+        version="1.0",
+        py_modules=["test_isolation"],
+    )
+    # An impossible regular constraint that would break the build if it leaked.
+    constraints = _create_constraints_file(
+        script=script, filename="constraints.txt", content="setuptools==2000\n"
+    )
+    # A satisfiable build constraint.
+    build_constraints = _create_constraints_file(
+        script=script,
+        filename="build_constraints.txt",
+        content="setuptools>=40.0.0\n",
+    )
+    script.environ["PIP_CONSTRAINT"] = path_to_url(str(constraints))
+    result = _run_pip_install_with_build_constraints(
+        script=script,
+        data=data,
+        project_dir=project_dir,
+        build_constraints_file=build_constraints,
+        extra_args=installer_args,
+    )
+    result.assert_installed("test_isolation", editable=False, without_files=["."])
+
+
+@pytest.mark.parametrize("installer_args", INSTALLER_ARGS)
+def test_build_constraint_is_enforced(
+    script: PipTestEnvironment, data: TestData, tmpdir: Path, installer_args: list[str]
+) -> None:
+    """An unsatisfiable build constraint must make the build fail."""
+    project_dir = create_test_package_with_setup(
+        script,
+        name="test_isolation",
+        version="1.0",
+        py_modules=["test_isolation"],
+    )
+    build_constraints = _create_constraints_file(
+        script=script, filename="build_constraints.txt", content="setuptools==2000\n"
+    )
+    result = _run_pip_install_with_build_constraints(
+        script=script,
+        data=data,
+        project_dir=project_dir,
+        build_constraints_file=build_constraints,
+        extra_args=installer_args,
+        expect_error=True,
+    )
+    assert "setuptools==2000" in result.stderr

--- a/tests/unit/test_build_constraints.py
+++ b/tests/unit/test_build_constraints.py
@@ -48,9 +48,10 @@ class TestSubprocessBuildEnvironmentInstaller:
     def test_install_passes_build_constraints(
         self, mock_call_subprocess: mock.Mock, tmp_path: Path
     ) -> None:
-        """With build constraints, each file is passed via both --constraint and
-        --build-constraint (so nested builds are constrained too), and the
-        inherited-constraint ignore flag is not set."""
+        """With build constraints, each file is forwarded with --build-constraint
+        and the inherited-constraint ignore flag is set, so the subprocess
+        ignores inherited regular constraints and applies the build constraints
+        instead."""
         installer = SubprocessBuildEnvironmentInstaller(
             make_test_finder(),
             build_constraints=["build-constraints.txt"],
@@ -68,6 +69,6 @@ class TestSubprocessBuildEnvironmentInstaller:
         args = mock_call_subprocess.call_args.args[0]
         kwargs = mock_call_subprocess.call_args.kwargs
         assert "--use-feature" not in args
-        assert args[args.index("--constraint") + 1] == "build-constraints.txt"
+        assert "--constraint" not in args
         assert args[args.index("--build-constraint") + 1] == "build-constraints.txt"
-        assert "extra_environ" not in kwargs
+        assert kwargs.get("extra_environ") == {"_PIP_IN_BUILD_IGNORE_CONSTRAINTS": "1"}

--- a/tests/unit/test_build_constraints.py
+++ b/tests/unit/test_build_constraints.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import os
+import warnings
 from pathlib import Path
 from unittest import mock
-
-import pytest
 
 from pip._internal.build_env import SubprocessBuildEnvironmentInstaller
 from pip._internal.build_env.base import Prefix
@@ -16,94 +15,21 @@ from tests.lib import make_test_finder
 
 
 class TestSubprocessBuildEnvironmentInstaller:
-    """Test SubprocessBuildEnvironmentInstaller build constraints functionality."""
-
-    @mock.patch.dict(os.environ, {}, clear=True)
-    def test_deprecation_check_no_pip_constraint(self) -> None:
-        """Test no deprecation warning when PIP_CONSTRAINT is not set."""
-        finder = make_test_finder()
-        installer = SubprocessBuildEnvironmentInstaller(
-            finder,
-            build_constraint_feature_enabled=False,
-        )
-
-        # Should not raise any warning
-        installer._deprecation_constraint_check()
-
-    @mock.patch.dict(os.environ, {"PIP_CONSTRAINT": ""})
-    def test_deprecation_check_empty_pip_constraint(self) -> None:
-        """Test no deprecation warning for empty PIP_CONSTRAINT."""
-        finder = make_test_finder()
-        installer = SubprocessBuildEnvironmentInstaller(
-            finder,
-            build_constraint_feature_enabled=False,
-        )
-
-        # Should not raise any warning since PIP_CONSTRAINT is empty
-        installer._deprecation_constraint_check()
-
-    @mock.patch.dict(os.environ, {"PIP_CONSTRAINT": "   "})
-    def test_deprecation_check_whitespace_pip_constraint(self) -> None:
-        """Test no deprecation warning for whitespace-only PIP_CONSTRAINT."""
-        finder = make_test_finder()
-        installer = SubprocessBuildEnvironmentInstaller(
-            finder,
-            build_constraint_feature_enabled=False,
-        )
-
-        # Should not raise any warning since PIP_CONSTRAINT is only whitespace
-        installer._deprecation_constraint_check()
-
-    @mock.patch.dict(os.environ, {"PIP_CONSTRAINT": "constraints.txt"})
-    def test_deprecation_check_feature_enabled(self) -> None:
-        """Test no deprecation warning when build-constraint feature is enabled."""
-        finder = make_test_finder()
-        installer = SubprocessBuildEnvironmentInstaller(
-            finder,
-            build_constraint_feature_enabled=True,
-        )
-
-        # Should not raise any warning
-        installer._deprecation_constraint_check()
-
-    @mock.patch.dict(os.environ, {"PIP_CONSTRAINT": "constraints.txt"})
-    def test_deprecation_check_warning_shown(self) -> None:
-        """Test deprecation warning emitted when PIP_CONSTRAINT is set
-        and build-constraint is not enabled."""
-        finder = make_test_finder()
-        installer = SubprocessBuildEnvironmentInstaller(
-            finder,
-            build_constraint_feature_enabled=False,
-        )
-
-        with pytest.warns(PipDeprecationWarning) as warning_info:
-            installer._deprecation_constraint_check()
-
-        assert len(warning_info) == 1
-        message = str(warning_info[0].message)
-        assert (
-            "Setting PIP_CONSTRAINT will not affect build constraints in the future"
-            in message
-        )
-        assert (
-            "to specify build constraints using "
-            "--build-constraint or PIP_BUILD_CONSTRAINT" in message
-        )
+    """Test SubprocessBuildEnvironmentInstaller build constraint handling."""
 
     @mock.patch("pip._internal.build_env.installer.call_subprocess")
     @mock.patch.dict(os.environ, {"PIP_CONSTRAINT": "constraints.txt"})
-    def test_install_calls_deprecation_check(
+    def test_install_ignores_regular_constraints_by_default(
         self, mock_call_subprocess: mock.Mock, tmp_path: Path
     ) -> None:
-        """Test install method calls deprecation check and proceeds with warning."""
-        finder = make_test_finder()
-        installer = SubprocessBuildEnvironmentInstaller(
-            finder,
-            build_constraint_feature_enabled=False,
-        )
+        """Without build constraints, the isolated build environment ignores
+        any inherited constraints (such as via PIP_CONSTRAINT) and emits no
+        warning."""
+        installer = SubprocessBuildEnvironmentInstaller(make_test_finder())
         prefix = Prefix(str(tmp_path))
 
-        with pytest.warns(PipDeprecationWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", PipDeprecationWarning)
             installer.install(
                 requirements=["setuptools"],
                 prefix=prefix,
@@ -111,5 +37,37 @@ class TestSubprocessBuildEnvironmentInstaller:
                 for_req=None,
             )
 
-        # Verify that call_subprocess was called (install proceeded after warning)
         mock_call_subprocess.assert_called_once()
+        args = mock_call_subprocess.call_args.args[0]
+        kwargs = mock_call_subprocess.call_args.kwargs
+        assert "--use-feature" not in args
+        assert kwargs.get("extra_environ") == {"_PIP_IN_BUILD_IGNORE_CONSTRAINTS": "1"}
+
+    @mock.patch("pip._internal.build_env.installer.call_subprocess")
+    @mock.patch.dict(os.environ, {"PIP_CONSTRAINT": "constraints.txt"})
+    def test_install_passes_build_constraints(
+        self, mock_call_subprocess: mock.Mock, tmp_path: Path
+    ) -> None:
+        """With build constraints, each file is passed via both --constraint and
+        --build-constraint (so nested builds are constrained too), and the
+        inherited-constraint ignore flag is not set."""
+        installer = SubprocessBuildEnvironmentInstaller(
+            make_test_finder(),
+            build_constraints=["build-constraints.txt"],
+        )
+        prefix = Prefix(str(tmp_path))
+
+        installer.install(
+            requirements=["setuptools"],
+            prefix=prefix,
+            kind="build dependencies",
+            for_req=None,
+        )
+
+        mock_call_subprocess.assert_called_once()
+        args = mock_call_subprocess.call_args.args[0]
+        kwargs = mock_call_subprocess.call_args.kwargs
+        assert "--use-feature" not in args
+        assert args[args.index("--constraint") + 1] == "build-constraints.txt"
+        assert args[args.index("--build-constraint") + 1] == "build-constraints.txt"
+        assert "extra_environ" not in kwargs


### PR DESCRIPTION
Completes the `gone_in="26.2"` deprecation: `PIP_CONSTRAINT` and config-file constraints no longer affect isolated build environments. Build dependencies are constrained only with `--build-constraint` or `PIP_BUILD_CONSTRAINT`. Second and final phase of the deprecation; towards #13787.

`build-constraint` moves into `ALWAYS_ENABLED_FEATURES` (like `truststore`), so `--use-feature=build-constraint` is accepted but now a no-op that reports the feature is always enabled. The former opt-in becomes the default: with no build constraints the subprocess installer ignores any inherited constraints; with them it passes each file via both `--constraint` and `--build-constraint`, so nested builds stay constrained.

Drops the now-dead `build_constraint_feature_enabled` plumbing and the redundant `base_command` warning.

Also fixes `test_constraints_dont_pass_through`, which set `PIP_CONSTRAINT` via `mock.patch.dict` that never reached the subprocess, so it passed without testing the behavior. It now uses `script.environ`.
