### PR TITLE
Make install --report, direct_url.json and inspect agree on origin/editable state

### DIFF
--- a/news/14075.bugfix.rst
+++ b/news/14075.bugfix.rst
@@ -1,0 +1,5 @@
+Make ``pip install --report``, the recorded ``direct_url.json`` and ``pip inspect``
+describe a local ``--editable`` install with a ``#subdirectory=`` fragment the same
+way as the non-editable form: the subdirectory is kept out of the URL, in the
+``subdirectory`` field. ``pip inspect`` also no longer errors out on a malformed
+``direct_url.json`` -- such a distribution is now reported without a ``direct_url``.

--- a/src/pip/_internal/commands/inspect.py
+++ b/src/pip/_internal/commands/inspect.py
@@ -11,7 +11,7 @@ from pip._internal.cli.base_command import Command
 from pip._internal.cli.status_codes import SUCCESS
 from pip._internal.metadata import BaseDistribution, get_environment
 from pip._internal.utils.compat import stdlib_pkgs
-from pip._internal.utils.urls import path_to_url
+from pip._internal.utils.direct_url_helpers import direct_url_for_editable
 
 logger = logging.getLogger(__name__)
 
@@ -70,18 +70,15 @@ class InspectCommand(Command):
         # direct_url. Note that we don't have download_info (as in the installation
         # report) since it is not recorded in installed metadata.
         direct_url = dist.direct_url
-        if direct_url is not None:
-            res["direct_url"] = direct_url.to_dict_compat()
-        else:
-            # Emulate direct_url for legacy editable installs.
+        if direct_url is None:
+            # Legacy editable installs (.egg-link) have no direct_url.json;
+            # synthesize the same DirectUrl a modern local editable install
+            # records, so the serialized shape is identical.
             editable_project_location = dist.editable_project_location
             if editable_project_location is not None:
-                res["direct_url"] = {
-                    "url": path_to_url(editable_project_location),
-                    "dir_info": {
-                        "editable": True,
-                    },
-                }
+                direct_url = direct_url_for_editable(editable_project_location)
+        if direct_url is not None:
+            res["direct_url"] = direct_url.to_dict_compat()
         # installer
         installer = dist.installer
         if dist.installer:

--- a/src/pip/_internal/models/direct_url.py
+++ b/src/pip/_internal/models/direct_url.py
@@ -33,7 +33,16 @@ class DirectUrl(PackagingDirectUrl):
 
     @classmethod
     def from_json(cls, s: str) -> DirectUrl:
-        return cls.from_dict(json.loads(s))
+        obj = json.loads(s)
+        if not isinstance(obj, dict):
+            # Guard against a direct_url.json / origin.json whose top-level
+            # value is not a JSON object (e.g. a list or a bare scalar) so
+            # callers get a DirectUrlValidationError they already handle
+            # rather than an unexpected TypeError/AttributeError.
+            raise DirectUrlValidationError(
+                f"Expected a JSON object, got {type(obj).__name__}"
+            )
+        return cls.from_dict(obj)
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict_compat(), sort_keys=True)

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -712,7 +712,24 @@ class RequirementPreparer:
             req.ensure_has_source_dir(self.src_dir)
             req.update_editable()
             assert req.source_dir
