### PR TITLE
Replace deprecated `@abc.abstractproperty` with `@property`

### DIFF
--- a/src/pip/_internal/distributions/base.py
+++ b/src/pip/_internal/distributions/base.py
@@ -34,6 +34,7 @@ class AbstractDistribution(metaclass=abc.ABCMeta):
         self.req = req
 
     @property
+    @abc.abstractmethod
     def build_tracker_id(self) -> str | None:
         """A string that uniquely identifies this requirement to the build tracker.
 

--- a/src/pip/_internal/distributions/base.py
+++ b/src/pip/_internal/distributions/base.py
@@ -33,7 +33,7 @@ class AbstractDistribution(metaclass=abc.ABCMeta):
         super().__init__()
         self.req = req
 
-    @abc.abstractproperty
+    @property
     def build_tracker_id(self) -> str | None:
         """A string that uniquely identifies this requirement to the build tracker.
 


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->


Python 3.16 has deprecated the `abc.abstractproperty` decorator, which was soft-deprecated since 3.3 and it now raises a warning when installing with Python 3.16 (built from CPython `main`):

```console
❯ ./python.exe -m pip install pip
/Users/hugo/.local/lib/python3.16/site-packages/pip/_internal/distributions/base.py:36: DeprecationWarning: 'abc.abstractproperty' is deprecated and slated for removal in Python 3.21
  @abc.abstractproperty
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: pip in /Users/hugo/.local/lib/python3.16/site-packages (26.1.2)
```

`@property` can be used instead for all versions supported by pip:

* https://docs.python.org/3.16/whatsnew/3.16.html#deprecated
* https://docs.python.org/3.16/library/abc.html#abc.abstractproperty
* https://docs.python.org/3.10/library/abc.html#abc.abstractproperty


Does this need a news entry?
