### PR TITLE
Validate tar link targets after filter fallback

### DIFF
--- a/news/14156.bugfix.rst
+++ b/news/14156.bugfix.rst
@@ -1,0 +1,1 @@
+Reject tar archive links that resolve outside extraction destinations.

--- a/src/pip/_internal/utils/unpacking.py
+++ b/src/pip/_internal/utils/unpacking.py
@@ -212,6 +212,22 @@ def untar_file(filename: str, location: str) -> None:
                         if lnk_lead == name_lead:
                             member.linkname = lnk_rest
 
+            def check_link_target(member: tarfile.TarInfo) -> None:
+                if not member.islnk() and not member.issym():
+                    return
+
+                target = os.path.join(
+                    location, os.path.dirname(member.name), member.linkname
+                )
+                if is_within_directory(location, target, resolve_symlinks=True):
+                    return
+
+                exc = tarfile.LinkOutsideDestinationError(
+                    member, os.path.realpath(target)
+                )
+                message = "Invalid member in the tar file {}: {}"
+                raise InstallationError(message.format(filename, exc))
+
             def pip_filter(member: tarfile.TarInfo, path: str) -> tarfile.TarInfo:
                 orig_mode = member.mode
                 try:
@@ -229,6 +245,7 @@ def untar_file(filename: str, location: str) -> None:
                             # Ignore the error there, but do use the
                             # more lax `tar_filter`
                             member = tarfile.tar_filter(member, location)
+                            check_link_target(member)
                         else:
                             raise
                 except tarfile.TarError as exc:

--- a/tests/unit/test_utils_unpacking.py
+++ b/tests/unit/test_utils_unpacking.py
@@ -242,6 +242,100 @@ class TestUnpackArchives:
 
         assert "is outside the destination" in str(e.value)
 
+    @pytest.mark.skipif(
+        not hasattr(tarfile, "data_filter"),
+        reason="tarfile filters (PEP-721) not available",
+    )
+    def test_unpack_tar_filter_fallback_rejects_outside_hardlink(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Test that the fallback for CPython issue #107845 still rejects links
+        outside the extraction destination.
+        """
+        monkeypatch.setattr(sys, "version_info", (3, 11, 4))
+
+        test_tar = os.path.join(self.tempdir, "test_tar_filter_fallback.tar")
+        extract_path = os.path.join(self.tempdir, "extract_path")
+        victim_path = os.path.join(self.tempdir, "victim.txt")
+        with open(victim_path, "wb") as f:
+            f.write(b"safe\n")
+
+        with tarfile.open(test_tar, "w") as mytar:
+            dir_tarinfo = tarfile.TarInfo("pkg")
+            dir_tarinfo.type = tarfile.DIRTYPE
+            mytar.addfile(dir_tarinfo)
+
+            hardlink_tarinfo = tarfile.TarInfo("pkg/link")
+            hardlink_tarinfo.type = tarfile.LNKTYPE
+            hardlink_tarinfo.linkname = "../victim.txt"
+            mytar.addfile(hardlink_tarinfo)
+
+            file_data = io.BytesIO(b"overwritten\n")
+            file_tarinfo = tarfile.TarInfo("pkg/link")
+            file_tarinfo.size = len(file_data.getbuffer())
+            mytar.addfile(file_tarinfo, fileobj=file_data)
+
+        with pytest.raises(InstallationError) as e:
+            untar_file(test_tar, extract_path)
+
+        assert "would link to" in str(e.value)
+        assert "outside the destination" in str(e.value)
+        with open(victim_path, "rb") as f:
+            assert f.read() == b"safe\n"
+
+    @pytest.mark.skipif(
+        not hasattr(tarfile, "data_filter"),
+        reason="tarfile filters (PEP-721) not available",
+    )
+    def test_unpack_tar_filter_fallback_allows_safe_links(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """
+        Test that the CPython issue #107845 fallback still permits links that
+        resolve inside the extraction destination.
+        """
+        monkeypatch.setattr(sys, "version_info", (3, 11, 4))
+        original_data_filter = tarfile.data_filter
+
+        def data_filter_with_link_bug(
+            member: tarfile.TarInfo, location: str
+        ) -> tarfile.TarInfo:
+            if member.islnk() or member.issym():
+                target = os.path.join(
+                    location, os.path.dirname(member.name), member.linkname
+                )
+                raise tarfile.LinkOutsideDestinationError(member, target)
+            return original_data_filter(member, location)
+
+        monkeypatch.setattr(tarfile, "data_filter", data_filter_with_link_bug)
+
+        test_tar = os.path.join(self.tempdir, "test_tar_filter_fallback.tar")
+        extract_path = os.path.join(self.tempdir, "extract_path")
+        content = b"file content"
+
+        with tarfile.open(test_tar, "w") as mytar:
+            file_tarinfo = tarfile.TarInfo("regular_file.txt")
+            file_tarinfo.size = len(content)
+            mytar.addfile(file_tarinfo, io.BytesIO(content))
+
+            hardlink_tarinfo = tarfile.TarInfo("hardlink.txt")
+            hardlink_tarinfo.type = tarfile.LNKTYPE
+            hardlink_tarinfo.linkname = "regular_file.txt"
+            mytar.addfile(hardlink_tarinfo)
+
+            symlink_tarinfo = tarfile.TarInfo("symlink.txt")
+            symlink_tarinfo.type = tarfile.SYMTYPE
+            symlink_tarinfo.linkname = "regular_file.txt"
+            mytar.addfile(symlink_tarinfo)
+
+        untar_file(test_tar, extract_path)
+
+        with open(os.path.join(extract_path, "hardlink.txt"), "rb") as f:
+            assert f.read() == content
+        with open(os.path.join(extract_path, "symlink.txt"), "rb") as f:
+            assert f.read() == content
+
     @pytest.mark.parametrize(
         "input_prefix, unpack_prefix",
         [


### PR DESCRIPTION
## What does this PR do?

This re-checks tar hardlink and symlink targets after the CPython #107845 `tarfile.data_filter` fallback uses the more permissive `tarfile.tar_filter`. It rejects fallback link targets that resolve outside the extraction destination and adds regression coverage for an outside hardlink plus positive coverage for safe in-destination links on the affected fallback path.

The pre-fix reproducer on a simulated affected `sys.version_info == (3, 11, 4)` allowed a hardlink archive member to redirect a later file write outside the extraction directory. After this change, the same reproducer raises `InstallationError` and the outside file remains unchanged.

## Validation

- `PYTHONPATH=src /tmp/pip-test-venv/bin/python -m pytest tests/unit/test_utils_unpacking.py::TestUnpackArchives::test_unpack_tar_filter_fallback_rejects_outside_hardlink tests/unit/test_utils_unpacking.py::TestUnpackArchives::test_unpack_tar_filter_fallback_allows_safe_links -q`
- `PYTHONPATH=src /tmp/pip-test-venv/bin/python -m pytest tests/unit/test_utils_unpacking.py -q`
- `PYTHONPATH=src python -m py_compile src/pip/_internal/utils/unpacking.py tests/unit/test_utils_unpacking.py`
- `git diff --check`
- `/tmp/pip-test-venv/bin/python -m ruff check src/pip/_internal/utils/unpacking.py tests/unit/test_utils_unpacking.py`

## PR Checklist:

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: OpenAI Codex