### PR TITLE
Fix line continuations in requirements files with trailing whitespace after backslash

### DIFF
--- a/news/b001c397-88d1-43d0-aeb7-e98da8048112.bugfix.rst
+++ b/news/b001c397-88d1-43d0-aeb7-e98da8048112.bugfix.rst
@@ -1,0 +1,1 @@
+Fix line continuations in requirements files when a backslash is followed by trailing whitespace.

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -497,7 +497,10 @@ def join_lines(lines_enum: ReqFileLines) -> ReqFileLines:
     primary_line_number = None
     new_line: list[str] = []
     for line_number, line in lines_enum:
-        if not line.endswith("\\") or COMMENT_RE.match(line):
+        # Strip trailing whitespace so that lines ending with '\ '
+        # (backslash followed by spaces) are still treated as continuations.
+        stripped = line.rstrip()
+        if not stripped.endswith("\\") or COMMENT_RE.match(line):
             if COMMENT_RE.match(line):
                 # this ensures comments are always matched later
                 line = " " + line
@@ -511,14 +514,12 @@ def join_lines(lines_enum: ReqFileLines) -> ReqFileLines:
         else:
             if not new_line:
                 primary_line_number = line_number
-            new_line.append(line.strip("\\"))
+            new_line.append(stripped.strip("\\"))
 
     # last line contains \
     if new_line:
         assert primary_line_number is not None
         yield primary_line_number, "".join(new_line)
-
-    # TODO: handle space after '\'.
 
 
 def ignore_comments(lines_enum: ReqFileLines) -> ReqFileLines:

--- a/tests/unit/test_req_file.py
+++ b/tests/unit/test_req_file.py
@@ -198,6 +198,38 @@ class TestJoinLines:
         ]
         assert expect == list(join_lines(lines))
 
+    def test_join_lines_with_trailing_space_after_backslash(self) -> None:
+        lines = enumerate(
+            [
+                "line 1",
+                "line 2:1 \\ ",
+                "line 2:2",
+                "line 3:1 \\  ",
+                "line 3:2",
+            ],
+            start=1,
+        )
+        expect = [
+            (1, "line 1"),
+            (2, "line 2:1 line 2:2"),
+            (4, "line 3:1 line 3:2"),
+        ]
+        assert expect == list(join_lines(lines))
+
+    def test_last_line_with_escape_and_trailing_space(self) -> None:
+        lines = enumerate(
+            [
+                "line 1",
+                "line 2 \\ ",
+            ],
+            start=1,
+        )
+        expect = [
+            (1, "line 1"),
+            (2, "line 2 "),
+        ]
+        assert expect == list(join_lines(lines))
+
 
 class LineProcessor(Protocol):
     def __call__(


### PR DESCRIPTION
## Summary

Fix line continuations in requirements files when a backslash is followed by trailing whitespace.

## Problem

Currently, `pip` fails to parse requirements files with line continuations when there is trailing whitespace after a backslash. For example:

```
line 1:1 \ 
line 1:2
```

This causes the continuation to be ignored, leading to unexpected behavior.

## Solution

Modify the `join_lines` function in `req_file.py` to strip trailing whitespace before checking for a trailing backslash. This ensures lines like `\ ` (backslash followed by spaces) are still treated as continuations.

## Changes

- Updated `join_lines` in `src/pip/_internal/req/req_file.py`
- Added tests for trailing space after backslash
- Removed the `TODO: handle space after '\'` comment
- Added news fragment

## Testing

Added unit tests to verify the fix works for:
- Middle lines with trailing space after backslash
- Last line with escape and trailing space