### PR TITLE
Reject malformed wheel record paths

### DIFF
--- a/news/10118.bugfix.rst
+++ b/news/10118.bugfix.rst
@@ -1,2 +1,2 @@
-Prevent a malformed ``RECORD`` file from causing pip to remove the installation
-root during package installation or uninstallation. (#10118)
+Prevent a malformed ``RECORD`` file from causing pip to remove unrelated files
+during installation or uninstallation.

--- a/news/10118.bugfix.rst
+++ b/news/10118.bugfix.rst
@@ -1,0 +1,2 @@
+Prevent a malformed ``RECORD`` file from causing pip to remove the installation
+root during package installation or uninstallation. (#10118)

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -50,7 +50,7 @@ from pip._internal.utils.unpacking import (
     set_extracted_file_to_default_mode_plus_executable,
     zip_item_is_executable,
 )
-from pip._internal.utils.wheel import parse_wheel
+from pip._internal.utils.wheel import parse_wheel, record_path_resolves_to_base
 
 
 class File(Protocol):
@@ -82,20 +82,26 @@ def csv_io_kwargs(mode: str) -> dict[str, Any]:
     return {"mode": mode, "newline": "", "encoding": "utf-8"}
 
 
-def _validate_record_path(record_path: str, lib_dir: str, wheel_path: str) -> None:
+def _validate_record_path(
+    record_row: Sequence[str], lib_dir: str, wheel_path: str
+) -> None:
     """Validate a RECORD path before installing the wheel.
 
     RECORD paths are relative to the installation root.  In particular, a
     path that normalizes to the installation root is never a file owned by the
     distribution, and must not be allowed to make the root appear in RECORD.
     """
-    if not record_path or os.path.isabs(record_path):
+    record_path = record_row[0] if record_row else ""
+    if not record_path:
+        raise InstallationError(
+            f"The wheel {wheel_path!r} has an invalid empty RECORD entry."
+        )
+    if os.path.isabs(record_path):
         raise InstallationError(
             f"The wheel {wheel_path!r} has an invalid RECORD entry {record_path!r}."
         )
 
-    target = os.path.normpath(os.path.join(lib_dir, record_path))
-    if os.path.normcase(target) == os.path.normcase(os.path.normpath(lib_dir)):
+    if record_path_resolves_to_base(record_path, lib_dir):
         raise InstallationError(
             f"The wheel {wheel_path!r} has an invalid RECORD entry "
             f"{record_path!r} that refers to the installation root."
@@ -499,11 +505,7 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     record_text = distribution.read_text("RECORD")
     record_rows = list(csv.reader(record_text.splitlines()))
     for row in record_rows:
-        if not row:
-            raise InstallationError(
-                f"The wheel {wheel_path!r} has an invalid empty RECORD entry."
-            )
-        _validate_record_path(row[0], lib_dir, wheel_path)
+        _validate_record_path(row, lib_dir, wheel_path)
 
     # Record details of the files moved
     #   installed = files copied from the wheel to the destination

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -91,8 +91,7 @@ def _validate_record_path(record_path: str, lib_dir: str, wheel_path: str) -> No
     """
     if not record_path or os.path.isabs(record_path):
         raise InstallationError(
-            f"The wheel {wheel_path!r} has an invalid RECORD entry "
-            f"{record_path!r}."
+            f"The wheel {wheel_path!r} has an invalid RECORD entry {record_path!r}."
         )
 
     target = os.path.normpath(os.path.join(lib_dir, record_path))

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -82,6 +82,27 @@ def csv_io_kwargs(mode: str) -> dict[str, Any]:
     return {"mode": mode, "newline": "", "encoding": "utf-8"}
 
 
+def _validate_record_path(record_path: str, lib_dir: str, wheel_path: str) -> None:
+    """Validate a RECORD path before installing the wheel.
+
+    RECORD paths are relative to the installation root.  In particular, a
+    path that normalizes to the installation root is never a file owned by the
+    distribution, and must not be allowed to make the root appear in RECORD.
+    """
+    if not record_path or os.path.isabs(record_path):
+        raise InstallationError(
+            f"The wheel {wheel_path!r} has an invalid RECORD entry "
+            f"{record_path!r}."
+        )
+
+    target = os.path.normpath(os.path.join(lib_dir, record_path))
+    if os.path.normcase(target) == os.path.normcase(os.path.normpath(lib_dir)):
+        raise InstallationError(
+            f"The wheel {wheel_path!r} has an invalid RECORD entry "
+            f"{record_path!r} that refers to the installation root."
+        )
+
+
 def fix_script(path: str) -> bool:
     """Replace #!python with #!/path/to/python
     Return True if file was changed.
@@ -472,6 +493,19 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     else:
         lib_dir = scheme.platlib
 
+    distribution = get_wheel_distribution(
+        FilesystemWheel(wheel_path),
+        canonicalize_name(name),
+    )
+    record_text = distribution.read_text("RECORD")
+    record_rows = list(csv.reader(record_text.splitlines()))
+    for row in record_rows:
+        if not row:
+            raise InstallationError(
+                f"The wheel {wheel_path!r} has an invalid empty RECORD entry."
+            )
+        _validate_record_path(row[0], lib_dir, wheel_path)
+
     # Record details of the files moved
     #   installed = files copied from the wheel to the destination
     #   changed = files changed while installing (scripts #! line typically)
@@ -570,10 +604,6 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
     files = chain(files, other_scheme_files)
 
     # Get the defined entry points
-    distribution = get_wheel_distribution(
-        FilesystemWheel(wheel_path),
-        canonicalize_name(name),
-    )
     console, gui = get_entrypoints(distribution)
 
     def is_entrypoint_wrapper(file: File) -> bool:
@@ -713,9 +743,6 @@ def _install_wheel(  # noqa: C901, PLR0915 function is too long
         with open(requested_path, "wb"):
             pass
         generated.append(requested_path)
-
-    record_text = distribution.read_text("RECORD")
-    record_rows = list(csv.reader(record_text.splitlines()))
 
     rows = get_csv_rows_for_installed(
         record_rows,

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -8,7 +8,11 @@ from collections.abc import Callable, Generator, Iterable
 from importlib.util import cache_from_source
 from typing import Any
 
-from pip._internal.exceptions import LegacyDistutilsInstall, UninstallMissingRecord
+from pip._internal.exceptions import (
+    InstallationError,
+    LegacyDistutilsInstall,
+    UninstallMissingRecord,
+)
 from pip._internal.locations import get_bin_prefix, get_bin_user
 from pip._internal.metadata import BaseDistribution
 from pip._internal.utils.compat import WINDOWS
@@ -76,8 +80,26 @@ def uninstallation_paths(dist: BaseDistribution) -> Generator[str, None, None]:
     if entries is None:
         raise UninstallMissingRecord(distribution=dist)
 
+    normalized_location = normalize_path(location, resolve_symlinks=False)
     for entry in entries:
+        if os.path.isabs(entry):
+            raise InstallationError(
+                f"Cannot uninstall {dist}: RECORD entry {entry!r} is an absolute path."
+            )
+
         path = os.path.join(location, entry)
+        normalized_path = normalize_path(path, resolve_symlinks=False)
+        if normalized_path == normalized_location:
+            raise InstallationError(
+                f"Cannot uninstall {dist}: RECORD entry {entry!r} refers to the "
+                "installation root."
+            )
+        if os.path.isdir(path) and not os.path.islink(path):
+            raise InstallationError(
+                f"Cannot uninstall {dist}: RECORD entry {entry!r} refers to a "
+                "directory."
+            )
+
         yield path
         if path.endswith(".py"):
             dn, fn = os.path.split(path)

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -82,11 +82,6 @@ def uninstallation_paths(dist: BaseDistribution) -> Generator[str, None, None]:
 
     normalized_location = normalize_path(location, resolve_symlinks=False)
     for entry in entries:
-        if os.path.isabs(entry):
-            raise InstallationError(
-                f"Cannot uninstall {dist}: RECORD entry {entry!r} is an absolute path."
-            )
-
         path = os.path.join(location, entry)
         normalized_path = normalize_path(path, resolve_symlinks=False)
         if normalized_path == normalized_location:

--- a/src/pip/_internal/req/req_uninstall.py
+++ b/src/pip/_internal/req/req_uninstall.py
@@ -21,6 +21,7 @@ from pip._internal.utils.logging import getLogger, indent_log
 from pip._internal.utils.misc import ask, normalize_path, renames, rmtree
 from pip._internal.utils.temp_dir import AdjacentTempDirectory, TempDirectory
 from pip._internal.utils.virtualenv import running_under_virtualenv
+from pip._internal.utils.wheel import record_path_resolves_to_base
 
 logger = getLogger(__name__)
 
@@ -80,11 +81,9 @@ def uninstallation_paths(dist: BaseDistribution) -> Generator[str, None, None]:
     if entries is None:
         raise UninstallMissingRecord(distribution=dist)
 
-    normalized_location = normalize_path(location, resolve_symlinks=False)
     for entry in entries:
         path = os.path.join(location, entry)
-        normalized_path = normalize_path(path, resolve_symlinks=False)
-        if normalized_path == normalized_location:
+        if record_path_resolves_to_base(entry, location):
             raise InstallationError(
                 f"Cannot uninstall {dist}: RECORD entry {entry!r} refers to the "
                 "installation root."

--- a/src/pip/_internal/utils/wheel.py
+++ b/src/pip/_internal/utils/wheel.py
@@ -1,6 +1,7 @@
 """Support functions for working with wheel files."""
 
 import logging
+import os.path
 from email.message import Message
 from email.parser import Parser
 from zipfile import BadZipFile, ZipFile
@@ -8,11 +9,20 @@ from zipfile import BadZipFile, ZipFile
 from pip._vendor.packaging.utils import canonicalize_name
 
 from pip._internal.exceptions import UnsupportedWheel
+from pip._internal.utils.misc import normalize_path
 
 VERSION_COMPATIBLE = (1, 0)
 
 
 logger = logging.getLogger(__name__)
+
+
+def record_path_resolves_to_base(record_path: str, base: str) -> bool:
+    """Return whether a RECORD path resolves exactly to its base directory."""
+    path = os.path.join(base, record_path)
+    return normalize_path(path, resolve_symlinks=False) == normalize_path(
+        base, resolve_symlinks=False
+    )
 
 
 def parse_wheel(wheel_zip: ZipFile, name: str) -> tuple[str, Message]:

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -347,6 +347,21 @@ def test_wheel_record_lines_in_deterministic_order(
     assert record_lines == sorted(record_lines)
 
 
+def test_install_rejects_record_entry_for_installation_root(
+    script: PipTestEnvironment, tmpdir: Path
+) -> None:
+    package = make_wheel_with_file(
+        "malformedrecord",
+        "1.0",
+        record="./,,\n",
+    ).save_to_dir(tmpdir)
+
+    result = script.pip("install", package, "--no-index", expect_error=True)
+
+    assert "invalid RECORD entry './'" in result.stderr
+    assert not (script.site_packages_path / "malformedrecord").exists()
+
+
 def test_wheel_record_lines_have_hash_for_data_files(
     script: PipTestEnvironment,
 ) -> None:

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -362,6 +362,21 @@ def test_install_rejects_record_entry_for_installation_root(
     assert not (script.site_packages_path / "malformedrecord").exists()
 
 
+def test_install_rejects_empty_record_entry(
+    script: PipTestEnvironment, tmpdir: Path
+) -> None:
+    package = make_wheel_with_file(
+        "malformedrecord",
+        "1.0",
+        record="\n",
+    ).save_to_dir(tmpdir)
+
+    result = script.pip("install", package, "--no-index", expect_error=True)
+
+    assert "invalid empty RECORD entry" in result.stderr
+    assert not (script.site_packages_path / "malformedrecord").exists()
+
+
 def test_wheel_record_lines_have_hash_for_data_files(
     script: PipTestEnvironment,
 ) -> None:

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 import os
 import sys
@@ -612,6 +613,27 @@ def test_uninstall_rejects_record_entry_for_installation_root(
     assert "installation root" in result.stderr
     assert sentinel.exists()
     assert (script.site_packages_path / "malformedrecord").exists()
+
+
+def test_uninstall_accepts_absolute_record_file(
+    script: PipTestEnvironment, tmpdir: Path
+) -> None:
+    package = make_wheel(
+        "absoluterecord",
+        "1.0",
+        extra_files={"absoluterecord/__init__.py": ""},
+    ).save_to_dir(tmpdir)
+    script.pip("install", package, "--no-index")
+
+    absolute_file = script.bin_path / "absolute-record-file"
+    absolute_file.write_text("owned by absoluterecord")
+    record_path = script.site_packages_path / "absoluterecord-1.0.dist-info" / "RECORD"
+    with record_path.open("a", newline="", encoding="utf-8") as record_file:
+        csv.writer(record_file).writerow([str(absolute_file), "", ""])
+
+    script.pip("uninstall", "absoluterecord", "-y")
+
+    assert not absolute_file.exists()
 
 
 @pytest.mark.skipif("sys.platform == 'win32'")

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -602,16 +602,12 @@ def test_uninstall_rejects_record_entry_for_installation_root(
     ).save_to_dir(tmpdir)
     script.pip("install", package, "--no-index")
 
-    record_path = (
-        script.site_packages_path / "malformedrecord-1.0.dist-info" / "RECORD"
-    )
+    record_path = script.site_packages_path / "malformedrecord-1.0.dist-info" / "RECORD"
     record_path.write_text("./,,\n")
     sentinel = script.site_packages_path / "sentinel.py"
     sentinel.write_text("sentinel")
 
-    result = script.pip(
-        "uninstall", "malformedrecord", "-y", expect_error=True
-    )
+    result = script.pip("uninstall", "malformedrecord", "-y", expect_error=True)
 
     assert "installation root" in result.stderr
     assert sentinel.exists()

--- a/tests/functional/test_uninstall.py
+++ b/tests/functional/test_uninstall.py
@@ -22,6 +22,7 @@ from tests.lib import (
     need_svn,
 )
 from tests.lib.local_repos import local_checkout, local_repo
+from tests.lib.wheel import make_wheel
 
 
 def test_basic_uninstall(script: PipTestEnvironment, data: TestData) -> None:
@@ -589,6 +590,32 @@ def test_uninstall_without_record_fails(
         hint = f"The package was installed by {installer}."
     assert f"hint: {hint}" in result2.stderr
     assert_all_changes(result.files_after, result2, ignore_changes)
+
+
+def test_uninstall_rejects_record_entry_for_installation_root(
+    script: PipTestEnvironment, tmpdir: Path
+) -> None:
+    package = make_wheel(
+        "malformedrecord",
+        "1.0",
+        extra_files={"malformedrecord/__init__.py": ""},
+    ).save_to_dir(tmpdir)
+    script.pip("install", package, "--no-index")
+
+    record_path = (
+        script.site_packages_path / "malformedrecord-1.0.dist-info" / "RECORD"
+    )
+    record_path.write_text("./,,\n")
+    sentinel = script.site_packages_path / "sentinel.py"
+    sentinel.write_text("sentinel")
+
+    result = script.pip(
+        "uninstall", "malformedrecord", "-y", expect_error=True
+    )
+
+    assert "installation root" in result.stderr
+    assert sentinel.exists()
+    assert (script.site_packages_path / "malformedrecord").exists()
 
 
 @pytest.mark.skipif("sys.platform == 'win32'")

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -72,13 +72,30 @@ def test_uninstallation_paths_rejects_installation_root(
         list(uninstallation_paths(dist()))
 
 
-def test_uninstallation_paths_rejects_directories(tmp_path: Path) -> None:
+def test_uninstallation_paths_rejects_absolute_installation_root(
+    tmp_path: Path,
+) -> None:
+    class dist:
+        def iter_declared_entries(self) -> Iterator[str] | None:
+            return iter([str(tmp_path)])
+
+        location = str(tmp_path)
+
+    with pytest.raises(InstallationError, match="installation root"):
+        list(uninstallation_paths(dist()))
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_uninstallation_paths_rejects_directories(
+    tmp_path: Path, absolute: bool
+) -> None:
     directory = tmp_path / "directory"
     directory.mkdir()
 
     class dist:
         def iter_declared_entries(self) -> Iterator[str] | None:
-            return iter([directory.name])
+            entry = str(directory) if absolute else directory.name
+            return iter([entry])
 
         location = str(tmp_path)
 
@@ -86,15 +103,37 @@ def test_uninstallation_paths_rejects_directories(tmp_path: Path) -> None:
         list(uninstallation_paths(dist()))
 
 
-def test_uninstallation_paths_rejects_absolute_paths(tmp_path: Path) -> None:
+def test_uninstallation_paths_accepts_absolute_file(tmp_path: Path) -> None:
+    file = tmp_path / "file"
+    file.touch()
+
     class dist:
         def iter_declared_entries(self) -> Iterator[str] | None:
-            return iter([str(tmp_path)])
+            return iter([str(file)])
 
         location = str(tmp_path / "site-packages")
 
-    with pytest.raises(InstallationError, match="absolute path"):
-        list(uninstallation_paths(dist()))
+    assert list(uninstallation_paths(dist())) == [str(file)]
+
+
+@pytest.mark.skipif("sys.platform == 'win32'")
+@pytest.mark.parametrize("absolute", [False, True])
+def test_uninstallation_paths_accepts_symlink_directory(
+    tmp_path: Path, absolute: bool
+) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    symlink = tmp_path / "symlink"
+    symlink.symlink_to(target, target_is_directory=True)
+
+    class dist:
+        def iter_declared_entries(self) -> Iterator[str] | None:
+            entry = str(symlink) if absolute else symlink.name
+            return iter([entry])
+
+        location = str(tmp_path)
+
+    assert list(uninstallation_paths(dist())) == [str(symlink)]
 
 
 def test_compressed_listing(tmpdir: Path) -> None:

--- a/tests/unit/test_req_uninstall.py
+++ b/tests/unit/test_req_uninstall.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 import pytest
 
 import pip._internal.req.req_uninstall
+from pip._internal.exceptions import InstallationError
 from pip._internal.req.req_uninstall import (
     StashedUninstallPathSet,
     UninstallPathSet,
@@ -55,6 +56,45 @@ def test_uninstallation_paths() -> None:
     paths2 = list(uninstallation_paths(d))
 
     assert paths2 == paths
+
+
+@pytest.mark.parametrize("entry", [".", "./"])
+def test_uninstallation_paths_rejects_installation_root(
+    tmp_path: Path, entry: str
+) -> None:
+    class dist:
+        def iter_declared_entries(self) -> Iterator[str] | None:
+            return iter([entry])
+
+        location = str(tmp_path)
+
+    with pytest.raises(InstallationError, match="installation root"):
+        list(uninstallation_paths(dist()))
+
+
+def test_uninstallation_paths_rejects_directories(tmp_path: Path) -> None:
+    directory = tmp_path / "directory"
+    directory.mkdir()
+
+    class dist:
+        def iter_declared_entries(self) -> Iterator[str] | None:
+            return iter([directory.name])
+
+        location = str(tmp_path)
+
+    with pytest.raises(InstallationError, match="directory"):
+        list(uninstallation_paths(dist()))
+
+
+def test_uninstallation_paths_rejects_absolute_paths(tmp_path: Path) -> None:
+    class dist:
+        def iter_declared_entries(self) -> Iterator[str] | None:
+            return iter([str(tmp_path)])
+
+        location = str(tmp_path / "site-packages")
+
+    with pytest.raises(InstallationError, match="absolute path"):
+        list(uninstallation_paths(dist()))
 
 
 def test_compressed_listing(tmpdir: Path) -> None:

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import ntpath
 import os
 import pathlib
 import sys
@@ -119,6 +120,23 @@ def test_normalized_outrows(
 ) -> None:
     actual = wheel._normalized_outrows(outrows)
     assert actual == expected
+
+
+def test_fs_to_record_path_preserves_path_on_different_windows_drives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # CI does not reliably provide multiple Windows drives. Emulate the drive
+    # split at this helper boundary and ensure relpath is never attempted.
+    def fail_relpath(path: str, start: str) -> str:
+        raise AssertionError("os.path.relpath() must not be used across drives")
+
+    monkeypatch.setattr(wheel.os.path, "splitdrive", ntpath.splitdrive)
+    monkeypatch.setattr(wheel.os.path, "relpath", fail_relpath)
+
+    path = "D:/scripts/example.exe"
+    lib_dir = "C:/site-packages"
+
+    assert wheel._fs_to_record_path(path, lib_dir) == path
 
 
 def call_get_csv_rows_for_installed(tmpdir: Path, text: str) -> list[InstalledCSVRow]:


### PR DESCRIPTION
<!---
Thank you for your pull request! Before submitting, please make sure you've:
- Read the CONTRIBUTING.md file carefully
- Added a news file fragment (see https://pip.pypa.io/en/latest/development/contributing/#news-entries)
-->

## What does this PR do?

Fixes #10118.

A malformed wheel RECORD entry such as ./ can cause pip to treat the installation root as package-owned.

A later update, reinstall, or uninstall can then remove unrelated files from site-packages.

This PR hardens RECORD path handling.

On install:

empty paths are rejected;
absolute wheel paths are rejected;
paths that resolve to the installation root are rejected;
validation happens before installation file operations begin.

On uninstall:

entries that resolve to the installation root are rejected;
entries that name real directories are rejected;
valid relative file paths continue to work;
valid absolute installed RECORD file paths continue to work;
symlinks continue to identify the symlink itself rather than the directory they point to.

Absolute paths are valid in an installed RECORD. This includes Windows cases where pip cannot make a path relative because the file and lib_dir are on different logical disks.

The tests cover these cases directly.

### Verification

The exact submitted commit was independently verified with [FalseGreen](https://falsegreen.com/) against a frozen verification contract.

The verification covers:

relative and absolute paths resolving to the installation root;
relative and absolute real-directory entries;
valid relative file entries;
valid absolute installed RECORD file entries;
Windows different-logical-disk path conversion;
relative and absolute symlink-directory entries;
the original malformed ./ install and uninstall regression.

6/6 verification criteria passed.

Verified source:

a650ad175ea02c5d0fd5a17b8000736c75af0e3e

The verification is scoped to these criteria. It does not claim broader correctness of pip.

## PR Checklist:

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Codex