### PR TITLE
Block HTTPS-to-HTTP redirects to untrusted origins

### DIFF
--- a/news/3174.bugfix.rst
+++ b/news/3174.bugfix.rst
@@ -1,1 +1,1 @@
-Refuse to follow HTTPS-to-HTTP redirects to untrusted origins.
+Refuse to follow redirect chains that downgrade HTTPS to an untrusted HTTP origin.

--- a/news/3174.bugfix.rst
+++ b/news/3174.bugfix.rst
@@ -1,0 +1,1 @@
+Refuse to follow HTTPS-to-HTTP redirects to untrusted origins.

--- a/src/pip/_internal/index/sources.py
+++ b/src/pip/_internal/index/sources.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import mimetypes
 import os
+import urllib.parse
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 
@@ -24,7 +25,7 @@ logger = logging.getLogger(__name__)
 FoundCandidates = Iterable[InstallationCandidate]
 FoundLinks = Iterable[Link]
 CandidatesFromPage = Callable[[Link], Iterable[InstallationCandidate]]
-PageValidator = Callable[[Link], bool]
+PageValidator = Callable[[str], bool]
 
 
 class LinkSource:
@@ -190,7 +191,16 @@ class _RemoteFileSource(LinkSource):
         return self._link
 
     def page_candidates(self) -> FoundCandidates:
-        if not self._page_validator(self._link):
+        if not self._page_validator(self._link.url):
+            host = urllib.parse.urlparse(self._link.url).hostname
+            logger.warning(
+                "The repository located at %s is not a trusted or secure host and "
+                "is being ignored. If this repository is available via HTTPS we "
+                "recommend you use HTTPS instead, otherwise you may silence "
+                "this warning and allow it anyway with '--trusted-host %s'.",
+                host,
+                host,
+            )
             return
         yield from self._candidates_from_page(self._link)
 

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -22,6 +22,7 @@ from collections.abc import Generator, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
+    cast,
 )
 
 from pip._vendor import requests, urllib3
@@ -36,7 +37,6 @@ from pip._vendor.urllib3.exceptions import InsecureRequestWarning
 from pip import __version__
 from pip._internal.exceptions import SSLMissingError
 from pip._internal.metadata import get_default_environment
-from pip._internal.models.link import Link
 from pip._internal.network.auth import MultiDomainBasicAuth
 from pip._internal.network.cache import SafeFileCache
 from pip._internal.network.utils import raise_connection_error
@@ -511,7 +511,7 @@ class PipSession(requests.Session):
         super().rebuild_auth(prepared_request, response)
         if self._request_has_used_https(response.request):
             # requests does not preserve custom attributes when copying a request.
-            setattr(prepared_request, "_pip_has_used_https", True)
+            cast(Any, prepared_request)._pip_has_used_https = True
 
     def get_redirect_target(self, resp: Response) -> str | None:
         target = super().get_redirect_target(resp)

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -529,11 +529,10 @@ class PipSession(requests.Session):
 
         source_scheme = urllib.parse.urlparse(resp.url).scheme.lower()
         redirect_url = urllib.parse.urljoin(resp.url, target)
-        redirect_scheme = urllib.parse.urlparse(redirect_url).scheme.lower()
         # Avoid downgrading HTTPS unless pip already considers the target secure.
         if (
             source_scheme == "https"
-            and redirect_scheme == "http"
+            and scheme.lower() == "http"
             and not self.is_secure_origin(Link(redirect_url))
         ):
             return None

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -444,9 +444,9 @@ class PipSession(requests.Session):
         for host, port in self.pip_trusted_origins:
             yield ("*", host, "*" if port is None else port)
 
-    def is_secure_origin(self, location: Link) -> bool:
+    def is_secure_origin(self, url: str) -> bool:
         # Determine if this url used a secure transport mechanism
