### PR TITLE
Apply require-hashes to isolated build dependencies

### DIFF
--- a/docs/html/topics/secure-installs.md
+++ b/docs/html/topics/secure-installs.md
@@ -39,6 +39,10 @@ FooProject == 1.2 \
 
   If there is a dependency that is not spelled out and hashed in the requirements file, it will result in an error.
 
+  When installing from a source distribution, this also applies to build
+  dependencies. Pin and hash them in a build constraints file passed with
+  `--build-constraint`.
+
 - Requirements must be pinned (either to a URL, filesystem path or using `==`).
 
   This prevents a surprising hash mismatch upon the release of a new version that matches the requirement specifier.

--- a/docs/html/user_guide.rst
+++ b/docs/html/user_guide.rst
@@ -303,6 +303,9 @@ Example build constraints file (``build-constraints.txt``):
    # Pin Cython for packages that use it to build
    cython==0.29.24
 
+When using ``--require-hashes``, build dependencies must also be pinned and
+hashed in this file.
+
 The ``--build-constraint`` option can be set with the ``PIP_BUILD_CONSTRAINT``
 environment variable.
 

--- a/news/13984.bugfix.rst
+++ b/news/13984.bugfix.rst
@@ -1,0 +1,1 @@
+Apply ``--require-hashes`` to dependencies installed into isolated build environments.

--- a/src/pip/_internal/build_env/installer.py
+++ b/src/pip/_internal/build_env/installer.py
@@ -43,9 +43,11 @@ class SubprocessBuildEnvironmentInstaller:
         self,
         finder: PackageFinder,
         build_constraints: list[str] | None = None,
+        require_hashes: bool = False,
     ) -> None:
         self.finder = finder
         self._build_constraints = build_constraints or []
+        self._require_hashes = require_hashes
 
     def install(
         self,
@@ -134,6 +136,8 @@ class SubprocessBuildEnvironmentInstaller:
         # constrains any nested builds.
         for constraint_file in self._build_constraints:
             args.extend(["--build-constraint", constraint_file])
+        if self._require_hashes:
+            args.append("--require-hashes")
 
         if finder.uploaded_prior_to:
             args.extend(["--uploaded-prior-to", finder.uploaded_prior_to.isoformat()])
@@ -178,6 +182,7 @@ class InprocessBuildEnvironmentInstaller:
         wheel_cache: WheelCache,
         build_constraints: Sequence[InstallRequirement] = (),
         verbosity: int = 0,
+        require_hashes: bool = False,
     ) -> None:
         from pip._internal.operations.prepare import RequirementPreparer
 
@@ -202,9 +207,7 @@ class InprocessBuildEnvironmentInstaller:
             build_isolation="virtual",
             check_build_deps=False,
             progress_bar="off",
-            # TODO: hash-checking should be extended to build deps, but that is
-            # deferred for later as it'd be a breaking change.
-            require_hashes=False,
+            require_hashes=require_hashes,
             use_user_site=False,
             lazy_wheel=False,
             legacy_resolver=False,

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -208,11 +208,13 @@ class RequirementCommand(IndexGroupCommand):
                 build_constraints=build_constraint_reqs,
                 verbosity=verbosity,
                 wheel_cache=WheelCache(options.cache_dir),
+                require_hashes=options.require_hashes,
             )
         else:
             env_installer = SubprocessBuildEnvironmentInstaller(
                 finder,
                 build_constraints=build_constraints,
+                require_hashes=options.require_hashes,
             )
 
         if not options.build_isolation:

--- a/tests/functional/test_build_constraints.py
+++ b/tests/functional/test_build_constraints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -259,3 +260,72 @@ def test_build_constraint_is_enforced(
         expect_error=True,
     )
     assert "setuptools==2000" in result.stderr
