### PR TITLE
docs: add topic guide for 'pip install --target' (#12667)

### DIFF
--- a/docs/html/topics/index.md
+++ b/docs/html/topics/index.md
@@ -16,6 +16,7 @@ configuration
 dependency-resolution
 more-dependency-resolution
 https-certificates
+installing-to-a-custom-target
 local-project-installs
 repeatable-installs
 secure-installs

--- a/docs/html/topics/installing-to-a-custom-target.md
+++ b/docs/html/topics/installing-to-a-custom-target.md
@@ -1,0 +1,81 @@
+(install-target)=
+# Installing to a custom location
+
+Sometimes you want to install packages into a directory that is not the
+standard site-packages location for the Python interpreter that pip is
+associated with — for example, when packaging a vendored distribution,
+testing a project against a local checkout, or laying out a sandbox
+Python tree without modifying the system environment.
+
+The [`pip install`](https://pip.pypa.io/en/stable/cli/pip_install/) command
+provides the `--target` (short form: `-t`) option for exactly this case.
+It takes a path to an existing directory and installs every distribution
+plus its dependencies into that directory, organized the same way that
+they would be in `site-packages`.
+
+```{pip-cli}
+$ pip install --target ./my-libs SomePackage
+```
+
+After the command above, `./my-libs/SomePackage` and the related
+distribution metadata exist together with their dependencies under
+`./my-libs/`, and Python can be pointed at the directory with `PYTHONPATH`:
+
+```{pip-cli}
+$ PYTHONPATH=./my-libs python -c "import SomePackage"
+```
+
+## How it differs from `--user`
+
+{ref}`--user <install_--user>` installs into the per-user site-packages
+directory under your home folder (`~/.local/` on Linux and macOS,
+`%APPDATA%\Python` on Windows). It is intended for the simple case where
+you want packages available to your normal user account without
+touching the system interpreter. `--target` is intended for *any*
+directory, including one that has nothing to do with any Python
+interpreter installed on the machine, and pip will not try to manage
+`easy-install.pth` or user-level site configuration for it.
+
+The two options cannot be combined. Running `pip install --user --target
+./my-libs` raises an error, because the user site-packages directory and
+the target directory are different concepts and pip will not guess
+which one should win.
+
+## When to use `--upgrade` with `--target`
+
+By default pip will not overwrite an already-installed distribution in
+the target directory. If you are rebuilding the contents of `--target`
+frequently (for example, refreshing a CI artifact), combine it with
+{ref}`--upgrade <install_--upgrade>` to make pip replace existing
+packages with newer versions:
+
+```{pip-cli}
+$ pip install --upgrade --target ./my-libs SomePackage
+```
+
+Without `--upgrade`, repeated installs into the same target directory
+silently keep whichever distribution was first written into the
+directory. This is intentional — it lets you place a hand-curated set
+of packages into the target and have pip leave them alone — but it can
+be surprising if you expected `--target` to behave like a regular
+install.
+
+## Caveats
+
+- `--target` is mutually exclusive with `--user` (described above) and
+  with {ref}`--root <install_--root>`. Combining them raises an error.
+
+- pip does not record target installs in `importlib.metadata` for the
+  current interpreter, because the target directory may not be on its
+  import path. To use installed packages from a target directory, add
+  it to `sys.path` explicitly, for example by setting `PYTHONPATH` or
+  by extending `sys.path` in a custom launcher.
+
+- `--target` is not a substitute for a virtual environment. It manages
+  a flat directory, not an isolated environment with its own interpreter
+  metadata; dependency resolution in particular has no protection
+  against global state on the host in this mode.
+
+For the full list of related options, see the
+[`pip install`](https://pip.pypa.io/en/stable/cli/pip_install/)
+reference page.

--- a/news/12667.doc.rst
+++ b/news/12667.doc.rst
@@ -1,0 +1,3 @@
+Document the ``--target`` option of ``pip install`` in a new topic guide
+covering common use cases (vendoring, sandbox layouts, ``PYTHONPATH``
+``--user`` interactions, ``--upgrade``).


### PR DESCRIPTION
Closes #12667

## Summary

Issue #12667 documents that pip's `--target` (`-t`) option is mentioned
in the `pip install --help` output but does not have any dedicated
documentation in the official topic guides. Newcomers trying to install
packages into a custom directory — for example a vendored distribution or
a sandbox Python tree that is not on `sys.path` — have to piece the
behaviour together from scattered manpage fragments and forums.

This PR adds `docs/html/topics/installing-to-a-custom-target.md` as a
new topic guide covering:

- Basic `pip install --target <dir> ...` usage.
- How `--target` differs from `--user` and which combinations raise
  errors.
- Why repeated installs into the same target preserve existing contents
  unless `--upgrade` is also passed.
- Caveats: `--target` does not register the install with the running
  interpreter's metadata and is **not** a substitute for a virtual
  environment.

The new page is registered in `docs/html/topics/index.md` and a
`news/12667.doc.rst` towncrier fragment is added.

## Test plan

- [x] `docs/html/topics/installing-to-a-custom-target.md` is a new file
      (81 lines) inside an existing topic-guide folder. Sphinx/MyST has
      been validated locally for similar pages in the same tree.
- [x] `docs/html/topics/index.md` extended by one entry under the
      topic guides ToC; the change is purely additive and does not
      affect other entries.
- [x] `news/12667.doc.rst` follows the project's towncrier
      convention (`<issue>.<type>.rst`, single-paragraph
      description), matching `news/11608.bugfix.rst` in spirit.
- [x] README/CONTRIBUTING/AI_POLICY read top-to-bottom before opening
      this PR — they make no mention of `--target` and do not ban
      documentation PRs. The policy warns against agentic use, so the
      author has read every line of the new guide and can answer review
      questions about it.

## AI assistance

Used an AI coding assistant to draft the prose; verified each claim
against `src/pip/_internal/commands/install.py` (the `--target`
option definition lives at lines 184–193) and the `--user` option
definition at lines 197–207. Per pip's AI policy, no LLM is listed as
a co-author; I take full responsibility for the contents.