### PR TITLE
docs: document the --target option for pip install

### DIFF
--- a/docs/html/cli/pip_install.rst
+++ b/docs/html/cli/pip_install.rst
@@ -91,6 +91,36 @@ combination with ``--quiet``).
 
 The format of the JSON report is described in :doc:`../reference/installation-report`.
 
+Installing to a target directory
+--------------------------------
+
+The :ref:`--target <install_--target>` option installs packages into a specific
+directory rather than into the current environment's ``site-packages``. This is
+useful when you want to collect dependencies for deployment, bundle libraries
+with an application, or install into a location managed by another tool.
+
+By default, pip will not replace files or directories that already exist in the
+target directory. Use :ref:`--upgrade <install_--upgrade>` to replace existing
+packages.
+
+For example:
+
+.. tab:: Unix/macOS
+
+   .. code-block:: console
+
+      $ python -m pip install --target ./extern requests
+
+.. tab:: Windows
+
+   .. code-block:: console
+
+      C:\> py -m pip install --target extern requests
+
+Because ``--target`` installs outside of a regular Python environment, it
+implies ``--ignore-installed`` and cannot be combined with :ref:`--user
+<install_--user>`.
+
 Installation Order
 ------------------
 

--- a/news/12667.doc.rst
+++ b/news/12667.doc.rst
@@ -1,0 +1,1 @@
+Document the ``--target`` option in the :doc:`pip install <cli/pip_install>` reference page, including a usage example and notes on its interaction with ``--upgrade`` and ``--user``.


### PR DESCRIPTION
Document the `--target` option in the `pip install` reference page.

Closes #12667.

## Summary

The `--target` flag was previously only visible in the auto-generated option list and not explained anywhere in the narrative documentation. This change adds a dedicated **Installing to a target directory** section that:

- Explains the purpose of `--target`.
- Shows Unix/macOS and Windows examples.
- Notes the default "do not replace existing files" behavior and the need for `--upgrade` to force replacement.
- Mentions that `--target` implies `--ignore-installed` and is incompatible with `--user`.

A news fragment has been added as required by the PR template.

## Test Plan

- Verified the added reStructuredText renders without syntax errors using `doc8`.
- Confirmed the news fragment is picked up by towncrier (`python -m towncrier check`).
