### PR TITLE
Fix self version check when run as a zipapp

### DIFF
--- a/news/13084.bugfix.rst
+++ b/news/13084.bugfix.rst
@@ -1,0 +1,2 @@
+Fix ``pip``'s self version check reporting an outdated version from the
+environment instead of the running pip when run as a zipapp.

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -9,6 +9,7 @@ import os.path
 import sys
 from dataclasses import dataclass
 
+from pip import __version__
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.rich.console import Group
@@ -37,6 +38,7 @@ from pip._internal.utils.misc import (
     ExternallyManagedEnvironment,
     check_externally_managed,
     ensure_dir,
+    running_under_zipapp,
 )
 
 _WEEK = datetime.timedelta(days=7)
@@ -133,25 +135,30 @@ class SelfCheckState:
 class UpgradePrompt:
     old: str
     new: str
+    show_upgrade_hint: bool = True
 
     def __rich__(self) -> Group:
-        if WINDOWS:
-            pip_cmd = f"{get_best_invocation_for_this_python()} -m pip"
-        else:
-            pip_cmd = get_best_invocation_for_this_pip()
-
         notice = "[bold][[reset][blue]notice[reset][bold]][reset]"
-        return Group(
+        lines = [
             Text(),
             Text.from_markup(
                 f"{notice} A new release of pip is available: "
                 f"[red]{self.old}[reset] -> [green]{self.new}[reset]"
             ),
-            Text.from_markup(
-                f"{notice} To update, run: "
-                f"[green]{escape(pip_cmd)} install --upgrade pip"
-            ),
-        )
+        ]
+        if self.show_upgrade_hint:
+            if WINDOWS:
+                pip_cmd = f"{get_best_invocation_for_this_python()} -m pip"
+            else:
+                pip_cmd = get_best_invocation_for_this_pip()
+
+            lines.append(
+                Text.from_markup(
+                    f"{notice} To update, run: "
+                    f"[green]{escape(pip_cmd)} install --upgrade pip"
+                )
+            )
+        return Group(*lines)
 
 
 def _get_current_remote_pip_version(
@@ -183,7 +190,10 @@ def _get_current_remote_pip_version(
 
 
 def _compute_upgrade_prompt(
-    local_version: Version, remote_version_str: str, installed_by_pip: bool
+    local_version: Version,
+    remote_version_str: str,
+    installed_by_pip: bool,
+    show_upgrade_hint: bool = True,
 ) -> UpgradePrompt | None:
     remote_version = parse_version(remote_version_str)
     logger.debug("Remote version of pip: %s", remote_version)
@@ -198,7 +208,11 @@ def _compute_upgrade_prompt(
         and local_version.base_version != remote_version.base_version
     )
     if local_version_is_older:
-        return UpgradePrompt(old=str(local_version), new=remote_version_str)
+        return UpgradePrompt(
+            old=str(local_version),
+            new=remote_version_str,
+            show_upgrade_hint=show_upgrade_hint,
+        )
 
     return None
 
@@ -215,13 +229,24 @@ def pip_self_version_check_fetch(
     Pair with :func:`pip_self_version_check_emit`, which displays the prompt
     after the command body runs.
     """
-    installed_dist = get_default_environment().get_distribution("pip")
-    if not installed_dist:
-        return None
-    try:
-        check_externally_managed()
-    except ExternallyManagedEnvironment:
-        return None
+    is_zipapp = running_under_zipapp()
+
+    if is_zipapp:
+        # Use the running pip's version; environment scans target the installed
+        # pip, not the zipapp. Skip checks that don't apply to zipapps.
+        local_version = parse_version(__version__)
+        installed_by_pip = True
+    else:
+        installed_dist = get_default_environment().get_distribution("pip")
+        if not installed_dist:
+            return None
+        try:
+            check_externally_managed()
+        except ExternallyManagedEnvironment:
+            return None
+
+        local_version = installed_dist.version
+        installed_by_pip = installed_dist.installer == "pip"
 
     state = SelfCheckState(cache_dir=options.cache_dir)
     current_time = datetime.datetime.now(datetime.timezone.utc)
@@ -234,9 +259,10 @@ def pip_self_version_check_fetch(
         state.set(remote_version_str, current_time)
 
     return _compute_upgrade_prompt(
-        local_version=installed_dist.version,
+        local_version=local_version,
         remote_version_str=remote_version_str,
-        installed_by_pip=installed_dist.installer == "pip",
+        installed_by_pip=installed_by_pip,
+        show_upgrade_hint=not is_zipapp,
     )
 
 

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -9,13 +9,13 @@ import os.path
 import sys
 from dataclasses import dataclass
 
-from pip import __version__
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
 from pip._vendor.rich.console import Group
 from pip._vendor.rich.markup import escape
 from pip._vendor.rich.text import Text
 
+from pip import __version__
 from pip._internal.index.collector import LinkCollector
 from pip._internal.index.package_finder import PackageFinder
 from pip._internal.metadata import get_default_environment

--- a/src/pip/_internal/self_outdated_check.py
+++ b/src/pip/_internal/self_outdated_check.py
@@ -229,9 +229,7 @@ def pip_self_version_check_fetch(
     Pair with :func:`pip_self_version_check_emit`, which displays the prompt
     after the command body runs.
     """
-    is_zipapp = running_under_zipapp()
-
-    if is_zipapp:
+    if running_under_zipapp():
         # Use the running pip's version; environment scans target the installed
         # pip, not the zipapp. Skip checks that don't apply to zipapps.
         local_version = parse_version(__version__)
@@ -262,7 +260,7 @@ def pip_self_version_check_fetch(
         local_version=local_version,
         remote_version_str=remote_version_str,
         installed_by_pip=installed_by_pip,
-        show_upgrade_hint=not is_zipapp,
+        show_upgrade_hint=not running_under_zipapp(),
     )
 
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -14,7 +14,7 @@ import sysconfig
 import urllib.parse
 from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from functools import partial
+from functools import cache, partial
 from io import StringIO
 from itertools import filterfalse, tee, zip_longest
 from pathlib import Path
@@ -92,6 +92,7 @@ def get_pip_version() -> str:
     return f"pip {__version__} from {pip_pkg_dir} (python {get_major_minor_version()})"
 
 
+@cache
 def running_under_zipapp() -> bool:
     return not pathlib.Path(pip_location).resolve().parent.is_dir()
 

--- a/src/pip/_internal/utils/misc.py
+++ b/src/pip/_internal/utils/misc.py
@@ -92,6 +92,10 @@ def get_pip_version() -> str:
     return f"pip {__version__} from {pip_pkg_dir} (python {get_major_minor_version()})"
 
 
+def running_under_zipapp() -> bool:
+    return not pathlib.Path(pip_location).resolve().parent.is_dir()
+
+
 def get_runnable_pip() -> str:
     """Get a file to pass to a Python executable, to run the currently-running pip.
 
@@ -100,7 +104,7 @@ def get_runnable_pip() -> str:
     """
     source = pathlib.Path(pip_location).resolve().parent
 
-    if not source.is_dir():
+    if running_under_zipapp():
         # This would happen if someone is using pip from inside a zip file. In that
         # case, we can use that directly.
         return str(source)

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -276,3 +276,31 @@ def test_fetch_skipped_when_pip_not_installed(
     result = pip_self_version_check_fetch(session=Mock(), options=fake_options)
     assert result is None
     mocked_get_remote.assert_not_called()
+
+
+@patch("pip._internal.self_outdated_check.__version__", "24.2")
+@patch("pip._internal.self_outdated_check.running_under_zipapp", new=lambda: True)
+@patch("pip._internal.self_outdated_check._get_current_remote_pip_version")
+def test_fetch_zipapp_compares_running_version(
+    mocked_get_remote: Mock, tmpdir: Path
+) -> None:
+    mocked_get_remote.return_value = "24.3.1"
+    fake_options = Values({"cache_dir": str(tmpdir)})
+
+    result = pip_self_version_check_fetch(session=Mock(), options=fake_options)
+
+    assert result == UpgradePrompt(old="24.2", new="24.3.1", show_upgrade_hint=False)
+
+
+@patch("pip._internal.self_outdated_check.__version__", "24.3.1")
+@patch("pip._internal.self_outdated_check.running_under_zipapp", new=lambda: True)
+@patch("pip._internal.self_outdated_check._get_current_remote_pip_version")
+def test_fetch_zipapp_current_is_silent(
+    mocked_get_remote: Mock, tmpdir: Path
+) -> None:
+    mocked_get_remote.return_value = "24.3.1"
+    fake_options = Values({"cache_dir": str(tmpdir)})
+
+    result = pip_self_version_check_fetch(session=Mock(), options=fake_options)
+
+    assert result is None

--- a/tests/unit/test_self_check_outdated.py
+++ b/tests/unit/test_self_check_outdated.py
@@ -295,9 +295,7 @@ def test_fetch_zipapp_compares_running_version(
 @patch("pip._internal.self_outdated_check.__version__", "24.3.1")
 @patch("pip._internal.self_outdated_check.running_under_zipapp", new=lambda: True)
 @patch("pip._internal.self_outdated_check._get_current_remote_pip_version")
-def test_fetch_zipapp_current_is_silent(
-    mocked_get_remote: Mock, tmpdir: Path
-) -> None:
+def test_fetch_zipapp_current_is_silent(mocked_get_remote: Mock, tmpdir: Path) -> None:
     mocked_get_remote.return_value = "24.3.1"
     fake_options = Values({"cache_dir": str(tmpdir)})
 


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

fixes #13084
 
The self version check read the pip installed in the environment rather than the running pip, so the upgrade notice could be wrong when running from a zipapp.
Since a pip zipapp doesn’t have dist-info metadata, compare `__version__` instead.

Also, `pip install --upgrade pip` can’t update the zipapp itself, so the update command hint is omitted, as shown below:

```console
# pip
[notice] A new release of pip is available: 24.2 -> 26.2
[notice] To update, run: python -m pip install --upgrade pip

# zipapp pip
[notice] A new release of pip is available: 24.2 -> 26.2
```
Dropping the upgrade command hint seemed like the simplest option, but I’m open to alternatives if there is a better approach. 

<!-- What problem does this solve? Include the issue number if applicable. -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

Assisted-by : gpt-5.6-sol (code review)