### PR TITLE
test: Spawn subprocess directly for git commits

### DIFF
--- a/tests/functional/test_freeze.py
+++ b/tests/functional/test_freeze.py
@@ -332,7 +332,7 @@ def test_freeze_git_clone(script: PipTestEnvironment) -> None:
     # in issue #1867).
     (repo_dir / "newfile").touch()
     script.run("git", "add", "newfile", cwd=repo_dir)
-    _git_commit(script, repo_dir, message="...")
+    _git_commit(repo_dir, message="...")
     result = script.pip("freeze", expect_stderr=True)
     expected = textwrap.dedent("""
             ...-e ...@...#egg=version_pkg

--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -45,7 +45,7 @@ def checkout_new_branch(script: PipTestEnvironment, repo_dir: str, branch: str) 
 
 
 def do_commit(script: PipTestEnvironment, dest: str) -> str:
-    _git_commit(script, dest, message="test commit", allow_empty=True)
+    _git_commit(dest, message="test commit", allow_empty=True)
     return get_head_sha(script, dest)
 
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -912,7 +912,6 @@ def _create_main_file(
 
 
 def _git_commit(
-    env_or_script: PipTestEnvironment,
     repo_dir: StrPath,
     message: str | None = None,
     allow_empty: bool = False,
@@ -922,7 +921,6 @@ def _git_commit(
     Run git-commit.
 
     Args:
-      env_or_script: pytest's `script` or `env` argument.
       repo_dir: a path to a Git repository.
       message: an optional commit message.
     """
@@ -946,7 +944,7 @@ def _git_commit(
     ]
     new_args.extend(args)
     new_args.extend(["-m", message])
-    env_or_script.run(*new_args, cwd=repo_dir)
+    subprocess.check_call(new_args, cwd=os.fspath(repo_dir))
 
 
 def _vcs_add(
@@ -1043,7 +1041,7 @@ def _create_test_package_with_subdirectory(
 
     script.run("git", "init", cwd=version_pkg_path)
     script.run("git", "add", ".", cwd=version_pkg_path)
-    _git_commit(script, version_pkg_path, message="initial version")
+    _git_commit(version_pkg_path, message="initial version")
 
     return version_pkg_path
 
@@ -1117,7 +1115,7 @@ def _change_test_package_version(
         version_pkg_path, name="version_pkg", output="some different version"
     )
     # Pass -a to stage the change to the main file.
-    _git_commit(script, version_pkg_path, message="messed version", stage_modified=True)
+    _git_commit(version_pkg_path, message="messed version", stage_modified=True)
 
 
 @contextmanager

--- a/tests/lib/git_submodule_helpers.py
+++ b/tests/lib/git_submodule_helpers.py
@@ -11,7 +11,7 @@ def _create_test_package_submodule(env: PipTestEnvironment) -> Path:
     env.run("touch", "testfile", cwd=submodule_path)
     env.run("git", "init", cwd=submodule_path)
     env.run("git", "add", ".", cwd=submodule_path)
-    _git_commit(env, submodule_path, message="initial version / submodule")
+    _git_commit(submodule_path, message="initial version / submodule")
 
     return submodule_path
 
@@ -22,7 +22,7 @@ def _change_test_package_submodule(
     submodule_path.joinpath("testfile").write_text("this is a changed file")
     submodule_path.joinpath("testfile2").write_text("this is an added file")
     env.run("git", "add", ".", cwd=submodule_path)
-    _git_commit(env, submodule_path, message="submodule change")
+    _git_commit(submodule_path, message="submodule change")
 
 
 def _pull_in_submodule_changes_to_module(
@@ -35,7 +35,7 @@ def _pull_in_submodule_changes_to_module(
     submodule_path = module_path / rel_path
     env.run("git", "pull", "-q", "origin", "master", cwd=submodule_path)
     # Pass -a to stage the submodule changes that were just pulled in.
-    _git_commit(env, module_path, message="submodule change", stage_modified=True)
+    _git_commit(module_path, message="submodule change", stage_modified=True)
 
 
 def _create_test_package_with_submodule(
@@ -61,7 +61,7 @@ def _create_test_package_with_submodule(
                         """))
     env.run("git", "init", cwd=version_pkg_path)
     env.run("git", "add", ".", cwd=version_pkg_path)
-    _git_commit(env, version_pkg_path, message="initial version")
+    _git_commit(version_pkg_path, message="initial version")
 
     submodule_path = _create_test_package_submodule(env)
 
@@ -73,6 +73,6 @@ def _create_test_package_with_submodule(
         rel_path,
         cwd=version_pkg_path,
     )
-    _git_commit(env, version_pkg_path, message="initial version w submodule")
+    _git_commit(version_pkg_path, message="initial version w submodule")
 
     return version_pkg_path, submodule_path


### PR DESCRIPTION
Running git commit via the script or environment run method is unnecessary, so switch to using subprocess.check_call like all of the other VCS helpers.

In particular, script.run has been crashing in macOS CI due to a TOCTOU race with a git lock file. (The script runner keep tracks of files additions/changes/deletions, but we don't use that here.) For example: https://github.com/pypa/pip/actions/runs/28814849019/job/85451566648

... although the submodule tests are skipped as a newer git release broke them a long time ago, so maybe this isn't safe?


