### PR TITLE
Warn about dependency confusion with --extra-index-url

### DIFF
--- a/news/11694.doc.rst
+++ b/news/11694.doc.rst
@@ -1,0 +1,1 @@
+Warn that ``--extra-index-url`` can expose users to dependency confusion.

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -453,7 +453,9 @@ def extra_index_url() -> Option:
         default=[],
         help="Extra URLs of package indexes to use in addition to "
         "--index-url. Should follow the same rules as "
-        "--index-url.",
+        "--index-url. Using this option to search for packages which "
+        "are not in the main repository is unsafe. This is a class of "
+        "security issue known as dependency confusion.",
     )
 
 


### PR DESCRIPTION
Fixes #11694.

- Add the security warning to the shared option help text, so it appears in both CLI help and generated command reference documentation.
- Keep the existing example warning unchanged.

The wording follows the warning already used in the installation examples and calls out dependency confusion where users first encounter the option.