### PR TITLE
perf(index): filter find-links entries before url conversion

### DIFF
--- a/news/d54d50c4-da3a-402b-886d-e6cecc11237a.bugfix.rst
+++ b/news/d54d50c4-da3a-402b-886d-e6cecc11237a.bugfix.rst
@@ -1,0 +1,2 @@
+Improve local ``--find-links`` directory scanning performance by avoiding URL
+conversion for files that are not valid package archives or HTML pages.

--- a/src/pip/_internal/index/sources.py
+++ b/src/pip/_internal/index/sources.py
@@ -60,9 +60,8 @@ class _FlatDirectoryToUrls:
         and project_name_to_urls at the same time
         """
         for entry in os.scandir(self._path):
-            url = path_to_url(entry.path)
-            if _is_html_file(url):
-                self._page_candidates.append(url)
+            if _is_html_file(entry.name):
+                self._page_candidates.append(path_to_url(entry.path))
                 continue
 
             # File must have a valid wheel or sdist name,
@@ -75,7 +74,7 @@ class _FlatDirectoryToUrls:
                 except InvalidSdistFilename:
                     continue
 
-            self._project_name_to_urls[project_filename].append(url)
+            self._project_name_to_urls[project_filename].append(path_to_url(entry.path))
         self._scanned_directory = True
 
     @property

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -37,6 +37,7 @@ from pip._internal.models.link import (
     _ensure_quoted_url,
 )
 from pip._internal.network.session import PipSession
+from pip._internal.utils.urls import path_to_url
 
 from tests.lib import (
     TestData,
@@ -939,6 +940,36 @@ def check_links_include(links: list[Link], names: list[str]) -> None:
         assert any(
             link.url.endswith(name) for link in links
         ), f"name {name!r} not among links: {links}"
+
+
+def test_flat_directory_source_ignores_non_package_files_before_url_conversion(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "ignored file #1.txt").touch()
+    (tmp_path / "demo_pkg-1.0-py3-none-any.whl").touch()
+    (tmp_path / "page with spaces.html").touch()
+
+    def guarded_path_to_url(path: str) -> str:
+        assert "ignored file" not in path
+        return path_to_url(path)
+
+    with mock.patch(
+        "pip._internal.index.sources.path_to_url", side_effect=guarded_path_to_url
+    ):
+        source = _FlatDirectorySource(
+            candidates_from_page=lambda link: [
+                InstallationCandidate("demo-pkg", "1.0", link)
+            ],
+            path=os.fspath(tmp_path),
+            project_name="demo-pkg",
+        )
+
+        file_links = list(source.file_links())
+        page_candidates = list(source.page_candidates())
+
+    check_links_include(file_links, names=["demo_pkg-1.0-py3-none-any.whl"])
+    assert len(page_candidates) == 1
+    check_links_include([page_candidates[0].link], names=["page%20with%20spaces.html"])
 
 
 class TestLinkCollector:


### PR DESCRIPTION
## Summary

- Classify local `--find-links` directory entries by filename before converting them to file URLs
- Preserve the same file links and HTML page candidates for valid package archives and HTML pages
- Avoid URL conversion for unrelated files in large flat directories

## Performance Model

| Observed path | Target path |
|:---|:---|
| Convert every directory entry path to a URL before checking whether it is usable | Check the entry name first, then convert only retained entries |
| Run URL quoting and `mimetypes.guess_type()` on unrelated files | Keep unrelated files on the cheap discard path |
| Broad scan pays conversion cost for files that are never exposed as links | Broad scan only pays conversion cost for package files and HTML pages |

Profile before the change confirmed the cost: in 20 scans of a directory with 5,000 unrelated files, 50 wheels, and 10 HTML pages, `_scan_directory()` spent about 1.98s in `path_to_url()` and about 1.01s in HTML MIME checks.

## Benchmark

### Apple M3, 24 GiB RAM, CPython 3.14.5

Target workload: `_FlatDirectoryToUrls.project_name_to_urls` scanning a local `--find-links` directory with:

- 5,000 unrelated `.txt` files with spaces/symbols in their names
- 50 valid `demo_pkg` wheel filenames
- 10 HTML page files

Expected output is unchanged: 50 URLs under `demo-pkg` and 10 page candidate URLs.

| | Min | Median | Mean | OPS | Rounds |
|:---|---:|---:|---:|---:|---:|
| `6b0011b49` (base) | 48.325ms | 49.340ms | 49.522ms | 20.2 ops/s | 40 |
| `9f8243c09` (head) | 15.411ms | 15.752ms | 15.710ms | 63.7 ops/s | 40 |
| **Speedup** | **3.14x** | **3.13x** | **3.15x** | **3.15x** | |

<details>
<summary><b>Reproduce the benchmark locally</b></summary>

```bash
uv run python -c 'import pathlib, statistics, tempfile, time
from pip._internal.index.sources import _FlatDirectoryToUrls

root = pathlib.Path(tempfile.mkdtemp(prefix="pip-find-links-scan-"))
for i in range(5000):
    (root / f"irrelevant file {i:04d} with spaces and symbols # ignored.txt").touch()
for i in range(50):
    (root / f"demo_pkg-{i}.0-py3-none-any.whl").touch()
for i in range(10):
    (root / f"page-{i}.html").touch()

def scan_once():
    source = _FlatDirectoryToUrls(str(root))
    urls = source.project_name_to_urls
    pages = source.page_candidates
    assert len(urls["demo-pkg"]) == 50
    assert len(pages) == 10

for _ in range(3):
    scan_once()
samples = []
for _ in range(40):
    start = time.perf_counter()
    scan_once()
    samples.append(time.perf_counter() - start)
print(f"min={min(samples)*1000:.3f}ms median={statistics.median(samples)*1000:.3f}ms mean={statistics.mean(samples)*1000:.3f}ms ops={1/statistics.mean(samples):.1f} rounds={len(samples)}")'
```

</details>

## Changelog

Added `news/d54d50c4-da3a-402b-886d-e6cecc11237a.bugfix.rst`.

## Stack

| Order | PR | Branch | Merge after |
|:---:|:---|:---|:---|
| 1 | Current PR | `perf/find-links-scan-filter` | `main` |

Existing open performance PRs were checked and are independent of this change: #14122, #14108, #14106, #14088, #14103, #14045, #14026, and #13860.

## Test plan

- [x] Benchmarked base vs. head with the command above
- [x] Profiled the baseline with `cProfile`
- [x] `uv run ruff check src/pip/_internal/index/sources.py tests/unit/test_collector.py`
- [x] `uv run pytest tests/unit/test_collector.py -q`
