### PR TITLE
Use ephemeral ports for download server tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1048,7 +1048,7 @@ def html_index_with_onetime_server(
     """Serve files from a generated pypi index, erroring if a file is downloaded more
     than once.
 
-    Provide `-i http://localhost:8000` to pip invocations to point them at this server.
+    The server listens on an ephemeral port assigned by the operating system.
     """
 
     class InDirectoryServer(http.server.ThreadingHTTPServer):
@@ -1063,7 +1063,7 @@ def html_index_with_onetime_server(
     class Handler(OneTimeDownloadHandler):
         _seen_paths: ClassVar[set[str]] = set()
 
-    with patch_getfqdn(), InDirectoryServer(("", 8000), Handler) as httpd:
+    with patch_getfqdn(), InDirectoryServer(("", 0), Handler) as httpd:
         server_thread = threading.Thread(target=httpd.serve_forever)
         server_thread.start()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1048,7 +1048,7 @@ def html_index_with_onetime_server(
     """Serve files from a generated pypi index, erroring if a file is downloaded more
     than once.
 
-    The server listens on an ephemeral port assigned by the operating system.
+    Provide `-i http://localhost:<port>` to pip invocations, where `<port>` is the server's assigned port.
     """
 
     class InDirectoryServer(http.server.ThreadingHTTPServer):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1048,7 +1048,8 @@ def html_index_with_onetime_server(
     """Serve files from a generated pypi index, erroring if a file is downloaded more
     than once.
 
-    Provide `-i http://localhost:<port>` to pip invocations, where `<port>` is the server's assigned port.
+    Provide `-i http://localhost:<port>` to pip invocations, where `<port>` is
+    the server's assigned port.
     """
 
     class InDirectoryServer(http.server.ThreadingHTTPServer):

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1244,7 +1244,7 @@ def download_server_html_index(
             "-d",
             str(download_dir),
             "-i",
-            "http://localhost:8000",
+            f"http://localhost:{html_index_with_onetime_server.server_port}",
             *args,
         ]
         result = script.pip(*pip_args, allow_error=allow_error)


### PR DESCRIPTION
## What does this PR do?

The download tests use a fixed port (`8000`) for their local HTTP server. When pytest-xdist runs them in parallel, workers can collide while binding that port.

This change lets the operating system assign an available port and passes the assigned port to pip. This keeps the tests isolated and allows them to run under xdist.

## Testing

- `nox -s test-3.10 -- tests/functional/test_download.py -n auto`
  - 58 passed
- `nox -s lint`

## PR Checklist:

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file.

Assisted-by: Codex