### PR TITLE
reject file:// urls in pylock packages fetched from a URL

### DIFF
--- a/news/14174.bugfix.rst
+++ b/news/14174.bugfix.rst
@@ -1,0 +1,3 @@
+Reject a package ``url`` with a ``file://`` scheme in a ``pylock.toml`` fetched
+from a remote URL, so a remote lock file can no longer make pip read a local
+file or an SMB share while still allowing it to reference other http(s) hosts.

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -183,6 +183,21 @@ def _package_dist_url(
             return path_to_url(path)
     else:
         assert url is not None  # guaranteed by packaging.pylock validation
+        # The path branch above stops a relative or absolute path from escaping
+        # a URL-obtained lock's location. The url field is returned as-is, so a
+        # file:// value would still be read off the local filesystem (or an SMB
+        # share on Windows, leaking credentials) even though the lock came from
+        # a remote server. Reject that, mirroring the directory-entry check,
+        # while still allowing a remote lock to reference other http(s) hosts.
+        if (
+            _is_url(pylock_path_or_url)
+            and not pylock_path_or_url.startswith("file://")
+            and urlsplit(url).scheme == "file"
+        ):
+            raise InstallationError(
+                f"The file:// url {url!r} is not allowed in a pylock file "
+                f"obtained from a URL: {pylock_path_or_url!r}"
+            )
         return url
 
 

--- a/src/pip/_internal/utils/pylock.py
+++ b/src/pip/_internal/utils/pylock.py
@@ -183,12 +183,7 @@ def _package_dist_url(
             return path_to_url(path)
     else:
         assert url is not None  # guaranteed by packaging.pylock validation
-        # The path branch above stops a relative or absolute path from escaping
-        # a URL-obtained lock's location. The url field is returned as-is, so a
-        # file:// value would still be read off the local filesystem (or an SMB
-        # share on Windows, leaking credentials) even though the lock came from
-        # a remote server. Reject that, mirroring the directory-entry check,
-        # while still allowing a remote lock to reference other http(s) hosts.
+        # A file:// url in a lock fetched from a URL would still be read locally.
         if (
             _is_url(pylock_path_or_url)
             and not pylock_path_or_url.startswith("file://")

--- a/tests/unit/test_utils_pylock.py
+++ b/tests/unit/test_utils_pylock.py
@@ -105,6 +105,36 @@ def test_package_dist_url_scheme_path_remote_lock_file(path: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "file://attacker/share/pkg.tgz",
+        "file:/etc/passwd",
+    ],
+)
+def test_package_dist_url_file_scheme_remote_lock_file(url: str) -> None:
+    """A remote lock file cannot point a package url at the local filesystem."""
+    with pytest.raises(InstallationError, match="file:// url"):
+        _package_dist_url(
+            "https://example.com/pylock.toml",
+            path=None,
+            url=url,
+        )
+
+
+def test_package_dist_url_cross_host_url_remote_lock_file() -> None:
+    """A remote lock file may still reference packages on other http(s) hosts."""
+    assert (
+        _package_dist_url(
+            "https://example.com/pylock.toml",
+            path=None,
+            url="https://other.example/pkg.tgz",
+        )
+        == "https://other.example/pkg.tgz"
+    )
+
+
+@pytest.mark.parametrize(
     "pylock_path_or_url,package_vcs,expected",
     [
         (


### PR DESCRIPTION
## What does this PR do?

When a `pylock.toml` is fetched from an http(s) URL, `_package_dist_url` returns a package's `url` field unchanged, so an entry with `url = "file:///etc/passwd"` (or `file://host/share/pkg.whl` on Windows) makes pip read a local file or reach an SMB share even though the lock came from a remote server. #14159 closed this for the relative `path` field, and `package_directory_requirement_url` already refuses local targets for directory entries; this applies the same rule to the `url` field used by wheel/sdist/archive/vcs packages, while still letting a remote lock reference other http(s) hosts.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
