### PR TITLE
ci: Attempt to reduce winget flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,9 @@ jobs:
         shell: pwsh
         run: |
           for ($i = 1; $i -le 3; $i++) {
-            winget install --accept-source-agreements --accept-package-agreements -e --id Slik.Subversion
+            winget source reset --force
+            winget source update winget
+            winget install --source winget --accept-source-agreements --accept-package-agreements -e --id Slik.Subversion
             if ($LASTEXITCODE -eq 0) { break }
             if ($i -eq 3) { exit $LASTEXITCODE }
             Start-Sleep -Seconds (10 * $i)


### PR DESCRIPTION
- Clear the source cache before installing svn
- Only use the winget community repository and ignore the msstore repository to reduce the surface that can go wrong

Both of these strategies have been [suggested in threads](https://github.com/microsoft/winget-cli/issues/5617) about flaky winget errors.

No idea if this will work, but it's worth a shot. 