-            req.download_info = direct_url_for_editable(req.unpacked_source_directory)
+            assert req.link is not None
+            if req.link.is_existing_dir():
+                # A local directory installed with --editable: build the same
+                # PEP 610 DirectUrl a non-editable local directory would get
+                # (keeping any #subdirectory= fragment out of the URL), just
+                # with editable=True, so that the install report, the recorded
+                # direct_url.json and ``pip inspect`` all describe it the same
+                # way.
+                req.download_info = direct_url_for_editable(
+                    req.source_dir, subdirectory=req.link.subdirectory_fragment
+                )
+            else:
+                # A VCS editable: pip has checked the project out into the src
+                # directory; record that checkout location (PEP 610 records
+                # editables as a local dir_info).
+                req.download_info = direct_url_for_editable(
+                    req.unpacked_source_directory
+                )
 
             dist = _get_prepared_distribution(
                 req,

--- a/src/pip/_internal/utils/direct_url_helpers.py
+++ b/src/pip/_internal/utils/direct_url_helpers.py
@@ -33,10 +33,13 @@ def direct_url_as_pep440_direct_reference(direct_url: DirectUrl, name: str) -> s
     return requirement
 
 
-def direct_url_for_editable(source_dir: str) -> DirectUrl:
+def direct_url_for_editable(
+    source_dir: str, subdirectory: str | None = None
+) -> DirectUrl:
     return DirectUrl(
         url=path_to_url(source_dir),
         dir_info=DirInfo(editable=True),
+        subdirectory=subdirectory,
     )
 
 

--- a/tests/functional/test_inspect.py
+++ b/tests/functional/test_inspect.py
@@ -1,6 +1,11 @@
 import json
+from pathlib import Path
+from typing import Any
 
 import pytest
+from packaging.utils import canonicalize_name
+
+from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME
 
 from tests.lib import PipTestEnvironment, ScriptFactory, TestData
 
@@ -23,6 +28,27 @@ def simple_script(
     return script
 
 
+def _make_project(path: Path, *, name: str, version: str = "1.0") -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    path.joinpath("pyproject.toml").write_text(
+        f'[project]\nname = "{name}"\nversion = "{version}"\n'
+    )
+    package_dir = path / canonicalize_name(name).replace("-", "_")
+    package_dir.mkdir(exist_ok=True)
+    package_dir.joinpath("__init__.py").write_text("")
+    return path
+
+
+def _inspect_entry(script: PipTestEnvironment, name: str, **kwargs: Any) -> Any:
+    result = script.pip("inspect", **kwargs)
+    assert "Traceback" not in result.stderr
+    data = json.loads(result.stdout)
+    for entry in data["installed"]:
+        if canonicalize_name(entry["metadata"]["name"]) == canonicalize_name(name):
+            return entry
+    return None
+
+
 def test_inspect_basic(simple_script: PipTestEnvironment) -> None:
     """
     Test default behavior of inspect command.
@@ -42,3 +68,75 @@ def test_inspect_basic(simple_script: PipTestEnvironment) -> None:
     assert installed_by_name["simplewheel"]["requested"] is True
     assert installed_by_name["simplewheel"]["installer"] == "pip"
     assert "environment" in report
+
+
+@pytest.mark.parametrize("editable", [False, True], ids=["not-editable", "editable"])
+def test_inspect_direct_url_local_directory(
+    script: PipTestEnvironment, tmp_path: Path, editable: bool
+) -> None:
+    """``pip inspect`` serializes ``direct_url`` for a local directory install
+    exactly as pip recorded it in ``direct_url.json`` (same shape for a normal
+    and a PEP 660 editable install; editable state lives in dir_info.editable)."""
+    project_path = _make_project(tmp_path / "pkga", name="pkga")
+    args = ["install", "--no-build-isolation", "--no-index"]
+    if editable:
+        args.append("--editable")
+    args.append(str(project_path))
+    result = script.pip(*args)
+    recorded = result.get_created_direct_url("pkga")
+    assert recorded is not None
+
+    entry = _inspect_entry(script, "pkga")
+    assert entry is not None
+    assert entry["direct_url"] == recorded.to_dict_compat()
+    assert entry["direct_url"]["url"].endswith("/pkga")
+    assert entry["direct_url"]["dir_info"] == ({"editable": True} if editable else {})
+    assert "subdirectory" not in entry["direct_url"]
+    assert entry["metadata_location"]
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("[]", id="json-array"),
+        pytest.param("not a json document", id="not-json"),
+        pytest.param('{"url": 1}', id="wrong-value-type"),
+    ],
+)
+def test_inspect_malformed_direct_url(
+    script: PipTestEnvironment, tmp_path: Path, content: str
+) -> None:
+    """A missing/malformed ``direct_url.json`` must not make ``pip inspect``
+    crash, and pip must not invent a more specific origin than it knows: the
+    entry simply carries no ``direct_url``."""
+    project_path = _make_project(tmp_path / "pkga", name="pkga")
+    result = script.pip(
+        "install",
+        "--no-build-isolation",
+        "--no-index",
+        str(project_path),
+    )
+    direct_url_path = result.get_created_direct_url_path("pkga")
+    assert direct_url_path and direct_url_path.name == DIRECT_URL_METADATA_NAME
+    direct_url_path.write_text(content)
+
+    entry = _inspect_entry(script, "pkga", allow_stderr_warning=True)
+    assert entry is not None
+    assert "direct_url" not in entry
+
+
+def test_inspect_no_direct_url(
+    script: PipTestEnvironment, shared_data: TestData
+) -> None:
+    """A package installed from an index/find-links has no ``direct_url.json``;
+    ``pip inspect`` reports it without a ``direct_url`` (no invented origin)."""
+    script.pip(
+        "install",
+        "--no-index",
+        "-f",
+        shared_data.find_links,
+        "simplewheel==1.0",
+    )
+    entry = _inspect_entry(script, "simplewheel")
+    assert entry is not None
+    assert "direct_url" not in entry

--- a/tests/functional/test_install_report.py
+++ b/tests/functional/test_install_report.py
@@ -6,11 +6,55 @@ from typing import Any
 import pytest
 from packaging.utils import canonicalize_name
 
-from ..lib import PipTestEnvironment, TestData
+from ..lib import PipTestEnvironment, TestData, TestPipResult
 
 
 def _install_dict(report: dict[str, Any]) -> dict[str, Any]:
     return {canonicalize_name(i["metadata"]["name"]): i for i in report["install"]}
+
+
+def _make_project(path: Path, *, name: str, version: str = "1.0") -> Path:
+    """Create a minimal PEP 621 project at ``path`` and return ``path``."""
+    path.mkdir(parents=True, exist_ok=True)
+    path.joinpath("pyproject.toml").write_text(
+        f'[project]\nname = "{name}"\nversion = "{version}"\n'
+    )
+    package_dir = path / canonicalize_name(name).replace("-", "_")
+    package_dir.mkdir(exist_ok=True)
+    package_dir.joinpath("__init__.py").write_text("")
+    return path
+
+
+def _inspect_entry(script: PipTestEnvironment, name: str) -> dict[str, Any]:
+    """Return the ``pip inspect`` entry for ``name``."""
+    inspect = json.loads(script.pip("inspect").stdout)
+    for entry in inspect["installed"]:
+        if canonicalize_name(entry["metadata"]["name"]) == canonicalize_name(name):
+            return entry
+    raise AssertionError(f"{name} not found in pip inspect output")
+
+
+def _assert_agree(
+    script: PipTestEnvironment,
+    report: dict[str, Any],
+    result: TestPipResult,
+    name: str,
+) -> dict[str, Any]:
+    """``pip install --report``, the recorded ``direct_url.json`` and ``pip inspect``
+    must all describe the same install the same way. Returns ``download_info``.
+    """
+    installed = result.get_created_direct_url(name)
+    assert installed is not None, f"no direct_url.json recorded for {name}"
+    report_entry = _install_dict(report)[canonicalize_name(name)]
+    download_info = report_entry["download_info"]
+    assert report_entry["is_direct"] is True
+    # report download_info == what pip recorded on disk as direct_url.json ...
+    assert download_info == installed.to_dict_compat()
+    # ... == what pip inspect serializes back from that same direct_url.json
+    assert _inspect_entry(script, name)["direct_url"] == download_info
+    # a local directory is a dir_info, never inferred as a VCS checkout
+    assert "vcs_info" not in download_info
+    return download_info
 
 
 def test_install_report_basic(
@@ -331,7 +375,14 @@ def test_install_report_local_path_with_extras(
     assert pkga_report["metadata"]["name"] == "pkga"
     assert pkga_report["is_direct"] is True
     assert pkga_report["requested"] is True
+    # The extras drive dependency selection (``simple`` is pulled in) but must
+    # not leak into the direct-URL metadata as if they were part of the path.
     assert pkga_report["requested_extras"] == ["test"]
+    pkga_download_info = pkga_report["download_info"]
+    assert pkga_download_info["url"].endswith("/pkga")
+    assert "[" not in pkga_download_info["url"]
+    assert pkga_download_info["dir_info"] == {}
+    assert "subdirectory" not in pkga_download_info
     simple_report = report["install"][1]
     assert simple_report["metadata"]["name"] == "simple"
     assert simple_report["is_direct"] is False
@@ -373,11 +424,113 @@ def test_install_report_editable_local_path_with_extras(
     assert pkga_report["is_direct"] is True
     assert pkga_report["requested"] is True
     assert pkga_report["requested_extras"] == ["test"]
+    # Same contract as the non-editable case: extras select ``simple`` but are
+    # not folded into the (editable) direct-URL metadata.
+    pkga_download_info = pkga_report["download_info"]
+    assert pkga_download_info["url"].endswith("/pkga")
+    assert "[" not in pkga_download_info["url"]
+    assert pkga_download_info["dir_info"] == {"editable": True}
+    assert "subdirectory" not in pkga_download_info
     simple_report = report["install"][1]
     assert simple_report["metadata"]["name"] == "simple"
     assert simple_report["is_direct"] is False
     assert simple_report["requested"] is False
     assert "requested_extras" not in simple_report
+
+
+def test_install_report_local_directory(
+    script: PipTestEnvironment, tmp_path: Path
+) -> None:
+    """A plain local directory install: --report download_info, the recorded
+    direct_url.json and ``pip inspect`` all describe it as the same dir_info."""
+    project_path = _make_project(tmp_path / "pkga", name="pkga")
+    report_path = tmp_path / "report.json"
+    result = script.pip(
+        "install",
+        "--no-build-isolation",
+        "--no-index",
+        str(project_path),
+        "--report",
+        str(report_path),
+    )
+    report = json.loads(report_path.read_text())
+    download_info = _assert_agree(script, report, result, "pkga")
+    assert download_info["url"].endswith("/pkga")
+    assert download_info["dir_info"] == {}
+    assert "subdirectory" not in download_info
+
+
+def test_install_report_editable_local_directory(
+    script: PipTestEnvironment, tmp_path: Path
+) -> None:
+    """A PEP 660 editable local directory: the three views agree, and the URL
+    is the project directory (editable state lives in ``dir_info.editable``)."""
+    project_path = _make_project(tmp_path / "pkga", name="pkga")
+    report_path = tmp_path / "report.json"
+    result = script.pip(
+        "install",
+        "--no-build-isolation",
+        "--no-index",
+        "--editable",
+        str(project_path),
+        "--report",
+        str(report_path),
+    )
+    report = json.loads(report_path.read_text())
+    download_info = _assert_agree(script, report, result, "pkga")
+    assert download_info["url"].endswith("/pkga")
+    assert download_info["dir_info"] == {"editable": True}
+    assert "subdirectory" not in download_info
+
+
+@pytest.mark.parametrize("editable", [False, True], ids=["not-editable", "editable"])
+def test_install_report_local_file_url_with_subdirectory(
+    script: PipTestEnvironment, tmp_path: Path, editable: bool
+) -> None:
+    """A direct-URL requirement with a local ``file://`` URL and a
+    ``#subdirectory=`` fragment: the subdirectory is kept out of the URL and in
+    the ``subdirectory`` field, identically for the editable and non-editable
+    forms, and matches the recorded direct_url.json and ``pip inspect``."""
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    _make_project(outer / "sub", name="subpkg", version="2.0")
+    requirement = f"subpkg @ {outer.as_uri()}#subdirectory=sub"
+    report_path = tmp_path / "report.json"
+    args = ["install", "--no-build-isolation", "--no-index"]
+    if editable:
+        args.append("--editable")
+    args += [requirement, "--report", str(report_path)]
+    result = script.pip(*args)
+    report = json.loads(report_path.read_text())
+    download_info = _assert_agree(script, report, result, "subpkg")
+    assert download_info["url"].endswith("/outer")
+    assert "/sub" not in download_info["url"]
+    assert download_info["subdirectory"] == "sub"
+    assert download_info["dir_info"] == ({"editable": True} if editable else {})
+
+
+@pytest.mark.git
+@pytest.mark.parametrize("editable", [False, True], ids=["not-editable", "editable"])
+def test_install_report_local_directory_inside_git_checkout(
+    script: PipTestEnvironment, tmp_path: Path, editable: bool
+) -> None:
+    """A local directory that merely happens to live in a git checkout is still
+    reported as a local directory (dir_info), never inferred as a VCS checkout,
+    in the report, the recorded direct_url.json and ``pip inspect``."""
+    project_path = _make_project(tmp_path / "gitpkg", name="gitpkg")
+    script.run("git", "init", "-q", cwd=str(project_path))
+    report_path = tmp_path / "report.json"
+    args = ["install", "--no-build-isolation", "--no-index"]
+    if editable:
+        args.append("--editable")
+    args += [str(project_path), "--report", str(report_path)]
+    result = script.pip(*args)
+    report = json.loads(report_path.read_text())
+    download_info = _assert_agree(script, report, result, "gitpkg")
+    assert "vcs_info" not in download_info
+    assert "dir_info" in download_info
+    assert download_info["dir_info"] == ({"editable": True} if editable else {})
+    assert download_info["url"].endswith("/gitpkg")
 
 
 def test_install_report_to_stdout(

--- a/tests/unit/metadata/test_metadata.py
+++ b/tests/unit/metadata/test_metadata.py
@@ -30,15 +30,33 @@ def test_dist_get_direct_url_no_metadata(mock_read_text: mock.Mock) -> None:
     mock_read_text.assert_called_once_with(DIRECT_URL_METADATA_NAME)
 
 
-@mock.patch.object(BaseDistribution, "read_text", return_value="{}")
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("{}", id="empty-object"),
+        pytest.param("not a json document", id="not-json"),
+        pytest.param('{"url": 1}', id="wrong-value-type"),
+        # A top-level value that is not a JSON object must be rejected the same
+        # way (it used to raise an uncaught TypeError/AttributeError and crash
+        # `pip inspect` / `pip freeze` / `pip show`).
+        pytest.param("[]", id="json-array"),
+        pytest.param('"file:///x"', id="json-string"),
+        pytest.param("42", id="json-number"),
+    ],
+)
 def test_dist_get_direct_url_invalid_json(
-    mock_read_text: mock.Mock, caplog: pytest.LogCaptureFixture
+    content: str, caplog: pytest.LogCaptureFixture
 ) -> None:
     class FakeDistribution(BaseDistribution):
         canonical_name = cast(NormalizedName, "whatever")  # Needed for error logging.
 
     dist = FakeDistribution()  # type: ignore
-    with caplog.at_level(logging.WARNING):
+    with (
+        mock.patch.object(
+            BaseDistribution, "read_text", return_value=content
+        ) as mock_read_text,
+        caplog.at_level(logging.WARNING),
+    ):
         assert dist.direct_url is None
 
     mock_read_text.assert_called_once_with(DIRECT_URL_METADATA_NAME)

--- a/tests/unit/test_direct_url.py
+++ b/tests/unit/test_direct_url.py
@@ -16,6 +16,15 @@ def test_from_json() -> None:
     assert not direct_url.dir_info.editable
 
 
+@pytest.mark.parametrize("payload", ["[]", '"file:///x"', "42", "true", "null"])
+def test_from_json_non_object(payload: str) -> None:
+    # A direct_url.json / origin.json whose top-level value is not a JSON object
+    # must raise DirectUrlValidationError (which callers already handle), not an
+    # unexpected TypeError/AttributeError.
+    with pytest.raises(DirectUrlValidationError, match="Expected a JSON object"):
+        DirectUrl.from_json(payload)
+
+
 def test_to_json() -> None:
     direct_url = DirectUrl(
         url="file:///home/user/archive.tgz",

--- a/tests/unit/test_direct_url_helpers.py
+++ b/tests/unit/test_direct_url_helpers.py
@@ -7,8 +7,10 @@ from pip._internal.models.direct_url import ArchiveInfo, DirectUrl, DirInfo, Vcs
 from pip._internal.models.link import Link
 from pip._internal.utils.direct_url_helpers import (
     direct_url_as_pep440_direct_reference,
+    direct_url_for_editable,
     direct_url_from_link,
 )
+from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs.git import Git
 
 
@@ -173,6 +175,27 @@ def test_from_link_dir(tmpdir: Path) -> None:
     direct_url = direct_url_from_link(Link(dir_url))
     assert direct_url.url == dir_url
     assert direct_url.dir_info
+
+
+def test_for_editable() -> None:
+    direct_url = direct_url_for_editable("/home/user/project")
+    direct_url.validate()
+    assert direct_url.url == path_to_url("/home/user/project")
+    assert direct_url.dir_info
+    assert direct_url.dir_info.editable is True
+    assert direct_url.subdirectory is None
+
+
+def test_for_editable_with_subdirectory() -> None:
+    # The subdirectory is kept in its own field, out of the URL, exactly like
+    # direct_url_from_link does for a non-editable local directory.
+    direct_url = direct_url_for_editable("/home/user/project", subdirectory="pkg_dir")
+    direct_url.validate()
+    assert direct_url.url == path_to_url("/home/user/project")
+    assert "pkg_dir" not in direct_url.url
+    assert direct_url.subdirectory == "pkg_dir"
+    assert direct_url.dir_info
+    assert direct_url.dir_info.editable is True
 
 
 def test_from_link_hide_user_password() -> None:


### PR DESCRIPTION
…itable state

pip decides "what a distribution's origin / editable state looks like" in several independent places, and they had drifted:

* prepare.py recorded an editable local directory via direct_url_for_editable(req.unpacked_source_directory) -- the #subdirectory= fragment folded into the URL path and no subdirectory field -- whereas a non-editable local directory keeps the subdirectory in its own PEP 610 field. Same install, different internal + on-disk shape.
* commands/inspect.py hand-rolled a third copy of the DirInfo direct_url dict for legacy .egg-link editables instead of the one canonical builder.
* DirectUrl.from_json(json.loads(s)) crashed with AttributeError/TypeError when direct_url.json's top-level value was not a JSON object (e.g. "[]"), so `pip inspect` / `pip freeze` / `pip show` errored out instead of the already-handled "ignore + warn".

Changes (no new/renamed public keys, no report or inspect schema bump, no new kind of direct-url object -- normalize internally, serialize as before):

* direct_url_for_editable() gains an optional `subdirectory`, kept out of the URL exactly like direct_url_from_link()'s directory branch.
* prepare_editable_requirement() builds a local-directory editable's DirectUrl the same way as a non-editable local directory (source_dir + subdirectory=link.subdirectory_fragment, editable=True). VCS editables are untouched; with no #subdirectory= the result is byte-identical to before.
* commands/inspect.py reuses direct_url_for_editable() for the legacy editable case and serialises through DirectUrl.to_dict_compat() like the normal path; distributions with missing/invalid metadata still get no direct_url key (no invented origin).
* DirectUrl.from_json() rejects a non-object top level with DirectUrlValidationError, which callers already handle.

Extras keep driving dependency selection but no longer risk leaking into direct_url metadata as part of the path/URL/origin.

Adds regression coverage that `pip install --report`, the recorded direct_url.json and `pip inspect` describe the same install identically for: a plain local directory, a PEP 660 editable, editable installs with extras, a local file:// URL with a #subdirectory= fragment (editable and not), and a local directory that merely lives inside a git checkout (reported as a directory, never inferred as VCS); plus the negative side: a missing or malformed direct_url.json must not crash inspect/report or invent an origin.

<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

<!-- What problem does this solve? Include the issue number if applicable. -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->
