### PR TITLE
Fix crash on invalid entry points

### DIFF
--- a/news/8573.bugfix.rst
+++ b/news/8573.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a crash when installing or uninstalling a distribution with an invalid
+entry point under the deprecated ``pkg_resources`` metadata backend.

--- a/news/8573.bugfix.rst
+++ b/news/8573.bugfix.rst
@@ -1,2 +1,2 @@
 Fix a crash when installing or uninstalling a distribution with an invalid
-entry point under the deprecated ``pkg_resources`` metadata backend.
+entry point.

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -15,7 +15,7 @@ from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.exceptions import InvalidWheel, UnsupportedWheel
+from pip._internal.exceptions import InstallationError, InvalidWheel, UnsupportedWheel
 from pip._internal.metadata.base import (
     BaseDistribution,
     BaseEntryPoint,
@@ -199,7 +199,13 @@ class Distribution(BaseDistribution):
 
     def iter_entry_points(self) -> Iterable[BaseEntryPoint]:
         # importlib.metadata's EntryPoint structure satisfies BaseEntryPoint.
-        return self._dist.entry_points
+        try:
+            return self._dist.entry_points
+        except ValueError as e:
+            # Python 3.15+ validates entry points while parsing.
+            raise InstallationError(
+                f"Error parsing entry points for {self.raw_name}: {e}"
+            ) from e
 
     def _metadata_impl(self) -> email.message.Message:
         # From Python 3.10+, importlib.metadata declares PackageMetadata as the

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -16,7 +16,12 @@ from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.exceptions import InvalidWheel, NoneMetadataError, UnsupportedWheel
+from pip._internal.exceptions import (
+    InstallationError,
+    InvalidWheel,
+    NoneMetadataError,
+    UnsupportedWheel,
+)
 from pip._internal.utils.egg_link import egg_link_path_from_location
 from pip._internal.utils.misc import display_path, normalize_path
 from pip._internal.utils.wheel import parse_wheel, read_wheel_metadata_file
@@ -208,7 +213,13 @@ class Distribution(BaseDistribution):
         return content
 
     def iter_entry_points(self) -> Iterable[BaseEntryPoint]:
-        for group, entries in self._dist.get_entry_map().items():
+        try:
+            entry_map = self._dist.get_entry_map()
+        except ValueError as e:
+            raise InstallationError(
+                f"Error parsing entry points for {self.raw_name}: {e}"
+            ) from e
+        for group, entries in entry_map.items():
             for name, entry_point in entries.items():
                 name, _, value = str(entry_point).partition("=")
                 yield EntryPoint(name=name.strip(), value=value.strip(), group=group)

--- a/tests/unit/metadata/test_metadata_pkg_resources.py
+++ b/tests/unit/metadata/test_metadata_pkg_resources.py
@@ -10,7 +10,7 @@ from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import parse as parse_version
 
-from pip._internal.exceptions import UnsupportedWheel
+from pip._internal.exceptions import InstallationError, UnsupportedWheel
 from pip._internal.metadata.pkg_resources import (
     Distribution,
     Environment,
@@ -124,3 +124,20 @@ def test_wheel_metadata_throws_on_bad_unicode() -> None:
     with pytest.raises(UnsupportedWheel) as e:
         metadata.get_metadata("METADATA")
     assert "METADATA" in str(e.value)
+
+
+def test_iter_entry_points_throws_on_invalid_entry_point() -> None:
+    dist = Distribution(
+        pkg_resources.DistInfoDistribution(
+            location="<in-memory>",
+            metadata=InMemoryMetadata(
+                {"entry_points.txt": b"[console_scripts]\nhello = hello:\n"},
+                "<in-memory>",
+            ),
+            project_name="simple",
+        ),
+    )
+
+    with pytest.raises(InstallationError) as e:
+        list(dist.iter_entry_points())
+    assert "hello = hello:" in str(e.value)

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -430,7 +430,6 @@ class TestInstallUnpackedWheel:
         assert os.path.basename(wheel_path) in exc_text
         assert "example" in exc_text
 
-    @pytest.mark.xfail(strict=True)
     @pytest.mark.parametrize("entrypoint", ["hello = hello", "hello = hello:"])
     @pytest.mark.parametrize("entrypoint_type", ["console_scripts", "gui_scripts"])
     def test_invalid_entrypoints_fail(

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -439,15 +439,13 @@ class TestInstallUnpackedWheel:
         wheel_path = make_wheel(
             "simple", "0.1.0", entry_points={entrypoint_type: [entrypoint]}
         ).save_to_dir(tmpdir)
-        with pytest.raises(InstallationError) as e:
+        with pytest.raises(InstallationError):
             wheel.install_wheel(
                 "simple",
                 str(wheel_path),
                 scheme=self.scheme,
                 req_description="simple",
             )
-
-        assert entrypoint in str(e.value)
 
     @pytest.mark.parametrize("bad_name", ["../../outside", "..", "."])
     @pytest.mark.parametrize("entry_point_type", ["console_scripts", "gui_scripts"])

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -448,9 +448,7 @@ class TestInstallUnpackedWheel:
                 req_description="simple",
             )
 
-        exc_text = str(e.value)
-        assert os.path.basename(wheel_path) in exc_text
-        assert entrypoint in exc_text
+        assert entrypoint in str(e.value)
 
     @pytest.mark.parametrize("bad_name", ["../../outside", "..", "."])
     @pytest.mark.parametrize("entry_point_type", ["console_scripts", "gui_scripts"])


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?
Fixes #8573.

pkg_resources raises a plain `ValueError` when `entry_points.txt` contains an invalid entry point, causing pip to display a traceback. This change catches `ValueError` and re-raises it as `InstallationError`.

Note: this previously only affected the deprecated `pkg_resources` metadata backend.

Starting with Python 3.15, `importlib.metadata` also validates entry points while parsing, so the importlib backend applies the same exception handling.

<!-- What problem does this solve? Include the issue number if applicable. -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

Assisted-by: gpt-5.6-sol (code review)