### PR TITLE
Compare cache origin URL without credentials

### DIFF
--- a/news/14232.bugfix.rst
+++ b/news/14232.bugfix.rst
@@ -1,0 +1,3 @@
+Compare the cache entry's origin URL against the credential-stripped download
+URL, so that re-recording an authenticated archive no longer reports a false
+mismatch and no longer writes the credentials to the log.

--- a/src/pip/_internal/cache.py
+++ b/src/pip/_internal/cache.py
@@ -280,15 +280,21 @@ class WheelCache(Cache):
                     e,
                 )
             else:
+                # origin.json is written with the user:password stripped from
+                # the URL, so the URL read back has to be compared against that
+                # same representation. Comparing it against the raw URL makes an
+                # authenticated download mismatch against its own cache entry,
+                # and logging the raw URL puts the credentials in the log.
                 # TODO: use DirectUrl.equivalent when
                 # https://github.com/pypa/pip/pull/10564 is merged.
-                if origin.url != download_info.url:
+                download_url = download_info.to_dict()["url"]
+                if origin.url != download_url:
                     logger.warning(
                         "Origin URL %s in cache entry %s does not match download URL "
                         "%s. This is likely a pip bug or a cache corruption issue. "
                         "Will overwrite it with the new value.",
                         origin.url,
                         cache_dir,
-                        download_info.url,
+                        download_url,
                     )
         origin_path.write_text(download_info.to_json(), encoding="utf-8")

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import NoReturn
@@ -7,6 +8,7 @@ import pytest
 from pip._vendor.packaging.tags import Tag, interpreter_name, interpreter_version
 
 from pip._internal.cache import SimpleWheelCache, WheelCache, _hash_dict
+from pip._internal.models.direct_url import ArchiveInfo, DirectUrl
 from pip._internal.models.link import Link
 from pip._internal.utils.misc import ensure_dir
 from pip._internal.utils.urls import path_to_url
@@ -152,3 +154,55 @@ def test_wheel_cache_entry_none_for_existing_directory(tmpdir: Path) -> None:
 
     assert wc.get_cache_entry(link, "example", supported_tags) is None
     assert wc.get(link, "example", supported_tags) is link
+
+
+def test_record_download_origin_authenticated_url_is_not_a_mismatch(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Recording the same authenticated archive twice is not a mismatch.
+
+    origin.json is written with the credentials stripped, so comparing the URL
+    read back against the raw one would never match, and the warning would put
+    the password in the log.
+    """
+    download_info = DirectUrl(
+        url="https://user:hunter2@example.test/pkg.tar.gz",
+        archive_info=ArchiveInfo(),
+    )
+    cache_dir = os.fspath(tmp_path)
+
+    WheelCache.record_download_origin(cache_dir, download_info)
+    with caplog.at_level(logging.WARNING):
+        WheelCache.record_download_origin(cache_dir, download_info)
+
+    assert caplog.records == []
+
+
+def test_record_download_origin_mismatch_warning_hides_credentials(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A genuine mismatch still warns, with the credentials stripped."""
+    cache_dir = os.fspath(tmp_path)
+    WheelCache.record_download_origin(
+        cache_dir,
+        DirectUrl(
+            url="https://user:hunter2@example.test/one.tar.gz",
+            archive_info=ArchiveInfo(),
+        ),
+    )
+    with caplog.at_level(logging.WARNING):
+        WheelCache.record_download_origin(
+            cache_dir,
+            DirectUrl(
+                url="https://user:s3cr3t@example.test/two.tar.gz",
+                archive_info=ArchiveInfo(),
+            ),
+        )
+
+    (record,) = caplog.records
+    message = record.getMessage()
+    assert "does not match download URL" in message
+    assert "one.tar.gz" in message
+    assert "two.tar.gz" in message
+    assert "hunter2" not in message
+    assert "s3cr3t" not in message


### PR DESCRIPTION
Fixes #14232.

## What does this PR do?

`origin.json` is written through PEP 610 serialization, which strips `user:password` from the URL. `record_download_origin` then compared the URL read back from that file against the raw in-memory `download_info.url`.

For an authenticated archive the two never match. Recording the same file twice reports a mismatch that did not happen, and the warning prints the raw URL — so the password ends up in terminal and CI logs.

Reproduced with the script from the issue:

```console
$ python repro.py
WARNING Origin URL https://example.test/pkg.tar.gz in cache entry /tmp/tmp9egbu41b
does not match download URL https://user:SUPERSECRET@example.test/pkg.tar.gz.
This is likely a pip bug or a cache corruption issue. Will overwrite it with the new value.
```

After the change the same script prints nothing, and a genuine mismatch still warns with the credentials stripped:

```
WARNING Origin URL https://example.test/one.tar.gz in cache entry /tmp/tmp4a0u_mw2
does not match download URL https://example.test/DOS.tar.gz. ...
```

The comparison uses `download_info.to_dict()["url"]`, which is the same value `to_dict_compat()` writes to the file — `to_dict_compat` only adds `generate_legacy_hash`, so the stripping parameters are unchanged.

## Tests

Two tests in `tests/unit/test_cache.py`, one per property. Both fail on current `main`:

```
>       assert caplog.records == []
>       assert "s3cr3t" not in message
2 failed, 8 deselected
```

and pass with the change (`10 passed` for the whole file). `ruff check`, `ruff format --check` and `mypy` are clean on the touched files.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude (Opus 5)