### PR TITLE
reject cross-location paths in pylock files fetched from a URL

### DIFF
--- a/news/14159.bugfix.rst
+++ b/news/14159.bugfix.rst
@@ -1,0 +1,3 @@
+Reject a package ``path`` in a ``pylock.toml`` fetched from a URL when it
+resolves outside the lock file's own location, so a remote lock file can no
+longer point at the local filesystem or another host.

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -157,13 +157,10 @@ def _package_dist_url(
             # relative path, join to pylock location
             if _is_url(pylock_path_or_url):
                 dist_url = urljoin(pylock_path_or_url, path)
-                # A relative path must resolve within the lock file's own
-                # location. os.path.isabs does not consider "file:..." (or any
-                # other scheme-carrying value) absolute, so such a path reaches
-                # here and urljoin honors its scheme, discarding the pylock base.
-                # That lets a lock file obtained from a URL point at the local
-                # filesystem or another host, which the absolute-path branch
-                # below is meant to forbid. Reject anything that leaves the base.
+                # os.path.isabs does not treat a scheme-carrying value like
+                # "file:..." as absolute, so it reaches here and urljoin honors
+                # its scheme, discarding the pylock base. Only keep the result
+                # if its scheme and host still match the lock's own.
                 base = urlsplit(pylock_path_or_url)
                 target = urlsplit(dist_url)
                 if (target.scheme, target.netloc) != (base.scheme, base.netloc):

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -156,7 +156,22 @@ def _package_dist_url(
         if not os.path.isabs(path):
             # relative path, join to pylock location
             if _is_url(pylock_path_or_url):
-                return urljoin(pylock_path_or_url, path)
+                dist_url = urljoin(pylock_path_or_url, path)
+                # A relative path must resolve within the lock file's own
+                # location. os.path.isabs does not consider "file:..." (or any
+                # other scheme-carrying value) absolute, so such a path reaches
+                # here and urljoin honors its scheme, discarding the pylock base.
+                # That lets a lock file obtained from a URL point at the local
+                # filesystem or another host, which the absolute-path branch
+                # below is meant to forbid. Reject anything that leaves the base.
+                base = urlsplit(pylock_path_or_url)
+                target = urlsplit(dist_url)
+                if (target.scheme, target.netloc) != (base.scheme, base.netloc):
+                    raise InstallationError(
+                        f"Path {path!r} in pylock file obtained from a URL "
+                        f"resolves outside its location: {pylock_path_or_url!r}"
+                    )
+                return dist_url
             else:
                 return path_to_url(
                     os.path.join(os.path.dirname(pylock_path_or_url), path)

--- a/tests/unit/test_utils_pylock.py
+++ b/tests/unit/test_utils_pylock.py
@@ -87,6 +87,24 @@ def test_package_dist_url_abs_path_remote_lock_file() -> None:
 
 
 @pytest.mark.parametrize(
+    "path",
+    [
+        "file:///etc/passwd",
+        "file://attacker/share/pkg.tgz",
+        "https://attacker.example/pkg.tgz",
+    ],
+)
+def test_package_dist_url_scheme_path_remote_lock_file(path: str) -> None:
+    """A path in a remote lock file cannot escape the lock file's location."""
+    with pytest.raises(InstallationError, match="resolves outside its location"):
+        _package_dist_url(
+            "https://example.com/pylock.toml",
+            path=path,
+            url=None,
+        )
+
+
+@pytest.mark.parametrize(
     "pylock_path_or_url,package_vcs,expected",
     [
         (


### PR DESCRIPTION
## What does this PR do?

pip resolves each package's `path` from a pylock file against the location the lock file itself came from. When the lock is fetched over http or https (`pip install -r https://host/pylock.toml`), the branch that handles an absolute `path` deliberately refuses anything pointing at the local filesystem, but that guard only runs for values `os.path.isabs` treats as absolute. A `path` such as `file:///etc/passwd` is not absolute by that test, so it falls through to `urljoin`, which honors the embedded scheme and drops the http base, leaving pip with a `file://` (or another host's) URL derived from a remote lock. On Windows a `file://host/share/...` value becomes an SMB fetch that leaks credentials before any hash is checked. I ran into this while reading how the absolute-path case is rejected and noticed the relative branch never re-checks the origin. The fix keeps a resolved URL only when its scheme and host still match the pylock file's own, so a lock obtained from a URL can no longer reach the local machine or a different server.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
