### PR TITLE
Report the wheel path when a wheel cannot be read

### DIFF
--- a/news/13147.bugfix.rst
+++ b/news/13147.bugfix.rst
@@ -1,0 +1,2 @@
+Report a corrupt or unreadable wheel as a pip error naming the wheel file,
+instead of displaying an uncaught ``zipfile.BadZipFile`` traceback.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -27,7 +27,7 @@ from typing import (
     Protocol,
     cast,
 )
-from zipfile import ZipFile, ZipInfo
+from zipfile import BadZipFile, ZipFile, ZipInfo
 
 from pip._vendor.distlib.scripts import ScriptMaker
 from pip._vendor.distlib.util import get_export_entry
@@ -755,16 +755,19 @@ def install_wheel(
     requested: bool = False,
     script_executable: str | None = None,
 ) -> None:
-    with ZipFile(wheel_path, allowZip64=True) as z:
-        with req_error_context(req_description):
-            _install_wheel(
-                name=name,
-                wheel_zip=z,
-                wheel_path=wheel_path,
-                scheme=scheme,
-                pycompile=pycompile,
-                warn_script_location=warn_script_location,
-                direct_url=direct_url,
-                requested=requested,
-                script_executable=script_executable,
-            )
+    with req_error_context(req_description):
+        try:
+            with ZipFile(wheel_path, allowZip64=True) as z:
+                _install_wheel(
+                    name=name,
+                    wheel_zip=z,
+                    wheel_path=wheel_path,
+                    scheme=scheme,
+                    pycompile=pycompile,
+                    warn_script_location=warn_script_location,
+                    direct_url=direct_url,
+                    requested=requested,
+                    script_executable=script_executable,
+                )
+        except BadZipFile as e:
+            raise InstallationError(f"Failed to read {wheel_path}: {e}") from e

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -11,6 +11,7 @@ from email import message_from_string
 from pathlib import Path
 from typing import cast
 from unittest.mock import patch
+from zipfile import ZIP_STORED, ZipFile
 
 import pytest
 
@@ -429,6 +430,45 @@ class TestInstallUnpackedWheel:
         exc_text = str(e.value)
         assert os.path.basename(wheel_path) in exc_text
         assert "example" in exc_text
+
+    @pytest.mark.parametrize("corruption", ["not-a-zip", "bad-crc"])
+    def test_corrupt_wheel_error_names_the_file(
+        self, data: TestData, tmpdir: Path, corruption: str
+    ) -> None:
+        """A corrupt wheel should fail with an InstallationError naming the
+        file, rather than an unhandled zipfile.BadZipFile traceback.
+        """
+        self.prep(data, tmpdir)
+        wheel_path = make_wheel(
+            "simple", "0.1.0", extra_files={"simple/__init__.py": "canary = 1"}
+        ).save_to_dir(tmpdir)
+
+        if corruption == "not-a-zip":
+            Path(wheel_path).write_bytes(b"this is not a wheel")
+        else:
+            # Rewrite the wheel uncompressed, then flip a byte of an installed
+            # file so that reading it fails its CRC check part way through the
+            # install, after the metadata has been read successfully.
+            with ZipFile(wheel_path) as z:
+                contents = {
+                    info.filename: z.read(info.filename) for info in z.infolist()
+                }
+            with ZipFile(wheel_path, "w", ZIP_STORED) as z:
+                for filename, payload in contents.items():
+                    z.writestr(filename, payload)
+            raw = bytearray(Path(wheel_path).read_bytes())
+            raw[raw.index(b"canary")] = ord("X")
+            Path(wheel_path).write_bytes(bytes(raw))
+
+        with pytest.raises(InstallationError) as e:
+            wheel.install_wheel(
+                "simple",
+                str(wheel_path),
+                scheme=self.scheme,
+                req_description="simple",
+            )
+
+        assert wheel_path in str(e.value)
 
     @pytest.mark.parametrize("entrypoint", ["hello = hello", "hello = hello:"])
     @pytest.mark.parametrize("entrypoint_type", ["console_scripts", "gui_scripts"])


### PR DESCRIPTION
Closes #13147.

When a wheel can't be read, `install_wheel` lets `zipfile.BadZipFile` escape, so pip prints `ERROR: Exception:` and a traceback that never says which file was bad. The traceback in #13147 ends in `zipfile.py`, several frames below anything that knows the wheel path, which is exactly the problem the reporter ran into: a large install fails and there's nothing to identify the offending package.

Two ways in, both easy to hit with a truncated download or a damaged cache entry:

```
zipfile.BadZipFile: File is not a zip file
zipfile.BadZipFile: Bad CRC-32 for file 'sample/__init__.py'
```

The first comes from opening the archive, the second from reading a member part way through the install.

This catches `BadZipFile` and raises `InstallationError` naming the wheel. I also moved `req_error_context` outward so it wraps the `ZipFile(...)` call as well, which means the message picks up the requirement too:

```
ERROR: For req: sample==1.0. Failed to read /tmp/x/sample-1.0-py3-none-any.whl: Bad CRC-32 for file 'sample/__init__.py'
```

Being an `InstallationError` it prints as a normal pip error rather than a traceback.

I kept the catch to `BadZipFile` because that is what I could actually reproduce for both paths, including the CRC case from the issue. I'd rather not add speculative excepts for things I haven't seen fail. There's precedent for this shape of handling in `utils/wheel.py`, which already turns `BadZipFile` into `UnsupportedWheel` when reading metadata.

One thing worth knowing for review: a corrupt `METADATA` doesn't reach this code. `read_wheel_metadata_file` catches it earlier and already produces a decent message naming the member, though not the wheel. I found that while writing the test, which is why the CRC test corrupts an ordinary installed file instead.

The test covers both entry points, parametrized. Both fail on main with the raw `BadZipFile` above and pass with the change. Full unit suite is unchanged otherwise: 1904 passed against a 1902 baseline, the +2 being these, with the same three pre-existing `test_utils_unpacking` symlink failures I get on Windows either way. ruff, ruff format and mypy are clean on both files.
