### PR TITLE
Fix a typo in the email address in SECURITY.md 

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ official website](https://www.python.org/dev/security/) for
 instructions on how to report a security-related problem to
 the Python Security Response Team responsibly.
 
-To reach the response team, email `security at python dot org`.
+To reach the response team, email `security@python.org`.
 
 Pip relies on the Python Security Response Team (PSRT) to triage
 and respond to security reports. PSRT members balance security


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?
This PR fixes a typo in the email address in SECURITY.md, changing it from `security at python dot org` to `security@python.org`.
<!-- What problem does this solve? Include the issue number if applicable. -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

