### PR TITLE
Verify content-range offset before resuming download

### DIFF
--- a/news/14131.bugfix.rst
+++ b/news/14131.bugfix.rst
@@ -1,3 +1,2 @@
-Restart an interrupted download if the server resumes a range request from an
-unexpected offset, instead of appending the misplaced bytes and corrupting the
-saved file.
+Fail an interrupted download instead of corrupting the saved file when the
+server resumes a range request from a different offset than was requested.

--- a/news/14131.bugfix.rst
+++ b/news/14131.bugfix.rst
@@ -1,0 +1,3 @@
+Restart an interrupted download if the server resumes a range request from an
+unexpected offset, instead of appending the misplaced bytes and corrupting the
+saved file.

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -257,13 +257,15 @@ class Downloader:
                     download.size = _get_http_response_size(resume_resp)
                     first_resp = resume_resp
                 else:
-                    # A 206 body is written at the current file offset, so the
-                    # server must resume from exactly where we asked. If its
-                    # Content-Range says otherwise, the bytes would land in the
-                    # wrong place; fail instead of silently corrupting the file.
-                    expected = f"bytes {download.bytes_received}-"
-                    content_range = resume_resp.headers.get("content-range", "")
-                    if content_range and not content_range.startswith(expected):
+                    # A 206 body is written at the current file offset, so when
+                    # the server declares a Content-Range it must resume from
+                    # exactly the byte we asked for. If it starts elsewhere the
+                    # bytes would land in the wrong place; fail rather than
+                    # silently corrupt the file.
+                    content_range = resume_resp.headers.get("Content-Range", "")
+                    resumed_at = content_range.lower().partition("bytes ")[2]
+                    resumed_at = resumed_at.partition("-")[0]
+                    if resumed_at and resumed_at != str(download.bytes_received):
                         raise IncompleteDownloadError(download)
 
                 self._process_response(download, resume_resp)

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -6,6 +6,7 @@ import email.message
 import logging
 import mimetypes
 import os
+import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -51,6 +52,21 @@ def _get_http_response_etag_or_last_modified(resp: Response) -> str | None:
     The return value can be used in an If-Range header.
     """
     return resp.headers.get("etag", resp.headers.get("last-modified"))
+
+
+_CONTENT_RANGE_START_RE = re.compile(r"\s*bytes\s+(\d+)-", re.IGNORECASE)
+
+
+def _get_content_range_start(resp: Response) -> int | None:
+    """Return the first-byte offset declared in the Content-Range header.
+
+    Returns None if the header is absent or does not carry a numeric start
+    (e.g. an unsatisfied-range "bytes */1234").
+    """
+    match = _CONTENT_RANGE_START_RE.match(resp.headers.get("content-range", ""))
+    if match is None:
+        return None
+    return int(match.group(1))
 
 
 def _log_download(
@@ -256,6 +272,18 @@ class Downloader:
                     download.reset_file()
                     download.size = _get_http_response_size(resume_resp)
                     first_resp = resume_resp
+                else:
+                    # The body of a 206 is written at the current offset, so a
+                    # server that resumes from a different offset than requested
+                    # would corrupt the file. Discard what we have and restart
+                    # rather than trust the misplaced bytes.
+                    resumed_from = _get_content_range_start(resume_resp)
+                    if (
+                        resumed_from is not None
+                        and resumed_from != download.bytes_received
+                    ):
+                        download.reset_file()
+                        continue
 
                 self._process_response(download, resume_resp)
             except (ConnectionError, ReadTimeoutError, ProtocolError, OSError):

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -257,11 +257,8 @@ class Downloader:
                     download.size = _get_http_response_size(resume_resp)
                     first_resp = resume_resp
                 else:
-                    # A 206 body is written at the current file offset, so when
-                    # the server declares a Content-Range it must resume from
-                    # exactly the byte we asked for. If it starts elsewhere the
-                    # bytes would land in the wrong place; fail rather than
-                    # silently corrupt the file.
+                    # If the resume request starts at the wrong location, fail
+                    # outright since the server is misbehaving.
                     content_range = resume_resp.headers.get("Content-Range", "")
                     resumed_at = content_range.lower().partition("bytes ")[2]
                     resumed_at = resumed_at.partition("-")[0]

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -6,7 +6,6 @@ import email.message
 import logging
 import mimetypes
 import os
-import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -52,21 +51,6 @@ def _get_http_response_etag_or_last_modified(resp: Response) -> str | None:
     The return value can be used in an If-Range header.
     """
     return resp.headers.get("etag", resp.headers.get("last-modified"))
