### PR TITLE
Add iso 8601 durations reference to pip install --uploaded-prior-to docs

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -540,7 +540,7 @@ def uploaded_prior_to() -> Option:
             "Only consider packages uploaded prior to the given value. "
             "Accepts an ISO 8601 datetime (e.g., '2023-01-01T00:00:00Z', "
             "uses local timezone if none specified) "
-            "or an ISO 8601 duration in days "
+            "or duration in integer days with syntax `P<n>D` "
             "(e.g., 'P3D' for packages uploaded at least 3 days ago). "
             "Only effective when using indexes that provide "
             "upload-time metadata."

--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -539,7 +539,8 @@ def uploaded_prior_to() -> Option:
         help=(
             "Only consider packages uploaded prior to the given value. "
             "Accepts an ISO 8601 datetime (e.g., '2023-01-01T00:00:00Z', "
-            "uses local timezone if none specified) or a duration in days "
+            "uses local timezone if none specified) "
+            "or an ISO 8601 duration in days "
             "(e.g., 'P3D' for packages uploaded at least 3 days ago). "
             "Only effective when using indexes that provide "
             "upload-time metadata."


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

Docs-only update. Clarify `pip install` option `--uploaded-prior-to` also uses ISO 8601 duration. Although some English speakers correctly interprets that the ISO 8601 applies to both datetime and durations, other speakers may not notice the parallel grammar structure. 

- [Related discussions at Python Discourse](https://discuss.python.org/t/what-is-the-syntax-used-by-pip-upload-prior-to/108518/6)


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.
<!-- If checked and you have used AI tools, add a line below: Assisted-by: <tool name, e.g. Claude> -->

**Zero** AI assistance was used in writing the code or making the commit.