### PR TITLE
Reject unsafe wheel RECORD paths

### DIFF
--- a/news/10118.bugfix.rst
+++ b/news/10118.bugfix.rst
@@ -1,0 +1,2 @@
+Prevent a malformed ``RECORD`` file from causing pip to remove the installation
+root during package installation or uninstallation. (#10118)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -82,6 +82,27 @@ def csv_io_kwargs(mode: str) -> dict[str, Any]:
     return {"mode": mode, "newline": "", "encoding": "utf-8"}
 
 
+def _validate_record_path(record_path: str, lib_dir: str, wheel_path: str) -> None:
+    """Validate a RECORD path before installing the wheel.
+
+    RECORD paths are relative to the installation root.  In particular, a
+    path that normalizes to the installation root is never a file owned by the
+    distribution, and must not be allowed to make the root appear in RECORD.
+    """
+    if not record_path or os.path.isabs(record_path):
+        raise InstallationError(
+            f"The wheel {wheel_path!r} has an invalid RECORD entry "
+            f"{record_path!r}."
+        )
+
+    target = os.path.normpath(os.path.join(lib_dir, record_path))
+    if os.path.normcase(target) == os.path.normcase(os.path.normpath(lib_dir)):
+        raise InstallationError(
+            f"The wheel {wheel_path!r} has an invalid RECORD entry "
+            f"{record_path!r} that refers to the installation root."
+        )
+
+
 def fix_script(path: str) -> bool:
     """Replace #!python with #!/path/to/python
     Return True if file was changed.
@@ -472,6 +493,19 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     else:
         lib_dir = scheme.platlib
 
+    distribution = get_wheel_distribution(
+        FilesystemWheel(wheel_path),
+        canonicalize_name(name),
+    )
+    record_text = distribution.read_text("RECORD")
+    record_rows = list(csv.reader(record_text.splitlines()))
+    for row in record_rows:
+        if not row:
+            raise InstallationError(
+                f"The wheel {wheel_path!r} has an invalid empty RECORD entry."
+            )
+        _validate_record_path(row[0], lib_dir, wheel_path)
+
     # Record details of the files moved
     #   installed = files copied from the wheel to the destination
     #   changed = files changed while installing (scripts #! line typically)
@@ -570,10 +604,6 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     files = chain(files, other_scheme_files)
 
     # Get the defined entry points
-    distribution = get_wheel_distribution(
-        FilesystemWheel(wheel_path),
-        canonicalize_name(name),
-    )
     console, gui = get_entrypoints(distribution)
 
     def is_entrypoint_wrapper(file: File) -> bool:
@@ -713,9 +743,6 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
         with open(requested_path, "wb"):
             pass
         generated.append(requested_path)
-
-    record_text = distribution.read_text("RECORD")
-    record_rows = list(csv.reader(record_text.splitlines()))
 
     rows = get_csv_rows_for_installed(
         record_rows,

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -8,7 +8,11 @@ from collections.abc import Callable, Generator, Iterable
 from importlib.util import cache_from_source
 from typing import Any
 
-from pip._internal.exceptions import LegacyDistutilsInstall, UninstallMissingRecord
+from pip._internal.exceptions import (
+    InstallationError,
+    LegacyDistutilsInstall,
+    UninstallMissingRecord,
+)
 from pip._internal.locations import get_bin_prefix, get_bin_user
 from pip._internal.metadata import BaseDistribution
 from pip._internal.utils.compat import WINDOWS
@@ -76,8 +80,26 @@ def uninstallation_paths(dist: BaseDistribution) -> Generator[str, None, None]:
     if entries is None:
         raise UninstallMissingRecord(distribution=dist)
 
+    normalized_location = normalize_path(location, resolve_symlinks=False)
     for entry in entries:
+        if os.path.isabs(entry):
+            raise InstallationError(
+                f"Cannot uninstall {dist}: RECORD entry {entry!r} is an absolute path."
+            )
+
         path = os.path.join(location, entry)
+        normalized_path = normalize_path(path, resolve_symlinks=False)
+        if normalized_path == normalized_location:
+            raise InstallationError(
+                f"Cannot uninstall {dist}: RECORD entry {entry!r} refers to the "
+                "installation root."
+            )
+        if os.path.isdir(path) and not os.path.islink(path):
+            raise InstallationError(
+                f"Cannot uninstall {dist}: RECORD entry {entry!r} refers to a "
+                "directory."
+            )
+
         yield path
         if path.endswith(".py"):
             dn, fn = os.path.split(path)

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -347,6 +347,21 @@ def test_wheel_record_lines_in_deterministic_order(
     assert record_lines == sorted(record_lines)
 
 
+def test_install_rejects_record_entry_for_installation_root(
+    script: PipTestEnvironment, tmpdir: Path
+) -> None:
+    package = make_wheel_with_file(
+        "malformedrecord",
+        "1.0",
+        record="./,,\n",
+    ).save_to_dir(tmpdir)
+
+    result = script.pip("install", package, "--no-index", expect_error=True)
+
+    assert "invalid RECORD entry './'" in result.stderr
+    assert not (script.site_packages_path / "malformedrecord").exists()
+
+
 def test_wheel_record_lines_have_hash_for_data_files(
     script: PipTestEnvironment,
 ) -> None:

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -22,6 +22,7 @@ from tests.lib import (
     need_svn,
 )
 from tests.lib.local_repos import local_checkout, local_repo
+from tests.lib.wheel import make_wheel
 
 
 def test_basic_uninstall(script: PipTestEnvironment, data: TestData) -> None:
@@ -589,6 +590,32 @@ def test_uninstall_without_record_fails(
         hint = f"The package was installed by {installer}."
     assert f"hint: {hint}" in result2.stderr
     assert_all_changes(result.files_after, result2, ignore_changes)
+
+
+def test_uninstall_rejects_record_entry_for_installation_root(
+    script: PipTestEnvironment, tmpdir: Path
+) -> None:
+    package = make_wheel(
+        "malformedrecord",
+        "1.0",
+        extra_files={"malformedrecord/__init__.py": ""},
+    ).save_to_dir(tmpdir)
+    script.pip("install", package, "--no-index")
+
+    record_path = (
+        script.site_packages_path / "malformedrecord-1.0.dist-info" / "RECORD"
+    )
+    record_path.write_text("./,,\n")
+    sentinel = script.site_packages_path / "sentinel.py"
+    sentinel.write_text("sentinel")
+
+    result = script.pip(
+        "uninstall", "malformedrecord", "-y", expect_error=True
+    )
+
+    assert "installation root" in result.stderr
+    assert sentinel.exists()
+    assert (script.site_packages_path / "malformedrecord").exists()
 
 
 @pytest.mark.skipif("sys.platform == 'win32'")

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 import pytest
 
 import pip._internal.req.req_uninstall
+from pip._internal.exceptions import InstallationError
 from pip._internal.req.req_uninstall import (
     StashedUninstallPathSet,
     UninstallPathSet,
@@ -55,6 +56,45 @@ def test_uninstallation_paths() -> None:
     paths2 = list(uninstallation_paths(d))
 
     assert paths2 == paths
+
+
+@pytest.mark.parametrize("entry", [".", "./"])
+def test_uninstallation_paths_rejects_installation_root(
+    tmp_path: Path, entry: str
+) -> None:
+    class dist:
+        def iter_declared_entries(self) -> Iterator[str] | None:
+            return iter([entry])
+
+        location = str(tmp_path)
+
+    with pytest.raises(InstallationError, match="installation root"):
+        list(uninstallation_paths(dist()))
+
+
+def test_uninstallation_paths_rejects_directories(tmp_path: Path) -> None:
+    directory = tmp_path / "directory"
+    directory.mkdir()
+
+    class dist:
+        def iter_declared_entries(self) -> Iterator[str] | None:
+            return iter([directory.name])
+
+        location = str(tmp_path)
+
+    with pytest.raises(InstallationError, match="directory"):
+        list(uninstallation_paths(dist()))
+
+
+def test_uninstallation_paths_rejects_absolute_paths(tmp_path: Path) -> None:
+    class dist:
+        def iter_declared_entries(self) -> Iterator[str] | None:
+            return iter([str(tmp_path)])
+
+        location = str(tmp_path / "site-packages")
+
+    with pytest.raises(InstallationError, match="absolute path"):
+        list(uninstallation_paths(dist()))
 
 
 def test_compressed_listing(tmpdir: Path) -> None:


### PR DESCRIPTION
## Summary

- validate wheel `RECORD` entries before installation writes begin
- reject uninstall entries that resolve to the installation root, absolute paths, or real directories
- preserve normal relative-file and symlink-directory behavior
- add install, uninstall, and unit regressions for malformed metadata

## Root cause

An entry such as `./` in a distribution's `RECORD` normalized to the whole installation root. During update or reinstall, pip could therefore treat all of `site-packages` as owned by that distribution and remove it.

The fix treats malformed metadata as an error before it can authorize installation or uninstall file operations.

Fixes #10118.

## Validation

- Commit: `7c5431c6de12aa97ed95231699b7458bb242778d`
- Full local suite: `3105 passed, 96 skipped, 18 xfailed, 2 xpassed`
- FalseGreen: accepted, signed source-bound attestation

### FalseGreen verification

**Accepted**

#### Claim verified

The verified criteria establish that the installation path validator rejects empty, absolute, and root-normalizing RECORD entries while accepting a normal relative file path and that the unit tests covering ordinary relative files plus installation-root, real-directory, and absolute-path RECORD handling pass.

#### Verification criteria

Criteria passed: 2/2
Criteria failed: 0
Criteria not executed: 0

**1. Malformed RECORD paths are rejected before installation file operations. — Passed**

Description: The installation path validator rejects empty, absolute, and root-normalizing RECORD entries while accepting a normal relative file path.

Method:
Executed the frozen verifier command in the FalseGreen verification environment.
- Frozen command evidence: 1 command(s); exact argv is retained in the JSON attestation.
- Evidence protocol: `exit\_code`

Coverage:
- Semantic coverage: not captured by the task contract or verifier evidence.
- Verification commands: 1/1 passed
- Runtime: 1101 ms

Observed:
- commands\_expected: 1
- commands\_run: 1
- commands\_passed: 1
- commands\_failed: 0
- Command 1: exit status `0`, passed, 1101 ms
Evidence source: FalseGreen verification environment

**2. Focused uninstall RECORD safety tests pass. — Passed**

Description: The unit tests covering ordinary relative files plus installation-root, real-directory, and absolute-path RECORD handling pass.

Method:
Executed the frozen verifier command in the FalseGreen verification environment.
- Frozen command evidence: 1 command(s); exact argv is retained in the JSON attestation.
- Evidence protocol: `exit\_code`

Coverage:
- Semantic coverage: not captured by the task contract or verifier evidence.
- Verification commands: 1/1 passed
- Runtime: 3044 ms

Observed:
- commands\_expected: 1
- commands\_run: 1
- commands\_passed: 1
- commands\_failed: 0
- Command 2: exit status `0`, passed, 3044 ms
Evidence source: FalseGreen verification environment

#### Scope

This report applies only to the source state identified above. This verification establishes only the criteria listed above for that source state. It does not claim the repository is bug-free, formally verified, or correct outside the verified criteria.

Not verified:
- Behavior outside the frozen verification criteria.

Environment: Python 3.13.15

#### Source

Source digest: `sha256:6b9177482ad2d8d0232ad6c4b3d1b4ebe71b307efb743c405d2f61121d2e4252`
Git commit: unavailable / uncommitted workspace
Task: `task\_4de88f3d906b4581b8ed4512faff107c`
Run: `run\_8b44ab3fa82047aa9070ab6cc40dd49e`
Verifier: FalseGreen `0.16.6`

Attestation: signed by FalseGreen (`sha256:384dae665e08b987346b2ecdb5978abc9e6bb783af775756bcb7617b34c7503e`)
Outcome class: `verified`
