### PR TITLE
restrict AdjacentTempDirectory to owner-only permissions

### DIFF
--- a/news/14162.bugfix.rst
+++ b/news/14162.bugfix.rst
@@ -1,0 +1,3 @@
+Create the temporary directory that stashes files during uninstall
+(``AdjacentTempDirectory``) with owner-only ``0o700`` permissions, matching the
+other temporary directories pip creates.

--- a/src/pip/_internal/utils/temp_dir.py
+++ b/src/pip/_internal/utils/temp_dir.py
@@ -277,7 +277,11 @@ class AdjacentTempDirectory(TempDirectory):
         for candidate in self._generate_names(name):
             path = os.path.join(root, candidate)
             try:
-                os.mkdir(path)
+                # Match the 0o700 that tempfile.mkdtemp() (used by the base
+                # class and the fallback below) applies; a bare os.mkdir()
+                # honors the umask and typically yields a world-readable
+                # 0o755 directory next to site-packages.
+                os.mkdir(path, 0o700)
             except OSError as ex:
                 # Continue if the name exists already
                 if ex.errno != errno.EEXIST:

--- a/tests/unit/test_utils_temp_dir.py
+++ b/tests/unit/test_utils_temp_dir.py
@@ -184,6 +184,16 @@ def test_adjacent_directory_exists(name: str, tmpdir: Path) -> None:
         assert expect_name == os.path.split(atmp_dir.path)[1]
 
 
+@pytest.mark.skipif("sys.platform == 'win32'")
+def test_adjacent_directory_permissions(tmpdir: Path) -> None:
+    original = os.path.join(tmpdir, "pkg")
+    ensure_dir(original)
+
+    with AdjacentTempDirectory(original) as atmp_dir:
+        mode = stat.S_IMODE(os.stat(atmp_dir.path).st_mode)
+    assert mode == 0o700
+
+
 def test_adjacent_directory_permission_error(monkeypatch: pytest.MonkeyPatch) -> None:
     name = "ABC"
 


### PR DESCRIPTION
## What does this PR do?

`AdjacentTempDirectory._create` builds its directory with a bare `os.mkdir(path)`, so it lands at `0o777 & ~umask` (0o755 under the usual umask of 022) instead of the 0o700 that `TempDirectory._create` and this method's own `tempfile.mkdtemp` fallback apply. That directory is created next to site-packages rather than under a private temp root, and it holds the files stashed out of site-packages while a package is being uninstalled or upgraded, so on a shared host its contents are reachable by other local users for the duration of the operation. Passing `mode=0o700` to `os.mkdir` brings this branch in line with the rest of the module.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
