### PR TITLE
fix(resolvelib): check finder.find_all_candidates in _has_any_candidates

### DIFF
--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -784,16 +784,7 @@ class Factory:
         """
         Check if there are any candidates available for the project name.
         """
-        return any(
-            self.find_candidates(
-                project_name,
-                requirements={project_name: []},
-                incompatibilities={},
-                constraint=Constraint.empty(),
-                prefers_installed=True,
-                is_satisfied_by=lambda r, c: True,
-            )
-        )
+        return bool(self._finder.find_all_candidates(project_name))
 
     def get_installation_error(
         self,


### PR DESCRIPTION
## Description
This PR resolves issue #14193 by calling `self._finder.find_all_candidates(project_name)` in `_has_any_candidates()` in `src/pip/_internal/resolution/resolvelib/factory.py`.

## Details
- Prevents spurious 'no matching distributions available for your environment' messages during resolution conflicts when candidate distributions actually exist.