### PR TITLE
Allow opting out of Git partial clones

### DIFF
--- a/docs/html/topics/vcs-support.md
+++ b/docs/html/topics/vcs-support.md
@@ -65,6 +65,10 @@ When passing a commit hash, specifying a full hash is preferable to a partial
 hash because a full hash allows pip to operate more efficiently (e.g. by
 making fewer network calls).
 
+pip requests partial clones by default when using Git 2.17 or later. If a Git
+server or network configuration cannot complete partial clones, set
+`PIP_NO_GIT_PARTIAL_CLONE=1` to use a full clone instead.
+
 ### Mercurial
 
 The supported schemes are `hg+file`, `hg+http`, `hg+https`, `hg+ssh`

--- a/docs/html/topics/vcs-support.md
+++ b/docs/html/topics/vcs-support.md
@@ -66,7 +66,7 @@ hash because a full hash allows pip to operate more efficiently (e.g. by
 making fewer network calls).
 
 pip requests partial clones by default when using Git 2.17 or later. If a Git
-server or network configuration cannot complete partial clones, set
+server or network configuration doesn't support partial clones, set
 `PIP_NO_GIT_PARTIAL_CLONE=1` to use a full clone instead.
 
 ### Mercurial

--- a/docs/html/topics/vcs-support.md
+++ b/docs/html/topics/vcs-support.md
@@ -65,9 +65,11 @@ When passing a commit hash, specifying a full hash is preferable to a partial
 hash because a full hash allows pip to operate more efficiently (e.g. by
 making fewer network calls).
 
-pip requests partial clones by default when using Git 2.17 or later. If a Git
-server or network configuration doesn't support partial clones, set
-`PIP_NO_GIT_PARTIAL_CLONE=1` to use a full clone instead.
+Pip requests partial clones by default when using Git 2.17 or later, and will
+detect when git advertises support for partial clones. If a Git server or
+network configuration incorrectly claims to support partial clones, but does
+not do so in practice, setting `PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER=1`
+will force pip to ignore the claim and use a full clone.
 
 ### Mercurial
 

--- a/news/11043.feature.rst
+++ b/news/11043.feature.rst
@@ -1,0 +1,1 @@
+Allow opting out of Git partial clones with ``PIP_NO_GIT_PARTIAL_CLONE``.

--- a/news/11043.feature.rst
+++ b/news/11043.feature.rst
@@ -1,1 +1,1 @@
-Allow opting out of Git partial clones with ``PIP_NO_GIT_PARTIAL_CLONE``.
+Allow opting out of Git partial clones with ``PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER``.

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -9,7 +9,7 @@ from dataclasses import replace
 from typing import Any
 
 from pip._internal.exceptions import BadCommand, InstallationError
