### PR TITLE
chore: Use list for pytest parametrize values

### DIFF
--- a/tests/unit/metadata/test_metadata_pkg_resources.py
+++ b/tests/unit/metadata/test_metadata_pkg_resources.py
@@ -58,16 +58,16 @@ workingset_stdlib = _MockWorkingSet(
 
 @pytest.mark.parametrize(
     "ws, req_name",
-    itertools.chain(
-        itertools.product(
+    [
+        *itertools.product(
             [workingset],
             (d.project_name for d in workingset),
         ),
-        itertools.product(
+        *itertools.product(
             [workingset_stdlib],
             (d.project_name for d in workingset_stdlib),
         ),
-    ),
+    ],
 )
 def test_get_distribution(ws: _MockWorkingSet, req_name: str) -> None:
     """Ensure get_distribution() finds all kinds of distributions."""


### PR DESCRIPTION
Addresses this deprecation warning from pytest:

```
venv/lib/python3.14/site-packages/_pytest/python.py:124
venv/lib/python3.14/site-packages/_pytest/python.py:124
venv/lib/python3.14/site-packages/_pytest/python.py:124
  /home/ichard26/dev/oss/pip/venv/lib/python3.14/site-packages/_pytest/python.py:124: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
  Test: tests/unit/metadata/test_metadata_pkg_resources.py::test_get_distribution, argvalues type: chain
  Please convert to a list or tuple.
  See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)
```