### PR TITLE
Fix print_usage() emitting raw Rich markup in option-error output

### DIFF
--- a/news/14136.bugfix.rst
+++ b/news/14136.bugfix.rst
@@ -1,0 +1,1 @@
+Fix option-error usage block printing raw Rich markup (e.g. ``[optparse.groups]Usage:[/]``) instead of rendered text when an invalid option is passed.

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -344,7 +344,7 @@ class ConfigOptionParser(CustomOptionParser):
         self.print_usage(sys.stderr)
         self.exit(UNKNOWN_ERROR, f"{msg}\n")
 
-    def print_help(self, file: Any = None) -> None:
+    def _make_pip_console(self, file: Any = None) -> PipConsole:
         # This is unfortunate but necessary since arguments may have not been
         # parsed yet at this point, so detect --no-color manually.
         no_color = (
@@ -352,7 +352,16 @@ class ConfigOptionParser(CustomOptionParser):
             or bool(strtobool(os.environ.get("PIP_NO_COLOR", "no") or "no"))
             or "NO_COLOR" in os.environ
         )
-        console = PipConsole(
+        return PipConsole(
             theme=Theme(PrettyHelpFormatter.styles), no_color=no_color, file=file
         )
+
+    def print_usage(self, file: Any = None) -> None:
+        """Override to render Rich markup in the usage line."""
+        if self.usage:
+            console = self._make_pip_console(file=file)
+            console.print(self.get_usage().rstrip(), highlight=False)
+
+    def print_help(self, file: Any = None) -> None:
+        console = self._make_pip_console(file=file)
         console.print(self.format_help().rstrip(), highlight=False)

--- a/tests/unit/test_cli_colors.py
+++ b/tests/unit/test_cli_colors.py
@@ -1,6 +1,8 @@
+import io
 import optparse
 
 import pip._internal.cli.parser
+from pip._internal.cli.parser import ConfigOptionParser, PrettyHelpFormatter
 
 
 def test_color_formatter_option_strings() -> None:
@@ -16,4 +18,29 @@ def test_color_formatter_option_strings() -> None:
     assert (
         "[optparse.shortargs]-t[/], [optparse.longargs]--test-option[/]"
         " [optparse.metavar]<test_option>[/]" == strs
+    )
+
+
+def test_print_usage_renders_rich_markup() -> None:
+    """print_usage() must not emit raw Rich markup tags to the output stream.
+
+    Regression test for https://github.com/pypa/pip/issues/14136:
+    ConfigOptionParser.error() calls print_usage(sys.stderr), which previously
+    fell through to the base optparse implementation and wrote raw markup such
+    as ``[optparse.groups]Usage:[/]`` literally instead of rendering it.
+    """
+    parser = ConfigOptionParser(
+        name="install",
+        usage="%prog install [options] <requirement specifier>",
+        formatter=PrettyHelpFormatter(),
+    )
+    buf = io.StringIO()
+    parser.print_usage(file=buf)
+    output = buf.getvalue()
+
+    assert "[optparse.groups]" not in output, (
+        f"Raw Rich markup found in print_usage() output: {output!r}"
+    )
+    assert "Usage:" in output, (
+        f"Expected 'Usage:' in rendered output but got: {output!r}"
     )


### PR DESCRIPTION
## Summary

Fixes #14136

When pip encounters an invalid option (e.g. `pip install --hi`), it calls
`ConfigOptionParser.error()`, which in turn calls `self.print_usage(sys.stderr)`.
That fell through to the base `optparse.OptionParser.print_usage()` implementation,
which writes the raw output of `formatter.format_usage()` directly to the file
without rendering it through Rich. The result was literal markup tags appearing
on the terminal:

```
[optparse.groups]Usage:[/]
  pip install \[options] <requirement specifier> ...

no such option: --hi
```

The same problem existed for `print_help()`, which was already fixed by
overriding it in `ConfigOptionParser` to use `PipConsole`. This PR applies
the same fix to `print_usage()`.

The shared no-color detection logic is extracted into a private helper method
`_make_pip_console()` to avoid duplicating it in both overrides.

## Changes

- `src/pip/_internal/cli/parser.py`: extract `_make_pip_console()` helper;
  override `print_usage()` to render through `PipConsole`.
- `tests/unit/test_cli_colors.py`: add regression test asserting that
  `print_usage()` output does not contain raw Rich markup tags.
- `news/14136.bugfix.rst`: changelog fragment.

## Test plan

- `python -m pytest tests/unit/test_cli_colors.py` passes (including new test).
- Manually verified: `python -m pip install --hi` now shows rendered "Usage:"
  instead of `[optparse.groups]Usage:[/]`.