### PR TITLE
Make `pip config get` read the active configuration

### DIFF
--- a/news/11700.bugfix.rst
+++ b/news/11700.bugfix.rst
@@ -1,0 +1,5 @@
+Make ``pip config get`` report the active configuration, like ``pip config
+list`` already does, instead of looking only in the file that would be modified
+by ``pip config set``. Values coming from the file named by ``PIP_CONFIG_FILE``
+are no longer reported as missing. Passing ``--user``, ``--global`` or
+``--site`` still narrows the lookup to that file.

--- a/src/pip/_internal/commands/configuration.py
+++ b/src/pip/_internal/commands/configuration.py
@@ -122,8 +122,13 @@ class ConfigurationCommand(Command):
         # Determine which configuration files are to be loaded
         #    Depends on whether the command is modifying.
         try:
+            # "get" only reads the configuration, so - like "list" - it
+            # reports the active configuration as a whole unless the user
+            # narrows it down with an explicit file option. Restricting it to
+            # a single variant would hide values coming from the other
+            # configuration files, in particular PIP_CONFIG_FILE.
             load_only = self._determine_file(
-                options, need_value=(action in ["get", "set", "unset", "edit"])
+                options, need_value=(action in ["set", "unset", "edit"])
             )
         except PipError as e:
             logger.error(e.args[0])

--- a/tests/functional/test_configuration.py
+++ b/tests/functional/test_configuration.py
@@ -118,6 +118,24 @@ class TestBasicLoading(ConfigurationMixin):
         assert "freeze.timeout: 10" in result.stdout
         assert re.search(r"env:\n(  .+\n)+", result.stdout)
 
+    def test_get_reads_the_env_config_file(self, script: PipTestEnvironment) -> None:
+        """``pip config get`` reports the active configuration, so a value
+        that only lives in the PIP_CONFIG_FILE file is still found rather than
+        reported as missing.
+        """
+        config_file = script.scratch_path / "test-pip.cfg"
+        script.environ["PIP_CONFIG_FILE"] = str(config_file)
+        config_file.write_text(textwrap.dedent("""            [global]
+            timeout = 60
+            """))
+
+        result = script.pip("config", "get", "global.timeout")
+        assert result.stdout.strip() == "60"
+
+        # An explicit file option still narrows the lookup to that one file,
+        # which does not hold the key.
+        script.pip("config", "--user", "get", "global.timeout", expect_error=True)
+
     def test_user_values(self, script: PipTestEnvironment) -> None:
         """Test that the user pip configuration set using --user
         is correctly displayed under "user".  This configuration takes place


### PR DESCRIPTION
## What does this PR do?

Fixes #11700.

`pip config get` asks `_determine_file()` for a value, so with no explicit
`--user`/`--global`/`--site` it falls back to the file `pip config set` would write
to and loads only that variant. Any key defined elsewhere is then reported as
missing — most visibly the file named by `PIP_CONFIG_FILE`, which is loaded under
the separate `env` variant:

```console
$ PIP_CONFIG_FILE=pip.conf pip config list
global.index-url='https://example.test/simple'
$ PIP_CONFIG_FILE=pip.conf pip config get global.index-url
ERROR: No such key - global.index-url
```

`get` only reads, so it now behaves like `list` and reports the active
configuration. This matches the command's own docstring, which scopes the
default-file rule to "all *modifications*". Passing an explicit file option still
narrows the lookup to that file, so `pip config --user get ...` is unchanged.

Covered by a new test in `tests/functional/test_configuration.py`, which fails on
`main`.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude
