### PR TITLE
Improve error hint for excluded distributions

### DIFF
--- a/news/4646.bugfix.rst
+++ b/news/4646.bugfix.rst
@@ -1,0 +1,1 @@
+Suggest verbose output when distributions may have been excluded.

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -782,18 +782,8 @@ class PackageFinder:
     def requires_python_skipped_reasons(self) -> list[str]:
         return sorted(self._requires_python_skipped)
 
-    def log_skipped_link_warning(self, project_name: str) -> None:
-        if canonicalize_name(project_name) not in self._projects_with_skipped_links:
-            return
-        if any(
-            handler.name == "console" and handler.level <= logging.DEBUG
-            for handler in logging.getLogger().handlers
-        ):
-            return
-        logger.critical(
-            "Some packages may have been found and excluded. "
-            "To see details, re-run pip with -vv."
-        )
+    def has_skipped_links(self, project_name: str) -> bool:
+        return canonicalize_name(project_name) in self._projects_with_skipped_links
 
     def make_link_evaluator(self, project_name: str) -> LinkEvaluator:
         canonical_name = canonicalize_name(project_name)
@@ -1093,7 +1083,14 @@ class PackageFinder:
                 req,
                 _format_versions(best_candidate_result.all_candidates),
             )
-            self.log_skipped_link_warning(name)
+            if self.has_skipped_links(name) and not any(
+                handler.name == "console" and handler.level <= logging.DEBUG
+                for handler in logging.getLogger().handlers
+            ):
+                logger.critical(
+                    "Some packages may have been found and excluded. "
+                    "To see details, re-run pip with -vv."
+                )
 
             raise DistributionNotFound(f"No matching distribution found for {req}")
 

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -655,6 +655,11 @@ class PackageFinder:
         # the error message when resolution fails.
         self._requires_python_skipped: set[str] = set()
 
+        # Tracks projects for which at least one potentially relevant link was
+        # skipped. Used to direct users to the detailed verbose output when
+        # resolution fails.
+        self._projects_with_skipped_links: set[NormalizedName] = set()
+
         # Cache of the result of finding candidates
         self._all_candidates: dict[str, list[InstallationCandidate]] = {}
         self._best_candidates: dict[
@@ -777,6 +782,19 @@ class PackageFinder:
     def requires_python_skipped_reasons(self) -> list[str]:
         return sorted(self._requires_python_skipped)
 
+    def log_skipped_link_warning(self, project_name: str) -> None:
+        if canonicalize_name(project_name) not in self._projects_with_skipped_links:
+            return
+        if any(
+            handler.name == "console" and handler.level <= logging.DEBUG
+            for handler in logging.getLogger().handlers
+        ):
+            return
+        logger.critical(
+            "Some packages may have been found and excluded. "
+            "To see details, re-run pip with -vv."
+        )
+
     def make_link_evaluator(self, project_name: str) -> LinkEvaluator:
         canonical_name = canonicalize_name(project_name)
         formats = self.format_control.get_allowed_formats(canonical_name)
@@ -807,10 +825,27 @@ class PackageFinder:
                     no_eggs.append(link)
         return no_eggs + eggs
 
-    def _log_skipped_link(self, link: Link, result: LinkType, detail: str) -> None:
+    def _log_skipped_link(
+        self,
+        project_name: str,
+        link: Link,
+        result: LinkType,
+        detail: str,
+    ) -> None:
         # Put the link at the end so the reason is more visible and because
         # the link string is usually very long.
         logger.debug("Skipping link: %s: %s", detail, link)
+        if link.egg_fragment:
+            package_fragment = link.egg_fragment
+        else:
+            package_fragment, _ = link.splitext()
+        canonical_name = canonicalize_name(project_name)
+        try:
+            _find_name_version_sep(package_fragment, canonical_name)
+        except ValueError:
+            pass
+        else:
+            self._projects_with_skipped_links.add(canonical_name)
         if result == LinkType.requires_python_mismatch:
             self._requires_python_skipped.add(detail)
 
@@ -827,7 +862,12 @@ class PackageFinder:
             # when --uploaded-prior-to is specified
             raise InstallationError(detail)
         if result != LinkType.candidate:
-            self._log_skipped_link(link, result, detail)
+            self._log_skipped_link(
+                link_evaluator.project_name,
+                link,
+                result,
+                detail,
+            )
             return None
 
         try:
@@ -1053,6 +1093,7 @@ class PackageFinder:
                 req,
                 _format_versions(best_candidate_result.all_candidates),
             )
+            self.log_skipped_link_warning(name)
 
             raise DistributionNotFound(f"No matching distribution found for {req}")
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -757,6 +757,7 @@ class Factory:
                 req_disp,
                 ", ".join(versions) or "none",
             )
+        self._finder.log_skipped_link_warning(req.project_name)
         if str(req) == "requirements.txt":
             logger.info(
                 "HINT: You are attempting to install a package literally "

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -757,7 +757,14 @@ class Factory:
                 req_disp,
                 ", ".join(versions) or "none",
             )
-        self._finder.log_skipped_link_warning(req.project_name)
+        if self._finder.has_skipped_links(req.project_name) and not any(
+            handler.name == "console" and handler.level <= logging.DEBUG
+            for handler in logging.getLogger().handlers
+        ):
+            logger.critical(
+                "Some packages may have been found and excluded. "
+                "To see details, re-run pip with -vv."
+            )
         if str(req) == "requirements.txt":
             logger.info(
                 "HINT: You are attempting to install a package literally "

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -280,6 +280,9 @@ def test_new_resolver_installed_message(script: PipTestEnvironment) -> None:
 
 def test_new_resolver_no_dist_message(script: PipTestEnvironment) -> None:
     create_basic_wheel_for_package(script, "A", "1.0")
+    script.scratch_path.joinpath("links.html").write_text(
+        '<a href="A-1.0.tar.gz">A-1.0.tar.gz</a>'
+    )
     result = script.pip(
         "install",
         "--no-cache-dir",
@@ -300,6 +303,68 @@ def test_new_resolver_no_dist_message(script: PipTestEnvironment) -> None:
         "Could not find a version that satisfies the requirement B" in result.stderr
     ), str(result)
     assert "No matching distribution found for B" in result.stderr, str(result)
+    assert "Some packages may have been found and excluded" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "resolver_args",
+    [
+        pytest.param((), id="resolvelib"),
+        pytest.param(("--use-deprecated=legacy-resolver",), id="legacy"),
+    ],
+)
+def test_excluded_dist_message(
+    script: PipTestEnvironment,
+    resolver_args: tuple[str, ...],
+) -> None:
+    script.scratch_path.joinpath("B-1.0-cp27-cp27m-any.whl").write_text("")
+    result = script.pip(
+        "install",
+        *resolver_args,
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "B",
+        expect_error=True,
+        expect_stderr=True,
+    )
+
+    assert (
+        "Some packages may have been found and excluded. "
+        "To see details, re-run pip with -vv."
+    ) in result.stderr, str(result)
+
+    verbose_result = script.pip(
+        "install",
+        *resolver_args,
+        "-vv",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "B",
+        expect_error=True,
+        expect_stderr=True,
+    )
+    assert "Skipping link: none of the wheel's tags" in verbose_result.stdout
+    assert "re-run pip with -vv" not in verbose_result.stderr
+
+    log_path = script.base_path.joinpath("pip.log")
+    logged_result = script.pip(
+        f"--log={log_path}",
+        "install",
+        *resolver_args,
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        script.scratch_path,
+        "B",
+        expect_error=True,
+        expect_stderr=True,
+    )
+    assert "Some packages may have been found and excluded" in logged_result.stderr
+    assert "Skipping link: none of the wheel's tags" in log_path.read_text()
 
 
 def test_new_resolver_installs_editable(script: PipTestEnvironment) -> None:


### PR DESCRIPTION
## What does this PR do?

When pip finds distributions for the requested project but excludes them, report that more detail is available with `-vv`. This covers both the current and legacy resolvers and avoids showing the hint for unrelated files.

Fixes #4646

## PR Checklist:

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Codex
