### PR TITLE
Skip pip show installed-files list unless --files

### DIFF
--- a/news/14117.bugfix.rst
+++ b/news/14117.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid reading installed file lists in ``pip show`` unless ``--files`` is used.

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -84,7 +84,7 @@ class _PackageInfo(NamedTuple):
 
 def search_packages_info(
     query: list[str],
-    include_files: bool = True,
+    include_files: bool,
 ) -> Generator[_PackageInfo, None, None]:
     """
     Gather details from installed distributions. Print distribution name,

--- a/src/pip/_internal/commands/show.py
+++ b/src/pip/_internal/commands/show.py
@@ -53,7 +53,7 @@ class ShowCommand(Command):
             return ERROR
         query = args
 
-        results = search_packages_info(query)
+        results = search_packages_info(query, include_files=options.files)
         if not print_results(
             results, list_files=options.files, verbose=options.verbose
         ):
@@ -82,7 +82,10 @@ class _PackageInfo(NamedTuple):
     files: list[str] | None
 
 
-def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None]:
+def search_packages_info(
+    query: list[str],
+    include_files: bool = True,
+) -> Generator[_PackageInfo, None, None]:
     """
     Gather details from installed distributions. Print distribution name,
     version, location, and installed files. Installed files requires a
@@ -133,11 +136,11 @@ def search_packages_info(query: list[str]) -> Generator[_PackageInfo, None, None
         except FileNotFoundError:
             entry_points = []
 
-        files_iter = dist.iter_declared_entries()
-        if files_iter is None:
-            files: list[str] | None = None
-        else:
-            files = sorted(files_iter)
+        files: list[str] | None = None
+        if include_files:
+            files_iter = dist.iter_declared_entries()
+            if files_iter is not None:
+                files = sorted(files_iter)
 
         metadata = dist.metadata
 

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -136,7 +136,7 @@ def test_find_package_not_found() -> None:
     """
     Test trying to get info about a nonexistent package.
     """
-    result = search_packages_info(["abcd3"])
+    result = search_packages_info(["abcd3"], include_files=False)
     assert len(list(result)) == 0
 
 
@@ -171,7 +171,7 @@ def test_search_any_case() -> None:
     Search for a package in any case.
 
     """
-    result = list(search_packages_info(["PIP"]))
+    result = list(search_packages_info(["PIP"], include_files=False))
     assert len(result) == 1
     assert result[0].name == "pip"
 
@@ -181,7 +181,9 @@ def test_more_than_one_package() -> None:
     Search for more than one package.
 
     """
-    result = list(search_packages_info(["pIp", "pytest", "Virtualenv"]))
+    result = list(
+        search_packages_info(["pIp", "pytest", "Virtualenv"], include_files=False)
+    )
     assert len(result) == 3
 
 

--- a/tests/functional/test_show.py
+++ b/tests/functional/test_show.py
@@ -6,7 +6,9 @@ import textwrap
 import pytest
 
 from pip import __version__
+from pip._internal.commands import create_command
 from pip._internal.commands.show import search_packages_info
+from pip._internal.metadata import BaseDistribution
 from pip._internal.utils.unpacking import untar_file
 
 from tests.lib import (
@@ -28,6 +30,28 @@ def test_basic_show(script: PipTestEnvironment) -> None:
     assert f"Version: {__version__}" in lines
     assert any(line.startswith("Location: ") for line in lines)
     assert "Requires: " in lines
+
+
+def test_show_without_files_does_not_read_installed_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Test that show does not read installed files without --files.
+    """
+    calls: list[str] = []
+
+    def iter_declared_entries(self: BaseDistribution) -> None:
+        calls.append(self.raw_name)
+
+    monkeypatch.setattr(
+        BaseDistribution, "iter_declared_entries", iter_declared_entries
+    )
+
+    command = create_command("show")
+    options, args = command.parse_args(["pip"])
+
+    assert command.run(options, args) == 0
+    assert calls == []
 
 
 def test_show_with_files_not_found(script: PipTestEnvironment, data: TestData) -> None:


### PR DESCRIPTION
Fixes #14117.

`pip show` builds and sorts the installed-files list for every package, but only prints it with `--files`. this skips that work unless `--files` is passed

<details>
<summary>Benchmark</summary>

same venv for both runs, switching only the pip source via PYTHONPATH. 2 warmups, 11 measured runs, median.

```text
# single
pip show Django
    baseline=0.1291s patched=0.1062s delta=0.0228s

# 3 dist
pip show Django scikit-learn scipy
    baseline=0.1447s patched=0.1141s delta=0.0305s

# 5 dist
pip show Django scikit-learn scipy numpy sympy
    baseline=0.1521s patched=0.1144s delta=0.0377s
```
</details> 