-        parsed = urllib.parse.urlparse(str(location))
+        parsed = urllib.parse.urlparse(url)
         origin_protocol, origin_host, origin_port = (
             parsed.scheme,
             parsed.hostname,
@@ -497,19 +497,21 @@ class PipSession(requests.Session):
             # secure origin and we should return True
             return True
 
-        # If we've gotten to this point, then the origin isn't secure and we
-        # will not accept it as a valid location to search. We will however
-        # log a warning that we are ignoring it.
-        logger.warning(
-            "The repository located at %s is not a trusted or secure host and "
-            "is being ignored. If this repository is available via HTTPS we "
-            "recommend you use HTTPS instead, otherwise you may silence "
-            "this warning and allow it anyway with '--trusted-host %s'.",
-            origin_host,
-            origin_host,
+        return False
+
+    @staticmethod
+    def _request_has_used_https(request: PreparedRequest) -> bool:
+        return bool(getattr(request, "_pip_has_used_https", False)) or (
+            urllib.parse.urlparse(request.url).scheme.lower() == "https"
         )
 
-        return False
+    def rebuild_auth(
+        self, prepared_request: PreparedRequest, response: Response
+    ) -> None:
+        super().rebuild_auth(prepared_request, response)
+        if self._request_has_used_https(response.request):
+            # requests does not preserve custom attributes when copying a request.
+            setattr(prepared_request, "_pip_has_used_https", True)
 
     def get_redirect_target(self, resp: Response) -> str | None:
         target = super().get_redirect_target(resp)
@@ -527,14 +529,19 @@ class PipSession(requests.Session):
             )
             return None
 
-        source_scheme = urllib.parse.urlparse(resp.url).scheme.lower()
         redirect_url = urllib.parse.urljoin(resp.url, target)
-        # Avoid downgrading HTTPS unless pip already considers the target secure.
+        redirect_scheme = urllib.parse.urlparse(redirect_url).scheme.lower()
         if (
-            source_scheme == "https"
-            and scheme.lower() == "http"
-            and not self.is_secure_origin(Link(redirect_url))
+            self._request_has_used_https(resp.request)
+            and redirect_scheme == "http"
+            and not self.is_secure_origin(redirect_url)
         ):
+            logger.warning(
+                "Not following redirect from %s to %s: an HTTPS request cannot "
+                "be redirected to an insecure origin.",
+                redact_auth_from_url(resp.url),
+                redact_auth_from_url(redirect_url),
+            )
             return None
         return target
 

--- a/src/pip/_internal/network/session.py
+++ b/src/pip/_internal/network/session.py
@@ -526,6 +526,17 @@ class PipSession(requests.Session):
                 redact_auth_from_url(target),
             )
             return None
+
+        source_scheme = urllib.parse.urlparse(resp.url).scheme.lower()
+        redirect_url = urllib.parse.urljoin(resp.url, target)
+        redirect_scheme = urllib.parse.urlparse(redirect_url).scheme.lower()
+        # Avoid downgrading HTTPS unless pip already considers the target secure.
+        if (
+            source_scheme == "https"
+            and redirect_scheme == "http"
+            and not self.is_secure_origin(Link(redirect_url))
+        ):
+            return None
         return target
 
     def request(self, method: str, url: str, *args: Any, **kwargs: Any) -> Response:  # type: ignore[override]

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -1011,6 +1011,22 @@ def check_links_include(links: list[Link], names: list[str]) -> None:
 
 
 class TestLinkCollector:
+    def test_insecure_page_source_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        link_collector = make_test_link_collector(
+            index_urls=["http://example.com/simple/"]
+        )
+        collected_sources = link_collector.collect_sources(
+            "demo", candidates_from_page=lambda link: []
+        )
+
+        source = collected_sources.index_urls[0]
+        assert source is not None
+        with caplog.at_level(logging.WARNING):
+            assert list(source.page_candidates()) == []
+        assert "repository located at example.com is not a trusted" in caplog.text
+
     @mock.patch("pip._internal.index.collector._get_simple_response")
     def test_fetch_response(self, mock_get_simple_response: mock.Mock) -> None:
         url = "https://pypi.org/simple/twine/"

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -1011,9 +1011,7 @@ def check_links_include(links: list[Link], names: list[str]) -> None:
 
 
 class TestLinkCollector:
-    def test_insecure_page_source_warns(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_insecure_page_source_warns(self, caplog: pytest.LogCaptureFixture) -> None:
         link_collector = make_test_link_collector(
             index_urls=["http://example.com/simple/"]
         )

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -32,7 +32,6 @@ from pip._internal.exceptions import (
     SSLMissingError,
     SSLVerificationError,
 )
-from pip._internal.models.link import Link
 from pip._internal.network.session import (
     HTTPAdapter,
     PipSession,

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -322,26 +322,10 @@ class TestPipSession:
         trusted: list[str],
         expected: bool,
     ) -> None:
-        class MockLogger:
-            def __init__(self) -> None:
-                self.called = False
-
-            def warning(self, *args: Any, **kwargs: Any) -> None:
-                self.called = True
-
         session = PipSession(trusted_hosts=trusted)
-        actual = session.is_secure_origin(Link(location))
+        actual = session.is_secure_origin(location)
         assert actual == expected
-
-        log_records = [(r.levelname, r.message) for r in caplog.records]
-        if expected:
-            assert not log_records
-            return
-
-        assert len(log_records) == 1
-        actual_level, actual_message = log_records[0]
-        assert actual_level == "WARNING"
-        assert "is not a trusted or secure host" in actual_message
+        assert not caplog.records
 
 
 class TestSessionProxy:
@@ -524,9 +508,30 @@ class TestRedirectScheme:
         session = PipSession()
         with caplog.at_level(logging.WARNING):
             assert session.get_redirect_target(resp) is None
-        assert "not a trusted or secure host" in caplog.text
+        assert "HTTPS request cannot be redirected to an insecure origin" in caplog.text
 
         assert list(session.resolve_redirects(resp, resp.request)) == []
+
+    def test_get_redirect_target_refuses_laundered_https_downgrade(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        first = self._make_redirect_response("http://127.0.0.1/bounce")
+        second = self._make_redirect_response(
+            "http://untrusted.example/package.whl",
+            source="http://127.0.0.1/bounce",
+        )
+        session = PipSession()
+
+        def send(request: requests.PreparedRequest, **kwargs: Any) -> requests.Response:
+            second.request = request
+            return second
+
+        session.send = send  # type: ignore[method-assign]
+        with caplog.at_level(logging.WARNING):
+            followed = list(session.resolve_redirects(first, first.request))
+
+        assert followed == [second]
+        assert "HTTPS request cannot be redirected to an insecure origin" in caplog.text
 
 
 class TestSSLContextAdapterMixinProxy:

--- a/tests/unit/test_network_session.py
+++ b/tests/unit/test_network_session.py
@@ -464,11 +464,13 @@ class TestSessionProxy:
 
 class TestRedirectScheme:
     @staticmethod
-    def _make_redirect_response(location: str) -> requests.Response:
+    def _make_redirect_response(
+        location: str, *, source: str = "https://example.com/"
+    ) -> requests.Response:
         resp = requests.Response()
         resp.status_code = 302
         resp.headers["Location"] = location
-        resp.url = "https://example.com/simple/foo/"
+        resp.url = source
         request = requests.PreparedRequest()
         request.prepare(method="GET", url=resp.url, headers={})
         resp.request = request
@@ -495,14 +497,36 @@ class TestRedirectScheme:
     @pytest.mark.parametrize(
         "location",
         [
-            "https://other.example.com/elsewhere/",
-            "http://other.example.com/elsewhere/",
-            "/relative/path/",
+            "https://other.example/",
+            "/relative/",
+            "//other.example/path/",
         ],
     )
-    def test_get_redirect_target_allows_http_schemes(self, location: str) -> None:
+    def test_get_redirect_target_allows_secure_redirects(self, location: str) -> None:
         resp = self._make_redirect_response(location)
         assert PipSession().get_redirect_target(resp) == location
+
+    def test_get_redirect_target_allows_http_redirect_from_http(self) -> None:
+        location = "http://other.example/"
+        resp = self._make_redirect_response(location, source="http://example.com/")
+        assert PipSession().get_redirect_target(resp) == location
+
+    def test_get_redirect_target_allows_trusted_http_origin(self) -> None:
+        location = "http://other.example/"
+        resp = self._make_redirect_response(location)
+        session = PipSession(trusted_hosts=["other.example"])
+        assert session.get_redirect_target(resp) == location
+
+    def test_get_redirect_target_refuses_https_downgrade(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        resp = self._make_redirect_response("http://other.example/")
+        session = PipSession()
+        with caplog.at_level(logging.WARNING):
+            assert session.get_redirect_target(resp) is None
+        assert "not a trusted or secure host" in caplog.text
+
+        assert list(session.resolve_redirects(resp, resp.request)) == []
 
 
 class TestSSLContextAdapterMixinProxy:


### PR DESCRIPTION
## What does this PR do?

Refuse redirects from HTTPS to HTTP unless pip already considers the destination a secure origin.

The check applies to the entire redirect chain, so an allowed hop through loopback or `--trusted-host` cannot launder a later redirect to an untrusted HTTP origin. HTTPS history is carried across Requests' reconstructed `PreparedRequest` objects.

`is_secure_origin()` remains a boolean-only policy check, while package-index warnings are emitted by the collector call site.

Fixes #3174.

Tests cover direct and multi-hop downgrades, HTTPS, relative and protocol-relative redirects, HTTP-origin redirects, trusted HTTP origins, and existing insecure-index warnings.

### Validation

- Change-focused redirect, secure-origin, and collector tests (`23 passed`)
- Affected unit modules without live-network tests (`164 passed, 5 skipped, 3 deselected`; Windows, Python 3.12)
- Ruff 0.16.1 (passed)
- Python compileall (passed)
- pre-commit.ci (passed)
- Full PR checks (`40 successful, 1 skipped`)

## PR Checklist:

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: OpenAI Codex