+
+
+@pytest.mark.parametrize("installer_args", INSTALLER_ARGS)
+def test_require_hashes_applies_to_build_dependencies(
+    script: PipTestEnvironment,
+    data: TestData,
+    tmpdir: Path,
+    installer_args: list[str],
+) -> None:
+    """Hash checking also covers build dependencies for both installers."""
+    sdist = data.packages / "simple-1.0.tar.gz"
+    requirements = script.scratch_path / "requirements.txt"
+    sdist_hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
+    requirements.write_text(f"{path_to_url(str(sdist))} --hash=sha256:{sdist_hash}\n")
+    setuptools_wheel = next(data.common_wheels.glob("setuptools-*.whl"))
+    setuptools_version = setuptools_wheel.name.split("-", 2)[1]
+    setuptools_hash = hashlib.sha256(setuptools_wheel.read_bytes()).hexdigest()
+    build_constraints = _create_constraints_file(
+        script=script,
+        filename="build_constraints.txt",
+        content=f"setuptools=={setuptools_version} --hash=sha256:{setuptools_hash}\n",
+    )
+
+    result = script.pip_install_local(
+        "--require-hashes",
+        "--build-constraint",
+        build_constraints,
+        "--requirement",
+        requirements,
+        *installer_args,
+        build_isolation=True,
+        find_links=data.common_wheels,
+    )
+
+    result.assert_installed("simple", editable=False)
+
+
+@pytest.mark.parametrize("installer_args", INSTALLER_ARGS)
+def test_require_hashes_rejects_unhashed_build_dependencies(
+    script: PipTestEnvironment,
+    data: TestData,
+    installer_args: list[str],
+) -> None:
+    """Unhashed build dependencies must not bypass hash-checking mode."""
+    sdist = data.packages / "simple-1.0.tar.gz"
+    requirements = script.scratch_path / "requirements.txt"
+    sdist_hash = hashlib.sha256(sdist.read_bytes()).hexdigest()
+    requirements.write_text(f"{path_to_url(str(sdist))} --hash=sha256:{sdist_hash}\n")
+    setuptools_wheel = next(data.common_wheels.glob("setuptools-*.whl"))
+    setuptools_version = setuptools_wheel.name.split("-", 2)[1]
+    build_constraints = _create_constraints_file(
+        script=script,
+        filename="build_constraints.txt",
+        content=f"setuptools=={setuptools_version}\n",
+    )
+
+    result = script.pip_install_local(
+        "--require-hashes",
+        "--build-constraint",
+        build_constraints,
+        "--requirement",
+        requirements,
+        *installer_args,
+        build_isolation=True,
+        find_links=data.common_wheels,
+        expect_error=True,
+    )
+
+    assert "build dependencies" in result.stderr

--- a/tests/unit/test_build_constraints.py
+++ b/tests/unit/test_build_constraints.py
@@ -7,8 +7,13 @@ import warnings
 from pathlib import Path
 from unittest import mock
 
-from pip._internal.build_env import SubprocessBuildEnvironmentInstaller
+from pip._internal.build_env import (
+    InprocessBuildEnvironmentInstaller,
+    SubprocessBuildEnvironmentInstaller,
+)
 from pip._internal.build_env.base import Prefix
+from pip._internal.cache import WheelCache
+from pip._internal.operations.build.build_tracker import get_build_tracker
 from pip._internal.utils.deprecation import PipDeprecationWarning
 
 from tests.lib import make_test_finder
@@ -72,3 +77,34 @@ class TestSubprocessBuildEnvironmentInstaller:
         assert "--constraint" not in args
         assert args[args.index("--build-constraint") + 1] == "build-constraints.txt"
         assert kwargs.get("extra_environ") == {"_PIP_IN_BUILD_IGNORE_CONSTRAINTS": "1"}
+
+    @mock.patch("pip._internal.build_env.installer.call_subprocess")
+    def test_install_passes_require_hashes(
+        self, mock_call_subprocess: mock.Mock, tmp_path: Path
+    ) -> None:
+        installer = SubprocessBuildEnvironmentInstaller(
+            make_test_finder(), require_hashes=True
+        )
+        prefix = Prefix(str(tmp_path))
+
+        installer.install(
+            requirements=["setuptools"],
+            prefix=prefix,
+            kind="build dependencies",
+            for_req=None,
+        )
+
+        args = mock_call_subprocess.call_args.args[0]
+        assert "--require-hashes" in args
+
+
+def test_inprocess_installer_requires_hashes() -> None:
+    with get_build_tracker() as tracker:
+        installer = InprocessBuildEnvironmentInstaller(
+            finder=make_test_finder(),
+            build_tracker=tracker,
+            wheel_cache=WheelCache(None),  # type: ignore
+            require_hashes=True,
+        )
+
+    assert installer._preparer.require_hashes


### PR DESCRIPTION
## What does this PR do?

Fixes #13984.

The existing `--require-hashes` option does not apply to packages installed into isolated PEP 517 build environments. This lets an unhashed build dependency be fetched and executed even when the top-level install is hash-checked.

This change propagates hash checking to both isolated build dependency installers. Subprocess installs receive `--require-hashes`, and in-process installs enable the existing requirement preparer hash validation. Build dependencies can now be pinned and hashed in a build constraints file.

Tests cover both installer paths, successful installation with an exact build dependency hash, and rejection of an unhashed build dependency.

Validation:
- `.venv/bin/python -m nox -s test-3.13 -- tests/unit/test_build_constraints.py tests/functional/test_build_constraints.py tests/unit/test_req.py tests/functional/test_pep517.py tests/functional/test_build_env.py`
- 148 passed, 3 Windows-only skips
- `.nox/lint/bin/pre-commit run --files src/pip/_internal/build_env/installer.py src/pip/_internal/cli/req_command.py tests/unit/test_build_constraints.py tests/functional/test_build_constraints.py docs/html/topics/secure-installs.md docs/html/user_guide.rst news/13984.bugfix.rst`
- All hooks passed

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment.
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and I have disclosed AI tool use below.

Assisted-by: OpenAI Codex