-from pip._internal.utils.misc import HiddenText, display_path, hide_url
+from pip._internal.utils.misc import HiddenText, display_path, hide_url, strtobool
 from pip._internal.utils.subprocess import make_command
 from pip._internal.vcs.versioncontrol import (
     AuthInfo,
@@ -280,8 +280,8 @@ class Git(VersionControl):
             flags = ()
         else:
             flags = ("--verbose", "--progress")
-        if self.get_git_version() >= (2, 17) and not os.environ.get(
-            "PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER"
+        if self.get_git_version() >= (2, 17) and not strtobool(
+            os.environ.get("PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER", "no") or "no"
         ):
             # Git added support for partial clone in 2.17
             # https://git-scm.com/docs/partial-clone

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -281,7 +281,7 @@ class Git(VersionControl):
         else:
             flags = ("--verbose", "--progress")
         if self.get_git_version() >= (2, 17) and not os.environ.get(
-            "PIP_NO_GIT_PARTIAL_CLONE"
+            "PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER"
         ):
             # Git added support for partial clone in 2.17
             # https://git-scm.com/docs/partial-clone

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -280,7 +280,9 @@ class Git(VersionControl):
             flags = ()
         else:
             flags = ("--verbose", "--progress")
-        if self.get_git_version() >= (2, 17):
+        if self.get_git_version() >= (2, 17) and not os.environ.get(
+            "PIP_NO_GIT_PARTIAL_CLONE"
+        ):
             # Git added support for partial clone in 2.17
             # https://git-scm.com/docs/partial-clone
             # Speeds up cloning by functioning without a complete copy of repository

--- a/src/pip/_internal/vcs/git.py
+++ b/src/pip/_internal/vcs/git.py
@@ -281,7 +281,7 @@ class Git(VersionControl):
         else:
             flags = ("--verbose", "--progress")
         if self.get_git_version() >= (2, 17) and not strtobool(
-            os.environ.get("PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER", "no") or "no"
+            os.environ.get("PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER", "no")
         ):
             # Git added support for partial clone in 2.17
             # https://git-scm.com/docs/partial-clone

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,7 @@ def isolate(tmpdir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
     monkeypatch.setenv("GIT_AUTHOR_NAME", "pip")
     monkeypatch.setenv("GIT_AUTHOR_EMAIL", "distutils-sig@python.org")
+    monkeypatch.delenv("PIP_NO_GIT_PARTIAL_CLONE", False)
 
     # We want to disable the version check from running in the tests
     monkeypatch.setenv("PIP_DISABLE_PIP_VERSION_CHECK", "true")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,7 +360,7 @@ def isolate(tmpdir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
     monkeypatch.setenv("GIT_AUTHOR_NAME", "pip")
     monkeypatch.setenv("GIT_AUTHOR_EMAIL", "distutils-sig@python.org")
-    monkeypatch.delenv("PIP_NO_GIT_PARTIAL_CLONE", False)
+    monkeypatch.delenv("PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER", False)
 
     # We want to disable the version check from running in the tests
     monkeypatch.setenv("PIP_DISABLE_PIP_VERSION_CHECK", "true")

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -884,6 +884,27 @@ class TestGitArgs(_TestVcsArgs):
 
         update_submodules_mock.assert_called_with(self.dest, verbosity=1)
 
+    def test_fetch_new_partial_clone_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PIP_NO_GIT_PARTIAL_CLONE", "1")
+        with mock.patch.object(self.svn, "get_git_version", return_value=(2, 17)):
+            with mock.patch.object(
+                self.svn, "update_submodules"
+            ) as update_submodules_mock:
+                self.svn.fetch_new(
+                    self.dest, hide_url(self.url), self.rev_options, verbosity=1
+                )
+
+        assert self.call_subprocess_mock.call_args_list[0][0][0] == [
+            "git",
+            "clone",
+            hide_url("git+http://username:password@git.example.com/"),
+            self.dest,
+        ]
+
+        update_submodules_mock.assert_called_with(self.dest, verbosity=1)
+
     def test_fetch_new_legacy(self) -> None:
         with mock.patch.object(self.svn, "get_git_version", return_value=(1, 0)):
             with mock.patch.object(

--- a/tests/unit/test_vcs.py
+++ b/tests/unit/test_vcs.py
@@ -887,7 +887,7 @@ class TestGitArgs(_TestVcsArgs):
     def test_fetch_new_partial_clone_disabled(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("PIP_NO_GIT_PARTIAL_CLONE", "1")
+        monkeypatch.setenv("PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER", "1")
         with mock.patch.object(self.svn, "get_git_version", return_value=(2, 17)):
             with mock.patch.object(
                 self.svn, "update_submodules"


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

Fixes #11043.

<!-- What problem does this solve? Include the issue number if applicable. -->
Adds `PIP_NO_PARTIAL_CLONE_FOR_BROKEN_GIT_SERVER` as an explicit opt-out for Git servers or network configurations that cannot complete partial clones. when set, pip performs a full clone instead.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

Assisted-by: OpenAI Codex (code review)