### PR TITLE
refactor: Move stdlib_pkgs from utils.compat to metadata.base

### DIFF
--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -4,8 +4,8 @@ from optparse import Values
 from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
-from pip._internal.operations.freeze import freeze
 from pip._internal.metadata.base import stdlib_pkgs
+from pip._internal.operations.freeze import freeze
 
 
 def _should_suppress_build_backends() -> bool:

--- a/src/pip/_internal/commands/freeze.py
+++ b/src/pip/_internal/commands/freeze.py
@@ -5,7 +5,7 @@ from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.operations.freeze import freeze
-from pip._internal.utils.compat import stdlib_pkgs
+from pip._internal.metadata.base import stdlib_pkgs
 
 
 def _should_suppress_build_backends() -> bool:

--- a/src/pip/_internal/commands/inspect.py
+++ b/src/pip/_internal/commands/inspect.py
@@ -10,7 +10,7 @@ from pip._internal.cli import cmdoptions
 from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.metadata import BaseDistribution, get_environment
-from pip._internal.utils.compat import stdlib_pkgs
+from pip._internal.metadata.base import stdlib_pkgs
 from pip._internal.utils.urls import path_to_url
 
 logger = logging.getLogger(__name__)

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -17,7 +17,7 @@ from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.exceptions import CommandError
 from pip._internal.metadata import BaseDistribution, get_environment
 from pip._internal.models.selection_prefs import SelectionPreferences
-from pip._internal.utils.compat import stdlib_pkgs
+from pip._internal.metadata.base import stdlib_pkgs
 from pip._internal.utils.misc import tabulate, write_output
 
 if TYPE_CHECKING:

--- a/src/pip/_internal/commands/list.py
+++ b/src/pip/_internal/commands/list.py
@@ -16,8 +16,8 @@ from pip._internal.cli.index_command import IndexGroupCommand
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.exceptions import CommandError
 from pip._internal.metadata import BaseDistribution, get_environment
-from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.metadata.base import stdlib_pkgs
+from pip._internal.models.selection_prefs import SelectionPreferences
 from pip._internal.utils.misc import tabulate, write_output
 
 if TYPE_CHECKING:

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -32,6 +32,8 @@ from pip._internal.utils.egg_link import egg_link_path_from_sys_path
 from pip._internal.utils.misc import is_local, normalize_path
 from pip._internal.utils.urls import url_to_path
 
+from ._json import msg_to_json
+
 # packages in the stdlib that may have installation metadata, but should not be
 # considered 'installed'.  this theoretically could be determined based on
 # dist.location (py27:`sysconfig.get_paths()['stdlib']`,
@@ -39,7 +41,6 @@ from pip._internal.utils.urls import url_to_path
 # make this ineffective, so hard-coding
 stdlib_pkgs = {"python", "wsgiref", "argparse"}
 
-from ._json import msg_to_json
 
 InfoPath = str | pathlib.PurePath
 

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -28,10 +28,16 @@ from pip._internal.models.direct_url import (
     DirectUrl,
     DirectUrlValidationError,
 )
-from pip._internal.utils.compat import stdlib_pkgs  # TODO: Move definition here.
 from pip._internal.utils.egg_link import egg_link_path_from_sys_path
 from pip._internal.utils.misc import is_local, normalize_path
 from pip._internal.utils.urls import url_to_path
+
+# packages in the stdlib that may have installation metadata, but should not be
+# considered 'installed'.  this theoretically could be determined based on
+# dist.location (py27:`sysconfig.get_paths()['stdlib']`,
+# py26:sysconfig.get_config_vars('LIBDEST')), but fear platform variation may
+# make this ineffective, so hard-coding
+stdlib_pkgs = {"python", "wsgiref", "argparse"}
 
 from ._json import msg_to_json
 

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -8,7 +8,7 @@ import os
 import sys
 from typing import IO
 
-__all__ = ["get_locale_encoding", "get_path_uid", "stdlib_pkgs", "tomllib", "WINDOWS"]
+__all__ = ["get_locale_encoding", "get_path_uid", "tomllib", "WINDOWS"]
 
 
 logger = logging.getLogger(__name__)

--- a/src/pip/_internal/utils/compat.py
+++ b/src/pip/_internal/utils/compat.py
@@ -87,13 +87,5 @@ else:
     from pip._vendor import tomli as tomllib
 
 
-# packages in the stdlib that may have installation metadata, but should not be
-# considered 'installed'.  this theoretically could be determined based on
-# dist.location (py27:`sysconfig.get_paths()['stdlib']`,
-# py26:sysconfig.get_config_vars('LIBDEST')), but fear platform variation may
-# make this ineffective, so hard-coding
-stdlib_pkgs = {"python", "wsgiref", "argparse"}
-
-
 # windows detection, covers cpython and ironpython
 WINDOWS = sys.platform.startswith("win") or (sys.platform == "cli" and os.name == "nt")


### PR DESCRIPTION
Moves the `stdlib_pkgs` set from `pip._internal.utils.compat` to `pip._internal.metadata.base`, resolving the existing `# TODO: Move definition here.` comment.

`stdlib_pkgs` is conceptually metadata-related (it identifies stdlib packages that may have installation metadata but should not be considered "installed"), so `metadata.base` is a more appropriate home than a compatibility utilities module.

**Changes:**
- Added `stdlib_pkgs` directly in `pip._internal.metadata.base`
- Removed the definition and `__all__` export from `pip._internal.utils.compat`
- Updated imports in:
  - `pip._internal.commands.freeze`
  - `pip._internal.commands.inspect`
  - `pip._internal.commands.list`

No functional changes.
