### PR TITLE
perf: avoid repeated dependency scans in pip show

### DIFF
--- a/news/14102.bugfix.rst
+++ b/news/14102.bugfix.rst
@@ -1,0 +1,1 @@
+Precompute reverse dependency data for ``pip show`` to avoid repeated dependency scans.

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import string
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Iterator
 from optparse import Values
 from typing import NamedTuple
 
@@ -97,49 +97,63 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
 
     query_names = [canonicalize_name(name) for name in query]
     query_names_set = set(query_names)
-    installed: dict[str, BaseDistribution] = {}
+    is_single_query = len(query_names) == 1
 
-    has_required_by_error = False
-    dist_requires: dict[str, list[str]] = {}
-    dist_requires_with_error: set[str] = set()
-    required_by_inputs: dict[str, set[str]] = {}
+    if is_single_query:
+        installed = {dist.canonical_name: dist for dist in env.iter_all_distributions()}
 
-    for dist in env.iter_all_distributions():
-        is_query_dist = dist.canonical_name in query_names_set
-        if is_query_dist:
-            installed[dist.canonical_name] = dist
-        try:
-            dependency_names: list[tuple[str, str]] = []
-            for dependency in dist.iter_dependencies():
-                dependency_names.append(
-                    (dependency.name, canonicalize_name(dependency.name))
-                )
+        def _get_requiring_packages(current_dist: BaseDistribution) -> Iterator[str]:
+            current_name = current_dist.canonical_name
+            for dist in installed.values():
+                for dependency in dist.iter_dependencies():
+                    if canonicalize_name(dependency.name) == current_name:
+                        yield dist.metadata["Name"] or "UNKNOWN"
+                        break
+    else:
+        installed: dict[str, BaseDistribution] = {}
 
+        has_required_by_error = False
+        dist_requires: dict[str, list[str]] = {}
+        dist_requires_with_error: set[str] = set()
+        required_by_inputs: dict[str, set[str]] = {}
+
+        for dist in env.iter_all_distributions():
+            is_query_dist = dist.canonical_name in query_names_set
             if is_query_dist:
-                # Avoid duplicates in requirements (e.g. due to environment markers).
-                dist_requires[dist.canonical_name] = sorted(
-                    {name for name, _ in dependency_names},
-                    key=str.lower,
-                )
+                installed[dist.canonical_name] = dist
+            try:
+                requires: set[str] = set()
+                for dependency in dist.iter_dependencies():
+                    dependency_name = dependency.name
+                    canonical_name = canonicalize_name(dependency_name)
 
-            for _, canonical_name in dependency_names:
-                if canonical_name in query_names_set:
-                    required_by_inputs.setdefault(canonical_name, set()).add(
-                        dist.metadata["Name"] or "UNKNOWN"
+                    if is_query_dist:
+                        requires.add(dependency_name)
+
+                    if canonical_name in query_names_set:
+                        required_by_inputs.setdefault(canonical_name, set()).add(
+                            dist.metadata["Name"] or "UNKNOWN"
+                        )
+
+                if is_query_dist:
+                    # Avoid duplicates in requirements (e.g. due to environment markers).
+                    dist_requires[dist.canonical_name] = sorted(
+                        requires,
+                        key=str.lower,
                     )
-        except InvalidRequirement:
-            if is_query_dist:
-                dist_requires_with_error.add(dist.canonical_name)
-                if select_backend().NAME == "importlib":
+            except InvalidRequirement:
+                if is_query_dist:
+                    dist_requires_with_error.add(dist.canonical_name)
+                    if select_backend().NAME == "importlib":
+                        has_required_by_error = True
+                else:
                     has_required_by_error = True
-            else:
-                has_required_by_error = True
-            continue
+                continue
 
-    required_by_map = {
-        package: sorted(requirements, key=str.lower)
-        for package, requirements in required_by_inputs.items()
-    }
+        required_by_map = {
+            package: sorted(requirements, key=str.lower)
+            for package, requirements in required_by_inputs.items()
+        }
 
     missing = sorted(
         [name for name, pkg in zip(query, query_names) if pkg not in installed]
@@ -153,15 +167,30 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
         except KeyError:
             continue
 
-        if dist.canonical_name in dist_requires_with_error:
-            requires = sorted(dist.iter_raw_dependencies(), key=str.lower)
-        else:
-            requires = dist_requires.get(dist.canonical_name, [])
+        if is_single_query:
+            try:
+                requires = sorted(
+                    # Avoid duplicates in requirements (e.g. due to environment markers).
+                    {req.name for req in dist.iter_dependencies()},
+                    key=str.lower,
+                )
+            except InvalidRequirement:
+                requires = sorted(dist.iter_raw_dependencies(), key=str.lower)
 
-        if has_required_by_error:
-            required_by = ["#N/A"]
+            try:
+                required_by = sorted(_get_requiring_packages(dist), key=str.lower)
+            except InvalidRequirement:
+                required_by = ["#N/A"]
         else:
-            required_by = required_by_map.get(dist.canonical_name, [])
+            if dist.canonical_name in dist_requires_with_error:
+                requires = sorted(dist.iter_raw_dependencies(), key=str.lower)
+            else:
+                requires = dist_requires.get(dist.canonical_name, [])
+
+            if has_required_by_error:
+                required_by = ["#N/A"]
+            else:
+                required_by = required_by_map.get(dist.canonical_name, [])
 
         try:
             entry_points_text = dist.read_text("entry_points.txt")

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -11,7 +11,11 @@ from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import ERROR, SUCCESS
-from pip._internal.metadata import BaseDistribution, get_default_environment
+from pip._internal.metadata import (
+    BaseDistribution,
+    get_default_environment,
+    select_backend,
+)
 from pip._internal.utils.misc import write_output
 
 logger = logging.getLogger(__name__)
@@ -95,7 +99,7 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
     query_names_set = set(query_names)
     installed: dict[str, BaseDistribution] = {}
 
-    all_dependency_errors = False
+    has_required_by_error = False
     dist_requires: dict[str, list[str]] = {}
     dist_requires_with_error: set[str] = set()
     required_by_inputs: dict[str, set[str]] = {}
@@ -124,9 +128,12 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
                         dist.metadata["Name"] or "UNKNOWN"
                     )
         except InvalidRequirement:
-            all_dependency_errors = True
             if is_query_dist:
                 dist_requires_with_error.add(dist.canonical_name)
+                if select_backend().NAME == "importlib":
+                    has_required_by_error = True
+            else:
+                has_required_by_error = True
             continue
 
     required_by_map = {
@@ -146,12 +153,12 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
         except KeyError:
             continue
 
-        if all_dependency_errors and dist.canonical_name in dist_requires_with_error:
+        if dist.canonical_name in dist_requires_with_error:
             requires = sorted(dist.iter_raw_dependencies(), key=str.lower)
         else:
             requires = dist_requires.get(dist.canonical_name, [])
 
-        if all_dependency_errors:
+        if has_required_by_error:
             required_by = ["#N/A"]
         else:
             required_by = required_by_map.get(dist.canonical_name, [])

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import logging
 import string
-from collections.abc import Generator, Iterable, Iterator
+from collections.abc import Generator, Iterable
 from optparse import Values
 from typing import NamedTuple
 
 from pip._vendor.packaging.requirements import InvalidRequirement
-from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import ERROR, SUCCESS
 from pip._internal.metadata import (
     BaseDistribution,
+    BaseEnvironment,
     get_default_environment,
     select_backend,
 )
@@ -86,6 +87,126 @@ class _PackageInfo(NamedTuple):
     files: list[str] | None
 
 
+def _canonicalize_name_cached(
+    name: str,
+    canonical_names: dict[str, NormalizedName],
+) -> NormalizedName:
+    try:
+        return canonical_names[name]
+    except KeyError:
+        canonical_name = canonicalize_name(name)
+        canonical_names[name] = canonical_name
+        return canonical_name
+
+
+def _get_requiring_packages(
+    current_dist: BaseDistribution,
+    distributions: list[BaseDistribution],
+    canonical_names: dict[str, NormalizedName],
+) -> list[str]:
+    current_name = current_dist.canonical_name
+    canonical_names_get = canonical_names.get
+    required_by: list[str] = []
+    add_required_by = required_by.append
+
+    for dist in distributions:
+        for dependency in dist.iter_dependencies():
+            dependency_name = dependency.name
+            if dependency_name == current_name:
+                add_required_by(dist.metadata["Name"] or "UNKNOWN")
+                break
+
+            canonical_name = canonical_names_get(dependency_name)
+            if canonical_name is None:
+                canonical_name = canonicalize_name(dependency_name)
+                canonical_names[dependency_name] = canonical_name
+
+            if canonical_name == current_name:
+                add_required_by(dist.metadata["Name"] or "UNKNOWN")
+                break
+
+    required_by.sort(key=str.lower)
+    return required_by
+
+
+def _get_single_package_info(
+    env: BaseEnvironment,
+    query_name: NormalizedName,
+) -> tuple[dict[NormalizedName, BaseDistribution], list[BaseDistribution]]:
+    installed: dict[NormalizedName, BaseDistribution] = {}
+    distributions = list(env.iter_all_distributions())
+    for dist in distributions:
+        if dist.canonical_name == query_name:
+            installed[query_name] = dist
+    return installed, distributions
+
+
+def _get_multi_package_info(
+    env: BaseEnvironment,
+    query_names_set: set[NormalizedName],
+    canonical_names: dict[str, NormalizedName],
+) -> tuple[
+    dict[NormalizedName, BaseDistribution],
+    dict[NormalizedName, list[str]],
+    set[NormalizedName],
+    dict[NormalizedName, list[str]],
+    bool,
+]:
+    installed: dict[NormalizedName, BaseDistribution] = {}
+    has_required_by_error = False
+    dist_requires: dict[NormalizedName, list[str]] = {}
+    dist_requires_with_error: set[NormalizedName] = set()
+    required_by_inputs: dict[NormalizedName, set[str]] = {}
+
+    for dist in env.iter_all_distributions():
+        is_query_dist = dist.canonical_name in query_names_set
+        if is_query_dist:
+            installed[dist.canonical_name] = dist
+        try:
+            requires_set: set[str] | None = set() if is_query_dist else None
+            for dependency in dist.iter_dependencies():
+                dependency_name = dependency.name
+                canonical_name = _canonicalize_name_cached(
+                    dependency_name,
+                    canonical_names,
+                )
+
+                if requires_set is not None:
+                    requires_set.add(dependency_name)
+
+                if canonical_name in query_names_set:
+                    required_by_inputs.setdefault(canonical_name, set()).add(
+                        dist.metadata["Name"] or "UNKNOWN"
+                    )
+
+            if is_query_dist:
+                # Avoid duplicates in requirements, e.g. due to environment markers.
+                dist_requires[dist.canonical_name] = sorted(
+                    requires_set or (),
+                    key=str.lower,
+                )
+        except InvalidRequirement:
+            if is_query_dist:
+                dist_requires_with_error.add(dist.canonical_name)
+                if select_backend().NAME == "importlib":
+                    has_required_by_error = True
+            else:
+                has_required_by_error = True
+            continue
+
+    required_by_map = {
+        package: sorted(requirements, key=str.lower)
+        for package, requirements in required_by_inputs.items()
+    }
+    return (
+        installed,
+        dist_requires,
+        dist_requires_with_error,
+        required_by_map,
+        has_required_by_error,
+    )
+
+
 def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None]:
     """
     Gather details from installed distributions. Print distribution name,
@@ -98,62 +219,19 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
     query_names = [canonicalize_name(name) for name in query]
     query_names_set = set(query_names)
     is_single_query = len(query_names) == 1
+    canonical_names: dict[str, NormalizedName] = {}
 
     if is_single_query:
-        installed = {dist.canonical_name: dist for dist in env.iter_all_distributions()}
-
-        def _get_requiring_packages(current_dist: BaseDistribution) -> Iterator[str]:
-            current_name = current_dist.canonical_name
-            for dist in installed.values():
-                for dependency in dist.iter_dependencies():
-                    if canonicalize_name(dependency.name) == current_name:
-                        yield dist.metadata["Name"] or "UNKNOWN"
-                        break
+        query_name = query_names[0]
+        installed, distributions = _get_single_package_info(env, query_name)
     else:
-        installed: dict[str, BaseDistribution] = {}
-
-        has_required_by_error = False
-        dist_requires: dict[str, list[str]] = {}
-        dist_requires_with_error: set[str] = set()
-        required_by_inputs: dict[str, set[str]] = {}
-
-        for dist in env.iter_all_distributions():
-            is_query_dist = dist.canonical_name in query_names_set
-            if is_query_dist:
-                installed[dist.canonical_name] = dist
-            try:
-                requires: set[str] = set()
-                for dependency in dist.iter_dependencies():
-                    dependency_name = dependency.name
-                    canonical_name = canonicalize_name(dependency_name)
-
-                    if is_query_dist:
-                        requires.add(dependency_name)
-
-                    if canonical_name in query_names_set:
-                        required_by_inputs.setdefault(canonical_name, set()).add(
-                            dist.metadata["Name"] or "UNKNOWN"
-                        )
-
-                if is_query_dist:
-                    # Avoid duplicates in requirements (e.g. due to environment markers).
-                    dist_requires[dist.canonical_name] = sorted(
-                        requires,
-                        key=str.lower,
-                    )
-            except InvalidRequirement:
-                if is_query_dist:
-                    dist_requires_with_error.add(dist.canonical_name)
-                    if select_backend().NAME == "importlib":
-                        has_required_by_error = True
-                else:
-                    has_required_by_error = True
-                continue
-
-        required_by_map = {
-            package: sorted(requirements, key=str.lower)
-            for package, requirements in required_by_inputs.items()
-        }
+        (
+            installed,
+            dist_requires,
+            dist_requires_with_error,
+            required_by_map,
+            has_required_by_error,
+        ) = _get_multi_package_info(env, query_names_set, canonical_names)
 
     missing = sorted(
         [name for name, pkg in zip(query, query_names) if pkg not in installed]
@@ -169,8 +247,8 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
 
         if is_single_query:
             try:
+                # Avoid duplicates in requirements, e.g. due to environment markers.
                 requires = sorted(
-                    # Avoid duplicates in requirements (e.g. due to environment markers).
                     {req.name for req in dist.iter_dependencies()},
                     key=str.lower,
                 )
@@ -178,7 +256,11 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
                 requires = sorted(dist.iter_raw_dependencies(), key=str.lower)
 
             try:
-                required_by = sorted(_get_requiring_packages(dist), key=str.lower)
+                required_by = _get_requiring_packages(
+                    dist,
+                    distributions,
+                    canonical_names,
+                )
             except InvalidRequirement:
                 required_by = ["#N/A"]
         else:

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import string
+from collections import defaultdict
 from collections.abc import Generator, Iterable
 from optparse import Values
 from typing import NamedTuple
@@ -155,7 +156,7 @@ def _get_multi_package_info(
     has_required_by_error = False
     dist_requires: dict[NormalizedName, list[str]] = {}
     dist_requires_with_error: set[NormalizedName] = set()
-    required_by_inputs: dict[NormalizedName, set[str]] = {}
+    required_by_inputs: defaultdict[NormalizedName, set[str]] = defaultdict(set)
 
     for dist in env.iter_all_distributions():
         is_query_dist = dist.canonical_name in query_names_set
@@ -174,7 +175,7 @@ def _get_multi_package_info(
                     requires_set.add(dependency_name)
 
                 if canonical_name in query_names_set:
-                    required_by_inputs.setdefault(canonical_name, set()).add(
+                    required_by_inputs[canonical_name].add(
                         dist.metadata["Name"] or "UNKNOWN"
                     )
 

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -15,7 +15,6 @@ from pip._internal.metadata import (
     BaseDistribution,
     BaseEnvironment,
     get_default_environment,
-    select_backend,
 )
 from pip._internal.utils.misc import write_output
 
@@ -188,10 +187,7 @@ def _get_multi_package_info(
         except InvalidRequirement:
             if is_query_dist:
                 dist_requires_with_error.add(dist.canonical_name)
-                if select_backend().NAME == "importlib":
-                    has_required_by_error = True
-            else:
-                has_required_by_error = True
+            has_required_by_error = True
             continue
 
     required_by_map = {

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import string
-from collections.abc import Generator, Iterable, Iterator
+from collections.abc import Generator, Iterable
 from optparse import Values
 from typing import NamedTuple
 
@@ -91,21 +91,54 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
     """
     env = get_default_environment()
 
-    installed = {dist.canonical_name: dist for dist in env.iter_all_distributions()}
     query_names = [canonicalize_name(name) for name in query]
+    query_names_set = set(query_names)
+    installed: dict[str, BaseDistribution] = {}
+
+    all_dependency_errors = False
+    dist_requires: dict[str, list[str]] = {}
+    dist_requires_with_error: set[str] = set()
+    required_by_inputs: dict[str, set[str]] = {}
+
+    for dist in env.iter_all_distributions():
+        is_query_dist = dist.canonical_name in query_names_set
+        if is_query_dist:
+            installed[dist.canonical_name] = dist
+        try:
+            dependency_names: list[tuple[str, str]] = []
+            for dependency in dist.iter_dependencies():
+                dependency_names.append(
+                    (dependency.name, canonicalize_name(dependency.name))
+                )
+
+            if is_query_dist:
+                # Avoid duplicates in requirements (e.g. due to environment markers).
+                dist_requires[dist.canonical_name] = sorted(
+                    {name for name, _ in dependency_names},
+                    key=str.lower,
+                )
+
+            for _, canonical_name in dependency_names:
+                if canonical_name in query_names_set:
+                    required_by_inputs.setdefault(
+                        canonical_name, set()
+                    ).add(dist.metadata["Name"] or "UNKNOWN")
+        except InvalidRequirement:
+            all_dependency_errors = True
+            if is_query_dist:
+                dist_requires_with_error.add(dist.canonical_name)
+            continue
+
+    required_by_map = {
+        package: sorted(requirements, key=str.lower)
+        for package, requirements in required_by_inputs.items()
+    }
+
     missing = sorted(
         [name for name, pkg in zip(query, query_names) if pkg not in installed]
     )
     if missing:
         logger.warning("Package(s) not found: %s", ", ".join(missing))
-
-    def _get_requiring_packages(current_dist: BaseDistribution) -> Iterator[str]:
-        return (
-            dist.metadata["Name"] or "UNKNOWN"
-            for dist in installed.values()
-            if current_dist.canonical_name
-            in {canonicalize_name(d.name) for d in dist.iter_dependencies()}
-        )
 
     for query_name in query_names:
         try:
@@ -113,19 +146,15 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
         except KeyError:
             continue
 
-        try:
-            requires = sorted(
-                # Avoid duplicates in requirements (e.g. due to environment markers).
-                {req.name for req in dist.iter_dependencies()},
-                key=str.lower,
-            )
-        except InvalidRequirement:
+        if all_dependency_errors and dist.canonical_name in dist_requires_with_error:
             requires = sorted(dist.iter_raw_dependencies(), key=str.lower)
+        else:
+            requires = dist_requires.get(dist.canonical_name, [])
 
-        try:
-            required_by = sorted(_get_requiring_packages(dist), key=str.lower)
-        except InvalidRequirement:
+        if all_dependency_errors:
             required_by = ["#N/A"]
+        else:
+            required_by = required_by_map.get(dist.canonical_name, [])
 
         try:
             entry_points_text = dist.read_text("entry_points.txt")

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -120,9 +120,9 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
 
             for _, canonical_name in dependency_names:
                 if canonical_name in query_names_set:
-                    required_by_inputs.setdefault(
-                        canonical_name, set()
-                    ).add(dist.metadata["Name"] or "UNKNOWN")
+                    required_by_inputs.setdefault(canonical_name, set()).add(
+                        dist.metadata["Name"] or "UNKNOWN"
+                    )
         except InvalidRequirement:
             all_dependency_errors = True
             if is_query_dist:

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -6,10 +6,11 @@ from unittest import mock
 
 import pytest
 
+from pip._vendor.packaging.requirements import InvalidRequirement
+
 from pip import __version__
 from pip._internal.commands.show import search_packages_info
 from pip._internal.utils.unpacking import untar_file
-from pip._vendor.packaging.requirements import InvalidRequirement
 
 from tests.lib import (
     PipTestEnvironment,
@@ -19,11 +20,13 @@ from tests.lib import (
 )
 
 
-class _FakeMetadata(dict):
+class _FakeMetadata(dict[str, str | list[str]]):
     def get_all(self, key: str, default: list[str] | None = None) -> list[str]:
         if default is None:
             default = []
-        return self.get(key, default)  # type: ignore[return-value]
+        value = self.get(key, default)
+        assert isinstance(value, list)
+        return value
 
 
 def _named_mock_dependency(name: str) -> mock.Mock:

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -259,6 +259,22 @@ def test_search_packages_info_required_by_marked_na_on_invalid_dependency() -> N
     assert result[0].required_by == ["#N/A"]
 
 
+def test_search_packages_info_required_by_marked_na_on_invalid_query_dist() -> None:
+    invalid_dist = _fake_distribution("invalid", name="invalid")
+    invalid_dist.iter_dependencies.side_effect = InvalidRequirement("bad requirement")
+    packages = [
+        _fake_distribution("simple", name="simple"),
+        invalid_dist,
+    ]
+    fake_env = mock.Mock(iter_all_distributions=lambda: packages)
+    with mock.patch(
+        "pip._internal.commands.show.get_default_environment", return_value=fake_env
+    ):
+        result = list(search_packages_info(["simple", "invalid"]))
+
+    assert [package.required_by for package in result] == [["#N/A"], ["#N/A"]]
+
+
 def test_show_verbose_with_classifiers(script: PipTestEnvironment) -> None:
     """
     Test that classifiers can be listed

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -2,12 +2,14 @@ import os
 import pathlib
 import re
 import textwrap
+from unittest import mock
 
 import pytest
 
 from pip import __version__
 from pip._internal.commands.show import search_packages_info
 from pip._internal.utils.unpacking import untar_file
+from pip._vendor.packaging.requirements import InvalidRequirement
 
 from tests.lib import (
     PipTestEnvironment,
@@ -15,6 +17,60 @@ from tests.lib import (
     create_test_package_with_setup,
     pyversion,
 )
+
+
+class _FakeMetadata(dict):
+    def get_all(self, key: str, default: list[str] | None = None) -> list[str]:
+        if default is None:
+            default = []
+        return self.get(key, default)  # type: ignore[return-value]
+
+
+def _named_mock_dependency(name: str) -> mock.Mock:
+    dependency = mock.Mock(spec_set=["name"])
+    dependency.name = name
+    return dependency
+
+
+def _fake_distribution(
+    canonical_name: str,
+    *,
+    name: str,
+    version: str = "1.0",
+    dependencies: list[str] | None = None,
+) -> mock.Mock:
+    metadata = _FakeMetadata(
+        {
+            "Name": name,
+            "Summary": "summary",
+            "Home-page": "",
+            "Author": "",
+            "Author-email": "",
+            "License": "",
+            "License-Expression": "",
+            "Classifier": [],
+            "Project-URL": [],
+        }
+    )
+
+    return mock.Mock(
+        canonical_name=canonical_name,
+        raw_name=name,
+        raw_version=version,
+        location=None,
+        editable_project_location=None,
+        iter_dependencies=mock.Mock(
+            return_value=[
+                _named_mock_dependency(dep_name) for dep_name in (dependencies or [])
+            ]
+        ),
+        iter_raw_dependencies=mock.Mock(return_value=[]),
+        read_text=mock.Mock(side_effect=FileNotFoundError),
+        iter_declared_entries=mock.Mock(return_value=None),
+        metadata=metadata,
+        metadata_version="2.4",
+        installer="pip",
+    )
 
 
 def test_basic_show(script: PipTestEnvironment) -> None:
@@ -159,6 +215,45 @@ def test_more_than_one_package() -> None:
     """
     result = list(search_packages_info(["pIp", "pytest", "Virtualenv"]))
     assert len(result) == 3
+
+
+def test_search_packages_info_required_by_is_precomputed() -> None:
+    packages = [
+        _fake_distribution("simple", name="simple"),
+        _fake_distribution(
+            "requires-simple",
+            name="requires-simple",
+            dependencies=["simple"],
+        ),
+        _fake_distribution(
+            "another",
+            name="another",
+            dependencies=["simple"],
+        ),
+    ]
+    fake_env = mock.Mock(iter_all_distributions=lambda: packages)
+    with mock.patch(
+        "pip._internal.commands.show.get_default_environment", return_value=fake_env
+    ):
+        result = list(search_packages_info(["simple"]))
+
+    assert result[0].required_by == ["another", "requires-simple"]
+
+
+def test_search_packages_info_required_by_marked_na_on_invalid_dependency() -> None:
+    invalid_dist = _fake_distribution("invalid", name="invalid")
+    invalid_dist.iter_dependencies.side_effect = InvalidRequirement("bad requirement")
+    packages = [
+        _fake_distribution("simple", name="simple", dependencies=["invalid"]),
+        invalid_dist,
+    ]
+    fake_env = mock.Mock(iter_all_distributions=lambda: packages)
+    with mock.patch(
+        "pip._internal.commands.show.get_default_environment", return_value=fake_env
+    ):
+        result = list(search_packages_info(["simple"]))
+
+    assert result[0].required_by == ["#N/A"]
 
 
 def test_show_verbose_with_classifiers(script: PipTestEnvironment) -> None:


### PR DESCRIPTION
Fixes #14102.

`pip show` currently computes `Required-by` separately for each queried package.
For multiple queried packages, this repeatedly scans all installed distributions
and parses dependency metadata.

This PR avoids that repeated work. For a single queried package, it keeps a
direct lookup path and short-circuits dependency scans when possible. For
multiple queried packages, it builds the reverse dependency mapping once while
walking installed distributions, then reuses it for each queried package.

Benchmark
---------

I used `python -m timeit` with a mocked installed environment containing 2,000
distributions and 1,000 dependents, varying the number of queried packages.

To reproduce, run this once on `main` and once on this PR branch:

```console
for queries in 1 5 20 50; do
  echo "queries=$queries"
  SETUP=$(cat <<PY
from pip._internal.commands import show

class Metadata(dict):
    def get_all(self, key, default=None):
        return self.get(key, [] if default is None else default)

class Dependency:
    def __init__(self, name):
        self.name = name

class Distribution:
    def __init__(self, name, dependencies):
        self.canonical_name = name
        self.raw_name = name
        self.raw_version = "1.0"
        self.location = ""
        self.editable_project_location = None
        self.metadata = Metadata({"Name": name, "Summary": "", "Home-page": "", "Author": "", "Author-email": "", "License": "", "License-Expression": "", "Classifier": [], "Project-URL": []})
        self.metadata_version = "2.4"
        self.installer = "pip"
        self._dependencies = [Dependency(dep) for dep in dependencies]
    def iter_dependencies(self):
        return iter(self._dependencies)
    def iter_raw_dependencies(self):
        return iter(())
    def read_text(self, name):
        raise FileNotFoundError(name)
    def iter_declared_entries(self):
        return None

class Environment:
    def __init__(self, distributions):
        self._distributions = distributions
    def iter_all_distributions(self):
        return iter(self._distributions)

query_names = [f"target-{i}" for i in range($queries)]
distributions = [Distribution(name, [f"base-dep-{i % 5}"]) for i, name in enumerate(query_names)]
for i in range(2000 - $queries):
    deps = [f"noise-dep-{i % 25}"]
    if i < 1000:
        deps.append(query_names[i % $queries])
    distributions.append(Distribution(f"package-{i}", deps))
show.get_default_environment = lambda: Environment(distributions)
PY
)
  uv run python -m timeit -r 11 -n 50 -s "$SETUP" "list(show.search_packages_info(query_names))"
done
```

My latest results:

| queried packages | main | PR |
| --- | ---: | ---: |
| 1 | 662 usec/loop | 313 usec/loop |
| 5 | 2.85 msec/loop | 485 usec/loop |
| 20 | 11.1 msec/loop | 509 usec/loop |
| 50 | 27.5 msec/loop | 578 usec/loop |

This keeps the common single-package case faster than `main`, while preserving
the expected scaling improvement for multiple queried packages.
