### PR TITLE
Refactor: Extract shared URL fetch logic into fetch_url_content

### DIFF
--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -1,8 +1,12 @@
 from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 from pip._vendor.requests.models import Response
 
 from pip._internal.exceptions import NetworkConnectionError
+
+if TYPE_CHECKING:
+    from pip._internal.network.session import PipSession
 
 # The following comments and HTTP headers were originally added by
 # Donald Stufft in git commit 22c562429a61bb77172039e480873fb239dd8c03.
@@ -96,3 +100,13 @@ def response_chunks(
             if not chunk:
                 break
             yield chunk
+
+
+def fetch_url_content(url: str, session: "PipSession") -> tuple[str, str]:
+    """Fetch content from a URL (http/https/file scheme).
+
+    Returns (final_url, text_content).
+    """
+    resp = session.get(url)
+    raise_for_status(resp)
+    return resp.url, resp.text

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -570,12 +570,9 @@ def get_file_content(
     scheme = urllib.parse.urlsplit(url).scheme
     # Pip has special support for file:// URLs (LocalFSAdapter).
     if scheme in ["http", "https", "file"]:
-        # Delay importing heavy network modules until absolutely necessary.
-        from pip._internal.network.utils import raise_for_status
+        from pip._internal.network.utils import fetch_url_content
 
-        resp = session.get(url)
-        raise_for_status(resp)
-        return resp.url, resp.text
+        return fetch_url_content(url, session)
 
     # Assume this is a bare path.
     try:

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -237,16 +237,13 @@ def package_wheel_requirement_url(
 
 
 def _get_pylock_path_or_url_content(path_or_url: str, session: PipSession) -> str:
-    # TODO: refactor - this is similar to req_file.get_file_content
     scheme = urlsplit(path_or_url).scheme
     # Pip has special support for file:// URLs (LocalFSAdapter).
     if scheme in ["http", "https", "file"]:
-        # Delay importing heavy network modules until absolutely necessary.
-        from pip._internal.network.utils import raise_for_status
+        from pip._internal.network.utils import fetch_url_content
 
-        resp = session.get(path_or_url)
-        raise_for_status(resp)
-        return resp.text
+        _, content = fetch_url_content(path_or_url, session)
+        return content
 
     # Assume this is a bare path.
     return Path(path_or_url).read_text(encoding="utf-8")


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?
Here's the summary:
Extracted duplicated URL-fetch logic from req_file.py and pylock.py into a shared fetch_url_content utility in network/utils.py, removing redundant HTTP/file URL handling and a stale TODO comment.
<!-- What problem does this solve? Include the issue number if applicable. -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->
AI disclosure: Checked and revised with [Mimo code](https://mimo.xiaomi.com/coder?lang=en)