### PR TITLE
Add --no-require-hashes

### DIFF
--- a/docs/html/topics/secure-installs.md
+++ b/docs/html/topics/secure-installs.md
@@ -57,7 +57,7 @@ This can be useful in deploy scripts, to ensure that the author of the requireme
 
 By default, when at least one requirement has hashes, hashes become required for all requirements. This behaviour notably prevent the combination of hashed requirements with local directories or VCS URLs.
 
-To help with such use cases, a `--no-require-hashes` option is available to disable this mechanism. Hashes are then verified only for requirements where they are provided.
+To help with such use cases, a `--no-require-hashes` flag is available to disable this mechanism. Hashes are then verified only for requirements where they are provided.
 
 ### Hash algorithms
 

--- a/docs/html/topics/secure-installs.md
+++ b/docs/html/topics/secure-installs.md
@@ -49,6 +49,16 @@ It is possible to force the hash checking mode to be enabled, by passing `--requ
 
 This can be useful in deploy scripts, to ensure that the author of the requirements file provided hashes. It is also a convenient way to bootstrap your list of hashes, since it shows the hashes of the packages it fetched. It fetches only the preferred archive for each package, so you may still need to add hashes for alternatives archives using {ref}`pip hash`: for instance if there is both a binary and a source distribution.
 
+### Disabling automatic enforcement of hash checking mode
+
+```{versionadded} 26.2
+
+```
+
+By default, when at least one requirement has hashes, hashes become required for all requirements. This behaviour notably prevent the combination of hashed requirements with local directories or VCS URLs.
+
+To help with such use cases, a `--no-require-hashes` option is available to disable this mechanism. Hashes are then verified only for requirements where they are provided.
+
 ### Hash algorithms
 
 The recommended hash algorithm at the moment is sha256, but stronger ones are allowed, including all those supported by `hashlib`. However, weaker ones such as md5, sha1, and sha224 are excluded to avoid giving a false sense of security.

--- a/news/14169.feature.rst
+++ b/news/14169.feature.rst
@@ -1,0 +1,2 @@
+Add ``--no-require-hashes`` to disable automatic enablement of
+``--require-hashes`` when encountering a requirement with hashes.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -1177,6 +1177,17 @@ require_hashes: Callable[..., Option] = partial(
 )
 
 
+no_require_hashes: Callable[..., Option] = partial(
+    Option,
+    "--no-require-hashes",
+    dest="no_require_hashes",
+    action="store_true",
+    default=False,
+    help="Do not automatically enable --require-hashes "
+    "when encountering a requirement with hashes.",
+)
+
+
 list_path: Callable[..., Option] = partial(
     PipOption,
     "--path",

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -313,11 +313,6 @@ class RequirementCommand(IndexGroupCommand):
         """
         requirements: list[InstallRequirement] = []
 
-        if options.require_hashes and options.no_require_hashes:
-            raise CommandError(
-                "--require-hashes and --no-require-hashes are mutually exclusive"
-            )
-
         if should_ignore_regular_constraints():
             # Inside an isolated build subprocess: apply the build constraints
             # (forwarded via --build-constraint) instead of the inherited ones.
@@ -427,8 +422,13 @@ class RequirementCommand(IndexGroupCommand):
                 )
                 requirements.append(req_to_add)
 
+        if options.require_hashes and options.no_require_hashes:
+            raise CommandError(
+                "--require-hashes and --no-require-hashes are mutually exclusive"
+            )
+
         # If any requirement has hash options, enable hash checking for all
-        # requirements, unlesss this mechanism has been explicitly disabled
+        # requirements, unless this mechanism has been explicitly disabled
         # with --no-require-hashes.
         if not options.no_require_hashes and any(
             req.has_hash_options for req in requirements

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -313,6 +313,11 @@ class RequirementCommand(IndexGroupCommand):
         """
         requirements: list[InstallRequirement] = []
 
+        if options.require_hashes and options.no_require_hashes:
+            raise CommandError(
+                "--require-hashes and --no-require-hashes are mutually exclusive"
+            )
+
         if should_ignore_regular_constraints():
             # Inside an isolated build subprocess: apply the build constraints
             # (forwarded via --build-constraint) instead of the inherited ones.
@@ -422,8 +427,12 @@ class RequirementCommand(IndexGroupCommand):
                 )
                 requirements.append(req_to_add)
 
-        # If any requirement has hash options, enable hash checking.
-        if any(req.has_hash_options for req in requirements):
+        # If any requirement has hash options, enable hash checking for all
+        # requirements, unlesss this mechanism has been explicitly disabled
+        # with --no-require-hashes.
+        if not options.no_require_hashes and any(
+            req.has_hash_options for req in requirements
+        ):
             options.require_hashes = True
 
         if not (

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -41,6 +41,7 @@ class DownloadCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.no_deps())
         self.cmd_opts.add_option(cmdoptions.src())
         self.cmd_opts.add_option(cmdoptions.require_hashes())
+        self.cmd_opts.add_option(cmdoptions.no_require_hashes())
         self.cmd_opts.add_option(cmdoptions.progress_bar())
         self.cmd_opts.add_option(cmdoptions.no_build_isolation())
         self.cmd_opts.add_option(cmdoptions.use_pep517())

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -322,6 +322,7 @@ class InstallCommand(RequirementCommand):
             help="Do not warn about broken dependencies",
         )
         self.cmd_opts.add_option(cmdoptions.require_hashes())
+        self.cmd_opts.add_option(cmdoptions.no_require_hashes())
         self.cmd_opts.add_option(cmdoptions.progress_bar())
         self.cmd_opts.add_option(cmdoptions.root_user_action())
 

--- a/src/pip/_internal/commands/lock.py
+++ b/src/pip/_internal/commands/lock.py
@@ -75,6 +75,7 @@ class LockCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.config_settings())
 
         self.cmd_opts.add_option(cmdoptions.require_hashes())
+        self.cmd_opts.add_option(cmdoptions.no_require_hashes())
         self.cmd_opts.add_option(cmdoptions.progress_bar())
 
         index_opts = cmdoptions.make_option_group(

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -75,6 +75,7 @@ class WheelCommand(RequirementCommand):
         self.cmd_opts.add_option(cmdoptions.config_settings())
 
         self.cmd_opts.add_option(cmdoptions.require_hashes())
+        self.cmd_opts.add_option(cmdoptions.no_require_hashes())
 
         index_opts = cmdoptions.make_option_group(
             cmdoptions.index_group,

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -58,6 +58,7 @@ SUPPORTED_OPTIONS: list[Callable[..., optparse.Option]] = [
     cmdoptions.only_binary,
     cmdoptions.prefer_binary,
     cmdoptions.require_hashes,
+    cmdoptions.no_require_hashes,
     cmdoptions.pre,
     cmdoptions.all_releases,
     cmdoptions.only_final,
@@ -224,6 +225,8 @@ def handle_option_line(
         # percolate options upward
         if opts.require_hashes:
             options.require_hashes = opts.require_hashes
+        if opts.no_require_hashes:
+            options.no_require_hashes = opts.no_require_hashes
         if opts.features_enabled:
             options.features_enabled.extend(
                 f for f in opts.features_enabled if f not in options.features_enabled

--- a/tests/data/lockfiles/pylock.mixed.toml
+++ b/tests/data/lockfiles/pylock.mixed.toml
@@ -1,0 +1,17 @@
+lock-version = "1.0"
+created-by = "pip"
+
+[[packages]]
+name = "simplewheel"
+version = "2.0"
+
+[[packages.wheels]]
+name = "simplewheel-2.0-1-py2.py3-none-any.whl"
+path = "../packages/simplewheel-2.0-1-py2.py3-none-any.whl"
+
+[packages.wheels.hashes]
+sha256 = "71e1ca6b16ae3382a698c284013f66504f2581099b2ce4801f60e9536236ceee"
+
+[[packages]]
+name = "singlemodule"
+directory = { path = "../src/singlemodule", editable = true }

--- a/tests/functional/test_install_pylock_reqs.py
+++ b/tests/functional/test_install_pylock_reqs.py
@@ -40,6 +40,57 @@ def test_install_pylock(
     ]
 
 
+def test_install_pylock_no_require_hashes(
+    script: PipTestEnvironment,
+    data: TestData,
+) -> None:
+    """Install from pylock with a mix of requirements with hash
+    and local directories, with --no-require-hashes."""
+    pylock_path = data.lockfiles.joinpath("pylock.mixed.toml")
+    cmd: list[str | Path] = [
+        "install",
+        "--no-index",
+        "--find-links",
+        data.common_wheels,  # to obtain build backend to build sdist
+        "--quiet",
+        "--report",
+        "-",
+        "--dry-run",
+        "-r",
+        pylock_path,
+    ]
+    # Mixing requirement with hashes and local directory fails because local
+    # directory has no hash
+    result = script.pip(
+        *cmd,
+        expect_error=True,
+    )
+    assert "experimental" in result.stderr
+    assert "there is no single file to hash" in result.stderr
+    # With --no-require-hashes, it succeeds
+    result = script.pip(
+        *cmd,
+        "--no-require-hashes",
+        allow_stderr_warning=True,
+    )
+    assert "experimental" in result.stderr
+    report = json.loads(result.stdout)
+    installed = sorted(report["install"], key=lambda r: r["metadata"]["name"])
+    assert [
+        (
+            r["metadata"]["name"],
+            r["metadata"]["version"],
+            r["is_direct"],
+            r["requested"],
+            r["download_info"].get("dir_info", {}).get("editable", False),
+        )
+        for r in installed
+    ] == [
+        ("simplewheel", "2.0", False, True, False),  # wheel
+        ("singlemodule", "0.0.1", True, True, True),  # directory, editable
+    ]
+
+
 def test_install_pylock_wheel_cache(
     script: PipTestEnvironment,
     data: TestData,

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -239,7 +239,7 @@ class TestRequirementSet:
             command.get_requirements(args, options, finder, session)
         assert not options.require_hashes
 
-    def test_require_hases_no_require_hasesh_in_reqs_file(
+    def test_require_hashes_no_require_hashes_in_reqs_file(
         self, data: TestData, tmpdir: Path
     ) -> None:
         finder = make_test_finder(find_links=[data.find_links])

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -209,6 +209,35 @@ class TestRequirementSet:
             command.get_requirements(args, options, finder, session)
         assert options.require_hashes
 
+    def test_auto_require_hashes(self, data: TestData, tmpdir: Path) -> None:
+        """A requirement with hashes auto-enables --require-hashes"""
+        finder = make_test_finder(find_links=[data.find_links])
+        session = finder._link_collector.session
+        command = cast(InstallCommand, create_command("install"))
+        reqs = (
+            r"simple==1.0 --hash=sha256:393043e672415891885c9a2a0929b1"
+            r"af95fb866d6ca016b42d2e6ce53619b653$"
+        )
+        with requirements_file(reqs, tmpdir) as reqs_file:
+            options, args = command.parse_args(["-r", os.fspath(reqs_file)])
+            command.get_requirements(args, options, finder, session)
+        assert options.require_hashes
+
+    def test_no_auto_require_hashes(self, data: TestData, tmpdir: Path) -> None:
+        """A requirement with hashes does not auto-enable --require-hashes
+        when --no-require-hashes is set"""
+        finder = make_test_finder(find_links=[data.find_links])
+        session = finder._link_collector.session
+        command = cast(InstallCommand, create_command("install"))
+        reqs = (
+            r"simple==1.0 --hash=sha256:393043e672415891885c9a2a0929b1"
+            r"af95fb866d6ca016b42d2e6ce53619b653$"
+        )
+        with requirements_file("--no-require-hashes\n" + reqs, tmpdir) as reqs_file:
+            options, args = command.parse_args(["-r", os.fspath(reqs_file)])
+            command.get_requirements(args, options, finder, session)
+        assert not options.require_hashes
+
     def test_unsupported_hashes(self, data: TestData) -> None:
         """VCS and dir links should raise errors when --require-hashes is
         on.

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -25,6 +25,7 @@ from pip._internal.cache import WheelCache
 from pip._internal.commands import create_command
 from pip._internal.commands.install import InstallCommand
 from pip._internal.exceptions import (
+    CommandError,
     HashErrors,
     InstallationError,
     InvalidWheelFilename,
@@ -237,6 +238,26 @@ class TestRequirementSet:
             options, args = command.parse_args(["-r", os.fspath(reqs_file)])
             command.get_requirements(args, options, finder, session)
         assert not options.require_hashes
+
+    def test_require_hases_no_require_hasesh_in_reqs_file(
+        self, data: TestData, tmpdir: Path
+    ) -> None:
+        finder = make_test_finder(find_links=[data.find_links])
+        session = finder._link_collector.session
+        command = cast(InstallCommand, create_command("install"))
+        reqs = (
+            r"simple==1.0 --hash=sha256:393043e672415891885c9a2a0929b1"
+            r"af95fb866d6ca016b42d2e6ce53619b653$"
+        )
+        with requirements_file(
+            "--require-hashes\n--no-require-hashes\n" + reqs, tmpdir
+        ) as reqs_file:
+            options, args = command.parse_args(["-r", os.fspath(reqs_file)])
+            with pytest.raises(
+                CommandError,
+                match="--require-hashes and --no-require-hashes are mutually exclusive",
+            ):
+                command.get_requirements(args, options, finder, session)
 
     def test_unsupported_hashes(self, data: TestData) -> None:
         """VCS and dir links should raise errors when --require-hashes is


### PR DESCRIPTION
closes #14169

closes #4995
leaving #6469 open: this is an alternative to address the use case
closes #13943
closes #13944 (can be tracked as part of #6469)
closes #11968 (I won't pursue that avenue myself)
