### PR TITLE
fix: report available candidates in resolver conflicts

### DIFF
--- a/news/14193.bugfix.rst
+++ b/news/14193.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid reporting available packages as having no matching distributions.

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -771,16 +771,7 @@ class Factory:
         """
         Check if there are any candidates available for the project name.
         """
-        return any(
-            self.find_candidates(
-                project_name,
-                requirements={project_name: []},
-                incompatibilities={},
-                constraint=Constraint.empty(),
-                prefers_installed=True,
-                is_satisfied_by=lambda r, c: True,
-            )
-        )
+        return bool(self._finder.find_all_candidates(project_name))
 
     def get_installation_error(
         self,

--- a/tests/unit/resolution_resolvelib/test_requirement.py
+++ b/tests/unit/resolution_resolvelib/test_requirement.py
@@ -115,6 +115,11 @@ def test_new_resolver_candidates_match_requirement(
             assert req.is_satisfied_by(c)
 
 
+def test_new_resolver_has_any_candidates(factory: Factory) -> None:
+    assert factory._has_any_candidates("simple")
+    assert not factory._has_any_candidates("missing")
+
+
 def test_new_resolver_full_resolve(factory: Factory, provider: PipProvider) -> None:
     """A very basic full resolve"""
     reqs = list(factory.make_requirements_from_spec("simplewheel", comes_from=None))


### PR DESCRIPTION
## What does this PR do?

Fix the resolver conflict diagnostic so the "no matching distributions" hint only names packages with no available candidates at all. The previous `_has_any_candidates()` call used `find_candidates()` with an empty requirement list, which always produced no candidates. It now checks the package finder directly with `find_all_candidates()`.

This keeps the existing environment-compatibility filtering in `PackageFinder` while avoiding a misleading hint when a candidate exists but another dependency constraint makes the resolution impossible.

Closes #14193

## Validation

- `PYTHONPATH=src python -m pytest -o addopts='' -p no:recording -p no:vcr tests/unit/resolution_resolvelib/test_requirement.py -q` (5 passed)
- `python -m ruff check src/pip/_internal/resolution/resolvelib/factory.py tests/unit/resolution_resolvelib/test_requirement.py`
- `git diff --check`

The broader functional resolver fixture requires generated `tests/data/common_wheels` from the project's nox setup, which is not present in this sparse checkout, so I have not claimed that suite passes.

## PR Checklist

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/code-of-conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (`news/14193.bugfix.rst`).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and I disclosed assisted preparation below.

I used coding assistance during preparation, but I reviewed and take responsibility for every changed line and the test behavior. No tool or model is listed as a co-author.
