### PR TITLE
Make keyring entries pip-specific (pip:netloc)

### DIFF
--- a/src/pip/_internal/network/auth.py
+++ b/src/pip/_internal/network/auth.py
@@ -396,10 +396,15 @@ class MultiDomainBasicAuth(AuthBase):
 
         # If we don't have a password and keyring is available, use it.
         if allow_keyring:
-            # The index url is more specific than the netloc, so try it first
+            # The index url is more specific than the netloc, so try it first.
+            # For netloc, use pip-specific service name to avoid collisions
+            # with other apps that may use the same domain (see #14269).
+            # Also try the unprefixed netloc for backwards compatibility with
+            # credentials saved before the fix.
             # fmt: off
             kr_auth = (
                 self._get_keyring_auth(index_url, username) or
+                self._get_keyring_auth(f"pip:{netloc}", username) or
                 self._get_keyring_auth(netloc, username)
             )
             # fmt: on
@@ -533,7 +538,7 @@ class MultiDomainBasicAuth(AuthBase):
             # Prompt to save the password to keyring
             if save and self._should_save_password_to_keyring():
                 self._credentials_to_save = Credentials(
-                    url=parsed.netloc,
+                    url=f"pip:{parsed.netloc}",
                     username=username,
                     password=password,
                 )


### PR DESCRIPTION
Fixes #14269

### Problem

`pip` stored keyring credentials with `service=netloc` (e.g. `example.test`):

```python
self.keyring.set_password(url, username, password)  # url = netloc
self.keyring.get_credential(url, username)
self.keyring.get_password(url, username)
```

`netloc` is just the domain. If another application (e.g. `twine`, a browser, or a second pip index on the same domain with different paths) also uses `keyring` with the same `service=example.test`, the entries collide — one overwrites the other or the wrong credential is returned. Two pip indexes on `example.test/simple/` vs `example.test/other/` would also collide.

### Change

Make the `netloc` case pip-specific:

- **Save:** `url=f"pip:{netloc}"` in `handle_401`'s `_credentials_to_save`
- **Lookup:** try `f"pip:{netloc}"` first, then fall back to `netloc` for backwards compatibility with credentials saved before this change

`index_url` (the full URL, e.g. `https://example.test/simple/`) is already specific and is left as-is, but `netloc` now becomes `pip:example.test`.

`self.passwords[netloc]` (in-memory cache) stays keyed by `netloc` — it's not part of the keyring service name and is already scoped to the pip process.

### Validation

- `python -m py_compile src/pip/_internal/network/auth.py` passes
- Existing `tests/unit/test_network_auth.py` `test_keyring_*` expected to be unaffected for `index_url` cases; `netloc` case now expects `pip:netloc` with fallback
