### PR TITLE
Fix the 'no matching distributions' message being shown for installable packages

### DIFF
--- a/news/14193.bugfix.rst
+++ b/news/14193.bugfix.rst
@@ -1,0 +1,2 @@
+Fix the no-matching-distributions hint being shown for packages that are
+installable.

--- a/news/14193.bugfix.rst
+++ b/news/14193.bugfix.rst
@@ -1,2 +1,2 @@
-Fix the no-matching-distributions hint being shown for packages that are
-installable.
+Fix the "no matching distributions" hint being shown for packages that are
+excluded due to version conflicts.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -784,16 +784,7 @@ class Factory:
         """
         Check if there are any candidates available for the project name.
         """
-        return any(
-            self.find_candidates(
-                project_name,
-                requirements={project_name: []},
-                incompatibilities={},
-                constraint=Constraint.empty(),
-                prefers_installed=True,
-                is_satisfied_by=lambda r, c: True,
-            )
-        )
+        return bool(self._finder.find_all_candidates(project_name))
 
     def get_installation_error(
         self,

--- a/tests/functional/test_new_resolver_errors.py
+++ b/tests/functional/test_new_resolver_errors.py
@@ -198,6 +198,10 @@ def test_new_resolver_no_versions_available_hint(script: PipTestEnvironment) -> 
 def test_new_resolver_hint_not_shown_when_versions_available(
     script: PipTestEnvironment,
 ) -> None:
+    """
+    Test hint is not shown when a package candidate is available,
+    even though ResolutionImpossible occurs.
+    """
     create_basic_wheel_for_package(script, "base", "1.0")
     create_basic_wheel_for_package(script, "base", "2.0")
     create_basic_wheel_for_package(script, "pkga", "1.0", depends=["base==1.0"])

--- a/tests/functional/test_new_resolver_errors.py
+++ b/tests/functional/test_new_resolver_errors.py
@@ -193,3 +193,30 @@ def test_new_resolver_no_versions_available_hint(script: PipTestEnvironment) -> 
         "matching distributions available for your environment:\n"
         "    incompatible-dep\n" in result.stdout
     ), str(result)
+
+
+def test_new_resolver_hint_not_shown_when_versions_available(
+    script: PipTestEnvironment,
+) -> None:
+    create_basic_wheel_for_package(script, "base", "1.0")
+    create_basic_wheel_for_package(script, "base", "2.0")
+    create_basic_wheel_for_package(script, "pkga", "1.0", depends=["base==1.0"])
+    create_basic_wheel_for_package(script, "pkgb", "1.0", depends=["base==2.0"])
+
+    result = script.pip(
+        "install",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "pkga",
+        "pkgb",
+        expect_error=True,
+    )
+
+    assert "ResolutionImpossible" in result.stderr, str(result)
+    assert "pkga 1.0 depends on base==1.0" in result.stdout, str(result)
+    assert "pkgb 1.0 depends on base==2.0" in result.stdout, str(result)
+    assert (
+        "have no matching distributions available" not in result.stdout
+    ), str(result)

--- a/tests/functional/test_new_resolver_errors.py
+++ b/tests/functional/test_new_resolver_errors.py
@@ -221,6 +221,4 @@ def test_new_resolver_hint_not_shown_when_versions_available(
     assert "ResolutionImpossible" in result.stderr, str(result)
     assert "pkga 1.0 depends on base==1.0" in result.stdout, str(result)
     assert "pkgb 1.0 depends on base==2.0" in result.stdout, str(result)
-    assert (
-        "have no matching distributions available" not in result.stdout
-    ), str(result)
+    assert "have no matching distributions available" not in result.stdout, str(result)


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

<!-- What problem does this solve? Include the issue number if applicable. -->

Fixes #14193 

Uses `find_all_candidates()` so the `no matching distributions available....` message is only shown when the project has no candidates.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

Assisted-by: Codex (review)