### PR TITLE
Revert build dependency installer isolation for legacy build environment

### DIFF
--- a/news/14227.bugfix.rst
+++ b/news/14227.bugfix.rst
@@ -1,0 +1,2 @@
+Reallow keyring installed in a (non-activated) virtual environment to be be used
+via the ``import`` provider method while installing build dependencies.

--- a/src/pip/_internal/distributions/sdist.py
+++ b/src/pip/_internal/distributions/sdist.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
+from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 from pip._internal.build_env import (
@@ -52,7 +53,7 @@ class SourceDistribution(AbstractDistribution):
         if build_isolation != "off":
             # Setup an isolated environment and install the build backend static
             # requirements in it.
-            self._prepare_build_backend()
+            self._prepare_build_backend(build_isolation)
             # Check that the build backend supports PEP 660. This cannot be done
             # earlier because we need to setup the build backend to verify it
             # supports build_editable, nor can it be done later, because we want
@@ -60,7 +61,7 @@ class SourceDistribution(AbstractDistribution):
             self.req.editable_sanity_check()
             # Install the dynamic build requirements.
             self._install_build_reqs(
-                build_env_installer, allow_editables=allow_editables
+                build_env_installer, build_isolation, allow_editables=allow_editables
             )
         else:
             # When not using build isolation, we still need to check that
@@ -91,13 +92,14 @@ class SourceDistribution(AbstractDistribution):
 
         self.req.configure_backend(self.req.build_env.python_executable)
 
-    def _prepare_build_backend(self) -> None:
+    def _prepare_build_backend(self, build_isolation: BuildIsolationMode) -> None:
         # Install the pyproject.toml declared build-time requirements.
         pyproject_requires = self.req.pyproject_requires
         assert pyproject_requires is not None
         assert not isinstance(self.req.build_env, NoOpBuildEnvironment)
 
-        with self.req.build_env:
+        context = self.req.build_env if build_isolation == "venv" else nullcontext()
+        with context:
             self.req.build_env.install_requirements(
                 pyproject_requires,
                 "overlay",
@@ -141,6 +143,7 @@ class SourceDistribution(AbstractDistribution):
     def _install_build_reqs(
         self,
         build_env_installer: BuildEnvironmentInstaller,
+        build_isolation: BuildIsolationMode,
         allow_editables: bool,
     ) -> None:
         # Install any extra build dependencies that the backend requests.
@@ -157,7 +160,8 @@ class SourceDistribution(AbstractDistribution):
         conflicting, missing = self.req.build_env.check_requirements(build_reqs)
         if conflicting:
             self._raise_conflicts("the backend dependencies", conflicting)
-        with self.req.build_env:
+        context = self.req.build_env if build_isolation == "venv" else nullcontext()
+        with context:
             self.req.build_env.install_requirements(
                 missing, "normal", kind="backend dependencies", for_req=self.req
             )

--- a/tests/functional/test_install_config.py
+++ b/tests/functional/test_install_config.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import os
 import ssl
 import tempfile
 import textwrap
+from base64 import b64encode
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -17,6 +21,10 @@ from tests.lib.server import (
     server_running,
 )
 from tests.lib.venv import VirtualEnvironment
+
+if TYPE_CHECKING:
+    from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
+
 
 TEST_PYPI_INITOOLS = "https://test.pypi.org/simple/initools/"
 
@@ -532,6 +540,117 @@ def test_prompt_for_keyring_if_needed(
         assert "get_credential was called" in logs
     else:
         assert "get_credential was called" not in logs
+
+
+@pytest.mark.parametrize(
+    "isolation",
+    [
+        pytest.param("", id="legacy-isolation"),
+        pytest.param(
+            "--use-feature=venv-isolation",
+            id="venv-isolation",
+            marks=pytest.mark.xfail(reason="needs inprocess-build-deps to work"),
+        ),
+    ],
+)
+def test_build_dependency_install_uses_same_keyring_as_root(
+    isolation: str, script: PipTestEnvironment, data: TestData
+) -> None:
+    """Ensure the root and build dependency pip processes use the same keyring.
+
+    When build dependencies are installed via a pip subprocess, it should be able
+    to import the same keyring directly. While normally the subprocess will be
+    able to find the same keyring by searching PATH, if the virtual environment
+    wasn't activated, pip may either fail to find keyring or pick a different
+    keyring (from the system).
+
+    See also: https://github.com/pypa/pip/issues/14227
+
+    NOTE: venv-isolation is still affected by this bug since it's necessary
+          to apply build isolation while install build dependencies. The
+          proper fix to also enable inprocess-build-deps (which will also
+          fix this for the custom isolation logic).
+    TODO: remove this test when the subprocess build installer is gone
+    """
+    script.pip_install_local("keyring", find_links=data.common_wheels)
+
+    keyring_module = script.site_packages_path / "keyring_test.py"
+    keyring_module.write_text(textwrap.dedent("""\
+        import os
+
+        import keyring
+        from keyring.backend import KeyringBackend
+        from keyring.credentials import SimpleCredential
+
+        class TestBackend(KeyringBackend):
+            priority = 1
+
+            def get_credential(self, url, username):
+                return SimpleCredential(username="USERNAME", password="PASSWORD")
+
+            def get_password(self, url, username):
+                return "PASSWORD"
+
+            def set_password(self, url, username, password):
+                pass
+        """))
+    script.environ["PYTHON_KEYRING_BACKEND"] = "keyring_test.TestBackend"
+
+    expected_auth = "Basic " + b64encode(b"USERNAME:PASSWORD").decode("ascii")
+
+    def unauthorized_response(
+        environ: WSGIEnvironment, start_response: StartResponse
+    ) -> list[bytes]:
+        start_response("401 Unauthorized", [("WWW-Authenticate", "Basic")])
+        return []
+
+    def authenticated_index(
+        environ: WSGIEnvironment, start_response: StartResponse
+    ) -> WSGIApplication:
+        if environ.get("HTTP_AUTHORIZATION") != expected_auth:
+            return unauthorized_response
+        return package_page({})
+
+    # Emulate the bug report setup which uses --extra-url-index (which pip will access
+    # while install build dependencies). To avoid hitting PyPI, spin up a no-op index
+    # for --index-url itself.
+    primary_index = make_mock_server()
+    primary_index.mock.side_effect = lambda _, __: package_page({})
+    primary_index_url = f"http://{primary_index.host}:{primary_index.port}/simple"
+    authenticated_extra_index = make_mock_server()
+    authenticated_extra_index.mock.side_effect = authenticated_index
+    extra_index_url = (
+        f"http://{authenticated_extra_index.host}:"
+        f"{authenticated_extra_index.port}/simple"
+    )
+
+    # The script runner automatically adds the venv bin directory to PATH.
+    path_without_keyring = script.scratch_path / "path-without-keyring"
+    path_without_keyring.mkdir()
+    script.environ["PATH"] = str(path_without_keyring)
+    with server_running(primary_index), server_running(authenticated_extra_index):
+        result = script.run(
+            # Run Python directly because the python executable was lost when
+            # we removed the venv's bin directory from PATH.
+            str(script.bin_path / f"python{script.exe}"),
+            "-m",
+            "pip",
+            "wheel",
+            "--no-cache-dir",
+            "--index-url",
+            primary_index_url,
+            "--extra-index-url",
+            extra_index_url,
+            "--find-links",
+            str(data.packages),
+            "--find-links",
+            str(data.common_wheels),
+            "pep518==3.0",
+            isolation,
+        )
+
+    assert result.returncode == 0, result
+    assert "Successfully built pep518" in result.stdout, result.stdout
 
 
 @pytest.mark.network


### PR DESCRIPTION
This was unneeded for the legacy isolation method (as `--ignore-installed` is used) and stops pip from being able to use the same keyring available in a venv while installing build dependencies (note that the virtual environment isn't activated so the subprocess keyring provider is useless here).

This is harder to fix (and thus left unfixed) for `venv-isolation` since the subprocess installer will use the temporary venv's Python executable to run pip, so there's no way for said pip subprocess to directly import keyring. The proper fix is to switch to the `inprocess installer` when using venv isolation.

So, I guess the real answer to everything is fix `inprocess-build-deps` and `venv-isolation` compatibility and aim to enable both together 🙃.

Fixes #14227.

This is a partial revert of a bugfix included in #14070.
