### PR TITLE
Replace per req permit_editable_wheels by a preparer and builder flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,7 @@ max-complexity = 33  # default is 10
 "src/pip/__pip-runner__.py" = ["UP"] # Must be compatible with Python 2.7
 
 [tool.ruff.lint.pylint]
-max-args = 15  # default is 5
+max-args = 16  # default is 5
 max-branches = 28  # default is 12
 max-returns = 15  # default is 6
 max-statements = 134  # default is 50

--- a/src/pip/_internal/build_env/installer.py
+++ b/src/pip/_internal/build_env/installer.py
@@ -208,6 +208,7 @@ class InprocessBuildEnvironmentInstaller:
             use_user_site=False,
             lazy_wheel=False,
             legacy_resolver=False,
+            allow_editables=True,
         )
 
     def install(
@@ -281,7 +282,9 @@ class InprocessBuildEnvironmentInstaller:
         reqs_to_build = [
             r for r in resolved_set.requirements_to_install if not r.is_wheel
         ]
-        _, build_failures = build(reqs_to_build, self._wheel_cache, verify=True)
+        _, build_failures = build(
+            reqs_to_build, self._wheel_cache, verify=True, allow_editables=True
+        )
         if build_failures:
             raise InstallWheelBuildError(build_failures)
 

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -162,6 +162,8 @@ class RequirementCommand(IndexGroupCommand):
         build_tracker: BuildTracker,
         session: PipSession,
         finder: PackageFinder,
+        *,
+        allow_editables: bool,
         use_user_site: bool,
         download_dir: str | None = None,
         verbosity: int = 0,
@@ -242,6 +244,7 @@ class RequirementCommand(IndexGroupCommand):
             lazy_wheel=lazy_wheel,
             verbosity=verbosity,
             legacy_resolver=legacy_resolver,
+            allow_editables=allow_editables,
         )
 
     @classmethod

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -120,6 +120,7 @@ class DownloadCommand(RequirementCommand):
             download_dir=options.download_dir,
             use_user_site=False,
             verbosity=self.verbosity,
+            allow_editables=False,
         )
 
         resolver = self.make_resolver(

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -450,12 +450,6 @@ class InstallCommand(RequirementCommand):
 
             wheel_cache = WheelCache(options.cache_dir)
 
-            # Only when installing is it permitted to use PEP 660.
-            # In other circumstances (pip wheel, pip download) we generate
-            # regular (i.e. non editable) metadata and wheels.
-            for req in reqs:
-                req.permit_editable_wheels = True
-
             preparer = self.make_requirement_preparer(
                 temp_build_dir=directory,
                 options=options,
@@ -464,6 +458,7 @@ class InstallCommand(RequirementCommand):
                 finder=finder,
                 use_user_site=options.use_user_site,
                 verbosity=self.verbosity,
+                allow_editables=True,
             )
             resolver = self.make_resolver(
                 preparer=preparer,
@@ -529,6 +524,7 @@ class InstallCommand(RequirementCommand):
                 reqs_to_build,
                 wheel_cache=wheel_cache,
                 verify=True,
+                allow_editables=True,
             )
 
             if build_failures:

--- a/src/pip/_internal/commands/lock.py
+++ b/src/pip/_internal/commands/lock.py
@@ -126,12 +126,6 @@ class LockCommand(RequirementCommand):
 
         wheel_cache = WheelCache(options.cache_dir)
 
-        # Only when installing is it permitted to use PEP 660.
-        # In other circumstances (pip wheel, pip download) we generate
-        # regular (i.e. non editable) metadata and wheels.
-        for req in reqs:
-            req.permit_editable_wheels = True
-
         preparer = self.make_requirement_preparer(
             temp_build_dir=directory,
             options=options,
@@ -140,6 +134,7 @@ class LockCommand(RequirementCommand):
             finder=finder,
             use_user_site=False,
             verbosity=self.verbosity,
+            allow_editables=True,
         )
         resolver = self.make_resolver(
             preparer=preparer,

--- a/src/pip/_internal/commands/wheel.py
+++ b/src/pip/_internal/commands/wheel.py
@@ -126,6 +126,7 @@ class WheelCommand(RequirementCommand):
             download_dir=options.wheel_dir,
             use_user_site=False,
             verbosity=self.verbosity,
+            allow_editables=False,
         )
 
         resolver = self.make_resolver(
@@ -154,6 +155,7 @@ class WheelCommand(RequirementCommand):
             reqs_to_build,
             wheel_cache=wheel_cache,
             verify=(not options.no_verify),
+            allow_editables=False,
         )
         for req in build_successes:
             assert req.link and req.link.is_wheel

--- a/src/pip/_internal/distributions/base.py
+++ b/src/pip/_internal/distributions/base.py
@@ -52,5 +52,6 @@ class AbstractDistribution(metaclass=abc.ABCMeta):
         build_env_installer: BuildEnvironmentInstaller,
         build_isolation: BuildIsolationMode,
         check_build_deps: bool,
+        allow_editables: bool,
     ) -> None:
         raise NotImplementedError()

