### PR TITLE
Warn on file conflicts when installing packages

### DIFF
--- a/news/4625.bugfix.rst
+++ b/news/4625.bugfix.rst
@@ -1,0 +1,1 @@
+Warn when installing a package overwrites files owned by another package

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -38,6 +38,7 @@ from pip._internal.locations import get_major_minor_version
 from pip._internal.metadata import (
     BaseDistribution,
     FilesystemWheel,
+    get_environment,
     get_wheel_distribution,
 )
 from pip._internal.models.direct_url import DIRECT_URL_METADATA_NAME, DirectUrl
@@ -432,6 +433,14 @@ class PipScriptMaker(ScriptMaker):
         return super().make(specification, options)
 
 
+def _get_conflicting_files_warning_message(conflicting_files: list[str]) -> str:
+    if len(conflicting_files) > 3:
+        return (
+            f"{', '.join(conflicting_files[:3])}, and {len(conflicting_files) - 3} more"
+        )
+    return f"{', '.join(conflicting_files)}"
+
+
 def _install_wheel(  # noqa: C901, PLR0915 function is too long
     name: str,
     wheel_zip: ZipFile,
@@ -473,6 +482,24 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     installed: dict[RecordPath, RecordPath] = {}
     changed: set[RecordPath] = set()
     generated: list[str] = []
+
+    # Track reocrd file owners and conflicting files
+    # file_owner_map: record_path -> owner
+    # conflicting_files_map: owner -> conflicting_files
+    file_owner_map: dict[str, str] = {}
+    conflicting_files_map: collections.defaultdict[str, list[str]] = (
+        collections.defaultdict(list)
+    )
+
+    distributions = get_environment(
+        [scheme.purelib, scheme.platlib]
+    ).iter_installed_distributions()
+    for installed_dist in distributions:
+        entries = installed_dist.iter_declared_entries()
+        if entries is None:
+            continue
+        for entry in entries:
+            file_owner_map[entry] = installed_dist.canonical_name
 
     def record_installed(
         srcfile: RecordPath, destfile: str, modified: bool = False
@@ -594,16 +621,37 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     files = chain(files, script_scheme_files)
 
     existing_parents = set()
+    canonicalized_wheel_name = canonicalize_name(name)
     for file in files:
         # directory creation is lazy and after file filtering
         # to ensure we don't install empty dirs; empty dirs can't be
         # uninstalled.
+        file_record_path = _fs_to_record_path(file.dest_path, lib_dir)
+        if (
+            file_record_path in file_owner_map
+            and file_owner_map[file_record_path] != canonicalized_wheel_name
+        ):
+            conflicting_files_map[file_owner_map[file_record_path]].append(
+                file_record_path
+            )
+
         parent_dir = os.path.dirname(file.dest_path)
         if parent_dir not in existing_parents:
             ensure_dir(parent_dir)
             existing_parents.add(parent_dir)
         file.save()
         record_installed(file.src_record_path, file.dest_path, file.changed)
+
+    if conflicting_files_map:
+        for victim in conflicting_files_map:
+            logger.warning(
+                "Installing %s overwrote %s files "
+                "(%s) which were already owned by %s",
+                canonicalized_wheel_name,
+                len(conflicting_files_map[victim]),
+                _get_conflicting_files_warning_message(conflicting_files_map[victim]),
+                victim,
+            )
 
     def pyc_source_file_paths() -> Generator[str, None, None]:
         # We de-duplicate installation paths, since there can be overlap (e.g.

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -2771,6 +2771,32 @@ def test_install_dist_restriction_without_target(script: PipTestEnvironment) -> 
     ), str(result)
 
 
+def test_install_package_with_conflicting_files_shows_warning(
+    script: PipTestEnvironment,
+) -> None:
+    pkga = create_basic_wheel_for_package(
+        script,
+        name="pkga",
+        version="1.0",
+        extra_files={"shared_module/__init__.py": "# pkga version"},
+    )
+    pkgb = create_basic_wheel_for_package(
+        script,
+        name="pkgb",
+        version="1.0",
+        extra_files={"shared_module/__init__.py": "# pkgb version"},
+    )
+    script.pip("install", "--no-index", pkga)
+    result = script.pip(
+        "install",
+        "--no-index",
+        pkgb,
+        allow_stderr_warning=True,
+    )
+    assert "pkga" in result.stderr
+    assert "shared_module" in result.stderr
+
+
 def test_install_dist_restriction_dry_run_doesnt_require_target(
     script: PipTestEnvironment,
 ) -> None:


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?
Fixes #4625.

The approach taken here is to iterate over the installed distributions and track each RECORD entry in a dictionary, with the owning distribution as the value. Then, during `_install_wheel`, each file path from the wheel is checked against this dictionary to determine whether another distribution already owns it. If so, the path is recorded and later included in a warning.

However, the current approach only warns after the overwrite has already happened, which is not ideal. We could mitigate this by aborting the installation and requiring an explicit flag to continue, but unless we want to take a stricter approach, that may not be the best default behavior.

Another possible approach would be to prompt the user when conflicts are detected and require confirmation before proceeding. This is similar to aborting unless a flag is provided, but is more interactive and less strict.

Before going with any of the approaches above, though, I would like to get some input from the team on which one fits pip better. Please let me know if you have any ideas or suggestions on the implementation :).

Also, here is the output when installing two conflicting packages:
```
$ pip install isbnlib
Collecting isbnlib
  Using cached isbnlib-3.10.14-py2.py3-none-any.whl.metadata (16 kB)
Using cached isbnlib-3.10.14-py2.py3-none-any.whl (52 kB)
Installing collected packages: isbnlib
Successfully installed isbnlib-3.10.14
$ pip install isbnlib2
Collecting isbnlib2
  Using cached isbnlib2-3.11.21-py3-none-any.whl.metadata (16 kB)
Using cached isbnlib2-3.11.21-py3-none-any.whl (67 kB)
Installing collected packages: isbnlib2
  WARNING: Installing isbnlib2 overwrote 37 files (isbnlib/__init__.py, isbnlib/_core.py, isbnlib/_cover.py, and 34 more) which were already owned by isbnlib
Successfully installed isbnlib2-3.11.21
```
## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->
