### PR TITLE
docs: clarify python3 command usage

### DIFF
--- a/docs/html/getting-started.md
+++ b/docs/html/getting-started.md
@@ -17,6 +17,12 @@ $ pip --version
 pip X.Y.Z from ... (python 3.N.N)
 ```
 
+```{note}
+The Python command name depends on how Python was installed. On macOS and
+some Linux systems, use `python3 --version` instead. Use the same command name
+when running pip as a module, for example `python3 -m pip`.
+```
+
 If that worked, congratulations! You have a working pip in your environment.
 
 If you got output that does not look like the sample above, please read

--- a/news/13800.doc.rst
+++ b/news/13800.doc.rst
@@ -1,0 +1,1 @@
+Clarified that the Python interpreter command may be named ``python3``.


### PR DESCRIPTION
## What does this PR do?

Clarifies that the Python interpreter may be installed as `python3` on macOS and some Linux systems, and shows the corresponding `python3 -m pip` command.

Closes #13800

## Validation

- `nox -s docs`

## PR Checklist:

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment.
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and disclosed the assistance below.

Assisted-by: OpenAI Codex (documentation draft and validation support; manually reviewed by the contributor)