### PR TITLE
Propagate SSL context to HTTPS proxy connections too

### DIFF
--- a/news/13465.bugfix.rst
+++ b/news/13465.bugfix.rst
@@ -1,4 +1,2 @@
-Fix certificate verification errors when installing packages through an
-HTTPS proxy with ``truststore`` enabled (the default on Python 3.10+). The
-connection to the proxy itself now uses the same SSL context as the
-connection to the destination host.
+Ensure truststore feature remains active while initially connecting to
+a HTTPS proxy.

--- a/news/13465.bugfix.rst
+++ b/news/13465.bugfix.rst
@@ -1,0 +1,4 @@
+Fix certificate verification errors when installing packages through an
+HTTPS proxy with ``truststore`` enabled (the default on Python 3.10+). The
+connection to the proxy itself now uses the same SSL context as the
+connection to the destination host.

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -295,10 +295,8 @@ class _SSLContextAdapterMixin:
             proxy_kwargs.setdefault("ssl_context", self._ssl_context)
             # For HTTPS proxies, urllib3 also opens a separate TLS connection
             # to the proxy itself (before tunnelling to the destination) and
-            # uses "proxy_ssl_context" for that handshake. Without setting it
-            # too, connecting through an HTTPS proxy falls back to plain
-            # OpenSSL verification instead of our SSL store, causing
-            # certificate verification failures. https://github.com/pypa/pip/issues/13465
+            # uses "proxy_ssl_context" for that handshake.
+            # https://github.com/pypa/pip/issues/13465
             proxy_kwargs.setdefault("proxy_ssl_context", self._ssl_context)
         return super().proxy_manager_for(proxy, **proxy_kwargs)  # type: ignore[misc]
 

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -293,6 +293,13 @@ class _SSLContextAdapterMixin:
         # context here too. https://github.com/pypa/pip/issues/13288
         if self._ssl_context is not None:
             proxy_kwargs.setdefault("ssl_context", self._ssl_context)
+            # For HTTPS proxies, urllib3 also opens a separate TLS connection
+            # to the proxy itself (before tunnelling to the destination) and
+            # uses "proxy_ssl_context" for that handshake. Without setting it
+            # too, connecting through an HTTPS proxy falls back to plain
+            # OpenSSL verification instead of our SSL store, causing
+            # certificate verification failures. https://github.com/pypa/pip/issues/13465
+            proxy_kwargs.setdefault("proxy_ssl_context", self._ssl_context)
         return super().proxy_manager_for(proxy, **proxy_kwargs)  # type: ignore[misc]
 
 

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -35,6 +35,7 @@ from pip._internal.exceptions import (
 from pip._internal.models.link import Link
 from pip._internal.network.session import (
     CI_ENVIRONMENT_VARIABLES,
+    HTTPAdapter,
     PipSession,
     user_agent,
 )
@@ -458,6 +459,36 @@ class TestSessionProxy:
         assert options.proxy is None
         assert session.trust_env is True
         assert self._resolved_proxy(session, "http://example.com") is not None
+
+
+class TestSSLContextAdapterMixinProxy:
+    """Regression tests for https://github.com/pypa/pip/issues/13465
+
+    When connecting through an HTTPS proxy, urllib3's ``ProxyManager`` opens
+    a TLS connection to the proxy itself using ``proxy_ssl_context``, which
+    is separate from the ``ssl_context`` used for the tunnelled connection to
+    the destination host. Only setting ``ssl_context`` leaves the proxy leg
+    verified with a plain, default SSL context (i.e. not truststore's system
+    trust store), which can cause spurious certificate verification errors.
+    """
+
+    def test_https_proxy_uses_same_ssl_context_for_both_legs(self) -> None:
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        session = PipSession(ssl_context=ssl_context)
+
+        adapter = cast(HTTPAdapter, session.adapters["https://"])
+        proxy_manager = adapter.proxy_manager_for("https://proxy.example:443")
+
+        assert proxy_manager.proxy_ssl_context is ssl_context
+        assert proxy_manager.connection_pool_kw["ssl_context"] is ssl_context
+
+    def test_no_ssl_context_leaves_proxy_ssl_context_unset(self) -> None:
+        session = PipSession()
+
+        adapter = cast(HTTPAdapter, session.adapters["https://"])
+        proxy_manager = adapter.proxy_manager_for("https://proxy.example:443")
+
+        assert proxy_manager.proxy_ssl_context is None
 
 
 class TestConnectionErrors:


### PR DESCRIPTION
When truststore is enabled (the default on Python 3.10+) and a request goes through an HTTPS proxy, urllib3 opens a separate TLS connection to the proxy itself before tunnelling to the destination. That connection uses urllib3's `proxy_ssl_context`, which is distinct from the `ssl_context` pip already passes for the tunnelled connection to the destination host.

Only `ssl_context` was being set, so the proxy leg fell back to urllib3's default SSL context (plain OpenSSL verification via certifi) instead of the system trust store. On the reporter's machine this meant a root certificate present in the Windows certificate store but not bundled with certifi caused certificate verification to fail whenever a request went through their HTTPS proxy.

This follows the same pattern already used to fix #13288 (pip/#13343): pass the SSL context through explicitly rather than mutating global state. I also considered calling `truststore.inject_into_ssl()`, which is what the reporter found to work, but that monkeypatches `ssl.SSLContext` process-wide, which affects unrelated code that builds server-side or otherwise independent SSL contexts. The targeted `proxy_ssl_context` fix avoids that.

Added a couple of unit tests covering `proxy_manager_for` with and without an SSL context set.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude
