### PR TITLE
Record real file paths for --target installations

### DIFF
--- a/news/7658.bugfix.rst
+++ b/news/7658.bugfix.rst
@@ -1,0 +1,3 @@
+Record the real paths of installed files when using ``--target``. Console
+scripts were recorded relative to the staging directory, so ``RECORD`` listed
+them as ``../../bin/<name>``, resolving above the target directory.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -43,6 +43,7 @@ from pip._internal.metadata import BaseEnvironment, get_environment
 from pip._internal.models.installation_report import InstallationReport
 from pip._internal.operations.build.build_tracker import get_build_tracker
 from pip._internal.operations.check import ConflictDetails, check_install_conflicts
+from pip._internal.operations.install.wheel import rewrite_record_paths_for_target
 from pip._internal.req import InstallationResult, install_given_reqs
 from pip._internal.req.req_install import (
     InstallRequirement,
@@ -623,6 +624,14 @@ class InstallCommand(RequirementCommand):
             lib_dir_list.append(platlib_dir)
         if os.path.exists(data_dir):
             lib_dir_list.append(data_dir)
+
+        # RECORD is written for the staging layout, where the .dist-info sits
+        # in the lib directory and scripts and data files sit beside it. The
+        # move below flattens all of that into target_dir, so fix the recorded
+        # paths up first, while the staging layout is still there to work from.
+        rewrite_record_paths_for_target(
+            [d for d in (purelib_dir, platlib_dir) if os.path.isdir(d)], data_dir
+        )
 
         for lib_dir in lib_dir_list:
             for item in os.listdir(lib_dir):

--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -233,6 +233,67 @@ def _fs_to_record_path(path: str, lib_dir: str) -> RecordPath:
     return cast("RecordPath", path)
 
 
+def _relative_within(path: str, root: str) -> str | None:
+    """RECORD-style path of ``path`` inside ``root``, or None if outside it."""
+    # On Windows a path on another logical disk is never inside root.
+    if os.path.splitdrive(path)[0].lower() != os.path.splitdrive(root)[0].lower():
+        return None
+    relative = os.path.relpath(path, root)
+    if relative == os.pardir or relative.startswith(os.pardir + os.sep):
+        return None
+    return relative.replace(os.path.sep, "/")
+
+
+def rewrite_record_paths_for_target(lib_dirs: list[str], data_dir: str) -> None:
+    """Rewrite staged RECORD files for the flattened ``--target`` layout.
+
+    A wheel is installed into a staging directory first, where the scheme
+    spreads its files over ``<staging>/lib/python``, ``<staging>/bin`` and so
+    on, and RECORD holds paths relative to the directory containing the
+    ``.dist-info``. ``pip install --target`` then flattens all of those into
+    one directory, which leaves the recorded paths wrong: a console script
+    recorded as ``../../bin/foo`` resolves *above* the target directory.
+
+    Recompute each path against the layout the files actually end up in,
+    where every scheme directory is collapsed onto the target root.
+    """
+    # The lib directories are nested inside the data directory, so they have
+    # to be tried first.
+    roots = [*lib_dirs, data_dir]
+
+    for lib_dir in lib_dirs:
+        if not os.path.isdir(lib_dir):
+            continue
+        for entry in os.listdir(lib_dir):
+            if not entry.endswith(".dist-info"):
+                continue
+            record_path = os.path.join(lib_dir, entry, "RECORD")
+            if not os.path.isfile(record_path):
+                continue
+
+            with open(record_path, **csv_io_kwargs("r")) as record_file:
+                rows = list(csv.reader(record_file))
+
+            changed = False
+            for row in rows:
+                if not row:
+                    continue
+                fs_path = os.path.join(lib_dir, row[0])
+                for root in roots:
+                    relative = _relative_within(fs_path, root)
+                    if relative is not None:
+                        break
+                else:
+                    continue
+                if relative != row[0]:
+                    row[0] = relative
+                    changed = True
+
+            if changed:
+                with open(record_path, **csv_io_kwargs("w")) as record_file:
+                    csv.writer(record_file).writerows(rows)
+
+
 def get_csv_rows_for_installed(
     old_csv_rows: list[list[str]],
     installed: dict[RecordPath, RecordPath],

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -34,6 +34,7 @@ from tests.lib import (
     _create_test_package,
     create_basic_wheel_for_package,
     create_test_package_with_setup,
+    make_wheel,
     need_bzr,
     need_mercurial,
     need_svn,
@@ -1268,6 +1269,31 @@ def test_install_package_with_target(script: PipTestEnvironment) -> None:
         "-t", target_dir, "singlemodule==0.0.1", "--upgrade"
     )
     result.did_update(singlemodule_py)
+
+
+def test_install_package_with_target_records_real_paths(
+    script: PipTestEnvironment,
+) -> None:
+    """
+    RECORD must describe where the files actually landed. --target flattens
+    the staging scheme into one directory, so a script staged in
+    ``<staging>/bin`` and recorded as ``../../bin/name`` would otherwise point
+    above the target directory.
+    """
+    wheel_path = make_wheel(
+        "scriptpkg", "1.0", console_scripts=["scriptpkg = scriptpkg:main"]
+    ).save_to_dir(script.scratch_path)
+    target_dir = script.scratch_path / "target"
+
+    script.pip("install", "--no-index", "--target", target_dir, wheel_path)
+
+    record = target_dir / "scriptpkg-1.0.dist-info" / "RECORD"
+    recorded = [line.split(",")[0] for line in record.read_text().splitlines() if line]
+
+    assert any(path.startswith("bin/") for path in recorded), recorded
+    for path in recorded:
+        assert not path.startswith("../"), f"{path} points outside the target"
+        assert (target_dir / path).exists(), f"{path} is recorded but missing"
 
 
 @pytest.mark.parametrize("target_option", ["--target", "-t"])


### PR DESCRIPTION
## What does this PR do?

Fixes #7658.

A wheel is installed into a staging directory whose scheme spreads files over
`<staging>/lib/python`, `<staging>/bin` and so on, and RECORD stores paths relative
to the directory holding the `.dist-info`. `_handle_target_dir()` then flattens all
of that into the target directory, but leaves RECORD describing the staging layout:

```console
$ pip install --target t scriptpkg
$ cat t/scriptpkg-1.0.dist-info/RECORD
../../bin/scriptpkg,sha256=...,108357
```

That resolves two levels *above* the target directory rather than to
`t/bin/scriptpkg`, so every recorded script path points outside the installation.

The staged RECORD files are now rewritten before the move, while the staging layout
is still there to resolve against, mapping each scheme directory onto the target
root. Paths that fall outside the known scheme directories are left alone.

Covered by a new test in `tests/functional/test_install.py`, which fails on `main`.
It asserts that no recorded path escapes the target and that every recorded path
exists.

Note this overlaps in `_handle_target_dir()` with #14268; happy to rebase whichever
lands second.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude
