### PR TITLE
Honour the cache options in isolated build environments

### DIFF
--- a/news/12031.bugfix.rst
+++ b/news/12031.bugfix.rst
@@ -1,0 +1,4 @@
+Pass the cache configuration to the pip subprocess that installs build
+dependencies, so that ``--no-cache-dir`` and ``--cache-dir`` are also honoured
+while building. Installing a package that has to be built no longer populates the
+default cache after ``--no-cache-dir``.

--- a/src/pip/_internal/build_env/installer.py
+++ b/src/pip/_internal/build_env/installer.py
@@ -43,9 +43,12 @@ class SubprocessBuildEnvironmentInstaller:
         self,
         finder: PackageFinder,
         build_constraints: list[str] | None = None,
+        *,
+        cache_dir: str | None = None,
     ) -> None:
         self.finder = finder
         self._build_constraints = build_constraints or []
+        self._cache_dir = cache_dir
 
     def install(
         self,
@@ -137,6 +140,13 @@ class SubprocessBuildEnvironmentInstaller:
 
         if finder.uploaded_prior_to:
             args.extend(["--uploaded-prior-to", finder.uploaded_prior_to.isoformat()])
+
+        # The subprocess would otherwise fall back on the default cache,
+        # ignoring the cache configuration of the command that spawned it.
+        if self._cache_dir:
+            args.extend(["--cache-dir", self._cache_dir])
+        else:
+            args.append("--no-cache-dir")
         args.append("--")
         args.extend(requirements)
 

--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -213,6 +213,7 @@ class RequirementCommand(IndexGroupCommand):
             env_installer = SubprocessBuildEnvironmentInstaller(
                 finder,
                 build_constraints=build_constraints,
+                cache_dir=options.cache_dir,
             )
 
         if not options.build_isolation:

--- a/tests/unit/test_build_constraints.py
+++ b/tests/unit/test_build_constraints.py
@@ -44,6 +44,48 @@ class TestSubprocessBuildEnvironmentInstaller:
         assert kwargs.get("extra_environ") == {"_PIP_IN_BUILD_IGNORE_CONSTRAINTS": "1"}
 
     @mock.patch("pip._internal.build_env.installer.call_subprocess")
+    def test_install_forwards_the_cache_dir(
+        self, mock_call_subprocess: mock.Mock, tmp_path: Path
+    ) -> None:
+        """The build environment uses the cache of the command that spawned
+        it, rather than falling back on the default location."""
+        installer = SubprocessBuildEnvironmentInstaller(
+            make_test_finder(), cache_dir="/some/cache"
+        )
+
+        installer.install(
+            requirements=["setuptools"],
+            prefix=Prefix(str(tmp_path)),
+            kind="build dependencies",
+            for_req=None,
+        )
+
+        args = mock_call_subprocess.call_args.args[0]
+        assert "--no-cache-dir" not in args
+        assert args[args.index("--cache-dir") + 1] == "/some/cache"
+
+    @mock.patch("pip._internal.build_env.installer.call_subprocess")
+    def test_install_forwards_a_disabled_cache(
+        self, mock_call_subprocess: mock.Mock, tmp_path: Path
+    ) -> None:
+        """A disabled cache must stay disabled in the build environment,
+        otherwise --no-cache-dir silently populates the default cache."""
+        installer = SubprocessBuildEnvironmentInstaller(
+            make_test_finder(), cache_dir=None
+        )
+
+        installer.install(
+            requirements=["setuptools"],
+            prefix=Prefix(str(tmp_path)),
+            kind="build dependencies",
+            for_req=None,
+        )
+
+        args = mock_call_subprocess.call_args.args[0]
+        assert "--no-cache-dir" in args
+        assert "--cache-dir" not in args
+
+    @mock.patch("pip._internal.build_env.installer.call_subprocess")
     @mock.patch.dict(os.environ, {"PIP_CONSTRAINT": "constraints.txt"})
     def test_install_passes_build_constraints(
         self, mock_call_subprocess: mock.Mock, tmp_path: Path


### PR DESCRIPTION
## What does this PR do?

Fixes #12031.

pip installs build dependencies by calling itself in a subprocess, and that command
line is built from the finder's options only. It forwards the index, proxy,
certificate and format settings, but nothing about the cache, so the cache
configuration of the outer command is silently dropped:

```console
$ PIP_CACHE_DIR=/tmp/c pip install --no-cache-dir ./needs-building
$ find /tmp/c -type f | wc -l
6
```

The build subprocess cached its downloads in the very cache the user asked pip not
to use. A custom `--cache-dir` was likewise ignored, so the subprocess wrote to the
default location instead.

The resolved cache directory is now passed to `SubprocessBuildEnvironmentInstaller`
and forwarded as `--cache-dir`, or `--no-cache-dir` when caching is off, alongside
the other options the subprocess already inherits.

Covered by two new tests in `tests/unit/test_build_constraints.py`, which assert on
the arguments handed to the subprocess.

<details>
<summary>An earlier revision of this PR did this via <code>os.environ</code> — that was wrong.</summary>

My first attempt exported `PIP_CACHE_DIR` / `PIP_NO_CACHE_DIR` from
`base_command.py`, next to the existing `PIP_NO_INPUT` handling. CI caught the
problem: `tests/unit` calls `Command.main()` in-process, so the exported variable
leaked into pytest's own environment and every later functional test inherited it,
which made `test_install_builds_wheels` use an ephemeral wheel cache. That is
exactly what the "without resorting to os.environ to hold these" TODO in
`base_command.py` is warning about, so this revision passes the value explicitly
instead and touches no global state.

</details>

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude
