### PR TITLE
perf: Optimize resolver hash option intersection

### DIFF
--- a/news/14105.bugfix.rst
+++ b/news/14105.bugfix.rst
@@ -1,0 +1,1 @@
+Optimize resolver hash-option intersection when combining constraints.

--- a/news/14105.bugfix.rst
+++ b/news/14105.bugfix.rst
@@ -1,1 +1,1 @@
-Optimize resolver hash-option intersection when combining constraints.
+Optimize resolver hash intersection when combining constraints.

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Container, Iterable
 from dataclasses import dataclass
 from typing import Optional
 
@@ -10,7 +10,7 @@ from pip._vendor.packaging.version import Version
 
 from pip._internal.models.link import Link, links_equivalent
 from pip._internal.req.req_install import InstallRequirement
-from pip._internal.utils.hashes import Hashes
+from pip._internal.utils.hashes import _HASH_INTERSECTION_LIST_SCAN_LIMIT, Hashes
 
 CandidateLookup = tuple[Optional["Candidate"], InstallRequirement | None]
 
@@ -59,7 +59,13 @@ class Constraint:
         else:
             hash_options = {}
             for alg in self.hash_options.keys() & other.hash_options.keys():
-                self_hashes = set(self.hash_options[alg])
+                self_hash_options = self.hash_options[alg]
+                self_hashes: Container[str] = self_hash_options
+                if (
+                    len(self_hash_options) * len(other.hash_options[alg])
+                    > _HASH_INTERSECTION_LIST_SCAN_LIMIT
+                ):
+                    self_hashes = set(self_hash_options)
                 hash_options[alg] = [
                     v for v in other.hash_options[alg] if v in self_hashes
                 ]

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -52,18 +52,26 @@ class Constraint:
             return NotImplemented
         specifier = self.specifier & other.specifier
         hashes = self.hashes & other.hashes(trust_internet=False)
-        if not self.hash_options:
-            hash_options = {alg: list(v) for alg, v in other.hash_options.items()}
-        elif not other.hash_options:
-            hash_options = {alg: list(v) for alg, v in self.hash_options.items()}
-        else:
+        self_hash_options = self.hash_options
+        other_hash_options = other.hash_options
+        if not self_hash_options:
             hash_options = {
-                alg: [v for v in other.hash_options[alg] if v in self.hash_options[alg]]
-                for alg in self.hash_options.keys() & other.hash_options.keys()
+                alg: list(v) for alg, v in other_hash_options.items()
             }
+        elif not other_hash_options:
+            hash_options = {
+                alg: list(v) for alg, v in self_hash_options.items()
+            }
+        else:
+            hash_options = {}
+            for alg in self_hash_options.keys() & other_hash_options.keys():
+                self_hashes = set(self_hash_options[alg])
+                hash_options[alg] = [
+                    v for v in other_hash_options[alg] if v in self_hashes
+                ]
         links = self.links
         if other.link:
-            links = links.union([other.link])
+            links = links.union((other.link,))
         return Constraint(specifier, hashes, hash_options, links)
 
     def is_satisfied_by(self, candidate: Candidate) -> bool:

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -52,26 +52,20 @@ class Constraint:
             return NotImplemented
         specifier = self.specifier & other.specifier
         hashes = self.hashes & other.hashes(trust_internet=False)
-        self_hash_options = self.hash_options
-        other_hash_options = other.hash_options
-        if not self_hash_options:
-            hash_options = {
-                alg: list(v) for alg, v in other_hash_options.items()
-            }
-        elif not other_hash_options:
-            hash_options = {
-                alg: list(v) for alg, v in self_hash_options.items()
-            }
+        if not self.hash_options:
+            hash_options = {alg: list(v) for alg, v in other.hash_options.items()}
+        elif not other.hash_options:
+            hash_options = {alg: list(v) for alg, v in self.hash_options.items()}
         else:
             hash_options = {}
-            for alg in self_hash_options.keys() & other_hash_options.keys():
-                self_hashes = set(self_hash_options[alg])
+            for alg in self.hash_options.keys() & other.hash_options.keys():
+                self_hashes = set(self.hash_options[alg])
                 hash_options[alg] = [
-                    v for v in other_hash_options[alg] if v in self_hashes
+                    v for v in other.hash_options[alg] if v in self_hashes
                 ]
         links = self.links
         if other.link:
-            links = links.union((other.link,))
+            links = links.union([other.link])
         return Constraint(specifier, hashes, hash_options, links)
 
     def is_satisfied_by(self, candidate: Candidate) -> bool:

--- a/src/pip/_internal/utils/hashes.py
+++ b/src/pip/_internal/utils/hashes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Iterable
+from collections.abc import Container, Iterable
 from typing import TYPE_CHECKING, BinaryIO, NoReturn
 
 from pip._internal.exceptions import HashMismatch, HashMissing, InstallationError
@@ -19,6 +19,9 @@ FAVORITE_HASH = "sha256"
 # Names of hashlib algorithms allowed by the --hash option and ``pip hash``
 # Currently, those are the ones at least as collision-resistant as sha256.
 STRONG_HASHES = ["sha256", "sha384", "sha512"]
+
+
+_HASH_INTERSECTION_LIST_SCAN_LIMIT = 64
 
 
 class Hashes:
