### PR TITLE
Stop --target losing the shared __pycache__ and data files under lib

### DIFF
--- a/news/10399.bugfix.rst
+++ b/news/10399.bugfix.rst
@@ -1,0 +1,4 @@
+Install the data files of a wheel that live under ``lib`` when using
+``--target``. The directory was skipped entirely because it also holds the
+staging area's ``purelib`` directory; its data files are now moved across
+individually.

--- a/news/12527.bugfix.rst
+++ b/news/12527.bugfix.rst
@@ -1,0 +1,4 @@
+Merge into the top-level ``__pycache__`` of a ``--target`` directory instead of
+skipping or replacing it. Installing a distribution no longer drops its own
+bytecode (while its ``RECORD`` still lists it), and ``--upgrade`` no longer
+deletes the bytecode of distributions already installed there.

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -630,30 +630,58 @@ class InstallCommand(RequirementCommand):
                     ddir = os.path.join(data_dir, item)
                     if any(s.startswith(ddir) for s in lib_dir_list[:-1]):
                         continue
-                target_item_dir = os.path.join(target_dir, item)
-                if os.path.exists(target_item_dir):
-                    if not upgrade:
-                        logger.warning(
-                            "Target directory %s already exists. Specify "
-                            "--upgrade to force replacement.",
-                            target_item_dir,
-                        )
-                        continue
-                    if os.path.islink(target_item_dir):
-                        logger.warning(
-                            "Target directory %s already exists and is "
-                            "a link. pip will not automatically replace "
-                            "links, please remove if replacement is "
-                            "desired.",
-                            target_item_dir,
-                        )
-                        continue
-                    if os.path.isdir(target_item_dir):
-                        shutil.rmtree(target_item_dir)
-                    else:
-                        os.remove(target_item_dir)
+                self._move_to_target_dir(
+                    os.path.join(lib_dir, item),
+                    os.path.join(target_dir, item),
+                    upgrade,
+                )
 
