### PR TITLE
Merge overlapping --target install directories

### DIFF
--- a/news/8799.bugfix.rst
+++ b/news/8799.bugfix.rst
@@ -1,0 +1,1 @@
+Merge overlapping package and ``.data`` directories for ``--target`` installs.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -624,12 +624,22 @@ class InstallCommand(RequirementCommand):
         if os.path.exists(data_dir):
             lib_dir_list.append(data_dir)
 
-        for lib_dir in lib_dir_list:
-            for item in os.listdir(lib_dir):
-                if lib_dir == data_dir:
-                    ddir = os.path.join(data_dir, item)
-                    if any(s.startswith(ddir) for s in lib_dir_list[:-1]):
-                        continue
+        # Merge scheme directories before applying target replacement behavior.
+        with TempDirectory(kind="target-staging") as staging:
+            for lib_dir in lib_dir_list:
+                for item in os.listdir(lib_dir):
+                    if lib_dir == data_dir:
+                        ddir = os.path.join(data_dir, item)
+                        if any(s.startswith(ddir) for s in lib_dir_list[:-1]):
+                            continue
+                    self._merge_into_staging(
+                        os.path.join(lib_dir, item),
+                        os.path.join(staging.path, item),
+                        staging.path,
+                        target_dir,
+                    )
+
+            for item in os.listdir(staging.path):
                 target_item_dir = os.path.join(target_dir, item)
                 if os.path.exists(target_item_dir):
                     if not upgrade:
@@ -653,7 +663,38 @@ class InstallCommand(RequirementCommand):
                     else:
                         os.remove(target_item_dir)
 