--- a/src/pip/_internal/distributions/installed.py
+++ b/src/pip/_internal/distributions/installed.py
@@ -29,5 +29,6 @@ class InstalledDistribution(AbstractDistribution):
         build_env_installer: BuildEnvironmentInstaller,
         build_isolation: BuildIsolationMode,
         check_build_deps: bool,
+        allow_editables: bool,
     ) -> None:
         pass

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -42,6 +42,7 @@ class SourceDistribution(AbstractDistribution):
         build_env_installer: BuildEnvironmentInstaller,
         build_isolation: BuildIsolationMode,
         check_build_deps: bool,
+        allow_editables: bool,
     ) -> None:
         # Load pyproject.toml and set up backend environment
         self.req.load_pyproject_toml()
@@ -58,7 +59,9 @@ class SourceDistribution(AbstractDistribution):
             # to avoid installing build requirements needlessly.
             self.req.editable_sanity_check()
             # Install the dynamic build requirements.
-            self._install_build_reqs(build_env_installer)
+            self._install_build_reqs(
+                build_env_installer, allow_editables=allow_editables
+            )
         else:
             # When not using build isolation, we still need to check that
             # the build backend supports PEP 660.
@@ -74,7 +77,7 @@ class SourceDistribution(AbstractDistribution):
                 self._raise_conflicts("the backend dependencies", conflicting)
             if missing:
                 self._raise_missing_reqs(missing)
-        self.req.prepare_metadata()
+        self.req.prepare_metadata(allow_editables)
 
     def _prepare_build_env(
         self,
@@ -136,14 +139,16 @@ class SourceDistribution(AbstractDistribution):
                 return backend.get_requires_for_build_editable()
 
     def _install_build_reqs(
-        self, build_env_installer: BuildEnvironmentInstaller
+        self,
+        build_env_installer: BuildEnvironmentInstaller,
+        allow_editables: bool,
     ) -> None:
         # Install any extra build dependencies that the backend requests.
         # This must be done in a second pass, as the pyproject.toml
         # dependencies must be installed before we can call the backend.
         if (
             self.req.editable
-            and self.req.permit_editable_wheels
+            and allow_editables
             and self.req.supports_pyproject_editable
         ):
             build_reqs = self._get_build_requires_editable()

--- a/src/pip/_internal/distributions/wheel.py
+++ b/src/pip/_internal/distributions/wheel.py
@@ -40,5 +40,6 @@ class WheelDistribution(AbstractDistribution):
         build_env_installer: BuildEnvironmentInstaller,
         build_isolation: BuildIsolationMode,
         check_build_deps: bool,
+        allow_editables: bool,
     ) -> None:
         pass

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -72,6 +72,7 @@ def _get_prepared_distribution(
     build_env_installer: BuildEnvironmentInstaller,
     build_isolation: BuildIsolationMode,
     check_build_deps: bool,
+    allow_editables: bool,
 ) -> BaseDistribution:
     """Prepare a distribution for installation."""
     abstract_dist = make_distribution_for_install_requirement(req)
@@ -79,7 +80,7 @@ def _get_prepared_distribution(
     if tracker_id is not None:
         with build_tracker.track(req, tracker_id):
             abstract_dist.prepare_distribution_metadata(
-                build_env_installer, build_isolation, check_build_deps
+                build_env_installer, build_isolation, check_build_deps, allow_editables
             )
     return abstract_dist.get_metadata_distribution()
 
@@ -359,6 +360,7 @@ class RequirementPreparer:
         lazy_wheel: bool,
         verbosity: int,
         legacy_resolver: bool,
+        allow_editables: bool,
     ) -> None:
         super().__init__()
 
@@ -400,6 +402,10 @@ class RequirementPreparer:
 
         # Previous "header" printed for a link-based InstallRequirement
         self._previous_requirement_header = ("", "")
+
+        # Do we allow preparing editable wheels?
+        # When using pip wheel, editables must still produce regular wheels
+        self.allow_editables = allow_editables
 
     def _log_preparing_link(self, req: InstallRequirement) -> None:
         """Provide context for the requirement being prepared."""
@@ -780,6 +786,7 @@ class RequirementPreparer:
             self.build_env_installer,
             self.build_isolation,
             self.check_build_deps,
+            self.allow_editables,
         )
 
         # If a PEP 658 .metadata file was used, check that fields relevant for
@@ -857,6 +864,7 @@ class RequirementPreparer:
                 self.build_env_installer,
                 self.build_isolation,
                 self.check_build_deps,
+                self.allow_editables,
             )
 
             req.check_if_exists(self.use_user_site)

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -260,7 +260,6 @@ def install_req_from_editable(
     hash_options: dict[str, list[str]] | None = None,
     constraint: bool = False,
     user_supplied: bool = False,
-    permit_editable_wheels: bool = False,
     config_settings: dict[str, str | list[str]] | None = None,
 ) -> InstallRequirement:
     if constraint:
