### PR TITLE
Correct macOS XDG configuration documentation

### DIFF
--- a/docs/html/topics/configuration.md
+++ b/docs/html/topics/configuration.md
@@ -59,16 +59,23 @@ Site
 ```{tab} MacOS
 
 Global
-: In a "pip" subdirectory of any of the paths set in the environment variable
-  `XDG_DATA_DIRS` (if it exists), for example {file}`/etc/xdg/pip/pip.conf`.
+: In a "pip" subdirectory of each path listed in the environment
+  variable `XDG_DATA_DIRS` (if it is non-empty).
 
-  This will be followed by loading {file}`/Library/Application Support/pip/pip.conf`.
+  If `XDG_DATA_DIRS` is unset or empty,
+  {file}`/Library/Application Support/pip/pip.conf` is loaded instead
+  (run `pip config debug` to identify the exact paths).
 
 User
-: {file}`$HOME/Library/Application Support/pip/pip.conf`
-  if directory `$HOME/Library/Application Support/pip` exists
-  else {file}`$HOME/.config/pip/pip.conf`, which respects the
-  `XDG_DATA_HOME` environment variable.
+: The user configuration file is loaded from one of the following
+  locations:
+
+  * {file}`$XDG_DATA_HOME/pip/pip.conf`, if `XDG_DATA_HOME` is
+    non-empty and {file}`$XDG_DATA_HOME/pip` exists.
+  * {file}`$HOME/Library/Application Support/pip/pip.conf`, if
+    `XDG_DATA_HOME` is unset or empty and
+    {file}`$HOME/Library/Application Support/pip` exists.
+  * {file}`$HOME/.config/pip/pip.conf`, otherwise.
 
   The legacy "per-user" configuration file is also loaded, if it exists: {file}`$HOME/.pip/pip.conf`.
 
@@ -97,7 +104,7 @@ Site
 ```
 
 ```{versionchanged} 26.2
-pip will also respect `XDG_CONFIG_DIRS` and `XDG_CONFIG_HOME` on macOS.
+Pip will also respect `XDG_DATA_DIRS` and `XDG_DATA_HOME` on macOS.
 ```
 
 ### `PIP_CONFIG_FILE`


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?


Correct the macOS configuration documentation to use `XDG_DATA_DIRS` and `XDG_DATA_HOME`, and clarify how they affect the global and user configuration paths.

Fixes #14200.

<!-- What problem does this solve? Include the issue number if applicable. -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

Assisted-by: Codex (review)