-                shutil.move(os.path.join(lib_dir, item), target_item_dir)
+                shutil.move(os.path.join(staging.path, item), target_item_dir)
+
+    def _merge_into_staging(
+        self, source: str, dest: str, staging_root: str, target_dir: str
+    ) -> None:
+        """Merge source into dest, warning on duplicate files."""
+        if not os.path.lexists(dest):
+            shutil.move(source, dest)
+            return
+        source_is_dir = os.path.isdir(source) and not os.path.islink(source)
+        dest_is_dir = os.path.isdir(dest) and not os.path.islink(dest)
+        if source_is_dir and dest_is_dir:
+            for child in os.listdir(source):
+                self._merge_into_staging(
+                    os.path.join(source, child),
+                    os.path.join(dest, child),
+                    staging_root,
+                    target_dir,
+                )
+            return
+        target_path = os.path.join(target_dir, os.path.relpath(dest, staging_root))
+        if source_is_dir != dest_is_dir:
+            raise InstallationError(
+                f"Cannot merge target path {target_path}: "
+                "file and directory conflict."
+            )
+        logger.warning(
+            "Target %s is provided more than once.",
+            target_path,
+        )
+        os.remove(dest)
+        shutil.move(source, dest)
 
     def _determine_conflicts(
         self, to_install: list[InstallRequirement]

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -47,6 +47,7 @@ from tests.lib.server import (
     package_page,
     server_running,
 )
+from tests.lib.wheel import make_wheel
 
 
 def test_refresh_package_sends_cache_control_header(
@@ -1268,6 +1269,154 @@ def test_install_package_with_target(script: PipTestEnvironment) -> None:
         "-t", target_dir, "singlemodule==0.0.1", "--upgrade"
     )
     result.did_update(singlemodule_py)
+
+
+@pytest.mark.parametrize("upgrade", [False, True])
+def test_install_package_with_target_merges_data_dir(
+    script: PipTestEnvironment, upgrade: bool
+) -> None:
+    """Merge overlapping package and .data directory trees."""
+    package = make_wheel(
+        "mypackage",
+        "0.0.1",
+        extra_files={
+            "mypackage/__init__.py": "",
+            "mypackage/sub/module.py": "",
+        },
+        extra_data_files={
+            "data/mypackage/data.txt": "hello",
+            "data/mypackage/sub/data.txt": "nested",
+        },
+    ).save_to_dir(script.scratch_path)
+
+    target_dir = script.scratch_path / "target"
+    args = ["--upgrade"] if upgrade else []
+    result = script.pip("install", "--no-index", "-t", target_dir, *args, package)
+    assert "already exists" not in result.stderr
+    result.did_create(Path("scratch") / "target" / "mypackage" / "__init__.py")
+    result.did_create(Path("scratch") / "target" / "mypackage" / "data.txt")
+    result.did_create(Path("scratch") / "target" / "mypackage" / "sub" / "module.py")
+    result.did_create(Path("scratch") / "target" / "mypackage" / "sub" / "data.txt")
+
+
+def test_install_package_with_target_duplicate_file_warns(
+    script: PipTestEnvironment,
+) -> None:
+    """Warn and use .data when package and .data contain the same file."""
+    package = make_wheel(
+        "mypackage",
+        "0.0.1",
+        extra_files={"mypackage/duplicate.txt": "from purelib"},
+        extra_data_files={"data/mypackage/duplicate.txt": "from data"},
+    ).save_to_dir(script.scratch_path)
+
+    target_dir = script.scratch_path / "target"
+    result = script.pip(
+        "install", "--no-index", "-t", target_dir, package, allow_stderr_warning=True
+    )
+    duplicate = Path("scratch") / "target" / "mypackage" / "duplicate.txt"
+    warning = f"Target {script.base_path / duplicate} is provided more than once."
+    assert result.stderr.count(warning) == 1
+    result.did_create(duplicate)
+    assert (script.base_path / duplicate).read_text() == "from data"
+
+
+@pytest.mark.parametrize(
+    "package_files, data_files",
+    [
+        (
+            {"mypackage/thing": "a file"},
+            {"data/mypackage/thing/inner.txt": "in a directory"},
+        ),
+        (
+            {"mypackage/thing/inner.txt": "in a directory"},
+            {"data/mypackage/thing": "a file"},
+        ),
+    ],
+)
+def test_install_package_with_target_file_dir_collision_fails(
+    script: PipTestEnvironment,
+    package_files: dict[str, bytes | str],
+    data_files: dict[str, str],
+) -> None:
+    """Reject conflicts between files and directories."""
+    package = make_wheel(
+        "mypackage",
+        "0.0.1",
+        extra_files=package_files,
+        extra_data_files=data_files,
+    ).save_to_dir(script.scratch_path)
+
+    target_dir = script.scratch_path / "target"
+    result = script.pip(
+        "install", "--no-index", "-t", target_dir, package, expect_error=True
+    )
+    conflict = target_dir / "mypackage" / "thing"
+    assert (
+        f"Cannot merge target path {conflict}: file and directory conflict."
+        in result.stderr
+    )
+    assert list(target_dir.iterdir()) == []
+
+
+def test_install_package_with_target_merge_and_existing_target(
+    script: PipTestEnvironment,
+) -> None:
+    """Preserve existing-target behavior when scheme trees overlap."""
+
+    def combined_wheel(version: str) -> str:
+        return make_wheel(
+            "mypackage",
+            version,
+            extra_files={"mypackage/__init__.py": f"# {version}"},
+            extra_data_files={
+                "data/mypackage/__init__.py": f"# data {version}",
+                "data/mypackage/data.txt": version,
+            },
+        ).save_to_dir(script.scratch_path)
+
+    target_dir = script.scratch_path / "target"
+    init_py = Path("scratch") / "target" / "mypackage" / "__init__.py"
+    data_txt = Path("scratch") / "target" / "mypackage" / "data.txt"
+
+    result = script.pip(
+        "install",
+        "--no-index",
+        "-t",
+        target_dir,
+        combined_wheel("1.0"),
+        allow_stderr_warning=True,
+    )
+    result.did_create(init_py)
+    result.did_create(data_txt)
+    assert (script.base_path / init_py).read_text() == "# data 1.0"
+
+    result = script.pip(
+        "install",
+        "--no-index",
+        "-t",
+        target_dir,
+        combined_wheel("2.0"),
+        allow_stderr_warning=True,
+    )
+    assert "already exists. Specify --upgrade" in result.stderr
+    assert "provided more than once" in result.stderr
+    result.did_not_update(init_py)
+    result.did_not_update(data_txt)
+
+    result = script.pip(
+        "install",
+        "--no-index",
+        "-t",
+        target_dir,
+        "--upgrade",
+        combined_wheel("2.0"),
+        allow_stderr_warning=True,
+    )
+    result.did_update(init_py)
+    result.did_update(data_txt)
+    assert (script.base_path / init_py).read_text() == "# data 2.0"
+    assert (script.base_path / data_txt).read_text() == "2.0"
 
 
 @pytest.mark.parametrize("target_option", ["--target", "-t"])


### PR DESCRIPTION
## What does this PR do?

Fixes #8799.

`pip install --target` installs wheel contents into separate scheme
directories before moving them into the target. When package and `.data`
directories overlapped, target handling skipped or replaced one tree depending
on `--upgrade`.

Merge the scheme directories in a staging directory before applying existing
target replacement behavior. Duplicate files emit a warning, and the later
scheme entry takes precedence. File-directory conflicts fail before target
contents move.

Tests cover nested merges with and without `--upgrade`, duplicate files, both
file-directory conflict directions, and existing targets.

Tested with:

- `.venv/bin/pytest -q tests/functional/test_install.py -k target` (15 passed)
- `.venv/bin/pre-commit run --all-files`

## PR Checklist:

- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude and Codex
