### PR TITLE
test: add more regression tests for self-referential extras

### DIFF
--- a/news/14160.trivial.rst
+++ b/news/14160.trivial.rst
@@ -1,0 +1,2 @@
+Expand self-referential extras regression tests to distinguish behaviour across
+pip versions before 20.3, 20.3 through 21.1, and 21.2+.

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -389,28 +389,41 @@ def test_install_self_referential_extras_after_partial_install(
     script.assert_installed(pkg="1", dep_a="1", dep_b="1")
 
 
+@pytest.mark.parametrize(
+    "initial_extras, initial_req",
+    [
+        ({}, "pkg==1"),
+        ({"a": ["dep_a"]}, "pkg[a]==1"),
+    ],
+    ids=["had-no-extra", "had-different-extras"],
+)
 def test_install_self_referential_extras_upgrade_different_extras(
     script: PipTestEnvironment,
+    initial_extras: dict[str, list[str]],
+    initial_req: str,
 ) -> None:
-    """Upgrading can change which extras exist and which deps they pull in."""
+    """Upgrading package can change which extras exist and which deps they pull in."""
     create_basic_wheel_for_package(script, "dep_a", "1")
+    create_basic_wheel_for_package(script, "dep_a", "2")
     create_basic_wheel_for_package(script, "dep_b", "1")
     create_basic_wheel_for_package(
         script,
         "pkg",
         "1",
-        extras={"a": ["dep_a"]},
+        extras=initial_extras,
     )
 
+    # Ensure dep_a ver 2 is present so pkg ver 2's dep_a==1 pin is a downgrade.
+    initial_install = [initial_req] if initial_extras else [initial_req, "dep_a==2"]
     script.pip(
         "install",
         "--no-cache-dir",
         "--no-index",
         "--find-links",
         script.scratch_path,
-        "pkg[a]",
+        *initial_install,
     )
-    script.assert_installed(pkg="1", dep_a="1")
+    script.assert_installed(pkg="1", dep_a="2")
     script.assert_not_installed("dep_b")
 
     create_basic_wheel_for_package(
@@ -418,7 +431,7 @@ def test_install_self_referential_extras_upgrade_different_extras(
         "pkg",
         "2",
         extras={
-            "a": ["dep_a"],
+            "a": ["dep_a==1"],
             "b": ["dep_b"],
             "all": ["pkg[a]", "pkg[b]"],
         },
@@ -433,51 +446,8 @@ def test_install_self_referential_extras_upgrade_different_extras(
         "pkg[all]==2",
         expect_stderr=True,
     )
-    assert "does not provide the extra 'b'" not in result.stderr, str(result)
-    script.assert_installed(pkg="2", dep_a="1", dep_b="1")
-
-
-def test_install_self_referential_extras_skips_older_versions_without_extras(
-    script: PipTestEnvironment,
-) -> None:
-    """Self-ref extras must not probe older installed versions lacking those extras."""
-    create_basic_wheel_for_package(script, "dep_a", "1")
-    create_basic_wheel_for_package(script, "dep_b", "1")
-    create_basic_wheel_for_package(script, "pkg", "1")
-    create_basic_wheel_for_package(script, "pkg", "2")
-
-    script.pip(
-        "install",
-        "--no-cache-dir",
-        "--no-index",
-        "--find-links",
-        script.scratch_path,
-        "pkg==1",
-    )
-    script.assert_installed(pkg="1")
-
-    create_basic_wheel_for_package(
-        script,
-        "pkg",
-        "3",
-        extras={
-            "a": ["dep_a"],
-            "b": ["dep_b"],
-            "all": ["pkg[a]", "pkg[b]"],
-        },
-    )
-
-    result = script.pip(
-        "install",
-        "--no-cache-dir",
-        "--no-index",
-        "--find-links",
-        script.scratch_path,
-        "pkg[all]==3",
-        expect_stderr=True,
-    )
     assert "does not provide the extra" not in result.stderr, str(result)
-    script.assert_installed(pkg="3", dep_a="1", dep_b="1")
+    script.assert_installed(pkg="2", dep_a="1", dep_b="1")
 
 
 def test_install_self_referential_extras_upgrade_changes_dep_version(

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -440,7 +440,7 @@ def test_install_self_referential_extras_upgrade_different_extras(
 def test_install_self_referential_extras_skips_older_versions_without_extras(
     script: PipTestEnvironment,
 ) -> None:
-    """Self-ref extras must not probe older installed versions that lack those extras."""
+    """Self-ref extras must not probe older installed versions lacking those extras."""
     create_basic_wheel_for_package(script, "dep_a", "1")
     create_basic_wheel_for_package(script, "dep_b", "1")
     create_basic_wheel_for_package(script, "pkg", "1")

--- a/tests/functional/test_install_extras.py
+++ b/tests/functional/test_install_extras.py
@@ -292,6 +292,320 @@ def test_install_self_referential_extras(
     script.assert_installed(pkg="1", dep_a="1", dep_b="1")
 
 
+def test_install_self_referential_extras_nested(
+    script: PipTestEnvironment,
+) -> None:
+    """Convenience extras can nest through other self-referential extras."""
+    create_basic_wheel_for_package(script, "pytest", "1")
+    create_basic_wheel_for_package(script, "sphinx", "1")
+    create_basic_wheel_for_package(script, "ruff", "1")
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1",
+        extras={
+            "test": ["pytest"],
+            "docs": ["sphinx"],
+            "format": ["ruff"],
+            "dev": ["pkg[test]", "pkg[format]"],
+            "all": ["pkg[dev]", "pkg[docs]"],
+        },
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[all]",
+    )
+    script.assert_installed(pkg="1", pytest="1", sphinx="1", ruff="1")
+
+
+def test_install_self_referential_extras_with_external_dep(
+    script: PipTestEnvironment,
+) -> None:
+    """A self-referential extra can also pull in an unrelated package."""
+    create_basic_wheel_for_package(script, "dep_a", "1")
+    create_basic_wheel_for_package(script, "other", "1")
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1",
+        extras={
+            "a": ["dep_a"],
+            "all": ["pkg[a]", "other"],
+        },
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[all]",
+    )
+    script.assert_installed(pkg="1", dep_a="1", other="1")
+
+
+def test_install_self_referential_extras_after_partial_install(
+    script: PipTestEnvironment,
+) -> None:
+    """Installing more extras on an already-installed version adds missing deps."""
+    create_basic_wheel_for_package(script, "dep_a", "1")
+    create_basic_wheel_for_package(script, "dep_b", "1")
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1",
+        extras={
+            "a": ["dep_a"],
+            "b": ["dep_b"],
+            "all": ["pkg[a, b]"],
+        },
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[a]",
+    )
+    script.assert_installed(pkg="1", dep_a="1")
+    script.assert_not_installed("dep_b")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[all]",
+    )
+    script.assert_installed(pkg="1", dep_a="1", dep_b="1")
+
+
+def test_install_self_referential_extras_upgrade_different_extras(
+    script: PipTestEnvironment,
+) -> None:
+    """Upgrading can change which extras exist and which deps they pull in."""
+    create_basic_wheel_for_package(script, "dep_a", "1")
+    create_basic_wheel_for_package(script, "dep_b", "1")
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1",
+        extras={"a": ["dep_a"]},
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[a]",
+    )
+    script.assert_installed(pkg="1", dep_a="1")
+    script.assert_not_installed("dep_b")
+
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "2",
+        extras={
+            "a": ["dep_a"],
+            "b": ["dep_b"],
+            "all": ["pkg[a]", "pkg[b]"],
+        },
+    )
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[all]==2",
+        expect_stderr=True,
+    )
+    assert "does not provide the extra 'b'" not in result.stderr, str(result)
+    script.assert_installed(pkg="2", dep_a="1", dep_b="1")
+
+
+def test_install_self_referential_extras_skips_older_versions_without_extras(
+    script: PipTestEnvironment,
+) -> None:
+    """Self-ref extras must not probe older installed versions that lack those extras."""
+    create_basic_wheel_for_package(script, "dep_a", "1")
+    create_basic_wheel_for_package(script, "dep_b", "1")
+    create_basic_wheel_for_package(script, "pkg", "1")
+    create_basic_wheel_for_package(script, "pkg", "2")
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg==1",
+    )
+    script.assert_installed(pkg="1")
+
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "3",
+        extras={
+            "a": ["dep_a"],
+            "b": ["dep_b"],
+            "all": ["pkg[a]", "pkg[b]"],
+        },
+    )
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[all]==3",
+        expect_stderr=True,
+    )
+    assert "does not provide the extra" not in result.stderr, str(result)
+    script.assert_installed(pkg="3", dep_a="1", dep_b="1")
+
+
+def test_install_self_referential_extras_upgrade_changes_dep_version(
+    script: PipTestEnvironment,
+) -> None:
+    """Self-referential extras follow upgraded dependency pins."""
+    create_basic_wheel_for_package(script, "dep", "1")
+    create_basic_wheel_for_package(script, "dep", "2")
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1",
+        extras={"a": ["dep==1"]},
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[a]",
+    )
+    script.assert_installed(pkg="1", dep="1")
+
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "2",
+        extras={
+            "a": ["dep==2"],
+            "all": ["pkg[a]"],
+        },
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[all]==2",
+    )
+    script.assert_installed(pkg="2", dep="2")
+
+
+def test_install_self_referential_extras_circular(
+    script: PipTestEnvironment,
+) -> None:
+    """Circular self-referential extras resolve without looping forever."""
+    create_basic_wheel_for_package(script, "dep_a", "1")
+    create_basic_wheel_for_package(script, "dep_b", "1")
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1",
+        extras={
+            "a": ["dep_a", "pkg[b]"],
+            "b": ["dep_b", "pkg[a]"],
+        },
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[a]",
+    )
+    script.assert_installed(pkg="1", dep_a="1", dep_b="1")
+
+
+def test_install_self_referential_extras_unknown_nested(
+    script: PipTestEnvironment,
+) -> None:
+    """A nested unknown extra warns the same way as a direct unknown extra."""
+    create_basic_wheel_for_package(script, "dep_a", "1")
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1",
+        extras={
+            "a": ["dep_a"],
+            "all": ["pkg[missing]"],
+        },
+    )
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[all]",
+        expect_stderr=True,
+    )
+    assert "pkg 1 does not provide the extra 'missing'" in result.stderr
+    script.assert_installed(pkg="1")
+    script.assert_not_installed("dep_a")
+
+
+def test_install_self_referential_extras_name_normalization(
+    script: PipTestEnvironment,
+) -> None:
+    """Self-referential extras honor PEP 685 extra name normalization."""
+    create_basic_wheel_for_package(script, "meh", "1")
+    create_basic_wheel_for_package(
+        script,
+        "pkg",
+        "1",
+        extras={
+            "x_y": ["meh"],
+            "all": ["pkg[x-y]"],
+        },
+    )
+
+    script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkg[all]",
+    )
+    script.assert_installed(pkg="1", meh="1")
+
+
 def test_install_setuptools_extras_inconsistency(
     script: PipTestEnvironment, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

<!-- What problem does this solve? Include the issue number if applicable. -->
As discussed in #14160, the current regression test introduced by #14157 was too naive, even old versions of pip (`v20.3 - v21.1.3`) were able to pass.

This PR added 9 more test cases to cover expected behaviour and prevent regression (local test results for v20.2 to latest & noxfile used are provided in #14160).

Closes #14160

### Should pass with 20.3+
1. **nested** — nested self-referential extras should work.
2. **external** — a self-referential extra can mix `pkg[a]` with an unrelated third-party dep in the same extra.
3. **partial** — after `pkg[a]` is already installed, installing `pkg[all]` with the same version adds only the missing deps.
4. **unknown** — a self-reference with unknown extra (`pkg[missing]`) must raise a warning as usual.
5. **upgrade-dep** — a self-referential extra whose dependency version requirements change across versions (from requiring `dep==1` to requiring `dep==2`) must bump `dep` to version 2.
6. **circular** — mutually dependent extras (extra `a` depends on extra `b` and vice versa) must resolve normally (`pip install pkg[a]` installs dependencies from both extras).

### Should pass with 21.2+
7 & 8. **upgrade-different-extras** (two scenarios: had-no-extra or had-different-extras) — with an older pkg already installed (with no extras defined or with different extras defined and installed), upgrading to a new version with an `all` extra should: 1) pull new deps and 2) downgrade an existing dep.

### Should pass with 24.1+
9. **normalize** — PEP 685 normalization should allow `"all": ["pkg[x-y]"]` to install extra defined as `x_y` in `pyproject.toml`.

### Corresponding test cases in `tests/functional/test_install_extras.py`:
| Case | Function |
| --- | --- |
| `nested` | `test_install_self_referential_extras_nested` |
| `external` | `test_install_self_referential_extras_with_external_dep` |
| `partial` | `test_install_self_referential_extras_after_partial_install` |`test_install_self_referential_extras_skips_older_versions_without_extras` |
| `unknown` | `test_install_self_referential_extras_unknown_nested` |
| `normalize` | `test_install_self_referential_extras_name_normalization` |
| `upgrade-dep` | `test_install_self_referential_extras_upgrade_changes_dep_version` |
| `circular` | `test_install_self_referential_extras_circular` |
| `upgrade-different-extras` | `test_install_self_referential_extras_upgrade_different_extras` |


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

## Disclosure:
Assisted-by: Cursor
It was used to write the nox file for testing the full matrix, and I have discussed the design of these test cases with it before implementation.