@@ -55,7 +58,11 @@ class Hashes:
         for alg, values in other._allowed.items():
             if alg not in self._allowed:
                 continue
-            new[alg] = [v for v in values if v in self._allowed[alg]]
+            allowed = self._allowed[alg]
+            lookup: Container[str] = allowed
+            if len(allowed) * len(values) > _HASH_INTERSECTION_LIST_SCAN_LIMIT:
+                lookup = set(allowed)
+            new[alg] = [v for v in values if v in lookup]
         return Hashes(new)
 
     @property

--- a/tests/unit/resolution_resolvelib/test_base.py
+++ b/tests/unit/resolution_resolvelib/test_base.py
@@ -1,0 +1,42 @@
+from pip._vendor.packaging.requirements import Requirement
+from pip._vendor.packaging.specifiers import SpecifierSet
+
+from pip._internal.req.req_install import InstallRequirement
+from pip._internal.resolution.resolvelib.base import Constraint
+from pip._internal.utils.hashes import Hashes
+
+
+def make_install_req(hash_options: dict[str, list[str]]) -> InstallRequirement:
+    return InstallRequirement(
+        Requirement("example"),
+        comes_from=None,
+        hash_options=hash_options,
+    )
+
+
+def test_constraint_and_intersects_hash_options_preserving_other_order() -> None:
+    constraint = Constraint(
+        SpecifierSet(),
+        Hashes(),
+        {"sha256": ["a", "b", "c", "d"]},
+        frozenset(),
+    )
+    ireq = make_install_req({"sha256": ["d", "b"]})
+
+    result = constraint & ireq
+
+    assert result.hash_options == {"sha256": ["d", "b"]}
+
+
+def test_constraint_and_intersects_hash_options_uses_other_order() -> None:
+    constraint = Constraint(
+        SpecifierSet(),
+        Hashes(),
+        {"sha256": ["b", "d"]},
+        frozenset(),
+    )
+    ireq = make_install_req({"sha256": ["d", "c", "b", "a"]})
+
+    result = constraint & ireq
+
+    assert result.hash_options == {"sha256": ["d", "b"]}

--- a/tests/unit/resolution_resolvelib/test_base.py
+++ b/tests/unit/resolution_resolvelib/test_base.py
@@ -1,5 +1,4 @@
 from pip._vendor.packaging.requirements import Requirement
-from pip._vendor.packaging.specifiers import SpecifierSet
 
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.resolution.resolvelib.base import Constraint
@@ -15,28 +14,22 @@ def make_install_req(hash_options: dict[str, list[str]]) -> InstallRequirement:
 
 
 def test_constraint_and_intersects_hash_options_preserving_other_order() -> None:
-    constraint = Constraint(
-        SpecifierSet(),
-        Hashes(),
-        {"sha256": ["a", "b", "c", "d"]},
-        frozenset(),
+    constraint = Constraint.from_ireq(
+        make_install_req({"sha256": ["a", "b", "c", "d"]})
     )
     ireq = make_install_req({"sha256": ["d", "b"]})
 
     result = constraint & ireq
 
+    assert result.hashes == Hashes({"sha256": ["b", "d"]})
     assert result.hash_options == {"sha256": ["d", "b"]}
 
 
 def test_constraint_and_intersects_hash_options_uses_other_order() -> None:
-    constraint = Constraint(
-        SpecifierSet(),
-        Hashes(),
-        {"sha256": ["b", "d"]},
-        frozenset(),
-    )
+    constraint = Constraint.from_ireq(make_install_req({"sha256": ["b", "d"]}))
     ireq = make_install_req({"sha256": ["d", "c", "b", "a"]})
 
     result = constraint & ireq
 
+    assert result.hashes == Hashes({"sha256": ["b", "d"]})
     assert result.hash_options == {"sha256": ["d", "b"]}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -465,6 +465,22 @@ class TestHashes:
         assert Hashes({"sha256": ["abcd"]}) == Hashes({"sha256": ["abcd"]})
         assert Hashes({"sha256": ["ab", "cd"]}) == Hashes({"sha256": ["cd", "ab"]})
 
+    def test_and_intersects_hashes(self) -> None:
+        hashes = Hashes(
+            {
+                "sha256": ["ab", "cd", "ef"],
+                "sha384": ["gh"],
+            }
+        )
+        other = Hashes(
+            {
+                "sha256": ["ij", "ef", "ab"],
+                "sha512": ["kl"],
+            }
+        )
+
+        assert hashes & other == Hashes({"sha256": ["ab", "ef"]})
+
     def test_hash(self) -> None:
         cache = {}
         cache[Hashes({"sha256": ["ab", "cd"]})] = 42


### PR DESCRIPTION
Fixes #14105.

`Constraint.__and__()` intersects per-algorithm hash options by iterating `other.hash_options[alg]` and checking each value against `self.hash_options[alg]`. Since both are lists, that membership check is linear, making the intersection O(n*m) for each shared hash algorithm.

This keeps the existing result order from `other.hash_options[alg]`, but builds a temporary set from `self.hash_options[alg]` so membership checks are O(1), reducing the intersection to O(n+m).

Tests run:

```console
uv run ruff check src/pip/_internal/resolution/resolvelib/base.py tests/unit/resolution_resolvelib/test_base.py
uv run pytest tests/unit/resolution_resolvelib/test_base.py -q
uv run pytest tests/unit/resolution_resolvelib -q
```