### PR TITLE
Use Path.as_uri() over PurePath.as_uri()

### DIFF
--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -437,7 +437,7 @@ class Git(VersionControl):
         if os.path.exists(url):
             # A local bare remote (git clone --mirror).
             # Needs a file:// prefix.
-            return pathlib.PurePath(url).as_uri()
+            return pathlib.Path(url).as_uri()
         scp_match = SCP_REGEX.match(url)
         if scp_match:
             # Add an ssh:// prefix and replace the ':' with a '/'.


### PR DESCRIPTION
The latter was deprecated for the former since Python 3.15 for being, in fact, impure.

There is one instance of this deprecation warning from the test suite:

```
tests/unit/test_vcs.py::test_git_remote_local_path
  /home/runner/work/pip/pip/.nox/test-3-15/lib/python3.15/site-packages/pip/_internal/vcs/git.py:440: DeprecationWarning: pathlib.PurePath.as_uri() is deprecated and scheduled for removal in Python 3.19. Use pathlib.Path.as_uri().
    return pathlib.PurePath(url).as_uri()
```