### PR TITLE
Remove a stale job name from allowed-skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,6 @@ jobs:
                 tests-unix,
                 tests-windows,
                 tests-zipapp,
-                tests-importlib-metadata,
               '
               || ''
             }}


### PR DESCRIPTION
## What does this PR do?

`tests-importlib-metadata` no longer exists

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

I used Claude to investigate configuration issues in pip's CI.
