### PR TITLE
Rewrite urllib3 retry warnings to be understandable

### DIFF
--- a/news/14242.feature.rst
+++ b/news/14242.feature.rst
@@ -1,0 +1,1 @@
+Improve readability of urllib3 warnings emitted when a HTTP request is retried

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -19,6 +19,7 @@ import sys
 import urllib.parse
 import warnings
 from collections.abc import Generator, Mapping, Sequence
+from functools import cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -39,11 +40,12 @@ from pip._internal.metadata import get_default_environment
 from pip._internal.models.link import Link
 from pip._internal.network.auth import MultiDomainBasicAuth
 from pip._internal.network.cache import SafeFileCache
-from pip._internal.network.utils import raise_connection_error
+from pip._internal.network.utils import Urllib3RetryFilter, raise_connection_error
 
 # Import ssl from compat so the initial import occurs in only one place.
 from pip._internal.utils.compat import has_tls
 from pip._internal.utils.glibc import libc_ver
+from pip._internal.utils.logging import FilterOnlyHandler
 from pip._internal.utils.misc import (
     build_url_from_netloc,
     looks_like_ci,
@@ -78,6 +80,13 @@ SECURE_ORIGINS: list[SecureOrigin] = [
     # ssh is always secure.
     ("ssh", "*", "*"),
 ]
+
+
+@cache
+def _install_retry_warning_handler() -> None:
+    _retry_warning_handler = FilterOnlyHandler()
+    _retry_warning_handler.addFilter(Urllib3RetryFilter())
+    logging.getLogger("pip._vendor").addHandler(_retry_warning_handler)
 
 
 @functools.lru_cache(maxsize=1)
@@ -322,6 +331,7 @@ class PipSession(requests.Session):
         :param trusted_hosts: Domains not to emit warnings for when not using
             HTTPS.
         """
+        _install_retry_warning_handler()
         super().__init__(*args, **kwargs)
 
         # Namespace the attribute with "pip_" just in case to prevent

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -19,7 +19,6 @@ import sys
 import urllib.parse
 import warnings
 from collections.abc import Generator, Mapping, Sequence
-from functools import cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -82,11 +81,14 @@ SECURE_ORIGINS: list[SecureOrigin] = [
 ]
 
 
-@cache
+_retry_warning_handler = FilterOnlyHandler()
+_retry_warning_handler.addFilter(Urllib3RetryFilter())
+
+
 def _install_retry_warning_handler() -> None:
-    _retry_warning_handler = FilterOnlyHandler()
-    _retry_warning_handler.addFilter(Urllib3RetryFilter())
-    logging.getLogger("pip._vendor").addHandler(_retry_warning_handler)
+    vendor_logger = logging.getLogger("pip._vendor")
+    if _retry_warning_handler not in vendor_logger.handlers:
+        vendor_logger.addHandler(_retry_warning_handler)
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/pip/_internal/network/utils.py
+++ b/src/pip/_internal/network/utils.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Generator
 from typing import Literal, NoReturn, TypeAlias, cast
 from urllib.parse import urlsplit
@@ -5,6 +6,7 @@ from urllib.parse import urlsplit
 from pip._vendor import requests, urllib3
 from pip._vendor.requests.models import Response
 from pip._vendor.urllib3.exceptions import TimeoutStateError
+from pip._vendor.urllib3.util.retry import Retry as Urllib3Retry
 
 from pip._internal.exceptions import (
     ConnectionFailedError,
@@ -13,6 +15,7 @@ from pip._internal.exceptions import (
     ProxyConnectionError,
     SSLVerificationError,
 )
+from pip._internal.utils.logging import VERBOSE
 from pip._internal.utils.misc import redact_auth_from_url
 
 TimeoutValue: TypeAlias = (
@@ -41,6 +44,8 @@ TimeoutValue: TypeAlias = (
 HEADERS: dict[str, str] = {"Accept-Encoding": "identity"}
 
 DOWNLOAD_CHUNK_SIZE = 256 * 1024
+
+logger = logging.getLogger(__name__)
 
 
 def raise_for_status(resp: Response) -> None:
@@ -204,3 +209,45 @@ def raise_connection_error(
     raise ConnectionFailedError(
         url, host, reason if isinstance(reason, Exception) else max_retry_error
     )
+
+
+class Urllib3RetryFilter(logging.Filter):
+    """A logging filter which captures urllib3's retrying warnings
+    and rewrites them to be more readable.
+
+    See https://github.com/urllib3/urllib3/issues/2580 for context.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # The warning we want has an unique extra attribute. Pop the attribute
+        # so if the warning is filtered repeatedly, we won't rewrite it again.
+        data = record.__dict__.pop("__urllib3-retry-warning", None)
+        if data is None:
+            return True
+
+        host = data["host"]
+        retry, error, _ = cast(tuple[Urllib3Retry, Exception, str], record.args)
+        try:
+            raise_connection_error(requests.ConnectionError(error), url="", timeout=0)
+        except ConnectionTimeoutError:
+            record.msg = f"{host} took too long to respond"
+        except SSLVerificationError:
+            record.msg = f"SSL verification failed while connecting to {host}"
+        except ConnectionFailedError:
+            record.msg = f"failed to connect to {host}"
+        else:
+            return True
+
+        assert isinstance(retry.total, int)
+        # The remaining retries is already decremented at the warning issuance
+        retries_left = retry.total + 1
+        if retries_left > 1:
+            record.msg += f", retrying {retries_left} more times"
+        elif retries_left == 1:
+            record.msg += ", retrying 1 last time"
+        if logger.isEnabledFor(VERBOSE):
+            # As it's hard to provide enough detail, show the original
+            # error under verbose mode.
+            record.msg += f": {error!s}"
+        record.args = ()
+        return True

--- a/src/pip/_internal/utils/logging.py
+++ b/src/pip/_internal/utils/logging.py
@@ -256,6 +256,17 @@ class BetterRotatingFileHandler(logging.handlers.RotatingFileHandler):
         return super()._open()
 
 
+class FilterOnlyHandler(logging.Handler):
+    """Passthrough logging handler used to apply filters.
+
+    A NullHandler cannot be used instead because it disables the normal handler
+    filtering process (it also provides a no-op handle() method).
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        pass
+
+
 class MaxLevelFilter(Filter):
     def __init__(self, level: int) -> None:
         self.level = level

--- a/src/pip/_vendor/urllib3/connectionpool.py
+++ b/src/pip/_vendor/urllib3/connectionpool.py
@@ -867,7 +867,16 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if not conn:
             # Try again
             log.warning(
-                "Retrying (%r) after connection broken by '%r': %s", retries, err, url
+                "Retrying (%r) after connection broken by '%r': %s",
+                retries,
+                err,
+                url,
+                # Provide extra attributes with the host needed by pip to rewrite
+                # this warning. Ideally, we'd go with a better solution, but
+                # backwards compatibility and other constraints make those
+                # unfeasible, so this is the least bad option.
+                # See also: https://github.com/urllib3/urllib3/issues/2580.
+                extra={"__urllib3-retry-warning": {"host": self.host}},
             )
             return self.urlopen(
                 method,

--- a/tests/lib/server.py
+++ b/tests/lib/server.py
@@ -5,6 +5,7 @@ import threading
 from base64 import b64encode
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import ExitStack, contextmanager
+from http.server import HTTPServer
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, patch
@@ -120,7 +121,7 @@ def make_mock_server(**kwargs: Any) -> _MockServer:
 
 
 @contextmanager
-def server_running(server: BaseWSGIServer) -> Iterator[None]:
+def server_running(server: BaseWSGIServer | HTTPServer) -> Iterator[None]:
     """Context manager for running the provided server in a separate thread."""
     thread = threading.Thread(target=server.serve_forever)
     thread.daemon = True

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -57,14 +57,21 @@ class Address:
     host: str
     port: int
 
-    @property
-    def url(self) -> str:
-        return f"http://{self.host}:{self.port}/"
+    def url(self, *, https: bool = False) -> str:
+        if https:
+            return f"https://{self.host}:{self.port}/"
+        else:
+            return f"http://{self.host}:{self.port}/"
 
 
 class InstantCloseHTTPHandler(BaseHTTPRequestHandler):
+    """A HTTP request handler that closes the underlying request TCP
+    socket immediately. Used for testing "connection reset by peer" and
+    similar errors.
+    """
+
     def handle(self) -> None:
-        self.connection.close()
+        self.request.close()
 
 
 class DelayedHTTPHandler(BaseHTTPRequestHandler):
@@ -558,20 +565,19 @@ class TestConnectionErrors:
         self, session: PipSession, instant_close_server: Address
     ) -> None:
         with pytest.raises(ConnectionFailedError) as e:
-            session.get(instant_close_server.url)
+            session.get(instant_close_server.url())
         message, context = render_diagnostic_error(e.value)
         assert message == (
             f"Failed to connect to {instant_close_server.host} "
-            f"while fetching {instant_close_server.url}"
+            f"while fetching {instant_close_server.url()}"
         )
         assert context == "the connection was closed without a reply from the server."
 
     def test_timeout(self, session: PipSession, delayed_server: Address) -> None:
-        url = delayed_server.url
         with pytest.raises(ConnectionTimeoutError) as e:
-            session.get(url, timeout=0.2)
+            session.get(delayed_server.url(), timeout=0.2)
         message, context = render_diagnostic_error(e.value)
-        assert message == f"Unable to fetch {url}"
+        assert message == f"Unable to fetch {delayed_server.url()}"
         assert context is not None
         assert context.startswith(
             f"{delayed_server.host} didn't respond within 0.2 seconds"
@@ -581,14 +587,13 @@ class TestConnectionErrors:
         self, session: PipSession, self_signed_server: Address
     ) -> None:
         """A self-signed certificate should produce a TLS verification diagnostic."""
-        url = f"https://{self_signed_server.host}:{self_signed_server.port}/"
         with pytest.raises(SSLVerificationError) as e:
-            session.get(url)
+            session.get(self_signed_server.url(https=True))
         message, _ = render_diagnostic_error(e.value)
         expected_host = self_signed_server.host
-        assert message == (
+        assert message.startswith(
             f"Failed to establish a secure connection to {expected_host} while "
-            f"fetching {url}"
+            "fetching https://"
         )
 
     def test_missing_python_ssl_support(

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -689,7 +689,7 @@ class TestRetryWarningRewriting:
                 with pytest.raises(DiagnosticPipError):
                     session.get(f"http://{server.server_name}:{server.server_port}/")
             assert caplog.messages == [
-                "failed to connect to localhost, retrying 1 last time"
+                f"failed to connect to {server.server_name}, retrying 1 last time"
             ]
 
     def test_selfsigned_cert(

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -670,9 +670,12 @@ class TestRetryWarningRewriting:
     def test_simple_urls(
         self, caplog: pytest.LogCaptureFixture, url: str, expected_message: str
     ) -> None:
-        with PipSession(retries=1) as session, pytest.raises(DiagnosticPipError):
+        with PipSession(retries=2) as session, pytest.raises(DiagnosticPipError):
             session.get(url)
-        assert caplog.messages == [f"{expected_message}, retrying 1 last time"]
+        assert caplog.messages == [
+            f"{expected_message}, retrying 2 more times",
+            f"{expected_message}, retrying 1 last time",
+        ]
 
     def test_timeout(
         self, caplog: pytest.LogCaptureFixture, delayed_server: Address

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -38,6 +38,7 @@ from pip._internal.network.session import (
     PipSession,
     user_agent,
 )
+from pip._internal.utils.logging import VERBOSE
 from pip._internal.utils.misc import CI_ENVIRONMENT_VARIABLES
 from pip._internal.utils.urls import path_to_url
 
@@ -650,3 +651,61 @@ class TestConnectionErrors:
             session.get(url)
         message, _ = render_diagnostic_error(e.value)
         assert message == f"Failed to connect to proxy {proxy}:443 while fetching {url}"
+
+
+@pytest.mark.network
+class TestRetryWarningRewriting:
+    @pytest.fixture(autouse=True)
+    def setup_caplog_level(self, caplog: pytest.LogCaptureFixture) -> Iterator[None]:
+        with caplog.at_level(logging.WARNING):
+            yield
+
+    @pytest.mark.parametrize(
+        "url, expected_message",
+        [
+            ("https://404.example.invalid", "failed to connect to 404.example.invalid"),
+            ("http://404.example.invalid", "failed to connect to 404.example.invalid"),
+        ],
+    )
+    def test_simple_urls(
+        self, caplog: pytest.LogCaptureFixture, url: str, expected_message: str
+    ) -> None:
+        with PipSession(retries=1) as session, pytest.raises(DiagnosticPipError):
+            session.get(url)
+        assert caplog.messages == [f"{expected_message}, retrying 1 last time"]
+
+    def test_timeout(
+        self, caplog: pytest.LogCaptureFixture, delayed_server: Address
+    ) -> None:
+        with PipSession(retries=1) as session, pytest.raises(DiagnosticPipError):
+            session.get(delayed_server.url(), timeout=0.1)
+        assert caplog.messages == [
+            "127.0.0.1 took too long to respond, retrying 1 last time"
+        ]
+
+    def test_connection_aborted(self, caplog: pytest.LogCaptureFixture) -> None:
+        with HTTPServer(("localhost", 0), InstantCloseHTTPHandler) as server:
+            with server_running(server), PipSession(retries=1) as session:
+                with pytest.raises(DiagnosticPipError):
+                    session.get(f"http://{server.server_name}:{server.server_port}/")
+            assert caplog.messages == [
+                "failed to connect to localhost, retrying 1 last time"
+            ]
+
+    def test_selfsigned_cert(
+        self, caplog: pytest.LogCaptureFixture, self_signed_server: Address
+    ) -> None:
+        with PipSession(retries=1) as session, pytest.raises(DiagnosticPipError):
+            session.get(self_signed_server.url(https=True))
+        assert caplog.messages == [
+            "SSL verification failed while connecting to localhost, "
+            "retrying 1 last time"
+        ]
+
+    def test_verbose(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(VERBOSE)
+        with PipSession(retries=1) as session, pytest.raises(DiagnosticPipError):
+            session.get("https://404.example.invalid")
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert not warnings[0].endswith("retrying 1 last time")


### PR DESCRIPTION
Towards https://github.com/pypa/pip/issues/10421. **This is in draft until https://github.com/urllib3/urllib3/pull/5140 is included in a urllib3 release.** 

The approach taken here is to install a logging filter on the `_vendor` logging handler which "sniffs" for the appropriate warnings and rewrites them. This rewriting is best effort because urllib3 gives us scant context to work with. Under verbose mode, the original error is appended as a "here's all of the context, sorry that it's unreadable" aid.

This is supported by an upstream PR to urllib3 (https://github.com/urllib3/urllib3/pull/5140) adding a special extra attribute to the retrying warning, providing for a clear identifying marker and extra information needed by pip (i.e. the target host).

Overall, this is quite hacky, but having discussed with the urllib3 maintainers, this is the most mutually acceptable compromise for improving these user-hostile warnings for pip.

## Example screenshots (and a question!)

<img width="2878" height="402" alt="image" src="https://github.com/user-attachments/assets/46935673-efd1-4b0e-b318-80e40fa9fbda" />

<img width="2844" height="408" alt="image" src="https://github.com/user-attachments/assets/95ecba91-9ecc-4544-ba75-f9490b008202" />

<img width="2880" height="440" alt="image" src="https://github.com/user-attachments/assets/896e9a16-182a-4197-8a0c-1164d0cbe133" />

... looking at these screenshots, I wonder if would be better to include the URL path that's being retried. While it's clear from context what URLs are being retried in these screeenshots, in other cases, the URL cannot be easily inferred. OTOH, some URLs are truly long (like PyPI's `files.pythonhosted.org` distribution URLs) and we probably don't want to print said URLs repeatedly. Let me know if you have any opinions.  