### PR TITLE
fix(search): compare string representation of dist.version with latest in print_dist_installation_info

### DIFF
--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -116,7 +116,7 @@ def transform_hits(hits: list[dict[str, str]]) -> list[TransformedHit]:
 def print_dist_installation_info(latest: str, dist: BaseDistribution | None) -> None:
     if dist is not None:
         with indent_log():
-            if dist.version == latest:
+            if str(dist.version) == str(latest):
                 write_output("INSTALLED: %s (latest)", dist.version)
             else:
                 write_output("INSTALLED: %s", dist.version)


### PR DESCRIPTION
## Description
This PR resolves issue #14177 by comparing string representations of `dist.version` and `latest` (`str(dist.version) == str(latest)`) in `print_dist_installation_info()` in `src/pip/_internal/commands/search.py`.

## Details
- Fixes type mismatch between `Version` object and `str` version string so that `INSTALLED: %s (latest)` is correctly printed when the installed version is the latest.