### PR TITLE
Fix symlink path traversal in untar fallback

### DIFF
--- a/news/14127.bugfix.rst
+++ b/news/14127.bugfix.rst
@@ -1,0 +1,2 @@
+Additional rejection of tar archives that write traverse outside
+the target directory when extracting on Python versions pre-PEP 721.

--- a/news/14127.bugfix.rst
+++ b/news/14127.bugfix.rst
@@ -1,2 +1,3 @@
-Additional rejection of tar archives that write traverse outside
-the target directory when extracting on Python versions pre-PEP 721.
+Additional rejection of tar archives that write outside the target
+directory through symlink traversal when extracting on Python
+versions pre-PEP 706.

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -76,13 +76,22 @@ def has_leading_dir(paths: Iterable[str]) -> bool:
     return True
 
 
-def is_within_directory(directory: str, target: str) -> bool:
+def is_within_directory(
+    directory: str, target: str, *, resolve_symlinks: bool = False
+) -> bool:
     """
     Return true if the absolute path of target is within the directory
     (including when target is equal to the directory).
+
+    When ``resolve_symlinks`` is true, resolve symlinks before comparing so
+    traversal through a symlink (e.g. "link/../file") is also caught.
     """
-    abs_directory = os.path.abspath(directory)
-    abs_target = os.path.abspath(target)
+    if resolve_symlinks:
+        abs_directory = os.path.realpath(directory)
+        abs_target = os.path.realpath(target)
+    else:
+        abs_directory = os.path.abspath(directory)
+        abs_target = os.path.abspath(target)
 
     return abs_target == abs_directory or abs_target.startswith(abs_directory + os.sep)
 
@@ -277,7 +286,13 @@ def _untar_without_filter(
         if leading:
             fn = split_leading_dir(fn)[1]
         path = os.path.join(location, fn)
-        if not is_within_directory(location, path):
+
+        # The plain check rejects textual ".." escapes; resolving symlinks also
+        # catches a later member redirected outside by an earlier member's
+        # symlink (e.g. "link/../file").
+        if not is_within_directory(location, path) or not is_within_directory(
+            location, path, resolve_symlinks=True
+        ):
             message = (
                 "The tar file ({}) has a file ({}) trying to install "
                 "outside target directory ({})"
@@ -286,6 +301,17 @@ def _untar_without_filter(
         if member.isdir():
             ensure_dir(path)
         elif member.issym():
+            # Reject symlinks resolving outside the destination, so a later
+            # member cannot be written through them.
+            target = os.path.join(os.path.dirname(path), member.linkname)
+            if not is_within_directory(location, target, resolve_symlinks=True):
+                message = (
+                    "The tar file ({}) has a file ({}) trying to install "
+                    "outside target directory ({})"
+                )
+                raise InstallationError(
+                    message.format(filename, member.name, member.linkname)
+                )
             if not is_symlink_target_in_tar(tar, member):
                 message = (
                     "The tar file ({}) has a file ({}) trying to install "

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -425,6 +425,74 @@ class TestUnpackArchives:
 
         assert not os.path.exists(os.path.join(extract_path, "evil_symlink"))
 
+    def test_unpack_tar_symlink_then_member_no_data_filter(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Reject a symlink to outside before a member is written through it."""
+        if hasattr(tarfile, "data_filter"):
+            monkeypatch.delattr("tarfile.data_filter")
+
+        tar_filepath = os.path.join(self.tempdir, "symlink_then_member.tar")
+        extract_path = os.path.join(self.tempdir, "extract_path")
+        outside_path = os.path.join(self.tempdir, "outside.txt")
+
+        with tarfile.open(tar_filepath, "w") as tar:
+            info = tarfile.TarInfo("outside_link")
+            info.type = tarfile.SYMTYPE
+            info.linkname = ".."
+            tar.addfile(info)
+
+            data = io.BytesIO(b"data\n")
+            info = tarfile.TarInfo("outside_link/outside.txt")
+            info.size = len(data.getbuffer())
+            tar.addfile(info, fileobj=data)
+
+            info = tarfile.TarInfo("..")
+            info.type = tarfile.DIRTYPE
+            tar.addfile(info)
+
+        with pytest.raises(InstallationError):
+            untar_file(tar_filepath, extract_path)
+
+        assert not os.path.exists(outside_path)
+        assert not os.path.exists(os.path.join(extract_path, "outside_link"))
+
+    def test_unpack_tar_nested_symlink_traversal_no_data_filter(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Reject a member that escapes through a chain of in-bounds symlinks."""
+        if hasattr(tarfile, "data_filter"):
+            monkeypatch.delattr("tarfile.data_filter")
+
+        tar_filepath = os.path.join(self.tempdir, "nested_traversal.tar")
+        extract_path = os.path.join(self.tempdir, "extract_path")
+        outside_path = os.path.join(self.tempdir, "outside.txt")
+
+        with tarfile.open(tar_filepath, "w") as tar:
+            info = tarfile.TarInfo(".")
+            info.type = tarfile.DIRTYPE
+            tar.addfile(info)
+
+            info = tarfile.TarInfo("redir")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "."
+            tar.addfile(info)
+
+            info = tarfile.TarInfo("redir/up")
+            info.type = tarfile.SYMTYPE
+            info.linkname = ".."
+            tar.addfile(info)
+
+            data = io.BytesIO(b"data\n")
+            info = tarfile.TarInfo("redir/up/outside.txt")
+            info.size = len(data.getbuffer())
+            tar.addfile(info, fileobj=data)
+
+        with pytest.raises(InstallationError):
+            untar_file(tar_filepath, extract_path)
+
+        assert not os.path.exists(outside_path)
+
 
 def test_unpack_tar_unicode(tmpdir: Path) -> None:
     test_tar = tmpdir / "test.tar"


### PR DESCRIPTION
An issue was reported to the PSRT as a possible security issue as an incomplete fix of CVE-2025-8869 affecting old bugfix versions of Python 3.10 and 3.11.

While I was able to reproduce the bug on 3.10.0, I did not categorize it as a security fix due to our security policy: https://github.com/pypa/pip/blob/main/SECURITY.md