### PR TITLE
Add a test for Requires-Python skip reasons without debug logging

### DIFF
--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -409,6 +409,20 @@ def test_finder_only_installs_data_require(data: TestData) -> None:
     assert {str(v.version) for v in links} == {"1.0.0", "3.3.0", "9.9.9"}
 
 
+def test_finder_records_requires_python_skips_without_debug_logging(
+    data: TestData, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO)
+    finder = make_test_finder(index_urls=[data.index_url("datarequire")])
+
+    finder.find_all_candidates("fakepackage")
+
+    assert finder.requires_python_skipped_reasons() == [
+        "2.6.0 Requires-Python <2.7",
+        "2.7.0 Requires-Python <3,>=2.7",
+    ]
+
+
 def test_finder_installs_pre_releases(data: TestData) -> None:
     """
     Test PackageFinder finds pre-releases if asked to.


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

Adds the follow-up regression test noted in #13333. It checks that Requires-Python skip reasons remain available when
debug logging is disabled.

Closes #13260.


<!-- What problem does this solve? Include the issue number if applicable. -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->
