### PR TITLE
Tweak news entries for pip 26.2

### DIFF
--- a/news/13680.removal.rst
+++ b/news/13680.removal.rst
@@ -1,0 +1,3 @@
+Newly published packages will no longer be immediately visible to pip
+if the index uses caching. To install a newly published package, use
+``--refresh-package``.

--- a/news/14044.bugfix.rst
+++ b/news/14044.bugfix.rst
@@ -1,2 +1,2 @@
 Never use persistent wheel cache for local directory requirements even if there
-is a matching entry, somehow.
+is a matching entry.

--- a/news/14110.bugfix.rst
+++ b/news/14110.bugfix.rst
@@ -1,1 +1,1 @@
-Fix ``Link.filename`` decoding the URL path twice.
+Fix decoding the URL path twice while determining a link filename (CVE-2026-13346).

--- a/news/14142.bugfix.rst
+++ b/news/14142.bugfix.rst
@@ -1,5 +1,5 @@
-Note: platformdirs 4.6.0+ adds support for ``XDG_*`` environment variables, so
-some directory locations may change on Unix if any of these are set:
+platformdirs 4.6.0+ adds support for ``XDG_*`` environment variables on macOS, so
+some directory locations may change if any of these are set:
 
 - ``XDG_CACHE_HOME``: The `pip cache directory <https://pip.pypa.io/en/stable/cli/pip_cache/>`_
   will be at ``$XDG_CACHE_HOME/pip``.


### PR DESCRIPTION
In particular, add a separate entry calling out that pip will no longer see newly published packages immediately and suggest using `--refresh-package` if needed. This will affect some people and it's being louder on this point.