### PR TITLE
docs: support self-referential extras officially w/ test

### DIFF
--- a/docs/html/reference/requirement-specifiers.md
+++ b/docs/html/reference/requirement-specifiers.md
@@ -59,3 +59,27 @@ A few example URL-based requirement specifiers:
 pip @ https://github.com/pypa/pip/archive/22.0.2.zip
 requests [security] @ https://github.com/psf/requests/archive/refs/heads/main.zip ; python_version >= "3.11"
 ```
+
+## Self-referential extras
+
+```{versionadded} 21.2
+Support for self-referential extras.
+```
+
+A package can define optional dependencies that refer back to itself with other extras. This is useful for creating convenience extras that combine multiple existing ones.
+
+For example, a `pyproject.toml` could define:
+
+```toml
+[project]
+name = "SomeProject"
+
+[project.optional-dependencies]
+test = ["pytest", "pytest-cov"]
+format = ["ruff"]
+docs = ["sphinx"]
+dev = ["SomeProject[test]", "SomeProject[format]"]  # separate form
+all = ["SomeProject[test, format, docs]"]  # combined form
+```
+
+Installing `SomeProject[all]` would install `pytest`, `pytest-cov`, `ruff`, and `sphinx`.

--- a/news/11296.doc.rst
+++ b/news/11296.doc.rst
@@ -1,1 +1,0 @@
-Document support for self-referential extras in requirement specifiers, also add a test case for the feature.

--- a/news/11296.doc.rst
+++ b/news/11296.doc.rst
@@ -1,0 +1,1 @@
+Document support for self-referential extras in requirement specifiers.

--- a/news/11296.doc.rst
+++ b/news/11296.doc.rst
@@ -1,1 +1,1 @@
-Document support for self-referential extras in requirement specifiers.
+Document support for self-referential extras in requirement specifiers, also add a test case for the feature.

--- a/news/11296.feature.rst
+++ b/news/11296.feature.rst
@@ -1,0 +1,1 @@
+Support self-referential extras officially. pip has supported this by accident since version 21.2.

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -255,6 +255,43 @@ def test_install_extras(script: PipTestEnvironment) -> None:
     script.assert_installed(a="1", b="1", dep="1", meh="1")
 
 
+@pytest.mark.parametrize(
+    "all_extra",
+    [
+        ["pkg[a]", "pkg[b]"],
+        ["pkg[a, b]"],
+    ],
+    ids=["separate-specifiers", "combined-specifier"],
+)
+def test_install_self_referential_extras(
+    script: PipTestEnvironment,
+    all_extra: list[str],
+) -> None:
+    """A package extra can depend on the same package with a different extra."""
+    create_basic_wheel_for_package(script, "dep_a", "1")
+    create_basic_wheel_for_package(script, "dep_b", "1")
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1",
+        extras={
+            "a": ["dep_a"],
+            "b": ["dep_b"],
+            "all": all_extra,
+        },
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[all]",
+    )
+    script.assert_installed(pkg="1", dep_a="1", dep_b="1")
+
+
 def test_install_setuptools_extras_inconsistency(
     script: PipTestEnvironment, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

<!-- What problem does this solve? Include the issue number if applicable. -->
As discussed in #11296, self-referential extras have been supported since `pip 21.2` from __2021__, yet no official documentation has mentioned this feature and no test case to ensure that it stays un-broken. An old PR (#13679) was created last year but closed without merge due to inactivity.

This PR added documentation for this feature, as well as a new test case.

Closes #11296

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

## Disclosure:
[Cursor](https://cursor.com/get-started), an LLM-powered IDE with an unknown `Auto` model, was used to aid documentation exploration.