### PR TITLE
strip path separators revealed by unquoting in Link.filename

### DIFF
--- a/news/14109.bugfix.rst
+++ b/news/14109.bugfix.rst
@@ -1,3 +1,3 @@
-Decode the filename component of a link before taking its basename, so a
-percent-encoded path separator in a URL can no longer make ``Link.filename``
-return a name that escapes the download directory.
+Strip path separators that are hidden when ``Link.filename`` takes its
+basename (a backslash, or a double-encoded separator), so a crafted link can
+no longer return a name that escapes the download directory.

--- a/news/14109.bugfix.rst
+++ b/news/14109.bugfix.rst
@@ -1,0 +1,3 @@
+Decode the filename component of a link before taking its basename, so a
+percent-encoded path separator in a URL can no longer make ``Link.filename``
+return a name that escapes the download directory.

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -427,10 +427,14 @@ class Link:
     def filename(self) -> str:
         path = self.path.rstrip("/")
         name = posixpath.basename(path)
-        # Decode the name and take the basename again: a percent-encoded path
-        # separator (e.g. %2F or %5C) survives the basename() above and would
-        # reappear after unquoting, letting a crafted link escape a directory
-        # the filename is later joined to.
+        # self.path is unquoted once at construction, so a single-encoded "/"
+        # is already a real separator the basename() above strips. Two cases
+        # still slip through: a "\" (posixpath.basename does not treat it as a
+        # separator, but it is one on Windows) and a double-encoded separator
+        # like %252F, which is still encoded here and would reappear after the
+        # unquote below. Decode again, fold "\" to "/", and re-take the
+        # basename so the name stays a single component before it is joined to
+        # a download directory.
         name = posixpath.basename(urllib.parse.unquote(name).replace("\\", "/"))
         if not name:
             # Make sure we don't leak auth information if the netloc

--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -427,13 +427,17 @@ class Link:
     def filename(self) -> str:
         path = self.path.rstrip("/")
         name = posixpath.basename(path)
+        # Decode the name and take the basename again: a percent-encoded path
+        # separator (e.g. %2F or %5C) survives the basename() above and would
+        # reappear after unquoting, letting a crafted link escape a directory
+        # the filename is later joined to.
+        name = posixpath.basename(urllib.parse.unquote(name).replace("\\", "/"))
         if not name:
             # Make sure we don't leak auth information if the netloc
             # includes a username and password.
             netloc, user_pass = split_auth_from_netloc(self.netloc)
             return netloc
 
-        name = urllib.parse.unquote(name)
         assert name, f"URL {self._url!r} produced no filename"
         return name
 

--- a/tests/unit/test_link.py
+++ b/tests/unit/test_link.py
@@ -33,15 +33,17 @@ class TestLink:
                 "http://yo/myproject-1.0%2Bfoobar.0-py2.py3-none-any.whl",
                 "myproject-1.0+foobar.0-py2.py3-none-any.whl",
             ),
-            # A percent-encoded path separator must not survive into the
-            # filename, otherwise it could escape the directory the name is
-            # later joined to.
+            # A path separator that is still hidden when basename() first runs
+            # must not survive into the filename and escape the directory the
+            # name is later joined to. A "\" is decoded at construction but
+            # posixpath.basename does not split on it (it is a separator on
+            # Windows); a double-encoded "/" stays encoded until the unquote.
             (
-                "https://example.com/packages/..%2F..%2F..%2Ftmp%2Fevil-1.0.tar.gz",
+                "https://example.com/packages/..%5C..%5Cevil-1.0.tar.gz",
                 "evil-1.0.tar.gz",
             ),
             (
-                "https://example.com/packages/..%5C..%5Cevil-1.0.tar.gz",
+                "https://example.com/packages/..%252F..%252Fevil-1.0.tar.gz",
                 "evil-1.0.tar.gz",
             ),
             # Test a path that ends in a slash.

--- a/tests/unit/test_link.py
+++ b/tests/unit/test_link.py
@@ -33,6 +33,17 @@ class TestLink:
                 "http://yo/myproject-1.0%2Bfoobar.0-py2.py3-none-any.whl",
                 "myproject-1.0+foobar.0-py2.py3-none-any.whl",
             ),
+            # A percent-encoded path separator must not survive into the
+            # filename, otherwise it could escape the directory the name is
+            # later joined to.
+            (
+                "https://example.com/packages/..%2F..%2F..%2Ftmp%2Fevil-1.0.tar.gz",
+                "evil-1.0.tar.gz",
+            ),
+            (
+                "https://example.com/packages/..%5C..%5Cevil-1.0.tar.gz",
+                "evil-1.0.tar.gz",
+            ),
             # Test a path that ends in a slash.
             ("https://example.com/path/", "path"),
             ("https://example.com/path//", "path"),


### PR DESCRIPTION
`Link.filename` takes `posixpath.basename` of `self.path` and then unquotes the result. `self.path` is already unquoted once at construction, so a single-encoded `/` (`%2F`) is a real separator by the time `basename` runs and gets stripped correctly. Two cases still slip through:

- A backslash: `posixpath.basename` doesn't treat `\` as a separator, but it is one on Windows, so `..%5C..%5Cevil-1.0.tar.gz` comes out of `filename` as `..\..\evil-1.0.tar.gz`.
- A double-encoded separator: `%252F` is unquoted to `%2F` at construction, survives `basename` as a literal, then the trailing `unquote(name)` turns it back into `/`, giving `../../evil-1.0.tar.gz`.

Both names are joined straight onto a directory in `operations/prepare.py` (`_check_download_dir`, `save_linked_requirement`) and `network/download.py`, so a crafted link can land the saved file outside the download directory. The fix unquotes the segment again, folds `\` to `/`, and re-takes the basename so the filename is always a single path component, matching how `sanitize_content_filename` guards the Content-Disposition path.
