### PR TITLE
Remove old versions when upgrading with --target

### DIFF
--- a/news/13763.bugfix.rst
+++ b/news/13763.bugfix.rst
@@ -1,0 +1,4 @@
+When installing with ``--target <dir> --upgrade``, remove the files and
+``.dist-info`` directories of the previous versions of the packages being
+upgraded, instead of leaving multiple versions' metadata in the target
+directory.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -625,6 +625,9 @@ class InstallCommand(RequirementCommand):
         if os.path.exists(data_dir):
             lib_dir_list.append(data_dir)
 
+        if upgrade:
+            self._remove_dists_being_upgraded(target_dir, lib_dir_list)
+
         for lib_dir in lib_dir_list:
             for item in os.listdir(lib_dir):
                 if lib_dir == data_dir:
@@ -655,6 +658,55 @@ class InstallCommand(RequirementCommand):
                         os.remove(target_item_dir)
 
                 shutil.move(os.path.join(lib_dir, item), target_item_dir)
+
+    def _remove_dists_being_upgraded(
+        self, target_dir: str, lib_dir_list: list[str]
+    ) -> None:
+        """Remove distributions in the target directory that are being
+        upgraded, so that no files or ``.dist-info`` directories of older
+        versions are left behind (see #13763).
+        """
+        new_names = {
+            dist.canonical_name
+            for dist in get_environment(lib_dir_list).iter_all_distributions()
+        }
+        if not new_names:
+            return
+        target_root = os.path.normpath(os.path.abspath(target_dir))
+
+        def is_inside_target(path: str) -> bool:
+            try:
+                return os.path.commonpath([target_root, path]) == target_root
+            except ValueError:
+                return False
+
+        for existing in get_environment([target_root]).iter_all_distributions():
+            if existing.canonical_name not in new_names:
+                continue
+            location = existing.location or target_root
+            removed_dirs = set()
+            for entry in existing.iter_declared_entries() or ():
+                path = os.path.normpath(os.path.join(location, entry))
+                # Never remove anything outside of the target directory.
+                if not is_inside_target(path):
+                    continue
+                if os.path.lexists(path) and not os.path.isdir(path):
+                    os.remove(path)
+                    removed_dirs.add(os.path.dirname(path))
+            if existing.info_location:
+                info_path = os.path.normpath(os.path.abspath(existing.info_location))
+                if is_inside_target(info_path) and os.path.isdir(info_path):
+                    shutil.rmtree(info_path)
+            # Clean up any directories left empty by the removals.
+            for directory in sorted(removed_dirs, key=len, reverse=True):
+                while (
+                    directory != target_root
+                    and is_inside_target(directory)
+                    and os.path.isdir(directory)
+                    and not os.listdir(directory)
+                ):
+                    os.rmdir(directory)
+                    directory = os.path.dirname(directory)
 
     def _determine_conflicts(
         self, to_install: list[InstallRequirement]

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1169,6 +1169,33 @@ def test_install_package_with_target(script: PipTestEnvironment) -> None:
     result.did_update(singlemodule_py)
 
 
+def test_install_package_with_target_upgrade_removes_old_version(
+    script: PipTestEnvironment,
+) -> None:
+    """
+    Upgrading in a target directory removes the previous version's files and
+    metadata rather than leaving both versions' .dist-info directories
+    behind (#13763).
+    """
+    target_dir = script.scratch_path / "target"
+    script.pip_install_local("-t", target_dir, "simple==1.0")
+    assert (target_dir / "simple-1.0.dist-info").exists()
+
+    result = script.pip_install_local("--upgrade", "-t", target_dir, "simple==2.0")
+    result.did_create(Path("scratch") / "target" / "simple-2.0.dist-info")
+    assert not (target_dir / "simple-1.0.dist-info").exists()
+
+    # Only the new version is visible to importlib.metadata.
+    versions = script.run(
+        "python",
+        "-c",
+        "import importlib.metadata as m;"
+        f"dists = m.distributions(path=[{os.fspath(target_dir)!r}]);"
+        "print(*(d.version for d in dists))",
+    )
+    assert versions.stdout.strip() == "2.0"
+
+
 @pytest.mark.parametrize("target_option", ["--target", "-t"])
 def test_install_package_to_usersite_with_target_must_fail(
     script: PipTestEnvironment, target_option: str


### PR DESCRIPTION
Fixes #13763

## Problem

`pip install --target <dir> --upgrade` documents that `--upgrade` will "replace existing packages in \<dir\> with new versions", but `_handle_target_dir()` only replaces items in the target directory whose *names* collide with newly installed ones. Since `.dist-info` directory names include the version, the previous version's metadata always survives an upgrade:

```
$ pip install --target tgt typing_extensions==4.11.0
$ pip install --target tgt --upgrade typing_extensions==4.12.2
$ ls tgt
typing_extensions-4.11.0.dist-info  typing_extensions-4.12.2.dist-info  typing_extensions.py
```

`importlib.metadata` then reports both versions as installed, and any files the new version no longer ships are also left behind. Reproduced with pip 26.1.2.

## Fix

Before moving the new files into the target directory (only when `--upgrade` is given, matching the existing replacement behavior), remove existing distributions in the target that match the canonical names of the distributions being installed:

- files are removed based on the distribution's declared entries (`RECORD`, via `BaseDistribution.iter_declared_entries()`, the same source `pip uninstall` uses),
- the metadata directory is removed,
- directories left empty by the removals are cleaned up,
- anything resolving outside the target directory is never touched.

## Verification

- New functional test `test_install_package_with_target_upgrade_removes_old_version` — fails on `main` (`simple-1.0.dist-info` survives the upgrade) and passes with this change, including asserting `importlib.metadata` sees only the new version.
- All `-k target` functional tests pass (10); `tests/functional/test_install.py` + `test_install_upgrade.py`: 177 passed, with the only failures being 4 pre-existing environment-dependent tests that fail identically on `main` in my sandbox.
- `ruff check` clean; `mypy` clean on the changed module.
- News fragment added.

## AI disclosure

This patch was developed with the assistance of an AI tool (Claude Code); I reproduced the issue, reviewed and verified the change and test results, and will respond to review feedback personally.
