### PR TITLE
Prefer X-Error-Message header over HTTP reason phrase in raise_for_status

### DIFF
--- a/news/14020.bugfix.rst
+++ b/news/14020.bugfix.rst
@@ -1,0 +1,1 @@
+Read ``X-Error-Message`` response header on HTTP errors and use its value as the error detail instead of the unreliable HTTP reason phrase.

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -42,6 +42,14 @@ def raise_for_status(resp: Response) -> None:
     else:
         reason = resp.reason
 
+    if 400 <= resp.status_code < 600:
+        # The HTTP reason phrase is unreliable: RFC 7230 section 6.1 says
+        # clients SHOULD ignore it, and servers often leave it empty.
+        # Prefer the X-Error-Message header when the server provides one.
+        x_error_message = resp.headers.get("X-Error-Message")
+        if x_error_message:
+            reason = x_error_message
+
     if 400 <= resp.status_code < 500:
         http_error_msg = (
             f"{resp.status_code} Client Error: {reason} for url: {resp.url}"

--- a/tests/unit/test_network_utils.py
+++ b/tests/unit/test_network_utils.py
@@ -27,6 +27,38 @@ def test_raise_for_status_raises_exception(status_code: int, error_type: str) ->
     )
 
 
+def test_raise_for_status_uses_x_error_message_header() -> None:
+    """When X-Error-Message header is present, use it instead of resp.reason."""
+    contents = b"downloaded"
+    resp = MockResponse(contents)
+    resp.status_code = 403
+    resp.url = "http://www.example.com/whatever.tgz"
+    resp.reason = "Forbidden"
+    resp.headers["X-Error-Message"] = "Package not found in registry"
+    with pytest.raises(NetworkConnectionError) as excinfo:
+        raise_for_status(resp)
+    assert str(excinfo.value) == (
+        "403 Client Error: Package not found in registry for url:"
+        " http://www.example.com/whatever.tgz"
+    )
+
+
+def test_raise_for_status_ignores_empty_x_error_message() -> None:
+    """Empty X-Error-Message header should be ignored."""
+    contents = b"downloaded"
+    resp = MockResponse(contents)
+    resp.status_code = 500
+    resp.url = "http://www.example.com/whatever.tgz"
+    resp.reason = "Internal Server Error"
+    resp.headers["X-Error-Message"] = ""
+    with pytest.raises(NetworkConnectionError) as excinfo:
+        raise_for_status(resp)
+    assert str(excinfo.value) == (
+        "500 Server Error: Internal Server Error for url:"
+        " http://www.example.com/whatever.tgz"
+    )
+
+
 def test_raise_for_status_does_not_raises_exception() -> None:
     contents = b"downloaded"
     resp = MockResponse(contents)


### PR DESCRIPTION
## Problem

`raise_for_status` builds its error detail from `resp.reason` (the HTTP reason phrase), which is unreliable in practice. RFC 7230 section 6.1 tells clients to ignore it, and many servers send an empty reason phrase. This produces unhelpful errors like:

403 Client Error: Forbidden for url: https://...


even when the server has a specific, actionable explanation to give.

## Solution

When a 4xx or 5xx response includes an `X-Error-Message` header, use its value as the error detail instead of `resp.reason`. Servers that do not send the header see no change in behaviour.

This pattern is already used by other ecosystems: Hugging Face Hub, RubyGems, and NuGet all support similar headers.

Closes #14020.