-                shutil.move(os.path.join(lib_dir, item), target_item_dir)
+    def _move_to_target_dir(self, source: str, target: str, upgrade: bool) -> None:
+        if os.path.exists(target):
+            # A top-level ``__pycache__`` holds the bytecode of the top-level
+            # modules of every distribution installed into the target
+            # directory, so it is not owned by the distribution being
+            # installed. Merge into it entry by entry instead of treating it
+            # as a whole: replacing it would delete bytecode belonging to
+            # previously installed distributions, and skipping it would drop
+            # the bytecode of the distribution being installed while its
+            # RECORD still claims the files were written.
+            if (
+                os.path.basename(target) == "__pycache__"
+                and os.path.isdir(source)
+                and os.path.isdir(target)
+                and not os.path.islink(target)
+            ):
+                for item in os.listdir(source):
+                    self._move_to_target_dir(
+                        os.path.join(source, item),
+                        os.path.join(target, item),
+                        upgrade,
+                    )
+                return
+
+            if not upgrade:
+                logger.warning(
+                    "Target directory %s already exists. Specify "
+                    "--upgrade to force replacement.",
+                    target,
+                )
+                return
+            if os.path.islink(target):
+                logger.warning(
+                    "Target directory %s already exists and is "
+                    "a link. pip will not automatically replace "
+                    "links, please remove if replacement is "
+                    "desired.",
+                    target,
+                )
+                return
+            if os.path.isdir(target):
+                shutil.rmtree(target)
+            else:
+                os.remove(target)
+
+        shutil.move(source, target)
 
     def _determine_conflicts(
         self, to_install: list[InstallRequirement]

--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -55,6 +55,7 @@ from pip._internal.utils.misc import (
     check_externally_managed,
     ensure_dir,
     get_pip_version,
+    normalize_path,
     protect_pip_from_modification_on_windows,
     warn_if_run_as_root,
     write_output,
@@ -138,6 +139,17 @@ def _arg_refers_to_pip(arg: str) -> bool:
     except InvalidRequirement:
         return False
     return canonicalize_name(req.name) == "pip"
+
+
+def _is_same_path(path: str, other: str) -> bool:
+    return normalize_path(path) == normalize_path(other)
+
+
+def _is_within(path: str, directory: str) -> bool:
+    """Whether ``path`` is ``directory`` itself or lives inside it."""
+    path = normalize_path(path)
+    directory = normalize_path(directory)
+    return path == directory or path.startswith(directory + os.sep)
 
 
 class InstallCommand(RequirementCommand):
@@ -626,15 +638,47 @@ class InstallCommand(RequirementCommand):
 
         for lib_dir in lib_dir_list:
             for item in os.listdir(lib_dir):
-                if lib_dir == data_dir:
-                    ddir = os.path.join(data_dir, item)
-                    if any(s.startswith(ddir) for s in lib_dir_list[:-1]):
-                        continue
-                self._move_to_target_dir(
-                    os.path.join(lib_dir, item),
-                    os.path.join(target_dir, item),
-                    upgrade,
-                )
+                source_item = os.path.join(lib_dir, item)
+                target_item = os.path.join(target_dir, item)
+                if lib_dir == data_dir and any(
+                    _is_within(lib, source_item) for lib in lib_dir_list[:-1]
+                ):
+                    # This data entry contains one of the scheme's lib
+                    # directories - <data>/lib also holds <data>/lib/python.
+                    # Moving it as a whole would carry the lib directory into
+                    # the target, but skipping it loses the data files that
+                    # live alongside, so move those individually instead.
+                    self._move_data_tree(
+                        source_item, target_item, lib_dir_list[:-1], upgrade
+                    )
+                    continue
+                self._move_to_target_dir(source_item, target_item, upgrade)
+
+    def _move_data_tree(
+        self, source: str, target: str, lib_dirs: list[str], upgrade: bool
+    ) -> None:
+        """Move the data files inside a directory that also holds a lib dir.
+
+        The lib directories are moved by their own pass over ``lib_dir_list``,
+        so they are stepped over here.
+        """
+        created = False
+        for item in os.listdir(source):
+            source_item = os.path.join(source, item)
+            if any(_is_same_path(source_item, lib) for lib in lib_dirs):
+                continue
+
+            if not created:
+                # Created lazily so that a directory holding nothing but a lib
+                # directory is not reproduced, empty, in the target.
+                ensure_dir(target)
+                created = True
+
+            target_item = os.path.join(target, item)
+            if any(_is_within(lib, source_item) for lib in lib_dirs):
+                self._move_data_tree(source_item, target_item, lib_dirs, upgrade)
+            else:
+                self._move_to_target_dir(source_item, target_item, upgrade)
 
     def _move_to_target_dir(self, source: str, target: str, upgrade: bool) -> None:
         if os.path.exists(target):

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1270,6 +1270,55 @@ def test_install_package_with_target(script: PipTestEnvironment) -> None:
     result.did_update(singlemodule_py)
 
 
+def test_install_package_with_target_merges_pycache(
+    script: PipTestEnvironment,
+) -> None:
+    """
+    The ``__pycache__`` at the top of a --target directory holds the bytecode
+    of the top-level modules of every distribution installed there, so it must
+    be merged into: installing a second distribution may neither skip it (which
+    drops the new bytecode) nor, under --upgrade, replace it (which deletes the
+    bytecode of the distributions already installed).
+    """
+    create_basic_wheel_for_package(
+        script, "pkga", "1.0", extra_files={"modulea.py": "a = 1"}
+    )
+    create_basic_wheel_for_package(
+        script, "pkgb", "1.0", extra_files={"moduleb.py": "b = 1"}
+    )
+    target_dir = script.scratch_path / "target"
+
+    def install(*args: str) -> TestPipResult:
+        return script.pip(
+            "install",
+            "--no-index",
+            "--find-links",
+            script.scratch_path,
+            "--target",
+            target_dir,
+            *args,
+        )
+
+    def pyc(stem: str) -> list[Path]:
+        return list(target_dir.glob(f"__pycache__/{stem}.*.pyc"))
+
+    install("pkga")
+    assert pyc("modulea"), "bytecode of the first distribution was not installed"
+
+    # Installing a second distribution must add to the shared __pycache__
+    # instead of skipping it and leaving a RECORD that claims otherwise.
+    # script.pip() also fails on the spurious "Target directory ... already
+    # exists" warning that skipping it used to emit.
+    install("pkgb")
+    assert pyc("moduleb"), "bytecode of the second distribution was dropped"
+    assert pyc("modulea"), "bytecode of the first distribution disappeared"
+
+    # --upgrade must not delete bytecode belonging to other distributions.
+    install("--upgrade", "pkgb")
+    assert pyc("moduleb")
+    assert pyc("modulea"), "--upgrade deleted another distribution's bytecode"
+
+
 @pytest.mark.parametrize("target_option", ["--target", "-t"])
 def test_install_package_to_usersite_with_target_must_fail(
     script: PipTestEnvironment, target_option: str

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -34,6 +34,7 @@ from tests.lib import (
     _create_test_package,
     create_basic_wheel_for_package,
     create_test_package_with_setup,
+    make_wheel,
     need_bzr,
     need_mercurial,
     need_svn,
@@ -1317,6 +1318,33 @@ def test_install_package_with_target_merges_pycache(
     install("--upgrade", "pkgb")
     assert pyc("moduleb")
     assert pyc("modulea"), "--upgrade deleted another distribution's bytecode"
+
+
+def test_install_package_with_target_data_files_under_lib(
+    script: PipTestEnvironment,
+) -> None:
+    """
+    Data files are skipped when their directory also holds one of the scheme's
+    lib directories: with ``home`` set to the staging directory, purelib is
+    ``<data>/lib/python``, so ``<data>/lib`` cannot simply be moved across.
+    The data files beside it must still be installed.
+    """
+    wheel_path = make_wheel(
+        "datalib",
+        "1.0",
+        extra_data_files={
+            "data/lib/somefile": "data under lib",
+            "data/share/other": "data under share",
+        },
+    ).save_to_dir(script.scratch_path)
+    target_dir = script.scratch_path / "target"
+
+    script.pip("install", "--no-index", "--target", target_dir, wheel_path)
+
+    assert (target_dir / "share" / "other").read_text() == "data under share"
+    assert (target_dir / "lib" / "somefile").read_text() == "data under lib"
+    # The staged lib directory itself must not be reproduced in the target.
+    assert not (target_dir / "lib" / "python").exists()
 
 
 @pytest.mark.parametrize("target_option", ["--target", "-t"])


### PR DESCRIPTION
## What does this PR do?

Fixes #12527. Fixes #10399.

Two bugs where `pip install --target` loses files. They are in the same loop in
`_handle_target_dir()`, so they are together in one PR; the two commits are separate
if you would rather take them one at a time.

**1. The shared `__pycache__` (#12527).** The `__pycache__` at the top of a target
directory holds the bytecode of the top-level modules of *every* distribution
installed there, so it is not owned by any one of them. It was treated like any
other top-level entry, which went wrong in both directions:

```console
$ pip install --target t threadpoolctl
$ pip install --target t six
WARNING: Target directory t\__pycache__ already exists. Specify --upgrade to force replacement.
# six's bytecode is dropped, though six's RECORD still lists it

$ pip install --target t --upgrade six
# threadpoolctl.cpython-312.pyc is deleted - it belongs to a package not being upgraded
```

The per-entry logic moves into `_move_to_target_dir()`, which recurses into
`__pycache__` so its contents are merged entry by entry, applying the same
`--upgrade` rules one level down.

**2. Data files under `lib` (#10399).** Any data entry containing one of the
scheme's lib directories was skipped outright. With `home` set to the staging
directory purelib is `<data>/lib/python`, so all of `<data>/lib` was skipped and a
wheel shipping `lib/somefile` silently lost it:

```console
$ pip install --target t datalib   # data files lib/somefile and share/other
$ ls t
datalib-1.0.dist-info  share       # no lib/
```

It cannot simply be moved either, as that would carry the lib directory into the
target, so the entry is descended into and the data files moved individually. The
target directory is created lazily, so a directory holding nothing but a lib
directory is not reproduced empty. The containment test also moves from a bare
`str.startswith()` to a normalised path comparison, so a sibling such as
`<data>/libfoo` is no longer treated as if it held `<data>/lib/python`.

Both are covered by new tests in `tests/functional/test_install.py`, each of which
fails without its fix.

Note this overlaps in `_handle_target_dir()` with #14268; happy to rebase whichever
lands second.

## PR Checklist:
- [x] I agree to follow the [PSF Code of Conduct](https://www.python.org/psf/conduct/).
- [x] I have read and have followed the [CONTRIBUTING.md](https://github.com/pypa/pip/blob/main/.github/CONTRIBUTING.md) file.
- [x] I have added a news file fragment (or this PR does not need one).
- [x] I have read and followed the [AI_POLICY.md](https://github.com/pypa/pip/blob/main/AI_POLICY.md) file, and if any AI tools were used, I have disclosed it below.

Assisted-by: Claude
