### PR TITLE
Render usage through Rich on option errors

### DIFF
--- a/news/14136.bugfix.rst
+++ b/news/14136.bugfix.rst
@@ -1,0 +1,1 @@
+Fix option errors printing the usage message with raw Rich markup.

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -344,7 +344,7 @@ class ConfigOptionParser(CustomOptionParser):
         self.print_usage(sys.stderr)
         self.exit(UNKNOWN_ERROR, f"{msg}\n")
 
-    def _create_console(self, file: Any = None) -> PipConsole:
+    def _create_console_for_help(self, file: Any = None) -> PipConsole:
         # This is unfortunate but necessary since arguments may have not been
         # parsed yet at this point, so detect --no-color manually.
         no_color = (
@@ -358,9 +358,9 @@ class ConfigOptionParser(CustomOptionParser):
 
     def print_usage(self, file: Any = None) -> None:
         if self.usage:
-            console = self._create_console(file)
+            console = self._create_console_for_help(file)
             console.print(self.get_usage(), highlight=False)
 
     def print_help(self, file: Any = None) -> None:
-        console = self._create_console(file)
+        console = self._create_console_for_help(file)
         console.print(self.format_help().rstrip(), highlight=False)

--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -344,7 +344,7 @@ class ConfigOptionParser(CustomOptionParser):
         self.print_usage(sys.stderr)
         self.exit(UNKNOWN_ERROR, f"{msg}\n")
 
-    def print_help(self, file: Any = None) -> None:
+    def _create_console(self, file: Any = None) -> PipConsole:
         # This is unfortunate but necessary since arguments may have not been
         # parsed yet at this point, so detect --no-color manually.
         no_color = (
@@ -352,7 +352,15 @@ class ConfigOptionParser(CustomOptionParser):
             or bool(strtobool(os.environ.get("PIP_NO_COLOR", "no") or "no"))
             or "NO_COLOR" in os.environ
         )
-        console = PipConsole(
+        return PipConsole(
             theme=Theme(PrettyHelpFormatter.styles), no_color=no_color, file=file
         )
+
+    def print_usage(self, file: Any = None) -> None:
+        if self.usage:
+            console = self._create_console(file)
+            console.print(self.get_usage(), highlight=False)
+
+    def print_help(self, file: Any = None) -> None:
+        console = self._create_console(file)
         console.print(self.format_help().rstrip(), highlight=False)

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -69,6 +69,15 @@ def _run_pip_without_virtualenv(
     return script.run("python", str(test_script), expect_error=expect_error)
 
 
+def test_option_error_prints_rendered_usage(script: PipTestEnvironment) -> None:
+    result = script.pip("install", "--updgrade", expect_error=True)
+
+    assert "no such option: --updgrade" in result.stderr
+    assert "Usage:" in result.stderr
+    assert "[optparse." not in result.stderr
+    assert "\\[options]" not in result.stderr
+
+
 def test_require_virtualenv_blocks_commands_when_not_in_venv(
     script: PipTestEnvironment,
 ) -> None:

--- a/tests/unit/test_cli_colors.py
+++ b/tests/unit/test_cli_colors.py
@@ -1,6 +1,26 @@
 import optparse
 
+import pytest
+
 import pip._internal.cli.parser
+
+
+def test_option_error_usage_is_rendered(capsys: pytest.CaptureFixture[str]) -> None:
+    formatter = pip._internal.cli.parser.PrettyHelpFormatter()
+    parser = pip._internal.cli.parser.ConfigOptionParser(
+        usage="\n%prog [options]",
+        name="test",
+        formatter=formatter,
+    )
+
+    with pytest.raises(SystemExit):
+        parser.error("no such option: --updgrade")
+
+    stderr = capsys.readouterr().err
+    assert "no such option: --updgrade" in stderr
+    assert "Usage:" in stderr
+    assert "[optparse." not in stderr
+    assert "\\[options]" not in stderr
 
 
 def test_color_formatter_option_strings() -> None:


### PR DESCRIPTION
Fixes #14136 

`print_usage()` fell through to plain optparse and printed the Rich markup literally. override it to render through `PipConsole`, like `print_help()`.

see below:

before

```console
❯ python -m pip install --updrade

[optparse.groups]Usage:[/]
  ../python -m pip install \[options] <requirement specifier> \[package-index-options] ...
  ../python -m pip install \[options] -r <requirements file> \[package-index-options] ...
  ../python -m pip install \[options] [-e] <vcs project url> ...
  ../python -m pip install \[options] [-e] <local project path> ...
  ../python -m pip install \[options] <archive url/path> ...

no such option: --updrade
```

after

```console
❯ PYTHONPATH=src python -m pip install --updrade

Usage:
  ../python -m pip install [options] <requirement specifier> [package-index-options] ...
  ../python -m pip install [options] -r <requirements file> [package-index-options] ...
  ../python -m pip install [options] [-e] <vcs project url> ...
  ../python -m pip install [options] [-e] <local project path> ...
  ../python -m pip install [options] <archive url/path> ...

no such option: --updrade
```