### PR TITLE
Close incomplete downloads before removing them

### DIFF
--- a/news/14237.bugfix.rst
+++ b/news/14237.bugfix.rst
@@ -1,0 +1,1 @@
+Report the incomplete-download error on Windows, not a ``PermissionError``.

--- a/src/pip/_internal/network/download.py
+++ b/src/pip/_internal/network/download.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import email.message
 import logging
 import mimetypes
@@ -210,11 +211,16 @@ class Downloader:
         filepath = join_within_directory(
             location, _get_http_response_filename(resp, link)
         )
-        with open(filepath, "wb") as content_file:
-            download = _FileDownload(link, content_file, download_size)
-            self._process_response(download, resp)
-            if download.is_incomplete():
-                self._attempt_resumes_or_redownloads(download, resp)
+        try:
+            with open(filepath, "wb") as content_file:
+                download = _FileDownload(link, content_file, download_size)
+                self._process_response(download, resp)
+                if download.is_incomplete():
+                    self._attempt_resumes_or_redownloads(download, resp)
+        except IncompleteDownloadError:
+            with contextlib.suppress(OSError):
+                os.remove(filepath)
+            raise
 
         content_type = resp.headers.get("Content-Type", "")
         return filepath, content_type
@@ -295,7 +301,6 @@ class Downloader:
 
         # No more resume attempts. Raise an error if the download is still incomplete.
         if download.is_incomplete():
-            os.remove(download.output_file.name)
             raise IncompleteDownloadError(download)
 
         # If we successfully completed the download via resume, manually cache it

--- a/tests/unit/test_network_download.py
+++ b/tests/unit/test_network_download.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, BinaryIO
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -21,6 +21,7 @@ from pip._internal.exceptions import (
 from pip._internal.models.link import Link
 from pip._internal.network.download import (
     Downloader,
+    _FileDownload,
     _get_http_response_size,
     _log_download,
     parse_content_disposition,
@@ -361,12 +362,10 @@ def test_downloader(
 
     with patch.object(Downloader, "_http_get", _http_get_mock):
         if expected_bytes is None:
-            remove = MagicMock(return_value=None)
-            with patch("os.remove", remove):
-                with pytest.raises(IncompleteDownloadError):
-                    downloader(link, str(tmpdir))
+            with pytest.raises(IncompleteDownloadError):
+                downloader(link, str(tmpdir))
             # Make sure the incomplete file is removed
-            remove.assert_called_once()
+            assert not (tmpdir / "foo.tgz").exists()
         else:
             filepath, _ = downloader(link, str(tmpdir))
             with open(filepath, "rb") as downloaded_file:
@@ -382,6 +381,66 @@ def test_downloader(
 
     # Make sure that the downloader makes additional requests for resumption
     _http_get_mock.assert_has_calls(calls)
+
+
+def _incomplete_response() -> MockResponse:
+    response = MockResponse(b"partial")
+    response.headers.update({"content-length": "12"})
+    response.status_code = 200
+    return response
+
+
+def test_incomplete_download_is_closed_before_removal(tmpdir: Path) -> None:
+    """Windows can't delete an open file."""
+    session = PipSession(resume_retries=0)
+    link = Link("http://example.com/foo.tgz")
+    downloader = Downloader(session, "on")
+
+    downloads: list[_FileDownload] = []
+
+    def record_download(
+        link: Link, output_file: BinaryIO, size: int | None
+    ) -> _FileDownload:
+        download = _FileDownload(link, output_file, size)
+        downloads.append(download)
+        return download
+
+    def remove_like_windows(filename: str) -> None:
+        if not downloads[-1].output_file.closed:
+            raise PermissionError("The file is being used by another process")
+        Path(filename).unlink()
+
+    with (
+        patch.object(
+            Downloader, "_http_get", MagicMock(return_value=_incomplete_response())
+        ),
+        patch("pip._internal.network.download._FileDownload", record_download),
+        patch("pip._internal.network.download.os.remove", remove_like_windows),
+        pytest.raises(IncompleteDownloadError),
+    ):
+        downloader(link, str(tmpdir))
+
+    assert not (tmpdir / "foo.tgz").exists()
+
+
+def test_failed_removal_does_not_mask_incomplete_download(tmpdir: Path) -> None:
+    session = PipSession(resume_retries=0)
+    link = Link("http://example.com/foo.tgz")
+    downloader = Downloader(session, "on")
+
+    def remove_denied(filename: str) -> None:
+        raise PermissionError("The file is being used by another process")
+
+    with (
+        patch.object(
+            Downloader, "_http_get", MagicMock(return_value=_incomplete_response())
+        ),
+        patch("pip._internal.network.download.os.remove", remove_denied),
+        pytest.raises(IncompleteDownloadError),
+    ):
+        downloader(link, str(tmpdir))
+
+    assert (tmpdir / "foo.tgz").exists()
 
 
 def test_downloader_resumes_on_protocol_error(tmpdir: Path) -> None:
@@ -573,6 +632,8 @@ def test_downloader_crashes_on_mismatched_resume_offset(tmpdir: Path) -> None:
     with patch.object(Downloader, "_http_get", _http_get_mock):
         with pytest.raises(IncompleteDownloadError):
             downloader(link, str(tmpdir))
+
+    assert not (tmpdir / "foo.tgz").exists()
 
 
 def test_downloader_without_content_length(tmpdir: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

Delete an incomplete download only after closing it. Builtin `open()` does not share delete access on Windows, so `os.remove` on the still-open file fails with `PermissionError` ([documented](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile)), masking the incomplete-download error and leaving the partial file behind. The partial file is now also removed when a server answers a resume request from the wrong offset, which used to leave it on disk on every platform.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

This bug was found with a sweep of pip's codebase using codex - gpt 5.6 sol ultra.