-
-
-_CONTENT_RANGE_START_RE = re.compile(r"\s*bytes\s+(\d+)-", re.IGNORECASE)
-
-
-def _get_content_range_start(resp: Response) -> int | None:
-    """Return the first-byte offset declared in the Content-Range header.
-
-    Returns None if the header is absent or does not carry a numeric start
-    (e.g. an unsatisfied-range "bytes */1234").
-    """
-    match = _CONTENT_RANGE_START_RE.match(resp.headers.get("content-range", ""))
-    if match is None:
-        return None
-    return int(match.group(1))
 
 
 def _log_download(
@@ -273,17 +257,14 @@ class Downloader:
                     download.size = _get_http_response_size(resume_resp)
                     first_resp = resume_resp
                 else:
-                    # The body of a 206 is written at the current offset, so a
-                    # server that resumes from a different offset than requested
-                    # would corrupt the file. Discard what we have and restart
-                    # rather than trust the misplaced bytes.
-                    resumed_from = _get_content_range_start(resume_resp)
-                    if (
-                        resumed_from is not None
-                        and resumed_from != download.bytes_received
-                    ):
-                        download.reset_file()
-                        continue
+                    # A 206 body is written at the current file offset, so the
+                    # server must resume from exactly where we asked. If its
+                    # Content-Range says otherwise, the bytes would land in the
+                    # wrong place; fail instead of silently corrupting the file.
+                    expected = f"bytes {download.bytes_received}-"
+                    content_range = resume_resp.headers.get("content-range", "")
+                    if content_range and not content_range.startswith(expected):
+                        raise IncompleteDownloadError(download)
 
                 self._process_response(download, resume_resp)
             except (ConnectionError, ReadTimeoutError, ProtocolError, OSError):

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -467,9 +467,9 @@ def test_downloader_resumes_on_truncated_http_stream(
         assert f.read() == body
 
 
-def test_downloader_restarts_on_mismatched_resume_offset(tmpdir: Path) -> None:
-    """A 206 that resumes from a different offset than requested must be
-    discarded, otherwise the misplaced bytes would corrupt the file."""
+def test_downloader_crashes_on_mismatched_resume_offset(tmpdir: Path) -> None:
+    """A 206 whose Content-Range starts at a different offset than requested
+    must fail, otherwise the misplaced bytes would corrupt the file."""
     body = b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89"
     session = PipSession(resume_retries=5)
     link = Link("http://example.com/foo.tgz")
@@ -483,20 +483,15 @@ def test_downloader_restarts_on_mismatched_resume_offset(tmpdir: Path) -> None:
     # The resume asks for bytes=24- but the server answers with content that
     # (per its Content-Range) starts at offset 0.
     mismatched = MockResponse(b"XXXXXXXXXXXX")
-    mismatched.headers.update({"content-length": "12", "content-range": "bytes 0-11/36"})
+    mismatched.headers.update(
+        {"content-length": "12", "content-range": "bytes 0-11/36"}
+    )
     mismatched.status_code = 206
 
-    # After the restart the server serves the whole file from the beginning.
-    restarted = MockResponse(body)
-    restarted.headers.update({"content-length": "36", "content-range": "bytes 0-35/36"})
-    restarted.status_code = 206
-
-    _http_get_mock = MagicMock(side_effect=[first, mismatched, restarted])
+    _http_get_mock = MagicMock(side_effect=[first, mismatched])
     with patch.object(Downloader, "_http_get", _http_get_mock):
-        filepath, _ = downloader(link, str(tmpdir))
-
-    with open(filepath, "rb") as f:
-        assert f.read() == body
+        with pytest.raises(IncompleteDownloadError):
+            downloader(link, str(tmpdir))
 
 
 def test_downloader_without_content_length(tmpdir: Path) -> None:

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -467,6 +467,38 @@ def test_downloader_resumes_on_truncated_http_stream(
         assert f.read() == body
 
 
+def test_downloader_restarts_on_mismatched_resume_offset(tmpdir: Path) -> None:
+    """A 206 that resumes from a different offset than requested must be
+    discarded, otherwise the misplaced bytes would corrupt the file."""
+    body = b"0cfa7e9d-1868-4dd7-9fb3-f2561d5dfd89"
+    session = PipSession(resume_retries=5)
+    link = Link("http://example.com/foo.tgz")
+    downloader = Downloader(session, "on")
+
+    # Incomplete first response (24 of 36 bytes).
+    first = MockResponse(body[:24])
+    first.headers.update({"content-length": "36"})
+    first.status_code = 200
+
+    # The resume asks for bytes=24- but the server answers with content that
+    # (per its Content-Range) starts at offset 0.
+    mismatched = MockResponse(b"XXXXXXXXXXXX")
+    mismatched.headers.update({"content-length": "12", "content-range": "bytes 0-11/36"})
+    mismatched.status_code = 206
+
+    # After the restart the server serves the whole file from the beginning.
+    restarted = MockResponse(body)
+    restarted.headers.update({"content-length": "36", "content-range": "bytes 0-35/36"})
+    restarted.status_code = 206
+
+    _http_get_mock = MagicMock(side_effect=[first, mismatched, restarted])
+    with patch.object(Downloader, "_http_get", _http_get_mock):
+        filepath, _ = downloader(link, str(tmpdir))
+
+    with open(filepath, "rb") as f:
+        assert f.read() == body
+
+
 def test_downloader_without_content_length(tmpdir: Path) -> None:
     """A response without a Content-Length header should be treated as an
     unknown size and still download fully.


### PR DESCRIPTION
On a resumed download, the 206 body is written at the current file position without checking the server's Content-Range, so a server that answers a bytes=N- request with content starting at a different offset silently corrupts the file. Parse the Content-Range start and, when it doesn't match the bytes already received, drop the partial data and restart instead of appending misplaced bytes.