### PR TITLE
[codex] Preserve blank link values in equivalence checks

### DIFF
--- a/src/pip/_internal/models/link.py
+++ b/src/pip/_internal/models/link.py
@@ -593,7 +593,10 @@ def _clean_link(link: Link) -> _CleanResult:
     # According to RFC 8089, an empty host in file: means localhost.
     if parsed.scheme == "file" and not netloc:
         netloc = "localhost"
-    fragment = urllib.parse.parse_qs(parsed.fragment)
+    fragment = urllib.parse.parse_qs(
+        "&".join(part for part in parsed.fragment.split("&") if "=" in part),
+        keep_blank_values=True,
+    )
     if "egg" in fragment:
         logger.debug("Ignoring egg= fragment in %s", link)
     try:
@@ -607,7 +610,7 @@ def _clean_link(link: Link) -> _CleanResult:
     hashes = {k: fragment[k][0] for k in _SUPPORTED_HASHES if k in fragment}
     return _CleanResult(
         parsed=parsed._replace(netloc=netloc, query="", fragment=""),
-        query=urllib.parse.parse_qs(parsed.query),
+        query=urllib.parse.parse_qs(parsed.query, keep_blank_values=True),
         subdirectory=subdirectory,
         hashes=hashes,
     )

--- a/tests/unit/test_link.py
+++ b/tests/unit/test_link.py
@@ -212,9 +212,19 @@ class TestLink:
             id="fragment-ordering",
         ),
         pytest.param(
+            "https://example.com/foo#subdirectory&subdirectory=bar",
+            "https://example.com/foo#subdirectory=bar",
+            id="fragment-bare-key",
+        ),
+        pytest.param(
             "https://example.com/foo?a=1&b=2",
             "https://example.com/foo?b=2&a=1",
             id="query-opordering",
+        ),
+        pytest.param(
+            "https://example.com/foo?a=&b=2",
+            "https://example.com/foo?b=2&a=",
+            id="blank-query-ordering",
         ),
     ],
 )
@@ -239,6 +249,16 @@ def test_links_equivalent(url1: str, url2: str) -> None:
             "https://example.com/foo#subdirectory=bar&egg=foo",
             "https://example.com/foo#subdirectory=rex",
             id="drop-egg-still-different",
+        ),
+        pytest.param(
+            "https://example.com/foo?a=",
+            "https://example.com/foo",
+            id="blank-query-value",
+        ),
+        pytest.param(
+            "https://example.com/foo#sha256=",
+            "https://example.com/foo",
+            id="blank-hash-value",
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- Keep blank query values and blank hash fragment values when normalizing links for equivalence.

## Validation
- tests/unit/test_link.py passed; ruff and diff check passed.

## Notes
- Opened as a draft PR for maintainer review.
