### PR TITLE
Always show LATEST in `pip index versions` output

### DIFF
--- a/news/12922.bugfix.rst
+++ b/news/12922.bugfix.rst
@@ -1,0 +1,3 @@
+Always report the ``LATEST`` version in ``pip index versions`` output. It was
+previously printed only when the package happened to be installed, even though
+it does not depend on the installed distribution.

--- a/src/pip/_internal/commands/index.py
+++ b/src/pip/_internal/commands/index.py
@@ -170,4 +170,4 @@ class IndexCommand(IndexGroupCommand):
         else:
             write_output(f"{query} ({latest})")
             write_output("Available versions: {}".format(", ".join(formatted_versions)))
-            print_dist_installation_info(latest, dist)
+            print_dist_installation_info(latest, dist, always_show_latest=True)

--- a/src/pip/_internal/commands/search.py
+++ b/src/pip/_internal/commands/search.py
@@ -113,17 +113,28 @@ def transform_hits(hits: list[dict[str, str]]) -> list[TransformedHit]:
     return list(packages.values())
 
 
-def print_dist_installation_info(latest: str, dist: BaseDistribution | None) -> None:
-    if dist is not None:
-        with indent_log():
+def print_dist_installation_info(
+    latest: str,
+    dist: BaseDistribution | None,
+    *,
+    always_show_latest: bool = False,
+) -> None:
+    # "pip search" prints one line per hit, so it only annotates the hits that
+    # are actually installed. Callers reporting on a single package pass
+    # always_show_latest to get the LATEST line unconditionally.
+    if dist is None and not always_show_latest:
+        return
+
+    with indent_log():
+        if dist is not None:
             write_output("INSTALLED: %s", dist.version)
-            if parse_version(latest).pre:
-                write_output(
-                    "LATEST:    %s (pre-release; install with `pip install --pre`)",
-                    latest,
-                )
-            else:
-                write_output("LATEST:    %s", latest)
+        if parse_version(latest).pre:
+            write_output(
+                "LATEST:    %s (pre-release; install with `pip install --pre`)",
+                latest,
+            )
+        else:
+            write_output("LATEST:    %s", latest)
 
 
 def get_installed_distribution(name: str) -> BaseDistribution | None:

--- a/tests/functional/test_index.py
+++ b/tests/functional/test_index.py
@@ -162,3 +162,37 @@ def test_index_versions_only_final_for_package(script: PipTestEnvironment) -> No
     )
     assert "1.0" in result.stdout
     assert "2.0a1" not in result.stdout
+
+
+def test_index_versions_shows_latest_when_not_installed(
+    script: PipTestEnvironment,
+) -> None:
+    """The LATEST line does not depend on the package being installed."""
+    wheelhouse_path = script.scratch_path / "wheelhouse"
+    wheelhouse_path.mkdir()
+    make_wheel("simple", "1.0").save_to_dir(wheelhouse_path)
+    make_wheel("simple", "2.0").save_to_dir(wheelhouse_path)
+
+    result = script.pip(
+        "index",
+        "versions",
+        "--no-index",
+        "--find-links",
+        wheelhouse_path,
+        "simple",
+    )
+    assert "LATEST:    2.0" in result.stdout
+    assert "INSTALLED:" not in result.stdout
+
+    # Once installed, both lines are reported.
+    script.pip("install", "--no-index", "--find-links", wheelhouse_path, "simple==1.0")
+    result = script.pip(
+        "index",
+        "versions",
+        "--no-index",
+        "--find-links",
+        wheelhouse_path,
+        "simple",
+    )
+    assert "INSTALLED: 1.0" in result.stdout
+    assert "LATEST:    2.0" in result.stdout


### PR DESCRIPTION
## What does this PR do?

Fixes #12922.

`print_dist_installation_info()` wraps both of its output lines in a check for an
installed distribution, so `pip index versions` prints the `LATEST` line only when
the queried package happens to be installed locally:

```console
$ pip index versions tomli-w
tomli-w (1.2.0)
Available versions: 1.2.0, 1.1.0, 1.0.0, ...
                                            <- no LATEST line
```

The latest version does not depend on what is installed, and `--json` already
reports `latest` unconditionally.

`LATEST` is now reported whenever the caller asks for it, and `INSTALLED` only when
the distribution is present. `pip search` prints one line per hit and only annotates
installed hits, so it is left as-is and the new behaviour is opted into by
`pip index versions`.

Covered by a new test in `tests/functional/test_index.py`, which fails on `main`.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude
