### PR TITLE
test: Pin default git branch to master

### DIFF
--- a/tests/functional/test_vcs_git.py
+++ b/tests/functional/test_vcs_git.py
@@ -128,7 +128,7 @@ def test_get_remote_url__no_remote(
 def test_get_current_branch(script: PipTestEnvironment) -> None:
     repo_dir = str(script.scratch_path)
 
-    script.run("git", "init", cwd=repo_dir)
+    script.run("git", "init", "-b", "master", cwd=repo_dir)
     sha = do_commit(script, repo_dir)
 
     assert Git.get_current_branch(repo_dir) == "master"
@@ -269,7 +269,7 @@ def test_resolve_commit_not_on_branch(
     repo_file = repo_path / "file.txt"
     clone_path = repo_path / "clone"
     repo_path.mkdir()
-    script.run("git", "init", cwd=str(repo_path))
+    script.run("git", "init", "-b", "master", cwd=str(repo_path))
 
     repo_file.write_text(".")
     script.run("git", "add", "file.txt", cwd=str(repo_path))

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -959,7 +959,9 @@ def _vcs_add(
     vcs: str = "git",
 ) -> pathlib.Path:
     if vcs == "git":
-        subprocess.check_call(["git", "init"], cwd=os.fspath(version_pkg_path))
+        subprocess.check_call(
+            ["git", "init", "-b", "master"], cwd=os.fspath(version_pkg_path)
+        )
         subprocess.check_call(["git", "add", "."], cwd=os.fspath(version_pkg_path))
         subprocess.check_call(
             ["git", "commit", "-m", "initial version"], cwd=os.fspath(version_pkg_path)


### PR DESCRIPTION
So tests don't fail depending on user/global git config.

Fixes #11058.
