### PR TITLE
Ignore negative Content-Length in file downloader

### DIFF
--- a/news/14119.bugfix.rst
+++ b/news/14119.bugfix.rst
@@ -1,2 +1,0 @@
-Treat a negative ``Content-Length`` response header as unknown size, so the
-download resume check no longer reports a truncated response as complete.

--- a/news/14119.bugfix.rst
+++ b/news/14119.bugfix.rst
@@ -1,2 +1,2 @@
-Reject a negative ``Content-Length`` response header so a truncated download
-is no longer treated as complete.
+Treat a negative ``Content-Length`` response header as unknown size, so the
+download resume check no longer reports a truncated response as complete.

--- a/news/14119.bugfix.rst
+++ b/news/14119.bugfix.rst
@@ -1,0 +1,2 @@
+Reject a negative ``Content-Length`` response header so a truncated download
+is no longer treated as complete.

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -30,9 +30,14 @@ logger = logging.getLogger(__name__)
 
 def _get_http_response_size(resp: Response) -> int | None:
     try:
-        return int(resp.headers["content-length"])
+        size = int(resp.headers["content-length"])
     except (ValueError, KeyError, TypeError):
         return None
+    # A negative length would make _FileDownload.is_incomplete() report a
+    # truncated download as complete, so treat it as unknown instead.
+    if size < 0:
+        return None
+    return size
 
 
 def _get_http_response_etag_or_last_modified(resp: Response) -> str | None:

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -114,6 +114,24 @@ def test_log_download(
 
 
 @pytest.mark.parametrize(
+    "content_length, expected",
+    [
+        ("0", 0),
+        ("36", 36),
+        ("", None),
+        ("not-a-number", None),
+        # A negative length must not be passed through: it would make
+        # _FileDownload.is_incomplete() treat a truncated download as complete.
+        ("-1", None),
+    ],
+)
+def test_get_http_response_size(content_length: str, expected: int | None) -> None:
+    resp = MockResponse(b"")
+    resp.headers["content-length"] = content_length
+    assert _get_http_response_size(resp) == expected
+
+
+@pytest.mark.parametrize(
     "filename, expected",
     [
         ("dir/file", "file"),


### PR DESCRIPTION
`_get_http_response_size` parses the server's `Content-Length` with `int()` and returns it unchecked, so a negative value (`Content-Length: -1`) sets `download.size` to -1. `_FileDownload.is_incomplete()` then compares `bytes_received < size`, which is always False for a negative size, so the resume / `IncompleteDownloadError` path is skipped for a truncated body.

In practice a truncated archive still fails downstream (wheel validator, or gzip/tar raising `EOFError`), so this isn't silent corruption. It just defeats the dedicated incomplete-download check and pushes the failure to a later, less specific error. The fix treats a negative length as unknown size, the same way a missing or non-numeric header is already handled.
