### PR TITLE
Don't crash on an invalid requirement marker

### DIFF
--- a/news/6385.bugfix.rst
+++ b/news/6385.bugfix.rst
@@ -1,0 +1,1 @@
+Show a clear error instead of a traceback for an invalid requirement marker.

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -356,9 +356,7 @@ def parse_req_from_line(name: str, line_source: str | None) -> RequirementParts:
             try:
                 markers = Marker(markers_as_string)
             except InvalidMarker as exc:
-                raise InstallationError(
-                    f"Invalid requirement: {name.strip()!r}: {exc}"
-                )
+                raise InstallationError(f"Invalid requirement: {name.strip()!r}: {exc}")
     else:
         markers = None
     name = name.strip()

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -18,7 +18,7 @@ from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 
 from pip._vendor.packaging import pylock
-from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.markers import InvalidMarker, Marker
 from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
 from pip._vendor.packaging.utils import parse_sdist_filename, parse_wheel_filename
 
@@ -353,7 +353,12 @@ def parse_req_from_line(name: str, line_source: str | None) -> RequirementParts:
         if not markers_as_string:
             markers = None
         else:
-            markers = Marker(markers_as_string)
+            try:
+                markers = Marker(markers_as_string)
+            except InvalidMarker as exc:
+                raise InstallationError(
+                    f"Invalid requirement: {name.strip()!r}: {exc}"
+                )
     else:
         markers = None
     name = name.strip()

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -640,6 +640,11 @@ class TestInstallRequirement:
         assert str(req.req.specifier) == ""
         assert str(req.markers) == 'os_name == "a; b"'
 
+    def test_markers_invalid(self) -> None:
+        with pytest.raises(InstallationError) as e:
+            install_req_from_line('name; python_version == "1"; python_version == "2"')
+        assert "Invalid requirement" in e.value.args[0]
+
     def test_markers_url(self) -> None:
         # test "URL; markers" syntax
         url = "http://foo.com/?p=bar.git;a=snapshot;h=v0.1;sf=tgz"


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->

Fixes #6385

`parse_req_from_line` passes the split-off marker to `Marker()` unguarded, 
so an invalid marker (e.g. two joined with a bare `;`) surfaces as a raw `InvalidMarker` traceback. 

catch it and raise `InstallationError`, like the `InvalidRequirement` handling just below.

 ---

```bash
$ pip install 'flask; python_version >= "3.6"; python_version < "4"'
```

before:
```bash
.......(skip)

  File "/Users/youngkwang-yang/pip/src/pip/_internal/req/constructors.py", line 441, in install_req_from_line
    parts = parse_req_from_line(name, line_source)
  File "/Users/youngkwang-yang/pip/src/pip/_internal/req/constructors.py", line 356, in parse_req_from_line
    markers = Marker(markers_as_string)
  File "/Users/youngkwang-yang/pip/src/pip/_vendor/packaging/markers.py", line 367, in __init__
    raise InvalidMarker(str(e)) from e
pip._vendor.packaging.markers.InvalidMarker: Expected end of marker expression
    python_version >= "3.6"; python_version < "4"
                           ^
```

after:
```nash
ERROR: Invalid requirement: 'flask': Expected end of marker expression
    python_version >= "3.6"; python_version < "4"
                           ^
``` 