### PR TITLE
Only warn once per bad-metadata location per pip run

### DIFF
--- a/news/11436.bugfix.rst
+++ b/news/11436.bugfix.rst
@@ -1,0 +1,1 @@
+Only emit the invalid-metadata warning once per location per run, instead of repeating it during the same command.

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -23,6 +23,12 @@ from ._dists import Distribution
 
 logger = logging.getLogger(__name__)
 
+# Locations we've already warned about due to bad metadata. Kept at module
+# level (not on _DistributionFinder) because a new finder is created every
+# time _iter_distributions() runs, and that happens multiple times within a
+# single pip invocation.
+_warned_bad_metadata: set[BasePath | None] = set()
+
 
 def _looks_like_wheel(location: str) -> bool:
     if not location.endswith(WHEEL_EXTENSION):
@@ -68,7 +74,9 @@ class _DistributionFinder:
             try:
                 name = get_dist_canonical_name(dist)
             except BadMetadata as e:
-                logger.warning("Skipping %s due to %s", info_location, e.reason)
+                if info_location not in _warned_bad_metadata:
+                    logger.warning("Skipping %s due to %s", info_location, e.reason)
+                    _warned_bad_metadata.add(info_location)
                 continue
             if name in self._found_names:
                 continue

--- a/src/pip/_internal/metadata/importlib/_envs.py
+++ b/src/pip/_internal/metadata/importlib/_envs.py
@@ -23,10 +23,8 @@ from ._dists import Distribution
 
 logger = logging.getLogger(__name__)
 
-# Locations we've already warned about due to bad metadata. Kept at module
-# level (not on _DistributionFinder) because a new finder is created every
-# time _iter_distributions() runs, and that happens multiple times within a
-# single pip invocation.
+# Used to avoid emitting duplicate invalid distribution metadata warnings for
+# the same dist-info directory.
 _warned_bad_metadata: set[BasePath | None] = set()
 
 


### PR DESCRIPTION
Fixes #11436

The issue thread is long and doesn't have a clean repro, so here's one:

```bash
python -m venv venv
mkdir -p <site-packages>/foo.dist-info
pip install requests
```

Output before this fix — same warning printed 4 times in one command:

```
WARNING: Skipping .../foo.dist-info due to invalid metadata entry 'name'
WARNING: Skipping .../foo.dist-info due to invalid metadata entry 'name'
Collecting requests
...
WARNING: Skipping .../foo.dist-info due to invalid metadata entry 'name'
Installing collected packages: urllib3, idna, charset_normalizer, certifi, requests
WARNING: Skipping .../foo.dist-info due to invalid metadata entry 'name'
WARNING: Skipping .../foo.dist-info due to invalid metadata entry 'name'
Successfully installed certifi-2026.6.17 charset_normalizer-3.4.7 idna-3.18 requests-2.34.2 urllib3-2.7.0
```

`_DistributionFinder` is recreated on every `_iter_distributions()` call, so per-instance memoization can't prevent repeats across a single pip run. This PR implements `_warned_bad_metadata` to module level and checks it in `_DistributionFinder._find_impl`, so each bad-metadata path only warns once per run.