### PR TITLE
Redact auth in wheel cache origin warnings

### DIFF
--- a/news/14232.bugfix.rst
+++ b/news/14232.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent wheel cache origin mismatch warnings from exposing URL credentials.

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -269,6 +269,7 @@ class WheelCache(Cache):
     @staticmethod
     def record_download_origin(cache_dir: str, download_info: DirectUrl) -> None:
         origin_path = Path(cache_dir) / ORIGIN_JSON_NAME
+        download_url = download_info.to_dict_compat()["url"]
         if origin_path.exists():
             try:
                 origin = DirectUrl.from_json(origin_path.read_text(encoding="utf-8"))
@@ -282,13 +283,14 @@ class WheelCache(Cache):
             else:
                 # TODO: use DirectUrl.equivalent when
                 # https://github.com/pypa/pip/pull/10564 is merged.
-                if origin.url != download_info.url:
+                origin_url = origin.to_dict_compat()["url"]
+                if origin_url != download_url:
                     logger.warning(
                         "Origin URL %s in cache entry %s does not match download URL "
                         "%s. This is likely a pip bug or a cache corruption issue. "
                         "Will overwrite it with the new value.",
-                        origin.url,
+                        origin_url,
                         cache_dir,
-                        download_info.url,
+                        download_url,
                     )
         origin_path.write_text(download_info.to_json(), encoding="utf-8")

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -269,7 +269,6 @@ class WheelCache(Cache):
     @staticmethod
     def record_download_origin(cache_dir: str, download_info: DirectUrl) -> None:
         origin_path = Path(cache_dir) / ORIGIN_JSON_NAME
-        download_url = download_info.to_dict_compat()["url"]
         if origin_path.exists():
             try:
                 origin = DirectUrl.from_json(origin_path.read_text(encoding="utf-8"))
@@ -283,13 +282,13 @@ class WheelCache(Cache):
             else:
                 # TODO: use DirectUrl.equivalent when
                 # https://github.com/pypa/pip/pull/10564 is merged.
-                origin_url = origin.to_dict_compat()["url"]
-                if origin_url != download_url:
+                download_url = download_info.to_dict_compat()["url"]
+                if origin.url != download_url:
                     logger.warning(
                         "Origin URL %s in cache entry %s does not match download URL "
                         "%s. This is likely a pip bug or a cache corruption issue. "
                         "Will overwrite it with the new value.",
-                        origin_url,
+                        origin.url,
                         cache_dir,
                         download_url,
                     )

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -282,6 +282,8 @@ class WheelCache(Cache):
             else:
                 # TODO: use DirectUrl.equivalent when
                 # https://github.com/pypa/pip/pull/10564 is merged.
+                # origin.url is already stripped because it came from the
+                # serialized origin.json file.
                 download_url = download_info.to_dict_compat()["url"]
                 if origin.url != download_url:
                     logger.warning(

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -7,6 +7,7 @@ import pytest
 from pip._vendor.packaging.tags import Tag, interpreter_name, interpreter_version
 
 from pip._internal.cache import SimpleWheelCache, WheelCache, _hash_dict
+from pip._internal.models.direct_url import ArchiveInfo, DirectUrl
 from pip._internal.models.link import Link
 from pip._internal.utils.misc import ensure_dir
 from pip._internal.utils.urls import path_to_url
@@ -152,3 +153,40 @@ def test_wheel_cache_entry_none_for_existing_directory(tmpdir: Path) -> None:
 
     assert wc.get_cache_entry(link, "example", supported_tags) is None
     assert wc.get(link, "example", supported_tags) is link
+
+
+def test_record_download_origin_ignores_stripped_auth_difference(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    download_info = DirectUrl(
+        url="https://user:secret@example.com/pkg.tar.gz",
+        archive_info=ArchiveInfo(),
+    )
+
+    WheelCache.record_download_origin(str(tmp_path), download_info)
+    WheelCache.record_download_origin(str(tmp_path), download_info)
+
+    assert caplog.records == []
+
+
+def test_record_download_origin_redacts_auth_from_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    old_info = DirectUrl(
+        url="https://old-user:old-secret@old.example/pkg.tar.gz",
+        archive_info=ArchiveInfo(),
+    )
+    new_info = DirectUrl(
+        url="https://new-user:new-secret@new.example/pkg.tar.gz",
+        archive_info=ArchiveInfo(),
+    )
+    WheelCache.record_download_origin(str(tmp_path), old_info)
+
+    WheelCache.record_download_origin(str(tmp_path), new_info)
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "old-secret" not in message
+    assert "new-secret" not in message
+    assert "https://old.example/pkg.tar.gz" in message
+    assert "https://new.example/pkg.tar.gz" in message


### PR DESCRIPTION
## What does this PR do?

Fixes #14232.

`record_download_origin()` writes a credential-stripped PEP 610 URL to `origin.json`, but previously compared and logged the raw in-memory URL. Re-recording an authenticated origin therefore produced a false mismatch warning containing the username and password.

This change compares the same serialized URL representation that is written to disk and uses those stripped values in genuine mismatch warnings. It adds regression coverage for both behaviors.

## PR Checklist:

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment.
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and I take full ownership and responsibility for every line.

Assisted-by: OpenAI Codex

## Tests

- `pytest -q tests/unit/test_cache.py`: 10 passed
- Black 26.5.1 passed
- Ruff 0.15.20 passed
- Mypy 2.1.0 passed for both changed Python files
- `git diff --check` passed