@@ -272,7 +271,6 @@ def install_req_from_editable(
         comes_from=comes_from,
         user_supplied=user_supplied,
         editable=True,
-        permit_editable_wheels=permit_editable_wheels,
         link=parts.link,
         constraint=constraint,
         isolated=isolated,
@@ -552,7 +550,6 @@ def install_req_drop_extras(ireq: InstallRequirement) -> InstallRequirement:
         extras=[],
         config_settings=ireq.config_settings,
         user_supplied=ireq.user_supplied,
-        permit_editable_wheels=ireq.permit_editable_wheels,
     )
 
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -79,7 +79,6 @@ class InstallRequirement:
         constraint: bool = False,
         extras: Collection[str] = (),
         user_supplied: bool = False,
-        permit_editable_wheels: bool = False,
         locked_link: Link | None = None,
         locked_version: Version | None = None,
     ) -> None:
@@ -88,7 +87,6 @@ class InstallRequirement:
         self.comes_from = comes_from
         self.constraint = constraint
         self.editable = editable
-        self.permit_editable_wheels = permit_editable_wheels
 
         # source_dir is the local directory where the linked requirement is
         # located, or unpacked. In case unpacking is needed, creating and
@@ -527,7 +525,7 @@ class InstallRequirement:
                 f"Consider using a build backend that supports PEP 660."
             )
 
-    def prepare_metadata(self) -> None:
+    def prepare_metadata(self, allow_editables: bool) -> None:
         """Ensure that project metadata is available.
 
         Under PEP 517 and PEP 660, call the backend hook to prepare the metadata.
@@ -537,11 +535,7 @@ class InstallRequirement:
         details = self.name or f"from {self.link}"
 
         assert self.pep517_backend is not None
-        if (
-            self.editable
-            and self.permit_editable_wheels
-            and self.supports_pyproject_editable
-        ):
+        if self.editable and allow_editables and self.supports_pyproject_editable:
             self.metadata_directory = generate_editable_metadata(
                 build_env=self.build_env,
                 backend=self.pep517_backend,

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -101,7 +101,6 @@ def make_install_req_from_editable(
         comes_from=template.comes_from,
         isolated=template.isolated,
         constraint=template.constraint,
-        permit_editable_wheels=template.permit_editable_wheels,
         hash_options=template.hash_options,
         config_settings=template.config_settings,
     )

--- a/src/pip/_internal/wheel_builder.py
+++ b/src/pip/_internal/wheel_builder.py
@@ -208,6 +208,7 @@ def build(
     requirements: Iterable[InstallRequirement],
     wheel_cache: WheelCache,
     verify: bool,
+    allow_editables: bool,
 ) -> BuildResult:
     """Build wheels.
 
@@ -232,7 +233,7 @@ def build(
                 req,
                 cache_dir,
                 verify,
-                req.editable and req.permit_editable_wheels,
+                req.editable and allow_editables,
             )
             if wheel_file:
                 # Record the download origin in the cache

--- a/tests/unit/resolution_resolvelib/conftest.py
+++ b/tests/unit/resolution_resolvelib/conftest.py
@@ -48,6 +48,7 @@ def preparer(finder: PackageFinder) -> Iterator[RequirementPreparer]:
                     finder=finder,
                     use_user_site=False,
                     verbosity=0,
+                    allow_editables=True,
                 )
 
                 yield preparer

--- a/tests/unit/test_req.py
+++ b/tests/unit/test_req.py
@@ -120,6 +120,7 @@ class TestRequirementSet:
                 lazy_wheel=False,
                 verbosity=0,
                 legacy_resolver=True,
+                allow_editables=True,
             )
             yield Resolver(
                 preparer=preparer,
@@ -861,7 +862,6 @@ class TestInstallRequirement:
         assert without_extras.constraint == req.constraint
         assert without_extras.config_settings == req.config_settings
         assert without_extras.user_supplied == req.user_supplied
-        assert without_extras.permit_editable_wheels == req.permit_editable_wheels
 
     @pytest.mark.parametrize(
         "inp, extras, out",
@@ -908,7 +908,6 @@ class TestInstallRequirement:
         assert extended.constraint == req.constraint
         assert extended.config_settings == req.config_settings
         assert extended.user_supplied == req.user_supplied
-        assert extended.permit_editable_wheels == req.permit_editable_wheels
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#14195 reminded me that, back then, I was not happy with the way I implemented this `permit_editable_wheels` per requirement flag.

In effect, it is a global mode that allows disabling editable metadata preparation and wheel building and use regular wheels for `pip wheel` and `pip download`. So making it per requirement flag was not a good ift.

With this PR I make it a flag on the preparer and propagate it to metadata preparation functions. And an argument to the build function.

This feels cleaner to me and should be more robust.

The two important tests about this still pass (`test_wheel_editable_pep660_basic` and `test_download_editable_pep660_basic`).