### PR TITLE
fix: render Rich markup in option error output

### DIFF
--- a/src/pip/_internal/cli/parser.py
+++ b/src/pip/_internal/cli/parser.py
@@ -344,6 +344,19 @@ class ConfigOptionParser(CustomOptionParser):
         self.print_usage(sys.stderr)
         self.exit(UNKNOWN_ERROR, f"{msg}\n")
 
+    def print_usage(self, file: Any = None) -> None:
+        if file is None:
+            file = sys.stderr
+        no_color = (
+            "--no-color" in sys.argv
+            or bool(strtobool(os.environ.get("PIP_NO_COLOR", "no") or "no"))
+            or "NO_COLOR" in os.environ
+        )
+        console = PipConsole(
+            theme=Theme(PrettyHelpFormatter.styles), no_color=no_color, file=file
+        )
+        console.print(self.format_usage().rstrip(), highlight=False)
+
     def print_help(self, file: Any = None) -> None:
         # This is unfortunate but necessary since arguments may have not been
         # parsed yet at this point, so detect --no-color manually.


### PR DESCRIPTION
When an option parsing error occurs, ConfigOptionParser.error() calls self.print_usage() which outputs raw Rich markup (e.g. [optparse.groups]Usage:[/]) because the inherited optparse.OptionParser.print_usage() writes with plain ile.write().

Overrides print_usage to render Rich markup through PipConsole, matching the pattern already used by print_help().

Fixes #14136