### PR TITLE
Skip phantom rows when rewriting installed RECORD

### DIFF
--- a/news/13873.bugfix.rst
+++ b/news/13873.bugfix.rst
@@ -1,0 +1,1 @@
+Skip phantom ``RECORD`` rows that do not correspond to files pip actually installed when rewriting an installed wheel's ``RECORD`` metadata.

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -245,11 +245,18 @@ def get_csv_rows_for_installed(
         path.
     """
     installed_rows: list[InstalledCSVRow] = []
+    installed_record_paths = set(installed.values())
+    accounted_for_paths: set[RecordPath] = set()
     for row in old_csv_rows:
         if len(row) > 3:
             logger.warning("RECORD line has more than three elements: %s", row)
         old_record_path = cast("RecordPath", row[0])
-        new_record_path = installed.pop(old_record_path, old_record_path)
+        new_record_path = installed.pop(old_record_path, None)
+        if new_record_path is None:
+            if old_record_path not in installed_record_paths:
+                continue
+            new_record_path = old_record_path
+        accounted_for_paths.add(new_record_path)
         if new_record_path in changed:
             digest, length = rehash(_record_to_fs_path(new_record_path, lib_dir))
         else:
@@ -261,7 +268,9 @@ def get_csv_rows_for_installed(
         digest, length = rehash(f)
         installed_rows.append((path, digest, length))
     return installed_rows + [
-        (installed_record_path, "", "") for installed_record_path in installed.values()
+        (installed_record_path, "", "")
+        for installed_record_path in installed.values()
+        if installed_record_path not in accounted_for_paths
     ]
 
 

--- a/tests/unit/test_wheel.py
+++ b/tests/unit/test_wheel.py
@@ -121,17 +121,31 @@ def test_normalized_outrows(
     assert actual == expected
 
 
-def call_get_csv_rows_for_installed(tmpdir: Path, text: str) -> list[InstalledCSVRow]:
+def call_get_csv_rows_for_installed(
+    tmpdir: Path,
+    text: str,
+    installed: dict[RecordPath, RecordPath] | None = None,
+) -> list[InstalledCSVRow]:
     path = tmpdir.joinpath("temp.txt")
     path.write_text(text)
 
-    # Test that an installed file appearing in RECORD has its filename
-    # updated in the new RECORD file.
-    installed = cast(dict[RecordPath, RecordPath], {"a": "z"})
     lib_dir = "/lib/dir"
 
     with open(path, **wheel.csv_io_kwargs("r")) as f:
         record_rows = list(csv.reader(f))
+
+    if installed is None:
+        installed = cast(
+            dict[RecordPath, RecordPath],
+            {
+                cast("RecordPath", row[0]): cast(
+                    "RecordPath",
+                    "z" if row[0] == "a" else row[0],
+                )
+                for row in record_rows
+            },
+        )
+
     outrows = wheel.get_csv_rows_for_installed(
         record_rows,
         installed=installed,
@@ -180,6 +194,47 @@ def test_get_csv_rows_for_installed__long_lines(
         "RECORD line has more than three elements: ['a', 'b', 'c', 'd']",
         "RECORD line has more than three elements: ['h', 'i', 'j', 'k']",
     ]
+
+def test_get_csv_rows_for_installed__skips_phantom_record_entries(
+    tmpdir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    text = textwrap.dedent("""\
+    a,b,c
+    ../../../tmp/evil.py,,
+    """)
+    outrows = call_get_csv_rows_for_installed(
+        tmpdir,
+        text,
+        installed=cast(dict[RecordPath, RecordPath], {"a": "z"}),
+    )
+    assert outrows == [
+        ("z", "b", "c"),
+    ]
+    assert len(caplog.records) == 0
+
+
+def test_get_csv_rows_for_installed__keeps_installed_paths_outside_lib_dir(
+    tmpdir: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    text = textwrap.dedent("""\
+    a,b,c
+    ../../../bin/docutils,d,e
+    """)
+    installed = cast(
+        dict[RecordPath, RecordPath],
+        {
+            "a": "z",
+            "docutils-0.22.4.data/scripts/docutils": "../../../bin/docutils",
+        },
+    )
+
+    outrows = call_get_csv_rows_for_installed(tmpdir, text, installed=installed)
+
+    assert outrows == [
+        ("z", "b", "c"),
+        ("../../../bin/docutils", "d", "e"),
+    ]
+    assert len(caplog.records) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

This is the install-side split of #13873.

When `get_csv_rows_for_installed()` rewrites an installed wheel's `RECORD`, it currently preserves rows that were never backed by an installed file. That lets a phantom `RECORD` entry survive into the on-disk metadata.

This change keeps only paths that pip actually accounted for during install:

- rows that matched an archive `RECORD` path in `installed`
- rows whose final installed `RECORD` path was already accounted for in `installed.values()`

Everything else is dropped from the rewritten `RECORD`, which filters phantom rows without dropping legitimate installed paths that live outside `lib_dir`.

The unit coverage adds regressions for both cases:

- a phantom traversal row is filtered out
- an installed script path outside `lib_dir` is preserved without producing a duplicate blank row

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.psf.org/code-of-conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Codex
